### PR TITLE
Don't copy subgraphs in cuthill_mckee_ordering().

### DIFF
--- a/networkx/utils/rcm.py
+++ b/networkx/utils/rcm.py
@@ -55,8 +55,8 @@ def cuthill_mckee_ordering(G, start=None):
     .. [2]  Steven S. Skiena. 1997. The Algorithm Design Manual. 
        Springer-Verlag New York, Inc., New York, NY, USA.
     """
-    for g in nx.connected_component_subgraphs(G):
-        for n in connected_cuthill_mckee_ordering(g, start):
+    for c in nx.connected_components(G):
+        for n in connected_cuthill_mckee_ordering(G.subgraph(c), start):
             yield n
 
 def reverse_cuthill_mckee_ordering(G, start=None):


### PR DESCRIPTION
The connected_component_subgraphs() function used in the cuthill_mckee_ordering() makes a copy.  That causes new node objects to be created which might not be desirable when returning a node ordering if the hash changes when a new object is created. 

The fix is to not copy nodes when forming a subgraph of connected nodes.

This fixes a bug identified in the stackoverflow question 
http://stackoverflow.com/questions/15451289/python-networkx-cannot-use-current-flow-betweenness-centrality-function/

Example that shows the problem:

``` python
import networkx as nx

g=nx.Graph()
a=object()
b=object()
c=object()
d=object()
g.add_edge(a,b,{'distance': 4.0})
g.add_edge(a,c,{'distance': 1.5})
g.add_edge(b,c,{'distance': 2.2})
g.add_edge(c,d,{'distance': 2.6})
result = nx.current_flow_betweenness_centrality(g, weight='distance')
```
