### PR TITLE
Don't use import * on nx_agraph and nx_pydot

### DIFF
--- a/networkx/drawing/__init__.py
+++ b/networkx/drawing/__init__.py
@@ -2,5 +2,5 @@
 
 from .layout import *
 from .nx_pylab import *
-from .nx_agraph import *
-from .nx_pydot import *
+import networkx.drawing.nx_agraph
+import networkx.drawing.nx_pydot

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -8,14 +8,15 @@ Interface to pygraphviz AGraph class.
 Examples
 --------
 >>> G=nx.complete_graph(5)
->>> A=nx.to_agraph(G)
->>> H=nx.from_agraph(A)
+>>> from networkx.drawing import nx_agraph
+>>> A=nx_agraph.to_agraph(G)
+>>> H=nx_agraph.from_agraph(A)
 
 See Also
 --------
 Pygraphviz: http://pygraphviz.github.io/
 """
-#    Copyright (C) 2004-2015 by
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -25,7 +26,7 @@ import os
 import sys
 import tempfile
 import networkx as nx
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Aric Hagberg <aric.hagberg@gmail.com>
 __all__ = ['from_agraph', 'to_agraph',
            'write_dot', 'read_dot',
            'graphviz_layout',
@@ -46,9 +47,10 @@ def from_agraph(A,create_using=None):
     Examples
     --------
     >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_agraph(K5)
-    >>> G=nx.from_agraph(A)
-    >>> G=nx.from_agraph(A)
+    >>> from networkx.drawing import nx_agraph
+    >>> A=nx_agraph.to_agraph(K5)
+    >>> G=nx_agraph.from_agraph(A)
+    >>> G=nx_agraph.from_agraph(A)
 
 
     Notes
@@ -117,7 +119,8 @@ def to_agraph(N):
     Examples
     --------
     >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_agraph(K5)
+    >>> from networkx.drawing import nx_agraph
+    >>> A=nx_agraph.to_agraph(K5)
 
     Notes
     -----
@@ -215,8 +218,9 @@ def graphviz_layout(G,prog='neato',root=None, args=''):
     Examples
     --------
     >>> G=nx.petersen_graph()
-    >>> pos=nx.graphviz_layout(G)
-    >>> pos=nx.graphviz_layout(G,prog='dot')
+    >>> from networkx.drawing import nx_agraph
+    >>> pos=nx_agraph.graphviz_layout(G)
+    >>> pos=nx_agraph.graphviz_layout(G,prog='dot')
 
     Notes
     -----
@@ -245,8 +249,9 @@ def pygraphviz_layout(G,prog='neato',root=None, args=''):
     Examples
     --------
     >>> G=nx.petersen_graph()
-    >>> pos=nx.graphviz_layout(G)
-    >>> pos=nx.graphviz_layout(G,prog='dot')
+    >>> from networkx.drawing import nx_agraph
+    >>> pos=nx_agraph.graphviz_layout(G)
+    >>> pos=nx_agraph.graphviz_layout(G,prog='dot')
 
     """
     try:

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -13,7 +13,7 @@ PyDotPlus: https://github.com/carlos-jenkins/pydotplus
 Graphviz:          http://www.research.att.com/sw/tools/graphviz/
 DOT Language:  http://www.graphviz.org/doc/info/lang.html
 """
-#    Copyright (C) 2004-2015 by
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -22,7 +22,7 @@ DOT Language:  http://www.graphviz.org/doc/info/lang.html
 import importlib
 from networkx.utils import open_file, make_str
 import networkx as nx
-__author__ = """Aric Hagberg (aric.hagberg@gmail.com)"""
+# Aric Hagberg <aric.hagberg@gmail.com>
 __all__ = ['write_dot', 'read_dot', 'graphviz_layout', 'pydot_layout',
            'to_pydot', 'from_pydot']
 
@@ -80,9 +80,10 @@ def from_pydot(P):
     Examples
     --------
     >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_pydot(K5)
-    >>> G=nx.from_pydot(A) # return MultiGraph
-    >>> G=nx.Graph(nx.from_pydot(A)) # make a Graph instead of MultiGraph
+    >>> from networkx.drawing import nx_pydot
+    >>> A=nx_pydot.to_pydot(K5)
+    >>> G=nx_pydot.from_pydot(A) # return MultiGraph
+    >>> G=nx.Graph(nx_pydot.from_pydot(A)) # make a Graph instead of MultiGraph
 
     """
     if P.get_strict(None): # pydot bug: get_strict() shouldn't take argument
@@ -162,7 +163,8 @@ def to_pydot(N, strict=True):
     Examples
     --------
     >>> K5=nx.complete_graph(5)
-    >>> P=nx.to_pydot(K5)
+    >>> from networkx.drawing import nx_pydot
+    >>> P=nx_pydot.to_pydot(K5)
 
     Notes
     -----
@@ -234,8 +236,9 @@ def graphviz_layout(G,prog='neato',root=None, **kwds):
     Examples
     --------
     >>> G=nx.complete_graph(4)
-    >>> pos=nx.graphviz_layout(G)
-    >>> pos=nx.graphviz_layout(G,prog='dot')
+    >>> from networkx.drawing import nx_pydot
+    >>> pos=nx_pydot.graphviz_layout(G)
+    >>> pos=nx_pydot.graphviz_layout(G,prog='dot')
 
     Notes
     -----
@@ -252,8 +255,9 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
     Examples
     --------
     >>> G=nx.complete_graph(4)
-    >>> pos=nx.pydot_layout(G)
-    >>> pos=nx.pydot_layout(G,prog='dot')
+    >>> from networkx.drawing import nx_pydot
+    >>> pos=nx_pydot.pydot_layout(G)
+    >>> pos=nx_pydot.pydot_layout(G,prog='dot')
     """
     import pydotplus
     P=to_pydot(G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -7,6 +7,7 @@ from nose import SkipTest
 from nose.tools import assert_true,assert_equal
 
 import networkx as nx
+from networkx.drawing import nx_agraph
 
 class TestAGraph(object):
     @classmethod
@@ -33,32 +34,32 @@ class TestAGraph(object):
 
     def agraph_checks(self, G):
         G = self.build_graph(G)
-        A=nx.to_agraph(G)
-        H=nx.from_agraph(A)
+        A=nx_agraph.to_agraph(G)
+        H=nx_agraph.from_agraph(A)
         self.assert_equal(G, H)
 
         fname=tempfile.mktemp()
-        nx.drawing.nx_agraph.write_dot(H,fname)
-        Hin=nx.drawing.nx_agraph.read_dot(fname)
+        nx_agraph.write_dot(H,fname)
+        Hin=nx_agraph.read_dot(fname)
         os.unlink(fname)
         self.assert_equal(H,Hin)
 
 
         (fd,fname)=tempfile.mkstemp()
         fh=open(fname,'w')
-        nx.drawing.nx_agraph.write_dot(H,fh)
+        nx_agraph.write_dot(H,fh)
         fh.close()
 
         fh=open(fname,'r')
-        Hin=nx.drawing.nx_agraph.read_dot(fh)
+        Hin=nx_agraph.read_dot(fh)
         fh.close()
         os.unlink(fname)
         self.assert_equal(H,Hin)
 
     def test_from_agraph_name(self):
         G=nx.Graph(name='test')
-        A=nx.to_agraph(G)
-        H=nx.from_agraph(A)
+        A=nx_agraph.to_agraph(G)
+        H=nx_agraph.from_agraph(A)
         assert_equal(G.name,'test')
 
 

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -8,6 +8,7 @@ from nose import SkipTest
 from nose.tools import assert_true
 
 import networkx as nx
+from networkx.drawing import nx_pydot
 from networkx.testing import assert_graphs_equal
 
 class TestPydot(object):
@@ -25,8 +26,8 @@ class TestPydot(object):
         G.add_edge('B','C')
         G.add_edge('A','D')
         G.add_node('E')
-        P = nx.to_pydot(G)
-        G2 = G.__class__(nx.from_pydot(P))
+        P = nx_pydot.to_pydot(G)
+        G2 = G.__class__(nx_pydot.from_pydot(P))
         assert_graphs_equal(G, G2)
 
         fname = tempfile.mktemp()
@@ -42,7 +43,7 @@ class TestPydot(object):
         e2=[(e.get_source(),e.get_destination()) for e in Pin.get_edge_list()]
         assert_true( sorted(e1)==sorted(e2) )
 
-        Hin = nx.drawing.nx_pydot.read_dot(fname)
+        Hin = nx_pydot.read_dot(fname)
         Hin = G.__class__(Hin)
         assert_graphs_equal(G, Hin)
 


### PR DESCRIPTION
This means to use the functions in either module you will need to say e.g. networkx.drawing.nx_agraph.write_dot() or from networkx.drawing.nx_agraph import write_dot; write_dot()