### PR TITLE
Allow arbitrary ranking function in girvan_newman.

### DIFF
--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -4,7 +4,7 @@ import networkx as nx
 __all__ = ['girvan_newman']
 
 
-def girvan_newman(G, weight=None):
+def girvan_newman(G, ranking=None):
     """Find communities in graph using Girvan–Newman method.
 
     Parameters
@@ -13,6 +13,17 @@ def girvan_newman(G, weight=None):
 
     weight : string, optional (default=None)
        Edge data key corresponding to the edge weight.
+
+    ranking : function
+        Function that takes a graph as input and outputs a
+        dictionary. The keys in the dictionary must be the edges of the
+        graph and the values must be comparable. The edges with the
+        highest value will be removed at each iteration of the
+        algorithm. The function will be called during each iteration of
+        the algorithm to recompute the edge rankings.
+
+        If not specified, the function
+        :func:`networkx.edge_betweenness_centrality` will be used.
 
     Returns
     -------
@@ -25,6 +36,23 @@ def girvan_newman(G, weight=None):
     >>> comp[0]
     ([0, 1, 2, 3, 4], [8, 9, 5, 6, 7])
 
+    To utilize edge weights when choosing an edge with, for example, the
+    edge betweenness centrality ranking function::
+
+        >>> from functools import partial
+        >>> G = nx.path_graph(10)
+        >>> ranking = partial(nx.edge_betweenness_centrality, weight='weight')
+        >>> comp = girvan_newman(G, ranking=ranking)
+        >>> comp[0]
+        ([0, 1, 2, 3, 4], [8, 9, 5, 6, 7])
+
+    To specify a different ranking algorithm, for example edge current
+    flow betweenness centrality, use the ``ranking`` keyword argument::
+
+        >>> G = nx.path_graph(10)
+        >>> ranking = nx.edge_current_flow_betweenness_centrality
+        >>> comp = girvan_newman(G, ranking=ranking)  # doctest: +SKIP
+
     Notes
     -----
     The Girvan–Newman algorithm detects communities by progressively removing
@@ -33,16 +61,18 @@ def girvan_newman(G, weight=None):
     the tightly knit community structure is exposed and result can be depicted
     as a dendrogram.
     """
+    if ranking is None:
+        ranking = nx.edge_betweenness_centrality
     g = G.copy().to_undirected()
     components = []
     while g.number_of_edges() > 0:
-        _remove_max_edge(g, weight)
+        _remove_max_edge(g, ranking)
         components.append(tuple(list(H)
                                 for H in nx.connected_component_subgraphs(g)))
     return components
 
 
-def _remove_max_edge(G, weight=None):
+def _remove_max_edge(G, ranking):
     """
     Removes edge with the highest value on betweenness centrality.
 
@@ -57,7 +87,7 @@ def _remove_max_edge(G, weight=None):
     """
     number_components = nx.number_connected_components(G)
     while nx.number_connected_components(G) <= number_components:
-        betweenness = nx.edge_betweenness_centrality(G, weight=weight)
+        betweenness = ranking(G)
         max_value = max(betweenness.values())
         # Use a list of edges because G is changed in the loop
         for edge in list(G.edges()):

--- a/networkx/algorithms/community/tests/test_centrality.py
+++ b/networkx/algorithms/community/tests/test_centrality.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
-from nose.tools import assert_equal
-import networkx as nx
 import collections
+from functools import partial
+
+from nose.tools import assert_equal
+
+import networkx as nx
 
 
 def validate_communities(result, expected):
@@ -56,7 +59,8 @@ class TestCommunities():
         validate_communities(result[2], [(1,), (2, ), (3, ), (4, ), (5, ), (6, ),
                                          (7, ), (8, ), (9, ), (10,), (11, ), (12, ),
                                          (13, ), (14, )])
-        result = nx.girvan_newman(g, weight='weight')
+        ranking = partial(nx.edge_betweenness_centrality, weight='weight')
+        result = nx.girvan_newman(g, ranking)
         assert_equal(len(result), 4)
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3, ), (4, 5, 6, ), (9, 10, 11, ),
@@ -67,7 +71,8 @@ class TestCommunities():
                                          (7, ), (8, ), (9, ), (10,), (11, ), (12, ),
                                          (13, ), (14, )])
         dg = g.to_directed()
-        result = nx.girvan_newman(dg, weight='weight')
+        ranking = partial(nx.edge_betweenness_centrality, weight='weight')
+        result = nx.girvan_newman(dg, ranking=ranking)
         assert_equal(len(result), 4)
         validate_communities(result[0], [(1, 2, 3, 4, 5, 6, 7), (8, 9, 10, 11, 12, 13, 14)])
         validate_communities(result[1], [(1, 2, 3, ), (4, 5, 6, ), (9, 10, 11, ),


### PR DESCRIPTION
This generalizes the `girvan_newman()` function to allow for arbitrary
ranking functions on the edges during each iteration.

This removes the `weight` argument from the function so it is backwards incompatible, but I believe the function has not appeared in a public release yet?

This covers all the functionality in https://bitbucket.org/bedwards/networkx-community/src/5f88c6ae0db47fd3a5b4a52988093b448f083ca8/networkx/algorithms/community/divisive.py so that file no longer needs to be merged into NetworkX.