### PR TITLE
all_node_cuts wrap up

### DIFF
--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -102,9 +102,16 @@ New functionalities
   Newman's approximation algorithm for finding node independent paths
   between two nodes.
 
+* [`#1391 <https://github.com/networkx/networkx/pull/1391>`_]
+  Added Kanevsky's algorithm for finding all minimum-size separating
+  node sets in an undirected graph. It is implemented as a generator
+  of node cut sets.
+
 * [`#1413 <https://github.com/networkx/networkx/pull/1413>`_]
   Added transitive closure and antichains function for directed acyclic
-  graphs in ``algorithms.dag``.
+  graphs in ``algorithms.dag``. The antichains function was contributed
+  by Peter Jipsen and Franco Saliola and originally developed for the
+  SAGE project.
 
 * [`#1425 <https://github.com/networkx/networkx/pull/1425>`_]
   Added generator function for the complete multipartite graph.

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -234,6 +234,10 @@ def test_non_repeated_cuts():
     G = max(list(nx.biconnected_component_subgraphs(K)), key=len)
     solution = [{32, 33}, {2, 33}, {0, 3}, {0, 1}, {29, 33}]
     cuts = list(nx.all_node_cuts(G))
+    if len(solution) != len(cuts):
+        print(nx.info(G))
+        print("Solution: {}".format(solution))
+        print("Result: {}".format(cuts))
     assert_true(len(solution) == len(cuts))
     for cut in cuts:
         assert_true(cut in solution)


### PR DESCRIPTION
I merged #1391 in a bit of a rush to be able to push #1414. This PR is for finishing up the last details. So far it makes `all_node_cuts` use the recently exposed `nx.antichains` function from #1413, and adds `all_node_cuts` to `api_2.0.rst`.

I also want to investigate a bit more a failed test for non repeated cuts in the pypy Travis CI (which is allowed to fail):

https://travis-ci.org/networkx/networkx/jobs/55252872#L2829

I think that it does not have to do with hash randomization, as most of the other failures there. However I cannot reproduce it in my machine (pypy 2.2.1 linux 64bit). So I added a bit of debug to that test to try to see what is going on. Also we saw a strange frailure only one time in a `pypy3` environment in another test: `test_kcutsets.test_configuration_model`. I cannot find the link of the failure right now. So far, it did not happen again.