### PR TITLE
Coveralls cannot load source files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
       conda config --set always_yes yes --set changeps1 no;
       conda update -q conda;
     fi
- 
+
   - if [[ "${PYTHON_VM}" == ipy ]]; then
       pushd ..;
       curl -L -o xamarin.pgp http://download.mono-project.com/repo/xamarin.gpg;
@@ -149,12 +149,12 @@ after_success:
   # each file. So the paths in .coverage must be modified to match the
   # repository paths. This is what `fixcoverage.py` does.
   #
-  # Report coverage for 2.7 and 3.4 only.
+  # Report coverage for 2.7 and 3.4 miniconda runs only.
   - if [[ "${PYTHON_VM}" != ipy ]]; then
       cp .coverage $TRAVIS_BUILD_DIR;
       cd $TRAVIS_BUILD_DIR;
       if [[ "${TRAVIS_PYTHON_VERSION}${OPTIONAL_DEPS}" =~ 2\.7miniconda|3\.4miniconda ]]; then
-        python fixcoverage.py "$VIRTUAL_ENV/lib/python.*/site-packages/networkx/" "$TRAVIS_BUILD_DIR/networkx/";
+        python fixcoverage.py ".*/networkx/" "$TRAVIS_BUILD_DIR/networkx/";
         coveralls;
       fi;
     fi

--- a/fixcoverage.py
+++ b/fixcoverage.py
@@ -7,10 +7,16 @@ def main(argv):
     dest = argv[2]
     with open('.coverage', 'rb') as f:
         coverage_data = pickle.load(f)
-    for filename in list(coverage_data['lines'].keys()):
+
+    # Prefilter to filenames in NetworkX
+    filenames = [filename for filename in coverage_data['lines'].keys()
+                 if 'networkx' in filename]
+
+    for filename in filenames:
         new_filename = re.sub(source, dest, filename)
         if new_filename != filename:
             coverage_data['lines'][new_filename] = coverage_data['lines'].pop(filename)
+
     with open('.coverage', 'wb') as f:
         pickle.dump(coverage_data, f)
 


### PR DESCRIPTION
E.g., https://coveralls.io/files/556354222

IIRC, this was broken for a long time before being fixed and now broken again.

EDIT: Or rather partially broken. Works for https://coveralls.io/files/556379931.
