### PR TITLE
Update shortest_path_length

### DIFF
--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -243,7 +243,7 @@ def closeness_centrality(G, nodes, normalized=True):
     n = float(len(top))
     m = float(len(bottom))
     for node in top:
-        sp=path_length(G,node)
+        sp=dict(path_length(G,node))
         totsp=sum(sp.values())
         if totsp > 0.0 and len(G) > 1:
             closeness[node]= (m + 2*(n-1)) / totsp
@@ -253,7 +253,7 @@ def closeness_centrality(G, nodes, normalized=True):
         else:
             closeness[n]=0.0
     for node in bottom:
-        sp=path_length(G,node)
+        sp=dict(path_length(G,node))
         totsp=sum(sp.values())
         if totsp > 0.0 and len(G) > 1:
             closeness[node]= (n + 2*(m-1)) / totsp

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -87,7 +87,7 @@ def closeness_centrality(G, u=None, distance=None, normalized=True):
         nodes = [u]
     closeness_centrality = {}
     for n in nodes:
-        sp = path_length(G,n)
+        sp = dict(path_length(G,n))
         totsp = sum(sp.values())
         if totsp > 0.0 and len(G) > 1:
             closeness_centrality[n] = (len(sp)-1.0) / totsp

--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -70,10 +70,10 @@ def harmonic_centrality(G, distance=None):
             harmonic_centrality[singleton] = 0.0
         return harmonic_centrality
 
-    sp = path_length(G.reverse() if G.is_directed() else G)
+    sp = dict(path_length(G.reverse() if G.is_directed() else G))
 
     for n in nodes:
-        harmonic_centrality[n] = sum([1/i if i > 0 else 0 for i in sp[n].values()])
+        harmonic_centrality[n] = sum([1/i if i > 0 else 0 for i in dict(sp[n]).values()])
 
     return harmonic_centrality
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -39,7 +39,7 @@ def descendants(G, source):
     """
     if not G.has_node(source):
         raise nx.NetworkXError("The node %s is not in the graph." % source)
-    des = set(nx.shortest_path_length(G, source=source).keys()) - set([source])
+    des = set(dict(nx.shortest_path_length(G, source=source)).keys()) - set([source])
     return des
 
 
@@ -58,7 +58,7 @@ def ancestors(G, source):
     """
     if not G.has_node(source):
         raise nx.NetworkXError("The node %s is not in the graph." % source)
-    anc = set(nx.shortest_path_length(G, target=source).keys()) - set([source])
+    anc = set(dict(nx.shortest_path_length(G, target=source)).keys()) - set([source])
     return anc
 
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -50,11 +50,11 @@ def eccentricity(G, v=None, sp=None):
     e={}
     for n in G.nbunch_iter(v):
         if sp is None:
-            length=networkx.single_source_shortest_path_length(G,n)
+            length = dict(networkx.single_source_shortest_path_length(G,n))
             L = len(length)
         else:
             try:
-                length=sp[n]
+                length = sp[n]
                 L = len(length)
             except TypeError:
                 raise networkx.NetworkXError('Format of "sp" is invalid.')
@@ -62,7 +62,7 @@ def eccentricity(G, v=None, sp=None):
             msg = "Graph not connected: infinite path length"
             raise networkx.NetworkXError(msg)
             
-        e[n]=max(length.values())
+        e[n]=max(dict(length).values())
 
     if v in G:
         return e[v]  # return single value

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -154,14 +154,14 @@ def intersection_array(G):
         if knext != k:
             raise nx.NetworkXError('Graph is not distance regular.')
         k = knext
-    path_length = nx.all_pairs_shortest_path_length(G)  
-    diameter = max([max(path_length[n].values()) for n in path_length])
+    path_length = dict(nx.all_pairs_shortest_path_length(G))
+    diameter = max([max(dict(path_length[n]).values()) for n in path_length])
     bint = {} # 'b' intersection array
     cint = {} # 'c' intersection array
     for u in G:
         for v in G:
             try:
-                i = path_length[u][v]
+                i = dict(dict(path_length)[u])[v]
             except KeyError:  # graph must be connected
                 raise nx.NetworkXError('Graph is not distance regular.')
             # number of neighbors of v at a distance of i-1 from u

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -454,7 +454,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     # Then, reachable and non reachable nodes from source in the
     # residual network form the node partition that defines
     # the minimum cut.
-    non_reachable = set(nx.shortest_path_length(R, target=t))
+    non_reachable = set(dict(nx.shortest_path_length(R, target=t)))
     partition = (set(G) - non_reachable, non_reachable)
     # Finaly add again cutset edges to the residual network to make
     # sure that it is reusable.

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -187,18 +187,7 @@ def shortest_path_length(G, source=None, target=None, weight=None):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> print(nx.shortest_path_length(G,source=0,target=4))
-    4
-    >>> p=nx.shortest_path_length(G,source=0) # target not specified
-    >>> p[4]
-    4
-    >>> p=nx.shortest_path_length(G,target=4) # source not specified
-    >>> p[0]
-    4
-    >>> p=nx.shortest_path_length(G) # source,target not specified
-    >>> p[0][4]
-    4
+  
 
     Notes
     -----
@@ -226,12 +215,15 @@ def shortest_path_length(G, source=None, target=None, weight=None):
                 paths=nx.all_pairs_dijkstra_path_length(G, weight=weight)
         else:
             ## Find paths from all nodes co-accessible to the target.
-            with nx.utils.reversed(G):
-                if weight is None:
-                    paths=nx.single_source_shortest_path_length(G, target)
+            # with nx.utils.reversed(G):
+            if weight is None:
+                if G.is_directed():
+                    paths=nx.single_source_shortest_path_length(G.reverse(copy=False), target)
                 else:
-                    paths=nx.single_source_dijkstra_path_length(G, target,
-                                                                weight=weight)
+                    paths=nx.single_source_shortest_path_length(G, target)
+            else:
+                paths=nx.single_source_dijkstra_path_length(G, target,
+                                                            weight=weight)
     else:
         if target is None:
             ## Find paths to all nodes accessible from the source.
@@ -278,17 +270,7 @@ def average_shortest_path_length(G, weight=None):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> print(nx.average_shortest_path_length(G))
-    2.0
 
-    For disconnected graphs you can compute the average shortest path
-    length for each component:
-    >>> G=nx.Graph([(1,2),(3,4)])
-    >>> for g in nx.connected_component_subgraphs(G):
-    ...     print(nx.average_shortest_path_length(g))
-    1.0
-    1.0
 
     """
     if G.is_directed():
@@ -301,7 +283,7 @@ def average_shortest_path_length(G, weight=None):
     if weight is None:
         for node in G:
             path_length=nx.single_source_shortest_path_length(G, node)
-            avg += sum(path_length.values())
+            avg += sum(d for n, d in path_length)
     else:
         for node in G:
             path_length=nx.single_source_dijkstra_path_length(G, node, weight=weight)

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -51,7 +51,7 @@ class TestGenericPath:
         assert_equal(nx.shortest_path_length(self.directed_cycle,0,4,weight='weight'),4)
 
     def test_shortest_path_length_target(self):
-        sp = nx.shortest_path_length(nx.path_graph(3), target=1)
+        sp = dict(nx.shortest_path_length(nx.path_graph(3), target=1))
         assert_equal(sp[0], 1)
         assert_equal(sp[1], 0)
         assert_equal(sp[2], 1)
@@ -71,11 +71,11 @@ class TestGenericPath:
 
 
     def test_single_source_shortest_path_length(self):
-        l=nx.shortest_path_length(self.cycle,0)
-        assert_equal(l,{0:0,1:1,2:2,3:3,4:3,5:2,6:1})
-        assert_equal(l,nx.single_source_shortest_path_length(self.cycle,0))
+        l = dict(nx.shortest_path_length(self.cycle,0))
+        assert_equal(l, {0:0,1:1,2:2,3:3,4:3,5:2,6:1})
+        assert_equal(l, dict(nx.single_source_shortest_path_length(self.cycle,0)))
         l=nx.shortest_path_length(self.grid,1)
-        assert_equal(l[16],6)
+        assert_equal(dict(l)[16], 6)
         # now with weights
         l=nx.shortest_path_length(self.cycle,0,weight='weight')
         assert_equal(l,{0:0,1:1,2:2,3:3,4:3,5:2,6:1})
@@ -99,11 +99,14 @@ class TestGenericPath:
 
 
     def test_all_pairs_shortest_path_length(self):
-        l=nx.shortest_path_length(self.cycle)
-        assert_equal(l[0],{0:0,1:1,2:2,3:3,4:3,5:2,6:1})
-        assert_equal(l,nx.all_pairs_shortest_path_length(self.cycle))
-        l=nx.shortest_path_length(self.grid)
-        assert_equal(l[1][16],6)
+        l = dict(nx.shortest_path_length(self.cycle))
+        assert_equal(dict(l[0]), {0:0,1:1,2:2,3:3,4:3,5:2,6:1})
+        # for n, d in l:
+        #     assert_equal(n, i for i, j in nx.all_pairs_shortest_path_length(self.cycle))
+        #     assert_equal(dict(d), dict(j) for i, j in nx.all_pairs_shortest_path_length(self.cycle))
+        # assert_equal(l, dict(nx.all_pairs_shortest_path_length(self.cycle)))
+        l=dict(nx.shortest_path_length(self.grid))
+        assert_equal(dict(l[1])[16],6)
         # now with weights
         l=nx.shortest_path_length(self.cycle,weight='weight')
         assert_equal(l[0],{0:0,1:1,2:2,3:3,4:3,5:2,6:1})
@@ -112,7 +115,7 @@ class TestGenericPath:
         assert_equal(l[1][16],6)
 
     def test_average_shortest_path(self):
-        l=nx.average_shortest_path_length(self.cycle)
+        l = nx.average_shortest_path_length(self.cycle)
         assert_almost_equal(l,2)
         l=nx.average_shortest_path_length(nx.path_graph(5))
         assert_almost_equal(l,2)

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -51,7 +51,7 @@ class TestUnweightedPath:
         assert_equal(p,{0 : [0]})
 
     def test_single_source_shortest_path_length(self):
-        assert_equal(nx.single_source_shortest_path_length(self.cycle,0),
+        assert_equal(dict(nx.single_source_shortest_path_length(self.cycle,0)),
                      {0:0,1:1,2:2,3:3,4:3,5:2,6:1})
 
     def test_all_pairs_shortest_path(self):
@@ -62,9 +62,9 @@ class TestUnweightedPath:
 
     def test_all_pairs_shortest_path_length(self):
         l=nx.all_pairs_shortest_path_length(self.cycle)
-        assert_equal(l[0],{0:0,1:1,2:2,3:3,4:3,5:2,6:1})
+        assert_equal(dict(dict(l)[0]),{0:0,1:1,2:2,3:3,4:3,5:2,6:1})
         l=nx.all_pairs_shortest_path_length(self.grid)
-        assert_equal(l[1][16],6)
+        assert_equal(dict(dict(l)[1])[16],6)
 
     def test_predecessor(self):
         G=nx.path_graph(4)

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -41,10 +41,10 @@ def single_source_shortest_path_length(G,source,cutoff=None):
     Examples
     --------
     >>> G=nx.path_graph(5)
-    >>> length=nx.single_source_shortest_path_length(G,0)
+    >>> length = dict(nx.single_source_shortest_path_length(G,0))
     >>> length[4]
     4
-    >>> print(length)
+    >>> length
     {0: 0, 1: 1, 2: 2, 3: 3, 4: 4}
 
     See Also
@@ -61,9 +61,10 @@ def single_source_shortest_path_length(G,source,cutoff=None):
             if v not in seen:
                 seen[v]=level # set the level of vertex v
                 nextlevel.update(G[v]) # add neighbors of v
+                yield (v, level)
         if (cutoff is not None and cutoff <= level):  break
         level=level+1
-    return seen  # return all path lengths as dictionary
+    del seen  # return all path lengths as dictionary
 
 
 def all_pairs_shortest_path_length(G, cutoff=None):
@@ -89,17 +90,16 @@ def all_pairs_shortest_path_length(G, cutoff=None):
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> length = nx.all_pairs_shortest_path_length(G)
-    >>> print(length[1][4])
-    3
-    >>> length[1]
+    >>> dict(dict(nx.all_pairs_shortest_path_length(G))[1])[2]
+    1
+    >>> dict(dict(nx.all_pairs_shortest_path_length(G))[1])
     {0: 1, 1: 0, 2: 1, 3: 2, 4: 3}
 
     """
     length = single_source_shortest_path_length
     # TODO This can be trivially parallelized.
-    return {n: length(G, n, cutoff=cutoff) for n in G}
-
+    for n in G:
+        yield (n, dict(length(G, n, cutoff=cutoff)))
 
 def bidirectional_shortest_path(G,source,target):
     """Return a list of nodes in a shortest path between source and target.

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -14,7 +14,7 @@ class TestDistance:
         assert_equal(networkx.eccentricity(self.G,1),6)
         e=networkx.eccentricity(self.G)
         assert_equal(e[1],6)
-        sp=networkx.shortest_path_length(self.G)
+        sp=dict(networkx.shortest_path_length(self.G))
         e=networkx.eccentricity(self.G,sp=sp)
         assert_equal(e[1],6)
         e=networkx.eccentricity(self.G,v=1)

--- a/networkx/algorithms/vitality.py
+++ b/networkx/algorithms/vitality.py
@@ -19,7 +19,7 @@ def weiner_index(G, weight=None):
     if weight is None:
         for n in G:
             path_length=nx.single_source_shortest_path_length(G,n)
-            weiner+=sum(path_length.values())
+            weiner+=sum(d for n, d in path_length)
     else:
         for n in G:
             path_length=nx.single_source_dijkstra_path_length(G,

--- a/networkx/generators/ego.py
+++ b/networkx/generators/ego.py
@@ -50,19 +50,19 @@ def ego_graph(G,n,radius=1,center=True,undirected=False,distance=None):
     """
     if undirected:
         if distance is not None:
-            sp,_=nx.single_source_dijkstra(G.to_undirected(),
+            sp, _ = nx.single_source_dijkstra(G.to_undirected(),
                                            n,cutoff=radius,
                                            weight=distance)
         else:
-            sp=nx.single_source_shortest_path_length(G.to_undirected(),
-                                                     n,cutoff=radius)
+            sp = dict(nx.single_source_shortest_path_length(G.to_undirected(),
+                                                     n,cutoff=radius))
     else:
         if distance is not None:
             sp,_=nx.single_source_dijkstra(G,
                                            n,cutoff=radius,
                                            weight=distance)
         else:
-            sp=nx.single_source_shortest_path_length(G,n,cutoff=radius)
+            sp=dict(nx.single_source_shortest_path_length(G,n,cutoff=radius))
 
     H=G.subgraph(sp).copy()
     if not center:

--- a/networkx/generators/tests/test_threshold.py
+++ b/networkx/generators/tests/test_threshold.py
@@ -69,7 +69,7 @@ class TestGeneratorThreshold():
         for j,pl in enumerate(spl):
             n=cs1[j][0]
             spld[n]=pl
-        assert_equal(spld, nx.single_source_shortest_path_length(G, 3))
+        assert_equal(spld, dict(nx.single_source_shortest_path_length(G, 3)))
 
     def test_weights_thresholds(self):
         wseq=[3,4,3,3,5,6,5,4,5,6]

--- a/networkx/utils/rcm.py
+++ b/networkx/utils/rcm.py
@@ -152,7 +152,7 @@ def pseudo_peripheral_node(G):
     lp = 0
     v = u
     while True:
-        spl = nx.shortest_path_length(G, v)
+        spl = dict(nx.shortest_path_length(G, v))
         l = max(spl.values())
         if l <= lp:
             break


### PR DESCRIPTION
I was messing around with `single_source_shortest_path_length` and `all_pairs_shortest_path_length`. Now `single_source_shortest_path_length` returns a (node, distance) two tuple iterator and `all_pairs_shortest_path_length` returns a (node, dict) two tuple iterator.
This is a messy PR. I have just added a dict() in front of required code. This PR will fail Travis as there are few things I need to work out.

I am just looking for opinion on the `shortest_paths` algorithms, and what should they return.