### PR TITLE
ENH: allow greedy_color strategies to be specified as strings

### DIFF
--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -202,7 +202,7 @@ def strategy_saturation_largest_first(G, colors):
                 distinct_colors[neighbour].add(color)
 
 
-GREEDY_COLOR_STRATEGIES = {
+STRATEGIES = {
     'largest_first': strategy_largest_first,
     'random_sequential': strategy_random_sequential,
     'smallest_last': strategy_smallest_last,
@@ -276,10 +276,10 @@ def greedy_color(G, strategy='largest_first', interchange=False):
     """
     colors = {}  # dictionary to keep track of the colors of the nodes
 
-    if nx.utils.is_string_like(strategy):
-        strategy = GREEDY_COLOR_STRATEGIES.get(strategy, None)
-        if strategy is None:
-            raise ValueError("Unrecognized Strategy: {0}".format(strategy))
+    strategy = STRATEGIES.get(strategy, strategy)
+    if not callable(strategy):
+        raise nx.NetworkXError('strategy must be callable or a valid string. '
+                               '{0} not valid.'.format(strategy))
 
     if len(G):
         if interchange and (

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -202,7 +202,20 @@ def strategy_saturation_largest_first(G, colors):
                 distinct_colors[neighbour].add(color)
 
 
-def greedy_color(G, strategy=strategy_largest_first, interchange=False):
+GREEDY_COLOR_STRATEGIES = {
+    'largest_first': strategy_largest_first,
+    'random_sequential': strategy_random_sequential,
+    'smallest_last': strategy_smallest_last,
+    'independent_set': strategy_independent_set,
+    'connected_sequential_bfs': strategy_connected_sequential_bfs,
+    'connected_sequential_dfs': strategy_connected_sequential_dfs,
+    'connected_sequential': strategy_connected_sequential,
+    'saturation_largest_first': strategy_saturation_largest_first,
+    'DSATUR': strategy_saturation_largest_first,
+}
+
+
+def greedy_color(G, strategy='largest_first', interchange=False):
     """Color a graph using various strategies of greedy graph coloring.
     The strategies are described in [1]_.
 
@@ -213,22 +226,23 @@ def greedy_color(G, strategy=strategy_largest_first, interchange=False):
     ----------
     G : NetworkX graph
 
-    strategy : function(G, colors)
-       A function that provides the coloring strategy, by returning nodes
-       in the ordering they should be colored. G is the graph, and colors
-       is a dict of the currently assigned colors, keyed by nodes.
+    strategy : string or function(G, colors)
+       A string or function providing the color strategy. Built-in options are:
 
-       You can pass your own ordering function, or use one of the built in:
+       * 'largest_first'
+       * 'random_sequential'
+       * 'smallest_last'
+       * 'independent_set'
+       * 'connected_sequential_bfs'
+       * 'connected_sequential_dfs'
+       * 'connected_sequential' (alias of 'connected_sequential_bfs')
+       * 'saturation_largest_first'
+       * 'DSATUR' (alias of 'saturation_largest_first')
 
-       * strategy_largest_first
-       * strategy_random_sequential
-       * strategy_smallest_last
-       * strategy_independent_set
-       * strategy_connected_sequential_bfs
-       * strategy_connected_sequential_dfs
-       * strategy_connected_sequential
-         (alias of strategy_connected_sequential_bfs)
-       * strategy_saturation_largest_first (also known as DSATUR)
+       Optionally, you may instead pass a function which implements the coloring
+       strategy, by returning nodes in the ordering they should be colored.
+       G is the graph, and colors is a dict of the currently assigned colors,
+       keyed by nodes.
 
     interchange: bool
        Will use the color interchange algorithm described by [2]_ if set
@@ -247,7 +261,7 @@ def greedy_color(G, strategy=strategy_largest_first, interchange=False):
     Examples
     --------
     >>> G = nx.cycle_graph(4)
-    >>> d = nx.coloring.greedy_color(G, strategy=nx.coloring.strategy_largest_first)
+    >>> d = nx.coloring.greedy_color(G, strategy='largest_first')
     >>> d in [{0: 0, 1: 1, 2: 0, 3: 1}, {0: 1, 1: 0, 2: 1, 3: 0}]
     True
 
@@ -261,6 +275,11 @@ def greedy_color(G, strategy=strategy_largest_first, interchange=False):
        ISBN 0-486-45353-7.
     """
     colors = {}  # dictionary to keep track of the colors of the nodes
+
+    if nx.utils.is_string_like(strategy):
+        strategy = GREEDY_COLOR_STRATEGIES.get(strategy, None)
+        if strategy is None:
+            raise ValueError("Unrecognized Strategy: {0}".format(strategy))
 
     if len(G):
         if interchange and (

--- a/networkx/algorithms/coloring/tests/test_coloring.py
+++ b/networkx/algorithms/coloring/tests/test_coloring.py
@@ -15,240 +15,240 @@ class TestColoring:
 ############################## RS tests ##############################
     def test_rs_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rs_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rs_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rs_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rs_shc(self):
         graph = rs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
         assert_true(verify_length(coloring, 2) or verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
 ############################## SLF tests ##############################
     def test_slf_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_slf_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_slf_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_slf_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_slf_shc(self):
         graph = slf_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
     def test_slf_hc(self):
         graph = slf_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
         assert_true(verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
 ############################## LF tests ##############################
     def test_lf_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_lf_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_lf_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_lf_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_lf_shc(self):
         graph = lf_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
         assert_true(verify_length(coloring, 2) or verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
         
     def test_lf_hc(self):
         graph = lf_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
         assert_true(verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
 ############################## SL tests ##############################
     def test_sl_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_sl_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_sl_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_sl_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_sl_shc(self):
         graph = sl_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
     
     def test_sl_hc(self):
         graph = sl_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
         assert_true(verify_length(coloring, 5))
         assert_true(verify_coloring(graph, coloring))
         
 ############################## GIS tests ##############################
     def test_gis_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_independent_set, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_gis_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_independent_set, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_gis_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_independent_set, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_gis_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_independent_set, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_gis_shc(self):
         graph = gis_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_independent_set, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
         assert_true(verify_length(coloring, 2) or verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_gis_hc(self):
         graph = gis_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_independent_set, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
 ############################## CS tests ##############################
     def test_cs_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_shc(self):
         graph = cs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_dfs_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential_dfs, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_dfs_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential_dfs, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_dfs_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential_dfs, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_dfs_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential_dfs, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_cs_dfs_shc(self):
         graph = cs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential_dfs, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
@@ -261,7 +261,7 @@ class TestColoring:
             (4, 5),
             (5, 6)
         ])
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=False)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
@@ -270,100 +270,100 @@ class TestColoring:
 # RSI
     def test_rsi_empty(self):
         graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
         assert_true(verify_length(coloring, 0))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rsi_oneNode(self):
         graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
         assert_true(verify_length(coloring, 1))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rsi_twoNodes(self):
         graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rsi_threeNodeClique(self):
         graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rsi_rsshc(self):
         graph = rs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))
 
     def test_rsi_shc(self):
         graph = rsi_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_random_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 # SLFI
     def test_slfi_slfshc(self):
         graph = oneNodeGraph()
-        assert_raises(nx.NetworkXPointlessConcept, nx.coloring.greedy_color, graph, strategy=nx.coloring.strategy_saturation_largest_first, interchange=True)
+        assert_raises(nx.NetworkXPointlessConcept, nx.coloring.greedy_color, graph, strategy='saturation_largest_first', interchange=True)
 
 # LFI
     def test_lfi_lfshc(self):
         graph = lf_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
         assert_true(verify_length(coloring, 2))
         assert_true(verify_coloring(graph, coloring))        
     
     def test_lfi_lfhc(self):
         graph = lf_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
         
     def test_lfi_shc(self):
         graph = lfi_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
     def test_lfi_hc(self):
         graph = lfi_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_largest_first, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
         assert_true(verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 # SLI
     def test_sli_slshc(self):
         graph = sl_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
     
     def test_sli_slhc(self):
         graph = sl_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
         assert_true(verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
         
     def test_sli_shc(self):
         graph = sli_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
         assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
         assert_true(verify_coloring(graph, coloring))
 
     def test_sli_hc(self):
         graph = sli_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_smallest_last, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
         assert_true(verify_length(coloring, 5))
         assert_true(verify_coloring(graph, coloring))
 #GISI
     def test_gisi_oneNode(self):
         graph = oneNodeGraph()
-        assert_raises(nx.NetworkXPointlessConcept, nx.coloring.greedy_color, graph, strategy=nx.coloring.strategy_independent_set, interchange=True)
+        assert_raises(nx.NetworkXPointlessConcept, nx.coloring.greedy_color, graph, strategy='independent_set', interchange=True)
 # CS
     def test_csi_csshc(self):
         graph = cs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy=nx.coloring.strategy_connected_sequential, interchange=True)
+        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=True)
         assert_true(verify_length(coloring, 3))
         assert_true(verify_coloring(graph, coloring))
 

--- a/networkx/algorithms/coloring/tests/test_coloring.py
+++ b/networkx/algorithms/coloring/tests/test_coloring.py
@@ -6,366 +6,89 @@ Run with nose: nosetests -v test_coloring.py
 
 __author__ = "\n".join(["Christian Olsson <chro@itu.dk>",
                         "Jan Aagaard Meier <jmei@itu.dk>",
-                        "Henrik Haugbølle <hhau@itu.dk>"])
+                        "Henrik Haugbølle <hhau@itu.dk>",
+                        "Jake VanderPlas <jakevdp@uw.edu>"])
 
 import networkx as nx
 from nose.tools import *
 
+ALL_STRATEGIES = [
+    'largest_first',
+    'random_sequential',
+    'smallest_last',
+    'independent_set',
+    'connected_sequential_bfs',
+    'connected_sequential_dfs',
+    'connected_sequential',
+    'saturation_largest_first',
+    'DSATUR',
+]
+
+# List of strategies where interchange=True results in an error
+INTERCHANGE_INVALID = [
+    'independent_set',
+    'saturation_largest_first',
+    'DSATUR'
+]
+    
+
 class TestColoring:
-############################## RS tests ##############################
-    def test_rs_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
+    def test_basic_cases(self):
+        def check_basic_case(graph_func, n_nodes, strategy, interchange):
+            graph = graph_func()
+            coloring = nx.coloring.greedy_color(graph,
+                                                strategy=strategy,
+                                                interchange=interchange)
+            assert_true(verify_length(coloring, n_nodes))
+            assert_true(verify_coloring(graph, coloring))
 
-    def test_rs_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
+        for graph_func, n_nodes in BASIC_TEST_CASES.items():
+            for interchange in [True, False]:
+                for strategy in ALL_STRATEGIES:
+                    if interchange and (strategy in INTERCHANGE_INVALID):
+                        continue
+                    yield (check_basic_case, graph_func,
+                           n_nodes, strategy, interchange)
 
-    def test_rs_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
+    def test_special_cases(self):
+        def check_special_case(strategy, graph_func, interchange, colors):
+            graph = graph_func()
+            coloring = nx.coloring.greedy_color(graph,
+                                                strategy=strategy,
+                                                interchange=interchange)
+            if not hasattr(colors, '__len__'):
+                colors = [colors]
+            assert_true(any(verify_length(coloring, n_colors)
+                            for n_colors in colors))
+            assert_true(verify_coloring(graph, coloring))
+            
+        for strategy, arglist in SPECIAL_TEST_CASES.items():
+            for args in arglist:
+                yield (check_special_case, strategy, args[0], args[1], args[2])
 
-    def test_rs_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
+    def test_interchange_invalid(self):
+        graph = one_node_graph()
+        def check_raises(strategy):
+            assert_raises(nx.NetworkXPointlessConcept,
+                          nx.coloring.greedy_color,
+                          graph, strategy=strategy, interchange=True)
 
-    def test_rs_shc(self):
-        graph = rs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=False)
-        assert_true(verify_length(coloring, 2) or verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
+        for strategy in INTERCHANGE_INVALID:
+            yield check_raises, strategy
 
-############################## SLF tests ##############################
-    def test_slf_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
+    def test_bad_inputs(self):
+        graph = one_node_graph()
+        assert_raises(nx.NetworkXError, nx.coloring.greedy_color,
+                      graph, strategy='invalid strategy')
 
-    def test_slf_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_slf_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_slf_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_slf_shc(self):
-        graph = slf_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_slf_hc(self):
-        graph = slf_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='saturation_largest_first', interchange=False)
-        assert_true(verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-
-############################## LF tests ##############################
-    def test_lf_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_lf_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_lf_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_lf_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_lf_shc(self):
+    def test_strategy_as_function(self):
         graph = lf_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
-        assert_true(verify_length(coloring, 2) or verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-        
-    def test_lf_hc(self):
-        graph = lf_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=False)
-        assert_true(verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
+        colors_1 = nx.coloring.greedy_color(graph,
+                                            'largest_first')
+        colors_2 = nx.coloring.greedy_color(graph,
+                                            nx.coloring.strategy_largest_first)
+        assert_equal(colors_1, colors_2)
 
-############################## SL tests ##############################
-    def test_sl_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_sl_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_sl_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_sl_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_sl_shc(self):
-        graph = sl_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-    
-    def test_sl_hc(self):
-        graph = sl_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=False)
-        assert_true(verify_length(coloring, 5))
-        assert_true(verify_coloring(graph, coloring))
-        
-############################## GIS tests ##############################
-    def test_gis_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_gis_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_gis_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_gis_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_gis_shc(self):
-        graph = gis_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
-        assert_true(verify_length(coloring, 2) or verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_gis_hc(self):
-        graph = gis_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='independent_set', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-############################## CS tests ##############################
-    def test_cs_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_shc(self):
-        graph = cs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_dfs_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_dfs_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_dfs_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_dfs_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_dfs_shc(self):
-        graph = cs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential_dfs', interchange=False)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_cs_disconnected(self):
-        # _connected_ sequential should still work on disconnected graphs
-        graph = nx.Graph()
-        graph.add_edges_from([
-            (1, 2),
-            (2, 3),
-            (4, 5),
-            (5, 6)
-        ])
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=False)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-
-############################## Interchange tests ##############################
-# RSI
-    def test_rsi_empty(self):
-        graph = emptyGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
-        assert_true(verify_length(coloring, 0))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_rsi_oneNode(self):
-        graph = oneNodeGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
-        assert_true(verify_length(coloring, 1))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_rsi_twoNodes(self):
-        graph = twoNodesGraph()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_rsi_threeNodeClique(self):
-        graph = threeNodeClique()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_rsi_rsshc(self):
-        graph = rs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_rsi_shc(self):
-        graph = rsi_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='random_sequential', interchange=True)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-# SLFI
-    def test_slfi_slfshc(self):
-        graph = oneNodeGraph()
-        assert_raises(nx.NetworkXPointlessConcept, nx.coloring.greedy_color, graph, strategy='saturation_largest_first', interchange=True)
-
-# LFI
-    def test_lfi_lfshc(self):
-        graph = lf_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
-        assert_true(verify_length(coloring, 2))
-        assert_true(verify_coloring(graph, coloring))        
-    
-    def test_lfi_lfhc(self):
-        graph = lf_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-        
-    def test_lfi_shc(self):
-        graph = lfi_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_lfi_hc(self):
-        graph = lfi_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='largest_first', interchange=True)
-        assert_true(verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-# SLI
-    def test_sli_slshc(self):
-        graph = sl_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
-    
-    def test_sli_slhc(self):
-        graph = sl_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
-        assert_true(verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-        
-    def test_sli_shc(self):
-        graph = sli_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
-        assert_true(verify_length(coloring, 3) or verify_length(coloring, 4))
-        assert_true(verify_coloring(graph, coloring))
-
-    def test_sli_hc(self):
-        graph = sli_hc()
-        coloring = nx.coloring.greedy_color(graph, strategy='smallest_last', interchange=True)
-        assert_true(verify_length(coloring, 5))
-        assert_true(verify_coloring(graph, coloring))
-#GISI
-    def test_gisi_oneNode(self):
-        graph = oneNodeGraph()
-        assert_raises(nx.NetworkXPointlessConcept, nx.coloring.greedy_color, graph, strategy='independent_set', interchange=True)
-# CS
-    def test_csi_csshc(self):
-        graph = cs_shc()
-        coloring = nx.coloring.greedy_color(graph, strategy='connected_sequential', interchange=True)
-        assert_true(verify_length(coloring, 3))
-        assert_true(verify_coloring(graph, coloring))
 
 ############################## Utility functions ##############################
 def verify_coloring(graph, coloring):
@@ -396,25 +119,35 @@ def dict_to_sets(colors):
 
     return sets
 
-############################## Graphs ##############################
-def emptyGraph():
+############################## Graph Generation ##############################
+def empty_graph():
     return nx.Graph()
 
-def oneNodeGraph():
+def one_node_graph():
     graph = nx.Graph()
     graph.add_nodes_from([1])
     return graph
 
-def twoNodesGraph():
+def two_node_graph():
     graph = nx.Graph()
     graph.add_nodes_from([1,2])
     graph.add_edges_from([(1,2)])
     return graph
 
-def threeNodeClique():
+def three_node_clique():
     graph = nx.Graph()
     graph.add_nodes_from([1,2, 3])
     graph.add_edges_from([(1,2), (1,3), (2,3)])
+    return graph
+
+def disconnected():
+    graph = nx.Graph()
+    graph.add_edges_from([
+        (1, 2),
+        (2, 3),
+        (4, 5),
+        (5, 6)
+    ])
     return graph
 
 def rs_shc():
@@ -668,3 +401,48 @@ def sli_hc():
     ])
     return graph
 
+
+#---------------------------------------------------------------------------
+# Basic tests for all strategies
+# For each basic graph function, specify the number of expected colors.
+BASIC_TEST_CASES = {empty_graph: 0,
+                    one_node_graph: 1,
+                    two_node_graph: 2,
+                    disconnected: 2,
+                    three_node_clique: 3}
+
+
+#---------------------------------------------------------------------------
+# Special test cases. Each strategy has a list of tuples of the form
+# (graph function, interchange, valid # of colors)
+SPECIAL_TEST_CASES = {
+    'random_sequential': [
+        (rs_shc, False, (2, 3)),
+        (rs_shc, True, 2),
+        (rsi_shc, True, (3, 4))],
+    'saturation_largest_first': [
+        (slf_shc, False, (3, 4)),
+        (slf_hc, False, 4)],
+    'largest_first': [
+        (lf_shc, False, (2, 3)),
+        (lf_hc, False, 4),
+        (lf_shc, True, 2),
+        (lf_hc, True, 3),
+        (lfi_shc, True, (3, 4)),
+        (lfi_hc, True, 4)],
+    'smallest_last': [
+        (sl_shc, False, (3, 4)),
+        (sl_hc, False, 5),
+        (sl_shc, True, 3),
+        (sl_hc, True, 4),
+        (sli_shc, True, (3, 4)),
+        (sli_hc, True, 5)],
+    'independent_set': [
+        (gis_shc, False, (2, 3)),
+        (gis_hc, False, 3)],
+    'connected_sequential': [
+        (cs_shc, False, (3, 4)),
+        (cs_shc, True, 3)],
+    'connected_sequential_dfs': [
+        (cs_shc, False, (3, 4))],
+}


### PR DESCRIPTION
I like the new ``greedy_color()`` algorithm, but passing strategy functions directly is inconvenient. This PR adds the ability to specify strategies as strings, and is entirely backward-compatible.

Here is an example:

```python
# Old syntax still works:
>>> colors1 = nx.coloring.greedy_color(G, strategy=nx.coloring.strategy_connected_sequential)

# New syntax works as follows
>>> colors2 = nx.coloring.greedy_color(G, strategy='connected_sequential')

>>> colors1 == colors2
True
```

This also helps improve the inline documentation:

Old documentation:
```python
>>> help(nx.coloring.greedy_color)
...
greedy_color(G, strategy=<function networkx.algorithms.coloring.greedy_coloring.strategy_largest_first>, interchange=False)
...
```

New documentation:
```python
>>> help(nx.coloring.greedy_color)
...
greedy_color(G, strategy='largest_first', interchange=False)
...
```

I think the new help output, with the default strategy as a string rather than the function, is much more user-friendly.