### PR TITLE
Apply alphas to individual nodes

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -375,6 +375,10 @@ def draw_networkx_nodes(G, pos,
     except ValueError:
         raise nx.NetworkXError('Bad value in node positions.')
 
+    if len(alpha) > 1:
+        node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)
+        alpha = None
+
     node_collection = ax.scatter(xy[:, 0], xy[:, 1],
                                  s=node_size,
                                  c=node_color,
@@ -975,6 +979,72 @@ def draw_nx(G, pos, **kwds):
     """For backward compatibility; use draw or draw_networkx."""
     draw(G, pos, **kwds)
 
+
+def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
+    """Apply an alpha (or list of alphas) to the colors provided.
+
+    Parameters
+    ----------
+
+    color : color string, or array of floats
+       Color of element. Can be a single color format string (default='r'),
+       or a  sequence of colors with the same length as nodelist.
+       If numeric values are specified they will be mapped to
+       colors using the cmap and vmin,vmax parameters.  See
+       matplotlib.scatter for more details.
+
+    alpha : float or array of floats
+       Alpha values for elements. This can be a single alpha value, in
+       which case it will be applied to all the elements of color. Otherwise,
+       if it is an array, the elements of alpha will be applied to the colors
+       in order (cycling through alpha multiple times if necessary).
+
+    elem_list : array of networkx objects
+       The list of elements which are being colored. These could be nodes, edges
+       or labels.
+
+    cmap : matplotlib colormap
+       Color map for use if colors is a list of floats corresponding to points on
+       a color mapping.
+
+    vmin, vmax : float
+       Minimum and maximum values for normalizing colors if a color mapping is used.
+
+    Returns
+    -------
+
+    rgba_colors : numpy ndarray
+        Array containing RGBA format values for each of the node colours.
+
+    """
+    import numbers
+    import itertools
+
+    try:
+        import numpy
+        from matplotlib.colors import colorConverter
+        import matplotlib.cm as cm
+    except ImportError:
+        raise ImportError("Matplotlib required for draw()")
+
+    # If we have been provided with a list of numbers as long as elem_list, apply the color mapping.
+    if len(colors) == len(elem_list) and isinstance(colors[0], numbers.Number):
+        mapper = cm.ScalarMappable(cmap=cmap)
+        mapper.set_clim(vmin, vmax)
+        rgba_colors = mapper.to_rgba(colors)
+    # Otherwise, convert colors to matplotlib's RGB using the colorConverter object.
+    # These are converted to numpy ndarrays to be consistent with the to_rgba method of ScalarMappable.
+    else:
+        try:
+            rgba_colors = numpy.array([colorConverter.to_rgba(colors)])
+        except ValueError:
+            rgba_colors = numpy.array([colorConverter.to_rgba(color) for color in colors])
+    # Set the final column of the rgba_colors to have the relevant alpha values.
+    try:
+        rgba_colors[:, -1] = list(itertools.islice(itertools.cycle(alpha), len(rgba_colors)))
+    except TypeError:
+        rgba_colors[:, -1] = alpha
+    return rgba_colors
 
 # fixture for nose tests
 def setup_module(module):

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -350,6 +350,7 @@ def draw_networkx_nodes(G, pos,
     draw_networkx_labels()
     draw_networkx_edge_labels()
     """
+    import collections
     try:
         import matplotlib.pyplot as plt
         import numpy
@@ -375,7 +376,7 @@ def draw_networkx_nodes(G, pos,
     except ValueError:
         raise nx.NetworkXError('Bad value in node positions.')
 
-    if len(alpha) > 1:
+    if isinstance(alpha, collections.Iterable):
         node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)
         alpha = None
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1042,7 +1042,15 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
             rgba_colors = numpy.array([colorConverter.to_rgba(color) for color in colors])
     # Set the final column of the rgba_colors to have the relevant alpha values.
     try:
-        rgba_colors[:, -1] = list(itertools.islice(itertools.cycle(alpha), len(rgba_colors)))
+        # If alpha is longer than the number of colors, resize to the number of elements.
+        # Also, if rgba_colors.size (the number of elements of rgba_colors) is the same as the number of
+        # elements, resize the array, to avoid it being interpreted as a colormap by scatter()
+        if len(alpha) > len(rgba_colors) or rgba_colors.size == len(elem_list):
+            rgba_colors.resize((len(elem_list), 4))
+            rgba_colors[1:, 0] = rgba_colors[0, 0]
+            rgba_colors[1:, 1] = rgba_colors[0, 1]
+            rgba_colors[1:, 2] = rgba_colors[0, 2]
+        rgba_colors[:,  3] = list(itertools.islice(itertools.cycle(alpha), len(rgba_colors)))
     except TypeError:
         rgba_colors[:, -1] = alpha
     return rgba_colors


### PR DESCRIPTION
This is my first contribution to a proper codebase, so any guidance would be great.

I've addressed issue #1199 regarding applying alphas to nodes in a similar manner to node colouring.

I haven't added any more tests, but have tested with some of the drawing examples, to make sure that they have the expected behaviour.

I haven't yet modified edges, since there is a lot more colour handling code in the `draw_networkx_edges` function.