### PR TITLE
Revert "Allow external packages to be installed in networkx.addons"

### DIFF
--- a/networkx/addons/__init__.py
+++ b/networkx/addons/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ version = release.write_versionfile()
 sys.path.pop(0)
 
 packages=["networkx",
-          "networkx.addons",
           "networkx.algorithms",
           "networkx.algorithms.assortativity",
           "networkx.algorithms.bipartite",


### PR DESCRIPTION
Reverts networkx/networkx#1595

This now deletes `networkx.addons` namespace and leaves users with the option to import the addons directly from their own packages, e.g. `nxmetis`, `nxlemon`, `nxmatplotlib`.

Flask recommends users to import addons from `flask.ext`, we could also do that. In that case we'll need changes in this PR.

As of now, I've not been able to think the difference between two, so it's all about the design and our choice.