### PR TITLE
bug - use of deprecated syntax (print and except) fixed

### DIFF
--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -15,6 +15,7 @@ something like 'current' as a stable URL for the most current version"""
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 import os
 import re
 import shutil
@@ -128,13 +129,11 @@ if __name__ == '__main__':
 
         sh('git add -A %s' % tag)
         sh('git commit -m"Updated doc release: %s"' % tag)
-        print
-        print 'Most recent 3 commits:'
+        print('\nMost recent 3 commits:')
         sys.stdout.flush()
         sh('git --no-pager log --oneline HEAD~3..')
     finally:
         cd(startdir)
 
-    print
-    print 'Now verify the build in: %r' % dest
-    print "If everything looks good, 'git push'"
+    print('\nNow verify the build in: %r' % dest)
+    print("If everything looks good, 'git push'")

--- a/doc/gitwash_dumper.py
+++ b/doc/gitwash_dumper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 ''' Checkout gitwash repo into directory and do search replace on name '''
 
+from __future__ import print_function
 import os
 from os.path import join as pjoin
 import shutil
@@ -79,7 +80,7 @@ def copy_replace(replace_pairs,
     for rep_glob in rep_globs:
         fnames += fnmatch.filter(out_fnames, rep_glob)
     if verbose:
-        print '\n'.join(fnames)
+        print('\n'.join(fnames))
     for fname in fnames:
         filename_search_replace(replace_pairs, fname, False)
         for in_exp, out_exp in renames:

--- a/doc/make_examples_rst.py
+++ b/doc/make_examples_rst.py
@@ -4,6 +4,7 @@ generate the rst files for the examples by iterating over the networkx examples
 """
 # This code was developed from the Matplotlib gen_rst.py module
 # and is distributed with the same license as Matplotlib
+from __future__ import print_function
 import os, glob
 
 import os
@@ -124,7 +125,7 @@ NetworkX Examples
                 not out_of_date(fullpath, outfile)):
                 continue
 
-            print '%s/%s'%(subdir,fname)
+            print('%s/%s' % (subdir,fname))
 
             fhstatic = file(static_file, 'w')
             fhstatic.write(contents)
@@ -167,13 +168,13 @@ if __name__ == '__main__':
         arg0,arg1,arg2=sys.argv[:3]
     except:
         arg0=sys.argv[0]
-        print """
+        print("""
 Usage:  %s exampledir sourcedir 
 
     exampledir: a directory containing the python code for the examples.
     sourcedir: a directory to put the generated documentation source for these examples.
 
-        """%arg0
+        """ % (arg0))
     else:
         main(arg1,arg2)
 

--- a/doc/make_gallery.py
+++ b/doc/make_gallery.py
@@ -16,7 +16,7 @@ template = """\
 link_template = """\
 <a href="%s"><img src="%s" border="0" alt="%s"/></a>
 """
-
+from __future__ import print_function
 import os, glob, re, shutil, sys
 import matplotlib
 matplotlib.use("Agg")
@@ -48,7 +48,7 @@ for example in all_examples:
         stale_examples.append(example)
 
 for example in stale_examples:
-    print example,
+    print(example, end=" ")
     png=example.replace('py','png')                             
     matplotlib.pyplot.figure(figsize=(6,6))
     stdout=sys.stdout
@@ -56,10 +56,10 @@ for example in stale_examples:
     try:
         execfile(example)
         sys.stdout=stdout
-        print " OK"
-    except ImportError,strerr:
+        print(" OK")
+    except ImportError as strerr:
         sys.stdout=stdout
-        sys.stdout.write(" FAIL: %s\n"%strerr)
+        sys.stdout.write(" FAIL: %s\n" % strerr)
         continue
     matplotlib.pyplot.clf()
     im=matplotlib.image.imread(png)


### PR DESCRIPTION
I am using networkx library to hold a syntantic analysis of python source code and I noticed that you had some deprecated python statements (print and except for Python:v2.5) that could be easily solve.
The new syntaxt shouldn't change anything of the library but mainly for the documentation

Hope it helps ;)