### PR TITLE
Support pydotplus as a (Python 3 compatible) replacement for pydot

### DIFF
--- a/networkx/drawing/__init__.py
+++ b/networkx/drawing/__init__.py
@@ -7,7 +7,10 @@ from networkx.drawing.nx_pylab import *
 # prefer pygraphviz/agraph (it's faster)
 from networkx.drawing.nx_agraph import *
 try:
-    import pydot
+    try:
+        import pydot
+    except ImportError:
+        import pydotplus as pydot
     import networkx.drawing.nx_pydot
     from networkx.drawing.nx_pydot import *
 except ImportError:

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -39,8 +39,11 @@ def write_dot(G,path):
     try:
         import pydot
     except ImportError:
-        raise ImportError("write_dot() requires pydot",
-                          "http://code.google.com/p/pydot/")
+        try:
+            import pydotplus as pydot
+        except ImportError:
+            raise ImportError("write_dot() requires pydot",
+                              "http://code.google.com/p/pydot/")
     P=to_pydot(G)
     path.write(P.to_string())
     return
@@ -65,8 +68,11 @@ def read_dot(path):
     try:
         import pydot
     except ImportError:
-        raise ImportError("read_dot() requires pydot",
-                          "http://code.google.com/p/pydot/")
+        try:
+            import pydotplus as pydot
+        except ImportError:
+            raise ImportError("read_dot() requires pydot",
+                              "http://code.google.com/p/pydot/")
 
     data=path.read()
     P=pydot.graph_from_dot_data(data)
@@ -176,8 +182,11 @@ def to_pydot(N, strict=True):
     try:
         import pydot
     except ImportError:
-        raise ImportError('to_pydot() requires pydot: '
-                          'http://code.google.com/p/pydot/')
+        try:
+            import pydotplus as pydot
+        except ImportError:
+            raise ImportError('to_pydot() requires pydot: '
+                              'http://code.google.com/p/pydot/')
 
     # set Graphviz graph type
     if N.is_directed():
@@ -266,8 +275,11 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
     try:
         import pydot
     except ImportError:
-        raise ImportError('pydot_layout() requires pydot ',
-                          'http://code.google.com/p/pydot/')
+        try:
+            import pydotplus as pydot
+        except ImportError:
+            raise ImportError('pydot_layout() requires pydot ',
+                              'http://code.google.com/p/pydot/')
 
     P=to_pydot(G)
     if root is not None :
@@ -303,7 +315,10 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
 def setup_module(module):
     from nose import SkipTest
     try:
-        import pydot
-        import dot_parser
+        try:
+            import pydot
+        except ImportError:
+            import pydotplus as pydot
+        # import dot_parser
     except:
         raise SkipTest("pydot not available")

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -14,8 +14,11 @@ class TestPydot(object):
     def setupClass(cls):
         global pydot
         try:
-            import pydot
-            import dot_parser
+            try:
+                import pydot
+            except ImportError:
+                import pydotplus as pydot
+            # import dot_parser
         except ImportError:
             raise SkipTest('pydot not available.')
 


### PR DESCRIPTION
pydotplus is a replacement for pydot that works on Python 3. This PR uses pydotplus if pydot isn't available. Tests pass for me (Python 3.4, Windows 64-bit).