### PR TITLE
Simplify and speed up nx.non_edges

### DIFF
--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,23 +1,25 @@
 import math
 
+from functools import partial
 from nose.tools import *
 
 import networkx as nx
 
 
+def _test_func(G, ebunch, expected, predict_func, **kwargs):
+    result = predict_func(G, ebunch, **kwargs)
+    exp_dict = dict((tuple(sorted([u, v])), score) for u, v, score in expected)
+    res_dict = dict((tuple(sorted([u, v])), score) for u, v, score in result)
+
+    assert_equal(len(exp_dict), len(res_dict))
+    for p in exp_dict:
+        assert_almost_equal(exp_dict[p], res_dict[p])
+
+
 class TestResourceAllocationIndex():
     def setUp(self):
         self.func = nx.resource_allocation_index
-
-        def test_func(G, ebunch, expected):
-            result = self.func(G, ebunch)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_almost_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func)
 
     def test_K5(self):
         G = nx.complete_graph(5)
@@ -67,16 +69,7 @@ class TestResourceAllocationIndex():
 class TestJaccardCoefficient():
     def setUp(self):
         self.func = nx.jaccard_coefficient
-
-        def test_func(G, ebunch, expected):
-            result = self.func(G, ebunch)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_almost_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func)
 
     def test_K5(self):
         G = nx.complete_graph(5)
@@ -123,16 +116,7 @@ class TestJaccardCoefficient():
 class TestAdamicAdarIndex():
     def setUp(self):
         self.func = nx.adamic_adar_index
-
-        def test_func(G, ebunch, expected):
-            result = self.func(G, ebunch)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_almost_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func)
 
     def test_K5(self):
         G = nx.complete_graph(5)
@@ -183,16 +167,7 @@ class TestAdamicAdarIndex():
 class TestPreferentialAttachment():
     def setUp(self):
         self.func = nx.preferential_attachment
-
-        def test_func(G, ebunch, expected):
-            result = self.func(G, ebunch)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func)
 
     def test_K5(self):
         G = nx.complete_graph(5)
@@ -238,16 +213,8 @@ class TestPreferentialAttachment():
 class TestCNSoundarajanHopcroft():
     def setUp(self):
         self.func = nx.cn_soundarajan_hopcroft
-
-        def test_func(G, ebunch, expected, community='community'):
-            result = self.func(G, ebunch, community)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func,
+                            community='community')
 
     def test_K5(self):
         G = nx.complete_graph(5)
@@ -369,16 +336,8 @@ class TestCNSoundarajanHopcroft():
 class TestRAIndexSoundarajanHopcroft():
     def setUp(self):
         self.func = nx.ra_index_soundarajan_hopcroft
-
-        def test_func(G, ebunch, expected, community='community'):
-            result = self.func(G, ebunch, community)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_almost_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func,
+                            community='community')
 
     def test_K5(self):
         G = nx.complete_graph(5)
@@ -501,17 +460,8 @@ class TestWithinInterCluster():
     def setUp(self):
         self.delta = 0.001
         self.func = nx.within_inter_cluster
-
-        def test_func(G, ebunch, expected, delta=self.delta,
-                      community='community'):
-            result = self.func(G, ebunch, delta, community)
-            for res, exp in zip(result, expected):
-                assert_true(isinstance(res, tuple))
-                assert_equal(3, len(res))
-                assert_equal(res[0], exp[0])
-                assert_equal(res[1], exp[1])
-                assert_almost_equal(res[2], exp[2])
-        self.test = test_func
+        self.test = partial(_test_func, predict_func=self.func,
+                            delta=self.delta, community='community')
 
     def test_K5(self):
         G = nx.complete_graph(5)

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -498,12 +498,9 @@ def non_edges(graph):
             for v in non_neighbors(graph, u):
                 yield (u, v)
     else:
-        S = set()
-        for u in graph.nodes_iter():
-            for v in non_neighbors(graph, u):
-                if (u, v) not in S:
-                    yield (u, v)
-                    S.add((v, u))
+        for u, v in itertools.combinations(graph, 2):
+            if not graph.has_edge(u, v):
+                yield (u, v)
 
 
 @not_implemented_for('directed')

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -498,8 +498,10 @@ def non_edges(graph):
             for v in non_neighbors(graph, u):
                 yield (u, v)
     else:
-        for u, v in itertools.combinations(graph, 2):
-            if not graph.has_edge(u, v):
+        nodes = set(graph)
+        while nodes:
+            u = nodes.pop()
+            for v in nodes - set(graph[u]):
                 yield (u, v)
 
 


### PR DESCRIPTION
This simplifies the code in `nx.non_edges` for undirected networks a bit. Performance comparison:

Old version:

    In [18]: G =nx.random_regular_graph(5, 2000, seed=1)
    
    In [19]: %timeit list(nx.non_edges(G))
    1 loops, best of 3: 2.52 s per loop

New version:

    In [10]: G = nx.random_regular_graph(5, 2000, seed=1)
    
    In [11]: %timeit list(nx.non_edges(G))
    1 loops, best of 3: 812 ms per loop

Since it doesn't keep a set of 'seen' edges, it probably uses less RAM (though I haven't checked).