### PR TITLE
Nearly complete alteration to k_core and core_number to add in-cores and out-cores

### DIFF
--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -13,6 +13,7 @@ http://arxiv.org/abs/cs.DS/0310049
 __author__ = "\n".join(['Dan Schult (dschult@colgate.edu)',
                         'Jason Grout (jason-sage@creativetrax.com)',
                         'Aric Hagberg (hagberg@lanl.gov)'])
+
 #    Copyright (C) 2004-2015 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -22,6 +22,8 @@ __author__ = "\n".join(['Dan Schult (dschult@colgate.edu)',
 #    BSD license.
 __all__ = ['core_number','k_core','k_shell','k_crust','k_corona','find_cores']
 
+import networkx as nx
+
 def core_number(G,direction=None):
     """Return the core number for each vertex.
 

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -13,7 +13,6 @@ http://arxiv.org/abs/cs.DS/0310049
 __author__ = "\n".join(['Dan Schult (dschult@colgate.edu)',
                         'Jason Grout (jason-sage@creativetrax.com)',
                         'Aric Hagberg (hagberg@lanl.gov)'])
-import json
 #    Copyright (C) 2004-2015 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
@@ -21,8 +20,6 @@ import json
 #    All rights reserved.
 #    BSD license.
 __all__ = ['core_number','k_core','k_shell','k_crust','k_corona','find_cores']
-
-import networkx as nx
 
 def core_number(G,direction=None):
     """Return the core number for each vertex.
@@ -75,23 +72,14 @@ def core_number(G,direction=None):
                 'Consider using G.remove_edges_from(G.selfloop_edges()).')
 
     if G.is_directed():
-        print "is_directed():"
         import itertools
         def neighbors(v,direction):
-            print "neighbors({})".format(v)
             if(direction):
                 if direction == 'in':
-                    print "direction == in"
-                    print "G.predecessors_iter({})",format(v)
                     return itertools.chain.from_iterable([G.predecessors_iter(v)])
-                    print list(G.predecessors_iter(v))
                 elif direction == 'out':
-                    print direction == "out"
-                    print "direction == out"
-                    print "G.successors_iter({})",format(v)
                     return itertools.chain.from_iterable([G.successors_iter(v)])
             else:
-                print "direction == None"
                 return itertools.chain.from_iterable([G.predecessors_iter(v),
                                                   G.successors_iter(v)])
     else:
@@ -114,15 +102,10 @@ def core_number(G,direction=None):
     node_pos = dict((v,pos) for pos,v in enumerate(nodes))
     # initial guesses for core is degree
     core=degrees
-    print "neighbors({})".format(v)
-    print str(set(neighbors(v,direction)))
     nbrs=dict((v,set(neighbors(v,direction))) for v in G)
     import copy
     for v in nodes:
-        print "v: {}".format(v)
         for u in nbrs[v]: # {4}
-            print "u: {}".format(u)
-            print "core[u]: {} core[v]: {}".format(core[u], core[v])
             if core[u] > core[v]: # 2 > 1
                 # bi-directional operation
                 nbrs[v].remove(u) # nbrs[4] = {1,3} # Assumes reciprocity!
@@ -189,8 +172,6 @@ def k_core(G,k=None,core_number=None,direction=None):
     
     if core_number is None:
         core_number=nx.core_number(G,direction=direction)
-        print direction
-        print core_number
     if k is None:
         k=max(core_number.values()) # max core
     nodes=(n for n in core_number if core_number[n]>=k)


### PR DESCRIPTION
The pull request is somewhat self explanatory, except for the exception I get when I run it:

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-4-67dabf7741d4> in <module>()
     45 import copy
     46 for v in nodes:
---> 47     for u in nbrs[v]: # {4}
     48         if core[u] > core[v]: # 2 > 1
     49             # bi-directional operation

RuntimeError: Set changed size during iteration
```

My hope is that someone smarter than me can implement this algorithm in a way that doesn't have the change during iteration problem. 

I suspect though, that the basic algorithm doesn't work for in-bound connetions. Look at line 95 in the original file...

```
nbrs[u].remove(v)
```

this assumes reciprocation. To make this work, I changed it to:

```
nbrs[v].remove[u] # remove the in-bound link
```

I can't figure out whether this should work or not, but I don't think it does. 

So, can someone smarter than me make this work? I would love to see this added to networkx.
