### PR TITLE
Fix unit test for katz centrality.

### DIFF
--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -315,8 +315,7 @@ class TestKatzEigenvectorVKatz(object):
             raise SkipTest('SciPy not available.')
 
     def test_eigenvector_v_katz_random(self):
-        np.random.seed(1234)
-        G = networkx.gnp_random_graph(10,0.5)
+        G = networkx.gnp_random_graph(10,0.5, seed=1234)
         l = float(max(eigvals(networkx.adjacency_matrix(G).todense())))
         e = networkx.eigenvector_centrality_numpy(G)
         k = networkx.katz_centrality_numpy(G, 1.0/l)


### PR DESCRIPTION
There was a random failure on TravisCI recently:

https://travis-ci.org/networkx/networkx/jobs/58959952

```
======================================================================
ERROR: test_katz_centrality.TestKatzEigenvectorVKatz.test_eigenvector_v_katz_random
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/networkx/algorithms/centrality/tests/test_katz_centrality.py", line 322, in test_eigenvector_v_katz_random
    k = networkx.katz_centrality_numpy(G, 1.0/l)
  File "<string>", line 2, in katz_centrality_numpy
  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/networkx/utils/decorators.py", line 68, in _not_implemented_for
    return f(*args,**kwargs)
  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/networkx/algorithms/centrality/katz.py", line 327, in katz_centrality_numpy
    centrality = np.linalg.solve( np.eye(n,n) - (alpha * A) , b)
  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/numpy/linalg/linalg.py", line 381, in solve
    r = gufunc(a, b, signature=signature, extobj=extobj)
  File "/home/travis/miniconda/envs/test-environment/lib/python3.4/site-packages/numpy/linalg/linalg.py", line 90, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
numpy.linalg.linalg.LinAlgError: Singular matrix
```

This should be investigated and fixed.