### PR TITLE
extend convert_bool in gexf.py and graphml.py to all valid boolean 

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -205,6 +205,7 @@ class GEXF(object):
 
     xml_type = dict(types)
     python_type = dict(reversed(a) for a in types)
+
     # http://www.w3.org/TR/xmlschema-2/#boolean
     convert_bool = {
         'true': True, 'false': False,

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -226,10 +226,10 @@ class GraphML(object):
 
     xml_type = dict(types)
     python_type = dict(reversed(a) for a in types)
-    # http://www.w3.org/TR/xmlschema-2/#boolean
+
+    # http://en.wikibooks.org/wiki/Java_Programming/Literals#Boolean_Literals
     convert_bool = {
         'true': True, 'false': False,
-        'True': True, 'False': False,
         '0': False, 0: False,
         '1': False, 1: True
     }
@@ -554,8 +554,10 @@ class GraphMLReader(GraphML):
             text=data_element.text
             # assume anything with subelements is a yfiles extension
             if text is not None and len(list(data_element))==0:
-                if data_type==bool:
-                    data[data_name] = self.convert_bool[text]
+                if data_type == bool:
+                    # Ignore cases.
+                    # http://docs.oracle.com/javase/6/docs/api/java/lang/Boolean.html#parseBoolean%28java.lang.String%29
+                    data[data_name] = self.convert_bool[text.lower()]
                 else:
                     data[data_name] = data_type(text)
             elif len(list(data_element)) > 0:

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -227,11 +227,16 @@ class GraphML(object):
     xml_type = dict(types)
     python_type = dict(reversed(a) for a in types)
 
-    # http://en.wikibooks.org/wiki/Java_Programming/Literals#Boolean_Literals
+    # This page says that data types in GraphML follow Java(TM).
+    #   http://graphml.graphdrawing.org/primer/graphml-primer.html#AttributesDefinition
+    # true and false are the only boolean literals:
+    #   http://en.wikibooks.org/wiki/Java_Programming/Literals#Boolean_Literals
     convert_bool = {
+        # We use data.lower() in actual use.
         'true': True, 'false': False,
+        # Include integer strings for convenience.
         '0': False, 0: False,
-        '1': False, 1: True
+        '1': True, 1: True
     }
 
 class GraphMLWriter(GraphML):

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -63,7 +63,7 @@ class TestGEXF(object):
         <attvalues>
           <attvalue for="0" value="http://webatlas.fr"/>
           <attvalue for="1" value="2"/>
-          <attvalue for="2" value="False"/>
+          <attvalue for="2" value="false"/>
         </attvalues>
       </node>
       <node id="2" label="RTGI">
@@ -77,7 +77,7 @@ class TestGEXF(object):
         <attvalues>
           <attvalue for="0" value="http://barabasilab.com"/>
           <attvalue for="1" value="1"/>
-          <attvalue for="2" value="True"/>
+          <attvalue for="2" value="true"/>
         </attvalues>
       </node>
     </nodes>

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -462,7 +462,7 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
 
 
     def test_bool(self):
-        s="""<?xml version="1.0" encoding="UTF-8"?>
+        s = """<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
@@ -484,18 +484,22 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
     <node id="n4">
       <data key="d0">True</data>
     </node>
+    <node id="n5">
+      <data key="d0">0</data>
+    </node>
+    <node id="n6">
+      <data key="d0">1</data>
+    </node>
   </graph>
 </graphml>
 """
         fh = io.BytesIO(s.encode('UTF-8'))
         G = nx.read_graphml(fh)
-        assert_equal(G.node['n0']['test'], True)
-        assert_equal(G.node['n2']['test'], False)
-        assert_equal(G.node['n3']['test'], False)
-        assert_equal(G.node['n4']['test'], True)
-
         H = nx.parse_graphml(s)
-        assert_equal(H.node['n0']['test'], True)
-        assert_equal(H.node['n2']['test'], False)
-        assert_equal(G.node['n3']['test'], False)
-        assert_equal(G.node['n4']['test'], True)
+        for graph in [G, H]:
+            assert_equal(graph.node['n0']['test'], True)
+            assert_equal(graph.node['n2']['test'], False)
+            assert_equal(graph.node['n3']['test'], False)
+            assert_equal(graph.node['n4']['test'], True)
+            assert_equal(graph.node['n5']['test'], False)
+            assert_equal(graph.node['n6']['test'], True)

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -472,28 +472,30 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
   </key>
   <graph id="G" edgedefault="directed">
     <node id="n0">
-      <data key="d0">True</data>
+      <data key="d0">true</data>
     </node>
     <node id="n1"/>
     <node id="n2">
-      <data key="d0">False</data>
-    </node>
-    <node id="n3">
-      <data key="d0">true</data>
-    </node>
-    <node id="n4">
       <data key="d0">false</data>
     </node>
-
-
+    <node id="n3">
+      <data key="d0">FaLsE</data>
+    </node>
+    <node id="n4">
+      <data key="d0">True</data>
+    </node>
   </graph>
 </graphml>
 """
         fh = io.BytesIO(s.encode('UTF-8'))
-        G=nx.read_graphml(fh)
-        assert_equal(G.node['n0']['test'],True)
-        assert_equal(G.node['n2']['test'],False)
+        G = nx.read_graphml(fh)
+        assert_equal(G.node['n0']['test'], True)
+        assert_equal(G.node['n2']['test'], False)
+        assert_equal(G.node['n3']['test'], False)
+        assert_equal(G.node['n4']['test'], True)
 
-        H=nx.parse_graphml(s)
-        assert_equal(H.node['n0']['test'],True)
-        assert_equal(H.node['n2']['test'],False)
+        H = nx.parse_graphml(s)
+        assert_equal(H.node['n0']['test'], True)
+        assert_equal(H.node['n2']['test'], False)
+        assert_equal(G.node['n3']['test'], False)
+        assert_equal(G.node['n4']['test'], True)


### PR DESCRIPTION
Follow-up to pull request #971 - recommend extending ``convert_bool`` to include true/false support for literal 0/1 and the string variants.

1. [graphml.py:224](https://github.com/networkx/networkx/blob/7d9682a07dcae30acab3c4841e33d31f727a3fb2/networkx/readwrite/graphml.py#L224)
1. [gexf.py:215](https://github.com/networkx/networkx/blob/87764469941cfa52a5aefc1b1b381a614b484c8d/networkx/readwrite/gexf.py#L215)

E.g., in [graphml.py:224](https://github.com/networkx/networkx/blob/7d9682a07dcae30acab3c4841e33d31f727a3fb2/networkx/readwrite/graphml.py#L224):

Old:
```python
convert_bool={'true':True,'false':False,
              'True': True, 'False': False}
```

New:
```python
convert_bool={'true':True,'false':False,
              'True': True, 'False': False
              '0': False, 0: False,
              '1': True, 1: True}
```

For reference, the [XML Schema Datatypes](http://www.w3.org/TR/xmlschema-2/#boolean) section on booleans.