### PR TITLE
Standardized Bellman-Ford function calls

### DIFF
--- a/doc/source/reference/algorithms.shortest_paths.rst
+++ b/doc/source/reference/algorithms.shortest_paths.rst
@@ -37,7 +37,6 @@ Advanced Interface
    single_source_dijkstra
    bidirectional_dijkstra
    dijkstra_predecessor_and_distance
-   bellman_ford
    bellman_ford_path
    bellman_ford_path_length
    single_source_bellman_ford_path

--- a/doc/source/reference/algorithms.shortest_paths.rst
+++ b/doc/source/reference/algorithms.shortest_paths.rst
@@ -38,6 +38,14 @@ Advanced Interface
    bidirectional_dijkstra
    dijkstra_predecessor_and_distance
    bellman_ford
+   bellman_ford_path
+   bellman_ford_path_length
+   single_source_bellman_ford_path
+   single_source_bellman_ford_path_length
+   all_pairs_bellman_ford_path
+   all_pairs_bellman_ford_path_length
+   single_source_bellman_ford
+   bellman_ford_predecessor_and_distance
    negative_edge_cycle
    johnson
 

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -271,7 +271,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
     def test_single_node_graph(self):
         G = nx.DiGraph()
         G.add_node(0)
-        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: None}, {0: 0}))
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: []}, {0: 0}))
         assert_equal(nx.goldberg_radzik(G, 0), ({0: None}, {0: 0}))
         assert_raises(KeyError, nx.bellman_ford_predecessor_and_distance, G, 1)
         assert_raises(KeyError, nx.goldberg_radzik, G, 1)
@@ -294,7 +294,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(1, 2, weight=-3)
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
-                     ({0: None, 1: 0, 2: 1, 3: 2, 4: 3},
+                     ({0: [], 1: [0], 2: [1], 3: [2], 4: [3]},
                       {0: 0, 1: 1, 2: -2, 3: -1, 4: 0}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2, 4: 3},
@@ -305,7 +305,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G.add_edge(10, 11)
         G.add_edge(10, 12)
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
-                     ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+                     ({0: [], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
@@ -318,7 +318,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
                           ('B', 'C', {'load': -10}),
                           ('C', 'A', {'load': 2})])
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0, weight='load'),
-                     ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+                     ({0: [], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
         assert_equal(nx.goldberg_radzik(G, 0, weight='load'),
                      ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
@@ -326,13 +326,13 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
     def test_multigraph(self):
         P, D = nx.bellman_ford_predecessor_and_distance(self.MXG, 's')
-        assert_equal(P['v'], 'u')
+        assert_equal(P['v'], ['u'])
         assert_equal(D['v'], 9)
         P, D = nx.goldberg_radzik(self.MXG, 's')
         assert_equal(P['v'], 'u')
         assert_equal(D['v'], 9)
         P, D = nx.bellman_ford_predecessor_and_distance(self.MXG4, 0)
-        assert_equal(P[2], 1)
+        assert_equal(P[2], [1])
         assert_equal(D[2], 4)
         P, D = nx.goldberg_radzik(self.MXG4, 0)
         assert_equal(P[2], 1)
@@ -340,7 +340,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
     def test_others(self):
         (P, D) = nx.bellman_ford_predecessor_and_distance(self.XG, 's')
-        assert_equal(P['v'], 'u')
+        assert_equal(P['v'], ['u'])
         assert_equal(D['v'], 9)
         (P, D) = nx.goldberg_radzik(self.XG, 's')
         assert_equal(P['v'], 'u')
@@ -348,19 +348,19 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
         G = nx.path_graph(4)
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
-                     ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
+                     ({0: [], 1: [0], 2: [1], 3: [2]}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 3),
-                     ({0: 1, 1: 2, 2: 3, 3: None}, {0: 3, 1: 2, 2: 1, 3: 0}))
+                     ({0: [1], 1: [2], 2: [3], 3: []}, {0: 3, 1: 2, 2: 1, 3: 0}))
         assert_equal(nx.goldberg_radzik(G, 3),
                      ({0: 1, 1: 2, 2: 3, 3: None}, {0: 3, 1: 2, 2: 1, 3: 0}))
 
         G = nx.grid_2d_graph(2, 2)
         pred, dist = nx.bellman_ford_predecessor_and_distance(G, (0, 0))
         assert_equal(sorted(pred.items()),
-                     [((0, 0), None), ((0, 1), (0, 0)),
-                      ((1, 0), (0, 0)), ((1, 1), (0, 1))])
+                     [((0, 0), []), ((0, 1), [(0, 0)]),
+                      ((1, 0), [(0, 0)]), ((1, 1), [(0, 1), (1, 0)])]) #Multiple shortest paths from, thus multiple predecessors
         assert_equal(sorted(dist.items()),
                      [((0, 0), 0), ((0, 1), 1), ((1, 0), 1), ((1, 1), 2)])
         pred, dist = nx.goldberg_radzik(G, (0, 0))

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -271,29 +271,29 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
     def test_single_node_graph(self):
         G = nx.DiGraph()
         G.add_node(0)
-        assert_equal(nx.bellman_ford(G, 0), ({0: None}, {0: 0}))
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: None}, {0: 0}))
         assert_equal(nx.goldberg_radzik(G, 0), ({0: None}, {0: 0}))
-        assert_raises(KeyError, nx.bellman_ford, G, 1)
+        assert_raises(KeyError, nx.bellman_ford_predecessor_and_distance, G, 1)
         assert_raises(KeyError, nx.goldberg_radzik, G, 1)
 
     def test_negative_weight_cycle(self):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(1, 2, weight=-7)
         for i in range(5):
-            assert_raises(nx.NetworkXUnbounded, nx.bellman_ford, G, i)
+            assert_raises(nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, i)
             assert_raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, i)
         G = nx.cycle_graph(5)  # undirected Graph
         G.add_edge(1, 2, weight=-3)
         for i in range(5):
-            assert_raises(nx.NetworkXUnbounded, nx.bellman_ford, G, i)
+            assert_raises(nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, i)
             assert_raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, i)
         G = nx.DiGraph([(1, 1, {'weight': -1})])
-        assert_raises(nx.NetworkXUnbounded, nx.bellman_ford, G, 1)
+        assert_raises(nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, 1)
         assert_raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, 1)
         # no negative cycle but negative weight
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(1, 2, weight=-3)
-        assert_equal(nx.bellman_ford(G, 0),
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2, 4: 3},
                       {0: 0, 1: 1, 2: -2, 3: -1, 4: 0}))
         assert_equal(nx.goldberg_radzik(G, 0),
@@ -304,7 +304,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.complete_graph(6)
         G.add_edge(10, 11)
         G.add_edge(10, 12)
-        assert_equal(nx.bellman_ford(G, 0),
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
                      ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
         assert_equal(nx.goldberg_radzik(G, 0),
@@ -317,7 +317,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G.add_edges_from([('A', 'B', {'load': 3}),
                           ('B', 'C', {'load': -10}),
                           ('C', 'A', {'load': 2})])
-        assert_equal(nx.bellman_ford(G, 0, weight='load'),
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0, weight='load'),
                      ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
         assert_equal(nx.goldberg_radzik(G, 0, weight='load'),
@@ -325,13 +325,13 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
 
     def test_multigraph(self):
-        P, D = nx.bellman_ford(self.MXG, 's')
+        P, D = nx.bellman_ford_predecessor_and_distance(self.MXG, 's')
         assert_equal(P['v'], 'u')
         assert_equal(D['v'], 9)
         P, D = nx.goldberg_radzik(self.MXG, 's')
         assert_equal(P['v'], 'u')
         assert_equal(D['v'], 9)
-        P, D = nx.bellman_ford(self.MXG4, 0)
+        P, D = nx.bellman_ford_predecessor_and_distance(self.MXG4, 0)
         assert_equal(P[2], 1)
         assert_equal(D[2], 4)
         P, D = nx.goldberg_radzik(self.MXG4, 0)
@@ -339,7 +339,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(D[2], 4)
 
     def test_others(self):
-        (P, D) = nx.bellman_ford(self.XG, 's')
+        (P, D) = nx.bellman_ford_predecessor_and_distance(self.XG, 's')
         assert_equal(P['v'], 'u')
         assert_equal(D['v'], 9)
         (P, D) = nx.goldberg_radzik(self.XG, 's')
@@ -347,17 +347,17 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(D['v'], 9)
 
         G = nx.path_graph(4)
-        assert_equal(nx.bellman_ford(G, 0),
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
-        assert_equal(nx.bellman_ford(G, 3),
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 3),
                      ({0: 1, 1: 2, 2: 3, 3: None}, {0: 3, 1: 2, 2: 1, 3: 0}))
         assert_equal(nx.goldberg_radzik(G, 3),
                      ({0: 1, 1: 2, 2: 3, 3: None}, {0: 3, 1: 2, 2: 1, 3: 0}))
 
         G = nx.grid_2d_graph(2, 2)
-        pred, dist = nx.bellman_ford(G, (0, 0))
+        pred, dist = nx.bellman_ford_predecessor_and_distance(G, (0, 0))
         assert_equal(sorted(pred.items()),
                      [((0, 0), None), ((0, 1), (0, 0)),
                       ((1, 0), (0, 0)), ((1, 1), (0, 1))])

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -488,3 +488,4 @@ class TestJohnsonAlgorithm(WeightedTestBase):
         validate_path(self.XG3, 0, 3, 15, nx.johnson(self.XG3)[0][3])
         validate_path(self.XG4, 0, 2, 4, nx.johnson(self.XG4)[0][2])
         validate_path(self.MXG4, 0, 2, 4, nx.johnson(self.MXG4)[0][2])
+

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -271,7 +271,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
     def test_single_node_graph(self):
         G = nx.DiGraph()
         G.add_node(0)
-        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: []}, {0: 0}))
+        assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: [None]}, {0: 0}))
         assert_equal(nx.goldberg_radzik(G, 0), ({0: None}, {0: 0}))
         assert_raises(KeyError, nx.bellman_ford_predecessor_and_distance, G, 1)
         assert_raises(KeyError, nx.goldberg_radzik, G, 1)
@@ -294,7 +294,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(1, 2, weight=-3)
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
-                     ({0: [], 1: [0], 2: [1], 3: [2], 4: [3]},
+                     ({0: [None], 1: [0], 2: [1], 3: [2], 4: [3]},
                       {0: 0, 1: 1, 2: -2, 3: -1, 4: 0}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2, 4: 3},
@@ -305,7 +305,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G.add_edge(10, 11)
         G.add_edge(10, 12)
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
-                     ({0: [], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
+                     ({0: [None], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
@@ -318,7 +318,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
                           ('B', 'C', {'load': -10}),
                           ('C', 'A', {'load': 2})])
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0, weight='load'),
-                     ({0: [], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
+                     ({0: [None], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
         assert_equal(nx.goldberg_radzik(G, 0, weight='load'),
                      ({0: None, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
@@ -348,18 +348,18 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
         G = nx.path_graph(4)
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
-                     ({0: [], 1: [0], 2: [1], 3: [2]}, {0: 0, 1: 1, 2: 2, 3: 3}))
+                     ({0: [None], 1: [0], 2: [1], 3: [2]}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 3),
-                     ({0: [1], 1: [2], 2: [3], 3: []}, {0: 3, 1: 2, 2: 1, 3: 0}))
+                     ({0: [1], 1: [2], 2: [3], 3: [None]}, {0: 3, 1: 2, 2: 1, 3: 0}))
         assert_equal(nx.goldberg_radzik(G, 3),
                      ({0: 1, 1: 2, 2: 3, 3: None}, {0: 3, 1: 2, 2: 1, 3: 0}))
 
         G = nx.grid_2d_graph(2, 2)
         pred, dist = nx.bellman_ford_predecessor_and_distance(G, (0, 0))
         assert_equal(sorted(pred.items()),
-                     [((0, 0), []), ((0, 1), [(0, 0)]),
+                     [((0, 0), [None]), ((0, 1), [(0, 0)]),
                       ((1, 0), [(0, 0)]), ((1, 1), [(0, 1), (1, 0)])]) #Multiple shortest paths from, thus multiple predecessors
         assert_equal(sorted(dist.items()),
                      [((0, 0), 0), ((0, 1), 1), ((1, 0), 1), ((1, 1), 2)])

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -271,6 +271,9 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
     def test_single_node_graph(self):
         G = nx.DiGraph()
         G.add_node(0)
+        assert_equal(nx.single_source_bellman_ford_path(G, 0), {0: [0]})
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)), {0: 0})
+        assert_equal(nx.single_source_bellman_ford(G, 0), ({0: 0}, {0: [0]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: [None]}, {0: 0}))
         assert_equal(nx.goldberg_radzik(G, 0), ({0: None}, {0: 0}))
         assert_raises(KeyError, nx.bellman_ford_predecessor_and_distance, G, 1)
@@ -280,19 +283,35 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(1, 2, weight=-7)
         for i in range(5):
+            assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford_path, G, i)
+            assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford_path_length, G, i)
+            assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford, G, i)
             assert_raises(nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, i)
             assert_raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, i)
         G = nx.cycle_graph(5)  # undirected Graph
         G.add_edge(1, 2, weight=-3)
         for i in range(5):
+            assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford_path, G, i)
+            assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford_path_length, G, i)
+            assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford, G, i)
             assert_raises(nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, i)
             assert_raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, i)
         G = nx.DiGraph([(1, 1, {'weight': -1})])
+        assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford_path, G, 1)
+        assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford_path_length, G, 1)
+        assert_raises(nx.NetworkXUnbounded, nx.single_source_bellman_ford, G, 1)
         assert_raises(nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, 1)
         assert_raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, 1)
         # no negative cycle but negative weight
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(1, 2, weight=-3)
+        assert_equal(nx.single_source_bellman_ford_path(G, 0),
+                     {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3], 4: [0, 1, 2, 3, 4]})
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)),
+                     {0: 0, 1: 1, 2: -2, 3: -1, 4: 0})
+        assert_equal(nx.single_source_bellman_ford(G, 0),
+                     ({0: 0, 1: 1, 2: -2, 3: -1, 4: 0},
+                      {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3], 4: [0, 1, 2, 3, 4]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
                      ({0: [None], 1: [0], 2: [1], 3: [2], 4: [3]},
                       {0: 0, 1: 1, 2: -2, 3: -1, 4: 0}))
@@ -304,6 +323,13 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.complete_graph(6)
         G.add_edge(10, 11)
         G.add_edge(10, 12)
+        assert_equal(nx.single_source_bellman_ford_path(G, 0),
+                     {0: [0], 1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 4], 5: [0, 5]})
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)),
+                     {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1})
+        assert_equal(nx.single_source_bellman_ford(G, 0),
+                     ({0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1},
+                      {0: [0], 1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 4], 5: [0, 5]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
                      ({0: [None], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
@@ -317,6 +343,13 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G.add_edges_from([('A', 'B', {'load': 3}),
                           ('B', 'C', {'load': -10}),
                           ('C', 'A', {'load': 2})])
+        assert_equal(nx.single_source_bellman_ford_path(G, 0, weight='load'),
+                     {0: [0], 1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 4], 5: [0, 5]})
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0, weight='load')),
+                     {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1})
+        assert_equal(nx.single_source_bellman_ford(G, 0, weight='load'),
+                     ({0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1},
+                      {0: [0], 1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 4], 5: [0, 5]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0, weight='load'),
                      ({0: [None], 1: [0], 2: [0], 3: [0], 4: [0], 5: [0]},
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
@@ -325,12 +358,26 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
                       {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1}))
 
     def test_multigraph(self):
+        assert_equal(nx.bellman_ford_path(self.MXG, 's', 'v'), ['s', 'x', 'u', 'v'])
+        assert_equal(nx.bellman_ford_path_length(self.MXG, 's', 'v'), 9)
+        assert_equal(nx.single_source_bellman_ford_path(self.MXG, 's')['v'], ['s', 'x', 'u', 'v'])
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(self.MXG, 's'))['v'], 9)
+        D, P = nx.single_source_bellman_ford(self.MXG, 's', target='v')
+        assert_equal(D['v'], 9)
+        assert_equal(P['v'], ['s', 'x', 'u', 'v'])
         P, D = nx.bellman_ford_predecessor_and_distance(self.MXG, 's')
         assert_equal(P['v'], ['u'])
         assert_equal(D['v'], 9)
         P, D = nx.goldberg_radzik(self.MXG, 's')
         assert_equal(P['v'], 'u')
-        assert_equal(D['v'], 9)
+        assert_equal(D['v'], 9)        
+        assert_equal(nx.bellman_ford_path(self.MXG4, 0, 2), [0, 1, 2])
+        assert_equal(nx.bellman_ford_path_length(self.MXG4, 0, 2), 4)
+        assert_equal(nx.single_source_bellman_ford_path(self.MXG4, 0)[2], [0, 1, 2])
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(self.MXG4, 0))[2], 4)
+        D, P = nx.single_source_bellman_ford(self.MXG4, 0, target=2)
+        assert_equal(D[2], 4)
+        assert_equal(P[2], [0, 1, 2])
         P, D = nx.bellman_ford_predecessor_and_distance(self.MXG4, 0)
         assert_equal(P[2], [1])
         assert_equal(D[2], 4)
@@ -339,6 +386,13 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(D[2], 4)
 
     def test_others(self):
+        assert_equal(nx.bellman_ford_path(self.XG, 's', 'v'), ['s', 'x', 'u', 'v'])
+        assert_equal(nx.bellman_ford_path_length(self.XG, 's', 'v'), 9)
+        assert_equal(nx.single_source_bellman_ford_path(self.XG, 's')['v'], ['s', 'x', 'u', 'v'])
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(self.XG, 's'))['v'], 9)
+        D, P = nx.single_source_bellman_ford(self.XG, 's', target='v')
+        assert_equal(D['v'], 9)
+        assert_equal(P['v'], ['s', 'x', 'u', 'v'])
         (P, D) = nx.bellman_ford_predecessor_and_distance(self.XG, 's')
         assert_equal(P['v'], ['u'])
         assert_equal(D['v'], 9)
@@ -347,20 +401,38 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(D['v'], 9)
 
         G = nx.path_graph(4)
+        assert_equal(nx.single_source_bellman_ford_path(G, 0),
+                     {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3]})
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)),
+                     {0: 0, 1: 1, 2: 2, 3: 3})
+        assert_equal(nx.single_source_bellman_ford(G, 0),
+                     ({0: 0, 1: 1, 2: 2, 3: 3}, {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0),
                      ({0: [None], 1: [0], 2: [1], 3: [2]}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.goldberg_radzik(G, 0),
                      ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
+        assert_equal(nx.single_source_bellman_ford_path(G, 3),
+                     {0: [3, 2, 1, 0], 1: [3, 2, 1], 2: [3, 2], 3: [3]})
+        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 3)),
+                     {0: 3, 1: 2, 2: 1, 3: 0})
+        assert_equal(nx.single_source_bellman_ford(G, 3),
+                     ({0: 3, 1: 2, 2: 1, 3: 0}, {0: [3, 2, 1, 0], 1: [3, 2, 1], 2: [3, 2], 3: [3]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 3),
                      ({0: [1], 1: [2], 2: [3], 3: [None]}, {0: 3, 1: 2, 2: 1, 3: 0}))
         assert_equal(nx.goldberg_radzik(G, 3),
                      ({0: 1, 1: 2, 2: 3, 3: None}, {0: 3, 1: 2, 2: 1, 3: 0}))
 
         G = nx.grid_2d_graph(2, 2)
+        dist, path = nx.single_source_bellman_ford(G, (0, 0))
+        assert_equal(sorted(dist.items()),
+                     [((0, 0), 0), ((0, 1), 1), ((1, 0), 1), ((1, 1), 2)])
+        assert_equal(sorted(path.items()),
+                     [((0, 0), [(0, 0)]), ((0, 1), [(0, 0), (0, 1)]),
+                      ((1, 0), [(0, 0), (1, 0)]),  ((1, 1), [(0, 0), (0, 1), (1, 1)])])
         pred, dist = nx.bellman_ford_predecessor_and_distance(G, (0, 0))
         assert_equal(sorted(pred.items()),
                      [((0, 0), [None]), ((0, 1), [(0, 0)]),
-                      ((1, 0), [(0, 0)]), ((1, 1), [(0, 1), (1, 0)])]) #Multiple shortest paths from, thus multiple predecessors
+                      ((1, 0), [(0, 0)]), ((1, 1), [(0, 1), (1, 0)])])
         assert_equal(sorted(dist.items()),
                      [((0, 0), 0), ((0, 1), 1), ((1, 0), 1), ((1, 1), 2)])
         pred, dist = nx.goldberg_radzik(G, (0, 0))

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -736,10 +736,16 @@ def bellman_ford_predecessor_and_distance(G, source, weight='weight'):
     if len(G) == 1:
         return pred, dist
 
-    return _bellman_ford(G, pred, dist, [source], weight)
+    if G.is_multigraph():
+        get_weight = lambda u, v, data: min(
+            eattr.get(weight, 1) for eattr in data.values())
+    else:
+        get_weight = lambda u, v, data: data.get(weight, 1)
+        
+    return (pred, _bellman_ford(G, [source], get_weight,pred=pred, dist=dist))
 
 
-def _bellman_ford(G, pred, dist, source, weight):
+def _bellman_ford(G, source, get_weight, pred=None, paths=None, dist=None, cutoff=None, target=None):
     """Relaxation loop for Bellman–Ford algorithm
 
     Parameters
@@ -774,6 +780,26 @@ def _bellman_ford(G, pred, dist, source, weight):
        negative cost (di)cycle.  Note: any negative weight edge in an
        undirected graph is a negative cost cycle
     """
+
+    if paths != None:
+        raise NotImplementedError(
+            "To Be Done: Parameter paths not yet implemented")       
+
+    if target != None:
+        raise NotImplementedError(
+            "To Be Done: Parameter target not yet implemented")
+    
+    if cutoff != None:
+        raise NotImplementedError(
+            "To Be Done: Parameter cutoff not yet implemented")
+
+            
+    if pred == None:
+        pred = {v: [] for v in source}
+    
+    if dist == None:
+        dist = {v: 0 for v in source}
+
     G_succ = G.succ if G.is_directed() else G.adj
     inf = float('inf')
     n = len(G)
@@ -789,7 +815,7 @@ def _bellman_ford(G, pred, dist, source, weight):
         if all(pred_u not in in_q for pred_u in pred[u]):
             dist_u = dist[u]
             for v, e in G_succ[u].items():
-                dist_v = dist_u + get_weight(e)
+                dist_v = dist_u + get_weight(v, u, e)
                 if dist_v < dist.get(v, inf):
                     if v not in in_q:
                         q.append(v)
@@ -805,7 +831,7 @@ def _bellman_ford(G, pred, dist, source, weight):
                 elif dist.get(v) != None and dist_v == dist.get(v):
                     pred[v].append(u)
 
-    return pred, dist
+    return dist
 
 def goldberg_radzik(G, source, weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -731,7 +731,7 @@ def bellman_ford_predecessor_and_distance(G, source, weight='weight'):
         raise nx.NetworkXUnbounded("Negative cost cycle detected.")
 
     dist = {source: 0}
-    pred = {source: None}
+    pred = {source: []}
 
     if len(G) == 1:
         return pred, dist
@@ -784,22 +784,24 @@ def _bellman_ford(G, pred, dist, source, weight):
     while q:
         u = q.popleft()
         in_q.remove(u)
-        # Skip relaxations if the predecessor of u is in the queue.
-        if pred[u] not in in_q:
-            dist_u = dist[u]
-            for v, e in G_succ[u].items():
-                dist_v = dist_u + weight(u, v, e)
-                if dist_v < dist.get(v, inf):
-                    if v not in in_q:
-                        q.append(v)
-                        in_q.add(v)
-                        count_v = count.get(v, 0) + 1
-                        if count_v == n:
-                            raise nx.NetworkXUnbounded(
-                                "Negative cost cycle detected.")
-                        count[v] = count_v
-                    dist[v] = dist_v
-                    pred[v] = u
+
+        dist_u = dist[u]
+        for v, e in G_succ[u].items():
+            dist_v = dist_u + get_weight(e)
+            if dist_v < dist.get(v, inf):
+                if v not in in_q:
+                    q.append(v)
+                    in_q.add(v)
+                    count_v = count.get(v, 0) + 1
+                    if count_v == n:
+                        raise nx.NetworkXUnbounded(
+                            "Negative cost cycle detected.")
+                    count[v] = count_v
+                dist[v] = dist_v
+                pred[v] = [u]
+                
+            elif dist.get(v) != None and dist_v == dist.get(v):
+                pred[v].append(u)
 
     return pred, dist
 
@@ -1259,6 +1261,7 @@ def johnson(G, weight='weight'):
     dist = {v: 0 for v in G}
     pred = {v: [None] for v in G}
     weight = _weight_function(G, weight)
+
     # Calculate distance of shortest paths
     dist_bellman = _bellman_ford(G, list(G), weight, pred=pred, dist=dist)
     # Update the weight function to take into account the Bellman--Ford

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -755,13 +755,9 @@ def bellman_ford_predecessor_and_distance(G, source, target=None, cutoff=None, w
     if len(G) == 1:
         return pred, dist
 
-    if G.is_multigraph():
-        get_weight = lambda u, v, data: min(
-            eattr.get(weight, 1) for eattr in data.values())
-    else:
-        get_weight = lambda u, v, data: data.get(weight, 1)
+    weight = _weight_function(G, weight)
         
-    return (pred, _bellman_ford(G, [source], get_weight,pred=pred, dist=dist, cutoff=cutoff, target=target))
+    return (pred, _bellman_ford(G, [source], weight,pred=pred, dist=dist, cutoff=cutoff, target=target))
 
 
 def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
@@ -836,7 +832,7 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
         if all(pred_u not in in_q for pred_u in pred[u]):
             dist_u = dist[u]
             for v, e in G_succ[u].items():
-                dist_v = dist_u + get_weight(v, u, e)
+                dist_v = dist_u + weight(v, u, e)
 
                 if cutoff is not None:
                     if dist_v > cutoff:
@@ -971,13 +967,9 @@ def bellman_ford_path_length(G, source, target, weight='weight'):
     if source == target:
         return 0
 
-    if G.is_multigraph():
-        get_weight = lambda u, v, data: min(
-            eattr.get(weight, 1) for eattr in data.values())
-    else:
-        get_weight = lambda u, v, data: data.get(weight, 1)
+    weight = _weight_function(G, weight)
     
-    length =  _bellman_ford(G, [source], get_weight, target=target)
+    length =  _bellman_ford(G, [source], weight, target=target)
     
     try:
         return length[target]
@@ -1069,13 +1061,9 @@ def single_source_bellman_ford_path_length(G, source, cutoff=None, weight='weigh
     single_source_dijkstra(), single_source_bellman_ford()
 
     """
-    if G.is_multigraph():
-        get_weight = lambda u, v, data: min(
-            eattr.get(weight, 1) for eattr in data.values())
-    else:
-        get_weight = lambda u, v, data: data.get(weight, 1)
+    weight = _weight_function(G, weight)
 
-    return iter(_bellman_ford(G, [source], get_weight, cutoff=cutoff).items())
+    return iter(_bellman_ford(G, [source], weight, cutoff=cutoff).items())
 
 def single_source_bellman_ford(G, source, target=None, cutoff=None, weight='weight'):
     """Compute shortest paths and lengths in a weighted graph G.
@@ -1128,14 +1116,10 @@ def single_source_bellman_ford(G, source, target=None, cutoff=None, weight='weig
     if source == target:
         return ({source: 0}, {source: [source]})
 
-    if G.is_multigraph():
-        get_weight = lambda u, v, data: min(
-            eattr.get(weight, 1) for eattr in data.values())
-    else:
-        get_weight = lambda u, v, data: data.get(weight, 1)
+    weight = _weight_function(G, weight)
 
     paths = {source: [source]}  # dictionary of paths
-    return (_bellman_ford(G, [source], get_weight, paths=paths, cutoff=cutoff,
+    return (_bellman_ford(G, [source], weight, paths=paths, cutoff=cutoff,
                      target=target), paths)
 
 def all_pairs_bellman_ford_path_length(G, cutoff=None, weight='weight'):

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -785,26 +785,27 @@ def _bellman_ford(G, pred, dist, source, weight):
         u = q.popleft()
         in_q.remove(u)
 
-        dist_u = dist[u]
-        for v, e in G_succ[u].items():
-            dist_v = dist_u + get_weight(e)
-            if dist_v < dist.get(v, inf):
-                if v not in in_q:
-                    q.append(v)
-                    in_q.add(v)
-                    count_v = count.get(v, 0) + 1
-                    if count_v == n:
-                        raise nx.NetworkXUnbounded(
-                            "Negative cost cycle detected.")
-                    count[v] = count_v
-                dist[v] = dist_v
-                pred[v] = [u]
-                
-            elif dist.get(v) != None and dist_v == dist.get(v):
-                pred[v].append(u)
+        # Skip relaxations if any of the predecessors of u is in the queue. If any is in the queue, its distance and follow-up computations will change
+        if all(pred_u not in in_q for pred_u in pred[u]):
+            dist_u = dist[u]
+            for v, e in G_succ[u].items():
+                dist_v = dist_u + get_weight(e)
+                if dist_v < dist.get(v, inf):
+                    if v not in in_q:
+                        q.append(v)
+                        in_q.add(v)
+                        count_v = count.get(v, 0) + 1
+                        if count_v == n:
+                            raise nx.NetworkXUnbounded(
+                                "Negative cost cycle detected.")
+                        count[v] = count_v
+                    dist[v] = dist_v
+                    pred[v] = [u]
+                    
+                elif dist.get(v) != None and dist_v == dist.get(v):
+                    pred[v].append(u)
 
     return pred, dist
-
 
 def goldberg_radzik(G, source, weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -19,6 +19,7 @@ from heapq import heappush, heappop
 from itertools import count
 import networkx as nx
 from networkx.utils import generate_unique_node
+import warnings as _warnings
 
 
 __all__ = ['dijkstra_path',
@@ -37,11 +38,11 @@ __all__ = ['dijkstra_path',
            'single_source_bellman_ford_path_length',
            'all_pairs_bellman_ford_path',
            'all_pairs_bellman_ford_path_length',
+           'bellman_ford',
            'bellman_ford_predecessor_and_distance',
            'negative_edge_cycle',
            'goldberg_radzik',
            'johnson']
-
 
 def _weight_function(G, weight):
     """Returns a function that returns the weight of an edge.
@@ -81,7 +82,6 @@ def _weight_function(G, weight):
     if G.is_multigraph():
         return lambda u, v, d: min(attr.get(weight, 1) for attr in d.values())
     return lambda u, v, data: data.get(weight, 1)
-
 
 def dijkstra_path(G, source, target, weight='weight'):
     """Returns the shortest weighted path from source to target in G.
@@ -658,8 +658,16 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
     # TODO This can be trivially parallelized.
     return {n: path(G, n, cutoff=cutoff, weight=weight) for n in G}
 
+def bellman_ford(G, source, weight='weight'):
+    _warnings.warn("bellman_ford() is deprecated, use bellman_ford_predecessor_and_distance() instead",
+                   DeprecationWarning)
+    """DEPRECATED: Use bellMan_ford_predecessor_and_distance() instead
+    
+    """
 
-def bellman_ford_predecessor_and_distance(G, source, weight='weight'):
+    return bellman_ford_predecessor_and_distance(G, source, weight=weight)
+    
+def bellman_ford_predecessor_and_distance(G, source, cutoff=None, weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths
     in weighted graphs.
 
@@ -750,7 +758,7 @@ def bellman_ford_predecessor_and_distance(G, source, weight='weight'):
     else:
         get_weight = lambda u, v, data: data.get(weight, 1)
         
-    return (pred, _bellman_ford(G, [source], get_weight,pred=pred, dist=dist))
+    return (pred, _bellman_ford(G, [source], get_weight,pred=pred, dist=dist, cutoff=cutoff))
 
 
 def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -554,10 +554,10 @@ def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight='weight'):
     The list of predecessors contains more than one element only when
     there are more than one shortest paths to the key node.
     """
+
     weight = _weight_function(G, weight)
     pred = {source: []}  # dictionary of predecessors
     return (pred, _dijkstra(G, source, weight, pred=pred, cutoff=cutoff))
-
 
 def all_pairs_dijkstra_path_length(G, cutoff=None, weight='weight'):
     """Compute shortest path lengths between all nodes in a weighted graph.
@@ -659,15 +659,17 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
     return {n: path(G, n, cutoff=cutoff, weight=weight) for n in G}
 
 def bellman_ford(G, source, weight='weight'):
-    _warnings.warn("bellman_ford() is deprecated, use bellman_ford_predecessor_and_distance() instead",
-                   DeprecationWarning)
-    """DEPRECATED: Use bellMan_ford_predecessor_and_distance() instead
-    
-    """
 
-    return bellman_ford_predecessor_and_distance(G, source, weight=weight)
+    """DEPRECATED: Has been replaced by function bellman_ford_predecessor_and_distance().
+       
+
+    """
+    _warnings.warn("Function bellman_ford() is deprecated, use function bellman_ford_predecessor_and_distance() instead.",
+                   DeprecationWarning)
+                   
+    return bellman_ford_predecessor_and_distance(G, source, weight=weight) 
     
-def bellman_ford_predecessor_and_distance(G, source, cutoff=None, weight='weight'):
+def bellman_ford_predecessor_and_distance(G, source, target=None, cutoff=None, weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths
     in weighted graphs.
 
@@ -717,7 +719,7 @@ def bellman_ford_predecessor_and_distance(G, source, cutoff=None, weight='weight
     >>> G = nx.path_graph(5, create_using = nx.DiGraph())
     >>> pred, dist = nx.bellman_ford_predecessor_and_distance(G, 0)
     >>> sorted(pred.items())
-    [(0, []), (1, [0]), (2, [1]), (3, [2]), (4, [3])]
+    [(0, [None]), (1, [0]), (2, [1]), (3, [2]), (4, [3])]
     >>> sorted(dist.items())
     [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
 
@@ -747,7 +749,7 @@ def bellman_ford_predecessor_and_distance(G, source, cutoff=None, weight='weight
         raise nx.NetworkXUnbounded("Negative cost cycle detected.")
 
     dist = {source: 0}
-    pred = {source: []}
+    pred = {source: [None]}
 
     if len(G) == 1:
         return pred, dist
@@ -758,7 +760,7 @@ def bellman_ford_predecessor_and_distance(G, source, cutoff=None, weight='weight
     else:
         get_weight = lambda u, v, data: data.get(weight, 1)
         
-    return (pred, _bellman_ford(G, [source], get_weight,pred=pred, dist=dist, cutoff=cutoff))
+    return (pred, _bellman_ford(G, [source], get_weight,pred=pred, dist=dist, cutoff=cutoff, target=target))
 
 
 def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
@@ -813,7 +815,7 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
     """
 
     if pred == None:
-        pred = {v: [] for v in source}
+        pred = {v: [None] for v in source}
     
     if dist == None:
         dist = {v: 0 for v in source}
@@ -859,11 +861,13 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
                     pred[v].append(u)
 
     if paths != None:
-        for dst in pred:
+        dsts = [target] if target != None else pred
+        for dst in dsts:
+        
             path = [dst]
             cur = dst
             
-            while len(pred[cur]) != 0:
+            while pred[cur][0] != None:
                 cur = pred[cur][0]
                 path.append(cur)
             
@@ -872,12 +876,12 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
     
 
     return dist
-    
+
 def bellman_ford_path(G, source, target, weight='weight'):
     """See dijkstra_path()
     
     """
-    (length, paths) = single_source_bellman_ford(G, source, target=target, weight=weight)
+    (lengths, paths) = single_source_bellman_ford(G, source, target=target, weight=weight)
     try:
         return paths[target]
     except KeyError:

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -811,10 +811,10 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
        undirected graph is a negative cost cycle
     """
 
-    if pred == None:
+    if pred is None:
         pred = {v: [None] for v in source}
     
-    if dist == None:
+    if dist is None:
         dist = {v: 0 for v in source}
 
     G_succ = G.succ if G.is_directed() else G.adj
@@ -854,17 +854,17 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
                     dist[v] = dist_v
                     pred[v] = [u]
                     
-                elif dist.get(v) != None and dist_v == dist.get(v):
+                elif dist.get(v) is not None and dist_v == dist.get(v):
                     pred[v].append(u)
 
-    if paths != None:
-        dsts = [target] if target != None else pred
+    if paths is not None:
+        dsts = [target] if target is not None else pred
         for dst in dsts:
         
             path = [dst]
             cur = dst
             
-            while pred[cur][0] != None:
+            while pred[cur][0] is not None:
                 cur = pred[cur][0]
                 path.append(cur)
             

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -139,7 +139,7 @@ def dijkstra_path(G, source, target, weight='weight'):
 
     See Also
     --------
-    bidirectional_dijkstra()
+    bidirectional_dijkstra(), bellman_ford_path()
     """
     (length, path) = single_source_dijkstra(G, source, target=target,
                                             weight=weight)
@@ -206,7 +206,8 @@ def dijkstra_path_length(G, source, target, weight='weight'):
 
     See Also
     --------
-    bidirectional_dijkstra
+    bidirectional_dijkstra(), bellman_ford_path_length()
+
     """
     if source == target:
         return 0
@@ -271,7 +272,7 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
 
     See Also
     --------
-    single_source_dijkstra()
+    single_source_dijkstra(), single_source_bellman_ford()
 
     """
     (length, path) = single_source_dijkstra(
@@ -334,7 +335,7 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
 
     See Also
     --------
-    single_source_dijkstra()
+    single_source_dijkstra(), single_source_bellman_ford_path_length()
 
     """
     weight = _weight_function(G, weight)
@@ -416,6 +417,7 @@ def single_source_dijkstra(G, source, target=None, cutoff=None,
     --------
     single_source_dijkstra_path()
     single_source_dijkstra_path_length()
+    single_source_bellman_ford()
     """
     if source == target:
         return ({source: 0}, {source: [source]})
@@ -651,7 +653,7 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
 
     See Also
     --------
-    floyd_warshall()
+    floyd_warshall(), all_pairs_bellman_ford_path()
 
     """
     path = single_source_dijkstra_path
@@ -661,7 +663,6 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
 def bellman_ford(G, source, weight='weight'):
 
     """DEPRECATED: Has been replaced by function bellman_ford_predecessor_and_distance().
-       
 
     """
     _warnings.warn("Function bellman_ford() is deprecated, use function bellman_ford_predecessor_and_distance() instead.",
@@ -878,8 +879,45 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
     return dist
 
 def bellman_ford_path(G, source, target, weight='weight'):
-    """See dijkstra_path()
-    
+    """Returns the shortest path from source to target in a weighted graph G.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node
+
+    target : node
+       Ending node
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight
+
+    Returns
+    -------
+    path : list
+       List of nodes in a shortest path.
+
+    Raises
+    ------
+    NetworkXNoPath
+       If no path exists between source and target.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> print(nx.bellman_ford_path(G,0,4))
+    [0, 1, 2, 3, 4]
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    dijkstra_path(), bellman_ford_path_length()
     """
     (lengths, paths) = single_source_bellman_ford(G, source, target=target, weight=weight)
     try:
@@ -889,8 +927,46 @@ def bellman_ford_path(G, source, target, weight='weight'):
             "node %s not reachable from %s" % (source, target))
             
 def bellman_ford_path_length(G, source, target, weight='weight'):
-    """See dijkstra_path_length()
-    
+    """Returns the shortest path length from source to target
+    in a weighted graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node label
+       starting node for path
+
+    target : node label
+       ending node for path
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight
+
+    Returns
+    -------
+    length : number
+        Shortest path length.
+
+    Raises
+    ------
+    NetworkXNoPath
+        If no path exists between source and target.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> print(nx.bellman_ford_path_length(G,0,4))
+    4
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    dijkstra_path_length(), bellman_ford_path()
     """
     if source == target:
         return 0
@@ -910,16 +986,88 @@ def bellman_ford_path_length(G, source, target, weight='weight'):
             "node %s not reachable from %s" % (source, target))
 
 def single_source_bellman_ford_path(G, source, cutoff=None, weight='weight'):
-    """See single_source_dijkstra_path()
-    
+    """Compute shortest path between source and all other reachable
+    nodes for a weighted graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node for path.
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight
+
+    cutoff : integer or float, optional
+       Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    paths : dictionary
+       Dictionary of shortest path lengths keyed by target.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> path=nx.single_source_bellman_ford_path(G,0)
+    >>> path[4]
+    [0, 1, 2, 3, 4]
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    single_source_dijkstra(), single_source_bellman_ford()
+
     """
     (length, path) = single_source_bellman_ford(
         G, source, cutoff=cutoff, weight=weight)
     return path
 
 def single_source_bellman_ford_path_length(G, source, cutoff=None, weight='weight'):
-    """See single_source_dijkstra_path_length()
-    
+    """Compute the shortest path length between source and all other
+    reachable nodes for a weighted graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node label
+       Starting node for path
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight.
+
+    cutoff : integer or float, optional
+       Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    length : iterator
+        (target, shortest path length) iterator
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> length = dict(nx.single_source_bellman_ford_path_length(G, 0))
+    >>> length[4]
+    4
+    >>> print(length)
+    {0: 0, 1: 1, 2: 2, 3: 3, 4: 4}
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    single_source_dijkstra(), single_source_bellman_ford()
+
     """
     if G.is_multigraph():
         get_weight = lambda u, v, data: min(
@@ -930,7 +1078,52 @@ def single_source_bellman_ford_path_length(G, source, cutoff=None, weight='weigh
     return iter(_bellman_ford(G, [source], get_weight, cutoff=cutoff).items())
 
 def single_source_bellman_ford(G, source, target=None, cutoff=None, weight='weight'):
-    """See single_source_dijkstra()
+    """Compute shortest paths and lengths in a weighted graph G.
+
+    Uses Bellman-Ford algorithm for shortest paths.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node label
+       Starting node for path
+
+    target : node label, optional
+       Ending node for path
+
+    cutoff : integer or float, optional
+       Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    distance,path : dictionaries
+       Returns a tuple of two dictionaries keyed by node.
+       The first dictionary stores distance from the source.
+       The second stores the path from the source to that node.
+
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> length,path=nx.single_source_bellman_ford(G,0)
+    >>> print(length[4])
+    4
+    >>> print(length)
+    {0: 0, 1: 1, 2: 2, 3: 3, 4: 4}
+    >>> path[4]
+    [0, 1, 2, 3, 4]
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    single_source_dijkstra()
+    single_source_bellman_ford_path()
+    single_source_bellman_ford_path_length()
     """
     if source == target:
         return ({source: 0}, {source: [source]})
@@ -946,15 +1139,77 @@ def single_source_bellman_ford(G, source, target=None, cutoff=None, weight='weig
                      target=target), paths)
 
 def all_pairs_bellman_ford_path_length(G, cutoff=None, weight='weight'):
-    """See all_pairs_dijkstra_path_length()
-    
+    """ Compute shortest path lengths between all nodes in a weighted graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight
+
+    cutoff : integer or float, optional
+       Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    distance : iterator
+        (source, dictionary) iterator with dictionary keyed by target and
+        shortest path length as the key value.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> length = dict(nx.all_pairs_bellman_ford_path_length(G))
+    >>> length[1][4]
+    3
+    >>> length[1]
+    {0: 1, 1: 0, 2: 1, 3: 2, 4: 3}
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    The dictionary returned only has keys for reachable node pairs.
     """
     length = single_source_bellman_ford_path_length
     for n in G:
         yield (n, dict(length(G, n, cutoff=cutoff, weight=weight)))
 
 def all_pairs_bellman_ford_path(G, cutoff=None, weight='weight'):
-    """See all_pairs_dijkstra_path()
+    """ Compute shortest paths between all nodes in a weighted graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight
+
+    cutoff : integer or float, optional
+       Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    distance : dictionary
+       Dictionary, keyed by source and target, of shortest paths.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(5)
+    >>> path=nx.all_pairs_bellman_ford_path(G)
+    >>> print(path[0][4])
+    [0, 1, 2, 3, 4]
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    See Also
+    --------
+    floyd_warshall(), all_pairs_dijkstra_path()
 
     """
     path = single_source_bellman_ford_path
@@ -1408,6 +1663,8 @@ def johnson(G, weight='weight'):
     all_pairs_shortest_path_length
     all_pairs_dijkstra_path
     bellman_ford_predecessor_and_distance
+    all_pairs_bellman_ford_path
+    all_pairs_bellman_ford_path_length
 
     """
     if not nx.is_weighted(G, weight=weight):


### PR DESCRIPTION
I found that the bellman_ford function call and return parameters are different in design from Dijkstra's and the BFS in unweighted network. So I have standardized these functions to match said function calls and return parameters.

To do so, I have added all the _path() and _path_length() and single_source_ and all_pairs functions accordingly to that "standard". These all now call a private function _bellman_ford() that performs the actual magic. Furthermore, I added multiple predecessor values when multiple shortest paths exist, just like the Dijkstra function does. Finally, I deprecated (not yet removed in case somebody uses it) the function bellman_ford() with a warning and replaced it with bellman_ford_predecessor_and_distance(), since that is what it actually does.

I already updated all dependent functions, existing tests and doctests. However, before merging additional work regarding unit tests on  the new functions, updating of the documentation and maybe a change of the shortest-path function also checking for negative weights needs to occur. I am willing to do that, but would first like to get your first impression before finishing that part.
