### PR TITLE
Replaces cumulative_sum with accumulate.

### DIFF
--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -84,7 +84,7 @@ def _compute_rc(G):
     deghist = nx.degree_histogram(G)
     total = sum(deghist)
     # number of nodes with degree > k (omit last entry which is zero)
-    nks = [total-cs for cs in nx.utils.cumulative_sum(deghist) if total-cs > 1]
+    nks = [total-cs for cs in nx.utils.accumulate(deghist) if total-cs > 1]
     deg=G.degree()
     edge_degrees=sorted(sorted((deg[u],deg[v])) for u,v in G.edges_iter()) 
     ek=G.number_of_edges()

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -342,7 +342,7 @@ def navigable_small_world_graph(n, p=1, q=1, r=2, dim=2, seed=None):
             if d <= p:
                 G.add_edge(p1,p2)
             probs.append(d**-r)
-        cdf = list(nx.utils.cumulative_sum(probs))
+        cdf = list(nx.utils.accumulate(probs))
         for _ in range(q):
             target = nodes[bisect_left(cdf,random.uniform(0, cdf[-1]))]
             G.add_edge(p1,target)

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -16,6 +16,28 @@ True
 #    BSD license.
 import sys
 import uuid
+# itertools.accumulate is only available on Python 3.2 or later.
+#
+# Once support for Python versions less than 3.2 is dropped, this code should
+# be removed.
+try:
+    from itertools import accumulate
+except ImportError:
+    import operator
+
+    # The code for this function is from the Python 3.5 documentation,
+    # distributed under the PSF license:
+    # <https://docs.python.org/3.5/library/itertools.html#itertools.accumulate>
+    def accumulate(iterable, func=operator.add):
+        it = iter(iterable)
+        try:
+            total = next(it)
+        except StopIteration:
+            return
+        yield total
+        for element in it:
+            total = func(total, element)
+            yield total
 
 import networkx as nx
 
@@ -84,17 +106,6 @@ else:
         """Return the string representation of t."""
         return str(x)
 
-def cumulative_sum(numbers):
-    """Yield cumulative sum of numbers.
-
-    >>> import networkx.utils as utils
-    >>> list(utils.cumulative_sum([1,2,3,4]))
-    [1, 3, 6, 10]
-    """
-    csum = 0
-    for n in numbers:
-        csum += n
-        yield csum
 
 def generate_unique_node():
     """ Generate a unique node label."""


### PR DESCRIPTION
Python 3.2 introduces the `itertools.accumulate()`. Before, we were
using less flexible custom code for performing the same task, in
`networkx.utils.misc.cumulative_sum`. This commit replaces calls to
`cumulative_sum` with calls to `itertools.accumulate()`.

Since we currently still support Python 2.7, this commit adds a fallback
equivalent definition of accumulate that matches the Python 3.2
implementation. Once support for Python 2.7 is dropped, all of this code
can be removed, and calls to `networkx.utils.accumulate()` can be
replaced by calls to `itertools.accumulate()`.

This will also affect pull request #1425; if one is merged, the other should be updated.