### PR TITLE
Turn off coverage for pypy travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,11 @@ script:
 
       # Run nosetests.
   - if [[ "${PYTHON_VM}" != ipy ]]; then
-      nosetests --verbosity=2 --with-coverage --cover-package=networkx;
+      if [[ "${PYTHON_VM}" == pypy ]]; then
+          nosetests --verbosity=2;
+      else
+          nosetests --verbosity=2 --with-coverage --cover-package=networkx;
+      fi;
     else
       mono "${IPY}" -X:ExceptionDetail -X:FullFrames -c 'from nose import main; main()' \--verbosity=2;
     fi


### PR DESCRIPTION
Turning off coverage for the pypy tests reduces time from 50 minutes to about 5 minutes.