### PR TITLE
node-link repr. contains graph dict 'as is'

### DIFF
--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -56,8 +56,9 @@ def node_link_data(G, attrs=_attrs):
 
     Notes
     -----
-    Graph, node, and link attributes are stored in this format but keys
-    for attributes must be strings if you want to serialize with JSON.
+    Graph, node, and link attributes are stored in this format. Note that
+    attribute keys will be converted to strings in order to comply with
+    JSON.
 
     The default value of attrs will be changed in a future release of NetworkX.
 
@@ -77,7 +78,7 @@ def node_link_data(G, attrs=_attrs):
     data = {}
     data['directed'] = G.is_directed()
     data['multigraph'] = multigraph
-    data['graph'] = list(G.graph.items())
+    data['graph'] = G.graph
     data['nodes'] = [dict(chain(G.node[n].items(), [(id_, n)])) for n in G]
     if multigraph:
         data['links'] = [
@@ -129,6 +130,7 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=_attrs):
     -----
     The default value of attrs will be changed in a future release of NetworkX.
 
+
     See Also
     --------
     node_link_data, adjacency_data, tree_data
@@ -147,7 +149,7 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=_attrs):
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
     key = None if not multigraph else attrs['key']
     mapping = []
-    graph.graph = dict(data.get('graph', []))
+    graph.graph = data.get('graph', {})
     c = count()
     for d in data['nodes']:
         node = d.get(id_, next(c))

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -23,10 +23,10 @@ class TestNodeLink:
         assert_equal(H.node[1]['color'],'red')
         assert_equal(H[1][2]['width'],7)
 
-        d=json.dumps(node_link_data(G))
+        d = json.dumps(node_link_data(G))
         H = node_link_graph(json.loads(d))
         assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.graph[1],'one')
+        assert_equal(H.graph['1'],'one')
         assert_equal(H.node[1]['color'],'red')
         assert_equal(H[1][2]['width'],7)
 


### PR DESCRIPTION
**Previously**
The `graph` attribute dictionary was previously split into a list of key-value pairs. This resulted in a counter-intuitive JSON representation with a structure that is different from the original `graph`-dict. The only upside was the ability to use numerical keys in the dictionary which is are not supported by JSON. This enabled a mapping of the following form:

    G = nx.Graph()
    G.graph[1] = 'val'
    json_graph.node_link_graph(json_graph.node_link_data(G))[1] # numerical key preserved

**Now**
With the new approach the JSON representation matches the python dict and the note in the docstring now explains the new behavior.

    G = nx.Graph()
    G.graph[1] = 'val'
    json_graph.node_link_graph(json_graph.node_link_data(G))['1'] # JSON has string-keys only

This pull request is a follow up on this [discussion](https://groups.google.com/forum/#!searchin/networkx-discuss/json/networkx-discuss/xAJsOedGg1Q/-2uCZ4mE_EEJ) on the mailing list.