### PR TITLE
git-core package name is obsolete for any supported version of debian or ubuntu

### DIFF
--- a/doc/source/developer/gitwash/git_install.rst
+++ b/doc/source/developer/gitwash/git_install.rst
@@ -8,7 +8,7 @@ Overview
 ========
 
 ================ =============
-Debian / Ubuntu  ``sudo apt-get install git-core``
+Debian / Ubuntu  ``sudo apt-get install git``
 Fedora           ``sudo yum install git-core``
 Windows          Download and install msysGit_
 OS X             Use the git-osx-installer_


### PR DESCRIPTION
Solves issue #1135
