### PR TITLE
Adds triangular lattice generator and grid layout

### DIFF
--- a/doc/source/reference/drawing.rst
+++ b/doc/source/reference/drawing.rst
@@ -78,8 +78,10 @@ Graph Layout
    :toctree: generated/
 
    circular_layout
+   grid_layout
+   hexagonal_lattice_layout
    random_layout
    shell_layout
    spring_layout
    spectral_layout
-
+   triangular_lattice_layout

--- a/doc/source/reference/generators.rst
+++ b/doc/source/reference/generators.rst
@@ -30,9 +30,6 @@ Classic
    cycle_graph
    dorogovtsev_goltsev_mendes_graph
    empty_graph
-   grid_2d_graph
-   grid_graph
-   hypercube_graph
    ladder_graph
    lollipop_graph
    null_graph
@@ -50,6 +47,19 @@ Expanders
 
    margulis_gabber_galil_graph
    chordal_cycle_graph
+
+
+Lattice
+-------
+.. automodule:: networkx.generators.lattice
+.. autosummary::
+   :toctree:generated/
+
+   grid_2d_graph
+   grid_graph
+   hexagonal_lattice_graph
+   hypercube_graph
+   triangular_lattice_graph
 
 
 Small

--- a/networkx/generators/__init__.py
+++ b/networkx/generators/__init__.py
@@ -8,6 +8,7 @@ from networkx.generators.directed import *
 from networkx.generators.ego import *
 from networkx.generators.expanders import *
 from networkx.generators.geometric import *
+from networkx.generators.lattice import *
 from networkx.generators.line import *
 from networkx.generators.random_graphs import *
 from networkx.generators.small import *

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -33,9 +33,6 @@ __all__ = [ 'balanced_tree',
             'dorogovtsev_goltsev_mendes_graph',
             'empty_graph',
             'full_rary_tree',
-            'grid_graph',
-            'grid_2d_graph',
-            'hypercube_graph',
             'ladder_graph',
             'lollipop_graph',
             'null_graph',
@@ -356,88 +353,6 @@ def empty_graph(n=0,create_using=None):
     G.name="empty_graph(%d)"%n
     return G
 
-def grid_2d_graph(m,n,periodic=False,create_using=None):
-    """ Return the 2d grid graph of mxn nodes,
-        each connected to its nearest neighbors.
-        Optional argument periodic=True will connect
-        boundary nodes via periodic boundary conditions.
-    """
-    G=empty_graph(0,create_using)
-    G.name="grid_2d_graph"
-    rows=range(m)
-    columns=range(n)
-    G.add_nodes_from( (i,j) for i in rows for j in columns )
-    G.add_edges_from( ((i,j),(i-1,j)) for i in rows for j in columns if i>0 )
-    G.add_edges_from( ((i,j),(i,j-1)) for i in rows for j in columns if j>0 )
-    if G.is_directed():
-        G.add_edges_from( ((i,j),(i+1,j)) for i in rows for j in columns if i<m-1 )
-        G.add_edges_from( ((i,j),(i,j+1)) for i in rows for j in columns if j<n-1 )
-    if periodic:
-        if n>2:
-            G.add_edges_from( ((i,0),(i,n-1)) for i in rows )
-            if G.is_directed():
-                G.add_edges_from( ((i,n-1),(i,0)) for i in rows )
-        if m>2:
-            G.add_edges_from( ((0,j),(m-1,j)) for j in columns )
-            if G.is_directed():
-                G.add_edges_from( ((m-1,j),(0,j)) for j in columns )
-        G.name="periodic_grid_2d_graph(%d,%d)"%(m,n)
-    return G
-
-
-def grid_graph(dim,periodic=False):
-    """ Return the n-dimensional grid graph.
-
-    The dimension is the length of the list 'dim' and the
-    size in each dimension is the value of the list element.
-
-    E.g. G=grid_graph(dim=[2,3]) produces a 2x3 grid graph.
-
-    If periodic=True then join grid edges with periodic boundary conditions.
-
-    """
-    dlabel="%s"%dim
-    if dim==[]:
-        G=empty_graph(0)
-        G.name="grid_graph(%s)"%dim
-        return G
-    if not is_list_of_ints(dim):
-        raise nx.NetworkXError("dim is not a list of integers")
-    if min(dim)<=0:
-        raise nx.NetworkXError(\
-              "dim is not a list of strictly positive integers")
-    if periodic:
-        func=cycle_graph
-    else:
-        func=path_graph
-
-    dim=list(dim)
-    current_dim=dim.pop()
-    G=func(current_dim)
-    while len(dim)>0:
-        current_dim=dim.pop()
-        # order matters: copy before it is cleared during the creation of Gnew
-        Gold=G.copy()
-        Gnew=func(current_dim)
-        # explicit: create_using=None
-        # This is so that we get a new graph of Gnew's class.
-        G=nx.cartesian_product(Gnew,Gold)
-    # graph G is done but has labels of the form (1,(2,(3,1)))
-    # so relabel
-    H=nx.relabel_nodes(G, flatten)
-    H.name="grid_graph(%s)"%dlabel
-    return H
-
-def hypercube_graph(n):
-    """Return the n-dimensional hypercube.
-
-    Node labels are the integers 0 to 2**n - 1.
-
-    """
-    dim=n*[2]
-    G=grid_graph(dim)
-    G.name="hypercube_graph_(%d)"%n
-    return G
 
 def ladder_graph(n,create_using=None):
     """Return the Ladder graph of length n.

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+#
+# lattice.py - functions for generating graphs of point lattices
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions for generating graphs representing `point lattices`_, such as
+rectangular or triangular grid graphs.
+
+The :func:`grid_2d_graph`, :func:`triangular_lattice_graph`, and
+:func:`hexagonal_lattice_graph` functions correspond to the three
+`regular tilings of the plane`_, the square, triangular, and hexagonal
+tilings, respectively.
+
+.. _point lattices: http://mathworld.wolfram.com/PointLattice.html
+.. _regular tilings of the plane: https://en.wikipedia.org/wiki/List_of_regular_polytopes_and_compounds#Euclidean_tilings
+
+"""
+from __future__ import division
+
+from itertools import chain
+
+from networkx.classes import Graph
+from networkx.algorithms.operators.product import cartesian_product
+from networkx.exception import NetworkXError
+from networkx.relabel import relabel_nodes
+from networkx.utils import flatten
+from networkx.utils import is_list_of_ints
+from networkx.generators.classic import cycle_graph
+from networkx.generators.classic import empty_graph
+from networkx.generators.classic import path_graph
+
+__all__ = ['grid_2d_graph', 'grid_graph', 'hypercube_graph',
+           'triangular_lattice_graph']
+
+
+def grid_2d_graph(m, n, periodic=False, create_using=None):
+    """Returns the two-dimensional grid graph.
+
+    Parameters
+    ----------
+    m, n : int
+        The dimensions of the graph. The number of nodes will be ``m *
+        n``.
+
+    periodic : bool
+        If this is ``True`` the nodes on the grid boundaries are joined
+        to the corresponding nodes on the opposite grid boundaries.
+
+    create_using : NetworkX graph
+        If specified, a graph whose type matches that of this object
+        will be returned.
+
+    Returns
+    -------
+    NetworkX graph
+        The (possibly periodic) grid graph of the specified dimensions.
+
+    """
+    G = empty_graph(0, create_using)
+    G.name = "grid_2d_graph"
+    rows = range(m)
+    columns = range(n)
+    G.add_nodes_from((i, j) for i in rows for j in columns)
+    G.add_edges_from(((i, j), (i - 1, j)) for i in rows for j in columns
+                     if i > 0)
+    G.add_edges_from(((i, j), (i, j - 1)) for i in rows for j in columns
+                     if j > 0)
+    if G.is_directed():
+        G.add_edges_from(((i, j), (i + 1, j)) for i in rows for j in columns
+                         if i < m - 1)
+        G.add_edges_from(((i, j), (i, j + 1)) for i in rows for j in columns
+                         if j < n - 1)
+    if periodic:
+        if n > 2:
+            G.add_edges_from(((i, 0), (i, n - 1)) for i in rows)
+            if G.is_directed():
+                G.add_edges_from(((i, n - 1), (i, 0)) for i in rows)
+        if m > 2:
+            G.add_edges_from(((0, j), (m - 1, j)) for j in columns)
+            if G.is_directed():
+                G.add_edges_from(((m - 1, j), (0, j)) for j in columns)
+        G.name = "periodic_grid_2d_graph(%d,%d)" % (m, n)
+    return G
+
+
+def grid_graph(dim, periodic=False):
+    """Returns the *n*-dimensional grid graph.
+
+    The dimension *n* is the length of the list ``dim`` and the size in
+    each dimension is the value of the corresponding list element.
+
+    Parameters
+    ----------
+    dim : list
+        A list of integers representing the size of each dimension. The
+        number of dimensions is the length of this list.
+
+    periodic : bool
+        If this is ``True`` the nodes on the grid boundaries are joined
+        to the corresponding nodes on the opposite grid boundaries.
+
+    Returns
+    -------
+    NetworkX graph
+        The (possibly periodic) grid graph of the specified dimensions.
+
+    Examples
+    --------
+    To produce a 2 × 3 × 4 grid graph, a graph on 24 nodes::
+
+        >>> G = grid_graph(dim=[2, 3, 4])
+        >>> len(G)
+        24
+
+    """
+    dlabel = "%s" % dim
+    if dim == []:
+        G = empty_graph(0)
+        G.name = "grid_graph(%s)" % dim
+        return G
+    if not is_list_of_ints(dim):
+        raise NetworkXError("dim is not a list of integers")
+    if min(dim) <= 0:
+        raise NetworkXError("dim is not a list of strictly positive integers")
+    if periodic:
+        func = cycle_graph
+    else:
+        func = path_graph
+
+    dim = list(dim)
+    current_dim = dim.pop()
+    G = func(current_dim)
+    while len(dim) > 0:
+        current_dim = dim.pop()
+        # order matters: copy before it is cleared during the creation of Gnew
+        Gold = G.copy()
+        Gnew = func(current_dim)
+        # explicit: create_using = None
+        # This is so that we get a new graph of Gnew's class.
+        G = cartesian_product(Gnew, Gold)
+    # graph G is done but has labels of the form (1,(2,(3,1)))
+    # so relabel
+    H = relabel_nodes(G, flatten)
+    H.name = "grid_graph(%s)" % dlabel
+    return H
+
+
+def hypercube_graph(n):
+    """Returns the *n*-dimensional hypercube graph.
+
+    The nodes are the integers between 0 and ``2 ** n - 1``, inclusive.
+
+    For more information on the hypercube graph, see the Wikipedia
+    article *`Hypercube graph`_*.
+
+    .. _Hypercube graph: https://en.wikipedia.org/wiki/Hypercube_graph
+
+    Parameters
+    ----------
+    n : int
+        The dimension of the hypercube. The number of nodes in the graph
+        will be ``2 ** n - 1``.
+
+    Returns
+    -------
+    NetworkX graph
+        The hypercube graph of dimension *n*. This graph has ``2 ** n``
+        nodes.
+
+    """
+    dim = n * [2]
+    G = grid_graph(dim)
+    G.name = "hypercube_graph_(%d)" % n
+    return G
+
+
+def triangular_lattice_graph(m, n, periodic=False, create_using=None):
+    """Returns the *m* × *n* triangular lattice graph.
+
+    The *`triangular lattice graph`_* is a two-dimensional grid graph in
+    which each grid unit has a chord (in other words, each square has a
+    diagonal edge).
+
+    The returned graph will have ``m`` rows and ``n`` columns of
+    primitive units.
+
+    .. _triangular lattice graph: http://mathworld.wolfram.com/TriangularGrid.html
+
+    Parameters
+    ----------
+    m : int
+        The number of rows in the lattice.
+
+    n : int
+        The number of columns in the lattice.
+
+    periodic : bool
+        Whether to join the boundary vertices of the grid using periodic
+        boundary conditions.
+
+    create_using : NetworkX graph
+        If specified, this must be an instance of a NetworkX graph
+        class; the type of this graph dictates the type of the output
+        graph. If not specified, the returned graph will have the same
+        type as the input graph.
+
+    Returns
+    -------
+    NetworkX graph
+        The *m* × *n* triangular lattice graph.
+
+    """
+    G = grid_2d_graph(m, n, periodic=periodic, create_using=create_using)
+    # If the graph is periodic, add edges as if the lattice were on a torus.
+    rows = m if periodic else m - 1
+    cols = n if periodic else n - 1
+    # Add the triangle edges: a chord within each square.
+    diag = lambda i, j: ((i + 1) % m, (j + 1) % n)
+    chords = (((i, j), diag(i, j)) for i in range(rows) for j in range(cols))
+    G.add_edges_from(chords)
+    # If the graph is directed, add the reverse edges as well.
+    if G.is_directed():
+        G.add_edges_from((v, u) for (u, v) in G.edges())
+    G.name = 'triangular_lattice_graph({}, {})'.format(m, n)
+    return G
+
+
+def hexagonal_lattice_graph(m, n, periodic=False, create_using=None):
+    """Returns the *m* × *n* hexagonal lattice graph.
+
+    The *hexagonal lattice graph* is a graph whose nodes and edges are
+    the vertices and edges of the `hexagonal tiling`_ of the plane.
+
+    The returned graph will have ``m`` rows of hexagons and ``n / 2``
+    columns of hexagons.
+
+    .. _hexagonal tiling: https://en.wikipedia.org/wiki/Hexagonal_tiling
+
+    Parameters
+    ----------
+    m : int
+        The number of rows of hexagons in the lattice.
+
+    n : int
+        Twice the number of columns of hexagons in the lattice.
+
+    periodic : bool
+        Whether to join the boundary vertices of the grid using periodic
+        boundary conditions.
+
+    create_using : NetworkX graph
+        If specified, this must be an instance of a NetworkX graph
+        class; the type of this graph dictates the type of the output
+        graph. If not specified, the returned graph will have the same
+        type as the input graph.
+
+    Returns
+    -------
+    NetworkX graph
+        The *m* × *n* hexagonal lattice graph.
+
+    """
+    G = create_using if create_using is not None else Graph()
+    G.clear()
+    G.add_nodes_from((i, j) for i in range(m) for j in range(n))
+    # Add "row" edges and "column" edges.
+    row_edges = (((i, j), (i, j + 1)) for i in range(m) for j in range(n - 1))
+    col_edges = (((i, 2 * j + (i % 2)), (i + 1, 2 * j + (i % 2)))
+                 for i in range(m - 1) for j in range((n // 2) - 1))
+    G.add_edges_from(chain(row_edges, col_edges))
+    if G.is_directed():
+        G.add_edges_from((v, u) for (u, v) in G.edges())
+    G.name = 'hexagonal_lattice_graph({}, {})'.format(m, n)
+    return G

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -226,56 +226,6 @@ class TestGeneratorClassic():
         assert_equal(G.name, 'empty_graph(42)')
         assert_true(isinstance(G,Graph))
 
-    def test_grid_2d_graph(self):
-        n=5;m=6
-        G=grid_2d_graph(n,m)
-        assert_equal(number_of_nodes(G), n*m)
-        assert_equal(degree_histogram(G), [0,0,4,2*(n+m)-8,(n-2)*(m-2)])
-        DG=grid_2d_graph(n,m, create_using=DiGraph())
-        assert_equal(DG.succ, G.adj)
-        assert_equal(DG.pred, G.adj)
-        MG=grid_2d_graph(n,m, create_using=MultiGraph())
-        assert_equal(sorted(MG.edges()), sorted(G.edges()))
-
-    def test_grid_graph(self):
-        """grid_graph([n,m]) is a connected simple graph with the
-        following properties:
-        number_of_nodes=n*m
-        degree_histogram=[0,0,4,2*(n+m)-8,(n-2)*(m-2)]
-        """
-        for n, m in [(3, 5), (5, 3), (4, 5), (5, 4)]:
-            dim=[n,m]
-            g=grid_graph(dim)
-            assert_equal(number_of_nodes(g), n*m)
-            assert_equal(degree_histogram(g), [0,0,4,2*(n+m)-8,(n-2)*(m-2)])
-            assert_equal(dim,[n,m])
-
-        for n, m in [(1, 5), (5, 1)]:
-            dim=[n,m]
-            g=grid_graph(dim)
-            assert_equal(number_of_nodes(g), n*m)
-            assert_true(is_isomorphic(g,path_graph(5)))
-            assert_equal(dim,[n,m])
-
-#        mg=grid_graph([n,m], create_using=MultiGraph())
-#        assert_equal(mg.edges(), g.edges())
-
-    def test_hypercube_graph(self):
-        for n, G in [(0, null_graph()), (1, path_graph(2)),
-                     (2, cycle_graph(4)), (3, cubical_graph())]:
-            g=hypercube_graph(n)
-            assert_true(is_isomorphic(g, G))
-
-        g=hypercube_graph(4)
-        assert_equal(degree_histogram(g), [0, 0, 0, 0, 16])
-        g=hypercube_graph(5)
-        assert_equal(degree_histogram(g), [0, 0, 0, 0, 0, 32])
-        g=hypercube_graph(6)
-        assert_equal(degree_histogram(g), [0, 0, 0, 0, 0, 0, 64])
-
-#        mg=hypercube_graph(6, create_using=MultiGraph())
-#        assert_equal(mg.edges(), g.edges())
-
     def test_ladder_graph(self):
         for i, G in [(0, empty_graph(0)), (1, path_graph(2)),
                      (2, hypercube_graph(2)), (10, grid_graph([2,10]))]:
@@ -341,23 +291,6 @@ class TestGeneratorClassic():
 
         mp=path_graph(10, create_using=MultiGraph())
         assert_equal(sorted(mp.edges()), sorted(p.edges()))
-
-    def test_periodic_grid_2d_graph(self):
-        g=grid_2d_graph(0,0, periodic=True)
-        assert_equal(dict(g.degree()), {})
-
-        for m, n, G in [(2, 2, cycle_graph(4)), (1, 7, cycle_graph(7)),
-                     (7, 1, cycle_graph(7)), (2, 5, circular_ladder_graph(5)),
-                     (5, 2, circular_ladder_graph(5)), (2, 4, cubical_graph()),
-                     (4, 2, cubical_graph())]:
-            g=grid_2d_graph(m,n, periodic=True)
-            assert_true(is_isomorphic(g, G))
-
-        DG=grid_2d_graph(4, 2, periodic=True, create_using=DiGraph())
-        assert_equal(DG.succ,g.adj)
-        assert_equal(DG.pred,g.adj)
-        MG=grid_2d_graph(4, 2, periodic=True, create_using=MultiGraph())
-        assert_equal(sorted(MG.edges()), sorted(g.edges()))
 
     def test_star_graph(self):
         assert_true(is_isomorphic(star_graph(0), empty_graph(1)))

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -1,0 +1,191 @@
+# test_lattice.py - unit tests for the lattice module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.generators.lattice` module."""
+import itertools
+
+from nose.tools import assert_equal
+from nose.tools import assert_true
+
+import networkx as nx
+
+
+class TestGrid2DGraph:
+    """Unit tests for the :func:`networkx.generators.lattice.grid_2d_graph`
+    function.
+
+    """
+    def test_number_of_vertices(self):
+        m, n = 5, 6
+        G = nx.grid_2d_graph(m, n)
+        assert_equal(len(G), m * n)
+
+    def test_degree_distribution(self):
+        m, n = 5, 6
+        G = nx.grid_2d_graph(m, n)
+        expected_histogram = [0, 0, 4, 2 * (m + n) - 8, (m - 2) * (n - 2)]
+        assert_equal(nx.degree_histogram(G), expected_histogram)
+
+    def test_directed(self):
+        m, n = 5, 6
+        G = nx.grid_2d_graph(m, n)
+        H = nx.grid_2d_graph(m, n, create_using=nx.DiGraph())
+        assert_equal(H.succ, G.adj)
+        assert_equal(H.pred, G.adj)
+
+    def test_multigraph(self):
+        m, n = 5, 6
+        G = nx.grid_2d_graph(m, n)
+        H = nx.grid_2d_graph(m, n, create_using=nx.MultiGraph())
+        assert_equal(list(H.edges()), list(G.edges()))
+
+    def test_periodic(self):
+        G = nx.grid_2d_graph(0, 0, periodic=True)
+        assert_equal(dict(G.degree()), {})
+
+        for m, n, H in [(2, 2, nx.cycle_graph(4)), (1, 7, nx.cycle_graph(7)),
+                        (7, 1, nx.cycle_graph(7)),
+                        (2, 5, nx.circular_ladder_graph(5)),
+                        (5, 2, nx.circular_ladder_graph(5)),
+                        (2, 4, nx.cubical_graph()),
+                        (4, 2, nx.cubical_graph())]:
+            G = nx.grid_2d_graph(m, n, periodic=True)
+            assert_true(nx.could_be_isomorphic(G, H))
+
+    def test_periodic_directed(self):
+        G = nx.grid_2d_graph(4, 2, periodic=True)
+        H = nx.grid_2d_graph(4, 2, periodic=True, create_using=nx.DiGraph())
+        assert_equal(H.succ, G.adj)
+        assert_equal(H.pred, G.adj)
+
+    def test_periodic_multigraph(self):
+        G = nx.grid_2d_graph(4, 2, periodic=True)
+        H = nx.grid_2d_graph(4, 2, periodic=True, create_using=nx.MultiGraph())
+        assert_equal(list(G.edges()), list(H.edges()))
+
+
+class TestGridGraph:
+    """Unit tests for the :func:`networkx.generators.lattice.grid_graph`
+    function.
+
+    """
+
+    def test_grid_graph(self):
+        """grid_graph([n,m]) is a connected simple graph with the
+        following properties:
+        number_of_nodes = n*m
+        degree_histogram = [0,0,4,2*(n+m)-8,(n-2)*(m-2)]
+        """
+        for n, m in [(3, 5), (5, 3), (4, 5), (5, 4)]:
+            dim = [n, m]
+            g = nx.grid_graph(dim)
+            assert_equal(len(g), n*m)
+            assert_equal(nx.degree_histogram(g), [0, 0, 4, 2 * (n + m) - 8,
+                                                  (n - 2) * (m - 2)])
+            assert_equal(dim, [n, m])
+
+        for n, m in [(1, 5), (5, 1)]:
+            dim = [n, m]
+            g = nx.grid_graph(dim)
+            assert_equal(len(g), n*m)
+            assert_true(nx.is_isomorphic(g, nx.path_graph(5)))
+            assert_equal(dim, [n, m])
+
+#        mg = grid_graph([n,m], create_using=MultiGraph())
+#        assert_equal(mg.edges(), g.edges())
+
+
+class TestHypercubeGraph:
+    """Unit tests for the :func:`networkx.generators.lattice.hypercube_graph`
+    function.
+
+    """
+
+    def test_special_cases(self):
+        for n, H in [(0, nx.null_graph()), (1, nx.path_graph(2)),
+                     (2, nx.cycle_graph(4)), (3, nx.cubical_graph())]:
+            G = nx.hypercube_graph(n)
+            assert_true(nx.could_be_isomorphic(G, H))
+
+    def test_degree_distribution(self):
+        for n in range(1, 10):
+            G = nx.hypercube_graph(n)
+            expected_histogram = [0] * n + [2 ** n]
+            assert_equal(nx.degree_histogram(G), expected_histogram)
+
+
+class TestTriangularLatticeGraph:
+    """Unit tests for the
+    :func:`networkx.generators.lattice.triangular_lattice_graph`
+    function.
+
+    """
+
+    def test_lattice_points(self):
+        """Tests that the graph is really a triangular lattice."""
+        m = 3
+        n = 4
+        G = nx.triangular_lattice_graph(m, n)
+        assert_equal(len(G), m * n)
+        for (i, j) in itertools.product(range(m - 1), range(n - 1)):
+            assert_true((i, j + 1) in G[(i, j)])
+            assert_true((i + 1, j) in G[(i, j)])
+            assert_true((i + 1, j + 1) in G[(i, j)])
+
+    def test_directed(self):
+        """Tests for creating a directed triangular lattice."""
+        G = nx.triangular_lattice_graph(3, 4, create_using=nx.Graph())
+        H = nx.triangular_lattice_graph(3, 4, create_using=nx.DiGraph())
+        assert_true(H.is_directed())
+        assert_equal(H.succ, G.adj)
+        assert_equal(H.pred, G.adj)
+
+    def test_multigraph(self):
+        """Tests for creating a triangular lattice multigraph."""
+        G = nx.triangular_lattice_graph(3, 4, create_using=nx.Graph())
+        H = nx.triangular_lattice_graph(3, 4, create_using=nx.MultiGraph())
+        assert_equal(list(H.edges()), list(G.edges()))
+
+
+class TestHexagonalLatticeGraph:
+    """Unit tests for the
+    :func:`networkx.generators.lattice.hexagonal_lattice_graph`
+    function.
+
+    """
+
+    def test_lattice_points(self):
+        """Tests that the graph is really a hexagonal lattice."""
+        m = 3
+        n = 5
+        G = nx.hexagonal_lattice_graph(m, n)
+        assert_equal(len(G), m * n)
+        C_6 = nx.cycle_graph(6)
+        hexagons = [
+            [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)],
+            [(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)],
+            [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)],
+            [(2, 0), (2, 1), (2, 2), (3, 0), (3, 1), (3, 2)],
+            [(2, 2), (2, 3), (2, 4), (3, 2), (3, 3), (3, 4)],
+            ]
+        for hexagon in hexagons:
+            assert_true(nx.is_isomorphic(G.subgraph(hexagon), C_6))
+
+    def test_directed(self):
+        """Tests for creating a directed hexagonal lattice."""
+        G = nx.hexagonal_lattice_graph(3, 5, create_using=nx.Graph())
+        H = nx.hexagonal_lattice_graph(3, 5, create_using=nx.DiGraph())
+        assert_true(H.is_directed())
+        assert_equal(H.succ, G.adj)
+        assert_equal(H.pred, G.adj)
+
+    def test_multigraph(self):
+        """Tests for creating a hexagonal lattice multigraph."""
+        G = nx.hexagonal_lattice_graph(3, 5, create_using=nx.Graph())
+        H = nx.hexagonal_lattice_graph(3, 5, create_using=nx.MultiGraph())
+        assert_equal(list(H.edges()), list(G.edges()))


### PR DESCRIPTION
In addition to creating a new generator for triangular lattice graph,
this commit creates a new module, `networkx.generators.lattice`. It
moves `grid_2d_graph`, `grid_graph`, and `hypercube_graph` generators
from the `networkx.generators.classic` module to the new `lattice`
module.

Finally, this commit creates a new layout function, `grid_layout`, for
graphs that have a natural embedding in the two-dimensional integer
lattice.

This is an implementation of (a subset of) the behavior provided by #1489 by @joelmiller. Compared to that pull request, this pull request is missing the correct positioning for a triangular lattice layout and the hexagonal lattice graph generator.
