### PR TITLE
added documentation

### DIFF
--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -126,6 +126,8 @@ def adjacency_matrix(G, nodelist=None, weight='weight'):
 
     Notes
     -----
+    For directed graphs, entry i,j corresponds to an edge from i to j.
+    
     If you want a pure Python adjacency matrix representation try
     networkx.convert.to_dict_of_dicts which will return a
     dictionary-of-dictionaries format that can be addressed as a


### PR DESCRIPTION
Added a line documenting the (typical but not always used) convention that entry i,j corresponds to an edge from i to j. I couldn't find this documented elsewhere, and it is not clear from reading the code in to_scipy_sparse_matrix