### PR TITLE
Update Git docs

### DIFF
--- a/doc/source/developer/gitwash/following_latest.rst
+++ b/doc/source/developer/gitwash/following_latest.rst
@@ -25,12 +25,33 @@ You now have a copy of the code tree in the new ``networkx`` directory.
 Updating the code
 =================
 
-From time to time you may want to pull down the latest code.  Do this with::
+From time to time you may want to pull down the latest code. It is necessary
+to add the networkx repository as a remote to your configuration file. We call it
+upstream.
+
+   git remote set-url upstream https://github.com/networkx/networkx.git
+
+Now git knows where to fetch updates from.
 
    cd networkx
-   git pull
+   git fetch upstream
 
 The tree in ``networkx`` will now have the latest changes from the initial
-repository.
+repository, unless you have made local changes in the meantime. In this case, you have to merge.
+
+    git merge upstream/master
+
+It is also possible to update your local fork directly from GitHub:
+
+1. Open your fork on GitHub.
+2. Click on 'Pull Requests'.
+3. Click on 'New Pull Request'. By default, GitHub will compare the original with your fork. If
+you didn’t make any changes, there is nothing to compare.
+4. Click on 'Switching the base' or click 'Edit' and switch the base manually. Now GitHub will
+compare your fork with the original, and you should see all the latest changes.
+5. Click on 'Click to create a pull request for this comparison' and name your pull request.
+6. Click on Send pull request.
+7. Scroll down and click 'Merge pull request' and finally 'Confirm merge'. You will be able to merge 
+it automatically unless you didnot change you local repo.
 
 .. include:: links.inc

--- a/doc/source/developer/gitwash/forking_hell.rst
+++ b/doc/source/developer/gitwash/forking_hell.rst
@@ -5,7 +5,7 @@ Making your own copy (fork) of networkx
 ======================================================
 
 You need to do this only once.  The instructions here are very similar
-to the instructions at http://help.github.com/forking/ |emdash| please see
+to the instructions at https://help.github.com/articles/fork-a-repo/ |emdash| please see
 that page for more detail.  We're repeating some of it here just to give the
 specifics for the `networkx`_ project, and to suggest some default names.
 

--- a/doc/source/developer/gitwash/git_links.inc
+++ b/doc/source/developer/gitwash/git_links.inc
@@ -1,7 +1,7 @@
 .. This (-*- rst -*-) format file contains commonly used link targets
-   and name substitutions.  It may be included in many files,
+   and name substitutions. It may be included in many files,
    therefore it should only contain link targets and name
-   substitutions.  Try grepping for "^\.\. _" to find plausible
+   substitutions. Try grepping for "^\.\. _" to find plausible
    candidates for this list.
 
 .. NOTE: reST targets are
@@ -12,20 +12,16 @@
 .. _git: http://git-scm.com/
 .. _github: http://github.com
 .. _github help: http://help.github.com
+.. _github more help: https://help.github.com/articles/what-are-other-good-resources-for-learning-git-and-github/
 .. _msysgit: http://code.google.com/p/msysgit/downloads/list
 .. _git-osx-installer: http://code.google.com/p/git-osx-installer/downloads/list
 .. _subversion: http://subversion.tigris.org/
-.. _git cheat sheet: http://github.com/guides/git-cheat-sheet
-.. _pro git book: http://progit.org/
 .. _git svn crash course: http://git-scm.com/course/svn.html
-.. _learn.github: http://learn.github.com/
 .. _network graph visualizer: http://github.com/blog/39-say-hello-to-the-network-graph-visualizer
 .. _git user manual: http://schacon.github.com/git/user-manual.html
 .. _git tutorial: http://schacon.github.com/git/gittutorial.html
-.. _git community book: http://book.git-scm.com/
-.. _git ready: http://www.gitready.com/
-.. _git casts: http://www.gitcasts.com/
-.. _Fernando's git page: http://www.fperez.org/py4science/git.html
+.. _Nick Quaranto: http://www.gitready.com/
+.. _Fernando Perez: http://www.fperez.org/py4science/git.html
 .. _git magic: http://www-cs-students.stanford.edu/~blynn/gitmagic/index.html
 .. _git concepts: http://www.eecs.harvard.edu/~cduan/technical/git/
 .. _git clone: http://schacon.github.com/git/git-clone.html
@@ -44,8 +40,7 @@
 .. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _tangled working copy problem: http://tomayko.com/writings/the-thing-about-git 
-.. _git management: http://kerneltrap.org/Linux/Git_Management
-.. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
+.. _Linus Torvalds: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
 .. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
 .. _deleting master on github: http://matthew-brett.github.com/pydagogue/gh_delete_master.html

--- a/doc/source/developer/gitwash/git_resources.rst
+++ b/doc/source/developer/gitwash/git_resources.rst
@@ -9,7 +9,7 @@ Tutorials and summaries
 
 `github help`_ is Git's own help and tutorial site. `github more help`_
  lists more resources for learning Git and GitHub, including YouTube
-channels. The list is constantly update. In case you are used to subversion_
+channels. The list is constantly updated. In case you are used to subversion_
 , you can directly consult the `git svn crash course`_.
 
 To make full use of Git, you need to understand the concept behind Git.
@@ -22,7 +22,7 @@ in many languages
 * `git concepts`_ |emdash| a technical page on the concepts
 
 Other than that, many devlopers list their personal tipps and tricks.
-Among theres are `Fernando Perez`_, `Nick Quaranto`_ and `Linus Torvalds`_.
+Among others there are `Fernando Perez`_, `Nick Quaranto`_ and `Linus Torvalds`_.
 
 Manual pages online
 ===================

--- a/doc/source/developer/gitwash/git_resources.rst
+++ b/doc/source/developer/gitwash/git_resources.rst
@@ -21,7 +21,7 @@ The following pages might help you:
 in many languages
 * `git concepts`_ |emdash| a technical page on the concepts
 
-Other than that, many devlopers list their personal tipps and tricks.
+Other than that, many devlopers list their personal tips and tricks.
 Among others there are `Fernando Perez`_, `Nick Quaranto`_ and `Linus Torvalds`_.
 
 Manual pages online

--- a/doc/source/developer/gitwash/git_resources.rst
+++ b/doc/source/developer/gitwash/git_resources.rst
@@ -7,34 +7,22 @@ git resources
 Tutorials and summaries
 =======================
 
-* `github help`_ has an excellent series of how-to guides.
-* `learn.github`_ has an excellent series of tutorials
-* The `pro git book`_ is a good in-depth book on git. 
-* A `git cheat sheet`_ is a page giving summaries of common commands.
-* The `git user manual`_ 
-* The `git tutorial`_
-* The `git community book`_
-* `git ready`_ |emdash| a nice series of tutorials
-* `git casts`_ |emdash| video snippets giving git how-tos.
+`github help`_ is Git's own help and tutorial site. `github more help`_
+ lists more resources for learning Git and GitHub, including YouTube
+channels. The list is constantly update. In case you are used to subversion_
+, you can directly consult the `git svn crash course`_.
+
+To make full use of Git, you need to understand the concept behind Git.
+The following pages might help you:
+
+* `git parable`_ |emdash| an easy read parable
+* `git foundation`_ |emdash| more on the git parable
 * `git magic`_ |emdash| extended introduction with intermediate detail
-* The `git parable`_ is an easy read explaining the concepts behind git.
-* `git foundation`_ expands on the `git parable`_.
-* Fernando Perez' git page |emdash| `Fernando's git page`_ |emdash| many
-  links and tips
-* A good but technical page on `git concepts`_
-* `git svn crash course`_: git for those of us used to subversion_
+in many languages
+* `git concepts`_ |emdash| a technical page on the concepts
 
-Advanced git workflow
-=====================
-
-There are many ways of working with git; here are some posts on the
-rules of thumb that other projects have come up with:
-
-* Linus Torvalds on `git management`_
-* Linus Torvalds on `linux git workflow`_ .  Summary; use the git tools
-  to make the history of your edits as clean as possible; merge from
-  upstream edits as little as possible in branches where you are doing
-  active development.
+Other than that, many devlopers list their personal tipps and tricks.
+Among theres are `Fernando Perez`_, `Nick Quaranto`_ and `Linus Torvalds`_.
 
 Manual pages online
 ===================


### PR DESCRIPTION
First I only wanted to update and correct the steps listed on http://networkx.github.io/documentation/latest/developer/gitwash/following_latest.html, but then I saw that many links on http://networkx.github.io/documentation/latest/developer/gitwash/git_resources.html are also outdated. So I decided to clean that page and soft-redirect visitors to https://help.github.com/articles/what-are-other-good-resources-for-learning-git-and-github/ instead of listing outdated links.