### PR TITLE
ENH : if explicitly passed labels draw them by default

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -119,11 +119,10 @@ def draw(G, pos=None, ax=None, hold=None, **kwds):
         else:
             ax = cf.gca()
 
- # allow callers to override the hold state by passing hold=True|False
-
     if 'with_labels' not in kwds:
-        kwds['with_labels'] = False
+        kwds['with_labels'] = 'labels' in kwds
     b = plt.ishold()
+    # allow callers to override the hold state by passing hold=True|False
     h = kwds.pop('hold', None)
     if h is not None:
         plt.hold(h)
@@ -873,15 +872,15 @@ def draw_networkx_edge_labels(G, pos,
 
 def draw_circular(G, **kwargs):
     """Draw the graph G with a circular layout.
-    
+
     Parameters
     ----------
     G : graph
        A networkx graph
-       
+
     **kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the pos parameter which is not used by this 
+       with the exception of the pos parameter which is not used by this
        function.
     """
     draw(G, circular_layout(G), **kwargs)
@@ -889,15 +888,15 @@ def draw_circular(G, **kwargs):
 
 def draw_random(G, **kwargs):
     """Draw the graph G with a random layout.
-    
+
     Parameters
     ----------
     G : graph
        A networkx graph
-       
+
     **kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the pos parameter which is not used by this 
+       with the exception of the pos parameter which is not used by this
        function.
     """
     draw(G, random_layout(G), **kwargs)
@@ -905,15 +904,15 @@ def draw_random(G, **kwargs):
 
 def draw_spectral(G, **kwargs):
     """Draw the graph G with a spectral layout.
-    
+
     Parameters
     ----------
     G : graph
        A networkx graph
-       
+
     **kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the pos parameter which is not used by this 
+       with the exception of the pos parameter which is not used by this
        function.
     """
     draw(G, spectral_layout(G), **kwargs)
@@ -921,7 +920,7 @@ def draw_spectral(G, **kwargs):
 
 def draw_spring(G, **kwargs):
     """Draw the graph G with a spring layout.
-    
+
     Parameters
     ----------
     G : graph
@@ -929,7 +928,7 @@ def draw_spring(G, **kwargs):
 
     **kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the pos parameter which is not used by this 
+       with the exception of the pos parameter which is not used by this
        function.
     """
     draw(G, spring_layout(G), **kwargs)
@@ -937,15 +936,15 @@ def draw_spring(G, **kwargs):
 
 def draw_shell(G, **kwargs):
     """Draw networkx graph with shell layout.
-    
+
     Parameters
     ----------
     G : graph
        A networkx graph
-       
+
     **kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the pos parameter which is not used by this 
+       with the exception of the pos parameter which is not used by this
        function.
     """
     nlist = kwargs.get('nlist', None)


### PR DESCRIPTION
If the user passes in labels as a kwarg, default to drawing them
(but don't if `with_labels` is explicitly False).

This is a follow up to the discussion in #936.

Not sure how you want this behavior documented.

I can get rid of the whitespace changes if you want as well.
