### PR TITLE
Drop official Python3.1 support

### DIFF
--- a/networkx/release.py
+++ b/networkx/release.py
@@ -238,7 +238,6 @@ classifiers = [
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
But pretty much everything will work OK.  Some small issues with xml.etree are annoying to support specially for Python3.1.

Addresses #974
