### PR TITLE
clarified edge attribute update precedence in add_edges_from()

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -524,6 +524,9 @@ class DiGraph(Graph):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
+        Edge attributes specified in edges as a tuple take precedence
+        over attributes specified generally.        
+
         Examples
         --------
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -744,6 +744,9 @@ class Graph(object):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
+        Edge attributes specified in edges as a tuple take precedence
+        over attributes specified generally.
+
         Examples
         --------
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -294,6 +294,9 @@ class MultiGraph(Graph):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
+        Edge attributes specified in edges as a tuple take precedence
+        over attributes specified generally.
+
         Examples
         --------
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc


### PR DESCRIPTION
Hi,

`add_nodes_from` clearly mentions attribute update precendence and I think `add_edges_from` should do so, too.

Kind regards,
Arne
