### PR TITLE
Fix name of ford_fulkerson_flow_and_auxiliary in the docs

### DIFF
--- a/doc/source/reference/algorithms.flow.rst
+++ b/doc/source/reference/algorithms.flow.rst
@@ -13,7 +13,7 @@ Ford-Fulkerson
    min_cut
    ford_fulkerson
    ford_fulkerson_flow
-   ford_fulkerson_flow_and_residual
+   ford_fulkerson_flow_and_auxiliary
 
 Network Simplex
 ---------------


### PR DESCRIPTION
I forgot to change the name in the last commit of #11
