### PR TITLE
average_degree_connectivity formatting fix.

### DIFF
--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -70,7 +70,8 @@ def average_degree_connectivity(G, source="in+out", target="in+out",
        Directed graphs only. Use "in"- or "out"-degree for target node.
 
     nodes: list or iterable (optional)
-        Compute neighbor connectivity for these nodes. The default is all nodes.
+        Compute neighbor connectivity for these nodes. The default is all
+        nodes.
 
     weight : string or None, optional (default=None)
        The edge attribute that holds the numerical value used as a weight.
@@ -109,16 +110,16 @@ def average_degree_connectivity(G, source="in+out", target="in+out",
     target_degree = G.degree
     neighbors = G.neighbors
     if G.is_directed():
-        direction = {'out':G.out_degree,
-                     'in':G.in_degree,
+        direction = {'out': G.out_degree,
+                     'in': G.in_degree,
                      'in+out': G.degree}
         source_degree = direction[source]
         target_degree = direction[target]
         if source == 'in':
-            neighbors=G.predecessors
+            neighbors = G.predecessors
         elif source == 'out':
-            neighbors=G.successors
+            neighbors = G.successors
     return _avg_deg_conn(G, neighbors, source_degree, target_degree,
                          nodes=nodes, weight=weight)
 
-k_nearest_neighbors=average_degree_connectivity
+k_nearest_neighbors = average_degree_connectivity

--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -44,7 +44,7 @@ def _avg_deg_conn(G, neighbors, source_degree, target_degree,
 
 def average_degree_connectivity(G, source="in+out", target="in+out",
                                 nodes=None, weight=None):
-    r"""Compute the average degree connectivity of graph.
+    """Compute the average degree connectivity of graph.
 
     The average degree connectivity is the average nearest neighbor degree of
     nodes with degree k. For weighted graphs, an analogous measure can
@@ -97,7 +97,7 @@ def average_degree_connectivity(G, source="in+out", target="in+out",
     Notes
     -----
     This algorithm is sometimes called "k nearest neighbors' and is also
-    available as `k_nearest_neighbors`.
+    available as ``k_nearest_neighbors``.
 
     References
     ----------


### PR DESCRIPTION
Just a simple formatting fix and also some pep8 formatting.

BTW I was wondering how much of pep8 does networkx follows? I find a lot of pep8 errors in the codebase here and then. I was wondering if pep8 is compromised a little. I would love to get some feedback.