### PR TITLE
Fix layout for single node graphs and shells

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -176,13 +176,13 @@ def shell_layout(G, nlist=None, dim=2, scale=1, center=None):
 
     if len(G) == 0:
         return {}
-    elif len(G) == 1:
-        return {G.nodes()[0]: center}
+    if len(G) == 1:
+        return {nx.utils.arbitrary_element(G): center}
 
 
     if nlist is None:
         # draw the whole graph in one shell
-        nlist = [list(G.nodes())]
+        nlist = [list(G)]
 
     if len(nlist[0]) == 1:
         # single node at center
@@ -587,8 +587,9 @@ def _rescale_layout(pos,scale=1):
         pos[:,i]-=pos[:,i].mean()
         lim=max(pos[:,i].max(),lim)
     # rescale to (-scale,scale) in all directions, preserves aspect
-    for i in range(pos.shape[1]):
-        pos[:,i]*=scale/lim
+    if lim > 0:
+        for i in range(pos.shape[1]):
+            pos[:,i]*=scale/lim
     return pos
 
 

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -59,3 +59,11 @@ class TestLayout(object):
 
         pos=nx.drawing.layout._sparse_fruchterman_reingold(A,dim=3)
         assert_equal(pos.shape,(6,3))
+
+    def test_single_nodes(self):
+        G=nx.path_graph(1)
+        vpos = nx.shell_layout(G)
+        assert(vpos[0].any() == False)
+        G=nx.path_graph(3)
+        vpos = nx.shell_layout(G, [[0], [1,2]])
+        assert(vpos[0].any() == False)


### PR DESCRIPTION
_rescale_layout was dividing by zero for single shells.
Add tests.