### PR TITLE
Clarifies error message in configuration_model

### DIFF
--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -107,8 +107,9 @@ def configuration_model(deg_sequence,create_using=None,seed=None):
 
     >>> G.remove_edges_from(G.selfloop_edges())
     """
-    if not sum(deg_sequence)%2 ==0:
-        raise nx.NetworkXError('Invalid degree sequence')
+    if sum(deg_sequence) % 2 != 0:
+        msg = 'Invalid degree sequence: sum of degrees must be even, not odd'
+        raise nx.NetworkXError(msg)
 
     if create_using is None:
         create_using = nx.MultiGraph()


### PR DESCRIPTION
Changes the error message when a degree sequence with an odd sum is
provided to the `configuration_model` function so that it indicates that
the user must provide a degree sequence with an even sum.

This fixes issue #1800.