### PR TITLE
Allows copying a graph without attribute data.

### DIFF
--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -81,7 +81,7 @@ def clique_removal(G):
         Approximating maximum independent sets by excluding subgraphs.
         BIT Numerical Mathematics, 32(2), 180–196. Springer.
     """
-    graph = G.copy()
+    graph = G.copy(with_data=False)
     c_i, i_i = ramsey.ramsey_R2(graph)
     cliques = [c_i]
     isets = [i_i]

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -62,7 +62,7 @@ def strategy_smallest_last(G, colors):
     built is returned.
     """
     len_g = len(G)
-    available_g = G.copy()
+    available_g = G.copy(with_data=False)
     nodes = [None] * len_g
 
     for i in range(len_g):
@@ -84,7 +84,7 @@ def strategy_independent_set(G, colors):
     no_colored = 0
     k = 0
 
-    uncolored_g = G.copy()
+    uncolored_g = G.copy(with_data=False)
     while no_colored < len_g:  # While there are uncolored nodes
         available_g = uncolored_g.copy()
 

--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -33,6 +33,7 @@ def girvan_newman(G, weight=None):
     the tightly knit community structure is exposed and result can be depicted
     as a dendrogram.
     """
+    # The copy of G here must include the edge weight data.
     g = G.copy().to_undirected()
     components = []
     while g.number_of_edges() > 0:

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -175,7 +175,7 @@ def _is_separating_set(G, cut):
     if len(cut) == len(G) - 1:
         return True
 
-    H = G.copy()
+    H = G.copy(with_data=False)
     H.remove_nodes_from(cut)
     if nx.is_connected(H):
         return False

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -69,7 +69,7 @@ def rich_club_coefficient(G, normalized=True, Q=100):
     if normalized:
         # make R a copy of G, randomize with Q*|E| double edge swaps
         # and use rich_club coefficient of R to normalize
-        R = G.copy()
+        R = G.copy(with_data=False)
         E = R.number_of_edges()
         nx.double_edge_swap(R,Q*E,max_tries=Q*E*10)
         rcran=_compute_rc(R)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1273,8 +1273,16 @@ class Graph(object):
         self.node.clear()
         self.graph.clear()
 
-    def copy(self):
+    def copy(self, with_data=True):
         """Return a copy of the graph.
+
+        Parameters
+        ----------
+        with_data : bool
+            If ``True``, the returned graph will have a deep copy of the
+            graph, node, and edge attributes of this object. Otherwise,
+            the returned graph will only have a copy of the nodes and
+            edges of this object.
 
         Returns
         -------
@@ -1285,11 +1293,6 @@ class Graph(object):
         --------
         to_directed: return a directed copy of the graph.
 
-        Notes
-        -----
-        This makes a complete copy of the graph including all of the
-        node or edge attributes.
-
         Examples
         --------
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
@@ -1297,7 +1300,12 @@ class Graph(object):
         >>> H = G.copy()
 
         """
-        return deepcopy(self)
+        if with_data:
+            return deepcopy(self)
+        G = nx.Graph()
+        G.add_nodes_from(self)
+        G.add_edges_from(self.edges())
+        return G
 
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -210,6 +210,17 @@ class BaseAttrGraphTester(BaseGraphTester):
         H=G.__class__(G)
         self.is_shallow_copy(H,G)
 
+    def test_copy_without_data(self):
+        """Tests for creating a copy of the graph without any of the
+        graph, node, or edge data attributes.
+
+        """
+        G = self.K3.copy(with_data=False)
+        nodes = set(self.K3)
+        assert_equal(G.graph, {})
+        assert_equal(G.node, {v: {} for v in nodes})
+        assert_equal(G.edge, {u: {v: {} for v in nodes - {u}} for u in nodes})
+
     def test_copy_attr(self):
         G=self.Graph(foo=[])
         G.add_node(0,foo=[])


### PR DESCRIPTION
Adds the `with_data` keyword argument to the `Graph.copy()` method,
which specifies whether the graph, node, and edge data will be included
in the copy of the graph object.

This commit also updates algorithms that include a call to
`Graph.copy()` to use `with_data=False` if they really do not need a
copy of the data.

This should theoretically allow both our algorithms and user algorithms to save some memory when copies of large graphs are made.