### PR TITLE
Fallback to string type in GraphML reader if none given in <key>

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -530,9 +530,3 @@ def teardown_module(module):
         os.unlink('test.graphml')
     except:
         pass
-
-if __name__ == '__main__':
-    import networkx as nx
-    G=nx.read_graphml("Graph1.graphml")
-    print G.edges()
-    print G.nodes()


### PR DESCRIPTION
Addresses #784

Is there any harm in guessing the type as a string and use warnings.warn to notify the user that something is suspicious with the GraphML file?
