### PR TITLE
Docstring fix for adjlist and multiline_adjlist.

### DIFF
--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -165,10 +165,6 @@ def parse_adjlist(lines, comments = '#', delimiter = None,
     delimiter : string, optional
        Separator for node labels.  The default is whitespace.
 
-    create_using: NetworkX graph container
-       Use given NetworkX graph for holding nodes or edges.
-
-
     Returns
     -------
     G: NetworkX graph
@@ -248,10 +244,6 @@ def read_adjlist(path, comments="#", delimiter=None, create_using=None,
 
     delimiter : string, optional
        Separator for node labels.  The default is whitespace.
-
-    create_using: NetworkX graph container
-       Use given NetworkX graph for holding nodes or edges.
-
 
     Returns
     -------

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -41,7 +41,7 @@ from networkx.utils import make_str, open_file
 import networkx as nx
 
 
-def generate_adjlist(G, delimiter = ' '):
+def generate_adjlist(G, delimiter=' '):
     """Generate a single line of the graph G in adjacency list format.
 
     Parameters
@@ -74,11 +74,11 @@ def generate_adjlist(G, delimiter = ' '):
     write_adjlist, read_adjlist
 
     """
-    directed=G.is_directed()
-    seen=set()
-    for s,nbrs in G.adjacency_iter():
-        line = make_str(s)+delimiter
-        for t,data in nbrs.items():
+    directed = G.is_directed()
+    seen = set()
+    for s, nbrs in G.adjacency_iter():
+        line = make_str(s) + delimiter
+        for t, data in nbrs.items():
             if not directed and t in seen:
                 continue
             if G.is_multigraph():
@@ -90,8 +90,9 @@ def generate_adjlist(G, delimiter = ' '):
             seen.add(s)
         yield line[:-len(delimiter)]
 
-@open_file(1,mode='wb')
-def write_adjlist(G, path, comments="#", delimiter=' ', encoding = 'utf-8'):
+
+@open_file(1, mode='wb')
+def write_adjlist(G, path, comments="#", delimiter=' ', encoding='utf-8'):
     """Write graph G in single-line adjacency-list format to path.
 
 
@@ -133,19 +134,19 @@ def write_adjlist(G, path, comments="#", delimiter=' ', encoding = 'utf-8'):
     """
     import sys
     import time
-    pargs=comments + " ".join(sys.argv) + '\n'
+    pargs = comments + " ".join(sys.argv) + '\n'
     header = (pargs
-             + comments + " GMT %s\n" % (time.asctime(time.gmtime()))
-             + comments + " %s\n" % (G.name))
+              + comments + " GMT {}\n".format(time.asctime(time.gmtime()))
+              + comments + " {}\n".format(G.name))
     path.write(header.encode(encoding))
 
     for line in generate_adjlist(G, delimiter):
-        line+='\n'
+        line += '\n'
         path.write(line.encode(encoding))
 
 
-def parse_adjlist(lines, comments = '#', delimiter = None,
-                  create_using = None, nodetype = None):
+def parse_adjlist(lines, comments='#', delimiter=None,
+                  create_using=None, nodetype=None):
     """Parse lines of a graph adjacency list representation.
 
     Parameters
@@ -189,42 +190,43 @@ def parse_adjlist(lines, comments = '#', delimiter = None,
 
     """
     if create_using is None:
-        G=nx.Graph()
+        G = nx.Graph()
     else:
         try:
-            G=create_using
+            G = create_using
             G.clear()
         except:
             raise TypeError("Input graph is not a NetworkX graph type")
 
     for line in lines:
-        p=line.find(comments)
-        if p>=0:
+        p = line.find(comments)
+        if p >= 0:
             line = line[:p]
         if not len(line):
             continue
-        vlist=line.strip().split(delimiter)
-        u=vlist.pop(0)
+        vlist = line.strip().split(delimiter)
+        u = vlist.pop(0)
         # convert types
         if nodetype is not None:
             try:
-                u=nodetype(u)
+                u = nodetype(u)
             except:
-                raise TypeError("Failed to convert node (%s) to type %s"\
-                                %(u,nodetype))
+                raise TypeError("Failed to convert node ({}) to type {}"
+                                .format(u, nodetype))
         G.add_node(u)
         if nodetype is not None:
             try:
-                vlist=map(nodetype,vlist)
+                vlist = map(nodetype, vlist)
             except:
-                raise TypeError("Failed to convert nodes (%s) to type %s"\
-                                    %(','.join(vlist),nodetype))
+                raise TypeError("Failed to convert nodes ({}) to type {}"
+                                .format(','.join(vlist), nodetype))
         G.add_edges_from([(u, v) for v in vlist])
     return G
 
-@open_file(0,mode='rb')
+
+@open_file(0, mode='rb')
 def read_adjlist(path, comments="#", delimiter=None, create_using=None,
-                 nodetype=None, encoding = 'utf-8'):
+                 nodetype=None, encoding='utf-8'):
     """Read graph in adjacency list format from path.
 
     Parameters
@@ -294,12 +296,14 @@ def read_adjlist(path, comments="#", delimiter=None, create_using=None,
     """
     lines = (line.decode(encoding) for line in path)
     return parse_adjlist(lines,
-                         comments = comments,
-                         delimiter = delimiter,
-                         create_using = create_using,
-                         nodetype = nodetype)
+                         comments=comments,
+                         delimiter=delimiter,
+                         create_using=create_using,
+                         nodetype=nodetype)
 
 # fixture for nose tests
+
+
 def teardown_module(module):
     import os
     for fname in ['test.adjlist', 'test.adjlist.gz']:

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -207,10 +207,6 @@ def parse_multiline_adjlist(lines, comments = '#', delimiter = None,
     delimiter : string, optional
        Separator for node labels.  The default is whitespace.
 
-    create_using: NetworkX graph container
-       Use given NetworkX graph for holding nodes or edges.
-
-
     Returns
     -------
     G: NetworkX graph
@@ -321,10 +317,6 @@ def read_multiline_adjlist(path, comments="#", delimiter=None,
 
     delimiter : string, optional
        Separator for node labels.  The default is whitespace.
-
-    create_using: NetworkX graph container
-       Use given NetworkX graph for holding nodes or edges.
-
 
     Returns
     -------

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -43,7 +43,8 @@ __all__ = ['generate_multiline_adjlist',
 from networkx.utils import make_str, open_file
 import networkx as nx
 
-def generate_multiline_adjlist(G, delimiter = ' '):
+
+def generate_multiline_adjlist(G, delimiter=' '):
     """Generate a single line of the graph G in multiline adjacency list format.
 
     Parameters
@@ -86,58 +87,59 @@ def generate_multiline_adjlist(G, delimiter = ' '):
     """
     if G.is_directed():
         if G.is_multigraph():
-            for s,nbrs in G.adjacency_iter():
-                nbr_edges=[ (u,data)
-                            for u,datadict in nbrs.items()
-                            for key,data in datadict.items()]
-                deg=len(nbr_edges)
-                yield make_str(s)+delimiter+"%i"%(deg)
-                for u,d in nbr_edges:
+            for s, nbrs in G.adjacency_iter():
+                nbr_edges = [(u, data)
+                             for u, datadict in nbrs.items()
+                             for key, data in datadict.items()]
+                deg = len(nbr_edges)
+                yield make_str(s) + delimiter + str(deg)
+                for u, d in nbr_edges:
                     if d is None:
                         yield make_str(u)
                     else:
-                        yield make_str(u)+delimiter+make_str(d)
-        else: # directed single edges
-            for s,nbrs in G.adjacency_iter():
-                deg=len(nbrs)
-                yield make_str(s)+delimiter+"%i"%(deg)
-                for u,d in nbrs.items():
-                   if d is None:
-                       yield make_str(u)
-                   else:
-                       yield make_str(u)+delimiter+make_str(d)
-    else: # undirected
+                        yield make_str(u) + delimiter + make_str(d)
+        else:  # directed single edges
+            for s, nbrs in G.adjacency_iter():
+                deg = len(nbrs)
+                yield make_str(s) + delimiter + str(deg)
+                for u, d in nbrs.items():
+                    if d is None:
+                        yield make_str(u)
+                    else:
+                        yield make_str(u) + delimiter + make_str(d)
+    else:  # undirected
         if G.is_multigraph():
-            seen=set()  # helper dict used to avoid duplicate edges
-            for s,nbrs in G.adjacency_iter():
-                nbr_edges=[ (u,data)
-                            for u,datadict in nbrs.items()
-                            if u not in seen
-                            for key,data in datadict.items()]
-                deg=len(nbr_edges)
-                yield make_str(s)+delimiter+"%i"%(deg)
-                for u,d in nbr_edges:
+            seen = set()  # helper dict used to avoid duplicate edges
+            for s, nbrs in G.adjacency_iter():
+                nbr_edges = [(u, data)
+                             for u, datadict in nbrs.items()
+                             if u not in seen
+                             for key, data in datadict.items()]
+                deg = len(nbr_edges)
+                yield make_str(s) + delimiter + str(deg)
+                for u, d in nbr_edges:
                     if d is None:
                         yield make_str(u)
                     else:
-                        yield make_str(u)+delimiter+make_str(d)
+                        yield make_str(u) + delimiter + make_str(d)
                 seen.add(s)
-        else: # undirected single edges
-            seen=set()  # helper dict used to avoid duplicate edges
-            for s,nbrs in G.adjacency_iter():
-                nbr_edges=[ (u,d) for u,d in nbrs.items() if u not in seen]
-                deg=len(nbr_edges)
-                yield  make_str(s)+delimiter+"%i"%(deg)
-                for u,d in nbr_edges:
+        else:  # undirected single edges
+            seen = set()  # helper dict used to avoid duplicate edges
+            for s, nbrs in G.adjacency_iter():
+                nbr_edges = [(u, d) for u, d in nbrs.items() if u not in seen]
+                deg = len(nbr_edges)
+                yield make_str(s) + delimiter + str(deg)
+                for u, d in nbr_edges:
                     if d is None:
                         yield make_str(u)
                     else:
-                        yield make_str(u)+delimiter+make_str(d)
+                        yield make_str(u) + delimiter + make_str(d)
                 seen.add(s)
 
-@open_file(1,mode='wb')
+
+@open_file(1, mode='wb')
 def write_multiline_adjlist(G, path, delimiter=' ',
-                            comments='#', encoding = 'utf-8'):
+                            comments='#', encoding='utf-8'):
     """ Write the graph G in multiline adjacency list format to path
 
     Parameters
@@ -175,19 +177,20 @@ def write_multiline_adjlist(G, path, delimiter=' ',
     import sys
     import time
 
-    pargs=comments+" ".join(sys.argv)
-    header = ("%s\n" % (pargs)
-             + comments + " GMT %s\n" % (time.asctime(time.gmtime()))
-             + comments + " %s\n" % (G.name))
+    pargs = comments + " ".join(sys.argv)
+    header = ("{}\n".format(pargs)
+              + comments + " GMT {}\n".format(time.asctime(time.gmtime()))
+              + comments + " {}\n".format(G.name))
     path.write(header.encode(encoding))
 
     for multiline in generate_multiline_adjlist(G, delimiter):
-        multiline+='\n'
+        multiline += '\n'
         path.write(multiline.encode(encoding))
 
-def parse_multiline_adjlist(lines, comments = '#', delimiter = None,
-                            create_using = None, nodetype = None,
-                            edgetype = None):
+
+def parse_multiline_adjlist(lines, comments='#', delimiter=None,
+                            create_using=None, nodetype=None,
+                            edgetype=None):
     """Parse lines of a multiline adjacency list representation of a graph.
 
     Parameters
@@ -225,76 +228,79 @@ def parse_multiline_adjlist(lines, comments = '#', delimiter = None,
     """
     from ast import literal_eval
     if create_using is None:
-        G=nx.Graph()
+        G = nx.Graph()
     else:
         try:
-            G=create_using
+            G = create_using
             G.clear()
         except:
             raise TypeError("Input graph is not a networkx graph type")
 
     for line in lines:
-        p=line.find(comments)
-        if p>=0:
+        p = line.find(comments)
+        if p >= 0:
             line = line[:p]
-        if not line: continue
+        if not line:
+            continue
         try:
-            (u,deg)=line.strip().split(delimiter)
-            deg=int(deg)
+            (u, deg) = line.strip().split(delimiter)
+            deg = int(deg)
         except:
-            raise TypeError("Failed to read node and degree on line (%s)"%line)
+            raise TypeError("Failed to read node and degree on line ({})".format(line))
         if nodetype is not None:
             try:
-                u=nodetype(u)
+                u = nodetype(u)
             except:
-                raise TypeError("Failed to convert node (%s) to type %s"\
-                      %(u,nodetype))
+                raise TypeError("Failed to convert node ({}) to type {}"
+                                .format(u, nodetype))
         G.add_node(u)
         for i in range(deg):
             while True:
                 try:
                     line = next(lines)
                 except StopIteration:
-                    msg = "Failed to find neighbor for node (%s)" % (u,)
+                    msg = "Failed to find neighbor for node ({})".format(u)
                     raise TypeError(msg)
-                p=line.find(comments)
-                if p>=0:
+                p = line.find(comments)
+                if p >= 0:
                     line = line[:p]
-                if line: break
-            vlist=line.strip().split(delimiter)
-            numb=len(vlist)
-            if numb<1:
-                continue # isolated node
-            v=vlist.pop(0)
-            data=''.join(vlist)
+                if line:
+                    break
+            vlist = line.strip().split(delimiter)
+            numb = len(vlist)
+            if numb < 1:
+                continue  # isolated node
+            v = vlist.pop(0)
+            data = ''.join(vlist)
             if nodetype is not None:
                 try:
-                    v=nodetype(v)
+                    v = nodetype(v)
                 except:
                     raise TypeError(
-                            "Failed to convert node (%s) to type %s"\
-                                       %(v,nodetype))
+                        "Failed to convert node ({}) to type {}"
+                        .format(v, nodetype))
             if edgetype is not None:
                 try:
-                    edgedata={'weight':edgetype(data)}
+                    edgedata = {'weight': edgetype(data)}
                 except:
                     raise TypeError(
-                            "Failed to convert edge data (%s) to type %s"\
-                                    %(data, edgetype))
+                        "Failed to convert edge data ({}) to type {}"
+                        .format(data, edgetype))
             else:
-                try: # try to evaluate
-                    edgedata=literal_eval(data)
+                try:  # try to evaluate
+                    edgedata = literal_eval(data)
                 except:
-                    edgedata={}
-            G.add_edge(u,v,attr_dict=edgedata)
+                    edgedata = {}
+            G.add_edge(u, v, attr_dict=edgedata)
 
     return G
 
-@open_file(0,mode='rb')
+
+@open_file(0, mode='rb')
 def read_multiline_adjlist(path, comments="#", delimiter=None,
                            create_using=None,
                            nodetype=None, edgetype=None,
-                           encoding = 'utf-8'):
+                           encoding='utf-8'):
     """Read graph in multi-line adjacency list format from path.
 
     Parameters
@@ -368,11 +374,11 @@ def read_multiline_adjlist(path, comments="#", delimiter=None,
     """
     lines = (line.decode(encoding) for line in path)
     return parse_multiline_adjlist(lines,
-                                   comments = comments,
-                                   delimiter = delimiter,
-                                   create_using = create_using,
-                                   nodetype = nodetype,
-                                   edgetype = edgetype)
+                                   comments=comments,
+                                   delimiter=delimiter,
+                                   create_using=create_using,
+                                   nodetype=nodetype,
+                                   edgetype=edgetype)
 
 
 # fixture for nose tests


### PR DESCRIPTION
#1604 

Also fixes pep8 and uses the newer str.format.