### PR TITLE
New gml reader and writer

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -277,7 +277,7 @@ def raise_with_context(msg, tokens):
 
 
 def string_item(s):
-    return unescape(s.replace('"', '').decode('ascii'))
+    return unescape(s.replace('"', ''))
 
 
 def parse_graph(tokens):

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -222,7 +222,7 @@ def parse_gml(lines, relabel=True):
         lines = lines.split('\n')
 
     elms = parse(lines)
-    G = nx.MultiGraph()
+    G = nx.MultiDiGraph()
 
     edge_elms = filter(partial(filter_and_build_elm, G), elms)
     # remaining entries should be only edges
@@ -240,17 +240,6 @@ def parse_gml(lines, relabel=True):
                               'duplicate node labels found. '
                   'Use relabel=False.')
         nx.relabel_nodes(G, dict(mapping), copy = False)
-    return G
-
-
-def convert_graph_type(G):
-    """ G is assumed to be a MultiGraph """
-    directed   = G.graph.pop('directed', 0)
-    multigraph = G.graph.pop('multigraph', False)
-    if directed == 1:
-        G = nx.MultiDiGraph(G) if multigraph else nx.DiGraph(G)
-    elif not multigraph:
-        G = nx.Graph(G)
     return G
 
 
@@ -481,6 +470,17 @@ def escape_string(s):
 
 def unescape_string(s):
     return unescape(s, name_to_code_entities)
+
+
+def convert_graph_type(G):
+    """ G is assumed to be a MultiDiGraph """
+    directed   = G.graph.pop('directed', 0)
+    multigraph = G.graph.pop('multigraph', False)
+    if directed == 0:
+        G = nx.MultiGraph(G) if multigraph else nx.Graph(G)
+    elif not multigraph:
+        G = nx.DiGraph(G)
+    return G
 
 
 # fixture for nose tests

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -26,10 +26,10 @@ http://www-personal.umich.edu/~mejn/netdata/
 """
 from __future__ import unicode_literals
 
-__author__ = [
-    """Aric Hagberg (hagberg@lanl.gov)""",
-    """Luca Pandini (luca1.pandini@gmail.com)"""
-]
+__author__ = """\n""".join([
+    'Aric Hagberg (hagberg@lanl.gov)',
+    'Luca Pandini (luca1.pandini@gmail.com)'
+])
 #    Copyright (C) 2008-2010 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -66,6 +66,11 @@ except ImportError:
     # Python 3.x
     import html.entities as htmlentitydefs
 
+try:
+    unichr(0)
+except NameError:
+    unichr = chr
+
 def unescape(text):
     def fixup(m):
         text = m.group(0)
@@ -131,7 +136,7 @@ def read_gml(path, relabel=False):
     >>> H=nx.read_gml('test.gml')
     """
 
-    G = parse_gml(path.read(), relabel=relabel)
+    G = parse_gml(path.read().decode('utf-8'), relabel=relabel)
     return G
 
 @open_file(1, mode='wb')
@@ -200,7 +205,7 @@ def parse_gml(lines, relabel=True):
     if relabel and len(G):
         # relabel, but check for duplicate labels first
         mapping = [ (n, d['label']) for n, d in G.node.items() ]
-        labels = zip(*mapping)[1]
+        nodes, labels = zip(*mapping)
         if len(set(labels)) != len(G):
             raise NetworkXError('Failed to relabel nodes: '
                               'duplicate node labels found. '
@@ -356,9 +361,10 @@ def add_attribute(attrs, attribute):
 
 
 def ensure_correct_ids(G):
+    # import pdb;pdb.set_trace()
     for n in G.node:
         if not is_int(n):
-          mapping = zip(G.node.keys(), range(0, len(G)))
+          mapping = list(zip(G.node.keys(), range(0, len(G))))
           nx.relabel_nodes(G, dict(mapping), copy = False)
           for old, new in mapping: G.node[new]['label'] = '"{}"'.format(old)
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -364,10 +364,10 @@ def add_attribute(attrs, attribute):
 def ensure_correct_ids(G):
     for n in G.node:
         if not is_int(n):
-          mapping = list(zip(G.node.keys(), range(0, len(G))))
-          nx.relabel_nodes(G, dict(mapping), copy = False)
-          for old, new in mapping: G.node[new]['label'] = '"{}"'.format(old)
-
+            mapping = list(zip(G.node.keys(), range(0, len(G))))
+            nx.relabel_nodes(G, dict(mapping), copy = False)
+            for old, new in mapping: G.node[new]['label'] = '"{}"'.format(old)
+            break
 
 def format_attribute(k, v, indent='  '):
     if isinstance(v, list): v = format_list_attribute(k, v, indent)

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -137,7 +137,8 @@ def read_gml(path, relabel=False):
     >>> H=nx.read_gml('test.gml')
     """
 
-    G = parse_gml(path.read().decode('utf-8'), relabel=relabel)
+    lines = map(lambda line: line.decode('utf-8'), path.readlines())
+    G = parse_gml(lines, relabel=relabel)
     return G
 
 @open_file(1, mode='wb')

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -241,22 +241,13 @@ def ignore_line(line):
     return not len(line) or line.strip().startswith('#')
 
 
-def skip_ignored_lines(lines):
+def remove_ignored_lines(lines):
     lines[:] = list(ifilterfalse(ignore_line, lines))
-    return lines
-
-def normalized_lines(lines):
-    return labeled_lines(skip_ignored_lines(lines))
-
-
-def labeled_lines(lines):
-    for i, line in enumerate(lines):
-        if line.strip().startswith('"'): lines[i] = 'label ' + line
     return lines
 
 
 def tokenize(lines):
-    s = ('\n'.join(normalized_lines(lines))
+    s = ('\n'.join(remove_ignored_lines(lines))
              .replace('[', ' [ ')
              .replace(']', ' ] '))
     # This way a quoted string is a token

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -42,10 +42,6 @@ __all__ = ['read_gml', 'parse_gml', 'generate_gml', 'write_gml']
 from cgi import escape
 from collections import deque
 from functools import partial
-try:
-    from types import StringTypes as str_types
-except ImportError:
-    str_types = (str)
 
 import networkx as nx
 from networkx.exception import NetworkXError
@@ -67,9 +63,14 @@ except ImportError:
     import html.entities as htmlentitydefs
 
 try:
-    unichr(0)
+    chr = unichr
 except NameError:
-    unichr = chr
+    pass
+
+try:
+    str = unicode
+except NameError:
+    pass
 
 def unescape(text):
     def fixup(m):
@@ -78,15 +79,15 @@ def unescape(text):
             # character reference
             try:
                 if text[:3] == "&#x":
-                    return unichr(int(text[3:-1], 16))
+                    return chr(int(text[3:-1], 16))
                 else:
-                    return unichr(int(text[2:-1]))
+                    return chr(int(text[2:-1]))
             except ValueError:
                 pass
         else:
             # named entity
             try:
-                text = unichr(htmlentitydefs.name2codepoint[text[1:-1]])
+                text = chr(htmlentitydefs.name2codepoint[text[1:-1]])
             except KeyError:
                 pass
         return text # leave as is
@@ -187,7 +188,7 @@ def write_gml(G, path):
 
 
 def parse_gml(lines, relabel=True):
-    if isinstance(lines, str_types):
+    if isinstance(lines, str):
         lines = lines.split('\n')
     elms = parse(lines)
     G = nx.MultiGraph()
@@ -361,7 +362,6 @@ def add_attribute(attrs, attribute):
 
 
 def ensure_correct_ids(G):
-    # import pdb;pdb.set_trace()
     for n in G.node:
         if not is_int(n):
           mapping = list(zip(G.node.keys(), range(0, len(G))))
@@ -393,10 +393,10 @@ def format_dict_attribute(k, v, indent):
 
 
 def format_value(v, indent='  '):
-    if isinstance(v, str_types) and v.startswith('"'): v = v.replace('"', '')
+    if isinstance(v, str) and v.startswith('"'): v = v.replace('"', '')
     if isinstance(v, bool):         return 1 if v else 0
     if isinstance(v, (int, float)): return v
-    else: return '"{}"'.format(escape(v, quote = True))
+    else: return '"{}"'.format(escape(str(v), quote = True))
 
 
 # fixture for nose tests

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -108,7 +108,8 @@ def read_gml(path, relabel=False):
 
     Returns
     -------
-    G : MultiGraph or MultiDiGraph
+    G : Graph, DiGraph, MultiGraph or MultiDiGraph depending on whether the
+        graph is indirect, direct, has edges with same source and target.
 
     NetworkXError
         If relabel is True and there are nodes with the same label.
@@ -163,11 +164,10 @@ def write_gml(G, path):
 
     This implementation does not support all Python data types as GML
     data.  Nodes, node attributes, edge attributes, and graph
-    attributes must be either dictionaries or single stings or
-    numbers.  If they are not an attempt is made to represent them as
-    strings.  For example, a tuple as edge data
-    G.add_node(0, {'somedata': (1,2) }), will be represented in the GML file
-    as::
+    attributes must be either dictionaries, lists with at least two elements,
+    single stings or numbers.  If they are not an attempt is made to represent 
+    them as strings.  For example, a tuple as edge data will be represented in 
+    the GML file as::
 
        edge [
          source 1
@@ -202,7 +202,8 @@ def parse_gml(lines, relabel=True):
 
     Returns
     -------
-    G : MultiGraph or MultiDiGraph
+    G : Graph, DiGraph, MultiGraph or MultiDiGraph depending on whether the
+        graph is indirect, direct, has edges with same source and target.
 
     Raises
     ------
@@ -263,6 +264,33 @@ def convert_graph_type(G):
 
 
 def generate_gml(G):
+    """Generate a single entry of the graph G in GML format.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    Returns
+    -------
+    lines: string
+       Lines in GML format.
+
+    Notes
+    -----
+    This implementation does not support all Python data types as GML
+    data.  Nodes, node attributes, edge attributes, and graph
+    attributes must be either dictionaries, lists with at least two elements,
+    single stings or numbers.  If they are not an attempt is made to represent 
+    them as strings.  For example, a tuple as edge data will be represented in 
+    the GML file as::
+
+       edge [
+         source 1
+         target 2
+         somedata "(1, 2)"
+       ]
+    """
+
     ensure_correct_ids(G)
     indent, lines = '  ', ['graph [']
     if G.is_directed(): G.graph['directed'] = True

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -41,7 +41,6 @@ __all__ = ['read_gml', 'parse_gml', 'generate_gml', 'write_gml']
 
 from cgi import escape
 from collections import deque
-from itertools import (ifilter, ifilterfalse)
 from functools import partial
 from types import StringTypes
 
@@ -185,7 +184,7 @@ def parse_gml(lines, relabel=True):
     elms = parse(lines)
     G = nx.MultiGraph()
 
-    edge_elms = list(ifilter(partial(filter_and_build_elm, G), elms))
+    edge_elms = filter(partial(filter_and_build_elm, G), elms)
     # remaining entries should be only edges
     for k, v in edge_elms:
         add_edge(G, v)
@@ -229,6 +228,11 @@ def generate_gml(G):
     return '\n'.join(lines)
 
 
+def filterfalse(predicate, iterable):
+    fn = lambda *args: not predicate(*args)
+    return filter(fn, iterable)
+
+
 def is_int(v):
     try:
         int(v)
@@ -242,7 +246,7 @@ def ignore_line(line):
 
 
 def remove_ignored_lines(lines):
-    lines[:] = list(ifilterfalse(ignore_line, lines))
+    lines[:] = filterfalse(ignore_line, lines)
     return lines
 
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -249,8 +249,7 @@ def ignore_line(line):
 
 
 def remove_ignored_lines(lines):
-    lines[:] = filterfalse(ignore_line, lines)
-    return lines
+    return filterfalse(ignore_line, lines)
 
 
 def tokenize(lines):

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -110,10 +110,11 @@ def read_gml(path, relabel=False):
     -------
     G : MultiGraph or MultiDiGraph
 
-    Raises
-    ------
-    ImportError
-        If the pyparsing module is not available.
+    NetworkXError
+        If relabel is True and there are nodes with the same label.
+
+    SyntaxError
+        If a syntax error is encountered while parsing. 
 
     See Also
     --------
@@ -121,7 +122,6 @@ def read_gml(path, relabel=False):
 
     Notes
     -----
-    Requires pyparsing: http://pyparsing.wikispaces.com/
     The GML specification says that files should be ASCII encoded, with any
     extended ASCII characters (iso8859-1) appearing as HTML character entities.
 
@@ -132,9 +132,9 @@ def read_gml(path, relabel=False):
 
     Examples
     --------
-    >>> G=nx.path_graph(4)
+    >>> G = nx.path_graph(4)
     >>> nx.write_gml(G,'test.gml')
-    >>> H=nx.read_gml('test.gml')
+    >>> H = nx.read_gml('test.gml')
     """
 
     lines = map(lambda line: line.decode('utf-8'), path.readlines())
@@ -165,14 +165,14 @@ def write_gml(G, path):
     data.  Nodes, node attributes, edge attributes, and graph
     attributes must be either dictionaries or single stings or
     numbers.  If they are not an attempt is made to represent them as
-    strings.  For example, a list as edge data
-    G[1][2]['somedata']=[1,2,3], will be represented in the GML file
+    strings.  For example, a tuple as edge data
+    G.add_node(0, {'somedata': (1,2) }), will be represented in the GML file
     as::
 
        edge [
          source 1
          target 2
-         somedata "[1, 2, 3]"
+         somedata "(1, 2)"
        ]
 
 
@@ -189,6 +189,44 @@ def write_gml(G, path):
 
 
 def parse_gml(lines, relabel=True):
+    """Parse GML graph from a string or iterable.
+
+    Parameters
+    ----------
+    lines : string or iterable
+       Data in GML format.
+
+    relabel : bool, optional
+       If True use the GML node label attribute for node names otherwise use
+       the node id.
+
+    Returns
+    -------
+    G : MultiGraph or MultiDiGraph
+
+    Raises
+    ------
+    NetworkXError
+        If relabel is True and there are nodes with the same label.
+
+    SyntaxError
+        If a syntax error is encountered while parsing. 
+
+    See Also
+    --------
+    write_gml, read_gml
+
+    Notes
+    -----
+    This stores nested GML attributes as dictionaries in the
+    NetworkX graph, node, and edge attribute structures.
+
+    References
+    ----------
+    GML specification:
+    http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html
+    """
+
     if isinstance(lines, str):
         lines = lines.split('\n')
     elms = parse(lines)

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -106,7 +106,6 @@ class TestGraph(object):
         assert_equals(node_ids[1][1], G.node["Node 2"])
         assert_equals(node_ids[2][1], G.node["Node 3"])
         assert_equals(e12, G.edge["Node 1"]["Node 2"])
-        print G.edge
         assert_equals(e12, G.edge["Node 2"]["Node 1"])
         assert_equals(e23, G.edge["Node 2"]["Node 3"])
         assert_equals(e23, G.edge["Node 3"]["Node 2"])

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -56,22 +56,6 @@ class TestGraph(object):
           ]
           """
 
-        self.gml_label_as_string_literal = """
-          graph [
-            "graph label"
-            node [
-              "node label 0"
-            ]
-            node [
-              "node label 1"
-            ]
-            edge [
-              source 0
-              target 1
-              "edge label"
-            ]
-          ]"""
-
         self.gml_without_graph = """ [
             name "G1"
             node [
@@ -138,12 +122,6 @@ class TestGraph(object):
         assert_equals(0, len(G))
         assert_equals(0, len(G.edge))
 
-    def test_string_literal_label(self):
-        G = networkx.parse_gml(self.gml_label_as_string_literal, relabel=False)
-        assert_equals(G.graph, {'label': "graph label"})
-        assert_equals(G.node[0], {'label': "node label 0"})
-        assert_equals(G.node[1], {'label': "node label 1"})
-        assert_equals(G.edge[0][1], {'label': "edge label"})
 
     @raises(SyntaxError)
     def test_missing_graph_parse_gml(self):

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -238,7 +238,7 @@ class TestGraph(object):
   name "path_graph(1)"
   node [
     id 0
-    demo "This is &quot;quoted&quot; and this is a copyright: &#169;"
+    demo "This is &quot;quoted&quot; and this is a copyright: &copy;"
   ]
 ]"""
         assert_equal(data, answer)

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -101,7 +101,7 @@ class TestGraph(object):
         e31 = {'label': 'Edge from node 3 to node 1'}
 
         G = networkx.parse_gml(self.simple_data)
-        for k, v in G.graph.iteritems(): assert_equals(v, graph[k])
+        for k, v in G.graph.items(): assert_equals(v, graph[k])
         assert_equals(node_ids[0][1], G.node["Node 1"])
         assert_equals(node_ids[1][1], G.node["Node 2"])
         assert_equals(node_ids[2][1], G.node["Node 3"])
@@ -113,7 +113,7 @@ class TestGraph(object):
         assert_equals(e31, G.edge["Node 1"]["Node 3"])
 
         G = networkx.parse_gml(self.simple_data, relabel=False)
-        for k, v in G.graph.iteritems(): assert_equals(v, graph[k])
+        for k, v in G.graph.items(): assert_equals(v, graph[k])
         for i, (n, d) in enumerate(G.nodes_iter(data=True)):
             assert_equals(n, node_ids[i][0])
             assert_equals(d, node_ids[i][1])
@@ -217,7 +217,7 @@ class TestGraph(object):
     target 1
   ]
 ]"""
-        assert_equal(data, answer)
+        assert_equal(answer, data)
 
 
     def test_quotes(self):
@@ -234,7 +234,6 @@ class TestGraph(object):
         fobj.seek(0)
         # Should be bytes in 2.x and 3.x
         data = fobj.read().strip()
-        fobj.seek(0)
         answer = b"""graph [
   name "path_graph(1)"
   node [
@@ -243,7 +242,7 @@ class TestGraph(object):
   ]
 ]"""
         assert_equal(data, answer)
-        G = networkx.read_gml(fobj)
+        G = networkx.read_gml(fobj.name)
         assert_equal('path_graph(1)', G.graph['name'])
         assert_equal(1, len(G))
         assert_equal(G.node[0], {'demo': 'This is "quoted" and this is a copyright: ©'})

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -106,6 +106,7 @@ class TestGraph(object):
         assert_equals(node_ids[1][1], G.node["Node 2"])
         assert_equals(node_ids[2][1], G.node["Node 3"])
         assert_equals(e12, G.edge["Node 1"]["Node 2"])
+        print G.edge
         assert_equals(e12, G.edge["Node 2"]["Node 1"])
         assert_equals(e23, G.edge["Node 2"]["Node 3"])
         assert_equals(e23, G.edge["Node 3"]["Node 2"])
@@ -246,3 +247,46 @@ class TestGraph(object):
         assert_equal('path_graph(1)', G.graph['name'])
         assert_equal(1, len(G))
         assert_equal(G.node[0], {'demo': 'This is "quoted" and this is a copyright: ©'})
+
+
+    def test_generate_gml_directed_attribute(self):
+        gml = """graph [
+  directed 1
+]"""
+        G = networkx.MultiDiGraph()
+        assert_equal(gml, networkx.generate_gml(G))
+        gml = """graph [
+]"""
+        G = networkx.MultiGraph()
+        assert_equal(gml, networkx.generate_gml(G))
+
+
+    def test_parse_gml_directed_attribute(self):
+        gml = "graph []"
+        G = networkx.parse_gml(gml)
+        assert(isinstance(G, networkx.Graph))
+        assert_false(isinstance(G, networkx.DiGraph))
+        assert_false(isinstance(G, networkx.MultiGraph))
+        gml = "graph [directed 1]"
+        G = networkx.parse_gml(gml)
+        assert(isinstance(G, networkx.DiGraph))
+        assert_false(isinstance(G, networkx.MultiDiGraph))
+        gml = """graph [
+            node []
+            node []
+            edge [source 0 target 1]
+            edge [source 0 target 1]
+        ]"""
+        G = networkx.parse_gml(gml, relabel=False)
+        assert(isinstance(G, networkx.MultiGraph))
+        assert_false(isinstance(G, networkx.MultiDiGraph))
+        gml = """graph [
+            directed 1
+            node []
+            node []
+            edge [source 0 target 1]
+            edge [source 0 target 1]
+        ]"""
+        G = networkx.parse_gml(gml, relabel=False)
+        assert(isinstance(G, networkx.MultiDiGraph))
+

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -106,11 +106,8 @@ class TestGraph(object):
         assert_equals(node_ids[1][1], G.node["Node 2"])
         assert_equals(node_ids[2][1], G.node["Node 3"])
         assert_equals(e12, G.edge["Node 1"]["Node 2"])
-        assert_equals(e12, G.edge["Node 2"]["Node 1"])
         assert_equals(e23, G.edge["Node 2"]["Node 3"])
-        assert_equals(e23, G.edge["Node 3"]["Node 2"])
         assert_equals(e31, G.edge["Node 3"]["Node 1"])
-        assert_equals(e31, G.edge["Node 1"]["Node 3"])
 
         G = networkx.parse_gml(self.simple_data, relabel=False)
         for k, v in G.graph.items(): assert_equals(v, graph[k])
@@ -260,16 +257,64 @@ class TestGraph(object):
         assert_equal(gml, networkx.generate_gml(G))
 
 
-    def test_parse_gml_directed_attribute(self):
-        gml = "graph []"
-        G = networkx.parse_gml(gml)
+    # def test_parse_gml_directed_attribute(self):
+    #     gml = "graph []"
+    #     G = networkx.parse_gml(gml)
+    #     assert(isinstance(G, networkx.Graph))
+    #     assert_false(isinstance(G, networkx.DiGraph))
+    #     assert_false(isinstance(G, networkx.MultiGraph))
+    #     gml = "graph [directed 1 node[] node[] edge[source 0 target 1]]"
+    #     G = networkx.parse_gml(gml, relabel=False)
+    #     assert(isinstance(G, networkx.DiGraph))
+    #     assert_equal({0: {1: {}}, 1: {}}, G.edge)
+    #     assert_false(isinstance(G, networkx.MultiDiGraph))
+    #     gml = """graph [
+    #         node []
+    #         node []
+    #         edge [source 0 target 1]
+    #         edge [source 0 target 1]
+    #     ]"""
+    #     G = networkx.parse_gml(gml, relabel=False)
+    #     assert(isinstance(G, networkx.MultiGraph))
+    #     assert_false(isinstance(G, networkx.MultiDiGraph))
+    #     gml = """graph [
+    #         directed 1
+    #         node []
+    #         node []
+    #         edge [source 0 target 1]
+    #         edge [source 0 target 1]
+    #     ]"""
+    #     G = networkx.parse_gml(gml, relabel=False)
+    #     assert(isinstance(G, networkx.MultiDiGraph))
+
+    def test_parse_gml_graph_type(self):
+        gml = """graph [
+            node []
+            node []
+            edge [source 0 target 1]
+        ]"""
+        G = networkx.parse_gml(gml, relabel=False)
         assert(isinstance(G, networkx.Graph))
-        assert_false(isinstance(G, networkx.DiGraph))
-        assert_false(isinstance(G, networkx.MultiGraph))
-        gml = "graph [directed 1]"
-        G = networkx.parse_gml(gml)
+        assert_equal({0: {1: {}}, 1: {0: {}}}, G.edge)
+        assert_false(isinstance(G, (networkx.DiGraph, networkx.MultiGraph)))
+
+
+    def test_parse_gml_digraph_type(self):
+        gml = """graph [
+            node []
+
+            directed 1
+
+            node []
+            edge [source 0 target 1]
+        ]"""
+        G = networkx.parse_gml(gml, relabel=False)
         assert(isinstance(G, networkx.DiGraph))
-        assert_false(isinstance(G, networkx.MultiDiGraph))
+        assert_equal({0: {1: {}}, 1: {}}, G.edge)
+        assert_false(isinstance(G, (networkx.MultiGraph, networkx.MultiDiGraph)))
+
+
+    def test_parse_gml_multigraph_type(self):
         gml = """graph [
             node []
             node []
@@ -277,8 +322,12 @@ class TestGraph(object):
             edge [source 0 target 1]
         ]"""
         G = networkx.parse_gml(gml, relabel=False)
+        assert_equal({0: {1: {0: {}, 1: {}}}, 1: {0: {0: {}, 1: {}}}}, G.edge)
         assert(isinstance(G, networkx.MultiGraph))
         assert_false(isinstance(G, networkx.MultiDiGraph))
+
+
+    def test_parse_gml_multidigraph_type(self):
         gml = """graph [
             directed 1
             node []
@@ -288,4 +337,5 @@ class TestGraph(object):
         ]"""
         G = networkx.parse_gml(gml, relabel=False)
         assert(isinstance(G, networkx.MultiDiGraph))
+        assert_equal({0: {1: {0: {}, 1: {}}}, 1: {}}, G.edge)
 


### PR DESCRIPTION
This idea is born from issue #972 and the discussion followed suit. This push aims to replace the old GML file format parser and generator with one stricter, faster and less buggy.

- it doesn't have external dependencies
- supports attribute lists – unlike what the `write_gml` documentation says, GML supports list attributes as long as they have at least two elements.
- ensures node ids are integers, if not sets the label as the old id value and assigns an increasing number as id.
- it's more tested.

I'm naturally opened to discussion and modifications.

Luca :)
