### PR TITLE
Adds a generator for the chordal p-cycle graph.

### DIFF
--- a/doc/source/reference/generators.rst
+++ b/doc/source/reference/generators.rst
@@ -33,12 +33,20 @@ Classic
    hypercube_graph
    ladder_graph
    lollipop_graph
-   margulis_gabber_galil_graph
    null_graph
    path_graph
    star_graph
    trivial_graph
    wheel_graph
+
+Expanders
+---------
+.. automodule:: networkx.generators.expanders
+.. autosummary::
+   :toctree:generated/
+
+   margulis_gabber_galil_graph
+   chordal_cycle_graph
 
 Small
 -----

--- a/networkx/generators/__init__.py
+++ b/networkx/generators/__init__.py
@@ -7,6 +7,7 @@ from networkx.generators.classic import *
 from networkx.generators.degree_seq import *
 from networkx.generators.directed import *
 from networkx.generators.ego import *
+from networkx.generators.expanders import *
 from networkx.generators.geometric import *
 from networkx.generators.hybrid import *
 from networkx.generators.line import *

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -33,7 +33,6 @@ __all__ = [ 'balanced_tree',
             'hypercube_graph',
             'ladder_graph',
             'lollipop_graph',
-            'margulis_gabber_galil_graph',
             'null_graph',
             'path_graph',
             'star_graph',
@@ -453,52 +452,6 @@ def lollipop_graph(m,n,create_using=None):
     G.name="lollipop_graph(%d,%d)"%(m,n)
     return G
 
-def margulis_gabber_galil_graph(n, create_using=None):
-    """Return the Margulis-Gabber-Galil undirected MultiGraph on `n^2` nodes.
-
-    The undirected MultiGraph is regular with degree `8`. Nodes are integer
-    pairs. The second-largest eigenvalue of the adjacency matrix of the graph
-    is at most `5 \sqrt{2}`, regardless of `n`.
-
-    Parameters
-    ----------
-    n : int
-        Determines the number of nodes in the graph: `n^2`.
-    create_using : graph-like
-        A graph-like object that receives the constructed edges. If ``None``,
-        then a :class:`~networkx.MultiGraph` instance is used.
-
-    Returns
-    -------
-    G : graph
-        The constructed undirected multigraph.
-
-    Raises
-    ------
-    NetworkXError
-        If the graph is directed or not a multigraph.
-
-    """
-    if create_using is None:
-        create_using = nx.MultiGraph()
-    elif create_using.is_directed() or not create_using.is_multigraph():
-        msg = "`create_using` must be an undirected multigraph."
-        raise nx.NetworkXError(msg)
-
-    G = create_using
-    G.clear()
-    for x in range(n):
-        for y in range(n):
-            a = (x, y)
-            for b in (
-                    ((x + 2*y) % n, y),
-                    ((x + (2*y + 1)) % n, y),
-                    (x, (y + 2*x) % n),
-                    (x, (y + (2*x + 1)) % n),
-                    ):
-                G.add_edge(a, b)
-    G.graph['name'] = "margulis_gabber_galil_graph({0})".format(n)
-    return G
 
 def null_graph(create_using=None):
     """Return the Null graph with no nodes or edges.

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -1,0 +1,151 @@
+# Copyright 2014 "cheebee7i".
+# Copyright 2014 "alexbrc".
+# Copyright 2014 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>.
+"""Provides explicit constructions of expander graphs.
+
+"""
+import itertools
+import networkx as nx
+
+__all__ = ['margulis_gabber_galil_graph', 'chordal_cycle_graph']
+
+
+# Other discrete torus expanders can be constructed by using the following edge
+# sets. For more information, see Chapter 4, "Expander Graphs", in
+# "Pseudorandomness", by Salil Vadhan.
+#
+# For a directed expander, add edges from (x, y) to:
+#
+#     (x, y),
+#     ((x + 1) % n, y),
+#     (x, (y + 1) % n),
+#     (x, (x + y) % n),
+#     (-y % n, x)
+#
+# For an undirected expander, add the reverse edges.
+#
+# Also appearing in the paper of Gabber and Galil:
+#
+#     (x, y),
+#     (x, (x + y) % n),
+#     (x, (x + y + 1) % n),
+#     ((x + y) % n, y),
+#     ((x + y + 1) % n, y)
+#
+# and:
+#
+#     (x, y),
+#     ((x + 2*y) % n, y),
+#     ((x + (2*y + 1)) % n, y),
+#     ((x + (2*y + 2)) % n, y),
+#     (x, (y + 2*x) % n),
+#     (x, (y + (2*x + 1)) % n),
+#     (x, (y + (2*x + 2)) % n),
+#
+def margulis_gabber_galil_graph(n, create_using=None):
+    """Return the Margulis-Gabber-Galil undirected MultiGraph on `n^2` nodes.
+
+    The undirected MultiGraph is regular with degree `8`. Nodes are integer
+    pairs. The second-largest eigenvalue of the adjacency matrix of the graph
+    is at most `5 \sqrt{2}`, regardless of `n`.
+
+    Parameters
+    ----------
+    n : int
+        Determines the number of nodes in the graph: `n^2`.
+    create_using : graph-like
+        A graph-like object that receives the constructed edges. If ``None``,
+        then a :class:`~networkx.MultiGraph` instance is used.
+
+    Returns
+    -------
+    G : graph
+        The constructed undirected multigraph.
+
+    Raises
+    ------
+    NetworkXError
+        If the graph is directed or not a multigraph.
+
+    """
+    if create_using is None:
+        create_using = nx.MultiGraph()
+    elif create_using.is_directed() or not create_using.is_multigraph():
+        msg = "`create_using` must be an undirected multigraph."
+        raise nx.NetworkXError(msg)
+
+    G = create_using
+    G.clear()
+    for (x, y) in itertools.product(range(n), repeat=2):
+        for (u, v) in (((x + 2 * y) % n, y), ((x + (2 * y + 1)) % n, y),
+                       (x, (y + 2 * x) % n), (x, (y + (2 * x + 1)) % n)):
+            G.add_edge((x, y), (u, v))
+    G.graph['name'] = "margulis_gabber_galil_graph({0})".format(n)
+    return G
+
+
+def chordal_cycle_graph(p, create_using=None):
+    """Return the chordal cycle graph on `p` nodes.
+
+    The returned graph is a cycle graph on `p` nodes with chords joining each
+    vertex `x` to its inverse modulo `p`. This graph is a (mildly explicit)
+    3-regular expander [1]_.
+
+    ``p`` *must* be a prime number.
+
+    Parameters
+    ----------
+    p : a prime number
+
+        The number of vertices in the graph. This also indicates where the
+        chordal edges in the cycle will be created.
+
+    create_using : graph-like
+        A graph-like object that receives the constructed edges. If ``None``,
+        then a :class:`~networkx.MultiGraph` instance is used.
+
+    Returns
+    -------
+    G : graph
+        The constructed undirected multigraph.
+
+    Raises
+    ------
+    NetworkXError
+
+        If the graph provided in ``create_using`` is directed or not a
+        multigraph.
+
+    References
+    ----------
+
+    .. [1] Theorem 4.4.2 in A. Lubotzky. "Discrete groups, expanding graphs and
+           invariant measures", volume 125 of Progress in Mathematics.
+           Birkhäuser Verlag, Basel, 1994.
+
+    """
+    if create_using is None:
+        create_using = nx.MultiGraph()
+    elif create_using.is_directed() or not create_using.is_multigraph():
+        msg = "`create_using` must be an undirected multigraph."
+        raise nx.NetworkXError(msg)
+    G = create_using
+    G.clear()
+    for x in range(p):
+        left = (x - 1) % p
+        right = (x + 1) % p
+        # Here we apply Fermat's Little Theorem to compute the multiplicative
+        # inverse of x in Z/pZ. By Fermat's Little Theorem,
+        #
+        #     x^p = x (mod p)
+        #
+        # Therefore,
+        #
+        #     x * x^(p - 2) = 1 (mod p)
+        #
+        # The number 0 is a special case: we just let its inverse be itself.
+        chord = pow(x, p - 2, p) if x > 0 else 0
+        for y in (left, right, chord):
+            G.add_edge(x, y)
+    G.graph['name'] = "chordal_cycle_graph({0})".format(p)
+    return G

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -327,35 +327,6 @@ class TestGeneratorClassic():
         mb=lollipop_graph(m1, m2, create_using=MultiGraph())
         assert_true(mb.edges(), b.edges())
 
-    def test_margulis_gabber_galil_graph(self):
-        try:
-            # Scipy is required for conversion to an adjacency matrix.
-            # We also use scipy for computing the eigenvalues,
-            # but this second use could be done using only numpy.
-            import numpy as np
-            import scipy.linalg
-            has_scipy = True
-        except ImportError as e:
-            has_scipy = False
-        for n in 2, 3, 5, 6, 10:
-            g = margulis_gabber_galil_graph(n)
-            assert_equal(number_of_nodes(g), n*n)
-            for node in g:
-                assert_equal(g.degree(node), 8)
-                assert_equal(len(node), 2)
-                for i in node:
-                    assert_equal(int(i), i)
-                    assert_true(0 <= i < n)
-            if has_scipy:
-                # Eigenvalues are already sorted using the scipy eigvalsh,
-                # but the implementation in numpy does not guarantee order.
-                w = sorted(scipy.linalg.eigvalsh(adjacency_matrix(g).A))
-                assert_less(w[-2], 5*np.sqrt(2))
-
-    def test_margulis_gabber_galil_graph_badinput(self):
-        assert_raises(nx.NetworkXError, margulis_gabber_galil_graph, 3, nx.DiGraph())
-        assert_raises(nx.NetworkXError, margulis_gabber_galil_graph, 3, nx.Graph())
-
     def test_null_graph(self):
         assert_equal(number_of_nodes(null_graph()), 0)
 

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -1,0 +1,72 @@
+# Copyright 2014 "cheebee7i".
+# Copyright 2014 "alexbrc".
+# Copyright 2014 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>.
+"""Unit tests for the :mod:`networkx.generators.expanders` module.
+
+"""
+try:
+    import scipy
+    is_scipy_available = True
+except:
+    is_scipy_available = False
+
+import networkx as nx
+from networkx import adjacency_matrix
+from networkx import number_of_nodes
+from networkx.generators.expanders import chordal_cycle_graph
+from networkx.generators.expanders import margulis_gabber_galil_graph
+
+from nose import SkipTest
+from nose.tools import assert_equal
+from nose.tools import assert_less
+from nose.tools import assert_raises
+from nose.tools import assert_true
+
+
+def test_margulis_gabber_galil_graph():
+    try:
+        # Scipy is required for conversion to an adjacency matrix.
+        # We also use scipy for computing the eigenvalues,
+        # but this second use could be done using only numpy.
+        import numpy as np
+        import scipy.linalg
+        has_scipy = True
+    except ImportError as e:
+        has_scipy = False
+    for n in 2, 3, 5, 6, 10:
+        g = margulis_gabber_galil_graph(n)
+        assert_equal(number_of_nodes(g), n*n)
+        for node in g:
+            assert_equal(g.degree(node), 8)
+            assert_equal(len(node), 2)
+            for i in node:
+                assert_equal(int(i), i)
+                assert_true(0 <= i < n)
+        if has_scipy:
+            # Eigenvalues are already sorted using the scipy eigvalsh,
+            # but the implementation in numpy does not guarantee order.
+            w = sorted(scipy.linalg.eigvalsh(adjacency_matrix(g).A))
+            assert_less(w[-2], 5*np.sqrt(2))
+
+
+def test_chordal_cycle_graph():
+    """Test for the :func:`networkx.chordal_cycle_graph` function."""
+    if not is_scipy_available:
+        raise SkipTest('SciPy is not available')
+    primes = [3, 5, 7, 11]
+    for p in primes:
+        G = chordal_cycle_graph(p)
+        assert_equal(len(G), p)
+        # TODO The second largest eigenvalue should be smaller than a constant,
+        # independent of the number of nodes in the graph:
+        #
+        #     eigs = sorted(scipy.linalg.eigvalsh(adjacency_matrix(G).A))
+        #     assert_less(eigs[-2], ...)
+        #
+
+
+def test_margulis_gabber_galil_graph_badinput():
+    assert_raises(nx.NetworkXError, margulis_gabber_galil_graph, 3,
+                  nx.DiGraph())
+    assert_raises(nx.NetworkXError, margulis_gabber_galil_graph, 3,
+                  nx.Graph())


### PR DESCRIPTION
Adds the chordal p-cycle graph, a mildly explicit algebraic construction
of a family of 3-regular expander graphs. Also, moves both the existing
expander graph generator function (for the Margulis-Gabber-Galil
expander) and the new chordal cycle graph function to a new module,
`networkx.generators.expanders`.
