### PR TITLE
Added new generator function equivalent to simple_cycles

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -192,3 +192,110 @@ def simple_cycles(G):
                 B[node][:] = []
             dummy=circuit(startnode, startnode, component)
     return result
+
+@not_implemented_for('undirected')
+def simple_cycles_generator(G):
+    """Generator function of all simple cycles (elementary circuits) of a 
+    directed graph.
+
+    A simple cycle, or elementary circuit, is a closed path where no
+    node appears twice, except that the first and last node are the same.
+    Two elementary circuits are distinct if they are not cyclic permutations
+    of each other.
+
+    Parameters
+    ----------
+    G : NetworkX DiGraph
+       A directed graph
+
+    Returns
+    -------
+    Does not return a specific array but a generator iterable which are 
+    well suited to avoid memory errors (because they do not find all cycles at
+    once, but one after the other). The generator can easily build a list but
+    its main advantage is that only one cycle is provided until next iteration
+    is triggered.
+
+    Example:
+    >>> G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
+    >>> [cycle for cycle in nx.simple_cycles_generator(G)]
+    [[0, 0], [0, 1, 2, 0], [0, 2, 0], [1, 2, 1], [2, 2]]
+
+    See Also
+    --------
+    cycle_basis (for undirected graphs)
+
+    Notes
+    -----
+    The implementation follows pp. 79-80 in [1]_.
+
+    The time complexity is O((n+e)(c+1)) for n nodes, e edges and c
+    elementary circuits.
+
+    References
+    ----------
+    .. [1] Finding all the elementary circuits of a directed graph.
+       D. B. Johnson, SIAM Journal on Computing 4, no. 1, 77-84, 1975.
+       http://dx.doi.org/10.1137/0204007
+
+    See Also
+    --------
+    cycle_basis
+    """
+    # Jon Olav Vik, 2010-08-09
+    def _unblock(thisnode):
+        """Recursively unblock and remove nodes from B[thisnode]."""
+        if blocked[thisnode]:
+            blocked[thisnode] = False
+            while B[thisnode]:
+                _unblock(B[thisnode].pop())
+
+    def circuit(thisnode, startnode, component):
+        closed = False # set to True if elementary path is closed
+        path.append(thisnode)
+        blocked[thisnode] = True
+        for nextnode in component[thisnode]: # direct successors of thisnode
+            if nextnode == startnode:
+                yield path + [startnode]
+                closed = True
+            elif not blocked[nextnode]:
+                for cycle in circuit(nextnode, startnode, component):
+                    yield cycle
+                    closed = True
+        if closed:
+            _unblock(thisnode)
+        else:
+            for nextnode in component[thisnode]:
+                if thisnode not in B[nextnode]: # TODO: use set for speedup?
+                    B[nextnode].append(thisnode)
+        path.pop() # remove thisnode from path
+        return
+
+    path = [] # stack of nodes in current path
+    blocked = defaultdict(bool) # vertex: blocked from search?
+    B = defaultdict(list) # graph portions that yield no elementary circuit
+    # in the generator function, no need to define a result array    
+    #result = [] # list to accumulate the circuits found
+    # Johnson's algorithm requires some ordering of the nodes.
+    # They might not be sortable so we assign an arbitrary ordering.
+    ordering=dict(zip(G,range(len(G))))
+    for s in ordering:
+        # Build the subgraph induced by s and following nodes in the ordering
+        subgraph = G.subgraph(node for node in G
+                              if ordering[node] >= ordering[s])
+        # Find the strongly connected component in the subgraph
+        # that contains the least node according to the ordering
+        strongcomp = nx.strongly_connected_components(subgraph)
+        mincomp=min(strongcomp,
+                    key=lambda nodes: min(ordering[n] for n in nodes))
+        component = G.subgraph(mincomp)
+        if component:
+            # smallest node in the component according to the ordering
+            startnode = min(component,key=ordering.__getitem__)
+            for node in component:
+                blocked[node] = False
+                B[node][:] = []
+            circuit_gen = circuit(startnode, startnode, component)
+            for cycle in circuit_gen:
+                yield cycle
+    return


### PR DESCRIPTION
This pull request implements a new generator function which is equivalent to simple_cycles (called simple_cycles_generator). The idea sparked when trying to speed up the function in https://github.com/networkx/networkx/pull/874 and the use of a generator function as a means to to avoid memory errors for graphs with lots of cycles was also suggested in https://github.com/networkx/networkx/pull/888.

The original algorithm is recursive and the transformation into a generator function preserves the recursive structure. (For an example of a recursive generator structure, see http://stackoverflow.com/questions/6694404/help-understanding-how-this-recursive-python-function-works/6694827#6694827).

Any comments on the code are most welcome. 

Also, I would like to add the filtering options implemented in https://github.com/networkx/networkx/pull/888 to this new generator function but I am not sure how it works regarding the work flow. Here, I just implemented the generator function mimicking the original algorithm, should I create another branch for the generator function with filtering options? or is it maintainer work to do this kind of merging? 
