### PR TITLE
Fix nondeterministic unit tests for double-edge swap.

### DIFF
--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -2,6 +2,9 @@
 from nose.tools import *
 from networkx import *
 
+import random
+random.seed(0)
+
 def test_double_edge_swap():
     graph = barabasi_albert_graph(200,1)
     degrees = sorted(graph.degree().values())
@@ -32,7 +35,6 @@ def test_connected_double_edge_swap_not_connected():
     G = nx.path_graph(3)
     G.add_path([10,11,12])
     G = nx.connected_double_edge_swap(G)
-
 
 def test_degree_seq_c4():
     G = cycle_graph(4)


### PR DESCRIPTION
Been getting the following error from time to time:

```
======================================================================
ERROR: test_richclub.test_richclub_normalized
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.6/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/virtualenv/python2.7.6/lib/python2.7/site-packages/networkx/algorithms/tests/test_richclub.py", line 16, in test_richclub_normalized
    rcNorm = nx.richclub.rich_club_coefficient(G,Q=2)
  File "/home/travis/virtualenv/python2.7.6/lib/python2.7/site-packages/networkx/algorithms/richclub.py", line 74, in rich_club_coefficient
    nx.double_edge_swap(R,Q*E,max_tries=Q*E*10)
  File "/home/travis/virtualenv/python2.7.6/lib/python2.7/site-packages/networkx/algorithms/swap.py", line 95, in double_edge_swap
    raise nx.NetworkXAlgorithmError(e)
NetworkXAlgorithmError: Maximum number of swap attempts (120) exceeded before desired swaps achieved (12).
```

Probably need to seed the random number generator. But it doesn't look like doube_edge_swap takes a prng.  Need to be modified to something like:

```
def double_edge_swap(G, nswap=1, max_tries=100, prng=None):
    if prng is None:
        prng = np.random

    ....
    v = prng.choice(list(G[u]))
    y = prng.choice(list(G[x]))
```

For a PRNG API, we need to choose between the stdlib's random module or NumPy's RandomState class.  They are not compatible, and if we want to allow people to pass in a PRNG to various functions/classes, I don't think it's good for NetworkX to use two different PRNG APIs.  My preference would be to use NumPy's throughout, as it has much more functionality.
