### PR TITLE
corrected docstring

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -66,13 +66,13 @@ def connected_component_subgraphs(G, copy=True):
     G : NetworkX graph
        An undirected graph.
 
+    copy: bool (default=True)
+      If True make a copy of the graph attributes
+
     Returns
     -------
     comp : generator
       A generator of graphs, one for each connected component of G.
-
-    copy: bool (default=True)
-      If True make a copy of the graph attributes
 
     Examples
     --------


### PR DESCRIPTION
The docstring of connected_component_subgraphs() had one parameter (copy=True) listed as a Return.
