### PR TITLE
Fixes issue #1539 Bug in relabel_nodes for isolated nodes

### DIFF
--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -107,6 +107,8 @@ def _relabel_inplace(G, mapping):
             new = mapping[old]
         except KeyError:
             continue
+        if new == old:
+            continue
         try:
             G.add_node(new, attr_dict=G.node[old])
         except KeyError:

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -137,6 +137,13 @@ class TestRelabel():
         assert_equal(sorted(G.edges()),
                      [('aardvark', 'bear'), ('aardvark', 'bear')])
 
+    def test_relabel_isolated_nodes_to_same(self):
+        G=Graph()
+        G.add_nodes_from(range(4))
+        mapping={1:1}
+        H=relabel_nodes(G, mapping, copy=False)
+        assert_equal(sorted(H.nodes()), list(range(4)))
+
     @raises(KeyError)
     def test_relabel_nodes_missing(self):
         G=Graph([('A','B'),('A','C'),('B','C'),('C','D')])


### PR DESCRIPTION
Fixes #1593 relabel_nodes(copy=False) bug removed an isolated node when relabeled to itself.

Fix is that any node relabeled to itself is simply skipped in the relabeling.