### PR TITLE
Add approximation import

### DIFF
--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -1,4 +1,3 @@
-from networkx.algorithms.approximation import *
 from networkx.algorithms.assortativity import *
 from networkx.algorithms.block import *
 from networkx.algorithms.boundary import *
@@ -37,7 +36,6 @@ from networkx.algorithms.swap import *
 from networkx.algorithms.graphical import *
 from networkx.algorithms.simple_paths import *
 
-import networkx.algorithms.approximation
 import networkx.algorithms.assortativity
 import networkx.algorithms.bipartite
 import networkx.algorithms.centrality

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -1,3 +1,4 @@
+from networkx.algorithms.approximation import *
 from networkx.algorithms.assortativity import *
 from networkx.algorithms.block import *
 from networkx.algorithms.boundary import *
@@ -36,6 +37,7 @@ from networkx.algorithms.swap import *
 from networkx.algorithms.graphical import *
 from networkx.algorithms.simple_paths import *
 
+import networkx.algorithms.approximation
 import networkx.algorithms.assortativity
 import networkx.algorithms.bipartite
 import networkx.algorithms.centrality

--- a/networkx/algorithms/approximation/__init__.py
+++ b/networkx/algorithms/approximation/__init__.py
@@ -1,3 +1,8 @@
+'''
+    .. warning:: The approximation submodule is not imported automatically with networkx.
+    
+    Approximate algorithms can be imported with ``from networkx.algorithms import approximation``.
+'''
 from networkx.algorithms.approximation.clustering_coefficient import *
 from networkx.algorithms.approximation.clique import *
 from networkx.algorithms.approximation.connectivity import *


### PR DESCRIPTION
This submodule is not accessible when one imports networkX with `import networkx as nx`.
Is there a particular reason *not* to import this submodule with the rest of the package?
