### PR TITLE
Fix docstring for strongly_connected_components

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -215,14 +215,14 @@ def strongly_connected_component_subgraphs(G, copy=True):
     ----------
     G : NetworkX Graph
        A graph.
+    copy : boolean, optional
+      if copy is True, Graph, node, and edge attributes are copied to
+      the subgraphs.
 
     Returns
     -------
     comp : generator of lists
       A list of graphs, one for each strongly connected component of G.
-    copy : boolean
-      if copy is True, Graph, node, and edge attributes are copied to
-      the subgraphs.
 
     See Also
     --------


### PR DESCRIPTION
The "copy" keyword argument was incorrectly placed in the Returns
section of the docstring. This moves it to the correct location, under
Parameters.