### PR TITLE
ENH: add reverse kwarg for topo sort

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -71,7 +71,7 @@ def is_directed_acyclic_graph(G):
     if not G.is_directed():
         return False
     try:
-        topological_sort(G)
+        topological_sort(G, reverse=True)
         return True
     except nx.NetworkXUnfeasible:
         return False
@@ -93,6 +93,7 @@ def topological_sort(G, nbunch=None, reverse=False):
 
     reverse : bool, optional
         Return postorder instead of preorder if True.
+        Reverse mode is a bit more efficient.
 
     Raises
     ------
@@ -173,6 +174,7 @@ def topological_sort_recursive(G, nbunch=None, reverse=False):
 
     reverse : bool, optional
         Return postorder instead of preorder if True.
+        Reverse mode is a bit more efficient.
 
     Raises
     ------

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -21,6 +21,22 @@ class TestDAG:
         assert_equal(nx.topological_sort(DG),[1, 3, 2])
         assert_equal(nx.topological_sort_recursive(DG),[1, 3, 2])
 
+    def test_reverse_topological_sort1(self):
+        DG=nx.DiGraph()
+        DG.add_edges_from([(1,2),(1,3),(2,3)])
+        assert_equal(nx.topological_sort(DG, reverse=True),[3, 2, 1])
+        assert_equal(nx.topological_sort_recursive(DG, reverse=True),[3, 2, 1])
+
+        DG.add_edge(3,2)
+        assert_raises(nx.NetworkXUnfeasible,
+                nx.topological_sort, DG, reverse=True)
+        assert_raises(nx.NetworkXUnfeasible,
+                nx.topological_sort_recursive, DG, reverse=True)
+        
+        DG.remove_edge(2,3)
+        assert_equal(nx.topological_sort(DG, reverse=True),[2, 3, 1])
+        assert_equal(nx.topological_sort_recursive(DG, reverse=True),[2, 3, 1])
+
     def test_is_directed_acyclic_graph(self):
         G = nx.generators.complete_graph(2)
         assert_false(nx.is_directed_acyclic_graph(G))

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -90,12 +90,11 @@ def _relabel_inplace(G, mapping):
         D = nx.DiGraph(list(mapping.items()))
         D.remove_edges_from(D.selfloop_edges())
         try:
-            nodes = nx.topological_sort(D)
+            nodes = nx.topological_sort(D, reverse=True)
         except nx.NetworkXUnfeasible:
             raise nx.NetworkXUnfeasible('The node label sets are overlapping '
                                         'and no ordering can resolve the '
                                         'mapping. Use copy=True.')
-        nodes.reverse()  # reverse topological order
     else:
         # non-overlapping label sets
         nodes = old_labels


### PR DESCRIPTION
Add an option to reverse the topo sort list; the reversed order is more natural.

The interface is inspired by http://networkx.github.io/documentation/latest/_modules/networkx/algorithms/traversal/breadth_first_search.html#bfs_edges and also python `list.sort()` and `sorted()`.  Some of the networkx code uses the topo sort just to check for cycles, and these checks could be sped up a bit by using `reverse=True` to avoid the list(reversed(ordered)) at the end of the call, but I haven't made these changes because I'm not up for writing the benchmarking code.
