### PR TITLE
Expand data keyword in G.edges and add default keyword

### DIFF
--- a/doc/source/tutorial/tutorial.rst
+++ b/doc/source/tutorial/tutorial.rst
@@ -198,6 +198,12 @@ Note that for undirected graphs this actually looks at each edge twice.
 (3, 4, 0.375)
 (4, 3, 0.375)
 
+Convenient access to all edges is achieved with the edges method.
+
+>>> for (u,v,d) in FG.edges(data='weight'):
+...     if d<0.5: print('(%d, %d, %.3f)'%(n,nbr,d))
+(1, 2, 0.125)
+(3, 4, 0.375)
 
 Adding attributes to graphs, nodes, and edges
 ---------------------------------------------

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -150,8 +150,8 @@ class DiGraph(Graph):
     ...            (n,nbr,eattr['weight'])
     (1, 2, 4)
     (2, 3, 8)
-    >>> [ (u,v,edata['weight']) for u,v,edata in G.edges(data=True) if 'weight' in edata ]
-    [(1, 2, 4), (2, 3, 8)]
+    >>> G.edges(data='weight')
+    [(1, 2, 4), (2, 3, 8), (3, 4, None), (4, 5, None)]
 
     **Reporting:**
 
@@ -772,7 +772,7 @@ class DiGraph(Graph):
     neighbors = successors
     neighbors_iter = successors_iter
 
-    def edges_iter(self, nbunch=None, data=False):
+    def edges_iter(self, nbunch=None, data=False, default=None):
         """Return an iterator over the edges.
 
         Edges are returned as tuples with optional data
@@ -783,8 +783,13 @@ class DiGraph(Graph):
         nbunch : iterable container, optional (default= all nodes)
             A container of nodes.  The container will be iterated
             through once.
-        data : bool, optional (default=False)
-            If True, return edge attribute dict in 3-tuple (u,v,data).
+        data : string or bool, optional (default=False)
+            The edge attribute returned in 3-tuple (u,v,ddict[data]).
+            If True, return edge attribute dict in 3-tuple (u,v,ddict).
+            If False, return 2-tuple (u,v). 
+        default : value, optional (default=None)
+            Value used for edges that dont have the requested attribute.
+            Only relevant if data is not True or False.
 
         Returns
         -------
@@ -803,11 +808,14 @@ class DiGraph(Graph):
         Examples
         --------
         >>> G = nx.DiGraph()   # or MultiDiGraph, etc
-        >>> G.add_path([0,1,2,3])
+        >>> G.add_path([0,1,2])
+        >>> G.add_edge(2,3,weight=5)
         >>> [e for e in G.edges_iter()]
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges_iter(data=True)) # default data is {} (empty dict)
-        [(0, 1, {}), (1, 2, {}), (2, 3, {})]
+        [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
+        >>> list(G.edges_iter(data='weight', default=1)) 
+        [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges_iter([0,2]))
         [(0, 1), (2, 3)]
         >>> list(G.edges_iter(0))
@@ -818,10 +826,15 @@ class DiGraph(Graph):
             nodes_nbrs=self.adj.items()
         else:
             nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
-        if data:
+        if data is True:
             for n,nbrs in nodes_nbrs:
-                for nbr,data in nbrs.items():
-                    yield (n,nbr,data)
+                for nbr,ddict in nbrs.items():
+                    yield (n,nbr,ddict)
+        elif data is not False:
+            for n,nbrs in nodes_nbrs:
+                for nbr,ddict in nbrs.items():
+                    d=ddict[data] if data in ddict else default
+                    yield (n,nbr,d)
         else:
             for n,nbrs in nodes_nbrs:
                 for nbr in nbrs:

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -358,12 +358,15 @@ class BaseAttrGraphTester(BaseGraphTester):
         G=self.Graph()
         G.add_edge(1,2,foo='bar')
         assert_equal(G.edges(data=True), [(1,2,{'foo':'bar'})])
+        assert_equal(G.edges(data='foo'), [(1,2,'bar')])
 
     def test_edge_attr2(self):
         G=self.Graph()
         G.add_edges_from([(1,2),(3,4)],foo='foo')
         assert_equal(sorted(G.edges(data=True)),
                      [(1,2,{'foo':'foo'}),(3,4,{'foo':'foo'})])
+        assert_equal(sorted(G.edges(data='foo')),
+                     [(1,2,'foo'),(3,4,'foo')])
 
     def test_edge_attr3(self):
         G=self.Graph()
@@ -440,6 +443,8 @@ class BaseAttrGraphTester(BaseGraphTester):
         G.add_edge(1,1,weight=2)
         assert_equal(G.selfloop_edges(data=True),
                 [(0,0,{}),(1,1,{'weight':2})])
+        assert_equal(G.selfloop_edges(data='weight'),
+                [(0,0,None),(1,1,2)])
 
 
 class TestGraph(BaseAttrGraphTester):


### PR DESCRIPTION
This is one feature for the 2.0 API as discussed in #1246 
It change G.edges in a backward compatible way. 
 
For G.edges(data=data)
If data is True, the whole data dictionary is returned for each edge.
If data is False, no data is returned.
Otherwise data is used as the attribute name of the edge data to return.

The code
    ```[ (u,v,edata['weight']) for u,v,edata in G.edges(data=True) ]```
can become (either works)
    ```G.edges(data='weight')```

The code

    for n,nbrs in G.adjacency_iter():
        for nbr,ddict in nbrs.items():
            print (n,nbr,ddict.get('weight',1))

can become (either works)
    ```G.edges(data='weight', default=1)```