### PR TITLE
Add longest path algorithm for DAGs

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -16,7 +16,8 @@ __all__ = ['descendants',
            'topological_sort', 
            'topological_sort_recursive',
            'is_directed_acyclic_graph',
-           'is_aperiodic']
+           'is_aperiodic',
+           'single_target_longest_path_length_in_dag']
 
 def descendants(G, source):
     """Return all nodes reachable from `source` in G.
@@ -271,3 +272,64 @@ def is_aperiodic(G):
         return g==1
     else:
         return g==1 and nx.is_aperiodic(G.subgraph(set(G)-set(levels)))
+
+def single_target_longest_path_length_in_dag(G, target, weight='weight'):
+    """Compute the longest path length between target and all other
+    nodes from which the target is reachable for a weighted graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    target : node label
+       Final node for path
+
+    weight : string, optional (default='weight')
+       Edge data key corresponding to the edge weight.
+
+    Returns
+    -------
+    length : dictionary
+       Dictionary of longest lengths keyed by source.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> length=nx.single_target_longest_path_length_in_dag(G,5)
+    >>> length[4]
+    4
+    >>> print(length)
+    {0: 4, 1: 3, 2: 2, 3: 1, 4: 0}
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    TODO: other interfaces
+
+    """
+    dist = {target: 0}  # dictionary of final distances
+    top_sorted = topological_sort(G)
+
+    for v in top_sorted[::-1]:
+        if G.is_multigraph():
+            edata = []
+            for w, keydata in G[v].items():
+                maxweight = max((dd.get(weight, 1)
+                    for k, dd in keydata.items()))
+                edata.append((w, {weight: maxweight}))
+        else:
+            edata = iter(G[v].items())
+
+        for w, edgedata in edata:
+            if w in dist:
+                ww_dist = dist[w] + edgedata.get(weight, 1)
+                if v not in dist:
+                    dist[v] = ww_dist
+                else:
+                    dist[v] = max(dist[v], ww_dist)
+
+    return dist

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -94,6 +94,50 @@ class TestDAG:
         assert_equal(descendants(G, 3), set())
         assert_raises(nx.NetworkXError, descendants, G, 8)
 
+    def test_single_target_longest_path_length1(self):
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (1, 3), (2, 3)])
+        assert_equal(nx.single_target_longest_path_length_in_dag(G, target=3), {1: 2, 2: 1, 3: 0})
+
+    def test_single_target_longest_path_length2(self):
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (2, 3), (4, 5), (4, 6)])
+        assert_equal(nx.single_target_longest_path_length_in_dag(G, target=5), {4:1, 5:0})
+
+    def test_single_target_longest_path_length3(self):
+        G = nx.MultiDiGraph()
+        G.add_weighted_edges_from([(2, 3, 3),
+                                   (9, 10, 1),
+                                   (13, 14, 0),
+                                   (16, 18, 4),
+                                   (1, 5, 5),
+                                   (7, 17, 12),
+                                   (4, 8, 6),
+                                   (11, 15, 7),
+                                   (6, 12, 10),
+                                   (1, 2, 0),
+                                   (2, 3, 0),
+                                   (3, 4, 0),
+                                   (4, 5, 0),
+                                   (5, 6, 0),
+                                   (6, 7, 0),
+                                   (7, 8, 0),
+                                   (8, 9, 0),
+                                   (9, 10, 0),
+                                   (10, 11, 0),
+                                   (11, 12, 0),
+                                   (12, 13, 0),
+                                   (13, 14, 0),
+                                   (14, 15, 0),
+                                   (15, 16, 0),
+                                   (16, 17, 0),
+                                   (17, 18, 0),
+                                   ])
+        true_dist = {18: 0, 17: 0, 16: 4, 15: 4, 14: 4, 13: 4, 12: 4, 11: 11, 10: 11,
+                     9: 12, 8: 12, 7: 12, 6: 14, 5: 14, 4: 18, 3: 18, 2: 21, 1: 21}
+        dist = nx.single_target_longest_path_length_in_dag(G, target=18)
+        assert_equal(dist, true_dist)
+
 
 def test_is_aperiodic_cycle():
     G=nx.DiGraph()


### PR DESCRIPTION
Hello!

Looks like there is no longest path algorithm for DAGs in networkx, thought it's simple linear time dynamic programming, so here is my basic implementation.

If it is OK, I'll add some wrapper functions:

longest_path_in_dag(G, source, target)
longest_path_length_in_dag(G, source, target)
critical_path(G)