### PR TITLE
Overload graph generators to allow nodes or numbers

### DIFF
--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -3,7 +3,7 @@
 Generators and functions for bipartite graphs.
 
 """
-#    Copyright (C) 2006-2011 by 
+#    Copyright (C) 2006-2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -11,9 +11,11 @@ Generators and functions for bipartite graphs.
 #    BSD license.
 import math
 import random
-import networkx 
+import networkx
 from functools import reduce
 import networkx as nx
+from networkx.utils import nodes_or_number
+
 __author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
                             'Pieter Swart (swart@lanl.gov)',
                             'Dan Schult(dschult@colgate.edu)'])
@@ -28,6 +30,7 @@ __all__=['configuration_model',
          ]
 
 
+@nodes_or_number([0, 1])
 def complete_bipartite_graph(n1, n2, create_using=None):
     """Return the complete bipartite graph `K_{n_1,n_2}`.
 
@@ -58,13 +61,15 @@ def complete_bipartite_graph(n1, n2, create_using=None):
             raise nx.NetworkXError("Directed Graph not supported")
         G = create_using
         G.clear()
-    
-    top = set(range(n1))
-    bottom = set(range(n1, n1+n2))
+
+    n1, top = n1
+    n2, bottom = n2
+    if isinstance(n2, int):
+        bottom = [n1 + i for i in bottom]
     G.add_nodes_from(top, bipartite=0)
     G.add_nodes_from(bottom, bipartite=1)
     G.add_edges_from((u, v) for u in top for v in bottom)
-    G.graph['name'] = "complete_bipartite_graph(%d,%d)" % (n1, n2)
+    G.graph['name'] = "complete_bipartite_graph(%s,%s)" % (n1, n2)
     return G
 
 
@@ -80,7 +85,7 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
     create_using : NetworkX graph instance, optional
        Return graph of this type.
     seed : integer, optional
-       Seed for random number generator. 
+       Seed for random number generator.
 
     Nodes from the set A are connected to nodes in the set B by
     choosing randomly from the possible free stubs, one in A and
@@ -104,12 +109,12 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
     elif create_using.is_directed():
         raise networkx.NetworkXError(\
                 "Directed Graph not supported")
-        
+
 
     G=networkx.empty_graph(0,create_using)
 
     if not seed is None:
-        random.seed(seed)    
+        random.seed(seed)
 
     # length and sum of each sequence
     lena=len(aseq)
@@ -123,17 +128,17 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
               %(suma,sumb))
 
     G=_add_nodes_with_bipartite_label(G,lena,lenb)
-                       
+
     if max(aseq)==0: return G  # done if no edges
 
     # build lists of degree-repeated vertex numbers
     stubs=[]
-    stubs.extend([[v]*aseq[v] for v in range(0,lena)])  
+    stubs.extend([[v]*aseq[v] for v in range(0,lena)])
     astubs=[]
     astubs=[x for subseq in stubs for x in subseq]
 
     stubs=[]
-    stubs.extend([[v]*bseq[v-lena] for v in range(lena,lena+lenb)])  
+    stubs.extend([[v]*bseq[v-lena] for v in range(lena,lena+lenb)])
     bstubs=[]
     bstubs=[x for subseq in stubs for x in subseq]
 
@@ -148,7 +153,7 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
 
 
 def havel_hakimi_graph(aseq, bseq, create_using=None):
-    """Return a bipartite graph from two given degree sequences using a 
+    """Return a bipartite graph from two given degree sequences using a
     Havel-Hakimi style construction.
 
     Nodes from the set A are connected to nodes in the set B by
@@ -202,8 +207,8 @@ def havel_hakimi_graph(aseq, bseq, create_using=None):
     if max(aseq)==0: return G  # done if no edges
 
     # build list of degree-repeated vertex numbers
-    astubs=[[aseq[v],v] for v in range(0,naseq)]  
-    bstubs=[[bseq[v-naseq],v] for v in range(naseq,naseq+nbseq)]  
+    astubs=[[aseq[v],v] for v in range(0,naseq)]
+    bstubs=[[bseq[v-naseq],v] for v in range(naseq,naseq+nbseq)]
     astubs.sort()
     while astubs:
         (degree,u)=astubs.pop() # take of largest degree node in the a set
@@ -276,8 +281,8 @@ def reverse_havel_hakimi_graph(aseq, bseq, create_using=None):
     if max(aseq)==0: return G  # done if no edges
 
     # build list of degree-repeated vertex numbers
-    astubs=[[aseq[v],v] for v in range(0,lena)]  
-    bstubs=[[bseq[v-lena],v] for v in range(lena,lena+lenb)]  
+    astubs=[[aseq[v],v] for v in range(0,lena)]
+    bstubs=[[bseq[v-lena],v] for v in range(lena,lena+lenb)]
     astubs.sort()
     bstubs.sort()
     while astubs:
@@ -296,7 +301,7 @@ def reverse_havel_hakimi_graph(aseq, bseq, create_using=None):
 
 
 def alternating_havel_hakimi_graph(aseq, bseq,create_using=None):
-    """Return a bipartite graph from two given degree sequences using 
+    """Return a bipartite graph from two given degree sequences using
     an alternating Havel-Hakimi style construction.
 
     Nodes from the set A are connected to nodes in the set B by
@@ -350,14 +355,14 @@ def alternating_havel_hakimi_graph(aseq, bseq,create_using=None):
 
     if max(aseq)==0: return G  # done if no edges
     # build list of degree-repeated vertex numbers
-    astubs=[[aseq[v],v] for v in range(0,naseq)]  
-    bstubs=[[bseq[v-naseq],v] for v in range(naseq,naseq+nbseq)]  
+    astubs=[[aseq[v],v] for v in range(0,naseq)]
+    bstubs=[[bseq[v-naseq],v] for v in range(naseq,naseq+nbseq)]
     while astubs:
         astubs.sort()
         (degree,u)=astubs.pop() # take of largest degree node in the a set
         if degree==0: break # done, all are zero
         bstubs.sort()
-        small=bstubs[0:degree // 2]  # add these low degree targets     
+        small=bstubs[0:degree // 2]  # add these low degree targets
         large=bstubs[(-degree+degree // 2):] # and these high degree targets
         stubs=[x for z in zip(large,small) for x in z] # combine, sorry
         if len(stubs)<len(small)+len(large): # check for zip truncation
@@ -373,7 +378,7 @@ def alternating_havel_hakimi_graph(aseq, bseq,create_using=None):
     return G
 
 def preferential_attachment_graph(aseq,p,create_using=None,seed=None):
-    """Create a bipartite graph with a preferential attachment model from 
+    """Create a bipartite graph with a preferential attachment model from
     a given single degree sequence.
 
     Parameters
@@ -385,7 +390,7 @@ def preferential_attachment_graph(aseq,p,create_using=None,seed=None):
     create_using : NetworkX graph instance, optional
        Return graph of this type.
     seed : integer, optional
-       Seed for random number generator. 
+       Seed for random number generator.
 
     References
     ----------
@@ -406,13 +411,13 @@ def preferential_attachment_graph(aseq,p,create_using=None,seed=None):
         raise networkx.NetworkXError(\
                 "Directed Graph not supported")
 
-    if p > 1: 
+    if p > 1:
         raise networkx.NetworkXError("probability %s > 1"%(p))
 
     G=networkx.empty_graph(0,create_using)
 
     if not seed is None:
-        random.seed(seed)    
+        random.seed(seed)
 
     naseq=len(aseq)
     G=_add_nodes_with_bipartite_label(G,naseq,0)
@@ -428,9 +433,9 @@ def preferential_attachment_graph(aseq,p,create_using=None,seed=None):
             else:
                 bb=[ [b]*G.degree(b) for b in range(naseq,G.number_of_nodes())]
                 # flatten the list of lists into a list.
-                bbstubs=reduce(lambda x,y: x+y, bb) 
+                bbstubs=reduce(lambda x,y: x+y, bb)
                 # choose preferentially a bottom node.
-                target=random.choice(bbstubs) 
+                target=random.choice(bbstubs)
                 G.add_node(target,bipartite=1)
                 G.add_edge(source,target)
         vv.remove(vv[0])
@@ -453,20 +458,20 @@ def random_graph(n, m, p, seed=None, directed=False):
     p : float
         Probability for edge creation.
     seed : int, optional
-        Seed for random number generator (default=None). 
+        Seed for random number generator (default=None).
     directed : bool, optional (default=False)
-        If True return a directed graph 
-      
+        If True return a directed graph
+
     Notes
     -----
     This function is not imported in the main namespace.
     To use it you have to explicitly import the bipartite package.
 
-    The bipartite random graph algorithm chooses each of the n*m (undirected) 
+    The bipartite random graph algorithm chooses each of the n*m (undirected)
     or 2*nm (directed) possible edges with probability p.
 
     This algorithm is O(n+m) where m is the expected number of edges.
-    
+
     The nodes are assigned the attribute 'bipartite' with the value 0 or 1
     to indicate which bipartite set the node belongs to.
 
@@ -476,7 +481,7 @@ def random_graph(n, m, p, seed=None, directed=False):
 
     References
     ----------
-    .. [1] Vladimir Batagelj and Ulrik Brandes, 
+    .. [1] Vladimir Batagelj and Ulrik Brandes,
        "Efficient generation of large random networks",
        Phys. Rev. E, 71, 036113, 2005.
     """
@@ -493,10 +498,10 @@ def random_graph(n, m, p, seed=None, directed=False):
         return G
     if p >= 1:
         return nx.complete_bipartite_graph(n,m)
-        
-    lp = math.log(1.0 - p)  
 
-    v = 0 
+    lp = math.log(1.0 - p)
+
+    v = 0
     w = -1
     while v < n:
         lr = math.log(1.0 - random.random())
@@ -508,9 +513,9 @@ def random_graph(n, m, p, seed=None, directed=False):
             G.add_edge(v, n+w)
 
     if directed:
-        # use the same algorithm to 
+        # use the same algorithm to
         # add edges from the "m" to "n" set
-        v = 0 
+        v = 0
         w = -1
         while v < n:
             lr = math.log(1.0 - random.random())
@@ -538,10 +543,10 @@ def gnmk_random_graph(n, m, k, seed=None, directed=False):
     k : int
         The number of edges
     seed : int, optional
-        Seed for random number generator (default=None). 
+        Seed for random number generator (default=None).
     directed : bool, optional (default=False)
-        If True return a directed graph 
-        
+        If True return a directed graph
+
     Examples
     --------
     from networkx.algorithms import bipartite

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -41,6 +41,14 @@ class TestGeneratorsBipartite():
         mG=complete_bipartite_graph(7, 3, create_using=MultiGraph())
         assert_equal(sorted(mG.edges()), sorted(G.edges()))
 
+        # specify nodes rather than number of nodes
+        G = complete_bipartite_graph([1, 2], ['a', 'b'])
+        has_edges = G.has_edge(1,'a') & G.has_edge(1,'b') &\
+                G.has_edge(2,'a') & G.has_edge(2,'b')
+        assert_true(has_edges)
+        assert_equal(G.size(), 4)
+
+
     def test_configuration_model(self):
         aseq=[3,3,3,3]
         bseq=[2,2,2,2,2]

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -24,7 +24,8 @@ import networkx as nx
 from networkx.algorithms.bipartite.generators import complete_bipartite_graph
 from networkx.utils import accumulate
 from networkx.utils import flatten
-from networkx.utils import is_list_of_ints
+from networkx.utils import nodes_or_number
+from networkx.utils import pairwise
 
 __author__ ="""Aric Hagberg (hagberg@lanl.gov)\nPieter Swart (swart@lanl.gov)"""
 
@@ -194,18 +195,20 @@ def barbell_graph(m1,m2,create_using=None):
         G.add_edge(m1+m2-1,m1+m2)
     return G
 
-def complete_graph(n,create_using=None):
+@nodes_or_number(0)
+def complete_graph(n, create_using=None):
     """ Return the complete graph K_n with n nodes.
 
     Node labels are the integers 0 to n-1.
     """
-    G=empty_graph(n,create_using)
-    G.name="complete_graph(%d)"%(n)
-    if n>1:
+    n_name, nodes = n
+    G=empty_graph(n_name, create_using)
+    G.name="complete_graph(%s)"%(n_name,)
+    if len(nodes) > 1:
         if G.is_directed():
-            edges=itertools.permutations(range(n),2)
+            edges=itertools.permutations(nodes, 2)
         else:
-            edges=itertools.combinations(range(n),2)
+            edges=itertools.combinations(nodes, 2)
         G.add_edges_from(edges)
     return G
 
@@ -280,18 +283,23 @@ def circulant_graph(n, offsets, create_using=None):
             G.add_edge(i, (i + j) % n)
     return G
 
-def cycle_graph(n,create_using=None):
-    """Return the cycle graph C_n over n nodes.
+@nodes_or_number(0)
+def cycle_graph(n, create_using=None):
+    """Return the cycle graph C_n of cyclicly connected nodes.
 
-    C_n is the n-path with two end-nodes connected.
+    C_n is a path with its two end-nodes connected.
 
-    Node labels are the integers 0 to n-1
+    If `nodes` is an iterable, it contains the nodes in the cycle.
+    Otherwise `range(nodes)` is used and `nodes` must be a number.
+
     If create_using is a DiGraph, the direction is in increasing order.
 
     """
-    G=path_graph(n,create_using)
-    G.name="cycle_graph(%d)"%n
-    if n>1: G.add_edge(n-1,0)
+    n_orig, nodes = n
+    G = empty_graph(nodes, create_using)
+    G.name="cycle_graph(%s)"%(n_orig,)
+    G.add_edges_from(nx.utils.pairwise(nodes))
+    G.add_edge(nodes[-1], nodes[0])
     return G
 
 def dorogovtsev_goltsev_mendes_graph(n,create_using=None):
@@ -321,10 +329,12 @@ def dorogovtsev_goltsev_mendes_graph(n,create_using=None):
             new_node += 1
     return G
 
-def empty_graph(n=0,create_using=None):
+@nodes_or_number(0)
+def empty_graph(n=0, create_using=None):
     """Return the empty graph with n nodes and zero edges.
 
-    Node labels are the integers 0 to n-1
+    If n is iterable, it holds the node labels.
+    Otherwise node labels are the integers 0 to n-1
 
     For example:
     >>> G=nx.empty_graph(10)
@@ -332,28 +342,32 @@ def empty_graph(n=0,create_using=None):
     10
     >>> G.number_of_edges()
     0
+    >>> G=nx.empty_graph("ABC")
+    >>> G.number_of_nodes()
+    3
+    >>> sorted(G)
+    ['A', 'B', 'C']
 
     The variable create_using should point to a "graph"-like object that
-    will be cleaned (nodes and edges will be removed) and refitted as
-    an empty "graph" with n nodes with integer labels. This capability
+    will be cleared (nodes and edges will be removed) and refitted as
+    an empty "graph" with nodes specified in n. This capability
     is useful for specifying the class-nature of the resulting empty
     "graph" (i.e. Graph, DiGraph, MyWeirdGraphClass, etc.).
 
     The variable create_using has two main uses:
     Firstly, the variable create_using can be used to create an
-    empty digraph, network,etc.  For example,
+    empty digraph, multigraph, etc.  For example,
 
     >>> n=10
     >>> G=nx.empty_graph(n,create_using=nx.DiGraph())
 
     will create an empty digraph on n nodes.
 
-    Secondly, one can pass an existing graph (digraph, pseudograph,
+    Secondly, one can pass an existing graph (digraph, multigraph,
     etc.) via create_using. For example, if G is an existing graph
-    (resp. digraph, pseudograph, etc.), then empty_graph(n,create_using=G)
-    will empty G (i.e. delete all nodes and edges using G.clear() in
-    base) and then add n nodes and zero edges, and return the modified
-    graph (resp. digraph, pseudograph, etc.).
+    (resp. digraph, multigraph, etc.), then empty_graph(n, create_using=G)
+    will empty G (i.e. delete all nodes and edges using G.clear())
+    and then add n nodes and zero edges, and return the modified graph.
 
     See also create_empty_copy(G).
 
@@ -365,10 +379,12 @@ def empty_graph(n=0,create_using=None):
         G=create_using
         G.clear()
 
-    G.add_nodes_from(range(n))
-    G.name="empty_graph(%d)"%n
+    n_name, nodes = n
+    G.name="empty_graph(%s)"%(n_name,)
+    G.add_nodes_from(nodes)
     return G
 
+@nodes_or_number([0,1])
 def grid_2d_graph(m,n,periodic=False,create_using=None):
     """ Return the 2d grid graph of mxn nodes,
         each connected to its nearest neighbors.
@@ -376,35 +392,41 @@ def grid_2d_graph(m,n,periodic=False,create_using=None):
         boundary nodes via periodic boundary conditions.
     """
     G=empty_graph(0,create_using)
-    G.name="grid_2d_graph"
-    rows=range(m)
-    columns=range(n)
+    row_name, rows = m
+    col_name, columns = n
+    G.name="grid_2d_graph(%s, %s)"%(row_name, col_name)
     G.add_nodes_from( (i,j) for i in rows for j in columns )
-    G.add_edges_from( ((i,j),(i-1,j)) for i in rows for j in columns if i>0 )
-    G.add_edges_from( ((i,j),(i,j-1)) for i in rows for j in columns if j>0 )
+    G.add_edges_from( ((i,j),(pi,j)) for pi,i in pairwise(rows) for j in columns )
+    G.add_edges_from( ((i,j),(i,pj)) for i in rows for pj,j in pairwise(columns) )
     if G.is_directed():
-        G.add_edges_from( ((i,j),(i+1,j)) for i in rows for j in columns if i<m-1 )
-        G.add_edges_from( ((i,j),(i,j+1)) for i in rows for j in columns if j<n-1 )
+        G.add_edges_from( ((pi,j),(i,j)) for pi,i in pairwise(rows) for j in columns )
+        G.add_edges_from( ((i,pj),(i,j)) for i in rows for pj,j in pairwise(columns) )
     if periodic:
-        if n>2:
-            G.add_edges_from( ((i,0),(i,n-1)) for i in rows )
+        if len(columns)>2:
+            f = columns[0]
+            l = columns[-1]
+            G.add_edges_from( ((i,f),(i,l)) for i in rows )
             if G.is_directed():
-                G.add_edges_from( ((i,n-1),(i,0)) for i in rows )
-        if m>2:
-            G.add_edges_from( ((0,j),(m-1,j)) for j in columns )
+                G.add_edges_from( ((i,l),(i,f)) for i in rows )
+        if len(rows)>2:
+            f = rows[0]
+            l = rows[-1]
+            G.add_edges_from( ((f,j),(l,j)) for j in columns )
             if G.is_directed():
-                G.add_edges_from( ((m-1,j),(0,j)) for j in columns )
-        G.name="periodic_grid_2d_graph(%d,%d)"%(m,n)
+                G.add_edges_from( ((l,j),(f,j)) for j in columns )
+        G.name="periodic_grid_2d_graph(%s,%s)"%(m,n)
     return G
 
 
 def grid_graph(dim,periodic=False):
     """ Return the n-dimensional grid graph.
 
-    The dimension is the length of the list 'dim' and the
-    size in each dimension is the value of the list element.
+    'dim' is a list with the size in each dimension or an
+    iterable of nodes for each dimension. The dimension of
+    the grid_graph is the length of the list 'dim'.
 
     E.g. G=grid_graph(dim=[2,3]) produces a 2x3 grid graph.
+    E.g. G=grid_graph(dim=[range(7,9), range(3,6)]) produces a 2x3 grid graph.
 
     If periodic=True then join grid edges with periodic boundary conditions.
 
@@ -414,11 +436,6 @@ def grid_graph(dim,periodic=False):
         G=empty_graph(0)
         G.name="grid_graph(%s)"%dim
         return G
-    if not is_list_of_ints(dim):
-        raise nx.NetworkXError("dim is not a list of integers")
-    if min(dim)<=0:
-        raise nx.NetworkXError(\
-              "dim is not a list of strictly positive integers")
     if periodic:
         func=cycle_graph
     else:
@@ -470,7 +487,8 @@ def ladder_graph(n,create_using=None):
     G.add_edges_from([(v,v+n) for v in range(n)])
     return G
 
-def lollipop_graph(m,n,create_using=None):
+@nodes_or_number([0, 1])
+def lollipop_graph(m, n, create_using=None):
     """Return the Lollipop Graph; `K_m` connected to `P_n`.
 
     This is the Barbell Graph without the right barbell.
@@ -487,23 +505,31 @@ def lollipop_graph(m,n,create_using=None):
     Fill's etext on Random Walks on Graphs.)
 
     """
+    m, m_nodes = m
+    n, n_nodes = n
+    M = len(m_nodes)
+    N = len(n_nodes)
+    if isinstance(m, int):
+        n_nodes = [len(m_nodes) + i for i in n_nodes]
     if create_using is not None and create_using.is_directed():
         raise nx.NetworkXError("Directed Graph not supported")
-    if m<2:
+    if M < 2:
         raise nx.NetworkXError(\
               "Invalid graph description, m should be >=2")
-    if n<0:
+    if N < 0:
         raise nx.NetworkXError(\
               "Invalid graph description, n should be >=0")
+
     # the ball
-    G=complete_graph(m,create_using)
+    G = complete_graph(m_nodes, create_using)
     # the stick
-    G.add_nodes_from([v for v in range(m,m+n)])
-    if n>1:
-        G.add_edges_from([(v,v+1) for v in range(m,m+n-1)])
+    G.add_nodes_from(n_nodes)
+    if N > 1:
+        G.add_edges_from(pairwise(n_nodes))
     # connect ball to stick
-    if m>0: G.add_edge(m-1,m)
-    G.name="lollipop_graph(%d,%d)"%(m,n)
+    if M > 0 and N > 0:
+        G.add_edge(m_nodes[-1], n_nodes[0])
+    G.name="lollipop_graph(%s, %s)"%(m, n)
     return G
 
 
@@ -517,27 +543,50 @@ def null_graph(create_using=None):
     G.name="null_graph()"
     return G
 
-def path_graph(n,create_using=None):
-    """Return the Path graph P_n of n nodes linearly connected by n-1 edges.
+@nodes_or_number(0)
+def path_graph(n, create_using=None):
+    """Return the Path graph P_n of linearly connected nodes.
 
-    Node labels are the integers 0 to n - 1.
+    If `nodes` is an iterable, it contains the nodes in the path.
+    Otherwise `range(nodes)` is used and `nodes` must be a number.
+
     If create_using is a DiGraph then the edges are directed in
     increasing order.
 
     """
-    G=empty_graph(n,create_using)
-    G.name="path_graph(%d)"%n
-    G.add_edges_from([(v,v+1) for v in range(n-1)])
+    n_name, nodes = n
+    G = empty_graph(nodes, create_using)
+    G.name="path_graph(%s)"%(n_name,)
+    G.add_edges_from(nx.utils.pairwise(nodes))
     return G
 
-def star_graph(n,create_using=None):
-    """ Return the Star graph with n+1 nodes: one center node, connected to n outer nodes.
+@nodes_or_number(0)
+def star_graph(n, create_using=None):
+    """ Return the Star graph: one center node connected to n outer nodes.
 
-   Node labels are the integers 0 to n.
+    Parameters
+    ==========
+    n : int or iterable
+        If an integer, node labels are 0 to n with center 0.
+        If an iterable of nodes, the center is the first.
 
+    create_using : graph, optional (default Graph())
+       Return graph of this type. The instance will be cleared.
+
+    Notes
+    =====
+    The graph has n+1 nodes for integer n.
+    So `star_graph(3)` is the same as `star_graph(range(4))`.
     """
-    G=complete_bipartite_graph(1,n,create_using)
-    G.name="star_graph(%d)"%n
+    n_name, nodes = n
+    if isinstance(n_name, int):
+        nodes = nodes + [n_name] # there should be n+1 nodes
+    first=nodes[0]
+    G = empty_graph(nodes, create_using)
+    if G.is_directed():
+        raise nx.NetworkXError("Directed Graph not supported")
+    G.add_edges_from((first, v) for v in nodes[1:])
+    G.name="star_graph(%s)"%(n_name,)
     return G
 
 def trivial_graph(create_using=None):
@@ -548,19 +597,23 @@ def trivial_graph(create_using=None):
     G.name="trivial_graph()"
     return G
 
-def wheel_graph(n,create_using=None):
+@nodes_or_number(0)
+def wheel_graph(n, create_using=None):
     """ Return the wheel graph: a single hub node connected to each node of the (n-1)-node cycle graph.
 
-   Node labels are the integers 0 to n - 1.
+    Node labels are the integers 0 to n - 1.
 
     """
-    if n == 0:
-        return nx.empty_graph(n, create_using=create_using)
-    G=star_graph(n-1,create_using)
-    G.name="wheel_graph(%d)"%n
-    G.add_edges_from([(v,v+1) for v in range(1,n-1)])
-    if n>2:
-        G.add_edge(1,n-1)
+    n_name, nodes = n
+    if n_name == 0:
+        G = nx.empty_graph(0, create_using=create_using)
+        G.name = "wheel_graph(0)"
+        return G
+    G = star_graph(nodes, create_using)
+    G.name="wheel_graph(%s)"%(n_name,)
+    if len(G) > 2:
+        G.add_edges_from(pairwise(nodes[1:]))
+        G.add_edge(nodes[-1],nodes[1])
     return G
 
 
@@ -569,25 +622,24 @@ def complete_multipartite_graph(*block_sizes):
 
     Parameters
     ----------
-
-    block_sizes : tuple of integers
-
-       The number of vertices in each block of the multipartite graph. The
-       length of this tuple is the number of blocks.
+    block_sizes : tuple of integers or tuple of node iterables
+       The arguments can either all be integer number of nodes or they
+       can all be iterables of nodes. If integers, they represent the
+       number of vertices in each block of the multipartite graph.
+       If iterables, each is used to create the nodes for that block.
+       The length of block_sizes is the number of blocks.
 
     Returns
     -------
-
     G : NetworkX Graph
 
-       Returns the complete multipartite graph with the specified block sizes.
+       Returns the complete multipartite graph with the specified blocks.
 
-       For each node, the node attribute ``'block'`` is an integer indicating
-       which block contains the node.
+       For each node, the node attribute ``'block'`` is an integer
+       indicating which block contains the node.
 
     Examples
     --------
-
     Creating a complete tripartite graph, with blocks of one, two, and three
     vertices, respectively.
 
@@ -602,9 +654,12 @@ def complete_multipartite_graph(*block_sizes):
         >>> list(G.edges(4))
         [(4, 0), (4, 1), (4, 2)]
 
+        >>> G = nx.complete_multipartite_graph('a', 'bc', 'def')
+        >>> [G.node[u]['block'] for u in sorted(G)]
+        [0, 1, 1, 2, 2, 2]
+
     Notes
     -----
-
     This function generalizes several other graph generator functions.
 
     - If no block sizes are given, this returns the null graph.
@@ -617,21 +672,32 @@ def complete_multipartite_graph(*block_sizes):
 
     See also
     --------
-
     complete_bipartite_graph
-
     """
-    G = nx.empty_graph(sum(block_sizes))
-    # If block_sizes is (n1, n2, n3, ...), create pairs of the form (0, n1),
-    # (n1, n1 + n2), (n1 + n2, n1 + n2 + n3), etc.
-    extents = zip([0] + list(accumulate(block_sizes)), accumulate(block_sizes))
-    blocks = [range(start, end) for start, end in extents]
-    for (i, block) in enumerate(blocks):
-        G.add_nodes_from(block, block=i)
-    # Across blocks, all vertices should be adjacent. We can use
-    # itertools.combinations() because the complete multipartite graph is an
-    # undirected graph.
+    # The complete multipartite graph is an undirected simple graph.
+    G = nx.Graph()
+    G.name = 'complete_multiparite_graph{}'.format(block_sizes)
+
+    if len(block_sizes) == 0:
+        return G
+
+    # set up blocks of nodes
+    try:
+        extents = pairwise(accumulate((0,) + block_sizes))
+        blocks = [range(start, end) for start, end in extents]
+    except TypeError:
+        blocks = block_sizes
+
+    # add nodes with block attribute
+    # while checking that ints are not mixed with iterables
+    try:
+        for (i, block) in enumerate(blocks):
+            G.add_nodes_from(block, block=i)
+    except TypeError:
+        raise nx.NetworkXError("Arguments must be all ints or all iterables")
+
+    # Across blocks, all vertices should be adjacent.
+    # We can use itertools.combinations() because undirected.
     for block1, block2 in itertools.combinations(blocks, 2):
         G.add_edges_from(itertools.product(block1, block2))
-    G.name = 'complete_multiparite_graph{0}'.format(block_sizes)
     return G

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -23,11 +23,13 @@ from functools import reduce
 from itertools import product
 import math, random, sys
 import networkx as nx
+from networkx.utils import nodes_or_number
 
 #---------------------------------------------------------------------------
 #  Random Geometric Graphs
 #---------------------------------------------------------------------------
 
+@nodes_or_number(0)
 def random_geometric_graph(n, radius, dim=2, pos=None):
     """Returns a random geometric graph in the unit cube.
 
@@ -37,8 +39,8 @@ def random_geometric_graph(n, radius, dim=2, pos=None):
 
     Parameters
     ----------
-    n : int
-        Number of nodes
+    n : int or iterable
+        Number of nodes or iterable of nodes
     radius: float
         Distance threshold value
     dim : int, optional
@@ -80,9 +82,10 @@ def random_geometric_graph(n, radius, dim=2, pos=None):
     .. [1] Penrose, Mathew, Random Geometric Graphs,
        Oxford Studies in Probability, 5, 2003.
     """
+    n_name, nodes = n
     G=nx.Graph()
     G.name="Random Geometric Graph"
-    G.add_nodes_from(range(n))
+    G.add_nodes_from(nodes)
     if pos is None:
         # random positions
         for n in G:
@@ -102,7 +105,7 @@ def random_geometric_graph(n, radius, dim=2, pos=None):
                 G.add_edge(u,v)
     return G
 
-
+@nodes_or_number(0)
 def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
                                  weight=None):
     r"""Returns a geographical threshold graph.
@@ -120,8 +123,8 @@ def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
 
     Parameters
     ----------
-    n : int
-        Number of nodes
+    n : int or iterable
+        Number of nodes or iterable of nodes
     theta: float
         Threshold value
     alpha: float, optional
@@ -168,9 +171,10 @@ def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
        in Algorithms and Models for the Web-Graph (WAW 2007),
        Antony Bonato and Fan Chung (Eds), pp. 209--216, 2007
     """
+    n_name, nodes = n
     G=nx.Graph()
     # add n nodes
-    G.add_nodes_from([v for v in range(n)])
+    G.add_nodes_from(nodes)
     if weight is None:
         # choose weights from exponential distribution
         for n in G:
@@ -205,7 +209,7 @@ def geographical_threshold_edges(G, theta, alpha=2):
             if wu+wv >= theta*r**alpha:
                 yield(u,v)
 
-
+@nodes_or_number(0)
 def waxman_graph(n, alpha=0.4, beta=0.1, L=None, domain=(0, 0, 1, 1)):
     r"""Return a Waxman random graph.
 
@@ -226,8 +230,8 @@ def waxman_graph(n, alpha=0.4, beta=0.1, L=None, domain=(0, 0, 1, 1)):
 
     Parameters
     ----------
-    n : int
-        Number of nodes
+    n : int or iterable
+        Number of nodes or iterable of nodes
     alpha: float
         Model parameter
     beta: float
@@ -249,8 +253,9 @@ def waxman_graph(n, alpha=0.4, beta=0.1, L=None, domain=(0, 0, 1, 1)):
        IEEE J. Select. Areas Commun. 6(9),(1988) 1617-1622.
     """
     # build graph of n nodes with random positions in the unit square
+    n_name, nodes = n
     G = nx.Graph()
-    G.add_nodes_from(range(n))
+    G.add_nodes_from(nodes)
     (xmin,ymin,xmax,ymax)=domain
     for n in G:
         G.node[n]['pos']=(xmin + ((xmax-xmin)*random.random()),

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -140,9 +140,12 @@ class TestGeneratorClassic():
             assert_true(number_of_nodes(g) == m)
             assert_true(number_of_edges(g) == m * (m - 1) // 2)
 
-
         mg=complete_graph(m, create_using=MultiGraph())
         assert_equal(sorted(mg.edges()), sorted(g.edges()))
+
+        g = complete_graph("abc")
+        assert_equal(sorted(g.nodes()), ['a', 'b', 'c'])
+        assert_equal(g.size(), 3)
 
     def test_complete_digraph(self):
         # complete_graph(m) is a connected graph with
@@ -151,6 +154,11 @@ class TestGeneratorClassic():
             g = complete_graph(m,create_using=nx.DiGraph())
             assert_true(number_of_nodes(g) == m)
             assert_true(number_of_edges(g) == m * (m - 1))
+
+        g = complete_graph("abc", create_using=nx.DiGraph())
+        assert_equal(len(g), 3)
+        assert_equal(g.size(), 6)
+        assert_true(g.is_directed())
 
     def test_circular_ladder_graph(self):
         G=circular_ladder_graph(5)
@@ -183,6 +191,15 @@ class TestGeneratorClassic():
         G=cycle_graph(4, create_using=DiGraph())
         assert_false(G.has_edge(2,1))
         assert_true(G.has_edge(1,2))
+        assert_true(G.is_directed())
+
+        G=cycle_graph("abc")
+        assert_equal(len(G), 3)
+        assert_equal(G.size(), 3)
+        g=cycle_graph("abc", nx.DiGraph())
+        assert_equal(len(g), 3)
+        assert_equal(g.size(), 3)
+        assert_true(g.is_directed())
 
     def test_dorogovtsev_goltsev_mendes_graph(self):
         G=dorogovtsev_goltsev_mendes_graph(0)
@@ -213,6 +230,10 @@ class TestGeneratorClassic():
         assert_equal(number_of_nodes(G), 42)
         assert_equal(number_of_edges(G), 0)
         assert_equal(G.name, 'empty_graph(42)')
+
+        G=empty_graph("abc")
+        assert_equal(len(G), 3)
+        assert_equal(G.size(), 0)
 
         # create empty digraph
         G=empty_graph(42,create_using=DiGraph(name="duh"))
@@ -246,6 +267,8 @@ class TestGeneratorClassic():
         assert_equal(DG.pred, G.adj)
         MG=grid_2d_graph(n,m, create_using=MultiGraph())
         assert_equal(sorted(MG.edges()), sorted(G.edges()))
+        g=grid_2d_graph(range(n), range(m))
+        assert_equal(sorted(g.edges()), sorted(G.edges()))
 
     def test_grid_graph(self):
         """grid_graph([n,m]) is a connected simple graph with the
@@ -269,6 +292,10 @@ class TestGeneratorClassic():
 
 #        mg=grid_graph([n,m], create_using=MultiGraph())
 #        assert_equal(mg.edges(), g.edges())
+
+        g=grid_graph([range(7,9), range(3,6)])
+        assert_equal(number_of_nodes(g), 2*3)
+        assert_true(is_isomorphic(g, grid_graph([2,3])))
 
     def test_hypercube_graph(self):
         for n, G in [(0, null_graph()), (1, path_graph(2)),
@@ -306,7 +333,7 @@ class TestGeneratorClassic():
             assert_equal(number_of_nodes(b), m1+m2)
             assert_equal(number_of_edges(b), m1*(m1-1)/2 + m2)
             assert_equal(b.name,
-                         'lollipop_graph(' + str(m1) + ',' + str(m2) + ')')
+                         'lollipop_graph(' + str(m1) + ', ' + str(m2) + ')')
 
         # Raise NetworkXError if m<2
         assert_raises(networkx.exception.NetworkXError,
@@ -326,6 +353,10 @@ class TestGeneratorClassic():
 
         mb=lollipop_graph(m1, m2, create_using=MultiGraph())
         assert_equal(sorted(mb.edges()), sorted(b.edges()))
+
+        g=lollipop_graph([1,2,3,4], "abc")
+        assert_equal(len(g), 7)
+        assert_equal(g.size(), 9)
 
     def test_null_graph(self):
         assert_equal(number_of_nodes(null_graph()), 0)
@@ -352,6 +383,14 @@ class TestGeneratorClassic():
         mp=path_graph(10, create_using=MultiGraph())
         assert_equal(sorted(mp.edges()), sorted(p.edges()))
 
+        G=path_graph("abc")
+        assert_equal(len(G), 3)
+        assert_equal(G.size(), 2)
+        g=path_graph("abc", nx.DiGraph())
+        assert_equal(len(g), 3)
+        assert_equal(g.size(), 2)
+        assert_true(g.is_directed())
+
     def test_periodic_grid_2d_graph(self):
         g=grid_2d_graph(0,0, periodic=True)
         assert_equal(dict(g.degree()), {})
@@ -369,10 +408,16 @@ class TestGeneratorClassic():
         MG=grid_2d_graph(4, 2, periodic=True, create_using=MultiGraph())
         assert_equal(sorted(MG.edges()), sorted(g.edges()))
 
+        gg=grid_2d_graph(range(4), range(2), periodic=True)
+        assert_true(is_isomorphic(gg, g))
+        ggg=grid_2d_graph("abcd", "ef", periodic=True)
+        assert_true(is_isomorphic(ggg, g))
+
     def test_star_graph(self):
         assert_true(is_isomorphic(star_graph(0), empty_graph(1)))
         assert_true(is_isomorphic(star_graph(1), path_graph(2)))
         assert_true(is_isomorphic(star_graph(2), path_graph(3)))
+        assert_true(is_isomorphic(star_graph(5), nx.complete_bipartite_graph(1,5)))
 
         s=star_graph(10)
         assert_equal(sorted(d for n, d in s.degree()),
@@ -383,6 +428,10 @@ class TestGeneratorClassic():
 
         ms=star_graph(10, create_using=MultiGraph())
         assert_equal(sorted(ms.edges()), sorted(s.edges()))
+
+        G=star_graph("abcdefg")
+        assert_equal(len(G), 7)
+        assert_equal(G.size(), 6)
 
     def test_trivial_graph(self):
         assert_equal(number_of_nodes(trivial_graph()), 1)
@@ -405,6 +454,10 @@ class TestGeneratorClassic():
 
         mg=wheel_graph(10, create_using=MultiGraph())
         assert_equal(sorted(mg.edges()), sorted(g.edges()))
+
+        G=wheel_graph("abc")
+        assert_equal(len(G), 3)
+        assert_equal(G.size(), 3)
 
     def test_complete_0_partite_graph(self):
         """Tests that the complete 0-partite graph is the null graph."""

--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -6,15 +6,21 @@ class TestGeneratorsGeometric():
     def test_random_geometric_graph(self):
         G=nx.random_geometric_graph(50,0.25)
         assert_equal(len(G),50)
+        G=nx.random_geometric_graph(range(50),0.25)
+        assert_equal(len(G),50)
 
     def test_geographical_threshold_graph(self):
         G=nx.geographical_threshold_graph(50,100)
+        assert_equal(len(G),50)
+        G=nx.geographical_threshold_graph(range(50),100)
         assert_equal(len(G),50)
 
     def test_waxman_graph(self):
         G=nx.waxman_graph(50,0.5,0.1)
         assert_equal(len(G),50)
         G=nx.waxman_graph(50,0.5,0.1,L=1)
+        assert_equal(len(G),50)
+        G=nx.waxman_graph(range(50),0.5,0.1)
         assert_equal(len(G),50)
         
     def test_naviable_small_world(self):

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -10,6 +10,7 @@ from networkx.utils import is_string_like
 __all__ = [
     'not_implemented_for',
     'open_file',
+    'nodes_or_number',
 ]
 
 def not_implemented_for(*graph_types):
@@ -40,11 +41,11 @@ def not_implemented_for(*graph_types):
     Decorate functions like this::
 
        @not_implemnted_for('directed')
-       def sp_function():
+       def sp_function(G):
            pass
 
        @not_implemnted_for('directed','multigraph')
-       def sp_np_function():
+       def sp_np_function(G):
            pass
     """
     @decorator
@@ -225,3 +226,60 @@ def open_file(path_arg, mode='r'):
         return result
 
     return _open_file
+
+
+def nodes_or_number(which_args):
+    """Decorator to allow number of nodes or container of nodes.
+
+    Parameters
+    ----------
+    which_args : int or sequence of ints
+        Location of the node arguments in args. Even if the argument is a
+        named positional argument (with a default value), you must specify its
+        index as a positional argument.
+        If more than one node argument is allowed, can be a list of locations.
+
+    Returns
+    -------
+    _nodes_or_numbers : function
+        Function which replaces int args with ranges.
+
+    Examples
+    --------
+    Decorate functions like this::
+
+       @nodes_or_number(0)
+       def empty_graph(nodes):
+           pass
+
+       @nodes_or_number([0,1])
+       def grid_2d_graph(m1, m2, periodic=False):
+           pass
+
+       @nodes_or_number(1)
+       def full_rary_tree(r, n)
+           # r is a number. n can be a number of a list of nodes
+           pass
+    """
+    @decorator
+    def _nodes_or_number(f, *args, **kw):
+        # form tuple of arg positions to be converted.
+        try:
+            iter_wa = iter(which_args)
+        except TypeError:
+            iter_wa = (which_args,)
+        # change each argument in turn
+        new_args = list(args)
+        for i in iter_wa:
+            n = args[i]
+            try:
+                nodes = list(range(n))
+            except TypeError:
+                nodes = tuple(n)
+            else:
+                if n < 0:
+                    msg = "Negative number of nodes not valid: %i" % n
+                    raise nx.NetworkXError(msg)
+            new_args[i] = (n, nodes)
+        return f(*new_args, **kw)
+    return _nodes_or_number


### PR DESCRIPTION
Create decorator ```@nodes_or_number(which_args)``` which replaces the arguments numbered by ```which_args``` with a 2-tuple ```(n_name, nodes)``` where ```n_name``` is the original argument value and ```nodes``` is the resulting list of nodes.  ```which_args``` can be a positive integer or a list of positive integers. The integers point to which argument includes the nodes. Keyword identity is not needed for any of the use_cases I have run into.

The reason for the 2-tuple is so that ```G.name``` can include the original call signature. Also, ```star_graph(9)``` has 10 nodes in it while ```star_graph(range(9))``` has 9 nodes. So that particular function needs to know how it was actually called. 

Implemented for ```empty_graph``` in first commit and then many others in the next two commits.
Generators which now allow integers or containers of nodes are:

    empty_graph
    complete_graph
    path_graph
    cycle_graph
    star_graph
    wheel_graph
    grid_2d_graph
    random_geometric_graph
    geographical_threshold_graph
    waxman_graph
    grid_graph
    lollipop_graph
    complete_bipartite_graph

These are the only generators that make sense to allow containers of nodes or integer number of nodes. So this issue should not expand in the future. 

I have adjusted the doc_strings and hope it is clear.
