### PR TITLE
Added utility function to convert dicts of numbers to numpy vector

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -110,6 +110,9 @@ def dict_to_numpy_array(d,mapping=None):
     except ImportError:
         raise ImportError(
           "dict_to_numpy_array requires numpy : http://scipy.org/ ")
+    # ensure d is a dictionary of dictionaries, not a dictionary of numbers 
+    if len(d.values()) > 0 and not isinstance(d.values()[0], dict):
+        return dict_to_numpy_vector(d,mapping)
     if mapping is None:
         s=set(d.keys())
         for k,v in d.items():
@@ -124,3 +127,21 @@ def dict_to_numpy_array(d,mapping=None):
             a[i,j] = value 
     return a
 
+
+def dict_to_numpy_vector(d,mapping=None):
+    """Convert a dictionary of numbers to a 1d numpy array 
+    with optional mapping."""
+    try:
+        import numpy 
+    except ImportError:
+        raise ImportError(
+          "dict_to_numpy_array requires numpy : http://scipy.org/ ")
+    if mapping is None:
+        s=set(d.keys())
+        mapping=dict(zip(s,range(len(s))))
+    n=len(mapping)
+    a = numpy.zeros(n)
+    for k1, value in d.items():
+        i=mapping[k1]
+        a[i] = value 
+    return a


### PR DESCRIPTION
I often use networkx to construct distance matrices:

``` python
# distance matrix construction
import networkx as nx

G = nx.DiGraph()
G.add_edge('a', 'b')
G.add_edge('b', 'c')
G.add_edge('c', 'd')

lengths = nx.shortest_path_length(G)
# lengths => {'a': {'a': 0, 'c': 1, 'b': 1, 'e': 2}, 'c': {'c': 0, 'e': 1}, 'b': {'b': 0}, 'e': {'e': 0}}

dm = nx.utils.dict_to_numpy_array(lengths)
```

This returns the distance matrix as expected:

``` python
[[ 0.  1.  2.  3.]
 [ 0.  0.  1.  2.]
 [ 0.  0.  0.  1.]
 [ 0.  0.  0.  0.]]
```

However, if you restrict your shortest paths to a single source, then `shortest_path_length` returns a dictionary of path lengths, not a dictionary of dictionaries.  (If you supply a `target` and `source` parameter, it returns a single number, the path length).

``` python
G = nx.DiGraph()
G.add_edge('a', 'b')
G.add_edge('b', 'c')
G.add_edge('c', 'd')

lengths = nx.shortest_path_length(G, source='a')
# lengths =>  {'a': 0, 'c': 1, 'b': 1, 'e': 2}
dm = nx.utils.dict_to_numpy_array(lengths)  # => Attribute Error
```

will lead to an **AttributeError: 'int' object has no attribute 'keys'** on line 116 of `networkx/utils/misc.py`.

To accommodate this case, I created a `dict_to_numpy_vector` function, and modified the existing `dict_to_numpy_array` function to check for this special case and dispatch the new function when appropriate.   Now it returns: `[ 0.  1.  2.  3.]`

I've also updated the mapping function for the vector case:

``` python
sorted_nodes = sorted(G.nodes())
mapping = dict([(n,i) for (i,n) in enumerate(sorted_nodes)])
print nx.utils.dict_to_numpy_array(lengths, mapping)  # => [ 0.  2.  1.  3.]
```
