### PR TITLE
Bug in capacity scaling min-cost flow

### DIFF
--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -3,7 +3,7 @@
 import networkx as nx
 from nose.tools import assert_equal, assert_raises
 
-class TestNetworkSimplex:
+class TestMinCostFlow:
     def test_simple_digraph(self):
         G = nx.DiGraph()
         G.add_node('a', demand = -5)
@@ -376,3 +376,26 @@ class TestNetworkSimplex:
         flowCost, H = nx.capacity_scaling(G)
         assert_equal(flowCost, -2)
         assert_equal(H, {1: {1: {'x': 2}}})
+
+    def test_bone_shaped(self):
+        # From #1283
+        G = nx.DiGraph()
+        G.add_node(0, demand=-4)
+        G.add_node(1, demand=2)
+        G.add_node(2, demand=2)
+        G.add_node(3, demand=4)
+        G.add_node(4, demand=-2)
+        G.add_node(5, demand=-2)
+        G.add_edge(0, 1, capacity=4)
+        G.add_edge(0, 2, capacity=4)
+        G.add_edge(4, 3, capacity=4)
+        G.add_edge(5, 3, capacity=4)
+        G.add_edge(0, 3, capacity=0)
+        flowCost, H = nx.network_simplex(G)
+        assert_equal(flowCost, 0)
+        assert_equal(
+            H, {0: {1: 2, 2: 2, 3: 0}, 1: {}, 2: {}, 3: {}, 4: {3: 2}, 5: {3: 2}})
+        flowCost, H = nx.capacity_scaling(G)
+        assert_equal(flowCost, 0)
+        assert_equal(
+            H, {0: {1: 2, 2: 2, 3: 0}, 1: {}, 2: {}, 3: {}, 4: {3: 2}, 5: {3: 2}})


### PR DESCRIPTION
Discovered in #1280.

Test case:

``` python
>>> G = nx.DiGraph()
>>> G.add_node(0, demand=-4)
>>> G.add_node(1, demand=2)
>>> G.add_node(2, demand=2)
>>> G.add_node(3, demand=4)
>>> G.add_node(4, demand=-2)
>>> G.add_node(5, demand=-2)
>>> G.add_edge(0, 1, capacity=4)
>>> G.add_edge(0, 2, capacity=4)
>>> G.add_edge(4, 3, capacity=4)
>>> G.add_edge(5, 3, capacity=4)
>>> G.add_edge(0, 3, capacity=0)
>>> nx.network_simplex(G)
(0, {0: {1: 2, 2: 2, 3: 0}, 1: {}, 2: {}, 3: {}, 4: {3: 2}, 5: {3: 2}})
>>> nx.capacity_scaling(G)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/line/too/long/algorithms/flow/capacityscaling.py", line 349, in capacity_scaling
    raise nx.NetworkXUnfeasible('No flow satisfying all demands.')
networkx.exception.NetworkXUnfeasible: No flow satisfying all demands.
```

In the (Δ = 4)-scaling phase, `capacity_scaling` attempts to find a path to send flow from 0 to 3, finds none and declares the problem infeasible instead of moving to the next scaling phase.
