### PR TITLE
readwrite module for interfacing with RDF

### DIFF
--- a/networkx/readwrite/__init__.py
+++ b/networkx/readwrite/__init__.py
@@ -14,3 +14,4 @@ from networkx.readwrite.gml import *
 from networkx.readwrite.graphml import *
 from networkx.readwrite.gexf import *
 from networkx.readwrite.nx_shp import *
+from networkx.readwrite.rdf import *

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -116,7 +116,7 @@ def _relabel(G):
     return nx.relabel_nodes(G, dict(mapping))
 
 
-def _from_bipartite(N, G):
+def _from_bipartite(N):
     """Reconstruct previously imported RDF graph G from bipartite
     representation N.
     """
@@ -130,7 +130,7 @@ def _from_bipartite(N, G):
     return G
 
 
-def _from_multigraph(N, G):
+def _from_multigraph(N):
     """Reconstruct previously imported RDF graph G from directed labeled
     multigraph representation N.
     """

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+*******
+RDF
+*******
+Read and write graphs in RDF format.
+
+"RDF is a standard model for data interchange on the Web. RDF has
+features that facilitate data merging even if the underlying schemas
+differ, and it specifically supports the evolution of schemas over time
+without requiring all the data consumers to be changed.
+
+RDF extends the linking structure of the Web to use URIs to name the
+relationship between things as well as the two ends of the link (this is
+usually referred to as a 'triple'). Using this simple model, it allows
+structured and semi-structured data to be mixed, exposed, and shared
+across different applications.
+
+This linking structure forms a directed, labeled graph, where the edges
+represent the named link between two resources, represented by the graph
+nodes. This graph view is the easiest possible mental model for RDF and
+is often used in easy-to-understand visual explanations."
+
+https://www.w3.org/RDF/
+
+Requires rdflib: https://github.com/RDFLib/rdflib
+
+Serialization formats
+---------------------
+All serialization formats supported by `rdflib` are supported, currently::
+
+* RDF/XML (http://www.w3.org/TR/rdf-syntax-grammar/)
+* Notation 3 (http://www.w3.org/TeamSubmission/n3/)
+* Turtle (http://www.w3.org/TeamSubmission/turtle/)
+* N-Triples (http://www.w3.org/TR/rdf-testcases/#ntriples)
+* Trix (https://www.hpl.hp.com/techreports/2004/HPL-2004-56)
+
+"""
+
+__author__ = """Pedro Silva (psilva+git@pedrosilva.pt)"""
+#    Copyright (C) 2013 by
+#    Pedro Silva <psilva+git@pedrosilva.pt>
+#    All rights reserved.
+#    BSD license.
+
+__all__ = ['read_rdf', 'parse_rdf', 'generate_rdf', 'write_rdf']
+
+import networkx as nx
+from networkx.exception import NetworkXError
+
+# map(lambda x: x.name,
+#     filter(lambda x: x.kind is rdflib.serializer.Serializer,
+#            rdflib.plugin.plugins()))
+
+
+def from_rdfgraph(G, create_using=None):
+    """Return a NetworkX MultiDiGraph or (bipartite) Graph from an
+    rdflib Graph.
+
+    Parameters
+    ----------
+    G : rdflib Graph
+      A graph created with rdflib
+
+    create_using : NetworkX graph class instance
+      The output is created using the given graph class instance
+
+    Examples
+    --------
+    >>> K5=nx.complete_graph(5)
+    >>> A=nx.to_rdfgraph(K5)
+    >>> G=nx.from_rdfgraphf(A)
+
+    Notes
+    -----
+    The default representation, returned when `create_using` is None is
+    a bipartite graph, in which case the graph G will be an undirected
+    graph with two sets of nodes: one set for RDF statements (the
+    hyperedges), and one set for the actual triples (one node for each
+    subject, predicate, and object). Each statement edge connects its
+    respective triple.
+
+    If `create_using` is passed as a Multi(Di)Graph, then we proceed
+    with a (un)directed labeled multigraph, in which case the graph will
+    possibly contain multiple reifications of the same entity, occurring
+    both as edge (predicate) and as node (subject or object).
+
+    References
+    ----------
+    Hayes, J. (2004). A graph model for RDF. Technische Universität
+    Darmstadt. Retrieved from
+    http://www.dcc.uchile.cl/~cgutierr/papers/rdfgraphmodel.pdf
+    """
+    if create_using is not None and not create_using.is_multigraph():
+        raise NetworkXError('RDF graph model requires a multigraph',
+                            '''(s, p, o) followed by (s, p', o) is valid RDF
+     and implies repeated edges between s and o''')
+
+    # assign defaults
+    N = nx.empty_graph(0, create_using)
+    N.name = G.identifier
+
+    # `node_keys` is a dict with monotonic integers as keys and rdflib
+    # objects as values. `start` is an offset for new rdflib objects
+    # indices computed through the second enumerate, below
+    nodes = G.all_nodes() | set(G.predicates())
+    node_keys = dict([reversed(n) for n in (enumerate(nodes))])
+    offset = len(nodes)
+
+    # populate the nx graph: Because RDF terms are pretty verbose, and
+    # to closely follow Hayes (2004), nodes are simple integers, and the
+    # rdflib objects themselves are stored under the 'label' attribute
+    for n, (s, p, o) in enumerate(G, start=offset):
+
+        # If the same rdflib object occurs more than once, its key is
+        # retrieved from the node_keys structure initialized above
+        _subject = node_keys.get(s, n)
+        _object = node_keys.get(o, n+offset)
+        _predicate = node_keys.get(p, n+offset*2)
+        _statement = 's%d' % (n-offset)
+
+        # bipartite branch
+        if create_using is None:
+            N.add_node(_statement, bipartite=0)
+            N.add_node(_subject, label=s, bipartite=1)
+            N.add_node(_object, label=o, bipartite=1)
+            N.add_node(_predicate, label=p, bipartite=1)
+            N.add_edges_from(zip([_statement]*3,
+                                 [_subject, _object, _predicate]))
+        # directed labeled multigraph branch
+        else:
+            N.add_node(_subject, label=s)
+            N.add_node(_object, label=o)
+            N.add_edge(_subject, _object, label=p)
+
+    return N

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -44,7 +44,7 @@ __author__ = """Pedro Silva (psilva+git@pedrosilva.pt)"""
 #    BSD license.
 
 __all__ = ['read_rdf', 'from_rdfgraph', 'write_rdf', 'to_rdfgraph',
-           'read_rgml', 'from_rgmlgraph']
+           'read_rgml', 'from_rgmlgraph', 'write_rgml']
 
 import networkx as nx
 from networkx.exception import NetworkXError
@@ -260,12 +260,12 @@ def from_rgmlgraph(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
     G.bind('rgml', str(rgml))
 
     try:
-        graph_lit = G.value(predicate=rdf.type, object=rgml.Graph, any=False)
+        graph_node = G.value(predicate=rdf.type, object=rgml.Graph, any=False)
     except rdflib.exceptions.UniquenessError:
         raise NetworkXError('from_rgmlgraph() does not support nested graphs ')
 
     try:
-        directed = G.value(subject=graph_lit, predicate=rgml.directed)
+        directed = G.value(subject=graph_node, predicate=rgml.directed, any=False)
     except rdflib.exceptions.UniquenessError:
         raise NetworkXError('from_rgmlgraph() does not support mixed graphs ')
 
@@ -279,7 +279,7 @@ def from_rgmlgraph(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
     }""", initNs=dict(rgml=rgml, rdf=rdf))
 
     if len(hyperedges):
-        raise NetworkXError('from_rgml() does not support hypergraphs')
+        raise NetworkXError('from_rgml() does not support hypergraphs ')
 
     # assign defaults
     create_using = nx.Graph()
@@ -335,7 +335,7 @@ def read_rgml(path, format='xml', relabel=True):
 
     G = rdflib.Graph()
     G.load(path, format=format)
-    return from_rgmlgraph(G, relabel)
+    return from_rgmlgraph(G, relabel=relabel)
 
 
 def write_rgml(N, path, format='xml'):
@@ -530,8 +530,6 @@ def to_rdfgraph(N):
          and all([isinstance(x,
                              rdflib.term.Identifier) for x in edges_labels]):
 
-        print nodes_labels
-        print edges_labels
         return _from_multigraph(N)
 
     else:

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -44,7 +44,7 @@ __author__ = """Pedro Silva (psilva+git@pedrosilva.pt)"""
 #    BSD license.
 
 __all__ = ['read_rdf', 'from_rdfgraph', 'write_rdf', 'to_rdfgraph',
-           'read_rgml', 'from_rgml']
+           'read_rgml', 'from_rgmlgraph']
 
 import networkx as nx
 from networkx.exception import NetworkXError
@@ -63,7 +63,7 @@ def _get_rdflib_plugins(kind):
 
 
 def _make_elements(G, kind, **kwargs):
-    """Given graph rdflib graph `G`, rdflib class `kind`, and namespace
+    """Given rdflib graph `G`, rdflib class `kind`, and namespace
     keywords `**kwargs`, return dict of dicts with keys objects of class
     `kind`, and values dicts of attributes obtained from triples where
     the key objects appear as subjects, and consisting of the respective
@@ -107,8 +107,8 @@ def _relabel(G):
     return nx.relabel_nodes(G, dict(mapping))
 
 
-def from_rgml(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
-              relabel=True):
+def from_rgmlgraph(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
+                   relabel=True):
     """Return a NetworkX graph from an rdflib RGML graph.
 
     Parameters
@@ -229,7 +229,7 @@ def read_rgml(path, format='xml', relabel=True):
 
     G = rdflib.Graph()
     G.load(path, format=format)
-    return from_rdfrgml(G, relabel)
+    return from_rgmlgraph(G, relabel)
 
 
 def from_rdfgraph(G, create_using=None):

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -43,14 +43,19 @@ __author__ = """Pedro Silva (psilva+git@pedrosilva.pt)"""
 #    All rights reserved.
 #    BSD license.
 
-__all__ = ['read_rdf', 'parse_rdf', 'generate_rdf', 'write_rdf']
+__all__ = ['read_rdf', 'from_rdfgraph', 'to_rdfgraph', 'write_rdf']
 
 import networkx as nx
 from networkx.exception import NetworkXError
 
-# map(lambda x: x.name,
-#     filter(lambda x: x.kind is rdflib.serializer.Serializer,
-#            rdflib.plugin.plugins()))
+
+def _get_rdflib_plugins(kind):
+    try:
+        import rdflib
+    except ImportError:
+        raise ImportError('_get_rdflib_plugins() requires rdflib ',
+                          'https://github.com/RDFLib/rdflib ')
+    return [p.name for p in rdflib.plugin.plugins() if p.kind is kind]
 
 
 def from_rdfgraph(G, create_using=None):
@@ -134,3 +139,29 @@ def from_rdfgraph(G, create_using=None):
             N.add_edge(_subject, _object, label=p)
 
     return N
+
+
+def read_rdf(path, format='xml', create_using=None):
+    """Return a NetworkX MultiDiGraph or (bipartite) Graph from an rdf
+    file on path.
+
+    Parameters
+    ----------
+    path : file or string
+       File name or file handle or url to read.
+
+    format : string
+       RDFlib parser to use ({})
+
+    See from_rdfgraph() for details.
+    """
+    try:
+        import rdflib
+    except ImportError:
+        raise ImportError('read_rdf() requires rdflib ',
+                          'https://github.com/RDFLib/rdflib ')
+    read_rdf.__doc__.format(_get_rdflib_plugins(rdflib.parser.Parser))
+
+    G = rdflib.Graph()
+    G.load(path, format=format)
+    return from_rdfgraph(G, create_using)

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -508,14 +508,14 @@ def to_rdfgraph(N):
     If the above fail, then we generate an RGML graph.
     """
     rdflib = _rdflib()
-    nodes = N.nodes_iter(data=True)
-    edges = N.edges_iter(data=True)
+    nodes = N.nodes(data=True)
+    edges = N.edges(data=True)
 
-    nodes_bipartite = iter([x[-1].get('bipartite') for x in nodes])
-    edges_terms = iter([x[-1].get('term') for x in edges])
+    nodes_bipartite = [x[-1].get('bipartite') for x in nodes]
+    edges_terms = [x[-1].get('term') for x in edges]
 
-    nodes_labels = iter([x[-1].get('label') for x in nodes])
-    edges_labels = iter([x[-1].get('label') for x in edges])
+    nodes_labels = [x[-1].get('label') for x in nodes]
+    edges_labels = [x[-1].get('label') for x in edges]
 
     if all([x for x in nodes_bipartite if x]) \
        and all([x in [0, 1] for x in nodes_bipartite]) \
@@ -523,12 +523,15 @@ def to_rdfgraph(N):
 
         return _from_bipartite(N)
 
-    elif all(nodes_labels) and all(edges_labels) \
-        and all([isinstance(x,
-                            rdflib.term.Identifier) for x in nodes_labels]) \
-        and all([isinstance(x,
-                            rdflib.term.Identifier) for x in edges_labels]):
+    elif nodes_labels and edges_labels \
+         and all(nodes_labels) and all(edges_labels) \
+         and all([isinstance(x,
+                             rdflib.term.Identifier) for x in nodes_labels]) \
+         and all([isinstance(x,
+                             rdflib.term.Identifier) for x in edges_labels]):
 
+        print nodes_labels
+        print edges_labels
         return _from_multigraph(N)
 
     else:

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -169,6 +169,40 @@ def _parse_attrs(attrs, rgml, rdflib):
         yield k, v
 
 
+def _is_bipartite(nodes, edges):
+    """Return true if graph composed of nodes and edges has been imported
+    as a bipartite RDF graph, false otherwise.
+    """
+    nodes_bipartite = [x[-1].get('bipartite') for x in nodes]
+    edges_terms = [x[-1].get('term') for x in edges]
+
+    all_bipartite = all([x for x in nodes_bipartite if x])
+    all_partitioned = all([x in [0, 1] for x in nodes_bipartite])
+    all_terms = all([x in ['subject',
+                           'object',
+                           'predicate'] for x in edges_terms])
+
+    return all_bipartite and all_partitioned and all_terms
+
+
+def _is_multigraph(nodes, edges):
+    """Return true if graph composed of nodes and edges has been imported
+    as a multiple directed labeled RDF graph, false otherwise.
+    """
+    rdflib = _rdflib()
+    nodes_labels = [x[-1].get('label') for x in nodes]
+    edges_labels = [x[-1].get('label') for x in edges]
+
+    have_labels = nodes_labels and edges_labels
+    true_labels = all(nodes_labels) and all(edges_labels)
+    nodes_terms = all([isinstance(x, rdflib.term.Identifier)
+                       for x in nodes_labels])
+    edges_terms = all([isinstance(x, rdflib.term.Identifier)
+                       for x in edges_labels])
+
+    return have_labels and true_labels and nodes_terms and edges_terms
+
+
 def from_rgmlgraph(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
                    relabel=True):
     """Return a NetworkX graph from an rdflib RGML graph.
@@ -499,40 +533,6 @@ def to_rdfgraph(N):
         return _from_multigraph(N)
     else:
         return to_rgmlgraph(N)
-
-
-def _is_bipartite(nodes, edges):
-    """Return true if graph composed of nodes and edges has been imported
-    as a bipartite RDF graph, false otherwise.
-    """
-    nodes_bipartite = [x[-1].get('bipartite') for x in nodes]
-    edges_terms = [x[-1].get('term') for x in edges]
-
-    all_bipartite = all([x for x in nodes_bipartite if x])
-    all_partitioned = all([x in [0, 1] for x in nodes_bipartite])
-    all_terms = all([x in ['subject',
-                           'object',
-                           'predicate'] for x in edges_terms])
-
-    return all_bipartite and all_partitioned and all_terms
-
-
-def _is_multigraph(nodes, edges):
-    """Return true if graph composed of nodes and edges has been imported
-    as a multiple directed labeled RDF graph, false otherwise.
-    """
-    rdflib = _rdflib()
-    nodes_labels = [x[-1].get('label') for x in nodes]
-    edges_labels = [x[-1].get('label') for x in edges]
-
-    have_labels = nodes_labels and edges_labels
-    true_labels = all(nodes_labels) and all(edges_labels)
-    nodes_terms = all([isinstance(x, rdflib.term.Identifier)
-                       for x in nodes_labels])
-    edges_terms = all([isinstance(x, rdflib.term.Identifier)
-                       for x in edges_labels])
-
-    return have_labels and true_labels and nodes_terms and edges_terms
 
 
 def read_rdf(path, fmt='xml', create_using=None):

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -189,7 +189,7 @@ def from_rgmlgraph(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
     """
     rdflib = _rdflib()
     if namespace not in [str(x[1]) for x in G.namespaces()]:
-        raise NetworkXError('from_rgml() requires an RGML-namespaced graph ',
+        raise NetworkXError('from_rgmlgraph() requires an RGML-namespaced graph ',
                             namespace)
 
     rdf = rdflib.RDF
@@ -199,12 +199,12 @@ def from_rgmlgraph(G, namespace='http://purl.org/puninj/2001/05/rgml-schema#',
     try:
         graph_lit = G.value(predicate=rdf.type, object=rgml.Graph, any=False)
     except rdflib.exceptions.UniquenessError:
-        raise NetworkXError('from_rgml() does not support nested graphs ')
+        raise NetworkXError('from_rgmlgraph() does not support nested graphs ')
 
     try:
         directed = G.value(subject=graph_lit, predicate=rgml.directed)
     except rdflib.exceptions.UniquenessError:
-        raise NetworkXError('from_rgml() does not support mixed graphs ')
+        raise NetworkXError('from_rgmlgraph() does not support mixed graphs ')
 
     hyperedges = G.query("""SELECT DISTINCT ?edge
     WHERE {
@@ -264,7 +264,7 @@ def read_rgml(path, format='xml', relabel=True):
       If True use the RGML node label attribute for node names,
       otherwise use the rdflib object itself.
 
-    See from_rgml() for details.
+    See from_rgmlgraph() for details.
 
     """
     rdflib = _rdflib()
@@ -473,7 +473,7 @@ def to_rdfgraph(N):
         return _from_multigraph(N)
 
     else:
-        return _from_rgml(N)
+        return to_rgmlgraph(N)
 
 
 def write_rdf(N, path, format='xml'):

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -363,6 +363,10 @@ def read_rgml(path, fmt='xml', relabel=True):
       If True use the RGML node label attribute for node names,
       otherwise use the rdflib object itself.
 
+    Examples
+    --------
+    >>> N = nx.read_rgml("test.rdf")
+
     See from_rgmlgraph() for details.
 
     """
@@ -390,7 +394,7 @@ def write_rgml(N, path, fmt='xml'):
 
     Examples
     --------
-    >>> N=nx.path_graph(4)
+    >>> N = nx.path_graph(4)
     >>> nx.write_rgml(N, "test.rdf")
 
     Notes
@@ -406,7 +410,6 @@ def write_rgml(N, path, fmt='xml'):
         raise NetworkXError('Format not available', fmt, plugins)
     G = to_rgmlgraph(N)
     G.serialize(path, format=fmt)
-    return G
 
 
 def from_rdfgraph(G, create_using=None):
@@ -423,9 +426,9 @@ def from_rdfgraph(G, create_using=None):
 
     Examples
     --------
-    >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_rdfgraph(K5)
-    >>> G=nx.from_rdfgraph(A)
+    >>> K5 = nx.complete_graph(5)
+    >>> A = nx.to_rdfgraph(K5)
+    >>> G = nx.from_rdfgraph(A)
 
     Notes
     -----
@@ -549,6 +552,10 @@ def read_rdf(path, fmt='xml', create_using=None):
                              application/rdf+xml, application/xhtml+xml,
                              rdfa, nt, turtle)
 
+    Examples
+    --------
+    >>> N = nx.read_rdf("test.rdf")
+
     See from_rdfgraph() for details.
     """
     rdflib = _rdflib()
@@ -591,4 +598,4 @@ def write_rdf(N, path, fmt='xml'):
         raise NetworkXError('Format not available', fmt, plugins)
     G = to_rdfgraph(N)
     G.serialize(path, format=fmt)
-    return G
+

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -43,13 +43,16 @@ __author__ = """Pedro Silva (psilva+git@pedrosilva.pt)"""
 #    All rights reserved.
 #    BSD license.
 
-__all__ = ['read_rdf', 'from_rdfgraph', 'to_rdfgraph', 'write_rdf']
+__all__ = ['read_rdf', 'from_rdfgraph']
 
 import networkx as nx
 from networkx.exception import NetworkXError
 
 
 def _get_rdflib_plugins(kind):
+    """Return list of strings corresponding to parsers or serializers
+    accepted by rdflib.
+    """
     try:
         import rdflib
     except ImportError:
@@ -74,7 +77,7 @@ def from_rdfgraph(G, create_using=None):
     --------
     >>> K5=nx.complete_graph(5)
     >>> A=nx.to_rdfgraph(K5)
-    >>> G=nx.from_rdfgraphf(A)
+    >>> G=nx.from_rdfgraph(A)
 
     Notes
     -----

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -307,7 +307,7 @@ def write_rgml(N, path, format='xml'):
     write_rdf.__doc__.format(_get_rdflib_plugins(rdflib.serializer.Serializer))
 
     G = to_rgmlgraph(N)
-    G.serialize(format=format)
+    G.serialize(path, format=format)
     return G
 
 

--- a/networkx/readwrite/rdf.py
+++ b/networkx/readwrite/rdf.py
@@ -136,8 +136,13 @@ def _from_multigraph(N):
     """
     rdflib = _rdflib()
     G = rdflib.Graph(identifier=N.name)
-    edges = N.edges_iter(data=True)
-    for s, o, p in edges:
+
+    # I think we don't need to consider disconnected nodes, since that
+    # is impossible to represent in straight RDF. That is, RDF has a
+    # concept of disconnected triples, but not terms, which are
+    # properly analogous to nodes in networkx
+
+    for s, o, p in N.edges_iter(data=True):
         _subject = N.node[s]['label']
         _object = N.node[o]['label']
         _predicate = p['label']

--- a/networkx/readwrite/tests/test_rdf.py
+++ b/networkx/readwrite/tests/test_rdf.py
@@ -194,31 +194,56 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
         fh = io.BytesIO(self.simple_data.encode('UTF-8'))
         fh.seek(0)
 
-        rdflib = rdf._rdflib()
-        assert_raises(rdflib.plugin.PluginException,
+        assert_raises(NetworkXError,
                       networkx.read_rdf,
                       fh,
-                      format='does not exist')
+                      fmt='does not exist')
 
         assert_true(type(networkx.read_rdf(fh,
                                            create_using=None,
-                                           format='nt')) is networkx.Graph,
+                                           fmt='nt')) is networkx.Graph,
                     'Returns NetworkX graph')
 
 
     def test_write_rdf(self):
         fh=io.BytesIO()
-        networkx.write_rdf(networkx.barabasi_albert_graph(100,1,0), fh, format='n3')
+        networkx.write_rdf(networkx.barabasi_albert_graph(100,1,0), fh, fmt='n3')
         fh.seek(0)
-        assert_true(isinstance(networkx.read_rdf(fh, format='n3'),
+        assert_true(isinstance(networkx.read_rdf(fh, fmt='n3'),
                                networkx.Graph),
                     'Roundtrip NX <-> RDF in N3 format')
 
+        assert_raises(NetworkXError,
+                      networkx.write_rdf,
+                      networkx.barabasi_albert_graph(100, 1, 0),
+                      fh,
+                      fmt='does not exist')
+
+    def test_read_rgml(self):
+        fh = io.BytesIO(self.rgml_data.encode('UTF-8'))
+        fh.seek(0)
+
+        assert_raises(NetworkXError,
+                      networkx.read_rgml,
+                      fh,
+                      fmt='does not exist')
+
+        N = networkx.read_rdf(fh, create_using=None)
+        assert_true(type(N) is networkx.Graph, 'Returns NetworkX graph')
+        
     def test_write_rgml(self):
         fh=io.BytesIO()
-        networkx.write_rgml(networkx.barabasi_albert_graph(100,1,0), fh, format='n3')
+        networkx.write_rgml(networkx.barabasi_albert_graph(100,1,0), fh, fmt='n3')
         fh.seek(0)
-        assert_true(isinstance(networkx.read_rgml(fh, format='n3'),
+
+        assert_raises(NetworkXError,
+                      networkx.write_rgml,
+                      networkx.barabasi_albert_graph(100, 1, 0),
+                      fh,
+                      fmt='does not exist')
+        fh.seek(0)
+
+        assert_true(isinstance(networkx.read_rgml(fh, fmt='n3'),
                                networkx.Graph),
                     'Roundtrip NX <-> RDF in N3 format')
 

--- a/networkx/readwrite/tests/test_rdf.py
+++ b/networkx/readwrite/tests/test_rdf.py
@@ -111,6 +111,30 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
         assert_equals(len(nodes), 6, 'Number of unique nodes')
         [assert_true(n[0] in range(10), 'Correct node id') for n in nodes]
 
+    def test_to_rdfgraph(self):
+        fh = io.BytesIO(self.simple_data.encode('UTF-8'))
+        fh.seek(0)
+
+        rdflib = rdf._rdflib()
+        G = rdflib.Graph()
+        G.load(fh, format='nt')
+
+        # bipartite representation
+        N = networkx.from_rdfgraph(G, create_using=None)
+        G1 = networkx.to_rdfgraph(N)
+        assert_true(G.isomorphic(G1), 'Isomorphic round-trip bipartite conversion.')
+        
+        # directed labeled multigraph representation
+        N = networkx.from_rdfgraph(G, create_using=networkx.MultiDiGraph())
+        G1 = networkx.to_rdfgraph(N)
+        assert_true(G.isomorphic(G1), 'Isomorphic round-trip multigraph conversion.')
+
+        # generic graph representation
+        N = networkx.barabasi_albert_graph(100, 1, 0)
+        G1 = networkx.to_rdfgraph(N)
+        assert_true('rgml' in [str(x[0]) for x in G1.namespaces()],
+                    'NetworkX generated graph in RGML namespace')
+        
     def test_read_rdf(self):
         try:
             import rdflib
@@ -129,3 +153,4 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
                                            create_using=None,
                                            format='nt')) is networkx.Graph,
                     'Returns NetworkX graph')
+

--- a/networkx/readwrite/tests/test_rdf.py
+++ b/networkx/readwrite/tests/test_rdf.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for rdf.
+"""
+import io
+import networkx
+from networkx.exception import NetworkXError
+from nose import SkipTest
+from nose.tools import assert_equals, assert_raises, assert_true
+
+
+class TestRdf():
+    @classmethod
+    def setupClass(cls):
+        try:
+            import rdflib
+        except ImportError:
+            raise SkipTest('rdflib not available.')
+
+    def setUp(self):
+        self.simple_data = """<http://www.w3.org/2001/08/rdf-test/> <http://purl.org/dc/elements/1.1/creator>   "Dave Beckett" .
+<http://www.w3.org/2001/08/rdf-test/> <http://purl.org/dc/elements/1.1/creator>   "Jan Grant" .
+<http://www.w3.org/2001/08/rdf-test/> <http://purl.org/dc/elements/1.1/publisher> _:a .
+_:a                                   <http://purl.org/dc/elements/1.1/title>     "World Wide Web Consortium" .
+_:a                                   <http://purl.org/dc/elements/1.1/source>    <http://www.w3.org/> .
+"""
+
+    def test_from_rdfgraph(self):
+        fh = io.BytesIO(self.simple_data.encode('UTF-8'))
+        fh.seek(0)
+
+        try:
+            import rdflib
+        except ImportError:
+            raise SkipTest('rdflib not available.')
+
+        G = rdflib.Graph()
+        G.load(fh, format='nt')
+
+        assert_raises(NetworkXError,
+                      networkx.from_rdfgraph,
+                      G,
+                      create_using=networkx.Graph())
+
+        # bipartite representation
+        N = networkx.from_rdfgraph(G, create_using=None)
+        assert_true(networkx.bipartite.is_bipartite(N),
+                    'Returns bipartite representation')
+
+        statements = [n for n in N.nodes(data=True) if n[1]['bipartite'] == 0]
+        nodes = [n for n in N.nodes(data=True) if n[1]['bipartite'] == 1]
+
+        assert_equals(len(statements), 5, 'Number of statements')
+        assert_equals(len(nodes), 10, 'Number of unique nodes')
+        [assert_true(s[0][0] == 's',
+                     'Correct statement node id prefix') for s in statements]
+        [assert_true(n[0] in range(10), 'Correct node id') for n in nodes]
+
+        # directed labeled multigraph representation
+        N = networkx.from_rdfgraph(G, create_using=networkx.MultiDiGraph())
+        assert_true(N.is_directed(), 'Returns directed representation')
+        assert_true(N.is_multigraph(), 'Returns multigraph representation')
+
+        nodes = N.nodes(data=True)
+
+        assert_equals(len(nodes), 6, 'Number of unique nodes')
+        [assert_true(n[0] in range(10), 'Correct node id') for n in nodes]
+
+    def test_read_rdf(self):
+        try:
+            import rdflib
+        except ImportError:
+            raise SkipTest('rdflib not available.')
+
+        fh = io.BytesIO(self.simple_data.encode('UTF-8'))
+        fh.seek(0)
+
+        assert_raises(rdflib.plugin.PluginException,
+                      networkx.read_rdf,
+                      fh,
+                      format='does not exist')
+
+        assert_true(type(networkx.read_rdf(fh,
+                                           create_using=None,
+                                           format='nt')) is networkx.Graph,
+                    'Returns NetworkX graph')

--- a/networkx/readwrite/tests/test_rdf.py
+++ b/networkx/readwrite/tests/test_rdf.py
@@ -11,6 +11,13 @@ from nose.tools import assert_equals, assert_raises, assert_true
 
 
 class TestRdf():
+    @classmethod
+    def setupClass(cls):
+        try:
+            rdflib = rdf._rdflib()
+        except ImportError:
+            raise SkipTest('rdflib is not available')
+
     def setUp(self):
         self.simple_data = """<http://www.w3.org/2001/08/rdf-test/> <http://purl.org/dc/elements/1.1/creator>   "Dave Beckett" .
 <http://www.w3.org/2001/08/rdf-test/> <http://purl.org/dc/elements/1.1/creator>   "Jan Grant" .
@@ -44,7 +51,7 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
 <Node rdf:ID="n1" rgml:weight="0.1" rgml:label="http://www.w3.org/Home/Lassila"/>
 <Node rdf:ID="n2" rgml:weight="0.5" rgml:label="Ora Lassila"/>
 
-<Edge rdf:ID="e1" rgml:weight="1" rgml:label="Creator">
+<Edge rdf:ID="e1" rgml:weight="1">
     <source rdf:resource="#n1"/>
     <target rdf:resource="#n2"/>
 </Edge>
@@ -70,15 +77,54 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
         assert_equals(len(N), 2, 'Number of nodes')
         assert_equals(len(N.edges()), 1, 'Number of edges')
 
+        namespace = 'http://purl.org/puninj/2001/05/rgml-schema#'
+        rgml = rdflib.Namespace(namespace)
+        G.bind('rgml', str(rgml))
+
+        # mixed graph
+        graph_node = G.value(predicate=rdflib.RDF.type,
+                             object=rgml.Graph,
+                             any=False)
+        G.add((graph_node, rgml.directed, rdflib.term.Literal(False)))
+        G.add((graph_node, rgml.directed, rdflib.term.Literal(True)))
+        with assert_raises(NetworkXError) as e:
+            networkx.from_rgmlgraph(G)
+        assert_equals(e.exception.message, 'from_rgmlgraph() does not support mixed graphs ', 'Mixed graph')
+        G.remove((graph_node, rgml.directed, rdflib.term.Literal(False)))
+        G.remove((graph_node, rgml.directed, rdflib.term.Literal(True)))
+
+        # Nested graph
+        graph_node = rdflib.term.BNode()
+        G.add((graph_node, rdflib.RDF.type, rgml.Graph))
+        with assert_raises(NetworkXError) as e:
+            networkx.from_rgmlgraph(G)
+        assert_equals(e.exception.message, 'from_rgmlgraph() does not support nested graphs ', 'Nested/multiple graphs')
+        G.remove((graph_node, rdflib.RDF.type, rgml.Graph))
+
+        # hypergraph
+        hyperedge_node = rdflib.term.BNode()
+        seq_node = rdflib.term.BNode()
+        node1_node = rdflib.term.BNode()
+        node2_node = rdflib.term.BNode()
+        node3_node = rdflib.term.BNode()
+        G.add((hyperedge_node, rgml.nodes, seq_node))
+        G.add((seq_node, rdflib.RDF.li, node1_node))
+        G.add((seq_node, rdflib.RDF.li, node2_node))
+        G.add((seq_node, rdflib.RDF.li, node3_node))
+        G.add((hyperedge_node, rdflib.RDF.type, rgml.Edge))
+        G.add((node1_node, rdflib.RDF.type, rgml.Node))
+        G.add((node2_node, rdflib.RDF.type, rgml.Node))
+        G.add((node3_node, rdflib.RDF.type, rgml.Node))
+        G.add((seq_node, rdflib.RDF.type, rdflib.RDF.Seq))
+        with assert_raises(NetworkXError) as e:
+            networkx.from_rgmlgraph(G)
+        assert_equals(e.exception.message, 'from_rgml() does not support hypergraphs ', 'Hypergraphs')
+        
     def test_from_rdfgraph(self):
         fh = io.BytesIO(self.simple_data.encode('UTF-8'))
         fh.seek(0)
 
-        try:
-            import rdflib
-        except ImportError:
-            raise SkipTest('rdflib not available.')
-
+        rdflib = rdf._rdflib()
         G = rdflib.Graph()
         G.load(fh, format='nt')
 
@@ -131,19 +177,24 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
 
         # generic graph representation
         N = networkx.barabasi_albert_graph(100, 1, 0)
+        N.label = 'RGML Graph'
+        for n in N:
+            N.node[n]['label'] = n
+            N.node[n]['weight'] = n
+            N.node[n]['some other attribute'] = n
+        for i, (u, v) in enumerate(N.edges()):
+            N.edge[u][v]['label'] = i
+            N.edge[u][v]['weight'] = i
+            N.edge[u][v]['some other attribute'] = i
         G1 = networkx.to_rdfgraph(N)
         assert_true('rgml' in [str(x[0]) for x in G1.namespaces()],
                     'NetworkX generated graph in RGML namespace')
         
     def test_read_rdf(self):
-        try:
-            import rdflib
-        except ImportError:
-            raise SkipTest('rdflib not available.')
-
         fh = io.BytesIO(self.simple_data.encode('UTF-8'))
         fh.seek(0)
 
+        rdflib = rdf._rdflib()
         assert_raises(rdflib.plugin.PluginException,
                       networkx.read_rdf,
                       fh,
@@ -154,3 +205,40 @@ _:a                                   <http://purl.org/dc/elements/1.1/source>  
                                            format='nt')) is networkx.Graph,
                     'Returns NetworkX graph')
 
+
+    def test_write_rdf(self):
+        fh=io.BytesIO()
+        networkx.write_rdf(networkx.barabasi_albert_graph(100,1,0), fh, format='n3')
+        fh.seek(0)
+        assert_true(isinstance(networkx.read_rdf(fh, format='n3'),
+                               networkx.Graph),
+                    'Roundtrip NX <-> RDF in N3 format')
+
+    def test_write_rgml(self):
+        fh=io.BytesIO()
+        networkx.write_rgml(networkx.barabasi_albert_graph(100,1,0), fh, format='n3')
+        fh.seek(0)
+        assert_true(isinstance(networkx.read_rgml(fh, format='n3'),
+                               networkx.Graph),
+                    'Roundtrip NX <-> RDF in N3 format')
+
+    def test__relabel(self):
+        N = networkx.Graph()
+        N.add_nodes_from([(0, {'label':'a'}), (1, {'label':'a'})])
+        assert_raises(NetworkXError,
+                      rdf._relabel,
+                      N)
+
+    def test__rdflib(self):
+        try:
+            import builtins
+        except ImportError:
+            import __builtin__ as builtins
+
+        realimport = builtins.__import__
+
+        def myimport(a, b, c, d):
+            raise ImportError
+        builtins.__import__ = myimport
+        assert_raises(ImportError, rdf._rdflib)
+        builtins.__import__ = realimport


### PR DESCRIPTION
Read and write graphs in [RDF](https://www.w3.org/RDF/) format. Requires [rdflib](https://github.com/RDFLib/rdflib). This module adds 8 new functions:
- [from_rgmlgraph](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L280)
- [to_rgmlgraph](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L342)
- [read_rgml](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L392)
- [write_rgml](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L424)
- [from_rdfgraph](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L456)
- [to_rdfgraph](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L542)
- [read_rdf](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L579)
- [write_rdf](https://github.com/pedros/networkx/blob/readwrite/rdf/networkx/readwrite/rdf.py#L608)

It can load arbitrary RDF graphs, or RGML-namespaced graphs. [RGML](https://www.cs.rpi.edu/research/groups/pb/punin/public_html/RGML/) is the RDF Graph Modeling Language, an RDF ontology for generic graphs.

For arbitrary RDF graphs, it can represent them as multiple directed labeled graphs as per the RDF specification, with terms that occur as subject/object and, later on, as a predicate, being reified multiple times. Since this is not optimal for connectivity analyses, it also recognizes that RDF graphs are, in fact, hypergraphs, and as such represents them as bipartite graphs where each node in one partition has 3 edges pointing to subject, predicate, and object nodes in the other partition.

For more information, see [Hayes, J. (2004). A graph model for RDF. Technische Universität Darmstadt](http://www.dcc.uchile.cl/~cgutierr/papers/rdfgraphmodel.pdf)

All serialization formats supported by `rdflib` are supported, currently:
- [RDF/XML](http://www.w3.org/TR/rdf-syntax-grammar/)
- [Notation 3](http://www.w3.org/TeamSubmission/n3/)
- [Turtle](http://www.w3.org/TeamSubmission/turtle/)
- [N-Triples](http://www.w3.org/TR/rdf-testcases/#ntriples)
- [Trix](https://www.hpl.hp.com/techreports/2004/HPL-2004-56)
