### PR TITLE
Eigenvector_centrality power method shifted to A+I

### DIFF
--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -69,12 +69,15 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
 
     Notes
     ------
-    The measure was introduced by [1]_.
+    The measure was introduced by [1]_ and is discussed in [2]_.
 
-    The eigenvector calculation is done by the power iteration method and has
-    no guarantee of convergence. The iteration will stop after ``max_iter``
-    iterations or an error tolerance of ``number_of_nodes(G)*tol`` has been
-    reached.
+    Eigenvector convergence: The power iteration method is used to compute
+    the eigenvector and convergence is not guaranteed. Our method stops after
+    ``max_iter`` iterations or when the vector change is below an error
+    tolerance of ``number_of_nodes(G)*tol``. We actually use (A+I) rather
+    than the adjacency matrix A because it shifts the spectrum to enable
+    discerning the correct eigenvector even for networks with multiple
+    dominant eigenvalues.
 
     For directed graphs this is "left" eigenvector centrality which corresponds
     to the in-edges in the graph. For out-edges eigenvector centrality
@@ -111,8 +114,8 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
     # make up to max_iter iterations
     for i in range(max_iter):
         xlast = x
-        x = dict.fromkeys(xlast, 0)
-        # do the multiplication y^T = x^T A
+        x = xlast.copy() # Start with xlast times I to iterate with (A+I)
+        # do the multiplication y^T = x^T A (left eigenvector)
         for n in x:
             for nbr in G[n]:
                 x[nbr] += xlast[n] * G[n][nbr].get(weight, 1)

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -41,6 +41,9 @@ class TestEigenvectorCentrality(object):
         b=networkx.eigenvector_centrality_numpy(G)
         for n in sorted(G):
             assert_almost_equal(b[n],b_answer[n],places=4)
+        b=networkx.eigenvector_centrality(G)
+        for n in sorted(G):
+            assert_almost_equal(b[n],b_answer[n],places=4)
 
 
     def test_P3_unweighted(self):


### PR DESCRIPTION
By computing eigenvectors with repeated multiplication by A+I
the spectrum is shifted so that the positive real eigenvalue
is dominant even for odd path graphs and others with multiple
dominant eigenvalues. Fixes #1704 