### PR TITLE
Make the copy inside simple_cycles a shallow one.

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -168,7 +168,7 @@ def simple_cycles(G):
     # Johnson's algorithm requires some ordering of the nodes.
     # We assign the arbitrary ordering given by the strongly connected comps
     # There is no need to track the ordering as each node removed as processed.
-    subG = type(G)(G.edges()) # save the actual graph so we can mutate it here
+    subG = type(G)(G.edges_iter()) # save the actual graph so we can mutate it here
                               # We only take the edges because we do not want to
                               # copy edge and node attributes here.
     sccs = list(nx.strongly_connected_components(subG))


### PR DESCRIPTION
The previous copy copied all the node and edge attributes. Those are unnecessary for the function to work.
Also, in cases where the node attributes cannot be copied, the function fails on the copy and does not perform graph analysis.
