### PR TITLE
Use symmetric eigen solver in laplacian_spectrum

### DIFF
--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -41,8 +41,8 @@ def laplacian_spectrum(G, weight='weight'):
     --------
     laplacian_matrix
     """
-    from scipy.linalg import eigvals
-    return eigvals(nx.laplacian_matrix(G,weight=weight).todense())
+    from scipy.linalg import eigvalsh
+    return eigvalsh(nx.laplacian_matrix(G,weight=weight).todense())
 
 def adjacency_spectrum(G, weight='weight'):
     """Return eigenvalues of the adjacency matrix of G.


### PR DESCRIPTION
For those who rely on the return type being complex this may be a breaking change because `eigvalsh` returns real values.
