### PR TITLE
More Pythonic behaviour for the grid_graph generator

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -370,6 +370,7 @@ def grid_graph(dim,periodic=False):
     else:
         func=path_graph
 
+    dim=list(dim)
     current_dim=dim.pop()
     G=func(current_dim)
     while len(dim)>0:

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -254,14 +254,18 @@ class TestGeneratorClassic():
         degree_histogram=[0,0,4,2*(n+m)-8,(n-2)*(m-2)]
         """
         for n, m in [(3, 5), (5, 3), (4, 5), (5, 4)]:
-            g=grid_graph([n,m])
+            dim=[n,m]
+            g=grid_graph(dim)
             assert_equal(number_of_nodes(g), n*m)
             assert_equal(degree_histogram(g), [0,0,4,2*(n+m)-8,(n-2)*(m-2)])
+            assert_equal(dim,[n,m])
         
         for n, m in [(1, 5), (5, 1)]:
-            g=grid_graph([n,m])
+            dim=[n,m]
+            g=grid_graph(dim)
             assert_equal(number_of_nodes(g), n*m)
             assert_true(is_isomorphic(g,path_graph(5)))
+            assert_equal(dim,[n,m])
 
 #        mg=grid_graph([n,m], create_using=MultiGraph())
 #        assert_equal(mg.edges(), g.edges())


### PR DESCRIPTION
The current implementation of `networkx.grid_graph` mutates the `dim`  input parameter, requiring calling code to copy the list prior. The current behaviour certainly isn't wrong, it might just be surprising in some circumstances. 

This pull request alters this functionality to allow:

``` python
dim=[3,4]
G=grid_graph(dim)
```

Rather than:

``` python
dim=[3,4]
G=grid_graph(list(dim))
```
