### PR TITLE
Fix density to handle single node with self loop case.

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -83,13 +83,15 @@ def density(G):
 
     Notes
     -----
-    The density is 0 for an graph without edges and 1.0 for a complete graph.
-
+    The density is 0 for a graph without edges and 1 for a complete graph.
     The density of multigraphs can be higher than 1.
+
+    Self loops are counted in the total number of edges so graphs with self
+    loops can have density higher than 1.
     """
     n=number_of_nodes(G)
     m=number_of_edges(G)
-    if m==0: # includes cases n==0 and n==1
+    if m==0 or n <= 1:
         d=0.0
     else:
         if G.is_directed():

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -69,12 +69,21 @@ class TestFunction(object):
 
     def test_degree_histogram(self):
         assert_equal(networkx.degree_histogram(self.G), [1,1,1,1,1])
+
     def test_density(self):
         assert_equal(networkx.density(self.G), 0.5)
         assert_equal(networkx.density(self.DG), 0.3)
         G=networkx.Graph()
         G.add_node(1)
         assert_equal(networkx.density(G), 0.0)
+
+    def test_density_selfloop(self):
+        G = nx.Graph()
+        G.add_edge(1,1)
+        assert_equal(networkx.density(G), 0.0)
+        G.add_edge(1,2)
+        assert_equal(networkx.density(G), 2.0)
+
     def test_freeze(self):
         G=networkx.freeze(self.G)
         assert_equal(G.frozen,True)


### PR DESCRIPTION
Make note that graphs with self loops can have density > 1.
Addresses #795
