### PR TITLE
Make selfloop methods return iterator instead of list in graph class

### DIFF
--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -62,7 +62,7 @@ def rich_club_coefficient(G, normalized=True, Q=100):
     if G.is_multigraph() or G.is_directed():
         raise Exception('rich_club_coefficient is not implemented for ',
                         'directed or multiedge graphs.')
-    if len(G.selfloop_edges()) > 0:
+    if G.number_of_selfloops() > 0:
         raise Exception('rich_club_coefficient is not implemented for ',
                         'graphs with self loops.')
     rc=_compute_rc(G)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1576,7 +1576,7 @@ class Graph(object):
         >>> G.number_of_selfloops()
         1
         """
-        return len(list(self.selfloop_edges()))
+        return sum(1 for _ in self.selfloop_edges())
 
     def size(self, weight=None):
         """Return the number of edges.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1508,7 +1508,7 @@ class Graph(object):
         [1]
 
         """
-        return [n for n, nbrs in self.adj.items() if n in nbrs]
+        return (n for n, nbrs in self.adj.items() if n in nbrs)
 
     def selfloop_edges(self, data=False, default=None):
         """Return a list of selfloop edges.
@@ -1539,20 +1539,20 @@ class Graph(object):
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
         >>> G.add_edge(1,1)
         >>> G.add_edge(1,2)
-        >>> G.selfloop_edges()
+        >>> list(G.selfloop_edges())
         [(1, 1)]
-        >>> G.selfloop_edges(data=True)
+        >>> list(G.selfloop_edges(data=True))
         [(1, 1, {})]
         """
         if data is True:
-            return [(n, n, nbrs[n])
-                    for n, nbrs in self.adj.items() if n in nbrs]
+            return ((n, n, nbrs[n])
+                    for n, nbrs in self.adj.items() if n in nbrs)
         elif data is not False:
-            return [(n, n, nbrs[n].get(data, default))
-                    for n, nbrs in self.adj.items() if n in nbrs]
+            return ((n, n, nbrs[n].get(data, default))
+                    for n, nbrs in self.adj.items() if n in nbrs)
         else:
-            return [(n, n)
-                    for n, nbrs in self.adj.items() if n in nbrs]
+            return ((n, n)
+                    for n, nbrs in self.adj.items() if n in nbrs)
 
     def number_of_selfloops(self):
         """Return the number of selfloop edges.
@@ -1576,7 +1576,7 @@ class Graph(object):
         >>> G.number_of_selfloops()
         1
         """
-        return len(self.selfloop_edges())
+        return len(list(self.selfloop_edges()))
 
     def size(self, weight=None):
         """Return the number of edges.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -878,42 +878,42 @@ class MultiGraph(Graph):
         >>> G = nx.MultiGraph()   # or MultiDiGraph
         >>> G.add_edge(1,1)
         >>> G.add_edge(1,2)
-        >>> G.selfloop_edges()
+        >>> list(G.selfloop_edges())
         [(1, 1)]
-        >>> G.selfloop_edges(data=True)
+        >>> list(G.selfloop_edges(data=True))
         [(1, 1, {})]
-        >>> G.selfloop_edges(keys=True)
+        >>> list(G.selfloop_edges(keys=True))
         [(1, 1, 0)]
-        >>> G.selfloop_edges(keys=True, data=True)
+        >>> list(G.selfloop_edges(keys=True, data=True))
         [(1, 1, 0, {})]
         """
         if data is True:
             if keys:
-                return [(n, n, k, d)
+                return ((n, n, k, d)
                         for n, nbrs in self.adj.items()
-                        if n in nbrs for k, d in nbrs[n].items()]
+                        if n in nbrs for k, d in nbrs[n].items())
             else:
-                return [(n, n, d)
+                return ((n, n, d)
                         for n, nbrs in self.adj.items()
-                        if n in nbrs for d in nbrs[n].values()]
+                        if n in nbrs for d in nbrs[n].values())
         elif data is not False:
             if keys:
-                return [(n, n, k, d.get(data, default))
+                return ((n, n, k, d.get(data, default))
                         for n, nbrs in self.adj.items()
-                        if n in nbrs for k, d in nbrs[n].items()]
+                        if n in nbrs for k, d in nbrs[n].items())
             else:
-                return [(n, n, d.get(data, default))
+                return ((n, n, d.get(data, default))
                         for n, nbrs in self.adj.items()
-                        if n in nbrs for d in nbrs[n].values()]
+                        if n in nbrs for d in nbrs[n].values())
         else:
             if keys:
-                return [(n, n, k)
+                return ((n, n, k)
                         for n, nbrs in self.adj.items()
-                        if n in nbrs for k in nbrs[n].keys()]
+                        if n in nbrs for k in nbrs[n].keys())
             else:
-                return [(n, n)
+                return ((n, n)
                         for n, nbrs in self.adj.items()
-                        if n in nbrs for d in nbrs[n].values()]
+                        if n in nbrs for d in nbrs[n].values())
 
     def number_of_edges(self, u=None, v=None):
         """Return the number of edges between two nodes.

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -148,7 +148,7 @@ class BaseGraphTester(object):
         G=self.K3.copy()
         G.add_edge(0,0)
         assert_equal(list(G.nodes_with_selfloops()), [0])
-        assert_equal(G.selfloop_edges(),[(0,0)])
+        assert_equal(list(G.selfloop_edges()), [(0, 0)])
         assert_equal(G.number_of_selfloops(),1)
         G.remove_edge(0,0)
         G.add_edge(0,0)
@@ -419,10 +419,10 @@ class BaseAttrGraphTester(BaseGraphTester):
         G=self.K3.copy()
         G.add_edge(0,0)
         G.add_edge(1,1,weight=2)
-        assert_equal(G.selfloop_edges(data=True),
-                [(0,0,{}),(1,1,{'weight':2})])
-        assert_equal(G.selfloop_edges(data='weight'),
-                [(0,0,None),(1,1,2)])
+        assert_equal(list(G.selfloop_edges(data=True)),
+                [(0, 0, {}), (1, 1, {'weight':2})])
+        assert_equal(list(G.selfloop_edges(data='weight')),
+                [(0, 0, None), (1, 1, 2)])
 
 
 class TestGraph(BaseAttrGraphTester):

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -91,8 +91,8 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
         G=self.K3
         G.add_edge(0,0)
         assert_equal(list(G.nodes_with_selfloops()), [0])
-        assert_equal(G.selfloop_edges(),[(0,0)])
-        assert_equal(G.selfloop_edges(data=True),[(0,0,{})])
+        assert_equal(list(G.selfloop_edges()), [(0, 0)])
+        assert_equal(list(G.selfloop_edges(data=True)), [(0, 0, {})])
         assert_equal(G.number_of_selfloops(),1)
 
     def test_selfloops2(self):

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -713,7 +713,7 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
         c = col + row
         # selfloop entries get double counted when symmetrizing
         # so we subtract the data on the diagonal
-        selfloops = G.selfloop_edges(data=True)
+        selfloops = list(G.selfloop_edges(data=True))
         if selfloops:
             diag_index,diag_data = zip(*((index[u],-d.get(weight,1))
                                          for u,v,d in selfloops


### PR DESCRIPTION
This PR updates the methods `nodes_with_selfloops`, `selfloop_edges`, `number_of_selfloops` in `network/classes/graph.py` and `network/classes/multigraph.py`. These functions now return an iterator instead of lists.