### PR TITLE
Allow selection of pickling protocol in write_gpickle

### DIFF
--- a/networkx/readwrite/gpickle.py
+++ b/networkx/readwrite/gpickle.py
@@ -40,7 +40,7 @@ except ImportError:
 
 
 @open_file(1, mode='wb')
-def write_gpickle(G, path):
+def write_gpickle(G, path, protocol=pickle.HIGHEST_PROTOCOL):
     """Write graph in Python pickle format.
 
     Pickles are a serialized byte stream of a Python object [1]_.
@@ -50,9 +50,13 @@ def write_gpickle(G, path):
     ----------
     G : graph
        A NetworkX graph
+
     path : file or string
        File or filename to write.
        Filenames ending in .gz or .bz2 will be compressed.
+
+    protocol : integer
+        Pickling protocol to use. Default value: ``pickle.HIGHEST_PROTOCOL``.
 
     Examples
     --------
@@ -63,7 +67,7 @@ def write_gpickle(G, path):
     ----------
     .. [1] http://docs.python.org/library/pickle.html
     """
-    pickle.dump(G, path, pickle.HIGHEST_PROTOCOL)
+    pickle.dump(G, path, protocol)
 
 
 @open_file(0, mode='rb')

--- a/networkx/readwrite/tests/test_gpickle.py
+++ b/networkx/readwrite/tests/test_gpickle.py
@@ -49,3 +49,16 @@ class TestGpickle(object):
             assert_graphs_equal(G, Gin)
             os.close(fd)
             os.unlink(fname)
+
+    def test_protocol(self):
+        for G in [self.G, self.DG, self.MG, self.MDG,
+                  self.fG, self.fDG, self.fMG, self.fMDG]:
+            with tempfile.TemporaryFile() as f:
+                nx.write_gpickle(G, f, 0)
+                f.seek(0)
+                Gin = nx.read_gpickle(f)
+                assert_nodes_equal(G.nodes(data=True),
+                                   Gin.nodes(data=True))
+                assert_edges_equal(G.edges(data=True),
+                                   Gin.edges(data=True))
+                assert_graphs_equal(G, Gin)


### PR DESCRIPTION
After Python 2.7, new pickling protocols were added in Python 3.0 and 3.4. Always using the highest protocol creates problems when one needs to work with multiple Python versions. This PR adds an optional `protocol` parameter to `write_gpickle` which defaults to `pickle.HIGHEST_PROTOCOL` if omitted.
