### PR TITLE
Show max iterations in non-convergence error for Katz centrality

### DIFF
--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -177,8 +177,8 @@ def katz_centrality(G, alpha=0.1, beta=1.0,
                 x[n] *= s
             return x
 
-    raise nx.NetworkXError('Power iteration failed to converge in ',
-                           '%d iterations."%(i+1))')
+    raise nx.NetworkXError('Power iteration failed to converge in '
+                           '%d iterations.' % max_iter)
 
 @not_implemented_for('multigraph')
 def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -34,7 +34,12 @@ class TestKatzCentrality(object):
     def test_maxiter(self):
         alpha = 0.1
         G = networkx.path_graph(3)
-        b = networkx.katz_centrality(G, alpha, max_iter=0)
+        max_iter = 0
+        try:
+            b = networkx.katz_centrality(G, alpha, max_iter=max_iter)
+        except networkx.NetworkXError as e:
+            assert str(max_iter) in e.args[0], "max_iter value not in error msg"
+            raise # So that the decorater sees the exception.
 
     def test_beta_as_scalar(self):
         alpha = 0.1


### PR DESCRIPTION
The old error code ended up with a couple extra quote marks, so it never actually showed the intended error message. This patch fixes that problem, and tests that fix.
