### PR TITLE
Adds vertex and edge contraction functions.

### DIFF
--- a/doc/source/reference/algorithms.minors.rst
+++ b/doc/source/reference/algorithms.minors.rst
@@ -6,4 +6,6 @@ Minors
 .. autosummary::
    :toctree: generated/
 
+   contracted_edge
+   contracted_nodes
    quotient_graph

--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -120,6 +120,10 @@ New functionalities
   Added function for computing quotient graphs; also created a new module,
   ``networkx.algorithms.minors``.
 
+* [`#1437 <https://github.com/networkx/networkx/pull/1439>`_]
+  Added node and edge contraction functions to
+  :mod:`networkx.algorithms.minors`.
+
 * [`#1445 <https://github.com/networkx/networkx/pull/1448>`_]
   Added a new modularity matrix module to ``networkx.linalg``,
   and associated spectrum functions to the ``networkx.linalg.spectrum``

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -7,11 +7,12 @@
 # NetworkX is distributed under a BSD license; see LICENSE.txt for more
 # information.
 """Provides functions for computing minors of a graph."""
+from itertools import chain
 from itertools import combinations
 from itertools import permutations
 from itertools import product
 
-__all__ = ['quotient_graph']
+__all__ = ['contracted_edge', 'contracted_nodes', 'quotient_graph']
 
 
 def peek(iterable):
@@ -69,21 +70,17 @@ def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
 
     Parameters
     ----------
-
     G : NetworkX graph
-
        The graph for which to return the quotient graph with the specified node
        relation.
 
     node_relation : Boolean function with two arguments
-
        This function must represent an equivalence relation on the nodes of
        ``G``. It must take two arguments *u* and *v* and return ``True``
        exactly when *u* and *v* are in the same equivalence class. The
-       equivalence classes form the vertices in the returned graph.
+       equivalence classes form the nodes in the returned graph.
 
     edge_relation : Boolean function with two arguments
-
        This function must represent an edge relation on the *blocks* of ``G``
        in the partition induced by ``node_relation``. It must take two
        arguments, *B* and *C*, each one a set of nodes, and return ``True``
@@ -91,12 +88,10 @@ def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
        the returned graph.
 
        If ``edge_relation`` is not specified, it is assumed to be the following
-       relation. Block *B* is related to block *C* if and only if some vertex
-       in *B* is adjacent to some vertex in *C*, according to the edge set of
-       ``G``.
+       relation. Block *B* is related to block *C* if and only if some node in
+       *B* is adjacent to some node in *C*, according to the edge set of ``G``.
 
     create_using : NetworkX graph
-
        If specified, this must be an instance of a NetworkX graph class. The
        nodes and edges of the quotient graph will be added to this graph and
        returned. If not specified, the returned graph will have the same type
@@ -104,15 +99,12 @@ def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
 
     Returns
     -------
-
     NetworkX graph
-
        The quotient graph of ``G`` under the equivalence relation specified by
        ``node_relation``.
 
     Examples
     --------
-
     The quotient graph of the complete bipartite graph under the "same
     neighbors" equivalence relation is `K_2`. Under this relation, two nodes
     are equivalent if they are not adjacent but have the same neighbor set::
@@ -147,16 +139,19 @@ def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
         >>> nx.is_isomorphic(C, Q)
         True
 
-    Vertex identification can be represented as the quotient of a graph under
-    the equivalence relation that places the two vertices in one block and each
-    other vertex in its own singleton block::
+    Node identification can be represented as the quotient of a graph under the
+    equivalence relation that places the two nodes in one block and each other
+    node in its own singleton block::
 
         >>> import networkx as nx
         >>> K24 = nx.complete_bipartite_graph(2, 4)
         >>> K34 = nx.complete_bipartite_graph(3, 4)
-        >>> vertices = {1, 2}
-        >>> is_contracted = lambda u, v: u in vertices and v in vertices
+        >>> C = nx.contracted_nodes(K34, 1, 2)
+        >>> nodes = {1, 2}
+        >>> is_contracted = lambda u, v: u in nodes and v in nodes
         >>> Q = nx.quotient_graph(K34, is_contracted)
+        >>> nx.is_isomorphic(Q, C)
+        True
         >>> nx.is_isomorphic(Q, K24)
         True
 
@@ -164,12 +159,12 @@ def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
 
     """
     H = type(create_using)() if create_using is not None else type(G)()
-    # Compute the blocks of the partition on the vertices of G induced by the
+    # Compute the blocks of the partition on the nodes of G induced by the
     # equivalence relation R.
     H.add_nodes_from(equivalence_classes(G, node_relation))
     # By default, the edge relation is the relation defined as follows. B is
-    # adjacent to C if a vertex in B is adjacent to a vertex in C, according to
-    # the edge set of G.
+    # adjacent to C if a node in B is adjacent to a node in C, according to the
+    # edge set of G.
     #
     # This is not a particularly efficient implementation of this relation:
     # there are O(n^2) pairs to check and each check may require O(log n) time
@@ -179,3 +174,134 @@ def quotient_graph(G, node_relation, edge_relation=None, create_using=None):
     block_pairs = permutations(H, 2) if H.is_directed() else combinations(H, 2)
     H.add_edges_from((b, c) for (b, c) in block_pairs if edge_relation(b, c))
     return H
+
+
+def contracted_nodes(G, u, v, self_loops=True):
+    """Returns the graph that results from contracting ``u`` and ``v``.
+
+    Node contraction identifies the two nodes as a single node incident to any
+    edge that was incident to the original two nodes.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+       The graph whose nodes will be contracted.
+
+    u, v : nodes
+       Must be nodes in ``G``.
+
+    self_loops : Boolean
+       If this is ``True``, any edges joining ``u`` and ``v`` in ``G`` become
+       self-loops on the new node in the returned graph.
+
+    Returns
+    -------
+    Networkx graph
+       A new graph object of the same type as ``G`` (leaving ``G`` unmodified)
+       with ``u`` and ``v`` identified in a single node. The right node ``v``
+       will be merged into the node ``u``, so only ``u`` will appear in the
+       returned graph.
+
+    Examples
+    --------
+    Contracting two nonadjacent nodes of the cycle graph on four nodes `C_4`
+    yields the path graph (ignoring parallel edges)::
+
+        >>> import networkx as nx
+        >>> G = nx.cycle_graph(4)
+        >>> M = nx.contracted_nodes(G, 1, 3)
+        >>> P3 = nx.path_graph(3)
+        >>> nx.is_isomorphic(M, P3)
+        True
+
+    See also
+    --------
+    contracted_edge
+    quotient_graph
+
+    """
+    H = G.copy()
+    if H.is_directed():
+        in_edges = ((w, u, d) for w, x, d in G.in_edges(v, data=True)
+                    if self_loops or w != u)
+        out_edges = ((u, w, d) for x, w, d in G.out_edges(v, data=True)
+                     if self_loops or w != u)
+        new_edges = chain(in_edges, out_edges)
+    else:
+        new_edges = ((u, w, d) for x, w, d in G.edges(v, data=True)
+                     if self_loops or w != u)
+    v_data = H.node[v]
+    H.remove_node(v)
+    H.add_edges_from(new_edges)
+    if 'contraction' in H.node[u]:
+        H.node[u]['contraction'][v] = v_data
+    else:
+        H.node[u]['contraction'] = {v: v_data}
+    return H
+
+
+def contracted_edge(G, edge, self_loops=True):
+    """Returns the graph that results from contracting the specified edge.
+
+    Edge contraction identifies the two endpoints of the edge as a single node
+    incident to any edge that was incident to the original two nodes. A graph
+    that results from edge contraction is called a *minor* of the original
+    graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+       The graph whose edge will be contracted.
+
+    edge : tuple
+       Must be a pair of nodes in ``G``.
+
+    self_loops : Boolean
+       If this is ``True``, any edges (including ``edge``) joining the
+       endpoints of ``edge`` in ``G`` become self-loops on the new node in the
+       returned graph.
+
+    Returns
+    -------
+    Networkx graph
+       A new graph object of the same type as ``G`` (leaving ``G`` unmodified)
+       with endpoints of ``edge`` identified in a single node. The right node
+       of ``edge`` will be merged into the left one, so only the left one will
+       appear in the returned graph.
+
+    Raises
+    ------
+    ValueError
+       If ``edge`` is not an edge in ``G``.
+
+    Examples
+    --------
+    Attempting to contract two nonadjacent nodes yields an error::
+
+        >>> import networkx as nx
+        >>> G = nx.cycle_graph(4)
+        >>> nx.contracted_edge(G, (1, 3))
+        Traceback (most recent call last):
+          ...
+        ValueError: Edge (1, 3) does not exist in graph G; cannot contract it
+
+    Contracting two adjacent nodes in the cycle graph on *n* nodes yields the
+    cycle graph on *n - 1* nodes::
+
+        >>> import networkx as nx
+        >>> C5 = nx.cycle_graph(5)
+        >>> C4 = nx.cycle_graph(4)
+        >>> M = nx.contracted_edge(C5, (0, 1), self_loops=False)
+        >>> nx.is_isomorphic(M, C4)
+        True
+
+    See also
+    --------
+    contracted_nodes
+    quotient_graph
+
+    """
+    if not G.has_edge(*edge):
+        raise ValueError('Edge {0} does not exist in graph G; cannot contract'
+                         ' it'.format(edge))
+    return contracted_nodes(G, *edge, self_loops=self_loops)

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -7,77 +7,141 @@
 # NetworkX is distributed under a BSD license; see LICENSE.txt for more
 # information.
 """Unit tests for the :mod:`networkx.algorithms.minors` module."""
+from nose.tools import assert_equal
 from nose.tools import assert_true
+from nose.tools import raises
 
 import networkx as nx
 
 
-# # This test requires merging pull request #1425.
-# def test_quotient_graph_complete_multipartite():
-#     """Tests that the quotient graph of the complete *n*-partite graph under
-#     the "same neighbors" node relation is the complete graph on *n* nodes.
+class TestQuotient(object):
+    """Unit tests for computing quotient graphs."""
 
-#     """
-#     G = nx.complete_multipartite_graph(2, 3, 4)
-#     # Two nodes are equivalent if they are not adjacent but have the same
-#     # neighbor set.
-#     same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
-#                                    and G[u] == G[v])
-#     expected = nx.complete_graph(3)
-#     actual = nx.quotient_graph(G, same_neighbors)
-#     # It won't take too long to run a graph isomorphism algorithm on such small
-#     # graphs.
-#     assert_true(nx.is_isomorphic(expected, actual))
+    def test_quotient_graph_complete_multipartite(self):
+        """Tests that the quotient graph of the complete *n*-partite graph
+        under the "same neighbors" node relation is the complete graph on *n*
+        nodes.
+
+        """
+        G = nx.complete_multipartite_graph(2, 3, 4)
+        # Two nodes are equivalent if they are not adjacent but have the same
+        # neighbor set.
+        same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
+                                       and G[u] == G[v])
+        expected = nx.complete_graph(3)
+        actual = nx.quotient_graph(G, same_neighbors)
+        # It won't take too long to run a graph isomorphism algorithm on such
+        # small graphs.
+        assert_true(nx.is_isomorphic(expected, actual))
+
+    def test_quotient_graph_complete_bipartite(self):
+        """Tests that the quotient graph of the complete bipartite graph under
+        the "same neighbors" node relation is `K_2`.
+
+        """
+        G = nx.complete_bipartite_graph(2, 3)
+        # Two nodes are equivalent if they are not adjacent but have the same
+        # neighbor set.
+        same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
+                                       and G[u] == G[v])
+        expected = nx.complete_graph(2)
+        actual = nx.quotient_graph(G, same_neighbors)
+        # It won't take too long to run a graph isomorphism algorithm on such
+        # small graphs.
+        assert_true(nx.is_isomorphic(expected, actual))
+
+    def test_quotient_graph_edge_relation(self):
+        """Tests for specifying an alternate edge relation for the quotient
+        graph.
+
+        """
+        G = nx.path_graph(5)
+        identity = lambda u, v: u == v
+        peek = lambda x: next(iter(x))
+        same_parity = lambda b, c: peek(b) % 2 == peek(c) % 2
+        actual = nx.quotient_graph(G, identity, same_parity)
+        expected = nx.Graph()
+        expected.add_edges_from([(0, 2), (0, 4), (2, 4)])
+        expected.add_edge(1, 3)
+        assert_true(nx.is_isomorphic(actual, expected))
+
+    def test_condensation_as_quotient(self):
+        """This tests that the condensation of a graph can be viewed as the
+        quotient graph under the "in the same connected component" equivalence
+        relation.
+
+        """
+        # This example graph comes from the file `test_strongly_connected.py`.
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (2, 3), (2, 11), (2, 12), (3, 4), (4, 3),
+                          (4, 5), (5, 6), (6, 5), (6, 7), (7, 8), (7, 9),
+                          (7, 10), (8, 9), (9, 7), (10, 6), (11, 2), (11, 4),
+                          (11, 6), (12, 6), (12, 11)])
+        scc = list(nx.strongly_connected_components(G))
+        C = nx.condensation(G, scc)
+        component_of = C.graph['mapping']
+        # Two nodes are equivalent if they are in the same connected component.
+        same_component = lambda u, v: component_of[u] == component_of[v]
+        Q = nx.quotient_graph(G, same_component)
+        assert_true(nx.is_isomorphic(C, Q))
 
 
-def test_quotient_graph_complete_bipartite():
-    """Tests that the quotient graph of the complete bipartite graph under the
-    "same neighbors" node relation is `K_2`.
+class TestContraction(object):
+    """Unit tests for node and edge contraction functions."""
 
-    """
-    G = nx.complete_bipartite_graph(2, 3)
-    # Two nodes are equivalent if they are not adjacent but have the same
-    # neighbor set.
-    same_neighbors = lambda u, v: (u not in G[v] and v not in G[u]
-                                   and G[u] == G[v])
-    expected = nx.complete_graph(2)
-    actual = nx.quotient_graph(G, same_neighbors)
-    # It won't take too long to run a graph isomorphism algorithm on such small
-    # graphs.
-    assert_true(nx.is_isomorphic(expected, actual))
+    def test_undirected_node_contraction(self):
+        """Tests for node contraction in an undirected graph."""
+        G = nx.cycle_graph(4)
+        actual = nx.contracted_nodes(G, 0, 1)
+        expected = nx.complete_graph(3)
+        expected.add_edge(0, 0)
+        assert_true(nx.is_isomorphic(actual, expected))
 
+    def test_directed_node_contraction(self):
+        """Tests for node contraction in a directed graph."""
+        G = nx.DiGraph(nx.cycle_graph(4))
+        actual = nx.contracted_nodes(G, 0, 1)
+        expected = nx.DiGraph(nx.complete_graph(3))
+        expected.add_edge(0, 0)
+        expected.add_edge(0, 0)
+        assert_true(nx.is_isomorphic(actual, expected))
 
-def test_quotient_graph_edge_relation():
-    """Tests for specifying an alternate edge relation for the quotient graph.
+    def test_node_attributes(self):
+        """Tests that node contraction preserves node attributes."""
+        G = nx.cycle_graph(4)
+        # Add some data to the two nodes being contracted.
+        G.node[0] = dict(foo='bar')
+        G.node[1] = dict(baz='xyzzy')
+        actual = nx.contracted_nodes(G, 0, 1)
+        # We expect that contracting the nodes 0 and 1 in C_4 yields K_3, but
+        # with nodes labeled 0, 2, and 3, and with a self-loop on 0.
+        expected = nx.complete_graph(3)
+        expected = nx.relabel_nodes(expected, {1: 2, 2: 3})
+        expected.add_edge(0, 0)
+        expected.node[0] = dict(foo='bar', contraction={1: dict(baz='xyzzy')})
+        assert_true(nx.is_isomorphic(actual, expected))
+        assert_equal(actual.node, expected.node)
 
-    """
-    G = nx.path_graph(5)
-    identity = lambda u, v: u == v
-    peek = lambda x: next(iter(x))
-    same_parity = lambda b, c: peek(b) % 2 == peek(c) % 2
-    actual = nx.quotient_graph(G, identity, same_parity)
-    expected = nx.Graph()
-    expected.add_edges_from([(0, 2), (0, 4), (2, 4)])
-    expected.add_edge(1, 3)
-    assert_true(nx.is_isomorphic(actual, expected))
+    def test_without_self_loops(self):
+        """Tests for node contraction without preserving self-loops."""
+        G = nx.cycle_graph(4)
+        actual = nx.contracted_nodes(G, 0, 1, self_loops=False)
+        expected = nx.complete_graph(3)
+        assert_true(nx.is_isomorphic(actual, expected))
 
+    def test_undirected_edge_contraction(self):
+        """Tests for edge contraction in an undirected graph."""
+        G = nx.cycle_graph(4)
+        actual = nx.contracted_edge(G, (0, 1))
+        expected = nx.complete_graph(3)
+        expected.add_edge(0, 0)
+        assert_true(nx.is_isomorphic(actual, expected))
 
-def test_condensation_as_quotient():
-    """This tests that the condensation of a graph can be viewed as the
-    quotient graph under the "in the same connected component" equivalence
-    relation.
+    @raises(ValueError)
+    def test_nonexistent_edge(self):
+        """Tests that attempting to contract a non-existent edge raises an
+        exception.
 
-    """
-    # This example graph comes from the file `test_strongly_connected.py`.
-    G = nx.DiGraph()
-    G.add_edges_from([(1, 2), (2, 3), (2, 11), (2, 12), (3, 4), (4, 3), (4, 5),
-                      (5, 6), (6, 5), (6, 7), (7, 8), (7, 9), (7, 10), (8, 9),
-                      (9, 7), (10, 6), (11, 2), (11, 4), (11, 6), (12, 6),
-                      (12, 11)])
-    scc = list(nx.strongly_connected_components(G))
-    C = nx.condensation(G, scc)
-    component_of = C.graph['mapping']
-    # Two vertices are equivalent if they are in the same connected component.
-    same_component = lambda u, v: component_of[u] == component_of[v]
-    Q = nx.quotient_graph(G, same_component)
-    assert_true(nx.is_isomorphic(C, Q))
+        """
+        G = nx.cycle_graph(4)
+        nx.contracted_edge(G, (0, 2))


### PR DESCRIPTION
This implements vertex and edge contraction as functions that return new
graph objects with the specified vertices or edge contracted.

This fixes issue #1057 (by creating entirely new code that I agree to license under NetworkX's BSD license).

This pull request needs some attention though.

1. I'm not sure how node attributes should be handled. Currently the code stores them in a dictionary on the contracted edge. Should they be dropped completely? Accordingly, there's an unimplemented test there.
2. Currently the code keeps the first vertex argument and removes the second argument. Should both vertices be removed and a new vertex created? How should it be named?

This pull request complements pull request #1437: if one is merged, the other needs to be rebased and merged, since they both are creating a new file called `minors.py`.
