### PR TITLE
Makes girvan_newman return communities as sets.

### DIFF
--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -1,11 +1,21 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
+# centrality.py - functions for computing communities using centrality notions
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions for computing communities based on centrality notions."""
+
 import networkx as nx
 
 __all__ = ['girvan_newman']
 
 
 def girvan_newman(G, weight=None):
-    """Find communities in graph using Girvan–Newman method.
+    """Finds communities in a graph using the Girvan–Newman method.
 
     Parameters
     ----------
@@ -16,50 +26,82 @@ def girvan_newman(G, weight=None):
 
     Returns
     -------
-    List of tuples which contains the clusters of nodes.
+    iterator
+        Iterator over tuples of sets of nodes in ``G``. Each set of
+        nodes is a community, each tuple is a sequence of communities at
+        a particular level of the algorithm.
 
     Examples
     --------
-    >>> G = nx.path_graph(10)
-    >>> comp = girvan_newman(G)
-    >>> comp[0]
-    ([0, 1, 2, 3, 4], [8, 9, 5, 6, 7])
+    To get the first pair of communities::
+
+        >>> G = nx.path_graph(10)
+        >>> comp = girvan_newman(G)
+        >>> tuple(sorted(c) for c in list(comp)[0])
+        ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9])
+
+    To get only the first *k* tuples of communities, use
+    :func:`itertools.islice`::
+
+        >>> import itertools
+        >>> G = nx.path_graph(8)
+        >>> k = 2
+        >>> comp = girvan_newman(G)
+        >>> for communities in itertools.islice(comp, k):
+        ...     print(tuple(sorted(c) for c in communities))
+        ...
+        ([0, 1, 2, 3], [4, 5, 6, 7])
+        ([0, 1], [2, 3], [4, 5], [6, 7])
+
+    To stop getting tuples of communities once the number of communities
+    is greater than *k*, use :func:`itertools.takewhile`::
+
+        >>> import itertools
+        >>> G = nx.path_graph(8)
+        >>> k = 4
+        >>> comp = girvan_newman(G)
+        >>> limited = itertools.takewhile(lambda c: len(c) <= k, comp)
+        >>> for communities in limited:
+        ...     print(tuple(sorted(c) for c in communities))
+        ...
+        ([0, 1, 2, 3], [4, 5, 6, 7])
+        ([0, 1], [2, 3], [4, 5], [6, 7])
 
     Notes
     -----
-    The Girvan–Newman algorithm detects communities by progressively removing
-    edges from the original graph. Algorithm removes edge with the highest
-    betweenness centrality at each step. As the graph breaks down into pieces,
-    the tightly knit community structure is exposed and result can be depicted
-    as a dendrogram.
+    The Girvan–Newman algorithm detects communities by progressively
+    removing edges from the original graph. The algorithm removes *all*
+    edges with the highest betweenness centrality at each step. As the
+    graph breaks down into pieces, the tightly knit community structure
+    is exposed and the result can be depicted as a dendrogram.
+
     """
     g = G.copy().to_undirected()
-    components = []
     while g.number_of_edges() > 0:
-        _remove_max_edge(g, weight)
-        components.append(tuple(list(H)
-                                for H in nx.connected_component_subgraphs(g)))
-    return components
+        yield _without_most_central_edges(g, weight=weight)
 
 
-def _remove_max_edge(G, weight=None):
+def _without_most_central_edges(G, weight=None):
+    """Returns the connected components of the graph that results from
+    repeatedly removing the edges of maximum betweenness centrality.
+
+    This function modifies the graph ``G`` in-place; that is, it removes
+    edges on the graph ``G``.
+
+    The ``weight`` parameter is passed directly to the function that
+    computes edge betweenness centrality.
+
     """
-    Removes edge with the highest value on betweenness centrality.
-
-    Repeat this step until more connected components than the connected
-    components of the original graph are detected.
-
-    It is part of Girvan–Newman algorithm.
-
-    :param G: NetworkX graph
-    :param weight: string, optional (default=None) Edge data key corresponding
-    to the edge weight.
-    """
-    number_components = nx.number_connected_components(G)
-    while nx.number_connected_components(G) <= number_components:
+    original_num_components = nx.number_connected_components(G)
+    num_new_components = original_num_components
+    while num_new_components <= original_num_components:
+        # Remove the edges of maximum betweenness centrality.
         betweenness = nx.edge_betweenness_centrality(G, weight=weight)
-        max_value = max(betweenness.values())
+        max_betweenness = max(betweenness.values())
         # Use a list of edges because G is changed in the loop
-        for edge in list(G.edges()):
-            if betweenness[edge] == max_value:
-                G.remove_edge(*edge)
+        G.remove_edges_from(e for e in list(G.edges())
+                            if betweenness[e] == max_betweenness)
+        # Get the new connected components after having removed the edges.
+        new_components = tuple(nx.connected_components(G))
+        num_new_components = len(new_components)
+    return new_components

--- a/networkx/algorithms/community/tests/test_centrality.py
+++ b/networkx/algorithms/community/tests/test_centrality.py
@@ -14,7 +14,7 @@ class TestCommunities():
     def test_girvan_newman_no_edges(self):
         g = nx.Graph()
         g.add_nodes_from([1, 2, 3, 4, 5])
-        result = nx.girvan_newman(g)
+        result = list(nx.girvan_newman(g))
         assert_equal(len(result), 0)
         validate_communities(result, [])
 
@@ -24,7 +24,7 @@ class TestCommunities():
                           (6, 4), (6, 5), (5, 4), (7, 8), (8, 9),
                           (9, 11), (9, 10), (10, 11), (8, 12), (12, 13),
                           (12, 14), (13, 14)])
-        result = nx.girvan_newman(g)
+        result = list(nx.girvan_newman(g))
         assert_equal(len(result), 3)
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3), (4, 5, 6), (9, 10, 11), (12, 13, 14),
@@ -33,7 +33,7 @@ class TestCommunities():
                                          (7, ), (8, ), (9, ), (10,), (11, ), (12, ),
                                          (13, ), (14, )])
         dg = g.to_directed()
-        result = nx.girvan_newman(dg)
+        result = list(nx.girvan_newman(dg))
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3), (4, 5, 6), (9, 10, 11), (12, 13, 14),
                                          (7, ), (8, )])
@@ -48,7 +48,7 @@ class TestCommunities():
                                    (7, 8, 1), (8, 9, 13), (9, 11, 1), (9, 10, 10),
                                    (10, 11, 2), (8, 12, 6), (12, 13, 5), (12, 14, 6),
                                    (13, 14, 4)])
-        result = nx.girvan_newman(g)
+        result = list(nx.girvan_newman(g))
         assert_equal(len(result), 3)
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3), (4, 5, 6), (9, 10, 11), (12, 13, 14),
@@ -56,7 +56,7 @@ class TestCommunities():
         validate_communities(result[2], [(1,), (2, ), (3, ), (4, ), (5, ), (6, ),
                                          (7, ), (8, ), (9, ), (10,), (11, ), (12, ),
                                          (13, ), (14, )])
-        result = nx.girvan_newman(g, weight='weight')
+        result = list(nx.girvan_newman(g, weight='weight'))
         assert_equal(len(result), 4)
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3, ), (4, 5, 6, ), (9, 10, 11, ),
@@ -67,7 +67,7 @@ class TestCommunities():
                                          (7, ), (8, ), (9, ), (10,), (11, ), (12, ),
                                          (13, ), (14, )])
         dg = g.to_directed()
-        result = nx.girvan_newman(dg, weight='weight')
+        result = list(nx.girvan_newman(dg, weight='weight'))
         assert_equal(len(result), 4)
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3, ), (4, 5, 6, ), (9, 10, 11, ),


### PR DESCRIPTION
Previously, the community-finding algorithm `girvan_newman` returned a
list of tuples of lists of nodes. Now the function returns an iterator
over tuples of sets of nodes, each set representing a community. This
matches the behavior of the other community-finding functions.

This also prevents computing the connected components of the graph an
additional time when yielding the tuples of communities.