### PR TITLE
Use "left eigenvector" (in-edges) in centrality

### DIFF
--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -58,9 +58,9 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
     after max_iter iterations or an error tolerance of
     number_of_nodes(G)*tol has been reached.
 
-    For directed graphs this is "right" eigevector centrality.  For
-    "left" eigenvector centrality, first reverse the graph with
-    G.reverse().
+    For directed graphs this is "left" eigevector centrality which corresponds
+    to the in-edges in the graph.  For out-edges eigenvector centrality
+    first reverse the graph with G.reverse().
 
     See Also
     --------
@@ -89,10 +89,10 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
     for i in range(max_iter):
         xlast = x
         x = dict.fromkeys(xlast, 0)
-        # do the multiplication y=Ax
+        # do the multiplication y^T = x^T A
         for n in x:
             for nbr in G[n]:
-                x[n] += xlast[nbr]*G[n][nbr].get(weight, 1)
+                x[nbr] += xlast[n] * G[n][nbr].get(weight, 1)
         # normalize vector
         try:
             s = 1.0/sqrt(sum(v**2 for v in x.values()))
@@ -139,9 +139,9 @@ def eigenvector_centrality_numpy(G, weight='weight'):
     ------
     This algorithm uses the NumPy eigenvalue solver.
 
-    For directed graphs this is "right" eigevector centrality.  For
-    "left" eigenvector centrality, first reverse the graph with
-    G.reverse().
+    For directed graphs this is "left" eigevector centrality which corresponds
+    to the in-edges in the graph.  For out-edges eigenvector centrality
+    first reverse the graph with G.reverse().
 
     See Also
     --------
@@ -161,7 +161,7 @@ def eigenvector_centrality_numpy(G, weight='weight'):
         raise nx.NetworkXException('Empty graph.')
 
     A = nx.adj_matrix(G, nodelist=G.nodes(), weight='weight')
-    eigenvalues,eigenvectors = np.linalg.eig(A)
+    eigenvalues,eigenvectors = np.linalg.eig(A.T)
     # eigenvalue indices in reverse sorted order
     ind = eigenvalues.argsort()[::-1]
     # eigenvector of largest eigenvalue at ind[0], normalized

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -111,6 +111,11 @@ def katz_centrality(G, alpha=0.1, beta=1.0,
     When `\alpha = 1/\lambda_{max}` and `\beta=1` Katz centrality is the same as
     eigenvector centrality.
 
+    For directed graphs this finds "left" eigenvectors which corresponds
+    to the in-edges in the graph.  For out-edges Katz centrality
+    first reverse the graph with G.reverse().
+
+
     References
     ----------
     .. [1] M. Newman, Networks: An Introduction. Oxford University Press,
@@ -149,12 +154,12 @@ def katz_centrality(G, alpha=0.1, beta=1.0,
     for i in range(max_iter):
         xlast = x
         x = dict.fromkeys(xlast, 0)
-        # do the multiplication y = Alpha * Ax - Beta
+        # do the multiplication y^T = Alpha * x^T A - Beta
         for n in x:
             for nbr in G[n]:
-                x[n] += xlast[nbr] * G[n][nbr].get(weight,1)
+                x[nbr] += xlast[n] * G[n][nbr].get(weight, 1)
+        for n in x:
             x[n] = alpha*x[n] + b[n]
-
         # check convergence
         err = sum([abs(x[n]-xlast[n]) for n in x])
         if err < nnodes*tol:
@@ -253,6 +258,10 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,
     `\alpha = 1/\lambda_{max}` and `\beta=1` Katz centrality is the same as
     eigenvector centrality.
 
+    For directed graphs this finds "left" eigenvectors which corresponds
+    to the in-edges in the graph.  For out-edges Katz centrality
+    first reverse the graph with G.reverse().
+
     References
     ----------
     .. [1] M. Newman, Networks: An Introduction. Oxford University Press,
@@ -285,7 +294,7 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,
         except (TypeError,ValueError):
             raise nx.NetworkXError('beta must be a number')
 
-    A = nx.adj_matrix(G, nodelist=nodelist, weight=weight)
+    A = nx.adj_matrix(G, nodelist=nodelist, weight=weight).T
     n = np.array(A).shape[0]
     centrality = np.linalg.solve( np.eye(n,n) - (alpha * A) , b)
     if normalized:

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -76,7 +76,7 @@ class TestEigenvectorCentralityDirected(object):
                (7,8),(8,6),(8,7)]
 
         G.add_edges_from(edges,weight=2.0)
-        self.G=G
+        self.G=G.reverse()
         self.G.evc=[0.25368793,  0.19576478,  0.32817092,  0.40430835,
                     0.48199885, 0.15724483,  0.51346196,  0.32475403]
 
@@ -87,23 +87,36 @@ class TestEigenvectorCentralityDirected(object):
                (7,8),(8,6),(8,7)]
 
         G.add_edges_from(edges)
-        self.H=G
+        self.H=G.reverse()
         self.H.evc=[0.25368793,  0.19576478,  0.32817092,  0.40430835,
                     0.48199885, 0.15724483,  0.51346196,  0.32475403]
 
 
     def test_eigenvector_centrality_weighted(self):
         G=self.G
+        p=networkx.eigenvector_centrality(G)
+        for (a,b) in zip(list(p.values()),self.G.evc):
+            assert_almost_equal(a,b,places=4)
+
+    def test_eigenvector_centrality_weighted_numpy(self):
+        G=self.G
         p=networkx.eigenvector_centrality_numpy(G)
         for (a,b) in zip(list(p.values()),self.G.evc):
             assert_almost_equal(a,b)
 
+
     def test_eigenvector_centrality_unweighted(self):
+        G=self.H
+        p=networkx.eigenvector_centrality(G)
+        for (a,b) in zip(list(p.values()),self.G.evc):
+            assert_almost_equal(a,b,places=4)
+
+
+    def test_eigenvector_centrality_unweighted_numpy(self):
         G=self.H
         p=networkx.eigenvector_centrality_numpy(G)
         for (a,b) in zip(list(p.values()),self.G.evc):
             assert_almost_equal(a,b)
-
 
 class TestEigenvectorCentralityExceptions(object):
     numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -226,7 +226,7 @@ class TestKatzCentralityDirected(object):
         edges = [(1, 2),(1, 3),(2, 4),(3, 2),(3, 5),(4, 2),(4, 5),(4, 6),(5, 6),
                  (5, 7),(5, 8),(6, 8),(7, 1),(7, 5),(7, 8),(8, 6),(8, 7)]
         G.add_edges_from(edges, weight=2.0)
-        self.G = G
+        self.G = G.reverse()
         self.G.alpha = 0.1
         self.G.evc = [
             0.3289589783189635,
@@ -240,7 +240,7 @@ class TestKatzCentralityDirected(object):
             ]
 
         H = networkx.DiGraph(edges)
-        self.H = G
+        self.H = G.reverse()
         self.H.alpha = 0.1
         self.H.evc = [
             0.3289589783189635,
@@ -253,14 +253,14 @@ class TestKatzCentralityDirected(object):
             0.34229059218038554,
             ]
 
-    def test_eigenvector_centrality_weighted(self):
+    def test_katz_centrality_weighted(self):
         G = self.G
         alpha = self.G.alpha
         p = networkx.katz_centrality(G, alpha)
         for (a, b) in zip(list(p.values()), self.G.evc):
             assert_almost_equal(a, b)
 
-    def test_eigenvector_centrality_unweighted(self):
+    def test_katz_centrality_unweighted(self):
         G = self.H
         alpha = self.H.alpha
         p = networkx.katz_centrality(G, alpha)
@@ -279,14 +279,14 @@ class TestKatzCentralityDirectedNumpy(TestKatzCentralityDirected):
         except ImportError:
             raise SkipTest('NumPy not available.')
 
-    def test_eigenvector_centrality_weighted(self):
+    def test_katz_centrality_weighted(self):
         G = self.G
         alpha = self.G.alpha
         p = networkx.katz_centrality_numpy(G, alpha)
         for (a, b) in zip(list(p.values()), self.G.evc):
             assert_almost_equal(a, b)
 
-    def test_eigenvector_centrality_unweighted(self):
+    def test_katz_centrality_unweighted(self):
         G = self.H
         alpha = self.H.alpha
         p = networkx.katz_centrality_numpy(G, alpha)


### PR DESCRIPTION
Change both Katz centrality and eigenvector centrality for directed graphs to use "left eigenvector" centrality (in-edges).
Use G.reverse() to get out-edge centrality.

Addresses #1016
