### PR TITLE
Add mailmap file for correct git shortlog stats.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Aric Hagberg <aric.hagberg@gmail.com> aric
+Aric Hagberg <aric.hagberg@gmail.com> aric <none@none>
+Chris Ellison <cellison@cse.ucdavis.edu> cellison <none@none>
+Dan Schult <dschult@colgate.edu> dschult <none@none>


### PR DESCRIPTION
This will ensure that stats created with `git shortlog -sn` correctly aggregate commits even if the raw log has different names for some developers.
