### PR TITLE
Add iterlen() to utils/misc.py

### DIFF
--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -19,6 +19,7 @@ __all__ = ['nonisomorphic_trees',
            'number_of_nonisomorphic_trees']
 
 import networkx as nx
+from networkx.utils import iterlen
 
 
 def nonisomorphic_trees(order, create="graph"):
@@ -76,7 +77,7 @@ def number_of_nonisomorphic_trees(order):
     ----------
 
     """
-    return sum(1 for _ in nonisomorphic_trees(order))
+    return iterlen(nonisomorphic_trees(order))
 
 
 def _next_rooted_tree(predecessor, p=None):

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -175,3 +175,18 @@ def dict_to_numpy_array1(d,mapping=None):
         i = mapping[k1]
         a[i] = d[k1]
     return a
+
+def iterlen(iterator):
+    """Returns the number of elements in the iterator.
+
+    This will exhaust the iterator, use carefully.
+    >>> i = iter([1, 2, 3])
+    >>> iterlen(i)
+    3
+    >>> next(i)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    StopIteration
+    """
+    # inspired by ilen(), more-itertools
+    return sum(1 for _ in iterator)

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -48,6 +48,11 @@ def test_make_str_with_bytes():
         assert_true(isinstance(y, str))
         assert_true(len(y) == 7)
 
+def test_iterlen():
+    G = nx.complete_graph(5)
+    assert_equal(iterlen(G.edges()), 10)
+    assert_equal(iterlen(G.nodes()), 5)
+
 def test_make_str_with_unicode():
     import sys
     PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
As we move towards a more iterators heavy codebase, `iterlen()` could come in handy. Makes it more readable than `sum(1 for _ in iterator)`.