### PR TITLE
Allow external packages to be installed in networkx.addons

### DIFF
--- a/networkx/addons/__init__.py
+++ b/networkx/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ version = release.write_versionfile()
 sys.path.pop(0)
 
 packages=["networkx",
+          "networkx.addons",
           "networkx.algorithms",
           "networkx.algorithms.assortativity",
           "networkx.algorithms.bipartite",


### PR DESCRIPTION
This allows various addons to be installed for networkx inside `networkx.addons` namespace. We can discuss whether we have to take this in with `1.10` or `2.0`.