### PR TITLE
merge data of G and H instead replace

### DIFF
--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -324,8 +324,8 @@ def compose(G, H, name=None):
         name = "compose( %s, %s )" % (G.name, H.name)
     R = G.__class__()
     R.name = name
-    R.add_nodes_from(H.nodes())
-    R.add_nodes_from(G.nodes())
+    R.add_nodes_from(G.nodes_iter(data=True))
+    R.add_nodes_from(H.nodes_iter(data=True))
     if G.is_multigraph():
         R.add_edges_from(G.edges_iter(keys=True, data=True))
     else:
@@ -335,9 +335,6 @@ def compose(G, H, name=None):
     else:
         R.add_edges_from(H.edges_iter(data=True))
 
-    # add node attributes, H attributes take precedent over G attributes
-    R.node.update(G.node)
-    R.node.update(H.node)
     # add graph attributes, H attributes take precedent over G attributes
     R.graph.update(G.graph)
     R.graph.update(H.graph)

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -324,8 +324,10 @@ def compose(G, H, name=None):
         name = "compose( %s, %s )" % (G.name, H.name)
     R = G.__class__()
     R.name = name
-    R.add_nodes_from(G.nodes_iter(data=True))
-    R.add_nodes_from(H.nodes_iter(data=True))
+
+    R.add_nodes_from(G.nodes(data=True))
+    R.add_nodes_from(H.nodes(data=True))
+
     if G.is_multigraph():
         R.add_edges_from(G.edges_iter(keys=True, data=True))
     else:

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -226,6 +226,13 @@ def test_union_and_compose():
     E=disjoint_union(G1,G2)
     assert_equal(sorted(E.nodes()),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
 
+    G = nx.Graph()
+    H = nx.Graph()
+    G.add_nodes_from([(1, {'a1': 1})])
+    H.add_nodes_from([(1, {'b1': 1})])
+    R = compose(G, H)
+    assert_equal(R.node, {1: {'a1': 1, 'b1': 1}})
+
 
 def test_union_multigraph():
     G=nx.MultiGraph()


### PR DESCRIPTION
compose func merge edges data
e.g. R=compose(G,H)
G.edge = 2: {3: {'p_b': 1}
H.edge = 2: {3: {'s_b': 2}

R.edge = 2: {3: {'p_b': 1, 's_b': 2}

, but not for nodes
G.node = 3: {'p_b': 1}
H.node = 3: {'s_b': 2}

R.node = 3: {'s_b': 2} # 'p_b' missed
