### PR TITLE
Fix bug in checking minimum version for requests library in test_pr.py

### DIFF
--- a/tools/test_pr.py
+++ b/tools/test_pr.py
@@ -344,7 +344,7 @@ if __name__ == '__main__':
     # Test for requests version.
     import requests
     major, minor, rev = map(int, requests.__version__.split('.'))
-    if minor < 10:
+    if major == 0 and minor < 10:
         print("test_pr.py:")
         print("The requests python library must be version 0.10.0",
                 "or above, you have version",


### PR DESCRIPTION
The script `tools/test_pr.py` depends on the requests library >= 0.10.0. When checking for it, only minor version is considered, thus the script fails with requests >= 1.0.0.
