### PR TITLE
Added support for reading the labels of curved yEd edges

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -475,8 +475,14 @@ class GraphMLReader(GraphML):
                                 (self.NS_Y, node_type, self.NS_Y))
                 if node_label is not None:
                     data['label'] = node_label.text
-                edge_label = data_element.find("{%s}PolyLineEdge/{%s}EdgeLabel"%
-                                               (self.NS_Y, (self.NS_Y)))
+
+                # check all the diffrent types of edges avaivable in yEd.
+                for e in ['PolyLineEdge', 'SplineEdge', 'QuadCurveEdge', 'BezierEdge', 'ArcEdge']:
+                	edge_label = data_element.find("{%s}%s/{%s}EdgeLabel"%
+                                               (self.NS_Y, e, (self.NS_Y)))
+                	if edge_label is not None:
+                		break
+                
                 if edge_label is not None:
                     data['label'] = edge_label.text
         return data


### PR DESCRIPTION
I had some problems with graphml.read_graphml function discarding labels of curved edges, so i took the liberty of fixing it! :)

This commit makes it so that labels of curved edges, which were
previously discarded, are added to the graph just like straight ones.
