### PR TITLE
Adds number_of_isolates function and updates docs.

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -173,7 +173,7 @@ class TestEdgelist:
         bipartite.write_edgelist(G,fname)  
         H=bipartite.read_edgelist(fname,nodetype=int)
         # isolated nodes are not written in edgelist
-        G.remove_nodes_from(nx.isolates(G))
+        G.remove_nodes_from(list(nx.isolates(G)))
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)

--- a/networkx/algorithms/isolate.py
+++ b/networkx/algorithms/isolate.py
@@ -1,33 +1,41 @@
-# encoding: utf-8
-"""
-Functions for identifying isolate (degree zero) nodes.
-"""
-#    Copyright (C) 2004-2015 by 
+# -*- encoding: utf-8 -*-
+#    Copyright 2015 NetworkX developers.
+#    Copyright (C) 2004-2015 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+"""
+Functions for identifying isolate (degree zero) nodes.
+"""
 import networkx as nx
+
 __author__ = """\n""".join(['Drew Conway <drew.conway@nyu.edu>',
                             'Aric Hagberg <hagberg@lanl.gov>'])
-__all__=['is_isolate','isolates']
 
-def is_isolate(G,n):
-    """Determine of node n is an isolate (degree zero).  
+__all__ = ['is_isolate', 'isolates', 'number_of_isolates']
+
+
+def is_isolate(G, n):
+    """Determines whether a node is an isolate.
+
+    An *isolate* is a node with no neighbors (that is, with degree
+    zero). For directed graphs, this means no in-neighbors and no
+    out-neighbors.
 
     Parameters
     ----------
-    G : graph
-        A networkx graph
+    G : NetworkX graph
+
     n : node
-        A node in G
+        A node in ``G``.
 
     Returns
     -------
-    isolate : bool
-       True if n has no neighbors, False otherwise.
-    
+    is_isolate : bool
+       ``True`` if and only if ``n`` has no neighbors.
+
     Examples
     --------
     >>> G=nx.Graph()
@@ -38,40 +46,70 @@ def is_isolate(G,n):
     >>> nx.is_isolate(G,3)
     True
     """
-    return G.degree(n)==0 
+    return G.degree(n) == 0
+
 
 def isolates(G):
-    """Return list of isolates in the graph.
+    """Iterator over isolates in the graph.
 
-    Isolates are nodes with no neighbors (degree zero).
+    An *isolate* is a node with no neighbors (that is, with degree
+    zero). For directed graphs, this means no in-neighbors and no
+    out-neighbors.
 
     Parameters
     ----------
-    G : graph
-        A networkx graph
+    G : NetworkX graph
 
     Returns
     -------
-    isolates : list
-       List of isolate nodes.
-    
+    iterator
+        An iterator over the isolates of ``G``.
+
     Examples
     --------
-    >>> G = nx.Graph()
-    >>> G.add_edge(1,2)
-    >>> G.add_node(3)
-    >>> nx.isolates(G)
-    [3]
+    To get a list of all isolates of a graph, use the :class:`list`
+    constructor::
 
-    To remove all isolates in the graph use
-    >>> G.remove_nodes_from(nx.isolates(G))
-    >>> list(G)
-    [1, 2]
+        >>> G = nx.Graph()
+        >>> G.add_edge(1, 2)
+        >>> G.add_node(3)
+        >>> list(nx.isolates(G))
+        [3]
 
-    For digraphs isolates have zero in-degree and zero out_degre
-    >>> G = nx.DiGraph([(0,1),(1,2)])
-    >>> G.add_node(3)
-    >>> nx.isolates(G)
-    [3]
+    To remove all isolates in the graph, first create a list of the
+    isolates, then use :meth:`Graph.remove_nodes_from`::
+
+        >>> G.remove_nodes_from(list(nx.isolates(G)))
+        >>> list(G)
+        [1, 2]
+
+    For digraphs, isolates have zero in-degree and zero out_degre::
+
+        >>> G = nx.DiGraph([(0, 1), (1, 2)])
+        >>> G.add_node(3)
+        >>> list(nx.isolates(G))
+        [3]
+
     """
-    return [n for (n,d) in G.degree() if d==0]
+    return (n for n, d in G.degree() if d == 0)
+
+
+def number_of_isolates(G):
+    """Returns the number of isolates in the graph.
+
+    An *isolate* is a node with no neighbors (that is, with degree
+    zero). For directed graphs, this means no in-neighbors and no
+    out-neighbors.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    Returns
+    -------
+    int
+        The number of degree zero nodes in the graph ``G``.
+
+    """
+    # TODO This can be parallelized.
+    return sum(1 for v in isolates(G))

--- a/networkx/algorithms/tests/test_isolate.py
+++ b/networkx/algorithms/tests/test_isolate.py
@@ -1,0 +1,37 @@
+# test_isolate.py - unit tests for the isolate module
+#
+# Copyright 2015 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.isolates` module."""
+from nose.tools import assert_equal
+from nose.tools import assert_false
+from nose.tools import assert_true
+
+import networkx as nx
+
+
+def test_is_isolate():
+    G = nx.Graph()
+    G.add_edge(0, 1)
+    G.add_node(2)
+    assert_false(nx.is_isolate(G, 0))
+    assert_false(nx.is_isolate(G, 1))
+    assert_true(nx.is_isolate(G, 2))
+
+
+def test_isolates():
+    G = nx.Graph()
+    G.add_edge(0, 1)
+    G.add_nodes_from([2, 3])
+    assert_equal(sorted(nx.isolates(G)), [2, 3])
+
+
+def test_number_of_isolates():
+    G = nx.Graph()
+    G.add_edge(0, 1)
+    G.add_nodes_from([2, 3])
+    assert_equal(nx.number_of_isolates(G), 2)

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -181,7 +181,7 @@ class TestEdgelist:
         nx.write_edgelist(G,fname)  
         H=nx.read_edgelist(fname,nodetype=int)
         # isolated nodes are not written in edgelist
-        G.remove_nodes_from(nx.isolates(G))
+        G.remove_nodes_from(list(nx.isolates(G)))
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)


### PR DESCRIPTION
This commit makes several changes to the `networkx.algorithms.isolate`
module. It

- updates and clarifies docstrings,
- makes PEP8 fixes,
- changes `isolates()` to return an iterator instead of a list,
- adds a `number_of_isolates()` function,
- adds a new unit test module, `test_isolate.py`.

With this new `number_of_isolates()` function, pull request #1831 could be simplified.