### PR TITLE
Non-recursive and faster simple_cycles

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -122,7 +122,7 @@ def simple_cycles(G):
     --------
     >>> G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
     >>> list(nx.simple_cycles(G))
-    [[0], [0, 1, 2], [0, 2], [1, 2], [2]]
+    [[0, 0], [0, 1, 2, 0], [0, 2, 0], [1, 2, 1], [2, 2]]
 
     Notes
     -----
@@ -137,7 +137,7 @@ def simple_cycles(G):
     >>> copyG.remove_nodes_from([1])
     >>> copyG.remove_edges_from([(0,1)])
     >>> list(nx.simple_cycles(G)
-    [[0], [0, 2], [2]]
+    [[0, 0], [0, 2, 0], [2, 2]]
 
     References
     ----------
@@ -171,9 +171,9 @@ def simple_cycles(G):
     subG=G.copy()   # save the actual graph so we can mutate it here
     sccs = nx.strongly_connected_components(subG)
     while sccs:
-        scc=sccs.pop(0)
+        scc=sccs.pop()
         # order of scc determines ordering of nodes
-        startnode = scc.pop(0)
+        startnode = scc.pop()
         # Processing node runs "circuit" routine from recursive version
         path=[startnode]
         blocked = set() # vertex: blocked from search?
@@ -188,7 +188,7 @@ def simple_cycles(G):
 #                    print thisnode,nbrs,":",nextnode,blocked,B,path,stack,startnode
 #                    f=raw_input("pause")
                 if nextnode == startnode:
-                    yield path[:]
+                    yield path + [startnode]
                     closed.update(path)
 #                        print "Found a cycle",path,closed
                 elif nextnode not in blocked:
@@ -276,7 +276,7 @@ def recursive_simple_cycles(G):
         blocked[thisnode] = True
         for nextnode in component[thisnode]: # direct successors of thisnode
             if nextnode == startnode:
-                result.append(path[:])
+                result.append(path + [startnode])
                 closed = True
             elif not blocked[nextnode]:
                 if circuit(nextnode, startnode, component):

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -49,9 +49,9 @@ class TestCycles:
     def test_simple_cycles(self):
         G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
         c=sorted(nx.simple_cycles(G))
-        ca=[[0], [0, 1, 2], [0, 2], [1, 2], [2]]
+        ca=[[0, 0], [0, 1, 2, 0], [0, 2, 0], [1, 2, 1], [2, 2]]
         for (a,b) in zip(c,ca):
-            assert_true(self.is_cyclic_permutation(a,b))
+            assert_true(self.is_cyclic_permutation(a[:-1],b[:-1]))
 
     @raises(nx.NetworkXNotImplemented)
     def test_simple_cycles_graph(self):
@@ -68,12 +68,13 @@ class TestCycles:
         G = nx.DiGraph()
         G.add_path([1,2,3,1])
         c=sorted(nx.simple_cycles(G))
-        assert_equal(c,[[1,2,3]])
+        assert_equal(len(c),1)
+        assert_true(self.is_cyclic_permutation(c[0][:-1],[1,2,3]))
         G.add_path([10,20,30,10])
         c=sorted(nx.simple_cycles(G))
-        ca=[[1,2,3],[10,20,30]]
+        ca=[[1,2,3,1],[10,20,30,10]]
         for (a,b) in zip(c,ca):
-            assert_true(self.is_cyclic_permutation(a,b))
+            assert_true(self.is_cyclic_permutation(a[:-1],b[:-1]))
 
     def test_simple_cycles_empty(self):
         G = nx.DiGraph()
@@ -118,4 +119,4 @@ class TestCycles:
             rcc=sorted(nx.recursive_simple_cycles(G))
             assert_equal(len(cc),len(rcc))
             for c in cc:
-                assert_true(any(self.is_cyclic_permutation(c,rc) for rc in rcc))
+                assert_true(any(self.is_cyclic_permutation(c[:-1],rc[:-1]) for rc in rcc))


### PR DESCRIPTION
Copied simple_cycles to recursive_simple_cycles and added a new
simple_cycles that is the same algorithm but not recursive.  Two
changes in the API for simple_cycle are that
1) it now returns a generator instead of returning a list.
2) Cycles no longer repeat the first node as the last.  The last
node in the list is assumed to connect to the first node on the list.

Tests added to compare output of simple_cycles and recursive_simple_cycles

Thanks to erikasantos and friedsoap for instigating this and suggesting
helpful changes (which I incorporated).  This addresses #874 #888 #889
