### PR TITLE
Main changes to add node and edge filtering capacity to simple_cycles

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -115,7 +115,7 @@ def simple_cycles(G,list_of_nodes=[],list_of_edges=[]):
     Returns
     -------
     A list of circuits, where each circuit is a list of nodes, with the first
-    and last node being the same. The list of circuit can be negatively 
+    and last node being the same. The list of circuits can be negatively 
     filtered by nodes (only circuits NOT containing the nodes defined in 
     list_of_nodes are included in the results) or positively filtered by edges 
     (only circuits containing the edges defined in list_of_edges are included
@@ -172,15 +172,17 @@ def simple_cycles(G,list_of_nodes=[],list_of_edges=[]):
             elif not blocked[nextnode]:
                 if circuit(nextnode, startnode, component):
                     closed = True
-            # Filter out the cycles containing an edge from list_of_edges           
+            # Pop out the cycles NOT containing an edge from list_of_edges           
             if result != [] and list_of_edges != []:
                 for edge in list_of_edges:
                     if not contains_sequence(result[len(result)-1],edge):
                         result.pop(len(result)-1)
-                    # if it is not a directed graph, also remove cycles containing
+                        break
+                    # if it is not a directed graph, pop out cycles containing
                     # the edge inverse.
                     if not G.is_directed() and not contains_sequence(result[len(result)-1],edge.reverse()):
                         result.pop(len(result)-1)
+                        break
         if closed:
             _unblock(thisnode)
         else:


### PR DESCRIPTION
I modified the simple_cycles algorithm because I was getting a MemoryError due to the size of the result array (I was studying (almost) complete digraphs which are the worst case for simple cycles since (almost) all of cycles exists. The biggest complete digraph for which all cycles can be found in a 32-bit machine is an 11 node one; a 12 node one raises a MemoryError). However, I did not require all simple cycles but only some: the ones going through specific nodes or edges: that is the main idea behind this modification . Thus, I  modified simple_cycles accordingly, so that now you can filter the results either by providing a list of nodes AND/ OR a list of edges. The node filter is negative (cycles containing the defined nodes do not appear in result) and edges are positively filtered (one cycles containing _all_ the defined edge(s) are included in results).

So, the outcome of this modification is a refined search of the simple cycles within a graph, either by avoiding specific nodes or by filtering cycles containing specific edges.

Consequently, in both cases, the size of the result is lower due to the filtering, enabling to analyse bigger graphs or to make quicker searches (providing a node list speeds up the calculation since the search bypasses the predefined nodes; the edge filtering does not reduce cpu time).

The code seems to work for digraphs. I also added some code for the case of undirected graphs to generalise the edge definition. I am however not sure whether simple_cycles is supposed to deal with undirected graph, if not, please discard the modification https://github.com/Friedsoap/networkx/commit/e7edff2cc54587b092b5207b1cf3f0c2fff14fe6
