### PR TITLE
Fix bug for iterator input for digraph.degree

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -922,7 +922,7 @@ class DiGraph(Graph):
 
         """
         if nbunch is None:
-            nodes_nbrs=( (n,succs,self.pred[n]) for n,succs in self.succ.iteritems())
+            nodes_nbrs=( (n,succs,self.pred[n]) for n,succs in self.succ.items())
         else:
             nodes_nbrs=( (n,self.succ[n],self.pred[n]) for n in self.nbunch_iter(nbunch))
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -922,18 +922,16 @@ class DiGraph(Graph):
 
         """
         if nbunch is None:
-            nodes_nbrs=zip(iter(self.succ.items()),iter(self.pred.items()))
+            nodes_nbrs=( (n,succs,self.pred[n]) for n,succs in self.succ.iteritems())
         else:
-            nodes_nbrs=zip(
-                ((n,self.succ[n]) for n in self.nbunch_iter(nbunch)),
-                ((n,self.pred[n]) for n in self.nbunch_iter(nbunch)))
+            nodes_nbrs=( (n,self.succ[n],self.pred[n]) for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for (n,succ),(n2,pred) in nodes_nbrs:
+            for n,succ,pred in nodes_nbrs:
                 yield (n,len(succ)+len(pred))
         else:
         # edge weighted graph - degree is sum of edge weights
-            for (n,succ),(n2,pred) in nodes_nbrs:
+            for n,succ,pred in nodes_nbrs:
                yield (n,
                       sum((succ[nbr].get(weight,1) for nbr in succ))+
                       sum((pred[nbr].get(weight,1) for nbr in pred)))

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -623,20 +623,20 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         """
         if nbunch is None:
-            nodes_nbrs = zip(iter(self.succ.items()), iter(self.pred.items()))
+            nodes_nbrs = ( (n, succ, self.pred[n])
+                    for n,succ in self.succ.items() )
         else:
-            nodes_nbrs = zip(
-                ((n, self.succ[n]) for n in self.nbunch_iter(nbunch)),
-                ((n, self.pred[n]) for n in self.nbunch_iter(nbunch)))
+            nodes_nbrs = ( (n, self.succ[n], self.pred[n])
+                    for n in self.nbunch_iter(nbunch))
 
         if weight is None:
-            for (n, succ), (n2, pred) in nodes_nbrs:
+            for n, succ, pred in nodes_nbrs:
                 indeg = sum([len(data) for data in pred.values()])
                 outdeg = sum([len(data) for data in succ.values()])
                 yield (n, indeg + outdeg)
         else:
             # edge weighted graph - degree is sum of nbr edge weights
-            for (n, succ), (n2, pred) in nodes_nbrs:
+            for n, succ, pred in nodes_nbrs:
                 deg = sum([d.get(weight, 1)
                            for data in pred.values()
                            for d in data.values()])

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -103,6 +103,7 @@ class BaseDiGraphTester(BaseGraphTester):
         assert_equal(list(G.degree_iter()),[(0,4),(1,4),(2,4)])
         assert_equal(dict(G.degree_iter()),{0:4,1:4,2:4})
         assert_equal(list(G.degree_iter(0)),[(0,4)])
+        assert_equal(list(G.degree_iter(iter([0]))),[(0,4)]) #run through iterator
 
     def test_in_degree(self):
         G=self.K3
@@ -110,6 +111,7 @@ class BaseDiGraphTester(BaseGraphTester):
         assert_equal(G.in_degree(),{0:2,1:2,2:2})
         assert_equal(G.in_degree(0),2)
         assert_equal(G.in_degree([0]),{0:2})
+        assert_equal(G.in_degree(iter([0])),{0:2})
         assert_raises((KeyError,networkx.NetworkXError), G.in_degree,-1)
 
     def test_in_degree_iter(self):
@@ -117,6 +119,7 @@ class BaseDiGraphTester(BaseGraphTester):
         assert_equal(list(G.in_degree_iter()),[(0,2),(1,2),(2,2)])
         assert_equal(dict(G.in_degree_iter()),{0:2,1:2,2:2})
         assert_equal(list(G.in_degree_iter(0)),[(0,2)])
+        assert_equal(list(G.in_degree_iter(iter([0]))),[(0,2)]) #run through iterator
 
     def test_in_degree_iter_weighted(self):
         G=self.K3
@@ -127,6 +130,7 @@ class BaseDiGraphTester(BaseGraphTester):
         assert_equal(list(G.in_degree_iter(weight='other')),[(0,2),(1,2.2),(2,2)])
         assert_equal(dict(G.in_degree_iter(weight='other')),{0:2,1:2.2,2:2})
         assert_equal(list(G.in_degree_iter(1,weight='other')),[(1,2.2)])
+        assert_equal(list(G.in_degree_iter(iter([1]),weight='other')),[(1,2.2)])
 
     def test_out_degree(self):
         G=self.K3
@@ -134,6 +138,7 @@ class BaseDiGraphTester(BaseGraphTester):
         assert_equal(G.out_degree(),{0:2,1:2,2:2})
         assert_equal(G.out_degree(0),2)
         assert_equal(G.out_degree([0]),{0:2})
+        assert_equal(G.out_degree(iter([0])),{0:2})
         assert_raises((KeyError,networkx.NetworkXError), G.out_degree,-1)
 
     def test_out_degree_iter_weighted(self):
@@ -145,12 +150,14 @@ class BaseDiGraphTester(BaseGraphTester):
         assert_equal(list(G.out_degree_iter(weight='other')),[(0,2.2),(1,2),(2,2)])
         assert_equal(dict(G.out_degree_iter(weight='other')),{0:2.2,1:2,2:2})
         assert_equal(list(G.out_degree_iter(0,weight='other')),[(0,2.2)])
+        assert_equal(list(G.out_degree_iter(iter([0]),weight='other')),[(0,2.2)])
 
     def test_out_degree_iter(self):
         G=self.K3
         assert_equal(list(G.out_degree_iter()),[(0,2),(1,2),(2,2)])
         assert_equal(dict(G.out_degree_iter()),{0:2,1:2,2:2})
         assert_equal(list(G.out_degree_iter(0)),[(0,2)])
+        assert_equal(list(G.out_degree_iter(iter([0]))),[(0,2)])
 
     def test_size(self):
         G=self.K3

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -144,6 +144,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(G.degree(),{0:4,1:4,2:4})
         assert_equal(G.degree(0),4)
         assert_equal(G.degree([0]),{0:4})
+        assert_equal(G.degree(iter([0])),{0:4})
         assert_raises((KeyError,networkx.NetworkXError), G.degree,-1)
 
     def test_degree_iter(self):
@@ -151,6 +152,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(list(G.degree_iter()),[(0,4),(1,4),(2,4)])
         assert_equal(dict(G.degree_iter()),{0:4,1:4,2:4})
         assert_equal(list(G.degree_iter(0)),[(0,4)])
+        assert_equal(list(G.degree_iter(iter([0]))),[(0,4)])
         G.add_edge(0,1,weight=0.3,other=1.2)
         assert_equal(list(G.degree_iter(weight='weight')),[(0,4.3),(1,4.3),(2,4)])
         assert_equal(list(G.degree_iter(weight='other')),[(0,5.2),(1,5.2),(2,4)])
@@ -162,6 +164,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(G.in_degree(),{0:2,1:2,2:2})
         assert_equal(G.in_degree(0),2)
         assert_equal(G.in_degree([0]),{0:2})
+        assert_equal(G.in_degree(iter([0])),{0:2})
         assert_raises((KeyError,networkx.NetworkXError), G.in_degree,-1)
 
     def test_in_degree_iter(self):
@@ -169,6 +172,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(list(G.in_degree_iter()),[(0,2),(1,2),(2,2)])
         assert_equal(dict(G.in_degree_iter()),{0:2,1:2,2:2})
         assert_equal(list(G.in_degree_iter(0)),[(0,2)])
+        assert_equal(list(G.in_degree_iter(iter([0]))),[(0,2)])
         assert_equal(list(G.in_degree_iter(0,weight='weight')),[(0,2)])
 
     def test_out_degree(self):
@@ -177,6 +181,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(G.out_degree(),{0:2,1:2,2:2})
         assert_equal(G.out_degree(0),2)
         assert_equal(G.out_degree([0]),{0:2})
+        assert_equal(G.out_degree(iter([0])),{0:2})
         assert_raises((KeyError,networkx.NetworkXError), G.out_degree,-1)
 
     def test_out_degree_iter(self):
@@ -184,6 +189,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(list(G.out_degree_iter()),[(0,2),(1,2),(2,2)])
         assert_equal(dict(G.out_degree_iter()),{0:2,1:2,2:2})
         assert_equal(list(G.out_degree_iter(0)),[(0,2)])
+        assert_equal(list(G.out_degree_iter(iter([0]))),[(0,2)])
         assert_equal(list(G.out_degree_iter(0,weight='weight')),[(0,2)])
 
 


### PR DESCRIPTION
digraph.degree( iter([0]) ) doesn't work because the iterator is used twice. 
Bug introduced in 2010 during conversion for python3.
This PR also adds tests for this same bug.