### PR TITLE
Adds a graph "walk" power operation.

### DIFF
--- a/doc/source/reference/algorithms.operators.rst
+++ b/doc/source/reference/algorithms.operators.rst
@@ -41,3 +41,4 @@ Operators
    strong_product
    tensor_product
    power
+   walk_power

--- a/doc/source/reference/algorithms.rst
+++ b/doc/source/reference/algorithms.rst
@@ -53,4 +53,5 @@ Algorithms
    algorithms.tree
    algorithms.triads
    algorithms.vitality
+   algorithms.walks
    algorithms.wiener

--- a/doc/source/reference/algorithms.walks.rst
+++ b/doc/source/reference/algorithms.walks.rst
@@ -1,0 +1,11 @@
+*****
+Walks
+*****
+
+.. automodule:: networkx.algorithms.walks
+.. autosummary::
+   :toctree: generated/
+
+   all_pairs_number_of_walks
+   number_of_walks
+   single_source_number_of_walks

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -1,6 +1,7 @@
 from networkx.algorithms.assortativity import *
 from networkx.algorithms.boundary import *
 from networkx.algorithms.centrality import *
+from networkx.algorithms.chordal import *
 from networkx.algorithms.cluster import *
 from networkx.algorithms.clique import *
 from networkx.algorithms.communicability_alg import *
@@ -12,35 +13,36 @@ from networkx.algorithms.cycles import *
 from networkx.algorithms.cuts import *
 from networkx.algorithms.dag import *
 from networkx.algorithms.distance_measures import *
+from networkx.algorithms.distance_regular import *
 from networkx.algorithms.dominance import *
 from networkx.algorithms.dominating import *
+from networkx.algorithms.euler import *
+from networkx.algorithms.graphical import *
 from networkx.algorithms.hierarchy import *
 from networkx.algorithms.hybrid import *
+from networkx.algorithms.isolate import *
+from networkx.algorithms.link_analysis import *
+from networkx.algorithms.link_prediction import *
 from networkx.algorithms.matching import *
 from networkx.algorithms.minors import *
 from networkx.algorithms.mis import *
-from networkx.algorithms.link_analysis import *
-from networkx.algorithms.link_prediction import *
 from networkx.algorithms.operators import *
 from networkx.algorithms.reciprocity import *
+from networkx.algorithms.richclub import *
 from networkx.algorithms.shortest_paths import *
+from networkx.algorithms.simple_paths import *
 from networkx.algorithms.smetric import *
+from networkx.algorithms.swap import *
 from networkx.algorithms.triads import *
 from networkx.algorithms.traversal import *
-from networkx.algorithms.isolate import *
-from networkx.algorithms.euler import *
 from networkx.algorithms.vitality import *
-from networkx.algorithms.chordal import *
-from networkx.algorithms.richclub import *
-from networkx.algorithms.distance_regular import *
-from networkx.algorithms.swap import *
-from networkx.algorithms.graphical import *
-from networkx.algorithms.simple_paths import *
+from networkx.algorithms.walks import *
 from networkx.algorithms.wiener import *
 
 import networkx.algorithms.assortativity
 import networkx.algorithms.bipartite
 import networkx.algorithms.centrality
+import networkx.algorithms.chordal
 import networkx.algorithms.cluster
 import networkx.algorithms.clique
 import networkx.algorithms.components
@@ -49,10 +51,9 @@ import networkx.algorithms.coloring
 import networkx.algorithms.flow
 import networkx.algorithms.isomorphism
 import networkx.algorithms.link_analysis
+import networkx.algorithms.operators
 import networkx.algorithms.shortest_paths
 import networkx.algorithms.traversal
-import networkx.algorithms.chordal
-import networkx.algorithms.operators
 import networkx.algorithms.tournament
 import networkx.algorithms.tree
 

--- a/networkx/algorithms/tests/test_walks.py
+++ b/networkx/algorithms/tests/test_walks.py
@@ -1,0 +1,95 @@
+# test_walks.py - unit tests for the walks module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.walks` module."""
+from nose.tools import assert_equal
+from nose.tools import raises
+
+from networkx import all_pairs_number_of_walks
+from networkx import cycle_graph
+from networkx import DiGraph
+from networkx import empty_graph
+from networkx import number_of_walks
+from networkx import single_source_number_of_walks
+
+
+class TestNumberOfWalks(object):
+    """Unit tests for the
+    :func:`networkx.algorithms.walks.number_of_walks` function.
+
+    """
+
+    def setup(self):
+        self.G = DiGraph(['ab', 'bc', 'ca'])
+
+    def test_neither_source_nor_target(self):
+        num_walks = number_of_walks(self.G, 3)
+        expected = {'a': {'a': 1, 'b': 0, 'c': 0},
+                    'b': {'a': 0, 'b': 1, 'c': 0},
+                    'c': {'a': 0, 'b': 0, 'c': 1}}
+        assert_equal(num_walks, expected)
+
+    def test_source_only(self):
+        num_walks = number_of_walks(self.G, 2, source='c')
+        expected = {'a': 0, 'b': 1, 'c': 0}
+        assert_equal(num_walks, expected)
+
+    def test_target_only(self):
+        num_walks = number_of_walks(self.G, 2, target='c')
+        expected = {'a': 1, 'b': 0, 'c': 0}
+        assert_equal(num_walks, expected)
+
+    def test_source_and_target(self):
+        num_walks = number_of_walks(self.G, 2, source='a', target='c')
+        assert_equal(num_walks, 1)
+
+
+class TestSingleSourceNumberOfWalks(object):
+    """Unit tests for the
+    :func:`networkx.algorithms.walks.single_source_number_of_walks`
+    function.
+
+    """
+
+    def test_no_target(self):
+        G = cycle_graph(4)
+        source = 0
+        k = 3
+        num_walks = single_source_number_of_walks(G, k, source)
+        expected = {0: 0, 1: 4, 2: 0, 3: 4}
+        assert_equal(num_walks, expected)
+
+    def test_target(self):
+        G = cycle_graph(4)
+        source = 0
+        target = 1
+        k = 3
+        num_walks = single_source_number_of_walks(G, k, source, target=target)
+        assert_equal(num_walks, 4)
+
+    @raises(ValueError)
+    def test_single_source_negative_length(self):
+        single_source_number_of_walks(empty_graph(1), -1, 0)
+
+
+class TestAllPairsNumberOfWalks(object):
+    """Unit tests for the
+    :func:`networkx.algorithms.walks.all_pairs_number_of_walks`
+    function.
+
+    """
+
+    def test_basic(self):
+        G = cycle_graph(4)
+        k = 3
+        num_walks = all_pairs_number_of_walks(G, k)
+        expected = {0: {0: 0, 1: 4, 2: 0, 3: 4},
+                    1: {0: 4, 1: 0, 2: 4, 3: 0},
+                    2: {0: 0, 1: 4, 2: 0, 3: 4},
+                    3: {0: 4, 1: 0, 2: 4, 3: 0}}
+        assert_equal(num_walks, expected)

--- a/networkx/algorithms/walks.py
+++ b/networkx/algorithms/walks.py
@@ -1,0 +1,187 @@
+# walks.py - functions for computing walks in a graph
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions for computing walks in a graph.
+
+The simplest interface for computing the number of walks in a graph is
+the :func:`number_of_walks` function. For more advanced usage, use the
+:func:`single_source_number_of_walks` or
+:func:`all_pairs_number_of_walks` functions.
+
+"""
+from collections import Counter
+from collections import deque
+
+import networkx as nx
+
+__all__ = ['all_pairs_number_of_walks', 'number_of_walks',
+           'single_source_number_of_walks']
+
+
+def number_of_walks(G, walk_length, source=None, target=None):
+    """Computes the number of walks of a particular length in the graph
+    `G`.
+
+    A *walk* is a sequence of nodes in which each adjacent pair of nodes
+    in the sequence is adjacent in the graph.
+
+    Neither the `source` nor the `target` nodes are required for this
+    function; see the *Returns* section for more information on how
+    these keyword arguments affect the output of this function.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    walk_length: int
+        A nonnegative integer representing the length of a walk.
+
+    source : node
+        A node in the graph `G`. If not specified, the number of walks
+        from all possible source nodes in the graph will be computed.
+
+    target : node
+        A node in the graph `G`. If not specified, the number of walks
+        to all possible target nodes in the graph will be computed.
+
+    Returns
+    -------
+    dict or int
+        If both `source` and `target` are specified, the number of walks
+        connecting `source` to `target` of length `walk_length` is
+        returned.
+
+        If `source` but not `target` is specified, the return value is a
+        dictionary whose keys are target nodes and whose values are the
+        number of walks of length `walk_length` from the source node to
+        the target node.
+
+        If `target` but not `source` is specified, the return value is a
+        dictionary whose keys are source nodes and whose values are the
+        number of walks of length `walk_length` from the source node to
+        the target node.
+
+        If neither `source` nor `target` are specified, this returns a
+        dictionary of dictionaries in which outer keys are source nodes,
+        inner keys are target nodes, and inner values are the number of
+        walks of length `walk_length` connecting those nodes.
+
+    Raises
+    ------
+    ValueError
+        If `walk_length` is negative.
+
+    """
+    if source is None and target is None:
+        return all_pairs_number_of_walks(G, walk_length)
+    if source is None and target is not None:
+        # Temporarily reverse the edges of the graph *in-place*, then
+        # compute the number of walks from target to the various
+        # sources.
+        with nx.utils.reversed(G):
+            return single_source(G, walk_length, target)
+    return single_source(G, walk_length, source, target=target)
+
+
+def single_source_number_of_walks(G, walk_length, source, target=None):
+    """Returns the number of walks from `source` to each other node in
+    the graph `G`.
+
+    A *walk* is a sequence of nodes in which each adjacent pair of nodes
+    in the sequence is adjacent in the graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    walk_length: int
+        A nonnegative integer representing the length of a walk.
+
+    source : node
+        A node in the graph `G`.
+
+    target : node
+        A node in the graph `G`. If not specified, the number of walks
+        from `source` to each other node in the graph is returned.
+
+    Returns
+    -------
+    dict or int
+        If `target` is not specified, the return value is a dictionary
+        whose keys are target nodes and whose values are the number of
+        walks of length `walk_length` from the source node to the target
+        node.
+
+        If `target` is a node in the graph, this simply returns the
+        number of walks from `source` to `target` in `G`.
+
+    Raises
+    ------
+    ValueError
+        If `walk_length` is negative.
+
+    """
+    if walk_length < 0:
+        raise ValueError('walk length must be a positive integer')
+    # Create a counter to store the number of walks of length
+    # `walk_length`. Ensure that even unreachable vertices have count zero.
+    result = Counter({v: 0 for v in G})
+    queue = deque()
+    queue.append((source, 0))
+    # TODO We could reduce the number of iterations in this loop by performing
+    # multiple `popleft()` calls at once, since the queue is partitioned into
+    # slices in which all enqueued vertices in the slice are at the same
+    # distance from the source. In other words, if we keep track of the
+    # *number* of vertices at each distance, we could just immediately dequeue
+    # all of those vertices.
+    while queue:
+        (u, distance) = queue.popleft()
+        if distance == walk_length:
+            result[u] += 1
+        else:
+            # Using `nx.edges()` accounts for multiedges as well.
+            queue.extend((v, distance + 1) for u_, v in nx.edges(G, u))
+    if target is None:
+        # Return the result as a true dictionary instead of a Counter object.
+        return dict(result)
+    return result[target]
+
+
+#: Rename this function for the sake of brevity in this module.
+single_source = single_source_number_of_walks
+
+
+def all_pairs_number_of_walks(G, walk_length):
+    """Returns the number of walks connecting each pair of nodes in
+    `G`.
+
+    A *walk* is a sequence of nodes in which each adjacent pair of nodes
+    in the sequence is adjacent in the graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    walk_length: int
+        A nonnegative integer representing the length of a walk.
+
+    Returns
+    -------
+    dict
+        A dictionary of dictionaries in which outer keys are source
+        nodes, inner keys are target nodes, and inner values are the
+        number of walks of length `walk_length` connecting those nodes.
+
+    Raises
+    ------
+    ValueError
+        If `walk_length` is negative.
+
+    """
+    # TODO This algorithm can be trivially parallelized.
+    return {v: single_source_number_of_walks(G, walk_length, v) for v in G}


### PR DESCRIPTION
This adds the `networkx.algorithms.operators.product.pow` function, which
computes a power of a given a graph. If SciPy is available, this
function computes the power of the adjacency matrix of the graph. If
SciPy is not available, it falls back to a naive (and slow)
exponentiation-by-squaring implementation using only the graph
primitives provided by NetworkX.
