### PR TITLE
Fixing algorithmic mistake in ramsey.py

### DIFF
--- a/networkx/algorithms/approximation/ramsey.py
+++ b/networkx/algorithms/approximation/ramsey.py
@@ -34,4 +34,14 @@ def ramsey_R2(G):
 
     c_1.add(node)
     i_2.add(node)
-    return (max([c_1, c_2]), max([i_1, i_2]))
+
+    # max here should based on size of sets/lists
+    max_c = c_1
+    if len(c_2) > len(c_1):
+        max_c = c2
+
+    max_i = i_1
+    if len(i_2) > len(i_1):
+        max_i = i2
+
+    return (max_c, max_i)


### PR DESCRIPTION
Same issue as in clique.py
The definition of max for lists of sets/lists is not the one that returns the largest in terms of size.
We now insure the return of the largest elements