### PR TITLE
Add all minimum-size k node cutsets algorithm.

### DIFF
--- a/doc/source/reference/algorithms.connectivity.rst
+++ b/doc/source/reference/algorithms.connectivity.rst
@@ -5,6 +5,15 @@ Connectivity
 .. automodule:: networkx.algorithms.connectivity
 
 
+K-node-cutsets
+--------------
+.. automodule:: networkx.algorithms.connectivity.kcutsets
+.. autosummary::
+   :toctree: generated/
+
+   all_node_cuts
+
+
 Flow-based Connectivity
 -----------------------
 .. automodule:: networkx.algorithms.connectivity.connectivity

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -84,9 +84,13 @@ Thanks especially to the following contributors:
  - Nick Mancuso wrote the approximation algorithms for dominating set,
    edge dominating set, independent set, max clique, and min-weighted
    vertex cover.
- - Brian Cloteaux contributed the linear-time graphicality tests and Havel-Hakimi graph generators
+ - Brian Cloteaux contributed the linear-time graphicality tests and 
+   Havel-Hakimi graph generators.
  - Alejandro Weinstein contributed the directed Laplacian code
  - Dustin Smith wrote the dictionary to numpy array function
  - Mathieu Larose sped up the topological sort code
  - Vincent Gauthier contributed the Katz centrality algorithm
  - Sérgio Nery Simões developed the code for finding all simple paths
+ - Peter Jipsen and Franco Saliola contributed the antichains generator.
+   This function was originally developed for the SAGE project. Included
+   in NetworkX with permission from the authors.

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -55,7 +55,7 @@ from networkx.algorithms.bipartite import projected_graph, project, is_bipartite
 # connectivity
 from networkx.algorithms.connectivity import (minimum_edge_cut, minimum_node_cut,
     average_node_connectivity, edge_connectivity, node_connectivity,
-    stoer_wagner, all_pairs_node_connectivity)
+    stoer_wagner, all_pairs_node_connectivity, all_node_cuts)
 # isomorphism
 from networkx.algorithms.isomorphism import (is_isomorphic, could_be_isomorphic,
     fast_could_be_isomorphic, faster_could_be_isomorphic)

--- a/networkx/algorithms/connectivity/__init__.py
+++ b/networkx/algorithms/connectivity/__init__.py
@@ -2,11 +2,13 @@
 """
 from .connectivity import *
 from .cuts import *
+from .kcutsets import *
 from .stoerwagner import *
 from .utils import *
 
 __all__ = sum([connectivity.__all__,
                cuts.__all__,
+               kcutsets.__all__,
                stoerwagner.__all__,
                utils.__all__,
               ], [])

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+"""
+Kanevsky all minimum node k cutsets
+"""
+from operator import itemgetter
+
+import networkx as nx
+from .utils import build_auxiliary_node_connectivity
+from networkx.algorithms.flow import build_residual_network
+from networkx.algorithms.flow import edmonds_karp
+from networkx.algorithms.flow import shortest_augmenting_path
+# Define the default maximum flow function.
+default_flow_func = edmonds_karp
+
+
+__author__ = '\n'.join(['Jordi Torrents <jtorrents@milnou.net>'])
+
+__all__ = ['all_node_cuts']
+
+def all_node_cuts(G, k=None, flow_func=None):
+    r"""Returns all minimum k cutsets of an undirected graph G. 
+
+    This implementation is based on Kanevsky's algorithm [1]_ for finding all
+    minimum-size node cut-sets of an undirected graph G; ie the set (or sets) 
+    of nodes of cardinality equal to the node connectivity of G. Thus if 
+    removed, would break G into two or more connected components.
+   
+    Parameters
+    ----------
+    G : NetworkX graph
+        Undirected graph
+
+    k : Integer
+        Node connectivity of the input graph. If k is None, then it is 
+        computed. Default value: None.
+
+    flow_func : function
+        Function to perform the underlying flow computations. Default value
+        edmonds_karp. This function performs better in sparse graphs with
+        right tailed degree distributions. shortest_augmenting_path will
+        perform better in denser graphs.
+        
+
+    Returns
+    -------
+    cuts : a generator of node cutsets
+        Each node cutset has cardinality equal to the node connectivity of
+        the input graph.
+
+    Examples
+    --------
+    >>> # A two-dimensional grid graph has 4 cutsets of cardinality 2
+    >>> G = nx.grid_2d_graph(5, 5)
+    >>> cutsets = list(nx.all_node_cuts(G))
+    >>> len(cutsets)
+    4
+    >>> all(2 == len(cutset) for cutset in cutsets)
+    True
+    >>> nx.node_connectivity(G)
+    2
+
+    Notes
+    -----
+    This implementation is based on the sequential algorithm for finding all
+    minimum-size separating vertex sets in a graph [1]_. The main idea is to
+    compute minimum cuts using local maximum flow computations among a set 
+    of nodes of highest degree and all other non-adjacent nodes in the Graph.
+    Once we find a minimum cut, we add an edge between the high degree
+    node and the target node of the local maximum flow computation to make 
+    sure that we will not find that minimum cut again.
+
+    See also
+    --------
+    node_connectivity
+    edmonds_karp
+    shortest_augmenting_path
+
+    References
+    ----------
+    .. [1]  Kanevsky, A. (1993). Finding all minimum-size separating vertex 
+            sets in a graph. Networks 23(6), 533--541.
+            http://onlinelibrary.wiley.com/doi/10.1002/net.3230230604/abstract
+
+    """
+    # Initialize data structures.
+    # Even-Tarjan reduction is what we call auxiliary digraph 
+    # for node connectivity.
+    H = build_auxiliary_node_connectivity(G)
+    mapping = H.graph['mapping']
+    R = build_residual_network(H, 'capacity')
+    kwargs = dict(capacity='capacity', residual=R)
+    # Define default flow function
+    if flow_func is None:
+        flow_func = default_flow_func
+    if flow_func is shortest_augmenting_path:
+        kwargs['two_phase'] = True
+    # Begin the actual algorithm
+    # step 1: Find node connectivity k of G
+    if k is None:
+        k = nx.node_connectivity(G, flow_func=flow_func)
+    # step 2: 
+    # Find k nodes with top degree, call it X:
+    degree = G.degree().items()
+    X = set(n for n, d in sorted(degree, key=itemgetter(1), reverse=True)[:k])
+    # Check if X is a k-node-cutset
+    if is_separating_set(G, X):
+        yield X
+
+    for x in X:
+        # step 3: Compute local connectivity flow of x with all other
+        # non adjacent nodes in G
+        non_adjacent = (n for n in set(G) - X if n not in G[x])
+        for v in non_adjacent:
+            # step 4: compute maximum flow in an Even-Tarjan reduction H of G
+            # and step:5 build the associated residual network R
+            R = flow_func(H, '%sB' % mapping[x], '%sA' % mapping[v], **kwargs)
+            flow_value = R.graph['flow_value']
+
+            if flow_value == k:
+                ## Remove saturated edges form the residual network
+                saturated_edges = list((u, w, d) for (u, w, d) in 
+                                        R.edges_iter(data=True)
+                                        if d['capacity'] == d['flow'])
+                R.remove_edges_from(saturated_edges)
+                # step 6: shrink the strongly connected components of 
+                # residual flow network R and call it L
+                L = nx.condensation(R)
+                cmap = L.graph['mapping']
+                # step 7: Compute antichains of L; they map to closed sets in H
+                # Any edge in H that links a closed set is part of a cutset
+                antichains = antichain_generator(L)
+
+                found = False
+                while not found:
+                    antichain = next(antichains, None)
+                    if antichain is None:
+                        break
+                    # Nodes in an antichain of the condensation graph of
+                    # the residual network map to a closed set of nodes that
+                    # define a node partition of the auxiliary digraph H.
+                    S = set(n for n, scc in cmap.items() if scc in antichain)
+                    # Find the cutset that links the node partition (S,~S) in H
+                    cutset = set()
+                    for u, nbrs in ((n, H[n]) for n in S):
+                        cutset.update((u, w) for w in nbrs if w not in S)
+                    # The edges in H that form the cutset are internal edges
+                    # (ie edges that represent a node of the original graph G)
+                    node_cut = set(H.node[n]['id'] for edge in cutset for n in edge)
+
+                    if len(node_cut) == k:
+                        yield node_cut
+                        # Add an edge (x, v) to make sure that we do not
+                        # find this cutset again. This is equivalent
+                        # of adding the edge in the input graph 
+                        # G.add_edge(x, v) and then regenerate H and R:
+                        # Add edges to the auxiliary digraph.
+                        H.add_edge('%sB' % mapping[x], '%sA' % mapping[v],
+                                   capacity=1)
+                        H.add_edge('%sB' % mapping[v], '%sA' % mapping[x],
+                                   capacity=1)
+                        # Add edges to the residual network.
+                        R.add_edge('%sB' % mapping[x], '%sA' % mapping[v],
+                                   capacity=1)
+                        R.add_edge('%sA' % mapping[v], '%sB' % mapping[x],
+                                   capacity=1)
+                        found = True
+                # Add again the saturated edges to reuse the residual network
+                R.add_edges_from(saturated_edges)
+
+
+def transitive_closure(G):
+    """Based on http://www.ics.uci.edu/~eppstein/PADS/PartialOrder.py"""
+    TC = nx.DiGraph()
+    TC.add_nodes_from(G.nodes_iter())
+    TC.add_edges_from(G.edges_iter())
+    for v in G:
+        TC.add_edges_from((v, u) for u in nx.dfs_preorder_nodes(G, source=v)
+                          if v != u)
+    return TC
+
+   
+def antichain_generator(G):
+    # Based on SAGE combinat.posets.hasse_diagram.py
+    TC = transitive_closure(G)
+    #print nx.to_numpy_matrix(TC)
+    antichains_queues = [([], nx.topological_sort(G, reverse=True))]
+    while antichains_queues:
+        (antichain, queue) = antichains_queues.pop()
+        # Invariant:
+        #  - the elements of antichain are independent
+        #  - the elements of queue are independent from those of antichain
+        yield antichain
+        while queue:
+            x = queue.pop()
+            new_antichain = antichain + [x]
+            new_queue = [t for t in queue if not ((t in TC[x]) or (x in TC[t]))]
+            antichains_queues.append((new_antichain, new_queue))
+
+
+def is_separating_set(G, cut):
+    if not nx.is_connected(G):
+        raise nx.NetworkXError('Input graph is disconnected')
+
+    if len(cut) == len(G) - 1:
+        return True
+
+    H = G.copy()
+    H.remove_nodes_from(cut)
+    if nx.is_connected(H):
+        return False
+    return True

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -82,6 +82,9 @@ def all_node_cuts(G, k=None, flow_func=None):
             http://onlinelibrary.wiley.com/doi/10.1002/net.3230230604/abstract
 
     """
+    if not nx.is_connected(G):
+        raise nx.NetworkXError('Input graph is disconnected.')
+
     # Initialize data structures.
     # Even-Tarjan reduction is what we call auxiliary digraph 
     # for node connectivity.
@@ -103,7 +106,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     degree = G.degree().items()
     X = set(n for n, d in sorted(degree, key=itemgetter(1), reverse=True)[:k])
     # Check if X is a k-node-cutset
-    if is_separating_set(G, X):
+    if _is_separating_set(G, X):
         yield X
 
     for x in X:
@@ -197,10 +200,8 @@ def antichain_generator(G):
             antichains_queues.append((new_antichain, new_queue))
 
 
-def is_separating_set(G, cut):
-    if not nx.is_connected(G):
-        raise nx.NetworkXError('Input graph is disconnected')
-
+def _is_separating_set(G, cut):
+    """Assumes that the input graph is connected"""
     if len(cut) == len(G) - 1:
         return True
 

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -88,6 +88,8 @@ def all_node_cuts(G, k=None, flow_func=None):
         raise nx.NetworkXError('Input graph is disconnected.')
 
     # Initialize data structures.
+    # Keep track of the cuts already computed so we do not repeat them.
+    seen = []
     # Even-Tarjan reduction is what we call auxiliary digraph 
     # for node connectivity.
     H = build_auxiliary_node_connectivity(G)
@@ -109,6 +111,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     X = set(n for n, d in sorted(degree, key=itemgetter(1), reverse=True)[:k])
     # Check if X is a k-node-cutset
     if _is_separating_set(G, X):
+        seen.append(X)
         yield X
 
     for x in X:
@@ -147,7 +150,9 @@ def all_node_cuts(G, k=None, flow_func=None):
                     node_cut = set(H.node[n]['id'] for edge in cutset for n in edge)
 
                     if len(node_cut) == k:
-                        yield node_cut
+                        if node_cut not in seen:
+                            yield node_cut
+                            seen.append(node_cut)
                         # Add an edge (x, v) to make sure that we do not
                         # find this cutset again. This is equivalent
                         # of adding the edge in the input graph 
@@ -179,7 +184,7 @@ def transitive_closure(G):
 
    
 def antichain_generator(G):
-    """Generates antichains from a graph that represents a Hasse diagram.
+    """Generates antichains from a DAG.
 
     This function was originally developed by Peter Jipsen and Franco Saliola
     for the SAGE project. It's included in NetworkX with permission from the 

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -179,6 +179,15 @@ def transitive_closure(G):
 
    
 def antichain_generator(G):
+    """Generates antichains from a graph that represents a Hasse diagram.
+
+    This function was originally developed by Peter Jipsen and Franco Saliola
+    for the SAGE project. It's included in NetworkX with permission from the 
+    authors. Original SAGE code at:
+
+    https://sage.informatik.uni-goettingen.de/src/combinat/posets/hasse_diagram.py
+
+    """
     # Based on SAGE combinat.posets.hasse_diagram.py
     TC = transitive_closure(G)
     antichains_queues = [([], nx.topological_sort(G, reverse=True))]

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -6,9 +6,11 @@ from operator import itemgetter
 
 import networkx as nx
 from .utils import build_auxiliary_node_connectivity
-from networkx.algorithms.flow import build_residual_network
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import shortest_augmenting_path
+from networkx.algorithms.flow import (
+    build_residual_network,
+    edmonds_karp,
+    shortest_augmenting_path,
+)
 # Define the default maximum flow function.
 default_flow_func = edmonds_karp
 
@@ -131,13 +133,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                 cmap = L.graph['mapping']
                 # step 7: Compute antichains of L; they map to closed sets in H
                 # Any edge in H that links a closed set is part of a cutset
-                antichains = antichain_generator(L)
-
-                found = False
-                while not found:
-                    antichain = next(antichains, None)
-                    if antichain is None:
-                        break
+                for antichain in antichain_generator(L):
                     # Nodes in an antichain of the condensation graph of
                     # the residual network map to a closed set of nodes that
                     # define a node partition of the auxiliary digraph H.
@@ -166,7 +162,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                                    capacity=1)
                         R.add_edge('%sA' % mapping[v], '%sB' % mapping[x],
                                    capacity=1)
-                        found = True
+                        break
                 # Add again the saturated edges to reuse the residual network
                 R.add_edges_from(saturated_edges)
 
@@ -185,7 +181,6 @@ def transitive_closure(G):
 def antichain_generator(G):
     # Based on SAGE combinat.posets.hasse_diagram.py
     TC = transitive_closure(G)
-    #print nx.to_numpy_matrix(TC)
     antichains_queues = [([], nx.topological_sort(G, reverse=True))]
     while antichains_queues:
         (antichain, queue) = antichains_queues.pop()

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -117,7 +117,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     for x in X:
         # step 3: Compute local connectivity flow of x with all other
         # non adjacent nodes in G
-        non_adjacent = (n for n in set(G) - X if n not in G[x])
+        non_adjacent = set(G) - X - set(G[x])
         for v in non_adjacent:
             # step 4: compute maximum flow in an Even-Tarjan reduction H of G
             # and step:5 build the associated residual network R
@@ -126,9 +126,9 @@ def all_node_cuts(G, k=None, flow_func=None):
 
             if flow_value == k:
                 ## Remove saturated edges form the residual network
-                saturated_edges = list((u, w, d) for (u, w, d) in 
-                                        R.edges_iter(data=True)
-                                        if d['capacity'] == d['flow'])
+                saturated_edges = [(u, w, d) for (u, w, d) in
+                                    R.edges_iter(data=True)
+                                    if d['capacity'] == d['flow']]
                 R.remove_edges_from(saturated_edges)
                 # step 6: shrink the strongly connected components of 
                 # residual flow network R and call it L
@@ -143,8 +143,8 @@ def all_node_cuts(G, k=None, flow_func=None):
                     S = set(n for n, scc in cmap.items() if scc in antichain)
                     # Find the cutset that links the node partition (S,~S) in H
                     cutset = set()
-                    for u, nbrs in ((n, H[n]) for n in S):
-                        cutset.update((u, w) for w in nbrs if w not in S)
+                    for u in S:
+                        cutset.update((u, w) for w in H[u] if w not in S)
                     # The edges in H that form the cutset are internal edges
                     # (ie edges that represent a node of the original graph G)
                     node_cut = set(H.node[n]['id'] for edge in cutset for n in edge)

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -1,0 +1,188 @@
+# Jordi Torrents
+# Test for k-cutsets
+from nose.tools import assert_equal, assert_false, assert_true
+import networkx as nx
+
+##
+## Some nice synthetic graphs
+##
+def graph_example_1():
+    G = nx.convert_node_labels_to_integers(nx.grid_graph([5,5]),
+                                            label_attribute='labels')
+    rlabels = nx.get_node_attributes(G, 'labels')
+    labels = dict((v, k) for k, v in rlabels.items())
+
+    for nodes in [(labels[(0,0)], labels[(1,0)]),
+                    (labels[(0,4)], labels[(1,4)]),
+                    (labels[(3,0)], labels[(4,0)]),
+                    (labels[(3,4)], labels[(4,4)]) ]:
+        new_node = G.order()+1
+        # Petersen graph is triconnected
+        P = nx.petersen_graph()
+        G = nx.disjoint_union(G,P)
+        # Add two edges between the grid and P
+        G.add_edge(new_node+1, nodes[0])
+        G.add_edge(new_node, nodes[1])
+        # K5 is 4-connected
+        K = nx.complete_graph(5)
+        G = nx.disjoint_union(G,K)
+        # Add three edges between P and K5
+        G.add_edge(new_node+2,new_node+11)
+        G.add_edge(new_node+3,new_node+12)
+        G.add_edge(new_node+4,new_node+13)
+        # Add another K5 sharing a node
+        G = nx.disjoint_union(G,K)
+        nbrs = G[new_node+10]
+        G.remove_node(new_node+10)
+        for nbr in nbrs:
+            G.add_edge(new_node+17, nbr)
+        G.add_edge(new_node+16, new_node+5)
+
+    G.name = 'Example graph for connectivity'
+    return G
+
+
+def torrents_and_ferraro_graph():
+    G = nx.convert_node_labels_to_integers(nx.grid_graph([5,5]),
+                                            label_attribute='labels')
+    rlabels = nx.get_node_attributes(G, 'labels')
+    labels = dict((v, k) for k, v in rlabels.items())
+
+    for nodes in [ (labels[(0,4)], labels[(1,4)]),
+                    (labels[(3,4)], labels[(4,4)]) ]:
+        new_node = G.order()+1
+        # Petersen graph is triconnected
+        P = nx.petersen_graph()
+        G = nx.disjoint_union(G,P)
+        # Add two edges between the grid and P
+        G.add_edge(new_node+1, nodes[0])
+        G.add_edge(new_node, nodes[1])
+        # K5 is 4-connected
+        K = nx.complete_graph(5)
+        G = nx.disjoint_union(G,K)
+        # Add three edges between P and K5
+        G.add_edge(new_node+2,new_node+11)
+        G.add_edge(new_node+3,new_node+12)
+        G.add_edge(new_node+4,new_node+13)
+        # Add another K5 sharing a node
+        G = nx.disjoint_union(G,K)
+        nbrs = G[new_node+10]
+        G.remove_node(new_node+10)
+        for nbr in nbrs:
+            G.add_edge(new_node+17, nbr)
+        # Commenting this makes the graph not biconnected !!
+        # This stupid mistake make one reviewer very angry :P
+        G.add_edge(new_node+16, new_node+8)
+
+    for nodes in [(labels[(0,0)], labels[(1,0)]),
+                    (labels[(3,0)], labels[(4,0)])]:
+        new_node = G.order()+1
+        # Petersen graph is triconnected
+        P = nx.petersen_graph()
+        G = nx.disjoint_union(G,P)
+        # Add two edges between the grid and P
+        G.add_edge(new_node+1, nodes[0])
+        G.add_edge(new_node, nodes[1])
+        # K5 is 4-connected
+        K = nx.complete_graph(5)
+        G = nx.disjoint_union(G,K)
+        # Add three edges between P and K5
+        G.add_edge(new_node+2,new_node+11)
+        G.add_edge(new_node+3,new_node+12)
+        G.add_edge(new_node+4,new_node+13)
+        # Add another K5 sharing two nodes
+        G = nx.disjoint_union(G,K)
+        nbrs = G[new_node+10]
+        G.remove_node(new_node+10)
+        for nbr in nbrs:
+            G.add_edge(new_node+17, nbr)
+        nbrs2 = G[new_node+9]
+        G.remove_node(new_node+9)
+        for nbr in nbrs2:
+            G.add_edge(new_node+18, nbr)
+
+    G.name = 'Example graph for connectivity'
+    return G
+
+
+# Helper function
+def _check_separating_sets(G):
+    for Gc in nx.connected_component_subgraphs(G):
+        if len(Gc) < 3:
+            continue
+        for cut in nx.all_node_cuts(Gc):
+            assert_equal(nx.node_connectivity(Gc), len(cut))
+            H = Gc.copy()
+            H.remove_nodes_from(cut)
+            assert_false(nx.is_connected(H))
+
+
+def test_torrents_and_ferraro_graph():
+    G = torrents_and_ferraro_graph()
+    _check_separating_sets(G)
+
+
+def test_example_1():
+    G = graph_example_1()
+    _check_separating_sets(G)
+
+def test_random_gnp():
+    G = nx.gnp_random_graph(100, 0.1)
+    _check_separating_sets(G)
+
+
+def test_shell():
+    constructor=[(20,80,0.8),(80,180,0.6)]
+    G = nx.random_shell_graph(constructor)
+    _check_separating_sets(G)
+
+
+def test_configuration():
+    deg_seq = nx.utils.create_degree_sequence(100,nx.utils.powerlaw_sequence)
+    G = nx.Graph(nx.configuration_model(deg_seq))
+    G.remove_edges_from(G.selfloop_edges())
+    _check_separating_sets(G)
+
+
+def test_karate():
+    G = nx.karate_club_graph()
+    _check_separating_sets(G)
+
+
+def _generate_no_biconnected(max_attempts=50):
+    attempts = 0
+    while True:
+        G = nx.fast_gnp_random_graph(100,0.0575)
+        if nx.is_connected(G) and not nx.is_biconnected(G):
+            attempts = 0
+            yield G
+        else:
+            if attempts >= max_attempts:
+                msg = "Tried %d times: no suitable Graph."%attempts
+                raise Exception(msg % max_attempts)
+            else:
+                attempts += 1
+
+
+def test_articulation_points():
+    Ggen = _generate_no_biconnected()
+    for i in range(3):
+        G = next(Ggen)
+        articulation_points = list({a} for a in nx.articulation_points(G))
+        for cut in nx.all_node_cuts(G):
+            assert_true(cut in articulation_points)
+
+
+def test_grid_2d_graph():
+    # All minimum node cuts of a 2d grid
+    # are the four pairs of nodes that are
+    # neighbors of the four corner nodes.
+    G = nx.grid_2d_graph(5, 5)
+    solution = [
+        set([(0, 1), (1, 0)]),
+        set([(3, 0), (4, 1)]),
+        set([(3, 4), (4, 3)]),
+        set([(0, 3), (1, 4)]),
+    ]
+    for cut in nx.all_node_cuts(G):
+        assert_true(cut in solution)

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -225,3 +225,15 @@ def test_is_separating_set():
         G = nx.star_graph(i)
         max_degree_node = max(G, key=G.degree)
         assert_true(_is_separating_set(G, {max_degree_node}))
+
+
+def test_non_repeated_cuts():
+    # The algorithm was repeating the cut {0, 1} for the giant biconnected
+    # component of the Karate club graph.
+    K = nx.karate_club_graph()
+    G = max(list(nx.biconnected_component_subgraphs(K)), key=len)
+    solution = [{32, 33}, {2, 33}, {0, 3}, {0, 1}, {29, 33}]
+    cuts = list(nx.all_node_cuts(G))
+    assert_true(len(solution) == len(cuts))
+    for cut in cuts:
+        assert_true(cut in solution)

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -1,6 +1,6 @@
 # Jordi Torrents
 # Test for k-cutsets
-from nose.tools import assert_equal, assert_false, assert_true
+from nose.tools import assert_equal, assert_false, assert_true, assert_raises
 import networkx as nx
 
 ##
@@ -186,3 +186,9 @@ def test_grid_2d_graph():
     ]
     for cut in nx.all_node_cuts(G):
         assert_true(cut in solution)
+
+
+def test_disconnected_graph():
+    G = nx.fast_gnp_random_graph(100, 0.01)
+    cuts = nx.all_node_cuts(G)
+    assert_raises(nx.NetworkXError, next, cuts)


### PR DESCRIPTION
This PR implements Kanevsky's algorithm for all minimum-size separating
node sets in an undirected graph as a generator of node sets.

The most tricky thing about the implementation is that for reusing the
residual network and the auxiliary graph for node connectivity (which
is key for speed) we have to keep removing and adding edges to them
instead of regenerating both each time we have to modify the input
graph (the algorithm prescrives to add an edge each time we find
a node cutset to avoid finding it again).

This PR uses almost as is a function from SAGE (see `compute_antichains`),
maybe we should ask permission to it's author to include it given that SAGE
is GPL and we are BSD?