### PR TITLE
Add pydot_ng as a supported pydot lib

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -19,6 +19,7 @@ DOT Language:  http://www.graphviz.org/doc/info/lang.html
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+import importlib
 from networkx.utils import open_file, make_str
 import networkx as nx
 __author__ = """Aric Hagberg (aric.hagberg@gmail.com)"""
@@ -36,7 +37,7 @@ PYDOT_LIBRARIES = ['pydot', 'pydotplus', 'pydot_ng']
 def load_pydot():
     for library in PYDOT_LIBRARIES:
         try:
-            module = __import__(library, fromlist=[''])
+            module = importlib.import_module(library)
         except ImportError:
             pass
         else:

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -31,7 +31,7 @@ try:
 except NameError:
     basestring = str
 
-PYDOT_LIBRARIES = ['pydot', 'pydotplus']
+PYDOT_LIBRARIES = ['pydot', 'pydotplus', 'pydot_ng']
 
 def load_pydot():
     for library in PYDOT_LIBRARIES:


### PR DESCRIPTION
pydot_ng is a another pydot fork

URL: https://pypi.python.org/pypi/pydot-ng