### PR TITLE
Removes reference to nonexistent function

### DIFF
--- a/doc/source/reference/utils.rst
+++ b/doc/source/reference/utils.rst
@@ -16,7 +16,6 @@ Helper Functions
    iterable
    is_list_of_ints
    make_str
-   cumulative_sum
    generate_unique_node
    default_opener
 


### PR DESCRIPTION
Pull request #1463 removed the `cumulative_sum` function. This commit removes the reference to it in the documentation.