### PR TITLE
Make add_edge return key for multiedges.

### DIFF
--- a/examples/subclass/globaledgekey.py
+++ b/examples/subclass/globaledgekey.py
@@ -1,0 +1,68 @@
+"""
+A subclass of the MultiDiGraph class which uses a global edge key.
+
+"""
+from __future__ import print_function
+
+from collections import OrderedDict
+import networkx as nx
+
+class MultiDiGraph(nx.MultiDiGraph):
+    """
+    Example subclass of the NetworkX MultiDiGraph class.
+
+    Each edge is assigned a globally unique key.
+
+    self.edges_dict maps edge keys to (u, v, data) tuples.
+    This can be useful for algorithms that are primarily edge-based.
+
+    """
+    _next_key = 0
+    edges_dict = OrderedDict()
+
+    def _keyfunc(self, u, v):
+        key = self._next_key
+        self._next_key += 1
+        return key
+
+    def add_edge(self, u, v, key=None, attr_dict=None, **attr):
+        # ignore passed in key
+        base = super(MultiDiGraph, self)
+        key = base.add_edge(u, v, attr_dict=attr_dict, **attr)
+        self.edges_dict[key] = (u, v, self.succ[u][v][key])
+        return key
+
+    def remove_edge(self, u, v, key=None):
+        base = super(MultiDiGraph, self)
+        key, data = base.remove_edge(u, v, key=key)
+        del self.edges_dict[key]
+        return key, data
+
+    def remove_edge_with_key(self, key):
+        u, v, _ = self.edges_dict[key]
+        k, data = self.remove_edge(u, v, key=key)
+        return k, data
+
+    def get_edge_data_with_key(self, key):
+        u, v, data = self.edges_dict[key]
+        return data
+
+    def size(self):
+        return len(self.edges_dict)
+
+def main():
+    G = MultiDiGraph()
+    k1 = G.add_edge(0, 1, color='red')
+    k2 = G.add_edge(0, 1, color='blue')
+    G.remove_edge(0, 1, key=k1)
+    data = G.remove_edge_with_key(k2)
+    G.add_cycle(range(5, 10), weight=3)
+
+    for key, val in G.edges_dict.items():
+        print(key)
+        print(val)
+        print()
+
+
+if __name__=='__main__':
+    main()

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -245,6 +245,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
     #adjlist_dict_factory=dict
     edge_key_dict_factory=dict
     #edge_attr_dict_factory=dict
+
     def __init__(self, data=None, **attr):
         self.edge_key_dict_factory = self.edge_key_dict_factory
         DiGraph.__init__(self, data, **attr)
@@ -320,25 +321,22 @@ class MultiDiGraph(MultiGraph,DiGraph):
             self.succ[v] = self.adjlist_dict_factory()
             self.pred[v] = self.adjlist_dict_factory()
             self.node[v] = {}
+
+        if key is None:
+            key = self._keyfunc(u, v)
+
+        # add edge
         if v in self.succ[u]:
-            keydict=self.adj[u][v]
-            if key is None:
-                # find a unique integer key
-                # other methods might be better here?
-                key=len(keydict)
-                while key in keydict:
-                    key+=1
-            datadict=keydict.get(key,self.edge_key_dict_factory())
+            keydict = self.adj[u][v]
+            datadict = keydict.get(key, self.edge_key_dict_factory())
             datadict.update(attr_dict)
-            keydict[key]=datadict
+            keydict[key] = datadict
         else:
-            # selfloops work this way without special treatment
-            if key is None:
-                key=0
-            datadict=self.edge_attr_dict_factory()
+            # New selfloops are also handled by this without special treatment.
+            keydict = self.edge_key_dict_factory()
+            datadict = keydict.get(key, self.edge_attr_dict_factory())
             datadict.update(attr_dict)
-            keydict=self.edge_key_dict_factory()
-            keydict[key]=datadict
+            keydict[key] = datadict
             self.succ[u][v] = keydict
             self.pred[v][u] = keydict
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -273,6 +273,11 @@ class MultiDiGraph(MultiGraph,DiGraph):
             Edge data (or labels or objects) can be assigned using
             keyword arguments.
 
+        Returns
+        -------
+        key : hashable identifier
+            The key of the added edge.
+
         See Also
         --------
         add_edges_from : add a collection of edges
@@ -340,6 +345,8 @@ class MultiDiGraph(MultiGraph,DiGraph):
             self.succ[u][v] = keydict
             self.pred[v][u] = keydict
 
+        return key
+
     def remove_edge(self, u, v, key=None):
         """Remove an edge between u and v.
 
@@ -350,6 +357,13 @@ class MultiDiGraph(MultiGraph,DiGraph):
         key : hashable identifier, optional (default=None)
             Used to distinguish multiple edges between a pair of nodes.
             If None remove a single (abritrary) edge between u and v.
+
+        Returns
+        -------
+        key : hashable identifier
+            The key of the edge that was deleted.
+        data : dict-like
+            The data of the edge that was deleted.
 
         Raises
         ------
@@ -384,24 +398,31 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         try:
-            d=self.adj[u][v]
+            d = self.adj[u][v]
         except (KeyError):
-            raise NetworkXError(
-                "The edge %s-%s is not in the graph."%(u,v))
-        # remove the edge with specified data
+            msg = "The edge {0}-{1} is not in the graph.".format(u,v)
+            raise NetworkXError(msg)
+
+        # remove the edge with specified key
         if key is None:
-            d.popitem()
+            key, data = d.popitem()
         else:
             try:
-                del d[key]
+                data = d[key]
             except (KeyError):
-                raise NetworkXError(
-                "The edge %s-%s with key %s is not in the graph."%(u,v,key))
-        if len(d)==0:
+                msg = "The edge {0}-{1} with key {2} is not in the graph."
+                msg = msg.format(u, v, key)
+                raise NetworkXError(msg)
+            else:
+                del d[key]
+
+        if not d:
+            # remove the key entries if last edge
             # remove the key entries if last edge
             del self.succ[u][v]
             del self.pred[v][u]
 
+        return key, data
 
     def edges_iter(self, nbunch=None, data=False, keys=False, default=None):
         """Return an iterator over the edges.

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -181,10 +181,10 @@ class MultiDiGraph(MultiGraph,DiGraph):
     the edge data and holds edge attribute values keyed by attribute names.
 
     Each of these four dicts in the dict-of-dict-of-dict-of-dict
-    structure can be replaced by a user defined dict-like object.  
-    In general, the dict-like features should be maintained but 
-    extra features can be added. To replace one of the dicts create 
-    a new graph class by changing the class(!) variable holding the 
+    structure can be replaced by a user defined dict-like object.
+    In general, the dict-like features should be maintained but
+    extra features can be added. To replace one of the dicts create
+    a new graph class by changing the class(!) variable holding the
     factory for that dict-like structure. The variable names
     are node_dict_factory, adjlist_dict_factory, edge_key_dict_factory
     and edge_attr_dict_factory.
@@ -419,7 +419,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         keys : bool, optional (default=False)
             If True, return edge keys with each edge.
         default : value, optional (default=None)
@@ -449,7 +449,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges_iter(data=True)) # default data is {} (empty dict)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges(keys=True)) # default keys are integers
         [(0, 1, 0), (1, 2, 0), (2, 3, 0)]
@@ -600,7 +600,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -659,7 +659,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -711,7 +711,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -807,8 +807,8 @@ class MultiDiGraph(MultiGraph,DiGraph):
         Parameters
         ----------
         reciprocal : bool (optional)
-          If True only keep edges that appear in both directions 
-          in the original digraph. 
+          If True only keep edges that appear in both directions
+          in the original digraph.
 
         Returns
         -------
@@ -837,7 +837,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         If you have subclassed MultiGraph to use dict-like objects in the
         data structure, those changes do not transfer to the MultiDiGraph
         created by this method.
-        
+
         """
         H=MultiGraph()
         H.name=self.name
@@ -940,7 +940,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         if copy:
             H = self.__class__(name="Reverse of (%s)"%self.name)
             H.add_nodes_from(self)
-            H.add_edges_from( (v,u,k,deepcopy(d)) for u,v,k,d 
+            H.add_edges_from( (v,u,k,deepcopy(d)) for u,v,k,d
                               in self.edges(keys=True, data=True) )
             H.graph=deepcopy(self.graph)
             H.node=deepcopy(self.node)

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -182,10 +182,10 @@ class MultiGraph(Graph):
     the edge data and holds edge attribute values keyed by attribute names.
 
     Each of these four dicts in the dict-of-dict-of-dict-of-dict
-    structure can be replaced by a user defined dict-like object.  
-    In general, the dict-like features should be maintained but 
-    extra features can be added. To replace one of the dicts create 
-    a new graph class by changing the class(!) variable holding the 
+    structure can be replaced by a user defined dict-like object.
+    In general, the dict-like features should be maintained but
+    extra features can be added. To replace one of the dicts create
+    a new graph class by changing the class(!) variable holding the
     factory for that dict-like structure. The variable names
     are node_dict_factory, adjlist_dict_factory, edge_key_dict_factory
     and edge_attr_dict_factory.
@@ -622,7 +622,7 @@ class MultiGraph(Graph):
         [(0, 1), (1, 2), (2, 3)]
         >>> G.edges(data=True) # default edge data is {} (empty dictionary)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> G.edges(keys=True) # default keys are integers
         [(0, 1, 0), (1, 2, 0), (2, 3, 0)]
@@ -652,7 +652,7 @@ class MultiGraph(Graph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         default : value, optional (default=None)
             Value used for edges that dont have the requested attribute.
             Only relevant if data is not True or False.
@@ -682,7 +682,7 @@ class MultiGraph(Graph):
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges_iter(data=True)) # default data is {} (empty dict)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges(keys=True)) # default keys are integers
         [(0, 1, 0), (1, 2, 0), (2, 3, 0)]
@@ -792,7 +792,7 @@ class MultiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -894,7 +894,7 @@ class MultiGraph(Graph):
         G.add_edges_from( (u,v,key,deepcopy(datadict))
                            for u,nbrs in self.adjacency_iter()
                            for v,keydict in nbrs.items()
-                           for key,datadict in keydict.items() ) 
+                           for key,datadict in keydict.items() )
         G.graph=deepcopy(self.graph)
         G.node=deepcopy(self.node)
         return G


### PR DESCRIPTION
I think this may have been brought up long ago, but I couldn't remember.  Edit 05-2016: #278

Presently, when you add an edge to a multi(di)graph and do not specify the edge key, then we will construct one for you. The constructed key is not returned back to the user, so the user has no feedback or simple way to obtain the edge data for the added edge.

Should we return the constructed key for multi(di)graphs? 

```
>>> g = nx.MultiGraph()
>>> g.add_edge(0, 1, weight=5)
0
>>> g.add_edge(0, 1, weight=10)
1
>>> g.get_edge_data(0, 1, key=1)
{'weight': 10}
```

Users may not care about the details of how a particular key is assigned, but they do care about the particular assignments.