### PR TITLE
Ordered graphs

### DIFF
--- a/networkx/classes/__init__.py
+++ b/networkx/classes/__init__.py
@@ -1,5 +1,7 @@
-from networkx.classes.graph import Graph
-from networkx.classes.digraph import DiGraph
-from networkx.classes.multigraph import MultiGraph
-from networkx.classes.multidigraph import MultiDiGraph
-from networkx.classes.function import *
+from .graph import Graph
+from .digraph import DiGraph
+from .multigraph import MultiGraph
+from .multidigraph import MultiDiGraph
+from .ordered import *
+
+from .function import *

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -1,0 +1,55 @@
+"""
+OrderedDict variants of the default base classes.
+
+These classes are especially useful for doctests and unit tests.
+
+"""
+try:
+    # Python 2.7+
+    from collections import OrderedDict
+except ImportError:
+    # Oython 2.6
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        OrderedDict = None
+
+from .graph import Graph
+from .multigraph import MultiGraph
+from .digraph import DiGraph
+from .multidigraph import MultiDiGraph
+
+__all__ = []
+
+if OrderedDict is not None:
+    __all__.extend([
+    'OrderedGraph',
+    'OrderedDiGraph',
+    'OrderedMultiGraph',
+    'OrderedMultiDiGraph'
+])
+
+    class OrderedGraph(Graph):
+        node_dict_factory = OrderedDict
+        adjlist_dict_factory = OrderedDict
+        edge_attr_dict_factory = OrderedDict
+
+
+    class OrderedDiGraph(DiGraph):
+        node_dict_factory = OrderedDict
+        adjlist_dict_factory = OrderedDict
+        edge_attr_dict_factory = OrderedDict
+
+
+    class OrderedMultiGraph(MultiGraph):
+        node_dict_factory = OrderedDict
+        adjlist_dict_factory = OrderedDict
+        edge_key_dict_factory = OrderedDict
+        edge_attr_dict_factory = OrderedDict
+
+
+    class OrderedMultiDiGraph(MultiDiGraph):
+        node_dict_factory = OrderedDict
+        adjlist_dict_factory = OrderedDict
+        edge_key_dict_factory = OrderedDict
+        edge_attr_dict_factory = OrderedDict

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -1,8 +1,6 @@
 """
 OrderedDict variants of the default base classes.
 
-These classes are especially useful for doctests and unit tests.
-
 """
 try:
     # Python 2.7+

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -2,15 +2,7 @@
 OrderedDict variants of the default base classes.
 
 """
-try:
-    # Python 2.7+
-    from collections import OrderedDict
-except ImportError:
-    # Oython 2.6
-    try:
-        from ordereddict import OrderedDict
-    except ImportError:
-        OrderedDict = None
+from collections import OrderedDict
 
 from .graph import Graph
 from .multigraph import MultiGraph
@@ -19,35 +11,34 @@ from .multidigraph import MultiDiGraph
 
 __all__ = []
 
-if OrderedDict is not None:
-    __all__.extend([
+__all__.extend([
     'OrderedGraph',
     'OrderedDiGraph',
     'OrderedMultiGraph',
-    'OrderedMultiDiGraph'
+    'OrderedMultiDiGraph',
 ])
 
-    class OrderedGraph(Graph):
-        node_dict_factory = OrderedDict
-        adjlist_dict_factory = OrderedDict
-        edge_attr_dict_factory = OrderedDict
+class OrderedGraph(Graph):
+    node_dict_factory = OrderedDict
+    adjlist_dict_factory = OrderedDict
+    edge_attr_dict_factory = OrderedDict
 
 
-    class OrderedDiGraph(DiGraph):
-        node_dict_factory = OrderedDict
-        adjlist_dict_factory = OrderedDict
-        edge_attr_dict_factory = OrderedDict
+class OrderedDiGraph(DiGraph):
+    node_dict_factory = OrderedDict
+    adjlist_dict_factory = OrderedDict
+    edge_attr_dict_factory = OrderedDict
 
 
-    class OrderedMultiGraph(MultiGraph):
-        node_dict_factory = OrderedDict
-        adjlist_dict_factory = OrderedDict
-        edge_key_dict_factory = OrderedDict
-        edge_attr_dict_factory = OrderedDict
+class OrderedMultiGraph(MultiGraph):
+    node_dict_factory = OrderedDict
+    adjlist_dict_factory = OrderedDict
+    edge_key_dict_factory = OrderedDict
+    edge_attr_dict_factory = OrderedDict
 
 
-    class OrderedMultiDiGraph(MultiDiGraph):
-        node_dict_factory = OrderedDict
-        adjlist_dict_factory = OrderedDict
-        edge_key_dict_factory = OrderedDict
-        edge_attr_dict_factory = OrderedDict
+class OrderedMultiDiGraph(MultiDiGraph):
+    node_dict_factory = OrderedDict
+    adjlist_dict_factory = OrderedDict
+    edge_key_dict_factory = OrderedDict
+    edge_attr_dict_factory = OrderedDict

--- a/networkx/classes/tests/test_ordered.py
+++ b/networkx/classes/tests/test_ordered.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from nose.tools import *
+from nose import SkipTest
+
+import networkx as nx
+
+from networkx.classes.ordered import OrderedDict
+
+if OrderedDict is None:
+    raise SkipTest('OrderedDict not available')
+
+
+class SmokeTestOrdered(object):
+    # Just test instantiation.
+    def test_graph():
+        G = nx.OrderedGraph()
+
+    def test_digraph():
+        G = nx.OrderedDiGraph()
+
+    def test_multigraph():
+        G = nx.OrderedMultiGraph()
+
+    def test_multidigraph():
+        G = nx.OrderedMultiDiGraph()
+

--- a/networkx/classes/tests/test_ordered.py
+++ b/networkx/classes/tests/test_ordered.py
@@ -1,14 +1,4 @@
-#!/usr/bin/env python
-from nose.tools import *
-from nose import SkipTest
-
 import networkx as nx
-
-from networkx.classes.ordered import OrderedDict
-
-if OrderedDict is None:
-    raise SkipTest('OrderedDict not available')
-
 
 class SmokeTestOrdered(object):
     # Just test instantiation.


### PR DESCRIPTION
For doctests (and perhaps unit tests as well---for example, unit tests for `edge_dfs` could actually be written properly), it might make more sense to use ordered graphs. This PR provides such graphs as part of the `networkx` API.