### PR TITLE
Fix bug in gml writer

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -277,8 +277,6 @@ def generate_gml(G):
     def listify(d,indent,indentlevel):
         result='[ \n'
         for k,v in d.items():
-            if type(v)==dict:
-                v=listify(v,indent,indentlevel+1)
             result += (indentlevel+1)*indent + \
                 string_item(k,v,indentlevel*indent)+'\n'
         return result+indentlevel*indent+"]"


### PR DESCRIPTION
Remove unneeded extra recursive call to listify.
It added an extra set of double quotes.

Pointed out in report at http://stackoverflow.com/questions/19352960/networkx-parse-gml-writing-unusable-gml-files
