### PR TITLE
Cleans docs and simplifies bipartite.redundancy

### DIFF
--- a/networkx/algorithms/bipartite/redundancy.py
+++ b/networkx/algorithms/bipartite/redundancy.py
@@ -1,32 +1,40 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """Node redundancy for bipartite graphs."""
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    Aric Hagberg <hagberg@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+from __future__ import division
+
 from itertools import combinations
-import networkx as nx
+
+from networkx import NetworkXError
 
 __author__ = """\n""".join(['Jordi Torrents <jtorrents@milnou.net>',
                             'Aric Hagberg (hagberg@lanl.gov)'])
 __all__ = ['node_redundancy']
 
-def node_redundancy(G, nodes=None):
-    r"""Compute bipartite node redundancy coefficient.
 
-    The redundancy coefficient of a node `v` is the fraction of pairs of 
+def node_redundancy(G, nodes=None):
+    """Computes the node redundancy coefficients for the nodes in the bipartite
+    graph ``G``.
+
+    The redundancy coefficient of a node `v` is the fraction of pairs of
     neighbors of `v` that are both linked to other nodes. In a one-mode
-    projection these nodes would be linked together even if `v`  were 
+    projection these nodes would be linked together even if `v` were
     not there.
-    
+
+    More formally, for any vertex `v`, the *redundancy coefficient of `v`* is
+    defined by
+
     .. math::
 
-        rc(v) = \frac{|\{\{u,w\} \subseteq N(v),
-        \: \exists v' \neq  v,\: (v',u) \in E\: 
-        \mathrm{and}\: (v',w) \in E\}|}{ \frac{|N(v)|(|N(v)|-1)}{2}}
+        rc(v) = \frac{|\{\{u, w\} \subseteq N(v),
+        \: \exists v' \neq  v,\: (v',u) \in E\:
+        \mathrm{and}\: (v',w) \in E\}|}{ \frac{|N(v)|(|N(v)|-1)}{2}},
 
-    where `N(v)` are the neighbors of `v` in `G`.
+    where `N(v)` is the set of neighbors of `v` in ``G``.
 
     Parameters
     ----------
@@ -43,42 +51,71 @@ def node_redundancy(G, nodes=None):
 
     Examples
     --------
-    >>> from networkx.algorithms import bipartite
-    >>> G = nx.cycle_graph(4)
-    >>> rc = bipartite.node_redundancy(G)
-    >>> rc[0]
-    1.0
+    Compute the redundancy coefficient of each node in a graph::
 
-    Compute the average redundancy for the graph:
+        >>> import networkx as nx
+        >>> from networkx.algorithms import bipartite
+        >>> G = nx.cycle_graph(4)
+        >>> rc = bipartite.node_redundancy(G)
+        >>> rc[0]
+        1.0
 
-    >>> sum(rc.values())/len(G)
-    1.0
+    Compute the average redundancy for the graph::
 
-    Compute the average redundancy for a set of nodes:
+        >>> import networkx as nx
+        >>> from networkx.algorithms import bipartite
+        >>> G = nx.cycle_graph(4)
+        >>> rc = bipartite.node_redundancy(G)
+        >>> sum(rc.values()) / len(G)
+        1.0
 
-    >>> nodes = [0, 2]
-    >>> sum(rc[n] for n in nodes)/len(nodes)
-    1.0
+    Compute the average redundancy for a set of nodes::
+
+        >>> import networkx as nx
+        >>> from networkx.algorithms import bipartite
+        >>> G = nx.cycle_graph(4)
+        >>> rc = bipartite.node_redundancy(G)
+        >>> nodes = [0, 2]
+        >>> sum(rc[n] for n in nodes) / len(nodes)
+        1.0
+
+    Raises
+    ------
+    NetworkXError
+        If any of the nodes in the graph (or in ``nodes``, if specified) has
+        (out-)degree less than two (which would result in division by zero,
+        according to the definition of the redundancy coefficient).
 
     References
     ----------
     .. [1] Latapy, Matthieu, Clémence Magnien, and Nathalie Del Vecchio (2008).
-       Basic notions for the analysis of large two-mode networks. 
+       Basic notions for the analysis of large two-mode networks.
        Social Networks 30(1), 31--48.
+
     """
     if nodes is None:
         nodes = G
-    rc = {}
-    for v in nodes:
-        overlap = 0.0
-        for u, w in combinations(G[v], 2):
-            if len((set(G[u]) & set(G[w])) - set([v])) > 0:
-                overlap += 1
-        if overlap > 0:
-            n = len(G[v])
-            norm = 2.0/(n*(n-1))
-        else:
-            norm = 1.0
-        rc[v] = overlap*norm
-    return rc
+    if any(len(G[v]) < 2 for v in nodes):
+        raise NetworkXError('Cannot compute redundancy coefficient for a node'
+                            ' that has fewer than two neighbors.')
+    # TODO This can be trivially parallelized.
+    return {v: _node_redundancy(G, v) for v in nodes}
 
+
+def _node_redundancy(G, v):
+    """Returns the redundancy of the node ``v`` in the bipartite graph ``G``.
+
+    If ``G`` is a graph with ``n`` nodes, the redundancy of a node is the ratio
+    of the "overlap" of ``v`` to the maximum possible overlap of ``v``
+    according to its degree. The overlap of ``v`` is the number of pairs of
+    neighbors that have mutual neighbors themselves, other than ``v``.
+
+    ``v`` must have at least two neighbors in ``G``.
+
+    """
+    n = len(G[v])
+    # TODO On Python 3, we could just use `G[u].keys() & G[w].keys()` instead
+    # of instantiating the entire sets.
+    overlap = sum(1 for (u, w) in combinations(G[v], 2)
+                  if (set(G[u]) & set(G[w])) - {v})
+    return (2 * overlap) / (n * (n - 1))

--- a/networkx/algorithms/bipartite/tests/test_redundancy.py
+++ b/networkx/algorithms/bipartite/tests/test_redundancy.py
@@ -1,0 +1,44 @@
+# test_redundancy.py - unit tests for the bipartite.redundancy module
+#
+# Copyright 2015 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.bipartite.redundancy` module.
+
+"""
+from __future__ import division
+
+from nose.tools import assert_equal
+from nose.tools import assert_true
+from nose.tools import raises
+
+from networkx import cycle_graph
+from networkx import NetworkXError
+from networkx.algorithms.bipartite import complete_bipartite_graph
+from networkx.algorithms.bipartite import node_redundancy
+
+
+def test_no_redundant_nodes():
+    G = complete_bipartite_graph(2, 2)
+    rc = node_redundancy(G)
+    assert_true(all(redundancy == 1 for redundancy in rc.values()))
+
+
+def test_redundant_nodes():
+    G = cycle_graph(6)
+    edge = {0, 3}
+    G.add_edge(*edge)
+    redundancy = node_redundancy(G)
+    for v in edge:
+        assert_equal(redundancy[v], 2 / 3)
+    for v in set(G) - edge:
+        assert_equal(redundancy[v], 1)
+
+
+@raises(NetworkXError)
+def test_not_enough_neighbors():
+    G = complete_bipartite_graph(1, 2)
+    node_redundancy(G)


### PR DESCRIPTION
Cleans and updates the documentation for the
`networkx.algorithms.bipartite.redundancy` module, and creates a
corresponding test module.

Also simplifies the code for computing the node redundancy.

I did some (minimal) timing tests, and this appears to be about the same as the previous code.