### PR TITLE
Fixes #1275

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -136,7 +136,7 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
        The edge attribute that holds the numerical value used as a weight.
        If None, then each edge has weight 1.
 
-    count_zeros : bool (default=False)       
+    count_zeros : bool
        If False include only the nodes with nonzero clustering in the average.
 
     Returns


### PR DESCRIPTION
I'm not familiar with the documentation standards for functions in networkx, though have noticed other functions which seem to also try and manually duplicate in writing the default values already implied in the function signature.  If the networkx project is interested in moving away from that redundancy I can look to clean up the documentation elsewhere under a separate new issue.  Let me know.
