### PR TITLE
Speed up k-corona computation.

### DIFF
--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -271,7 +271,7 @@ def k_crust(G,k=None,core_number=None):
 def k_corona(G, k, core_number=None):
     """Return the k-corona of G.
 
-    The k-corona is the subset of vertices in the k-core which have
+    The k-corona is the subgraph of nodes in the k-core which have
     exactly k neighbours in the k-core.
 
     Parameters
@@ -319,6 +319,6 @@ def k_corona(G, k, core_number=None):
     if core_number is None:
         core_number = nx.core_number(G)
     nodes = (n for n in core_number
-             if core_number[n] >= k
+             if core_number[n] == k
              and len([v for v in G[n] if core_number[v] >= k]) == k)
     return G.subgraph(nodes).copy()


### PR DESCRIPTION
- Only nodes from the k-shell can be in the k-corona (no need to consider all the nodes in the k-core).
- Also fix the pydoc (s/subset/subgraph/ and s/vertices/nodes/ for consistency).
