### PR TITLE
Add k-(node)-components algorithm.

### DIFF
--- a/doc/source/reference/algorithms.connectivity.rst
+++ b/doc/source/reference/algorithms.connectivity.rst
@@ -5,6 +5,14 @@ Connectivity
 .. automodule:: networkx.algorithms.connectivity
 
 
+K-node-components
+-----------------
+.. automodule:: networkx.algorithms.connectivity.kcomponents
+.. autosummary::
+   :toctree: generated/
+
+   k_components
+
 K-node-cutsets
 --------------
 .. automodule:: networkx.algorithms.connectivity.kcutsets
@@ -12,7 +20,6 @@ K-node-cutsets
    :toctree: generated/
 
    all_node_cuts
-
 
 Flow-based Connectivity
 -----------------------

--- a/doc/source/reference/api_1.10.rst
+++ b/doc/source/reference/api_1.10.rst
@@ -187,6 +187,11 @@ New functionalities
   solves all pairs shortest path problem. This is ``johnson`` at
   ``algorithms.shortest_paths``
 
+* [`#1414 <https://github.com/networkx/networkx/pull/1414>`_]
+  Added Moody and White algorithm for identifying ``k_components`` in a
+  graph, which is based on Kanevsky's algorithm for finding all minimum-size
+  node cut-sets (implemented in ``all_node_cuts`` #1391).
+
 Removed functionalities
 -----------------------
 

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -59,7 +59,7 @@ from networkx.algorithms.bipartite import (projected_graph, project, is_bipartit
 # connectivity
 from networkx.algorithms.connectivity import (minimum_edge_cut, minimum_node_cut,
     average_node_connectivity, edge_connectivity, node_connectivity,
-    stoer_wagner, all_pairs_node_connectivity, all_node_cuts)
+    stoer_wagner, all_pairs_node_connectivity, all_node_cuts, k_components)
 # isomorphism
 from networkx.algorithms.isomorphism import (is_isomorphic, could_be_isomorphic,
     fast_could_be_isomorphic, faster_could_be_isomorphic)

--- a/networkx/algorithms/connectivity/__init__.py
+++ b/networkx/algorithms/connectivity/__init__.py
@@ -2,12 +2,14 @@
 """
 from .connectivity import *
 from .cuts import *
+from .kcomponents import *
 from .kcutsets import *
 from .stoerwagner import *
 from .utils import *
 
 __all__ = sum([connectivity.__all__,
                cuts.__all__,
+               kcomponents.__all__,
                kcutsets.__all__,
                stoerwagner.__all__,
                utils.__all__,

--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""
+Moody and White algorithm for k-components
+"""
+from collections import defaultdict
+from itertools import combinations
+from operator import itemgetter
+
+import networkx as nx
+from networkx.utils import not_implemented_for
+# Define the default maximum flow function.
+from networkx.algorithms.flow import edmonds_karp
+default_flow_func = edmonds_karp
+
+__author__ = '\n'.join(['Jordi Torrents <jtorrents@milnou.net>'])
+
+__all__ = ['k_components']
+
+
+@not_implemented_for('directed')
+def k_components(G, flow_func=None):
+    r"""Returns the k-component structure of a graph G.
+    
+    A `k`-component is a maximal subgraph of a graph G that has, at least,
+    node connectivity `k`: we need to remove at least `k` nodes to break it
+    into more components. `k`-components have an inherent hierarchical
+    structure because they are nested in terms of connectivity: a connected
+    graph can contain several 2-components, each of which can contain
+    one or more 3-components, and so forth.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    flow_func : function
+        Function to perform the underlying flow computations. Default value
+        :meth:`edmonds_karp`. This function performs better in sparse graphs with
+        right tailed degree distributions. :meth:`shortest_augmenting_path` will
+        perform better in denser graphs.
+
+    Returns
+    -------
+    k_components : dict
+        Dictionary with all connectivity levels `k` in the input Graph as keys
+        and a list of sets of nodes that form a k-component of level `k` as
+        values.
+
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If the input graph is directed.
+
+    Examples
+    --------
+    >>> # Petersen graph has 10 nodes and it is triconnected, thus all
+    >>> # nodes are in a single component on all three connectivity levels
+    >>> G = nx.petersen_graph()
+    >>> k_components = nx.k_components(G)
+   
+    Notes
+    -----
+    Moody and White [1]_ (appendix A) provide an algorithm for identifying
+    k-components in a graph, which is based on Kanevsky's algorithm [2]_
+    for finding all minimum-size node cut-sets of a graph (implemented in
+    :meth:`all_node_cuts` function):
+
+        1. Compute node connectivity, k, of the input graph G.
+
+        2. Identify all k-cutsets at the current level of connectivity using
+           Kanevsky's algorithm.
+
+        3. Generate new graph components based on the removal of
+           these cutsets. Nodes in a cutset belong to both sides
+           of the induced cut.
+
+        4. If the graph is neither complete nor trivial, return to 1;
+           else end.
+
+    This implementation also uses some heuristics (see [3]_ for details) 
+    to speed up the computation.
+
+    See also
+    --------
+    node_connectivity
+    all_node_cuts
+
+    References
+    ----------
+    .. [1]  Moody, J. and D. White (2003). Social cohesion and embeddedness:
+            A hierarchical conception of social groups.
+            American Sociological Review 68(1), 103--28.
+            http://www2.asanet.org/journals/ASRFeb03MoodyWhite.pdf
+
+    .. [2]  Kanevsky, A. (1993). Finding all minimum-size separating vertex
+            sets in a graph. Networks 23(6), 533--541.
+            http://onlinelibrary.wiley.com/doi/10.1002/net.3230230604/abstract
+
+    .. [3]  Torrents, J. and F. Ferraro (2015). Structural Cohesion:
+            Visualization and Heuristics for Fast Computation.
+            http://arxiv.org/pdf/1503.04476v1
+
+    """
+    # Dictionary with connectivity level (k) as keys and a list of
+    # sets of nodes that form a k-component as values. Note that 
+    # k-compoents can overlap (but only k - 1 nodes).
+    k_components = defaultdict(list)
+    # Define default flow function
+    if flow_func is None:
+        flow_func = default_flow_func
+    # Bicomponents as a base to check for higher order k-components
+    for component in  nx.connected_components(G):
+        # isolated nodes have connectivity 0
+        comp = set(component)
+        if len(comp) > 1:
+            k_components[1].append(comp)
+    bicomponents = list(nx.biconnected_component_subgraphs(G))
+    for bicomponent in bicomponents:
+        bicomp = set(bicomponent)
+        # avoid considering dyads as bicomponents
+        if len(bicomp) > 2:
+            k_components[2].append(bicomp)
+    for B in bicomponents:
+        if len(B) <= 2:
+            continue
+        k = nx.node_connectivity(B, flow_func=flow_func)
+        if k > 2:
+            k_components[k].append(set(B.nodes_iter()))
+        # Perform cuts in a DFS like order.
+        cuts = list(nx.all_node_cuts(B, k=k, flow_func=flow_func))
+        stack = [(k, _generate_partition(B, cuts, k))]
+        while stack:
+            (parent_k, partition) = stack[-1]
+            try:
+                nodes = next(partition)
+                C = B.subgraph(nodes)
+                this_k = nx.node_connectivity(C, flow_func=flow_func)
+                if this_k > parent_k and this_k > 2:
+                    k_components[this_k].append(set(C.nodes_iter()))
+                cuts = list(nx.all_node_cuts(C, k=this_k, flow_func=flow_func))
+                if cuts:
+                    stack.append((this_k, _generate_partition(C, cuts, this_k)))
+            except StopIteration:
+                stack.pop()
+
+    # This is necessary because k-components may only be reported at their
+    # maximum k level. But we want to return a dictionary in which keys are
+    # connectivity levels and values list of sets of components, without
+    # skipping any connectivity level. Also, it's possible that subsets of
+    # an already detected k-component appear at a level k. Checking for this
+    # in the while loop above penalizes the common case. Thus we also have to
+    # _consolidate all connectivity levels in _reconstruct_k_components.
+    return _reconstruct_k_components(k_components)
+
+
+def _consolidate(sets, k):
+    """Merge sets that share k or more elements.
+
+    See: http://rosettacode.org/wiki/Set_consolidation
+
+    The iterative python implementation posted there is
+    faster than this because of the overhead of building a
+    Graph and calling nx.connected_components, but it's not
+    clear for us if we can use it in NetworkX because there
+    is no licence for the code.
+
+    """
+    G = nx.Graph()
+    nodes = {i: s for i, s in enumerate(sets)}
+    G.add_nodes_from(nodes)
+    G.add_edges_from((u, v) for u, v in combinations(nodes, 2)
+                     if len(nodes[u] & nodes[v]) >= k)
+    for component in nx.connected_components(G):
+        yield set.union(*[nodes[n] for n in component])
+
+
+def _generate_partition(G, cuts, k):
+    def has_nbrs_in_partition(G, node, partition):
+        for n in G[node]:
+            if n in partition:
+                return True
+        return False
+    components = []
+    nodes = ({n for n, d in G.degree().items() if d > k} - 
+             {n for cut in cuts for n in cut})
+    H = G.subgraph(nodes)
+    for cc in nx.connected_components(H):
+        component = set(cc)
+        for cut in cuts:
+            for node in cut:
+                if has_nbrs_in_partition(G, node, cc):
+                    component.add(node)
+        if len(component) < G.order():
+            components.append(component)
+    for component in _consolidate(components, k+1):
+        yield component
+
+
+def _reconstruct_k_components(k_comps):
+    result = dict()
+    max_k = max(k_comps)
+    for k in reversed(range(1, max_k+1)):
+        if k == max_k:
+            result[k] = list(_consolidate(k_comps[k], k))
+        elif k not in k_comps:
+            result[k] = list(_consolidate(result[k+1], k))
+        else:
+            nodes_at_k = set.union(*k_comps[k])
+            to_add = [c for c in result[k+1] if any(n not in nodes_at_k for n in c)]
+            if to_add:
+                result[k] = list(_consolidate(k_comps[k] + to_add, k))
+            else:
+                result[k] = list(_consolidate(k_comps[k], k))
+    return result
+
+
+def build_k_number_dict(kcomps):
+    result = {}
+    for k, comps in sorted(kcomps.items(), key=itemgetter(0)):
+        for comp in comps:
+            for node in comp:
+                result[node] = k
+    return result

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -1,0 +1,256 @@
+# Test for Moody and White k-components algorithm
+from nose.tools import assert_equal, assert_true, raises
+import networkx as nx
+from networkx.algorithms.connectivity.kcomponents import (
+    build_k_number_dict,
+    _consolidate,
+)
+
+##
+## A nice synthetic graph
+##
+def torrents_and_ferraro_graph():
+    # Graph from http://arxiv.org/pdf/1503.04476v1 p.26
+    G = nx.convert_node_labels_to_integers(
+        nx.grid_graph([5, 5]),
+        label_attribute='labels',
+    )
+    rlabels = nx.get_node_attributes(G, 'labels')
+    labels = {v: k for k, v in rlabels.items()}
+
+    for nodes in [(labels[(0,4)], labels[(1,4)]),
+                  (labels[(3,4)], labels[(4,4)])]:
+        new_node = G.order() + 1
+        # Petersen graph is triconnected
+        P = nx.petersen_graph()
+        G = nx.disjoint_union(G, P)
+        # Add two edges between the grid and P
+        G.add_edge(new_node+1, nodes[0])
+        G.add_edge(new_node, nodes[1])
+        # K5 is 4-connected
+        K = nx.complete_graph(5)
+        G = nx.disjoint_union(G, K)
+        # Add three edges between P and K5
+        G.add_edge(new_node+2, new_node+11)
+        G.add_edge(new_node+3, new_node+12)
+        G.add_edge(new_node+4, new_node+13)
+        # Add another K5 sharing a node
+        G = nx.disjoint_union(G, K)
+        nbrs = G[new_node+10]
+        G.remove_node(new_node+10)
+        for nbr in nbrs:
+            G.add_edge(new_node+17, nbr)
+        # This edge makes the graph biconnected; it's
+        # needed because K5s share only one node.
+        G.add_edge(new_node+16, new_node+8)
+
+    for nodes in [(labels[(0, 0)], labels[(1, 0)]),
+                  (labels[(3, 0)], labels[(4, 0)])]:
+        new_node = G.order() + 1
+        # Petersen graph is triconnected
+        P = nx.petersen_graph()
+        G = nx.disjoint_union(G, P)
+        # Add two edges between the grid and P
+        G.add_edge(new_node+1, nodes[0])
+        G.add_edge(new_node, nodes[1])
+        # K5 is 4-connected
+        K = nx.complete_graph(5)
+        G = nx.disjoint_union(G, K)
+        # Add three edges between P and K5
+        G.add_edge(new_node+2, new_node+11)
+        G.add_edge(new_node+3, new_node+12)
+        G.add_edge(new_node+4, new_node+13)
+        # Add another K5 sharing two nodes
+        G = nx.disjoint_union(G,K)
+        nbrs = G[new_node+10]
+        G.remove_node(new_node+10)
+        for nbr in nbrs:
+            G.add_edge(new_node+17, nbr)
+        nbrs2 = G[new_node+9]
+        G.remove_node(new_node+9)
+        for nbr in nbrs2:
+            G.add_edge(new_node+18, nbr)
+
+    G.name = 'Example graph for connectivity'
+    return G
+
+@raises(nx.NetworkXNotImplemented)
+def test_directed():
+    G = nx.gnp_random_graph(10, 0.2, directed=True)
+    nx.k_components(G)
+
+# Helper function
+def _check_connectivity(G):
+    result = nx.k_components(G)
+    for k, components in result.items():
+        if k < 3:
+            continue
+        for component in components:
+            C = G.subgraph(component)
+            assert_true(nx.node_connectivity(C) >= k)
+
+def test_torrents_and_ferraro_graph():
+    G = torrents_and_ferraro_graph()
+    _check_connectivity(G)
+
+def test_random_gnp():
+    G = nx.gnp_random_graph(50, 0.2)
+    _check_connectivity(G)
+
+def test_shell():
+    constructor=[(20, 80, 0.8), (80, 180, 0.6)]
+    G = nx.random_shell_graph(constructor)
+    _check_connectivity(G)
+
+def test_configuration():
+    deg_seq = nx.utils.create_degree_sequence(100, nx.utils.powerlaw_sequence)
+    G = nx.Graph(nx.configuration_model(deg_seq))
+    G.remove_edges_from(G.selfloop_edges())
+    _check_connectivity(G)
+
+def test_karate():
+    G = nx.karate_club_graph()
+    _check_connectivity(G)
+
+def test_karate_component_number():
+    karate_k_num = {
+        0: 4, 1: 4, 2: 4, 3: 4, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4, 9: 2,
+        10: 3, 11: 1, 12: 2, 13: 4, 14: 2, 15: 2, 16: 2, 17: 2,
+        18: 2, 19: 3, 20: 2, 21: 2, 22: 2, 23: 3, 24: 3, 25: 3,
+        26: 2, 27: 3, 28: 3, 29: 3, 30: 4, 31: 3, 32: 4, 33: 4
+    }
+    G = nx.karate_club_graph()
+    k_components = nx.k_components(G)
+    k_num = build_k_number_dict(k_components)
+    assert_equal(karate_k_num, k_num)
+
+
+def test_torrents_and_ferraro_detail_3_and_4():
+    solution = {
+        3: [{25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 42},
+            {44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 61},
+            {63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 79, 80},
+            {81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 93, 94, 95, 99, 100},
+            {39, 40, 41, 42, 43},
+            {58, 59, 60, 61, 62},
+            {76, 77, 78, 79, 80},
+            {96, 97, 98, 99, 100},
+        ],
+        4: [{35, 36, 37, 38, 42},
+            {39, 40, 41, 42, 43},
+            {54, 55, 56, 57, 61},
+            {58, 59, 60, 61, 62},
+            {73, 74, 75, 79, 80},
+            {76, 77, 78, 79, 80},
+            {93, 94, 95, 99, 100},
+            {96, 97, 98, 99, 100},
+        ],
+    }
+    G = torrents_and_ferraro_graph()
+    result = nx.k_components(G)
+    for k, components in result.items():
+        if k < 3:
+            continue
+        assert_true(len(components) == len(solution[k]))
+        for component in components:
+            assert_true(component in solution[k])
+
+def test_davis_southern_women():
+    G = nx.davis_southern_women_graph()
+    _check_connectivity(G)
+
+def test_davis_southern_women_detail_3_and_4():
+    solution = {
+        3: [{
+            'Nora Fayette',
+            'E10',
+            'Myra Liddel',
+            'E12',
+            'E14',
+            'Frances Anderson',
+            'Evelyn Jefferson',
+            'Ruth DeSand',
+            'Helen Lloyd',
+            'Eleanor Nye',
+            'E9',
+            'E8',
+            'E5',
+            'E4',
+            'E7',
+            'E6',
+            'E1',
+            'Verne Sanderson',
+            'E3',
+            'E2',
+            'Theresa Anderson',
+            'Pearl Oglethorpe',
+            'Katherina Rogers',
+            'Brenda Rogers',
+            'E13',
+            'Charlotte McDowd',
+            'Sylvia Avondale',
+            'Laura Mandeville',
+            },
+        ],
+        4: [{
+            'Nora Fayette',
+            'E10',
+            'Verne Sanderson',
+            'E12',
+            'Frances Anderson',
+            'Evelyn Jefferson',
+            'Ruth DeSand',
+            'Helen Lloyd',
+            'Eleanor Nye',
+            'E9',
+            'E8',
+            'E5',
+            'E4',
+            'E7',
+            'E6',
+            'Myra Liddel',
+            'E3',
+            'Theresa Anderson',
+            'Katherina Rogers',
+            'Brenda Rogers',
+            'Charlotte McDowd',
+            'Sylvia Avondale',
+            'Laura Mandeville',
+            },
+        ],
+    }
+    G = nx.davis_southern_women_graph()
+    result = nx.k_components(G)
+    for k, components in result.items():
+        if k < 3:
+            continue
+        assert_true(len(components) == len(solution[k]))
+        for component in components:
+            assert_true(component in solution[k])
+
+
+def test_set_consolidation_rosettacode():
+    # Tests from http://rosettacode.org/wiki/Set_consolidation
+    def list_of_sets_equal(result, solution):
+        assert_equal(
+            {frozenset(s) for s in result},
+            {frozenset(s) for s in solution}
+        )
+    question = [{'A', 'B'}, {'C', 'D'}]
+    solution = [{'A', 'B'}, {'C', 'D'}]
+    list_of_sets_equal(_consolidate(question, 1), solution)
+    question = [{'A', 'B'}, {'B', 'C'}]
+    solution = [{'A', 'B', 'C'}]
+    list_of_sets_equal(_consolidate(question, 1), solution)
+    question = [{'A', 'B'}, {'C', 'D'}, {'D', 'B'}]
+    solution = [{'A', 'C', 'B', 'D'}]
+    list_of_sets_equal(_consolidate(question, 1), solution)
+    question = [{'H', 'I', 'K'}, {'A', 'B'}, {'C', 'D'}, {'D', 'B'}, {'F', 'G', 'H'}]
+    solution = [{'A', 'C', 'B', 'D'}, {'G', 'F', 'I', 'H', 'K'}]
+    list_of_sets_equal(_consolidate(question, 1), solution)
+    question = [{'A','H'}, {'H','I','K'}, {'A','B'}, {'C','D'}, {'D','B'}, {'F','G','H'}]
+    solution = [{'A', 'C', 'B', 'D', 'G', 'F', 'I', 'H', 'K'}]
+    list_of_sets_equal(_consolidate(question, 1), solution)
+    question = [{'H','I','K'}, {'A','B'}, {'C','D'}, {'D','B'}, {'F','G','H'}, {'A','H'}]
+    solution = [{'A', 'C', 'B', 'D', 'G', 'F', 'I', 'H', 'K'}]
+    list_of_sets_equal(_consolidate(question, 1), solution)


### PR DESCRIPTION
Add Moody and White algorithm for for identifying k-components in a graph,
which is based on Kanevsky's algorithm for finding all minimum-size node
cut-sets (implemented in `all_node_cuts` function #1391). This algorithm
consists in keep cutting a graph until we obtain either a complete or a
trivial graph.

`all_node_cuts` is doing most of the work here, the only tricky
implementation thing is the generation of partitions. The authors say that
``Nodes in a cutset belong to both sides of the induced cut.'', but an
induced cut can split a graph in more than two sides. Thus, after a cut,
we have to merge the node sets that (after adding the nodes in the cut set)
share at least k nodes.

I found out that this is very related to set consolidation. I've adapted a
nice function from  http://rosettacode.org/wiki/Set_consolidation . However
it's not clear the license of this implementation. I'll try to figure out.