### PR TITLE
Fix missing SkipTest import in utils tests

### DIFF
--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -1,4 +1,5 @@
 from nose.tools import *
+from nose import SkipTest
 import networkx as nx
 from networkx.utils import *
 


### PR DESCRIPTION
nose.SkipTest import needed for skipping numpy tests
