### PR TITLE
algerbraic_connecitivity tests are not skipped for scipy < 0.12

### DIFF
--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -20,12 +20,26 @@ try:
     from numpy.linalg import norm, qr
     from numpy.random import normal
     from scipy.linalg import eigh, inv
-    from scipy.linalg.blas import (dasum, daxpy, ddot)
     from scipy.sparse import csc_matrix, spdiags
     from scipy.sparse.linalg import eigsh, lobpcg
     __all__ = ['algebraic_connectivity', 'fiedler_vector', 'spectral_ordering']
 except ImportError:
     __all__ = []
+
+try:
+    from scipy.linalg.blas import dasum, daxpy, ddot
+except ImportError:
+
+    if __all__:
+        # Make sure the imports succeeded.
+
+        # Use minimal replacements if BLAS is unavailable from SciPy.
+        dasum = partial(norm, ord=1)
+        ddot = dot
+
+        def daxpy(x, y, a):
+            y += a * x
+            return y
 
 _tracemin_method = compile('^tracemin(?:_(.*))?$')
 

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -54,10 +54,7 @@ class TestAlgebraicConnectivity(object):
         global numpy
         try:
             import numpy.linalg
-            # Some needed blas functions were not available in SciPy <0.12.
-            # https://github.com/networkx/networkx/issues/1169
-            from scipy.linalg.blas import (dasum, daxpy, ddot)
-            import scipy.sparse.linalg
+            import scipy.sparse
         except ImportError:
             raise SkipTest('SciPy not available.')
 
@@ -200,9 +197,6 @@ class TestSpectralOrdering(object):
         try:
             import numpy.linalg
             import scipy.sparse
-            # Some needed blas functions were not available in SciPy <0.12.
-            # https://github.com/networkx/networkx/issues/1169
-            from scipy.linalg.blas import (dasum, daxpy, ddot)
         except ImportError:
             raise SkipTest('SciPy not available.')
 


### PR DESCRIPTION
It seems that the low level functions in `scipy.linalg.blas` used in `algebraic_connectivity` were added at scipy 0.12:

http://docs.scipy.org/doc/scipy/reference/linalg.blas.html

At work I'm using Debian stable which ships with `scipy` 0.10, the tests for `algebraic_connectivity` throw errors in this context (eg `AttributeError: 'module' object has no attribute 'algebraic_connectivity'`). I guess that scipy is detected, and thus test are not skipped, but functions are not imported in the namespace because `from scipy.linalg.blas import (dasum, daxpy, ddot)` fails.
