### PR TITLE
Add the option to export the incidence matrix in sparse format

### DIFF
--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -1,7 +1,7 @@
 """
 Adjacency matrix and incidence matrix of graphs.
 """
-#    Copyright (C) 2004-2011 by 
+#    Copyright (C) 2004-2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -17,38 +17,41 @@ __all__ = ['incidence_matrix',
            ]
 
 
-def incidence_matrix(G, nodelist=None, edgelist=None, 
-                     oriented=False, weight=None):
+def incidence_matrix(G, nodelist=None, edgelist=None,
+                     oriented=False, weight=None, sparse=False):
     """Return incidence matrix of G.
 
     The incidence matrix assigns each row to a node and each column to an edge.
-    For a standard incidence matrix a 1 appears wherever a row's node is 
+    For a standard incidence matrix a 1 appears wherever a row's node is
     incident on the column's edge.  For an oriented incidence matrix each
     edge is assigned an orientation (arbitrarily for undirected and aligning to
-    direction for directed).  A -1 appears for the tail of an edge and 1 
+    direction for directed).  A -1 appears for the tail of an edge and 1
     for the head of the edge.  The elements are zero otherwise.
-    
+
     Parameters
     ----------
     G : graph
-       A NetworkX graph 
+       A NetworkX graph
 
     nodelist : list, optional   (default= all nodes in G)
        The rows are ordered according to the nodes in nodelist.
        If nodelist is None, then the ordering is produced by G.nodes().
 
-    edgelist : list, optional (default= all edges in G) 
+    edgelist : list, optional (default= all edges in G)
        The columns are ordered according to the edges in edgelist.
        If edgelist is None, then the ordering is produced by G.edges().
 
     oriented: bool, optional (default=False)
-       If True, matrix elements are +1 or -1 for the head or tail node 
+       If True, matrix elements are +1 or -1 for the head or tail node
        respectively of each edge.  If False, +1 occurs at both nodes.
 
     weight : string or None, optional (default=None)
        The edge data key used to provide each value in the matrix.
        If None, then each edge has weight 1.  Edge weights, if used,
        should be positive so that the orientation can provide the sign.
+
+    sparse : bool, optional (default=False)
+        If True, matrix returned is in sparse format.
 
     Returns
     -------
@@ -57,10 +60,10 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
 
     Notes
     -----
-    For MultiGraph/MultiDiGraph, the edges in edgelist should be 
+    For MultiGraph/MultiDiGraph, the edges in edgelist should be
     (u,v,key) 3-tuples.
 
-    "Networks are the best discrete model for so many problems in 
+    "Networks are the best discrete model for so many problems in
     applied mathematics" [1]_.
 
     References
@@ -73,6 +76,12 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
     except ImportError:
         raise ImportError(
           "incidence_matrix() requires numpy: http://scipy.org/ ")
+    if sparse:
+        try:
+            import scipy.sparse as sparse
+        except ImportError:
+            raise ImportError(
+            "Sparse output requires numpy: http://scipy.org/ ")
     if nodelist is None:
         nodelist = G.nodes()
     if edgelist is None:
@@ -80,7 +89,10 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
             edgelist = G.edges(keys=True)
         else:
             edgelist = G.edges()
-    A = np.zeros((len(nodelist),len(edgelist)))
+    if sparse:
+        A = sparse.lil_matrix((len(nodelist),len(edgelist)))
+    else:
+        A = np.zeros((len(nodelist),len(edgelist)))
     node_index = dict( (node,i) for i,node in enumerate(nodelist) )
     for ei,e in enumerate(edgelist):
         (u,v) = e[:2]
@@ -105,7 +117,10 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
         else:
             A[ui,ei] = wt
             A[vi,ei] = wt
-    return np.asmatrix(A)
+    if sparse:
+        return A
+    else:
+        return np.asmatrix(A)
 
 def adjacency_matrix(G, nodelist=None, weight='weight'):
     """Return adjacency matrix of G.
@@ -113,9 +128,9 @@ def adjacency_matrix(G, nodelist=None, weight='weight'):
     Parameters
     ----------
     G : graph
-       A NetworkX graph 
+       A NetworkX graph
 
-    nodelist : list, optional       
+    nodelist : list, optional
        The rows and columns are ordered according to the nodes in nodelist.
        If nodelist is None, then the ordering is produced by G.nodes().
 


### PR DESCRIPTION
The incidence matrix is huge in size (#nodes x #edges) but really sparse, since there are only two non-zeros elements per column. The way the code is right now does not allow to export the incidence matrix of a large graph (million nodes by million edges) as it initializes the result as a dense matrix full of zeros. However, using a sparse representation, as the one in scipy.sparse.lil_matrix, would make it work.
