### PR TITLE
Fixes and extends Wiener index, vitality functions

### DIFF
--- a/doc/source/reference/algorithms.wiener.rst
+++ b/doc/source/reference/algorithms.wiener.rst
@@ -1,0 +1,9 @@
+************
+Wiener index
+************
+
+.. automodule:: networkx.algorithms.wiener
+.. autosummary::
+   :toctree: generated/
+
+   wiener_index

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -35,6 +35,7 @@ from networkx.algorithms.distance_regular import *
 from networkx.algorithms.swap import *
 from networkx.algorithms.graphical import *
 from networkx.algorithms.simple_paths import *
+from networkx.algorithms.wiener import *
 
 import networkx.algorithms.assortativity
 import networkx.algorithms.bipartite

--- a/networkx/algorithms/tests/test_vitality.py
+++ b/networkx/algorithms/tests/test_vitality.py
@@ -1,35 +1,43 @@
-#!/usr/bin/env python
-from nose.tools import *
+from nose.tools import assert_equal
+
 import networkx as nx
 
-class TestVitality:
+class TestClosenessVitality(object):
 
-    def test_closeness_vitality_unweighted(self):
-        G=nx.cycle_graph(3)
-        v=nx.closeness_vitality(G)
-        assert_equal(v,{0:4.0, 1:4.0, 2:4.0})
-        assert_equal(v[0],4.0)
+    def test_unweighted(self):
+        G = nx.cycle_graph(3)
+        vitality = nx.closeness_vitality(G)
+        assert_equal(vitality, {0: 2, 1: 2, 2: 2})
 
-    def test_closeness_vitality_weighted(self):
-        G=nx.Graph()
-        G.add_cycle([0,1,2],weight=2)
-        v=nx.closeness_vitality(G,weight='weight')
-        assert_equal(v,{0:8.0, 1:8.0, 2:8.0})
+    def test_weighted(self):
+        G = nx.Graph()
+        G.add_cycle([0, 1, 2], weight=2)
+        vitality = nx.closeness_vitality(G, weight='weight')
+        assert_equal(vitality, {0: 4, 1: 4, 2: 4})
 
-    def test_closeness_vitality_unweighted_digraph(self):
-        G=nx.DiGraph()
-        G.add_cycle([0,1,2])
-        v=nx.closeness_vitality(G)
-        assert_equal(v,{0:8.0, 1:8.0, 2:8.0})
+    def test_unweighted_digraph(self):
+        G = nx.DiGraph(nx.cycle_graph(3))
+        vitality = nx.closeness_vitality(G)
+        assert_equal(vitality, {0: 4, 1: 4, 2: 4})
 
-    def test_closeness_vitality_weighted_digraph(self):
-        G=nx.DiGraph()
-        G.add_cycle([0,1,2],weight=2)
-        v=nx.closeness_vitality(G,weight='weight')
-        assert_equal(v,{0:16.0, 1:16.0, 2:16.0})
+    def test_weighted_digraph(self):
+        G = nx.DiGraph()
+        G.add_cycle([0, 1, 2], weight=2)
+        G.add_cycle([2, 1, 0], weight=2)
+        vitality = nx.closeness_vitality(G, weight='weight')
+        assert_equal(vitality, {0: 8, 1: 8, 2: 8})
 
-    def test_closeness_vitality_weighted_multidigraph(self):
-        G=nx.MultiDiGraph()
-        G.add_cycle([0,1,2],weight=2)
-        v=nx.closeness_vitality(G,weight='weight')
-        assert_equal(v,{0:16.0, 1:16.0, 2:16.0})
+    def test_weighted_multidigraph(self):
+        G = nx.MultiDiGraph()
+        G.add_cycle([0, 1, 2], weight=2)
+        G.add_cycle([2, 1, 0], weight=2)
+        vitality = nx.closeness_vitality(G,weight='weight')
+        assert_equal(vitality, {0: 8, 1: 8, 2: 8})
+
+    def test_disconnecting_graph(self):
+        """Tests that the closeness vitality of a node whose removal
+        disconnects the graph is negative infinity.
+
+        """
+        G = nx.path_graph(3)
+        assert_equal(nx.closeness_vitality(G, node=1), -float('inf'))

--- a/networkx/algorithms/tests/test_wiener.py
+++ b/networkx/algorithms/tests/test_wiener.py
@@ -1,0 +1,80 @@
+# test_wiener.py - unit tests for the wiener module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.wiener` module."""
+from __future__ import division
+
+from nose.tools import eq_
+
+from networkx import complete_graph
+from networkx import DiGraph
+from networkx import empty_graph
+from networkx import path_graph
+from networkx import wiener_index
+
+
+class TestWienerIndex(object):
+    """Unit tests for computing the Wiener index of a graph."""
+
+    def test_disconnected_graph(self):
+        """Tests that the Wiener index of a disconnected graph is
+        positive infinity.
+
+        """
+        eq_(wiener_index(empty_graph(2)), float('inf'))
+
+    def test_directed(self):
+        """Tests that each pair of nodes in the directed graph is
+        counted once when computing the Wiener index.
+
+        """
+        G = complete_graph(3)
+        H = DiGraph(G)
+        eq_(2 * wiener_index(G), wiener_index(H))
+
+    def test_complete_graph(self):
+        """Tests that the Wiener index of the complete graph is simply
+        the number of edges.
+
+        """
+        n = 10
+        G = complete_graph(n)
+        eq_(wiener_index(G), n * (n - 1) / 2)
+
+    def test_path_graph(self):
+        """Tests that the Wiener index of the path graph is correctly
+        computed.
+
+        """
+        # In P_n, there are n - 1 pairs of vertices at distance one, n -
+        # 2 pairs at distance two, n - 3 at distance three, ..., 1 at
+        # distance n - 1, so the Wiener index should be
+        #
+        #     1 * (n - 1) + 2 * (n - 2) + ... + (n - 2) * 2 + (n - 1) * 1
+        #
+        # For example, in P_5,
+        #
+        #     1 * 4 + 2 * 3 + 3 * 2 + 4 * 1 = 2 (1 * 4 + 2 * 3)
+        #
+        # and in P_6,
+        #
+        #     1 * 5 + 2 * 4 + 3 * 3 + 4 * 2 + 5 * 1 = 2 (1 * 5 + 2 * 4) + 3 * 3
+        #
+        # assuming n is *odd*, this gives the formula
+        #
+        #     2 \sum_{i = 1}^{(n - 1) / 2} [i * (n - i)]
+        #
+        # assuming n is *even*, this gives the formula
+        #
+        #     2 \sum_{i = 1}^{n / 2} [i * (n - i)] - (n / 2) ** 2
+        #
+        n = 9
+        G = path_graph(n)
+        expected = 2 * sum(i * (n - i) for i in range(1, (n // 2) + 1))
+        actual = wiener_index(G)
+        eq_(expected, actual)

--- a/networkx/algorithms/vitality.py
+++ b/networkx/algorithms/vitality.py
@@ -1,84 +1,73 @@
-"""
-Vitality measures.
-"""
 #    Copyright (C) 2012 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-import networkx as nx
+"""
+Vitality measures.
+"""
+from .wiener import wiener_index
+
 __author__ = "\n".join(['Aric Hagberg (hagberg@lanl.gov)',
                         'Renato Fabbri'])
 __all__ = ['closeness_vitality']
 
-def weiner_index(G, weight=None):
-    # compute sum of distances between all node pairs
-    # (with optional weights)
-    weiner=0.0
-    if weight is None:
-        for n in G:
-            path_length=nx.single_source_shortest_path_length(G,n)
-            weiner+=sum(d for n, d in path_length)
-    else:
-        for n in G:
-            path_length = nx.single_source_dijkstra_path_length(G,
-                    n,weight=weight)
-            weiner += sum(d for n, d in path_length)
-    return weiner
 
+def closeness_vitality(G, node=None, weight=None):
+    """Returns the closeness vitality for nodes in the graph.
 
-def closeness_vitality(G, weight=None):
-    """Compute closeness vitality for nodes.
-
-    Closeness vitality of a node is the change in the sum of distances
-    between all node pairs when excluding that node.
+    The *closeness vitality* of a node, defined in Section 3.6.2 of [1],
+    is the change in the sum of distances between all node pairs when
+    excluding that node.
 
     Parameters
     ----------
-    G : graph
+    G : NetworkX graph
+        A strongly-connected graph.
 
-    weight : None or string (optional)
-       The name of the edge attribute used as weight. If None the edge
-       weights are ignored.
+    weight : string
+        The name of the edge attribute used as weight. This is passed
+        directly to the :func:`~networkx.wiener_index` function.
+
+    node : object
+        If specified, only the closeness vitality for this node will be
+        returned. Otherwise, a dictionary mappping each node to its
+        closeness vitality will be returned.
 
     Returns
     -------
-    nodes : dictionary
-       Dictionary with nodes as keys and closeness vitality as the value.
+    dictionary or float
+        If ``node`` is ``None``, this function returnes a dictionary
+        with nodes as keys and closeness vitality as the
+        value. Otherwise, it returns only the closeness vitality for the
+        specified ``node``.
+
+        The closeness vitality of a node may be negative infinity if
+        removing that node would disconnect the graph.
 
     Examples
     --------
-    >>> G=nx.cycle_graph(3)
+    >>> import networkx as nx
+    >>> G = nx.cycle_graph(3)
     >>> nx.closeness_vitality(G)
-    {0: 4.0, 1: 4.0, 2: 4.0}
+    {0: 2.0, 1: 2.0, 2: 2.0}
 
     See Also
     --------
-    closeness_centrality()
+    closeness_centrality
 
     References
     ----------
-    .. [1] Ulrik Brandes, Sec. 3.6.2 in
-       Network Analysis: Methodological Foundations, Springer, 2005.
-       http://books.google.com/books?id=TTNhSm7HYrIC
+    .. [1] Ulrik Brandes, Thomas Erlebach (eds.).
+           *Network Analysis: Methodological Foundations*.
+           Springer, 2005.
+           <http://books.google.com/books?id=TTNhSm7HYrIC>
+
     """
-    multigraph = G.is_multigraph()
-    wig = weiner_index(G,weight)
-    closeness_vitality = {}
-    for n in G:
-        # remove edges connected to node n and keep list of edges with data
-        # could remove node n but it doesn't count anyway
-        if multigraph:
-            edges = list(G.edges(n,data=True,keys=True))
-            if G.is_directed():
-                edges += list(G.in_edges(n,data=True,keys=True))
-        else:
-            edges = list(G.edges(n,data=True))
-            if G.is_directed():
-                edges += list(G.in_edges(n,data=True))
-        G.remove_edges_from(edges)
-        closeness_vitality[n] = wig - weiner_index(G,weight)
-        # add edges and data back to graph
-        G.add_edges_from(edges)
-    return closeness_vitality
+    if node is not None:
+        before = wiener_index(G, weight=weight)
+        after = wiener_index(G.subgraph(set(G) - {node}), weight=weight)
+        return before - after
+    # TODO This can be trivially parallelized.
+    return {v: closeness_vitality(G, node=v, weight=weight) for v in G}

--- a/networkx/algorithms/wiener.py
+++ b/networkx/algorithms/wiener.py
@@ -1,0 +1,86 @@
+# wiener.py - functions related to the Wiener index of a graph
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions related to the Wiener index of a graph."""
+from __future__ import division
+
+from itertools import chain
+
+from .components import is_connected
+from .components import is_strongly_connected
+from .shortest_paths import shortest_path_length as spl
+
+__all__ = ['wiener_index']
+
+#: Rename the :func:`chain.from_iterable` function for the sake of
+#: brevity.
+chaini = chain.from_iterable
+
+
+def wiener_index(G, weight=None):
+    """Returns the Wiener index of the given graph.
+
+    The *Wiener index* of a graph is the sum of the shortest-path
+    distances between each pair of reachable nodes. For pairs of nodes
+    in undirected graphs, only one orientation of the pair is counted.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    weight : object
+        The edge attribute to use as distance when computing
+        shortest-path distances. This is passed directly to the
+        :func:`networkx.shortest_path_length` function.
+
+    Returns
+    -------
+    float
+        The Wiener index of the graph ``G``.
+
+    Raises
+    ------
+    NetworkXError
+        If the graph ``G`` is not connected.
+
+    Notes
+    -----
+    If a pair of nodes is not reachable, the distance is assumed to be
+    infinity. This means that for graphs that are not
+    strongly-connected, this function returns ``inf``.
+
+    The Wiener index is not usually defined for directed graphs, however
+    this function uses the natural generalization of the Wiener index to
+    directed graphs.
+
+    Examples
+    --------
+    The Wiener index of the (unweighted) complete graph on *n* nodes
+    equals the number of pairs of the *n* nodes, since each pair of
+    nodes is at distance one::
+
+        >>> import networkx as nx
+        >>> n = 10
+        >>> G = nx.complete_graph(n)
+        >>> nx.wiener_index(G) == n * (n - 1) / 2
+        True
+
+    Graphs that are not strongly-connected have infinite Wiener index::
+
+        >>> G = nx.empty_graph(2)
+        >>> nx.wiener_index(G)
+        inf
+
+    """
+    is_directed = G.is_directed()
+    if (is_directed and not is_strongly_connected(G)) or \
+            (not is_directed and not is_connected(G)):
+        return float('inf')
+    total = sum(chaini(p.values() for v, p in spl(G, weight=weight)))
+    # Need to account for double counting pairs of nodes in undirected graphs.
+    return total if is_directed else total / 2


### PR DESCRIPTION
Previously, the closeness vitality function was using an incorrect
definition of the Wiener index, counting each orientation of a pair of
nodes in an undirected graph twice. This commit corrects the behavior of
the Wiener index function and therefore the closeness vitality function.

Correcting the Wiener index function also corrects another case for the
closeness vitality function: when removing a node causes a graph to
become disconnected. By definition, the closeness vitality of a node
whose removal causes the graph to become disconnected should be negative
infinity. This commit fixes the Wiener index function to return positive
infinity on a disconnected graph.

Furthermore, this commit improves the closeness vitality function so
that it does not mutate the graph in order to compute the vitality
value.

Finally, this places the Wiener index function in its own module,
documents it, and makes it available to the end user.