### PR TITLE
Fixed GEXF 'viz' XML Namespace in GEXFwriter

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -261,7 +261,7 @@ class GEXFWriter(GEXF):
                             'xsi:schemaLocation':self.SCHEMALOCATION,
                             'version':self.VERSION})
 
-        ET.register_namespace('viz', "http://www.gexf.net/1.2draft/viz.xsd")
+        ET.register_namespace('viz', self.NS_VIZ)
 
         # counters for edge and attribute identifiers
         self.edge_id=itertools.count()

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -175,7 +175,7 @@ class GEXF(object):
        }
     versions['1.1draft']=d
     d={'NS_GEXF':"http://www.gexf.net/1.2draft",
-       'NS_VIZ':"http://www.gexf.net/1.2draft/viz",
+       'NS_VIZ':"http://www.gexf.net/1.2draft/viz.xsd",
        'NS_XSI':"http://www.w3.org/2001/XMLSchema-instance",
        'SCHEMALOCATION':' '.join(['http://www.gexf.net/1.2draft',
                                 'http://www.gexf.net/1.2draft/gexf.xsd'
@@ -247,7 +247,7 @@ class GEXFWriter(GEXF):
     def __init__(self, graph=None, encoding="utf-8", prettyprint=True,
                  version='1.1draft'):
         try:
-            import xml.etree.ElementTree
+            import xml.etree.ElementTree as ET
         except ImportError:
              raise ImportError('GEXF writer requires '
                                'xml.elementtree.ElementTree')
@@ -257,9 +257,11 @@ class GEXFWriter(GEXF):
         self.xml = Element("gexf",
                            {'xmlns':self.NS_GEXF,
                             'xmlns:xsi':self.NS_XSI,
-                            'xmlns:viz':self.NS_VIZ,
+                            #'xmlns:viz':self.NS_VIZ,
                             'xsi:schemaLocation':self.SCHEMALOCATION,
                             'version':self.VERSION})
+
+        ET.register_namespace('viz', "http://www.gexf.net/1.2draft/viz.xsd")
 
         # counters for edge and attribute identifiers
         self.edge_id=itertools.count()


### PR DESCRIPTION
I had a need to write a GEXF file that included the 'viz' attributes of nodes (position, color, size). I found that the current version of networkx generated a GEXF XML file with an incorrect namespace for the xmlns:viz (it returned 'ns0' tags instead of 'viz', see example below). I was able to correct this issue by:

1) Correcting the NS_VIZ URL (it was pointing to an incorrect URL).
2) Adding the "ET.register_namespace" method to the GEXFwriter **init** so that the namespace is properly registered.

Example:

The following code:

``` python
import networkx as nx

DG = nx.DiGraph()

DG.add_weighted_edges_from([("a", "b", 10)])

DG.node['a']['viz'] = {
    'position': {'x': 0, 'y': 0, 'z': 0},
    'size': 10,
    'color' : {'a': '1', 'r':"153", 'g':"153", 'b':"153"}}

DG.node['b']['viz'] = {
    'position': {'x': 50, 'y': 50, 'z': 0},
    'size': 10,
    'color' : {'a': '1', 'r':"153", 'g':"153", 'b':"153"}}

nx.write_gexf(DG, "gephi.gexf", version='1.2draft')
```

Creates the following <b>incorrect</b> XML file (note the 'ns0' tags instead of 'viz'):

``` xml
<gexf xmlns:ns0="http://www.gexf.net/1.2draft/viz" version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:viz="http://www.gexf.net/1.2draft/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance">
  <graph defaultedgetype="directed" mode="static">
    <nodes>
      <node id="a" label="a">
        <ns0:color a="1" b="153" g="153" r="153" />
        <ns0:size value="10" />
        <ns0:position x="0" y="0" z="0" />
      </node>
      <node id="b" label="b">
        <ns0:color a="1" b="153" g="153" r="153" />
        <ns0:size value="10" />
        <ns0:position x="50" y="50" z="0" />
      </node>
    </nodes>
    <edges>
      <edge id="0" source="a" target="b" weight="10" />
    </edges>
  </graph>
</gexf>
```

The new code that I'm proposing in this pull request fixes the "ns0" tags:

``` xml
<?xml version='1.0' encoding='utf-8'?>
<gexf xmlns:viz="http://www.gexf.net/1.2draft/viz.xsd" version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance">
  <graph defaultedgetype="directed" mode="static">
    <nodes>
      <node id="a" label="a">
        <viz:color a="1" b="153" g="153" r="153" />
        <viz:size value="10" />
        <viz:position x="0" y="0" z="0" />
      </node>
      <node id="b" label="b">
        <viz:color a="1" b="153" g="153" r="153" />
        <viz:size value="10" />
        <viz:position x="50" y="50" z="0" />
      </node>
    </nodes>
    <edges>
      <edge id="0" source="a" target="b" weight="10" />
    </edges>
  </graph>
</gexf>
```

Thank you for your consideration. I'm open to comments.
