### PR TITLE
Changes to current_flow_closeness_centrality

### DIFF
--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -16,7 +16,7 @@ import networkx as nx
 from networkx.algorithms.centrality.flow_matrix import *
 
 
-def current_flow_closeness_centrality(G, weight='weight',
+def current_flow_closeness_centrality(G, weight='weight', normalized=False,
                                       dtype=float, solver='lu'):
     """Compute current-flow closeness centrality for nodes.
 
@@ -49,7 +49,8 @@ def current_flow_closeness_centrality(G, weight='weight',
 
     Notes
     -----
-    Normalization is currently undefined for this function.
+    Normalization is currently undefined for this function (it is kept
+    in the argument list for legacy code).
 
     The algorithm is from Brandes [1]_.
 


### PR DESCRIPTION
PEP-8 changes, disabled normalization (kept it as a keyword argument for legacy support), and removed duplicate code.

Normalization is a problem here. The docstring says that normalization results in a 1/(n-1) modification, but this isn't borne out by the code: it's actually multiplying by (n-1). 

Furthermore, it appears that normalization isn't necessary with this particular algorithm, as it inverts the core centrality calculation (resulting in correct behavior). This has the effect of producing results in the range [0,1] when weights are default in any case. What would be normalized?
