### PR TITLE
Added option to return negative cycles from Bellman-Ford algorithm.

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from nose.tools import *
 import networkx as nx
+import sys
 
 class TestWeightedPath:
 
@@ -188,10 +189,18 @@ class TestWeightedPath:
         G.add_edge(1, 2, weight = -7)
         for i in range(5):
             assert_raises(nx.NetworkXUnbounded, nx.bellman_ford, G, i)
+            
+        # negative weight cycle that user asks for
+        G = nx.cycle_graph(5, create_using = nx.DiGraph())
+        G.add_edge(1, 2, weight = -7)
+        assert_equal(nx.bellman_ford(G, 0, return_negative_cycle=True), 
+            ({0: 4, 1: 0, 2: 1, 3: 2, 4: 3}, {0: -3, 1: 1, 2: -6, 3: -5, 4: -4}))
+            
         G = nx.cycle_graph(5)  # undirected Graph
         G.add_edge(1, 2, weight = -3)
         for i in range(5):
             assert_raises(nx.NetworkXUnbounded, nx.bellman_ford, G, i)
+        
         # no negative cycle but negative weight
         G = nx.cycle_graph(5, create_using = nx.DiGraph())
         G.add_edge(1, 2, weight = -3)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -489,7 +489,7 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
                                              weight=weight)
     return paths
 
-def bellman_ford(G, source, weight = 'weight'):
+def bellman_ford(G, source, weight = 'weight', return_negative_cycle = False):
     """Compute shortest path lengths and predecessors on shortest paths
     in weighted graphs.
 
@@ -508,6 +508,10 @@ def bellman_ford(G, source, weight = 'weight'):
 
     weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight
+    
+    return_negative_cycle: boolean, optional (default=False)
+       If a negative cycle is detected, return the path instead of
+       thowing an Exception.
 
     Returns
     -------
@@ -581,6 +585,8 @@ def bellman_ford(G, source, weight = 'weight'):
         if no_changes:
             break
     else:
+        if return_negative_cycle:
+            return pred, dist
         raise nx.NetworkXUnbounded("Negative cost cycle detected.")
     return pred, dist
 


### PR DESCRIPTION
This patch adds an option to return the results of the Bellman-Ford algorithm when negative weight cycles are detected.

One of the advantages of the Bellman-Ford algorithm is its ability to detect negative-weight cycles in a directed graph. http://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm

Currently Networkx raises an exception when a negative weight cycle is detected. However, in some problems (the one I'm looking at has to do with foreign currency arbitrage) it is useful to identify the negative weight cycles and the paths that cause them. Currently, there are no facilities in Networkx to do this.

This change should not impact user code at all, because it adds a default keyword argument to an existing function. The function will return the same output as before in the default case, and similar output to before in the case where the option is turned on. New tests added and all tests pass.
