### PR TITLE
Moves triad_graph function to generators package.

### DIFF
--- a/doc/source/reference/generators.rst
+++ b/doc/source/reference/generators.rst
@@ -228,3 +228,12 @@ Non Isomorphic Trees
 
    nonisomorphic_trees
    number_of_nonisomorphic_trees
+
+
+Triads
+------
+.. automodule:: networkx.generators.triads
+.. autosummary::
+   :toctree: generated/
+
+   triad_graph

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -12,16 +12,12 @@
 """Functions for analyzing triads of a graph."""
 from __future__ import division
 
-import networkx as nx
+from networkx.utils import not_implemented_for
 
 __author__ = '\n'.join(['Alex Levenson (alex@isnontinvain.com)',
                         'Diederik van Liere (diederik.vanliere@rotman.utoronto.ca)'])
 
 __all__ = ['triadic_census']
-
-#: The names of each type of triad.
-TRIAD_NAMES = ('003', '012', '102', '021D', '021U', '021C', '111D', '111U',
-               '030T', '030C', '201', '120D', '120U', '120C', '210', '300')
 
 #: The integer codes representing each type of triad.
 #:
@@ -31,42 +27,14 @@ TRICODES = (1, 2, 2, 3, 2, 4, 6, 8, 2, 6, 5, 7, 3, 8, 7, 11, 2, 6, 4, 8, 5, 9,
             9, 12, 8, 13, 14, 15, 3, 7, 8, 11, 7, 12, 14, 15, 8, 14, 13, 15,
             11, 15, 15, 16)
 
+#: The names of each type of triad. The order of the elements is
+#: important: it corresponds to the tricodes given in :data:`TRICODES`.
+TRIAD_NAMES = ('003', '012', '102', '021D', '021U', '021C', '111D', '111U',
+               '030T', '030C', '201', '120D', '120U', '120C', '210', '300')
+
+
 #: A dictionary mapping triad code to triad name.
 TRICODE_TO_NAME = {i: TRIAD_NAMES[code - 1] for i, code in enumerate(TRICODES)}
-
-
-def triad_graphs():
-    """Returns a dictionary mapping triad name to triad graph."""
-
-    def abc_graph():
-        """Returns a directed graph on three nodes, named ``'a'``, ``'b'``, and
-        ``'c'``.
-
-        """
-        G = nx.DiGraph()
-        G.add_nodes_from('abc')
-        return G
-
-    tg = {name: abc_graph() for name in TRIAD_NAMES}
-    tg['012'].add_edges_from([('a', 'b')])
-    tg['102'].add_edges_from([('a', 'b'), ('b', 'a')])
-    tg['102'].add_edges_from([('a', 'b'), ('b', 'a')])
-    tg['021D'].add_edges_from([('b', 'a'), ('b', 'c')])
-    tg['021U'].add_edges_from([('a', 'b'), ('c', 'b')])
-    tg['021C'].add_edges_from([('a', 'b'), ('b', 'c')])
-    tg['111D'].add_edges_from([('a', 'c'), ('c', 'a'), ('b', 'c')])
-    tg['111U'].add_edges_from([('a', 'c'), ('c', 'a'), ('c', 'b')])
-    tg['030T'].add_edges_from([('a', 'b'), ('c', 'b'), ('a', 'c')])
-    tg['030C'].add_edges_from([('b', 'a'), ('c', 'b'), ('a', 'c')])
-    tg['201'].add_edges_from([('a', 'b'), ('b', 'a'), ('a', 'c'), ('c', 'a')])
-    tg['120D'].add_edges_from([('b', 'c'), ('b', 'a'), ('a', 'c'), ('c', 'a')])
-    tg['120C'].add_edges_from([('a', 'b'), ('b', 'c'), ('a', 'c'), ('c', 'a')])
-    tg['120U'].add_edges_from([('a', 'b'), ('c', 'b'), ('a', 'c'), ('c', 'a')])
-    tg['210'].add_edges_from([('a', 'b'), ('b', 'c'), ('c', 'b'), ('a', 'c'),
-                              ('c', 'a')])
-    tg['300'].add_edges_from([('a', 'b'), ('b', 'a'), ('b', 'c'), ('c', 'b'),
-                              ('a', 'c'), ('c', 'a')])
-    return tg
 
 
 def _tricode(G, v, u, w):
@@ -82,6 +50,7 @@ def _tricode(G, v, u, w):
     return sum(x for u, v, x in combos if v in G[u])
 
 
+@not_implemented_for('undirected')
 def triadic_census(G):
     """Determines the triadic census of a directed graph.
 
@@ -103,6 +72,10 @@ def triadic_census(G):
     This algorithm has complexity `O(m)` where `m` is the number of edges in
     the graph.
 
+    See also
+    --------
+    triad_graph
+
     References
     ----------
     .. [1] Vladimir Batagelj and Andrej Mrvar, A subquadratic triad census
@@ -111,9 +84,6 @@ def triadic_census(G):
         http://vlado.fmf.uni-lj.si/pub/networks/doc/triads/triads.pdf
 
     """
-    if not G.is_directed():
-        raise nx.NetworkXError('Not defined for undirected graphs.')
-
     # Initialize the count for each triad to be zero.
     census = {name: 0 for name in TRIAD_NAMES}
     n = len(G)

--- a/networkx/generators/__init__.py
+++ b/networkx/generators/__init__.py
@@ -3,17 +3,18 @@ A package for generating various graphs in networkx.
 
 """
 from networkx.generators.classic import *
+from networkx.generators.community import *
 from networkx.generators.degree_seq import *
 from networkx.generators.directed import *
 from networkx.generators.ego import *
 from networkx.generators.expanders import *
 from networkx.generators.geometric import *
+from networkx.generators.intersection import *
 from networkx.generators.line import *
+from networkx.generators.nonisomorphic_trees import *
+from networkx.generators.random_clustered import *
 from networkx.generators.random_graphs import *
 from networkx.generators.small import *
-from networkx.generators.stochastic import *
 from networkx.generators.social import *
-from networkx.generators.intersection import *
-from networkx.generators.random_clustered import *
-from networkx.generators.community import *
-from networkx.generators.nonisomorphic_trees import *
+from networkx.generators.stochastic import *
+from networkx.generators.triads import *

--- a/networkx/generators/tests/test_triads.py
+++ b/networkx/generators/tests/test_triads.py
@@ -1,0 +1,21 @@
+# test_triads.py - unit tests for the triads module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.generators.triads` module."""
+from nose.tools import assert_equal
+from nose.tools import raises
+
+from networkx import triad_graph
+
+def test_triad_graph():
+    G = triad_graph('030T')
+    assert_equal([tuple(e) for e in ('ab', 'ac', 'cb')], sorted(G.edges()))
+
+@raises(ValueError)
+def test_invalid_name():
+    triad_graph('bogus')

--- a/networkx/generators/triads.py
+++ b/networkx/generators/triads.py
@@ -1,0 +1,81 @@
+# triads.py - generators for triad graphs
+#
+# Copyright 2015 NetworkX developers.
+# Copyright 2011 Reya Group <http://www.reyagroup.com>
+# Copyright 2011 Alex Levenson <alex@isnotinvain.com>
+# Copyright 2011 Diederik van Liere <diederik.vanliere@rotman.utoronto.ca>
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions that generate the triad graphs, that is, the possible
+digraphs on three nodes.
+
+"""
+from networkx.classes import DiGraph
+
+__all__ = ['triad_graph']
+
+#: Dictionary mapping triad name to list of directed edges in the
+#: digraph representation of that triad (with nodes ``'a'``, ``'b'``,
+#: and ``'c'``).
+TRIAD_EDGES = {'003': [],
+               '012': ['ab'],
+               '102': ['ab', 'ba'],
+               '021D': ['ba', 'bc'],
+               '021U': ['ab', 'cb'],
+               '021C': ['ab', 'bc'],
+               '111D': ['ac', 'ca', 'bc'],
+               '111U': ['ac', 'ca', 'cb'],
+               '030T': ['ab', 'cb', 'ac'],
+               '030C': ['ba', 'cb', 'ac'],
+               '201': ['ab', 'ba', 'ac', 'ca'],
+               '120D': ['bc', 'ba', 'ac', 'ca'],
+               '120U': ['ab', 'cb', 'ac', 'ca'],
+               '120C': ['ab', 'bc', 'ac', 'ca'],
+               '210': ['ab', 'bc', 'cb', 'ac', 'ca'],
+               '300': ['ab', 'ba', 'bc', 'cb', 'ac', 'ca']
+               }
+
+
+def triad_graph(triad_name):
+    """Returns the triad graph with the given name.
+
+    Each string in the following tuple is a valid triad name::
+
+        ('003', '012', '102', '021D', '021U', '021C', '111D', '111U',
+         '030T', '030C', '201', '120D', '120U', '120C', '210', '300')
+
+    Each triad name corresponds to one of the possible valid digraph on
+    three nodes.
+
+    Parameters
+    ----------
+    triad_name : string
+        The name of a triad, as described above.
+
+    Returns
+    -------
+    :class:`~networkx.DiGraph`
+        The digraph on three nodes with the given name. The nodes of the
+        graph are the single-character strings ``'a'``, ``'b'``, and
+        ``'c'``.
+
+    Raises
+    ------
+    :exc:`ValueError`
+        If ``triad_name`` is not the name of a triad.
+
+    See also
+    --------
+    triadic_census
+
+    """
+    if triad_name not in TRIAD_EDGES:
+        raise ValueError('unknown triad name "{}"; use one of the triad names'
+                         ' in the TRIAD_NAMES constant'.format(triad_name))
+    G = DiGraph()
+    G.add_nodes_from('abc')
+    G.add_edges_from(TRIAD_EDGES[triad_name])
+    return G


### PR DESCRIPTION
Previously, the `triad_graphs` function in the
`networkx.algorithms.triads` module, returned a dictionary containing a
graph representing each possible triad. This commit moves that function
to a new module, `networkx.generators.triads`, and adds previously
missing test code for that function. It also modifies the function to
return a single graph instead of a dictionary of graphs. The dictionary
can now be generated by the code

    from networkx.algorithms.triads import TRIAD_NAMES
    triad_graphs = {name: triad_graph(name) for name in TRIAD_NAMES}

This commit should improve test coverage.