### PR TITLE
Python3 tests fixed for nx_shp.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,12 +100,13 @@ install:
   ### Install any prerequisites or dependencies necessary to run the build.
 
   - if [[ "${OPTIONAL_DEPS}" =~ pip|source ]]; then
-      sudo apt-get install graphviz libsuitesparse-dev libgdal-dev;
-      pip install --global-option=build_ext --global-option=-I/usr/include/gdal;
+      sudo apt-get install graphviz libsuitesparse-dev;
     fi
-  # Skip pydot for Python 3.x due to incompatibility
+  # Skip GDAL and pydot for Python 3.x due to incompatibility
   - if [[ "${TRAVIS_PYTHON_VERSION}${OPTIONAL_DEPS}" =~ 2\..(pip|source) ]]; then
+      sudo apt-get install libgdal-dev;
       pip install pygraphviz pydot2;
+      pip install --global-option=build_ext --global-option=-I/usr/include/gdal GDAL==1.10.0;
     fi
   - if [ "${OPTIONAL_DEPS}" == "pip" ]; then
       pip install --use-wheel pyyaml;

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,13 +100,12 @@ install:
   ### Install any prerequisites or dependencies necessary to run the build.
 
   - if [[ "${OPTIONAL_DEPS}" =~ pip|source ]]; then
-      sudo apt-get install graphviz libsuitesparse-dev;
+      sudo apt-get install graphviz libsuitesparse-dev libgdal-dev;
+      pip install --global-option=build_ext --global-option=-I/usr/include/gdal;
     fi
-  # Skip GDAL and pydot for Python 3.x due to incompatibility
+  # Skip pydot for Python 3.x due to incompatibility
   - if [[ "${TRAVIS_PYTHON_VERSION}${OPTIONAL_DEPS}" =~ 2\..(pip|source) ]]; then
-      sudo apt-get install libgdal-dev;
       pip install pygraphviz pydot2;
-      pip install --global-option=build_ext --global-option=-I/usr/include/gdal GDAL==1.10.0;
     fi
   - if [ "${OPTIONAL_DEPS}" == "pip" ]; then
       pip install --use-wheel pyyaml;

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -50,7 +50,8 @@ class TestShp(object):
         for path, name in zip(self.paths, self.names):
             feat = ogr.Feature(lyr.GetLayerDefn())
             g = ogr.Geometry(ogr.wkbLineString)
-            map(lambda xy: g.AddPoint_2D(*xy), path)
+            for p in path:
+                g.AddPoint_2D(*p)
             feat.SetGeometry(g)
             feat.SetField("Name", name)
             lyr.CreateFeature(feat)
@@ -60,7 +61,8 @@ class TestShp(object):
 
     def testload(self):
         expected = nx.DiGraph()
-        map(expected.add_path, self.paths)
+        for p in self.paths:
+            expected.add_path(p)
         G = nx.read_shp(self.shppath)
         assert_equal(sorted(expected.node), sorted(G.node))
         assert_equal(sorted(expected.edges()), sorted(G.edges()))
@@ -101,7 +103,7 @@ class TestShp(object):
             while feature:
                 coords = []
                 ref = feature.GetGeometryRef()
-                for i in xrange(ref.GetPointCount()):
+                for i in range(ref.GetPointCount()):
                     coords.append(ref.GetPoint_2D(i))
                 name = feature.GetFieldAsString('Name')
                 assert_equal(graph.get_edge_data(*coords)['Name'], name)


### PR DESCRIPTION
Remove xrange and map to make nx_shp tests work with python3.
Fixes #1227 

All changes to test_shp.py are for python3. 
All changes to nx_shp.py are to take advantage of "new" gdal/ogr iterator functionality for loops.