### PR TITLE
Use pydotplus for v1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
   - if [[ "${OPTIONAL_DEPS}" == miniconda ]]; then
       DEPS="pyyaml numpy scipy matplotlib Cython pandas pip";
       sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran libsuitesparse-dev;
-      sudo apt-get install libgdal-dev;
+      sudo apt-get install libgdal-dev graphviz;
       conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $DEPS gdal;
       conda install -n test-environment --channel https://conda.binstar.org/patricksnape scikits-sparse;
       source activate test-environment;
@@ -103,7 +103,6 @@ install:
       fi;
       python -c "from osgeo import ogr;print('importing ogr worked')";
       if [[ "${TRAVIS_PYTHON_VERSION}" =~ "2.7" ]]; then
-        sudo apt-get install graphviz;
         pip install pygraphviz;
       fi;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,10 +96,15 @@ install:
       conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $DEPS gdal;
       conda install -n test-environment --channel https://conda.binstar.org/patricksnape scikits-sparse;
       source activate test-environment;
+      if [[ "${TRAVIS_PYTHON_VERSION}" =~ "3.3" ]]; then
+          pip install https://pypi.python.org/packages/source/p/pydotplus/pydotplus-2.0.2.tar.gz#md5=0e2fc3dbdfd846819d4cd3769cb4595b;
+      else
+          pip install pydotplus;
+      fi;
       python -c "from osgeo import ogr;print('importing ogr worked')";
       if [[ "${TRAVIS_PYTHON_VERSION}" =~ "2.7" ]]; then
         sudo apt-get install graphviz;
-        pip install pygraphviz pydot2;
+        pip install pygraphviz;
       fi;
     fi
   - if [[ "${PYTHON_VM}" != ipy ]]; then

--- a/doc/source/reference/api_1.11.rst
+++ b/doc/source/reference/api_1.11.rst
@@ -16,6 +16,12 @@ API changes
   The defaul values revert to the v1.9 values (center is the origin
   for circular layouts and domain is [0, scale) for others.
 
+* [`#1924 <https://github.com/networkx/networkx/pull/1924>`_]
+  Replace pydot with pydotplus for drawing with the pydot interface.
+
+* [`#1888 <https://github.com/networkx/networkx/pull/1888>`_]
+  Replace support for Python3.2 with support for Python 3.5.
+
 Miscellaneous changes
 ---------------------
 

--- a/doc/source/reference/news.rst
+++ b/doc/source/reference/news.rst
@@ -12,6 +12,7 @@ Support for Python 3.5 added, drop support for Python 3.2.
 
 Highlights
 ~~~~~~~~~~
+Pydot features now use pydotplus.
 Fixes installation on some machines and test with appveyor, 
 Restores default center and scale of layout routines,
 Fixes various docs including no symbolic links in examples.

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -9,7 +9,7 @@ Either this module or nx_pygraphviz can be used to interface with graphviz.
 
 See Also
 --------
-Pydot: http://code.google.com/p/pydot/
+PyDotPlus: https://github.com/carlos-jenkins/pydotplus
 Graphviz:          http://www.research.att.com/sw/tools/graphviz/
 DOT Language:  http://www.graphviz.org/doc/info/lang.html
 """
@@ -32,29 +32,12 @@ try:
 except NameError:
     basestring = str
 
-PYDOT_LIBRARIES = ['pydot', 'pydotplus', 'pydot_ng']
-
-def load_pydot():
-    for library in PYDOT_LIBRARIES:
-        try:
-            module = importlib.import_module(library)
-        except ImportError:
-            pass
-        else:
-            break
-    else:
-        msg = "pydot could not be loaded: http://code.google.com/p/pydot/"
-        raise ImportError(msg)
-
-    return module
-
 @open_file(1, mode='w')
 def write_dot(G, path):
     """Write NetworkX graph G to Graphviz dot format on path.
 
     Path can be a string or a file handle.
     """
-    pydot = load_pydot()
     P=to_pydot(G)
     path.write(P.to_string())
     return
@@ -76,7 +59,10 @@ def read_dot(path):
     -----
     Use G=nx.Graph(nx.read_dot(path)) to return a Graph instead of a MultiGraph.
     """
-    pydot = load_pydot()
+    try:
+        import pydotplus as pydot
+    except ImportError:
+        raise ImportError("pydotplus required for read_dot()")
     data = path.read()
     P = pydot.graph_from_dot_data(data)
     return from_pydot(P)
@@ -182,8 +168,10 @@ def to_pydot(N, strict=True):
     -----
 
     """
-    pydot = load_pydot()
-
+    try:
+        import pydotplus as pydot
+    except ImportError:
+        raise ImportError("pydotplus required for to_pydot()")
     # set Graphviz graph type
     if N.is_directed():
         graph_type='digraph'
@@ -268,8 +256,10 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
     >>> pos=nx.pydot_layout(G)
     >>> pos=nx.pydot_layout(G,prog='dot')
     """
-    pydot = load_pydot()
-
+    try:
+        import pydotplus as pydot
+    except ImportError:
+        raise ImportError("pydotplus required for to_pydot()")
     P=to_pydot(G)
     if root is not None :
         P.set("root",make_str(root))
@@ -289,7 +279,7 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
 
     node_pos={}
     for n in G.nodes():
-        pydot_node = pydot.Node(make_str(n)).get_name().encode('utf-8')
+        pydot_node = pydot.Node(make_str(n)).get_name()
         node=Q.get_node(pydot_node)
 
         if isinstance(node,list):
@@ -304,6 +294,6 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
 def setup_module(module):
     from nose import SkipTest
     try:
-        pydot = load_pydot()
+        import pydotplus as pydot
     except ImportError:
-        raise SkipTest("pydot not available")
+        raise SkipTest("pydotplus not available")

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -3,7 +3,7 @@
 Pydot
 *****
 
-Import and export NetworkX graphs in Graphviz dot format using pydot.
+Import and export NetworkX graphs in Graphviz dot format using pydotplus.
 
 Either this module or nx_pygraphviz can be used to interface with graphviz.
 
@@ -59,12 +59,9 @@ def read_dot(path):
     -----
     Use G=nx.Graph(nx.read_dot(path)) to return a Graph instead of a MultiGraph.
     """
-    try:
-        import pydotplus as pydot
-    except ImportError:
-        raise ImportError("pydotplus required for read_dot()")
+    import pydotplus
     data = path.read()
-    P = pydot.graph_from_dot_data(data)
+    P = pydotplus.graph_from_dot_data(data)
     return from_pydot(P)
 
 def from_pydot(P):
@@ -95,18 +92,19 @@ def from_pydot(P):
 
     if P.get_type()=='graph': # undirected
         if multiedges:
-            create_using=nx.MultiGraph()
+            N = nx.MultiGraph()
         else:
-            create_using=nx.Graph()
+            N = nx.Graph()
     else:
         if multiedges:
-            create_using=nx.MultiDiGraph()
+            N = nx.MultiDiGraph()
         else:
-            create_using=nx.DiGraph()
+            N = nx.DiGraph()
 
     # assign defaults
-    N=nx.empty_graph(0,create_using)
-    N.name=P.get_name()
+    name=P.get_name().strip('"')
+    if name != '':
+        N.name = name
 
     # add nodes, attributes to N.node_attr
     for p in P.get_node_list():
@@ -140,15 +138,17 @@ def from_pydot(P):
                 N.add_edge(source_node,destination_node,**attr)
 
     # add default attributes for graph, nodes, edges
-    N.graph['graph']=P.get_attributes()
+    pattr = P.get_attributes()
+    if pattr:
+        N.graph['graph'] = pattr
     try:
         N.graph['node']=P.get_node_defaults()[0]
     except:# IndexError,TypeError:
-        N.graph['node']={}
+        pass #N.graph['node']={}
     try:
         N.graph['edge']=P.get_edge_defaults()[0]
     except:# IndexError,TypeError:
-        N.graph['edge']={}
+        pass #N.graph['edge']={}
     return N
 
 def to_pydot(N, strict=True):
@@ -168,10 +168,7 @@ def to_pydot(N, strict=True):
     -----
 
     """
-    try:
-        import pydotplus as pydot
-    except ImportError:
-        raise ImportError("pydotplus required for to_pydot()")
+    import pydotplus
     # set Graphviz graph type
     if N.is_directed():
         graph_type='digraph'
@@ -179,12 +176,13 @@ def to_pydot(N, strict=True):
         graph_type='graph'
     strict=N.number_of_selfloops()==0 and not N.is_multigraph()
 
-    name = N.graph.get('name')
+    name = N.name
     graph_defaults=N.graph.get('graph',{})
-    if name is None:
-        P = pydot.Dot(graph_type=graph_type,strict=strict,**graph_defaults)
+    if name is '':
+        P = pydotplus.Dot('', graph_type=graph_type, strict=strict,
+                      **graph_defaults)
     else:
-        P = pydot.Dot('"%s"'%name,graph_type=graph_type,strict=strict,
+        P = pydotplus.Dot('"%s"'%name, graph_type=graph_type, strict=strict,
                       **graph_defaults)
     try:
         P.set_node_defaults(**N.graph['node'])
@@ -197,19 +195,20 @@ def to_pydot(N, strict=True):
 
     for n,nodedata in N.nodes_iter(data=True):
         str_nodedata=dict((k,make_str(v)) for k,v in nodedata.items())
-        p=pydot.Node(make_str(n),**str_nodedata)
+        p=pydotplus.Node(make_str(n),**str_nodedata)
         P.add_node(p)
 
     if N.is_multigraph():
         for u,v,key,edgedata in N.edges_iter(data=True,keys=True):
             str_edgedata=dict((k,make_str(v)) for k,v in edgedata.items())
-            edge=pydot.Edge(make_str(u),make_str(v),key=make_str(key),**str_edgedata)
+            edge=pydotplus.Edge(make_str(u), make_str(v),
+                    key=make_str(key), **str_edgedata)
             P.add_edge(edge)
 
     else:
         for u,v,edgedata in N.edges_iter(data=True):
             str_edgedata=dict((k,make_str(v)) for k,v in edgedata.items())
-            edge=pydot.Edge(make_str(u),make_str(v),**str_edgedata)
+            edge=pydotplus.Edge(make_str(u),make_str(v),**str_edgedata)
             P.add_edge(edge)
     return P
 
@@ -256,10 +255,7 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
     >>> pos=nx.pydot_layout(G)
     >>> pos=nx.pydot_layout(G,prog='dot')
     """
-    try:
-        import pydotplus as pydot
-    except ImportError:
-        raise ImportError("pydotplus required for to_pydot()")
+    import pydotplus
     P=to_pydot(G)
     if root is not None :
         P.set("root",make_str(root))
@@ -275,11 +271,11 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
         print("And then run %s on file.dot"%(prog))
         return
 
-    Q=pydot.graph_from_dot_data(D)
+    Q=pydotplus.graph_from_dot_data(D)
 
     node_pos={}
     for n in G.nodes():
-        pydot_node = pydot.Node(make_str(n)).get_name()
+        pydot_node = pydotplus.Node(make_str(n)).get_name()
         node=Q.get_node(pydot_node)
 
         if isinstance(node,list):
@@ -294,6 +290,6 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
 def setup_module(module):
     from nose import SkipTest
     try:
-        import pydotplus as pydot
+        import pydotplus
     except ImportError:
         raise SkipTest("pydotplus not available")

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -14,9 +14,9 @@ class TestPydot(object):
     def setupClass(cls):
         global pydot
         try:
-            pydot = nx.drawing.nx_pydot.load_pydot()
+            import pydotplus as pydot
         except ImportError:
-            raise SkipTest('pydot not available.')
+            raise SkipTest('pydotplus not available.')
 
     def build_graph(self, G):
         G.add_edge('A','B')
@@ -28,7 +28,12 @@ class TestPydot(object):
 
     def assert_equal(self, G1, G2):
         assert_true( sorted(G1.nodes())==sorted(G2.nodes()) )
-        assert_true( sorted(G1.edges())==sorted(G2.edges()) )
+        if G1.is_directed():
+            assert_true(sorted(G1.edges()) == sorted(G2.edges()))
+        else:
+            e1 = sorted(map(sorted, G1.edges()))
+            e2 = sorted(map(sorted, G2.edges()))
+            assert_true(e1 == e2)
 
     def pydot_checks(self, G):
         H, P = self.build_graph(G)

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -8,42 +8,31 @@ from nose import SkipTest
 from nose.tools import assert_true
 
 import networkx as nx
+from networkx.testing import assert_graphs_equal
 
 class TestPydot(object):
     @classmethod
     def setupClass(cls):
-        global pydot
+        global pydotplus
         try:
-            import pydotplus as pydot
+            import pydotplus
         except ImportError:
             raise SkipTest('pydotplus not available.')
 
-    def build_graph(self, G):
+    def pydot_checks(self, G):
         G.add_edge('A','B')
         G.add_edge('A','C')
         G.add_edge('B','C')
         G.add_edge('A','D')
         G.add_node('E')
-        return G, nx.to_pydot(G)
-
-    def assert_equal(self, G1, G2):
-        assert_true( sorted(G1.nodes())==sorted(G2.nodes()) )
-        if G1.is_directed():
-            assert_true(sorted(G1.edges()) == sorted(G2.edges()))
-        else:
-            e1 = sorted(map(sorted, G1.edges()))
-            e2 = sorted(map(sorted, G2.edges()))
-            assert_true(e1 == e2)
-
-    def pydot_checks(self, G):
-        H, P = self.build_graph(G)
-        G2 = H.__class__(nx.from_pydot(P))
-        self.assert_equal(H, G2)
+        P = nx.to_pydot(G)
+        G2 = G.__class__(nx.from_pydot(P))
+        assert_graphs_equal(G, G2)
 
         fname = tempfile.mktemp()
         assert_true( P.write_raw(fname) )
 
-        Pin = pydot.graph_from_dot_file(fname)
+        Pin = pydotplus.graph_from_dot_file(fname)
 
         n1 = sorted([p.get_name() for p in P.get_node_list()])
         n2 = sorted([p.get_name() for p in Pin.get_node_list()])
@@ -54,8 +43,9 @@ class TestPydot(object):
         assert_true( sorted(e1)==sorted(e2) )
 
         Hin = nx.drawing.nx_pydot.read_dot(fname)
-        Hin = H.__class__(Hin)
-        self.assert_equal(H, Hin)
+        Hin = G.__class__(Hin)
+        assert_graphs_equal(G, Hin)
+
 #        os.unlink(fname)
 
 


### PR DESCRIPTION
Use pydotplus for all supported python versions
- change to "import pydotplus"; remove flexible import cruft
- remove encode("utf-8") in pydot_layout node names
- in tests: sort edges for undirected 2-tuples
- in travis.yml: pip install from tar.gz for python3.3 (pip couldn't find)
- use assert_graphs_equal in tests
- fix from_pydot to no longer create attributes 'name', 'graph', 'node' and 'edge' with value ''
