### PR TITLE
Remove unnecessary np.outer function for slightly better performance in google_matrix algorithm

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -257,7 +257,7 @@ def google_matrix(G, alpha=0.85, personalization=None,
 
     M /= M.sum(axis=1)  # Normalize rows to sum to 1
 
-    return alpha * M + (1 - alpha) * np.outer(np.ones(N), p)
+    return alpha * M + (1 - alpha) * p
 
 
 def pagerank_numpy(G, alpha=0.85, personalization=None, weight='weight',


### PR DESCRIPTION
As far as I can tell there doesn't seem to be a need for the np.outer as numpy broadcasts the vector. Removing the function results in an improvement in speed.
