### PR TITLE
Only rescale if fixed is None

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -308,7 +308,6 @@ def _fruchterman_reingold(A, dim=2, k=None, pos=None, fixed=None,
         pos+=delta_pos
         # cool temperature
         t-=dt
-        pos=_rescale_layout(pos)
     return pos
 
 
@@ -381,7 +380,6 @@ def _sparse_fruchterman_reingold(A, dim=2, k=None, pos=None, fixed=None,
         pos+=(displacement*t/length).T
         # cool temperature
         t-=dt
-        pos=_rescale_layout(pos)
     return pos
 
 


### PR DESCRIPTION
For the Fruchterman-Reingold layout only rescale positions on return and if only if no nodes are requested to have fixed positions.

This might cause some algorithm performance issues if the spring physics generates large or small numbers?

Addresses #1228.
