### PR TITLE
Code and tests for temporal VF2

### DIFF
--- a/networkx/algorithms/isomorphism/__init__.py
+++ b/networkx/algorithms/isomorphism/__init__.py
@@ -1,4 +1,5 @@
 from networkx.algorithms.isomorphism.isomorph import *
 from networkx.algorithms.isomorphism.vf2userfunc import *
 from networkx.algorithms.isomorphism.matchhelpers import *
+from networkx.algorithms.isomorphism.temporalisomorphvf2 import *
 

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -29,9 +29,12 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         >>> from networkx.algorithms import isomorphism
         >>> G1 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
+
         >>> G2 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
+
         Add temporal information to the edges.
         >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
+
         """
         self.d = d
         super(TimeRespectingGraphMatcher, self).__init__(G1, G2)
@@ -97,9 +100,12 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         >>> from networkx.algorithms import isomorphism
         >>> G1 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
+
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
+
         Add temporal information to the edges.
         >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
+
         """
         self.d = d
         super(TimeRespectingDiGraphMatcher, self).__init__(G1, G2)

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import networkx as nx
 from datetime import datetime, timedelta
-from isomorphvf2 import GraphMatcher, DiGraphMatcher
+from .isomorphvf2 import GraphMatcher, DiGraphMatcher
 
 __all__ = ['TimeRespectingGraphMatcher',
            'TimeRespectingDiGraphMatcher']
@@ -32,7 +33,6 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         >>> G2 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
 
-        Add temporal information to the edges.
         >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
         """
         self.d = d
@@ -102,7 +102,6 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
 
-        Add temporal information to the edges.
         >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
         """
         self.d = d

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -1,0 +1,215 @@
+import networkx as nx
+from datetime import datetime, timedelta
+from isomorphvf2 import GraphMatcher, DiGraphMatcher
+
+__all__ = ['TimeRespectingGraphMatcher',
+           'TimeRespectingDiGraphMatcher']
+
+def get_date(dictionary):
+    '''
+    Given the data dictionary of an edge, return the datetime.
+    '''
+    if 'date' in dictionary:
+        date = dictionary['date']
+        return datetime.strptime(date, '%Y-%m-%d')
+    elif 'datetime' in dictionary:
+        dt = dictionary['datetime']
+        return datetime.strptime(dt, '%Y-%m-%d %H:%M:%S')
+
+class TimeRespectingGraphMatcher(GraphMatcher):
+
+    def __init__(self, G1, G2, d = timedelta()):
+        """Initialize TimeRespectingGraphMatcher.
+
+        G1 and G2 should be nx.Graph or nx.MultiGraph instances.
+
+        Examples
+        --------
+        To create a TimeRespectingGraphMatcher which checks for syntactic and semantic feasibility:
+
+        >>> from networkx.algorithms import isomorphism
+        >>> G1 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
+        >>> G2 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
+        Add temporal information to the edges.
+        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
+        """
+        self.d = d
+        super(TimeRespectingGraphMatcher, self).__init__(G1, G2)
+    
+    def one_hop(self, Gx, Gx_node, neighbors):
+        '''
+        Edges one hop out from a node in the mapping should be time-respecting w.r.t. each other.
+        '''
+        time_respecting = True
+        dates = []
+        for n in neighbors:
+            if type(Gx) == type(nx.Graph()): # Graph G[u][v] returns the data dictionary.
+                dates.append(get_date(Gx[Gx_node][n]))
+            else: # MultiGraph G[u][v] returns a dictionary of key -> data dictionary.
+                for edge in Gx[Gx_node][n].values(): # Iterates all edges between node pair.
+                    dates.append(get_date(edge))
+        if any(x is None for x in dates):
+            raise ValueError('Date or datetime not supplied for at least one edge.')
+        dates.sort() # Small to large.
+        if 0 < len(dates) and not (dates[-1] - dates[0] <= self.d):
+            time_respecting = False
+        return time_respecting
+    
+    def two_hop(self, Gx, core_x, Gx_node, neighbors):
+        '''
+        Paths of length 2 from Gx_node should be time-respecting.
+        '''
+        time_respecting = True
+        for neigh in neighbors:
+            out_neighbors = [b for b in Gx[neigh] if b in core_x]
+            out_neighbors.append(Gx_node) # Include Gx_node as a neighbor, since it's not in the mapping.
+            if not self.one_hop(Gx, neigh, out_neighbors):
+                time_respecting = False
+                break
+        return time_respecting
+
+    def semantic_feasibility(self, G1_node, G2_node):
+        """Returns True if adding (G1_node, G2_node) is semantically feasible.
+
+        Any subclass which redefines semantic_feasibility() must maintain
+        the self.tests if needed, to keep the match() method functional. Implementations
+        should consider multigraphs.
+        """
+        neighbors = [n for n in self.G1[G1_node] if n in self.core_1]
+        if not self.one_hop(self.G1, G1_node, neighbors): # Fail fast on first node.
+            return False
+        if not self.two_hop(self.G1, self.core_1, G1_node, neighbors):
+            return False
+        # Otherwise, this node is sematically feasible!
+        return True
+
+
+class TimeRespectingDiGraphMatcher(DiGraphMatcher):
+
+    def __init__(self, G1, G2, d = timedelta()):
+        """Initialize TimeRespectingDiGraphMatcher.
+
+        G1 and G2 should be nx.DiGraph or nx.MultiDiGraph instances.
+
+        Examples
+        --------
+        To create a TimeRespectingDiGraphMatcher which checks for syntactic and semantic feasibility:
+
+        >>> from networkx.algorithms import isomorphism
+        >>> G1 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
+        >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
+        Add temporal information to the edges.
+        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
+        """
+        self.d = d
+        super(TimeRespectingDiGraphMatcher, self).__init__(G1, G2)
+    
+    def get_pred_dates(self, Gx, Gx_node, core_x, pred):
+        '''
+        Get the dates of edges from predecessors.
+        '''
+        pred_dates = []
+        if type(Gx) == type(nx.DiGraph()): # Graph G[u][v] returns the data dictionary.
+            for n in pred:
+                pred_dates.append(get_date(Gx[n][Gx_node]))
+        else: # MultiGraph G[u][v] returns a dictionary of key -> data dictionary.
+            for n in pred:
+                for data_dict in Gx[n][Gx_node].values(): # Iterates all edge data between node pair.
+                    pred_dates.append(get_date(data_dict))
+        return pred_dates
+    
+    def get_succ_dates(self, Gx, Gx_node, core_x, succ):
+        '''
+        Get the dates of edges to successors.
+        '''
+        succ_dates = []
+        if type(Gx) == type(nx.DiGraph()): # Graph G[u][v] returns the data dictionary.
+            for n in succ:
+                succ_dates.append(get_date(Gx[Gx_node][n]))
+        else: # MultiGraph G[u][v] returns a dictionary of key -> data dictionary.
+            for n in succ:
+                for data_dict in Gx[Gx_node][n].values(): # Iterates all edge data between node pair.
+                    succ_dates.append(get_date(data_dict))
+        return succ_dates
+
+    def one_hop(self, Gx, Gx_node, core_x, pred, succ):
+        '''
+        The ego node.
+        '''
+        time_respecting = True
+        pred_dates = self.get_pred_dates(Gx, Gx_node, core_x, pred)
+        succ_dates = self.get_succ_dates(Gx, Gx_node, core_x, succ)
+        if not (self.test_one(pred_dates, succ_dates) and self.test_two(pred_dates, succ_dates)):
+            time_respecting = False
+        return time_respecting
+    
+    def two_hop_pred(self, Gx, Gx_node, core_x, pred, succ):
+        '''
+        The predeccessors of the ego node.
+        '''
+        time_respecting = True
+        for p in pred:
+            pred_p, succ_p = [n for n in Gx.predecessors(p) if n in core_x], [n for n in Gx.successors(p) if n in core_x]
+            succ_p.append(Gx_node)
+            if not self.one_hop(Gx, p, core_x, pred_p, succ_p):
+                time_respecting = False
+                break
+        return time_respecting
+
+    def two_hop_succ(self, Gx, Gx_node, core_x, pred, succ):
+        '''
+        The successors of the ego node.
+        '''
+        time_respecting = True
+        for s in succ:
+            pred_s, succ_s = [n for n in Gx.predecessors(s) if n in core_x], [n for n in Gx.successors(s) if n in core_x]
+            pred_s.append(Gx_node)
+            if not self.one_hop(Gx, s, core_x, pred_s, succ_s):
+                time_respecting = False
+                break
+        return time_respecting
+    
+    def test_one(self, pred_dates, succ_dates):
+        '''
+        Edges one hop out from Gx_node in the mapping should be time-respecting w.r.t. each other, regardless of direction.
+        '''
+        time_respecting = True
+        dates = pred_dates + succ_dates
+        
+        if any(x is None for x in dates):
+            raise ValueError('Date or datetime not supplied for at least one edge.')
+        
+        dates.sort() # Small to large.
+        if 0 < len(dates) and not (dates[-1] - dates[0] <= self.d):
+            time_respecting = False
+        return time_respecting
+    
+    def test_two(self, pred_dates, succ_dates):
+        '''
+        Edges from a dual Gx_node in the mapping should be ordered in a time-respecting manner.
+        '''
+        time_respecting = True
+        pred_dates.sort()
+        succ_dates.sort()
+        # First out before last in; negative of the necessary condition for time-respect.
+        if 0 < len(succ_dates) and 0 < len(pred_dates) and succ_dates[0] < pred_dates[-1]:
+            time_respecting = False
+        return time_respecting
+
+    def semantic_feasibility(self, G1_node, G2_node):
+        """Returns True if adding (G1_node, G2_node) is semantically feasible.
+
+        Any subclass which redefines semantic_feasibility() must maintain
+        the self.tests if needed, to keep the match() method functional. Implementations
+        should consider multigraphs.
+        """
+        pred, succ = [n for n in self.G1.predecessors(G1_node) if n in self.core_1], [n for n in self.G1.successors(G1_node) if n in self.core_1]
+        if not self.one_hop(self.G1, G1_node, self.core_1, pred, succ): # Fail fast on first node.
+            return False
+        if not self.two_hop_pred(self.G1, G1_node, self.core_1, pred, succ):
+            return False
+        if not self.two_hop_succ(self.G1, G1_node, self.core_1, pred, succ):
+            return False
+        # Otherwise, this node is sematically feasible!
+        return True
+

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -92,8 +92,7 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         >>> G2 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
 
-        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1, G2, 
-        'date', timedelta(days=1))
+        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1, G2, 'date', timedelta(days=1))
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
@@ -164,8 +163,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
 
-        >>> GM = isomorphism.TimeRespectingDiGraphMatcher(G1, G2, 
-        'date', timedelta(days=1))
+        >>> GM = isomorphism.TimeRespectingDiGraphMatcher(G1, G2, 'date', timedelta(days=1))
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -44,7 +44,8 @@ Handles directed and undirected graphs and graphs with parallel edges.
 """
 
 #    This extension was originally coded by Ursula Redmond
-#    during postgraduate research at the Clique Research Cluster.
+#    during postgraduate research at the Clique Research Cluster,
+#    and subsequently the Insight Centre for Data Analytics.
 #    Padraig Cunningham, principal investigator.
 #    School of Computer Science and Informatics, University College Dublin.
 
@@ -56,21 +57,6 @@ from .isomorphvf2 import GraphMatcher, DiGraphMatcher
 __all__ = ['TimeRespectingGraphMatcher',
            'TimeRespectingDiGraphMatcher']
 
-def get_date(dictionary, temporal_attribute_name):
-    '''
-    A future refactor will remove this conversion step.
-    Given the data dictionary of an edge, return the datetime.
-    '''
-    #if 'date' in dictionary:
-        #date = dictionary['date']
-        #return datetime.strptime(date, '%Y-%m-%d')
-    #elif 'datetime' in dictionary:
-        #dt = dictionary['datetime']
-        #return datetime.strptime(dt, '%Y-%m-%d %H:%M:%S')
-    
-    date = dictionary[temporal_attribute_name]
-    return datetime.strptime(date, '%Y-%m-%d')
-    
 
 class TimeRespectingGraphMatcher(GraphMatcher):
 
@@ -102,10 +88,10 @@ class TimeRespectingGraphMatcher(GraphMatcher):
         dates = []
         for n in neighbors:
             if type(Gx) == type(nx.Graph()): # Graph G[u][v] returns the data dictionary.
-                dates.append(get_date(Gx[Gx_node][n], self.temporal_attribute_name))
+                dates.append(Gx[Gx_node][n][self.temporal_attribute_name])
             else: # MultiGraph G[u][v] returns a dictionary of key -> data dictionary.
                 for edge in Gx[Gx_node][n].values(): # Iterates all edges between node pair.
-                    dates.append(get_date(edge, self.temporal_attribute_name))
+                    dates.append(edge[self.temporal_attribute_name])
         if any(x is None for x in dates):
             raise ValueError('Datetime not supplied for at least one edge.')
         dates.sort() # Small to large.
@@ -171,11 +157,11 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         pred_dates = []
         if type(Gx) == type(nx.DiGraph()): # Graph G[u][v] returns the data dictionary.
             for n in pred:
-                pred_dates.append(get_date(Gx[n][Gx_node], self.temporal_attribute_name))
+                pred_dates.append(Gx[n][Gx_node][self.temporal_attribute_name])
         else: # MultiGraph G[u][v] returns a dictionary of key -> data dictionary.
             for n in pred:
-                for data_dict in Gx[n][Gx_node].values(): # Iterates all edge data between node pair.
-                    pred_dates.append(get_date(data_dict, self.temporal_attribute_name))
+                for edge in Gx[n][Gx_node].values(): # Iterates all edge data between node pair.
+                    pred_dates.append(edge[self.temporal_attribute_name])
         return pred_dates
     
     def get_succ_dates(self, Gx, Gx_node, core_x, succ):
@@ -185,11 +171,11 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         succ_dates = []
         if type(Gx) == type(nx.DiGraph()): # Graph G[u][v] returns the data dictionary.
             for n in succ:
-                succ_dates.append(get_date(Gx[Gx_node][n], self.temporal_attribute_name))
+                succ_dates.append(Gx[Gx_node][n][self.temporal_attribute_name])
         else: # MultiGraph G[u][v] returns a dictionary of key -> data dictionary.
             for n in succ:
-                for data_dict in Gx[Gx_node][n].values(): # Iterates all edge data between node pair.
-                    succ_dates.append(get_date(data_dict, self.temporal_attribute_name))
+                for edge in Gx[Gx_node][n].values(): # Iterates all edge data between node pair.
+                    succ_dates.append(edge[self.temporal_attribute_name])
         return succ_dates
 
     def one_hop(self, Gx, Gx_node, core_x, pred, succ):

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -34,7 +34,6 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         Add temporal information to the edges.
         >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
-
         """
         self.d = d
         super(TimeRespectingGraphMatcher, self).__init__(G1, G2)
@@ -105,7 +104,6 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         Add temporal information to the edges.
         >>> GM = isomorphism.TimeRespectingGraphMatcher(G1,G2)
-
         """
         self.d = d
         super(TimeRespectingDiGraphMatcher, self).__init__(G1, G2)

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -4,18 +4,35 @@
 Time-respecting VF2 Algorithm
 *****************************
 
-An extension of the VF2 algorithm for time-respecting graph ismorphism testing in temporal graphs.
+An extension of the VF2 algorithm for time-respecting graph ismorphism 
+testing in temporal graphs.
 
-A temporal graph is one in which edges contain a datetime attribute, denoting when interaction occurred between the incident nodes. A time-respecting subgraph of a temporal graph is a subgraph such that all interactions incident to a node occurred within a time threshold, delta, of each other. A directed time-respecting subgraph has the added constraint that incoming interactions to a node must precede outgoing interactions from the same node - this enforces a sense of directed flow.
+A temporal graph is one in which edges contain a datetime attribute, 
+denoting when interaction occurred between the incident nodes. A 
+time-respecting subgraph of a temporal graph is a subgraph such that 
+all interactions incident to a node occurred within a time threshold, 
+delta, of each other. A directed time-respecting subgraph has the 
+added constraint that incoming interactions to a node must precede 
+outgoing interactions from the same node - this enforces a sense of 
+directed flow.
 
 Introduction
 ------------
 
-The TimeRespectingGraphMatcher and TimeRespectingDiGraphMatcher extend the GraphMatcher and DiGraphMatcher classes, respectively, to include temporal constraints on matches. This is achieved through a semantic check, via the semantic_feasibility() function.
+The TimeRespectingGraphMatcher and TimeRespectingDiGraphMatcher 
+extend the GraphMatcher and DiGraphMatcher classes, respectively, 
+to include temporal constraints on matches. This is achieved through 
+a semantic check, via the semantic_feasibility() function.
 
-As well as including G1 (the graph in which to seek embeddings) and G2 (the subgraph structure of interest), the name of the temporal attribute on the edges and the time threshold, delta, must be supplied as arguments to the matching constructors.
+As well as including G1 (the graph in which to seek embeddings) and 
+G2 (the subgraph structure of interest), the name of the temporal 
+attribute on the edges and the time threshold, delta, must be supplied 
+as arguments to the matching constructors.
 
-A delta of zero is the strictest temporal constraint on the match - only embeddings in which all interactions occur at the same time will be returned. A delta of one day will allow embeddings in which adjacent interactions occur up to a day apart.
+A delta of zero is the strictest temporal constraint on the match - 
+only embeddings in which all interactions occur at the same time will 
+be returned. A delta of one day will allow embeddings in which 
+adjacent interactions occur up to a day apart.
 
 Examples
 --------
@@ -26,15 +43,21 @@ Examples will be provided when the datetime type has been incorporated.
 Temporal Subgraph Isomorphism
 -----------------------------
 
-A brief discussion of the somewhat diverse current literature will be included here.
+A brief discussion of the somewhat diverse current literature will be 
+included here.
 
 References
 ----------
 
-[1] Redmond, U. and Cunningham, P. Temporal subgraph isomorphism. In: The 2013 IEEE/ACM International Conference on Advances in Social Networks Analysis and Mining (ASONAM). Niagara Falls, Canada; 2013: pages 1451 - 1452. [65]
+[1] Redmond, U. and Cunningham, P. Temporal subgraph isomorphism. In: 
+The 2013 IEEE/ACM International Conference on Advances in Social 
+Networks Analysis and Mining (ASONAM). Niagara Falls, Canada; 2013: 
+pages 1451 - 1452. [65]
 
-[2] Redmond, U. and Cunningham, P. A temporal network analysis reveals the unprofitability of arbitrage in The Prosper Marketplace. In: Expert Systems with Applications; Pergamon; 2013: 40(9): pages 3715 - 3721. [64]
+For a discussion of the literature on temporal networks:
 
+[3] P. Holme and J. Saramaki. Temporal networks. Physics Reports, 
+519(3):97–125, 2012.
 
 Notes
 -----
@@ -42,12 +65,6 @@ Notes
 Handles directed and undirected graphs and graphs with parallel edges.
 
 """
-
-#    This extension was originally coded by Ursula Redmond
-#    during postgraduate research at the Clique Research Cluster,
-#    and subsequently the Insight Centre for Data Analytics.
-#    Padraig Cunningham, principal investigator.
-#    School of Computer Science and Informatics, University College Dublin.
 
 from __future__ import absolute_import
 import networkx as nx
@@ -67,24 +84,26 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         Examples
         --------
-        To create a TimeRespectingGraphMatcher which checks for syntactic and semantic feasibility:
+        To create a TimeRespectingGraphMatcher which checks for 
+        syntactic and semantic feasibility:
 
         >>> from networkx.algorithms import isomorphism
         >>> G1 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
 
         >>> G2 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
 
-        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1, G2, 'date', timedelta(days=1))
+        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1, G2, 
+        'date', timedelta(days=1))
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
         super(TimeRespectingGraphMatcher, self).__init__(G1, G2)
     
     def one_hop(self, Gx, Gx_node, neighbors):
-        '''
-        Edges one hop out from a node in the mapping should be time-respecting w.r.t. each other.
-        '''
-        time_respecting = True
+        """
+        Edges one hop out from a node in the mapping should be 
+        time-respecting with respect to each other.
+        """
         dates = []
         for n in neighbors:
             if type(Gx) == type(nx.Graph()): # Graph G[u][v] returns the data dictionary.
@@ -94,15 +113,14 @@ class TimeRespectingGraphMatcher(GraphMatcher):
                     dates.append(edge[self.temporal_attribute_name])
         if any(x is None for x in dates):
             raise ValueError('Datetime not supplied for at least one edge.')
-        dates.sort() # Small to large.
-        if 0 < len(dates) and not (dates[-1] - dates[0] <= self.delta):
-            time_respecting = False
-        return time_respecting
+        return not dates or max(dates) - min(dates) <= self.delta
     
     def two_hop(self, Gx, core_x, Gx_node, neighbors):
-        '''
+        """
         Paths of length 2 from Gx_node should be time-respecting.
-        '''
+        """
+        
+        #return any(not self.one_hop(Gx, v, [w for w in Gx[v] if w in core_x] + [Gx_node]) for v in neighbors)
         time_respecting = True
         for neigh in neighbors:
             out_neighbors = [b for b in Gx[neigh] if b in core_x]
@@ -113,11 +131,12 @@ class TimeRespectingGraphMatcher(GraphMatcher):
         return time_respecting
 
     def semantic_feasibility(self, G1_node, G2_node):
-        """Returns True if adding (G1_node, G2_node) is semantically feasible.
+        """Returns True if adding (G1_node, G2_node) is semantically 
+        feasible.
 
-        Any subclass which redefines semantic_feasibility() must maintain
-        the self.tests if needed, to keep the match() method functional. Implementations
-        should consider multigraphs.
+        Any subclass which redefines semantic_feasibility() must 
+        maintain the self.tests if needed, to keep the match() method 
+        functional. Implementations should consider multigraphs.
         """
         neighbors = [n for n in self.G1[G1_node] if n in self.core_1]
         if not self.one_hop(self.G1, G1_node, neighbors): # Fail fast on first node.
@@ -137,23 +156,25 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         Examples
         --------
-        To create a TimeRespectingDiGraphMatcher which checks for syntactic and semantic feasibility:
+        To create a TimeRespectingDiGraphMatcher which checks for 
+        syntactic and semantic feasibility:
 
         >>> from networkx.algorithms import isomorphism
         >>> G1 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
 
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
 
-        >>> GM = isomorphism.TimeRespectingDiGraphMatcher(G1, G2, 'date', timedelta(days=1))
+        >>> GM = isomorphism.TimeRespectingDiGraphMatcher(G1, G2, 
+        'date', timedelta(days=1))
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
         super(TimeRespectingDiGraphMatcher, self).__init__(G1, G2)
     
     def get_pred_dates(self, Gx, Gx_node, core_x, pred):
-        '''
+        """
         Get the dates of edges from predecessors.
-        '''
+        """
         pred_dates = []
         if type(Gx) == type(nx.DiGraph()): # Graph G[u][v] returns the data dictionary.
             for n in pred:
@@ -165,9 +186,9 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return pred_dates
     
     def get_succ_dates(self, Gx, Gx_node, core_x, succ):
-        '''
+        """
         Get the dates of edges to successors.
-        '''
+        """
         succ_dates = []
         if type(Gx) == type(nx.DiGraph()): # Graph G[u][v] returns the data dictionary.
             for n in succ:
@@ -179,20 +200,17 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return succ_dates
 
     def one_hop(self, Gx, Gx_node, core_x, pred, succ):
-        '''
+        """
         The ego node.
-        '''
-        time_respecting = True
+        """
         pred_dates = self.get_pred_dates(Gx, Gx_node, core_x, pred)
         succ_dates = self.get_succ_dates(Gx, Gx_node, core_x, succ)
-        if not (self.test_one(pred_dates, succ_dates) and self.test_two(pred_dates, succ_dates)):
-            time_respecting = False
-        return time_respecting
+        return self.test_one(pred_dates, succ_dates) and self.test_two(pred_dates, succ_dates)
     
     def two_hop_pred(self, Gx, Gx_node, core_x, pred, succ):
-        '''
+        """
         The predeccessors of the ego node.
-        '''
+        """
         time_respecting = True
         for p in pred:
             pred_p, succ_p = [n for n in Gx.predecessors(p) if n in core_x], [n for n in Gx.successors(p) if n in core_x]
@@ -203,9 +221,9 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return time_respecting
 
     def two_hop_succ(self, Gx, Gx_node, core_x, pred, succ):
-        '''
+        """
         The successors of the ego node.
-        '''
+        """
         time_respecting = True
         for s in succ:
             pred_s, succ_s = [n for n in Gx.predecessors(s) if n in core_x], [n for n in Gx.successors(s) if n in core_x]
@@ -216,9 +234,11 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return time_respecting
     
     def test_one(self, pred_dates, succ_dates):
-        '''
-        Edges one hop out from Gx_node in the mapping should be time-respecting w.r.t. each other, regardless of direction.
-        '''
+        """
+        Edges one hop out from Gx_node in the mapping should be 
+        time-respecting with respect to each other, regardless of 
+        direction.
+        """
         time_respecting = True
         dates = pred_dates + succ_dates
         
@@ -231,9 +251,10 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return time_respecting
     
     def test_two(self, pred_dates, succ_dates):
-        '''
-        Edges from a dual Gx_node in the mapping should be ordered in a time-respecting manner.
-        '''
+        """
+        Edges from a dual Gx_node in the mapping should be ordered in 
+        a time-respecting manner.
+        """
         time_respecting = True
         pred_dates.sort()
         succ_dates.sort()
@@ -243,11 +264,12 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return time_respecting
 
     def semantic_feasibility(self, G1_node, G2_node):
-        """Returns True if adding (G1_node, G2_node) is semantically feasible.
+        """Returns True if adding (G1_node, G2_node) is semantically 
+        feasible.
 
-        Any subclass which redefines semantic_feasibility() must maintain
-        the self.tests if needed, to keep the match() method functional. Implementations
-        should consider multigraphs.
+        Any subclass which redefines semantic_feasibility() must 
+        maintain the self.tests if needed, to keep the match() method 
+        functional. Implementations should consider multigraphs.
         """
         pred, succ = [n for n in self.G1.predecessors(G1_node) if n in self.core_1], [n for n in self.G1.successors(G1_node) if n in self.core_1]
         if not self.one_hop(self.G1, G1_node, self.core_1, pred, succ): # Fail fast on first node.

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -1,11 +1,6 @@
 """
     Tests for the temporal aspect of the Temporal VF2 isomorphism algorithm.
 """
-
-import os
-import struct
-import random
-
 from nose.tools import assert_true, assert_false, assert_equal
 from nose import SkipTest
 import networkx as nx
@@ -62,8 +57,8 @@ def put_time_config_2(G, att_name):
     G[4][5][att_name] = date(2015, 1, 2)
     return G
 
-class TestTimeRespectingGraphMatcher(object):
 
+class TestTimeRespectingGraphMatcher(object):
     """
         A test class for the undirected temporal graph matcher.
     """
@@ -147,8 +142,6 @@ class TestTimeRespectingGraphMatcher(object):
     
 
 class TestDiTimeRespectingGraphMatcher(object):
-
-
     """
         A test class for the directed time-respecting graph matcher.
     """
@@ -210,7 +203,4 @@ class TestDiTimeRespectingGraphMatcher(object):
         gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 2)
-
-
-
 

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -10,51 +10,56 @@ from nose.tools import assert_true, assert_false, assert_equal
 from nose import SkipTest
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 def provide_g1_edgelist():
     return [(0, 1), (0, 2), (1, 2), (2, 4), (1, 3), (3, 4), (4, 5)]
 
 def put_same_time(G, att_name):
     for e in G.edges(data=True):
-        e[2][att_name] = date(2015, 01, 01)
+        e[2][att_name] = date(2015, 1, 1)
+    return G
+
+def put_same_datetime(G, att_name):
+    for e in G.edges(data=True):
+        e[2][att_name] = datetime(2015, 1, 1)
     return G
 
 def put_sequence_time(G, att_name):
-    current_date = date(2015, 01, 01)
+    current_date = date(2015, 1, 1)
     for e in G.edges(data=True):
         current_date += timedelta(days=1)
         e[2][att_name] = current_date
     return G
 
 def put_time_config_0(G, att_name):
-    G[0][1][att_name] = date(2015, 01, 02)
-    G[0][2][att_name] = date(2015, 01, 02)
-    G[1][2][att_name] = date(2015, 01, 03)
-    G[1][3][att_name] = date(2015, 01, 01)
-    G[2][4][att_name] = date(2015, 01, 01)
-    G[3][4][att_name] = date(2015, 01, 03)
-    G[4][5][att_name] = date(2015, 01, 03)
+    G[0][1][att_name] = date(2015, 1, 2)
+    G[0][2][att_name] = date(2015, 1, 2)
+    G[1][2][att_name] = date(2015, 1, 3)
+    G[1][3][att_name] = date(2015, 1, 1)
+    G[2][4][att_name] = date(2015, 1, 1)
+    G[3][4][att_name] = date(2015, 1, 3)
+    G[4][5][att_name] = date(2015, 1, 3)
     return G
 
 def put_time_config_1(G, att_name):
-    G[0][1][att_name] = date(2015, 01, 02)
-    G[0][2][att_name] = date(2015, 01, 01)
-    G[1][2][att_name] = date(2015, 01, 03)
-    G[1][3][att_name] = date(2015, 01, 01)
-    G[2][4][att_name] = date(2015, 01, 02)
-    G[3][4][att_name] = date(2015, 01, 04)
-    G[4][5][att_name] = date(2015, 01, 03)
+    G[0][1][att_name] = date(2015, 1, 2)
+    G[0][2][att_name] = date(2015, 1, 1)
+    G[1][2][att_name] = date(2015, 1, 3)
+    G[1][3][att_name] = date(2015, 1, 1)
+    G[2][4][att_name] = date(2015, 1, 2)
+    G[3][4][att_name] = date(2015, 1, 4)
+    G[4][5][att_name] = date(2015, 1, 3)
     return G
 
 def put_time_config_2(G, att_name):
-    G[0][1][att_name] = date(2015, 01, 01)
-    G[0][2][att_name] = date(2015, 01, 01)
-    G[1][2][att_name] = date(2015, 01, 03)
-    G[1][3][att_name] = date(2015, 01, 02)
-    G[2][4][att_name] = date(2015, 01, 02)
-    G[3][4][att_name] = date(2015, 01, 03)
-    G[4][5][att_name] = date(2015, 01, 02)
+    G[0][1][att_name] = date(2015, 1, 1)
+    G[0][2][att_name] = date(2015, 1, 1)
+    G[1][2][att_name] = date(2015, 1, 3)
+    G[1][3][att_name] = date(2015, 1, 2)
+    G[2][4][att_name] = date(2015, 1, 2)
+    G[3][4][att_name] = date(2015, 1, 3)
+    G[4][5][att_name] = date(2015, 1, 2)
     return G
 
 class TestTimeRespectingGraphMatcher(object):
@@ -77,6 +82,15 @@ class TestTimeRespectingGraphMatcher(object):
         G1 = self.provide_g1_topology()
         temporal_name = 'date'
         G1 = put_same_time(G1, temporal_name)
+        G2 = self.provide_g2_path_3edges()
+        d = timedelta()
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
+        assert_true(gm.subgraph_is_isomorphic())
+
+    def test_timdelta_zero_datetime_timeRespecting_returnsTrue(self):
+        G1 = self.provide_g1_topology()
+        temporal_name = 'date'
+        G1 = put_same_datetime(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta()
         gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -10,49 +10,51 @@ from nose.tools import assert_true, assert_false, assert_equal
 from nose import SkipTest
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
-from datetime import timedelta
+from datetime import date, timedelta
 
 def provide_g1_edgelist():
     return [(0, 1), (0, 2), (1, 2), (2, 4), (1, 3), (3, 4), (4, 5)]
 
 def put_same_time(G, att_name):
     for e in G.edges(data=True):
-        e[2][att_name] = '2015-01-01'
+        e[2][att_name] = date(2015, 01, 01)
     return G
 
 def put_sequence_time(G, att_name):
-    for i, e in enumerate(G.edges(data=True)):
-        e[2][att_name] = '2015-01-0' + str(i+1)
+    current_date = date(2015, 01, 01)
+    for e in G.edges(data=True):
+        current_date += timedelta(days=1)
+        e[2][att_name] = current_date
     return G
 
 def put_time_config_0(G, att_name):
-    G[0][1][att_name] = '2015-01-02'
-    G[0][2][att_name] = '2015-01-02'
-    G[1][2][att_name] = '2015-01-03'
-    G[1][3][att_name] = '2015-01-01'
-    G[2][4][att_name] = '2015-01-01'
-    G[3][4][att_name] = '2015-01-03'
-    G[4][5][att_name] = '2015-01-03'
+    G[0][1][att_name] = date(2015, 01, 02)
+    G[0][2][att_name] = date(2015, 01, 02)
+    G[1][2][att_name] = date(2015, 01, 03)
+    G[1][3][att_name] = date(2015, 01, 01)
+    G[2][4][att_name] = date(2015, 01, 01)
+    G[3][4][att_name] = date(2015, 01, 03)
+    G[4][5][att_name] = date(2015, 01, 03)
     return G
 
 def put_time_config_1(G, att_name):
-    G[0][1][att_name] = '2015-01-02'
-    G[0][2][att_name] = '2015-01-01'
-    G[1][2][att_name] = '2015-01-03'
-    G[1][3][att_name] = '2015-01-01'
-    G[2][4][att_name] = '2015-01-02'
-    G[3][4][att_name] = '2015-01-04'
-    G[4][5][att_name] = '2015-01-03'
+    G[0][1][att_name] = date(2015, 01, 02)
+    G[0][2][att_name] = date(2015, 01, 01)
+    G[1][2][att_name] = date(2015, 01, 03)
+    G[1][3][att_name] = date(2015, 01, 01)
+    G[2][4][att_name] = date(2015, 01, 02)
+    G[3][4][att_name] = date(2015, 01, 04)
+    G[4][5][att_name] = date(2015, 01, 03)
     return G
 
 def put_time_config_2(G, att_name):
-    G[0][1][att_name] = '2015-01-01'
-    G[0][2][att_name] = '2015-01-01'
-    G[1][2][att_name] = '2015-01-03'
-    G[1][3][att_name] = '2015-01-02'
-    G[2][4][att_name] = '2015-01-02'
-    G[3][4][att_name] = '2015-01-03'
-    G[4][5][att_name] = '2015-01-02'
+    G[0][1][att_name] = date(2015, 01, 01)
+    G[0][2][att_name] = date(2015, 01, 01)
+    G[1][2][att_name] = date(2015, 01, 03)
+    G[1][3][att_name] = date(2015, 01, 02)
+    G[2][4][att_name] = date(2015, 01, 02)
+    G[3][4][att_name] = date(2015, 01, 03)
+    G[4][5][att_name] = date(2015, 01, 02)
     return G
 
 class TestTimeRespectingGraphMatcher(object):

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -15,44 +15,44 @@ from datetime import timedelta
 def provide_g1_edgelist():
     return [(0, 1), (0, 2), (1, 2), (2, 4), (1, 3), (3, 4), (4, 5)]
 
-def put_same_time(G):
+def put_same_time(G, att_name):
     for e in G.edges(data=True):
-        e[2]['date'] = '2015-01-01'
+        e[2][att_name] = '2015-01-01'
     return G
 
-def put_sequence_time(G):
+def put_sequence_time(G, att_name):
     for i, e in enumerate(G.edges(data=True)):
-        e[2]['date'] = '2015-01-0' + str(i+1)
+        e[2][att_name] = '2015-01-0' + str(i+1)
     return G
 
-def put_time_config_0(G):
-    G[0][1]['date'] = '2015-01-02'
-    G[0][2]['date'] = '2015-01-02'
-    G[1][2]['date'] = '2015-01-03'
-    G[1][3]['date'] = '2015-01-01'
-    G[2][4]['date'] = '2015-01-01'
-    G[3][4]['date'] = '2015-01-03'
-    G[4][5]['date'] = '2015-01-03'
+def put_time_config_0(G, att_name):
+    G[0][1][att_name] = '2015-01-02'
+    G[0][2][att_name] = '2015-01-02'
+    G[1][2][att_name] = '2015-01-03'
+    G[1][3][att_name] = '2015-01-01'
+    G[2][4][att_name] = '2015-01-01'
+    G[3][4][att_name] = '2015-01-03'
+    G[4][5][att_name] = '2015-01-03'
     return G
 
-def put_time_config_1(G):
-    G[0][1]['date'] = '2015-01-02'
-    G[0][2]['date'] = '2015-01-01'
-    G[1][2]['date'] = '2015-01-03'
-    G[1][3]['date'] = '2015-01-01'
-    G[2][4]['date'] = '2015-01-02'
-    G[3][4]['date'] = '2015-01-04'
-    G[4][5]['date'] = '2015-01-03'
+def put_time_config_1(G, att_name):
+    G[0][1][att_name] = '2015-01-02'
+    G[0][2][att_name] = '2015-01-01'
+    G[1][2][att_name] = '2015-01-03'
+    G[1][3][att_name] = '2015-01-01'
+    G[2][4][att_name] = '2015-01-02'
+    G[3][4][att_name] = '2015-01-04'
+    G[4][5][att_name] = '2015-01-03'
     return G
 
-def put_time_config_2(G):
-    G[0][1]['date'] = '2015-01-01'
-    G[0][2]['date'] = '2015-01-01'
-    G[1][2]['date'] = '2015-01-03'
-    G[1][3]['date'] = '2015-01-02'
-    G[2][4]['date'] = '2015-01-02'
-    G[3][4]['date'] = '2015-01-03'
-    G[4][5]['date'] = '2015-01-02'
+def put_time_config_2(G, att_name):
+    G[0][1][att_name] = '2015-01-01'
+    G[0][2][att_name] = '2015-01-01'
+    G[1][2][att_name] = '2015-01-03'
+    G[1][3][att_name] = '2015-01-02'
+    G[2][4][att_name] = '2015-01-02'
+    G[3][4][att_name] = '2015-01-03'
+    G[4][5][att_name] = '2015-01-02'
     return G
 
 class TestTimeRespectingGraphMatcher(object):
@@ -73,44 +73,58 @@ class TestTimeRespectingGraphMatcher(object):
 
     def test_timdelta_zero_timeRespecting_returnsTrue(self):
         G1 = self.provide_g1_topology()
-        G1 = put_same_time(G1)
+        temporal_name = 'date'
+        G1 = put_same_time(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta()
-        gm = iso.TimeRespectingGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
+        assert_true(gm.subgraph_is_isomorphic())
+
+    def test_attNameStrange_timdelta_zero_timeRespecting_returnsTrue(self):
+        G1 = self.provide_g1_topology()
+        temporal_name = 'strange_name'
+        G1 = put_same_time(G1, temporal_name)
+        G2 = self.provide_g2_path_3edges()
+        d = timedelta()
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
         assert_true(gm.subgraph_is_isomorphic())
 
     def test_notTimeRespecting_returnsFalse(self):
         G1 = self.provide_g1_topology()
-        G1 = put_sequence_time(G1)
+        temporal_name = 'date'
+        G1 = put_sequence_time(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta()
-        gm = iso.TimeRespectingGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
         assert_false(gm.subgraph_is_isomorphic())
 
     def test_timdelta_one_config0_returns_no_embeddings(self):
         G1 = self.provide_g1_topology()
-        G1 = put_time_config_0(G1)
+        temporal_name = 'date'
+        G1 = put_time_config_0(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta(days=1)
-        gm = iso.TimeRespectingGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 0)
 
     def test_timdelta_one_config1_returns_four_embedding(self):
         G1 = self.provide_g1_topology()
-        G1 = put_time_config_1(G1)
+        temporal_name = 'date'
+        G1 = put_time_config_1(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta(days=1)
-        gm = iso.TimeRespectingGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 4)
     
     def test_timdelta_one_config2_returns_ten_embeddings(self):
         G1 = self.provide_g1_topology()
-        G1 = put_time_config_2(G1)
+        temporal_name = 'date'
+        G1 = put_time_config_2(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta(days=1)
-        gm = iso.TimeRespectingGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
         L = list(gm.subgraph_isomorphisms_iter())
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 10)
@@ -135,36 +149,49 @@ class TestDiTimeRespectingGraphMatcher(object):
 
     def test_timdelta_zero_same_dates_returns_true(self):
         G1 = self.provide_g1_topology()
-        G1 = put_same_time(G1)
+        temporal_name = 'date'
+        G1 = put_same_time(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta()
-        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
+        assert_true(gm.subgraph_is_isomorphic())
+
+    def test_attNameStrange_timdelta_zero_same_dates_returns_true(self):
+        G1 = self.provide_g1_topology()
+        temporal_name = 'strange'
+        G1 = put_same_time(G1, temporal_name)
+        G2 = self.provide_g2_path_3edges()
+        d = timedelta()
+        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
         assert_true(gm.subgraph_is_isomorphic())
 
     def test_timdelta_one_config0_returns_no_embeddings(self):
         G1 = self.provide_g1_topology()
-        G1 = put_time_config_0(G1)
+        temporal_name = 'date'
+        G1 = put_time_config_0(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta(days=1)
-        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 0)
 
     def test_timdelta_one_config1_returns_one_embedding(self):
         G1 = self.provide_g1_topology()
-        G1 = put_time_config_1(G1)
+        temporal_name = 'date'
+        G1 = put_time_config_1(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta(days=1)
-        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 1)
     
     def test_timdelta_one_config2_returns_two_embeddings(self):
         G1 = self.provide_g1_topology()
-        G1 = put_time_config_2(G1)
+        temporal_name = 'date'
+        G1 = put_time_config_2(G1, temporal_name)
         G2 = self.provide_g2_path_3edges()
         d = timedelta(days=1)
-        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, d)
+        gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 2)
 


### PR DESCRIPTION
This feature is a directed and undirected extension to the DiGraphMatcher and GraphMatcher classes, respectively. The returned isomorphic embeddings capture temporal information in the graph, assuming the edges have a "date" or "datetime" attribute.

Both incorporate a temporal constraint: timedelta "d". All interactions adjacent to a node must happen within time "d" of each other. In the directed case, all incoming interactions must precede all outgoing interactions.

This work was part of my PhD research at University College Dublin. Citation: http://dl.acm.org/citation.cfm?id=2492586 Paper available on request.
