### PR TITLE
fix load_betweeness bug

### DIFF
--- a/networkx/algorithms/centrality/load.py
+++ b/networkx/algorithms/centrality/load.py
@@ -63,20 +63,25 @@ def newman_betweenness_centrality(G,v=None,cutoff=None,
     if v is not None:   # only one node
         betweenness=0.0
         for source in G:
-            ubetween=_node_betweenness(G,source,cutoff,normalized,weight)
-            betweenness+=ubetween[v]
+            ubetween = _node_betweenness(G, source, cutoff, False, weight)
+            betweenness += ubetween[v] if v in ubetween else 0
+        if normalized:
+            order = G.order()
+            if order <= 2:
+                return betweenness # no normalization b=0 for all nodes
+            betweenness *= 1.0 / ((order-1) * (order-2))
         return betweenness
     else:
-        betweenness={}.fromkeys(G,0.0)
+        betweenness = {}.fromkeys(G,0.0)
         for source in betweenness:
-            ubetween=_node_betweenness(G,source,cutoff,False,weight)
+            ubetween = _node_betweenness(G, source, cutoff, False, weight)
             for vk in ubetween:
-                betweenness[vk]+=ubetween[vk]
+                betweenness[vk] += ubetween[vk]
         if normalized:
-            order=len(betweenness)
-            if order <=2:
+            order = G.order()
+            if order <= 2:
                 return betweenness # no normalization b=0 for all nodes
-            scale=1.0/((order-1)*(order-2))
+            scale = 1.0 / ((order-1) * (order-2))
             for v in betweenness:
                 betweenness[v] *= scale
         return betweenness  # all nodes

--- a/networkx/algorithms/centrality/tests/test_load_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_load_centrality.py
@@ -20,7 +20,6 @@ class TestLoadCentrality:
         G.add_edge(4,5,weight=4)
         self.G=G
         self.exact_weighted={0: 4.0, 1: 0.0, 2: 8.0, 3: 6.0, 4: 8.0, 5: 0.0}
-
         self.K = nx.krackhardt_kite_graph()
         self.P3 = nx.path_graph(3)
         self.P4 = nx.path_graph(4)
@@ -29,14 +28,22 @@ class TestLoadCentrality:
         self.C4=nx.cycle_graph(4)
         self.T=nx.balanced_tree(r=2, h=2)
         self.Gb = nx.Graph()
-        self.Gb.add_edges_from([(0,1), (0,2), (1,3), (2,3), 
-                                (2,4), (4,5), (3,5)])
+        self.Gb.add_edges_from([(0, 1), (0, 2), (1, 3), (2, 3), 
+                                (2, 4), (4, 5), (3, 5)])
+        self.F = nx.florentine_families_graph()
+        self.D = nx.cycle_graph(3, create_using=nx.DiGraph())
+        self.D.add_edges_from([(3, 0), (4, 3)])
 
-
-        F = nx.florentine_families_graph()
-        self.F = F
-
-
+    def test_not_strongly_connected(self):
+        b = nx.load_centrality(self.D)
+        result = {0: 5./12,
+                  1: 1./4,
+                  2: 1./12,
+                  3: 1./4,
+                  4: 0.000}
+        for n in sorted(self.D):
+            assert_almost_equal(result[n], b[n], places=3)
+            assert_almost_equal(result[n], nx.load_centrality(self.D, n), places=3)
 
     def test_weighted_load(self):
         b=nx.load_centrality(self.G,weight='weight',normalized=False)


### PR DESCRIPTION
When computing `load_betweenness` for one node in a digraph that is not strongly connected, NetworkX throws an error if the node of interest is not in the dictionary returned by the `_node_betweenness` helper function. Only nodes reachable from source are in that dictionary.

This pull request fixes the bug and adds a test that computes load betweenness for each node of a non strongly connected digraph. I think that this bug is the same reported in #755.
