### PR TITLE
Pep8

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -42,10 +42,10 @@ del sys
 # Release data
 from networkx import release
 
-__author__   = '%s <%s>\n%s <%s>\n%s <%s>' % \
-              ( release.authors['Hagberg'] + release.authors['Schult'] + \
-                release.authors['Swart'] )
-__license__  = release.license
+__author__ = '%s <%s>\n%s <%s>\n%s <%s>' % \
+    (release.authors['Hagberg'] + release.authors['Schult'] +
+        release.authors['Swart'])
+__license__ = release.license
 
 __date__ = release.date
 __version__ = release.version
@@ -62,8 +62,8 @@ address = {Pasadena, CA USA},
 pages = {11--15}
 }"""
 
-#These are import orderwise
-from networkx.exception import  *
+# These are import orderwise
+from networkx.exception import *
 import networkx.external
 import networkx.utils
 
@@ -87,7 +87,7 @@ from networkx.generators import *
 import networkx.readwrite
 from networkx.readwrite import *
 
-#Need to test with SciPy, when available
+# Need to test with SciPy, when available
 import networkx.algorithms
 from networkx.algorithms import *
 import networkx.linalg
@@ -97,4 +97,3 @@ from networkx.tests.test import run as test
 
 import networkx.drawing
 from networkx.drawing import *
-

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -22,6 +22,7 @@ __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
 
+
 class Graph(object):
     """
     Base class for undirected graphs.
@@ -180,7 +181,7 @@ class Graph(object):
     edge data keyed by neighbor.  The inner dict (edge_attr) represents
     the edge data and holds edge attribute values keyed by attribute names.
 
-    Each of these three dicts can be replaced by a user defined 
+    Each of these three dicts can be replaced by a user defined
     dict-like object. In general, the dict-like features should be
     maintained but extra features can be added. To replace one of the
     dicts create a new graph class by changing the class(!) variable
@@ -249,9 +250,10 @@ class Graph(object):
     True
 
     """
-    node_dict_factory=dict
-    adjlist_dict_factory=dict
-    edge_attr_dict_factory=dict
+    node_dict_factory = dict
+    adjlist_dict_factory = dict
+    edge_attr_dict_factory = dict
+
     def __init__(self, data=None, **attr):
         """Initialize a graph with edges, name, graph attributes.
 
@@ -291,21 +293,22 @@ class Graph(object):
         self.edge_attr_dict_factory = self.edge_attr_dict_factory
 
         self.graph = {}   # dictionary for graph attributes
-        self.node = ndf() # empty node attribute dict
+        self.node = ndf()  # empty node attribute dict
         self.adj = ndf()  # empty adjacency dict
         # attempt to load graph with data
         if data is not None:
-            convert.to_networkx_graph(data,create_using=self)
+            convert.to_networkx_graph(data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
         self.edge = self.adj
 
     @property
     def name(self):
-        return self.graph.get('name','')
+        return self.graph.get('name', '')
+
     @name.setter
     def name(self, s):
-        self.graph['name']=s
+        self.graph['name'] = s
 
     def __str__(self):
         """Return the graph name.
@@ -338,7 +341,7 @@ class Graph(object):
         """
         return iter(self.node)
 
-    def __contains__(self,n):
+    def __contains__(self, n):
         """Return True if n is a node, False otherwise. Use the expression
         'n in G'.
 
@@ -402,7 +405,6 @@ class Graph(object):
         """
         return self.adj[n]
 
-
     def add_node(self, n, attr_dict=None, **attr):
         """Add a single node n and update node attributes.
 
@@ -447,19 +449,18 @@ class Graph(object):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         if n not in self.node:
             self.adj[n] = self.adjlist_dict_factory()
             self.node[n] = attr_dict
-        else: # update attr even if node already exists
+        else:  # update attr even if node already exists
             self.node[n].update(attr_dict)
-
 
     def add_nodes_from(self, nodes, **attr):
         """Add multiple nodes.
@@ -509,7 +510,7 @@ class Graph(object):
         for n in nodes:
             # keep all this inside try/except because
             # CPython throws TypeError on n not in self.succ,
-            # while pre-2.7.5 ironpython throws on self.succ[n] 
+            # while pre-2.7.5 ironpython throws on self.succ[n]
             try:
                 if n not in self.node:
                     self.adj[n] = self.adjlist_dict_factory()
@@ -517,7 +518,7 @@ class Graph(object):
                 else:
                     self.node[n].update(attr)
             except TypeError:
-                nn,ndict = n
+                nn, ndict = n
                 if nn not in self.node:
                     self.adj[nn] = {}
                     newdict = attr.copy()
@@ -528,7 +529,7 @@ class Graph(object):
                     olddict.update(attr)
                     olddict.update(ndict)
 
-    def remove_node(self,n):
+    def remove_node(self, n):
         """Remove node n.
 
         Removes the node n and all adjacent edges.
@@ -561,14 +562,13 @@ class Graph(object):
         """
         adj = self.adj
         try:
-            nbrs = list(adj[n].keys()) # keys handles self-loops (allow mutation later)
+            nbrs = list(adj[n].keys())  # keys handles self-loops (allow mutation later)
             del self.node[n]
-        except KeyError: # NetworkXError if n not in self
-            raise NetworkXError("The node %s is not in the graph."%(n,))
+        except KeyError:  # NetworkXError if n not in self
+            raise NetworkXError("The node %s is not in the graph." % (n,))
         for u in nbrs:
             del adj[u][n]   # remove all edges n-u in graph
         del adj[n]          # now remove node
-
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -601,11 +601,10 @@ class Graph(object):
             try:
                 del self.node[n]
                 for u in list(adj[n].keys()):   # keys() handles self-loops
-                    del adj[u][n]         #(allows mutation of dict in loop)
+                    del adj[u][n]  # (allows mutation of dict in loop)
                 del adj[n]
             except KeyError:
                 pass
-
 
     def nodes_iter(self, data=False):
         """Return an iterator over the nodes.
@@ -780,12 +779,12 @@ class Graph(object):
         """
         # set up attribute dictionary
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.node:
@@ -795,11 +794,10 @@ class Graph(object):
             self.adj[v] = self.adjlist_dict_factory()
             self.node[v] = {}
         # add the edge
-        datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
+        datadict = self.adj[u].get(v, self.edge_attr_dict_factory())
         datadict.update(attr_dict)
         self.adj[u][v] = datadict
         self.adj[v][u] = datadict
-
 
     def add_edges_from(self, ebunch, attr_dict=None, **attr):
         """Add all the edges in ebunch.
@@ -846,36 +844,35 @@ class Graph(object):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # process ebunch
         for e in ebunch:
-            ne=len(e)
-            if ne==3:
-                u,v,dd = e
-            elif ne==2:
-                u,v = e
+            ne = len(e)
+            if ne == 3:
+                u, v, dd = e
+            elif ne == 2:
+                u, v = e
                 dd = {}
             else:
-                raise NetworkXError(\
-                    "Edge tuple %s must be a 2-tuple or 3-tuple."%(e,))
+                raise NetworkXError(
+                    "Edge tuple %s must be a 2-tuple or 3-tuple." % (e,))
             if u not in self.node:
                 self.adj[u] = self.adjlist_dict_factory()
                 self.node[u] = {}
             if v not in self.node:
                 self.adj[v] = self.adjlist_dict_factory()
                 self.node[v] = {}
-            datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
+            datadict = self.adj[u].get(v, self.edge_attr_dict_factory())
             datadict.update(attr_dict)
             datadict.update(dd)
             self.adj[u][v] = datadict
             self.adj[v][u] = datadict
-
 
     def add_weighted_edges_from(self, ebunch, weight='weight', **attr):
         """Add all the edges in ebunch as weighted edges with specified
@@ -908,7 +905,7 @@ class Graph(object):
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
         >>> G.add_weighted_edges_from([(0,1,3.0),(1,2,7.5)])
         """
-        self.add_edges_from(((u,v,{weight:d}) for u,v,d in ebunch),**attr)
+        self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch), **attr)
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -942,9 +939,7 @@ class Graph(object):
             if u != v:  # self-loop needs only one entry removed
                 del self.adj[v][u]
         except KeyError:
-            raise NetworkXError("The edge %s-%s is not in the graph"%(u,v))
-
-
+            raise NetworkXError("The edge %s-%s is not in the graph" % (u, v))
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -973,14 +968,13 @@ class Graph(object):
         >>> ebunch=[(1,2),(2,3)]
         >>> G.remove_edges_from(ebunch)
         """
-        adj=self.adj
+        adj = self.adj
         for e in ebunch:
-            u,v = e[:2]  # ignore edge data if present
+            u, v = e[:2]  # ignore edge data if present
             if u in adj and v in adj[u]:
                 del adj[u][v]
                 if u != v:  # self loop needs only one entry removed
                     del adj[v][u]
-
 
     def has_edge(self, u, v):
         """Return True if the edge (u,v) is in the graph.
@@ -1024,7 +1018,6 @@ class Graph(object):
         except KeyError:
             return False
 
-
     def neighbors(self, n):
         """Return a list of the nodes connected to the node n.
 
@@ -1064,7 +1057,7 @@ class Graph(object):
         try:
             return list(self.adj[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the graph."%(n,))
+            raise NetworkXError("The node %s is not in the graph." % (n,))
 
     def neighbors_iter(self, n):
         """Return an iterator over all neighbors of node n.
@@ -1087,7 +1080,7 @@ class Graph(object):
         try:
             return iter(self.adj[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the graph."%(n,))
+            raise NetworkXError("The node %s is not in the graph." % (n,))
 
     def edges(self, nbunch=None, data=False, default=None):
         """Return a list of edges.
@@ -1127,7 +1120,7 @@ class Graph(object):
         [(0, 1), (1, 2), (2, 3)]
         >>> G.edges(data=True) # default edge data is {} (empty dictionary)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> G.edges([0,3])
         [(0, 1), (3, 2)]
@@ -1151,7 +1144,7 @@ class Graph(object):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         default : value, optional (default=None)
             Value used for edges that dont have the requested attribute.
             Only relevant if data is not True or False.
@@ -1179,7 +1172,7 @@ class Graph(object):
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges_iter(data=True)) # default data is {} (empty dict)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges_iter([0,3]))
         [(0, 1), (3, 2)]
@@ -1187,32 +1180,31 @@ class Graph(object):
         [(0, 1)]
 
         """
-        seen={}     # helper dict to keep track of multiply stored edges
+        seen = {}     # helper dict to keep track of multiply stored edges
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
         if data is True:
-            for n,nbrs in nodes_nbrs:
-                for nbr,ddict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, ddict in nbrs.items():
                     if nbr not in seen:
-                        yield (n,nbr,ddict)
-                seen[n]=1
-        elif data is not False:
-            for n,nbrs in nodes_nbrs:
-                for nbr,ddict in nbrs.items():
-                    if nbr not in seen:
-                        d=ddict[data] if data in ddict else default
-                        yield (n,nbr,d)
+                        yield (n, nbr, ddict)
                 seen[n] = 1
-        else: # data is False
-            for n,nbrs in nodes_nbrs:
+        elif data is not False:
+            for n, nbrs in nodes_nbrs:
+                for nbr, ddict in nbrs.items():
+                    if nbr not in seen:
+                        d = ddict[data] if data in ddict else default
+                        yield (n, nbr, d)
+                seen[n] = 1
+        else:  # data is False
+            for n, nbrs in nodes_nbrs:
                 for nbr in nbrs:
                     if nbr not in seen:
-                        yield (n,nbr)
+                        yield (n, nbr)
                 seen[n] = 1
         del seen
-
 
     def get_edge_data(self, u, v, default=None):
         """Return the attribute dictionary associated with edge (u,v).
@@ -1286,7 +1278,7 @@ class Graph(object):
         [[1], [0, 2], [1, 3], [2]]
 
         """
-        return list(map(list,iter(self.adj.values())))
+        return list(map(list, iter(self.adj.values())))
 
     def adjacency_iter(self):
         """Return an iterator of (node, adjacency dict) tuples for all nodes.
@@ -1349,9 +1341,9 @@ class Graph(object):
 
         """
         if nbunch in self:      # return a single node
-            return next(self.degree_iter(nbunch,weight))[1]
+            return next(self.degree_iter(nbunch, weight))[1]
         else:           # return a dict
-            return dict(self.degree_iter(nbunch,weight))
+            return dict(self.degree_iter(nbunch, weight))
 
     def degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, degree).
@@ -1391,17 +1383,16 @@ class Graph(object):
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n,len(nbrs)+(n in nbrs)) # return tuple (n,degree)
+            for n, nbrs in nodes_nbrs:
+                yield (n, len(nbrs) + (n in nbrs))  # return tuple (n,degree)
         else:
-        # edge weighted graph - degree is sum of nbr edge weights
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum((nbrs[nbr].get(weight,1) for nbr in nbrs)) +
-                              (n in nbrs and nbrs[n].get(weight,1)))
-
+            # edge weighted graph - degree is sum of nbr edge weights
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum((nbrs[nbr].get(weight, 1) for nbr in nbrs)) +
+                    (n in nbrs and nbrs[n].get(weight, 1)))
 
     def clear(self):
         """Remove all nodes and edges from the graph.
@@ -1454,7 +1445,6 @@ class Graph(object):
         """Return True if graph is a multigraph, False otherwise."""
         return False
 
-
     def is_directed(self):
         """Return True if graph is directed, False otherwise."""
         return False
@@ -1504,14 +1494,14 @@ class Graph(object):
         [(0, 1)]
         """
         from networkx import DiGraph
-        G=DiGraph()
-        G.name=self.name
+        G = DiGraph()
+        G.name = self.name
         G.add_nodes_from(self)
-        G.add_edges_from( ((u,v,deepcopy(data))
-                           for u,nbrs in self.adjacency_iter()
-                           for v,data in nbrs.items()) )
-        G.graph=deepcopy(self.graph)
-        G.node=deepcopy(self.node)
+        G.add_edges_from(((u, v, deepcopy(data))
+            for u, nbrs in self.adjacency_iter()
+            for v, data in nbrs.items()))
+        G.graph = deepcopy(self.graph)
+        G.node = deepcopy(self.node)
         return G
 
     def to_undirected(self):
@@ -1590,27 +1580,26 @@ class Graph(object):
         >>> H.edges()
         [(0, 1), (1, 2)]
         """
-        bunch =self.nbunch_iter(nbunch)
+        bunch = self.nbunch_iter(nbunch)
         # create new graph and copy subgraph into it
         H = self.__class__()
         # copy node and attribute dictionaries
         for n in bunch:
-            H.node[n]=self.node[n]
+            H.node[n] = self.node[n]
         # namespace shortcuts for speed
-        H_adj=H.adj
-        self_adj=self.adj
+        H_adj = H.adj
+        self_adj = self.adj
         # add nodes and edges (undirected method)
         for n in H.node:
-            Hnbrs=H.adjlist_dict_factory()
-            H_adj[n]=Hnbrs
-            for nbr,d in self_adj[n].items():
+            Hnbrs = H.adjlist_dict_factory()
+            H_adj[n] = Hnbrs
+            for nbr, d in self_adj[n].items():
                 if nbr in H_adj:
                     # add both representations of edge: n-nbr and nbr-n
-                    Hnbrs[nbr]=d
-                    H_adj[nbr][n]=d
-        H.graph=self.graph
+                    Hnbrs[nbr] = d
+                    H_adj[nbr][n] = d
+        H.graph = self.graph
         return H
-
 
     def nodes_with_selfloops(self):
         """Return a list of nodes with self loops.
@@ -1635,7 +1624,7 @@ class Graph(object):
         >>> G.nodes_with_selfloops()
         [1]
         """
-        return [ n for n,nbrs in self.adj.items() if n in nbrs ]
+        return [n for n, nbrs in self.adj.items() if n in nbrs]
 
     def selfloop_edges(self, data=False, default=None):
         """Return a list of selfloop edges.
@@ -1672,15 +1661,14 @@ class Graph(object):
         [(1, 1, {})]
         """
         if data is True:
-            return [ (n,n,nbrs[n])
-                     for n,nbrs in self.adj.items() if n in nbrs ]
+            return [(n, n, nbrs[n])
+                    for n, nbrs in self.adj.items() if n in nbrs]
         elif data is not False:
-            return [ (n,n,nbrs[n].get(data,default) )
-                     for n,nbrs in self.adj.items() if n in nbrs ]
+            return [(n, n, nbrs[n].get(data, default))
+                    for n, nbrs in self.adj.items() if n in nbrs]
         else:
-            return [ (n,n)
-                     for n,nbrs in self.adj.items() if n in nbrs ]
-
+            return [(n, n)
+                    for n, nbrs in self.adj.items() if n in nbrs]
 
     def number_of_selfloops(self):
         """Return the number of selfloop edges.
@@ -1705,7 +1693,6 @@ class Graph(object):
         1
         """
         return len(self.selfloop_edges())
-
 
     def size(self, weight=None):
         """Return the number of edges.
@@ -1740,7 +1727,7 @@ class Graph(object):
         >>> G.size(weight='weight')
         6.0
         """
-        s=sum(self.degree(weight=weight).values())/2
+        s = sum(self.degree(weight=weight).values()) / 2
         if weight is None:
             return int(s)
         else:
@@ -1783,7 +1770,6 @@ class Graph(object):
         else:
             return 0
 
-
     def add_star(self, nodes, **attr):
         """Add a star.
 
@@ -1809,8 +1795,8 @@ class Graph(object):
 
         """
         nlist = list(nodes)
-        v=nlist[0]
-        edges=((v,n) for n in nlist[1:])
+        v = nlist[0]
+        edges = ((v, n) for n in nlist[1:])
         self.add_edges_from(edges, **attr)
 
     def add_path(self, nodes, **attr):
@@ -1836,7 +1822,7 @@ class Graph(object):
 
         """
         nlist = list(nodes)
-        edges=zip(nlist[:-1],nlist[1:])
+        edges = zip(nlist[:-1], nlist[1:])
         self.add_edges_from(edges, **attr)
 
     def add_cycle(self, nodes, **attr):
@@ -1862,9 +1848,8 @@ class Graph(object):
 
         """
         nlist = list(nodes)
-        edges=zip(nlist,nlist[1:]+[nlist[0]])
+        edges = zip(nlist, nlist[1:] + [nlist[0]])
         self.add_edges_from(edges, **attr)
-
 
     def nbunch_iter(self, nbunch=None):
         """Return an iterator of nodes contained in nbunch that are
@@ -1908,28 +1893,28 @@ class Graph(object):
         nbunch is not hashable, a NetworkXError is raised.
         """
         if nbunch is None:   # include all nodes via iterator
-            bunch=iter(self.adj.keys())
-        elif nbunch in self: # if nbunch is a single node
-            bunch=iter([nbunch])
+            bunch = iter(self.adj.keys())
+        elif nbunch in self:  # if nbunch is a single node
+            bunch = iter([nbunch])
         else:                # if nbunch is a sequence of nodes
-            def bunch_iter(nlist,adj):
+            def bunch_iter(nlist, adj):
                 try:
                     for n in nlist:
                         if n in adj:
                             yield n
                 except TypeError as e:
-                    message=e.args[0]
+                    message = e.args[0]
                     import sys
                     sys.stdout.write(message)
                     # capture error for non-sequence/iterator nbunch.
                     if 'iter' in message:
-                        raise NetworkXError(\
+                        raise NetworkXError(
                             "nbunch is not a node or a sequence of nodes.")
                     # capture error for unhashable node.
                     elif 'hashable' in message:
-                        raise NetworkXError(\
+                        raise NetworkXError(
                             "Node %s in the sequence nbunch is not a valid node."%n)
                     else:
                         raise
-            bunch=bunch_iter(nbunch,self.adj)
+            bunch = bunch_iter(nbunch, self.adj)
         return bunch

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -15,6 +15,7 @@ __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
 
+
 class MultiDiGraph(MultiGraph,DiGraph):
     """A directed graph class that can store multiedges.
 
@@ -181,10 +182,10 @@ class MultiDiGraph(MultiGraph,DiGraph):
     the edge data and holds edge attribute values keyed by attribute names.
 
     Each of these four dicts in the dict-of-dict-of-dict-of-dict
-    structure can be replaced by a user defined dict-like object.  
-    In general, the dict-like features should be maintained but 
-    extra features can be added. To replace one of the dicts create 
-    a new graph class by changing the class(!) variable holding the 
+    structure can be replaced by a user defined dict-like object.
+    In general, the dict-like features should be maintained but
+    extra features can be added. To replace one of the dicts create
+    a new graph class by changing the class(!) variable holding the
     factory for that dict-like structure. The variable names
     are node_dict_factory, adjlist_dict_factory, edge_key_dict_factory
     and edge_attr_dict_factory.
@@ -241,10 +242,11 @@ class MultiDiGraph(MultiGraph,DiGraph):
     [(2, 2, 0), (2, 1, 2), (2, 1, 1), (1, 1, 0)]
 
     """
-    #node_dict_factory=dict    # already assigned in Graph
-    #adjlist_dict_factory=dict
-    edge_key_dict_factory=dict
-    #edge_attr_dict_factory=dict
+    # node_dict_factory=dict    # already assigned in Graph
+    # adjlist_dict_factory=dict
+    edge_key_dict_factory = dict
+    # edge_attr_dict_factory=dict
+
     def __init__(self, data=None, **attr):
         self.edge_key_dict_factory = self.edge_key_dict_factory
         DiGraph.__init__(self, data, **attr)
@@ -304,12 +306,12 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.succ:
@@ -321,24 +323,24 @@ class MultiDiGraph(MultiGraph,DiGraph):
             self.pred[v] = self.adjlist_dict_factory()
             self.node[v] = {}
         if v in self.succ[u]:
-            keydict=self.adj[u][v]
+            keydict = self.adj[u][v]
             if key is None:
                 # find a unique integer key
                 # other methods might be better here?
-                key=len(keydict)
+                key = len(keydict)
                 while key in keydict:
-                    key+=1
-            datadict=keydict.get(key,self.edge_key_dict_factory())
+                    key += 1
+            datadict = keydict.get(key, self.edge_key_dict_factory())
             datadict.update(attr_dict)
-            keydict[key]=datadict
+            keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
-                key=0
-            datadict=self.edge_attr_dict_factory()
+                key = 0
+            datadict = self.edge_attr_dict_factory()
             datadict.update(attr_dict)
-            keydict=self.edge_key_dict_factory()
-            keydict[key]=datadict
+            keydict = self.edge_key_dict_factory()
+            keydict[key] = datadict
             self.succ[u][v] = keydict
             self.pred[v][u] = keydict
 
@@ -386,10 +388,10 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         try:
-            d=self.adj[u][v]
+            d = self.adj[u][v]
         except (KeyError):
             raise NetworkXError(
-                "The edge %s-%s is not in the graph."%(u,v))
+                "The edge %s-%s is not in the graph." % (u, v))
         # remove the edge with specified data
         if key is None:
             d.popitem()
@@ -398,12 +400,11 @@ class MultiDiGraph(MultiGraph,DiGraph):
                 del d[key]
             except (KeyError):
                 raise NetworkXError(
-                "The edge %s-%s with key %s is not in the graph."%(u,v,key))
-        if len(d)==0:
+                "The edge %s-%s with key %s is not in the graph." % (u, v, key))
+        if len(d) == 0:
             # remove the key entries if last edge
             del self.succ[u][v]
             del self.pred[v][u]
-
 
     def edges_iter(self, nbunch=None, data=False, keys=False, default=None):
         """Return an iterator over the edges.
@@ -419,7 +420,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         keys : bool, optional (default=False)
             If True, return edge keys with each edge.
         default : value, optional (default=None)
@@ -449,7 +450,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges_iter(data=True)) # default data is {} (empty dict)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges(keys=True)) # default keys are integers
         [(0, 1, 0), (1, 2, 0), (2, 3, 0)]
@@ -466,26 +467,26 @@ class MultiDiGraph(MultiGraph,DiGraph):
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
         if data is True:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,ddict in keydict.items():
-                        yield (n,nbr,key,ddict) if keys else (n,nbr,ddict)
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, ddict in keydict.items():
+                        yield (n, nbr, key, ddict) if keys else (n, nbr, ddict)
         elif data is not False:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,ddict in keydict.items():
-                        d=ddict[data] if data in ddict else default
-                        yield (n,nbr,key,d) if keys else (n,nbr,d)
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, ddict in keydict.items():
+                        d = ddict[data] if data in ddict else default
+                        yield (n, nbr, key, d) if keys else (n, nbr, d)
         else:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
                     for key in keydict:
-                        yield (n,nbr,key) if keys else (n,nbr)
+                        yield (n, nbr, key) if keys else (n, nbr)
 
     # alias out_edges to edges
-    out_edges_iter=edges_iter
+    out_edges_iter = edges_iter
 
     def out_edges(self, nbunch=None, keys=False, data=False):
         """Return a list of the outgoing edges.
@@ -519,7 +520,6 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         return list(self.out_edges_iter(nbunch, keys=keys, data=data))
 
-
     def in_edges_iter(self, nbunch=None, data=False, keys=False):
         """Return an iterator over the incoming edges.
 
@@ -543,25 +543,25 @@ class MultiDiGraph(MultiGraph,DiGraph):
         edges_iter : return an iterator of edges
         """
         if nbunch is None:
-            nodes_nbrs=self.pred.items()
+            nodes_nbrs = self.pred.items()
         else:
-            nodes_nbrs=((n,self.pred[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.pred[n]) for n in self.nbunch_iter(nbunch))
         if data:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,data in keydict.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, data in keydict.items():
                         if keys:
-                            yield (nbr,n,key,data)
+                            yield (nbr, n, key, data)
                         else:
-                            yield (nbr,n,data)
+                            yield (nbr, n, data)
         else:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
-                    for key,data in keydict.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
+                    for key, data in keydict.items():
                         if keys:
-                            yield (nbr,n,key)
+                            yield (nbr, n, key)
                         else:
-                            yield (nbr,n)
+                            yield (nbr, n)
 
     def in_edges(self, nbunch=None, keys=False, data=False):
         """Return a list of the incoming edges.
@@ -587,7 +587,6 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         return list(self.in_edges_iter(nbunch, keys=keys, data=data))
 
-
     def degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, degree).
 
@@ -600,7 +599,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -624,28 +623,27 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs=zip(iter(self.succ.items()),iter(self.pred.items()))
+            nodes_nbrs = zip(iter(self.succ.items()), iter(self.pred.items()))
         else:
-            nodes_nbrs=zip(
-                ((n,self.succ[n]) for n in self.nbunch_iter(nbunch)),
-                ((n,self.pred[n]) for n in self.nbunch_iter(nbunch)))
+            nodes_nbrs = zip(
+                ((n, self.succ[n]) for n in self.nbunch_iter(nbunch)),
+                ((n, self.pred[n]) for n in self.nbunch_iter(nbunch)))
 
         if weight is None:
-            for (n,succ),(n2,pred) in nodes_nbrs:
+            for (n, succ), (n2, pred) in nodes_nbrs:
                 indeg = sum([len(data) for data in pred.values()])
                 outdeg = sum([len(data) for data in succ.values()])
                 yield (n, indeg + outdeg)
         else:
-        # edge weighted graph - degree is sum of nbr edge weights
-            for (n,succ),(n2,pred) in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            # edge weighted graph - degree is sum of nbr edge weights
+            for (n, succ), (n2, pred) in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in pred.values()
                            for d in data.values()])
-                deg += sum([d.get(weight,1)
+                deg += sum([d.get(weight, 1)
                            for data in succ.values()
                            for d in data.values()])
                 yield (n, deg)
-
 
     def in_degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, in-degree).
@@ -659,7 +657,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -683,21 +681,20 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.pred.items()
+            nodes_nbrs = self.pred.items()
         else:
-            nodes_nbrs=((n,self.pred[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.pred[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum([len(data) for data in nbrs.values()]) )
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum([len(data) for data in nbrs.values()]))
         else:
             # edge weighted graph - degree is sum of nbr edge weights
-            for n,pred in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            for n, pred in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in pred.values()
                            for d in data.values()])
                 yield (n, deg)
-
 
     def out_degree_iter(self, nbunch=None, weight=None):
         """Return an iterator for (node, out-degree).
@@ -711,7 +708,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -735,16 +732,16 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs=self.succ.items()
+            nodes_nbrs = self.succ.items()
         else:
-            nodes_nbrs=((n,self.succ[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.succ[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
-                yield (n, sum([len(data) for data in nbrs.values()]) )
+            for n, nbrs in nodes_nbrs:
+                yield (n, sum([len(data) for data in nbrs.values()]))
         else:
-            for n,succ in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            for n, succ in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in succ.values()
                            for d in data.values()])
                 yield (n, deg)
@@ -807,8 +804,8 @@ class MultiDiGraph(MultiGraph,DiGraph):
         Parameters
         ----------
         reciprocal : bool (optional)
-          If True only keep edges that appear in both directions 
-          in the original digraph. 
+          If True only keep edges that appear in both directions
+          in the original digraph.
 
         Returns
         -------
@@ -837,24 +834,24 @@ class MultiDiGraph(MultiGraph,DiGraph):
         If you have subclassed MultiGraph to use dict-like objects in the
         data structure, those changes do not transfer to the MultiDiGraph
         created by this method.
-        
+
         """
-        H=MultiGraph()
-        H.name=self.name
+        H = MultiGraph()
+        H.name = self.name
         H.add_nodes_from(self)
         if reciprocal is True:
-            H.add_edges_from( (u,v,key,deepcopy(data))
-                              for u,nbrs in self.adjacency_iter()
-                              for v,keydict in nbrs.items()
-                              for key,data in keydict.items()
-                              if self.has_edge(v,u,key))
+            H.add_edges_from((u, v, key, deepcopy(data))
+                            for u, nbrs in self.adjacency_iter()
+                            for v, keydict in nbrs.items()
+                            for key, data in keydict.items()
+                            if self.has_edge(v, u, key))
         else:
-            H.add_edges_from( (u,v,key,deepcopy(data))
-                              for u,nbrs in self.adjacency_iter()
-                              for v,keydict in nbrs.items()
-                              for key,data in keydict.items())
-        H.graph=deepcopy(self.graph)
-        H.node=deepcopy(self.node)
+            H.add_edges_from((u, v, key, deepcopy(data))
+                            for u, nbrs in self.adjacency_iter()
+                            for v, keydict in nbrs.items()
+                            for key, data in keydict.items())
+        H.graph = deepcopy(self.graph)
+        H.node = deepcopy(self.node)
         return H
 
     def subgraph(self, nbunch):
@@ -901,27 +898,27 @@ class MultiDiGraph(MultiGraph,DiGraph):
         H = self.__class__()
         # copy node and attribute dictionaries
         for n in bunch:
-            H.node[n]=self.node[n]
+            H.node[n] = self.node[n]
         # namespace shortcuts for speed
-        H_succ=H.succ
-        H_pred=H.pred
-        self_succ=self.succ
-        self_pred=self.pred
+        H_succ = H.succ
+        H_pred = H.pred
+        self_succ = self.succ
+        self_pred = self.pred
         # add nodes
         for n in H:
-            H_succ[n]=H.adjlist_dict_factory()
-            H_pred[n]=H.adjlist_dict_factory()
+            H_succ[n] = H.adjlist_dict_factory()
+            H_pred[n] = H.adjlist_dict_factory()
         # add edges
         for u in H_succ:
-            Hnbrs=H_succ[u]
-            for v,edgedict in self_succ[u].items():
+            Hnbrs = H_succ[u]
+            for v, edgedict in self_succ[u].items():
                 if v in H_succ:
                     # add both representations of edge: u-v and v-u
                     # they share the same edgedict
-                    ed=edgedict.copy()
-                    Hnbrs[v]=ed
-                    H_pred[v][u]=ed
-        H.graph=self.graph
+                    ed = edgedict.copy()
+                    Hnbrs[v] = ed
+                    H_pred[v][u] = ed
+        H.graph = self.graph
         return H
 
     def reverse(self, copy=True):
@@ -940,12 +937,12 @@ class MultiDiGraph(MultiGraph,DiGraph):
         if copy:
             H = self.__class__(name="Reverse of (%s)"%self.name)
             H.add_nodes_from(self)
-            H.add_edges_from( (v,u,k,deepcopy(d)) for u,v,k,d 
-                              in self.edges(keys=True, data=True) )
-            H.graph=deepcopy(self.graph)
-            H.node=deepcopy(self.node)
+            H.add_edges_from((v, u, k, deepcopy(d)) for u, v, k, d
+                              in self.edges(keys=True, data=True))
+            H.graph = deepcopy(self.graph)
+            H.node = deepcopy(self.node)
         else:
-            self.pred,self.succ=self.succ,self.pred
-            self.adj=self.succ
-            H=self
+            self.pred, self.succ = self.succ, self.pred
+            self.adj = self.succ
+            H = self
         return H

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -13,6 +13,7 @@ __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
 
+
 class MultiGraph(Graph):
     """
     An undirected graph class that can store multiedges.
@@ -182,10 +183,10 @@ class MultiGraph(Graph):
     the edge data and holds edge attribute values keyed by attribute names.
 
     Each of these four dicts in the dict-of-dict-of-dict-of-dict
-    structure can be replaced by a user defined dict-like object.  
-    In general, the dict-like features should be maintained but 
-    extra features can be added. To replace one of the dicts create 
-    a new graph class by changing the class(!) variable holding the 
+    structure can be replaced by a user defined dict-like object.
+    In general, the dict-like features should be maintained but
+    extra features can be added. To replace one of the dicts create
+    a new graph class by changing the class(!) variable holding the
     factory for that dict-like structure. The variable names
     are node_dict_factory, adjlist_dict_factory, edge_key_dict_factory
     and edge_attr_dict_factory.
@@ -242,10 +243,11 @@ class MultiGraph(Graph):
     [(2, 2, 0), (2, 1, 2), (2, 1, 1), (1, 1, 0)]
 
     """
-    #node_dict_factory=dict    # already assigned in Graph
-    #adjlist_dict_factory=dict
-    edge_key_dict_factory=dict
-    #edge_attr_dict_factory=dict
+    # node_dict_factory=dict    # already assigned in Graph
+    # adjlist_dict_factory=dict
+    edge_key_dict_factory = dict
+    # edge_attr_dict_factory=dict
+
     def __init__(self, data=None, **attr):
         self.edge_key_dict_factory = self.edge_key_dict_factory
         Graph.__init__(self, data, **attr)
@@ -305,12 +307,12 @@ class MultiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.adj:
@@ -320,27 +322,26 @@ class MultiGraph(Graph):
             self.adj[v] = self.adjlist_dict_factory()
             self.node[v] = {}
         if v in self.adj[u]:
-            keydict=self.adj[u][v]
+            keydict = self.adj[u][v]
             if key is None:
                 # find a unique integer key
                 # other methods might be better here?
-                key=len(keydict)
+                key = len(keydict)
                 while key in keydict:
-                    key+=1
-            datadict=keydict.get(key,self.edge_attr_dict_factory())
+                    key += 1
+            datadict = keydict.get(key, self.edge_attr_dict_factory())
             datadict.update(attr_dict)
-            keydict[key]=datadict
+            keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
-                key=0
-            datadict=self.edge_attr_dict_factory()
+                key = 0
+            datadict = self.edge_attr_dict_factory()
             datadict.update(attr_dict)
-            keydict=self.edge_key_dict_factory()
-            keydict[key]=datadict
+            keydict = self.edge_key_dict_factory()
+            keydict[key] = datadict
             self.adj[u][v] = keydict
             self.adj[v][u] = keydict
-
 
     def add_edges_from(self, ebunch, attr_dict=None, **attr):
         """Add all the edges in ebunch.
@@ -390,33 +391,32 @@ class MultiGraph(Graph):
         """
         # set up attribute dict
         if attr_dict is None:
-            attr_dict=attr
+            attr_dict = attr
         else:
             try:
                 attr_dict.update(attr)
             except AttributeError:
-                raise NetworkXError(\
+                raise NetworkXError(
                     "The attr_dict argument must be a dictionary.")
         # process ebunch
         for e in ebunch:
-            ne=len(e)
-            if ne==4:
-                u,v,key,dd = e
-            elif ne==3:
-                u,v,dd = e
-                key=None
-            elif ne==2:
-                u,v = e
+            ne = len(e)
+            if ne == 4:
+                u, v, key, dd = e
+            elif ne == 3:
+                u, v, dd = e
+                key = None
+            elif ne == 2:
+                u, v = e
                 dd = {}
-                key=None
+                key = None
             else:
-                raise NetworkXError(\
-                    "Edge tuple %s must be a 2-tuple, 3-tuple or 4-tuple."%(e,))
-            ddd={}
+                raise NetworkXError(
+                    "Edge tuple %s must be a 2-tuple, 3-tuple or 4-tuple." % (e,))
+            ddd = {}
             ddd.update(attr_dict)
             ddd.update(dd)
             self.add_edge(u, v, key, ddd)
-
 
     def remove_edge(self, u, v, key=None):
         """Remove an edge between u and v.
@@ -462,10 +462,10 @@ class MultiGraph(Graph):
 
         """
         try:
-            d=self.adj[u][v]
+            d = self.adj[u][v]
         except (KeyError):
             raise NetworkXError(
-                "The edge %s-%s is not in the graph."%(u,v))
+                "The edge %s-%s is not in the graph." % (u, v))
         # remove the edge with specified data
         if key is None:
             d.popitem()
@@ -474,13 +474,13 @@ class MultiGraph(Graph):
                 del d[key]
             except (KeyError):
                 raise NetworkXError(
-                "The edge %s-%s with key %s is not in the graph."%(u,v,key))
-        if len(d)==0:
+                    "The edge %s-%s with key %s is not in the graph." % (
+                        u, v, key))
+        if len(d) == 0:
             # remove the key entries if last edge
             del self.adj[u][v]
             if u!=v:  # check for selfloop
                 del self.adj[v][u]
-
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -526,7 +526,6 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
-
 
     def has_edge(self, u, v, key=None):
         """Return True if the graph has an edge between nodes u and v.
@@ -622,7 +621,7 @@ class MultiGraph(Graph):
         [(0, 1), (1, 2), (2, 3)]
         >>> G.edges(data=True) # default edge data is {} (empty dictionary)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> G.edges(keys=True) # default keys are integers
         [(0, 1, 0), (1, 2, 0), (2, 3, 0)]
@@ -652,7 +651,7 @@ class MultiGraph(Graph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         default : value, optional (default=None)
             Value used for edges that dont have the requested attribute.
             Only relevant if data is not True or False.
@@ -682,7 +681,7 @@ class MultiGraph(Graph):
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges_iter(data=True)) # default data is {} (empty dict)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges_iter(data='weight', default=1)) 
+        >>> list(G.edges_iter(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges(keys=True)) # default keys are integers
         [(0, 1, 0), (1, 2, 0), (2, 3, 0)]
@@ -696,35 +695,34 @@ class MultiGraph(Graph):
         [(0, 1)]
 
         """
-        seen={}     # helper dict to keep track of multiply stored edges
+        seen = {}     # helper dict to keep track of multiply stored edges
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
         if data is True:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
                     if nbr not in seen:
-                        for key,ddict in keydict.items():
-                            yield (n,nbr,key,ddict) if keys else (n,nbr,ddict)
-                seen[n]=1
+                        for key, ddict in keydict.items():
+                            yield (n, nbr, key, ddict) if keys else (n, nbr, ddict)
+                seen[n] = 1
         elif data is not False:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
                     if nbr not in seen:
-                        for key,ddict in keydict.items():
-                            d=ddict[data] if data in ddict else default
-                            yield (n,nbr,key,d) if keys else (n,nbr,d)
-                seen[n]=1
+                        for key, ddict in keydict.items():
+                            d = ddict[data] if data in ddict else default
+                            yield (n, nbr, key, d) if keys else (n, nbr, d)
+                seen[n] = 1
         else:
-            for n,nbrs in nodes_nbrs:
-                for nbr,keydict in nbrs.items():
+            for n, nbrs in nodes_nbrs:
+                for nbr, keydict in nbrs.items():
                     if nbr not in seen:
                         for key in keydict:
-                            yield (n,nbr,key) if keys else (n,nbr)
+                            yield (n, nbr, key) if keys else (n, nbr)
                 seen[n] = 1
         del seen
-
 
     def get_edge_data(self, u, v, key=None, default=None):
         """Return the attribute dictionary associated with edge (u,v).
@@ -792,7 +790,7 @@ class MultiGraph(Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -818,23 +816,22 @@ class MultiGraph(Graph):
         if nbunch is None:
             nodes_nbrs = self.adj.items()
         else:
-            nodes_nbrs=((n,self.adj[n]) for n in self.nbunch_iter(nbunch))
+            nodes_nbrs = ((n, self.adj[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for n,nbrs in nodes_nbrs:
+            for n, nbrs in nodes_nbrs:
                 deg = sum([len(data) for data in nbrs.values()])
-                yield (n, deg+(n in nbrs and len(nbrs[n])))
+                yield (n, deg + (n in nbrs and len(nbrs[n])))
         else:
-        # edge weighted graph - degree is sum of nbr edge weights
-            for n,nbrs in nodes_nbrs:
-                deg = sum([d.get(weight,1)
+            # edge weighted graph - degree is sum of nbr edge weights
+            for n, nbrs in nodes_nbrs:
+                deg = sum([d.get(weight, 1)
                            for data in nbrs.values()
                            for d in data.values()])
                 if n in nbrs:
-                    deg += sum([d.get(weight,1)
-                           for key,d in nbrs[n].items()])
+                    deg += sum([d.get(weight, 1)
+                                for key, d in nbrs[n].items()])
                 yield (n, deg)
-
 
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""
@@ -889,16 +886,15 @@ class MultiGraph(Graph):
         [(0, 1)]
         """
         from networkx.classes.multidigraph import MultiDiGraph
-        G=MultiDiGraph()
+        G = MultiDiGraph()
         G.add_nodes_from(self)
-        G.add_edges_from( (u,v,key,deepcopy(datadict))
-                           for u,nbrs in self.adjacency_iter()
-                           for v,keydict in nbrs.items()
-                           for key,datadict in keydict.items() ) 
-        G.graph=deepcopy(self.graph)
-        G.node=deepcopy(self.node)
+        G.add_edges_from((u, v, key, deepcopy(datadict))
+                            for u, nbrs in self.adjacency_iter()
+                            for v, keydict in nbrs.items()
+                            for key, datadict in keydict.items())
+        G.graph = deepcopy(self.graph)
+        G.node = deepcopy(self.node)
         return G
-
 
     def selfloop_edges(self, data=False, keys=False, default=None):
         """Return a list of selfloop edges.
@@ -942,32 +938,31 @@ class MultiGraph(Graph):
         """
         if data is True:
             if keys:
-                return [ (n,n,k,d)
-                         for n,nbrs in self.adj.items()
-                         if n in nbrs for k,d in nbrs[n].items()]
+                return [(n, n, k, d)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for k, d in nbrs[n].items()]
             else:
-                return [ (n,n,d)
-                         for n,nbrs in self.adj.items()
-                         if n in nbrs for d in nbrs[n].values()]
+                return [(n, n, d)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for d in nbrs[n].values()]
         elif data is not False:
             if keys:
-                return [ (n,n,k,d.get(data,default))
-                         for n,nbrs in self.adj.items()
-                         if n in nbrs for k,d in nbrs[n].items()]
+                return [(n, n, k, d.get(data, default))
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for k, d in nbrs[n].items()]
             else:
-                return [ (n,n,d.get(data,default))
-                         for n,nbrs in self.adj.items()
-                         if n in nbrs for d in nbrs[n].values()]
+                return [(n, n, d.get(data, default))
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for d in nbrs[n].values()]
         else:
             if keys:
-                return [ (n,n,k)
-                     for n,nbrs in self.adj.items()
-                     if n in nbrs for k in nbrs[n].keys()]
+                return [(n, n, k)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for k in nbrs[n].keys()]
             else:
-                return [ (n,n)
-                     for n,nbrs in self.adj.items()
-                     if n in nbrs for d in nbrs[n].values()]
-
+                return [(n, n)
+                        for n, nbrs in self.adj.items()
+                        if n in nbrs for d in nbrs[n].values()]
 
     def number_of_edges(self, u=None, v=None):
         """Return the number of edges between two nodes.
@@ -1002,11 +997,10 @@ class MultiGraph(Graph):
         """
         if u is None: return self.size()
         try:
-            edgedata=self.adj[u][v]
+            edgedata = self.adj[u][v]
         except KeyError:
-            return 0 # no such edge
+            return 0  # no such edge
         return len(edgedata)
-
 
     def subgraph(self, nbunch):
         """Return the subgraph induced on nodes in nbunch.
@@ -1047,25 +1041,25 @@ class MultiGraph(Graph):
         >>> H.edges()
         [(0, 1), (1, 2)]
         """
-        bunch =self.nbunch_iter(nbunch)
+        bunch = self.nbunch_iter(nbunch)
         # create new graph and copy subgraph into it
         H = self.__class__()
         # copy node and attribute dictionaries
         for n in bunch:
-            H.node[n]=self.node[n]
+            H.node[n] = self.node[n]
         # namespace shortcuts for speed
-        H_adj=H.adj
-        self_adj=self.adj
+        H_adj = H.adj
+        self_adj = self.adj
         # add nodes and edges (undirected method)
         for n in H:
-            Hnbrs=H.adjlist_dict_factory()
-            H_adj[n]=Hnbrs
-            for nbr,edgedict in self_adj[n].items():
+            Hnbrs = H.adjlist_dict_factory()
+            H_adj[n] = Hnbrs
+            for nbr, edgedict in self_adj[n].items():
                 if nbr in H_adj:
                     # add both representations of edge: n-nbr and nbr-n
                     # they share the same edgedict
-                    ed=edgedict.copy()
-                    Hnbrs[nbr]=ed
-                    H_adj[nbr][n]=ed
-        H.graph=self.graph
+                    ed = edgedict.copy()
+                    Hnbrs[nbr] = ed
+                    H_adj[nbr][n] = ed
+        H.graph = self.graph
         return H

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -18,6 +18,7 @@ __all__.extend([
     'OrderedMultiDiGraph',
 ])
 
+
 class OrderedGraph(Graph):
     node_dict_factory = OrderedDict
     adjlist_dict_factory = OrderedDict


### PR DESCRIPTION
For programmers that use linter tools in their editors, code that  doesn't conform to PEP8 (https://www.python.org/dev/peps/pep-0008/) tends to become somewhat obtrusive. A perfect example is SublimeLinter. In any case, Python code should conform to PEP8 and NetworkX lacks this in some parts of its code. This PR more or less fixes this in base classes (classes folder). Any changes to other parts of the code should also incorporate pep8 style fixes around the area that's being edited.