### PR TITLE
r/networkx.github.com/networkx.github.io/

### DIFF
--- a/doc/source/reference/introduction.rst
+++ b/doc/source/reference/introduction.rst
@@ -224,7 +224,7 @@ many that we have not developed yet too.  If you implement a
 graph algorithm that might be useful for others please let 
 us know through the 
 `NetworkX Google group <http://groups.google.com/group/networkx-discuss>`_
-or the Github `Developer Zone <http://networkx.github.com/networkx/networkx>`_.
+or the Github `Developer Zone <http://networkx.github.io/networkx/networkx>`_.
 
 As an example here is code to use Dijkstra's algorithm to 
 find the shortest weighted path: 

--- a/doc/source/templates/layout.html
+++ b/doc/source/templates/layout.html
@@ -1,9 +1,9 @@
 {% extends "!layout.html" %}
 
 {% block rootrellink %}
-        <li><a href="http://networkx.github.com/">NetworkX Home </a> |&nbsp;</li>
-        <li><a href="http://networkx.github.com/documentation.html">Documentation </a>|&nbsp;</li>
-        <li><a href="http://networkx.github.com/download.html">Download </a> |&nbsp;</li>
+        <li><a href="http://networkx.github.io/">NetworkX Home </a> |&nbsp;</li>
+        <li><a href="http://networkx.github.io/documentation.html">Documentation </a>|&nbsp;</li>
+        <li><a href="http://networkx.github.io/download.html">Download </a> |&nbsp;</li>
         <li><a href="http://github.com/networkx">Developer (Github)</a></li>
 
 


### PR DESCRIPTION
This standardizes all documentation to reflect the [Github's change to the `github.io` domain for pages](https://github.com/blog/1452-new-github-pages-domain-github-io).

Sister PR in  networkx/networkx-website#6