### PR TITLE
Add function to find a single cycle.

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -364,23 +364,25 @@ def find_cycle(G, source=None, orientation='original'):
         is 'forward'. When the direction is reverse, the value of ``direction``
         is 'reverse'.
 
-    Example
-    -------
+    Examples
+    --------
     In this example, we construct a DAG and find, in the first call, that there
-    are no directed cycles. In the second call, we ignore edge orientations
-    and find that there is an undirected cycle. Note that the second call finds
-    a directed cycle while effectively traversing an undirected graph, and so,
-    we found an "undirected cycle".
+    are no directed cycles, and so an exception is raised. In the second call,
+    we ignore edge orientations and find that there is an undirected cycle.
+    Note that the second call finds a directed cycle while effectively
+    traversing an undirected graph, and so, we found an "undirected cycle".
 
     >>> import networkx as nx
     >>> G = nx.DiGraph([(0,1), (0,2), (1,2)])
-    >>> list(find_cycle(G, orientation='original'))
-    []
+    >>> try:
+    ...    find_cycle(G, orientation='original')
+    ... except:
+    ...    pass
+    ...
     >>> list(find_cycle(G, orientation='ignore'))
     [(0, 1, 'forward'), (1, 2, 'forward'), (0, 2, 'reverse')]
 
     """
-
     out_edge, key, tailhead = helper_funcs(G, orientation)
 
     explored = set()
@@ -446,7 +448,7 @@ def find_cycle(G, source=None, orientation='original'):
 
     else:
         assert(len(cycle) == 0)
-        return cycle
+        raise nx.exception.NetworkXNoCycle('No cycle found.')
 
     # We now have a list of edges which ends on a cycle.
     # So we need to remove from the beginning edges that are not relevant.

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -153,9 +153,7 @@ class TestFindCycle(object):
 
     def test_graph(self):
         G = nx.Graph(self.edges)
-        x = list(find_cycle(G, self.nodes))
-        x_ = []
-        assert_equal(x, x_)
+        assert_raises(nx.exception.NetworkXNoCycle, find_cycle, G, self.nodes)
 
     def test_digraph(self):
         G = nx.DiGraph(self.edges)
@@ -205,13 +203,12 @@ class TestFindCycle(object):
         # when 4 is visited from the first time (so we must make sure that 4
         # is not visited from 2, and hence, we respect the edge orientation).
         G = nx.MultiDiGraph([(0,1), (1,2), (2,3), (4,2)])
-        x = list(find_cycle(G, [0,1,2,3,4], orientation='original'))
-        x_ = []
-        assert_equal(x, x_)
+        assert_raises(nx.exception.NetworkXNoCycle,
+                      find_cycle, G, [0,1,2,3,4], orientation='original')
 
     def test_dag(self):
         G = nx.DiGraph([(0,1), (0,2), (1,2)])
-        x = list(find_cycle(G, orientation='original'))
-        assert_equal(x, [])
+        assert_raises(nx.exception.NetworkXNoCycle,
+                      find_cycle, G, orientation='original')
         x = list(find_cycle(G, orientation='ignore'))
         assert_equal(x, [(0,1,FORWARD), (1,2,FORWARD), (0,2,REVERSE)])

--- a/networkx/exception.py
+++ b/networkx/exception.py
@@ -42,6 +42,10 @@ class NetworkXNoPath(NetworkXUnfeasible):
     """Exception for algorithms that should return a path when running
     on graphs where such a path does not exist."""
 
+class NetworkXNoCycle(NetworkXUnfeasible):
+    """Exception for algorithms that should return a cycle when running
+    on graphs where such a cycle does not exist."""
+
 class NetworkXUnbounded(NetworkXAlgorithmError):
     """Exception raised by algorithms trying to solve a maximization
     or a minimization problem instance that is unbounded."""


### PR DESCRIPTION
This PR depends on #1193.  
- [x] Merge #1193 

It adds the ability to find a single cycle, if one exists, on a graph of any type.  As for existing functionality:  `simple_cycles` does not work for undirected graphs, but is also not suitable for multidigraphs because it does not provide key data.  Similarly, `cycle_basis` is only meant for simple undirected graphs.  This new function `find_cycle` works for any graph and returns a single cycle found via a depth-first traversal of the edges.  It inherits the ability to ignore edge orientations as well, greatly extending the functionality for directed graphs.

One example where this function can be useful is when calculating the intersection of weighted matroids.  In that situation, one must add edges in a directed graph until an undirected cycle is formed.  Then you must find that cycle, and remove an offending edge.

An example usage:

```
>>> G = nx.DiGraph([(0,1), (0,2), (1,2)])
>>> list(find_cycle(G, orientation='respect'))
[]
>>> list(find_cycle(G, orientation='ignore'))
[(0, 1, 1), (1, 2, 1), (0, 2, 0)]
```

`G` is a DAG and so, it has no directed cycles.  So `find_cycle` returns an empty cycle.  If we allow `find_cycle` to ignore edge orientations, then it finds an undirected cycle in the directed graph.  Thus, `G` is not a directed tree.
