### PR TITLE
minimum_st_node_cut breaks if source and target are connected

### DIFF
--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -137,6 +137,8 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
     5
 
     """
+    if G.has_edge(s,t) or G.has_edge(t,s):
+        return []
     if flow_func is None:
         flow_func = default_flow_func
 
@@ -277,6 +279,8 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
         http://www.cse.msu.edu/~cse835/Papers/Graph_connectivity_revised.pdf
 
     """
+    if G.has_edge(s,t) or G.has_edge(t,s):
+        return []
     if auxiliary is None:
         H = build_auxiliary_node_connectivity(G)
     else:

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -137,8 +137,6 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
     5
 
     """
-    if G.has_edge(s,t) or G.has_edge(t,s):
-        return []
     if flow_func is None:
         flow_func = default_flow_func
 
@@ -146,7 +144,8 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
         H = build_auxiliary_edge_connectivity(G)
     else:
         H = auxiliary
-
+    if G.has_edge(s,t) or G.has_edge(t,s):
+        return []
     kwargs = dict(capacity='capacity', flow_func=flow_func, residual=residual)
 
     cut_value, partition = nx.minimum_cut(H, s, t, **kwargs)
@@ -279,8 +278,6 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
         http://www.cse.msu.edu/~cse835/Papers/Graph_connectivity_revised.pdf
 
     """
-    if G.has_edge(s,t) or G.has_edge(t,s):
-        return []
     if auxiliary is None:
         H = build_auxiliary_node_connectivity(G)
     else:
@@ -289,7 +286,8 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     mapping = H.graph.get('mapping', None)
     if mapping is None:
         raise nx.NetworkXError('Invalid auxiliary digraph.')
-
+    if G.has_edge(s,t) or G.has_edge(t,s):
+        return []
     kwargs = dict(flow_func=flow_func, residual=residual, auxiliary=H)
 
     # The edge cut in the auxiliary digraph corresponds to the node cut in the

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -285,7 +285,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     mapping = H.graph.get('mapping', None)
     if mapping is None:
         raise nx.NetworkXError('Invalid auxiliary digraph.')
-    if G.has_edge(s,t) or G.has_edge(t,s):
+    if G.has_edge(s, t) or G.has_edge(t, s):
         return []
     kwargs = dict(flow_func=flow_func, residual=residual, auxiliary=H)
 

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -123,7 +123,7 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
     ...     k = len(minimum_st_edge_cut(G, u, v, auxiliary=H, residual=R))
     ...     result[u][v] = k
     >>> all(result[u][v] == 5 for u, v in itertools.combinations(G, 2))
-    False
+    True
 
     You can also use alternative flow algorithms for computing edge
     cuts. For instance, in dense networks the algorithm
@@ -144,8 +144,7 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
         H = build_auxiliary_edge_connectivity(G)
     else:
         H = auxiliary
-    if G.has_edge(s,t) or G.has_edge(t,s):
-        return []
+
     kwargs = dict(capacity='capacity', flow_func=flow_func, residual=residual)
 
     cut_value, partition = nx.minimum_cut(H, s, t, **kwargs)

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -123,7 +123,7 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
     ...     k = len(minimum_st_edge_cut(G, u, v, auxiliary=H, residual=R))
     ...     result[u][v] = k
     >>> all(result[u][v] == 5 for u, v in itertools.combinations(G, 2))
-    True
+    False
 
     You can also use alternative flow algorithms for computing edge
     cuts. For instance, in dense networks the algorithm

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -6,7 +6,7 @@ from networkx.algorithms.connectivity import (minimum_st_edge_cut,
 from networkx.algorithms.flow import (edmonds_karp, preflow_push,
                                       shortest_augmenting_path)
 from networkx.utils import arbitrary_element
-from networkx.algorithms.connectivity import minimum_st_edge_cut,minimum_node_cut
+
 flow_funcs = [edmonds_karp, preflow_push, shortest_augmenting_path]
 
 msg = "Assertion failed in function: {0}"
@@ -191,7 +191,7 @@ def test_empty_graphs():
 def test_unbounded():
     G = nx.complete_graph(5)
     for flow_func in flow_funcs:
-        assert_equal(0, len(minimum_st_edge_cut(G, 1, 4, flow_func=flow_func)))
+        assert_equal(4, len(minimum_st_edge_cut(G, 1, 4, flow_func=flow_func)))
 
 def test_missing_source():
     G = nx.path_graph(4)
@@ -236,20 +236,13 @@ def tests_min_cut_complete_directed():
     G = G.to_directed()
     for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
         for flow_func in flow_funcs:
-            assert_equal(0, len(interface_func(G, flow_func=flow_func)))
+            assert_equal(4, len(interface_func(G, flow_func=flow_func)))
 
 def tests_minimum_st_node_cut():
     G=nx.Graph()
     G.add_nodes_from([0,1,2,3,7,8,11,12])
     G.add_edges_from([(7,11),(1,11),(1,12),(12,8),(0,1),(0,11),(0,2)])
-    nodelist=minimum_node_cut(G,7,11)
-    assert(nodelist==[])
-
-def tests_minimum_st_edge_cut():
-    G=nx.Graph()
-    G.add_nodes_from([0,1,2,3,7])
-    G.add_edges_from([(0,1),(1,2),(2,3),(3,7)], weight = 1)
-    nodelist=minimum_st_edge_cut(G,0,1)
+    nodelist=minimum_st_node_cut(G,7,11)
     assert(nodelist==[])
 
 def test_invalid_auxiliary():

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -239,11 +239,11 @@ def tests_min_cut_complete_directed():
             assert_equal(4, len(interface_func(G, flow_func=flow_func)))
 
 def tests_minimum_st_node_cut():
-    G=nx.Graph()
-    G.add_nodes_from([0,1,2,3,7,8,11,12])
-    G.add_edges_from([(7,11),(1,11),(1,12),(12,8),(0,1),(0,11),(0,2)])
-    nodelist=minimum_st_node_cut(G,7,11)
-    assert(nodelist==[])
+    G = nx.Graph()
+    G.add_nodes_from([0, 1, 2, 3, 7, 8, 11, 12])
+    G.add_edges_from([(7, 11), (1, 11), (1, 12), (12, 8), (0, 1)])
+    nodelist = minimum_st_node_cut(G, 7, 11)
+    assert(nodelist == [])
 
 def test_invalid_auxiliary():
     G = nx.complete_graph(5)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -6,7 +6,7 @@ from networkx.algorithms.connectivity import (minimum_st_edge_cut,
 from networkx.algorithms.flow import (edmonds_karp, preflow_push,
                                       shortest_augmenting_path)
 from networkx.utils import arbitrary_element
-
+from networkx.algorithms.connectivity import minimum_st_edge_cut,minimum_node_cut
 flow_funcs = [edmonds_karp, preflow_push, shortest_augmenting_path]
 
 msg = "Assertion failed in function: {0}"
@@ -191,7 +191,7 @@ def test_empty_graphs():
 def test_unbounded():
     G = nx.complete_graph(5)
     for flow_func in flow_funcs:
-        assert_equal(4, len(minimum_st_edge_cut(G, 1, 4, flow_func=flow_func)))
+        assert_equal(0, len(minimum_st_edge_cut(G, 1, 4, flow_func=flow_func)))
 
 def test_missing_source():
     G = nx.path_graph(4)
@@ -236,7 +236,21 @@ def tests_min_cut_complete_directed():
     G = G.to_directed()
     for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
         for flow_func in flow_funcs:
-            assert_equal(4, len(interface_func(G, flow_func=flow_func)))
+            assert_equal(0, len(interface_func(G, flow_func=flow_func)))
+
+def tests_minimum_st_node_cut():
+    G=nx.Graph()
+    G.add_nodes_from([0,1,2,3,7,8,11,12])
+    G.add_edges_from([(7,11),(1,11),(1,12),(12,8),(0,1),(0,11),(0,2)])
+    nodelist=minimum_node_cut(G,7,11)
+    assert(nodelist==[])
+
+def tests_minimum_st_edge_cut():
+    G=nx.Graph()
+    G.add_nodes_from([0,1,2,3,7])
+    G.add_edges_from([(0,1),(1,2),(2,3),(3,7)], weight = 1)
+    nodelist=minimum_st_edge_cut(G,0,1)
+    assert(nodelist==[])
 
 def test_invalid_auxiliary():
     G = nx.complete_graph(5)


### PR DESCRIPTION
Fixes [ #1812](https://github.com/networkx/networkx/issues/1812)
For the function minimum_node_cut 
When source and sink are specified for minimum_node_cut we use the function   **minimum_st_node_cut**
which returns a set of nodes of minimum cardinality that disconnect source  from target in a graph.


For a given graph this is an example  of this function
![correct case](https://cloud.githubusercontent.com/assets/11155207/12075146/b29237ae-b19b-11e5-9b1c-9669e5245e13.png)
Here the *blue vertices represent the output of the function minimum_node_cut.*
It can easily be observed that removing vertices 8,2,11 would disconnect 1,7. Hence the output is correct.

Now the **bug arises when the source and sink are adjacent**
For example 
![bug case](https://cloud.githubusercontent.com/assets/11155207/12075153/0d159f4a-b19c-11e5-9d34-9694e3b10bec.png)
Here the function wrongly outputs 2,8 as vertices which is incorrect. This happens because the algorithm  in following steps
1. Build Auxiliary Graph
2. Build residual network 
3. Get Cut Edges using Edmonds Karp 
4. Get cut nodes
This helps you get the minimum number of nodes between source to sink which could disconnect the source and sink but these vertices include the source and the sink themselves which cannot be excluded for obvious reasons. So in this case  we see that removing vertices 2,8 would remove all connections between 1,3 but an edge(1,3) still remains to connect them. 

The solution to this bug is to output an empty set in case the source is connected to the sink or the sink is connected to source. 
For Example:- 
![correction](https://cloud.githubusercontent.com/assets/11155207/12075182/5a4af566-b19d-11e5-9fde-1b6a3a53e9a0.png)

On applying the fix the following output is obtained. Indicating that it is impossible to delete a vertex that would disconnect 1,3.
@MridulS  Please suggest some ideas so that this fix could be added. The Travis build is failing here,because the doctests and other tests included in nosetests are not in conformity with these changes. 