### PR TITLE
Fix, now raise NetworkXError instead of TypeError

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1768,7 +1768,7 @@ class Graph(object):
                     # capture error for unhashable node.
                     elif 'hashable' in message:
                         raise NetworkXError(
-                            "Node %s in the sequence nbunch is not a valid node."%n)
+                            "Node {} in the sequence nbunch is not a valid node.".format(n))
                     else:
                         raise
             bunch = bunch_iter(nbunch, self.adj)


### PR DESCRIPTION
Instead of :

```
'dict' objects are unhashableTraceback (most recent call last):
  File "<builtin>/app_main.py", line 75, in run_toplevel
  File "mk_graph_file.py", line 34, in <module>
    if d['weight'] > 3])
  File "/usr/local/lib/pypy2.7/dist-packages/networkx/classes/graph.py", line 1488, in subgraph
    for n in bunch:
  File "/usr/local/lib/pypy2.7/dist-packages/networkx/classes/graph.py", line 1815, in bunch_iter
    "Node %s in the sequence nbunch is not a valid node."%n)
TypeError: not all arguments converted during string formatting
```

You get:

```
'dict' objects are unhashableTraceback (most recent call last):
  File "<builtin>/app_main.py", line 75, in run_toplevel
  File "mk_graph_file.py", line 34, in <module>
    if d['weight'] > 3])
  File "/usr/local/lib/pypy2.7/dist-packages/networkx/classes/graph.py", line 1488, in subgraph
    for n in bunch:
  File "/usr/local/lib/pypy2.7/dist-packages/networkx/classes/graph.py", line 1815, in bunch_iter
    "Node {} in the sequence nbunch is not a valid node.".format(n))
NetworkXError: Node ('java', 'performance', {'weight': 5}) in the sequence nbunch is not a valid node.
```