### PR TITLE
Use sphinx stable branch via github on ReadTheDocs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,6 @@ numpy >= 1.6
 matplotlib
 pandas
 pydotplus
-sphinx >= 1.3
+-e git://github.com/sphinx-doc/sphinx.git@stable#egg=Sphinx-origin_stable
 sphinxcontrib-bibtex
 sphinx_rtd_theme


### PR DESCRIPTION
The stable branch of sphinx has the one-line fix for autosummary.
So even though the release on pypi doesn't have it, we can get it from github.
Fixes #1796 without creating our own fork of sphinx.

When sphinx 1.4 comes out we can switch back to using the pypi version.