### PR TITLE
Format cycles from simple_cycles w/o last node

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -122,7 +122,7 @@ def simple_cycles(G):
     --------
     >>> G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
     >>> list(nx.simple_cycles(G))
-    [[0, 0], [0, 1, 2, 0], [0, 2, 0], [1, 2, 1], [2, 2]]
+    [[2], [2, 1], [2, 0], [2, 0, 1], [0]]
 
     Notes
     -----
@@ -136,8 +136,8 @@ def simple_cycles(G):
     >>> copyG = G.copy()
     >>> copyG.remove_nodes_from([1])
     >>> copyG.remove_edges_from([(0,1)])
-    >>> list(nx.simple_cycles(G)
-    [[0, 0], [0, 2, 0], [2, 2]]
+    >>> list(nx.simple_cycles(copyG))
+    [[2], [2, 0], [0]]
 
     References
     ----------
@@ -188,7 +188,7 @@ def simple_cycles(G):
 #                    print thisnode,nbrs,":",nextnode,blocked,B,path,stack,startnode
 #                    f=raw_input("pause")
                 if nextnode == startnode:
-                    yield path + [startnode]
+                    yield path[:]
                     closed.update(path)
 #                        print "Found a cycle",path,closed
                 elif nextnode not in blocked:
@@ -238,8 +238,8 @@ def recursive_simple_cycles(G):
 
     Example:
     >>> G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
-    >>> nx.simple_cycles(G)
-    [[0, 0], [0, 1, 2, 0], [0, 2, 0], [1, 2, 1], [2, 2]]
+    >>> nx.recursive_simple_cycles(G)
+    [[0], [0, 1, 2], [0, 2], [1, 2], [2]]
 
     See Also
     --------
@@ -276,7 +276,7 @@ def recursive_simple_cycles(G):
         blocked[thisnode] = True
         for nextnode in component[thisnode]: # direct successors of thisnode
             if nextnode == startnode:
-                result.append(path + [startnode])
+                result.append(path[:])
                 closed = True
             elif not blocked[nextnode]:
                 if circuit(nextnode, startnode, component):

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 class TestCycles:
     def setUp(self):
-        G=networkx.Graph() 
+        G=networkx.Graph()
         G.add_cycle([0,1,2,3])
         G.add_cycle([0,3,4,5])
         G.add_cycle([0,1,6,7,8])
@@ -31,7 +31,7 @@ class TestCycles:
         sort_cy= sorted( sorted(c) for c in cy )
         assert_equal(sort_cy, [[0,1,2,3],[0,1,6,7,8],[0,3,4,5]])
         # test disconnected graphs
-        G.add_cycle(list("ABC")) 
+        G.add_cycle(list("ABC"))
         cy=networkx.cycle_basis(G,9)
         sort_cy= sorted(sorted(c) for c in cy[:-1]) + [sorted(cy[-1])]
         assert_equal(sort_cy, [[0,1,2,3],[0,1,6,7,8],[0,3,4,5],['A','B','C']])
@@ -48,10 +48,10 @@ class TestCycles:
 
     def test_simple_cycles(self):
         G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
-        c=sorted(nx.simple_cycles(G))
-        ca=[[0, 0], [0, 1, 2, 0], [0, 2, 0], [1, 2, 1], [2, 2]]
-        for (a,b) in zip(c,ca):
-            assert_true(self.is_cyclic_permutation(a[:-1],b[:-1]))
+        cc=sorted(nx.simple_cycles(G))
+        ca=[[0], [0, 1, 2], [0, 2], [1, 2], [2]]
+        for c in cc:
+            assert_true(any(self.is_cyclic_permutation(c,rc) for rc in ca))
 
     @raises(nx.NetworkXNotImplemented)
     def test_simple_cycles_graph(self):
@@ -66,15 +66,15 @@ class TestCycles:
 
     def test_simple_cycles_small(self):
         G = nx.DiGraph()
-        G.add_path([1,2,3,1])
+        G.add_cycle([1,2,3])
         c=sorted(nx.simple_cycles(G))
         assert_equal(len(c),1)
-        assert_true(self.is_cyclic_permutation(c[0][:-1],[1,2,3]))
-        G.add_path([10,20,30,10])
-        c=sorted(nx.simple_cycles(G))
-        ca=[[1,2,3,1],[10,20,30,10]]
-        for (a,b) in zip(c,ca):
-            assert_true(self.is_cyclic_permutation(a[:-1],b[:-1]))
+        assert_true(self.is_cyclic_permutation(c[0],[1,2,3]))
+        G.add_cycle([10,20,30])
+        cc=sorted(nx.simple_cycles(G))
+        ca=[[1,2,3],[10,20,30]]
+        for c in cc:
+            assert_true(any(self.is_cyclic_permutation(c,rc) for rc in ca))
 
     def test_simple_cycles_empty(self):
         G = nx.DiGraph()
@@ -119,4 +119,4 @@ class TestCycles:
             rcc=sorted(nx.recursive_simple_cycles(G))
             assert_equal(len(cc),len(rcc))
             for c in cc:
-                assert_true(any(self.is_cyclic_permutation(c[:-1],rc[:-1]) for rc in rcc))
+                assert_true(any(self.is_cyclic_permutation(c,rc) for rc in rcc))


### PR DESCRIPTION
Cycles in networkx are represented by a list of nodes.  But
simple_cycles() repeated the last node of the cycle.  This removes
that repetition to bring simple_cycles in line with other cycle
routines.  Related discussion in #889, #890.

Also corrected some doctests and updated tests for this change.
