### PR TITLE
Integration of Ben Edwards' GSoC project 2011 on community detection

### DIFF
--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -1,1 +1,17 @@
+from networkx.algorithms.community.random_community import *
+from networkx.algorithms.community.community_utils import *
+from networkx.algorithms.community.community_quality import *
+from networkx.algorithms.community.quality import *
+from networkx.algorithms.community.partition import *
+from networkx.algorithms.community.laplacian_spectral import *
+from networkx.algorithms.community.kernighan_lin import *
+from networkx.algorithms.community.divisive import *
+from networkx.algorithms.community.random_community_graph import *
+import networkx.algorithms.community.random_community
+import networkx.algorithms.community.community_utils
+import networkx.algorithms.community.community_quality
+import networkx.algorithms.community.partition
+import networkx.algorithms.community.laplacian_spectral
+import networkx.algorithms.community.random_community_graph
+import networkx.algorithms.community.divisive
 from networkx.algorithms.community.kclique import *

--- a/networkx/algorithms/community/community_quality.py
+++ b/networkx/algorithms/community/community_quality.py
@@ -232,7 +232,7 @@ def community_performance(G,C):
     """
 
     if not nx.is_partition(G,C):
-        raise NetworkXError("C is not a partition of G")
+        raise nx.NetworkXError("C is not a partition of G")
     P = 0.0
     aff = {}
     n = G.order()
@@ -289,7 +289,7 @@ def community_coverage(G,C):
        http://arxiv.org/abs/0906.0612
     """
     if not nx.is_partition(G,C):
-        raise NetworkXError("C is not a partition of G")
+        raise nx.NetworkXError("C is not a partition of G")
 
     aff = {}
     for i in G.nodes_iter():
@@ -303,3 +303,4 @@ def community_coverage(G,C):
             else:
                 P += 1
     return P/G.number_of_edges()
+

--- a/networkx/algorithms/community/community_quality.py
+++ b/networkx/algorithms/community/community_quality.py
@@ -1,0 +1,305 @@
+import networkx as nx
+
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+
+def cut_size(G, c1, c2, weight='weight'):
+    """Determine the cut size between two communities
+
+    The cut size is the sum of the costs (weights) of the edges
+    between two sets. For unweighted graphs the cost of an edge
+    is 1.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    c1,c2 : set
+      community 1
+    weight : key
+      Edge data key to use as weight.  If None all edges have weight 1.
+
+    Returns
+    -------
+    cut_size: int
+      Number of edges between two communities
+
+    Examples
+    --------
+    >>> G = nx.barbell_graph(3,0)
+    >>> nx.cut_size(G,nx.spectral_partition(G),0,1)
+    1
+    >>> G = nx.Multigraph()
+    >>> G.add_edge('a','b')
+    >>> G.add_edge('a','b')
+    >>> nx.cut_size(G,set(['a']),set(['b']))
+    2
+
+    Notes
+    -----
+    If Using MultiGraph or MultiDiGraph the cut is the total number
+    of edges including multiplicity, or the sum of the weights on
+    the multiple edges.
+
+    References
+    ----------
+    """
+    cut_size = sum(d.get(weight,1) for u,v,d
+                   in G.edges_iter(c1,data=True) if v in c2)
+    if G.is_directed():
+        cut_size += sum(d.get(weight,1) for u,v,d
+                        in G.edges_iter(c2,data=True) if v in c1)
+    return cut_size
+
+def volume(G,S,weight=None):
+    """Returns the volume of a set of vertices on a graph G
+
+    Volume is defined as the sum of weights on edges from vertices
+    in S. [1]
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    S : container
+      container of nodes
+    weight : keyword, optional default=None
+      keyword for weight on the edges.
+
+    Returns
+    -------
+    volume : numeric
+      volume of the container S in G
+
+    See Also
+    --------
+    normalized_cut_size
+    conductance
+    expansion
+
+    References
+    ----------
+    ..[1] David Gleich. 'Heirarchicical Directed Spectral Graph Partitioning'. Website
+          report. http://www.stanford.edu/~dgleich/publications/directed-spectral.pdf
+
+    """
+    return sum(d.get(weight,1) for u,v,d in G.edges_iter(S,data=True))
+
+def normalized_cut_size(G,c1,c2,weight=None):
+    """Returns the normalized cut size between two containers of nodes
+    c1 and c2.
+
+    The normalized cut size is defined as the cut size times the sum
+    of the reciprocal sizes of the volumes of the two cuts.[1]
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    c1, c2 : container
+      containsers of nodes
+    weight : keyword, optional default=None
+      keyword for weight on edges
+
+    Returns
+    -------
+    normalized_cut_size : float
+
+    See Also
+    --------
+    cut_size
+    volume
+    conductance
+    expansion
+
+    References
+    ----------
+    ..[1] David Gleich. 'Heirarchicical Directed Spectral Graph Partitioning'. Website
+          report. http://www.stanford.edu/~dgleich/publications/directed-spectral.pdf
+    """
+    return nx.cut_size(G,c1,c2,weight)*(1./nx.volume(c1,weight) + \
+                                        1./nx.volume(c2,weight))
+
+def conductance(G,c1,c2,weight=None):
+    """Return the conductance between two containers of nodes c1 and c2.
+
+    Conductance is defined by the cut size between two sets of nodes divided
+    by the minimum volume of the c1 and c2/.[1]
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    c1, c2 : container
+      container of nodes
+    weight : keyword, optional default=None
+      keyword for weight on edges
+
+    Returns
+    -------
+    conductance : float
+
+    See Also
+    --------
+    cut_size
+    volume
+    normalized_cut_size
+    expansion
+
+    References
+    ----------
+    ..[1] David Gleich. 'Heirarchicical Directed Spectral Graph Partitioning'. Website
+          report. http://www.stanford.edu/~dgleich/publications/directed-spectral.pdf
+    """
+    return nx.cut_size(G,c1,c2,weight)/float(min(nx.volume(c1,weight),
+                                                 nx.volume(c2,weight)))
+
+def expansion(G, S1, S2, weight=None):
+    """Return the edge expansion for G with node sets S1 and S2.
+
+    Expansion is the cut size between two sets of nodes divided
+    by the minimum of the sizes of U and V [1]_.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    S1, S2 : container
+      Container of nodes (e.g. set)
+    weight : key
+      Edge data key to use as weight.  If None, edge weights are set to 1.
+
+    Returns
+    -------
+    expansion : float
+
+    See Also
+    --------
+    cut_size
+    volume
+    conductance
+    normalized_cut_size
+
+    References
+    ----------
+    .. [1] Fan Chung, Spectral Graph Theory 
+       (CBMS Regional Conference Series in Mathematics, No. 92), 
+       American Mathematical Society, 1997, ISBN 0-8218-0315-8
+       http://www.math.ucsd.edu/~fan/research/revised.html
+    """
+    return float(nx.cut_size(G, S1, S2, weight)) / min(len(S1), len(S2))
+
+def community_performance(G,C):
+    """Determine the performance of a community C on a
+    graph G.
+
+    Performance is the ratio of existing intra community edges
+    plus no existant inter community edges and total possible edges.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    C : list of sets
+      Community Structure
+
+    Returns
+    -------
+    P : float
+      performance of the community
+
+    Raises
+    ------
+    NetworkXError
+      If C is not a partition of the graph
+
+    Examples
+    --------
+    >>> G = nx.karate_club_graph()
+    >>> nx.community_performance(G,nx.spectral_partition(G))
+    0.6149732603208558
+
+    Notes
+    -----
+    Defined for all Graphs. If multigraph only counts multiplicity
+    once.
+
+    References
+    ----------
+    .. [1] Santo Fortunato 'Community Detection in Graphs' Physical Reports
+       Volume 486, Issue 3-5 p. 75-174
+       http://arxiv.org/abs/0906.0612 
+    """
+
+    if not nx.is_partition(G,C):
+        raise NetworkXError("C is not a partition of G")
+    P = 0.0
+    aff = {}
+    n = G.order()
+    for i in G.nodes_iter():
+        aff[i] = nx.affiliation(i,C)[0]
+    for i in G.nodes_iter():
+        for j in G.nodes_iter():
+            if G.has_edge(i,j) and aff[i] ==aff[j]:
+                P += 1
+            elif (not G.has_edge(i,j)) and (not aff[i]==aff[j]):
+                P += 1
+    return P/(n*(n-1)) #This correct for both directed and undirected
+                       #if G is undirected we count twice so divide by 2
+                       #if G is dirceted we count once but there are twice
+                       #as many edges 
+        
+def community_coverage(G,C):
+    """Determine the coverage of a community C on a graph G.
+
+    Coverage is defined as the ratio of intra-community edges to
+    the total number of edges
+
+    Parameters
+    ----------
+    G : NetworkXGraph
+    C : list of sets
+      Community Structure
+
+    Returns
+    -------
+    P : float
+      coverage of the community
+
+    Raises
+    -------
+    NetworkXError
+     If C is not a partion of the nodes of G
+
+    Examples
+    --------
+    >>> G = nx.barbell_graph(3,0)
+    >>> nx.community_coverage(G,nx.spectral_partition(G))
+    0.8571428571428571
+
+    Notes
+    -----
+    On MultiGraphs and MultiDiGraphs uses the multiplicity of
+    edges.
+
+    References
+    ----------
+    .. [1] Santo Fortunato 'Community Detection in Graphs' Physical Reports
+       Volume 486, Issue 3-5 p. 75-174
+       http://arxiv.org/abs/0906.0612
+    """
+    if not nx.is_partition(G,C):
+        raise NetworkXError("C is not a partition of G")
+
+    aff = {}
+    for i in G.nodes_iter():
+        aff[i] = nx.affiliation(i,C)[0]
+
+    P = 0.0
+    for (i,j) in G.edges_iter():
+        if aff[i] == aff[j]:
+            if G.is_multigraph():
+                P += len(G.edge[i][j])
+            else:
+                P += 1
+    return P/G.number_of_edges()

--- a/networkx/algorithms/community/community_utils.py
+++ b/networkx/algorithms/community/community_utils.py
@@ -1,0 +1,137 @@
+from collections import defaultdict
+import itertools
+import networkx as nx
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+def is_partition(N,C):
+    """Determines whether C partitions N
+
+    Parameters
+    ----------
+    G : Container
+    C : list of sets
+
+    Returns
+    -------
+    is_partition : boolean
+       Whether C is a partition of G
+
+    Examples
+    --------
+    >>> G = nx.barbell_graph(3,0)
+    >>> nx.is_partition(G.nodes(),[set(range(3)),set(range(3,6))])
+    True
+    >>> nx.is_partition(G.nodes(),[set(range(3)),set(range(2,6))])
+    False
+
+    References
+    ----------
+    .. [1] M. E. J Newman 'Networks: An Introduction', pages 359
+       Oxford University Press 2011.
+    """
+    for n in N:
+        aff = affiliation(n,C)
+        if not len(aff) == 1:
+            return False
+    return True
+
+def affiliation(n,C):
+    """Return the affiliation of n for a given
+    community C
+
+    Parameters
+    ----------
+    n : object
+    C : list of sets
+      Community structure to search in
+
+    Returns
+    -------
+    aff : list of ints
+      Index of affiliation of n
+
+    Examples
+    --------
+    >>> C = [set(['a','b']),set(['a'])]
+    >>> nx.affiliation('a',C)
+    [0,1]
+    >>> nx.affiliation('b',C)
+    [0]
+    """
+    aff = []
+    i = 0
+    for c in C:
+        if n in c:
+            aff.append(i)
+        i+=1
+    return aff
+
+def draw_partition(G,C,*args,**kwargs):
+    """Not for release, just for testing"""
+    try:
+        import nx_opengl
+        draw = nx_opengl.draw_opengl
+    except ImportError:
+        draw = nx.draw
+            
+    colors = ['r','b','g','c','m','k','y']
+
+    nc = []
+    for n in G:
+        aff = nx.affiliation(n,C)[0]
+        nc.append(colors[aff % 7])
+
+    draw(G,*args,node_color=nc,**kwargs)
+
+def affiliation_dict(community):
+    """Return dictionary mapping node to a list of community labels.
+    The community labels are arbitrary.
+    """
+    aff=defaultdict(list)
+    for i,partition in enumerate(community):
+        for n in partition:
+            aff[n].append(i)
+    return aff
+            
+def community_sets(affiliation):
+    """Return list of community sets from affiliation dictionary
+    """
+    communities=defaultdict(set)
+    for n,cc in affiliation.items():
+        try: # overlapping communites, dict value is list
+            for c in cc:
+                communities[c].add(n)
+        except TypeError: # non-overlapping, dict value is single item
+            communities[cc].add(n)
+    return list(communities.values())
+
+def unique_community(G,community):
+    """Return True if community partitions G into unique sets.
+    """
+    community_size=sum(len(c) for c in community)
+    # communitity size must have same number of nodes as G
+    if not len(G)==community_size:
+        return False  
+    # check that the set of nodes in the communities is the same as G
+    if not set(G)==set.union(*community):
+        return False
+    return True
+    
+def overlapping_community(G,community):
+    """Return True if community partitions G into overlapping sets.
+    """
+    community_size=sum(len(c) for c in community)
+    # community size must be larger to be overlapping
+    if not len(G) < community_size:
+        return False
+    # check that the set of nodes in the communities is the same as G
+    if not set(G)==set.union(*community):
+        return False
+    return True
+

--- a/networkx/algorithms/community/divisive.py
+++ b/networkx/algorithms/community/divisive.py
@@ -1,0 +1,194 @@
+import functools
+from operator import itemgetter
+import random
+import networkx as nx
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+def divisive_partition(G, number_of_partitions, edge_ranking):
+    # edge ranking is a function that returns a dictionary
+    """Return the partition created by successively removing
+    the edge with the highest value as measured by edge_ranking.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    number_of_partitions : int
+      Number of partitions to create
+    edge_ranking : function from NetworkXGraph to dict
+      A function that takes a NetworkXGraph as a single
+      parameter and returns a dictionary keyed by
+      edges. The values in the dictionary must be
+      comparable.
+
+    Returns
+    -------
+    partition : list of sets
+      Partition of the nodes of G
+
+    Raises
+    ------
+    NetworkXError
+      If the number of partitions is not in (0,len(G)]
+
+    See Also
+    --------
+    edge_betweenness_partition
+    edge_current_betweenness_partition
+    """
+    if number_of_partitions <= 0:
+        raise nx.NetworkXError("number_of_partitions must be >0")
+    elif number_of_partitions == 1:
+        return [set(G)]
+    elif number_of_partitions == len(G):
+        return map(set,[[n] for n in G])
+    elif number_of_partitions > len(G):
+        raise nx.NetworkXError("number_of_partitions must be <= len(G)")
+
+    H = G.copy()
+    while True:
+        cc = nx.connected_components(H)
+        if len(cc) >= number_of_partitions:
+            break
+        ranking = edge_ranking(H).items()
+        edge = max(ranking,key=itemgetter(1))[0]
+        H.remove_edge(*edge)
+    return map(set,cc)
+
+def edge_betweenness_partition(G, number_of_partitions, normalized=True,
+                               weight=None):
+    """Return the partition created by successively removing
+    the edge with the highest edge betweenness.
+
+    This algorithm works by calculating the edge betweenness for all
+    edges and removing the edge with the highest value. It is then
+    determined whether the graph has been broken into connected
+    components equal to the number of partitions. If so the partition
+    is returned
+
+    Parameters
+    ----------
+    G : NetworkX Graph, DiGraph or MultiGraph
+      Graph to be partitioned
+    number_of_partitions : int
+      Number of partitions of the graph
+    normalized : boolean optional, default=True
+      Whether to normalize the edge betweenness calculation
+    weight : key, optional, default=None
+      The key to use if using wieghts for edge betweenness calculation
+
+    Returns
+    -------
+    C : list of sets
+      Partition of G
+
+    Raises
+    ------
+    NetworkXError
+      If number_of_partitions is <= 0 or if
+      number_of_partitions > len(G)
+      
+    Examples
+    --------
+    >>> G = nx.karate_club_graph()
+    >>> nx.edge_betweenness_partition(G,2)
+    [set([2,8,9,14,15,18,20,22,23,24,25,26,27,28,29,30,31,32,33]),
+     set([0,1,3,4,5,6,7,10,11,12,13,16,17,19,21])]
+
+    See Also
+    --------
+    edge_current_flow_betweenness_partition
+    divisive partition
+
+    Notes
+    -----
+    This algorithm is fairly slow, as both the calculation of connected
+    components and edge betweenness relies on all pairs shortest
+    path algorithms. They could potentially be combined to cut down
+    on overall computation time.
+
+    References
+    ----------
+    .. [1] Santo Fortunato 'Community Detection in Graphs' Physical Reports
+       Volume 486, Issue 3-5 p. 75-174
+       http://arxiv.org/abs/0906.0612"""
+    ranking = functools.partial(nx.edge_betweenness_centrality,
+                                normalized=normalized,
+                                weight=weight)
+    return divisive_partition(G, number_of_partitions, ranking)
+
+def edge_current_flow_betweenness_partition(G, number_of_partitions, 
+                                            normalized=True,  weight=None):
+    """Return the partition created by successively removing
+    the edge with the highest edge current flow betweenness.
+
+    This algorithm works by calculating the edge current flow
+    betweenness for all edges and removing the edge with the
+    highest value. It is then determined whether the graph has
+    been broken into connected components equal to the number
+    of partitions. If so the partition is returned.
+
+    Parameters
+    ----------
+    G : NetworkX Graph, DiGraph or MultiGraph
+      Graph to be partitioned
+    number_of_partitions : int
+      Number of partitions of the graph
+    normalized : boolean optional, default=True
+      Whether to normalize the edge betweenness calculation
+    weight : key, optional, default=None
+      The key to use if using wieghts for edge betweenness calculation
+
+    Returns
+    -------
+    C : list of sets
+      Partition of G
+
+
+    Raises
+    ------
+    NetworkXError
+      If number_of_partitions is <= 0 or
+      number_of_partitions > len(G)
+
+    Examples
+    --------
+    >>> G = nx.karate_club_graph()
+    >>> nx.edge_current_flow_betweenness_partition(G,2)
+    [set([0,1,2,3,4,5,6,7,9,10,11,12,13,16,17,19,21]),
+     set([8,14,15,18,20,22,23,24,25,26,27,28,29,30,31,32,33])]
+
+
+    See Also
+    --------
+    edge_betweenness_partition
+    divisive_partition
+
+    Notes
+    -----
+    This algorithm is extremely slow, as the recalculation of the edge
+    current flow betweenness is extremely slow.
+
+    References
+    ----------
+    .. [1] Santo Fortunato 'Community Detection in Graphs' Physical Reports
+       Volume 486, Issue 3-5 p. 75-174
+       http://arxiv.org/abs/0906.0612"""
+    ranking = functools.partial(nx.edge_current_flow_betweenness_centrality,
+                                normalized=normalized,
+                                weight=weight)
+    return divisive_partition(G, number_of_partitions, ranking)
+
+
+if __name__=='__main__':
+    G = nx.barbell_graph(3,0)
+    C = edge_current_flow_betweenness_partition(G,2)
+#    C = edge_betweenness_partition2(G,2)
+    print C
+#    assert_equal([set([0,1,2]),set([3,4,5])],C)
+

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -1,0 +1,190 @@
+from collections import defaultdict
+from operator import itemgetter
+import random
+import networkx as nx
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+def _compute_delta(G,A,B,weight):
+    # helper to compute initial swap deltas for a pass
+    delta = defaultdict(float)
+    for u,v,d in G.edges(data=True):
+        w = d.get(weight,1)
+        if u in A:
+            if v in A:
+                delta[u] -= w
+                delta[v] -= w
+            elif v in B:
+                delta[u] += w
+                delta[v] += w
+        elif u in B:
+            if v in A:
+                delta[u] += w
+                delta[v] += w
+            elif v in B:
+                delta[u] -= w
+                delta[v] -= w
+    return delta
+
+def _update_delta(delta,G,A,B,u,v,weight):
+    # helper to update swap deltas during single pass
+    for _,nbr,d in G.edges(u,data=True):
+        w = d.get(weight,1)
+        if nbr in A:
+            delta[nbr] += 2*w
+        if nbr in B:
+            delta[nbr] -= 2*w
+    for _,nbr,d in G.edges(v,data=True):
+        w = d.get(weight,1)
+        if nbr in A:
+            delta[nbr] -= 2*w
+        if nbr in B:
+            delta[nbr] += 2*w
+    return delta
+
+def _kernighan_lin_pass(G, A, B, weight):
+    # do a single iteration of Kernighan-Lin algorithm 
+    # returns list of  (g_i,u_i,v_i) for i node pairs u_i,v_i
+    multigraph = G.is_multigraph()
+    delta = _compute_delta(G,A,B,weight)
+    swapped = set()
+    gains = []
+    while len(swapped) < len(G):
+        gain = []
+        for u in A-swapped:
+            for v in B-swapped:
+                try:
+                    if multigraph:
+                        w = sum(d.get(weight,1) for k,d in G[u][v].items())
+                    else:
+                        w = G[u][v].get(weight,1)
+                except KeyError:
+                    w = 0
+                gain.append((delta[u] + delta[v] -2 * w, u, v)) 
+        if len(gain) == 0:
+            break
+        maxg,u,v = max(gain,key=itemgetter(0))
+        swapped.update(set([u,v]))
+        gains.append((maxg,u,v))
+        delta = _update_delta(delta, G, A-swapped, B-swapped, u, v, weight)
+    return gains        
+    
+
+def kernighan_lin_bisection(G, partition=None, max_iter=10, weight='weight'):
+    """Partition G into two node sets using the Kernighan-Lin Algorithm.
+
+    This algorithm paritions a network into two sets by iteratively
+    swapping pairs of nodes to reduce the edge cut between the two sets.
+
+    Parameters
+    ----------
+    G : graph
+    partition : list (optional)
+      List of two containers (e.g. sets) containing an intial partition.
+      If not specified a random balanaced partition is used.
+    max_iter : int
+      Maximum number of times to attempt swaps
+      to find an improvemement before giving up
+    weight : key (default='weight')
+      Edge data key to use as weight.  If None the weights are all set to 1.
+
+    Returns
+    -------
+    partition : list of sets
+      Partition of the nodes of the graph into two sets
+
+    Raises
+    -------
+    NetworkXError
+      if partition is not a valid partition of the graph into two communities
+
+    Examples
+    --------
+    >>> G = nx.barbell_graph(3,0)
+    >>> nx.kernighan_lin(G)
+
+    Notes
+    -----
+
+    References
+    ----------
+    .. [1] Kernighan, B. W.; Lin, Shen (1970). 
+       An efficient heuristic procedure for partitioning graphs. 
+       Bell Systems Technical Journal 49: 291-307. Oxford University Press 2011.
+    """
+    if G.is_directed():
+        raise NetworkXError('Not defined for directed graphs.')
+    if partition is None:
+        # split randomly into two balanced partitions
+        nodes = G.nodes()
+        random.shuffle(nodes)
+        h = len(nodes)/2
+        A,B = [set(nodes[:h]),set(nodes[h:])]
+    else:
+        try:
+            # make a copy of partition as two sets
+            A,B = set(partition[0]),set(partition[1]) 
+        except:
+            raise ValueError('partition must be two sets')
+        if not nx.unique_community(G, [A,B]):
+            raise nx.NetworkXError("partition invalid")
+    i=0
+    while i < max_iter:
+        i+=1
+        # gains is a list of  (g_i,u_i,v_i) for i node pairs u_i,v_i
+        gains = _kernighan_lin_pass(G, A, B, weight)
+        # cumulative sum of gains
+        csum = list(nx.utils.cumulative_sum(c for c,u,v in gains))
+        # index of max cumulative sum
+        index = csum.index(max(csum))
+        cgain = csum[index]
+        if cgain <= 0:
+            break
+        # node pairs corresponding to gains[0],...,gains[index]
+        anodes,bnodes = map(set,zip(*gains[:index+1])[1:3])
+        A |= bnodes
+        A -= anodes
+        B |= anodes
+        B -= bnodes
+    return A,B
+if __name__=='__main__':
+    import networkx as nx
+    import numpy as np
+    import pylab
+    # example from
+    # http://users.eecs.northwestern.edu/~haizhou/357/lec2.pdf
+    A = np.matrix([[0,  1,  2,  3,  2,  4],
+                   [1,  0,  1,  4,  2,  1],
+                   [2,  1,  0,  3,  2,  1],
+                   [3,  4,  3,  0,  4,  3],
+                   [2,  2,  2,  4,  0,  2],
+                   [4,  1,  1,  3,  2,  0]])
+
+    G=nx.from_numpy_matrix(A)
+    G=nx.relabel_nodes(G,dict(enumerate('abcdef')))
+    print(kernighan_lin_bisection(G,partition=[set(['a','b','c']),set(['d','e','f'])]))
+
+    G=nx.barbell_graph(3,0)
+    M = nx.MultiGraph(G)
+    M.add_edge(2,3)
+    M.add_edge(2,3)
+#    M.add_edge(2,3)
+    A,B=kernighan_lin_bisection(M)
+    print(A,B)
+    # G=nx.cycle_graph(50)
+    # A,B=kernighan_lin_bisection2(G)
+    # print A,B
+    print(nx.cut_size(M,A,B))
+    pos=nx.spring_layout(M)
+    pylab.clf()
+    nx.draw_networkx_nodes(G,pos,nodelist=A,node_color='r')
+    nx.draw_networkx_nodes(G,pos,nodelist=B,node_color='b')
+    nx.draw_networkx_labels(G,pos)
+    nx.draw_networkx_edges(G,pos)
+    pylab.draw()
+

--- a/networkx/algorithms/community/laplacian_spectral.py
+++ b/networkx/algorithms/community/laplacian_spectral.py
@@ -1,0 +1,112 @@
+import bisect
+import random
+import networkx as nx
+
+from functools import partial
+from operator import itemgetter
+from networkx.utils.decorators import requires
+
+
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+
+def spectral_bisection(G, weight='weight'):
+    """Bisect the graph using the Laplacian eigenvectors.
+
+    This method calculates the eigenvector v associated with the second
+    largest eigenvalue of the Laplacian. The partition is defined by the
+    nodes which are associated with either positive or negative values in v.
+
+    Parameters
+    ----------
+    G : NetworkX Graph or MultiGraph
+    weight : dict key
+       Edge data key to use as weight.  If None the partition will use
+       unweighted edges.
+
+    Returns
+    --------
+    bisection : list of sets
+      List with two sets of nodes
+
+    Raises
+    ------
+    ImportError
+      If NumPy is not available
+    
+    Examples
+    --------
+    >>> G = nx.karate_club_graph()
+    >>> nx.spectral_partition(G)
+    [set([9, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]),
+     set([0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 16, 17, 19, 21])]
+
+    Notes
+    -----
+    This algorithm splits the eigenvector at the value 0.
+
+    References
+    ----------
+    .. [1] M. E. J Newman 'Networks: An Introduction', pages 364-370
+       Oxford University Press 2011.
+    """
+    if not nx.is_connected(G):
+        raise NetworkXError('graph is not connected')
+
+    v2 = laplacian_eigenvector(G, weight=weight)
+    cut_value = 0
+    return [set([n for n,v in v2 if v < cut_value]),
+            set([n for n,v in v2 if v >= cut_value])]
+    
+
+def directed_laplacian(G, nodelist=None, weight='weight', walk='simple'):
+    L=sparse_directed_laplacian(G, nodelist=nodelist, weight=weight, walk=walk)
+    return L.todense()
+
+def simple_directed_laplacian(G, nodelist=None, weight='weight'):
+    # G strongly connected, aperiodic
+    import numpy as np
+    from scipy.sparse import spdiags
+    from scipy.sparse.linalg import eigsh
+    n = len(G)
+    A = nx.to_scipy_sparse_matrix(G,nodelist=nodelist,weight=weight)
+    data = np.asarray(A.sum(axis=1).T)
+    D_inv = spdiags(1.0/data,0,n,n)
+    P = D_inv*A
+    Pi = spdiags(eigsh(P,1,which='LM')[1].T,0,n,n)
+    return identity(n) - (Pi*P + P.T*Pi)/2.0
+
+
+def lazy_directed_laplacian(G, nodelist=None, weight='weight'):
+    # G strongly connected, not aperiodic
+    import numpy as np
+    from scipy.sparse import spdiags,identity
+    from scipy.sparse.linalg import eigsh
+    n = len(G)
+    A = nx.to_scipy_sparse_matrix(G,nodelist=nodelist,weight=weight)
+    data = np.asarray(A.sum(axis=1).T)
+    D_inv = spdiags(1.0/data,0,n,n)
+    P = (identity(n) + D_inv*A)/2.0
+    Pi = spdiags(eigsh(P,1,which='LM')[1].T,0,n,n)
+    return identity(n) - (Pi*P + P.T*Pi)/2.0
+
+def pagerank_directed_laplacian(G, nodelist=None, weight='weight',alpha=0.99):
+    # G not strongly connected, not aperiodic
+    import numpy as np
+    n = len(G)
+    A = nx.to_scipy_sparse_matrix(G,nodelist=nodelist,weight=weight)
+    data = np.asarray(A.sum(axis=1).T)
+    D_inv = np.diagflat(1.0/data)
+    P = alpha*(D_inv*A) + (1-alpha)/n
+    eigenvalues,eigenvectors = np.linalg.eig(P)
+    index = np.argsort(eigenvalues)[0]
+    Pi = np.diagflat(eigenvectors[:,index])
+    return np.identity(n)-(Pi*P + P.T*Pi)/2.0
+
+    

--- a/networkx/algorithms/community/laplacian_spectral.py
+++ b/networkx/algorithms/community/laplacian_spectral.py
@@ -1,10 +1,6 @@
-import bisect
-import random
 import networkx as nx
 
-from functools import partial
-from operator import itemgetter
-from networkx.utils.decorators import requires
+from .spectrum import laplacian_eigenvector
 
 
 #    Copyright(C) 2011 by
@@ -57,7 +53,7 @@ def spectral_bisection(G, weight='weight'):
        Oxford University Press 2011.
     """
     if not nx.is_connected(G):
-        raise NetworkXError('graph is not connected')
+        raise nx.NetworkXError('graph is not connected')
 
     v2 = laplacian_eigenvector(G, weight=weight)
     cut_value = 0
@@ -66,7 +62,7 @@ def spectral_bisection(G, weight='weight'):
     
 
 def directed_laplacian(G, nodelist=None, weight='weight', walk='simple'):
-    L=sparse_directed_laplacian(G, nodelist=nodelist, weight=weight, walk=walk)
+    L = nx.sparse_directed_laplacian(G, nodelist=nodelist, weight=weight, walk=walk)
     return L.todense()
 
 def simple_directed_laplacian(G, nodelist=None, weight='weight'):
@@ -80,7 +76,7 @@ def simple_directed_laplacian(G, nodelist=None, weight='weight'):
     D_inv = spdiags(1.0/data,0,n,n)
     P = D_inv*A
     Pi = spdiags(eigsh(P,1,which='LM')[1].T,0,n,n)
-    return identity(n) - (Pi*P + P.T*Pi)/2.0
+    return nx.identity(n) - (Pi*P + P.T*Pi)/2.0
 
 
 def lazy_directed_laplacian(G, nodelist=None, weight='weight'):

--- a/networkx/algorithms/community/partition.py
+++ b/networkx/algorithms/community/partition.py
@@ -1,0 +1,211 @@
+from copy import deepcopy
+import random
+import networkx as nx
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+
+
+def spectral_modularity_partition(G):
+    """Return a node partition based on the Modularity Matrix 
+    eigenvectors.
+
+    This method calculates the eigenvector v associated with the second
+    largest eigenvalue of the Modularity Matrix. Where the Modularity Matrix
+    is defined as
+
+    ..math::
+        B_{ij} = A_{ij} - \\frac{k_ik_j}{2m}
+
+    where A is the adjacency matrix and k_i is the degree of node i, and m
+    is the number of edges in the graph. Nodes are put in one partition if
+    their corresponding value in the eigenvector is <0 and the other partition
+    if it is >=0
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+
+    Returns
+    --------
+    C : list of sets
+      Spectral Modularity partition of the nodes in G
+
+    Raises
+    ------
+    ImportError
+      If NumPy is not available
+
+    Examples
+    --------
+    >>> G = nx.karate_club_graph()
+    >>> nx.spectral_partition(G)
+    [set([0, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 16, 17, 19, 21]),
+     set([8, 9, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33])]
+
+
+    Notes
+    -----
+    Defined for Graphs, DiGraphs, MultiGraphs, and MultiDiGraphs.
+
+    References
+    ----------
+    .. [1] M. E. J Newman 'Networks: An Introduction', pages 373-378
+       Oxford University Press 2011.
+    """
+    try:
+        import numpy as np
+    except:
+        raise ImportError("spectral_partition() \
+                           requires NumPy: http://scipy.org/")
+
+
+    k = np.matrix(G.degree().values())
+    m = G.number_of_edges()
+    B = nx.adj_matrix(G) - (k.transpose()*k)/(2.0*m)
+    eigenvalues,eigenvectors=np.linalg.eig(B)
+    # sort and keep smallest nonzero 
+    index=np.argsort(eigenvalues)[-1] # -1 index is largest eigenvalue
+    v2 = zip(np.real(eigenvectors[:,index]),G)
+    
+    C = [set(),set()]
+    
+    for (u,n) in v2:
+        if u < 0:
+            C[0].add(n)
+        else:
+            C[1].add(n)
+    return C
+            
+def greedy_max_modularity_partition(G,C_init=None,max_iter=10):
+    """Partition a graph G into two communities using greedy modularity
+    maximization.
+
+    The algorithm works by selecting a node to change communities by
+    which will maximize the modularity. The swap is made and the
+    community structure with the highest modularity is kept.
+    
+    Parameters
+    ----------
+    G : NetworkX Graph
+    C_init : list of sets option default (None)
+      Community Partition
+    max_iter : int
+      Maximum number of times to attempt swaps
+      to find an improvemement before giving up
+
+    Returns
+    -------
+    C : list of sets
+      Partition of the nodes of the graph
+
+    Raises
+    -------
+    NetworkXError
+      if C_init is not a valid partition of the
+      graph into two communities or if G is a MultiGraph
+
+    Examples
+    --------
+    >>> G = nx.barbell_graph(3,0)
+    >>> nx.greedy_max_modularity_partition(G)
+    [set([0,1,2]),set([3,4,5])]
+
+    Notes
+    -----
+    Defined on all Graph, DiGraph, not defined for MultiGraph
+
+    References
+    ----------
+    .. [1] M. E. J Newman 'Networks: An Introduction', pages 373-375
+       Oxford University Press 2011."""
+
+    if G.is_multigraph():
+        raise nx.NetworkXError("greed_max_modularity() not defined for multigraph")
+    if C_init is None:
+        m1 = G.order()/2
+        m2 = G.order()-m1
+        C = nx.random_partition(G.nodes(),partition_sizes=[m1,m2])
+    else:
+        if not nx.is_partition(G,C_init):
+            raise nx.NetworkXError("C_init doesn't partition G")
+        if not len(C_init) == 2:
+            raise nx.NetworkXError("C_init doesn't partition G into 2 communities")
+        C = deepcopy(C_init)
+            
+
+    C_mod = nx.modularity(G,C)
+    Cmax = deepcopy(C)
+    Cnext = deepcopy(C)
+
+    Cmax_mod = C_mod
+    Cnext_mod = C_mod
+
+    itrs = 0
+
+    m = float(G.number_of_edges())
+    while Cmax_mod >= C_mod and itrs < max_iter:
+        C = deepcopy(Cmax)
+        C_mod = Cmax_mod
+        Cnext = deepcopy(Cmax)
+        Cnext_mod = Cmax_mod
+        ns = set(G.nodes())
+        while ns:
+            max_swap = -1.0
+            max_node = None
+            max_nod_comm = None
+            dc =[sum(G.degree(Cnext[0]).values()), \
+                 sum(G.degree(Cnext[1]).values())]
+            for n in ns:
+                n_comm = nx.affiliation(n,Cnext)[0]
+                d_eii = -len(set(G.neighbors(n)).intersection(Cnext[n_comm]))/m
+                d_ejj = len(set(G.neighbors(n)).intersection(Cnext[1-n_comm]))/m
+                d_sum_ai = (G.degree(n)/(2*m**2))* \
+                           (dc[n_comm]-dc[1-n_comm]-G.degree(n))
+                swap_change = d_eii + d_ejj + d_sum_ai
+
+                if swap_change > max_swap:
+                    max_swap = swap_change
+                    max_node = n
+                    max_node_comm = n_comm
+            Cnext[max_node_comm].remove(max_node)
+            Cnext[1-max_node_comm].add(max_node)
+            Cnext_mod += max_swap
+            ns.remove(max_node)
+            if Cnext_mod > Cmax_mod:
+                Cmax = deepcopy(Cnext)
+                Cmax_mod = Cnext_mod
+        itrs += 1
+    return C
+
+def recursive_partition(G,
+                        partition_function,
+                        depth,
+                        dendogram=False,
+                        **kwargs):
+
+    """Recursively partition the graph G using the
+    the algorithm defined by partition function depth
+    times.
+    """
+    C = [set(G)]
+    if dendogram:
+        D = nx.Graph()
+    for _ in range(depth):
+        C_next = []
+        for c in C:
+            C_next_add = partition_function(G.subgraph(c),**kwargs)
+            if dendogram:
+                D.add_edges_from(zip([frozenset(c)]*len(C_next_add),
+                                     map(frozenset,C_next_add)))
+            C_next += C_next_add
+        C = deepcopy(C_next)
+    if dendogram:
+        return D
+    else:
+        return C

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -1,0 +1,90 @@
+import random
+import networkx as nx
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+def modularity(G, communities, weight='weight'):
+    r"""Determines the Modularity of a partition C
+    on a graph G.
+
+    Modularity is defined as
+
+    .. math::
+
+        Q = \frac{1}{2m} \sum_{ij} \left( A_{ij} - \frac{k_ik_j}{2m}\right) 
+            \delta(c_i,c_j)
+
+    where `m` is the number of edges, `A` is the adjacency matrix of G, 
+    `k_i` is the degree of `i` and `\delta(c_i,c_j)` is 1 if `i` and `j` 
+    are in the same community and 0 otherwise.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+
+    communinities : list of sets
+      Non-overlaping sets of nodes 
+
+    Returns
+    -------
+    Q : Float
+      The Modularity of the paritition
+
+    Raises
+    ------
+    NetworkXError
+      If C is not a partition of the Nodes of G
+
+    Examples
+    --------
+    >>> G = nx.Graph()
+    >>> nx.modularity(G,nx.kernighan_lin(G))
+    0.3571428571428571
+
+    Notes
+    -----
+    Defined on all Graph types, tested on Graph.
+    Add more tests.
+    
+    References
+    ----------
+    .. [1] M. E. J Newman 'Networks: An Introduction', page 224
+       Oxford University Press 2011.
+    """
+    if not nx.unique_community(G, communities):
+        raise NetworkXError("communities is not a unique partition of G")
+
+    multigraph = G.is_multigraph()
+    m = float(G.size(weight=weight))
+    directed = G.is_directed()
+    if G.is_directed():
+        out_degree = G.out_degree(weight=weight)
+        in_degree = G.in_degree(weight=weight)
+        norm = 1.0/m
+    else:
+        out_degree = G.degree(weight=weight)
+        in_degree = out_degree
+        norm = 1.0/(2.0*m)
+    affiliation = nx.affiliation_dict(communities)
+    Q = 0.0
+    for u in G:
+        nbrs = (v for v in G if affiliation[u] == affiliation[v])
+        for v in nbrs:
+            try:
+                if multigraph:
+                    w = sum(d.get(weight,1) for k,d in G[u][v].items())
+                else:
+                    w = G[u][v].get(weight,1)
+            except KeyError:
+                w = 0
+            #  double count self loop if undirected
+            if u == v and not directed:
+                w *= 2.0
+            Q += w - in_degree[u] * out_degree[v] * norm
+    return Q*norm
+

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -1,4 +1,3 @@
-import random
 import networkx as nx
 #    Copyright(C) 2011 by
 #    Ben Edwards <bedwards@cs.unm.edu>
@@ -57,7 +56,7 @@ def modularity(G, communities, weight='weight'):
        Oxford University Press 2011.
     """
     if not nx.unique_community(G, communities):
-        raise NetworkXError("communities is not a unique partition of G")
+        raise nx.NetworkXError("communities is not a unique partition of G")
 
     multigraph = G.is_multigraph()
     m = float(G.size(weight=weight))

--- a/networkx/algorithms/community/random_community.py
+++ b/networkx/algorithms/community/random_community.py
@@ -1,0 +1,189 @@
+from copy import copy
+import random
+import networkx as nx
+
+#    Copyright (C) 2004-2011 by 
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+
+__author__ = "\n".join(['Aric Hagberg (hagberg@lanl.gov)',
+                        'Ben Edwards (bedwards@cs.unm.edu)'])
+
+
+def random_partition(N,
+                    number_of_partitions=None,
+                    partition_sizes=None):
+    """Partition a container of objects N.
+
+    Can either specify the number of partitions or the
+    size of each partition.
+
+    Parameters
+    ----------
+    N : iterable
+      Iterable container of hashable objects
+    number_of_partitions : int
+      Number of partitions
+    partition_sizes : iterable of ints
+      Sizes of partitions
+
+    Returns
+    -------
+    C : list of sets
+      Partition of N
+
+    Raises
+    ------
+    NetworkXError
+      If neither the number of partitions or partitions sizes
+      are included or if the sum of the partitions sizes is not
+      the same as the number of objects in N
+
+    Examples
+    --------
+    >>> nx.random_partition(range(10),number_of_partitions=2)
+    [set([1, 3, 4, 7, 8]), set([0, 2, 5, 6, 9])]
+    >>> nx.random_partition(range(10),partition_sizes=[3,7])
+    [set([2, 5, 6]), set([0, 1, 3, 4, 7, 8, 9])]
+    """
+    
+    if partition_sizes is None and number_of_partitions is None:
+        raise nx.NetworkXError("Must include either number of paritions \
+                            or parition sizes")
+
+    if partition_sizes is None:
+        C = [set() for _ in range(number_of_partitions)]
+        for n in N:
+            C[random.randrange(0,number_of_partitions)].add(n)
+    else:
+        if not sum(partition_sizes) == len(N):
+            raise nx.NetworkXError("Size of partitions must sum to the number \
+                                 of objects")
+        C = [set() for _ in range(len(partition_sizes))]
+        ns = copy(N)
+        i = 0
+        for s in partition_sizes:
+            for _ in range(s):
+                n = ns.pop(random.randrange(0,len(ns)))
+                C[i].add(n)
+            i+=1
+    return C
+
+def random_p_community(N,p,number_of_communities=None):
+    """Create a random set of communities from iterable N.
+
+    Each n in N is a member of a community with probability p
+    p can either be a single value, in which case the number of
+    communiites must be specified, or it can be a iterable of values
+    containing the probability of an object being a member of a
+    community at that index.
+
+    Parameters
+    ----------
+    N : iterable
+      Iterable container of hashable objects
+    p : float or container of floats
+      Probability of an object being in a community
+    number_of_communities: int
+      Inferred from p if p is a container, otherwise
+      must be specified
+
+    Returns
+    -------
+    C : list of sets
+       Community division of N
+
+    Raises
+    ------
+    NetworkXError
+      If p is not specified correctly
+
+    See Also
+    --------
+      random_m_community
+
+    Examples
+    --------
+    >>> nx.random_p_community(range(10),.1,number_of_communities = 4)
+    [set(), set([1, 2]), set([5]), set()]
+    >>> nx.random_p_community(range(10),[.1,.5,.1])
+    [set([0, 1]), set([0, 3, 6, 8]), set([3])]
+    """
+    if number_of_communities is None:
+        try:
+            number_of_communities = len(p)
+        except TypeError:
+            raise nx.NetworkXError("Must specify number of communities or probabilty \
+                                 p of being in each community")
+    else:
+        p = [p]*number_of_communities
+
+    C = [set() for _ in range(number_of_communities)]
+    for n in N:
+        i = 0
+        for c in range(number_of_communities):
+            if random.random() < p[i]:
+                C[c].add(n)
+            i += 1
+    return C
+
+def random_m_community(N,m,number_of_communities=None):
+    """Create a random set of communities from iterable N.
+
+    Each community has size exactly m. m can either be a single
+    int or a containter of ints containing the sizes of each
+    community.
+
+    Parameters
+    ----------
+    N : iterable
+      Iterable container of hashable objects
+    m : int or container of ints
+      Sizes of each community
+    number_of_communities : int
+      Number of communities to create, inferred from m if m is a
+      container.
+
+    Returns
+    -------
+    C : list of sets
+      Communities of objects
+
+    Raises
+    ------
+    NetworkXError
+      If m is not specified correctly or if the size of a community
+      exceeds the number of objects in N
+
+    See Also
+    --------
+    random_p_community
+
+    Examples
+    --------
+    >>> nx.random_m_community(range(10),2,number_of_communities=3)
+    [set([1, 6]), set([8, 9]), set([8, 9])]
+    >>> nx.random_m_community(range(10),[2,3,3,3])
+    [set([0, 8]), set([3, 7, 9]), set([2, 7, 8]), set([1, 2, 8])]
+    """
+    
+    if number_of_communities is None:
+        try:
+            number_of_communities = len(m)
+        except TypeError:
+            raise nx.NetworkXError("Must specify number of communities or \
+                                    size m of each community")
+    else:
+        m = [m]*number_of_communities
+
+    C = []
+    for c in range(number_of_communities):
+        C.append(set())
+        if m[c] > len(N):
+            raise nx.NetworkXError("Community size %i is greater than \
+                                    size of N"%c)
+        while len(C[c]) < m[c]:
+            C[c].add(random.choice(N))
+    return C
+            

--- a/networkx/algorithms/community/random_community_graph.py
+++ b/networkx/algorithms/community/random_community_graph.py
@@ -1,0 +1,439 @@
+import itertools
+import math
+import networkx as nx
+import random
+#    Copyright(C) 2011 by
+#    Ben Edwards <bedwards@cs.unm.edu>
+#    Aric Hagberg <hagberg@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+__author__="""\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
+                          'Aric Hagberg (hagberg@lanl.gov)'])
+
+try:
+    from scipy.special import zeta as _zeta
+except:
+    def _zeta(alpha,x):
+        z = 0.0
+        z_prev = -1.0
+        n = 0
+        while z - z_prev > tol:
+            z_prev = z
+            z += 1.0/((xmin + n)**alpha)
+            n+=1
+        return z
+    
+
+""" not correct for fast version, either implement slow version or
+figure out correct fast version
+def random_block_model_graph(sizes, P, seed=None, directed=False):
+    Return the random block model graph with a partition of sizes.
+
+    A block model graph is a graph of communities with sizes defined by
+    s in sizes. Nodes in community i and j are connected with probability
+    P[i][j].
+
+    Paramters
+    ---------
+    sizes : list of ints
+      Sizes of groups
+    P : list of list of floats
+      probability of connecting a node in community i to a node in
+      community j, with i,j in [0,len(sizes)-1]
+    directed : boolean optional, default=False
+      Whether to create a directed graph
+    seed : int optional, default None
+      A seed for the random number generator
+
+    Returns
+    -------
+    G : NetworkX Graph or DiGraph
+      random partition graph of size sum(gs)
+
+    Raises
+    ------
+    NetworkXError
+      Any P[i][j] is not in [0,1]
+      If len(P) is not equal len(sizes)
+      If len(P[i]) for all i is not equal
+      to the len(sizes)
+
+    Examples
+    --------
+
+    Notes
+    -----
+    This is a generalization of the random_partition_graph which allows
+    different probabilities of connections between communities.
+      
+    References
+    ----------
+    
+    # Use geometric method for O(n+m) complexity algorithm
+    # partition=nx.community_sets(nx.get_node_attributes(G,'affiliation'))
+    if not seed is None:
+        random.seed(seed)
+
+    if not len(P) == len(sizes):
+        raise nx.NetworkXError("len(P) does not match len(sizes)")
+
+    for i in range(len(P)):
+        if not len(P[i])==len(sizes):
+            raise nx.NetworkXError("len(P[%i]) does not match len(sizes)"%i)
+        for j in range(len(P[i])):
+            if not 0 <= P[i][j] <= 1:
+                raise nx.NetworkXError("P[%i][%i] not in [0,1]"%(i,j))
+
+    if directed:
+        G = nx.DiGraph()
+    else:
+        G = nx.Graph()
+    n = sum(sizes)
+    G.add_nodes_from(range(n))
+    # start with len(sizes) groups of gnp random graphs with parameter P[i][i]
+    # graphs are unioned together with node labels starting at
+    # 0, sizes[0], sizes[0]+sizes[1], ...
+    next_group = {} # maps node key (int) to first node in next group
+    start = 0
+    group = 0
+    for n in sizes:
+        edges = ((u+start,v+start) 
+                 for u,v in 
+                 nx.fast_gnp_random_graph(n, P[group][group], directed=directed).edges())
+        G.add_edges_from(edges)
+        next_group.update(dict.fromkeys(range(start,start+n),start+n))
+        for u in range(start,start+n):
+            G.node[u]['affiliation']=group
+        group += 1
+        start += n
+
+    # connect each node in group randomly with the nodes not in group
+    # use geometric method like fast_gnp_random_graph()
+
+    n = len(G)
+    if directed:
+        for u in range(n):
+            v = 0
+            while v < n:
+                lr = math.log(1.0 - random.random())
+                i = G.node[u]['affiliation']
+                j = G.node[v]['affiliation']
+                lp = math.log(1.0 - P[i][j])
+                v += int(lr/lp)
+                # skip over nodes in the same group as v, including self loops
+                if next_group.get(v,n)==next_group[u]:
+                    v = next_group[u]
+                if v < n:
+                    G.add_edge(u,v)
+                    v += 1
+    else:
+        for u in range(n-1):
+            v = next_group[u] # start with next node not in this group
+            while v < n:
+                i = G.node[u]['affiliation']
+                j = G.node[v]['affiliation']
+                lp = math.log(1.0 - P[i][j])  
+                lr = math.log(1.0 - random.random())
+                v += int(lr/lp)
+                if v < n:
+                    G.add_edge(u,v)
+                    v += 1
+    return G
+"""        
+
+def LFR_benchmark_graph(n,
+                        tau1,
+                        tau2,
+                        mu,
+                        average_degree=None,
+                        min_degree=None,
+                        max_degree=None,
+                        min_community=None,
+                        max_community=None,
+                        tol=1.0e-7,
+                        max_iters=500,
+                        seed=None):
+    """Generate the LFR benchmark graph for community finding
+    algorithm testing.
+
+    This algorithm proceeds as follows:
+
+    1) Find a degree sequence with power a power_law distribution,
+       and minimum value min_degree, which has approximate average
+       degree average_degree. This is accomplished by either:
+          a) specifying min_degree and not the average degree.
+          b) Specifying the average degree, in which case a suitable
+             minimum degree will be found.
+       max_degree can also be specified otherwise it will be set to
+       n. Each node u will have mu*degree(u) out of community links
+       and (1-mu)*degree(u) in community links.
+    2) Generate community sizes according to a powerlaw with exponent
+       tau2. If max_community an min_community are not specified
+       they will be selected to be the min_degree and max_degree.
+       Community sizes are generated until the sum of their sizes
+       is equal to n.
+    3) Each node will be randomly assigned a community with the
+       condition that the community is large enough for the nodes
+       in community degree((1-mu)*degree(u)). If a community grows
+       too large a random node will be selected for reassignment
+       to a new community, until all nodes have been assinged a
+       community.
+    4) Each node u then adds (1-mu)*degree(u) in community links
+       and mu*degree(u) out of community links.
+
+    Parameters
+    ----------
+    n : int
+      Number of nodes
+    tau1 : float > 1
+      Power law exponent for degree distribution
+    tau2 : float > 1
+      Power law exponent for the size of communities
+    average_degree : float
+      Desired average degree
+    min_degree : int
+      Minimum degree
+    max_degree : int, optional (default=n)
+      Maximum degree
+    min_community : int, optional (default=min_degree)
+      Minimum community size
+    max_community : iny, optional
+      Maximum community size
+    tol : float, optional (default=1.0e-7)
+      tolerance to match average degree
+    max_iters : int, optional (default=500)
+      number of iterations to try to create
+      community sizes, degree distribution,
+      community affiliation
+    seed : int, optional (default=None)
+      A random integer value seed
+
+    Returns
+    -------
+    G : NetworkXGraph
+      the LFR benchmark graph
+    C : list of sets
+      the actual community structure of the graph
+
+    Raises
+    ------
+    NetworkXError
+      If tau1 or tau2 <= 1
+      If mu is not in [0,1]
+      If max_degree is not in (0,n]
+      If neither average_degree or min_degree is not specified
+      If both average degree or min_degree is specified
+      If a suitable min_degree cannot be found
+      If max_community > n
+      If min_community < 0
+      If a valid degree sequence cannot be created in max_iters
+      If a valid set of community sizes cannot be created in max_iters
+      If a valid community assignment cannot be created in 10*n*max_iters
+
+      Examples
+      --------
+      >>> G,C = nx.LFR_benchmark_graph(1000,
+      ...                              3,
+      ...                              1.5,
+      ...                              .1,
+      ...                              average_degree=15,
+      ...                              min_community=10,
+      ...                              seed=42)
+      >>> len(C)
+      7
+
+      Notes
+      -----
+      This algorithm differs slightly from the original way it was
+      presented[1].
+        1)  Rather than connecting the graph via a configuration
+            model then rewiring to match the in community and out
+            community degree, we do this wiring explicitly at the
+            end, which should be equivalent.
+        2)  In the code posted on the author's website [2] they
+            calculate the random powerlaw distributed variables
+            and their average using continuous approximations, we
+            use the discrete distributions here as both degree
+            and community size are discrete.
+
+       Though the authors describe the algorithm as quite robust,
+       testing during development indicates that a somewhat narrower
+       parameter set is likely to successfully produce a graph.
+       Some suggestions have been provided in the event of exceptions.
+       Time benchmarks are somewhat similar to those provided 
+
+       References
+       ----------
+       .. [1] 'Benchmark graphs for testing community detection algorithms',
+              Andrea Lancichinetti, Santo Fortunato, and Filippo Radicchi,
+              Phys. Rev. E 78, 046110 2008
+       .. [2] http://santo.fortunato.googlepages.com/inthepress2
+       """
+    if not seed is None:
+        random.seed(seed)
+    if not tau1 > 1:
+        raise nx.NetworkXError("tau1 must be > 1")
+    if not tau2 > 1:
+        raise nx.NetworkXError("tau2 must be > 2")
+    if not 0 <= mu <= 1:
+        raise nx.NetworkXError("mu must be in [0,1]")
+        
+    deg_seq = _powerlaw_degree_sequence(n,
+                                        tau1,
+                                        average_degree,
+                                        min_degree,
+                                        max_degree,
+                                        tol=tol,
+                                        max_iters=max_iters)
+
+    comm_sizes = _powerlaw_community_sequence(n,
+                                              tau2,
+                                              deg_seq,
+                                              min_size=min_community,
+                                              max_size=max_community,
+                                              max_iters=max_iters)
+
+    return _LFR_benchmark_graph(deg_seq,
+                                comm_sizes,
+                                mu,
+                                tol=tol,
+                                max_iters=max_iters)
+
+def _powerlaw_degree_sequence(n,
+                              gamma,
+                              average_degree=None,
+                              min_degree=None,
+                              max_degree=None,
+                              seed=None,
+                              tol=1.0e-7,
+                              max_iters=500):
+
+    if max_degree is None:
+        max_degree = n
+    elif not 0 < max_degree <=n:
+        raise nx.NetworkXError("max_degree must be in (0,n]")
+
+    if min_degree is None and average_degree is None:
+        raise nx.NetworkXError("Must assign either min_degree or average_degree")
+    elif not min_degree is None and not average_degree is None:
+        raise nx.NetworkXError("Must assign either min_degree or average_degree, not both")
+    if not seed is None:
+        random.seed(seed)
+
+    if min_degree is None and not average_degree is None:
+        min_deg_top = max_degree
+        min_deg_bot = 1
+        min_deg_mid = (min_deg_top-min_deg_bot)/2.0 + min_deg_bot
+        itrs=0
+        mid_avg_deg = 0.0
+        while abs(mid_avg_deg - average_degree) > tol:
+            if itrs > max_iters:
+                raise nx.NetworkXError("Could not match average_degree")
+            mid_avg_deg = 0.0
+            for x in range(int(min_deg_mid),max_degree+1):
+                mid_avg_deg += (x**(-gamma+1.0))/_zeta(gamma,min_deg_mid)
+            if mid_avg_deg > average_degree:
+                min_deg_top = min_deg_mid
+                min_deg_mid = (min_deg_top-min_deg_bot)/2.0 + min_deg_bot
+            else:
+                min_deg_bot = min_deg_mid
+                min_deg_mid = (min_deg_top-min_deg_bot)/2.0 + min_deg_bot
+            itrs += 1
+        min_degree = int(min_deg_mid + .5)
+
+    itrs = 0
+    while True:
+        if itrs > max_iters:
+            raise nx.NetworkXError("Could not create Valid Degree Sequence")
+        deg_seq = []
+        while len(deg_seq) < n:
+            temp_pl = nx.utils.zipf_rv(gamma,min_degree)
+            if temp_pl <= max_degree:
+                deg_seq.append(temp_pl)
+        itrs += 1
+        if sum(deg_seq) % 2 == 0:
+            break
+    # pick kmin, kmax
+    # generate sequence
+    # check to make sure it is divisible by two, doesn't have to be graphical  
+    return deg_seq
+
+def _powerlaw_community_sequence(n,
+                                 beta,
+                                 degree_sequence,
+                                 min_size=None,
+                                 max_size=None,
+                                 seed=None,
+                                 max_iters=500):
+    if not seed is None:
+        random.seed(seed)
+
+    if min_size is None:
+        min_size = min(degree_sequence)
+    if max_size is None:
+        max_size = max(degree_sequence)
+    n = len(degree_sequence)
+    itrs = 0
+    while True:
+        if itrs > max_iters:
+            raise nx.NetworkXError("Could not create valid community sequence")
+        comm_sizes = []
+        while sum(comm_sizes) < n:
+            temp_pl = nx.utils.zipf_rv(beta,min_size)
+            if temp_pl <= max_size:
+                comm_sizes.append(temp_pl)
+            itrs+=1
+        if sum(comm_sizes) ==n:
+            break
+    return comm_sizes
+
+
+def _LFR_benchmark_graph(degree_sequence, community_sizes, mu,
+                         tol=1.0e-7, max_iters=500, seed=None):
+    if not seed is None:
+        random.seed(seed)
+    if not 0 <= mu <= 1:
+        raise nx.NetworkXError("mu must be in [0,1]")
+
+    # assign communities
+    comm = [set() for _ in range(len(community_sizes))]
+    n = len(degree_sequence)
+    free = range(n)
+    i = 0
+    while free:
+        v = free.pop()
+        c = random.choice(range(len(community_sizes)))
+        s = int(degree_sequence[v]*(1-mu) + .5)
+        if s < community_sizes[c]: # add to this community
+            comm[c].add(v)
+        else: # put back on free list
+            free.append(v)
+        # if the community is too big, remove a node            
+        if len(comm[c]) > community_sizes[c]:
+            u = comm[c].pop()
+            free.append(u)
+        if i > 10*n*max_iters:
+            raise nx.NetworkXError('Could not assign communities. '
+                                   'Try increasing min_community')
+        i += 1
+
+
+    # build graph
+    G = nx.Graph()
+    G.add_nodes_from(range(n))
+    for c in comm:
+        for u in c:
+            while G.degree(u) < round(degree_sequence[u]*(1-mu)):
+                v  = random.choice(list(c))
+                G.add_edge(u,v)
+            while G.degree(u) < degree_sequence[u]:
+                v = random.choice(range(n))
+                if not v in c:
+                    G.add_edge(u,v)
+    G.graph['partition'] = comm
+    return G
+
+if __name__ == '__main__':
+    degree_seq = _powerlaw_degree_sequence(100,2.1,10)
+    community_sizes = _powerlaw_community_sequence(100,2.1,degree_seq,min_size=20)
+    G = _LFR_benchmark_graph(degree_seq, community_sizes,.1)

--- a/networkx/algorithms/community/spectrum.py
+++ b/networkx/algorithms/community/spectrum.py
@@ -1,0 +1,418 @@
+import networkx as nx
+from collections import defaultdict
+from itertools import repeat
+from math import sqrt
+from networkx.utils.decorators import require
+
+def adjacency_matrix(G,weight=None):
+    A = {}
+    for u in G:
+        A[u] = defaultdict(repeat(0).next)
+        for v in G.neighbors_iter(u):
+            A[u][v] = G[u][v].get(weight,1.0)
+    return A
+
+def laplacian(G,weight=None):
+    L = {}
+    for u in G:
+        L[u] = defaultdict(repeat(0).next)
+        L[u][u] = G.degree(u)
+        for v in G.neighbors_iter(u):
+            L[u][v] -= G[u][v].get(weight,1)
+    return L
+
+def normalized_laplacian(G,weight=None):
+    L = {}
+    degrees = G.degree(weight=weight)
+    for u in G:
+        L[u] = defaultdict(repeat(0).next)
+        L[u][u] = 1.0
+        for v in G.neighbors_iter(u):
+            L[u][v] -= G[u][v].get(weight,1.0)/sqrt(degrees(u)*degrees(v))
+    return L
+
+def normalized_directed_laplacian(G,weight=None,walk_type=None,alpha=0.99):
+    if not G.is_directed():
+        nx.NetworkxError("Directed Laplacian only implemented for directed graphs")
+
+    if walk_type is None:
+        if nx.is_strongly_connected(G):
+            if nx.is_aperiodic(G):
+                walk_type = "random"
+            else:
+                walk_type = "lazy"
+        else:
+            walk_type = "pagerank"
+
+    n = float(G.order())
+    degrees = G.out_degree(weight=weight)
+
+    if walk_type == "random":
+        P = dict((u,defaultdict(repeat(0.0).next)) for u in G)
+        pi = stationary_distribution(G,weight=weight)
+        for u in G:
+            for v in G[u]:
+                P[u][v] = G[u][v].get(weight,1.0)/float(degrees[u])
+    elif walk_type == "lazy":
+        P = dict((u,defaultdict(repeat(0.0).next)) for u in G)
+        pi = lazy_stationary_distribution(G,weight=weight)
+        for u in G:
+            P[u][u] = .5
+            for v in G[u]:
+                P[u][v] += G[u][v].get(weight,1.0)/float(degrees[u]*2)
+    elif walk_type == "pagerank":
+        P = dict((u,defaultdict(repeat((1.0-alpha)/n).next)) for u in G)
+        pi = pagerank_stationary_distribution(G,weight=weight)
+        for u in G:
+            for v in G[u]:
+                P[u][v] += alpha*G[u][v].get(weight,1.0)/float(degrees[u])
+        L = dict((u,defaultdict()) for u in G)
+        for u in G: # do this as a special case, cause this is actually a dense matrix
+            L[u] = defaultdict()
+            for v in G:
+                L[u][v] = .5*(sqrt(pi[u])*P[u][v]*(1/sqrt(pi[v])) + (1/sqrt(pi[u]))*P[v][u]*sqrt(pi[v]))
+            L[u][u] = 1.0 - L[u][u]
+        return L
+        
+    else:
+        raise nx.NetworkXError("walk_type must be random, lazy, or pagerank")
+
+
+    L = dict((u,defaultdict(repeat(0.0).next)) for u in G)
+    for u in G:
+        L[u][u] = 1.0
+        for v in G[u]:
+            L[u][v] -= .5*(sqrt(pi[u])*P[u][v]*(1/sqrt(pi[v])) + (1/sqrt(pi[u]))*P[v][u]*sqrt(pi[v]))
+            if not u in G[v]:
+                L[v][u] = L[u][v]
+
+    return L
+
+def stationary_distribution(G,x_init=None,weight=None,tol=1.e-8,max_steps=1000):
+    n = G.order()
+    if x_init is None:
+        ds = float(sum(G.in_degree(weight=weight).values()))
+        x = dict((v,G.in_degree(v,weight=weight)/ds) for v in G)
+    else:
+        x_norm = sum(x_init[v] for v in x_init)
+        x = dict((v,x_init[v]/x_norm) for v in x_init)
+
+    degrees = G.out_degree(weight=weight)
+    i = 0
+    while True:
+        x_new = {}
+        err = 0.0
+        for u in G:
+            x_new[u] = sum(x[v]*G[v][u].get(weight,1.0)/degrees[v]
+                           for v in G.predecessors_iter(u))
+            err += abs(x[u] - x_new[u])
+        x = x_new
+        i += 1
+        if err < tol*n:
+            break
+        if i > max_steps:
+            raise nx.NetworkXError("Could not converge")
+    return x
+
+def lazy_stationary_distribution(G,x_init=None,weight=None,tol=1.e-8,max_steps=1000):
+    n = G.order()
+    if x_init is None:
+        ds = float(sum(G.in_degree(weight=weight).values()))
+        x = dict((v,G.in_degree(v,weight=weight)/ds) for v in G)
+    else:
+        x_norm = sum(x_init[v] for v in x_init)
+        x = dict((v,x_init[v]/x_norm) for v in x_init)
+
+    degrees = G.out_degree(weight=weight)
+    i = 0
+    while True:
+        x_new = {}
+        err = 0.0
+        for u in G:
+            x_new[u] = sum(x[v]*G[v][u].get(weight,1.0)/(degrees[v]*2.0)
+                           for v in G.predecessors_iter(u))
+            x_new[u] += x[u]/2.
+            err += abs(x[u] - x_new[u])
+        x = x_new
+        i += 1
+        if err < tol*n:
+            break
+        if i > max_steps:
+            raise nx.NetworkXError("Could not converge")
+    return x
+
+def pagerank_stationary_distribution(G,alpha=.99,x_init=None,weight=None,tol=1.e-8,max_steps=1000):
+    n = G.order()
+    if x_init is None:
+        ds = float(sum(G.in_degree(weight=weight).values()))
+        x = dict((u,G.in_degree(u,weight=weight)/ds) for u in G)
+    else:
+        x_norm = sum(x_init[u] for u in x_init)
+        x = dict((n,x_init[u]/x_norm) for u in x_init)
+
+    degrees = G.out_degree(weight=weight)
+    i = 0
+    while True:
+        x_new = {}
+        err = 0.0
+        for u in G:
+            x_new[u] = sum(alpha*x[v]*G[v][u].get(weight,1.0)/degrees[v]
+                           for v in G.predecessors_iter(u))
+            x_new[u] += (1.0-alpha)
+            err += abs(x[u] - x_new[u])
+        x = x_new
+        i += 1
+        if err < tol*n:
+            break
+        if i > max_steps:
+            raise nx.NetworkXError("Could not converge")
+    return x
+
+def adjacency_matrix_numpy(G,nodelist=None,weight='weight'):
+    """Return adjacency matrix of G.
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph 
+
+    nodelist : list, optional       
+       The rows and columns are ordered according to the nodes in nodelist.
+       If nodelist is None, then the ordering is produced by G.nodes().
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to provide each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    A : numpy matrix
+      Adjacency matrix representation of G.
+
+    Notes
+    -----
+    If you want a pure Python adjacency matrix representation try
+    networkx.convert.to_dict_of_dicts which will return a
+    dictionary-of-dictionaries format that can be addressed as a
+    sparse matrix.
+
+    For MultiGraph/MultiDiGraph, the edges weights are summed.
+    See to_numpy_matrix for other options.
+
+    See Also
+    --------
+    to_numpy_matrix
+    to_dict_of_dicts
+    """
+    return nx.to_numpy_matrix(G,nodelist=nodelist,weight=weight)
+
+@require('numpy')
+def laplacian_numpy(G,nodelist=None,weight='weight'):
+    """Return the Laplacian matrix of G.
+
+    The graph Laplacian is the matrix L = D - A, where
+    A is the adjacency matrix and D is the diagonal matrix of node degrees.
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph 
+
+    nodelist : list, optional       
+       The rows and columns are ordered according to the nodes in nodelist.
+       If nodelist is None, then the ordering is produced by G.nodes().
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to compute each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    L : NumPy array
+      Laplacian of G.
+
+    Notes
+    -----
+    For MultiGraph/MultiDiGraph, the edges weights are summed.
+    See to_numpy_matrix for other options.
+
+    See Also
+    --------
+    to_numpy_matrix
+    normalized_laplacian
+    """
+    import numpy as np
+
+    # this isn't the most efficient way to do this...
+    if G.is_multigraph():
+        A=np.asarray(nx.to_numpy_matrix(G,nodelist=nodelist,weight=weight))
+        I=np.identity(A.shape[0])
+        D=I*np.sum(A,axis=1)
+        L=D-A
+        return L
+    # Graph or DiGraph, this is faster than above 
+    if nodelist is None:
+        nodelist=G.nodes()
+    n=len(nodelist)
+    index=dict( (n,i) for i,n in enumerate(nodelist) )
+    L = np.zeros((n,n))
+    for ui,u in enumerate(nodelist):
+        totalwt=0.0
+        for v,d in G[u].items():
+            try:
+                vi=index[v]
+            except KeyError:
+                continue
+            wt=d.get(weight,1)
+            L[ui,vi]= -wt
+            totalwt+=wt
+        L[ui,ui]= totalwt
+    return L
+
+@require('numpy')
+def normalized_laplacian_numpy(G,nodelist=None,weight='weight'):
+    r"""Return the normalized Laplacian matrix of G.
+
+    The normalized graph Laplacian is the matrix
+    
+    .. math::
+        
+        NL = D^{-1/2} L D^{-1/2}
+
+    where `L` is the graph Laplacian and `D` is the diagonal matrix of
+    node degrees.
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph 
+
+    nodelist : list, optional       
+       The rows and columns are ordered according to the nodes in nodelist.
+       If nodelist is None, then the ordering is produced by G.nodes().
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to compute each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    L : NumPy array
+      Normalized Laplacian of G.
+
+    Notes
+    -----
+    For MultiGraph/MultiDiGraph, the edges weights are summed.
+    See to_numpy_matrix for other options.
+
+    See Also
+    --------
+    laplacian
+
+    References
+    ----------
+    .. [1] Fan Chung-Graham, Spectral Graph Theory, 
+       CBMS Regional Conference Series in Mathematics, Number 92, 1997.
+    """
+    # FIXME: this isn't the most efficient way to do this...
+    import numpy as np
+    if G.is_multigraph():
+        A=np.asarray(nx.to_numpy_matrix(G,nodelist=nodelist,weight=weight))
+        d=np.sum(A,axis=1)
+        n=A.shape[0]
+        I=np.identity(n)
+        L=I*d-A
+        osd=np.zeros(n)
+        for i in range(n):
+            if d[i]>0: osd[i]=np.sqrt(1.0/d[i])
+        T=I*osd
+        L=np.dot(T,np.dot(L,T))
+        return L
+    # Graph or DiGraph, this is faster than above 
+    if nodelist is None:
+        nodelist = G.nodes()
+    n=len(nodelist)
+    L = np.zeros((n,n))
+    deg = np.zeros((n,n))
+    index=dict( (n,i) for i,n in enumerate(nodelist) )
+    for ui,u in enumerate(nodelist):
+        totalwt=0.0
+        for v,data in G[u].items():
+            try:
+                vi=index[v]
+            except KeyError:
+                continue
+            wt=data.get(weight,1)
+            L[ui,vi]= -wt
+            totalwt+=wt
+        L[ui,ui]= totalwt
+        if totalwt>0.0:
+            deg[ui,ui]= np.sqrt(1.0/totalwt)
+    L=np.dot(deg,np.dot(L,deg))
+    return L
+
+
+
+def sparse_normalized_directed_laplacian(G, nodelist=None, weight='weight', walk='simple'):
+    laplacian_type={'simple':simple_directed_laplacian,
+                    'lazy':lazy_directed_laplacian,
+                    'pagerank':pagerank_directed_laplacian}
+    try:
+        return laplacian_type[walk](G, nodelist=nodelist, weight='weight')
+    except KeyError:
+        raise nx.NetworkXError('walk must be simple|lazy|pagerank')
+
+@require('numpy')
+def laplacian_eigenvector(G, weight='weight'):
+    import numpy as np
+    if G.is_directed():
+        raise nx.NetworkXError('laplacian_eigenvector() ',
+                            'not implemented for directed graphs.')
+
+         # test explicitly because we really only need numpy
+    try: # use sparse solver if we have scipy
+        from scipy.sparse import spdiags
+        from scipy.sparse.linalg import eigsh
+        sparse = True
+    except ImportError: # fall back to numpy dense solver
+        sparse = False
+
+    n = len(G)
+    if n < 200: # dense solver is faster for small graphs
+        sparse = False
+
+    # set up sparse or dense Laplacian and eigensolver
+    if sparse:
+        # number of Lanczos vectors for ARPACK solver is np.sqrt(n)
+        # what is a good value?
+        eigsolver = partial(eigsh,k=2,which='SM',ncv=int(np.sqrt(n)))
+        if G.is_directed():
+            laplacian = nx.sparse_directed_laplacian
+        else:
+            laplacian = nx.sparse_laplacian
+    else:
+        eigsolver = np.linalg.eig
+        if G.is_directed():
+            laplacian = directed_laplacian
+        else:
+            laplacian = nx.laplacian
+
+    # create Laplacian and find eigenvalues
+    L = laplacian(G,weight=weight)
+    eigenvalues,eigenvectors = eigsolver(L)    
+    # sort and keep smallest nonzero 
+    index = np.argsort(eigenvalues)[1] # 0 index is zero eigenvalue
+    v2 = zip(G,np.real(eigenvectors[:,index]))
+    return v2
+
+@require('scipy.sparse')
+def sparse_laplacian(G,nodelist=None,weight='weight'):
+    # form Laplacian matrix
+    from scipy.sparse import spdiags
+    A = nx.to_scipy_sparse_matrix(G, nodelist=nodelist, weight=weight)
+    data = np.asarray(A.sum(axis=1).T)
+    D = spdiags(data,0,n,n)
+    return  D-A
+
+
+

--- a/networkx/algorithms/community/tests/test_community_quality.py
+++ b/networkx/algorithms/community/tests/test_community_quality.py
@@ -1,0 +1,55 @@
+import networkx as nx
+from nose.tools import *
+
+def test_cut_size():
+    G = nx.barbell_graph(3,0)
+    C = [set([0,1,4]),set([2,3,5])]
+    assert_equal(nx.cut_size(G,C[0],C[1]),4)
+    assert_equal(nx.cut_size(G,C[1],C[0]),4)
+    
+    C = [set([0,1,2]),set([3,4,5])]
+    assert_equal(nx.cut_size(G,C[0],C[1]),1)
+    assert_equal(nx.cut_size(G,C[1],C[0]),1)
+
+    GD = G.to_directed()
+    assert_equal(nx.cut_size(GD,C[0],C[1]),2)
+    assert_equal(nx.cut_size(GD,C[1],C[0]),2)
+    
+    C = [set([0,1,4]),set([2,3,5])]
+    assert_equal(nx.cut_size(GD,C[0],C[1]),8)
+    assert_equal(nx.cut_size(GD,C[1],C[0]),8)
+
+    G = nx.MultiGraph()
+    G.add_edge('a','b')
+    G.add_edge('a','b')
+    assert_equal(2,nx.cut_size(G,set(['a']),set(['b'])))
+
+def test_modularity():
+    G = nx.barbell_graph(3,0)
+
+    C = [set([0,1,4]),set([2,3,5])]
+
+    assert_almost_equal(-16/(14.**2),nx.modularity(G,C))
+
+    C = [set([0,1,2]),set([3,4,5])]
+
+    assert_almost_equal((35*2)/(14**2.),nx.modularity(G,C))
+
+def test_community_performance():
+    G = nx.barbell_graph(3,0)
+
+    C = [set([0,1,4]),set([2,3,5])]
+
+    assert_almost_equal(8/15., nx.community_performance(G,C))
+
+    C = [set([0,1,2]),set([3,4,5])]
+
+    assert_almost_equal(14./15,nx.community_performance(G,C))
+
+def test_community_coverage():
+    G = nx.barbell_graph(3,0)
+    C = [set([0,1,4]),set([2,3,5])]
+    assert_almost_equal(3/7.,nx.community_coverage(G,C))
+
+    C = [set([0,1,2]),set([3,4,5])]
+    assert_almost_equal(6/7.,nx.community_coverage(G,C))

--- a/networkx/algorithms/community/tests/test_community_utils.py
+++ b/networkx/algorithms/community/tests/test_community_utils.py
@@ -1,0 +1,22 @@
+import networkx as nx
+from nose.tools import *
+
+def test_affiliation():
+    C = [set(range(5)),set(range(5,10))]
+    for i in range(5):
+        assert_equal([0],nx.affiliation(i,C))
+    for i in range(5,10):
+        assert_equal([1],nx.affiliation(i,C))
+
+    C = [set(range(5)),set(range(2,7))]
+    assert_equal([0,1],nx.affiliation(2,C))
+    
+
+def test_is_partition():
+    C =[set(range(5)),set(range(5,10))]
+    assert_true(nx.is_partition(range(10),C))
+    C = [set(range(5)),set(range(4,10))]
+    assert_false(nx.is_partition(range(10),C))
+
+    
+    

--- a/networkx/algorithms/community/tests/test_divisive.py
+++ b/networkx/algorithms/community/tests/test_divisive.py
@@ -1,0 +1,57 @@
+import networkx as nx
+from nose.tools import *
+
+def test_edge_betweenness_partition():
+    G = nx.barbell_graph(3,0)
+    C = nx.edge_betweenness_partition(G,2)
+    assert_equal([set([0,1,2]),set([3,4,5])],C)
+
+    G = nx.barbell_graph(3,1)
+    C = nx.edge_betweenness_partition(G,3)
+    assert_equal(C,[set([0,1,2]),set([4,5,6]),set([3])])
+
+    C = nx.edge_betweenness_partition(G,7)
+    assert_equal(map(set,[[n] for n in G]),C)
+
+    C = nx.edge_betweenness_partition(G,1)
+    assert_equal([set(G)],C)
+
+    assert_raises(nx.NetworkXError,
+                  nx.edge_betweenness_partition,
+                  G,
+                  0)
+
+    assert_raises(nx.NetworkXError,
+                  nx.edge_betweenness_partition,
+                  G,
+                  -1)
+    assert_raises(nx.NetworkXError,
+                  nx.edge_betweenness_partition,
+                  G,
+                  10)
+
+def test_edge_current_flow_betweenness_partition():
+    G = nx.barbell_graph(3,0)
+    C = nx.edge_current_flow_betweenness_partition(G,2)
+    assert_equal([set([0,1,2]),set([3,4,5])],C)
+
+    G = nx.barbell_graph(3,1)
+    C = nx.edge_current_flow_betweenness_partition(G,7)
+    assert_equal(map(set,[[n] for n in G]),C)
+
+    C = nx.edge_current_flow_betweenness_partition(G,1)
+    assert_equal([set(G)],C)
+
+    assert_raises(nx.NetworkXError,
+                  nx.edge_current_flow_betweenness_partition,
+                  G,
+                  0)
+
+    assert_raises(nx.NetworkXError,
+                  nx.edge_current_flow_betweenness_partition,
+                  G,
+                  -1)
+    assert_raises(nx.NetworkXError,
+                  nx.edge_current_flow_betweenness_partition,
+                  G,
+                  10)

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -1,0 +1,25 @@
+import networkx as nx
+from nose.tools import *
+
+def assert_partition_equal(x,y):
+    assert_equal(set(map(frozenset,x)),set(map(frozenset,y)))
+
+def test_kernighan_lin():
+    G = nx.barbell_graph(3,0)
+    C = nx.kernighan_lin_bisection(G)
+    assert_partition_equal(C,[set([0,1,2]),set([3,4,5])])
+
+    assert_raises(nx.NetworkXError, nx.kernighan_lin_bisection, G,
+                  partition=[set(range(3)),set(range(2,6))])
+    assert_raises(nx.NetworkXError, nx.kernighan_lin_bisection, G,
+                  partition=[set(range(2)),set(range(2,3)),set(range(3,6))])
+
+
+def test_kernighan_lin_multigraph():
+    G = nx.cycle_graph(4)
+    M = nx.MultiGraph(G.edges())
+    M.add_edges_from(G.edges())
+    M.remove_edge(1,2)
+    A,B = nx.kernighan_lin_bisection(M)
+    assert_partition_equal([A,B],[set([0,1]),set([2,3])])
+

--- a/networkx/algorithms/community/tests/test_laplacian_spectral.py
+++ b/networkx/algorithms/community/tests/test_laplacian_spectral.py
@@ -1,0 +1,20 @@
+import networkx as nx
+from nose.tools import *
+
+def assert_partition_equal(x,y):
+    assert_equal(set(map(frozenset,x)),set(map(frozenset,y)))
+
+def test_spectral_partition():
+    G = nx.barbell_graph(3,0)
+    C = nx.spectral_bisection(G)
+    assert_partition_equal(C,[[0,1,2],[3,4,5]])
+    mapping=dict(enumerate('badfec'))
+
+    G = nx.relabel_nodes(G,mapping)
+    C = nx.spectral_bisection(G)
+    assert_partition_equal(C,[[mapping[0],mapping[1],mapping[2]],
+                              [mapping[3],mapping[4],mapping[5]]])
+#    assert_raises(nx.NetworkXError,
+#                  nx.spectral_partition, G, size=0)
+#    assert_raises(nx.NetworkXError,
+#                  nx.spectral_partition ,G, size=6)

--- a/networkx/algorithms/community/tests/test_partition.py
+++ b/networkx/algorithms/community/tests/test_partition.py
@@ -1,0 +1,39 @@
+import networkx as nx
+from nose.tools import *
+
+def assert_partition_equal(x,y):
+    assert_equal(set(map(frozenset,x)),set(map(frozenset,y)))
+
+def test_greedy_max_modularity_partition():
+    G = nx.barbell_graph(3,0)
+
+    C = nx.greedy_max_modularity_partition(G)
+
+    if 0 in C[0]:
+        assert_equal(C,[set([0,1,2]),set([3,4,5])])
+    else:
+        assert_equal(C,[set([3,4,5]),set([0,1,2])])
+
+    assert_raises(nx.NetworkXError,
+                  nx.greedy_max_modularity_partition,
+                  G,
+                  C_init=[set(range(3)),set(range(2,6))])
+    assert_raises(nx.NetworkXError,
+                  nx.greedy_max_modularity_partition,
+                  G,
+                  C_init=[set(range(2)),set(range(2,3)),set(range(3,6))])
+
+    G = nx.MultiGraph()
+
+    assert_raises(nx.NetworkXError,
+                  nx.greedy_max_modularity_partition,
+                  G)
+
+def test_spectral_modularity_partition():
+    G = nx.barbell_graph(3,0)
+    C = nx.spectral_modularity_partition(G)
+    assert_partition_equal(C,[[3,4,5],[0,1,2]])
+    G = nx.karate_club_graph()
+    C = nx.spectral_modularity_partition(G)
+    assert_partition_equal(C,[[0, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 16, 17, 19, 21],
+                              [8, 9, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]])

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -1,0 +1,9 @@
+import networkx as nx
+from nose.tools import *
+def test_modularity():
+    G = nx.barbell_graph(3,0)
+    C = [set([0,1,4]),set([2,3,5])]
+    assert_almost_equal(-16/(14.**2),nx.modularity(G,C))
+    C = [set([0,1,2]),set([3,4,5])]
+    assert_almost_equal((35*2)/(14**2.),nx.modularity(G,C))
+

--- a/networkx/algorithms/community/tests/test_random_community.py
+++ b/networkx/algorithms/community/tests/test_random_community.py
@@ -1,0 +1,87 @@
+import networkx as nx
+from nose.tools import *
+
+def test_random_partition():
+    assert_raises(nx.NetworkXError,
+                  nx.random_partition,
+                  range(10),
+                  number_of_partitions=None,
+                  partition_sizes=None)
+    assert_raises(nx.NetworkXError,
+                  nx.random_partition,
+                  range(10),
+                  number_of_partitions=None,
+                  partition_sizes=[1,12])
+    C = nx.random_partition(range(10),number_of_partitions=3)
+    assert_true(nx.is_partition(range(10),C))
+
+    for i in range(10):
+        assert_equal(1,len(nx.affiliation(i,C)))
+
+    C = [set(range(5)),set(range(2,6))]
+    assert_false(nx.is_partition(range(6),C))
+
+    C = nx.random_partition(range(10),partition_sizes=[3,7])
+    assert_equal(len(C[0]),3)
+    assert_equal(len(C[1]),7)
+    
+def test_random_p_community():
+    assert_raises(nx.NetworkXError,
+                  nx.random_p_community,
+                  range(10),
+                  .1,
+                  number_of_communities=None)
+    
+    C = nx.random_p_community(range(10),1.0,5)
+
+    assert_equal(5,len(C))
+
+    for c in C:
+        assert_equal(c,set(range(10)))
+
+    C = nx.random_p_community(range(10),0.0,5)
+
+    assert_equal(5,len(C))
+
+    for c in C:
+        assert_equal(c,set())
+
+    C = nx.random_p_community(range(10),[0.0,1.0,0.0])
+
+    assert_equal(len(C),3)
+    assert_equal(C[0],set())
+    assert_equal(C[1],set(range(10)))
+    assert_equal(C[2],set())
+
+def test_random_m_community():
+
+    assert_raises(nx.NetworkXError,
+                  nx.random_m_community,
+                  range(10),
+                  3,
+                  number_of_communities=None)
+
+    assert_raises(nx.NetworkXError,
+                  nx.random_m_community,
+                  range(10),
+                  [1,12],
+                  number_of_communities=None)
+    
+    C = nx.random_m_community(range(10),10,5)
+    assert_equal(5,len(C))
+    for c in C:
+        assert_equal(c,set(range(10)))
+
+
+    C = nx.random_m_community(range(10),0,5)
+    assert_equal(5,len(C))
+    for c in C:
+        assert_equal(c,set())
+
+    C = nx.random_m_community(range(10),[0,1,3,5,10])
+    assert_equal(len(C),5)
+    assert_equal(C[0],set())
+    assert_equal(len(C[1]),1)
+    assert_equal(len(C[2]),3)
+    assert_equal(len(C[3]),5)
+    assert_equal(C[4],set(range(10)))

--- a/networkx/algorithms/community/tests/test_random_community_graph.py
+++ b/networkx/algorithms/community/tests/test_random_community_graph.py
@@ -1,0 +1,61 @@
+import networkx as nx
+from nose.tools import *
+
+    
+def test_LFR_benchmark_graph():
+    G = nx.LFR_benchmark_graph(250,
+                               3,
+                               1.5,
+                               0.1,
+                               average_degree=5,
+                               min_community=20,
+                               seed=10)
+    C = G.graph['partition']
+    #assert_equal([len(c) for c in C], [53,12,10,15,10])
+    assert_equal(len(G),250)
+    #Aassert_equal(len(G.edges()),157)
+    assert_true(nx.is_partition(G.nodes(),C))
+    assert_raises(nx.NetworkXError,
+                  nx.LFR_benchmark_graph,
+                  100,
+                  1.0,
+                  2.0,
+                  .1,
+                  min_degree=2)
+    assert_raises(nx.NetworkXError,
+                  nx.LFR_benchmark_graph,
+                  100,
+                  2.0,
+                  1.0,
+                  .1,
+                  min_degree=2)
+    assert_raises(nx.NetworkXError,
+                  nx.LFR_benchmark_graph,
+                  100,
+                  2.0,
+                  2.0,
+                  1.1,
+                  min_degree=2)
+    assert_raises(nx.NetworkXError,
+                  nx.LFR_benchmark_graph,
+                  100,
+                  2.0,
+                  2.0,
+                  -1.0,
+                  min_degree=2)
+    assert_raises(nx.NetworkXError,
+                  nx.LFR_benchmark_graph,
+                  100,
+                  2.0,
+                  2.0,
+                  .1,
+                  min_degree=None,
+                  average_degree=None)
+    assert_raises(nx.NetworkXError,
+                  nx.LFR_benchmark_graph,
+                  100,
+                  2.0,
+                  1.5,
+                  .1,
+                  min_degree=2,
+                  average_degree=5)


### PR DESCRIPTION
## Incomplete Pull Request

This pull request is incomplete and it's meant to discuss pulling @bjedwards'
GSoC project on community finding and other related code into the main networkx repository.
## General Remark

There have been several discussions on the mailing list showing interest in
replacing the basic Graph data structure with custom ones, e.g., using a
database instead of the dict of dict model. Should we rely on particular class
interfaces, for example, Graph.adjacency_iter or DiGraph.predecessors_iter,
instead of accessing the dictionary structures directly in order to facilitate
other data models?

Direct access of the dictionary structure is extremely
widespread throughout networkx; one could argue that any customized data
structure would have to expose a dictionary-like interface anyway because a
rewrite of networkx is not worth the time and effort.
## Observations
- spectrum.py and laplacian_spectral.py are disorganized and seem to serve
  similar purposes. Can we reorganize it?
- similarly quality.py and community_quality.py isn't all the code community
  related?
## Related Issues

The GSoC project issue #549 (used to be Trac 557), other related issues are an algorithm based on Newman(2006) PNAS #160 (Trac 158),
the Louvain method #239 (same on Trac), and a fast detection algorithm #245
(same on Trac).
