### PR TITLE
Adds local and global reaching centrality functions

### DIFF
--- a/doc/source/reference/algorithms.centrality.rst
+++ b/doc/source/reference/algorithms.centrality.rst
@@ -88,3 +88,11 @@ Harmonic Centrality
    :toctree: generated/
 
    harmonic_centrality
+
+Reaching
+--------
+.. autosummary::
+   :toctree: generated/
+
+   local_reaching_centrality
+   global_reaching_centrality

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -11,3 +11,4 @@ from .eigenvector import *
 from .harmonic import *
 from .katz import *
 from .load import *
+from .reaching import *

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -1,0 +1,211 @@
+# -*- encoding: utf-8 -*-
+#
+# reaching.py - functions for computing reaching centrality in a graph
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Provides functions for computing reaching centrality of a node or a graph.
+
+"""
+from __future__ import division
+
+import networkx as nx
+
+__all__ = ['global_reaching_centrality', 'local_reaching_centrality']
+
+#: Edge attribute key to use when converting the weight of an edge to a length.
+LENGTH_KEY = 'grc_lengths'
+
+
+def _average_weight(G, path, weight=None):
+    """Returns the average weight of an edge in a weighted path.
+
+    ``G`` is the graph containing the path.
+
+    ``path`` is the list of vertices that define the path.
+
+    ``weight`` is the edge attribute that gives the weight of the edge
+    in the graph ``G``. If ``None``, the graph is assumed to be
+    unweighted, and the average weight of an edge is assumed to be the
+    multiplicative inverse of the length of the path.
+
+    """
+    path_length = len(path) - 1
+    if path_length <= 0:
+        return 0
+    if weight is None:
+        return 1 / path_length
+    total_weight = sum(G.edge[i][j][weight] for i, j in zip(path, path[1:]))
+    return total_weight / path_length
+
+
+def global_reaching_centrality(G, weight=None, normalized=True):
+    """Returns the global reaching centrality of a directed graph.
+
+    The *global reaching centrality* of a weighted directed graph is the
+    average over all nodes of the difference between the local reaching
+    centrality of the node and the greatest local reaching centrality of
+    any node in the graph [1]_. For more information on the local
+    reaching centrality, see :func:`local_reaching_centrality`.
+    Informally, the local reaching centrality is the proportion of the
+    graph that is reachable from the neighbors of the node.
+
+    Parameters
+    ----------
+    G : DiGraph
+
+    weight : object
+        Attribute to use for edge weights. If ``None``, each edge weight
+        is assumed to be one. A higher weight implies a stronger
+        connection between nodes and a *shorter* path length.
+
+    normalized : bool
+        Whether to normalize the edge weights by the total sum of edge
+        weights.
+
+    Returns
+    -------
+    h : float
+        The global reaching centrality of the graph.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.DiGraph()
+    >>> G.add_edge(1, 2)
+    >>> G.add_edge(1, 3)
+    >>> nx.global_reaching_centrality(G)
+    1.0
+    >>> G.add_edge(3, 2)
+    >>> nx.global_reaching_centrality(G)
+    0.75
+
+    See also
+    --------
+    local_reaching_centrality
+
+    References
+    ----------
+    .. [1] Mones, Enys, Lilla Vicsek, and Tamás Vicsek.
+           "Hierarchy Measure for Complex Networks."
+           *PLoS ONE* 7.3 (2012): e33799.
+           https://dx.doi.org/10.1371/journal.pone.0033799
+
+    """
+    if nx.is_negatively_weighted(G, weight=weight):
+        raise nx.NetworkXError('edges of the graph must be postively weighted')
+
+    total_weight = G.size(weight=weight)
+    if total_weight <= 0:
+        raise nx.NetworkXError('Size of G must be positive')
+
+    # If provided, weights must be interpreted as connection strength
+    # (so higher weights are more likely to be chosen). However, the
+    # shortest path algorithms in NetworkX assume the provided "weight"
+    # is actually a distance (so edges with higher weight are less
+    # likely to be chosen). Therefore we need to invert the weights when
+    # computing shortest paths.
+    #
+    # If weight is None, we leave it as-is so that the shortest path
+    # algorithm can use a faster, unweighted algorithm.
+    if weight is not None:
+        as_distance = lambda u, v, d: total_weight / d.get(weight, 1)
+        shortest_paths = nx.shortest_path(G, weight=as_distance)
+    else:
+        shortest_paths = nx.shortest_path(G)
+
+    centrality = local_reaching_centrality
+    # TODO This can be trivially parallelized.
+    lrc = [centrality(G, node, paths, weight=weight, normalized=normalized)
+           for node, paths in shortest_paths.items()]
+
+    max_lrc = max(lrc)
+    return sum(max_lrc - c for c in lrc) / (len(G) - 1)
+
+
+def local_reaching_centrality(G, v, paths=None, weight=None, normalized=True):
+    """Returns the local reaching centrality of a node in a directed
+    graph.
+
+    The *local reaching centrality* of a node in a directed graph is the
+    proportion of other nodes reachable from that node [1]_.
+
+    Parameters
+    ----------
+    G : DiGraph
+        A NetworkX graph.
+
+    v : node
+        A node in the directed graph `G`.
+
+    paths : dictionary
+        If this is not ``None`` it must be a dictionary representation
+        of single-source shortest paths, as computed by, for example,
+        :func:`networkx.shortest_path` with source node ``v``. Use this
+        keyword argument if you intend to invoke this function many
+        times but don't want the paths to be recomputed each time.
+
+    weight : object
+        Attribute to use for edge weights. If ``None``, each edge weight
+        is assumed to be one. A higher weight implies a stronger
+        connection between nodes and a *shorter* path length.
+
+    normalized : bool
+        Whether to normalize the edge weights by the total sum of edge
+        weights.
+
+    Returns
+    -------
+    h : float
+        The local reaching centrality of the node ``v`` in the graph
+        ``G``.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.DiGraph()
+    >>> G.add_edge(1, 2)
+    >>> G.add_edge(1, 3)
+    >>> nx.local_reaching_centrality(G, 3)
+    0.0
+    >>> G.add_edge(3, 2)
+    >>> nx.local_reaching_centrality(G, 3)
+    0.5
+
+    See also
+    --------
+    global_reaching_centrality
+
+    References
+    ----------
+    .. [1] Mones, Enys, Lilla Vicsek, and Tamás Vicsek.
+           "Hierarchy Measure for Complex Networks."
+           *PLoS ONE* 7.3 (2012): e33799.
+           https://dx.doi.org/10.1371/journal.pone.0033799
+
+    """
+    if paths is None:
+        if weight is not None:
+            # Transform weights to lengths; this will overwrite the edge
+            # attribute with key LENGTH_KEY.
+            _weights_to_lengths(G, weight=weight)
+            paths = nx.shortest_path(G, source=v, weight=LENGTH_KEY)
+            _remove_lengths(G)
+        else:
+            paths = nx.shortest_path(G, source=v)
+    # If the graph is unweighted, simply return the proportion of nodes
+    # reachable from the source node ``v``.
+    if weight is None and G.is_directed():
+        return (len(paths) - 1) / (len(G) - 1)
+    if normalized and weight is not None:
+        norm = G.size(weight=weight) / G.size()
+    else:
+        norm = 1
+    # TODO This can be trivially parallelized.
+    avgw = (_average_weight(G, path, weight=weight) for path in paths.values())
+    sum_avg_weight = sum(avgw) / norm
+    return sum_avg_weight / (len(G) - 1)

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -1,0 +1,87 @@
+# reaching.py - unit tests for the reaching module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.centrality.reaching` module."""
+from __future__ import division
+
+from nose.tools import assert_almost_equal
+from nose.tools import assert_equal
+from nose.tools import raises
+
+from networkx import nx
+
+
+class TestGlobalReachingCentrality(object):
+    """Unit tests for the :func:`~nx.global_reaching_centrality` function."""
+
+    @raises(nx.NetworkXError)
+    def test_exception(self):
+        G = nx.DiGraph()
+        nx.global_reaching_centrality(G)
+
+    def test_directed_star(self):
+        G = nx.DiGraph()
+        G.add_edge(1, 2, {"weight": 0.5})
+        G.add_edge(1, 3, {"weight": 0.5})
+        grc = nx.global_reaching_centrality
+        assert_equal(grc(G, weight="weight", normalized=False), 0.5)
+        assert_equal(grc(G, weight="weight", normalized=True), 1)
+
+    def test_undirected_unweighted_star(self):
+        G = nx.star_graph(2)
+        assert_equal(nx.global_reaching_centrality(G, normalized=False), 0.25)
+
+    def test_undirected_weighted_star(self):
+        G = nx.Graph()
+        G.add_edge(1, 2, {"weight": 1})
+        G.add_edge(1, 3, {"weight": 2})
+        assert_equal(nx.global_reaching_centrality(G, normalized=False), 0.25)
+
+    def test_cycle_directed_unweighted(self):
+        G = nx.DiGraph()
+        G.add_edge(1, 2)
+        G.add_edge(2, 1)
+        assert_equal(nx.global_reaching_centrality(G), 0)
+
+    def test_cycle_undirected_unweighted(self):
+        G = nx.Graph()
+        G.add_edge(1, 2)
+        assert_equal(nx.global_reaching_centrality(G), 0)
+
+    def test_cycle_directed_weighted(self):
+        G = nx.DiGraph()
+        G.add_edge(1, 2, {"weight": 1})
+        G.add_edge(2, 1, {"weight": 1})
+        assert_equal(nx.global_reaching_centrality(G, weight="weight"), 0)
+
+    def test_cycle_undirected_weighted(self):
+        G = nx.Graph()
+        G.add_edge(1, 2, {"weight": 1})
+        grc = nx.global_reaching_centrality
+        assert_equal(grc(G, weight="weight", normalized=False), 0)
+
+    def test_directed_weighted(self):
+        G = nx.DiGraph()
+        G.add_edge("A", "B", {"weight": 5})
+        G.add_edge("B", "C", {"weight": 1})
+        G.add_edge("B", "D", {"weight": 0.25})
+        G.add_edge("D", "E", {"weight": 1})
+
+        denom = len(G) - 1
+        A_local = sum([5, 3, 2.625, 2.0833333333333]) / denom
+        B_local = sum([1, 0.25, 0.625]) / denom
+        C_local = 0
+        D_local = sum([1]) / denom
+        E_local = 0
+
+        local_reach_ctrs = [A_local, C_local, B_local, D_local, E_local]
+        max_local = max(local_reach_ctrs)
+        expected = sum(max_local - lrc for lrc in local_reach_ctrs) / denom
+        grc = nx.global_reaching_centrality
+        actual = grc(G, weight="weight", normalized=False)
+        assert_almost_equal(expected, actual, places=7)


### PR DESCRIPTION
This pull request supercedes pull request #6 to implement issue #698. It takes the code from #6 and updates and clarifies. It introduces two functions, `local_reaching_centrality`, a node centrality measure, and `global_reaching_centrality`, a centrality measure for an entire graph. Unlike the previous pull request which put the `global_reaching_centrality` function in the `algorithms/hierachy.py` module, these functions now live in a new module, `reaching.py`, under the `centrality` package.

The main issue, as noted in that pull request, is that it modifies the edge attribute dictionary during the computation. The only way I can think of fixing this problem without copying the entire graph is to allow, for example, the `weight` keyword argument of the `shortest_path` function to be a function instead of just a dictionary key. For example, `nx.shortest_path(G, weight=lambda u, v: total_weight / G.edge[u][v]['weight'])`.