### PR TITLE
Force double precision in scipy matrix for layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -437,7 +437,7 @@ def spectral_layout(G, dim=2, weight='weight', scale=1):
         # Sparse matrix
         if len(G)< 500:  # dense solver is faster for small graphs
             raise ValueError
-        A=nx.to_scipy_sparse_matrix(G, weight=weight,dtype='f')
+        A=nx.to_scipy_sparse_matrix(G, weight=weight,dtype='d')
         # Symmetrize directed graphs
         if G.is_directed():
             A=A+np.transpose(A)

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -53,7 +53,7 @@ class TestLayout(object):
         except ImportError:
             raise SkipTest('scipy not available.')
 
-        A=nx.to_scipy_sparse_matrix(self.Gs,dtype='f')
+        A=nx.to_scipy_sparse_matrix(self.Gs,dtype='d')
         pos=nx.drawing.layout._sparse_fruchterman_reingold(A)
         pos=nx.drawing.layout._sparse_spectral(A)
 


### PR DESCRIPTION
Gets rid of scipy eigs/eigsh warning of double precision only
