### PR TITLE
Set default value for alpha channel in viz:color elements

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -115,7 +115,7 @@ def generate_gexf(G, encoding='utf-8',prettyprint=True,version='1.1draft'):
         yield line
 
 @open_file(0,mode='rb')
-def read_gexf(path,node_type=str,relabel=False,version='1.1draft'):
+def read_gexf(path,node_type=None,relabel=False,version='1.1draft'):
     """Read graph in GEXF format from path.
 
     "GEXF (Graph Exchange XML Format) is a language for describing
@@ -127,8 +127,8 @@ def read_gexf(path,node_type=str,relabel=False,version='1.1draft'):
        File or filename to write.
        Filenames ending in .gz or .bz2 will be compressed.
 
-    node_type: Python type (default: str)
-       Convert node ids to this type
+    node_type: Python type (default: None)
+       Convert node ids to this type if not None.
 
     relabel : bool (default: False)
        If True relabel the nodes to use the GEXF node "label" attribute


### PR DESCRIPTION
When trying to read an gexf file created with Gephi, I got the following error.

```
File "/usr/local/lib/python2.7/dist-packages/networkx/readwrite/gexf.py", line 693, in add_viz
'a':float(color.get('a')),
TypeError: float() argument must be a string or a number
```

The alpha channel value was not set by Gephi and according to the [gexf 1.2 schema](http://gexf.net/1.2draft/viz.xsd) it is not required. Thus I suggest setting the default to 100.
