### PR TITLE
to_networkx_graph needs .update() instead of new dict

### DIFF
--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -89,10 +89,10 @@ def to_networkx_graph(data,create_using=None,multigraph_input=False):
             result= from_dict_of_dicts(data.adj,\
                     create_using=create_using,\
                     multigraph_input=data.is_multigraph())
-            if hasattr(data,'graph') and isinstance(data.graph,dict):
-                result.graph=data.graph.copy()
-            if hasattr(data,'node') and isinstance(data.node,dict):
-                result.node=dict( (n,dd.copy()) for n,dd in data.node.items() )
+            if hasattr(data,'graph'): # data.graph should be dict-like
+                result.graph.update(data.graph)
+            if hasattr(data,'node'): # data.node should be dict-like
+                result.node.update( (n,dd.copy()) for n,dd in data.node.items() )
             return result
         except:
             raise nx.NetworkXError("Input is not a correct NetworkX graph.")

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -215,3 +215,12 @@ class TestConvert():
 
         assert_true(self.edgelists_equal(nx.Graph(nx.MultiDiGraph(edges1)).edges(),edges1))
         assert_true(self.edgelists_equal(nx.Graph(nx.MultiDiGraph(edges2)).edges(),edges1))
+
+    def test_attribute_dict_integrity(self):
+        # we must not replace dict-like graph data structures with dicts 
+        G=OrderedGraph()
+        G.add_nodes_from("abc")
+        H=to_networkx_graph(G, create_using=OrderedGraph())
+        assert_equal(list(H.node),list(G.node))
+        H=OrderedDiGraph(G)
+        assert_equal(list(H.node),list(G.node))


### PR DESCRIPTION
In convert.to_networkx_graph, we are overwriting instead of 
updating the node dict.  We just need to update the existing dict.
Fixes #1718 
