### PR TITLE
Find max clique and independent set by cardinality

### DIFF
--- a/networkx/algorithms/approximation/ramsey.py
+++ b/networkx/algorithms/approximation/ramsey.py
@@ -26,7 +26,7 @@ def ramsey_R2(G):
         Maximum clique, Maximum independent set.
     """
     if not G:
-        return (set([]), set([]))
+        return set(), set()
 
     node = arbitrary_element(G)
     nbrs = nx.all_neighbors(G, node)
@@ -36,4 +36,6 @@ def ramsey_R2(G):
 
     c_1.add(node)
     i_2.add(node)
-    return (max([c_1, c_2]), max([i_1, i_2]))
+    # Choose the larger of the two cliques and the larger of the two
+    # independent sets, according to cardinality.
+    return max(c_1, c_2, key=len), max(i_1, i_2, key=len)

--- a/networkx/algorithms/approximation/tests/test_clique.py
+++ b/networkx/algorithms/approximation/tests/test_clique.py
@@ -10,66 +10,95 @@
 module.
 
 """
-from nose.tools import eq_
+from __future__ import division
+
 from nose.tools import assert_greater
+from nose.tools import assert_true
+from nose.tools import eq_
+
 import networkx as nx
-import networkx.algorithms.approximation as apxa
 from networkx.algorithms.approximation import max_clique
+from networkx.algorithms.approximation import clique_removal
 
 
-def test_clique_removal():
-    graph = nx.complete_graph(10)
-    i, cs = apxa.clique_removal(graph)
-    idens = nx.density(graph.subgraph(i))
-    eq_(idens, 0.0, "i-set not found by clique_removal!")
-    for clique in cs:
-        cdens = nx.density(graph.subgraph(clique))
-        eq_(cdens, 1.0, "clique not found by clique_removal!")
+def is_independent_set(G, nodes):
+    """Returns ``True`` if and only if ``nodes`` is a clique in ``G``.
 
-    graph = nx.trivial_graph(nx.Graph())
-    i, cs = apxa.clique_removal(graph)
-    idens = nx.density(graph.subgraph(i))
-    eq_(idens, 0.0, "i-set not found by ramsey!")
-    # we should only have 1-cliques. Just singleton nodes.
-    for clique in cs:
-        cdens = nx.density(graph.subgraph(clique))
-        eq_(cdens, 0.0, "clique not found by clique_removal!")
-
-    graph = nx.barbell_graph(10, 5, nx.Graph())
-    i, cs = apxa.clique_removal(graph)
-    idens = nx.density(graph.subgraph(i))
-    eq_(idens, 0.0, "i-set not found by ramsey!")
-    for clique in cs:
-        cdens = nx.density(graph.subgraph(clique))
-        eq_(cdens, 1.0, "clique not found by clique_removal!")
-
-
-def test_max_clique_smoke():
-    # smoke test
-    G = nx.Graph()
-    eq_(len(apxa.max_clique(G)),0)
-
-
-def test_max_clique():
-    # create a complete graph
-    graph = nx.complete_graph(30)
-    # this should return the entire graph
-    mc = apxa.max_clique(graph)
-    eq_(30, len(mc))
-
-
-def test_max_clique_by_cardinality():
-    """Tests that the maximum clique is computed according to maximum
-    cardinality of the sets.
-
-    For more information, see pull request #1531.
+    ``G`` is a NetworkX graph. ``nodes`` is an iterable of nodes in
+    ``G``.
 
     """
-    G = nx.complete_graph(5)
-    G.add_edge(4, 5)
-    clique = max_clique(G)
-    assert_greater(len(clique), 1)
+    return G.subgraph(nodes).number_of_edges() == 0
 
-    G = nx.lollipop_graph(30, 2)
-    clique = max_clique(G)
-    assert_greater(len(clique), 2)
+
+def is_clique(G, nodes):
+    """Returns ``True`` if and only if ``nodes`` is an independent set
+    in ``G``.
+
+    ``G`` is an undirected simple graph. ``nodes`` is an iterable of
+    nodes in ``G``.
+
+    """
+    H = G.subgraph(nodes)
+    n = len(H)
+    return H.number_of_edges() == n * (n - 1) // 2
+
+
+class TestCliqueRemoval(object):
+    """Unit tests for the
+    :func:`~networkx.algorithms.approximation.clique_removal` function.
+
+    """
+
+    def test_trivial_graph(self):
+        G = nx.trivial_graph()
+        independent_set, cliques = clique_removal(G)
+        assert_true(is_independent_set(G, independent_set))
+        assert_true(all(is_clique(G, clique) for clique in cliques))
+        # In fact, we should only have 1-cliques, that is, singleton nodes.
+        assert_true(all(len(clique) == 1 for clique in cliques))
+
+    def test_complete_graph(self):
+        G = nx.complete_graph(10)
+        independent_set, cliques = clique_removal(G)
+        assert_true(is_independent_set(G, independent_set))
+        assert_true(all(is_clique(G, clique) for clique in cliques))
+
+    def test_barbell_graph(self):
+        G = nx.barbell_graph(10, 5)
+        independent_set, cliques = clique_removal(G)
+        assert_true(is_independent_set(G, independent_set))
+        assert_true(all(is_clique(G, clique) for clique in cliques))
+
+
+class TestMaxClique(object):
+    """Unit tests for the :func:`networkx.algorithms.approximation.max_clique`
+    function.
+
+    """
+
+    def test_null_graph(self):
+        G = nx.null_graph()
+        eq_(len(max_clique(G)), 0)
+
+    def test_complete_graph(self):
+        graph = nx.complete_graph(30)
+        # this should return the entire graph
+        mc = max_clique(graph)
+        eq_(30, len(mc))
+
+    def test_maximal_by_cardinality(self):
+        """Tests that the maximal clique is computed according to maximum
+        cardinality of the sets.
+
+        For more information, see pull request #1531.
+
+        """
+        G = nx.complete_graph(5)
+        G.add_edge(4, 5)
+        clique = max_clique(G)
+        assert_greater(len(clique), 1)
+
+        G = nx.lollipop_graph(30, 2)
+        clique = max_clique(G)
+        assert_greater(len(clique), 2)


### PR DESCRIPTION
Before, the maximum clique and maximum independent set were chosen from
a collection of candidates according to the subset ordering on
sets. This commit changes the code to choose the maximum clique and
maximum independent set according to cardinality of the sets.

This pull request supercedes #1532.

There is a problem with this change: it affects one of the unit tests for the clique removal function. The unit test expects cliques to be of size greater than one, but now the function returns, among others, a clique of size one.