### PR TITLE
Fix tests that fail due to hash randomization

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -115,7 +115,7 @@ def degree_pearson_correlation_coefficient(G, x='out', y='in',
     --------
     >>> G=nx.path_graph(4)
     >>> r=nx.degree_pearson_correlation_coefficient(G) 
-    >>> r 
+    >>> print("%3.1f"%r)
     -0.5
 
     Notes

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -569,8 +569,12 @@ def from_numpy_matrix(A,create_using=None):
     >>> dt=[('weight',float),('cost',int)]
     >>> A=numpy.matrix([[(1.0,2)]],dtype=dt)
     >>> G=nx.from_numpy_matrix(A)
-    >>> G.edges(data=True)
-    [(0, 0, {'cost': 2, 'weight': 1.0})]
+    >>> G.edges()
+    [(0, 0)]
+    >>> G[0][0]['cost']
+    2
+    >>> G[0][0]['weight']
+    1.0
     """
     kind_to_python_type={'f':float,
                          'i':int,


### PR DESCRIPTION
Addresses #975

I couldn't get the dict_to_numpy_array() tests to fail as sin #975 (1000 tries, Python3.4 alpha)
