### PR TITLE
Use long type for GEXF with Python2 long or Python3 int.

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -196,11 +196,13 @@ class GEXF(object):
     try: # Python 3.x
         blurb = chr(1245) # just to trigger the exception
         types.extend([
+           (int, "long"),
            (str,"liststring"),
            (str,"anyURI"),
            (str,"string")])
     except ValueError: # Python 2.6+
         types.extend([
+           (long,"long"),
            (str,"liststring"),
            (str,"anyURI"),
            (str,"string"),


### PR DESCRIPTION
GEXF has a "long" integer type.  Use that for Python2 longs and the standard Python3 int.

Addresses #940
