### PR TITLE
Returning the minimum weight from a multigraph was inefficient

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -489,7 +489,8 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
                                              weight=weight)
     return paths
 
-def bellman_ford(G, source, weight = 'weight'):
+
+def bellman_ford(G, source, weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths
     in weighted graphs.
 
@@ -552,7 +553,7 @@ def bellman_ford(G, source, weight = 'weight'):
 
     """
     if source not in G:
-        raise KeyError("Node %s is not found in the graph"%source)
+        raise KeyError("Node %s is not found in the graph" % source)
     numb_nodes = len(G)
 
     dist = {source: 0}
@@ -569,7 +570,7 @@ def bellman_ford(G, source, weight = 'weight'):
             return edge_dict.get(weight,1)
 
     for i in range(numb_nodes):
-        no_changes=True
+        no_changes = True
         # Only need edges from nodes in dist b/c all others have dist==inf
         for u, dist_u in list(dist.items()): # get all edges from nodes in dist
             for v, edict in G[u].items():  # double loop handles undirected too
@@ -583,6 +584,7 @@ def bellman_ford(G, source, weight = 'weight'):
     else:
         raise nx.NetworkXUnbounded("Negative cost cycle detected.")
     return pred, dist
+
 
 def negative_edge_cycle(G, weight = 'weight'):
     """Return True if there exists a negative edge cycle anywhere in G.


### PR DESCRIPTION
In the previous code, you would essentially iterate through the `edge_dict.values()` values twice. First would be running the list comprehension to produce a list of weights, and then again to find the minimum value for the list produced. Passing the generator expression to `min()` produces what you're looking for in one full iteration. I also included a little code beautification à la pep8 as well but will revert it if necessary. 
