### PR TITLE
read_pajek() shouldn't require network name

### DIFF
--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -5,14 +5,14 @@ Pajek
 Read graphs in Pajek format.
 
 This implementation handles directed and undirected graphs including
-those with self loops and parallel edges.  
+those with self loops and parallel edges.
 
 Format
 ------
 See http://vlado.fmf.uni-lj.si/pub/networks/pajek/doc/draweps.htm
 for format information.
 """
-#    Copyright (C) 2008-2011 by 
+#    Copyright (C) 2008-2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -36,7 +36,7 @@ def generate_pajek(G):
     See http://vlado.fmf.uni-lj.si/pub/networks/pajek/doc/draweps.htm
     for format information.
     """
-    if G.name=='': 
+    if G.name=='':
        name='NetworkX'
     else:
        name=G.name
@@ -48,7 +48,7 @@ def generate_pajek(G):
     yield '*vertices %s'%(G.order())
     nodes = G.nodes()
     # make dictionary mapping nodes to integers
-    nodenumber=dict(zip(nodes,range(1,len(nodes)+1))) 
+    nodenumber=dict(zip(nodes,range(1,len(nodes)+1)))
     for n in nodes:
         na=G.node.get(n,{})
         x=na.get('x',0.0)
@@ -61,7 +61,7 @@ def generate_pajek(G):
             s+=' %s %s'%(make_qstr(k),make_qstr(v))
         yield s
 
-    # write edges with attributes         
+    # write edges with attributes
     if G.is_directed():
         yield '*arcs'
     else:
@@ -84,7 +84,7 @@ def write_pajek(G, path, encoding='UTF-8'):
     G : graph
        A Networkx graph
     path : file or string
-       File or filename to write.  
+       File or filename to write.
        Filenames ending in .gz or .bz2 will be compressed.
 
     Examples
@@ -101,14 +101,14 @@ def write_pajek(G, path, encoding='UTF-8'):
         line+='\n'
         path.write(line.encode(encoding))
 
-@open_file(0,mode='rb')
-def read_pajek(path,encoding='UTF-8'):
-    """Read graph in Pajek format from path. 
+@open_file(0, mode='rb')
+def read_pajek(path, encoding='UTF-8'):
+    """Read graph in Pajek format from path.
 
     Parameters
     ----------
     path : file or string
-       File or filename to write.  
+       File or filename to write.
        Filenames ending in .gz or .bz2 will be uncompressed.
 
     Returns
@@ -161,9 +161,14 @@ def parse_pajek(lines):
         except: #EOF
             break
         if l.lower().startswith("*network"):
-            label,name=l.split()
-            G.name=name
-        if l.lower().startswith("*vertices"):
+            try:
+                label, name = l.split()
+            except ValueError:
+                # Line was not of the form:  *network NAME
+                pass
+            else:
+                G.graph['name'] = name
+        elif l.lower().startswith("*vertices"):
             nodelabels={}
             l,nnodes=l.split()
             for i in range(int(nnodes)):
@@ -172,7 +177,7 @@ def parse_pajek(lines):
                 G.add_node(label)
                 nodelabels[id]=label
                 G.node[label]={'id':id}
-                try: 
+                try:
                     x,y,shape=splitline[2:5]
                     G.node[label].update({'x':float(x),
                                           'y':float(y),
@@ -181,7 +186,7 @@ def parse_pajek(lines):
                     pass
                 extra_attr=zip(splitline[5::2],splitline[6::2])
                 G.node[label].update(extra_attr)
-        if l.lower().startswith("*edges") or l.lower().startswith("*arcs"):
+        elif l.lower().startswith("*edges") or l.lower().startswith("*arcs"):
             if l.lower().startswith("*edge"):
                # switch from multidigraph to multigraph
                 G=nx.MultiGraph(G)
@@ -195,7 +200,7 @@ def parse_pajek(lines):
                 ui,vi=splitline[0:2]
                 u=nodelabels.get(ui,ui)
                 v=nodelabels.get(vi,vi)
-                # parse the data attached to this edge and put in a dictionary 
+                # parse the data attached to this edge and put in a dictionary
                 edge_data={}
                 try:
                     # there should always be a single value on the edge?
@@ -215,12 +220,12 @@ def parse_pajek(lines):
 
 
 def make_qstr(t):
-    """Return the string representation of t. 
+    """Return the string representation of t.
     Add outer double-quotes if the string has a space.
     """
-    if not is_string_like(t): 
+    if not is_string_like(t):
         t = str(t)
-    if " " in t: 
+    if " " in t:
         t=r'"%s"'%t
     return t
 

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -13,8 +13,8 @@ class TestPajek(object):
         self.data="""*network Tralala\n*vertices 4\n   1 "A1"         0.0938 0.0896   ellipse x_fact 1 y_fact 1\n   2 "Bb"         0.8188 0.2458   ellipse x_fact 1 y_fact 1\n   3 "C"          0.3688 0.7792   ellipse x_fact 1\n   4 "D2"         0.9583 0.8563   ellipse x_fact 1\n*arcs\n1 1 1  h2 0 w 3 c Blue s 3 a1 -130 k1 0.6 a2 -130 k2 0.6 ap 0.5 l "Bezier loop" lc BlueViolet fos 20 lr 58 lp 0.3 la 360\n2 1 1  h2 0 a1 120 k1 1.3 a2 -120 k2 0.3 ap 25 l "Bezier arc" lphi 270 la 180 lr 19 lp 0.5\n1 2 1  h2 0 a1 40 k1 2.8 a2 30 k2 0.8 ap 25 l "Bezier arc" lphi 90 la 0 lp 0.65\n4 2 -1  h2 0 w 1 k1 -2 k2 250 ap 25 l "Circular arc" c Red lc OrangeRed\n3 4 1  p Dashed h2 0 w 2 c OliveGreen ap 25 l "Straight arc" lc PineGreen\n1 3 1  p Dashed h2 0 w 5 k1 -1 k2 -20 ap 25 l "Oval arc" c Brown lc Black\n3 3 -1  h1 6 w 1 h2 12 k1 -2 k2 -15 ap 0.5 l "Circular loop" c Red lc OrangeRed lphi 270 la 180"""
         self.G=nx.MultiDiGraph()
         self.G.add_nodes_from(['A1', 'Bb', 'C', 'D2'])
-        self.G.add_edges_from([('A1', 'A1'), ('A1', 'Bb'), ('A1', 'C'), 
-                               ('Bb', 'A1'),('C', 'C'), ('C', 'D2'), 
+        self.G.add_edges_from([('A1', 'A1'), ('A1', 'Bb'), ('A1', 'C'),
+                               ('Bb', 'A1'),('C', 'C'), ('C', 'D2'),
                                ('D2', 'Bb')])
 
         self.G.graph['name']='Tralala'
@@ -37,7 +37,7 @@ class TestPajek(object):
     def test_parse_pajek(self):
         G=parse_pajek(self.data)
         assert_equal(sorted(G.nodes()), ['A1', 'Bb', 'C', 'D2'])
-        assert_edges_equal(G.edges(), [('A1', 'A1'), ('A1', 'Bb'), 
+        assert_edges_equal(G.edges(), [('A1', 'A1'), ('A1', 'Bb'),
                                        ('A1', 'C'), ('Bb', 'A1'),
                                        ('C', 'C'), ('C', 'D2'), ('D2', 'Bb')])
 
@@ -49,3 +49,11 @@ class TestPajek(object):
         assert_equal(self.G.graph,Gin.graph)
         for n in G.node:
             assert_equal(G.node[n],Gin.node[n])
+
+    def test_noname(self):
+        # Make sure we can parse a line such as:  *network
+        # Issue #952
+        line = "*network\n"
+        other_lines = self.data.split('\n')[1:]
+        data = line + '\n'.join(other_lines)
+        G = parse_pajek(data)


### PR DESCRIPTION
Attempt to read in a network with no name (pajek doesn't require one be included), the following bit of code in pajek.py fails:

``` python
        if l.lower().startswith("*network"):
            label,name=l.split()
            G.name=name
```

because there is no exception if the *network line lacks a name.
