### PR TITLE
Computes approximate clique using size of sets

### DIFF
--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -92,6 +92,13 @@ def clique_removal(G):
             cliques.append(c_i)
         if i_i:
             isets.append(i_i)
-
-    maxiset = max(isets)
+    
+    # max iset doesn't return the maximal set
+    # try with a clique 5 + 1 additional node, the max_clique(G) will fail and return only one node
+    # here we just return the biggest clique (iset), however, multiple biggest cliques can be found
+    lengths = [len(i) for i in isets]
+    indexOfMax = length.index(max(lengths))
+    maxiset = isets[indexOfMax]
+    
+    
     return maxiset, cliques

--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -97,7 +97,7 @@ def clique_removal(G):
     # try with a clique 5 + 1 additional node, the max_clique(G) will fail and return only one node
     # here we just return the biggest clique (iset), however, multiple biggest cliques can be found
     lengths = [len(i) for i in isets]
-    indexOfMax = length.index(max(lengths))
+    indexOfMax = lengths.index(max(lengths))
     maxiset = isets[indexOfMax]
     
     


### PR DESCRIPTION
Fixing the following algorithmic mistake:
max(list(sets)) does not return the maximum size set.