### PR TITLE
712 global reaching centrality

### DIFF
--- a/doc/source/reference/algorithms.rst
+++ b/doc/source/reference/algorithms.rst
@@ -38,6 +38,7 @@ Algorithms
    algorithms.product
    algorithms.rich_club
    algorithms.shortest_paths
+   algorithms.simple_paths
    algorithms.swap
    algorithms.traversal
    algorithms.vitality

--- a/doc/source/reference/algorithms.simple_paths.rst
+++ b/doc/source/reference/algorithms.simple_paths.rst
@@ -1,0 +1,9 @@
+************
+Simple Paths
+************
+
+.. automodule:: networkx.algorithms.simple_paths
+.. autosummary::
+   :toctree: generated/
+
+   all_simple_paths

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -76,3 +76,4 @@ Thanks especially to the following contributors:
  - Simon Knight improved the GraphML functions to handle yEd/yfiles data,
    and to handle types correctly.
  - Conrad Lee contributed the k-clique community finding algorithm.
+ - Sérgio Nery Simões wrote the function for finding all simple paths.

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -29,6 +29,7 @@ from networkx.algorithms.richclub import *
 from networkx.algorithms.distance_regular import *
 from networkx.algorithms.swap import *
 from networkx.algorithms.graphical import *
+from networkx.algorithms.simple_paths import *
 
 import networkx.algorithms.assortativity
 import networkx.algorithms.bipartite

--- a/networkx/algorithms/centrality/communicability_alg.py
+++ b/networkx/algorithms/centrality/communicability_alg.py
@@ -84,7 +84,7 @@ def communicability_centrality_exp(G):
     A[A!=0.0] = 1
     expA = scipy.linalg.expm(A)
     # convert diagonal to dictionary keyed by node
-    sc = dict(zip(nodelist,expA.diagonal()))
+    sc = dict(zip(nodelist,map(float,expA.diagonal())))
     return sc
 
 @require('numpy')
@@ -159,7 +159,7 @@ def communicability_centrality(G):
     expw = numpy.exp(w)
     xg = numpy.dot(vsquare,expw)
     # convert vector dictionary keyed by node
-    sc = dict(zip(nodelist,xg))
+    sc = dict(zip(nodelist,map(float,xg)))
     return sc
 
 @require('scipy')
@@ -259,7 +259,7 @@ def communicability_betweenness_centrality(G, normalized=True):
         B[i,:] = 0
         B[:,i] = 0
         B -= scipy.diag(scipy.diag(B))
-        sc[v] = B.sum()
+        sc[v] = float(B.sum())
         # put row and col back
         A[i,:] = row
         A[:,i] = col
@@ -361,7 +361,7 @@ def communicability(G):
             q = mapping[v]
             for j in range(len(nodelist)):
                 s += vec[:,j][p,0]*vec[:,j][q,0]*expw[j]
-            sc[u][v] = s
+            sc[u][v] = float(s)
     return sc
 
 @require('scipy')
@@ -436,7 +436,7 @@ def communicability_exp(G):
     for u in G:
         sc[u]={}
         for v in G:
-            sc[u][v] = expA[mapping[u],mapping[v]]
+            sc[u][v] = float(expA[mapping[u],mapping[v]])
     return sc
 
 @require('numpy')

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -134,7 +134,7 @@ def approximate_current_flow_betweenness_centrality(G, normalized=True,
     else:
         factor = nb/2.0
     # remap to original node names and "unnormalize" if required
-    return dict((ordering[k],v*factor) for k,v in betweenness.items())
+    return dict((ordering[k],float(v*factor)) for k,v in betweenness.items())
 
 
 def current_flow_betweenness_centrality(G, normalized=True, weight='weight',
@@ -240,7 +240,7 @@ def current_flow_betweenness_centrality(G, normalized=True, weight='weight',
     else:
         nb = 2.0
     for i,v in enumerate(H): # map integers to nodes
-        betweenness[v] = (betweenness[v]-i)*2.0/nb
+        betweenness[v] = float((betweenness[v]-i)*2.0/nb)
     return dict((ordering[k],v) for k,v in betweenness.items())
 
 
@@ -347,7 +347,7 @@ def edge_current_flow_betweenness_centrality(G, normalized=True,
             betweenness[e]+=(i+1-pos[i])*row[i]
             betweenness[e]+=(n-i-pos[i])*row[i]
         betweenness[e]/=nb
-    return dict(((ordering[s],ordering[t]),v) 
+    return dict(((ordering[s],ordering[t]),float(v))
                 for (s,t),v in betweenness.items())
 
 

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -114,7 +114,7 @@ def current_flow_closeness_centrality(G, normalized=True, weight='weight',
         nb=1.0
     for v in H:
         betweenness[v]=nb/(betweenness[v])
-    return dict((ordering[k],v) for k,v in betweenness.items())
+    return dict((ordering[k],float(v)) for k,v in betweenness.items())
 
 information_centrality=current_flow_closeness_centrality
 
@@ -125,4 +125,3 @@ def setup_module(module):
         import numpy
     except:
         raise SkipTest("NumPy not available")
-

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -155,7 +155,7 @@ def eigenvector_centrality_numpy(G):
     # eigenvector of largest eigenvalue at ind[0], normalized
     largest=np.array(eigenvectors[:,ind[0]]).flatten()
     norm=np.sign(largest.sum())*np.linalg.norm(largest)
-    centrality=dict(zip(G,largest/norm))
+    centrality=dict(zip(G,map(float,largest/norm)))
     return centrality
 
 

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -109,7 +109,7 @@ def global_reaching_centrality(G, weight=None, normalized=True):
     """
 
 
-    if G.size(weight=weight) < 1:
+    if G.size(weight=weight) <= 0:
         raise nx.NetworkXError("Size of G must be positive for global_reaching_centrality")
 
     if normalized and not(weight is None):

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -2,7 +2,7 @@
 """
 Flow Hierarchy.
 """
-#    Copyright (C) 2004-2011 by 
+#    Copyright (C) 2004-2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -21,23 +21,24 @@ def flow_hierarchy(G, weight=None):
     Parameters
     ----------
     G : DiGraph or MultiDiGraph
+       A directed graph
 
     weight : key,optional (default=None)
-l        Attribute to use for node weights. If None the weight defaults to 1.
+       Attribute to use for node weights. If None the weight defaults to 1.
 
     Returns
     -------
     h : float
-       Flow heirarchy value 
+       Flow heirarchy value
 
     Notes
     -----
     The algorithm described in [1]_ computes the flow hierarchy through
     exponentiation of the adjacency matrix.  This function implements an
-    alternative approach that finds strongly connected components.    
-    An edge is in a cycle if and only if it is in a strongly connected 
-    component, which can be found in `O(m)`time using Tarjan's algorithm.
-    
+    alternative approach that finds strongly connected components.
+    An edge is in a cycle if and only if it is in a strongly connected
+    component, which can be found in `O(m)` time using Tarjan's algorithm.
+
     References
     ----------
     .. [1] Luo, J.; Magee, C.L. (2011),

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Flow Hierarchy.
+Measures of how hierarchical a graph is, including 'Flow Hierarchy'
+and the 'Global reaching centrality'.
 """
 #    Copyright (C) 2004-2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
@@ -9,8 +10,10 @@ Flow Hierarchy.
 #    All rights reserved.
 #    BSD license.
 import networkx as nx
-__authors__ = "\n".join(['Ben Edwards (bedwards@cs.unm.edu)'])
-__all__ = ['flow_hierarchy']
+import itertools
+__authors__ = "\n".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                         'Conrad Lee (conradlee@gmail.com)'])
+__all__ = ['flow_hierarchy', 'global_reaching_centrality']
 
 def flow_hierarchy(G, weight=None):
     """Returns the flow hierarchy of a directed network.
@@ -29,7 +32,7 @@ def flow_hierarchy(G, weight=None):
     Returns
     -------
     h : float
-       Flow heirarchy value
+        Flow heirarchy value 
 
     Notes
     -----
@@ -51,3 +54,91 @@ def flow_hierarchy(G, weight=None):
         raise nx.NetworkXError("G must be a digraph in flow_heirarchy")
     scc = nx.strongly_connected_components(G)
     return 1.-sum(G.subgraph(c).size(weight) for c in scc)/float(G.size(weight))
+
+def pairwise(iterable):
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return itertools.izip(a, b)
+
+def weights_to_lengths(G, weight_key, length_key):
+    total_weight = float(G.size(weight=weight_key))
+    for i, j, attr_dict in G.edges_iter(data=True):
+        if attr_dict[weight_key] <= 0.:
+            raise nx.NetworkXError("All edges must have a positive weight to be converted into a length")
+        length = total_weight / attr_dict[weight_key]
+        G.edge[i][j][length_key] = length
+
+
+def global_reaching_centrality(G, weight=None):
+    """Returns the global reaching centrality of a directed network.
+
+    The global reaching centrality is based on the local reaching centrality,
+    which, for some node i, indicates the proportion of the graph that is
+    accessible from the outgoing edges of node i. For weighted directed graphs,
+    the weight is taken into account. See references for details.
+
+    Parameters
+    ----------
+    G : DiGraph
+
+    weight : key,optional (default=None)
+        Attribute to use for node weights. If None the weight defaults to 1.
+        A higher weight here implies a stronger connection between nodes and
+        a shorter path length.
+
+    Returns
+    -------
+    h : float
+        global reaching centrality
+
+    Notes
+    -----
+    The algorithm described in [1] computes the global reaching centrality
+    by using dijkstra's shortest path finding algorithm.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.DiGraph()
+    >>> G.add_edge(1, 2)
+    >>> G.add_edge(1, 3)
+    >>> nx.hierarchy.global_reaching_centrality(G)
+    1.0
+    >>> G.add_edge(3, 2)
+    >>> nx.hierarchy.global_reaching_centrality(G)
+    0.75
+
+    References
+    ----------
+    .. [1] @article{mones2012hierarchy,
+             title={Hierarchy measure for complex networks},
+             author={Mones, E. and Vicsek, L. and Vicsek, T.},
+             journal={Arxiv preprint arXiv:1202.0191},
+             year={2012}
+             }
+    """
+    lengths_key = "grc_lengths"
+    if not G.is_directed():
+        raise nx.NetworkXError("G must be a digraph in global_reaching_centrality")
+
+    # Transform weights to lengths in order to use nx.all_pairs_dijkstra_path
+    if not(weight is None):
+        weights_to_lengths(G, weight, lengths_key)
+
+    denom = float(G.order() - 1)
+    local_reaching_centralities = []
+    for node, path_dict in nx.all_pairs_dijkstra_path(G, weight=lengths_key).iteritems():
+        sum_avg_weight = len(path_dict) - 1
+        if not(weight is None):
+            avg_weights = []
+            for neighbor, path in path_dict.iteritems():
+                path_weights = [G.edge[i][j][weight] for i, j in pairwise(path)]
+                avg_path_weight = sum(path_weights) / float(len(path_weights))
+                avg_weights.append(avg_path_weight)
+            sum_avg_weight = sum(avg_weights)
+        local_reaching_centralities.append(sum_avg_weight / denom)
+    max_lrc = max(local_reaching_centralities)
+
+    # Clean up
+    return sum(max_lrc - lrc for lrc in local_reaching_centralities) / denom
+    

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -31,7 +31,6 @@ def flow_hierarchy(G, weight=None):
     weight : key,optional (default=None)
        Attribute to use for node weights. If None the weight defaults to 1.
 
-
     Returns
     -------
     h : float

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -29,13 +29,13 @@ def flow_hierarchy(G, weight=None):
        A directed graph
 
     weight : key,optional (default=None)
-        Attribute to use for node weights. If None the weight defaults to 1.
+       Attribute to use for node weights. If None the weight defaults to 1.
 
 
     Returns
     -------
     h : float
-        Flow heirarchy value 
+       Flow heirarchy value 
 
     Notes
     -----

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -11,9 +11,11 @@ and the 'Global reaching centrality'.
 #    BSD license.
 import networkx as nx
 import itertools
+
 __authors__ = "\n".join(['Ben Edwards (bedwards@cs.unm.edu)',
                          'Conrad Lee (conradlee@gmail.com)'])
 __all__ = ['flow_hierarchy', 'global_reaching_centrality']
+
 
 def flow_hierarchy(G, weight=None):
     """Returns the flow hierarchy of a directed network.
@@ -55,7 +57,7 @@ def flow_hierarchy(G, weight=None):
     scc = nx.strongly_connected_components(G)
     return 1.-sum(G.subgraph(c).size(weight) for c in scc)/float(G.size(weight))
 
-def global_reaching_centrality(G, weight=None):
+def global_reaching_centrality(G, weight=None, normalized=True):
     """Returns the global reaching centrality of a directed network.
 
     The global reaching centrality is based on the local reaching centrality,
@@ -104,9 +106,14 @@ def global_reaching_centrality(G, weight=None):
              }
     """
 
-
-    if G.size() < 1:
+    if G.size(weight=weight) < 1:
         raise nx.NetworkXError("Size of G must be positive for global_reaching_centrality")
+
+    if normalized and not(weight is None):
+        print "Num edges: %d \t Sum edge weight: %0.2f" % (G.size(), G.size(weight=weight))
+        norm = G.size(weight=weight) / G.size()
+    else:
+        norm = 1.
 
     # Transform weights to lengths in order to use nx.all_pairs_dijkstra_path
     # Will stomp all over edge attribute "grc_lengths" if in use
@@ -136,9 +143,9 @@ def global_reaching_centrality(G, weight=None):
                     else:
                         path_weight = float(sum([G.edge[i][j][weight] for i, j in path]))
                     avg_weights.append(path_weight / len(path))
-            sum_avg_weight = sum(avg_weights)
+            sum_avg_weight = sum(avg_weights) / norm
         local_reaching_centralities.append(sum_avg_weight / denom)
-    max_lrc = max(local_reaching_centralities)
+    max_lrc = max(local_reaching_centralities)   
     grc = sum(max_lrc - lrc for lrc in local_reaching_centralities) / denom
 
     # Clean up by removing "grc_lengths" edge attribute, if necessary

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -55,20 +55,6 @@ def flow_hierarchy(G, weight=None):
     scc = nx.strongly_connected_components(G)
     return 1.-sum(G.subgraph(c).size(weight) for c in scc)/float(G.size(weight))
 
-def pairwise(iterable):
-    a, b = itertools.tee(iterable)
-    next(b, None)
-    return itertools.izip(a, b)
-
-def weights_to_lengths(G, weight_key, length_key):
-    total_weight = float(G.size(weight=weight_key))
-    for i, j, attr_dict in G.edges_iter(data=True):
-        if attr_dict[weight_key] <= 0.:
-            raise nx.NetworkXError("All edges must have a positive weight to be converted into a length")
-        length = total_weight / attr_dict[weight_key]
-        G.edge[i][j][length_key] = length
-
-
 def global_reaching_centrality(G, weight=None):
     """Returns the global reaching centrality of a directed network.
 
@@ -117,19 +103,27 @@ def global_reaching_centrality(G, weight=None):
              year={2012}
              }
     """
-    lengths_key = "grc_lengths"
+
 
     if G.size() < 1:
         raise nx.NetworkXError("Size of G must be positive for global_reaching_centrality")
 
     # Transform weights to lengths in order to use nx.all_pairs_dijkstra_path
+    # Will stomp all over edge attribute "grc_lengths" if in use
     if not(weight is None):
-        weights_to_lengths(G, weight, lengths_key)
+        lengths_key = "grc_lengths"
+        total_weight = float(G.size(weight=weight))
+        for i, j, attr_dict in G.edges_iter(data=True):
+            if attr_dict[weight] <= 0.:
+                raise nx.NetworkXError("All edges must have a positive weight to be converted into a length")
+            length = total_weight / attr_dict[weight]
+            G.edge[i][j][lengths_key] = length
+    else:
+        lengths_key = None
 
     denom = float(G.order() - 1)
     local_reaching_centralities = []
     for node, path_dict in nx.all_pairs_dijkstra_path(G, weight=lengths_key).iteritems():
-
         if (weight is None) and G.is_directed():
             sum_avg_weight = len(path_dict) - 1
         else:
@@ -147,10 +141,16 @@ def global_reaching_centrality(G, weight=None):
     max_lrc = max(local_reaching_centralities)
     grc = sum(max_lrc - lrc for lrc in local_reaching_centralities) / denom
 
-    # Clean up
+    # Clean up by removing "grc_lengths" edge attribute, if necessary
     if (not weight is None):
         for i, j in G.edges_iter():
             del G.edge[i][j][lengths_key]
 
     return grc
     
+# Helper functions for global_reaching_centrality
+
+def pairwise(iterable):
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return itertools.izip(a, b)

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -182,8 +182,8 @@ def hits_numpy(G):
     e,ev=np.linalg.eig(A)
     m=e.argsort()[-1] # index of maximum eigenvalue
     a=np.array(ev[:,m]).flatten()
-    hubs=dict(zip(G.nodes(),h/h.sum()))
-    authorities=dict(zip(G.nodes(),a/a.sum()))
+    hubs=dict(zip(G.nodes(),map(float,h/h.sum())))
+    authorities=dict(zip(G.nodes(),map(float,a/a.sum())))
     return hubs,authorities
 
 
@@ -273,8 +273,8 @@ def hits_scipy(G,max_iter=100,tol=1.0e-6):
     a=np.asarray(x).flatten()
     # h=M*a
     h=np.asarray(M*a).flatten()
-    hubs=dict(zip(G.nodes(),h/h.sum()))
-    authorities=dict(zip(G.nodes(),a/a.sum()))
+    hubs=dict(zip(G.nodes(),map(float,h/h.sum())))
+    authorities=dict(zip(G.nodes(),map(float,a/a.sum())))
     return hubs,authorities
 
 

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -44,7 +44,7 @@ def all_simple_paths(G, source, target, cutoff=None):
 
     References
     ----------
-    ..[1] R. Sedgewick, "Algorithms in C, Part 5: Graph Algorithms",
+    .. [1] R. Sedgewick, "Algorithms in C, Part 5: Graph Algorithms",
        Addison Wesley Professional, 3rd ed., 2001.
 
     See Also

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#    Copyright (C) 2012 by
+#    Sergio Nery Simoes <sergionery@gmail.com>
+#    All rights reserved.
+#    BSD license.
+import networkx as nx
+__author__ = """\n""".join(['Sérgio Nery Simões <sergionery@gmail.com>'])
+__all__ = ['all_simple_paths']
+
+def all_simple_paths(G, source, target, cutoff=None):
+    """Genereate all simple paths in the graph G from source to target.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node for path.
+
+    target : node
+       Ending node for path.
+
+    cutoff : integer, optional
+        Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    path_generator: generator
+       A generator that produces lists of simple paths.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> for path in nx.all_simple_paths(G,source=0,target=4):
+    ...    print(path)
+    [0, 1, 2, 3, 4]
+
+    Notes
+    -----
+    This algorithm uses a modified depth-first search to generate the
+    paths [1]_.  A single path can be found in `O(V+E)` time but the
+    number of simple paths in a graph can be very large, e.g. `O(n!)` in
+    the complete graph of order n.
+
+    References
+    ----------
+    ..[1] R. Sedgewick, "Algorithms in C, Part 5: Graph Algorithms",
+       Addison Wesley Professional, 3rd ed., 2001.
+
+    See Also
+    --------
+    shortest_path
+    """
+    if cutoff is None:
+        cutoff = len(G)
+    visited = [source]
+    stack = [(v for u,v in G.edges(source))]
+    while stack:
+        children = stack[-1]
+        child = next(children, None)
+        if child is None:
+            stack.pop()
+            visited.pop()
+        elif len(visited) == cutoff:
+            if child == target or target in children:
+                if target not in visited:
+                    yield visited + [target]
+                    stack.pop()
+                    visited.pop()
+        elif child not in visited:
+            visited.append(child)
+            stack.append((v for u,v in G.edges(child)))
+            if child == target:
+                yield visited

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from nose.tools import *
 import networkx as nx
-
+import sys
 # Functions to test flow_hierarchy measure
 
 def test_flow_hierarchy_exception():
@@ -39,19 +39,20 @@ def test_grc_exception1():
 
 def test_grc_directed_star():
     G = nx.DiGraph()
-    G.add_edge(1,2)
-    G.add_edge(1,3)
-    assert_equal(nx.global_reaching_centrality(G), 1.0)
+    G.add_edge(1,2, {"weight": 0.5})
+    G.add_edge(1,3, {"weight": 0.5})
+    assert_equal(nx.global_reaching_centrality(G, weight="weight", normalized=False), 0.5)
+    assert_equal(nx.global_reaching_centrality(G, weight="weight", normalized=True), 1.0)
 
 def test_grc_undirected_unweighted_star():
     G = nx.star_graph(2)
-    assert_equal(nx.global_reaching_centrality(G), 0.25)
+    assert_equal(nx.global_reaching_centrality(G, normalized=False), 0.25)
 
 def test_grc_undirected_weighted_star():
     G = nx.Graph()
     G.add_edge(1,2,{"weight":1})
     G.add_edge(1,3,{"weight":2})
-    assert_equal(nx.global_reaching_centrality(G), 0.25)
+    assert_equal(nx.global_reaching_centrality(G, normalized=False), 0.25)
 
 def test_grc_cycle_directed_unweighted():
     G = nx.DiGraph()
@@ -73,7 +74,7 @@ def test_grc_cycle_directed_weighted():
 def test_grc_cycle_undirected_weighted():
     G = nx.Graph()
     G.add_edge(1, 2, {"weight": 1})
-    assert_equal(nx.global_reaching_centrality(G, weight="weight"), 0.)
+    assert_equal(nx.global_reaching_centrality(G, weight="weight", normalized=False), 0.)
 
 def test_grc_directed_weighted():
     G = nx.DiGraph()
@@ -93,5 +94,5 @@ def test_grc_directed_weighted():
     max_local = max(local_reach_ctrs)
     handcomputed_grc = sum([max_local - lrc for lrc in local_reach_ctrs]) / denom
 
-    algcomputed_grc = nx.global_reaching_centrality(G, weight="weight")
+    algcomputed_grc = nx.global_reaching_centrality(G, weight="weight", normalized=False)
     assert_almost_equal(handcomputed_grc, algcomputed_grc, places=7)

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -2,24 +2,26 @@
 from nose.tools import *
 import networkx as nx
 
-def test_hierarchy_exception():
+# Functions to test flow_hierarchy measure
+
+def test_flow_hierarchy_exception():
     G = nx.cycle_graph(5)
     assert_raises(nx.NetworkXError,nx.flow_hierarchy,G)
 
-def test_hierarchy_cycle():
+def test_flow_hierarchy_cycle():
     G = nx.cycle_graph(5,create_using=nx.DiGraph())
     assert_equal(nx.flow_hierarchy(G),0.0)
 
-def test_hierarchy_tree():
+def test_flow_hierarchy_tree():
     G = nx.full_rary_tree(2,16,create_using=nx.DiGraph())
     assert_equal(nx.flow_hierarchy(G),1.0)
 
-def test_hierarchy_1():
+def test_flow_hierarchy_1():
     G = nx.DiGraph()
     G.add_edges_from([(0,1),(1,2),(2,3),(3,1),(3,4),(0,4)])
     assert_equal(nx.flow_hierarchy(G),0.5)
 
-def test_hierarchy_weight():
+def test_flow_hierarchy_weight():
     G = nx.DiGraph()
     G.add_edges_from([(0,1,{'weight':.3}),
                       (1,2,{'weight':.1}),
@@ -28,3 +30,68 @@ def test_hierarchy_weight():
                       (3,4,{'weight':.3}),
                       (0,4,{'weight':.3})])
     assert_equal(nx.flow_hierarchy(G,weight='weight'),.75)
+
+# Functions to test global_reaching_centrality measure
+
+def test_grc_exception1():
+    G = nx.DiGraph()
+    assert_raises(nx.NetworkXError, nx.global_reaching_centrality, G)
+
+def test_grc_directed_star():
+    G = nx.DiGraph()
+    G.add_edge(1,2)
+    G.add_edge(1,3)
+    assert_equal(nx.global_reaching_centrality(G), 1.0)
+
+def test_grc_undirected_unweighted_star():
+    G = nx.star_graph(2)
+    assert_equal(nx.global_reaching_centrality(G), 0.25)
+
+def test_grc_undirected_weighted_star():
+    G = nx.Graph()
+    G.add_edge(1,2,{"weight":1})
+    G.add_edge(1,3,{"weight":2})
+    assert_equal(nx.global_reaching_centrality(G), 0.25)
+
+def test_grc_cycle_directed_unweighted():
+    G = nx.DiGraph()
+    G.add_edge(1, 2)
+    G.add_edge(2, 1)
+    assert_equal(nx.global_reaching_centrality(G), 0.)
+
+def test_grc_cycle_undirected_unweighted():
+    G = nx.Graph()
+    G.add_edge(1, 2)
+    assert_equal(nx.global_reaching_centrality(G), 0.)
+
+def test_grc_cycle_directed_weighted():
+    G = nx.DiGraph()
+    G.add_edge(1, 2, {"weight": 1})
+    G.add_edge(2, 1, {"weight": 1})
+    assert_equal(nx.global_reaching_centrality(G, weight="weight"), 0.)
+
+def test_grc_cycle_undirected_weighted():
+    G = nx.Graph()
+    G.add_edge(1, 2, {"weight": 1})
+    assert_equal(nx.global_reaching_centrality(G, weight="weight"), 0.)
+
+def test_grc_directed_weighted():
+    G = nx.DiGraph()
+    G.add_edge("A","B", {"weight":5.0})
+    G.add_edge("B","C", {"weight":1.0})
+    G.add_edge("B","D", {"weight":0.25})
+    G.add_edge("D","E", {"weight":1.0})
+    
+    denom = G.order() - 1
+    A_local = sum([5, 3, 2.625, 2.0833333333333]) / denom
+    B_local = sum([1, 0.25, 0.625]) / denom
+    C_local = 0
+    D_local = sum([1.,]) / denom
+    E_local = 0
+
+    local_reach_ctrs = [A_local, C_local, B_local, D_local, E_local]
+    max_local = max(local_reach_ctrs)
+    handcomputed_grc = sum([max_local - lrc for lrc in local_reach_ctrs]) / denom
+
+    algcomputed_grc = nx.global_reaching_centrality(G, weight="weight")
+    assert_almost_equal(handcomputed_grc, algcomputed_grc, places=7)

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from nose.tools import *
+import networkx as nx
+
+def test_all_simple_paths():
+    G = nx.path_graph(4)
+    paths = nx.all_simple_paths(G,0,3)
+    assert_equal(list(list(p) for p in paths),[[0,1,2,3]])
+
+def test_all_simple_paths_cutoff():
+    G = nx.complete_graph(4)
+    paths = nx.all_simple_paths(G,0,1,cutoff=1)
+    assert_equal(list(list(p) for p in paths),[[0,1]])
+    paths = nx.all_simple_paths(G,0,1,cutoff=2)
+    assert_equal(list(list(p) for p in paths),[[0,1],[0,2,1],[0,3,1]])
+
+def test_all_simple_paths_multigraph():
+    G = nx.MultiGraph([(1,2),(1,2)])
+    paths = nx.all_simple_paths(G,1,2)
+    assert_equal(list(list(p) for p in paths),[[1,2],[1,2]])
+
+def test_all_simple_paths_directed():
+    G = nx.DiGraph()
+    G.add_path([1,2,3])
+    G.add_path([3,2,1])
+    paths = nx.all_simple_paths(G,1,3)
+    assert_equal(list(list(p) for p in paths),[[1,2,3]])

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -715,6 +715,7 @@ class DiGraph(Graph):
         Notes
         -----
         Nodes in nbunch that are not in the graph will be (quietly) ignored.
+        For directed graphs this returns the out-edges.
 
         Examples
         --------

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1030,6 +1030,7 @@ class Graph(object):
         Notes
         -----
         Nodes in nbunch that are not in the graph will be (quietly) ignored.
+        For directed graphs this returns the out-edges.
 
         Examples
         --------
@@ -1073,6 +1074,7 @@ class Graph(object):
         Notes
         -----
         Nodes in nbunch that are not in the graph will be (quietly) ignored.
+        For directed graphs this returns the out-edges.
 
         Examples
         --------

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -353,7 +353,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         Notes
         -----
         Nodes in nbunch that are not in the graph will be (quietly) ignored.
-        For directed graphs edges() is the same as out_edges().
+        For directed graphs this returns the out-edges.
 
         Examples
         --------

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -537,6 +537,7 @@ class MultiGraph(Graph):
         Notes
         -----
         Nodes in nbunch that are not in the graph will be (quietly) ignored.
+        For directed graphs this returns the out-edges.
 
         Examples
         --------
@@ -586,6 +587,7 @@ class MultiGraph(Graph):
         Notes
         -----
         Nodes in nbunch that are not in the graph will be (quietly) ignored.
+        For directed graphs this returns the out-edges.
 
         Examples
         --------

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -13,14 +13,16 @@ matplotlib:     http://matplotlib.sourceforge.net/
 pygraphviz:     http://networkx.lanl.gov/pygraphviz/
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2010 by 
+#    Copyright (C) 2004-2012 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-
+import networkx as nx
+from networkx.drawing.layout import shell_layout,\
+    circular_layout,spectral_layout,spring_layout,random_layout
+__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
 __all__ = ['draw',
            'draw_networkx',
            'draw_networkx_nodes',
@@ -34,11 +36,6 @@ __all__ = ['draw',
            'draw_shell',
            'draw_graphviz']
 
-
-import networkx as nx
-from networkx.drawing.layout import shell_layout,\
-    circular_layout,spectral_layout,spring_layout,random_layout
-
 def draw(G, pos=None, ax=None, hold=None, **kwds):
     """Draw the graph G with Matplotlib (pylab).
 
@@ -46,19 +43,19 @@ def draw(G, pos=None, ax=None, hold=None, **kwds):
     labels or edge labels and using the full Matplotlib figure area
     and no axis labels by default.  See draw_networkx() for more
     full-featured drawing that allows title, axis labels etc.
-    
+
     Parameters
     ----------
     G : graph
-       A networkx graph 
+       A networkx graph
 
     pos : dictionary, optional
        A dictionary with nodes as keys and positions as values.
        If not specified a spring layout positioning will be computed.
        See networkx.layout for functions that compute node positions.
-       
+
     ax : Matplotlib Axes object, optional
-       Draw the graph in specified Matplotlib axes.  
+       Draw the graph in specified Matplotlib axes.
 
     hold : bool, optional
        Set the Matplotlib hold state.  If True subsequent draw
@@ -94,12 +91,12 @@ def draw(G, pos=None, ax=None, hold=None, **kwds):
 
     With pylab:
 
-    >>> import pylab as P # 
+    >>> import pylab as P #
     >>> import networkx as nx
     >>> G=nx.dodecahedral_graph()
     >>> nx.draw(G)  # networkx draw()
     >>> P.draw()    # pylab draw()
-    
+
     With pyplot
 
     >>> import matplotlib.pyplot as plt
@@ -110,8 +107,6 @@ def draw(G, pos=None, ax=None, hold=None, **kwds):
 
     Also see the NetworkX drawing examples at
     http://networkx.lanl.gov/gallery.html
-
-
     """
     try:
         import matplotlib.pylab as pylab
@@ -151,32 +146,32 @@ def draw_networkx(G, pos=None, with_labels=True, **kwds):
     Draw the graph with Matplotlib with options for node positions,
     labeling, titles, and many other drawing features.
     See draw() for simple drawing without labels or axes.
-    
+
     Parameters
     ----------
     G : graph
-       A networkx graph 
+       A networkx graph
 
     pos : dictionary, optional
        A dictionary with nodes as keys and positions as values.
        If not specified a spring layout positioning will be computed.
        See networkx.layout for functions that compute node positions.
-       
+
     with_labels :  bool, optional (default=True)
        Set to True to draw labels on the nodes.
 
     ax : Matplotlib Axes object, optional
-       Draw the graph in the specified Matplotlib axes.  
+       Draw the graph in the specified Matplotlib axes.
 
     nodelist : list, optional (default G.nodes())
-       Draw only specified nodes 
+       Draw only specified nodes
 
     edgelist : list, optional (default=G.edges())
        Draw only specified edges
 
     node_size : scalar or array, optional (default=300)
        Size of nodes.  If an array is specified it must be the
-       same length as nodelist. 
+       same length as nodelist.
 
     node_color : color string, or array of floats, (default='r')
        Node color. Can be a single color format string,
@@ -226,13 +221,13 @@ def draw_networkx(G, pos=None, with_labels=True, **kwds):
        Font size for text labels
 
     font_color : string, optional (default='k' black)
-       Font color string 
+       Font color string
 
     font_weight : string, optional (default='normal')
-       Font weight 
+       Font weight
 
     font_family : string, optional (default='sans-serif')
-       Font family 
+       Font family
 
     label : string, optional
         Label for graph legend
@@ -244,7 +239,7 @@ def draw_networkx(G, pos=None, with_labels=True, **kwds):
     >>> nx.draw(G,pos=nx.spring_layout(G)) # use spring layout
 
     >>> import pylab
-    >>> limits=pylab.axis('off') # turn of axis 
+    >>> limits=pylab.axis('off') # turn of axis
 
     Also see the NetworkX drawing examples at
     http://networkx.lanl.gov/gallery.html
@@ -256,7 +251,6 @@ def draw_networkx(G, pos=None, with_labels=True, **kwds):
     draw_networkx_edges()
     draw_networkx_labels()
     draw_networkx_edge_labels()
-
     """
     try:
         import matplotlib.pylab as pylab
@@ -270,7 +264,7 @@ def draw_networkx(G, pos=None, with_labels=True, **kwds):
         pos=nx.drawing.spring_layout(G) # default to spring layout
 
     node_collection=draw_networkx_nodes(G, pos, **kwds)
-    edge_collection=draw_networkx_edges(G, pos, **kwds) 
+    edge_collection=draw_networkx_edges(G, pos, **kwds)
     if with_labels:
         draw_networkx_labels(G, pos, **kwds)
     pylab.draw_if_interactive()
@@ -283,7 +277,7 @@ def draw_networkx_nodes(G, pos,
                         alpha=1.0,
                         cmap=None,
                         vmin=None,
-                        vmax=None, 
+                        vmax=None,
                         ax=None,
                         linewidths=None,
                         label = None,
@@ -295,22 +289,22 @@ def draw_networkx_nodes(G, pos,
     Parameters
     ----------
     G : graph
-       A networkx graph 
+       A networkx graph
 
     pos : dictionary
        A dictionary with nodes as keys and positions as values.
        If not specified a spring layout positioning will be computed.
        See networkx.layout for functions that compute node positions.
-       
+
     ax : Matplotlib Axes object, optional
-       Draw the graph in the specified Matplotlib axes.  
+       Draw the graph in the specified Matplotlib axes.
 
     nodelist : list, optional
        Draw only specified nodes (default G.nodes())
 
     node_size : scalar or array
        Size of nodes (default=300).  If an array is specified it must be the
-       same length as nodelist. 
+       same length as nodelist.
 
     node_color : color string, or array of floats
        Node color. Can be a single color format string (default='r'),
@@ -324,7 +318,7 @@ def draw_networkx_nodes(G, pos,
        marker, one of 'so^>v<dph8' (default='o').
 
     alpha : float
-       The node transparency (default=1.0) 
+       The node transparency (default=1.0)
 
     cmap : Matplotlib colormap
        Colormap for mapping intensities of nodes (default=None)
@@ -341,7 +335,7 @@ def draw_networkx_nodes(G, pos,
     Examples
     --------
     >>> G=nx.dodecahedral_graph()
-    >>> nodes=nx.draw_networkx_nodes(G,pos=nx.spring_layout(G)) 
+    >>> nodes=nx.draw_networkx_nodes(G,pos=nx.spring_layout(G))
 
     Also see the NetworkX drawing examples at
     http://networkx.lanl.gov/gallery.html
@@ -353,9 +347,6 @@ def draw_networkx_nodes(G, pos,
     draw_networkx_edges()
     draw_networkx_labels()
     draw_networkx_edge_labels()
-
-
-
     """
     try:
         import matplotlib.pylab as pylab
@@ -374,7 +365,7 @@ def draw_networkx_nodes(G, pos,
         nodelist=G.nodes()
 
     if not nodelist or len(nodelist)==0:  # empty nodelist, no drawing
-        return None 
+        return None
 
     try:
         xy=numpy.asarray([pos[v] for v in nodelist])
@@ -389,7 +380,7 @@ def draw_networkx_nodes(G, pos,
                                s=node_size,
                                c=node_color,
                                marker=node_shape,
-                               cmap=cmap, 
+                               cmap=cmap,
                                vmin=vmin,
                                vmax=vmax,
                                alpha=alpha,
@@ -410,7 +401,7 @@ def draw_networkx_edges(G, pos,
                         alpha=None,
                         edge_cmap=None,
                         edge_vmin=None,
-                        edge_vmax=None, 
+                        edge_vmax=None,
                         ax=None,
                         arrows=True,
                         label=None,
@@ -422,13 +413,13 @@ def draw_networkx_edges(G, pos,
     Parameters
     ----------
     G : graph
-       A networkx graph 
+       A networkx graph
 
     pos : dictionary
        A dictionary with nodes as keys and positions as values.
        If not specified a spring layout positioning will be computed.
        See networkx.layout for functions that compute node positions.
-       
+
     edgelist : collection of edge tuples
        Draw only specified edges(default=G.edges())
 
@@ -445,7 +436,7 @@ def draw_networkx_edges(G, pos,
        Edge line style (default='solid') (solid|dashed|dotted,dashdot)
 
     alpha : float
-       The edge transparency (default=1.0) 
+       The edge transparency (default=1.0)
 
     edge_ cmap : Matplotlib colormap
        Colormap for mapping intensities of edges (default=None)
@@ -454,9 +445,9 @@ def draw_networkx_edges(G, pos,
        Minimum and maximum for edge colormap scaling (default=None)
 
     ax : Matplotlib Axes object, optional
-       Draw the graph in the specified Matplotlib axes.  
+       Draw the graph in the specified Matplotlib axes.
 
-    arrows : bool, optional (default=True) 
+    arrows : bool, optional (default=True)
        For directed graphs, if True draw arrowheads.
 
     label : [None| string]
@@ -472,7 +463,7 @@ def draw_networkx_edges(G, pos,
     Examples
     --------
     >>> G=nx.dodecahedral_graph()
-    >>> edges=nx.draw_networkx_edges(G,pos=nx.spring_layout(G)) 
+    >>> edges=nx.draw_networkx_edges(G,pos=nx.spring_layout(G))
 
     Also see the NetworkX drawing examples at
     http://networkx.lanl.gov/gallery.html
@@ -484,7 +475,6 @@ def draw_networkx_edges(G, pos,
     draw_networkx_nodes()
     draw_networkx_labels()
     draw_networkx_edge_labels()
-
     """
     try:
         import matplotlib
@@ -510,7 +500,7 @@ def draw_networkx_edges(G, pos,
 
     # set edge positions
     edge_pos=numpy.asarray([(pos[e[0]],pos[e[1]]) for e in edgelist])
-    
+
     if not cb.iterable(width):
         lw = (width,)
     else:
@@ -519,13 +509,13 @@ def draw_networkx_edges(G, pos,
     if not cb.is_string_like(edge_color) \
            and cb.iterable(edge_color) \
            and len(edge_color)==len(edge_pos):
-        if numpy.alltrue([cb.is_string_like(c) 
+        if numpy.alltrue([cb.is_string_like(c)
                          for c in edge_color]):
             # (should check ALL elements)
             # list of color letters such as ['k','r','k',...]
-            edge_colors = tuple([colorConverter.to_rgba(c,alpha) 
+            edge_colors = tuple([colorConverter.to_rgba(c,alpha)
                                  for c in edge_color])
-        elif numpy.alltrue([not cb.is_string_like(c) 
+        elif numpy.alltrue([not cb.is_string_like(c)
                            for c in edge_color]):
             # If color specs are given as (rgb) or (rgba) tuples, we're OK
             if numpy.alltrue([cb.iterable(c) and len(c) in (3,4)
@@ -546,12 +536,12 @@ def draw_networkx_edges(G, pos,
                                      colors       = edge_colors,
                                      linewidths   = lw,
                                      antialiaseds = (1,),
-                                     linestyle    = style,     
-                                     transOffset = ax.transData,             
+                                     linestyle    = style,
+                                     transOffset = ax.transData,
                                      )
 
 
-    edge_collection.set_zorder(1) # edges go behind nodes            
+    edge_collection.set_zorder(1) # edges go behind nodes
     edge_collection.set_label(label)
     ax.add_collection(edge_collection)
 
@@ -564,7 +554,7 @@ def draw_networkx_edges(G, pos,
         edge_collection.set_alpha(alpha)
 
     if edge_colors is None:
-        if edge_cmap is not None: 
+        if edge_cmap is not None:
             assert(isinstance(edge_cmap, Colormap))
         edge_collection.set_array(numpy.asarray(edge_color))
         edge_collection.set_cmap(edge_cmap)
@@ -580,7 +570,7 @@ def draw_networkx_edges(G, pos,
 
         # a directed graph hack
         # draw thick line segments at head end of edge
-        # waiting for someone else to implement arrows that will work 
+        # waiting for someone else to implement arrows that will work
         arrow_colors = edge_colors
         a_pos=[]
         p=1.0-0.25 # make head segment 25 percent of edge length
@@ -602,22 +592,22 @@ def draw_networkx_edges(G, pos,
                 theta=numpy.arctan2(dy,dx)
                 xa=p*d*numpy.cos(theta)+x1
                 ya=p*d*numpy.sin(theta)+y1
-                
+
             a_pos.append(((xa,ya),(x2,y2)))
 
         arrow_collection = LineCollection(a_pos,
                                 colors       = arrow_colors,
                                 linewidths   = [4*ww for ww in lw],
                                 antialiaseds = (1,),
-                                transOffset = ax.transData,             
+                                transOffset = ax.transData,
                                 )
-        
-        arrow_collection.set_zorder(1) # edges go behind nodes            
+
+        arrow_collection.set_zorder(1) # edges go behind nodes
         arrrow_collection.set_label(label)
         ax.add_collection(arrow_collection)
 
 
-    # update view        
+    # update view
     minx = numpy.amin(numpy.ravel(edge_pos[:,:,0]))
     maxx = numpy.amax(numpy.ravel(edge_pos[:,:,0]))
     miny = numpy.amin(numpy.ravel(edge_pos[:,:,1]))
@@ -649,13 +639,13 @@ def draw_networkx_labels(G, pos,
     Parameters
     ----------
     G : graph
-       A networkx graph 
+       A networkx graph
 
     pos : dictionary, optional
        A dictionary with nodes as keys and positions as values.
        If not specified a spring layout positioning will be computed.
        See networkx.layout for functions that compute node positions.
-       
+
     font_size : int
        Font size for text labels (default=12)
 
@@ -669,10 +659,10 @@ def draw_networkx_labels(G, pos,
        Font weight (default='normal')
 
     alpha : float
-       The text transparency (default=1.0) 
+       The text transparency (default=1.0)
 
     ax : Matplotlib Axes object, optional
-       Draw the graph in the specified Matplotlib axes.  
+       Draw the graph in the specified Matplotlib axes.
 
 
     Examples
@@ -711,7 +701,7 @@ def draw_networkx_labels(G, pos,
     horizontalalignment=kwds.get('horizontalalignment','center')
     verticalalignment=kwds.get('verticalalignment','center')
 
-    text_items={}  # there is no text collection so we'll fake one        
+    text_items={}  # there is no text collection so we'll fake one
     for n, label in labels.items():
         (x,y)=pos[n]
         if not cb.is_string_like(label):
@@ -748,23 +738,23 @@ def draw_networkx_edge_labels(G, pos,
     Parameters
     ----------
     G : graph
-       A networkx graph 
+       A networkx graph
 
     pos : dictionary, optional
        A dictionary with nodes as keys and positions as values.
        If not specified a spring layout positioning will be computed.
        See networkx.layout for functions that compute node positions.
-       
+
     ax : Matplotlib Axes object, optional
-       Draw the graph in the specified Matplotlib axes.  
+       Draw the graph in the specified Matplotlib axes.
 
     alpha : float
-       The text transparency (default=1.0) 
+       The text transparency (default=1.0)
 
     edge_labels : dictionary
        Edge labels in a dictionary keyed by edge two-tuple of text
        labels (default=None). Only labels for the keys in the dictionary
-       are drawn. 
+       are drawn.
 
     label_pos : float
        Position of edge label along edge (0=head, 0.5=center, 1=tail)
@@ -790,7 +780,7 @@ def draw_networkx_edge_labels(G, pos,
     Examples
     --------
     >>> G=nx.dodecahedral_graph()
-    >>> edge_labels=nx.draw_networkx_edge_labels(G,pos=nx.spring_layout(G)) 
+    >>> edge_labels=nx.draw_networkx_edge_labels(G,pos=nx.spring_layout(G))
 
     Also see the NetworkX drawing examples at
     http://networkx.lanl.gov/gallery.html
@@ -802,7 +792,6 @@ def draw_networkx_edge_labels(G, pos,
     draw_networkx_nodes()
     draw_networkx_edges()
     draw_networkx_labels()
-
     """
     try:
         import matplotlib.pylab as pylab
@@ -820,19 +809,19 @@ def draw_networkx_edge_labels(G, pos,
         labels=dict( ((u,v), d) for u,v,d in G.edges(data=True) )
     else:
         labels = edge_labels
-    text_items={} 
+    text_items={}
     for (n1,n2), label in labels.items():
         (x1,y1)=pos[n1]
         (x2,y2)=pos[n2]
-        (x,y) = (x1 * label_pos + x2 * (1.0 - label_pos), 
-                 y1 * label_pos + y2 * (1.0 - label_pos)) 
+        (x,y) = (x1 * label_pos + x2 * (1.0 - label_pos),
+                 y1 * label_pos + y2 * (1.0 - label_pos))
 
-        if rotate: 
+        if rotate:
             angle=numpy.arctan2(y2-y1,x2-x1)/(2.0*numpy.pi)*360 # degrees
             # make label orientation "right-side-up"
-            if angle > 90: 
+            if angle > 90:
                 angle-=180
-            if angle < - 90: 
+            if angle < - 90:
                 angle+=180
             # transform data coordinate angle to screen coordinate angle
             xy=numpy.array((x,y))
@@ -871,12 +860,10 @@ def draw_networkx_edge_labels(G, pos,
 
     return text_items
 
-
-
 def draw_circular(G, **kwargs):
     """Draw the graph G with a circular layout."""
     draw(G,circular_layout(G),**kwargs)
-    
+
 def draw_random(G, **kwargs):
     """Draw the graph G with a random layout."""
     draw(G,random_layout(G),**kwargs)
@@ -892,7 +879,7 @@ def draw_spring(G, **kwargs):
 def draw_shell(G, **kwargs):
     """Draw networkx graph with shell layout."""
     nlist = kwargs.get('nlist', None)
-    if nlist != None:        
+    if nlist != None:
         del(kwargs['nlist'])
     draw(G,shell_layout(G,nlist=nlist),**kwargs)
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -603,7 +603,7 @@ def draw_networkx_edges(G, pos,
                                 )
 
         arrow_collection.set_zorder(1) # edges go behind nodes
-        arrrow_collection.set_label(label)
+        arrow_collection.set_label(label)
         ax.add_collection(arrow_collection)
 
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -234,6 +234,9 @@ def draw_networkx(G, pos=None, with_labels=True, **kwds):
     font_family : string, optional (default='sans-serif')
        Font family 
 
+    label : string, optional
+        Label for graph legend
+
     Examples
     --------
     >>> G=nx.dodecahedral_graph()
@@ -283,6 +286,7 @@ def draw_networkx_nodes(G, pos,
                         vmax=None, 
                         ax=None,
                         linewidths=None,
+                        label = None,
                         **kwds):
     """Draw the nodes of the graph G.
 
@@ -330,6 +334,9 @@ def draw_networkx_nodes(G, pos,
 
     linewidths : [None | scalar | sequence]
        Line width of symbol border (default =1.0)
+
+    label : [None| string]
+       Label for legend
 
     Examples
     --------
@@ -386,8 +393,9 @@ def draw_networkx_nodes(G, pos,
                                vmin=vmin,
                                vmax=vmax,
                                alpha=alpha,
-                               linewidths=linewidths)
-                               
+                               linewidths=linewidths,
+                               label=label)
+
 #    pylab.axes(ax)
     pylab.sci(node_collection)
     node_collection.set_zorder(2)
@@ -405,6 +413,7 @@ def draw_networkx_edges(G, pos,
                         edge_vmax=None, 
                         ax=None,
                         arrows=True,
+                        label=None,
                         **kwds):
     """Draw the edges of the graph G.
 
@@ -449,6 +458,9 @@ def draw_networkx_edges(G, pos,
 
     arrows : bool, optional (default=True) 
        For directed graphs, if True draw arrowheads.
+
+    label : [None| string]
+       Label for legend
 
     Notes
     -----
@@ -540,6 +552,7 @@ def draw_networkx_edges(G, pos,
 
 
     edge_collection.set_zorder(1) # edges go behind nodes            
+    edge_collection.set_label(label)
     ax.add_collection(edge_collection)
 
     # Note: there was a bug in mpl regarding the handling of alpha values for
@@ -600,6 +613,7 @@ def draw_networkx_edges(G, pos,
                                 )
         
         arrow_collection.set_zorder(1) # edges go behind nodes            
+        arrrow_collection.set_label(label)
         ax.add_collection(arrow_collection)
 
 

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -117,16 +117,16 @@ class TestShp(object):
         line = (
             "LINESTRING (0.9 0.9,4 2)",
         )
-        G.add_node(1, Wkb=points[0])
+        G.add_node(1, Wkt=points[0])
         G.add_node(2, Wkt=points[1])
         G.add_edge(1, 2, Wkt=line[0])
-        # try:
-        #     nx.write_shp(G, tpath)
-        # except Exception as e:
-        #     assert 'a'=='b', e
-    #     shpdir = ogr.Open(tpath)
-    #     self.checkgeom(shpdir.GetLayerByName("nodes"), points)
-    #     self.checkgeom(shpdir.GetLayerByName("edges"), line)
+        try:
+            nx.write_shp(G, tpath)
+        except Exception as e:
+            assert False, e
+        shpdir = ogr.Open(tpath)
+        self.checkgeom(shpdir.GetLayerByName("nodes"), points)
+        self.checkgeom(shpdir.GetLayerByName("edges"), line)
 
     def tearDown(self):
         self.deletetmp(self.drv, self.testdir, self.shppath)


### PR DESCRIPTION
This pull request implements the global reaching centrality measure (a measure of hierarchy), as described in  [ticket 712](https://networkx.lanl.gov/trac/ticket/712) in the networkx developer zone.

It includes unit tests as well.

There is one bit of code that should probably be handled more elegantly.  The global reaching centrality, as originally defined, assumes that high edge weights mean high connection strength.  At the same time, in the function we need to find the shortest paths between all pairs of nodes, where the shortest paths are the ones with the highest total edge weight. The shortest path finding algorithms implemented in NetworkX assume that edge weight is equivalent to path length, so the semantics are the opposite as in the case of global reaching centrality.  For this reason, in the case of weighted networks, for every edge I create an attribute called "grc_lengths" which is used by Dijkstra's algorithm.  This is problematic if the user happened to have already set an edge attribute called "grc_lengths"---that attribute vale will be changed (and then removed in the cleanup that takes place at the end).

We could solve this problem by working off a copy of the graph, on which we're allowed to trample on the user's edge attributes.