### PR TITLE
DOC: semiconnectedness

### DIFF
--- a/doc/source/reference/algorithms.component.rst
+++ b/doc/source/reference/algorithms.component.rst
@@ -68,8 +68,11 @@ Biconnected components
    articulation_points
 
 
+Semiconnectedness
+^^^^^^^^^^^^^^^^^
+.. automodule:: networkx.algorithms.components.semiconnected
+.. autosummary::
+   :toctree: generated/
 
-
-
-
+   is_semiconnected
 


### PR DESCRIPTION
I couldn't find `is_semiconnected` in the online docs so I added it here.  I'm not sure if this is the right way to do it -- I don't even know if the `algorithms.component.rst` is supposed to be hand-modified or if it's supposed to be generated automatically from the modules in the `algorithms` directory.  This PR is also not tested because I'm not sure how to do that.
