### PR TITLE
Refactor connected components

### DIFF
--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -8,6 +8,14 @@ NetworkX 1.9 to NetworkX 2.0.
 Please send comments and questions to the networkx-discuss mailing list:
 <http://groups.google.com/group/networkx-discuss>.
 
+API changes
+-----------
+* [`#1501 <https://github.com/networkx/networkx/pull/1501>`_]
+  ``connected_components`` is now a generator of sets of nodes. It was a
+  generator of lists. This PR also refactored the ``connected_components``
+  implementation making it faster, especially for large graphs.
+
+
 New functionalities
 -------------------
 

--- a/doc/source/reference/api_2.0.rst
+++ b/doc/source/reference/api_2.0.rst
@@ -11,9 +11,11 @@ Please send comments and questions to the networkx-discuss mailing list:
 API changes
 -----------
 * [`#1501 <https://github.com/networkx/networkx/pull/1501>`_]
-  ``connected_components`` is now a generator of sets of nodes. It was a
-  generator of lists. This PR also refactored the ``connected_components``
-  implementation making it faster, especially for large graphs.
+  ``connected_components``, ``weakly_connected_components``, and
+  ``strongly_connected_components`` return now a generator of sets of
+  nodes. Previously the generator was of lists of nodes. This PR also
+  refactored the ``connected_components`` and ``weakly_connected_components``
+  implementations making them faster, especially for large graphs.
 
 
 New functionalities

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -36,15 +36,15 @@ def attracting_components(G):
 
     Returns
     -------
-    attractors : generator of list
-        The list of attracting components, sorted from largest attracting
-        component to smallest attracting component.
+    attractors : generator of sets
+        A generator of sets of nodes, one for each attracting component of G.
 
     See Also
     --------
     number_attracting_components
     is_attracting_component 
     attracting_component_subgraphs
+
     """
     scc = list(nx.strongly_connected_components(G))
     cG = nx.condensation(G, scc)
@@ -129,6 +129,7 @@ def attracting_component_subgraphs(G, copy=True):
     attracting_components
     number_attracting_components
     is_attracting_component
+
     """
     for ac in attracting_components(G):
         if copy:

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -11,15 +11,19 @@ Biconnected components and articulation points.
 from itertools import chain
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
+
 __author__ = '\n'.join(['Jordi Torrents <jtorrents@milnou.net>',
                         'Dan Schult <dschult@colgate.edu>',
                         'Aric Hagberg <aric.hagberg@gmail.com>'])
-__all__ = ['biconnected_components',
-           'biconnected_component_edges',
-           'biconnected_component_subgraphs',
-           'is_biconnected',
-           'articulation_points',
-           ]
+
+__all__ = [
+    'biconnected_components',
+    'biconnected_component_edges',
+    'biconnected_component_subgraphs',
+    'is_biconnected',
+    'articulation_points',
+]
+
 
 @not_implemented_for('directed')
 def is_biconnected(G):
@@ -48,18 +52,18 @@ def is_biconnected(G):
 
     Examples
     --------
-    >>> G=nx.path_graph(4)
+    >>> G = nx.path_graph(4)
     >>> print(nx.is_biconnected(G))
     False
-    >>> G.add_edge(0,3)
+    >>> G.add_edge(0, 3)
     >>> print(nx.is_biconnected(G))
     True
 
     See Also
     --------
-    biconnected_components,
-    articulation_points,
-    biconnected_component_edges,
+    biconnected_components
+    articulation_points
+    biconnected_component_edges
     biconnected_component_subgraphs
 
     Notes
@@ -80,11 +84,13 @@ def is_biconnected(G):
     .. [1] Hopcroft, J.; Tarjan, R. (1973).
        "Efficient algorithms for graph manipulation".
        Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+
     """
     bcc = list(biconnected_components(G))
     if not bcc: # No bicomponents (it could be an empty graph)
         return False
     return len(bcc[0]) == len(G)
+
 
 @not_implemented_for('directed')
 def biconnected_component_edges(G):
@@ -116,14 +122,18 @@ def biconnected_component_edges(G):
 
     Examples
     --------
-    >>> G = nx.barbell_graph(4,2)
+    >>> G = nx.barbell_graph(4, 2)
     >>> print(nx.is_biconnected(G))
     False
-    >>> components = nx.biconnected_component_edges(G)
-    >>> G.add_edge(2,8)
+    >>> bicomponents_edges = list(nx.biconnected_component_edges(G))
+    >>> len(bicomponents_edges)
+    5
+    >>> G.add_edge(2, 8)
     >>> print(nx.is_biconnected(G))
     True
-    >>> components = nx.biconnected_component_edges(G)
+    >>> bicomponents_edges = list(nx.biconnected_component_edges(G))
+    >>> len(bicomponents_edges)
+    1
 
     See Also
     --------
@@ -148,11 +158,13 @@ def biconnected_component_edges(G):
     References
     ----------
     .. [1] Hopcroft, J.; Tarjan, R. (1973).
-       "Efficient algorithms for graph manipulation".
-       Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+           "Efficient algorithms for graph manipulation".
+           Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+
     """
-    for comp in _biconnected_dfs(G,components=True):
+    for comp in _biconnected_dfs(G, components=True):
         yield comp
+
 
 @not_implemented_for('directed')
 def biconnected_components(G):
@@ -185,14 +197,30 @@ def biconnected_components(G):
 
     Examples
     --------
-    >>> G = nx.barbell_graph(4,2)
+    >>> G = nx.lollipop_graph(5, 1)
     >>> print(nx.is_biconnected(G))
     False
-    >>> components = nx.biconnected_components(G)
-    >>> G.add_edge(2,8)
+    >>> bicomponents = list(nx.biconnected_components(G))
+    >>> len(bicomponents)
+    2
+    >>> G.add_edge(0, 5)
     >>> print(nx.is_biconnected(G))
     True
-    >>> components = nx.biconnected_components(G)
+    >>> bicomponents = list(nx.biconnected_components(G))
+    >>> len(bicomponents)
+    1
+
+    You can generate a sorted list of biconnected components, largest
+    first, using sort.
+
+    >>> G.remove_edge(0, 5)
+    >>> [len(c) for c in sorted(nx.biconnected_components(G), key=len, reverse=True)]
+    [5, 2]
+
+    If you only want the largest connected component, it's more
+    efficient to use max instead of sort.
+
+    >>> Gc = max(nx.biconnected_components(G), key=len)
 
     See Also
     --------
@@ -217,10 +245,11 @@ def biconnected_components(G):
     References
     ----------
     .. [1] Hopcroft, J.; Tarjan, R. (1973).
-       "Efficient algorithms for graph manipulation".
-       Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+           "Efficient algorithms for graph manipulation".
+           Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+
     """
-    for comp in _biconnected_dfs(G,components=True):
+    for comp in _biconnected_dfs(G, components=True):
         yield set(chain.from_iterable(comp))
 
 @not_implemented_for('directed')
@@ -254,10 +283,32 @@ def biconnected_component_subgraphs(G, copy=True):
 
     Examples
     --------
-    >>> G = nx.barbell_graph(4,2)
+
+    >>> G = nx.lollipop_graph(5, 1)
     >>> print(nx.is_biconnected(G))
     False
-    >>> subgraphs = list(nx.biconnected_component_subgraphs(G))
+    >>> bicomponents = list(nx.biconnected_component_subgraphs(G))
+    >>> len(bicomponents)
+    2
+    >>> G.add_edge(0, 5)
+    >>> print(nx.is_biconnected(G))
+    True
+    >>> bicomponents = list(nx.biconnected_component_subgraphs(G))
+    >>> len(bicomponents)
+    1
+
+    You can generate a sorted list of biconnected components, largest
+    first, using sort.
+
+    >>> G.remove_edge(0, 5)
+    >>> [len(c) for c in sorted(nx.biconnected_component_subgraphs(G),
+    ...                         key=len, reverse=True)]
+    [5, 2]
+
+    If you only want the largest connected component, it's more
+    efficient to use max instead of sort.
+
+    >>> Gc = max(nx.biconnected_component_subgraphs(G), key=len)
 
     See Also
     --------
@@ -284,14 +335,16 @@ def biconnected_component_subgraphs(G, copy=True):
     References
     ----------
     .. [1] Hopcroft, J.; Tarjan, R. (1973).
-       "Efficient algorithms for graph manipulation".
-       Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+           "Efficient algorithms for graph manipulation".
+           Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+
     """
     for comp_nodes in biconnected_components(G):
         if copy:
             yield G.subgraph(comp_nodes).copy()
         else:
             yield G.subgraph(comp_nodes)
+
 
 @not_implemented_for('directed')
 def articulation_points(G):
@@ -322,16 +375,17 @@ def articulation_points(G):
 
     Examples
     --------
-    >>> G = nx.barbell_graph(4,2)
+
+    >>> G = nx.barbell_graph(4, 2)
     >>> print(nx.is_biconnected(G))
     False
-    >>> list(nx.articulation_points(G))
-    [6, 5, 4, 3]
-    >>> G.add_edge(2,8)
+    >>> len(list(nx.articulation_points(G)))
+    4
+    >>> G.add_edge(2, 8)
     >>> print(nx.is_biconnected(G))
     True
-    >>> list(nx.articulation_points(G))
-    []
+    >>> len(list(nx.articulation_points(G)))
+    0
 
     See Also
     --------
@@ -356,10 +410,12 @@ def articulation_points(G):
     References
     ----------
     .. [1] Hopcroft, J.; Tarjan, R. (1973).
-       "Efficient algorithms for graph manipulation".
-       Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+           "Efficient algorithms for graph manipulation".
+           Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
+
     """
-    return _biconnected_dfs(G,components=False)
+    return _biconnected_dfs(G, components=False)
+
 
 @not_implemented_for('directed')
 def _biconnected_dfs(G, components=True):

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -17,9 +17,9 @@ class TestAttractingComponents(object):
 
     def test_attracting_components(self):
         ac = list(nx.attracting_components(self.G1))
-        assert_true([2] in ac)
-        assert_true([9] in ac)
-        assert_true([10] in ac)
+        assert_true({2} in ac)
+        assert_true({9} in ac)
+        assert_true({10} in ac)
 
         ac = list(nx.attracting_components(self.G2))
         ac = [tuple(sorted(x)) for x in ac]

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -23,7 +23,7 @@ class TestAttractingComponents(object):
 
         ac = list(nx.attracting_components(self.G2))
         ac = [tuple(sorted(x)) for x in ac]
-        assert_true(ac == [(1,2)])
+        assert_true(ac == [(1, 2)])
 
         ac = list(nx.attracting_components(self.G3))
         ac = [tuple(sorted(x)) for x in ac]
@@ -42,43 +42,6 @@ class TestAttractingComponents(object):
         assert_false(nx.is_attracting_component(self.G3))
         g2 = self.G3.subgraph([1, 2])
         assert_true(nx.is_attracting_component(g2))
-
-    def test_attracting_component_subgraphs(self):
-        subgraphs = list(nx.attracting_component_subgraphs(self.G1))
-        for subgraph in subgraphs:
-            assert_equal(len(subgraph), 1)
-        # test attrs copied to subgraphs
-        self.G2.add_edge(1,2,eattr='red')
-        self.G2.node[2]['nattr'] = 'blue'
-        self.G2.graph['gattr'] = 'green'
-        subgraphs = list(nx.attracting_component_subgraphs(self.G2))
-        assert_equal(len(subgraphs), 1)
-        SG2 = subgraphs[0]
-        assert_true(1 in SG2)
-        assert_true(2 in SG2)
-        assert_equal(SG2[1][2]['eattr'], 'red')
-        assert_equal(SG2.node[2]['nattr'], 'blue')
-        assert_equal(SG2.graph['gattr'], 'green')
-        SG2.add_edge(1, 2, eattr='blue')
-        assert_equal(SG2[1][2]['eattr'], 'blue')
-        assert_equal(self.G2[1][2]['eattr'], 'red')
-
-    def test_attracting_no_copy(self):
-        # test attrs not copied to subgraphs
-        self.G2.add_edge(1, 2, eattr='red')
-        self.G2.node[2]['nattr'] = 'blue'
-        self.G2.graph['gattr'] = 'green'
-        subgraphs = list(nx.attracting_component_subgraphs(self.G2, copy=False))
-        assert_equal(len(subgraphs), 1)
-        SG2 = subgraphs[0]
-        assert_true(1 in SG2)
-        assert_true(2 in SG2)
-        assert_equal(SG2[1][2]['eattr'], 'red')
-        assert_equal(SG2.node[2]['nattr'], 'blue')
-        assert_equal(SG2.graph['gattr'], 'green')
-        SG2.add_edge(1, 2, eattr='blue')
-        assert_equal(SG2[1][2]['eattr'], 'blue')
-        assert_equal(self.G2[1][2]['eattr'], 'blue')
 
     def test_connected_raise(self):
         G=nx.Graph()

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -7,13 +7,13 @@ from networkx import NetworkXNotImplemented
 class TestAttractingComponents(object):
     def setUp(self):
         self.G1 = nx.DiGraph()
-        self.G1.add_edges_from([(5,11),(11,2),(11,9),(11,10),
-                                (7,11),(7,8),(8,9),(3,8),(3,10)])
+        self.G1.add_edges_from([(5, 11), (11, 2), (11, 9), (11, 10),
+                                (7, 11), (7, 8), (8, 9), (3, 8), (3, 10)])
         self.G2 = nx.DiGraph()
-        self.G2.add_edges_from([(0,1),(0,2),(1,1),(1,2),(2,1)])
+        self.G2.add_edges_from([(0, 1), (0, 2), (1, 1), (1, 2), (2, 1)])
 
         self.G3 = nx.DiGraph()
-        self.G3.add_edges_from([(0,1),(1,2),(2,1),(0,3),(3,4),(4,3)])
+        self.G3.add_edges_from([(0, 1), (1, 2), (2, 1), (0, 3), (3, 4), (4, 3)])
 
     def test_attracting_components(self):
         ac = list(nx.attracting_components(self.G1))
@@ -27,45 +27,62 @@ class TestAttractingComponents(object):
 
         ac = list(nx.attracting_components(self.G3))
         ac = [tuple(sorted(x)) for x in ac]
-        assert_true((1,2) in ac)
-        assert_true((3,4) in ac)
+        assert_true((1, 2) in ac)
+        assert_true((3, 4) in ac)
         assert_equal(len(ac), 2)
 
     def test_number_attacting_components(self):
-        assert_equal(len(list(nx.attracting_components(self.G1))), 3)
-        assert_equal(len(list(nx.attracting_components(self.G2))), 1)
-        assert_equal(len(list(nx.attracting_components(self.G3))), 2)
+        assert_equal(nx.number_attracting_components(self.G1), 3)
+        assert_equal(nx.number_attracting_components(self.G2), 1)
+        assert_equal(nx.number_attracting_components(self.G3), 2)
 
     def test_is_attracting_component(self):
         assert_false(nx.is_attracting_component(self.G1))
         assert_false(nx.is_attracting_component(self.G2))
         assert_false(nx.is_attracting_component(self.G3))
-        g2 = self.G3.subgraph([1,2])
+        g2 = self.G3.subgraph([1, 2])
         assert_true(nx.is_attracting_component(g2))
 
     def test_attracting_component_subgraphs(self):
         subgraphs = list(nx.attracting_component_subgraphs(self.G1))
         for subgraph in subgraphs:
             assert_equal(len(subgraph), 1)
-
-        self.G2.add_edge(1,2,eattr='red')  # test attrs copied to subgraphs
-        self.G2.node[2]['nattr']='blue'
-        self.G2.graph['gattr']='green'
+        # test attrs copied to subgraphs
+        self.G2.add_edge(1,2,eattr='red')
+        self.G2.node[2]['nattr'] = 'blue'
+        self.G2.graph['gattr'] = 'green'
         subgraphs = list(nx.attracting_component_subgraphs(self.G2))
         assert_equal(len(subgraphs), 1)
-        SG2=subgraphs[0]
+        SG2 = subgraphs[0]
         assert_true(1 in SG2)
         assert_true(2 in SG2)
-        assert_equal(SG2[1][2]['eattr'],'red')
-        assert_equal(SG2.node[2]['nattr'],'blue')
-        assert_equal(SG2.graph['gattr'],'green')
-        SG2.add_edge(1,2,eattr='blue')
-        assert_equal(SG2[1][2]['eattr'],'blue')
-        assert_equal(self.G2[1][2]['eattr'],'red')
+        assert_equal(SG2[1][2]['eattr'], 'red')
+        assert_equal(SG2.node[2]['nattr'], 'blue')
+        assert_equal(SG2.graph['gattr'], 'green')
+        SG2.add_edge(1, 2, eattr='blue')
+        assert_equal(SG2[1][2]['eattr'], 'blue')
+        assert_equal(self.G2[1][2]['eattr'], 'red')
+
+    def test_attracting_no_copy(self):
+        # test attrs not copied to subgraphs
+        self.G2.add_edge(1, 2, eattr='red')
+        self.G2.node[2]['nattr'] = 'blue'
+        self.G2.graph['gattr'] = 'green'
+        subgraphs = list(nx.attracting_component_subgraphs(self.G2, copy=False))
+        assert_equal(len(subgraphs), 1)
+        SG2 = subgraphs[0]
+        assert_true(1 in SG2)
+        assert_true(2 in SG2)
+        assert_equal(SG2[1][2]['eattr'], 'red')
+        assert_equal(SG2.node[2]['nattr'], 'blue')
+        assert_equal(SG2.graph['gattr'], 'green')
+        SG2.add_edge(1, 2, eattr='blue')
+        assert_equal(SG2[1][2]['eattr'], 'blue')
+        assert_equal(self.G2[1][2]['eattr'], 'blue')
 
     def test_connected_raise(self):
         G=nx.Graph()
-        assert_raises(NetworkXNotImplemented,nx.attracting_components,G)
-        assert_raises(NetworkXNotImplemented,nx.number_attracting_components,G)
-        assert_raises(NetworkXNotImplemented,nx.is_attracting_component,G)
-        assert_raises(NetworkXNotImplemented,nx.attracting_component_subgraphs,G)
+        assert_raises(NetworkXNotImplemented, nx.attracting_components, G)
+        assert_raises(NetworkXNotImplemented, nx.number_attracting_components, G)
+        assert_raises(NetworkXNotImplemented, nx.is_attracting_component, G)
+        assert_raises(NetworkXNotImplemented, nx.attracting_component_subgraphs, G)

--- a/networkx/algorithms/components/tests/test_biconnected.py
+++ b/networkx/algorithms/components/tests/test_biconnected.py
@@ -87,6 +87,21 @@ def test_biconnected_component_subgraphs_cycle():
         assert_equal(g1[1][3]['eattr'],'blue')
         assert_equal(G[1][3]['eattr'],'red')
 
+def test_biconnected_component_subgraphs_no_copy():
+    G = nx.Graph()
+    G.add_edge(1, 2, eattr='red') # test attributes copied to subgraphs
+    G.node[1]['nattr'] = 'blue'
+    G.graph['gattr'] = 'green'
+    ccs = list(nx.biconnected_component_subgraphs(G, copy=False))
+    assert_equal(len(ccs), 1)
+    sg = ccs[0]
+    assert_equal(sg[1][2]['eattr'], 'red')
+    assert_equal(sg.node[1]['nattr'], 'blue')
+    assert_equal(sg.graph['gattr'], 'green')
+    sg[1][2]['eattr'] = 'blue'
+    assert_equal(G[1][2]['eattr'], 'blue')
+    assert_equal(sg[1][2]['eattr'], 'blue')
+
 
 def test_biconnected_components1():
     # graph example from

--- a/networkx/algorithms/components/tests/test_biconnected.py
+++ b/networkx/algorithms/components/tests/test_biconnected.py
@@ -4,146 +4,103 @@ import networkx as nx
 from networkx.algorithms.components import biconnected
 from networkx import NetworkXNotImplemented
 
-def assert_components_equal(x,y):
-    sx = set((frozenset([frozenset(e) for e in c]) for c in x))
-    sy = set((frozenset([frozenset(e) for e in c]) for c in y))
-    assert_equal(sx,sy)
+def assert_components_edges_equal(x, y):
+    sx = {frozenset([frozenset(e) for e in c]) for c in x}
+    sy = {frozenset([frozenset(e) for e in c]) for c in y}
+    assert_equal(sx, sy)
+
+
+def assert_components_equal(x, y):
+    sx = {frozenset(c) for c in x}
+    sy = {frozenset(c) for c in y}
+    assert_equal(sx, sy)
+
 
 def test_barbell():
-    G=nx.barbell_graph(8,4)
-    G.add_path([7,20,21,22])
-    G.add_cycle([22,23,24,25])
-    pts=set(biconnected.articulation_points(G))
-    assert_equal(pts,set([7,8,9,10,11,12,20,21,22]))
+    G = nx.barbell_graph(8, 4)
+    G.add_path([7, 20, 21, 22])
+    G.add_cycle([22, 23, 24, 25])
+    pts = set(nx.articulation_points(G))
+    assert_equal(pts, {7, 8, 9, 10, 11, 12, 20, 21, 22})
 
-    answer = [set([12, 13, 14, 15, 16, 17, 18, 19]),
-                set([0, 1, 2, 3, 4, 5, 6, 7]),
-                set([22, 23, 24, 25]),
-                set([11, 12]),
-                set([10, 11]),
-                set([9, 10]),
-                set([8, 9]),
-                set([7, 8]),
-                set([21, 22]),
-                set([20, 21]),
-                set([7, 20])]
-    bcc=list(biconnected.biconnected_components(G))
-    bcc.sort(key=len, reverse=True)
-    assert_equal(bcc,answer)
+    answer = [
+        {12, 13, 14, 15, 16, 17, 18, 19},
+        {0, 1, 2, 3, 4, 5, 6, 7},
+        {22, 23, 24, 25},
+        {11, 12},
+        {10, 11},
+        {9, 10},
+        {8, 9},
+        {7, 8},
+        {21, 22},
+        {20, 21},
+        {7, 20},
+    ]
+    assert_components_equal(list(nx.biconnected_components(G)), answer)
 
     G.add_edge(2,17)
-    pts=set(biconnected.articulation_points(G))
-    assert_equal(pts,set([7,20,21,22]))
+    pts = set(nx.articulation_points(G))
+    assert_equal(pts, {7, 20, 21, 22})
 
 def test_articulation_points_cycle():
     G=nx.cycle_graph(3)
-    G.add_cycle([1,3,4])
-    pts=set(biconnected.articulation_points(G))
-    assert_equal(pts,set([1]))
+    G.add_cycle([1, 3, 4])
+    pts=set(nx.articulation_points(G))
+    assert_equal(pts, {1})
 
 def test_is_biconnected():
     G=nx.cycle_graph(3)
-    assert_true(biconnected.is_biconnected(G))
-    G.add_cycle([1,3,4])
-    assert_false(biconnected.is_biconnected(G))
+    assert_true(nx.is_biconnected(G))
+    G.add_cycle([1, 3, 4])
+    assert_false(nx.is_biconnected(G))
 
 def test_empty_is_biconnected():
     G=nx.empty_graph(5)
-    assert_false(biconnected.is_biconnected(G))
-    G.add_edge(0,1)
-    assert_false(biconnected.is_biconnected(G))
+    assert_false(nx.is_biconnected(G))
+    G.add_edge(0, 1)
+    assert_false(nx.is_biconnected(G))
 
 def test_biconnected_components_cycle():
     G=nx.cycle_graph(3)
-    G.add_cycle([1,3,4])
-    pts = set(map(frozenset,biconnected.biconnected_components(G)))
-    assert_equal(pts,set([frozenset([0,1,2]),frozenset([1,3,4])]))
+    G.add_cycle([1, 3, 4])
+    answer = [{0, 1, 2}, {1, 3, 4}]
+    assert_components_equal(list(nx.biconnected_components(G)), answer)
 
 def test_biconnected_component_subgraphs_cycle():
     G=nx.cycle_graph(3)
-    G.add_cycle([1,3,4,5])
-    G.add_edge(1,3,eattr='red')  # test copying of edge data
-    G.node[1]['nattr']='blue'
-    G.graph['gattr']='green'
-    Gc = set(biconnected.biconnected_component_subgraphs(G))
-    assert_equal(len(Gc),2)
-    g1,g2=Gc
+    G.add_cycle([1, 3, 4, 5])
+    Gc = set(nx.biconnected_component_subgraphs(G))
+    assert_equal(len(Gc), 2)
+    g1, g2=Gc
     if 0 in g1:
-        assert_true(nx.is_isomorphic(g1,nx.Graph([(0,1),(0,2),(1,2)])))
-        assert_true(nx.is_isomorphic(g2,nx.Graph([(1,3),(1,5),(3,4),(4,5)])))
-        assert_equal(g2[1][3]['eattr'],'red')
-        assert_equal(g2.node[1]['nattr'],'blue')
-        assert_equal(g2.graph['gattr'],'green')
-        g2[1][3]['eattr']='blue'
-        assert_equal(g2[1][3]['eattr'],'blue')
-        assert_equal(G[1][3]['eattr'],'red')
+        assert_true(nx.is_isomorphic(g1, nx.Graph([(0,1),(0,2),(1,2)])))
+        assert_true(nx.is_isomorphic(g2, nx.Graph([(1,3),(1,5),(3,4),(4,5)])))
     else:
-        assert_true(nx.is_isomorphic(g1,nx.Graph([(1,3),(1,5),(3,4),(4,5)])))
-        assert_true(nx.is_isomorphic(g2,nx.Graph([(0,1),(0,2),(1,2)])))
-        assert_equal(g1[1][3]['eattr'],'red')
-        assert_equal(g1.node[1]['nattr'],'blue')
-        assert_equal(g1.graph['gattr'],'green')
-        g1[1][3]['eattr']='blue'
-        assert_equal(g1[1][3]['eattr'],'blue')
-        assert_equal(G[1][3]['eattr'],'red')
-
-def test_biconnected_component_subgraphs_no_copy():
-    G = nx.Graph()
-    G.add_edge(1, 2, eattr='red') # test attributes copied to subgraphs
-    G.node[1]['nattr'] = 'blue'
-    G.graph['gattr'] = 'green'
-    ccs = list(nx.biconnected_component_subgraphs(G, copy=False))
-    assert_equal(len(ccs), 1)
-    sg = ccs[0]
-    assert_equal(sg[1][2]['eattr'], 'red')
-    assert_equal(sg.node[1]['nattr'], 'blue')
-    assert_equal(sg.graph['gattr'], 'green')
-    sg[1][2]['eattr'] = 'blue'
-    assert_equal(G[1][2]['eattr'], 'blue')
-    assert_equal(sg[1][2]['eattr'], 'blue')
-
+        assert_true(nx.is_isomorphic(g1, nx.Graph([(1,3),(1,5),(3,4),(4,5)])))
+        assert_true(nx.is_isomorphic(g2, nx.Graph([(0,1),(0,2),(1,2)])))
 
 def test_biconnected_components1():
     # graph example from
     # http://www.ibluemojo.com/school/articul_algorithm.html
-    edges=[(0,1),
-           (0,5),
-           (0,6),
-           (0,14),
-           (1,5),
-           (1,6),
-           (1,14),
-           (2,4),
-           (2,10),
-           (3,4),
-           (3,15),
-           (4,6),
-           (4,7),
-           (4,10),
-           (5,14),
-           (6,14),
-           (7,9),
-           (8,9),
-           (8,12),
-           (8,13),
-           (10,15),
-           (11,12),
-           (11,13),
-           (12,13)]
+    edges=[
+        (0, 1), (0, 5), (0, 6), (0, 14), (1, 5), (1, 6), (1, 14), (2, 4),
+        (2, 10), (3, 4), (3, 15), (4, 6), (4, 7), (4, 10), (5, 14), (6, 14),
+        (7, 9), (8, 9), (8, 12), (8, 13), (10, 15), (11, 12), (11, 13), (12, 13)
+    ]
     G=nx.Graph(edges)
-    pts = set(biconnected.articulation_points(G))
-    assert_equal(pts,set([4,6,7,8,9]))
-    comps = list(biconnected.biconnected_component_edges(G))
+    pts = set(nx.articulation_points(G))
+    assert_equal(pts, {4, 6, 7, 8, 9})
+    comps = list(nx.biconnected_component_edges(G))
     answer = [
-        [(3,4),(15,3),(10,15),(10,4),(2,10),(4,2)],
-        [(13,12),(13,8),(11,13),(12,11),(8,12)],
-        [(9,8)],
-        [(7,9)],
-        [(4,7)],
-        [(6,4)],
-        [(14,0),(5,1),(5,0),(14,5),(14,1),(6,14),(6,0),(1,6),(0,1)],
-        ]
-    assert_components_equal(comps,answer)
+        [(3, 4), (15, 3), (10, 15), (10, 4), (2, 10), (4, 2)],
+        [(13, 12), (13, 8), (11, 13), (12, 11), (8, 12)],
+        [(9, 8)],
+        [(7, 9)],
+        [(4, 7)],
+        [(6, 4)],
+        [(14, 0), (5, 1), (5, 0), (14, 5), (14, 1), (6, 14), (6, 0), (1, 6), (0, 1)],
+    ]
+    assert_components_edges_equal(comps, answer)
 
 def test_biconnected_components2():
     G=nx.Graph()
@@ -152,64 +109,65 @@ def test_biconnected_components2():
     G.add_cycle('FIJHG')
     G.add_cycle('GIJ')
     G.add_edge('E','G')
-    comps = list(biconnected.biconnected_component_edges(G))
+    comps = list(nx.biconnected_component_edges(G))
     answer = [
-        [tuple('GF'),tuple('FI'),tuple('IG'),tuple('IJ'),tuple('JG'),tuple('JH'),tuple('HG')],
+        [tuple('GF'), tuple('FI'), tuple('IG'), tuple('IJ'),
+         tuple('JG'), tuple('JH'), tuple('HG')],
         [tuple('EG')],
-        [tuple('CD'),tuple('DE'),tuple('CE')],
-        [tuple('AB'),tuple('BC'),tuple('AC')]
+        [tuple('CD'), tuple('DE'), tuple('CE')],
+        [tuple('AB'), tuple('BC'), tuple('AC')]
         ]
-    assert_components_equal(comps,answer)
+    assert_components_edges_equal(comps, answer)
 
 def test_biconnected_davis():
     D = nx.davis_southern_women_graph()
-    bcc = list(biconnected.biconnected_components(D))[0]
+    bcc = list(nx.biconnected_components(D))[0]
     assert_true(set(D) == bcc) # All nodes in a giant bicomponent
     # So no articulation points
-    assert_equal(list(biconnected.articulation_points(D)),[])
+    assert_equal(len(list(nx.articulation_points(D))), 0)
 
 def test_biconnected_karate():
     K = nx.karate_club_graph()
-    answer = [set([0, 1, 2, 3, 7, 8, 9, 12, 13, 14, 15, 17, 18, 19,
-                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]),
-                set([0, 4, 5, 6, 10, 16]),
-                set([0, 11])]
-    bcc = list(biconnected.biconnected_components(K))
-    bcc.sort(key=len, reverse=True)
-    assert_true(list(biconnected.biconnected_components(K)) == answer)
-    assert_equal(list(biconnected.articulation_points(K)),[0])
+    answer = [{0, 1, 2, 3, 7, 8, 9, 12, 13, 14, 15, 17, 18, 19,
+               20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+              {0, 4, 5, 6, 10, 16},
+              {0, 11}]
+    bcc = list(nx.biconnected_components(K))
+    assert_components_equal(bcc, answer)
+    assert_equal(set(nx.articulation_points(K)), {0})
 
 def test_biconnected_eppstein():
     # tests from http://www.ics.uci.edu/~eppstein/PADS/Biconnectivity.py
     G1 = nx.Graph({
-        0: [1,2,5],
-        1: [0,5],
-        2: [0,3,4],
-        3: [2,4,5,6],
-        4: [2,3,5,6],
-        5: [0,1,3,4],
-        6: [3,4]})
+        0: [1, 2, 5],
+        1: [0, 5],
+        2: [0, 3, 4],
+        3: [2, 4, 5, 6],
+        4: [2, 3, 5, 6],
+        5: [0, 1, 3, 4],
+        6: [3, 4],
+    })
     G2 = nx.Graph({
-        0: [2,5],
-        1: [3,8],
-        2: [0,3,5],
-        3: [1,2,6,8],
+        0: [2, 5],
+        1: [3, 8],
+        2: [0, 3, 5],
+        3: [1, 2, 6, 8],
         4: [7],
-        5: [0,2],
-        6: [3,8],
+        5: [0, 2],
+        6: [3, 8],
         7: [4],
-        8: [1,3,6]})
-    assert_true(biconnected.is_biconnected(G1))
-    assert_false(biconnected.is_biconnected(G2))
-    answer_G2 = [set([1, 3, 6, 8]), set([0, 2, 5]), set([2, 3]), set([4, 7])]
-    bcc = list(biconnected.biconnected_components(G2))
-    bcc.sort(key=len, reverse=True)
-    assert_equal(bcc, answer_G2)
+        8: [1, 3, 6],
+    })
+    assert_true(nx.is_biconnected(G1))
+    assert_false(nx.is_biconnected(G2))
+    answer_G2 = [{1, 3, 6, 8}, {0, 2, 5}, {2, 3}, {4, 7}]
+    bcc = list(nx.biconnected_components(G2))
+    assert_components_equal(bcc, answer_G2)
 
 def test_connected_raise():
     DG = nx.DiGraph()
-    assert_raises(NetworkXNotImplemented,nx.biconnected_components,DG)
-    assert_raises(NetworkXNotImplemented,nx.biconnected_component_subgraphs,DG)
-    assert_raises(NetworkXNotImplemented,nx.biconnected_component_edges,DG)
-    assert_raises(NetworkXNotImplemented,nx.articulation_points,DG)
-    assert_raises(NetworkXNotImplemented,nx.is_biconnected,DG)
+    assert_raises(NetworkXNotImplemented, nx.biconnected_components, DG)
+    assert_raises(NetworkXNotImplemented, nx.biconnected_component_subgraphs, DG)
+    assert_raises(NetworkXNotImplemented, nx.biconnected_component_edges, DG)
+    assert_raises(NetworkXNotImplemented, nx.articulation_points, DG)
+    assert_raises(NetworkXNotImplemented, nx.is_biconnected, DG)

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -7,66 +7,86 @@ from networkx import NetworkXError,NetworkXNotImplemented
 class TestConnected:
 
     def setUp(self):
-        G1=cnlti(nx.grid_2d_graph(2,2),first_label=0,ordering="sorted")
-        G2=cnlti(nx.lollipop_graph(3,3),first_label=4,ordering="sorted")
-        G3=cnlti(nx.house_graph(),first_label=10,ordering="sorted")
-        self.G=nx.union(G1,G2)
-        self.G=nx.union(self.G,G3)
-        self.DG=nx.DiGraph([(1,2),(1,3),(2,3)])
-        self.grid=cnlti(nx.grid_2d_graph(4,4),first_label=1)
+        G1 = cnlti(nx.grid_2d_graph(2, 2), first_label=0, ordering="sorted")
+        G2 = cnlti(nx.lollipop_graph(3, 3), first_label=4, ordering="sorted")
+        G3 = cnlti(nx.house_graph(), first_label=10, ordering="sorted")
+        self.G = nx.union(G1, G2)
+        self.G = nx.union(self.G, G3)
+        self.DG = nx.DiGraph([(1, 2), (1, 3), (2, 3)])
+        self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1)
 
     def test_connected_components(self):
-        cc=nx.connected_components
-        G=self.G
-        C=[[0, 1, 2, 3], [4, 5, 6, 7, 8, 9], [10, 11, 12, 13, 14]]
-        assert_equal(sorted([sorted(g) for g in cc(G)]),sorted(C))
+        cc = nx.connected_components
+        G = self.G
+        C = {
+            frozenset([0, 1, 2, 3]),
+            frozenset([4, 5, 6, 7, 8, 9]),
+            frozenset([10, 11, 12, 13, 14])
+        }
+        assert_equal({frozenset(g) for g in cc(G)}, C)
 
     def test_number_connected_components(self):
-        ncc=nx.number_connected_components
-        assert_equal(ncc(self.G),3)
+        ncc = nx.number_connected_components
+        assert_equal(ncc(self.G), 3)
 
     def test_number_connected_components2(self):
-        ncc=nx.number_connected_components
-        assert_equal(ncc(self.grid),1)
+        ncc = nx.number_connected_components
+        assert_equal(ncc(self.grid), 1)
 
     def test_connected_components2(self):
-        cc=nx.connected_components
-        G=self.grid
-        C=[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]]
-        assert_equal(sorted([sorted(g) for g in cc(G)]),sorted(C))
+        cc = nx.connected_components
+        G = self.grid
+        C = {frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])}
+        assert_equal({frozenset(g) for g in cc(G)}, C)
 
     def test_node_connected_components(self):
-        ncc=nx.node_connected_component
-        G=self.grid
-        C=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-        assert_equal(sorted(ncc(G,1)),sorted(C))
+        ncc = nx.node_connected_component
+        G = self.grid
+        C = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+        assert_equal(ncc(G, 1), C)
 
     def test_connected_component_subgraphs(self):
         G=self.grid
-        G.add_edge(1,2,eattr='red') # test attributes copied to subgraphs
-        G.node[1]['nattr']='blue'
-        G.graph['gattr']='green'
-        ccs=list(nx.connected_component_subgraphs(G))
-        assert_equal(len(ccs),1)
-        sg=ccs[0]
-        assert_equal(sorted(sg.nodes()),list(range(1,17)))
-        assert_equal(sg[1][2]['eattr'],'red')
-        assert_equal(sg.node[1]['nattr'],'blue')
-        assert_equal(sg.graph['gattr'],'green')
-        sg[1][2]['eattr']='blue'
-        assert_equal(G[1][2]['eattr'],'red')
-        assert_equal(sg[1][2]['eattr'],'blue')
+        G.add_edge(1, 2, eattr='red') # test attributes copied to subgraphs
+        G.node[1]['nattr'] = 'blue'
+        G.graph['gattr'] = 'green'
+        ccs = list(nx.connected_component_subgraphs(G))
+        assert_equal(len(ccs), 1)
+        sg = ccs[0]
+        assert_equal(sorted(sg), list(range(1,17)))
+        assert_equal(sg[1][2]['eattr'], 'red')
+        assert_equal(sg.node[1]['nattr'], 'blue')
+        assert_equal(sg.graph['gattr'], 'green')
+        sg[1][2]['eattr'] = 'blue'
+        assert_equal(G[1][2]['eattr'], 'red')
+        assert_equal(sg[1][2]['eattr'], 'blue')
 
+    def test_connected_component_subgraphs_no_copy(self):
+        G=self.grid
+        G.add_edge(1, 2, eattr='red') # test attributes copied to subgraphs
+        G.node[1]['nattr'] = 'blue'
+        G.graph['gattr'] = 'green'
+        ccs = list(nx.connected_component_subgraphs(G, copy=False))
+        assert_equal(len(ccs), 1)
+        sg = ccs[0]
+        assert_equal(sorted(sg), list(range(1,17)))
+        assert_equal(sg[1][2]['eattr'], 'red')
+        assert_equal(sg.node[1]['nattr'], 'blue')
+        assert_equal(sg.graph['gattr'], 'green')
+        sg[1][2]['eattr'] = 'blue'
+        assert_equal(G[1][2]['eattr'], 'blue')
+        assert_equal(sg[1][2]['eattr'], 'blue')
 
     def test_is_connected(self):
         assert_true(nx.is_connected(self.grid))
-        G=nx.Graph()
-        G.add_nodes_from([1,2])
+        G = nx.Graph()
+        G.add_nodes_from([1, 2])
         assert_false(nx.is_connected(G))
 
     def test_connected_raise(self):
-        assert_raises(NetworkXNotImplemented,nx.connected_components,self.DG)
-        assert_raises(NetworkXNotImplemented,nx.number_connected_components,self.DG)
-        assert_raises(NetworkXNotImplemented,nx.connected_component_subgraphs,self.DG)
-        assert_raises(NetworkXNotImplemented,nx.node_connected_component,self.DG,1)
-        assert_raises(NetworkXNotImplemented,nx.is_connected,self.DG)
+        assert_raises(NetworkXNotImplemented, nx.connected_components, self.DG)
+        assert_raises(NetworkXNotImplemented, nx.number_connected_components, self.DG)
+        assert_raises(NetworkXNotImplemented, nx.connected_component_subgraphs, self.DG)
+        assert_raises(NetworkXNotImplemented, nx.node_connected_component, self.DG,1)
+        assert_raises(NetworkXNotImplemented, nx.is_connected, self.DG)
+        assert_raises(nx.NetworkXPointlessConcept, nx.is_connected, nx.Graph())

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -15,6 +15,33 @@ class TestConnected:
         self.DG = nx.DiGraph([(1, 2), (1, 3), (2, 3)])
         self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1)
 
+        self.gc = []
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (2, 3), (2, 8), (3, 4), (3, 7), (4, 5),
+                          (5, 3), (5, 6), (7, 4), (7, 6), (8, 1), (8, 7)])
+        C = [[3, 4, 5, 7], [1, 2, 8], [6]]
+        self.gc.append((G, C))
+
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (1, 3), (1, 4), (4, 2), (3, 4), (2, 3)])
+        C = [[2, 3, 4],[1]]
+        self.gc.append((G, C))
+
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (2, 3), (3, 2), (2, 1)])
+        C = [[1, 2, 3]]
+        self.gc.append((G,C))
+
+        # Eppstein's tests
+        G = nx.DiGraph({0:[1], 1:[2, 3], 2:[4, 5], 3:[4, 5], 4:[6], 5:[], 6:[]})
+        C = [[0], [1], [2],[ 3], [4], [5], [6]]
+        self.gc.append((G,C))
+
+        G = nx.DiGraph({0:[1], 1:[2, 3, 4], 2:[0, 3], 3:[4], 4:[3]})
+        C = [[0, 1, 2], [3, 4]]
+        self.gc.append((G, C))
+
+
     def test_connected_components(self):
         cc = nx.connected_components
         G = self.G
@@ -46,36 +73,13 @@ class TestConnected:
         assert_equal(ncc(G, 1), C)
 
     def test_connected_component_subgraphs(self):
-        G=self.grid
-        G.add_edge(1, 2, eattr='red') # test attributes copied to subgraphs
-        G.node[1]['nattr'] = 'blue'
-        G.graph['gattr'] = 'green'
-        ccs = list(nx.connected_component_subgraphs(G))
-        assert_equal(len(ccs), 1)
-        sg = ccs[0]
-        assert_equal(sorted(sg), list(range(1,17)))
-        assert_equal(sg[1][2]['eattr'], 'red')
-        assert_equal(sg.node[1]['nattr'], 'blue')
-        assert_equal(sg.graph['gattr'], 'green')
-        sg[1][2]['eattr'] = 'blue'
-        assert_equal(G[1][2]['eattr'], 'red')
-        assert_equal(sg[1][2]['eattr'], 'blue')
-
-    def test_connected_component_subgraphs_no_copy(self):
-        G=self.grid
-        G.add_edge(1, 2, eattr='red') # test attributes copied to subgraphs
-        G.node[1]['nattr'] = 'blue'
-        G.graph['gattr'] = 'green'
-        ccs = list(nx.connected_component_subgraphs(G, copy=False))
-        assert_equal(len(ccs), 1)
-        sg = ccs[0]
-        assert_equal(sorted(sg), list(range(1,17)))
-        assert_equal(sg[1][2]['eattr'], 'red')
-        assert_equal(sg.node[1]['nattr'], 'blue')
-        assert_equal(sg.graph['gattr'], 'green')
-        sg[1][2]['eattr'] = 'blue'
-        assert_equal(G[1][2]['eattr'], 'blue')
-        assert_equal(sg[1][2]['eattr'], 'blue')
+        wcc = nx.weakly_connected_component_subgraphs
+        cc = nx.connected_component_subgraphs
+        for G, C in self.gc:
+            U = G.to_undirected()
+            w = {frozenset(g) for g in wcc(G)}
+            c = {frozenset(g) for g in cc(U)}
+            assert_equal(w, c)
 
     def test_is_connected(self):
         assert_true(nx.is_connected(self.grid))

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -6,143 +6,167 @@ from networkx import NetworkXNotImplemented
 class TestStronglyConnected:
 
     def setUp(self):
-        self.gc=[]
-        G=nx.DiGraph()
-        G.add_edges_from([(1,2),(2,3),(2,8),(3,4),(3,7),
-                          (4,5),(5,3),(5,6),(7,4),(7,6),(8,1),(8,7)])
-        C=[[3, 4, 5, 7], [1, 2, 8],  [6]]
-        self.gc.append((G,C))
-
-        G= nx.DiGraph()
-        G.add_edges_from([(1,2),(1,3),(1,4),(4,2),(3,4),(2,3)])
-        C = [[2, 3, 4],[1]]
-        self.gc.append((G,C))
+        self.gc = []
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (2, 3), (2, 8), (3, 4), (3, 7), (4, 5),
+                          (5, 3), (5, 6), (7, 4), (7, 6), (8, 1), (8, 7)])
+        C = {frozenset([3, 4, 5, 7]), frozenset([1, 2, 8]), frozenset([6])}
+        self.gc.append((G, C))
 
         G = nx.DiGraph()
-        G.add_edges_from([(1,2),(2,3),(3,2),(2,1)])
-        C = [[1, 2, 3]]
-        self.gc.append((G,C))
+        G.add_edges_from([(1, 2), (1, 3), (1, 4), (4, 2), (3, 4), (2, 3)])
+        C = {frozenset([2, 3, 4]), frozenset([1])}
+        self.gc.append((G, C))
+
+        G = nx.DiGraph()
+        G.add_edges_from([(1, 2), (2, 3), (3, 2), (2, 1)])
+        C = {frozenset([1, 2, 3])}
+        self.gc.append((G, C))
 
         # Eppstein's tests
-        G = nx.DiGraph({ 0:[1],1:[2,3],2:[4,5],3:[4,5],4:[6],5:[],6:[]})
-        C = [[0],[1],[2],[3],[4],[5],[6]]
-        self.gc.append((G,C))
+        G = nx.DiGraph({0: [1], 1:[2, 3], 2:[4, 5], 3:[4, 5], 4:[6], 5:[], 6:[]})
+        C = {
+            frozenset([0]),
+            frozenset([1]),
+            frozenset([2]),
+            frozenset([3]),
+            frozenset([4]),
+            frozenset([5]),
+            frozenset([6]),
+        }
+        self.gc.append((G, C))
 
-        G = nx.DiGraph({0:[1],1:[2,3,4],2:[0,3],3:[4],4:[3]})
-        C = [[0,1,2],[3,4]]
-        self.gc.append((G,C))
-
+        G = nx.DiGraph({0:[1], 1:[2, 3, 4], 2:[0, 3], 3:[4], 4:[3]})
+        C = {frozenset([0, 1, 2]), frozenset([3, 4])}
+        self.gc.append((G, C))
 
     def test_tarjan(self):
-        scc=nx.strongly_connected_components
-        for G,C in self.gc:
-            assert_equal(sorted([sorted(g) for g in scc(G)]),sorted(C))
-
+        scc = nx.strongly_connected_components
+        for G, C in self.gc:
+            assert_equal({frozenset(g) for g in scc(G)}, C)
 
     def test_tarjan_recursive(self):
         scc=nx.strongly_connected_components_recursive
-        for G,C in self.gc:
-            assert_equal(sorted([sorted(g) for g in scc(G)]),sorted(C))
-
+        for G, C in self.gc:
+            assert_equal({frozenset(g) for g in scc(G)}, C)
 
     def test_kosaraju(self):
-        scc=nx.kosaraju_strongly_connected_components
-        for G,C in self.gc:
-            assert_equal(sorted([sorted(g) for g in scc(G)]),sorted(C))
+        scc = nx.kosaraju_strongly_connected_components
+        for G, C in self.gc:
+            assert_equal({frozenset(g) for g in scc(G)}, C)
 
     def test_number_strongly_connected_components(self):
-        ncc=nx.number_strongly_connected_components
-        for G,C in self.gc:
-            assert_equal(ncc(G),len(C))
+        ncc = nx.number_strongly_connected_components
+        for G, C in self.gc:
+            assert_equal(ncc(G), len(C))
 
     def test_is_strongly_connected(self):
-        for G,C in self.gc:
-            if len(C)==1:
+        for G, C in self.gc:
+            if len(C) == 1:
                 assert_true(nx.is_strongly_connected(G))
             else:
                 assert_false(nx.is_strongly_connected(G))
 
-
     def test_strongly_connected_component_subgraphs(self):
-        scc=nx.strongly_connected_component_subgraphs
-        for G,C in self.gc:
-            assert_equal(sorted([sorted(g.nodes()) for g in scc(G)]),sorted(C))
-        G,C=self.gc[0]
-        G.add_edge(1,2,eattr='red')
-        G.node[1]['nattr']='blue'
-        G.graph['gattr']='green'
-        sgs=sorted(list(scc(G)), key=len, reverse=False)[1]
-        assert_equal(sgs[1][2]['eattr'],'red')
-        assert_equal(sgs.node[1]['nattr'],'blue')
-        assert_equal(sgs.graph['gattr'],'green')
-        sgs[1][2]['eattr']='blue'
-        assert_equal(G[1][2]['eattr'],'red')
-        assert_equal(sgs[1][2]['eattr'],'blue')
+        scc = nx.strongly_connected_component_subgraphs
+        for G, C in self.gc:
+            assert_equal({frozenset(g) for g in scc(G)}, C)
+        G = nx.DiGraph()
+        G.add_edge(1, 2, eattr='red')
+        G.add_edge(2, 1, eattr='purple')
+        G.node[1]['nattr'] = 'blue'
+        G.graph['gattr'] = 'green'
+        sgs = list(scc(G))[0]
+        assert_equal(sgs[1][2]['eattr'], 'red')
+        assert_equal(sgs.node[1]['nattr'], 'blue')
+        assert_equal(sgs.graph['gattr'], 'green')
+        sgs[1][2]['eattr'] = 'blue'
+        assert_equal(G[1][2]['eattr'], 'red')
+        assert_equal(sgs[1][2]['eattr'], 'blue')
+
+    def test_no_copy(self):
+        scc = nx.strongly_connected_component_subgraphs
+        G = nx.DiGraph()
+        G.add_edge(1, 2, eattr='red')
+        G.add_edge(2, 1, eattr='purple')
+        G.node[1]['nattr'] = 'blue'
+        G.graph['gattr'] = 'green'
+        sgs = list(scc(G, copy=False))[0]
+        assert_equal(sgs[1][2]['eattr'], 'red')
+        assert_equal(sgs.node[1]['nattr'], 'blue')
+        assert_equal(sgs.graph['gattr'], 'green')
+        sgs[1][2]['eattr'] = 'blue'
+        assert_equal(G[1][2]['eattr'], 'blue')
+        assert_equal(sgs[1][2]['eattr'], 'blue')
 
     def test_contract_scc1(self):
         G = nx.DiGraph()
-        G.add_edges_from([(1,2),(2,3),(2,11),(2,12),(3,4),(4,3),(4,5),
-                          (5,6),(6,5),(6,7),(7,8),(7,9),(7,10),(8,9),
-                          (9,7),(10,6),(11,2),(11,4),(11,6),(12,6),(12,11)])
+        G.add_edges_from([
+            (1, 2), (2, 3), (2, 11), (2, 12), (3, 4), (4, 3), (4, 5), (5, 6),
+            (6, 5), (6, 7), (7, 8), (7, 9), (7, 10), (8, 9), (9, 7), (10, 6),
+            (11, 2), (11, 4), (11, 6), (12, 6), (12, 11),
+        ])
         scc = list(nx.strongly_connected_components(G))
         cG = nx.condensation(G, scc)
         # DAG
         assert_true(nx.is_directed_acyclic_graph(cG))
-        # # nodes
-        assert_equal(sorted(cG.nodes()),[0,1,2,3])
-        # # edges
+        # nodes
+        assert_equal(sorted(cG.nodes()), [0, 1, 2, 3])
+        # edges
         mapping={}
-        for i,component in enumerate(scc):
+        for i, component in enumerate(scc):
             for n in component:
                 mapping[n] = i
-        edge=(mapping[2],mapping[3])
+        edge = (mapping[2], mapping[3])
         assert_true(cG.has_edge(*edge))
-        edge=(mapping[2],mapping[5])
+        edge = (mapping[2], mapping[5])
         assert_true(cG.has_edge(*edge))
-        edge=(mapping[3],mapping[5])
+        edge = (mapping[3], mapping[5])
         assert_true(cG.has_edge(*edge))
 
     def test_contract_scc_isolate(self):
         # Bug found and fixed in [1687].
         G = nx.DiGraph()
-        G.add_edge(1,2)
-        G.add_edge(2,1)
+        G.add_edge(1, 2)
+        G.add_edge(2, 1)
         scc = list(nx.strongly_connected_components(G))
         cG = nx.condensation(G, scc)
-        assert_equal(cG.nodes(),[0])
-        assert_equal(cG.edges(),[])
+        assert_equal(list(cG.nodes()), [0])
+        assert_equal(list(cG.edges()), [])
 
     def test_contract_scc_edge(self):
         G = nx.DiGraph()
-        G.add_edge(1,2)
-        G.add_edge(2,1)
-        G.add_edge(2,3)
-        G.add_edge(3,4)
-        G.add_edge(4,3)
+        G.add_edge(1, 2)
+        G.add_edge(2, 1)
+        G.add_edge(2, 3)
+        G.add_edge(3, 4)
+        G.add_edge(4, 3)
         scc = list(nx.strongly_connected_components(G))
         cG = nx.condensation(G, scc)
-        assert_equal(cG.nodes(),[0,1])
+        assert_equal(cG.nodes(), [0, 1])
         if 1 in scc[0]:
-            edge = (0,1)
+            edge = (0, 1)
         else:
-            edge = (1,0)
-        assert_equal(cG.edges(),[edge])
+            edge = (1, 0)
+        assert_equal(list(cG.edges()), [edge])
 
     def test_condensation_mapping_and_members(self):
         G, C = self.gc[1]
+        C = sorted(C, key=len, reverse=True)
         cG = nx.condensation(G)
         mapping = cG.graph['mapping']
         assert_true(all(n in G for n in mapping))
         assert_true(all(0 == cN for n, cN in mapping.items() if n in C[0]))
         assert_true(all(1 == cN for n, cN in mapping.items() if n in C[1]))
         for n, d in cG.nodes(data=True):
-            assert_equal(C[n], cG.node[n]['members'])
+            assert_equal(set(C[n]), cG.node[n]['members'])
 
     def test_connected_raise(self):
         G=nx.Graph()
-        assert_raises(NetworkXNotImplemented,nx.strongly_connected_components,G)
-        assert_raises(NetworkXNotImplemented,nx.kosaraju_strongly_connected_components,G)
-        assert_raises(NetworkXNotImplemented,nx.strongly_connected_components_recursive,G)
-        assert_raises(NetworkXNotImplemented,nx.strongly_connected_component_subgraphs,G)
-        assert_raises(NetworkXNotImplemented,nx.is_strongly_connected,G)
-        assert_raises(NetworkXNotImplemented,nx.condensation,G)
+        assert_raises(NetworkXNotImplemented, nx.strongly_connected_components, G)
+        assert_raises(NetworkXNotImplemented, nx.kosaraju_strongly_connected_components, G)
+        assert_raises(NetworkXNotImplemented, nx.strongly_connected_components_recursive, G)
+        assert_raises(NetworkXNotImplemented, nx.strongly_connected_component_subgraphs, G)
+        assert_raises(NetworkXNotImplemented, nx.is_strongly_connected, G)
+        assert_raises(nx.NetworkXPointlessConcept, nx.is_strongly_connected, nx.DiGraph())
+        assert_raises(NetworkXNotImplemented, nx.condensation, G)

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -71,33 +71,6 @@ class TestStronglyConnected:
         scc = nx.strongly_connected_component_subgraphs
         for G, C in self.gc:
             assert_equal({frozenset(g) for g in scc(G)}, C)
-        G = nx.DiGraph()
-        G.add_edge(1, 2, eattr='red')
-        G.add_edge(2, 1, eattr='purple')
-        G.node[1]['nattr'] = 'blue'
-        G.graph['gattr'] = 'green'
-        sgs = list(scc(G))[0]
-        assert_equal(sgs[1][2]['eattr'], 'red')
-        assert_equal(sgs.node[1]['nattr'], 'blue')
-        assert_equal(sgs.graph['gattr'], 'green')
-        sgs[1][2]['eattr'] = 'blue'
-        assert_equal(G[1][2]['eattr'], 'red')
-        assert_equal(sgs[1][2]['eattr'], 'blue')
-
-    def test_no_copy(self):
-        scc = nx.strongly_connected_component_subgraphs
-        G = nx.DiGraph()
-        G.add_edge(1, 2, eattr='red')
-        G.add_edge(2, 1, eattr='purple')
-        G.node[1]['nattr'] = 'blue'
-        G.graph['gattr'] = 'green'
-        sgs = list(scc(G, copy=False))[0]
-        assert_equal(sgs[1][2]['eattr'], 'red')
-        assert_equal(sgs.node[1]['nattr'], 'blue')
-        assert_equal(sgs.graph['gattr'], 'green')
-        sgs[1][2]['eattr'] = 'blue'
-        assert_equal(G[1][2]['eattr'], 'blue')
-        assert_equal(sgs[1][2]['eattr'], 'blue')
 
     def test_contract_scc1(self):
         G = nx.DiGraph()

--- a/networkx/algorithms/components/tests/test_subgraph_copies.py
+++ b/networkx/algorithms/components/tests/test_subgraph_copies.py
@@ -1,0 +1,84 @@
+""" Tests for subgraphs attributes
+"""
+from copy import deepcopy
+from nose.tools import assert_equal
+import networkx as nx
+
+class TestSubgraphAttributesDicts:
+
+    def setUp(self):
+        self.undirected = [
+            nx.connected_component_subgraphs,
+            nx.biconnected_component_subgraphs,
+        ]
+        self.directed = [
+            nx.weakly_connected_component_subgraphs,
+            nx.strongly_connected_component_subgraphs,
+            nx.attracting_component_subgraphs,
+        ]
+        self.subgraph_funcs = self.undirected + self.directed
+        
+        self.D = nx.DiGraph()
+        self.D.add_edge(1, 2, eattr='red')
+        self.D.add_edge(2, 1, eattr='red')
+        self.D.node[1]['nattr'] = 'blue'
+        self.D.graph['gattr'] = 'green'
+
+        self.G = nx.Graph()
+        self.G.add_edge(1, 2, eattr='red')
+        self.G.node[1]['nattr'] = 'blue'
+        self.G.graph['gattr'] = 'green'
+
+    def test_subgraphs_default_copy_behavior(self):
+        # Test the default behavior of subgraph functions 
+        # For the moment (1.10) the default is to copy
+        for subgraph_func in self.subgraph_funcs:
+            G = deepcopy(self.G if subgraph_func in self.undirected else self.D)
+            SG = list(subgraph_func(G))[0]
+            assert_equal(SG[1][2]['eattr'], 'red')
+            assert_equal(SG.node[1]['nattr'], 'blue')
+            assert_equal(SG.graph['gattr'], 'green')
+            SG[1][2]['eattr'] = 'foo'
+            assert_equal(G[1][2]['eattr'], 'red')
+            assert_equal(SG[1][2]['eattr'], 'foo')
+            SG.node[1]['nattr'] = 'bar'
+            assert_equal(G.node[1]['nattr'], 'blue')
+            assert_equal(SG.node[1]['nattr'], 'bar')
+            SG.graph['gattr'] = 'baz'
+            assert_equal(G.graph['gattr'], 'green')
+            assert_equal(SG.graph['gattr'], 'baz')
+
+    def test_subgraphs_copy(self):
+        for subgraph_func in self.subgraph_funcs:
+            test_graph = self.G if subgraph_func in self.undirected else self.D
+            G = deepcopy(test_graph)
+            SG = list(subgraph_func(G, copy=True))[0]
+            assert_equal(SG[1][2]['eattr'], 'red')
+            assert_equal(SG.node[1]['nattr'], 'blue')
+            assert_equal(SG.graph['gattr'], 'green')
+            SG[1][2]['eattr'] = 'foo'
+            assert_equal(G[1][2]['eattr'], 'red')
+            assert_equal(SG[1][2]['eattr'], 'foo')
+            SG.node[1]['nattr'] = 'bar'
+            assert_equal(G.node[1]['nattr'], 'blue')
+            assert_equal(SG.node[1]['nattr'], 'bar')
+            SG.graph['gattr'] = 'baz'
+            assert_equal(G.graph['gattr'], 'green')
+            assert_equal(SG.graph['gattr'], 'baz')
+
+    def test_subgraphs_no_copy(self):
+        for subgraph_func in self.subgraph_funcs:
+            G = deepcopy(self.G if subgraph_func in self.undirected else self.D)
+            SG = list(subgraph_func(G, copy=False))[0]
+            assert_equal(SG[1][2]['eattr'], 'red')
+            assert_equal(SG.node[1]['nattr'], 'blue')
+            assert_equal(SG.graph['gattr'], 'green')
+            SG[1][2]['eattr'] = 'foo'
+            assert_equal(G[1][2]['eattr'], 'foo')
+            assert_equal(SG[1][2]['eattr'], 'foo')
+            SG.node[1]['nattr'] = 'bar'
+            assert_equal(G.node[1]['nattr'], 'bar')
+            assert_equal(SG.node[1]['nattr'], 'bar')
+            SG.graph['gattr'] = 'baz'
+            assert_equal(G.graph['gattr'], 'baz')
+            assert_equal(SG.graph['gattr'], 'baz')

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -8,80 +8,86 @@ class TestWeaklyConnected:
     def setUp(self):
         self.gc=[]
         G=nx.DiGraph()
-        G.add_edges_from([(1,2),(2,3),(2,8),(3,4),(3,7),
-                          (4,5),(5,3),(5,6),(7,4),(7,6),(8,1),(8,7)])
-        C=[[3, 4, 5, 7], [1, 2, 8],  [6]]
-        self.gc.append((G,C))
+        G.add_edges_from([(1, 2), (2, 3), (2, 8), (3, 4), (3, 7), (4, 5),
+                          (5, 3), (5, 6), (7, 4), (7, 6), (8, 1), (8, 7)])
+        C=[[3, 4, 5, 7], [1, 2, 8], [6]]
+        self.gc.append((G, C))
 
         G= nx.DiGraph()
-        G.add_edges_from([(1,2),(1,3),(1,4),(4,2),(3,4),(2,3)])
+        G.add_edges_from([(1, 2), (1, 3), (1, 4), (4, 2), (3, 4), (2, 3)])
         C = [[2, 3, 4],[1]]
-        self.gc.append((G,C))
+        self.gc.append((G, C))
 
         G = nx.DiGraph()
-        G.add_edges_from([(1,2),(2,3),(3,2),(2,1)])
+        G.add_edges_from([(1, 2), (2, 3), (3, 2), (2, 1)])
         C = [[1, 2, 3]]
         self.gc.append((G,C))
 
         # Eppstein's tests
-        G = nx.DiGraph({ 0:[1],1:[2,3],2:[4,5],3:[4,5],4:[6],5:[],6:[]})
-        C = [[0],[1],[2],[3],[4],[5],[6]]
+        G = nx.DiGraph({0:[1], 1:[2, 3], 2:[4, 5], 3:[4, 5], 4:[6], 5:[], 6:[]})
+        C = [[0], [1], [2],[ 3], [4], [5], [6]]
         self.gc.append((G,C))
 
-        G = nx.DiGraph({0:[1],1:[2,3,4],2:[0,3],3:[4],4:[3]})
-        C = [[0,1,2],[3,4]]
-        self.gc.append((G,C))
+        G = nx.DiGraph({0:[1], 1:[2, 3, 4], 2:[0, 3], 3:[4], 4:[3]})
+        C = [[0, 1, 2], [3, 4]]
+        self.gc.append((G, C))
 
 
     def test_weakly_connected_components(self):
-        wcc=nx.weakly_connected_components
-        cc=nx.connected_components
-        for G,C in self.gc:
-            U=G.to_undirected()
-            w=sorted([sorted(g) for g in wcc(G)])
-            c=sorted([sorted(g) for g in cc(U)])
-            assert_equal(w,c)
+        for G, C in self.gc:
+            U = G.to_undirected()
+            w = {frozenset(g) for g in nx.weakly_connected_components(G)}
+            c = {frozenset(g) for g in nx.connected_components(U)}
+            assert_equal(w, c)
 
     def test_number_weakly_connected_components(self):
-        wcc=nx.number_weakly_connected_components
-        cc=nx.number_connected_components
-        for G,C in self.gc:
-            U=G.to_undirected()
-            w=wcc(G)
-            c=cc(U)
-            assert_equal(w,c)
+        for G, C in self.gc:
+            U = G.to_undirected()
+            w = nx.number_weakly_connected_components(G)
+            c = nx.number_connected_components(U)
+            assert_equal(w, c)
 
     def test_weakly_connected_component_subgraphs(self):
-        wcc=nx.weakly_connected_component_subgraphs
-        cc=nx.connected_component_subgraphs
-        for G,C in self.gc:
-            U=G.to_undirected()
-            w=sorted([sorted(g.nodes()) for g in wcc(G)])
-            c=sorted([sorted(g.nodes()) for g in cc(U)])
-            assert_equal(w,c)
-        G,C=self.gc[0]
-        G.add_edge(1,2,eattr='red')
-        G.node[1]['nattr']='blue'
-        G.graph['gattr']='green'
-        sgs=list(wcc(G))[0]
-        assert_equal(sgs[1][2]['eattr'],'red')
-        assert_equal(sgs.node[1]['nattr'],'blue')
-        assert_equal(sgs.graph['gattr'],'green')
-        sgs[1][2]['eattr']='blue'
-        assert_equal(G[1][2]['eattr'],'red')
-        assert_equal(sgs[1][2]['eattr'],'blue')
+        wcc = nx.weakly_connected_component_subgraphs
+        cc = nx.connected_component_subgraphs
+        for G, C in self.gc:
+            U = G.to_undirected()
+            w = {frozenset(g) for g in wcc(G)}
+            c = {frozenset(g) for g in cc(U)}
+            assert_equal(w, c)
+        G, C = self.gc[0]
+        G.add_edge(1, 2, eattr='red')
+        G.node[1]['nattr'] = 'blue'
+        G.graph['gattr'] = 'green'
+        sgs = list(wcc(G))[0]
+        assert_equal(sgs[1][2]['eattr'], 'red')
+        assert_equal(sgs.node[1]['nattr'], 'blue')
+        assert_equal(sgs.graph['gattr'], 'green')
+        sgs[1][2]['eattr'] = 'blue'
+        assert_equal(G[1][2]['eattr'], 'red')
+        assert_equal(sgs[1][2]['eattr'], 'blue')
 
     def test_is_weakly_connected(self):
-        wcc=nx.is_weakly_connected
-        cc=nx.is_connected
-        for G,C in self.gc:
-            U=G.to_undirected()
-            assert_equal(wcc(G),cc(U))
+        for G, C in self.gc:
+            U = G.to_undirected()
+            assert_equal(nx.is_weakly_connected(G), nx.is_connected(U))
 
+    def test_no_copy(self):
+        G, C = self.gc[0]
+        G.add_edge(1, 2, eattr='red')
+        G.node[1]['nattr'] = 'blue'
+        G.graph['gattr'] = 'green'
+        sgs = list(nx.weakly_connected_component_subgraphs(G, copy=False))[0]
+        assert_equal(sgs[1][2]['eattr'], 'red')
+        assert_equal(sgs.node[1]['nattr'], 'blue')
+        assert_equal(sgs.graph['gattr'], 'green')
+        sgs[1][2]['eattr'] = 'blue'
+        assert_equal(G[1][2]['eattr'], 'blue')
+        assert_equal(sgs[1][2]['eattr'], 'blue')
 
     def test_connected_raise(self):
         G=nx.Graph()
-        assert_raises(NetworkXNotImplemented,nx.weakly_connected_components,G)
-        assert_raises(NetworkXNotImplemented,nx.number_weakly_connected_components,G)
-        assert_raises(NetworkXNotImplemented,nx.weakly_connected_component_subgraphs,G)
-        assert_raises(NetworkXNotImplemented,nx.is_weakly_connected,G)
+        assert_raises(NetworkXNotImplemented,nx.weakly_connected_components, G)
+        assert_raises(NetworkXNotImplemented,nx.number_weakly_connected_components, G)
+        assert_raises(NetworkXNotImplemented,nx.weakly_connected_component_subgraphs, G)
+        assert_raises(NetworkXNotImplemented,nx.is_weakly_connected, G)

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -6,14 +6,14 @@ from networkx import NetworkXNotImplemented
 class TestWeaklyConnected:
 
     def setUp(self):
-        self.gc=[]
-        G=nx.DiGraph()
+        self.gc = []
+        G = nx.DiGraph()
         G.add_edges_from([(1, 2), (2, 3), (2, 8), (3, 4), (3, 7), (4, 5),
                           (5, 3), (5, 6), (7, 4), (7, 6), (8, 1), (8, 7)])
-        C=[[3, 4, 5, 7], [1, 2, 8], [6]]
+        C = [[3, 4, 5, 7], [1, 2, 8], [6]]
         self.gc.append((G, C))
 
-        G= nx.DiGraph()
+        G = nx.DiGraph()
         G.add_edges_from([(1, 2), (1, 3), (1, 4), (4, 2), (3, 4), (2, 3)])
         C = [[2, 3, 4],[1]]
         self.gc.append((G, C))
@@ -55,35 +55,11 @@ class TestWeaklyConnected:
             w = {frozenset(g) for g in wcc(G)}
             c = {frozenset(g) for g in cc(U)}
             assert_equal(w, c)
-        G, C = self.gc[0]
-        G.add_edge(1, 2, eattr='red')
-        G.node[1]['nattr'] = 'blue'
-        G.graph['gattr'] = 'green'
-        sgs = list(wcc(G))[0]
-        assert_equal(sgs[1][2]['eattr'], 'red')
-        assert_equal(sgs.node[1]['nattr'], 'blue')
-        assert_equal(sgs.graph['gattr'], 'green')
-        sgs[1][2]['eattr'] = 'blue'
-        assert_equal(G[1][2]['eattr'], 'red')
-        assert_equal(sgs[1][2]['eattr'], 'blue')
 
     def test_is_weakly_connected(self):
         for G, C in self.gc:
             U = G.to_undirected()
             assert_equal(nx.is_weakly_connected(G), nx.is_connected(U))
-
-    def test_no_copy(self):
-        G, C = self.gc[0]
-        G.add_edge(1, 2, eattr='red')
-        G.node[1]['nattr'] = 'blue'
-        G.graph['gattr'] = 'green'
-        sgs = list(nx.weakly_connected_component_subgraphs(G, copy=False))[0]
-        assert_equal(sgs[1][2]['eattr'], 'red')
-        assert_equal(sgs.node[1]['nattr'], 'blue')
-        assert_equal(sgs.graph['gattr'], 'green')
-        sgs[1][2]['eattr'] = 'blue'
-        assert_equal(G[1][2]['eattr'], 'blue')
-        assert_equal(sgs[1][2]['eattr'], 'blue')
 
     def test_connected_raise(self):
         G=nx.Graph()

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -127,8 +127,17 @@ def simple_cycles(G):
     Examples
     --------
     >>> G = nx.DiGraph([(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)])
-    >>> list(nx.simple_cycles(G))
-    [[2], [2, 1], [2, 0], [2, 0, 1], [0]]
+    >>> len(list(nx.simple_cycles(G)))
+    5
+
+    To filter the cycles so that they don't include certain nodes or edges,
+    copy your graph and eliminate those nodes or edges before calling::
+
+    >>> copyG = G.copy()
+    >>> copyG.remove_nodes_from([1])
+    >>> copyG.remove_edges_from([(0, 1)])
+    >>> len(list(nx.simple_cycles(copyG)))
+    3
 
     Notes
     -----
@@ -136,15 +145,6 @@ def simple_cycles(G):
 
     The time complexity is `O((n+e)(c+1))` for `n` nodes, `e` edges and `c`
     elementary circuits.
-
-    To filter the cycles so that they don't include certain nodes or edges,
-    copy your graph and eliminate those nodes or edges before calling::
-
-        >>> copyG = G.copy()
-        >>> copyG.remove_nodes_from([1])
-        >>> copyG.remove_edges_from([(0,1)])
-        >>> list(nx.simple_cycles(copyG))
-        [[2], [2, 0], [0]]
 
     References
     ----------
@@ -160,6 +160,7 @@ def simple_cycles(G):
     See Also
     --------
     cycle_basis
+
     """
     def _unblock(thisnode,blocked,B):
         stack=set([thisnode])


### PR DESCRIPTION
Use a plain BFS to compute connected components instead of using the single source shortest path function. The latter also does a BFS but keeps track of the distances. This is only slightly faster (around 5% in my tests), but I think it's conceptually better. As @ysitu said, we have a tendency to abuse shortest paths functions for reachability.

This came out while working on #1414 and trying to speed up the set consolidation function, that uses connected_components.

Also, following @jfinkels example (great work!), I've cleaned up the `biconnected.py` docstrings and code, and improved the examples showing how to use `max` to get the largest [bi]connected component.

Another thing that I'm not sure if we should change now is that there is an inconsistency between `connected_components` and `biconnected_components`, the former yield lists of nodes and the latter sets of nodes. I prefer yielding sets, and I think that if we change it we'll not break user code, but I thought it was better to discuss it before making the change. Thoughts?