### PR TITLE
Adds function for computing a quotient graph.

### DIFF
--- a/doc/source/reference/algorithms.minors.rst
+++ b/doc/source/reference/algorithms.minors.rst
@@ -1,0 +1,9 @@
+******
+Minors
+******
+
+.. automodule:: networkx.algorithms.minors
+.. autosummary::
+   :toctree: generated/
+
+   quotient_graph

--- a/doc/source/reference/algorithms.rst
+++ b/doc/source/reference/algorithms.rst
@@ -38,6 +38,7 @@ Algorithms
    algorithms.link_analysis
    algorithms.link_prediction
    algorithms.matching
+   algorithms.minors
    algorithms.mis
    algorithms.mst
    algorithms.operators

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -106,6 +106,7 @@ is partially historical, and now, mostly arbitrary.
 - Vincent Gauthier
 - Sérgio Nery Simões
 - chebee7i, GitHub: `chebee7i <https://github.com/chebee7i>`_
+- Jeffrey Finkelstein
 
 
 Support

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -15,6 +15,7 @@ from networkx.algorithms.dominance import *
 from networkx.algorithms.dominating import *
 from networkx.algorithms.hierarchy import *
 from networkx.algorithms.matching import *
+from networkx.algorithms.minors import *
 from networkx.algorithms.mis import *
 from networkx.algorithms.mst import *
 from networkx.algorithms.link_analysis import *

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -1,0 +1,181 @@
+# minors.py - functions for computing minors of graphs
+#
+# Copyright 2015 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Provides functions for computing minors of a graph."""
+from itertools import combinations
+from itertools import permutations
+from itertools import product
+
+__all__ = ['quotient_graph']
+
+
+def peek(iterable):
+    """Returns an arbitrary element of ``iterable`` without removing it.
+
+    This is most useful for peeking at an arbitrary element of a set::
+
+        >>> peek({3, 2, 1})
+        1
+        >>> peek('hello')
+        'h'
+
+    """
+    return next(iter(iterable))
+
+
+def equivalence_classes(iterable, relation):
+    """Returns the set of equivalence classes of the given ``iterable`` under
+    the specified equivalence relation.
+
+    ``relation`` must be a Boolean-valued function that takes two argument. It
+    must represent an equivalence relation (that is, the relation induced by
+    the function must be reflexive, symmetric, and transitive).
+
+    The return value is a set of sets. It is a partition of the elements of
+    ``iterable``; duplicate elements will be ignored so it makes the most sense
+    for ``iterable`` to be a :class:`set`.
+
+    """
+    # For simplicity of implementation, we initialize the return value as a
+    # list of lists, then convert it to a set of sets at the end of the
+    # function.
+    blocks = []
+    # Determine the equivalence class for each element of the iterable.
+    for y in iterable:
+        # Each element y must be in *exactly one* equivalence class.
+        #
+        # Each block is guaranteed to be non-empty
+        for block in blocks:
+            x = peek(block)
+            if relation(x, y):
+                block.append(y)
+                break
+        else:
+            # If the element y is not part of any known equivalence class, it
+            # must be in its own, so we create a new singleton equivalence
+            # class for it.
+            blocks.append([y])
+    return {frozenset(block) for block in blocks}
+
+
+def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
+    """Returns the quotient graph of ``G`` under the specified equivalence
+    relation on nodes.
+
+    Parameters
+    ----------
+
+    G : NetworkX graph
+
+       The graph for which to return the quotient graph with the specified node
+       relation.
+
+    node_relation : Boolean function with two arguments
+
+       This function must represent an equivalence relation on the nodes of
+       ``G``. It must take two arguments *u* and *v* and return ``True``
+       exactly when *u* and *v* are in the same equivalence class. The
+       equivalence classes form the vertices in the returned graph.
+
+    edge_relation : Boolean function with two arguments
+
+       This function must represent an edge relation on the *blocks* of ``G``
+       in the partition induced by ``node_relation``. It must take two
+       arguments, *B* and *C*, each one a set of nodes, and return ``True``
+       exactly when there should be an edge joining block *B* to block *C* in
+       the returned graph.
+
+       If ``edge_relation`` is not specified, it is assumed to be the following
+       relation. Block *B* is related to block *C* if and only if some vertex
+       in *B* is adjacent to some vertex in *C*, according to the edge set of
+       ``G``.
+
+    create_using : NetworkX graph
+
+       If specified, this must be an instance of a NetworkX graph class. The
+       nodes and edges of the quotient graph will be added to this graph and
+       returned. If not specified, the returned graph will have the same type
+       as the input graph.
+
+    Returns
+    -------
+
+    NetworkX graph
+
+       The quotient graph of ``G`` under the equivalence relation specified by
+       ``node_relation``.
+
+    Examples
+    --------
+
+    The quotient graph of the complete bipartite graph under the "same
+    neighbors" equivalence relation is `K_2`. Under this relation, two nodes
+    are equivalent if they are not adjacent but have the same neighbor set::
+
+        >>> import networkx as nx
+        >>> G = nx.complete_bipartite_graph(2, 3)
+        >>> same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
+        ...                                and G[u] == G[v])
+        >>> Q = nx.quotient_graph(G, same_neighbors)
+        >>> K2 = nx.complete_graph(2)
+        >>> nx.is_isomorphic(Q, K2)
+        True
+
+    The quotient graph of a directed graph under the "same strongly connected
+    component" equivalence relation is the condensation of the graph (see
+    :func:`condensation`). This example comes from the Wikipedia article
+    *`Strongly connected component`_*::
+
+        >>> import networkx as nx
+        >>> G = nx.DiGraph()
+        >>> edges = ['ab', 'be', 'bf', 'bc', 'cg', 'cd', 'dc', 'dh', 'ea',
+        ...          'ef', 'fg', 'gf', 'hd', 'hf']
+        >>> G.add_edges_from(tuple(x) for x in edges)
+        >>> components = list(nx.strongly_connected_components(G))
+        >>> sorted(sorted(component) for component in components)
+        [['a', 'b', 'e'], ['c', 'd', 'h'], ['f', 'g']]
+        >>>
+        >>> C = nx.condensation(G, components)
+        >>> component_of = C.graph['mapping']
+        >>> same_component = lambda u, v: component_of[u] == component_of[v]
+        >>> Q = nx.quotient_graph(G, same_component)
+        >>> nx.is_isomorphic(C, Q)
+        True
+
+    Vertex identification can be represented as the quotient of a graph under
+    the equivalence relation that places the two vertices in one block and each
+    other vertex in its own singleton block::
+
+        >>> import networkx as nx
+        >>> K24 = nx.complete_bipartite_graph(2, 4)
+        >>> K34 = nx.complete_bipartite_graph(3, 4)
+        >>> vertices = {1, 2}
+        >>> is_contracted = lambda u, v: u in vertices and v in vertices
+        >>> Q = nx.quotient_graph(K34, is_contracted)
+        >>> nx.is_isomorphic(Q, K24)
+        True
+
+    .. _Strongly connected component: https://en.wikipedia.org/wiki/Strongly_connected_component
+
+    """
+    H = type(create_using)() if create_using is not None else type(G)()
+    # Compute the blocks of the partition on the vertices of G induced by the
+    # equivalence relation R.
+    H.add_nodes_from(equivalence_classes(G, node_relation))
+    # By default, the edge relation is the relation defined as follows. B is
+    # adjacent to C if a vertex in B is adjacent to a vertex in C, according to
+    # the edge set of G.
+    #
+    # This is not a particularly efficient implementation of this relation:
+    # there are O(n^2) pairs to check and each check may require O(log n) time
+    # (to check set membership). This can certainly be parallelized.
+    if edge_relation is None:
+        edge_relation = lambda b, c: any(v in G[u] for u, v in product(b, c))
+    block_pairs = permutations(H, 2) if H.is_directed() else combinations(H, 2)
+    H.add_edges_from((b, c) for (b, c) in block_pairs if edge_relation(b, c))
+    return H

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -1,0 +1,83 @@
+# test_minors.py - unit tests for the minors module
+#
+# Copyright 2015 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.minors` module."""
+from nose.tools import assert_true
+
+import networkx as nx
+
+
+# # This test requires merging pull request #1425.
+# def test_quotient_graph_complete_multipartite():
+#     """Tests that the quotient graph of the complete *n*-partite graph under
+#     the "same neighbors" node relation is the complete graph on *n* nodes.
+
+#     """
+#     G = nx.complete_multipartite_graph(2, 3, 4)
+#     # Two nodes are equivalent if they are not adjacent but have the same
+#     # neighbor set.
+#     same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
+#                                    and G[u] == G[v])
+#     expected = nx.complete_graph(3)
+#     actual = nx.quotient_graph(G, same_neighbors)
+#     # It won't take too long to run a graph isomorphism algorithm on such small
+#     # graphs.
+#     assert_true(nx.is_isomorphic(expected, actual))
+
+
+def test_quotient_graph_complete_bipartite():
+    """Tests that the quotient graph of the complete bipartite graph under the
+    "same neighbors" node relation is `K_2`.
+
+    """
+    G = nx.complete_bipartite_graph(2, 3)
+    # Two nodes are equivalent if they are not adjacent but have the same
+    # neighbor set.
+    same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
+                                   and G[u] == G[v])
+    expected = nx.complete_graph(2)
+    actual = nx.quotient_graph(G, same_neighbors)
+    # It won't take too long to run a graph isomorphism algorithm on such small
+    # graphs.
+    assert_true(nx.is_isomorphic(expected, actual))
+
+
+def test_quotient_graph_edge_relation():
+    """Tests for specifying an alternate edge relation for the quotient graph.
+
+    """
+    G = nx.path_graph(5)
+    identity = lambda u, v: u == v
+    peek = lambda x: next(iter(x))
+    same_parity = lambda b, c: peek(b) % 2 == peek(c) % 2
+    actual = nx.quotient_graph(G, identity, same_parity)
+    expected = nx.Graph()
+    expected.add_edges_from([(0, 2), (0, 4), (2, 4)])
+    expected.add_edge(1, 3)
+    assert_true(nx.is_isomorphic(actual, expected))
+
+
+def test_condensation_as_quotient():
+    """This tests that the condensation of a graph can be viewed as the
+    quotient graph under the "in the same connected component" equivalence
+    relation.
+
+    """
+    # This example graph comes from the file `test_strongly_connected.py`.
+    G = nx.DiGraph()
+    G.add_edges_from([(1, 2), (2, 3), (2, 11), (2, 12), (3, 4), (4, 3), (4, 5),
+                      (5, 6), (6, 5), (6, 7), (7, 8), (7, 9), (7, 10), (8, 9),
+                      (9, 7), (10, 6), (11, 2), (11, 4), (11, 6), (12, 6),
+                      (12, 11)])
+    scc = list(nx.strongly_connected_components(G))
+    C = nx.condensation(G, scc)
+    component_of = C.graph['mapping']
+    # Two vertices are equivalent if they are in the same connected component.
+    same_component = lambda u, v: component_of[u] == component_of[v]
+    Q = nx.quotient_graph(G, same_component)
+    assert_true(nx.is_isomorphic(C, Q))


### PR DESCRIPTION
The quotient graph of a graph `G` with respect to an equivalence
relation `R` on the nodes of `G` is the graph whose vertex set is the
equivalence classes of `R` and where there is an edge joining class `c` to
class `d` if the vertices in `c` are adjacent to the vertices in `d`.

This commit places that function in a new module,
`networkx/algorithms/minors.py`, for functions related to graph minors.

This is a generalization of some other functions already in NetworkX. For example, the [condensation][1] of a graph can be expressed as a quotient graph under the appropriate node and edge relations. You can see an example of this in one of the unit tests.

[1]: https://networkx.github.io/documentation/latest/reference/generated/networkx.algorithms.components.strongly_connected.condensation.html#condensation