### PR TITLE
Release 1.10

### DIFF
--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -132,24 +132,6 @@ def test_example_1():
     G = graph_example_1()
     _check_connectivity(G)
 
-def test_random_gnp():
-    G = nx.gnp_random_graph(50, 0.2)
-    _check_connectivity(G)
-
-def test_shell():
-    constructor=[(20,80,0.8),(80,180,0.6)]
-    G = nx.random_shell_graph(constructor)
-    _check_connectivity(G)
-
-## This test fails sometimes on Travis but passes most of the time.
-## So far we cannot reproduce it locally. See #1637 for debbuging efforts.
-##
-#def test_configuration():
-#    deg_seq = nx.utils.create_degree_sequence(100,nx.utils.powerlaw_sequence)
-#    G = nx.Graph(nx.configuration_model(deg_seq))
-#    G.remove_edges_from(G.selfloop_edges())
-#    _check_connectivity(G)
-
 def test_karate_0():
     G = nx.karate_club_graph()
     _check_connectivity(G)
@@ -187,9 +169,11 @@ def test_example_1_detail_3_and_4():
     }
     G = graph_example_1()
     result = k_components(G)
-    for k, components in solution.items():
+    for k, components in result.items():
+        if k < 3:
+            continue
         for component in components:
-            assert_true(component in result[k])
+            assert_true(component in solution[k])
 
 @raises(nx.NetworkXNotImplemented)
 def test_directed():

--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -141,11 +141,14 @@ def test_shell():
     G = nx.random_shell_graph(constructor)
     _check_connectivity(G)
 
-def test_configuration():
-    deg_seq = nx.utils.create_degree_sequence(100,nx.utils.powerlaw_sequence)
-    G = nx.Graph(nx.configuration_model(deg_seq))
-    G.remove_edges_from(G.selfloop_edges())
-    _check_connectivity(G)
+## This test fails sometimes on Travis but passes most of the time.
+## So far we cannot reproduce it locally. See #1637 for debbuging efforts.
+##
+#def test_configuration():
+#    deg_seq = nx.utils.create_degree_sequence(100,nx.utils.powerlaw_sequence)
+#    G = nx.Graph(nx.configuration_model(deg_seq))
+#    G.remove_edges_from(G.selfloop_edges())
+#    _check_connectivity(G)
 
 def test_karate_0():
     G = nx.karate_club_graph()

--- a/networkx/release.py
+++ b/networkx/release.py
@@ -179,7 +179,7 @@ minor = '10'
 
 ## Declare current release as a development release.
 ## Change to False before tagging a release; then change back.
-dev = True
+dev = False
 
 
 description = "Python package for creating and manipulating graphs and networks"


### PR DESCRIPTION
Cherry pick the two commits that remove tests based on random graphs for k-components approximation to the v1.10 branch. Those tests were failing sporadically on Travis and we were not able to reproduce them outside Travis. Since this algorithm is an approximation, and the removed tests were designed for the exact implementation at `connectivity.kcomponents.py`, it is better to just remove them for the approximation version of the algorithm.

Is there any other change that we need to add to the v1.10 branch before releasing it?