### PR TITLE
Add mapping dict as graph attribute in condensation.

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -309,11 +309,13 @@ def condensation(G, scc=None):
     Returns
     -------
     C : NetworkX DiGraph
-       The condensation of G. The node labels are integers corresponding
-       to the index of the component in the list of strongly connected
-       components. It has a graph attribute named 'mapping' with a
-       dictionary mapping the original nodes to the nodes in the
-       condensation graph (ie SCC) to which they belong.
+       The condensation graph C of G. The node labels are integers 
+       corresponding to the index of the component in the list of 
+       strongly connected components of G. C has a graph attribute named
+       'mapping' with a dictionary mapping the original nodes to the
+       nodes in C to which they belong. Each node in C also has a node
+       attribute 'members' with the list of original nodes in G that 
+       form the SCC that the node in C represents.
 
     Raises
     ------
@@ -327,15 +329,17 @@ def condensation(G, scc=None):
     if scc is None:
         scc = nx.strongly_connected_components(G)
     mapping = {}
+    members = {}
     C = nx.DiGraph()
-    for i,component in enumerate(scc):
-        for n in component:
-            mapping[n] = i
-    number_of_components = i+1
+    for i, component in enumerate(scc):
+        members[i] = component
+        mapping.update((n, i) for n in component)
+    number_of_components = i + 1
     C.add_nodes_from(range(number_of_components))
-    for u,v in G.edges():
-        if mapping[u] != mapping[v]:
-            C.add_edge(mapping[u],mapping[v])
+    C.add_edges_from((mapping[u], mapping[v]) for u, v in G.edges_iter()
+                     if mapping[u] != mapping[v])
+    # Add a list of members (ie original nodes) to each node (ie scc) in C.
+    nx.set_node_attributes(C, 'members', members)
     # Add mapping dict as graph attribute
     C.graph['mapping'] = mapping
     return C

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -128,13 +128,15 @@ class TestStronglyConnected:
             edge = (1,0)
         assert_equal(cG.edges(),[edge])
 
-    def test_condensation_mapping(self):
+    def test_condensation_mapping_and_members(self):
         G, C = self.gc[1]
         cG = nx.condensation(G)
         mapping = cG.graph['mapping']
         assert_true(all(n in G for n in mapping))
         assert_true(all(0 == cN for n, cN in mapping.items() if n in C[0]))
         assert_true(all(1 == cN for n, cN in mapping.items() if n in C[1]))
+        for n, d in cG.nodes(data=True):
+            assert_equal(C[n], cG.node[n]['members'])
 
     def test_connected_raise(self):
         G=nx.Graph()


### PR DESCRIPTION
I've found myself several times needing a mapping of original nodes to condensation nodes (ie strongly connected components). It is easy to compute that myself (especially since `condensation` function accepts precomputed SCC as a parameter). But then the function itself recalculates the mapping for building the condensation graph. Adding the mapping as graph attribute is simple, backwards compatible, and avoids redundant computations.

I've also updated `condensation` docstrings and added a test.
