### PR TITLE
Fix missing itertools dependency calling compose on a directed graph

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -8,6 +8,7 @@
 #    BSD license.
 #
 import networkx as nx
+import itertools
 __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                            'Pieter Swart (swart@lanl.gov)',
                            'Dan Schult(dschult@colgate.edu)'])


### PR DESCRIPTION
When calling graph.compose(other_graph) and they're both directed graphs, it fails with the message

```
.../venv/lib/python2.7/site-packages/networkx/classes/function.pyc in all_neighbors(graph, node)
    394     """
    395     if graph.is_directed():
--> 396         values = itertools.chain.from_iterable([graph.predecessors_iter(node),
    397                                                 graph.successors_iter(node)])
    398     else:

NameError: global name 'itertools' is not defined
```
