### PR TITLE
fix comparison error in categorical_node|edge_match.

### DIFF
--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -99,8 +99,8 @@ def categorical_node_match(attr, default):
     else:
         attrs = list(zip(attr, default)) # Python 3
         def match(data1, data2):
-            values1 = set([data1.get(attr, d) for attr, d in attrs])
-            values2 = set([data2.get(attr, d) for attr, d in attrs])
+            values1 = [data1.get(attr, d) for attr, d in attrs]
+            values2 = [data2.get(attr, d) for attr, d in attrs]
             return values1 == values2
     return match
 

--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -98,10 +98,9 @@ def categorical_node_match(attr, default):
             return data1.get(attr, default) == data2.get(attr, default)
     else:
         attrs = list(zip(attr, default)) # Python 3
+
         def match(data1, data2):
-            values1 = [data1.get(attr, d) for attr, d in attrs]
-            values2 = [data2.get(attr, d) for attr, d in attrs]
-            return values1 == values2
+            return all(data1.get(attr, d) == data2.get(attr, d) for attr, d in attrs)
     return match
 
 try:

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -1,0 +1,8 @@
+from nose.tools import assert_true
+from networkx.algorithms import isomorphism as iso
+
+
+def test_categorical_node_match():
+    nm = iso.categorical_node_match(['x', 'y', 'z'], [None]*3)
+    assert_true(nm(dict(x=1, y=2, z=3), dict(x=1, y=2, z=3)))
+    assert_true(not nm(dict(x=1, y=2, z=2), dict(x=1, y=2, z=1)))


### PR DESCRIPTION
a and b - nodes
they has attr: x, y, z

if a attr = {x:1, y: 1, z: 2}
and b attr = {x:1, y: 2, z: 2}
match return True. It's wrong.