### PR TITLE
"convert_bool" in gexf.py does not handle all bools

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -212,7 +212,7 @@ class GEXF(object):
 
     xml_type = dict(types)
     python_type = dict(reversed(a) for a in types)
-    convert_bool={'true':True,'false':False}
+    convert_bool={'false': False, 'False': False, 'true': True, 'True': True}
 
 #    try:
 #        register_namespace = ET.register_namespace

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -54,25 +54,28 @@ class TestGEXF(object):
         <attvalues>
           <attvalue for="0" value="http://gephi.org"/>
           <attvalue for="1" value="1"/>
+          <attvalue for="2" value="false"/>
         </attvalues>
       </node>
       <node id="1" label="Webatlas">
         <attvalues>
           <attvalue for="0" value="http://webatlas.fr"/>
           <attvalue for="1" value="2"/>
+          <attvalue for="2" value="False"/>
         </attvalues>
       </node>
       <node id="2" label="RTGI">
         <attvalues>
           <attvalue for="0" value="http://rtgi.fr"/>
           <attvalue for="1" value="1"/>
+          <attvalue for="2" value="true"/>
         </attvalues>
       </node>
       <node id="3" label="BarabasiLab">
         <attvalues>
           <attvalue for="0" value="http://barabasilab.com"/>
           <attvalue for="1" value="1"/>
-          <attvalue for="2" value="false"/>
+          <attvalue for="2" value="True"/>
         </attvalues>
       </node>
     </nodes>
@@ -91,22 +94,25 @@ class TestGEXF(object):
         self.attribute_graph.add_node('0',
                                       label='Gephi',
                                       url='http://gephi.org',
-                                      indegree=1)
+                                      indegree=1,
+                                      frog=False)
         self.attribute_graph.add_node('1',
                                       label='Webatlas',
                                       url='http://webatlas.fr',
-                                      indegree=2)
+                                      indegree=2,
+                                      frog=False)
 
         self.attribute_graph.add_node('2',
                                       label='RTGI',
                                       url='http://rtgi.fr',
-                                      indegree=1)
+                                      indegree=1,
+                                      frog=True)
 
         self.attribute_graph.add_node('3',
                                       label='BarabasiLab',
                                       url='http://barabasilab.com',
                                       indegree=1,
-                                      frog=False)
+                                      frog=True)
         self.attribute_graph.add_edge('0','1',id='0')
         self.attribute_graph.add_edge('0','2',id='1')
         self.attribute_graph.add_edge('1','0',id='2')
@@ -265,7 +271,7 @@ class TestGEXF(object):
         assert_equal(
             sorted(sorted(e) for e in G.edges()),
             sorted(sorted(e) for e in H.edges()))
-        # Reading a gexf graph always sets mode attribute to either 
+        # Reading a gexf graph always sets mode attribute to either
         # 'static' or 'dynamic'. Remove the mode attribute from the
         # read graph for the sake of comparing remaining attributes.
         del H.graph['mode']


### PR DESCRIPTION
in gexf, line 820-823:

```
                atype=gexf_keys[key]['type']
                value=a.get('value')
                if atype=='boolean':
                    value=self.convert_bool[value]
```

calls line 211:

```
    convert_bool={'true':True,'false':False}
```

However, values such as "True" will also evaluate as boolean (on line 822) but are not in the convert_bool dictionary resulting in the error:

```
KeyError: 'True'
```
