### PR TITLE
Allows from_numpy_matrix to create parallel edges

### DIFF
--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -3,6 +3,8 @@ from nose.tools import assert_raises, assert_true, assert_equal
 
 import networkx as nx
 from networkx.generators.classic import barbell_graph,cycle_graph,path_graph
+from networkx.testing.utils import assert_graphs_equal
+
 
 class TestConvertNumpy(object):
     numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
@@ -170,3 +172,25 @@ class TestConvertNumpy(object):
         A=nx.to_numpy_matrix(G,multigraph_weight=max)
         assert_equal(A[1,0],70)
                          
+    def test_from_numpy_matrix_parallel_edges(self):
+        """Tests that the :func:`networkx.from_numpy_matrix` function
+        interprets integer weights as the number of parallel edges when
+        creating a multigraph.
+
+        """
+        A = np.matrix([[1, 1], [1, 2]])
+        # First, with a simple graph, each integer entry in the adjacency
+        # matrix is interpreted as the weight of a single edge in the graph.
+        expected = nx.DiGraph()
+        edges = [(0, 0), (0, 1), (1, 0)]
+        expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
+        expected.add_edge(1, 1, weight=2)
+        actual = nx.from_numpy_matrix(A, create_using=nx.DiGraph())
+        assert_graphs_equal(actual, expected)
+        # Now each integer entry in the adjacency matrix is interpreted as the
+        # number of parallel edges in the graph.
+        expected = nx.MultiDiGraph()
+        edges = [(0, 0), (0, 1), (1, 0), (1, 1), (1, 1)]
+        expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
+        actual = nx.from_numpy_matrix(A, create_using=nx.MultiDiGraph())
+        assert_graphs_equal(actual, expected)


### PR DESCRIPTION
Adds the `parallel` keyword argument to the from_numpy_matrix()
function. If the adjacency matrix has integer entries, this is set to
`True`, and the `create_using` keyword argument is an instance of
`MultiGraph`, then each positive integer entry in the adjacency matrix
is interpreted as the number of parallel edges, each with weight 1,
joining two vertices. Otherwise, if any of these conditions is not met,
the function behaves as it previously did: an integer entry is
interpreted as the weight of a single edge joining the two vertices.

This is a backwards compatible change.