### PR TITLE
Add IRC channel to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Documentation
 Mailing List
    https://groups.google.com/forum/#!forum/networkx-discuss
 IRC
-   `irc://chat.freenode.net/networkx`_
+   `irc://chat.freenode.net/networkx`_ (for a web client click `here`_)
 Development
    https://github.com/networkx/networkx
 
@@ -43,3 +43,4 @@ Distributed with a BSD license; see LICENSE.txt::
    Pieter Swart <swart@lanl.gov>
 
 .. _irc://chat.freenode.net/networkx: irc://chat.freenode.net/networkx
+.. _here: http://webchat.freenode.net?channels=%23networkx

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ Documentation
    http://networkx.github.io
 Mailing List
    https://groups.google.com/forum/#!forum/networkx-discuss
+IRC
+   `irc://chat.freenode.net/networkx`_
 Development
    https://github.com/networkx/networkx
 
@@ -40,6 +42,4 @@ Distributed with a BSD license; see LICENSE.txt::
    Dan Schult <dschult@colgate.edu>
    Pieter Swart <swart@lanl.gov>
 
-
-
-
+.. _irc://chat.freenode.net/networkx: irc://chat.freenode.net/networkx


### PR DESCRIPTION
A IRC channel has been made where discussion can be performed
about networkx, using the popular opensource freenode servers
so it might as well be mentioned in the README.rst so people
can find it as needed.

https://freenode.net/