### PR TITLE
removed requirement of lib2to3

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -135,7 +135,7 @@ def literal_destringizer(rep):
             rep=rtp_fix_unicode(rep)
         try:
             return literal_eval(rep)
-        except ValueError:
+        except (SyntaxError):
             raise ValueError('%r is not a valid Python literal' % (orig_rep,))
     else:
         raise ValueError('%r is not a string' % (rep,))

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -68,8 +68,7 @@ try:
     literal_eval(r"u'\u4444'")
 except SyntaxError:
     # Remove 'u' prefixes in unicode literals in Python 3
-    rtp_fix_unicode = RefactoringTool(['lib2to3.fixes.fix_unicode'],
-                                      {'print_function': True})
+    rtp_fix_unicode = lambda s:s[1:]
 else:
     rtp_fix_unicode = None
 
@@ -131,14 +130,12 @@ def literal_destringizer(rep):
         If ``rep`` is not a Python literal.
     """
     if isinstance(rep, (str, unicode)):
-        orig_rep = rep
+        orig_rep=rep
+        if rtp_fix_unicode:
+            rep=rtp_fix_unicode(rep)
         try:
-            # Python 3.2 does not recognize 'u' prefixes before string literals
-            if rtp_fix_unicode:
-                rep = str(rtp_fix_unicode.refactor_string(
-                    rep + '\n', '<string>'))[:-1]
             return literal_eval(rep)
-        except (ParseError, SyntaxError, TokenError):
+        except ValueError:
             raise ValueError('%r is not a valid Python literal' % (orig_rep,))
     else:
         raise ValueError('%r is not a string' % (rep,))

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -41,9 +41,6 @@ except ImportError:
     from io import StringIO
 from ast import literal_eval
 from collections import defaultdict
-from lib2to3.pgen2.parse import ParseError
-from lib2to3.pgen2.tokenize import TokenError
-from lib2to3.refactor import RefactoringTool
 import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils import open_file


### PR DESCRIPTION
gml.py doesn't use lib2to3 anymore, 
so lib2to3 isn't required anymore in networkx
so programs using networkx can be "compiled" using py2exe

see https://github.com/networkx/networkx/issues/1775