### PR TITLE
Use networkx.testing functions for testing bipartite projections

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_project.py
+++ b/networkx/algorithms/bipartite/tests/test_project.py
@@ -1,92 +1,92 @@
 #!/usr/bin/env python
-from nose.tools import *
+from nose.tools import assert_equal
 import networkx as nx
 from networkx.algorithms import bipartite
-from networkx.testing import *
+from networkx.testing import assert_edges_equal, assert_nodes_equal
 
 class TestBipartiteProject:
 
     def test_path_projected_graph(self):
         G=nx.path_graph(4)
-        P=bipartite.projected_graph(G,[1,3]) 
-        assert_equal(sorted(P.nodes()),[1,3])
-        assert_equal(sorted(P.edges()),[(1,3)])
-        P=bipartite.projected_graph(G,[0,2]) 
-        assert_equal(sorted(P.nodes()),[0,2])
-        assert_equal(sorted(P.edges()),[(0,2)])
+        P=bipartite.projected_graph(G, [1, 3])
+        assert_nodes_equal(P.nodes(), [1, 3])
+        assert_edges_equal(P.edges(), [(1, 3)])
+        P=bipartite.projected_graph(G, [0, 2])
+        assert_nodes_equal(P.nodes(), [0, 2])
+        assert_edges_equal(P.edges(), [(0, 2)])
 
     def test_path_projected_properties_graph(self):
         G=nx.path_graph(4)
         G.add_node(1,name='one')
         G.add_node(2,name='two')
         P=bipartite.projected_graph(G,[1,3]) 
-        assert_equal(sorted(P.nodes()),[1,3])
-        assert_equal(sorted(P.edges()),[(1,3)])
+        assert_nodes_equal(P.nodes(),[1,3])
+        assert_edges_equal(P.edges(),[(1,3)])
         assert_equal(P.node[1]['name'],G.node[1]['name'])
         P=bipartite.projected_graph(G,[0,2]) 
-        assert_equal(sorted(P.nodes()),[0,2])
-        assert_equal(sorted(P.edges()),[(0,2)])
+        assert_nodes_equal(P.nodes(),[0,2])
+        assert_edges_equal(P.edges(),[(0,2)])
         assert_equal(P.node[2]['name'],G.node[2]['name'])
 
     def test_path_collaboration_projected_graph(self):
         G=nx.path_graph(4)
         P=bipartite.collaboration_weighted_projected_graph(G,[1,3]) 
-        assert_equal(sorted(P.nodes()),[1,3])
-        assert_equal(sorted(P.edges()),[(1,3)])
+        assert_nodes_equal(P.nodes(),[1,3])
+        assert_edges_equal(P.edges(),[(1,3)])
         P[1][3]['weight']=1
         P=bipartite.collaboration_weighted_projected_graph(G,[0,2]) 
-        assert_equal(sorted(P.nodes()),[0,2])
-        assert_equal(sorted(P.edges()),[(0,2)])
+        assert_nodes_equal(P.nodes(),[0,2])
+        assert_edges_equal(P.edges(),[(0,2)])
         P[0][2]['weight']=1
 
     def test_directed_path_collaboration_projected_graph(self):
         G=nx.DiGraph()
         G.add_path(list(range(4)))
         P=bipartite.collaboration_weighted_projected_graph(G,[1,3]) 
-        assert_equal(sorted(P.nodes()),[1,3])
-        assert_equal(sorted(P.edges()),[(1,3)])
+        assert_nodes_equal(P.nodes(),[1,3])
+        assert_edges_equal(P.edges(),[(1,3)])
         P[1][3]['weight']=1
         P=bipartite.collaboration_weighted_projected_graph(G,[0,2]) 
-        assert_equal(sorted(P.nodes()),[0,2])
-        assert_equal(sorted(P.edges()),[(0,2)])
+        assert_nodes_equal(P.nodes(),[0,2])
+        assert_edges_equal(P.edges(),[(0,2)])
         P[0][2]['weight']=1
 
     def test_path_weighted_projected_graph(self):
         G=nx.path_graph(4)
         P=bipartite.weighted_projected_graph(G,[1,3]) 
-        assert_equal(sorted(P.nodes()),[1,3])
-        assert_equal(sorted(P.edges()),[(1,3)])
+        assert_nodes_equal(P.nodes(),[1,3])
+        assert_edges_equal(P.edges(),[(1,3)])
         P[1][3]['weight']=1
         P=bipartite.weighted_projected_graph(G,[0,2]) 
-        assert_equal(sorted(P.nodes()),[0,2])
-        assert_equal(sorted(P.edges()),[(0,2)])
+        assert_nodes_equal(P.nodes(),[0,2])
+        assert_edges_equal(P.edges(),[(0,2)])
         P[0][2]['weight']=1
 
     def test_path_weighted_projected_directed_graph(self):
         G=nx.DiGraph()
         G.add_path(list(range(4)))
         P=bipartite.weighted_projected_graph(G,[1,3]) 
-        assert_equal(sorted(P.nodes()),[1,3])
-        assert_equal(sorted(P.edges()),[(1,3)])
+        assert_nodes_equal(P.nodes(),[1,3])
+        assert_edges_equal(P.edges(),[(1,3)])
         P[1][3]['weight']=1
         P=bipartite.weighted_projected_graph(G,[0,2]) 
-        assert_equal(sorted(P.nodes()),[0,2])
-        assert_equal(sorted(P.edges()),[(0,2)])
+        assert_nodes_equal(P.nodes(),[0,2])
+        assert_edges_equal(P.edges(),[(0,2)])
         P[0][2]['weight']=1
 
 
     def test_star_projected_graph(self):
         G=nx.star_graph(3)
         P=bipartite.projected_graph(G,[1,2,3])
-        assert_equal(sorted(P.nodes()),[1,2,3])
-        assert_equal(sorted(P.edges()),[(1,2),(1,3),(2,3)])
+        assert_nodes_equal(P.nodes(),[1,2,3])
+        assert_edges_equal(P.edges(),[(1,2),(1,3),(2,3)])
         P=bipartite.weighted_projected_graph(G,[1,2,3])
-        assert_equal(sorted(P.nodes()),[1,2,3])
-        assert_equal(sorted(P.edges()),[(1,2),(1,3),(2,3)])
+        assert_nodes_equal(P.nodes(),[1,2,3])
+        assert_edges_equal(P.edges(),[(1,2),(1,3),(2,3)])
 
         P=bipartite.projected_graph(G,[0])
-        assert_equal(sorted(P.nodes()),[0])
-        assert_equal(sorted(P.edges()),[])
+        assert_nodes_equal(P.nodes(),[0])
+        assert_edges_equal(P.edges(),[])
 
     def test_project_multigraph(self):
         G=nx.Graph()
@@ -121,13 +121,13 @@ class TestBipartiteProject:
         G.add_edge('A',2)
         G.add_edge('B',2)
         P=bipartite.projected_graph(G,'AB')
-        assert_equal(sorted(P.edges()),[('A','B')])
+        assert_edges_equal(P.edges(),[('A','B')])
         P=bipartite.weighted_projected_graph(G,'AB')
-        assert_equal(sorted(P.edges()),[('A','B')])
+        assert_edges_equal(P.edges(),[('A','B')])
         assert_equal(P['A']['B']['weight'],1)
 
         P=bipartite.projected_graph(G,'AB',multigraph=True)
-        assert_equal(sorted(P.edges()),[('A','B')])
+        assert_edges_equal(P.edges(),[('A','B')])
 
         G=nx.DiGraph()
         G.add_edge('A',1)
@@ -135,13 +135,13 @@ class TestBipartiteProject:
         G.add_edge('A',2)
         G.add_edge(2,'B')
         P=bipartite.projected_graph(G,'AB')
-        assert_equal(sorted(P.edges()),[('A','B')])
+        assert_edges_equal(P.edges(),[('A','B')])
         P=bipartite.weighted_projected_graph(G,'AB')
-        assert_equal(sorted(P.edges()),[('A','B')])
+        assert_edges_equal(P.edges(),[('A','B')])
         assert_equal(P['A']['B']['weight'],2)
 
         P=bipartite.projected_graph(G,'AB',multigraph=True)
-        assert_equal(sorted(P.edges()),[('A','B'),('A','B')])
+        assert_edges_equal(P.edges(),[('A','B'),('A','B')])
 
          
 class TestBipartiteWeightedProjection:
@@ -185,7 +185,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.weighted_projected_graph(self.G,'ABCDEF')
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -200,7 +200,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.weighted_projected_graph(self.N,'ABCDE')
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -214,7 +214,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.collaboration_weighted_projected_graph(self.G,'ABCDEF')
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -229,7 +229,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.collaboration_weighted_projected_graph(self.N,'ABCDE')
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -243,7 +243,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.weighted_projected_graph(self.G, 'ABCDEF', ratio=True)
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -258,7 +258,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.weighted_projected_graph(self.N, 'ABCDE', ratio=True)
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -272,7 +272,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.overlap_weighted_projected_graph(self.G,'ABCDEF', jaccard=False)
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -287,7 +287,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.overlap_weighted_projected_graph(self.N,'ABCDE', jaccard=False)
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -301,7 +301,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.overlap_weighted_projected_graph(self.G,'ABCDEF')
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -316,7 +316,7 @@ class TestBipartiteWeightedProjection:
         Panswer=nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P=bipartite.overlap_weighted_projected_graph(self.N,'ABCDE')
-        assert_equal(P.edges(),Panswer.edges())
+        assert_edges_equal(P.edges(),Panswer.edges())
         for u,v in P.edges():
             assert_equal(P[u][v]['weight'],Panswer[u][v]['weight'])
 
@@ -325,19 +325,19 @@ class TestBipartiteWeightedProjection:
             return len(set(G[u]) & set(G[v]))
         B = nx.path_graph(5) 
         G = bipartite.generic_weighted_projected_graph(B, [0, 2, 4], weight_function=shared) 
-        assert_equal(sorted(G.nodes()), [0, 2, 4]) 
-        assert_equal(G.edges(data=True), 
+        assert_nodes_equal(G.nodes(), [0, 2, 4]) 
+        assert_edges_equal(G.edges(data=True), 
                      [(0, 2, {'weight': 1}), (2, 4, {'weight': 1})] )
 
         G = bipartite.generic_weighted_projected_graph(B, [0, 2, 4]) 
-        assert_equal(sorted(G.nodes()), [0, 2, 4]) 
-        assert_equal(G.edges(data=True), 
+        assert_nodes_equal(G.nodes(), [0, 2, 4]) 
+        assert_edges_equal(G.edges(data=True), 
                      [(0, 2, {'weight': 1}), (2, 4, {'weight': 1})] )
         B = nx.DiGraph()
         B.add_path(list(range(5)))
         G = bipartite.generic_weighted_projected_graph(B, [0, 2, 4]) 
-        assert_equal(sorted(G.nodes()), [0, 2, 4]) 
-        assert_equal(G.edges(data=True), 
+        assert_nodes_equal(G.nodes(), [0, 2, 4]) 
+        assert_edges_equal(G.edges(data=True), 
                      [(0, 2, {'weight': 1}), (2, 4, {'weight': 1})] )
 
     def test_generic_weighted_projected_graph_custom(self):
@@ -355,9 +355,9 @@ class TestBipartiteWeightedProjection:
             B.edge[u][v]['weight'] = i + 1
         G = bipartite.generic_weighted_projected_graph(B, [0, 1],                   
                                                         weight_function=jaccard)
-        assert_equal(G.edges(data=True), [(0, 1, {'weight': 1.0})])
+        assert_edges_equal(G.edges(data=True), [(0, 1, {'weight': 1.0})])
         G = bipartite.generic_weighted_projected_graph(B, [0, 1],                   
                                                         weight_function=my_weight)
-        assert_equal(G.edges(data=True), [(0, 1, {'weight': 10})])
+        assert_edges_equal(G.edges(data=True), [(0, 1, {'weight': 10})])
         G = bipartite.generic_weighted_projected_graph(B, [0, 1])
-        assert_equal(G.edges(data=True), [(0, 1, {'weight': 2})])
+        assert_edges_equal(G.edges(data=True), [(0, 1, {'weight': 2})])


### PR DESCRIPTION
I think that this fixes the problems with bipartite projection tests in python 3.4 reported in #975. But I cannot test it at the moment. At my system (linux 64bit) it works with 2.7 and 3.3 (using `PYTHONHASHSEED=4` as @Arfrever reported).  

In this tests all nodes and edges are sortable, and by using `assert_nodes_equal` and  `assert_edges_equal` from `networkx.testing` I think that we correctly deal with the hash randomization issue.
