### PR TITLE
.travis.yml updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
   - "pypy"
 before_install:
   # Current TravisCI VM is Ubuntu 12.04 which has Python 2.7 and 3.2.


### PR DESCRIPTION
There was a recent update to TravisCI's build environment for Python. See:
http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/

The restructuring was such that having:

```
virtualenv:
    system_site_packages: true
```

caused problems for Python versions which do not have a system install (e.g. anything but 2.7 and 3.3 for Ubuntu). So we had to remove the declaration and manually activate the virtual environment for 2.7 and 3.3.
