### PR TITLE
Fixes formula for edge betweenness centrality

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -138,7 +138,7 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None,
 
     .. math::
 
-       c_B(v) =\sum_{s,t \in V} \frac{\sigma(s, t|e)}{\sigma(s, t)}
+       c_B(e) =\sum_{s,t \in V} \frac{\sigma(s, t|e)}{\sigma(s, t)}
 
     where `V` is the set of nodes,`\sigma(s, t)` is the number of
     shortest `(s, t)`-paths, and `\sigma(s, t|e)` is the number of


### PR DESCRIPTION
There's another issue that I couldn't fix. The first occurrence of `\sigma(s, t)` after the formula does not render correctly. 