### PR TITLE
networkx raises TypeError when reading input from .gml file

### DIFF
--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# encoding: utf-8
+from __future__ import unicode_literals
+
 import io
 from nose.tools import *
 from nose import SkipTest
@@ -52,8 +55,8 @@ graph [
   ]
   edge [
     source 3
-    target 1 label
-    "Edge from node 3 to node 1"
+    target 1
+    label "Edge from node 3 to node 1"
   ]
 ]
 """
@@ -136,12 +139,12 @@ graph
 
 
     def test_tuplelabels(self):
-      # https://github.com/networkx/networkx/pull/1048
-      # Writing tuple labels to GML failed.
-      G = networkx.Graph()
-      G.add_edge((0,1), (1,0))
-      data = '\n'.join(list(networkx.generate_gml(G)))
-      answer = """graph [
+        # https://github.com/networkx/networkx/pull/1048
+        # Writing tuple labels to GML failed.
+        G = networkx.Graph()
+        G.add_edge((0,1), (1,0))
+        data = '\n'.join(list(networkx.generate_gml(G)))
+        answer = """graph [
   node [
     id 0
     label "(0, 1)"
@@ -155,4 +158,29 @@ graph
     target 1
   ]
 ]"""
-      assert_equal(data, answer)
+        assert_equal(data, answer)
+
+
+    def test_quotes(self):
+        # https://github.com/networkx/networkx/issues/1061
+        # Encoding quotes as HTML entities.
+        import tempfile
+        G = networkx.path_graph(1)
+        # This is a unicode string (due to the __future__ import)
+        # It was decoded from utf-8 since that the encoding of this file.
+        attr = 'This is "quoted" and this is a copyright: ©'  # u'\xa9'
+        G.node[0]['demo'] = attr
+        fobj = tempfile.NamedTemporaryFile()
+        networkx.write_gml(G, fobj)
+        fobj.seek(0)
+        # Should be bytes in 2.x and 3.x
+        data = fobj.read().strip()
+        answer = b"""graph [
+  name "path_graph(1)"
+  node [
+    id 0
+    label "0"
+    demo "This is &quot;quoted&quot; and this is a copyright: &#169;"
+  ]
+]"""
+        assert_equal(data, answer)


### PR DESCRIPTION
Hello,
I'm reporting the Debian bug #735776 : 

```
networkx raises TypeError when reading input from .gml file:

$ python cart_product.py c3.gml c3.gml
graph [
  node [
    id 0
Traceback (most recent call last):
  File "cart_product.py", line 22, in <module>
    for line in nx.generate_gml(X):
  File "/usr/lib/pymodules/python2.7/networkx/readwrite/gml.py", line 328, in generate_gml
    yield 2*indent+'label %s'%label
TypeError: not all arguments converted during string formatting

[8<]

It seems that bug is fixed by applying the following patch (tested for
debian stable and sid):

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -325,7 +325,7 @@
         label=G.node[n].get('label',n)
         if is_string_like(label):
             label='"%s"'%label
-        yield 2*indent+'label %s'%label
+        yield 2*indent+'label {0}'.format(label)
         if n in G:
           for k,v in G.node[n].items():
               if k=='id' or k == 'label': continue
```
