### PR TITLE
JSON graph fix to handle unicode dict keys

### DIFF
--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -7,6 +7,7 @@
 from itertools import count,repeat
 import json
 import networkx as nx
+from networkx.utils import make_str
 __author__ = """Aric Hagberg <hagberg@lanl.gov>"""
 __all__ = ['node_link_data', 'node_link_graph']
 
@@ -104,13 +105,13 @@ def node_link_graph(data, directed=False, multigraph=True):
     for d in data['nodes']:
         node = d.get('id',next(c))
         mapping.append(node)
-        nodedata = dict((str(k),v) for k,v in d.items() if k!='id')
+        nodedata = dict((make_str(k),v) for k,v in d.items() if k!='id')
         graph.add_node(node, **nodedata)
     for d in data['links']:
         link_data = d.copy()
         source = link_data.pop('source')
         target = link_data.pop('target')
-        edgedata = dict((str(k),v) for k,v in d.items()
+        edgedata = dict((make_str(k),v) for k,v in d.items()
                         if k!='source' and k!='target')
         graph.add_edge(mapping[source],mapping[target],**edgedata)
     return graph

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -1,3 +1,4 @@
+#  -*- coding: utf-8 -*-
 import json
 from nose.tools import assert_equal, assert_raises, assert_not_equal,assert_true
 import networkx as nx
@@ -42,3 +43,16 @@ class TestNodeLink:
         H = node_link_graph(node_link_data(G))
         nx.is_isomorphic(G,H)
         assert_equal(H[1][2]['second']['color'],'blue')
+
+    def test_unicode_keys(self):
+        try:
+            q = unicode("qualité",'utf-8')
+        except NameError:
+            q = "qualité"
+        G = nx.Graph()
+        G.add_node(1, {q:q})
+        s = node_link_data(G)
+        output = json.dumps(s, ensure_ascii=False)
+        data = json.loads(output)
+        H = node_link_graph(data)
+        assert_equal(H.node[1][q], q)

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -7,6 +7,7 @@
 from itertools import count,repeat
 import json
 import networkx as nx
+from networkx.utils import make_str
 __author__ = """Aric Hagberg (hagberg@lanl.gov))"""
 __all__ = ['tree_data',
            'tree_graph']
@@ -101,7 +102,7 @@ def tree_graph(data):
             grandchildren = data.get('children',[])
             if grandchildren:
                 add_children(child,grandchildren)
-            nodedata = dict((str(k),v) for k,v in data.items() 
+            nodedata = dict((make_str(k),v) for k,v in data.items() 
                             if k!='id' and k!='children')
             graph.add_node(child,attr_dict=nodedata)
     root = data['id']


### PR DESCRIPTION
This fix allows unicode for attribute keys in the JSON graph format writers.

This code demonstrates the issue and should now work correctly

``` python
#  -*- coding: utf-8 -*-
import json
import networkx as nx
from networkx.readwrite import json_graph
G = nx.Graph()
q = u"qualité"
G.add_node(1, {q:q})
s = json_graph.node_link_data(G)
output = json.dumps(s, ensure_ascii=False)
data = json.loads(output)
H = json_graph.node_link_graph(data)
```
