### PR TITLE
Allows explicit conversion with parallel edges

### DIFF
--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -185,14 +185,27 @@ class TestConvertNumpy(object):
         edges = [(0, 0), (0, 1), (1, 0)]
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
         expected.add_edge(1, 1, weight=2)
-        actual = nx.from_numpy_matrix(A, create_using=nx.DiGraph())
+        actual = nx.from_numpy_matrix(A, parallel_edges=True,
+                                      create_using=nx.DiGraph())
+        assert_graphs_equal(actual, expected)
+        actual = nx.from_numpy_matrix(A, parallel_edges=False,
+                                      create_using=nx.DiGraph())
         assert_graphs_equal(actual, expected)
         # Now each integer entry in the adjacency matrix is interpreted as the
-        # number of parallel edges in the graph.
-        expected = nx.MultiDiGraph()
+        # number of parallel edges in the graph if the appropriate keyword
+        # argument is specified.
         edges = [(0, 0), (0, 1), (1, 0), (1, 1), (1, 1)]
+        expected = nx.MultiDiGraph()
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
-        actual = nx.from_numpy_matrix(A, create_using=nx.MultiDiGraph())
+        actual = nx.from_numpy_matrix(A, parallel_edges=True,
+                                      create_using=nx.MultiDiGraph())
+        assert_graphs_equal(actual, expected)
+        expected = nx.MultiDiGraph()
+        expected.add_edges_from(set(edges), weight=1)
+        # The sole self-loop (edge 0) on vertex 1 should have weight 2.
+        expected[1][1][0]['weight'] = 2
+        actual = nx.from_numpy_matrix(A, parallel_edges=False,
+                                      create_using=nx.MultiDiGraph())
         assert_graphs_equal(actual, expected)
 
     def test_symmetric(self):

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -204,14 +204,27 @@ class TestConvertNumpy(object):
         edges = [(0, 0), (0, 1), (1, 0)]
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
         expected.add_edge(1, 1, weight=2)
-        actual = nx.from_scipy_sparse_matrix(A, create_using=nx.DiGraph())
+        actual = nx.from_scipy_sparse_matrix(A, parallel_edges=True,
+                                             create_using=nx.DiGraph())
+        assert_graphs_equal(actual, expected)
+        actual = nx.from_scipy_sparse_matrix(A, parallel_edges=False,
+                                             create_using=nx.DiGraph())
         assert_graphs_equal(actual, expected)
         # Now each integer entry in the adjacency matrix is interpreted as the
-        # number of parallel edges in the graph.
-        expected = nx.MultiDiGraph()
+        # number of parallel edges in the graph if the appropriate keyword
+        # argument is specified.
         edges = [(0, 0), (0, 1), (1, 0), (1, 1), (1, 1)]
+        expected = nx.MultiDiGraph()
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
-        actual = nx.from_scipy_sparse_matrix(A, create_using=nx.MultiDiGraph())
+        actual = nx.from_scipy_sparse_matrix(A, parallel_edges=True,
+                                             create_using=nx.MultiDiGraph())
+        assert_graphs_equal(actual, expected)
+        expected = nx.MultiDiGraph()
+        expected.add_edges_from(set(edges), weight=1)
+        # The sole self-loop (edge 0) on vertex 1 should have weight 2.
+        expected[1][1][0]['weight'] = 2
+        actual = nx.from_scipy_sparse_matrix(A, parallel_edges=False,
+                                             create_using=nx.MultiDiGraph())
         assert_graphs_equal(actual, expected)
 
     def test_symmetric(self):


### PR DESCRIPTION
Adds the `parallel_edges` keyword argument to the `from_numpy_matrix`
and `from_scipy_sparse_matrix`. This allows the user to specify whether
to interpret an integer matrix as parallel edges in a multigraph or
single weighted edges in a multigraph.

This restores the default behavior of these functions that was changed
by pull request #1305.
