### PR TITLE
Adds Johnson's algorithm for computing all pairs shortest paths

### DIFF
--- a/doc/source/reference/algorithms.shortest_paths.rst
+++ b/doc/source/reference/algorithms.shortest_paths.rst
@@ -39,6 +39,7 @@ Advanced Interface
    dijkstra_predecessor_and_distance
    bellman_ford
    negative_edge_cycle
+   johnson
 
 
 Dense Graphs

--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -152,15 +152,15 @@ New functionalities
   Adds ``triadic_census`` function; also creates a new module,
   :mod:`networkx.algorithms.triads`.
 
-* [`#1476 <https://github.com/networkx/networkx/pull/1476>`_]
-  Adds functions for testing if a graph has weighted or negatively weighted
-  edges. Also adds a function for testing if a graph is empty. These are
-  ``is_weighted``, ``is_negatively_weighted``, and ``is_empty``.
-
 * [`#1481 <https://github.com/networkx/networkx/pull/1481>`_]
   Added Johnson's algorithm; one more algorithm for shortest paths. It
   solves all pairs shortest path problem. This is ``johnson`` at
   ``algorithms.shortest_paths``
+
+* [`#1476 <https://github.com/networkx/networkx/pull/1476>`_]
+  Adds functions for testing if a graph has weighted or negatively weighted
+  edges. Also adds a function for testing if a graph is empty. These are
+  ``is_weighted``, ``is_negatively_weighted``, and ``is_empty``.
 
 Removed functionalities
 -----------------------

--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -157,6 +157,11 @@ New functionalities
   edges. Also adds a function for testing if a graph is empty. These are
   ``is_weighted``, ``is_negatively_weighted``, and ``is_empty``.
 
+* [`#1481 <https://github.com/networkx/networkx/pull/1481>`_]
+  Added Johnson's algorithm; one more algorithm for shortest paths. It
+  solves all pairs shortest path problem. This is ``johnson`` at
+  ``algorithms.shortest_paths``
+
 Removed functionalities
 -----------------------
 

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -303,3 +303,60 @@ class TestBellmanFordAndGoldbergRadizk:
                       ((1, 0), (0, 0)), ((1, 1), (0, 1))])
         assert_equal(sorted(dist.items()),
                      [((0, 0), 0), ((0, 1), 1), ((1, 0), 1), ((1, 1), 2)])
+
+
+class TestJohnsonAlgorithm:
+
+    setUp = _setUp
+
+    @raises(nx.NetworkXError)
+    def test_single_node_graph(self):
+        G = nx.DiGraph()
+        G.add_node(0)
+        nx.johnson(G)
+
+    def test_negative_cycle(self):
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -5),
+                                     ('0', '2', 2), ('1', '2', 4),
+                                     ('2', '3', 1)])
+        assert_raises(nx.NetworkXUnbounded, nx.johnson, G)
+        G = nx.Graph()
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -5),
+                                     ('0', '2', 2), ('1', '2', 4),
+                                     ('2', '3', 1)])
+        assert_raises(nx.NetworkXUnbounded, nx.johnson, G)
+
+
+    def test_negative_weights(self):
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5),
+                                     ('0', '2', 2), ('1', '2', 4),
+                                     ('2', '3', 1)])
+        paths = nx.johnson(G)
+        assert_equal(paths, {'1': {'1': ['1'], '3': ['1', '2', '3'],
+                             '2': ['1', '2']}, '0': {'1': ['0', '1'],
+                             '0': ['0'], '3': ['0', '1', '2', '3'],
+                             '2': ['0', '1', '2']}, '3': {'3': ['3']},
+                             '2': {'3': ['2', '3'], '2': ['2']}})
+        paths = nx.johnson(G, new_weight='new_weight')
+        assert_equal(paths, {'1': {'1': ['1'], '3': ['1', '2', '3'],
+                             '2': ['1', '2']}, '0': {'1': ['0', '1'],
+                             '0': ['0'], '3': ['0', '1', '2', '3'],
+                             '2': ['0', '1', '2']}, '3': {'3': ['3']},
+                             '2': {'3': ['2', '3'], '2': ['2']}})
+        for u, v, w in G.edges(data=True):
+            assert_true('new_weight' in w)
+
+    @raises(nx.NetworkXError)
+    def test_unweighted_graph(self):
+        G = nx.path_graph(5)
+        nx.johnson(G)
+
+    def test_graphs(self):
+        validate_path(self.XG, 's', 'v', 9, nx.johnson(self.XG)['s']['v'])
+        validate_path(self.MXG, 's', 'v', 9, nx.johnson(self.MXG)['s']['v'])
+        validate_path(self.XG2, 1, 3, 4, nx.johnson(self.XG2)[1][3])
+        validate_path(self.XG3, 0, 3, 15, nx.johnson(self.XG3)[0][3])
+        validate_path(self.XG4, 0, 2, 4, nx.johnson(self.XG4)[0][2])
+        validate_path(self.MXG4, 0, 2, 4, nx.johnson(self.MXG4)[0][2])


### PR DESCRIPTION
Johnson's algorithm is one more algorithm for the shortest paths.
This algorithm solves all pairs shortest paths, and may be faster than Floyd–Warshall on sparse graphs.

For this reason, this pull request adds __johnson()__ which implements the main algorithm.
The ___reweight_graph_johnson()__ and ___add_node_johnson()__ are parts of the algorithm.