### PR TITLE
speed up the conversion from scipy sparse matrix format to networkx graph format

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -487,35 +487,31 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
 
 def _csr_gen_triples(A):
     # Helper function for conversion from csr formatted scipy.sparse matrix.
-    from scipy.lib.six import xrange
     nrows = A.shape[0]
     data, indices, indptr = A.data, A.indices, A.indptr
-    for i in xrange(nrows):
-        for j in xrange(indptr[i], indptr[i+1]):
+    for i in range(nrows):
+        for j in range(indptr[i], indptr[i+1]):
             yield i, indices[j], data[j]
 
 
 def _csc_gen_triples(A):
     # Helper function for conversion from csc formatted scipy.sparse matrix.
-    from scipy.lib.six import xrange
     ncols = A.shape[1]
     data, indices, indptr = A.data, A.indices, A.indptr
-    for i in xrange(ncols):
-        for j in xrange(indptr[i], indptr[i+1]):
+    for i in range(ncols):
+        for j in range(indptr[i], indptr[i+1]):
             yield indices[j], i, data[j]
 
 
 def _coo_gen_triples(A):
     # Helper function for conversion from coo formatted scipy.sparse matrix.
-    from scipy.lib.six import zip as izip
     row, col, data = A.row, A.col, A.data
-    return izip(row, col, data)
+    return zip(row, col, data)
 
 
 def _dok_gen_triples(A):
     # Helper function for conversion from coo formatted scipy.sparse matrix.
-    from scipy.lib.six import iteritems
-    for (r, c), v in iteritems(A):
+    for (r, c), v in A.items():
         yield r, c, v
 
 


### PR DESCRIPTION
This should at least partially address https://github.com/networkx/networkx/issues/1214.  For my example graph the ad-hocly benchmarked speedup was from

```
9.68582105637 to convert coo to networkx graph
43.8019390106 to convert csr to networkx graph
86.7659800053 to convert csc to networkx graph
9.93627977371 to convert dia to networkx graph
25.5183579922 to convert dok to networkx graph
```

to

```
9.72998905182 to convert coo to networkx graph
10.5054268837 to convert csr to networkx graph
10.1915411949 to convert csc to networkx graph
10.0377058983 to convert dia to networkx graph
10.8245711327 to convert dok to networkx graph
```

with time measured in seconds.  I think the matrix was 160000x160000 with about three nonzero entries per row.
