### PR TITLE
Add generator function for circulant graphs

### DIFF
--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -97,6 +97,10 @@ New functionalities
   Newman's approximation algorithm for finding node independent paths
   between two nodes.
 
+* [`#1436 <https://github.com/networkx/networkx/pull/1436`_]
+  Added a generator function for circulant graphs to the
+  ``networkx.generators.classic`` module.
+
 Removed functionalities
 -----------------------
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -24,6 +24,7 @@ __all__ = [ 'balanced_tree',
             'barbell_graph',
             'complete_graph',
             'circular_ladder_graph',
+            'circulant_graph',
             'cycle_graph',
             'dorogovtsev_goltsev_mendes_graph',
             'empty_graph',
@@ -205,6 +206,22 @@ def circular_ladder_graph(n,create_using=None):
     G.name="circular_ladder_graph(%d)"%n
     G.add_edge(0,n-1)
     G.add_edge(n,2*n-1)
+    return G
+
+
+def circulant_graph(n,offsets,create_using=None):
+    """Return the circulant graph Ci_n(x_1, x_2, ..., x_m) with n vertices.
+
+    Ci_n(x_1, ..., x_m) consists of n vertices 0, ..., n-1 such that the vertex
+    with label i is connected to the vertices labelled (i + x) and (i - x),
+    for all x in x_1 up to x_m, taken modulo n.
+    """
+    G=empty_graph(n,create_using)
+    G.name='circulant_graph(%d, [%s])' % (n, ', '.join(str(j) for j in offsets))
+    for i in range(n):
+        for j in offsets:
+            G.add_edge(i, (i - j) % n)
+            G.add_edge(i, (i + j) % n)
     return G
 
 def cycle_graph(n,create_using=None):

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -216,8 +216,8 @@ def circulant_graph(n,offsets,create_using=None):
     with label i is connected to the vertices labelled (i + x) and (i - x),
     for all x in x_1 up to x_m, taken modulo n.
     """
-    G=empty_graph(n,create_using)
-    G.name='circulant_graph(%d, [%s])' % (n, ', '.join(str(j) for j in offsets))
+    G = empty_graph(n, create_using)
+    G.name = 'circulant_graph(%d, [%s])' % (n, ', '.join(str(j) for j in offsets))
     for i in range(n):
         for j in offsets:
             G.add_edge(i, (i - j) % n)

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -209,12 +209,43 @@ def circular_ladder_graph(n,create_using=None):
     return G
 
 
-def circulant_graph(n,offsets,create_using=None):
-    """Return the circulant graph Ci_n(x_1, x_2, ..., x_m) with n vertices.
+def circulant_graph(n, offsets, create_using=None):
+    """Generates the circulant graph Ci_n(x_1, x_2, ..., x_m) with n vertices.
 
-    Ci_n(x_1, ..., x_m) consists of n vertices 0, ..., n-1 such that the vertex
-    with label i is connected to the vertices labelled (i + x) and (i - x),
-    for all x in x_1 up to x_m, taken modulo n.
+    Returns
+    -------
+    The graph Ci_n(x_1, ..., x_m) consisting of n vertices 0, ..., n-1 such
+    that the vertex with label i is connected to the vertices labelled (i + x)
+    and (i - x), for all x in x_1 up to x_m, with the indices taken modulo n.
+
+    Parameters
+    ----------
+    n : integer
+        The number of vertices the generated graph is to contain.
+    offsets : list of integers
+        A list of vertex offsets, x_1 up to x_m, as described above.
+    create_using : NetworkX graph type, optional
+        Use specified type to construct graph (default = networkx.Graph)
+
+    Examples
+    --------
+    Many well-known graph families are subfamilies of the circulant graphs; for
+    example, to generate the cycle graph on n points, we connect every vertex to
+    every other at offset plus or minus one. For n = 10,
+
+    >>> import networkx
+    >>> G = networkx.generators.classic.circulant_graph(10, [1])
+    >>> G.edges()
+    [(0, 9), (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8),
+     (8, 9)]
+
+    Similarly, we can generate the complete graph on 5 points with the set of
+    offsets [1, 2]:
+
+    >>> G = networkx.generators.classic.circulant_graph(5, [1, 2])
+    >>> G.edges()
+    [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
+
     """
     G = empty_graph(n, create_using)
     G.name = 'circulant_graph(%d, [%s])' % (n, ', '.join(str(j) for j in offsets))

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -143,6 +143,22 @@ class TestGeneratorClassic():
         mG=circular_ladder_graph(5, create_using=MultiGraph())
         assert_equal(mG.edges(), G.edges())
 
+    def test_circulant_graph(self):
+        # Ci_n(1) is the cycle graph for all n
+        Ci6_1 = circulant_graph(6, [1])
+        C6 = cycle_graph(6)
+        assert_equal(Ci6_1.edges(), C6.edges())
+
+        # Ci_n(1, 2, ..., n div 2) is the complete graph for all n
+        Ci7 = circulant_graph(7, [1, 2, 3])
+        K7 = complete_graph(7)
+        assert_equal(Ci7.edges(), K7.edges())
+
+        # Ci_6(1, 3) is K_3,3 i.e. the utility graph
+        Ci6_1_3 = circulant_graph(6, [1, 3])
+        K3_3 = complete_bipartite_graph(3, 3)
+        assert_true(is_isomorphic(Ci6_1_3, K3_3))
+
     def test_cycle_graph(self):
         G=cycle_graph(4)
         assert_equal(sorted(G.edges()), [(0, 1), (0, 3), (1, 2), (2, 3)])


### PR DESCRIPTION
This pull request adds a simple function for generating [circulant graphs](http://mathworld.wolfram.com/CirculantGraph.html), where every vertex is connected to those vertices with labels ±*j* of its own label, for all *j* in some set of 'jumps' *J*. A unit test is included which checks some common cases where well-known circulant graphs (such as the complete and cycle graphs) are generated.