### PR TITLE
Allow to write graphs in sorted order

### DIFF
--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -37,11 +37,12 @@ __all__ = ['generate_adjlist',
            'parse_adjlist',
            'read_adjlist']
 
-from networkx.utils import make_str, open_file
+from operator import itemgetter
+from networkx.utils import make_str, open_file, sorter
 import networkx as nx
 
 
-def generate_adjlist(G, delimiter = ' '):
+def generate_adjlist(G, delimiter = ' ', sort=False):
     """Generate a single line of the graph G in adjacency list format.
 
     Parameters
@@ -50,6 +51,8 @@ def generate_adjlist(G, delimiter = ' '):
 
     delimiter : string, optional
        Separator for node labels
+    sort : bool, optional (default=False)
+       Output in sorted order. Requires nodes to be sortable.
 
     Returns
     -------
@@ -76,13 +79,13 @@ def generate_adjlist(G, delimiter = ' '):
     """
     directed=G.is_directed()
     seen=set()
-    for s,nbrs in G.adjacency_iter():
+    for s,nbrs in sorter(G.adjacency_iter(), sort, key=itemgetter(0)):
         line = make_str(s)+delimiter
-        for t,data in nbrs.items():
+        for t,data in sorter(nbrs.items(), sort, key=itemgetter(0)):
             if not directed and t in seen:
                 continue
             if G.is_multigraph():
-                for d in data.values():
+                for d in sorter(data.values(), sort):
                     line += make_str(t) + delimiter
             else:
                 line += make_str(t) + delimiter
@@ -91,7 +94,7 @@ def generate_adjlist(G, delimiter = ' '):
         yield line[:-len(delimiter)]
 
 @open_file(1,mode='wb')
-def write_adjlist(G, path, comments="#", delimiter=' ', encoding = 'utf-8'):
+def write_adjlist(G, path, comments="#", delimiter=' ', encoding = 'utf-8', sort=False):
     """Write graph G in single-line adjacency-list format to path.
 
 
@@ -111,6 +114,9 @@ def write_adjlist(G, path, comments="#", delimiter=' ', encoding = 'utf-8'):
 
     encoding : string, optional
        Text encoding.
+
+    sort : bool, optional (default=False)
+       Output in sorted order. Requires nodes to be sortable.
 
     Examples
     --------
@@ -139,7 +145,7 @@ def write_adjlist(G, path, comments="#", delimiter=' ', encoding = 'utf-8'):
              + comments + " %s\n" % (G.name))
     path.write(header.encode(encoding))
 
-    for line in generate_adjlist(G, delimiter):
+    for line in generate_adjlist(G, delimiter, sort):
         line+='\n'
         path.write(line.encode(encoding))
 

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -41,10 +41,11 @@ __all__ = ['generate_edgelist',
            'read_weighted_edgelist',
            'write_weighted_edgelist']
 
-from networkx.utils import open_file, make_str
+from operator import itemgetter
+from networkx.utils import open_file, make_str, sorter
 import networkx as nx
 
-def generate_edgelist(G, delimiter=' ', data=True):
+def generate_edgelist(G, delimiter=' ', data=True, sort=False):
     """Generate a single line of the graph G in edge list format.
 
     Parameters
@@ -58,6 +59,9 @@ def generate_edgelist(G, delimiter=' ', data=True):
        If False generate no edge data.  If True use a dictionary 
        representation of edge data.  If a list of keys use a list of data
        values corresponding to the keys.
+
+    sort : bool, optional (default=False)
+       Output in sorted order. Requires nodes to be sortable.
 
     Returns
     -------
@@ -110,10 +114,10 @@ def generate_edgelist(G, delimiter=' ', data=True):
     write_adjlist, read_adjlist
     """
     if data is True or data is False:
-        for e in G.edges(data=data):
+        for e in sorter(G.edges(data=data), sort):
             yield delimiter.join(map(make_str,e))
     else:
-        for u,v,d in G.edges(data=True):
+        for u,v,d in sorter(G.edges(data=True), sort):
             e=[u,v]
             try:
                 e.extend(d[k] for k in data)
@@ -123,7 +127,7 @@ def generate_edgelist(G, delimiter=' ', data=True):
 
 @open_file(1,mode='wb')
 def write_edgelist(G, path, comments="#", delimiter=' ', data=True,
-                   encoding = 'utf-8'):
+                   encoding = 'utf-8', sort=False):
     """Write graph as a list of edges.
 
     Parameters
@@ -144,6 +148,8 @@ def write_edgelist(G, path, comments="#", delimiter=' ', data=True,
        in the list.
     encoding: string, optional
        Specify which encoding to use when writing file.
+    sort : bool, optional (default=False)
+       Output in sorted order. Requires nodes to be sortable.
 
     Examples
     --------
@@ -167,7 +173,7 @@ def write_edgelist(G, path, comments="#", delimiter=' ', data=True,
     write_weighted_edgelist()
     """
 
-    for line in generate_edgelist(G, delimiter, data):
+    for line in generate_edgelist(G, delimiter, data, sort):
         line+='\n'
         path.write(line.encode(encoding))
 

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -164,3 +164,11 @@ def dict_to_numpy_array1(d,mapping=None):
         i = mapping[k1]
         a[i] = d[k1]
     return a
+
+def sorter(l, sort, **kwargs):
+    """Return the iterable sorted or unsorted
+    """
+    if sort:
+        return sorted(l, **kwargs)
+    else:
+        return l


### PR DESCRIPTION
- with python3, graph output is no longer deterministic because of hash
  randomization
- add sort argument to writer functions to make the output optionally
  predictable
- fixes issue #1181
