### PR TITLE
Require Travis tests pass when installing dependencies from pip under CPython 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
 
   allow_failures:
     # 3.4 and pypy Wheels are not yet available.
-    - python: "3.4"
-      env: OPTIONAL_DEPS=pip
     - python: "pypy"
       env: OPTIONAL_DEPS=pip
     - env: OPTIONAL_DEPS=source


### PR DESCRIPTION
The necessary wheels for CPython 3.4 have apparently become available.

Coverage reporting is left unchanged.
