### PR TITLE
Fixes #928

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -276,7 +276,7 @@ class GEXFWriter(GEXF):
 
     def add_graph(self, G):
         # set graph attributes
-        if G.graph['mode']=='dynamic':
+        if G.graph.get('mode')=='dynamic':
             mode='dynamic'
         else:
             mode='static'

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -265,6 +265,10 @@ class TestGEXF(object):
         assert_equal(
             sorted(sorted(e) for e in G.edges()),
             sorted(sorted(e) for e in H.edges()))
+        # Reading a gexf graph always sets mode attribute to either 
+        # 'static' or 'dynamic'. Remove the mode attribute from the
+        # read graph for the sake of comparing remaining attributes.
+        del H.graph['mode']
         assert_equal(G.graph,H.graph)
 
     def test_serialize_ints_to_strings(self):


### PR DESCRIPTION
The existing implementation of `.gexf` serialization/deserialization exhibited several issues with reading and writing the graph's `mode` attribute, leading to dynamic graphs always being interpreted as static graphs.  This fix addresses these issues.  I have removed the `mode` parameter that was being passed to `GEXFWriter`'s constructor as the mode seems like an attribute that should be stored on the graph itself (which it now is) and `write_gexf` was not passing through a value for `mode` to the constructor anyway.  

There were several cases where data attributes pertaining to the mode of the graph were being defined but not used, which I've replaced with instance variables.
