### PR TITLE
Upgrade pip for cache installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ python:
   - "3.3"
   - "3.4"
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ env:
 
 before_install:
   ### Prepare the system to install prerequisites or dependencies
+  - pip install --upgrade pip
   - uname -a
   - printenv
   # Workaround for travis-ci/travis-ci#2683


### PR DESCRIPTION
Travis-CI still uses 6.x version of pip. However, pip 7.0.0 and later cache installed packages automatically in the form of wheels. Subsequent installs are therefore much faster which results in decrease of the total installation time.