### PR TITLE
Add a "name" attribute for each node in the force.py example graph.

### DIFF
--- a/examples/javascript/force.py
+++ b/examples/javascript/force.py
@@ -1,6 +1,6 @@
 """Example of writing JSON format graph data and using the D3 Javascript library to produce an HTML/Javascript drawing.
 """
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011-2012 by 
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -13,6 +13,10 @@ from networkx.readwrite import json_graph
 import http_server
 
 G = nx.barbell_graph(6,3)
+# this d3 example uses the name attribute for the mouse-hover value,
+# so add a name to each node
+for n in G:
+    G.node[n]['name'] = n
 # write json formatted data
 d = json_graph.node_link_data(G) # node-link format to serialize
 # write json 


### PR DESCRIPTION
The force.js example uses the "name" attribute for the mouse-over value.
This small fix uses the node id as the name so the mouse-over is defined.
