### PR TITLE
add support for python 3.5 and remove 3.2 in .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 *~
 .DS_Store
 build/*
+dist/
 networkx/version.py
 examples/*/*.png
 doc/source/networkx-documentation.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ language: python
 
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 cache:
   directories:


### PR DESCRIPTION
python 3.5 is now released and the package can be tested on it.
support for 3.2 is removed as per discussion in #1775.