### PR TITLE
BUG: fix test_read_LEDA on windows.

### DIFF
--- a/networkx/readwrite/tests/test_leda.py
+++ b/networkx/readwrite/tests/test_leda.py
@@ -24,12 +24,12 @@ class TestLEDA(object):
     def test_read_LEDA(self):
         data="""#header section	  \nLEDA.GRAPH \nstring\nint\n-1\n#nodes section\n5 \n|{v1}| \n|{v2}| \n|{v3}| \n|{v4}| \n|{v5}| \n\n#edges section\n7 \n1 2 0 |{4}| \n1 3 0 |{3}| \n2 3 0 |{2}| \n3 4 0 |{3}| \n3 5 0 |{7}| \n4 5 0 |{6}| \n5 1 0 |{foo}|"""
         G=nx.parse_leda(data)
-        (fd,fname)=tempfile.mkstemp()
-        fh=open(fname,'w')
-        b=fh.write(data)
-        fh.close()
-        Gin=nx.read_leda(fname)
-        assert_equal(sorted(G.nodes()),sorted(Gin.nodes()))
-        assert_equal(sorted(G.edges()),sorted(Gin.edges()))
-        os.close(fd)
-        os.unlink(fname)
+
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            fp.write(data)
+        try:
+            Gin = nx.read_leda(fp.name)
+            assert_equal(sorted(G.nodes()),sorted(Gin.nodes()))
+            assert_equal(sorted(G.edges()),sorted(Gin.edges()))
+        finally:
+            os.unlink(fp.name)


### PR DESCRIPTION
This is a fix for https://networkx.lanl.gov/trac/ticket/410, which is windows specific and is caused by the buggy re-open in text mode  on top of a created by mkstemp (which is binary).

I've fixed the bug by using the better NamedTemporaryFile available since python 2.6, and it simplifies the logic on every platform. I have included this patch in our networkx package in EPD/Canopy @ Enthought, and the test suite passes on all our supported platforms (RHEL5, OS X and Windows).
