### PR TITLE
Modify from_pandas_dataframe to accept non-square inputs 

### DIFF
--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -60,6 +60,13 @@ New functionalities
 * [`#1338 <https://github.com/networkx/networkx/pull/1338>`_]
   Added support for finding optimum branchings and arborescences.
 
+* [`#1340 <https://github.com/networkx/networkx/pull/1340>`_]
+  Added a ``from_pandas_dataframe`` function that accepts Pandas DataFrames
+  and returns a new graph object. At a minimum, the DataFrame must have two
+  columns, which define the nodes that make up an edge. However, the function
+  can also process an arbitrary number of additional columns as edge
+  attributes, such as 'weight'. 
+
 Removed functionalities
 -----------------------
 

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -90,3 +90,5 @@ Thanks especially to the following contributors:
  - Mathieu Larose sped up the topological sort code
  - Vincent Gauthier contributed the Katz centrality algorithm
  - Sérgio Nery Simões developed the code for finding all simple paths
+ - Ryan Nelson modified the from_pandas_dataframe function to accept
+   DataFrames with rows that define graph edges

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -138,23 +138,23 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
     Parameters
     ----------
     df : Pandas DataFrame
-      An edge list representation of a graph
+        An edge list representation of a graph
 
     source : str or int
-      A valid column name (string or iteger) for the source nodes (for the
-      directed case).
+        A valid column name (string or iteger) for the source nodes (for the
+        directed case).
 
     target : str or int
-      A valid column name (string or iteger) for the target nodes (for the
-      directed case).
+        A valid column name (string or iteger) for the target nodes (for the
+        directed case).
 
     edge_attr : str or int, iterable, True
-      A valid column name (str or integer) or list of column names that will
-      be used to retrieve items from the row and add them to the graph as edge
-      attributes. If `True`, all of the remaining columns will be added.
+        A valid column name (str or integer) or list of column names that will
+        be used to retrieve items from the row and add them to the graph as edge
+        attributes. If `True`, all of the remaining columns will be added.
 
     create_using : NetworkX graph
-       Use specified graph for result.  The default is Graph()
+        Use specified graph for result.  The default is Graph()
 
     See Also
     --------

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -193,7 +193,7 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
     if edge_attr:
         # If all additional columns requested, build up a list of tuples
         # [(name, index),...]
-        if edge_attr == True:
+        if edge_attr is True:
             # Create a list of all columns indices, ignore nodes
             edge_i = []
             for i, col in enumerate(df.columns):

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -129,29 +129,29 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
     zero or more columns of node attributes. Each row will be processed as one
     edge instance.
 
-    Note: This function uses DataFrame.iterrows, which is not guaranteed to
-    retain the data type in the row. This is only a problem if your row is
-    entirely numeric and a mix of ints and floats. In that case, all values
-    will be returned as floats.
+    Note: This function iterates over DataFrame.values, which is not
+    guaranteed to retain the data type across columns in the row. This is only
+    a problem if your row is entirely numeric and a mix of ints and floats. In
+    that case, all values will be returned as floats. See the
+    DataFrame.iterrows documentation for an example.
 
     Parameters
     ----------
     df : Pandas DataFrame
       An edge list representation of a graph
 
-    source : str (or int)
-      Column name (or index if no column names) of the source nodes (for the
+    source : str or int
+      A valid column name (string or iteger) for the source nodes (for the
       directed case).
 
-    target : str (or int)
-      Column name (or index if no column names) of the target nodes (for the
+    target : str or int
+      A valid column name (string or iteger) for the target nodes (for the
       directed case).
 
-    edge_attr : str (or int), iterable, True
-      A name (str or index if no column names) or list of names that will be
-      used to retrieve attributes from the row that should be added to the
-      graph as edge attributes. If `True` is passed as the key, all of the
-      remaining columns will be added.
+    edge_attr : str or int, iterable, True
+      A valid column name (str or integer) or list of column names that will
+      be used to retrieve items from the row and add them to the graph as edge
+      attributes. If `True`, all of the remaining columns will be added.
 
     create_using : NetworkX graph
        Use specified graph for result.  The default is Graph()

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,0 +1,37 @@
+from nose import SkipTest
+from nose.tools import assert_true
+
+import networkx as nx
+
+class TestConvertPandas(object):
+    numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    @classmethod
+    def setupClass(cls):
+        global np
+        global pd
+        try:
+            import numpy as np
+            import pandas as pd
+        except ImportError:
+            raise SkipTest('Pandas not available.')
+
+    def __init__(self, ):
+        self.r = np.random.RandomState(seed=1)
+        self.ints = self.r.random_integers(0, 10, size=(2,3))
+        self.index = ['A', 'B']
+        self.columns = ['A', 'E', 'F']
+
+        self.G1 = nx.Graph([('A', 'A', {'weight': 5}),
+                            ('A', 'F', {'weight': 9}),
+                            ('A', 'E', {'weight': 8}),
+                            ('A', 'B', {'weight': 5})])
+
+    def assert_equal(self, G1, G2):
+        assert_true( sorted(G1.nodes())==sorted(G2.nodes()) )
+        assert_true( sorted(G1.edges(data=True))==sorted(G2.edges(data=True)) )
+
+    def test_from_dataframe_remove_zeros(self, ):
+        df = pd.DataFrame(self.ints, columns=self.columns, index=self.index)
+        G=nx.from_pandas_dataframe(df)
+        self.assert_equal(G, self.G1)
+

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -7,16 +7,16 @@ class TestConvertPandas(object):
     numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
     @classmethod
     def setupClass(cls):
-        global np
-        global pd
         try:
-            import numpy as np
             import pandas as pd
         except ImportError:
             raise SkipTest('Pandas not available.')
 
     def __init__(self, ):
-        self.r = np.random.RandomState(seed=5)
+        global pd
+        import pandas as pd
+
+        self.r = pd.np.random.RandomState(seed=5)
         ints = self.r.random_integers(1, 10, size=(3,2))
         a = ['A', 'B', 'C']
         b = ['D', 'A', 'E']


### PR DESCRIPTION
First PR, so let me say that NetworkX has been very useful in the past. Thanks!

I was looking at the dev docs and was happy to see that there is some work being done to handle Pandas DataFrames as inputs for graph creation (from_pandas_dataframe). Unfortunately (for me), the source looks to be a very thin wrapper around from_numpy_matrix. This doesn't work for the DataFrames I create, which are sparse and not square (Example below). This PR modifies from_pandas_dataframe in a way that accepts non-square DFs. What I've done is to create a generator function that takes a DataFrame and returns an [ebunch](http://networkx.github.io/documentation/development/reference/glossary.html#term-ebunch). The generator is passed to the `add_edges_from` constructor. This works fine for all shapes of DataFrame, including the square case that is already covered.

Tested Python 3.4 on Linux.

There's still a couple of problems... First of all, I wrote a test that follows the from_numpy_matrix tests. Unfortunately, I wasn't working on my machine because it couldn't find `np` and `pd`. Pointers?  Second, should this have flags to ignore zero and nan? Or should they just be ignored without asking? 

Example:
I might have a connectivity DataFrame that looks like the following (just made this up):

donor|A|B|C|
---|---|---|---
accept|||
|D|2.7|0.4|0.3|
|E|0.00|0.03|0|
|F|0.00|0.7|2.1|
|G|0.52|0|1.2|

In this extreme example, there is not any overlap between the two sets and they are different lengths. I could [rebuild my DataFrame](http://stackoverflow.com/questions/21207872/construct-networkx-graph-from-pandas-dataframe) to have the same columns and indices ; however, this is a bit of extra work and creates a very large table of empty values. 

If the above Dataframe is stored in `df`, then the modified function will produce:

    G=nx.from_pandas_dataframe(df)
    print(G.edges(data=True))

[('A', 'G', {'weight': 0.52000000000000002}),
 ('A', 'D', {'weight': 2.7000000000000002}),
 ('G', 'C', {'weight': 1.2}),
 ('E', 'B', {'weight': 0.029999999999999999}),
 ('B', 'F', {'weight': 0.69999999999999996}),
 ('B', 'D', {'weight': 0.40000000000000002}),
 ('F', 'C', {'weight': 2.1000000000000001}),
 ('D', 'C', {'weight': 0.29999999999999999})]

