### PR TITLE
Use wheels with TravisCI for NumPy, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,13 @@ install:
   # Skipping gdal (errors during pip installs)
   - sudo apt-get update -qq
   - if [ "${OPTIONAL_DEPS}" == "true" ]; then sudo apt-get install graphviz; fi
-  - if [ "${OPTIONAL_DEPS}" == "true" ]; then pip install --use-wheel pyyaml pyparsing pygraphviz; fi
+  - if [ "${OPTIONAL_DEPS}" == "true" ]; then pip install --use-wheel pyyaml pyparsing; fi
+  - if [[ "${OPTIONAL_DEPS}" == 2* ]]; then pip install pygraphviz; fi
   - if [ "${OPTIONAL_DEPS}" == "true" ]; then $PIPINSTALL numpy scipy matplotlib Cython; fi
 
   # Try to install latest and greatest from source.
   - if [ "${FROM_SOURCE}" == "true" ]; then sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran; fi
-  - if [ "${FROM_SOURCE}" == "true" ]; then pip install --upgrade pyyaml pyparsing numpy scipy matplotlib Cython pygraphviz; fi
+  - if [ "${FROM_SOURCE}" == "true" ]; then pip install --upgrade pyyaml pyparsing numpy scipy matplotlib Cython; fi
 
 
 before_script:


### PR DESCRIPTION
For NumPy and SciPy, we should consider using wheels (via pip) instead of building from source---which we don't actually do at all right now because it is so slow.

Something similar to what they are doing here, perhaps.
https://github.com/astropy/package-template/pull/44

This is just a placeholder. I can definitely tackle this at some point, just not immediately.
