### PR TITLE
Make make_str() always return unicode, no matter the Python version.

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -70,6 +70,28 @@ def make_str(t):
     if is_string_like(t): return t
     return str(t)
 
+PY2 = sys.version_info[0] == 2
+if PY2:
+    def make_str(x):
+        if isinstance(x, unicode):
+            return x
+        else:
+            # Note, this will not work unless x is ascii-encoded.
+            # That is good, since we should be working with unicode anyway.
+            # Essentially, unless we are reading a file, we demand that users
+            # convert any encoded strings to unicode before using the library.
+            #
+            # Also, the str() is necessary to convert integers, etc.
+            # unicode(3) works, but unicode(3, 'unicode-escape') wants a buffer.
+            #
+            return unicode(str(x), 'unicode-escape')
+else:
+    def make_str(x):
+        if isinstance(x, str):
+             return x
+        else:
+             return str(x)
+
 def cumulative_sum(numbers):
     """Yield cumulative sum of numbers.
 

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 from nose.tools import *
 from nose import SkipTest
 import networkx as nx
@@ -32,6 +33,34 @@ def test_random_number_distribution():
     z=powerlaw_sequence(20,exponent=2.5)
     z=pareto_sequence(20,exponent=1.5)
     z=discrete_sequence(20,distribution=[0,0,0,0,1,1,1,1,2,2,3])
+
+def test_make_str_with_bytes():
+    import sys
+    PY2 = sys.version_info[0] == 2
+
+    x = "qualité"
+    y = make_str(x)
+    if PY2:
+        assert_true(isinstance(y, unicode))
+        # Since file encoding is utf-8, the é will be two bytes.
+        assert_true(len(y) == 8)
+    else:
+        assert_true(isinstance(y, str))
+        assert_true(len(y) == 7)
+
+def test_make_str_with_unicode():
+    import sys
+    PY2 = sys.version_info[0] == 2
+    if PY2:
+        x = unicode("qualité", encoding='utf-8')
+        y = make_str(x)
+        assert_true(isinstance(y, unicode))
+        assert_true(len(y) == 7)
+    else:
+        x = "qualité"
+        y = make_str(x)
+        assert_true(isinstance(y, str))
+        assert_true(len(y) == 7)
 
 class TestNumpyArray(object):
     numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test


### PR DESCRIPTION
I just noticed something about `make_str` that bothered me.  This pull request is built off @hagberg's branch for #989.  So make sure to merge #989 first, but its not strictly necessary, as merging this PR will merge both.

Consider the following example:

```
#  -*- coding: utf-8 -*-
# Example 1
from networkx.utils import make_str
x = "qualité"
y = make_str(x)
```

For Python 2, `y` is of type `str`, but as an encoded string. For Python 3, `y` is of type `str`, but as a unicode string.  This is consistent output type, but the interpretation is very different.  Now, consider:

```
#  -*- coding: utf-8 -*-
# Example 2
from networkx.utils import make_str
try:
    #2.x
    x = unicode("qualité")
except NameError:
    #3.x
    x = "qualité"
y = make_str(x)
```

For Python 2, `y` is of type `unicode`, whereas in Python 3, `y` is of type `str` (which is unicode).  Now, the types are different, but the interpretation is the same.

Overall, for Python 2, `make_str` returns either a `str` or a `unicode` object.  On one hand, this makes sense since the input was different in each case.   

On the other hand, its more confusing because it means that our code is possibly working with encoded strings or unicode strings.  Always working with unicode would make things easier to maintain, I think.  Additionally, this would be similar in spirit to how we handle `map`, `range` and `zip`---we always treat them as iterators so that our code treatment is uniform across Python versions.   Right now, internal NetworkX code handles "strings" differently depending on the Python version.  

Below is a new proposal for `make_str`.

```
PY2 = sys.version_info[0] == 2
if PY2:
    def make_str(x):
        if isinstance(x, unicode):
            return x
        else:
            # Note, this will not work unless x is ascii-encoded.
            # That is good, since we should be working with unicode anyway.
            # Essentially, unless we are reading a file, we demand that users convert
            # any encoded strings to unicode before using the library.
            # 
            # Also, the str() is necessary to convert integers, etc.
            # unicode(3) works, but unicode(3, 'unicode-escape') demands a buffer.
            #
            return unicode(str(x), 'unicode-escape')
else:
    def make_str(x):
        if isinstance(x, str):
             return x
        else:
             return str(x)
```

The important difference is that the `str` in name `make_str` is now interpreted to mean 'unicode', always.  Its forward looking to Python 3 just as map, range, zip, etc.  The benefit now is that all NetworkX code can be confident that make_str returns a unicode string. Note: the type will be different depending on the Python version, (e.g. unicode vs str) but we shouldn't care about the type as much as we care about what the type represents (e.g. encoded string vs unicode string).

In Python 3, examples 1 and 2 from above are the same.  unicode strings in and unicode strings out.

In Python 2, examples 1 and 2 differ but `y` represents a unicode string in both cases.  In example 1, `y` is a unicode object of length 8.  In example 2, 'y' is a unicode object of length 7.  The length 8 unicode string is probably not what the use wanted, but the user should also not expect us (NetworkX) to know how the string is encoded.  So the user should first decode to unicode and then pass it into `make_str`---in which case, the output would be the same as in example 2.  If `x` were an ascii encoded string, then examples 1 and 2 would be the same in Python 2 and `y` would be unicode strings in both cases.
