### PR TITLE
Find maximum clique by cardinality.

### DIFF
--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -92,6 +92,6 @@ def clique_removal(G):
             cliques.append(c_i)
         if i_i:
             isets.append(i_i)
-
-    maxiset = max(isets)
+    # Determine the largest independent set as measured by cardinality.
+    maxiset = max(isets, key=len)
     return maxiset, cliques

--- a/networkx/algorithms/approximation/tests/test_clique.py
+++ b/networkx/algorithms/approximation/tests/test_clique.py
@@ -1,6 +1,21 @@
-from nose.tools import *
+# test_clique.py - unit tests for the approximation.clique module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.approximation.clique`
+module.
+
+"""
+from nose.tools import eq_
+from nose.tools import assert_greater
 import networkx as nx
 import networkx.algorithms.approximation as apxa
+from networkx.algorithms.approximation import max_clique
+
 
 def test_clique_removal():
     graph = nx.complete_graph(10)
@@ -28,14 +43,33 @@ def test_clique_removal():
         cdens = nx.density(graph.subgraph(clique))
         eq_(cdens, 1.0, "clique not found by clique_removal!")
 
+
 def test_max_clique_smoke():
     # smoke test
     G = nx.Graph()
-    assert_equal(len(apxa.max_clique(G)),0)
+    eq_(len(apxa.max_clique(G)),0)
+
 
 def test_max_clique():
     # create a complete graph
     graph = nx.complete_graph(30)
     # this should return the entire graph
     mc = apxa.max_clique(graph)
-    assert_equals(30, len(mc))
+    eq_(30, len(mc))
+
+
+def test_max_clique_by_cardinality():
+    """Tests that the maximum clique is computed according to maximum
+    cardinality of the sets.
+
+    For more information, see pull request #1531.
+
+    """
+    G = nx.complete_graph(5)
+    G.add_edge(4, 5)
+    clique = max_clique(G)
+    assert_greater(len(clique), 1)
+
+    G = nx.lollipop_graph(30, 2)
+    clique = max_clique(G)
+    assert_greater(len(clique), 2)


### PR DESCRIPTION
Before, the maximum clique was chosen from a set of candidate cliques
according to the subset ordering on sets. This commit changes the code
to choose the maximum clique according to clique size.

This pull request supercedes #1531.