### PR TITLE
Make sure graph is connected in test_edge_cutset_random_graphs

### DIFF
--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -11,7 +11,7 @@ def _generate_no_biconnected(max_attempts=50):
             yield G
         else:
             if attempts >= max_attempts:
-                msg = "Tried %d times: no suitable Graph."
+                msg = "Tried %d times: no suitable Graph."%attempts
                 raise Exception(msg % max_attempts)
             else:
                 attempts += 1
@@ -138,6 +138,10 @@ def test_node_cutset_random_graphs():
 def test_edge_cutset_random_graphs():
     for i in range(5):
         G = nx.fast_gnp_random_graph(50,0.2)
+        if not nx.is_connected(G):
+            ccs = iter(nx.connected_components(G))
+            start = next(ccs)[0]
+            G.add_edges_from( (start,c[0]) for c in ccs )
         cutset = nx.minimum_edge_cut(G)
         assert_equal(nx.edge_connectivity(G), len(cutset))
         G.remove_edges_from(cutset)


### PR DESCRIPTION
Still possible for test_articulation_points to fail due to 50 random graphs in a row that aren't biconnected.  But I'll wait to fix that until it happens.
