### PR TITLE
A*: pep8 code and fix documentation

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -127,8 +127,8 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
 
 
 def astar_path_length(G, source, target, heuristic=None, weight='weight'):
-    """Return a list of nodes in a shortest path between source and target
-    using the A* ("A-star") algorithm.
+    """Return the length of the shortest path between source and target using
+    the A* ("A-star") algorithm.
 
     Parameters
     ----------


### PR DESCRIPTION
Hi,

I noticed that the docstring for `astar_path_length` wasn't correct, it seems to have been copy-pasted off `astar_path`. I took the opportunity to also clean up the source code so that it conforms to PEP8.
