### PR TITLE
Force ordering in dict_to_numpy_array functions

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -141,11 +141,19 @@ def dict_to_numpy_array2(d,mapping=None):
         mapping=dict(zip(s,range(len(s))))
     n=len(mapping)
     a = numpy.zeros((n, n))
-    for k1, row in d.items():
-        for k2, value in row.items():
-            i=mapping[k1]
-            j=mapping[k2]
-            a[i,j] = value
+    print(mapping)
+    for k1, i in mapping.items():
+#    for k1, row in d.items():
+        for k2, j in mapping.items():
+            try:
+                a[i,j]=d[k1][k2]
+            except KeyError:
+                pass
+#        for k2, value in row.items():
+#            a[i,j] = d[k1][k2]
+#            i=mapping[k1]
+#            j=mapping[k2]
+#            a[i,j] = value
     return a
 
 def dict_to_numpy_array1(d,mapping=None):
@@ -161,7 +169,7 @@ def dict_to_numpy_array1(d,mapping=None):
         mapping = dict(zip(s,range(len(s))))
     n = len(mapping)
     a = numpy.zeros(n)
-    for k1, value in d.items():
+    for k1,i in mapping.items():
         i = mapping[k1]
-        a[i] = value
+        a[i] = d[k1]
     return a

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -78,7 +78,7 @@ class TestNumpyArray(object):
     def test_dict_to_numpy_array1(self):
         d = {'a':1,'b':2}
         a = dict_to_numpy_array1(d)
-        assert_equal(a, numpy.array([1,2]))
+        assert_equal(a, numpy.array(list(d.values())))
         a = dict_to_numpy_array1(d, mapping = {'b':0,'a':1})
         assert_equal(a, numpy.array([2,1]))
 
@@ -86,7 +86,12 @@ class TestNumpyArray(object):
         d = {'a': {'a':1,'b':2},
              'b': {'a':10,'b':20}}
         a = dict_to_numpy_array(d)
-        assert_equal(a, numpy.array([[1,2],[10,20]]))
+        if list(d.keys())[0] == 'a':
+            assert_equal(a, numpy.array([[1,2],[10,20]]))
+        elif list(d.keys())[0] == 'b':
+            assert_equal(a, numpy.array([[20,10],[2,1]]))
+        else:
+            raise
         a = dict_to_numpy_array2(d, mapping = {'b':0,'a':1})
         assert_equal(a, numpy.array([[20,10],[2,1]]))
 
@@ -95,7 +100,12 @@ class TestNumpyArray(object):
         d = {'a': {'a':1,'b':2},
              'b': {'a':10,'b':20}}
         a = dict_to_numpy_array(d)
-        assert_equal(a, numpy.array([[1,2],[10,20]]))
+        if list(d.keys())[0] == 'a':
+            assert_equal(a, numpy.array([[1,2],[10,20]]))
+        elif list(d.keys())[0] == 'b':
+            assert_equal(a, numpy.array([[20,10],[2,1]]))
+        else:
+            raise
         d = {'a':1,'b':2}
-        a = dict_to_numpy_array1(d)
-        assert_equal(a, numpy.array([1,2]))
+        a = dict_to_numpy_array(d)
+        assert_equal(a, numpy.array(list(d.values())))


### PR DESCRIPTION
Force ordering to be that of the provided mapping dictionary or else create a mapping using the input data dictionary ordering.

Fix tests to determine ordering.

Addresses #975
