### PR TITLE
Adds planar graph class

### DIFF
--- a/networkx/classes/__init__.py
+++ b/networkx/classes/__init__.py
@@ -2,6 +2,7 @@ from .graph import Graph
 from .digraph import DiGraph
 from .multigraph import MultiGraph
 from .multidigraph import MultiDiGraph
+from .planar_graph import PlanarGraph
 from .ordered import *
 
 from .function import *

--- a/networkx/classes/planar_graph.py
+++ b/networkx/classes/planar_graph.py
@@ -1,0 +1,187 @@
+from ordered import OrderedGraph
+
+class NoPlanarityProvidedException(Exception):
+    pass
+
+class InconsistentPlanarityData(Exception):
+    pass
+
+class PlanarGraph(OrderedGraph):
+    def __init__(self, data=None, **attr):
+        self._has_planar_data = {}
+        self._computed_planar = True
+
+        self._adjacency_orders = {}
+        self._adjacency_indices = {}
+
+        super(PlanarGraph, self).__init__(data=data, **attr)
+
+    def _planar_data_complete(self):
+        return all(self._has_planar_data.values())
+
+    def _compute_planarity(self):
+        if not self._planar_data_complete():
+            raise NoPlanarityProvidedException()
+
+        self._computed_planar = True
+
+    def __getitem__(self, n):
+        if not self._computed_planar:
+            self._compute_planarity()
+        return super(PlanarGraph, self).__getitem__(n)
+
+    def add_node(self, n, attr_dict=None, **attr):
+        if n not in self.node:
+            self._has_planar_data[n] = True
+            self._adjacency_orders[n] = []
+            self._adjacency_indices[n] = {}
+
+        super(PlanarGraph, self).add_node(n, attr_dict=attr_dict, **attr)
+
+    def add_nodes_from(self, nodes, **attr):
+        for n in nodes:
+            try:
+                if n not in self.node:
+                    self._has_planar_data[n] = True
+                    self._adjacency_orders[n] = []
+                    self._adjacency_indices[n] = {}
+            except TypeError:
+                nn, ndict = n
+                if nn not in self.node:
+                    self._has_planar_data[nn] = True
+                    self._adjacency_orders[nn] = []
+                    self._adjacency_indices[nn] = {}
+
+        super(PlanarGraph, self).add_nodes_from(nodes, **attr)
+
+    def remove_node(self, n):
+        print("Removing " + str(n))
+        adjs = list(self.adj[n].keys())
+
+        super(PlanarGraph, self).remove_node(n)
+
+        del self._has_planar_data[n]
+        if n in self._adjacency_orders:
+            del self._adjacency_orders[n]
+        if n in self._adjacency_indices:
+            del self._adjacency_indices[n]
+
+        for neighbor in adjs:
+            if neighbor == n:
+                continue
+
+            if self._has_planar_data[neighbor]:
+                n_index = self._adjacency_indices[neighbor][n]
+                del self._adjacency_orders[neighbor][n_index]
+                del self._adjacency_indices[neighbor][n]
+                for moved in self._adjacency_orders[neighbor][n_index:]:
+                    self._adjacency_indices[neighbor][moved] -= 1
+
+    def remove_nodes_from(self, nodes):
+        ''' TODO this differs from graph! '''
+        for node in nodes:
+            if not node in self.node:
+                continue
+            self.remove_node(node)
+
+    def add_edge(self, u, v, attr_dict=None, **attr):
+        super(PlanarGraph, self).add_edge(u, v, attr_dict=attr_dict, **attr)
+        self._has_planar_data[u] = False
+        self._has_planar_data[v] = False
+        self._computed_planar = False
+
+    def insert_edge(self, u, u_pos, v, v_pos, attr_dict=None, **attr):
+        super(PlanarGraph, self).add_edge(u, v, attr_dict=attr_dict, **attr)
+
+        if self._has_planar_data[u]:
+            self._adjacency_orders[u].insert(u_pos, v)
+            self._adjacency_indices[u][v] = u_pos
+            for moved in self._adjacency_orders[u][(u_pos+1):]:
+                self._adjacency_indices[u][moved] += 1
+
+        if self._has_planar_data[v]:
+            self._adjacency_orders[v].insert(v_pos, u)
+            self._adjacency_indices[v][u] = v_pos
+            for moved in self._adjacency_orders[v][(v_pos+1):]:
+                self._adjacency_indices[v][moved] += 1
+
+        self._computed_planar = False
+
+    def provide_planarity_data(self, v, ordered_adjacencies):
+        if not len(set(ordered_adjacencies)) == len(ordered_adjacencies):
+            raise InconsistentPlanarityData()
+        if not set(ordered_adjacencies) == set(self.adj[v].keys()):
+            raise InconsistentPlanarityData()
+
+        self._adjacency_orders[v] = ordered_adjacencies
+        self._adjacency_indices[v] = {}
+        for i in range(0,len(ordered_adjacencies)):
+            self._adjacency_indices[v][ordered_adjacencies[i]] = i
+
+        self._has_planar_data[v] = True
+        self._computed_planar = False
+
+    def add_edges_from(self, ebunch, attr_dict=None, **attr):
+        super(PlanarGraph, self).add_edges_from(ebunch, attr_dict=attr_dict, **attr)
+
+        for e in ebunch:
+            u, v = e[:2]
+
+            self._has_planar_data[u] = False
+            self._has_planar_data[v] = False
+            self._computed_planar = False
+
+    def remove_edge(self, u, v):
+        super(PlanarGraph, self).remove_edge(u,v)
+
+        if self._has_planar_data[u]:
+            v_index = self._adjacency_indices[u][v]
+            del self._adjacency_orders[u][v_index]
+            del self._adjacency_indices[u][v]
+
+        if self._has_planar_data[v]:
+            u_index = self._adjacency_indices[v][u]
+            del self._adjacency_orders[v][u_index]
+            del self._adjacency_indices[v][u]
+
+    def remove_edges_from(self, ebunch):
+        """ TODO differs from graph """
+
+        for e in ebunch:
+            u, v = e[:2]
+            if not v in self.adj[u]:
+                continue
+            self.remove_edge(u, v)
+
+    def neighbors(self, n):
+        if not self._computed_planar:
+            self._compute_planarity()
+        return super(PlanarGraph, self).neighbors(n)
+
+    def neighbors_iter(self, n):
+        if not self._computed_planar:
+            self._compute_planarity()
+        return super(PlanarGraph, self).neighbors_iter(n)
+
+    def adjacency_list(self):
+        if not self._computed_planar:
+            self._compute_planarity()
+        return super(PlanarGraph, self).adjacency_list()
+
+    def adjacency_iter(self):
+        if not self._computed_planar:
+            self._compute_planarity()
+        return super(PlanarGraph, self).adjacency_iter()
+
+    def clear(self):
+        super(PlanarGraph, self).clear()
+        self._has_planar_data = {}
+        self._computed_planar = True
+        self._adjacency_orders = {}
+        self._adjacency_indices = {}
+
+    def to_directed(self):
+        raise NotImplementedError()
+
+    def subgraph(self, nbunch):
+        raise NotImplementedError()

--- a/networkx/classes/planar_graph.py
+++ b/networkx/classes/planar_graph.py
@@ -78,7 +78,20 @@ class PlanarGraph(OrderedGraph):
 
         Faces will be ordered clockwise for inner faces and counterclockwise for
         the outer face."""
+        if not self._computed_planar:
+            self._compute_planarity()
+
         return self._faces[face_id]
+
+    def faces(self):
+        """Returns all faces.
+
+        Faces are returned as a list of 2-tuples: (face_id, vertices)
+        """
+        if not self._computed_planar:
+            self._compute_planarity()
+
+        return tuple(self._faces.items())
 
     def _planar_data_complete(self):
         return all(self._has_planar_data.values())
@@ -100,7 +113,6 @@ class PlanarGraph(OrderedGraph):
         return [(u, side)] + self._grow_face(start_edge, v, next_vertex)
 
     def _canonicalize_face(self, face):
-        print("Face before: " + str(face))
         # TODO
         # Decide if we actually need this, or if a rotationally invariant hash is
         # enough?
@@ -108,7 +120,6 @@ class PlanarGraph(OrderedGraph):
             face if i == 0 else (face[i:] + face[:i])
             for i in range(len(face))
         ))
-        print("Face after: " + str(canonical))
         return canonical
 
     def _incorporate_face(self, face):
@@ -296,6 +307,10 @@ class PlanarGraph(OrderedGraph):
                 self._adjacency_indices[v][moved] += 1
 
         self._computed_planar = False
+
+    def provide_planarity_data_from(self, data):
+        for (v, ordered_adjacencies) in data.items():
+            self.provide_planarity_data(v, ordered_adjacencies)
 
     def provide_planarity_data(self, v, ordered_adjacencies):
         """Can be used to provide the order of adjacencies around a vertex, in

--- a/networkx/classes/planar_graph.py
+++ b/networkx/classes/planar_graph.py
@@ -71,9 +71,9 @@ class PlanarGraph(OrderedGraph):
 
         for u,v,side in face_edges:
             if side == 0:
-                self._right_face[frozenset((u,v))] = face_id
-            else:
                 self._left_face[frozenset((u,v))] = face_id
+            else:
+                self._right_face[frozenset((u,v))] = face_id
 
     def _create_faces(self):
         self._left_face = {}
@@ -136,14 +136,14 @@ class PlanarGraph(OrderedGraph):
         if v_index is None:
             raise NetworkXError("No edge base-v")
 
-        if u_index - v_index != 1 and not (u_index == len(self._adjacency_orders[base])-1 and v_index == 0):
+        if v_index - u_index != 1 and not (u_index == len(self._adjacency_orders[base])-1 and v_index == 0):
             print(self._adjacency_orders[base])
             raise NetworkXError("u and v are not consecutive neighbors of base")
 
-        if base < u:
-            face = self._right_face[frozenset((base,u))]
-        else:
+        if base < u: # incoming edge
             face = self._left_face[frozenset((base,u))]
+        else:
+            face = self._right_face[frozenset((base,u))]
 
         return face
 

--- a/networkx/classes/planar_graph.py
+++ b/networkx/classes/planar_graph.py
@@ -9,17 +9,16 @@ Self-loops are allowed but multiple edges are not.
 #    Lukas Barth (mail@tinloaf.de)
 #    All rights reserved.
 #    BSD license.
-from copy import deepcopy
-import networkx as nx
-from networkx.exception import NetworkXError
-import networkx.convert as convert
 
 __author__ = """\n""".join(['Lukas Barth (mail@tinloaf.de)'])
 
 import collections
+from copy import deepcopy
 
-from ordered import OrderedGraph
+import networkx as nx
 from networkx.exception import NetworkXError
+import networkx.convert as convert
+from networkx.classes.ordered import OrderedGraph
 
 class NoPlanarityProvidedException(Exception):
     pass

--- a/networkx/classes/planar_graph.py
+++ b/networkx/classes/planar_graph.py
@@ -1,7 +1,25 @@
-from ordered import OrderedGraph
+"""Base class for undirected graphs with planar embedding.
+
+The Graph class allows any hashable, comparable object as a node
+and can associate key/value attribute pairs with each undirected edge.
+
+Self-loops are allowed but multiple edges are not.
+"""
+#    Copyright (C) 2015 by
+#    Lukas Barth (mail@tinloaf.de)
+#    All rights reserved.
+#    BSD license.
+from copy import deepcopy
+import networkx as nx
 from networkx.exception import NetworkXError
+import networkx.convert as convert
+
+__author__ = """\n""".join(['Lukas Barth (mail@tinloaf.de)'])
+
 import collections
 
+from ordered import OrderedGraph
+from networkx.exception import NetworkXError
 
 class NoPlanarityProvidedException(Exception):
     pass

--- a/networkx/classes/tests/test_planar_graph.py
+++ b/networkx/classes/tests/test_planar_graph.py
@@ -3,7 +3,12 @@ from nose.tools import *
 import networkx
 from test_graph import BaseGraphTester
 
-class TestPlanarGraph(BaseGraphTester):
+class BasePlanarGraphTester(BaseGraphTester):
+    def test_adjacency_list(self):
+        G=self.K3
+        assert_equal(G.adjacency_list(),[[1,2],[2,0],[0,1]])
+
+class TestPlanarGraph(BasePlanarGraphTester):
     """Tests specific to dict-of-dict-of-dict graph data structure"""
     def setUp(self):
         self.Graph=networkx.PlanarGraph

--- a/networkx/classes/tests/test_planar_graph.py
+++ b/networkx/classes/tests/test_planar_graph.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+from nose.tools import *
+import networkx
+from test_graph import BaseGraphTester
+
+class TestPlanarGraph(BaseGraphTester):
+    """Tests specific to dict-of-dict-of-dict graph data structure"""
+    def setUp(self):
+        self.Graph=networkx.PlanarGraph
+        # build dict-of-dict-of-dict K3
+
+        self.k3edges=[(0, 1), (0, 2), (1, 2)]
+        self.k3nodes=[0, 1, 2]
+        self.K3=self.Graph()
+        self.K3.add_node(0)
+        self.K3.add_node(1)
+        self.K3.add_node(2)
+
+        self.K3.add_edges_from(self.k3edges)
+        self.K3.provide_planarity_data(0, [1,2])
+        self.K3.provide_planarity_data(1, [2,0])
+        self.K3.provide_planarity_data(2, [0,1])
+
+        self.K3.node[0]={}
+        self.K3.node[1]={}
+        self.K3.node[2]={}
+
+    def test_adjacency_iter(self):
+        G=self.K3
+        assert_equal(dict(G.adjacency_iter()),
+                {0: {1: {}, 2: {}}, 1: {0: {}, 2: {}}, 2: {0: {}, 1: {}}})
+
+    def test_getitem(self):
+        G=self.K3
+        assert_equal(G[0],{1: {}, 2: {}})
+        assert_raises(KeyError, G.__getitem__, 'j')
+        assert_raises((TypeError,networkx.NetworkXError), G.__getitem__, ['A'])
+
+    def test_add_node(self):
+        G=self.Graph()
+        G.add_node(0)
+        assert_equal(G.adj,{0:{}})
+        # test add attributes
+        G.add_node(1,c='red')
+        G.add_node(2,{'c':'blue'})
+        G.add_node(3,{'c':'blue'},c='red')
+        assert_raises(networkx.NetworkXError, G.add_node, 4, [])
+        assert_raises(networkx.NetworkXError, G.add_node, 4, 4)
+        assert_equal(G.node[1]['c'],'red')
+        assert_equal(G.node[2]['c'],'blue')
+        assert_equal(G.node[3]['c'],'red')
+        # test updating attributes
+        G.add_node(1,c='blue')
+        G.add_node(2,{'c':'red'})
+        G.add_node(3,{'c':'red'},c='blue')
+        assert_equal(G.node[1]['c'],'blue')
+        assert_equal(G.node[2]['c'],'red')
+        assert_equal(G.node[3]['c'],'blue')
+
+    def test_add_nodes_from(self):
+        G=self.Graph()
+        G.add_nodes_from([0,1,2])
+        assert_equal(G.adj,{0:{},1:{},2:{}})
+        # test add attributes
+        G.add_nodes_from([0,1,2],c='red')
+        assert_equal(G.node[0]['c'],'red')
+        assert_equal(G.node[2]['c'],'red')
+        # test that attribute dicts are not the same
+        assert(G.node[0] is not G.node[1])
+        # test updating attributes
+        G.add_nodes_from([0,1,2],c='blue')
+        assert_equal(G.node[0]['c'],'blue')
+        assert_equal(G.node[2]['c'],'blue')
+        assert(G.node[0] is not G.node[1])
+        # test tuple input
+        H=self.Graph()
+        H.add_nodes_from(G.nodes(data=True))
+        assert_equal(H.node[0]['c'],'blue')
+        assert_equal(H.node[2]['c'],'blue')
+        assert(H.node[0] is not H.node[1])
+        # specific overrides general
+        H.add_nodes_from([0,(1,{'c':'green'}),(3,{'c':'cyan'})],c='red')
+        assert_equal(H.node[0]['c'],'red')
+        assert_equal(H.node[1]['c'],'green')
+        assert_equal(H.node[2]['c'],'blue')
+        assert_equal(H.node[3]['c'],'cyan')
+
+    def test_remove_node(self):
+        G=self.K3
+        G.remove_node(0)
+        assert_equal(G.adj,{1:{2:{}},2:{1:{}}})
+        assert_raises((KeyError,networkx.NetworkXError), G.remove_node,-1)
+
+        # generator here to implement list,set,string...
+    def test_remove_nodes_from(self):
+        G=self.K3
+        G.remove_nodes_from([0,1])
+        assert_equal(G.adj,{2:{}})
+        G.remove_nodes_from([-1]) # silent fail
+
+    def test_add_edge(self):
+        G=self.Graph()
+        G.add_edge(0,1)
+        assert_equal(G.adj,{0: {1: {}}, 1: {0: {}}})
+        G=self.Graph()
+        G.add_edge(*(0,1))
+        assert_equal(G.adj,{0: {1: {}}, 1: {0: {}}})
+
+    def test_add_edges_from(self):
+        G=self.Graph()
+        G.add_edges_from([(0,1),(0,2,{'weight':3})])
+        assert_equal(G.adj,{0: {1:{}, 2:{'weight':3}}, 1: {0:{}}, \
+                2:{0:{'weight':3}}})
+        G=self.Graph()
+        G.add_edges_from([(0,1),(0,2,{'weight':3}),(1,2,{'data':4})],data=2)
+        assert_equal(G.adj,{\
+                0: {1:{'data':2}, 2:{'weight':3,'data':2}}, \
+                1: {0:{'data':2}, 2:{'data':4}}, \
+                2: {0:{'weight':3,'data':2}, 1:{'data':4}} \
+                })
+
+        assert_raises(networkx.NetworkXError,
+                      G.add_edges_from,[(0,)])  # too few in tuple
+        assert_raises(networkx.NetworkXError,
+                      G.add_edges_from,[(0,1,2,3)])  # too many in tuple
+        assert_raises(TypeError, G.add_edges_from,[0])  # not a tuple
+
+
+    def test_remove_edge(self):
+        G=self.K3
+        G.remove_edge(0,1)
+        assert_equal(G.adj,{0:{2:{}},1:{2:{}},2:{0:{},1:{}}})
+        assert_raises((KeyError,networkx.NetworkXError), G.remove_edge,-1,0)
+
+    def test_remove_edges_from(self):
+        G=self.K3
+        G.remove_edges_from([(0,1)])
+        assert_equal(G.adj,{0:{2:{}},1:{2:{}},2:{0:{},1:{}}})
+        G.remove_edges_from([(0,0)]) # silent fail
+
+    def test_clear(self):
+        G=self.K3
+        G.clear()
+        assert_equal(G.adj,{})
+
+    def test_edges_data(self):
+        G=self.K3
+        assert_equal(sorted(G.edges(data=True)),[(0,1,{}),(0,2,{}),(1,2,{})])
+        assert_equal(sorted(G.edges(0,data=True)),[(0,1,{}),(0,2,{})])
+        assert_raises((KeyError,networkx.NetworkXError), G.edges,-1)
+
+    def test_get_edge_data(self):
+        G=self.K3
+        assert_equal(G.get_edge_data(0,1),{})
+        assert_equal(G[0][1],{})
+        assert_equal(G.get_edge_data(10,20),None)
+        assert_equal(G.get_edge_data(-1,0),None)
+        assert_equal(G.get_edge_data(-1,0,default=1),1)

--- a/networkx/classes/tests/test_planar_graph.py
+++ b/networkx/classes/tests/test_planar_graph.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from itertools import combinations
+
 from nose.tools import *
 import networkx
 from test_graph import BaseGraphTester
@@ -54,6 +56,10 @@ class PlanarityTester(BasePlanarGraphTester):
 
         assert_equal(G.get_face(face), tuple((0,1,0,5,0,4,0,3,0,2)))
 
+    def test_euler(self):
+        facecount = len(self.K4.faces())
+        assert_equal(4 - 6 + facecount, 2)
+
 class TestPlanarGraph(PlanarityTester):
     """Tests specific to dict-of-dict-of-dict graph data structure"""
     def setUp(self):
@@ -75,6 +81,17 @@ class TestPlanarGraph(PlanarityTester):
         self.K3.node[0]={}
         self.K3.node[1]={}
         self.K3.node[2]={}
+
+        self.K4 = self.Graph()
+        self.K4.add_nodes_from([0,1,2,3])
+        self.K4.add_edges_from(combinations([0,1,2,3], 2))
+        self.K4.provide_planarity_data_from(
+            {0: [1,2,3],
+             1: [3,2,0],
+             2: [3,0,1],
+             3: [2,1,0]
+            }
+        )
 
     def test_adjacency_iter(self):
         G=self.K3

--- a/networkx/classes/tests/test_planar_graph.py
+++ b/networkx/classes/tests/test_planar_graph.py
@@ -52,6 +52,8 @@ class PlanarityTester(BasePlanarGraphTester):
         assert_equal(G.get_face_between(0,4,5), face)
         assert_equal(G.get_face_between(0,5,1), face)
 
+        assert_equal(G.get_face(face), tuple((0,1,0,5,0,4,0,3,0,2)))
+
 class TestPlanarGraph(PlanarityTester):
     """Tests specific to dict-of-dict-of-dict graph data structure"""
     def setUp(self):

--- a/networkx/classes/tests/test_planar_graph.py
+++ b/networkx/classes/tests/test_planar_graph.py
@@ -8,7 +8,34 @@ class BasePlanarGraphTester(BaseGraphTester):
         G=self.K3
         assert_equal(G.adjacency_list(),[[1,2],[2,0],[0,1]])
 
-class TestPlanarGraph(BasePlanarGraphTester):
+class PlanarityTester(BasePlanarGraphTester):
+    def test_face_assignment(self):
+        G = self.Graph()
+        G.add_nodes_from([0,1,2,3])
+        G.add_edges_from([
+            (0,1), (0,3), (0,2),
+            (1,3),
+            (2,3)
+        ])
+        G.provide_planarity_data(0, [1,3,2])
+        G.provide_planarity_data(1, [3,0])
+        G.provide_planarity_data(2, [0,3])
+        G.provide_planarity_data(3, [2,0,1])
+
+        outer_face = G.get_face_between(0, 2, 1)
+        assert_equal(G.get_face_between(1, 0, 3), outer_face)
+        assert_equal(G.get_face_between(3, 1, 2), outer_face)
+        assert_equal(G.get_face_between(2, 3, 0), outer_face)
+
+        inner_triangle_one = G.get_face_between(0, 3, 2)
+        assert_equal(G.get_face_between(3, 2, 0), inner_triangle_one)
+        assert_equal(G.get_face_between(2, 0, 3), inner_triangle_one)
+
+        inner_triangle_two = G.get_face_between(1, 3, 0)
+        assert_equal(G.get_face_between(3, 0, 1), inner_triangle_two)
+        assert_equal(G.get_face_between(0, 1, 3), inner_triangle_two)
+
+class TestPlanarGraph(PlanarityTester):
     """Tests specific to dict-of-dict-of-dict graph data structure"""
     def setUp(self):
         self.Graph=networkx.PlanarGraph

--- a/networkx/classes/tests/test_planar_graph.py
+++ b/networkx/classes/tests/test_planar_graph.py
@@ -35,6 +35,23 @@ class PlanarityTester(BasePlanarGraphTester):
         assert_equal(G.get_face_between(3, 0, 1), inner_triangle_two)
         assert_equal(G.get_face_between(0, 1, 3), inner_triangle_two)
 
+    def test_star(self):
+        G = self.Graph()
+        G.add_nodes_from([0,1,2,3,4,5])
+        G.add_edges_from([(0,1), (0,2), (0,3), (0,4), (0,5)])
+        G.provide_planarity_data(0, [1,2,3,4,5])
+        G.provide_planarity_data(1, [0])
+        G.provide_planarity_data(2, [0])
+        G.provide_planarity_data(3, [0])
+        G.provide_planarity_data(4, [0])
+        G.provide_planarity_data(5, [0])
+
+        face = G.get_face_between(0, 1, 2)
+        assert_equal(G.get_face_between(0,2,3), face)
+        assert_equal(G.get_face_between(0,3,4), face)
+        assert_equal(G.get_face_between(0,4,5), face)
+        assert_equal(G.get_face_between(0,5,1), face)
+
 class TestPlanarGraph(PlanarityTester):
     """Tests specific to dict-of-dict-of-dict graph data structure"""
     def setUp(self):


### PR DESCRIPTION
As mentioned in https://groups.google.com/forum/#!topic/networkx-discuss/YpulBDPTBls I currently work on supporting some operations that are only defined on planar graphs (stuff about faces, dual graphs, ...) in NetworkX.

This pull requests adds the first version of the graph data structure that I would like to use. Some comments:
- Anwering the question from Google Groups: Yes, I need a class for this, since lots of internal data must be computed, invalidated on changes and updated when requests are made.
- I'm not sure yet whether I like the fact that faces are computed whenever neighbors are accessed. This way, neighbors will be traversed in order of the embedding, but actually, faces are not needed for this.
- Obviously, all the methods that were only slightly modified from the base Graph need to inherit documentation..
