### PR TITLE
Add fast approximation for node connectivity.

### DIFF
--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -92,6 +92,11 @@ New functionalities
   ``algorithms.bipartite.generators``. The functions are not imported in the
   main  namespace, so to use it, the bipartite package has to be imported.
 
+* [`#1405 <https://github.com/networkx/networkx/pull/1405>`_]
+  Added fast approximation for node connectivity based on White and
+  Newman's approximation algorithm for finding node independent paths
+  between two nodes.
+
 Removed functionalities
 -----------------------
 

--- a/networkx/algorithms/approximation/__init__.py
+++ b/networkx/algorithms/approximation/__init__.py
@@ -1,5 +1,6 @@
 from networkx.algorithms.approximation.clustering_coefficient import *
 from networkx.algorithms.approximation.clique import *
+from networkx.algorithms.approximation.connectivity import *
 from networkx.algorithms.approximation.dominating_set import *
 from networkx.algorithms.approximation.independent_set import *
 from networkx.algorithms.approximation.matching import *

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -104,7 +104,7 @@ def local_node_connectivity(G, source, target, cutoff=None):
     exclude = set()
     for i in range(min(possible, cutoff)):
         try:
-            path = _bidirectional_shortest_path(G,source,target,exclude=exclude)
+            path = _bidirectional_shortest_path(G, source, target, exclude)
             exclude.update(set(path))
             K += 1
         except nx.NetworkXNoPath:
@@ -282,7 +282,7 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
     return all_pairs
 
 
-def _bidirectional_shortest_path(G, source, target, exclude=None):
+def _bidirectional_shortest_path(G, source, target, exclude):
     """Return shortest path between source and target ignoring nodes in the
     container 'exclude'.
 
@@ -297,7 +297,7 @@ def _bidirectional_shortest_path(G, source, target, exclude=None):
     target : node
         Ending node for path
 
-    exclude: container, iterable (optional)
+    exclude: container
         Container for nodes to exclude from the search for shortest paths
 
     Returns
@@ -326,7 +326,7 @@ def _bidirectional_shortest_path(G, source, target, exclude=None):
     
     """
     # call helper to do the real work
-    results = _bidirectional_pred_succ(G, source, target, exclude=exclude)
+    results = _bidirectional_pred_succ(G, source, target, exclude)
     pred, succ, w = results
 
     # build path from pred+w+succ
@@ -345,7 +345,7 @@ def _bidirectional_shortest_path(G, source, target, exclude=None):
     return path
 
 
-def _bidirectional_pred_succ(G, source, target, exclude=None):
+def _bidirectional_pred_succ(G, source, target, exclude):
     # does BFS from both source and target and meets in the middle
     # excludes nodes in the container "exclude" from the search
     if source is None or target is None:
@@ -354,9 +354,6 @@ def _bidirectional_pred_succ(G, source, target, exclude=None):
     if target == source:
         return ({target:None},{source:None},source)
 
-    if exclude is None:
-        exclude = set()
-    
     # handle either directed or undirected
     if G.is_directed():
         Gpred = G.predecessors_iter

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -43,7 +43,8 @@ def local_node_connectivity(G, source, target, cutoff=None):
         Ending node for node connectivity
 
     cutoff : integer
-        Maximum number of paths to consider. Default value None.
+        Maximum node connectivity to consider. If None, the minimum degree
+        of source or target is used as a cutoff. Default value None.
 
     Returns
     -------
@@ -56,7 +57,7 @@ def local_node_connectivity(G, source, target, cutoff=None):
     >>> # for each non adjacent node pair
     >>> from networkx.algorithms import approximation as approx
     >>> G = nx.icosahedral_graph()
-    >>> approx.local_node_connectivity(G,0,6)
+    >>> approx.local_node_connectivity(G, 0, 6)
     5
 
     Notes 
@@ -239,7 +240,9 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
         only over pairs of nodes in nbunch.
 
     cutoff : integer
-        Maximum node connectivity to consider. Default value None.
+        Maximum node connectivity to consider. If None, the minimum degree
+        of source or target is used as a cutoff in each pair of nodes.
+        Default value None.
 
     Returns
     -------

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -1,0 +1,405 @@
+""" Fast approximation for node connectivity
+"""
+#    Copyright (C) 2015 by 
+#    Jordi Torrents <jtorrents@milnou.net>
+#    All rights reserved.
+#    BSD license.
+import itertools
+from operator import itemgetter
+
+import networkx as nx
+
+__author__ = """\n""".join(['Jordi Torrents <jtorrents@milnou.net>'])
+
+__all__ = ['local_node_connectivity',
+           'node_connectivity',
+           'all_pairs_node_connectivity']
+
+INF = float('inf')
+
+
+def local_node_connectivity(G, source, target, cutoff=None):
+    """Compute node connectivity between source and target.
+    
+    Pairwise or local node connectivity between two distinct and nonadjacent 
+    nodes is the minimum number of nodes that must be removed (minimum 
+    separating cutset) to disconnect them. By Menger's theorem, this is equal 
+    to the number of node independent paths (paths that share no nodes other
+    than source and target). Which is what we compute in this function.
+
+    This algorithm is a fast approximation that gives an strict lower
+    bound on the actual number of node independent paths between two nodes [1]_. 
+    It works for both directed and undirected graphs.
+
+    Parameters
+    ----------
+
+    G : NetworkX graph
+
+    source : node
+        Starting node for node connectivity
+
+    target : node
+        Ending node for node connectivity
+
+    cutoff : integer
+        Maximum number of paths to consider. Default value None.
+
+    Returns
+    -------
+    k: integer
+       pairwise node connectivity
+
+    Examples
+    --------
+    >>> # Platonic icosahedral graph has node connectivity 5 
+    >>> # for each non adjacent node pair
+    >>> from networkx.algorithms import approximation as approx
+    >>> G = nx.icosahedral_graph()
+    >>> approx.local_node_connectivity(G,0,6)
+    5
+
+    Notes 
+    -----
+    This algorithm [1]_ finds node independents paths between two nodes by 
+    computing their shortest path using BFS, marking the nodes of the path 
+    found as 'used' and then searching other shortest paths excluding the 
+    nodes marked as used until no more paths exist. It is not exact because 
+    a shortest path could use nodes that, if the path were longer, may belong
+    to two different node independent paths. Thus it only guarantees an
+    strict lower bound on node connectivity.
+
+    Note that the authors propose a further refinement, losing accuracy and 
+    gaining speed, which is not implemented yet.
+
+    See also
+    --------
+    all_pairs_node_connectivity
+    node_connectivity
+
+    References
+    ----------
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+        Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
+        http://eclectic.ss.uci.edu/~drwhite/working.pdf
+ 
+    """
+    if target == source:
+        raise nx.NetworkXError("source and target have to be different nodes.")
+
+    # Maximum possible node independent paths
+    if G.is_directed():
+        possible = min(G.out_degree(source), G.in_degree(target))
+    else:
+        possible = min(G.degree(source), G.degree(target))
+
+    K = 0
+    if not possible:
+        return K
+    
+    if cutoff is None:
+        cutoff = INF
+
+    exclude = set()
+    for i in range(min(possible, cutoff)):
+        try:
+            path = _bidirectional_shortest_path(G,source,target,exclude=exclude)
+            exclude.update(set(path))
+            K += 1
+        except nx.NetworkXNoPath:
+            break
+
+    return K
+
+
+def node_connectivity(G, s=None, t=None):
+    r"""Returns an approximation for node connectivity for a graph or digraph G.
+
+    Node connectivity is equal to the minimum number of nodes that
+    must be removed to disconnect G or render it trivial. By Menger's theorem,
+    this is equal to the number of node independent paths (paths that 
+    share no nodes other than source and target).
+
+    If source and target nodes are provided, this function returns the 
+    local node connectivity: the minimum number of nodes that must be 
+    removed to break all paths from source to target in G.
+
+    This algorithm is based on a fast approximation that gives an strict lower
+    bound on the actual number of node independent paths between two nodes [1]_. 
+    It works for both directed and undirected graphs.
+   
+    Parameters
+    ----------
+    G : NetworkX graph
+        Undirected graph
+
+    s : node
+        Source node. Optional. Default value: None.
+
+    t : node
+        Target node. Optional. Default value: None.
+
+    Returns
+    -------
+    K : integer
+        Node connectivity of G, or local node connectivity if source
+        and target are provided.
+
+    Examples
+    --------
+    >>> # Platonic icosahedral graph is 5-node-connected 
+    >>> from networkx.algorithms import approximation as approx
+    >>> G = nx.icosahedral_graph()
+    >>> approx.node_connectivity(G)
+    5
+    
+    Notes
+    -----
+    This algorithm [1]_ finds node independents paths between two nodes by 
+    computing their shortest path using BFS, marking the nodes of the path 
+    found as 'used' and then searching other shortest paths excluding the 
+    nodes marked as used until no more paths exist. It is not exact because 
+    a shortest path could use nodes that, if the path were longer, may belong
+    to two different node independent paths. Thus it only guarantees an
+    strict lower bound on node connectivity.
+
+    See also
+    --------
+    all_pairs_node_connectivity
+    local_node_connectivity
+
+    References
+    ----------
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+        Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
+        http://eclectic.ss.uci.edu/~drwhite/working.pdf
+
+    """
+    if (s is not None and t is None) or (s is None and t is not None):
+        raise nx.NetworkXError('Both source and target must be specified.')
+
+    # Local node connectivity
+    if s is not None and t is not None:
+        if s not in G:
+            raise nx.NetworkXError('node %s not in graph' % s)
+        if t not in G:
+            raise nx.NetworkXError('node %s not in graph' % t)
+        return local_node_connectivity(G, s, t)
+
+    # Global node connectivity
+    if G.is_directed():
+        connected_func = nx.is_weakly_connected
+        iter_func = itertools.permutations
+        def neighbors(v):
+            return itertools.chain.from_iterable([G.predecessors_iter(v),
+                                                  G.successors_iter(v)])
+    else:
+        connected_func = nx.is_connected
+        iter_func = itertools.combinations
+        neighbors = G.neighbors_iter
+
+    if not connected_func(G):
+        return 0
+
+    # Choose a node with minimum degree
+    v, minimum_degree = min(G.degree().items(), key=itemgetter(1))
+    # Node connectivity is bounded by minimum degree
+    K = minimum_degree
+    # compute local node connectivity with all non-neighbors nodes
+    # and store the minimum
+    for w in set(G) - set(neighbors(v)) - set([v]):
+        K = min(K, local_node_connectivity(G, v, w, cutoff=K))
+    # Same for non adjacent pairs of neighbors of v
+    for x, y in iter_func(neighbors(v), 2):
+        if y not in G[x] and x != y:
+            K = min(K, local_node_connectivity(G, x, y, cutoff=K))
+    return K
+
+
+def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
+    """ Compute node connectivity between all pairs of nodes.
+
+    Pairwise or local node connectivity between two distinct and nonadjacent 
+    nodes is the minimum number of nodes that must be removed (minimum 
+    separating cutset) to disconnect them. By Menger's theorem, this is equal 
+    to the number of node independent paths (paths that share no nodes other
+    than source and target). Which is what we compute in this function.
+
+    This algorithm is a fast approximation that gives an strict lower
+    bound on the actual number of node independent paths between two nodes [1]_. 
+    It works for both directed and undirected graphs.
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    nbunch: container
+        Container of nodes. If provided node connectivity will be computed
+        only over pairs of nodes in nbunch.
+
+    cutoff : integer
+        Maximum node connectivity to consider. Default value None.
+
+    Returns
+    -------
+    K : dictionary
+        Dictionary, keyed by source and target, of pairwise node connectivity
+
+    See Also
+    --------
+    local_node_connectivity
+    all_pairs_node_connectivity
+
+    References
+    ----------
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+        Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
+        http://eclectic.ss.uci.edu/~drwhite/working.pdf
+    """
+    if nbunch is None:
+        nbunch = G
+    else:
+        nbunch = set(nbunch)
+
+    directed = G.is_directed()
+    if directed:
+        iter_func = itertools.permutations
+    else:
+        iter_func = itertools.combinations
+
+    all_pairs = {n: {} for n in nbunch}
+
+    for u, v in iter_func(nbunch, 2):
+        k = local_node_connectivity(G, u, v, cutoff=cutoff)
+        all_pairs[u][v] = k
+        if not directed:
+            all_pairs[v][u] = k
+
+    return all_pairs
+
+
+def _bidirectional_shortest_path(G, source, target, exclude=None):
+    """Return shortest path between source and target ignoring nodes in the
+    container 'exclude'.
+
+    Parameters
+    ----------
+
+    G : NetworkX graph
+
+    source : node
+        Starting node for path
+
+    target : node
+        Ending node for path
+
+    exclude: container, iterable (optional)
+        Container for nodes to exclude from the search for shortest paths
+
+    Returns
+    -------
+    path: list
+        Shortest path between source and target ignoring nodes in 'exclude'
+
+    Raises
+    ------
+    NetworkXNoPath: exception
+        If there is no path or if nodes are adjacent and have only one path
+        between them
+
+    Notes
+    -----
+    This function and its helper are originaly from
+    networkx.algorithms.shortest_paths.unweighted and are modified to 
+    accept the extra parameter 'exclude', which is a container for nodes 
+    already used in other paths that should be ignored.
+
+    References
+    ----------
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+        Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
+        http://eclectic.ss.uci.edu/~drwhite/working.pdf
+    
+    """
+    # call helper to do the real work
+    results = _bidirectional_pred_succ(G, source, target, exclude=exclude)
+    pred, succ, w = results
+
+    # build path from pred+w+succ
+    path = []
+    # from source to w
+    while w is not None:
+        path.append(w)
+        w = pred[w]
+    path.reverse()
+    # from w to target
+    w = succ[path[-1]]
+    while w is not None:
+        path.append(w)
+        w = succ[w]
+
+    return path
+
+
+def _bidirectional_pred_succ(G, source, target, exclude=None):
+    # does BFS from both source and target and meets in the middle
+    # excludes nodes in the container "exclude" from the search
+    if source is None or target is None:
+        raise nx.NetworkXException(\
+            "Bidirectional shortest path called without source or target")
+    if target == source:
+        return ({target:None},{source:None},source)
+
+    if exclude is None:
+        exclude = set()
+    
+    # handle either directed or undirected
+    if G.is_directed():
+        Gpred = G.predecessors_iter
+        Gsucc = G.successors_iter
+    else:
+        Gpred = G.neighbors_iter
+        Gsucc = G.neighbors_iter
+
+    # predecesssor and successors in search
+    pred = {source: None}
+    succ = {target: None}
+
+    # initialize fringes, start with forward
+    forward_fringe = [source]
+    reverse_fringe = [target]
+
+    level = 0
+    
+    while forward_fringe and reverse_fringe:
+        # Make sure that we iterate one step forward and one step backwards
+        # thus source and target will only tigger "found path" when they are
+        # adjacent and then they can be safely included in the container 'exclude'
+        level += 1
+        if not level % 2 == 0:
+            this_level = forward_fringe
+            forward_fringe = []
+            for v in this_level:
+                for w in Gsucc(v):
+                    if w in exclude:
+                        continue
+                    if w not in pred:
+                        forward_fringe.append(w)
+                        pred[w] = v
+                    if w in succ:
+                        return pred, succ, w # found path
+        else:
+            this_level = reverse_fringe
+            reverse_fringe = []
+            for v in this_level:
+                for w in Gpred(v):
+                    if w in exclude:
+                        continue
+                    if w not in succ:
+                        succ[w] = v
+                        reverse_fringe.append(w)
+                    if w in pred: 
+                        return pred, succ, w # found path
+
+    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))

--- a/networkx/algorithms/approximation/tests/test_connectivity.py
+++ b/networkx/algorithms/approximation/tests/test_connectivity.py
@@ -1,0 +1,158 @@
+import itertools
+from nose.tools import assert_true, assert_equal, assert_raises
+
+import networkx as nx
+from networkx.algorithms import approximation as approx
+
+
+def test_global_node_connectivity():
+    # Figure 1 chapter on Connectivity
+    G = nx.Graph()
+    G.add_edges_from([(1,2),(1,3),(1,4),(1,5),(2,3),(2,6),(3,4),
+                    (3,6),(4,6),(4,7),(5,7),(6,8),(6,9),(7,8),
+                    (7,10),(8,11),(9,10),(9,11),(10,11)])
+    assert_equal(2, approx.local_node_connectivity(G,1,11))
+    assert_equal(2, approx.node_connectivity(G))
+    assert_equal(2, approx.node_connectivity(G,1,11))
+
+def test_white_harary1():
+    # Figure 1b white and harary (2001)
+    # A graph with high adhesion (edge connectivity) and low cohesion
+    # (node connectivity)
+    G = nx.disjoint_union(nx.complete_graph(4), nx.complete_graph(4))
+    G.remove_node(7)
+    for i in range(4,7):
+        G.add_edge(0,i)
+    G = nx.disjoint_union(G, nx.complete_graph(4))
+    G.remove_node(G.order()-1)
+    for i in range(7,10):
+        G.add_edge(0,i)
+    assert_equal(1, approx.node_connectivity(G))
+
+def test_complete_graphs():
+    for n in range(5, 25, 5):
+        G = nx.complete_graph(n)
+        assert_equal(n-1, approx.node_connectivity(G))
+        assert_equal(n-1, approx.node_connectivity(G, 0, 3))
+
+def test_empty_graphs():
+    for k in range(5, 25, 5):
+        G = nx.empty_graph(k)
+        assert_equal(0, approx.node_connectivity(G))
+        assert_equal(0, approx.node_connectivity(G, 0, 3))
+
+def test_petersen():
+    G = nx.petersen_graph()
+    assert_equal(3, approx.node_connectivity(G))
+    assert_equal(3, approx.node_connectivity(G, 0, 5))
+
+# Approximation fails with tutte graph
+#def test_tutte():
+#    G = nx.tutte_graph()
+#    assert_equal(3, approx.node_connectivity(G))
+
+def test_dodecahedral():
+    G = nx.dodecahedral_graph()
+    assert_equal(3, approx.node_connectivity(G))
+    assert_equal(3, approx.node_connectivity(G, 0, 5))
+
+def test_octahedral():
+    G=nx.octahedral_graph()
+    assert_equal(4, approx.node_connectivity(G))
+    assert_equal(4, approx.node_connectivity(G, 0, 5))
+
+def test_icosahedral():
+    G=nx.icosahedral_graph()
+    assert_equal(5, approx.node_connectivity(G))
+    assert_equal(5, approx.node_connectivity(G, 0, 5))
+
+def test_only_source():
+    G = nx.complete_graph(5)
+    assert_raises(nx.NetworkXError, approx.node_connectivity, G, s=0)
+
+def test_only_target():
+    G = nx.complete_graph(5)
+    assert_raises(nx.NetworkXError, approx.node_connectivity, G, t=0)
+
+def test_missing_source():
+    G = nx.path_graph(4)
+    assert_raises(nx.NetworkXError, approx.node_connectivity, G, 10, 1)
+
+def test_missing_target():
+    G = nx.path_graph(4)
+    assert_raises(nx.NetworkXError, approx.node_connectivity, G, 1, 10)
+
+def test_source_equals_target():
+    G = nx.complete_graph(5)
+    assert_raises(nx.NetworkXError, approx.local_node_connectivity, G, 0, 0)
+
+
+def test_directed_node_connectivity():
+    G = nx.cycle_graph(10, create_using=nx.DiGraph()) # only one direction
+    D = nx.cycle_graph(10).to_directed() # 2 reciprocal edges
+    assert_equal(1, approx.node_connectivity(G))
+    assert_equal(1, approx.node_connectivity(G, 1, 4))
+    assert_equal(2,  approx.node_connectivity(D))
+    assert_equal(2,  approx.node_connectivity(D, 1, 4))
+
+
+class TestAllPairsNodeConnectivityApprox:
+
+    def setUp(self):
+        self.path = nx.path_graph(7)
+        self.directed_path = nx.path_graph(7, create_using=nx.DiGraph())
+        self.cycle = nx.cycle_graph(7)
+        self.directed_cycle = nx.cycle_graph(7, create_using=nx.DiGraph())
+        self.gnp = nx.gnp_random_graph(30, 0.1)
+        self.directed_gnp = nx.gnp_random_graph(30, 0.1, directed=True)
+        self.K20 = nx.complete_graph(20)
+        self.K10 = nx.complete_graph(10)
+        self.K5 = nx.complete_graph(5)
+        self.G_list = [self.path, self.directed_path, self.cycle,
+            self.directed_cycle, self.gnp, self.directed_gnp, self.K10, 
+            self.K5, self.K20]
+
+    def test_cycles(self):
+        K_undir = approx.all_pairs_node_connectivity(self.cycle)
+        for source in K_undir:
+            for target, k in K_undir[source].items():
+                assert_true(k == 2)
+        K_dir = approx.all_pairs_node_connectivity(self.directed_cycle)
+        for source in K_dir:
+            for target, k in K_dir[source].items():
+                assert_true(k == 1)
+
+    def test_complete(self):
+        for G in [self.K10, self.K5, self.K20]:
+            K = approx.all_pairs_node_connectivity(G)
+            for source in K:
+                for target, k in K[source].items():
+                    assert_true(k == len(G)-1)
+
+    def test_paths(self):
+        K_undir = approx.all_pairs_node_connectivity(self.path)
+        for source in K_undir:
+            for target, k in K_undir[source].items():
+                assert_true(k == 1)
+        K_dir = approx.all_pairs_node_connectivity(self.directed_path)
+        for source in K_dir:
+            for target, k in K_dir[source].items():
+                if source < target:
+                    assert_true(k == 1)
+                else:
+                    assert_true(k == 0)
+
+    def test_cutoff(self):
+        for G in [self.K10, self.K5, self.K20]:
+            for mp in [2, 3, 4]:
+                paths = approx.all_pairs_node_connectivity(G, cutoff=mp)
+                for source in paths:
+                    for target, K in paths[source].items():
+                        assert_true(K == mp)
+
+    def test_all_pairs_connectivity_nbunch(self):
+        G = nx.complete_graph(5)
+        nbunch = [0, 2, 3]
+        C = approx.all_pairs_node_connectivity(G, nbunch=nbunch)
+        assert_equal(len(C), len(nbunch))
+


### PR DESCRIPTION
This PR adds White and Newman's fast approximation algorithm for
finding node independent paths between two nodes. It finds them by
computing their shortest path using BFS, marking the nodes of the path
found as used and then searching other shortest paths excluding the
nodes marked as used until no more paths exist. It is not exact because
a shortest path could use nodes that, if the path were longer, may belong
to two different node independent paths. Thus it only guarantees an
strict lower bound on node connectivity.

This implementation uses a modified version of `bidirectional_shortest_path`
that accepts the extra parameter `exclude`, which is a container for nodes
already used in other paths that should be ignored.