### PR TITLE
Adjusts imports in drawing layouts with graphviz

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -151,7 +151,7 @@ In conjunction with either
 
       or
 
-      - pydot: http://code.google.com/p/pydot/
+      - pydotplus: https://github.com/carlos-jenkins/pydotplus
 
 provides graph drawing and graph layout algorithms.
 

--- a/doc/source/reference/legal.rst
+++ b/doc/source/reference/legal.rst
@@ -4,7 +4,7 @@ NetworkX is distributed with the BSD license.
 
 ::
 
-   Copyright (C) 2004-2012, NetworkX Developers
+   Copyright (C) 2004-2016, NetworkX Developers
    Aric Hagberg <hagberg@lanl.gov>
    Dan Schult <dschult@colgate.edu>
    Pieter Swart <swart@lanl.gov>

--- a/doc/source/tutorial/tutorial.rst
+++ b/doc/source/tutorial/tutorial.rst
@@ -18,14 +18,14 @@ along with identified pairs of nodes (called edges, links, etc).
 In NetworkX, nodes can be any hashable object e.g. a text string, an
 image, an XML object, another Graph, a customized node object, etc.
 (Note: Python's None object should not be used as a node as it
-determines whether optional function arguments have been assigned 
+determines whether optional function arguments have been assigned
 in many functions.)
 
 Nodes
 -----
 
 The graph G can be grown in several ways.
-NetworkX includes many graph generator functions 
+NetworkX includes many graph generator functions
 and facilities to read and write graphs in many formats.
 To get started though we'll look at simple manipulations.
 You can add one node at a time,
@@ -38,14 +38,14 @@ add a list of nodes,
 
 or add any :term:`nbunch` of nodes.
 An *nbunch* is any iterable container
-of nodes that is not itself a node 
+of nodes that is not itself a node
 in the graph. (e.g. a list, set, graph, file, etc..)
 
 >>> H=nx.path_graph(10)
 >>> G.add_nodes_from(H)
 
 Note that G now contains the nodes of H as nodes of G.
-In contrast, you could use the graph H as a node in G. 
+In contrast, you could use the graph H as a node in G.
 
 >>> G.add_node(H)
 
@@ -56,7 +56,7 @@ thinking about how to structure your application so that
 the nodes are useful entities.  Of course you can always
 use a unique identifier in G and have a separate dictionary
 keyed by identifier to the node information if you prefer.
-(Note: You should not change the node object if the hash 
+(Note: You should not change the node object if the hash
 depends on its contents.)
 
 Edges
@@ -68,24 +68,24 @@ G can also be grown by adding one edge at a time,
 >>> e=(2,3)
 >>> G.add_edge(*e) # unpack edge tuple*
 
-by adding a list of edges, 
+by adding a list of edges,
 
 >>> G.add_edges_from([(1,2),(1,3)])
 
 or by adding any :term:`ebunch` of edges.
 An *ebunch* is any iterable container
 of edge-tuples.  An edge-tuple can be a 2-tuple
-of nodes or a 3-tuple with 2 nodes followed by 
+of nodes or a 3-tuple with 2 nodes followed by
 an edge attribute dictionary, e.g. (2,3,{'weight':3.1415}).
 Edge attributes are discussed further below
 
 >>> G.add_edges_from(H.edges())
 
-One can demolish the graph in a similar fashion; using 
+One can demolish the graph in a similar fashion; using
 :meth:`Graph.remove_node`,
-:meth:`Graph.remove_nodes_from`, 
+:meth:`Graph.remove_nodes_from`,
 :meth:`Graph.remove_edge`
-and 
+and
 :meth:`Graph.remove_edges_from`, e.g.
 
 >>> G.remove_node(H)
@@ -128,13 +128,13 @@ Removing nodes or edges has similar syntax to adding:
 >>> G.remove_edge(1,3)
 
 When creating a graph structure by instantiating one of the graph
-classes you can specify data in several formats.  
+classes you can specify data in several formats.
 
 >>> H=nx.DiGraph(G)   # create a DiGraph using the connections from G
 >>> H.edges()
 [(1, 2), (2, 1)]
 >>> edgelist=[(0,1),(1,2),(2,3)]
->>> H=nx.Graph(edgelist) 
+>>> H=nx.Graph(edgelist)
 
 What to use as nodes and edges
 ------------------------------
@@ -144,12 +144,12 @@ edges. The most common choices are numbers or strings, but a node can
 be any hashable object (except None), and an edge can be associated
 with any object x using G.add_edge(n1,n2,object=x).
 
-As an example, n1 and n2 could be protein objects from the RCSB Protein 
-Data Bank, and x could refer to an XML record of publications detailing 
-experimental observations of their interaction. 
+As an example, n1 and n2 could be protein objects from the RCSB Protein
+Data Bank, and x could refer to an XML record of publications detailing
+experimental observations of their interaction.
 
 We have found this power quite useful, but its abuse
-can lead to unexpected surprises unless one is familiar with Python. 
+can lead to unexpected surprises unless one is familiar with Python.
 If in doubt, consider using :func:`convert_node_labels_to_integers` to obtain
 a more traditional graph with integer labels.
 
@@ -157,20 +157,20 @@ a more traditional graph with integer labels.
 Accessing edges
 ---------------
 
-In addition to the methods 
-:meth:`Graph.nodes`, 
-:meth:`Graph.edges`, and 
+In addition to the methods
+:meth:`Graph.nodes`,
+:meth:`Graph.edges`, and
 :meth:`Graph.neighbors`,
 iterator versions (e.g. :meth:`Graph.edges_iter`) can save you from
-creating large lists when you are just going to iterate 
+creating large lists when you are just going to iterate
 through them anyway.
 
 Fast direct access to the graph data structure is also possible
 using subscript notation.
 
 .. Warning::
-   Do not change the returned dict--it is part of 
-   the graph data structure and direct manipulation may leave the 
+   Do not change the returned dict--it is part of
+   the graph data structure and direct manipulation may leave the
    graph in an inconsistent state.
 
 >>> G[1]  # Warning: do not change the resulting dict
@@ -213,7 +213,7 @@ Python object you like, can be attached to graphs, nodes, or edges.
 Each graph, node, and edge can hold key/value attribute pairs
 in an associated attribute dictionary (the keys must be hashable).
 By default these are empty, but attributes can be added or changed using
-add_edge, add_node or direct manipulation of the attribute 
+add_edge, add_node or direct manipulation of the attribute
 dictionaries named G.graph, G.node and G.edge for a graph G.
 
 
@@ -269,14 +269,14 @@ Directed graphs
 ---------------
 
 The :class:`DiGraph` class provides additional methods specific to directed
-edges, e.g. 
-:meth:`DiGraph.out_edges`, 
-:meth:`DiGraph.in_degree`, 
-:meth:`DiGraph.predecessors`, 
-:meth:`DiGraph.successors` etc.  
-To allow algorithms to work with both classes easily, the directed 
-versions of neighbors() and degree() are equivalent to successors() 
-and the sum of in_degree() and out_degree() respectively even though 
+edges, e.g.
+:meth:`DiGraph.out_edges`,
+:meth:`DiGraph.in_degree`,
+:meth:`DiGraph.predecessors`,
+:meth:`DiGraph.successors` etc.
+To allow algorithms to work with both classes easily, the directed
+versions of neighbors() and degree() are equivalent to successors()
+and the sum of in_degree() and out_degree() respectively even though
 that may feel inconsistent at times.
 
 >>> DG=nx.DiGraph()
@@ -340,7 +340,7 @@ can also be generated by
     disjoint_union(G1,G2)    - graph union assuming all nodes are different
     cartesian_product(G1,G2) - return Cartesian product graph
     compose(G1,G2)           - combine graphs identifying nodes common to both
-    complement(G)            - graph complement 
+    complement(G)            - graph complement
     create_empty_copy(G)     - return an empty copy of the same graph class
     convert_to_undirected(G) - return an undirected representation of G
     convert_to_directed(G)   - return a directed representation of G
@@ -359,7 +359,7 @@ can also be generated by
 >>> K_3_5=nx.complete_bipartite_graph(3,5)
 >>> barbell=nx.barbell_graph(10,10)
 >>> lollipop=nx.lollipop_graph(10,20)
- 
+
 4. Using a stochastic graph generator, e.g.
 
 >>> er=nx.erdos_renyi_graph(100,0.15)
@@ -367,21 +367,21 @@ can also be generated by
 >>> ba=nx.barabasi_albert_graph(100,5)
 >>> red=nx.random_lobster(100,0.9,0.9)
 
-5. Reading a graph stored in a file using common graph formats, 
+5. Reading a graph stored in a file using common graph formats,
    such as edge lists, adjacency lists, GML, GraphML, pickle, LEDA and others.
 
 >>> nx.write_gml(red,"path.to.file")
 >>> mygraph=nx.read_gml("path.to.file")
 
-Details on graph formats: :doc:`/reference/readwrite` 
+Details on graph formats: :doc:`/reference/readwrite`
 
-Details on graph generator functions: :doc:`/reference/generators` 
+Details on graph generator functions: :doc:`/reference/generators`
 
 
-Analyzing graphs 
+Analyzing graphs
 ----------------
 
-The structure of G can be analyzed using various graph-theoretic 
+The structure of G can be analyzed using various graph-theoretic
 functions such as:
 
 >>> G=nx.Graph()
@@ -402,11 +402,11 @@ Functions that return node properties return dictionaries keyed by node label.
 >>> nx.degree(G)
 {1: 2, 2: 1, 3: 1, 'spam': 0}
 
-For values of specific nodes, you can provide a single node or an nbunch 
-of nodes as argument.  If a single node is specified, then a single value 
-is returned.  If an nbunch is specified, then the function will 
+For values of specific nodes, you can provide a single node or an nbunch
+of nodes as argument.  If a single node is specified, then a single value
+is returned.  If an nbunch is specified, then the function will
 return a dictionary.
- 
+
 >>> nx.degree(G,1)
 2
 >>> G.degree(1)
@@ -425,11 +425,11 @@ Details on graph algorithms supported: :doc:`/reference/algorithms`
 Drawing graphs
 --------------
 
-NetworkX is not primarily a graph drawing package but 
+NetworkX is not primarily a graph drawing package but
 basic drawing with Matplotlib as well as an interface to use the
-open source Graphviz software package are included.  
+open source Graphviz software package are included.
 These are part of the networkx.drawing package
-and will be imported if possible. 
+and will be imported if possible.
 See :doc:`/reference/drawing` for details.
 
 Note that the drawing package in NetworkX is not yet compatible with
@@ -439,11 +439,11 @@ First import Matplotlib's plot interface (pylab works too)
 
 >>> import matplotlib.pyplot as plt
 
-You may find it useful to interactively test code using "ipython -pylab", 
+You may find it useful to interactively test code using "ipython -pylab",
 which combines the power of ipython and matplotlib and provides a convenient
 interactive mode.
 
-To test if the import of networkx.drawing was successful 
+To test if the import of networkx.drawing was successful
 draw G using one of
 
 >>> nx.draw(G)
@@ -451,12 +451,12 @@ draw G using one of
 >>> nx.draw_circular(G)
 >>> nx.draw_spectral(G)
 
-when drawing to an interactive display. 
-Note that you may need to issue a Matplotlib 
+when drawing to an interactive display.
+Note that you may need to issue a Matplotlib
 
->>> plt.show() 
+>>> plt.show()
 
-command if you are not using matplotlib in interactive mode: (See 
+command if you are not using matplotlib in interactive mode: (See
 `Matplotlib FAQ <http://matplotlib.org/faq/installing_faq.html#matplotlib-compiled-fine-but-nothing-shows-up-when-i-use-it>`_
 )
 

--- a/doc/source/tutorial/tutorial.rst
+++ b/doc/source/tutorial/tutorial.rst
@@ -466,7 +466,7 @@ To save drawings to a file, use, for example
 >>> plt.savefig("path.png")
 
 writes to the file "path.png" in the local directory. If Graphviz
-and PyGraphviz, or pydot, are available on your system, you can also use
+and PyGraphviz, or pydotplus, are available on your system, you can also use
 
 >>> nx.draw_graphviz(G)
 >>> nx.write_dot(G,'file.dot')

--- a/examples/advanced/heavy_metal_umlaut.py
+++ b/examples/advanced/heavy_metal_umlaut.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Example using unicode strings as graph labels.  
+Example using unicode strings as graph labels.
 
 Also shows creative use of the Heavy Metal Umlaut:
 http://en.wikipedia.org/wiki/Heavy_metal_umlaut
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-__date__ = ""
-__credits__ = """"""
-__revision__ = ""
-#    Copyright (C) 2006 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/algorithms/blockmodel.py
+++ b/examples/algorithms/blockmodel.py
@@ -18,9 +18,7 @@ Example of creating a block model using the blockmodel function in NX.  Data use
 }
 
 """
-
-__author__ = """\n""".join(['Drew Conway <drew.conway@nyu.edu>',
-                            'Aric Hagberg <hagberg@lanl.gov>'])
+# Authors:  Drew Conway <drew.conway@nyu.edu>, Aric Hagberg <hagberg@lanl.gov>
 
 from collections import defaultdict
 import networkx as nx
@@ -41,8 +39,8 @@ def create_hc(G):
     Y=distance.squareform(distances)
     Z=hierarchy.complete(Y)  # Creates HC using farthest point linkage
     # This partition selection is arbitrary, for illustrive purposes
-    membership=list(hierarchy.fcluster(Z,t=1.15)) 
-    # Create collection of lists for blockmodel 
+    membership=list(hierarchy.fcluster(Z,t=1.15))
+    # Create collection of lists for blockmodel
     partition=defaultdict(list)
     for n,p in zip(list(range(len(G))),membership):
         partition[p].append(n)
@@ -50,16 +48,16 @@ def create_hc(G):
 
 if __name__ == '__main__':
     G=nx.read_edgelist("hartford_drug.edgelist")
-    
+
     # Extract largest connected component into graph H
     H=nx.connected_component_subgraphs(G)[0]
     # Makes life easier to have consecutively labeled integer nodes
-    H=nx.convert_node_labels_to_integers(H) 
+    H=nx.convert_node_labels_to_integers(H)
     # Create parititions with hierarchical clustering
     partitions=create_hc(H)
     # Build blockmodel graph
     BM=nx.blockmodel(H,partitions)
-    
+
 
     # Draw original graph
     pos=nx.spring_layout(H,iterations=100)
@@ -83,6 +81,3 @@ if __name__ == '__main__':
     plt.ylim(0,1)
     plt.axis('off')
     plt.savefig('hartford_drug_block_model.png')
-    
-    
-    

--- a/examples/algorithms/krackhardt_centrality.py
+++ b/examples/algorithms/krackhardt_centrality.py
@@ -2,11 +2,11 @@
 """
 Centrality measures of Krackhardt social network.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-__date__ = "$Date: 2005-05-12 14:33:11 -0600 (Thu, 12 May 2005) $"
-__credits__ = """"""
-__revision__ = "$Revision: 998 $"
-#    Copyright (C) 2004 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+# Date: 2005-05-12 14:33:11 -0600 (Thu, 12 May 2005)
+# Revision: 998
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/algorithms/rcm.py
+++ b/examples/algorithms/rcm.py
@@ -1,9 +1,9 @@
 # Cuthill-McKee ordering of matrices
-# The reverse Cuthill-McKee algorithm gives a sparse matrix ordering that 
+# The reverse Cuthill-McKee algorithm gives a sparse matrix ordering that
 # reduces the matrix bandwidth.
 # Requires NumPy
-# Copyright (C) 2011 by 
-# Aric Hagberg <aric.hagberg@gmail.com>
+# Copyright (C) 2011-2016 by
+# Author:    Aric Hagberg <aric.hagberg@gmail.com>
 # BSD License
 import networkx as nx
 from networkx.utils import reverse_cuthill_mckee_ordering
@@ -11,7 +11,7 @@ import numpy as np
 
 # build low-bandwidth numpy matrix
 G=nx.grid_2d_graph(3,3)
-rcm = list(reverse_cuthill_mckee_ordering(G))    
+rcm = list(reverse_cuthill_mckee_ordering(G))
 print("ordering",rcm)
 
 print("unordered Laplacian matrix")

--- a/examples/basic/properties.py
+++ b/examples/basic/properties.py
@@ -2,7 +2,7 @@
 """
 Compute some network properties for the lollipop graph.
 """
-#    Copyright (C) 2004 by 
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -25,7 +25,7 @@ for v in G.nodes():
 print('')
 print("average shortest path length %s" % (sum(pathlengths)/len(pathlengths)))
 
-# histogram of path lengths 
+# histogram of path lengths
 dist={}
 for p in pathlengths:
     if p in dist:

--- a/examples/basic/read_write.py
+++ b/examples/basic/read_write.py
@@ -2,8 +2,9 @@
 """
 Read and write graphs.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -18,7 +19,7 @@ try: # Python 2.6+
 except TypeError: # Python 3.x
     write_adjlist(G,sys.stdout.buffer) # write adjacency list to screen
 # write edgelist to grid.edgelist
-write_edgelist(G,path="grid.edgelist",delimiter=":") 
+write_edgelist(G,path="grid.edgelist",delimiter=":")
 # read edgelist from grid.edgelist
-H=read_edgelist(path="grid.edgelist",delimiter=":") 
+H=read_edgelist(path="grid.edgelist",delimiter=":")
 

--- a/examples/drawing/atlas.py
+++ b/examples/drawing/atlas.py
@@ -3,8 +3,9 @@
 Atlas of all graphs of 6 nodes or less.
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/drawing/atlas.py
+++ b/examples/drawing/atlas.py
@@ -4,7 +4,7 @@ Atlas of all graphs of 6 nodes or less.
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004 by 
+#    Copyright (C) 2004 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -21,60 +21,62 @@ def atlas6():
         Attempt to check for isomorphisms and remove.
     """
 
-    Atlas=graph_atlas_g()[0:208] # 208
+    Atlas = graph_atlas_g()[0:208] # 208
     # remove isolated nodes, only connected graphs are left
-    U=nx.Graph() # graph for union of all graphs in atlas
-    for G in Atlas: 
-        zerodegree=[n for n in G if G.degree(n)==0]
+    U = nx.Graph() # graph for union of all graphs in atlas
+    for G in Atlas:
+        zerodegree = [n for n in G if G.degree(n)==0]
         for n in zerodegree:
             G.remove_node(n)
-        U=nx.disjoint_union(U,G)
+        U = nx.disjoint_union(U, G)
 
-    # list of graphs of all connected components        
-    C=nx.connected_component_subgraphs(U)        
-    
-    UU=nx.Graph()        
-    # do quick isomorphic-like check, not a true isomorphism checker     
-    nlist=[] # list of nonisomorphic graphs
+    # list of graphs of all connected components
+    C = nx.connected_component_subgraphs(U)
+
+    UU = nx.Graph()
+    # do quick isomorphic-like check, not a true isomorphism checker
+    nlist = [] # list of nonisomorphic graphs
     for G in C:
         # check against all nonisomorphic graphs so far
-        if not iso(G,nlist):
+        if not iso(G, nlist):
             nlist.append(G)
-            UU=nx.disjoint_union(UU,G) # union the nonisomorphic graphs  
-    return UU            
+            UU = nx.disjoint_union(UU, G) # union the nonisomorphic graphs
+    return UU
 
 def iso(G1, glist):
     """Quick and dirty nonisomorphism checker used to check isomorphisms."""
     for G2 in glist:
-        if isomorphic(G1,G2):
+        if isomorphic(G1, G2):
             return True
-    return False        
+    return False
 
 
 if __name__ == '__main__':
-
-    import networkx as nx
-
     G=atlas6()
 
     print("graph has %d nodes with %d edges"\
-          %(nx.number_of_nodes(G),nx.number_of_edges(G)))
-    print(nx.number_connected_components(G),"connected components")
-
+          %(nx.number_of_nodes(G), nx.number_of_edges(G)))
+    print(nx.number_connected_components(G), "connected components")
 
     try:
-        from networkx import graphviz_layout
+        import pygraphviz
+        from networkx.drawing.nx_agraph import graphviz_layout
     except ImportError:
-        raise ImportError("This example needs Graphviz and either PyGraphviz or Pydot")
+        try:
+            import pydotplus
+            from networkx.drawing.nx_pydot import graphviz_layout
+        except ImportError:
+            raise ImportError("This example needs Graphviz and either "
+                              "PyGraphviz or PyDotPlus")
 
     import matplotlib.pyplot as plt
-    plt.figure(1,figsize=(8,8))
+    plt.figure(1, figsize=(8, 8))
     # layout graphs with positions using graphviz neato
-    pos=nx.graphviz_layout(G,prog="neato")
+    pos = graphviz_layout(G, prog="neato")
     # color nodes the same in each connected subgraph
-    C=nx.connected_component_subgraphs(G)
+    C = nx.connected_component_subgraphs(G)
     for g in C:
-        c=[random.random()]*nx.number_of_nodes(g) # random color...
+        c = [random.random()] * nx.number_of_nodes(g) # random color...
         nx.draw(g,
              pos,
              node_size=40,
@@ -83,4 +85,4 @@ if __name__ == '__main__':
              vmax=1.0,
              with_labels=False
              )
-    plt.savefig("atlas.png",dpi=75)   
+    plt.savefig("atlas.png", dpi=75)

--- a/examples/drawing/chess_masters.py
+++ b/examples/drawing/chess_masters.py
@@ -3,8 +3,8 @@
 """
 An example of the MultiDiGraph clas
 
-The function chess_pgn_graph reads a collection of chess 
-matches stored in the specified PGN file 
+The function chess_pgn_graph reads a collection of chess
+matches stored in the specified PGN file
 (PGN ="Portable Game Notation")
 Here the (compressed) default file ---
  chess_masters_WCC.pgn.bz2 ---
@@ -12,9 +12,9 @@ contains all 685 World Chess Championship matches
 from 1886 - 1985.
 (data from http://chessproblem.my-free-games.com/chess/games/Download-PGN.php)
 
-The chess_pgn_graph() function returns a MultiDiGraph 
-with multiple edges. Each node is 
-the last name of a chess master. Each edge is directed 
+The chess_pgn_graph() function returns a MultiDiGraph
+with multiple edges. Each node is
+the last name of a chess master. Each edge is directed
 from white to black and contains selected game info.
 
 The key statement in chess_pgn_graph below is
@@ -22,7 +22,7 @@ The key statement in chess_pgn_graph below is
 where game_info is a dict describing each game.
 
 """
-#    Copyright (C) 2006-2010 by 
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -31,19 +31,19 @@ where game_info is a dict describing each game.
 
 import networkx as nx
 
-# tag names specifying what game info should be 
+# tag names specifying what game info should be
 # stored in the dict on each digraph edge
-game_details=["Event", 
-              "Date", 
-              "Result", 
+game_details=["Event",
+              "Date",
+              "Result",
               "ECO",
               "Site"]
 
 def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
     """Read chess games in pgn format in pgn_file.
-    
+
     Filenames ending in .gz or .bz2 will be uncompressed.
-    
+
     Return the MultiDiGraph of players connected by a chess game.
     Edges contain game data in a dict.
 
@@ -58,7 +58,7 @@ def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
             tag,value=line[1:-1].split(' ',1)
             game[str(tag)]=value.strip('"')
         else:
-        # empty line after tag set indicates 
+        # empty line after tag set indicates
         # we finished reading game info
             if game:
                 white=game.pop('White')
@@ -69,9 +69,6 @@ def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
 
 
 if __name__ == '__main__':
-    import networkx as nx
-
-
     G=chess_pgn_graph()
 
     ngames=G.number_of_edges()
@@ -85,10 +82,10 @@ if __name__ == '__main__':
     Gcc=list(nx.connected_component_subgraphs(G.to_undirected()))
     if len(Gcc)>1:
         print("Note the disconnected component consisting of:")
-        print(Gcc[1].nodes())    
+        print(Gcc[1].nodes())
 
     # find all games with B97 opening (as described in ECO)
-    openings=set([game_info['ECO'] 
+    openings=set([game_info['ECO']
                   for (white,black,game_info) in G.edges(data=True)])
     print("\nFrom a total of %d different openings,"%len(openings))
     print('the following games used the Sicilian opening')
@@ -129,7 +126,7 @@ if __name__ == '__main__':
         else:
             wins[v]+=1.0
     try:
-        pos=nx.graphviz_layout(H)
+        pos=nx.nx_agraph.graphviz_layout(H)
     except:
         pos=nx.spring_layout(H,iterations=20)
 

--- a/examples/drawing/circular_tree.py
+++ b/examples/drawing/circular_tree.py
@@ -2,15 +2,20 @@ import networkx as nx
 import matplotlib.pyplot as plt
 
 try:
-    from networkx import graphviz_layout
+    import pygraphviz
+    from networkx.drawing.nx_agraph import graphviz_layout
 except ImportError:
-    raise ImportError("This example needs Graphviz and either PyGraphviz or Pydot")
+    try:
+        import pydotplus
+        from networkx.drawing.nx_pydot import graphviz_layout
+    except ImportError:
+        raise ImportError("This example needs Graphviz and either "
+                          "PyGraphviz or PyDotPlus")
 
-
-G=nx.balanced_tree(3,5)
-pos=nx.graphviz_layout(G,prog='twopi',args='')
-plt.figure(figsize=(8,8))
-nx.draw(G,pos,node_size=20,alpha=0.5,node_color="blue", with_labels=False)
+G = nx.balanced_tree(3, 5)
+pos = graphviz_layout(G, prog='twopi', args='')
+plt.figure(figsize=(8, 8))
+nx.draw(G, pos, node_size=20, alpha=0.5, node_color="blue", with_labels=False)
 plt.axis('equal')
 plt.savefig('circular_tree.png')
 plt.show()

--- a/examples/drawing/degree_histogram.py
+++ b/examples/drawing/degree_histogram.py
@@ -3,9 +3,10 @@
 Random graph from given degree sequence.
 Draw degree rank plot and graph with matplotlib.
 """
-__author__ = """Aric Hagberg <aric.hagberg@gmail.com>"""
-import networkx as nx
+# Author: Aric Hagberg <aric.hagberg@gmail.com>
 import matplotlib.pyplot as plt
+import networkx as nx
+
 G = nx.gnp_random_graph(100,0.02)
 
 degree_sequence=sorted(nx.degree(G).values(),reverse=True) # degree sequence
@@ -17,7 +18,7 @@ plt.title("Degree rank plot")
 plt.ylabel("degree")
 plt.xlabel("rank")
 
-# draw graph in inset 
+# draw graph in inset
 plt.axes([0.45,0.45,0.45,0.45])
 Gcc=sorted(nx.connected_component_subgraphs(G), key = len, reverse=True)[0]
 pos=nx.spring_layout(Gcc)

--- a/examples/drawing/edge_colormap.py
+++ b/examples/drawing/edge_colormap.py
@@ -3,17 +3,17 @@
 Draw a graph with matplotlib, color edges.
 You must have matplotlib>=87.7 for this to work.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
 try:
     import matplotlib.pyplot as plt
 except:
     raise
-    
+
 import networkx as nx
 
-G=nx.star_graph(20)  
+G=nx.star_graph(20)
 pos=nx.spring_layout(G)
-colors=range(20) 
+colors=range(20)
 nx.draw(G,pos,node_color='#A0CBE2',edge_color=colors,width=4,edge_cmap=plt.cm.Blues,with_labels=False)
 plt.savefig("edge_colormap.png") # save as png
 plt.show() # display

--- a/examples/drawing/ego_graph.py
+++ b/examples/drawing/ego_graph.py
@@ -4,7 +4,7 @@
 Example using the NetworkX ego_graph() function to return the main egonet of 
 the largest hub in a Barabási-Albert network.
 """
-__author__="""Drew Conway (drew.conway@nyu.edu)"""
+# Author:  Drew Conway (drew.conway@nyu.edu)
 
 from operator import itemgetter
 import networkx as nx

--- a/examples/drawing/four_grids.py
+++ b/examples/drawing/four_grids.py
@@ -3,8 +3,9 @@
 Draw a graph with matplotlib.
 You must have matplotlib for this to work.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -23,17 +24,17 @@ G=nx.grid_2d_graph(4,4)  #4x4 grid
 pos=nx.spring_layout(G,iterations=100)
 
 plt.subplot(221)
-nx.draw(G,pos,font_size=8) 
+nx.draw(G,pos,font_size=8)
 
 plt.subplot(222)
-nx.draw(G,pos,node_color='k',node_size=0,with_labels=False) 
+nx.draw(G,pos,node_color='k',node_size=0,with_labels=False)
 
 plt.subplot(223)
-nx.draw(G,pos,node_color='g',node_size=250,with_labels=False,width=6) 
+nx.draw(G,pos,node_color='g',node_size=250,with_labels=False,width=6)
 
 plt.subplot(224)
 H=G.to_directed()
-nx.draw(H,pos,node_color='b',node_size=20,with_labels=False) 
+nx.draw(H,pos,node_color='b',node_size=20,with_labels=False)
 
 plt.savefig("four_grids.png")
 plt.show()

--- a/examples/drawing/giant_component.py
+++ b/examples/drawing/giant_component.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This example illustrates the sudden appearance of a 
+This example illustrates the sudden appearance of a
 giant connected component in a binomial random graph.
 
 Requires pygraphviz and matplotlib to draw.
@@ -16,31 +16,39 @@ Requires pygraphviz and matplotlib to draw.
 try:
     import matplotlib.pyplot as plt
 except:
-    raise 
+    raise
 
 import networkx as nx
 import math
 
 try:
-    from networkx import graphviz_layout
-    layout=nx.graphviz_layout
+    import pygraphviz
+    from networkx.drawing.nx_agraph import graphviz_layout
+    layout = graphviz_layout
 except ImportError:
-    print("PyGraphviz not found; drawing with spring layout; will be slow.")
-    layout=nx.spring_layout
+    try:
+        import pydotplus
+        from networkx.drawing.nx_pydot import graphviz_layout
+        layout = graphviz_layout
+    except ImportError:
+        print("PyGraphviz and PyDotPlus not found;\n"
+              "drawing with spring layout;\n"
+              "will be slow.")
+        layout = nx.spring_layout
 
 
 n=150  # 150 nodes
 # p value at which giant component (of size log(n) nodes) is expected
-p_giant=1.0/(n-1)     
+p_giant=1.0/(n-1)
 # p value at which graph is expected to become completely connected
-p_conn=math.log(n)/float(n) 
-                       
+p_conn=math.log(n)/float(n)
+
 # the following range of p values should be close to the threshold
-pvals=[0.003, 0.006, 0.008, 0.015] 
+pvals=[0.003, 0.006, 0.008, 0.015]
 
 region=220 # for pylab 2x2 subplot layout
 plt.subplots_adjust(left=0,right=1,bottom=0,top=0.95,wspace=0.01,hspace=0.01)
-for p in pvals:    
+for p in pvals:
     G=nx.binomial_graph(n,p)
     pos=layout(G)
     region+=1
@@ -52,7 +60,7 @@ for p in pvals:
             )
     # identify largest connected component
     Gcc=sorted(nx.connected_component_subgraphs(G), key = len, reverse=True)
-    G0=Gcc[0] 
+    G0=Gcc[0]
     nx.draw_networkx_edges(G0,pos,
                            with_labels=False,
                            edge_color='r',
@@ -66,8 +74,6 @@ for p in pvals:
                                  edge_color='r',
                                  alpha=0.3,
                                  width=5.0
-                                 )         
+                                 )
 plt.savefig("giant_component.png")
 plt.show() # display
-
- 

--- a/examples/drawing/giant_component.py
+++ b/examples/drawing/giant_component.py
@@ -6,7 +6,7 @@ giant connected component in a binomial random graph.
 Requires pygraphviz and matplotlib to draw.
 
 """
-#    Copyright (C) 2006-2008
+#    Copyright (C) 2006-2016
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/drawing/house_with_colors.py
+++ b/examples/drawing/house_with_colors.py
@@ -3,7 +3,7 @@
 Draw a graph with matplotlib.
 You must have matplotlib for this to work.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
 try:
     import matplotlib.pyplot as plt
 except:

--- a/examples/drawing/knuth_miles.py
+++ b/examples/drawing/knuth_miles.py
@@ -18,8 +18,9 @@ References.
 
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -47,7 +48,7 @@ def miles_graph():
         if line.startswith("*"): # skip comments
             continue
 
-        numfind=re.compile("^\d+") 
+        numfind=re.compile("^\d+")
 
         if numfind.match(line): # this line is distances
             dist=line.split()
@@ -60,12 +61,12 @@ def miles_graph():
             cities.insert(0,city)
             (coord,pop)=coordpop.split("]")
             (y,x)=coord.split(",")
-        
+
             G.add_node(city)
             # assign position - flip x axis for matplotlib, shift origin
             G.position[city]=(-int(x)+7500,int(y)-3000)
             G.population[city]=float(pop)/1000.0
-    return G            
+    return G
 
 if __name__ == '__main__':
     import networkx as nx
@@ -87,7 +88,7 @@ if __name__ == '__main__':
         if d['weight'] < 300:
             H.add_edge(u,v)
 
-    # draw with matplotlib/pylab            
+    # draw with matplotlib/pylab
 
     try:
         import matplotlib.pyplot as plt

--- a/examples/drawing/labels_and_colors.py
+++ b/examples/drawing/labels_and_colors.py
@@ -4,12 +4,12 @@ Draw a graph with matplotlib, color by degree.
 
 You must have matplotlib for this to work.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
 import matplotlib.pyplot as plt
-    
+
 import networkx as nx
 
-G=nx.cubical_graph() 
+G=nx.cubical_graph()
 pos=nx.spring_layout(G) # positions for all nodes
 
 # nodes
@@ -17,12 +17,12 @@ nx.draw_networkx_nodes(G,pos,
                        nodelist=[0,1,2,3],
                        node_color='r',
                        node_size=500,
-		       alpha=0.8)
+               alpha=0.8)
 nx.draw_networkx_nodes(G,pos,
                        nodelist=[4,5,6,7],
                        node_color='b',
                        node_size=500,
-		       alpha=0.8)
+               alpha=0.8)
 
 # edges
 nx.draw_networkx_edges(G,pos,width=1.0,alpha=0.5)

--- a/examples/drawing/lanl_routes.py
+++ b/examples/drawing/lanl_routes.py
@@ -5,7 +5,8 @@ Routes to LANL from 186 sites on the Internet.
 This uses Graphviz for layout so you need PyGraphviz or PyDotPlus.
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
 #    Copyright (C) 2004-2016
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
@@ -33,7 +34,7 @@ def lanl_graph():
         G.add_edge(int(head), int(tail))
         time[int(head)] = float(rtt)
 
-    # get largest component and assign ping times to G0time dictionary        
+    # get largest component and assign ping times to G0time dictionary
     G0 = sorted(nx.connected_component_subgraphs(G), key = len, reverse=True)[0]
     G0.rtt = {}
     for n in G0:

--- a/examples/drawing/lanl_routes.py
+++ b/examples/drawing/lanl_routes.py
@@ -2,11 +2,11 @@
 """
 Routes to LANL from 186 sites on the Internet.
 
-This uses Graphviz for layout so you need PyGraphviz or Pydot.
+This uses Graphviz for layout so you need PyGraphviz or PyDotPlus.
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015
+#    Copyright (C) 2004-2016
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -19,58 +19,61 @@ def lanl_graph():
     """
     import networkx as nx
     try:
-        fh=open('lanl_routes.edgelist','r')
+        fh = open('lanl_routes.edgelist' , 'r')
     except IOError:
         print("lanl.edges not found")
         raise
 
-    G=nx.Graph()
+    G = nx.Graph()
 
-    time={}
-    time[0]=0 # assign 0 to center node
+    time = {}
+    time[0] = 0 # assign 0 to center node
     for line in fh.readlines():
-        (head,tail,rtt)=line.split()
-        G.add_edge(int(head),int(tail))
-        time[int(head)]=float(rtt)
+        (head, tail, rtt) = line.split()
+        G.add_edge(int(head), int(tail))
+        time[int(head)] = float(rtt)
 
     # get largest component and assign ping times to G0time dictionary        
-    G0=sorted(nx.connected_component_subgraphs(G), key = len, reverse=True)[0]
-    G0.rtt={}
+    G0 = sorted(nx.connected_component_subgraphs(G), key = len, reverse=True)[0]
+    G0.rtt = {}
     for n in G0:
-        G0.rtt[n]=time[n]
+        G0.rtt[n] = time[n]
 
     return G0
 
 if __name__ == '__main__':
-
     import networkx as nx
     import math
     try:
-        from networkx import graphviz_layout
+        import pygraphviz
+        from networkx.drawing.nx_agraph import graphviz_layout
     except ImportError:
-        raise ImportError("This example needs Graphviz and either PyGraphviz or Pydot")
+        try:
+            import pydotplus
+            from networkx.drawing.nx_pydot import graphviz_layout
+        except ImportError:
+            raise ImportError("This example needs Graphviz and either "
+                              "PyGraphviz or PyDotPlus")
 
     G=lanl_graph()
 
     print("graph has %d nodes with %d edges"\
-          %(nx.number_of_nodes(G),nx.number_of_edges(G)))
-    print(nx.number_connected_components(G),"connected components")
+          %(nx.number_of_nodes(G), nx.number_of_edges(G)))
+    print(nx.number_connected_components(G), "connected components")
 
     import matplotlib.pyplot as plt
-    plt.figure(figsize=(8,8))
+    plt.figure(figsize=(8, 8))
     # use graphviz to find radial layout
-    pos=nx.graphviz_layout(G,prog="twopi",root=0)
+    pos = graphviz_layout(G, prog="twopi", root=0)
     # draw nodes, coloring by rtt ping time
-    nx.draw(G,pos,
+    nx.draw(G, pos,
             node_color=[G.rtt[v] for v in G],
             with_labels=False,
             alpha=0.5,
             node_size=15)
     # adjust the plot limits
-    xmax=1.02*max(xx for xx,yy in pos.values())
-    ymax=1.02*max(yy for xx,yy in pos.values())
-    plt.xlim(0,xmax)
-    plt.ylim(0,ymax)
+    xmax = 1.02 * max(xx for xx,yy in pos.values())
+    ymax = 1.02 * max(yy for xx,yy in pos.values())
+    plt.xlim(0, xmax)
+    plt.ylim(0, ymax)
     plt.savefig("lanl_routes.png")
-
-

--- a/examples/drawing/node_colormap.py
+++ b/examples/drawing/node_colormap.py
@@ -3,12 +3,12 @@
 Draw a graph with matplotlib, color by degree.
 You must have matplotlib for this to work.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
 
 try:
     import matplotlib.pyplot as plt
 except:
-    raise 
+    raise
 import networkx as nx
 
 

--- a/examples/drawing/sampson.py
+++ b/examples/drawing/sampson.py
@@ -2,11 +2,12 @@
 """
 Sampson's monastery data.
 
-Shows how to read data from a zip file and plot multiple frames. 
+Shows how to read data from a zip file and plot multiple frames.
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2010 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2010-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -43,4 +44,3 @@ nx.draw_networkx_edges(G1,pos,alpha=0.25)
 nx.draw_networkx_edges(G2,pos,alpha=0.25)
 plt.savefig("sampson.png") # save as png
 plt.show() # display
-

--- a/examples/drawing/unix_email.py
+++ b/examples/drawing/unix_email.py
@@ -4,7 +4,7 @@ Create a directed graph, allowing multiple edges and self loops, from
 a unix mailbox.  The nodes are email addresses with links
 that point from the sender to the recievers.  The edge data
 is a Python email.Message object which contains all of
-the email message data. 
+the email message data.
 
 This example shows the power of XDiGraph to hold edge data
 of arbitrary Python objects (in this case a list of email messages).
@@ -15,8 +15,9 @@ You can load your own mailbox by naming it on the command line, eg
 python unixemail.py /var/spool/mail/username
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2005 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2005-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -42,7 +43,7 @@ def msgfactory(fp):
 if __name__ == '__main__':
 
     import networkx as nx
-    try: 
+    try:
         import matplotlib.pyplot as plt
     except:
         pass
@@ -56,7 +57,7 @@ if __name__ == '__main__':
 
     G=nx.MultiDiGraph() # create empty graph
 
-    # parse each messages and build graph 
+    # parse each messages and build graph
     for msg in mbox: # msg is python email.Message.Message object
         (source_name,source_addr) = parseaddr(msg['From']) # sender
         # get all recipients
@@ -68,12 +69,12 @@ if __name__ == '__main__':
         all_recipients = getaddresses(tos + ccs + resent_tos + resent_ccs)
         # now add the edges for this mail message
         for (target_name,target_addr) in all_recipients:
-            G.add_edge(source_addr,target_addr,message=msg)  
+            G.add_edge(source_addr,target_addr,message=msg)
 
     # print edges with message subject
     for (u,v,d) in G.edges_iter(data=True):
         print("From: %s To: %s Subject: %s"%(u,v,d['message']["Subject"]))
-    
+
 
     try: # draw
         pos=nx.spring_layout(G,iterations=10)

--- a/examples/drawing/weighted_graph.py
+++ b/examples/drawing/weighted_graph.py
@@ -2,12 +2,12 @@
 """
 An example using Graph as a weighted network.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
 try:
     import matplotlib.pyplot as plt
 except:
     raise
-    
+
 import networkx as nx
 
 G=nx.Graph()

--- a/examples/graph/atlas.py
+++ b/examples/graph/atlas.py
@@ -3,8 +3,9 @@
 Atlas of all graphs of 6 nodes or less.
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/graph/atlas.py
+++ b/examples/graph/atlas.py
@@ -4,7 +4,7 @@ Atlas of all graphs of 6 nodes or less.
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004 by 
+#    Copyright (C) 2004 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -21,60 +21,62 @@ def atlas6():
         Attempt to check for isomorphisms and remove.
     """
 
-    Atlas=graph_atlas_g()[0:208] # 208
+    Atlas = graph_atlas_g()[0:208] # 208
     # remove isolated nodes, only connected graphs are left
-    U=nx.Graph() # graph for union of all graphs in atlas
-    for G in Atlas: 
-        zerodegree=[n for n in G if G.degree(n)==0]
+    U = nx.Graph() # graph for union of all graphs in atlas
+    for G in Atlas:
+        zerodegree = [n for n in G if G.degree(n)==0]
         for n in zerodegree:
             G.remove_node(n)
-        U=nx.disjoint_union(U,G)
+        U = nx.disjoint_union(U, G)
 
-    # list of graphs of all connected components        
-    C=nx.connected_component_subgraphs(U)        
-    
-    UU=nx.Graph()        
-    # do quick isomorphic-like check, not a true isomorphism checker     
-    nlist=[] # list of nonisomorphic graphs
+    # list of graphs of all connected components
+    C = nx.connected_component_subgraphs(U)
+
+    UU = nx.Graph()
+    # do quick isomorphic-like check, not a true isomorphism checker
+    nlist = [] # list of nonisomorphic graphs
     for G in C:
         # check against all nonisomorphic graphs so far
-        if not iso(G,nlist):
+        if not iso(G, nlist):
             nlist.append(G)
-            UU=nx.disjoint_union(UU,G) # union the nonisomorphic graphs  
-    return UU            
+            UU = nx.disjoint_union(UU, G) # union the nonisomorphic graphs
+    return UU
 
 def iso(G1, glist):
     """Quick and dirty nonisomorphism checker used to check isomorphisms."""
     for G2 in glist:
-        if isomorphic(G1,G2):
+        if isomorphic(G1, G2):
             return True
-    return False        
+    return False
 
 
 if __name__ == '__main__':
-
-    import networkx as nx
-
     G=atlas6()
 
     print("graph has %d nodes with %d edges"\
-          %(nx.number_of_nodes(G),nx.number_of_edges(G)))
-    print(nx.number_connected_components(G),"connected components")
-
+          %(nx.number_of_nodes(G), nx.number_of_edges(G)))
+    print(nx.number_connected_components(G), "connected components")
 
     try:
-        from networkx import graphviz_layout
+        import pygraphviz
+        from networkx.drawing.nx_agraph import graphviz_layout
     except ImportError:
-        raise ImportError("This example needs Graphviz and either PyGraphviz or Pydot")
+        try:
+            import pydotplus
+            from networkx.drawing.nx_pydot import graphviz_layout
+        except ImportError:
+            raise ImportError("This example needs Graphviz and either "
+                              "PyGraphviz or PyDotPlus")
 
     import matplotlib.pyplot as plt
-    plt.figure(1,figsize=(8,8))
+    plt.figure(1, figsize=(8, 8))
     # layout graphs with positions using graphviz neato
-    pos=nx.graphviz_layout(G,prog="neato")
+    pos = graphviz_layout(G, prog="neato")
     # color nodes the same in each connected subgraph
-    C=nx.connected_component_subgraphs(G)
+    C = nx.connected_component_subgraphs(G)
     for g in C:
-        c=[random.random()]*nx.number_of_nodes(g) # random color...
+        c = [random.random()] * nx.number_of_nodes(g) # random color...
         nx.draw(g,
              pos,
              node_size=40,
@@ -83,4 +85,4 @@ if __name__ == '__main__':
              vmax=1.0,
              with_labels=False
              )
-    plt.savefig("atlas.png",dpi=75)   
+    plt.savefig("atlas.png", dpi=75)

--- a/examples/graph/atlas2.py
+++ b/examples/graph/atlas2.py
@@ -4,11 +4,10 @@ Write first 20 graphs from the graph atlas as graphviz dot files
 Gn.dot where n=0,19.
 Requires pygraphviz and graphviz.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-__date__ = "$Date: 2005-05-19 14:23:02 -0600 (Thu, 19 May 2005) $"
-__credits__ = """"""
-__revision__ = ""
-#    Copyright (C) 2006 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+# Date: 2005-05-19 14:23:02 -0600 (Thu, 19 May 2005)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/graph/atlas2.py
+++ b/examples/graph/atlas2.py
@@ -8,27 +8,27 @@ __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
 __date__ = "$Date: 2005-05-19 14:23:02 -0600 (Thu, 19 May 2005) $"
 __credits__ = """"""
 __revision__ = ""
-#    Copyright (C) 2006 by 
+#    Copyright (C) 2006 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
 
-import networkx as NX
+import networkx as nx
 from networkx.generators.atlas import *
 from pygraphviz import *
 
-atlas=graph_atlas_g()[0:20]
+atlas = graph_atlas_g()[0:20]
 
 
 for G in atlas:
     print("graph %s has %d nodes with %d edges"
           %(G.name,NX.number_of_nodes(G),NX.number_of_edges(G)))
-    A=NX.to_agraph(G)
-    A.graph_attr['label']=G.name 
+    A = nx.nx_agraph.to_agraph(G)
+    A.graph_attr['label'] = G.name
     # set default node attributes
-    A.node_attr['color']='red'
-    A.node_attr['style']='filled'
-    A.node_attr['shape']='circle'
-    A.write(G.name+'.dot')
+    A.node_attr['color'] = 'red'
+    A.node_attr['style'] = 'filled'
+    A.node_attr['shape'] = 'circle'
+    A.write(G.name + '.dot')

--- a/examples/graph/degree_sequence.py
+++ b/examples/graph/degree_sequence.py
@@ -2,11 +2,11 @@
 """
 Random graph from given degree sequence.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-__date__ = "$Date: 2004-11-03 08:11:09 -0700 (Wed, 03 Nov 2004) $"
-__credits__ = """"""
-__revision__ = "$Revision: 503 $"
-#    Copyright (C) 2004 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+# Date: 2004-11-03 08:11:09 -0700 (Wed, 03 Nov 2004)
+# Revision: 503
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/graph/erdos_renyi.py
+++ b/examples/graph/erdos_renyi.py
@@ -8,9 +8,9 @@ This graph is sometimes called the Erdős-Rényi graph
 but is different from G{n,p} or binomial_graph which is also
 sometimes called the Erdős-Rényi graph.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-__credits__ = """"""
-#    Copyright (C) 2004-2015 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/graph/expected_degree_sequence.py
+++ b/examples/graph/expected_degree_sequence.py
@@ -2,8 +2,9 @@
 """
 Random graph from given degree sequence.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/graph/football.py
+++ b/examples/graph/football.py
@@ -9,8 +9,9 @@ Requires Internet connection to download the URL
 http://www-personal.umich.edu/~mejn/netdata/football.zip
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2007 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2007-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/graph/knuth_miles.py
+++ b/examples/graph/knuth_miles.py
@@ -18,8 +18,9 @@ References.
 
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -47,7 +48,7 @@ def miles_graph():
         if line.startswith("*"): # skip comments
             continue
 
-        numfind=re.compile("^\d+") 
+        numfind=re.compile("^\d+")
 
         if numfind.match(line): # this line is distances
             dist=line.split()
@@ -60,12 +61,12 @@ def miles_graph():
             cities.insert(0,city)
             (coord,pop)=coordpop.split("]")
             (y,x)=coord.split(",")
-        
+
             G.add_node(city)
             # assign position - flip x axis for matplotlib, shift origin
             G.position[city]=(-int(x)+7500,int(y)-3000)
             G.population[city]=float(pop)/1000.0
-    return G            
+    return G
 
 if __name__ == '__main__':
     import networkx as nx
@@ -87,7 +88,7 @@ if __name__ == '__main__':
         if d['weight'] < 300:
             H.add_edge(u,v)
 
-    # draw with matplotlib/pylab            
+    # draw with matplotlib/pylab
 
     try:
         import matplotlib.pyplot as plt

--- a/examples/graph/napoleon_russian_campaign.py
+++ b/examples/graph/napoleon_russian_campaign.py
@@ -4,8 +4,9 @@ Minard's data from Napoleon's 1812-1813  Russian Campaign.
 http://www.math.yorku.ca/SCS/Gallery/minard/minard.txt
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -97,7 +98,7 @@ def minard_graph():
         x,y,name=line.split(',')
         c[name]=(float(x),float(y))
 
-    g=[]        
+    g=[]
 
     for data in [data1,data2,data3]:
         G=nx.Graph()
@@ -115,9 +116,9 @@ def minard_graph():
                 G.add_edge(i,last,{r:int(n)})
                 last=i
             i=i+1
-        g.append(G)        
+        g.append(G)
 
-    return g,c            
+    return g,c
 
 if __name__ == "__main__":
 

--- a/examples/graph/roget.py
+++ b/examples/graph/roget.py
@@ -21,11 +21,10 @@ References.
 
 """
 from __future__ import print_function
-__author__ = """Brendt Wohlberg\nAric Hagberg (hagberg@lanl.gov)"""
-__date__ = "$Date: 2005-04-01 07:56:22 -0700 (Fri, 01 Apr 2005) $"
-__credits__ = """"""
-__revision__ = ""
-#    Copyright (C) 2004 by 
+# Authors: Brendt Wohlberg, Aric Hagberg (hagberg@lanl.gov)
+# Date: 2005-04-01 07:56:22 -0700 (Fri, 01 Apr 2005)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -61,7 +60,7 @@ def roget_graph():
         # head
         numfind=re.compile("^\d+") # re to find the number of this word
         head=numfind.findall(headname)[0] # get the number
-    
+
         G.add_node(head)
 
         for tail in tails.split():
@@ -69,7 +68,7 @@ def roget_graph():
                 print("skipping self loop",head,tail, file=sys.stderr)
             G.add_edge(head,tail)
 
-    return G            
+    return G
 
 if __name__ == '__main__':
     from networkx import *

--- a/examples/graph/unix_email.py
+++ b/examples/graph/unix_email.py
@@ -4,7 +4,7 @@ Create a directed graph, allowing multiple edges and self loops, from
 a unix mailbox.  The nodes are email addresses with links
 that point from the sender to the recievers.  The edge data
 is a Python email.Message object which contains all of
-the email message data. 
+the email message data.
 
 This example shows the power of XDiGraph to hold edge data
 of arbitrary Python objects (in this case a list of email messages).
@@ -15,8 +15,9 @@ You can load your own mailbox by naming it on the command line, eg
 python unixemail.py /var/spool/mail/username
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2005 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2005-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -42,7 +43,7 @@ def msgfactory(fp):
 if __name__ == '__main__':
 
     import networkx as nx
-    try: 
+    try:
         import matplotlib.pyplot as plt
     except:
         pass
@@ -56,7 +57,7 @@ if __name__ == '__main__':
 
     G=nx.MultiDiGraph() # create empty graph
 
-    # parse each messages and build graph 
+    # parse each messages and build graph
     for msg in mbox: # msg is python email.Message.Message object
         (source_name,source_addr) = parseaddr(msg['From']) # sender
         # get all recipients
@@ -68,12 +69,12 @@ if __name__ == '__main__':
         all_recipients = getaddresses(tos + ccs + resent_tos + resent_ccs)
         # now add the edges for this mail message
         for (target_name,target_addr) in all_recipients:
-            G.add_edge(source_addr,target_addr,message=msg)  
+            G.add_edge(source_addr,target_addr,message=msg)
 
     # print edges with message subject
     for (u,v,d) in G.edges_iter(data=True):
         print("From: %s To: %s Subject: %s"%(u,v,d['message']["Subject"]))
-    
+
 
     try: # draw
         pos=nx.spring_layout(G,iterations=10)

--- a/examples/graph/words.py
+++ b/examples/graph/words.py
@@ -1,7 +1,7 @@
 """
 Words/Ladder Graph
 ------------------
-Generate  an undirected graph over the 5757 5-letter words in the 
+Generate  an undirected graph over the 5757 5-letter words in the
 datafile words_dat.txt.gz.  Two words are connected by an edge
 if they differ in one letter, resulting in 14,135 edges. This example
 is described in Section 1.1 in Knuth's book [1]_,[2]_.
@@ -13,10 +13,11 @@ References
    ACM Press, New York, 1993.
 .. [2] http://www-cs-faculty.stanford.edu/~knuth/sgb.html
 """
-__author__ = """\n""".join(['Aric Hagberg (hagberg@lanl.gov)',
-                            'Brendt Wohlberg',
-                            'hughdbrown@yahoo.com'])
-#    Copyright (C) 2004-2015 by 
+# Authors: Aric Hagberg (hagberg@lanl.gov),
+#          Brendt Wohlberg,
+#          hughdbrown@yahoo.com
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -38,7 +39,7 @@ def generate_graph(words):
             j = lookup[c] # lowercase.index(c)
             for cc in lowercase[j+1:]:
                 yield left + cc + right
-    candgen = ((word, cand) for word in sorted(words) 
+    candgen = ((word, cand) for word in sorted(words)
                for cand in edit_distance_one(word) if cand in words)
     G.add_nodes_from(words)
     for word, cand in candgen:

--- a/examples/javascript/force.py
+++ b/examples/javascript/force.py
@@ -1,12 +1,13 @@
 """Example of writing JSON format graph data and using the D3 Javascript library to produce an HTML/Javascript drawing.
 """
-#    Copyright (C) 2011-2012 by 
+# Author: Aric Hagberg <aric.hagberg@gmail.com>
+
+#    Copyright (C) 2011-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-__author__ = """Aric Hagberg <aric.hagberg@gmail.com>"""
 import json
 import networkx as nx
 from networkx.readwrite import json_graph
@@ -19,10 +20,9 @@ for n in G:
     G.node[n]['name'] = n
 # write json formatted data
 d = json_graph.node_link_data(G) # node-link format to serialize
-# write json 
+# write json
 json.dump(d, open('force/force.json','w'))
 print('Wrote node-link JSON data to force/force.json')
 # open URL in running web browser
 http_server.load_url('force/force.html')
 print('Or copy all files in force/ to webserver and load force/force.html')
-

--- a/examples/multigraph/chess_masters.py
+++ b/examples/multigraph/chess_masters.py
@@ -3,8 +3,8 @@
 """
 An example of the MultiDiGraph clas
 
-The function chess_pgn_graph reads a collection of chess 
-matches stored in the specified PGN file 
+The function chess_pgn_graph reads a collection of chess
+matches stored in the specified PGN file
 (PGN ="Portable Game Notation")
 Here the (compressed) default file ---
  chess_masters_WCC.pgn.bz2 ---
@@ -12,9 +12,9 @@ contains all 685 World Chess Championship matches
 from 1886 - 1985.
 (data from http://chessproblem.my-free-games.com/chess/games/Download-PGN.php)
 
-The chess_pgn_graph() function returns a MultiDiGraph 
-with multiple edges. Each node is 
-the last name of a chess master. Each edge is directed 
+The chess_pgn_graph() function returns a MultiDiGraph
+with multiple edges. Each node is
+the last name of a chess master. Each edge is directed
 from white to black and contains selected game info.
 
 The key statement in chess_pgn_graph below is
@@ -22,7 +22,7 @@ The key statement in chess_pgn_graph below is
 where game_info is a dict describing each game.
 
 """
-#    Copyright (C) 2006-2010 by 
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -31,19 +31,19 @@ where game_info is a dict describing each game.
 
 import networkx as nx
 
-# tag names specifying what game info should be 
+# tag names specifying what game info should be
 # stored in the dict on each digraph edge
-game_details=["Event", 
-              "Date", 
-              "Result", 
+game_details=["Event",
+              "Date",
+              "Result",
               "ECO",
               "Site"]
 
 def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
     """Read chess games in pgn format in pgn_file.
-    
+
     Filenames ending in .gz or .bz2 will be uncompressed.
-    
+
     Return the MultiDiGraph of players connected by a chess game.
     Edges contain game data in a dict.
 
@@ -58,7 +58,7 @@ def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
             tag,value=line[1:-1].split(' ',1)
             game[str(tag)]=value.strip('"')
         else:
-        # empty line after tag set indicates 
+        # empty line after tag set indicates
         # we finished reading game info
             if game:
                 white=game.pop('White')
@@ -69,9 +69,6 @@ def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
 
 
 if __name__ == '__main__':
-    import networkx as nx
-
-
     G=chess_pgn_graph()
 
     ngames=G.number_of_edges()
@@ -85,10 +82,10 @@ if __name__ == '__main__':
     Gcc=list(nx.connected_component_subgraphs(G.to_undirected()))
     if len(Gcc)>1:
         print("Note the disconnected component consisting of:")
-        print(Gcc[1].nodes())    
+        print(Gcc[1].nodes())
 
     # find all games with B97 opening (as described in ECO)
-    openings=set([game_info['ECO'] 
+    openings=set([game_info['ECO']
                   for (white,black,game_info) in G.edges(data=True)])
     print("\nFrom a total of %d different openings,"%len(openings))
     print('the following games used the Sicilian opening')
@@ -129,7 +126,7 @@ if __name__ == '__main__':
         else:
             wins[v]+=1.0
     try:
-        pos=nx.graphviz_layout(H)
+        pos=nx.nx_agraph.graphviz_layout(H)
     except:
         pos=nx.spring_layout(H,iterations=20)
 

--- a/examples/pygraphviz/pygraphviz_attributes.py
+++ b/examples/pygraphviz/pygraphviz_attributes.py
@@ -8,7 +8,7 @@ http://pygraphviz.github.io/
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006-2010 by 
+#    Copyright (C) 2006-2010 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -18,23 +18,23 @@ __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
 import networkx as nx
 
 # networkx graph
-G=nx.Graph()
+G = nx.Graph()
 # ad edges with red color
-G.add_edge(1,2,color='red')
-G.add_edge(2,3,color='red')
+G.add_edge(1, 2, color='red')
+G.add_edge(2, 3, color='red')
 # add nodes 3 and 4
 G.add_node(3)
 G.add_node(4)
 
-# convert to a graphviz agraph 
-A=nx.to_agraph(G)
+# convert to a graphviz agraph
+A = nx.nx_agraph.to_agraph(G)
 
 # write to dot file
 A.write('k5_attributes.dot')
 
 # convert back to networkx Graph with attributes on edges and
 # default attributes as dictionary data
-X=nx.from_agraph(A)
+X = nx.nx_agraph.from_agraph(A)
 print("edges")
 print(X.edges(data=True))
 print("default graph attributes")

--- a/examples/pygraphviz/pygraphviz_attributes.py
+++ b/examples/pygraphviz/pygraphviz_attributes.py
@@ -7,8 +7,9 @@ Also see the pygraphviz documentation and examples at
 http://pygraphviz.github.io/
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006-2010 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/pygraphviz/pygraphviz_draw.py
+++ b/examples/pygraphviz/pygraphviz_draw.py
@@ -9,19 +9,19 @@ http://pygraphviz.github.io/
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006 by 
+#    Copyright (C) 2006 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
 
-from networkx import *
+import networkx as nx
 
 # plain graph
 
-G=complete_graph(5)   # start with K5 in networkx
-A=to_agraph(G)        # convert to a graphviz graph
+G = nx.complete_graph(5)   # start with K5 in networkx
+A = nx.nx_agraph.to_agraph(G)        # convert to a graphviz graph
 A.layout()            # neato layout
 A.draw("k5.ps")       # write postscript in k5.ps with neato layout
 

--- a/examples/pygraphviz/pygraphviz_draw.py
+++ b/examples/pygraphviz/pygraphviz_draw.py
@@ -8,8 +8,9 @@ http://pygraphviz.github.io/
 
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/pygraphviz/pygraphviz_simple.py
+++ b/examples/pygraphviz/pygraphviz_simple.py
@@ -9,23 +9,23 @@ http://pygraphviz.github.io/
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006 by 
+#    Copyright (C) 2006 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
 
-from networkx import *
+import networkx as nx
 
 # plain graph
 
-G=complete_graph(5)   # start with K5 in networkx
-A=to_agraph(G)        # convert to a graphviz graph
-X1=from_agraph(A)     # convert back to networkx (but as Graph)
-X2=Graph(A)          # fancy way to do conversion
-G1=Graph(X1)          # now make it a Graph 
+G = nx.complete_graph(5)   # start with K5 in networkx
+A = nx.nx_agraph.to_agraph(G)        # convert to a graphviz graph
+X1 = nx.nx_agraph.from_agraph(A)     # convert back to networkx (but as Graph)
+X2 = nx.Graph(A)          # fancy way to do conversion
+G1 = nx.Graph(X1)          # now make it a Graph
 
 A.write('k5.dot')     # write to dot file
-X3=read_dot('k5.dot') # read from dotfile
+X3 = nx.nx_agraph.read_dot('k5.dot') # read from dotfile
 

--- a/examples/pygraphviz/pygraphviz_simple.py
+++ b/examples/pygraphviz/pygraphviz_simple.py
@@ -8,8 +8,9 @@ http://pygraphviz.github.io/
 
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2006 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2006-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>

--- a/examples/pygraphviz/write_dotfile.py
+++ b/examples/pygraphviz/write_dotfile.py
@@ -8,7 +8,8 @@ See http://networkx.github.io/documentation/latest/reference/drawing.html
 for more info.
 
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
 #    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>

--- a/examples/pygraphviz/write_dotfile.py
+++ b/examples/pygraphviz/write_dotfile.py
@@ -2,37 +2,42 @@
 """
 Write a dot file from a networkx graph for further processing with graphviz.
 
-You need to have either pygraphviz or pydot for this example.
+You need to have either pygraphviz or pydotplus for this example.
 
 See http://networkx.github.io/documentation/latest/reference/drawing.html
 for more info.
 
 """
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015 by 
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
 
-import networkx as NX
+import networkx as nx
 
 # and the following code block is not needed
 # but we want to see which module is used and
 # if and why it fails
 try:
-    m=NX.drawing.write_dot.__module__
-except:
-    print()
-    print("pygraphviz or pydot were not found ")
-    print("see http://networkx.github.io/documentation/latest/reference/drawing.html for info")
-    print()
-    raise
+    import pygraphviz
+    from networkx.drawing.nx_agraph import write_dot
+    print("using package pygraphviz")
+except ImportError:
+    try:
+        import pydotplus
+        from networkx.drawing.nx_pydot import write_dot
+        print("using package pydotplus")
+    except ImportError:
+        print()
+        print("Both pygraphviz and pydotplus were not found ")
+        print("see http://networkx.github.io/documentation"
+              "/latest/reference/drawing.html for info")
+        print()
+        raise
 
-print("using module", m)
-
-
-G=NX.grid_2d_graph(5,5)  # 5x5 grid
-NX.write_dot(G,"grid.dot")
+G=nx.grid_2d_graph(5,5)  # 5x5 grid
+write_dot(G,"grid.dot")
 print("Now run: neato -Tps grid.dot >grid.ps")

--- a/examples/subclass/antigraph.py
+++ b/examples/subclass/antigraph.py
@@ -1,7 +1,7 @@
 """ Complement graph class for small footprint when working on dense graphs.
 
-This class allows you to add the edges that *do not exist* in the dense 
-graph. However, when applying algorithms to this complement graph data 
+This class allows you to add the edges that *do not exist* in the dense
+graph. However, when applying algorithms to this complement graph data
 structure, it behaves as if it were the dense version. So it can be used
 directly in several NetworkX algorithms.
 
@@ -10,18 +10,16 @@ and biconnected_components algorithms but might also work for other
 algorithms.
 
 """
-#    Copyright (C) 2015 by 
+# Author: Jordi Torrents <jtorrents@milnou.net>
+
+#    Copyright (C) 2015-2016 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    All rights reserved.
 #    BSD license.
 import networkx as nx
 from networkx.exception import NetworkXError
 
-
-__author__ = """\n""".join(['Jordi Torrents <jtorrents@milnou.net>'])
-
 __all__ = ['AntiGraph']
-
 
 class AntiGraph(nx.Graph):
     """
@@ -31,9 +29,9 @@ class AntiGraph(nx.Graph):
     a low memory foodprint.
 
     In this class you add the edges that *do not exist* in the dense graph,
-    the report methods of the class return the neighbors, the edges and 
+    the report methods of the class return the neighbors, the edges and
     the degree as if it was the dense graph. Thus it's possible to use
-    an instance of this class with some of NetworkX functions. 
+    an instance of this class with some of NetworkX functions.
     """
 
     all_edge_dict = {'weight': 1}
@@ -60,7 +58,7 @@ class AntiGraph(nx.Graph):
 
 
     def neighbors(self, n):
-        """Return a list of the nodes connected to the node n in 
+        """Return a list of the nodes connected to the node n in
            the dense graph.
 
         Parameters
@@ -85,7 +83,7 @@ class AntiGraph(nx.Graph):
             raise NetworkXError("The node %s is not in the graph."%(n,))
 
     def neighbors_iter(self, n):
-        """Return an iterator over all neighbors of node n in the 
+        """Return an iterator over all neighbors of node n in the
            dense graph.
 
         """
@@ -114,7 +112,7 @@ class AntiGraph(nx.Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 

--- a/examples/subclass/printgraph.py
+++ b/examples/subclass/printgraph.py
@@ -1,8 +1,9 @@
 """
 Example subclass of the Graph class.
 """
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2015 by 
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -48,27 +49,27 @@ class PrintGraph(Graph):
         for n in nodes:
             self.remove_node(n)
 
-    def add_edge(self, u, v, attr_dict=None, **attr):  
+    def add_edge(self, u, v, attr_dict=None, **attr):
         Graph.add_edge(self,u,v,attr_dict=attr_dict,**attr)
         self.fh.write("Add edge: %s-%s\n"%(u,v))
 
-    def add_edges_from(self, ebunch, attr_dict=None, **attr):  
+    def add_edges_from(self, ebunch, attr_dict=None, **attr):
         for e in ebunch:
             u,v=e[0:2]
             self.add_edge(u,v,attr_dict=attr_dict,**attr)
 
-    def remove_edge(self, u, v): 
+    def remove_edge(self, u, v):
         Graph.remove_edge(self,u,v)
         self.fh.write("Remove edge: %s-%s\n"%(u,v))
 
-    def remove_edges_from(self, ebunch): 
+    def remove_edges_from(self, ebunch):
         for e in ebunch:
             u,v=e[0:2]
             self.remove_edge(u,v)
 
     def clear(self):
         self.name = ''
-        self.adj.clear() 
+        self.adj.clear()
         self.node.clear()
         self.graph.clear()
         self.fh.write("Clear graph\n")
@@ -81,13 +82,13 @@ class PrintGraph(Graph):
         # Here we use H.add_edge()
         bunch =set(self.nbunch_iter(nbunch))
 
-        if not copy: 
+        if not copy:
             # remove all nodes (and attached edges) not in nbunch
             self.remove_nodes_from([n for n in self if n not in bunch])
             self.name = "Subgraph of (%s)"%(self.name)
             return self
         else:
-            # create new graph and copy subgraph into it       
+            # create new graph and copy subgraph into it
             H = self.__class__()
             H.name = "Subgraph of (%s)"%(self.name)
             # add nodes
@@ -102,7 +103,7 @@ class PrintGraph(Graph):
                             H.add_edge(u,v,dd)
                     seen.add(u)
             # copy node and graph attr dicts
-            H.node=dict( (n,deepcopy(d)) 
+            H.node=dict( (n,deepcopy(d))
                          for (n,d) in self.node.items() if n in H)
             H.graph=deepcopy(self.graph)
             return H
@@ -124,7 +125,7 @@ if __name__=='__main__':
     G.remove_edges_from(list(zip(list(range(0o3)),list(range(1,4)))))
     print(G.edges(data=True))
 
-    
+
     G=PrintGraph()
     G.add_path(list(range(10)))
     print("subgraph")
@@ -132,4 +133,4 @@ if __name__=='__main__':
     H2=G.subgraph(list(range(4)),copy=False)
     print(H1.edges())
     print(H2.edges())
-                 
+

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -13,7 +13,7 @@ Create a graph with a single edge from a dictionary of dictionaries
 
 See Also
 --------
-nx_pygraphviz, nx_pydot
+nx_agraph, nx_pydot
 """
 #    Copyright (C) 2006-2013 by
 #    Aric Hagberg <hagberg@lanl.gov>
@@ -100,7 +100,7 @@ def to_networkx_graph(data,create_using=None,multigraph_input=False):
     # pygraphviz  agraph
     if hasattr(data,"is_strict"):
         try:
-            return nx.from_agraph(data,create_using=create_using)
+            return nx.nx_agraph.from_agraph(data,create_using=create_using)
         except:
             raise nx.NetworkXError("Input is not a correct pygraphviz graph.")
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -18,7 +18,7 @@ or equivalently
 
 See Also
 --------
-nx_pygraphviz, nx_pydot
+nx_agraph, nx_pydot
 """
 #    Copyright (C) 2006-2014 by
 #    Aric Hagberg <hagberg@lanl.gov>

--- a/networkx/drawing/__init__.py
+++ b/networkx/drawing/__init__.py
@@ -2,5 +2,5 @@
 
 from .layout import *
 from .nx_pylab import *
-from .nx_agraph import *
-from .nx_pydot import *
+from . import nx_agraph
+from . import nx_pydot

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -5,12 +5,15 @@ Layout
 
 Node positioning algorithms for graph drawing.
 
-The default scales and centering for these layouts are 
+The default scales and centering for these layouts are
 typically squares with side [0, 1] or [0, scale].
 The two circular layout routines (circular_layout and
 shell_layout) have size [-1, 1] or [-scale, scale].
 """
-#    Copyright (C) 2004-2015 by
+# Authors: Aric Hagberg <aric.hagberg@gmail.com>,
+#          Dan Schult <dschult@colgate.edu>
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -18,8 +21,7 @@ shell_layout) have size [-1, 1] or [-scale, scale].
 #    BSD license.
 import collections
 import networkx as nx
-__author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',
-                           'Dan Schult(dschult@colgate.edu)'])
+
 __all__ = ['circular_layout',
            'random_layout',
            'shell_layout',
@@ -568,7 +570,7 @@ def _rescale_layout(pos, scale=1.):
     # rescale to [0, scale) in each axis
 
     # Find max length over all dimensions
-    maxlim=0 
+    maxlim=0
     for i in range(pos.shape[1]):
         pos[:,i] -= pos[:,i].min() # shift min to zero
         maxlim = max(maxlim, pos[:,i].max())

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -15,7 +15,9 @@ See Also
 --------
 Pygraphviz: http://pygraphviz.github.io/
 """
-#    Copyright (C) 2004-2015 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -25,7 +27,7 @@ import os
 import sys
 import tempfile
 import networkx as nx
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+
 __all__ = ['from_agraph', 'to_agraph',
            'write_dot', 'read_dot',
            'graphviz_layout',

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -7,9 +7,9 @@ Interface to pygraphviz AGraph class.
 
 Examples
 --------
->>> G=nx.complete_graph(5)
->>> A=nx.to_agraph(G)
->>> H=nx.from_agraph(A)
+>>> G = nx.complete_graph(5)
+>>> A = nx.nx_agraph.to_agraph(G)
+>>> H = nx.nx_agraph.from_agraph(A)
 
 See Also
 --------
@@ -45,10 +45,10 @@ def from_agraph(A,create_using=None):
 
     Examples
     --------
-    >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_agraph(K5)
-    >>> G=nx.from_agraph(A)
-    >>> G=nx.from_agraph(A)
+    >>> K5 = nx.complete_graph(5)
+    >>> A = nx.nx_agraph.to_agraph(K5)
+    >>> G = nx.nx_agraph.from_agraph(A)
+    >>> G = nx.nx_agraph.from_agraph(A)
 
 
     Notes
@@ -116,8 +116,8 @@ def to_agraph(N):
 
     Examples
     --------
-    >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_agraph(K5)
+    >>> K5 = nx.complete_graph(5)
+    >>> A = nx.nx_agraph.to_agraph(K5)
 
     Notes
     -----
@@ -214,9 +214,9 @@ def graphviz_layout(G,prog='neato',root=None, args=''):
 
     Examples
     --------
-    >>> G=nx.petersen_graph()
-    >>> pos=nx.graphviz_layout(G)
-    >>> pos=nx.graphviz_layout(G,prog='dot')
+    >>> G = nx.petersen_graph()
+    >>> pos = nx.nx_agraph.graphviz_layout(G)
+    >>> pos = nx.nx_agraph.graphviz_layout(G, prog='dot')
 
     Notes
     -----
@@ -244,9 +244,9 @@ def pygraphviz_layout(G,prog='neato',root=None, args=''):
 
     Examples
     --------
-    >>> G=nx.petersen_graph()
-    >>> pos=nx.graphviz_layout(G)
-    >>> pos=nx.graphviz_layout(G,prog='dot')
+    >>> G = nx.petersen_graph()
+    >>> pos = nx.nx_agraph.graphviz_layout(G)
+    >>> pos = nx.nx_agraph.graphviz_layout(G, prog='dot')
 
     """
     try:

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -5,7 +5,7 @@ Pydot
 
 Import and export NetworkX graphs in Graphviz dot format using pydotplus.
 
-Either this module or nx_pygraphviz can be used to interface with graphviz.
+Either this module or nx_agraph can be used to interface with graphviz.
 
 See Also
 --------
@@ -57,7 +57,7 @@ def read_dot(path):
 
     Notes
     -----
-    Use G=nx.Graph(nx.read_dot(path)) to return a Graph instead of a MultiGraph.
+    Use G = nx.Graph(read_dot(path)) to return a Graph instead of a MultiGraph.
     """
     import pydotplus
     data = path.read()

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -13,7 +13,9 @@ PyDotPlus: https://github.com/carlos-jenkins/pydotplus
 Graphviz:          http://www.research.att.com/sw/tools/graphviz/
 DOT Language:  http://www.graphviz.org/doc/info/lang.html
 """
-#    Copyright (C) 2004-2015 by
+# Author: Aric Hagberg (aric.hagberg@gmail.com)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -22,7 +24,7 @@ DOT Language:  http://www.graphviz.org/doc/info/lang.html
 import importlib
 from networkx.utils import open_file, make_str
 import networkx as nx
-__author__ = """Aric Hagberg (aric.hagberg@gmail.com)"""
+
 __all__ = ['write_dot', 'read_dot', 'graphviz_layout', 'pydot_layout',
            'to_pydot', 'from_pydot']
 

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -79,10 +79,12 @@ def from_pydot(P):
 
     Examples
     --------
-    >>> K5=nx.complete_graph(5)
-    >>> A=nx.to_pydot(K5)
-    >>> G=nx.from_pydot(A) # return MultiGraph
-    >>> G=nx.Graph(nx.from_pydot(A)) # make a Graph instead of MultiGraph
+    >>> K5 = nx.complete_graph(5)
+    >>> A = nx.nx_pydot.to_pydot(K5)
+    >>> G = nx.nx_pydot.from_pydot(A) # return MultiGraph
+
+    # make a Graph instead of MultiGraph
+    >>> G = nx.Graph(nx.nx_pydot.from_pydot(A)) 
 
     """
     if P.get_strict(None): # pydot bug: get_strict() shouldn't take argument
@@ -161,8 +163,8 @@ def to_pydot(N, strict=True):
 
     Examples
     --------
-    >>> K5=nx.complete_graph(5)
-    >>> P=nx.to_pydot(K5)
+    >>> K5 = nx.complete_graph(5)
+    >>> P = nx.nx_pydot.to_pydot(K5)
 
     Notes
     -----
@@ -233,9 +235,9 @@ def graphviz_layout(G,prog='neato',root=None, **kwds):
 
     Examples
     --------
-    >>> G=nx.complete_graph(4)
-    >>> pos=nx.graphviz_layout(G)
-    >>> pos=nx.graphviz_layout(G,prog='dot')
+    >>> G = nx.complete_graph(4)
+    >>> pos = nx.nx_pydot.graphviz_layout(G)
+    >>> pos = nx.nx_pydot.graphviz_layout(G, prog='dot')
 
     Notes
     -----
@@ -251,9 +253,9 @@ def pydot_layout(G,prog='neato',root=None, **kwds):
 
     Examples
     --------
-    >>> G=nx.complete_graph(4)
-    >>> pos=nx.pydot_layout(G)
-    >>> pos=nx.pydot_layout(G,prog='dot')
+    >>> G = nx.complete_graph(4)
+    >>> pos = nx.nx_pydot.pydot_layout(G)
+    >>> pos = nx.nx_pydot.pydot_layout(G, prog='dot')
     """
     import pydotplus
     P=to_pydot(G)

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -13,7 +13,9 @@ matplotlib:     http://matplotlib.org/
 pygraphviz:     http://pygraphviz.github.io/
 
 """
-#    Copyright (C) 2004-2015 by
+# Author: Aric Hagberg (hagberg@lanl.gov)
+
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -22,7 +24,7 @@ pygraphviz:     http://pygraphviz.github.io/
 import networkx as nx
 from networkx.drawing.layout import shell_layout,\
     circular_layout,spectral_layout,spring_layout,random_layout
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
+
 __all__ = ['draw',
            'draw_networkx',
            'draw_networkx_nodes',

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -33,13 +33,13 @@ class TestAGraph(object):
 
     def agraph_checks(self, G):
         G = self.build_graph(G)
-        A=nx.to_agraph(G)
-        H=nx.from_agraph(A)
+        A = nx.nx_agraph.to_agraph(G)
+        H = nx.nx_agraph.from_agraph(A)
         self.assert_equal(G, H)
 
         fname=tempfile.mktemp()
         nx.drawing.nx_agraph.write_dot(H,fname)
-        Hin=nx.drawing.nx_agraph.read_dot(fname)
+        Hin = nx.nx_agraph.read_dot(fname)
         os.unlink(fname)
         self.assert_equal(H,Hin)
 
@@ -50,15 +50,15 @@ class TestAGraph(object):
         fh.close()
 
         fh=open(fname,'r')
-        Hin=nx.drawing.nx_agraph.read_dot(fh)
+        Hin = nx.nx_agraph.read_dot(fh)
         fh.close()
         os.unlink(fname)
         self.assert_equal(H,Hin)
 
     def test_from_agraph_name(self):
-        G=nx.Graph(name='test')
-        A=nx.to_agraph(G)
-        H=nx.from_agraph(A)
+        G = nx.Graph(name='test')
+        A = nx.nx_agraph.to_agraph(G)
+        H = nx.nx_agraph.from_agraph(A)
         assert_equal(G.name,'test')
 
 

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -25,8 +25,8 @@ class TestPydot(object):
         G.add_edge('B','C')
         G.add_edge('A','D')
         G.add_node('E')
-        P = nx.to_pydot(G)
-        G2 = G.__class__(nx.from_pydot(P))
+        P = nx.nx_pydot.to_pydot(G)
+        G2 = G.__class__(nx.nx_pydot.from_pydot(P))
         assert_graphs_equal(G, G2)
 
         fname = tempfile.mktemp()
@@ -42,7 +42,7 @@ class TestPydot(object):
         e2=[(e.get_source(),e.get_destination()) for e in Pin.get_edge_list()]
         assert_true( sorted(e1)==sorted(e2) )
 
-        Hin = nx.drawing.nx_pydot.read_dot(fname)
+        Hin = nx.nx_pydot.read_dot(fname)
         Hin = G.__class__(Hin)
         assert_graphs_equal(G, Hin)
 


### PR DESCRIPTION
No longer import nx_agraph and nx_pydot into the main namespace.
They can be accessed within networkx as e.g. ```nx.nx_agraph.write_dot```
or imported as ```from networkx.drawing.nx_agraph import write_dot```.

Changed examples and documentation appropriately.
I've checked [readthedocs.org](http://dschult-networkx.readthedocs.org/en/v1.11) with this PR.