### PR TITLE
Pajek utf8

### DIFF
--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -176,7 +176,7 @@ def parse_pajek(lines):
                 try:
                     splitline=[x.decode('utf-8') for x in
                            shlex.split(make_str(l).encode('utf-8'))]
-                except:
+                except AttributeError:
                     splitline = shlex.split(str(l))
                 id,label=splitline[0:2]
                 G.add_node(label)
@@ -202,7 +202,7 @@ def parse_pajek(lines):
                 try:
                     splitline = [x.decode('utf-8') for x in
                                  shlex.split(make_str(l).encode('utf-8'))]
-                except:
+                except AttributeError:
                     splitline = shlex.split(str(l))
 
                 if len(splitline)<2:

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -72,8 +72,6 @@ class TestPajek(object):
         nx.write_pajek(G,fh)
         fh.seek(0)
         H=nx.read_pajek(fh)
-        assert_equal(sorted(G.nodes()),sorted(H.nodes()))
-        assert_equal(
-            sorted(sorted(e) for e in G.edges()),
-            sorted(sorted(e) for e in H.edges()))
+        assert_nodes_equal(G.nodes(), H.nodes())
+        assert_edges_equal(G.edges(), H.edges())
         assert_equal(G.graph,H.graph)


### PR DESCRIPTION
Workaround for shlex.split for reading non-ascii encoded data with Python2.x.
