### PR TITLE
Build documentation on ReadTheDocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,14 @@ Mailing List
    https://groups.google.com/forum/#!forum/networkx-discuss
 Development
    https://github.com/networkx/networkx
-   
+
    .. image:: https://travis-ci.org/networkx/networkx.png?branch=master
       :target: https://travis-ci.org/networkx/networkx
-  
+
+   .. image:: https://readthedocs.org/projects/networkx/badge/?version=latest
+      :target: https://readthedocs.org/projects/networkx/?badge=latest
+      :alt: Documentation Status
+
    .. image:: https://coveralls.io/repos/networkx/networkx/badge.png?branch=master
       :target: https://coveralls.io/r/networkx/networkx?branch=master
 
@@ -30,7 +34,7 @@ A quick example that finds the shortest path between two nodes in an undirected 
    ['A', 'B', 'D']
 
 Distributed with a BSD license; see LICENSE.txt::
-    
+
    Copyright (C) 2004-2015 NetworkX Developers
    Aric Hagberg <hagberg@lanl.gov>
    Dan Schult <dschult@colgate.edu>

--- a/doc/make_examples_rst.py
+++ b/doc/make_examples_rst.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 generate the rst files for the examples by iterating over the networkx examples
 """
@@ -28,7 +27,7 @@ def out_of_date(original, derived):
     return (not os.path.exists(derived) or
             os.stat(derived).st_mtime < os.stat(original).st_mtime)
 
-def main(exampledir,sourcedir):    
+def main(exampledir,sourcedir):
 
     noplot_regex = re.compile(r"#\s*-\*-\s*noplot\s*-\*-")
 
@@ -169,7 +168,7 @@ if __name__ == '__main__':
     except:
         arg0=sys.argv[0]
         print("""
-Usage:  %s exampledir sourcedir 
+Usage:  %s exampledir sourcedir
 
     exampledir: a directory containing the python code for the examples.
     sourcedir: a directory to put the generated documentation source for these examples.

--- a/doc/make_gallery.py
+++ b/doc/make_gallery.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Generate a thumbnail gallery of examples.
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,6 +2,7 @@ ipython[nbconvert]
 numpy >= 1.6
 matplotlib
 pandas
+pydotplus
 sphinx >= 1.3
 sphinxcontrib-bibtex
 sphinx_rtd_theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,7 @@
+ipython[nbconvert]
+numpy >= 1.6
+matplotlib
+pandas
+sphinx >= 1.3
+sphinxcontrib-bibtex
+sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,26 +15,37 @@ import sys, os, re
 
 # Check Sphinx version
 import sphinx
-if sphinx.__version__ < "1.0.1":
-    raise RuntimeError("Sphinx 1.0.1 or newer required")
+if sphinx.__version__ < "1.3":
+    raise RuntimeError("Sphinx 1.3 or newer required")
+
+# Environment variable to know if the docs are being built on rtd.
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # If your extensions are in another directory, add it here.
-sys.path.insert(0, os.path.abspath('../..'))
+# These locations are relative to conf.py
 sys.path.append(os.path.abspath('../sphinxext'))
 
 # General configuration
 # ---------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.addons.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.pngmath',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.mathjax',
-              'numpydoc',
-              'sphinx.ext.coverage',
-              'sphinx.ext.autosummary','sphinx.ext.todo','sphinx.ext.doctest',
-              'sphinx.ext.intersphinx', 'customroles']
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    'sphinx.ext.autosummary',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.pngmath',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    #'sphinxcontrib.bibtex',
+    #'IPython.sphinxext.ipython_console_highlighting',
+    #'IPython.sphinxext.ipython_directive',
+]
+
 
 # generate autosummary pages
 autosummary_generate=True
@@ -53,7 +64,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'NetworkX'
-copyright = '2014, NetworkX Developers'
+copyright = '2015, NetworkX Developers'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
@@ -95,9 +106,12 @@ doctest_global_setup="import networkx as nx"
 
 # Options for HTML output
 # -----------------------
-import sphinx_rtd_theme
-html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+if not on_rtd:
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 #html_theme_options = {
 #    "rightsidebar": "true",
 #    "relbarbgcolor: "black"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,6 +13,25 @@
 from __future__ import print_function
 
 import sys, os, re
+import contextlib
+
+@contextlib.contextmanager
+def cd(newpath):
+    """
+    Change the current working directory to `newpath`, temporarily.
+
+    If the old current working directory no longer exists, do not return back.
+    """
+    oldpath = os.getcwd()
+    os.chdir(newpath)
+    try:
+        yield
+    finally:
+        try:
+            os.chdir(oldpath)
+        except OSError:
+            # If oldpath no longer exists, stay where we are.
+            pass
 
 # Check Sphinx version
 import sphinx
@@ -31,8 +50,12 @@ if on_rtd:
     # Build is not via Makefile (yet).
     # So we manually build the examples and gallery.
     import subprocess
-    subprocess.call([sys.executable, '../make_gallery.py'])
-    subprocess.call([sys.executable, '../make_examples.py', '../examples', 'source'])
+    with cd('..'):
+        # The Makefile is run from networkx/doc, so we need to move there
+        # from networkx/doc/source (which holds conf.py).
+        py = sys.executable
+        subprocess.call([py, 'make_gallery.py'])
+        subprocess.call([py, 'make_examples.py', '../examples', 'source'])
 
 # If your extensions are in another directory, add it here.
 # These locations are relative to conf.py

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,6 +10,7 @@
 #
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
+from __future__ import print_function
 
 import sys, os, re
 
@@ -20,6 +21,18 @@ if sphinx.__version__ < "1.3":
 
 # Environment variable to know if the docs are being built on rtd.
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+print
+print("Building on ReadTheDocs: {}".format(on_rtd))
+print
+print("Current working directory: {}".format(os.path.abspath(os.curdir)))
+print("Python: {}".format(sys.executable))
+
+if on_rtd:
+    # Build is not via Makefile (yet).
+    # So we manually build the examples and gallery.
+    import subprocess
+    subprocess.call([sys.executable, '../make_gallery.py'])
+    subprocess.call([sys.executable, '../make_examples.py', '../examples', 'source'])
 
 # If your extensions are in another directory, add it here.
 # These locations are relative to conf.py


### PR DESCRIPTION
This PR allows ReadTheDocs to build our documentation. They will be available here: https://networkx.readthedocs.org/en/latest/ once this is merged. After that, we will need to update networkx-website accordingly. There are also a number of places we need to cleanup the documentation, but that is another PR.