### PR TITLE
Add recognition algorithm for semiconnected graphs

### DIFF
--- a/networkx/algorithms/components/__init__.py
+++ b/networkx/algorithms/components/__init__.py
@@ -3,3 +3,4 @@ from networkx.algorithms.components.strongly_connected import *
 from networkx.algorithms.components.weakly_connected import *
 from networkx.algorithms.components.attracting import *
 from networkx.algorithms.components.biconnected import *
+from networkx.algorithms.components.semiconnected import *

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Semiconnectedness.
+"""
+
+__author__ = """ysitu <ysitu@users.noreply.github.com>"""
+# Copyright (C) 2014 ysitu <ysitu@users.noreply.github.com>
+# All rights reserved.
+# BSD license.
+
+import networkx as nx
+from networkx.utils import not_implemented_for
+
+__all__ = ['is_semiconnected']
+
+@not_implemented_for('undirected')
+def is_semiconnected(G):
+    """Return True if the graph is semiconnected, False otherwise.
+
+    A graph is semiconnected if, and only if, for any pair of nodes, either one
+    is reachable from the other, or they are mutually reachable.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        A directed graph.
+
+    Returns
+    -------
+    semiconnected : bool
+        True if the graph is semiconnected, False otherwise.
+
+    Raises
+    ------
+    NetworkXNotImplemented :
+        If the input graph is not directed.
+
+    NetworkXPointlessConcept :
+        If the graph is empty.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(4,create_using=nx.DiGraph())
+    >>> print(nx.is_semiconnected(G))
+    True
+    >>> G=nx.DiGraph([(1, 2), (3, 2)])
+    >>> print(nx.is_semiconnected(G))
+    False
+
+    See Also
+    --------
+    is_strongly_connected,
+    is_weakly_connected
+    """
+    if len(G) == 0:
+        raise nx.NetworkXPointlessConcept(
+            'Connectivity is undefined for the null graph.')
+
+    if not nx.is_weakly_connected(G):
+        return False
+
+    G = nx.condensation(G)
+    path = nx.topological_sort(G)
+    return all(G.has_edge(u, v) for u, v in zip(path[:-1], path[1:]))

--- a/networkx/algorithms/components/tests/test_semiconnected.py
+++ b/networkx/algorithms/components/tests/test_semiconnected.py
@@ -1,0 +1,53 @@
+from itertools import chain
+import networkx as nx
+from nose.tools import *
+
+class TestIsSemiconnected(object):
+
+    def test_undirected(self):
+        assert_raises(nx.NetworkXNotImplemented, nx.is_semiconnected,
+                      nx.Graph())
+        assert_raises(nx.NetworkXNotImplemented, nx.is_semiconnected,
+                      nx.MultiGraph())
+
+    def test_empty(self):
+        assert_raises(nx.NetworkXPointlessConcept, nx.is_semiconnected,
+                      nx.DiGraph())
+        assert_raises(nx.NetworkXPointlessConcept, nx.is_semiconnected,
+                      nx.MultiDiGraph())
+
+    def test_single_node_graph(self):
+        G = nx.DiGraph()
+        G.add_node(0)
+        ok_(nx.is_semiconnected(G))
+
+    def test_path(self):
+        G = nx.path_graph(100, create_using=nx.DiGraph())
+        ok_(nx.is_semiconnected(G))
+        G.add_edge(100, 99)
+        ok_(not nx.is_semiconnected(G))
+
+    def test_cycle(self):
+        G = nx.cycle_graph(100, create_using=nx.DiGraph())
+        ok_(nx.is_semiconnected(G))
+        G = nx.path_graph(100, create_using=nx.DiGraph())
+        G.add_edge(0, 99)
+        ok_(nx.is_semiconnected(G))
+
+    def test_tree(self):
+        G = nx.DiGraph()
+        G.add_edges_from(chain.from_iterable([(i, 2 * i + 1), (i, 2 * i + 2)]
+                                             for i in range(100)))
+        ok_(not nx.is_semiconnected(G))
+
+    def test_dumbbell(self):
+        G = nx.cycle_graph(100, create_using=nx.DiGraph())
+        G.add_edges_from((i + 100, (i + 1) % 100 + 100) for i in range(100))
+        ok_(not nx.is_semiconnected(G))  # G is disconnected.
+        G.add_edge(100, 99)
+        ok_(nx.is_semiconnected(G))
+
+    def test_alternating_path(self):
+        G = nx.DiGraph(chain.from_iterable([(i, i - 1), (i, i + 1)]
+                                           for i in range(0, 100, 2)))
+        ok_(not nx.is_semiconnected(G))


### PR DESCRIPTION
Addresses #1108.

This is put inside `networkx.algorithms.components` only due to similarity to other `is_*connected` functions. No function is provided to compute the "semiconnected components" since there is no well-known definition AFAIK.
