### PR TITLE
Enhancement: add collective influence measure

### DIFF
--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -113,6 +113,7 @@ is partially historical, and now, mostly arbitrary.
 - Thodoris Sotiropoulos, GitHub: `theosotr <https://github.com/theosotr>`_
 - Konstantinos Karakatsanis, GitHub: `k-karakatsanis <https://github.com/k-karakatsanis>`_
 - Ryan Nelson, GitHub: `rnelsonchem <https://github.com/rnelsonchem>`_
+- Sebastian Pucilowski
 
 Support
 -------

--- a/doc/source/reference/release_2.0.rst
+++ b/doc/source/reference/release_2.0.rst
@@ -92,3 +92,9 @@ API changes
        # recommended
        >>> tree.minimum_spanning_tree(G, algorithm='kruskal', weight='mass')
        >>> tree.minimum_spanning_edges(G, algorithm='prim', weight='mass')
+
+New functionalities
+-------------------
+* [`#1717 <https://github.com/networkx/networkx/pull/1717>`_]
+  Added the collective influence measure to the centrality package
+  (:samp:`networkx.algorithms.centrality`).

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -1,6 +1,7 @@
 from .betweenness import *
 from .betweenness_subset import *
 from .closeness import *
+from .collective_influence import *
 from .communicability_alg import *
 from .current_flow_closeness import *
 from .current_flow_betweenness import *

--- a/networkx/algorithms/centrality/collective_influence.py
+++ b/networkx/algorithms/centrality/collective_influence.py
@@ -55,7 +55,7 @@ def collective_influence(G, u=None, distance=2):
     reduced_degree = lambda node: G.degree(node)-1
 
     if u is None:
-        nodes = G.nodes_iter()
+        nodes = G.nodes()
     else:
         nodes = [u]
 

--- a/networkx/algorithms/centrality/collective_influence.py
+++ b/networkx/algorithms/centrality/collective_influence.py
@@ -65,8 +65,10 @@ def collective_influence(G, u=None, distance=2):
         path_lengths = nx.single_source_shortest_path_length(
             G, source=node, cutoff=distance
         )
-        frontier_nodes = {node for node, path_length in path_lengths.items()
-                          if path_length == distance}
+        frontier_nodes = {
+            node for node, path_length in path_lengths.items()
+            if path_length == distance
+        }
 
         collective_influence[node] = reduced_degree(node) * sum(map(reduced_degree, frontier_nodes))
 

--- a/networkx/algorithms/centrality/collective_influence.py
+++ b/networkx/algorithms/centrality/collective_influence.py
@@ -1,0 +1,74 @@
+# coding=utf8
+"""
+Collective influence measures.
+"""
+
+#   Copyright (C) 2015 by
+#   Sebastian Pucilowski <smopucilowski@gmail.com>
+#   All rights reserved.
+#   BSD license.
+import networkx as nx
+__author__ = "\n".join(['Sebastian Pucilowski <smopucilowski@gmail.com>'])
+__all__ = ['collective_influence']
+
+def collective_influence(G, u=None, distance=2):
+    r"""Collective influence of a network node.
+
+    The collective influence [1]_ [2]_ of a network node is the product of its
+    reduced degree and the total reduced degree of all nodes at distance `d`
+    from it.
+
+    .. math::
+
+        \text{CI}_l (i) = (k_i - 1) \sum_{j \in \partial \text{Ball}(i,j)} (k_j - 1)
+
+    Collective influence describes how many nodes can be reached from a given
+    node. Removing nodes with high collective influence is more effective in
+    fragmenting and destroying a network than nodes selected by other methods
+    (e.g. PageRank or closeness centrality).
+
+    Parameters
+    ---------
+    G : graph
+      A NetworkX graph
+    u : node, optional
+      Return only the value for node u
+    distance : optional (default=2)
+
+    Returns
+    -------
+    nodes : dictionary
+      Dictionary of nodes with collective influence as the value.
+
+    References
+    ----------
+      [1] Flaviano Morone and Hernán A. Makse:
+      Influence maximization in complex networks through optimal percolation
+      Nature 524, 65–68 (06 August 2015)
+      doi: 10.1038/nature14604
+      [2] István A. Kovács and Albert-László Barabási:
+      Network science: Destruction perfected
+      Nature 524, 38–39 (06 August 2015)
+      doi: 10.1038/524038a
+    """
+
+    reduced_degree = lambda node: G.degree(node)-1
+
+    if u is None:
+        nodes = G.nodes_iter()
+    else:
+        nodes = [u]
+
+    collective_influence = dict()
+    for node in nodes:
+        # Find all nodes at 'distance' steps from node
+        paths = nx.single_source_shortest_path(G, source=node, cutoff=distance)
+        frontier_nodes = {node for node, path in paths.items()
+                          if len(path)-1 == distance}
+
+        collective_influence[node] = reduced_degree(node) * sum(map(reduced_degree, frontier_nodes))
+
+    if u is not None:
+        return collective_influence[u]
+    else:
+        return collective_influence

--- a/networkx/algorithms/centrality/collective_influence.py
+++ b/networkx/algorithms/centrality/collective_influence.py
@@ -62,9 +62,11 @@ def collective_influence(G, u=None, distance=2):
     collective_influence = dict()
     for node in nodes:
         # Find all nodes at 'distance' steps from node
-        paths = nx.single_source_shortest_path(G, source=node, cutoff=distance)
-        frontier_nodes = {node for node, path in paths.items()
-                          if len(path)-1 == distance}
+        path_lengths = nx.single_source_shortest_path_length(
+            G, source=node, cutoff=distance
+        )
+        frontier_nodes = {node for node, path_length in path_lengths.items()
+                          if path_length == distance}
 
         collective_influence[node] = reduced_degree(node) * sum(map(reduced_degree, frontier_nodes))
 

--- a/networkx/algorithms/centrality/tests/test_collective_influence.py
+++ b/networkx/algorithms/centrality/tests/test_collective_influence.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+"""
+    Unit tests for collective influence.
+"""
+from nose.tools import *
+import networkx as nx
+
+class TestCollectiveInfluence(object):
+    def __init__(self):
+        # Sample network taken from Figure 1 in letter:
+        # István A. Kovács & Albert-László Barabási
+        # Network science: Destruction perfected
+        # Nature 524, 38–39 (06 August 2015)
+        # doi: 10.1038/524038a
+        edges = [
+            (1, 2), (1, 3), (1, 4), (1, 5), (1, 6),
+            (2, 7), (2, 8), (2, 9), (2, 10),
+            (3, 4), (3, 8), (3, 19),
+            (7, 8), (7, 11), (7, 13),
+            (8, 26),
+            (11, 14), (11, 12),
+            (12, 15), (12, 19), (12, 29),
+            (13, 22),
+            (14, 16), (14, 17), (14, 18), (14, 15),
+            (17, 18),
+            (19, 20), (19, 21),
+            (20, 21), (20, 22), (20, 23), (20, 24),
+            (21, 22), (21, 23), (21, 25),
+            (22, 26), (22, 27), (22, 28),
+            (26, 29),
+            (27, 28),
+            (29, 30),
+        ]
+        self.G = nx.Graph(edges)
+
+    def test_collective_influence_1(self):
+        collective_influence = nx.collective_influence(self.G)
+        assert_almost_equal(collective_influence[7], 63)
+        assert_almost_equal(collective_influence[22], 60)

--- a/networkx/algorithms/centrality/tests/test_collective_influence.py
+++ b/networkx/algorithms/centrality/tests/test_collective_influence.py
@@ -35,5 +35,5 @@ class TestCollectiveInfluence(object):
 
     def test_collective_influence_1(self):
         collective_influence = nx.collective_influence(self.G)
-        assert_almost_equal(collective_influence[7], 63)
-        assert_almost_equal(collective_influence[22], 60)
+        assert_equal(collective_influence[7],  63)
+        assert_equal(collective_influence[22], 60)


### PR DESCRIPTION
A new paper by Morone & Makse appearing in Nature a few days ago (doi:10.1038/nature14604) introduced the concept of Collective Influence. Briefy: this node measure quantifies the influence of a node by finding an optimal (minimal) set of structural influencers. Nodes with high collective influence, when removed, break down the network into many disconnected pieces.

This pull request implements their node measure.