### PR TITLE
Remove randomness from test_petersen to avoid fails

### DIFF
--- a/networkx/algorithms/tests/test_boundary.py
+++ b/networkx/algorithms/tests/test_boundary.py
@@ -91,11 +91,11 @@ class TestBoundary:
 
         cheeger(G,k)=min(|bdy(S)|/|S| for |S|=k, 0<k<=|V(G)|/2)
         """
-        from random import sample
+        from itertools import combinations
         P=nx.petersen_graph()
         def cheeger(G,k):
-            return min([float(len(nx.node_boundary(G,sample(G.nodes(),k))))/k 
-                        for n in range(100)])
+            return min( float(len(nx.node_boundary(G,nn)))/k
+                        for nn in combinations(G,k) )
 
         assert_almost_equals(cheeger(P,1),3.00,places=2)
         assert_almost_equals(cheeger(P,2),2.00,places=2)


### PR DESCRIPTION
Instead of taking the min of 100 random samples of k nodes,
we now take the min of all possible samples of k nodes.
There's only 10 nodes so it is still very fast.