### PR TITLE
Fixing algorithmic mistake in clique.py

### DIFF
--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -92,6 +92,13 @@ def clique_removal(G):
             cliques.append(c_i)
         if i_i:
             isets.append(i_i)
-
-    maxiset = max(isets)
+    
+    # max iset doesn't return the maximal set
+    # try with a clique 5 + 1 additional node, the max_clique(G) will fail and return only one node
+    # here we just return the biggest clique (iset), however, multiple biggest cliques can be found
+    lengths = [len(i) for i in isets]
+    indexOfMax = length.index(max(lengths))
+    maxiset = isets[indexOfMax]
+    
+    
     return maxiset, cliques


### PR DESCRIPTION
Currently 'maxiset' doesn't return the maximal set, but applies max() on a list of sets but what we need here is the biggest set.
Here is a fix.