### PR TITLE
Linear Algebra Directed Clustering

### DIFF
--- a/networkx/algorithms/small_world.py
+++ b/networkx/algorithms/small_world.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import networkx as nx
 
 
@@ -44,13 +45,15 @@ def _average_shortest_path_length_weakly_connected(G, weight=None):
                 continue
             node_1_avg.append(all_pairs[node_1][node_2])
         avg.extend(node_1_avg)
-    avg_path_len = sum(avg) / float(len(avg))
+    avg_path_len = sum(avg) / len(avg)
     return avg_path_len
 
 
-def small_world(G, n_iter=1000, use_transitivity=False):
-    r"""Calculates the small world coefficient for the network G.  The small
-    world coefficient is defined as:
+def small_world(G, n_iter=1000, use_transitivity=False,
+                null_graph_generator=nx.gnm_random_graph):
+    r"""Calculates the small world coefficient for the network G.
+
+    The small world coefficient is defined as:
 
     .. math::
 
@@ -72,10 +75,19 @@ def small_world(G, n_iter=1000, use_transitivity=False):
       shortest path length and the average transitivity (or clustering
       coefficient) for a network with the same number of edges and nodes as G.
 
-    use_transitivity : bool, option (default = False)
+    use_transitivity : bool, optional (default = False)
       if True, will use transitivity to calculate small worldness, if False
       will use average clustering coefficient instead.  Read [1]_ for an
       in-depth discussion of the difference between the two measures.
+
+    null_graph_generator : function, optional (default = nx.gnm_random_graph)
+      a function which generates a random graph, using the number of nodes
+      and the number of edges of G as an input. We assume the function signature
+      of the generator function is:
+        null_G = null_graph_generator(n, m, directed) where n is the number of
+     nodes in G, m is the number of edges, and directed is a boolean variable
+     depending on whether or not G was directed.
+
     ...
     Notes
     -----
@@ -112,7 +124,7 @@ def small_world(G, n_iter=1000, use_transitivity=False):
     rand_cc = []
     rand_shortest_path = []
     for I in range(n_iter):
-        random_G = nx.gnm_random_graph(n, m, directed=directed)
+        random_G = null_graph_generator(n, m, directed=directed)
         if directed:
             if not nx.is_weakly_connected(random_G):
                 random_G = nx.weakly_connected_component_subgraphs(random_G)[0]

--- a/networkx/algorithms/small_world.py
+++ b/networkx/algorithms/small_world.py
@@ -1,0 +1,144 @@
+import networkx as nx
+
+
+def _average_shortest_path_length_weakly_connected(G, weight=None):
+    r"""Return the average shortest path length for a directed graph.
+
+    Unlike average_shortest_path_length, which normalizes the
+    sum of the total path lengths by the maximum possible number of paths
+    `n(n-1)`, this function normalizes only by the number of actual paths that
+    a particular node has to other nodes in the graph.  For a weakly connected
+    graph, this number can be significantly smaller.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    weight : None or string, optional (default = None)
+       If None, every edge has weight/distance/cost 1.
+       If a string, use this edge attribute as the edge weight.
+       Any edge attribute not present defaults to 1.
+
+    Raises
+    ------
+    NetworkXError:
+       if the graph is not at least weakly connected.
+
+    For strongly connected graphs, this function and
+    average_shortest_path_length will give slightly different answer
+    because only paths to other nodes are considered here.
+    """
+    if G.is_directed():
+        if not nx.is_weakly_connected(G):
+            raise nx.NetworkXError("Graph is not connected.")
+    else:
+        if not nx.is_connected(G):
+            raise nx.NetworkXError("Graph is not connected.")
+
+    all_pairs = nx.all_pairs_dijkstra_path_length(G, weight=weight)
+    avg = []
+    for node_1 in all_pairs.iterkeys():
+        node_1_avg = []
+        for node_2 in all_pairs[node_1].iterkeys():
+            if node_1 == node_2:
+                continue
+            node_1_avg.append(all_pairs[node_1][node_2])
+        avg.extend(node_1_avg)
+    avg_path_len = sum(avg) / float(len(avg))
+    return avg_path_len
+
+
+def small_world(G, n_iter=1000, use_transitivity=False):
+    r"""Calculates the small world coefficient for the network G.  The small
+    world coefficient is defined as:
+
+    .. math::
+
+       S^{\vartriangle}(g) =\frac{\gamma^{\vartriangle}_g}{\lambda_g}
+
+    Where `\gamma^{\vartriangle}_g` is the ratio between the transitivity of
+    network `g` and the average transitivity of n_iter random networks with the
+    same amount of nodes and edges, and `\lambda_g` is the ratio between the
+    average shortest path length of network `g` and the average of the
+    average shortest path length of n_iter random networks.
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX graph
+
+    n_iter : int, optional (default=1000)
+      n_iter is the number of random networks used to calculate the average
+      shortest path length and the average transitivity (or clustering
+      coefficient) for a network with the same number of edges and nodes as G.
+
+    use_transitivity : bool, option (default = False)
+      if True, will use transitivity to calculate small worldness, if False
+      will use average clustering coefficient instead.  Read [1]_ for an
+      in-depth discussion of the difference between the two measures.
+    ...
+    Notes
+    -----
+    This implementation is based on algorithm 11 in [1]_. The authors propose
+    two different methods of calculating small worldness, one based on
+    transitivity, and one based on clustering coefficient.  For most networks,
+    the two measures give similar results, although this is not always the case.
+
+    See also
+    --------
+    average_clustering
+    transitivity
+    average_shortest_path_length
+
+    References
+    ----------
+    .. [1] Humphries MD, Gurney K (2008)
+    Network ‘Small-World-Ness’: A Quantitative Method for Determining Canonical
+    Network Equivalence.
+    PLoS ONE 3(4): e0002051. doi:10.1371/journal.pone.0002051
+    """
+
+    n = len(G)
+    m = len(G.edges())
+    directed = nx.is_directed(G)
+
+    if use_transitivity:
+        clustering_fcn = nx.transitivity
+    else:
+        clustering_fcn = nx.linalg.la_clustering
+
+    distance_fcn = _average_shortest_path_length_weakly_connected
+
+    rand_cc = []
+    rand_shortest_path = []
+    for I in range(n_iter):
+        random_G = nx.gnm_random_graph(n, m, directed=directed)
+        if directed:
+            if not nx.is_weakly_connected(random_G):
+                random_G = nx.weakly_connected_component_subgraphs(random_G)[0]
+                # The generated random graph might not have all the connected
+                # nodes - in which case use the largest component.
+        else:
+            if not nx.is_connected(random_G):
+                random_G = nx.connected_component_subgraphs(random_G)[0]
+
+        rand_cc.append(clustering_fcn(random_G))
+        rand_shortest_path.append(distance_fcn(random_G))
+
+    mean_shortest_path = sum(rand_shortest_path) / float(n_iter)
+    mean_cc = sum(rand_cc) / float(n_iter)
+
+    G_shortest_path = distance_fcn(G)
+    path_len_ratio = float(G_shortest_path) / mean_shortest_path
+
+    G_cc = clustering_fcn(G)
+    cc_ratio = float(G_cc) / mean_cc
+    small_worldness = cc_ratio / path_len_ratio
+
+    #rand_sw = []
+    #for cc, sp in zip(rand_cc, rand_shortest_path):
+    #    rand_sw.append((cc/mean_cc) / (sp/mean_shortest_path))
+    #sw_prob = stats.norm.pdf(small_worldness, loc=np.mean(rand_sw),
+    #    scale=np.std(rand_sw))
+
+    return small_worldness

--- a/networkx/linalg/__init__.py
+++ b/networkx/linalg/__init__.py
@@ -6,4 +6,5 @@ from networkx.linalg.graphmatrix import *
 import networkx.linalg.graphmatrix
 from networkx.linalg.laplacianmatrix import *
 import networkx.linalg.laplacianmatrix
-
+from networkx.linalg.linalg_clustering import *
+import networkx.linalg.linalg_clustering

--- a/networkx/linalg/linalg_clustering.py
+++ b/networkx/linalg/linalg_clustering.py
@@ -7,7 +7,11 @@ __all__ = ['la_clustering']
 
 
 def la_clustering(G, weight='weight'):
-    r""""    For unweighted graphs the clustering of each node `u`
+    r"""Calculates the clustering coefficient for every node
+    in G using the adjancency matrix.
+
+
+    For unweighted graphs the clustering of each node `u`
     is the fraction of possible triangles that exist,
     For each node find the fraction of possible triangles that exist,
 
@@ -53,6 +57,7 @@ def la_clustering(G, weight='weight'):
     -------
     out : dictionary
        Clustering coefficient for all nodes
+
     See Also
     --------
     clustering
@@ -61,8 +66,8 @@ def la_clustering(G, weight='weight'):
     -----
     .. [1] Clustering in Complex Directed Networks.  Giorgio Fagiolo.
     Physical Review E, 2007.
-    http://web1.sssup.it/pubblicazioni/ugov_files/303163_PRE_2007.pd
-    f"""
+    http://web1.sssup.it/pubblicazioni/ugov_files/303163_PRE_2007.pdf
+    """
 
     W = np.abs(nx.adjacency_matrix(G, weight=weight))
     W = W.todense()

--- a/networkx/linalg/linalg_clustering.py
+++ b/networkx/linalg/linalg_clustering.py
@@ -74,7 +74,7 @@ def la_clustering(G, weight='weight'):
     d_double = np.diag(np.dot(A, A))
 
     C = np.power(W, (1/3.0)) + np.power(W.T, (1/3.0))
-    C = np.diagonal(np.dot(C, C).dot(C))
+    C = np.diagonal(np.dot(C, C).dot(C)).copy()
     # Actual number of triangles present
     max_triangles = 2*(d_tot*(d_tot-1)-2*d_double)
     # Maximum number of triangles, the -2*d_double factor

--- a/networkx/linalg/linalg_clustering.py
+++ b/networkx/linalg/linalg_clustering.py
@@ -75,18 +75,26 @@ def la_clustering(G, weight='weight'):
                           'http://scipy.org/')
 
     W = np.abs(nx.adjacency_matrix(G, weight=weight))
-    W = W.todense()
     W = W / W.max()
-    A = np.array(W != 0, dtype=int)
-    d_out = np.sum(A, axis=1).flatten()
-    d_in = np.sum(A, axis=0).flatten()
+    A = W != 0
+    A = A.astype(int)
+    d_out = A.sum(axis=1).flatten()
+    d_in = A.sum(axis=0).flatten()
     d_tot = np.array(d_out + d_in, dtype=float)
-    d_double = np.diag(np.dot(A, A))
+    d_double = np.dot(A, A).diagonal()
 
-    C = np.power(W, (1/3.0)) + np.power(W.T, (1/3.0))
-    C = np.diagonal(np.dot(C, C).dot(C)).copy()
+    #C = np.power(W, (1/3.0)) + np.power(W.T, (1/3.0))
+    # Since we work with sparse matrix, we have to change it a bit:
+    W_T = W.T.copy()
+
+    W.data **= (1/3.0)
+    W_T.data **= (1/3.0)
+    C = W + W_T
+
+    C = np.dot(C, C).dot(C).diagonal().copy()
     # Actual number of triangles present
-    max_triangles = 2*(d_tot*(d_tot-1)-2*d_double)
+    max_triangles = 2*(d_tot*(d_tot-1)-2*d_double).flatten()
+
     # Maximum number of triangles, the -2*d_double factor
     # accounts for the presence of double edges.
     C /= max_triangles

--- a/networkx/linalg/linalg_clustering.py
+++ b/networkx/linalg/linalg_clustering.py
@@ -1,4 +1,3 @@
-import numpy as np
 import networkx as nx
 
 __author__ = ['Federico Vaggi (federico.vaggi@fmach.it)']
@@ -68,6 +67,12 @@ def la_clustering(G, weight='weight'):
     Physical Review E, 2007.
     http://web1.sssup.it/pubblicazioni/ugov_files/303163_PRE_2007.pdf
     """
+    try:
+        import numpy as np
+        import scipy
+    except ImportError:
+        raise ImportError('la_clustering() requires SciPy and Numpy: ',
+                          'http://scipy.org/')
 
     W = np.abs(nx.adjacency_matrix(G, weight=weight))
     W = W.todense()
@@ -90,3 +95,16 @@ def la_clustering(G, weight='weight'):
     C = dict(zip(G.nodes(), C))
     # Return as a dict to follow networkx API standards.
     return C
+
+
+def setup_module(module):
+    """Fixture for nose tests."""
+    from nose import SkipTest
+    try:
+        import numpy
+    except:
+        raise SkipTest("NumPy not available")
+    try:
+        import scipy
+    except:
+        raise SkipTest("SciPy not available")

--- a/networkx/linalg/linalg_clustering.py
+++ b/networkx/linalg/linalg_clustering.py
@@ -1,0 +1,87 @@
+import numpy as np
+import networkx as nx
+
+__author__ = ['Federico Vaggi (federico.vaggi@fmach.it)']
+
+__all__ = ['la_clustering']
+
+
+def la_clustering(G, weight='weight'):
+    r""""    For unweighted graphs the clustering of each node `u`
+    is the fraction of possible triangles that exist,
+    For each node find the fraction of possible triangles that exist,
+
+    .. math::
+
+      c_u = \frac{2 T(u)}{deg(u)(deg(u)-1)},
+
+    where `T(u)` is the number of triangles through node `u` and
+    `deg(u)` is the degree of `u`.
+
+    For directed graphs, the maximum number of triangles is:
+
+    .. math::
+
+      c_u = \frac{2 T(u)}{deg(u)(deg(u)-1)-deg_{double}(u)},
+
+    where `T(u)` is the number of triangles through node `u`,
+    `deg(u)` is the degree of `u`, and `deg_{double}(u)` is
+    the number of mutual edges that `u` has with other nodes.
+
+    For weighted graphs the clustering is defined
+    as the geometric average of the subgraph edge weights [1]_,
+
+    .. math::
+
+       c_u = \frac{1}{deg(u)(deg(u)-1))}
+            \sum_{uv} (\hat{w}_{uv} \hat{w}_{uw} \hat{w}_{vw})^{1/3}.
+
+    The edge weights `\hat{w}_{uv}` are normalized by the maximum weight in the
+    network `\hat{w}_{uv} = w_{uv}/\max(w)`.
+
+    The value of `c_u` is assigned to 0 if `deg(u) < 2`.
+
+    Parameters
+    ----------
+    G : graph
+
+    weight : string or None, optional (default=None)
+       The edge attribute that holds the numerical value used as a weight.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    out : dictionary
+       Clustering coefficient for all nodes
+    See Also
+    --------
+    clustering
+    average_clustering
+    References
+    -----
+    .. [1] Clustering in Complex Directed Networks.  Giorgio Fagiolo.
+    Physical Review E, 2007.
+    http://web1.sssup.it/pubblicazioni/ugov_files/303163_PRE_2007.pd
+    f"""
+
+    W = np.abs(nx.adjacency_matrix(G, weight=weight))
+    W = W.todense()
+    W = W / W.max()
+    A = np.array(W != 0, dtype=int)
+    d_out = np.sum(A, axis=1).flatten()
+    d_in = np.sum(A, axis=0).flatten()
+    d_tot = np.array(d_out + d_in, dtype=float)
+    d_double = np.diag(np.dot(A, A))
+
+    C = np.power(W, (1/3.0)) + np.power(W.T, (1/3.0))
+    C = np.diagonal(np.dot(C, C).dot(C))
+    # Actual number of triangles present
+    max_triangles = 2*(d_tot*(d_tot-1)-2*d_double)
+    # Maximum number of triangles, the -2*d_double factor
+    # accounts for the presence of double edges.
+    C /= max_triangles
+    C[max_triangles == 0] = 0
+    # If there are 0 possible triangles, then C is 0.
+    C = dict(zip(G.nodes(), C))
+    # Return as a dict to follow networkx API standards.
+    return C

--- a/networkx/linalg/tests/test_linalg_clustering.py
+++ b/networkx/linalg/tests/test_linalg_clustering.py
@@ -1,10 +1,8 @@
-from nose import SkipTest
-
 import networkx as nx
-from networkx.generators.degree_seq import havel_hakimi_graph
 
 class TestLinalg_Clustering(object):
-    numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
+
     @classmethod
     def setupClass(cls):
         global numpy
@@ -15,14 +13,6 @@ class TestLinalg_Clustering(object):
             from numpy.testing import assert_equal,assert_almost_equal
         except ImportError:
              raise SkipTest('NumPy not available.')
-
-        def setUp(self):
-            deg=[3,2,2,1,0]
-            self.G=havel_hakimi_graph(deg)
-            self.P=nx.path_graph(3)
-            self.WG=nx.Graph( (u,v,{'weight':0.5,'other':0.3})
-                    for (u,v) in self.G.edges_iter() )
-            self.WG.add_node(4)
 
     def test_undirected_unweighted_clustering(self):
         "Testing if the routine gives the same answer as the nx.clustering"

--- a/networkx/linalg/tests/test_linalg_clustering.py
+++ b/networkx/linalg/tests/test_linalg_clustering.py
@@ -1,4 +1,5 @@
 import networkx as nx
+from nose import SkipTest
 
 class TestLinalg_Clustering(object):
     numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test

--- a/networkx/linalg/tests/test_linalg_clustering.py
+++ b/networkx/linalg/tests/test_linalg_clustering.py
@@ -13,6 +13,10 @@ class TestLinalg_Clustering(object):
             from numpy.testing import assert_equal,assert_almost_equal
         except ImportError:
              raise SkipTest('NumPy not available.')
+        try:
+            import scipy
+        except ImportError:
+            raise SkipTest('SciPy not available.')
 
     def test_undirected_unweighted_clustering(self):
         "Testing if the routine gives the same answer as the nx.clustering"

--- a/networkx/linalg/tests/test_linalg_clustering.py
+++ b/networkx/linalg/tests/test_linalg_clustering.py
@@ -1,0 +1,56 @@
+from nose import SkipTest
+
+import networkx as nx
+from networkx.generators.degree_seq import havel_hakimi_graph
+
+class TestLinalg_Clustering(object):
+    numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    @classmethod
+    def setupClass(cls):
+        global numpy
+        global assert_equal
+        global assert_almost_equal
+        try:
+            import numpy
+            from numpy.testing import assert_equal,assert_almost_equal
+        except ImportError:
+             raise SkipTest('NumPy not available.')
+
+        def setUp(self):
+            deg=[3,2,2,1,0]
+            self.G=havel_hakimi_graph(deg)
+            self.P=nx.path_graph(3)
+            self.WG=nx.Graph( (u,v,{'weight':0.5,'other':0.3})
+                    for (u,v) in self.G.edges_iter() )
+            self.WG.add_node(4)
+
+    def test_undirected_unweighted_clustering(self):
+        "Testing if the routine gives the same answer as the nx.clustering"
+        n = 200
+        p = 0.3
+        G = nx.fast_gnp_random_graph(n, p, directed=False)
+        nx_C = nx.clustering(G)
+        linalg_C = nx.linalg.la_clustering(G)
+
+        for key in nx_C:
+            nx_c = nx_C[key]
+            linalg_c = linalg_C[key]
+            assert_almost_equal(nx_c, linalg_c)
+
+    def test_undirected_weighted_clustering(self):
+        "Testing if the routine gives the same answer as the nx.clustering"
+        n = 200
+        p = 0.3
+        G = nx.fast_gnp_random_graph(n, p, directed=False)
+
+        for edge in G.edges_iter():
+            weight = numpy.random.rand()
+            G.add_edge(edge[0], edge[1], weight=weight)
+
+        nx_C = nx.clustering(G, weight='weight')
+        linalg_C = nx.linalg.la_clustering(G)
+
+        for key in nx_C:
+            nx_c = nx_C[key]
+            linalg_c = linalg_C[key]
+            assert_almost_equal(nx_c, linalg_c)


### PR DESCRIPTION
This PR adds a clustering coefficient measure for directed graph.  Currently, this PR uses the adjacency matrix representation to calculate clustering coefficient, and as such, it leverages numpy to do all the calculations and sits in the linear algebra module.  Using numpy, it's possible to write the formula in a manner very similar to that used in the original reference.

I also added two tests to show that in the undirected case, the module gives the same answer as the clustering coefficient function already present in networkx.

Possible improvements to this PR include the use of sparse matrix throughout, which however would preclude the use of syntax mirroring that of the paper.