### PR TITLE
Add structure-only/shallow graph copy/to_directed/to_undirected/reverse

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -5,7 +5,6 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph
 from networkx.exception import NetworkXError
@@ -13,6 +12,7 @@ import networkx.convert as convert
 __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
+
 
 class DiGraph(Graph):
     """
@@ -162,6 +162,7 @@ class DiGraph(Graph):
 
     For details on these and other miscellaneous methods, see below.
     """
+
     def __init__(self, data=None, **attr):
         """Initialize a graph with edges, name, graph attributes.
 
@@ -196,8 +197,8 @@ class DiGraph(Graph):
         {'day': 'Friday'}
 
         """
-        self.graph = {} # dictionary for graph attributes
-        self.node = {} # dictionary for node attributes
+        self.graph = {}  # dictionary for graph attributes
+        self.node = {}  # dictionary for node attributes
         # We store two adjacency lists:
         # the  predecessors of node n are stored in the dict self.pred
         # the successors of node n are stored in the dict self.succ=self.adj
@@ -207,11 +208,10 @@ class DiGraph(Graph):
 
         # attempt to load graph with data
         if data is not None:
-            convert.to_networkx_graph(data,create_using=self)
+            convert.to_networkx_graph(data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
-        self.edge=self.adj
-
+        self.edge = self.adj
 
     def add_node(self, n, attr_dict=None, **attr):
         """Add a single node n and update node attributes.
@@ -257,20 +257,19 @@ class DiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         if n not in self.succ:
             self.succ[n] = {}
             self.pred[n] = {}
             self.node[n] = attr_dict
-        else: # update attr even if node already exists
+        else:  # update attr even if node already exists
             self.node[n].update(attr_dict)
-
 
     def add_nodes_from(self, nodes, **attr):
         """Add multiple nodes.
@@ -319,9 +318,9 @@ class DiGraph(Graph):
         """
         for n in nodes:
             try:
-                newnode=n not in self.succ
+                newnode = n not in self.succ
             except TypeError:
-                nn,ndict = n
+                nn, ndict = n
                 if nn not in self.succ:
                     self.succ[nn] = {}
                     self.pred[nn] = {}
@@ -372,17 +371,16 @@ class DiGraph(Graph):
 
         """
         try:
-            nbrs=self.succ[n]
+            nbrs = self.succ[n]
             del self.node[n]
-        except KeyError: # NetworkXError if n not in self
-            raise NetworkXError("The node %s is not in the digraph."%(n,))
+        except KeyError:  # NetworkXError if n not in self
+            raise NetworkXError("The node %s is not in the digraph." % (n,))
         for u in nbrs:
-            del self.pred[u][n] # remove all edges n-u in digraph
+            del self.pred[u][n]  # remove all edges n-u in digraph
         del self.succ[n]          # remove node from succ
         for u in self.pred[n]:
-            del self.succ[u][n] # remove all edges n-u in digraph
+            del self.succ[u][n]  # remove all edges n-u in digraph
         del self.pred[n]          # remove node from pred
-
 
     def remove_nodes_from(self, nbunch):
         """Remove multiple nodes.
@@ -412,17 +410,16 @@ class DiGraph(Graph):
         """
         for n in nbunch:
             try:
-                succs=self.succ[n]
+                succs = self.succ[n]
                 del self.node[n]
                 for u in succs:
-                    del self.pred[u][n] # remove all edges n-u in digraph
+                    del self.pred[u][n]  # remove all edges n-u in digraph
                 del self.succ[n]          # now remove node
                 for u in self.pred[n]:
-                    del self.succ[u][n] # remove all edges n-u in digraph
+                    del self.succ[u][n]  # remove all edges n-u in digraph
                 del self.pred[n]          # now remove node
             except KeyError:
-                pass # silent failure on remove
-
+                pass  # silent failure on remove
 
     def add_edge(self, u, v, attr_dict=None, **attr):
         """Add an edge between u and v.
@@ -474,27 +471,27 @@ class DiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.succ:
-            self.succ[u]={}
-            self.pred[u]={}
+            self.succ[u] = {}
+            self.pred[u] = {}
             self.node[u] = {}
         if v not in self.succ:
-            self.succ[v]={}
-            self.pred[v]={}
+            self.succ[v] = {}
+            self.pred[v] = {}
             self.node[v] = {}
         # add the edge
-        datadict=self.adj[u].get(v,{})
+        datadict = self.adj[u].get(v, {})
         datadict.update(attr_dict)
-        self.succ[u][v]=datadict
-        self.pred[v][u]=datadict
+        self.succ[u][v] = datadict
+        self.pred[v][u] = datadict
 
     def add_edges_from(self, ebunch, attr_dict=None, **attr):
         """Add all the edges in ebunch.
@@ -525,7 +522,7 @@ class DiGraph(Graph):
         will be updated when each duplicate edge is added.
 
         Edge attributes specified in edges as a tuple take precedence
-        over attributes specified generally.        
+        over attributes specified generally.
 
         Examples
         --------
@@ -541,25 +538,25 @@ class DiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dict.")
         # process ebunch
         for e in ebunch:
             ne = len(e)
-            if ne==3:
-                u,v,dd = e
-                assert hasattr(dd,"update")
-            elif ne==2:
-                u,v = e
+            if ne == 3:
+                u, v, dd = e
+                assert hasattr(dd, "update")
+            elif ne == 2:
+                u, v = e
                 dd = {}
             else:
-                raise NetworkXError(\
-                    "Edge tuple %s must be a 2-tuple or 3-tuple."%(e,))
+                raise NetworkXError(
+                    "Edge tuple %s must be a 2-tuple or 3-tuple." % (e,))
             if u not in self.succ:
                 self.succ[u] = {}
                 self.pred[u] = {}
@@ -568,12 +565,11 @@ class DiGraph(Graph):
                 self.succ[v] = {}
                 self.pred[v] = {}
                 self.node[v] = {}
-            datadict=self.adj[u].get(v,{})
+            datadict = self.adj[u].get(v, {})
             datadict.update(attr_dict)
             datadict.update(dd)
             self.succ[u][v] = datadict
             self.pred[v][u] = datadict
-
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -606,8 +602,7 @@ class DiGraph(Graph):
             del self.succ[u][v]
             del self.pred[v][u]
         except KeyError:
-            raise NetworkXError("The edge %s-%s not in graph."%(u,v))
-
+            raise NetworkXError("The edge %s-%s not in graph." % (u, v))
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -637,11 +632,10 @@ class DiGraph(Graph):
         >>> G.remove_edges_from(ebunch)
         """
         for e in ebunch:
-            (u,v)=e[:2]  # ignore edge data
+            (u, v) = e[:2]  # ignore edge data
             if u in self.succ and v in self.succ[u]:
                 del self.succ[u][v]
                 del self.pred[v][u]
-
 
     def has_successor(self, u, v):
         """Return True if node u has successor v.
@@ -657,7 +651,7 @@ class DiGraph(Graph):
         """
         return (u in self.pred and v in self.pred[u])
 
-    def successors_iter(self,n):
+    def successors_iter(self, n):
         """Return an iterator over successor nodes of n.
 
         neighbors_iter() and successors_iter() are the same.
@@ -665,14 +659,14 @@ class DiGraph(Graph):
         try:
             return iter(self.succ[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the digraph."%(n,))
+            raise NetworkXError("The node %s is not in the digraph." % (n,))
 
-    def predecessors_iter(self,n):
+    def predecessors_iter(self, n):
         """Return an iterator over predecessor nodes of n."""
         try:
             return iter(self.pred[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the digraph."%(n,))
+            raise NetworkXError("The node %s is not in the digraph." % (n,))
 
     def successors(self, n):
         """Return a list of successor nodes of n.
@@ -684,7 +678,6 @@ class DiGraph(Graph):
     def predecessors(self, n):
         """Return a list of predecessor nodes of n."""
         return list(self.predecessors_iter(n))
-
 
     # digraph definitions
     neighbors = successors
@@ -733,21 +726,21 @@ class DiGraph(Graph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.adj.items()
+            nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
         if data:
-            for n,nbrs in nodes_nbrs:
-                for nbr,data in nbrs.items():
-                    yield (n,nbr,data)
+            for n, nbrs in nodes_nbrs:
+                for nbr, data in nbrs.items():
+                    yield (n, nbr, data)
         else:
-            for n,nbrs in nodes_nbrs:
+            for n, nbrs in nodes_nbrs:
                 for nbr in nbrs:
-                    yield (n,nbr)
+                    yield (n, nbr)
 
     # alias out_edges to edges
-    out_edges_iter=edges_iter
-    out_edges=Graph.edges
+    out_edges_iter = edges_iter
+    out_edges = Graph.edges
 
     def in_edges_iter(self, nbunch=None, data=False):
         """Return an iterator over the incoming edges.
@@ -770,17 +763,17 @@ class DiGraph(Graph):
         edges_iter : return an iterator of edges
         """
         if nbunch is None:
-            nodes_nbrs=self.pred.items()
+            nodes_nbrs = self.pred.items()
         else:
-            nodes_nbrs=((n,self.pred[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.pred[n]) for n in self.nbunch_iter(nbunch))
         if data:
-            for n,nbrs in nodes_nbrs:
-                for nbr,data in nbrs.items():
-                    yield (nbr,n,data)
+            for n, nbrs in nodes_nbrs:
+                for nbr, data in nbrs.items():
+                    yield (nbr, n, data)
         else:
-            for n,nbrs in nodes_nbrs:
+            for n, nbrs in nodes_nbrs:
                 for nbr in nbrs:
-                    yield (nbr,n)
+                    yield (nbr, n)
 
     def in_edges(self, nbunch=None, data=False):
         """Return a list of the incoming edges.
@@ -803,7 +796,7 @@ class DiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -827,22 +820,21 @@ class DiGraph(Graph):
 
         """
         if nbunch is None:
-            nodes_nbrs=zip(iter(self.succ.items()),iter(self.pred.items()))
+            nodes_nbrs = zip(iter(self.succ.items()), iter(self.pred.items()))
         else:
-            nodes_nbrs=zip(
-                ((n,self.succ[n]) for n in self.nbunch_iter(nbunch)),
-                ((n,self.pred[n]) for n in self.nbunch_iter(nbunch)))
+            nodes_nbrs = zip(
+                ((n, self.succ[n]) for n in self.nbunch_iter(nbunch)),
+                ((n, self.pred[n]) for n in self.nbunch_iter(nbunch)))
 
         if weight is None:
-            for (n,succ),(n2,pred) in nodes_nbrs:
-                yield (n,len(succ)+len(pred))
+            for (n, succ), (n2, pred) in nodes_nbrs:
+                yield (n, len(succ) + len(pred))
         else:
-        # edge weighted graph - degree is sum of edge weights
-            for (n,succ),(n2,pred) in nodes_nbrs:
-               yield (n,
-                      sum((succ[nbr].get(weight,1) for nbr in succ))+
-                      sum((pred[nbr].get(weight,1) for nbr in pred)))
-
+            # edge weighted graph - degree is sum of edge weights
+            for (n, succ), (n2, pred) in nodes_nbrs:
+                yield (n,
+                       sum((succ[nbr].get(weight, 1) for nbr in succ)) +
+                       sum((pred[nbr].get(weight, 1) for nbr in pred)))
 
     def in_degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, in-degree).
@@ -856,7 +848,7 @@ class DiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -880,18 +872,17 @@ class DiGraph(Graph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.pred.items()
+            nodes_nbrs = self.pred.items()
         else:
-            nodes_nbrs=((n,self.pred[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.pred[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n,len(nbrs))
+            for n, nbrs in nodes_nbrs:
+                yield (n, len(nbrs))
         else:
-        # edge weighted graph - degree is sum of edge weights
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum(data.get(weight,1) for data in nbrs.values()))
-
+            # edge weighted graph - degree is sum of edge weights
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum(data.get(weight, 1) for data in nbrs.values()))
 
     def out_degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, out-degree).
@@ -905,7 +896,7 @@ class DiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -929,18 +920,17 @@ class DiGraph(Graph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.succ.items()
+            nodes_nbrs = self.succ.items()
         else:
-            nodes_nbrs=((n,self.succ[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.succ[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n,len(nbrs))
+            for n, nbrs in nodes_nbrs:
+                yield (n, len(nbrs))
         else:
-        # edge weighted graph - degree is sum of edge weights
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum(data.get(weight,1) for data in nbrs.values()))
-
+            # edge weighted graph - degree is sum of edge weights
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum(data.get(weight, 1) for data in nbrs.values()))
 
     def in_degree(self, nbunch=None, weight=None):
         """Return the in-degree of a node or nodes.
@@ -954,7 +944,7 @@ class DiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -980,9 +970,9 @@ class DiGraph(Graph):
         [0, 1]
         """
         if nbunch in self:      # return a single node
-            return next(self.in_degree_iter(nbunch,weight))[1]
+            return next(self.in_degree_iter(nbunch, weight))[1]
         else:           # return a dict
-            return dict(self.in_degree_iter(nbunch,weight))
+            return dict(self.in_degree_iter(nbunch, weight))
 
     def out_degree(self, nbunch=None, weight=None):
         """Return the out-degree of a node or nodes.
@@ -996,7 +986,7 @@ class DiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -1020,9 +1010,9 @@ class DiGraph(Graph):
 
         """
         if nbunch in self:      # return a single node
-            return next(self.out_degree_iter(nbunch,weight))[1]
+            return next(self.out_degree_iter(nbunch, weight))[1]
         else:           # return a dict
-            return dict(self.out_degree_iter(nbunch,weight))
+            return dict(self.out_degree_iter(nbunch, weight))
 
     def clear(self):
         """Remove all nodes and edges from the graph.
@@ -1045,109 +1035,15 @@ class DiGraph(Graph):
         self.node.clear()
         self.graph.clear()
 
-
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""
         return False
-
 
     def is_directed(self):
         """Return True if graph is directed, False otherwise."""
         return True
 
-    def to_directed(self):
-        """Return a directed copy of the graph.
-
-        Returns
-        -------
-        G : DiGraph
-            A deepcopy of the graph.
-
-        Notes
-        -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or MultiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1), (1, 0)]
-
-        If already directed, return a (deep) copy
-
-        >>> G = nx.DiGraph()   # or MultiDiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1)]
-        """
-        return deepcopy(self)
-
-    def to_undirected(self, reciprocal=False):
-        """Return an undirected representation of the digraph.
-
-        Parameters
-        ----------
-        reciprocal : bool (optional)
-          If True only keep edges that appear in both directions 
-          in the original digraph. 
-
-        Returns
-        -------
-        G : Graph
-            An undirected graph with the same name and nodes and
-            with edge (u,v,data) if either (u,v,data) or (v,u,data)
-            is in the digraph.  If both edges exist in digraph and
-            their edge data is different, only one edge is created
-            with an arbitrary choice of which edge data to use.
-            You must check and correct for this manually if desired.
-
-        Notes
-        -----
-        If edges in both directions (u,v) and (v,u) exist in the
-        graph, attributes for the new undirected edge will be a combination of
-        the attributes of the directed edges.  The edge data is updated
-        in the (arbitrary) order that the edges are encountered.  For
-        more customized control of the edge attributes use add_edge().
-
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar G=DiGraph(D) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-        """
-        H=Graph()
-        H.name=self.name
-        H.add_nodes_from(self)
-        if reciprocal is True:
-            H.add_edges_from( (u,v,deepcopy(d))
-                              for u,nbrs in self.adjacency_iter()
-                              for v,d in nbrs.items() 
-                              if v in self.pred[u])
-        else:
-            H.add_edges_from( (u,v,deepcopy(d))
-                              for u,nbrs in self.adjacency_iter()
-                              for v,d in nbrs.items() )
-        H.graph=deepcopy(self.graph)
-        H.node=deepcopy(self.node)
-        return H
-
-
-    def reverse(self, copy=True):
+    def reverse(self, copy=True, data=True):
         """Return the reverse of the graph.
 
         The reverse is a graph with the same nodes and edges
@@ -1155,24 +1051,24 @@ class DiGraph(Graph):
 
         Parameters
         ----------
-        copy : bool optional (default=True)
-            If True, return a new DiGraph holding the reversed edges.
-            If False, reverse the reverse graph is created using
-            the original graph (this changes the original graph).
+        copy : bool, optional
+            If True, make a copy before reversing the graph. Otherwise, reverse
+            the graph in place.
+
+        data : bool or string, optional
+            If False, copy only the graph structure. If equal to the string
+            'shallow', return a shallow copy. Otherwise, return a deep copy.
+            Ignored if 'copy' is False. Default value: True.
         """
         if copy:
-            H = self.__class__(name="Reverse of (%s)"%self.name)
-            H.add_nodes_from(self)
-            H.add_edges_from( (v,u,deepcopy(d)) for u,v,d 
-                              in self.edges(data=True) )
-            H.graph=deepcopy(self.graph)
-            H.node=deepcopy(self.node)
+            H = self.copy(data)
+            if data:
+                H.name = 'Reverse of (%s)' % self.name
         else:
-            self.pred,self.succ=self.succ,self.pred
-            self.adj=self.succ
-            H=self
+            H = self
+        H.pred, H.succ = H.succ, H.pred
+        H.adj = H.succ
         return H
-
 
     def subgraph(self, nbunch):
         """Return the subgraph induced on nodes in nbunch.
@@ -1218,22 +1114,22 @@ class DiGraph(Graph):
         H = self.__class__()
         # copy node and attribute dictionaries
         for n in bunch:
-            H.node[n]=self.node[n]
+            H.node[n] = self.node[n]
         # namespace shortcuts for speed
-        H_succ=H.succ
-        H_pred=H.pred
-        self_succ=self.succ
+        H_succ = H.succ
+        H_pred = H.pred
+        self_succ = self.succ
         # add nodes
         for n in H:
-            H_succ[n]={}
-            H_pred[n]={}
+            H_succ[n] = {}
+            H_pred[n] = {}
         # add edges
         for u in H_succ:
-            Hnbrs=H_succ[u]
-            for v,datadict in self_succ[u].items():
+            Hnbrs = H_succ[u]
+            for v, datadict in self_succ[u].items():
                 if v in H_succ:
                     # add both representations of edge: u-v and v-u
-                    Hnbrs[v]=datadict
-                    H_pred[v][u]=datadict
-        H.graph=self.graph
+                    Hnbrs[v] = datadict
+                    H_pred[v][u] = datadict
+        H.graph = self.graph
         return H

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -5,7 +5,6 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph
 from networkx.exception import NetworkXError
@@ -1044,98 +1043,7 @@ class DiGraph(Graph):
         """Return True if graph is directed, False otherwise."""
         return True
 
-    def to_directed(self):
-        """Return a directed copy of the graph.
-
-        Returns
-        -------
-        G : DiGraph
-            A deepcopy of the graph.
-
-        Notes
-        -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or MultiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1), (1, 0)]
-
-        If already directed, return a (deep) copy
-
-        >>> G = nx.DiGraph()   # or MultiDiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1)]
-        """
-        return deepcopy(self)
-
-    def to_undirected(self, reciprocal=False):
-        """Return an undirected representation of the digraph.
-
-        Parameters
-        ----------
-        reciprocal : bool (optional)
-          If True only keep edges that appear in both directions
-          in the original digraph.
-
-        Returns
-        -------
-        G : Graph
-            An undirected graph with the same name and nodes and
-            with edge (u,v,data) if either (u,v,data) or (v,u,data)
-            is in the digraph.  If both edges exist in digraph and
-            their edge data is different, only one edge is created
-            with an arbitrary choice of which edge data to use.
-            You must check and correct for this manually if desired.
-
-        Notes
-        -----
-        If edges in both directions (u,v) and (v,u) exist in the
-        graph, attributes for the new undirected edge will be a combination of
-        the attributes of the directed edges.  The edge data is updated
-        in the (arbitrary) order that the edges are encountered.  For
-        more customized control of the edge attributes use add_edge().
-
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar G=DiGraph(D) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-        """
-        H = Graph()
-        H.name = self.name
-        H.add_nodes_from(self)
-        if reciprocal is True:
-            H.add_edges_from((u, v, deepcopy(d))
-                             for u, nbrs in self.adjacency_iter()
-                             for v, d in nbrs.items()
-                             if v in self.pred[u])
-        else:
-            H.add_edges_from((u, v, deepcopy(d))
-                             for u, nbrs in self.adjacency_iter()
-                             for v, d in nbrs.items())
-        H.graph = deepcopy(self.graph)
-        H.node = deepcopy(self.node)
-        return H
-
-    def reverse(self, copy=True):
+    def reverse(self, copy=True, data=True):
         """Return the reverse of the graph.
 
         The reverse is a graph with the same nodes and edges
@@ -1143,22 +1051,23 @@ class DiGraph(Graph):
 
         Parameters
         ----------
-        copy : bool optional (default=True)
-            If True, return a new DiGraph holding the reversed edges.
-            If False, reverse the reverse graph is created using
-            the original graph (this changes the original graph).
+        copy : bool, optional
+            If True, make a copy before reversing the graph. Otherwise, reverse
+            the graph in place.
+
+        data : bool or string, optional
+            If False, copy only the graph structure. If equal to the string
+            'shallow', return a shallow copy. Otherwise, return a deep copy.
+            Ignored if 'copy' is False. Default value: True.
         """
         if copy:
-            H = self.__class__(name="Reverse of (%s)" % self.name)
-            H.add_nodes_from(self)
-            H.add_edges_from((v, u, deepcopy(d)) for u, v, d
-                             in self.edges(data=True))
-            H.graph = deepcopy(self.graph)
-            H.node = deepcopy(self.node)
+            H = self.copy(data)
+            if data:
+                H.name = 'Reverse of (%s)' % self.name
         else:
-            self.pred, self.succ = self.succ, self.pred
-            self.adj = self.succ
             H = self
+        H.pred, H.succ = H.succ, H.pred
+        H.adj = H.succ
         return H
 
     def subgraph(self, nbunch):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -13,7 +13,8 @@ For directed graphs see DiGraph and MultiDiGraph.
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
+from copy import copy, deepcopy
+from itertools import chain
 import networkx as nx
 from networkx.exception import NetworkXError
 import networkx.convert as convert
@@ -320,6 +321,39 @@ class Graph(object):
         {1: {}}
         """
         return self.adj[n]
+
+    def __copy__(self):
+        """Return a shallow copy of the graph. Use the expression 'copy(G)'
+        where 'copy' is imported from the 'copy' module.
+
+        Returns
+        -------
+        H : NetworkX graph
+            A shallow copy of the graph.
+
+        Notes
+        -----
+        H has new internal data dictionaries but shares the dictionary keys and
+        values with the original graph. Only internal data dictionaries defined
+        by NetworkX are copied. Subclasses should override this function to
+        provide proper shallow copying semantics.
+
+        Examples
+        --------
+        >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
+        >>> G.add_path([0,1,2,3])
+        >>> G = copy(G)
+        >>> sorted(map(sorted, G.edges_iter()))
+        [[0, 1], [1, 2], [2, 3]]
+        """
+        H = self.__class__()
+        H.graph.update(self.graph)
+        H.add_nodes_from(self.nodes_iter(data=True))
+        kwargs = {'data': True}
+        if self.is_multigraph():
+            kwargs['keys'] = True
+        H.add_edges_from(self.edges_iter(**kwargs))
+        return H
 
     def add_node(self, n, attr_dict=None, **attr):
         """Add a single node n and update node attributes.
@@ -1314,30 +1348,38 @@ class Graph(object):
         self.node.clear()
         self.graph.clear()
 
-    def copy(self):
+    def copy(self, data=True):
         """Return a copy of the graph.
 
         Returns
         -------
-        G : Graph
+        G : NetworkX graph
             A copy of the graph.
+
+        data : bool or string, optional
+            If False, copy only the graph structure. If equal to the string
+            'shallow', return a shallow copy. Otherwise, return a deep copy.
+            Default value: True.
 
         See Also
         --------
-        to_directed: return a directed copy of the graph.
-
-        Notes
-        -----
-        This makes a complete copy of the graph including all of the
-        node or edge attributes.
+        to_directed
+        to_undirected
 
         Examples
         --------
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
         >>> G.add_path([0,1,2,3])
         >>> H = G.copy()
-
         """
+        if not data:
+            H = self.__class__()
+            H.add_nodes_from(self)
+            kwargs = {} if not self.is_multigraph() else {'keys': True}
+            H.add_edges_from(self.edges_iter(**kwargs))
+            return H
+        elif data == 'shallow':
+            return copy(self)
         return deepcopy(self)
 
     def is_multigraph(self):
@@ -1348,27 +1390,33 @@ class Graph(object):
         """Return True if graph is directed, False otherwise."""
         return False
 
-    def to_directed(self):
-        """Return a directed representation of the graph.
+    def to_directed(self, data=True):
+        """Return a directed copy of the graph.
 
         Returns
         -------
-        G : DiGraph
-            A directed graph with the same name, same nodes, and with
-            each edge (u,v,data) replaced by two directed edges
-            (u,v,data) and (v,u,data).
+        G : NetworkX graph
+            A directed copy of the graph.
+
+        data : bool or string, optional
+            If False, copy only the graph structure. If equal to the string
+            'shallow', return a shallow copy. Otherwise, return a deep copy.
+            Default value: True.
 
         Notes
         -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
+        If G is directed, 'G.to_directed(data)' is equivalent to
+        'G.copy(data)'.
 
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
+        If G is undirected, each edge (u, v) becomes a pair of reciprocal edges
+        (u, v) and (v, u) with the same key (if G is a multigraph) and the same
+        data (if copied). Unless deep-copied, the key and the data contents are
+        referentially identical.
 
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
+        See Also
+        --------
+        copy
+        to_undirected
 
         Examples
         --------
@@ -1386,40 +1434,54 @@ class Graph(object):
         >>> H.edges()
         [(0, 1)]
         """
-        from networkx import DiGraph
-        G = DiGraph()
-        G.name = self.name
+        if self.is_directed():
+            return self.copy(data)
+        multigraph = self.is_multigraph()
+        G = nx.DiGraph() if not multigraph else nx.MultiDiGraph()
         G.add_nodes_from(self)
-        G.add_edges_from(((u, v, deepcopy(data))
-                          for u, nbrs in self.adjacency_iter()
-                          for v, data in nbrs.items()))
-        G.graph = deepcopy(self.graph)
-        G.node = deepcopy(self.node)
-        return G
+        if data:
+            G.graph.update(self.graph)
+            G.node.update(self.node)
+        kwargs = {'data': bool(data)}
+        if multigraph:
+            kwargs['keys'] = True
+        G.add_edges_from(chain.from_iterable(
+            [e, e[1::-1] + e[2:]]
+            for e in self.edges_iter(**kwargs)))
+        return deepcopy(G) if data and data != 'shallow' else G
 
-    def to_undirected(self):
+    def to_undirected(self, reciprocal=False, data=True):
         """Return an undirected copy of the graph.
 
         Returns
         -------
-        G : Graph/MultiGraph
-            A deepcopy of the graph.
+        G : NetworkX graph
+            An undirected copy of the graph.
+
+        reciprocal : bool, optional
+            If True, keep only edges that appear in both directions with the
+            same key.
+
+        data : bool or string, optional
+            If False, copy only the graph structure. If equal to the string
+            'shallow', return a shallow copy. Otherwise, return a deep copy.
+            Default value: True.
 
         See Also
         --------
-        copy, add_edge, add_edges_from
+        copy
+        to_directed
 
         Notes
         -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
+        If G is undirected, 'G.to_undirected(data)' is equivalent to
+        'G.copy(data)'.
 
-        This is in contrast to the similar G=DiGraph(D) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
+        If G is directed, each edge (u, v) becomes an undirected edge (u, v)
+        with the same key (if G is a multigraph) and the same data (if copied).
+        Each pair of reciprocal edges (with the same key if G is a multigraph)
+        becomes one undirected edge in the resulting graph. Their data, if
+        conflicting, are arbitrarily mixed.
 
         Examples
         --------
@@ -1432,7 +1494,25 @@ class Graph(object):
         >>> G2.edges()
         [(0, 1)]
         """
-        return deepcopy(self)
+        if not self.is_directed():
+            return self.copy(data)
+        multigraph = self.is_multigraph()
+        G = nx.Graph() if not multigraph else nx.MultiGraph()
+        G.add_nodes_from(self)
+        if data:
+            G.graph.update(self.graph)
+            G.node.update(self.node)
+        kwargs = {'data': bool(data)}
+        if multigraph:
+            kwargs['keys'] = True
+        edges = self.edges_iter(**kwargs)
+        if reciprocal:
+            if not multigraph:
+                edges = (e for e in edges if self.has_edge(e[1], e[0]))
+            else:
+                edges = (e for e in edges if self.has_edge(e[1], e[0], e[2]))
+        G.add_edges_from(edges)
+        return deepcopy(G) if data and data != 'shallow' else G
 
     def subgraph(self, nbunch):
         """Return the subgraph induced on nodes in nbunch.

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -5,7 +5,6 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph  # for doctests
 from networkx.classes.digraph import DiGraph
@@ -15,7 +14,8 @@ __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
 
-class MultiDiGraph(MultiGraph,DiGraph):
+
+class MultiDiGraph(MultiGraph, DiGraph):
     """A directed graph class that can store multiedges.
 
     Multiedges are multiple edges between two nodes.  Each edge
@@ -171,6 +171,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
     For details on these and other miscellaneous methods, see below.
     """
+
     def add_edge(self, u, v, key=None, attr_dict=None, **attr):
         """Add an edge between u and v.
 
@@ -226,12 +227,12 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.succ:
@@ -243,23 +244,23 @@ class MultiDiGraph(MultiGraph,DiGraph):
             self.pred[v] = {}
             self.node[v] = {}
         if v in self.succ[u]:
-            keydict=self.adj[u][v]
+            keydict = self.adj[u][v]
             if key is None:
                 # find a unique integer key
                 # other methods might be better here?
-                key=len(keydict)
+                key = len(keydict)
                 while key in keydict:
-                    key+=1
-            datadict=keydict.get(key,{})
+                    key += 1
+            datadict = keydict.get(key, {})
             datadict.update(attr_dict)
-            keydict[key]=datadict
+            keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
-                key=0
-            datadict={}
+                key = 0
+            datadict = {}
             datadict.update(attr_dict)
-            keydict={key:datadict}
+            keydict = {key: datadict}
             self.succ[u][v] = keydict
             self.pred[v][u] = keydict
 
@@ -307,10 +308,10 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         try:
-            d=self.adj[u][v]
+            d = self.adj[u][v]
         except (KeyError):
             raise NetworkXError(
-                "The edge %s-%s is not in the graph."%(u,v))
+                "The edge %s-%s is not in the graph." % (u, v))
         # remove the edge with specified data
         if key is None:
             d.popitem()
@@ -319,12 +320,11 @@ class MultiDiGraph(MultiGraph,DiGraph):
                 del d[key]
             except (KeyError):
                 raise NetworkXError(
-                "The edge %s-%s with key %s is not in the graph."%(u,v,key))
-        if len(d)==0:
+                    "The edge %s-%s with key %s is not in the graph." % (u, v, key))
+        if len(d) == 0:
             # remove the key entries if last edge
             del self.succ[u][v]
             del self.pred[v][u]
-
 
     def edges_iter(self, nbunch=None, data=False, keys=False):
         """Return an iterator over the edges.
@@ -373,26 +373,26 @@ class MultiDiGraph(MultiGraph,DiGraph):
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
         if data:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,data in keydict.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, data in keydict.items():
                         if keys:
-                            yield (n,nbr,key,data)
+                            yield (n, nbr, key, data)
                         else:
-                            yield (n,nbr,data)
+                            yield (n, nbr, data)
         else:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,data in keydict.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, data in keydict.items():
                         if keys:
-                            yield (n,nbr,key)
+                            yield (n, nbr, key)
                         else:
-                            yield (n,nbr)
+                            yield (n, nbr)
 
     # alias out_edges to edges
-    out_edges_iter=edges_iter
+    out_edges_iter = edges_iter
 
     def out_edges(self, nbunch=None, keys=False, data=False):
         """Return a list of the outgoing edges.
@@ -426,7 +426,6 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         return list(self.out_edges_iter(nbunch, keys=keys, data=data))
 
-
     def in_edges_iter(self, nbunch=None, data=False, keys=False):
         """Return an iterator over the incoming edges.
 
@@ -450,25 +449,25 @@ class MultiDiGraph(MultiGraph,DiGraph):
         edges_iter : return an iterator of edges
         """
         if nbunch is None:
-            nodes_nbrs=self.pred.items()
+            nodes_nbrs = self.pred.items()
         else:
-            nodes_nbrs=((n,self.pred[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.pred[n]) for n in self.nbunch_iter(nbunch))
         if data:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,data in keydict.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, data in keydict.items():
                         if keys:
-                            yield (nbr,n,key,data)
+                            yield (nbr, n, key, data)
                         else:
-                            yield (nbr,n,data)
+                            yield (nbr, n, data)
         else:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,data in keydict.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, data in keydict.items():
                         if keys:
-                            yield (nbr,n,key)
+                            yield (nbr, n, key)
                         else:
-                            yield (nbr,n)
+                            yield (nbr, n)
 
     def in_edges(self, nbunch=None, keys=False, data=False):
         """Return a list of the incoming edges.
@@ -494,7 +493,6 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         return list(self.in_edges_iter(nbunch, keys=keys, data=data))
 
-
     def degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, degree).
 
@@ -507,7 +505,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -531,28 +529,27 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs=zip(iter(self.succ.items()),iter(self.pred.items()))
+            nodes_nbrs = zip(iter(self.succ.items()), iter(self.pred.items()))
         else:
-            nodes_nbrs=zip(
-                ((n,self.succ[n]) for n in self.nbunch_iter(nbunch)),
-                ((n,self.pred[n]) for n in self.nbunch_iter(nbunch)))
+            nodes_nbrs = zip(
+                ((n, self.succ[n]) for n in self.nbunch_iter(nbunch)),
+                ((n, self.pred[n]) for n in self.nbunch_iter(nbunch)))
 
         if weight is None:
-            for (n,succ),(n2,pred) in nodes_nbrs:
+            for (n, succ), (n2, pred) in nodes_nbrs:
                 indeg = sum([len(data) for data in pred.values()])
                 outdeg = sum([len(data) for data in succ.values()])
                 yield (n, indeg + outdeg)
         else:
-        # edge weighted graph - degree is sum of nbr edge weights
-            for (n,succ),(n2,pred) in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            # edge weighted graph - degree is sum of nbr edge weights
+            for (n, succ), (n2, pred) in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in pred.values()
                            for d in data.values()])
-                deg += sum([d.get(weight,1)
-                           for data in succ.values()
-                           for d in data.values()])
+                deg += sum([d.get(weight, 1)
+                            for data in succ.values()
+                            for d in data.values()])
                 yield (n, deg)
-
 
     def in_degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, in-degree).
@@ -566,7 +563,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -590,21 +587,20 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.pred.items()
+            nodes_nbrs = self.pred.items()
         else:
-            nodes_nbrs=((n,self.pred[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.pred[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum([len(data) for data in nbrs.values()]) )
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum([len(data) for data in nbrs.values()]))
         else:
             # edge weighted graph - degree is sum of nbr edge weights
-            for n,pred in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            for n, pred in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in pred.values()
                            for d in data.values()])
                 yield (n, deg)
-
 
     def out_degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, out-degree).
@@ -618,7 +614,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -642,16 +638,16 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.succ.items()
+            nodes_nbrs = self.succ.items()
         else:
-            nodes_nbrs=((n,self.succ[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.succ[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum([len(data) for data in nbrs.values()]) )
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum([len(data) for data in nbrs.values()]))
         else:
-            for n,succ in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            for n, succ in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in succ.values()
                            for d in data.values()])
                 yield (n, deg)
@@ -663,99 +659,6 @@ class MultiDiGraph(MultiGraph,DiGraph):
     def is_directed(self):
         """Return True if graph is directed, False otherwise."""
         return True
-
-    def to_directed(self):
-        """Return a directed copy of the graph.
-
-        Returns
-        -------
-        G : MultiDiGraph
-            A deepcopy of the graph.
-
-        Notes
-        -----
-        If edges in both directions (u,v) and (v,u) exist in the
-        graph, attributes for the new undirected edge will be a combination of
-        the attributes of the directed edges.  The edge data is updated
-        in the (arbitrary) order that the edges are encountered.  For
-        more customized control of the edge attributes use add_edge().
-
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar G=DiGraph(D) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or MultiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1), (1, 0)]
-
-        If already directed, return a (deep) copy
-
-        >>> G = nx.MultiDiGraph()
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1)]
-        """
-        return deepcopy(self)
-
-    def to_undirected(self, reciprocal=False):
-        """Return an undirected representation of the digraph.
-
-        Parameters
-        ----------
-        reciprocal : bool (optional)
-          If True only keep edges that appear in both directions 
-          in the original digraph. 
-
-        Returns
-        -------
-        G : MultiGraph
-            An undirected graph with the same name and nodes and
-            with edge (u,v,data) if either (u,v,data) or (v,u,data)
-            is in the digraph.  If both edges exist in digraph and
-            their edge data is different, only one edge is created
-            with an arbitrary choice of which edge data to use.
-            You must check and correct for this manually if desired.
-
-        Notes
-        -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-        """
-        H=MultiGraph()
-        H.name=self.name
-        H.add_nodes_from(self)
-        if reciprocal is True:
-            H.add_edges_from( (u,v,key,deepcopy(data))
-                              for u,nbrs in self.adjacency_iter()
-                              for v,keydict in nbrs.items()
-                              for key,data in keydict.items()
-                              if self.has_edge(v,u,key))
-        else:
-            H.add_edges_from( (u,v,key,deepcopy(data))
-                              for u,nbrs in self.adjacency_iter()
-                              for v,keydict in nbrs.items()
-                              for key,data in keydict.items())
-        H.graph=deepcopy(self.graph)
-        H.node=deepcopy(self.node)
-        return H
 
     def subgraph(self, nbunch):
         """Return the subgraph induced on nodes in nbunch.
@@ -801,51 +704,25 @@ class MultiDiGraph(MultiGraph,DiGraph):
         H = self.__class__()
         # copy node and attribute dictionaries
         for n in bunch:
-            H.node[n]=self.node[n]
+            H.node[n] = self.node[n]
         # namespace shortcuts for speed
-        H_succ=H.succ
-        H_pred=H.pred
-        self_succ=self.succ
-        self_pred=self.pred
+        H_succ = H.succ
+        H_pred = H.pred
+        self_succ = self.succ
+        self_pred = self.pred
         # add nodes
         for n in H:
-            H_succ[n]={}
-            H_pred[n]={}
+            H_succ[n] = {}
+            H_pred[n] = {}
         # add edges
         for u in H_succ:
-            Hnbrs=H_succ[u]
-            for v,edgedict in self_succ[u].items():
+            Hnbrs = H_succ[u]
+            for v, edgedict in self_succ[u].items():
                 if v in H_succ:
                     # add both representations of edge: u-v and v-u
                     # they share the same edgedict
-                    ed=edgedict.copy()
-                    Hnbrs[v]=ed
-                    H_pred[v][u]=ed
-        H.graph=self.graph
-        return H
-
-    def reverse(self, copy=True):
-        """Return the reverse of the graph.
-
-        The reverse is a graph with the same nodes and edges
-        but with the directions of the edges reversed.
-
-        Parameters
-        ----------
-        copy : bool optional (default=True)
-            If True, return a new DiGraph holding the reversed edges.
-            If False, reverse the reverse graph is created using
-            the original graph (this changes the original graph).
-        """
-        if copy:
-            H = self.__class__(name="Reverse of (%s)"%self.name)
-            H.add_nodes_from(self)
-            H.add_edges_from( (v,u,k,deepcopy(d)) for u,v,k,d 
-                              in self.edges(keys=True, data=True) )
-            H.graph=deepcopy(self.graph)
-            H.node=deepcopy(self.node)
-        else:
-            self.pred,self.succ=self.succ,self.pred
-            self.adj=self.succ
-            H=self
+                    ed = edgedict.copy()
+                    Hnbrs[v] = ed
+                    H_pred[v][u] = ed
+        H.graph = self.graph
         return H

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -5,7 +5,6 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph  # for doctests
 from networkx.classes.digraph import DiGraph
@@ -661,99 +660,6 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """Return True if graph is directed, False otherwise."""
         return True
 
-    def to_directed(self):
-        """Return a directed copy of the graph.
-
-        Returns
-        -------
-        G : MultiDiGraph
-            A deepcopy of the graph.
-
-        Notes
-        -----
-        If edges in both directions (u,v) and (v,u) exist in the
-        graph, attributes for the new undirected edge will be a combination of
-        the attributes of the directed edges.  The edge data is updated
-        in the (arbitrary) order that the edges are encountered.  For
-        more customized control of the edge attributes use add_edge().
-
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar G=DiGraph(D) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or MultiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1), (1, 0)]
-
-        If already directed, return a (deep) copy
-
-        >>> G = nx.MultiDiGraph()
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1)]
-        """
-        return deepcopy(self)
-
-    def to_undirected(self, reciprocal=False):
-        """Return an undirected representation of the digraph.
-
-        Parameters
-        ----------
-        reciprocal : bool (optional)
-          If True only keep edges that appear in both directions
-          in the original digraph.
-
-        Returns
-        -------
-        G : MultiGraph
-            An undirected graph with the same name and nodes and
-            with edge (u,v,data) if either (u,v,data) or (v,u,data)
-            is in the digraph.  If both edges exist in digraph and
-            their edge data is different, only one edge is created
-            with an arbitrary choice of which edge data to use.
-            You must check and correct for this manually if desired.
-
-        Notes
-        -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-        """
-        H = MultiGraph()
-        H.name = self.name
-        H.add_nodes_from(self)
-        if reciprocal is True:
-            H.add_edges_from((u, v, key, deepcopy(data))
-                             for u, nbrs in self.adjacency_iter()
-                             for v, keydict in nbrs.items()
-                             for key, data in keydict.items()
-                             if self.has_edge(v, u, key))
-        else:
-            H.add_edges_from((u, v, key, deepcopy(data))
-                             for u, nbrs in self.adjacency_iter()
-                             for v, keydict in nbrs.items()
-                             for key, data in keydict.items())
-        H.graph = deepcopy(self.graph)
-        H.node = deepcopy(self.node)
-        return H
-
     def subgraph(self, nbunch):
         """Return the subgraph induced on nodes in nbunch.
 
@@ -819,30 +725,4 @@ class MultiDiGraph(MultiGraph, DiGraph):
                     Hnbrs[v] = ed
                     H_pred[v][u] = ed
         H.graph = self.graph
-        return H
-
-    def reverse(self, copy=True):
-        """Return the reverse of the graph.
-
-        The reverse is a graph with the same nodes and edges
-        but with the directions of the edges reversed.
-
-        Parameters
-        ----------
-        copy : bool optional (default=True)
-            If True, return a new DiGraph holding the reversed edges.
-            If False, reverse the reverse graph is created using
-            the original graph (this changes the original graph).
-        """
-        if copy:
-            H = self.__class__(name="Reverse of (%s)" % self.name)
-            H.add_nodes_from(self)
-            H.add_edges_from((v, u, k, deepcopy(d)) for u, v, k, d
-                             in self.edges(keys=True, data=True))
-            H.graph = deepcopy(self.graph)
-            H.node = deepcopy(self.node)
-        else:
-            self.pred, self.succ = self.succ, self.pred
-            self.adj = self.succ
-            H = self
         return H

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -5,7 +5,6 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph
 from networkx import NetworkXError
@@ -754,56 +753,6 @@ class MultiGraph(Graph):
     def is_directed(self):
         """Return True if graph is directed, False otherwise."""
         return False
-
-    def to_directed(self):
-        """Return a directed representation of the graph.
-
-        Returns
-        -------
-        G : MultiDiGraph
-            A directed graph with the same name, same nodes, and with
-            each edge (u,v,data) replaced by two directed edges
-            (u,v,data) and (v,u,data).
-
-        Notes
-        -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or MultiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1), (1, 0)]
-
-        If already directed, return a (deep) copy
-
-        >>> G = nx.DiGraph()   # or MultiDiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1)]
-        """
-        from networkx.classes.multidigraph import MultiDiGraph
-        G = MultiDiGraph()
-        G.add_nodes_from(self)
-        G.add_edges_from((u, v, key, deepcopy(datadict))
-                         for u, nbrs in self.adjacency_iter()
-                         for v, keydict in nbrs.items()
-                         for key, datadict in keydict.items())
-        G.graph = deepcopy(self.graph)
-        G.node = deepcopy(self.node)
-        return G
 
     def selfloop_edges(self, data=False, keys=False):
         """Return a list of selfloop edges.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -5,6 +5,7 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph
 from networkx import NetworkXError
@@ -753,6 +754,56 @@ class MultiGraph(Graph):
     def is_directed(self):
         """Return True if graph is directed, False otherwise."""
         return False
+
+    def to_directed(self):
+        """Return a directed representation of the graph.
+
+        Returns
+        -------
+        G : MultiDiGraph
+            A directed graph with the same name, same nodes, and with
+            each edge (u,v,data) replaced by two directed edges
+            (u,v,data) and (v,u,data).
+
+        Notes
+        -----
+        This returns a "deepcopy" of the edge, node, and
+        graph attributes which attempts to completely copy
+        all of the data and references.
+
+        This is in contrast to the similar D=DiGraph(G) which returns a
+        shallow copy of the data.
+
+        See the Python copy module for more information on shallow
+        and deep copies, http://docs.python.org/library/copy.html.
+
+
+        Examples
+        --------
+        >>> G = nx.Graph()   # or MultiGraph, etc
+        >>> G.add_path([0,1])
+        >>> H = G.to_directed()
+        >>> H.edges()
+        [(0, 1), (1, 0)]
+
+        If already directed, return a (deep) copy
+
+        >>> G = nx.DiGraph()   # or MultiDiGraph, etc
+        >>> G.add_path([0,1])
+        >>> H = G.to_directed()
+        >>> H.edges()
+        [(0, 1)]
+        """
+        from networkx.classes.multidigraph import MultiDiGraph
+        G = MultiDiGraph()
+        G.add_nodes_from(self)
+        G.add_edges_from((u, v, key, deepcopy(datadict))
+                         for u, nbrs in self.adjacency_iter()
+                         for v, keydict in nbrs.items()
+                         for key, datadict in keydict.items())
+        G.graph = deepcopy(self.graph)
+        G.node = deepcopy(self.node)
+        return G
 
     def selfloop_edges(self, data=False, keys=False):
         """Return a list of selfloop edges.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -5,13 +5,13 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
 import networkx as nx
 from networkx.classes.graph import Graph
 from networkx import NetworkXError
 __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
+
 
 class MultiGraph(Graph):
     """
@@ -172,6 +172,7 @@ class MultiGraph(Graph):
 
     For details on these and other miscellaneous methods, see below.
     """
+
     def add_edge(self, u, v, key=None, attr_dict=None, **attr):
         """Add an edge between u and v.
 
@@ -227,12 +228,12 @@ class MultiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.adj:
@@ -242,26 +243,25 @@ class MultiGraph(Graph):
             self.adj[v] = {}
             self.node[v] = {}
         if v in self.adj[u]:
-            keydict=self.adj[u][v]
+            keydict = self.adj[u][v]
             if key is None:
                 # find a unique integer key
                 # other methods might be better here?
-                key=len(keydict)
+                key = len(keydict)
                 while key in keydict:
-                    key+=1
-            datadict=keydict.get(key,{})
+                    key += 1
+            datadict = keydict.get(key, {})
             datadict.update(attr_dict)
-            keydict[key]=datadict
+            keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
-                key=0
-            datadict={}
+                key = 0
+            datadict = {}
             datadict.update(attr_dict)
-            keydict={key:datadict}
+            keydict = {key: datadict}
             self.adj[u][v] = keydict
             self.adj[v][u] = keydict
-
 
     def add_edges_from(self, ebunch, attr_dict=None, **attr):
         """Add all the edges in ebunch.
@@ -311,43 +311,42 @@ class MultiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # process ebunch
         for e in ebunch:
-            ne=len(e)
-            if ne==4:
-                u,v,key,dd = e
-            elif ne==3:
-                u,v,dd = e
-                key=None
-            elif ne==2:
-                u,v = e
+            ne = len(e)
+            if ne == 4:
+                u, v, key, dd = e
+            elif ne == 3:
+                u, v, dd = e
+                key = None
+            elif ne == 2:
+                u, v = e
                 dd = {}
-                key=None
+                key = None
             else:
-                raise NetworkXError(\
-                    "Edge tuple %s must be a 2-tuple, 3-tuple or 4-tuple."%(e,))
+                raise NetworkXError(
+                    "Edge tuple %s must be a 2-tuple, 3-tuple or 4-tuple." % (e,))
             if u in self.adj:
-                keydict=self.adj[u].get(v,{})
+                keydict = self.adj[u].get(v, {})
             else:
-                keydict={}
+                keydict = {}
             if key is None:
                 # find a unique integer key
                 # other methods might be better here?
-                key=len(keydict)
+                key = len(keydict)
                 while key in keydict:
-                    key+=1
-            datadict=keydict.get(key,{})
+                    key += 1
+            datadict = keydict.get(key, {})
             datadict.update(attr_dict)
             datadict.update(dd)
-            self.add_edge(u,v,key=key,attr_dict=datadict)
-
+            self.add_edge(u, v, key=key, attr_dict=datadict)
 
     def remove_edge(self, u, v, key=None):
         """Remove an edge between u and v.
@@ -393,10 +392,10 @@ class MultiGraph(Graph):
 
         """
         try:
-            d=self.adj[u][v]
+            d = self.adj[u][v]
         except (KeyError):
             raise NetworkXError(
-                "The edge %s-%s is not in the graph."%(u,v))
+                "The edge %s-%s is not in the graph." % (u, v))
         # remove the edge with specified data
         if key is None:
             d.popitem()
@@ -405,13 +404,12 @@ class MultiGraph(Graph):
                 del d[key]
             except (KeyError):
                 raise NetworkXError(
-                "The edge %s-%s with key %s is not in the graph."%(u,v,key))
-        if len(d)==0:
+                    "The edge %s-%s with key %s is not in the graph." % (u, v, key))
+        if len(d) == 0:
             # remove the key entries if last edge
             del self.adj[u][v]
-            if u!=v:  # check for selfloop
+            if u != v:  # check for selfloop
                 del self.adj[v][u]
-
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -457,7 +455,6 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
-
 
     def has_edge(self, u, v, key=None):
         """Return True if the graph has an edge between nodes u and v.
@@ -562,7 +559,7 @@ class MultiGraph(Graph):
         [(0, 1)]
 
         """
-        return list(self.edges_iter(nbunch, data=data,keys=keys))
+        return list(self.edges_iter(nbunch, data=data, keys=keys))
 
     def edges_iter(self, nbunch=None, data=False, keys=False):
         """Return an iterator over the edges.
@@ -612,34 +609,33 @@ class MultiGraph(Graph):
         [(0, 1)]
 
         """
-        seen={}     # helper dict to keep track of multiply stored edges
+        seen = {}     # helper dict to keep track of multiply stored edges
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
         if data:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
                     if nbr not in seen:
-                        for key,data in keydict.items():
+                        for key, data in keydict.items():
                             if keys:
-                                yield (n,nbr,key,data)
+                                yield (n, nbr, key, data)
                             else:
-                                yield (n,nbr,data)
-                seen[n]=1
+                                yield (n, nbr, data)
+                seen[n] = 1
         else:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
                     if nbr not in seen:
-                        for key,data in keydict.items():
+                        for key, data in keydict.items():
                             if keys:
-                                yield (n,nbr,key)
+                                yield (n, nbr, key)
                             else:
-                                yield (n,nbr)
+                                yield (n, nbr)
 
                 seen[n] = 1
         del seen
-
 
     def get_edge_data(self, u, v, key=None, default=None):
         """Return the attribute dictionary associated with edge (u,v).
@@ -707,7 +703,7 @@ class MultiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -733,23 +729,22 @@ class MultiGraph(Graph):
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
+            for n, nbrs in nodes_nbrs:
                 deg = sum([len(data) for data in nbrs.values()])
-                yield (n, deg+(n in nbrs and len(nbrs[n])))
+                yield (n, deg + (n in nbrs and len(nbrs[n])))
         else:
-        # edge weighted graph - degree is sum of nbr edge weights
-            for n,nbrs in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            # edge weighted graph - degree is sum of nbr edge weights
+            for n, nbrs in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in nbrs.values()
                            for d in data.values()])
                 if n in nbrs:
-                    deg += sum([d.get(weight,1)
-                           for key,d in nbrs[n].items()])
+                    deg += sum([d.get(weight, 1)
+                                for key, d in nbrs[n].items()])
                 yield (n, deg)
-
 
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""
@@ -758,57 +753,6 @@ class MultiGraph(Graph):
     def is_directed(self):
         """Return True if graph is directed, False otherwise."""
         return False
-
-    def to_directed(self):
-        """Return a directed representation of the graph.
-
-        Returns
-        -------
-        G : MultiDiGraph
-            A directed graph with the same name, same nodes, and with
-            each edge (u,v,data) replaced by two directed edges
-            (u,v,data) and (v,u,data).
-
-        Notes
-        -----
-        This returns a "deepcopy" of the edge, node, and
-        graph attributes which attempts to completely copy
-        all of the data and references.
-
-        This is in contrast to the similar D=DiGraph(G) which returns a
-        shallow copy of the data.
-
-        See the Python copy module for more information on shallow
-        and deep copies, http://docs.python.org/library/copy.html.
-
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or MultiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1), (1, 0)]
-
-        If already directed, return a (deep) copy
-
-        >>> G = nx.DiGraph()   # or MultiDiGraph, etc
-        >>> G.add_path([0,1])
-        >>> H = G.to_directed()
-        >>> H.edges()
-        [(0, 1)]
-        """
-        from networkx.classes.multidigraph import MultiDiGraph
-        G=MultiDiGraph()
-        G.add_nodes_from(self)
-        G.add_edges_from( (u,v,key,deepcopy(datadict))
-                           for u,nbrs in self.adjacency_iter()
-                           for v,keydict in nbrs.items()
-                           for key,datadict in keydict.items() ) 
-        G.graph=deepcopy(self.graph)
-        G.node=deepcopy(self.node)
-        return G
-
 
     def selfloop_edges(self, data=False, keys=False):
         """Return a list of selfloop edges.
@@ -848,24 +792,23 @@ class MultiGraph(Graph):
         """
         if data:
             if keys:
-                return [ (n,n,k,d) 
-                         for n,nbrs in self.adj.items() 
-                         if n in nbrs for k,d in nbrs[n].items()]
+                return [(n, n, k, d)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for k, d in nbrs[n].items()]
             else:
-                return [ (n,n,d) 
-                         for n,nbrs in self.adj.items() 
-                         if n in nbrs for d in nbrs[n].values()]
+                return [(n, n, d)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for d in nbrs[n].values()]
         else:
             if keys:
-                return [ (n,n,k)
-                     for n,nbrs in self.adj.items() 
-                     if n in nbrs for k in nbrs[n].keys()]
+                return [(n, n, k)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for k in nbrs[n].keys()]
 
             else:
-                return [ (n,n)
-                     for n,nbrs in self.adj.items() 
-                     if n in nbrs for d in nbrs[n].values()]
-
+                return [(n, n)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for d in nbrs[n].values()]
 
     def number_of_edges(self, u=None, v=None):
         """Return the number of edges between two nodes.
@@ -898,13 +841,13 @@ class MultiGraph(Graph):
         >>> G.number_of_edges(*e)
         1
         """
-        if u is None: return self.size()
+        if u is None:
+            return self.size()
         try:
-            edgedata=self.adj[u][v]
+            edgedata = self.adj[u][v]
         except KeyError:
-            return 0 # no such edge
+            return 0  # no such edge
         return len(edgedata)
-
 
     def subgraph(self, nbunch):
         """Return the subgraph induced on nodes in nbunch.
@@ -945,25 +888,25 @@ class MultiGraph(Graph):
         >>> H.edges()
         [(0, 1), (1, 2)]
         """
-        bunch =self.nbunch_iter(nbunch)
+        bunch = self.nbunch_iter(nbunch)
         # create new graph and copy subgraph into it
         H = self.__class__()
         # copy node and attribute dictionaries
         for n in bunch:
-            H.node[n]=self.node[n]
+            H.node[n] = self.node[n]
         # namespace shortcuts for speed
-        H_adj=H.adj
-        self_adj=self.adj
+        H_adj = H.adj
+        self_adj = self.adj
         # add nodes and edges (undirected method)
         for n in H:
-            Hnbrs={}
-            H_adj[n]=Hnbrs
-            for nbr,edgedict in self_adj[n].items():
+            Hnbrs = {}
+            H_adj[n] = Hnbrs
+            for nbr, edgedict in self_adj[n].items():
                 if nbr in H_adj:
                     # add both representations of edge: n-nbr and nbr-n
                     # they share the same edgedict
-                    ed=edgedict.copy()
-                    Hnbrs[nbr]=ed
-                    H_adj[nbr][n]=ed
-        H.graph=self.graph
+                    ed = edgedict.copy()
+                    Hnbrs[nbr] = ed
+                    H_adj[nbr][n] = ed
+        H.graph = self.graph
         return H


### PR DESCRIPTION
This addresses #1152.

To summarize the changes, first, I unified all implementations of `copy`/`to_directed`/`to_undirected` into `Graph` and those of `reverse` into `DiGraph`. So one implementation of each function will handle directed and undirected, simple and multigraphs.

Second, graphs can be copied in three ways as indicated by a `data` argument. It can be structure-only (`data=False`), shallow (`data='shallow'`) or deep (`data=True`). A structure-only copy shallow copies only nodes and edges (and keys if copying a multigraph). A shallow copy also includes graph, node and edge attributes but ignores any custom data if the user subclasses the built-in graph types. Both structure-only and shallow copies create new internal dictionaries while sharing the same keys and values with the original graph. A deep copy simply calls `deepcopy` to duplicate everything uniquely.

Third, `to_directed`/`to_undirected`/`reverse` also support the same copy semantics via `data` arguments but also ignore custom data during deep copy. Deep copy is now done via a single call to `deepcopy`. This ensure that a deep copy is referentially isomorphic to a shallow copy. In fact, this is achieved by first creating a shallow copy followed by calling `deepcopy` on it. Calling `to_directed`/`to_undirected` when the graph is already directed/undirected is the same as calling `copy`. An in-place reverse does not copy any data.

PEP8 fixes done with `autopep8` are also included in this PR.

The existing tests still pass. I do not have time to write new tests to cover every corner shortly.