### PR TITLE
Add all decorator modules to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,8 @@ include networkx/*/*/tests/*.py
 include networkx/*/*/tests/*.A99
 include networkx/*/*/tests/*.B99
 
+include networkx/external/decorator/*/*.py
+
 global-exclude *~
 global-exclude *.pyc
 global-exclude .svn


### PR DESCRIPTION
Currently networkx-1.8 source distributions contains only decorator2, but not decorator3 modules (depends on python version when making sdist).
