### PR TITLE
Ensure that write_gexf and write_graphml output XML declaration

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -579,7 +579,7 @@ class GEXFWriter(GEXF):
         if self.prettyprint:
             self.indent(self.xml)
         document = ElementTree(self.xml)
-        document.write(fh, encoding=self.encoding)
+        document.write(fh, encoding=self.encoding, xml_declaration=True)
 
 
     def indent(self, elem, level=0):

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -362,7 +362,7 @@ class GraphMLWriter(GraphML):
         if self.prettyprint:
             self.indent(self.xml)
         document = ElementTree(self.xml)
-        document.write(stream, encoding=self.encoding)
+        document.write(stream, encoding=self.encoding, xml_declaration=True)
 
     def indent(self, elem, level=0):
         # in-place prettyprint formatter


### PR DESCRIPTION
#1143 complained about duplicate XML declarations, which was supposedly fixed by #1172. But now it seems that XML declarations are consistently missing. Hopefully this fixes it.
