### PR TITLE
Fix normalized laplacian when the graph contains selfloops.

### DIFF
--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -140,29 +140,20 @@ def normalized_laplacian_matrix(G, nodelist=None, weight='weight'):
           "normalized_laplacian() requires numpy: http://scipy.org/ ")
     if G.is_multigraph():
         L = laplacian(G, nodelist=nodelist, weight=weight)
-        osd = np.zeros(n)
-        for i in range(n):
-            if d[i]>0: 
-                osd[i] = np.sqrt(1.0/d[i])
-        T=I*osd
-        L=np.dot(T,np.dot(L,T))
-        return L
-
-    if G.number_of_selfloops() == 0:
+        D = np.diag(L)
+    elif G.number_of_selfloops() == 0:
         L = laplacian(G, nodelist=nodelist, weight=weight)
         D = np.diag(L)
     else:
         A = np.array(nx.adj_matrix(G))
         D = np.sum(A, 1)
         L = np.diag(D) - A
-
-    with np.errstate(divide='ignore'): # Handle div by 0. It happens if there
-                                       # are unconnected nodes
+        
+    # Handle div by 0. It happens if there are unconnected nodes
+    with np.errstate(divide='ignore'): 
         Disqrt = np.diag(1 / np.sqrt(D))
     Disqrt[np.isinf(Disqrt)] = 0
-    
     Ln = np.dot(Disqrt, np.dot(L,Disqrt))
-
     return Ln
 
 # Function aliases

--- a/networkx/linalg/tests/test_laplaican.py
+++ b/networkx/linalg/tests/test_laplaican.py
@@ -23,7 +23,10 @@ class TestLaplacian(object):
                 for (u,v) in self.G.edges_iter() )
         self.WG.add_node(4)
         self.MG=nx.MultiGraph(self.G)
-
+        # Graph with selfloops
+        self.Gsl = self.G.copy()
+        for node in self.Gsl.nodes():
+            self.Gsl.add_edge(node, node)
 
     def test_laplacian(self):
         "Graph Laplacian"
@@ -57,9 +60,15 @@ class TestLaplacian(object):
                         [-0.408,  1.00, -0.50,  0.00 , 0.00], 
                         [-0.408, -0.50,  1.00,  0.00,  0.00], 
                         [-0.577,  0.00,  0.00,  1.00,  0.00],
-                        [ 0.00,  0.00,  0.00,  0.00,  0.00]]) 
+                        [ 0.00,  0.00,  0.00,  0.00,  0.00]])
+        Lsl = numpy.array([[ 0.75  , -0.2887, -0.2887, -0.3536,  0.],
+                           [-0.2887,  0.6667, -0.3333,  0.    ,  0.],
+                           [-0.2887, -0.3333,  0.6667,  0.    ,  0.],
+                           [-0.3536,  0.    ,  0.    ,  0.5   ,  0.],
+                           [ 0.    ,  0.    ,  0.    ,  0.    ,  0.]])
+
         assert_almost_equal(nx.normalized_laplacian(self.G),GL,decimal=3)
         assert_almost_equal(nx.normalized_laplacian(self.MG),GL,decimal=3)
         assert_almost_equal(nx.normalized_laplacian(self.WG),GL,decimal=3)
         assert_almost_equal(nx.normalized_laplacian(self.WG,weight='other'),GL,decimal=3)
-
+        assert_almost_equal(nx.normalized_laplacian(self.Gsl), Lsl, decimal=3)


### PR DESCRIPTION
When G contains selfloops, the normalized laplacian is defined as NL = D^{-1/2}
(D - A) D^{-1/2}, with A the adjencency matrix and D a diagonal matrix with the
sum of the rows of A in the diagonal. The current NetworkX implementation use D
with the degree of the nodes in the diagonal, which count selfloops twice (this
is the right convension in general, but not the correct one for computing the
normalized laplacian).
