### PR TITLE
Moves is_partition to community.utils.

### DIFF
--- a/doc/source/reference/algorithms.community.rst
+++ b/doc/source/reference/algorithms.community.rst
@@ -56,3 +56,11 @@ Partitions via centrality measures
    :toctree: generated/
 
    girvan_newman
+
+Validating partitions
+---------------------
+.. automodule:: networkx.algorithms.community.utils
+.. autosummary::
+   :toctree: generated/
+
+   is_partition

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -2,10 +2,10 @@ from networkx.algorithms.assortativity import *
 from networkx.algorithms.boundary import *
 from networkx.algorithms.chains import *
 from networkx.algorithms.centrality import *
+from networkx.algorithms.chordal import *
 from networkx.algorithms.cluster import *
 from networkx.algorithms.clique import *
 from networkx.algorithms.communicability_alg import *
-from networkx.algorithms.community import *
 from networkx.algorithms.components import *
 from networkx.algorithms.coloring import *
 from networkx.algorithms.core import *
@@ -14,11 +14,15 @@ from networkx.algorithms.cycles import *
 from networkx.algorithms.cuts import *
 from networkx.algorithms.dag import *
 from networkx.algorithms.distance_measures import *
+from networkx.algorithms.distance_regular import *
 from networkx.algorithms.dominance import *
 from networkx.algorithms.dominating import *
 from networkx.algorithms.efficiency import *
+from networkx.algorithms.euler import *
+from networkx.algorithms.graphical import *
 from networkx.algorithms.hierarchy import *
 from networkx.algorithms.hybrid import *
+from networkx.algorithms.isolate import *
 from networkx.algorithms.matching import *
 from networkx.algorithms.minors import *
 from networkx.algorithms.mis import *
@@ -26,58 +30,70 @@ from networkx.algorithms.link_analysis import *
 from networkx.algorithms.link_prediction import *
 from networkx.algorithms.operators import *
 from networkx.algorithms.reciprocity import *
-from networkx.algorithms.shortest_paths import *
-from networkx.algorithms.smetric import *
-from networkx.algorithms.triads import *
-from networkx.algorithms.traversal import *
-from networkx.algorithms.isolate import *
-from networkx.algorithms.euler import *
-from networkx.algorithms.vitality import *
-from networkx.algorithms.chordal import *
 from networkx.algorithms.richclub import *
-from networkx.algorithms.distance_regular import *
-from networkx.algorithms.swap import *
-from networkx.algorithms.graphical import *
+from networkx.algorithms.shortest_paths import *
 from networkx.algorithms.simple_paths import *
+from networkx.algorithms.smetric import *
+from networkx.algorithms.swap import *
+from networkx.algorithms.traversal import *
+from networkx.algorithms.triads import *
+from networkx.algorithms.vitality import *
 from networkx.algorithms.voronoi import *
 from networkx.algorithms.wiener import *
 
+# Make certain subpackages available to the user as direct imports from
+# the `networkx` namespace.
 import networkx.algorithms.assortativity
 import networkx.algorithms.bipartite
 import networkx.algorithms.centrality
+import networkx.algorithms.chordal
 import networkx.algorithms.cluster
 import networkx.algorithms.clique
 import networkx.algorithms.components
 import networkx.algorithms.connectivity
+import networkx.algorithms.community
 import networkx.algorithms.coloring
 import networkx.algorithms.flow
 import networkx.algorithms.isomorphism
 import networkx.algorithms.link_analysis
-import networkx.algorithms.shortest_paths
-import networkx.algorithms.traversal
-import networkx.algorithms.chordal
 import networkx.algorithms.operators
+import networkx.algorithms.shortest_paths
 import networkx.algorithms.tournament
+import networkx.algorithms.traversal
 import networkx.algorithms.tree
 
-# bipartite
-from networkx.algorithms.bipartite import (projected_graph, project, is_bipartite,
-    complete_bipartite_graph)
-# connectivity
-from networkx.algorithms.connectivity import (minimum_edge_cut, minimum_node_cut,
-    average_node_connectivity, edge_connectivity, node_connectivity,
-    stoer_wagner, all_pairs_node_connectivity, all_node_cuts, k_components)
-# isomorphism
-from networkx.algorithms.isomorphism import (is_isomorphic, could_be_isomorphic,
-    fast_could_be_isomorphic, faster_could_be_isomorphic)
-# flow
-from networkx.algorithms.flow import (maximum_flow, maximum_flow_value,
-    minimum_cut, minimum_cut_value, capacity_scaling, network_simplex,
-    min_cost_flow_cost, max_flow_min_cost, min_cost_flow, cost_of_flow)
-
-from .tree.recognition import *
-from .tree.mst import *
-from .tree.branchings import (
-	maximum_branching, minimum_branching,
-	maximum_spanning_arborescence, minimum_spanning_arborescence
-)
+# Make certain functions from some of the previous subpackages available
+# to the user as direct imports from the `networkx` namespace.
+from networkx.algorithms.bipartite import complete_bipartite_graph
+from networkx.algorithms.bipartite import is_bipartite
+from networkx.algorithms.bipartite import project
+from networkx.algorithms.bipartite import projected_graph
+from networkx.algorithms.connectivity import all_pairs_node_connectivity
+from networkx.algorithms.connectivity import all_node_cuts
+from networkx.algorithms.connectivity import average_node_connectivity
+from networkx.algorithms.connectivity import edge_connectivity
+from networkx.algorithms.connectivity import k_components
+from networkx.algorithms.connectivity import minimum_edge_cut
+from networkx.algorithms.connectivity import minimum_node_cut
+from networkx.algorithms.connectivity import node_connectivity
+from networkx.algorithms.connectivity import stoer_wagner
+from networkx.algorithms.flow import capacity_scaling
+from networkx.algorithms.flow import cost_of_flow
+from networkx.algorithms.flow import max_flow_min_cost
+from networkx.algorithms.flow import maximum_flow
+from networkx.algorithms.flow import maximum_flow_value
+from networkx.algorithms.flow import min_cost_flow
+from networkx.algorithms.flow import min_cost_flow_cost
+from networkx.algorithms.flow import minimum_cut
+from networkx.algorithms.flow import minimum_cut_value
+from networkx.algorithms.flow import network_simplex
+from networkx.algorithms.isomorphism import could_be_isomorphic
+from networkx.algorithms.isomorphism import fast_could_be_isomorphic
+from networkx.algorithms.isomorphism import faster_could_be_isomorphic
+from networkx.algorithms.isomorphism import is_isomorphic
+from networkx.algorithms.tree.branchings import maximum_branching
+from networkx.algorithms.tree.branchings import maximum_spanning_arborescence
+from networkx.algorithms.tree.branchings import minimum_branching
+from networkx.algorithms.tree.branchings import minimum_spanning_arborescence
+from networkx.algorithms.tree.recognition import *
+from networkx.algorithms.tree.mst import *

--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -1,6 +1,23 @@
+"""Functions for computing and measuring community structure.
+
+The functions in this class are not imported into the top-level
+:mod:`networkx` namespace. You can access these functions by importing
+the :mod:`networkx.algorithms.community` module, then accessing the
+functions as attributes of ``community``. For example::
+
+    >>> import networkx as nx
+    >>> from networkx.algorithms import community
+    >>> G = nx.barbell_graph(5, 1)
+    >>> communities_generator = community.girvan_newman(G)
+    >>> top_level_communities = next(communities_generator)
+    >>> sorted(map(sorted, top_level_communities))
+    [[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
+
+"""
 from networkx.algorithms.community.asyn_lpa import *
 from networkx.algorithms.community.centrality import *
 from networkx.algorithms.community.community_generators import *
 from networkx.algorithms.community.kclique import *
 from networkx.algorithms.community.kernighan_lin import *
 from networkx.algorithms.community.quality import *
+from networkx.algorithms.community.community_utils import *

--- a/networkx/algorithms/community/community_generators.py
+++ b/networkx/algorithms/community/community_generators.py
@@ -294,12 +294,13 @@ def LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=None,
     --------
     Basic usage::
 
+        >>> from networkx.algorithms.community import LFR_benchmark_graph
         >>> n = 250
         >>> tau1 = 3
         >>> tau2 = 1.5
         >>> mu = 0.1
-        >>> G = nx.LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=5,
-        ...                            min_community=20, seed=10)
+        >>> G = LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=5,
+        ...                         min_community=20, seed=10)
 
     Continuing the example above, you can get the communities from the
     node attributes of the graph::

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -32,13 +32,14 @@ def k_clique_communities(G, k, cliques=None):
 
     Examples
     --------
+    >>> from networkx.algorithms.community import k_clique_communities
     >>> G = nx.complete_graph(5)
     >>> K5 = nx.convert_node_labels_to_integers(G,first_label=2)
     >>> G.add_edges_from(K5.edges())
-    >>> c = list(nx.k_clique_communities(G, 4))
+    >>> c = list(k_clique_communities(G, 4))
     >>> list(c[0])
     [0, 1, 2, 3, 4, 5, 6]
-    >>> list(nx.k_clique_communities(G, 6))
+    >>> list(k_clique_communities(G, 6))
     []
 
     References

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -20,7 +20,7 @@ import random
 
 import networkx as nx
 from networkx.utils import not_implemented_for
-from .community_utils import is_partition
+from networkx.algorithms.community.community_utils import is_partition
 
 __all__ = ['kernighan_lin_bisection']
 

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -16,29 +16,9 @@ from functools import wraps
 
 import networkx as nx
 from networkx.utils import not_implemented_for
+from networkx.algorithms.community.community_utils import is_partition
 
 __all__ = ['coverage', 'performance']
-
-
-def is_partition(G, partition):
-    """Returns True if and only if `partition` is a partition of
-    the nodes of `G`.
-
-    A partition of a universe set is a family of pairwise disjoint sets
-    whose union equals the universe set.
-
-    `G` is a NetworkX graph.
-
-    `partition` is a sequence (not an iterator) of sets of nodes of
-    `G`.
-
-    """
-    # Alternate implementation:
-    #
-    #     return (len(G) == sum(len(c) for c in community) and
-    #             set(G) == set().union(*community))
-    #
-    return all(sum(1 if v in c else 0 for c in partition) == 1 for v in G)
 
 
 def require_partition(func):

--- a/networkx/algorithms/community/tests/test_asyn_lpa.py
+++ b/networkx/algorithms/community/tests/test_asyn_lpa.py
@@ -1,109 +1,46 @@
+from itertools import chain
+from itertools import combinations
+
 from nose.tools import assert_equal
-from networkx import asyn_lpa, Graph
+
+import networkx as nx
+from networkx.algorithms.community import asyn_lpa_communities
 
 
-def test_empty_graph():
-    # empty graph
-    test = Graph()
+class TestAsynLpaCommunities(object):
 
-    # ground truth
-    ground_truth = set()
+    def _check_communities(self, G, expected):
+        """Checks that the communities computed from the given graph ``G``
+        using the :func:`~networkx.asyn_lpa_communities` function match
+        the set of nodes given in ``expected``.
 
-    communities = asyn_lpa.asyn_lpa_communities(test)
-    result = {frozenset(c) for c in communities}
-    assert_equal(result, ground_truth)
+        ``expected`` must be a :class:`set` of :class:`frozenset`
+        instances, each element of which is a node in the graph.
 
+        """
+        communities = asyn_lpa_communities(G)
+        result = {frozenset(c) for c in communities}
+        assert_equal(result, expected)
 
-def test_single_node():
-    test = Graph()
+    def test_null_graph(self):
+        G = nx.null_graph()
+        ground_truth = set()
+        self._check_communities(G, ground_truth)
 
-    test.add_node('a')
+    def test_single_node(self):
+        G = nx.empty_graph(1)
+        ground_truth = {frozenset([0])}
+        self._check_communities(G, ground_truth)
 
-    # ground truth
-    ground_truth = set([frozenset(['a'])])
+    def test_simple_communities(self):
+        # This graph is the disjoint union of two triangles.
+        G = nx.Graph(['ab', 'ac', 'bc', 'de', 'df', 'fe'])
+        ground_truth = {frozenset('abc'), frozenset('def')}
+        self._check_communities(G, ground_truth)
 
-    communities = asyn_lpa.asyn_lpa_communities(test)
-    result = {frozenset(c) for c in communities}
-    assert_equal(result, ground_truth)
-
-
-def test_simple_communities():
-    test = Graph()
-
-    # c1
-    test.add_edge('a', 'b')
-    test.add_edge('a', 'c')
-    test.add_edge('b', 'c')
-
-    # c2
-    test.add_edge('d', 'e')
-    test.add_edge('d', 'f')
-    test.add_edge('f', 'e')
-
-    # ground truth
-    ground_truth = set([frozenset(['a', 'c', 'b']),
-                        frozenset(['e', 'd', 'f'])])
-
-    communities = asyn_lpa.asyn_lpa_communities(test)
-    result = {frozenset(c) for c in communities}
-    assert_equal(result, ground_truth)
-
-
-def test_several_communities():
-    test = Graph()
-
-    # c1
-    test.add_edge('1a', '1b')
-    test.add_edge('1a', '1c')
-    test.add_edge('1b', '1c')
-
-    # c2
-    test.add_edge('2a', '2b')
-    test.add_edge('2a', '2c')
-    test.add_edge('2b', '2c')
-
-    # c3
-    test.add_edge('3a', '3b')
-    test.add_edge('3a', '3c')
-    test.add_edge('3b', '3c')
-
-    # c4
-    test.add_edge('4a', '4b')
-    test.add_edge('4a', '4c')
-    test.add_edge('4b', '4c')
-
-    # c5
-    test.add_edge('5a', '5b')
-    test.add_edge('5a', '5c')
-    test.add_edge('5b', '5c')
-
-    # ground truth
-    ground_truth = set([frozenset(['1a', '1c', '1b']),
-                        frozenset(['2a', '2c', '2b']),
-                        frozenset(['3a', '3c', '3b']),
-                        frozenset(['4a', '4c', '4b']),
-                        frozenset(['5a', '5c', '5b'])])
-
-    communities = asyn_lpa.asyn_lpa_communities(test)
-    result = {frozenset(c) for c in communities}
-    assert_equal(result, ground_truth)
-
-def test_two_communities():
-    test = Graph()
-
-    # c1
-    c1_edges = [(0, 2), (0, 3), (0, 4), (0, 5), (1, 2), (1, 4), (1, 7), (2, 4), (2, 5),\
-                    (2, 6), (3, 7), (4, 10), (5, 7), (5, 11), (6, 7), (6, 11)]
-
-    # c2
-    c2_edges = [(8, 9), (8, 10), (8, 11), (8, 14), (8, 15), (9, 12), (9, 14), (10, 11),\
-                    (10, 12), (10, 13), (10, 14), (11, 13)]
-    test.add_edges_from(c1_edges + c2_edges)
-
-    # ground truth
-    ground_truth = set([frozenset([0, 1, 2, 3, 4, 5, 6, 7]),
-                        frozenset([8, 9, 10, 11, 12, 13, 14, 15])])
-
-    communities = asyn_lpa.asyn_lpa_communities(test)
-    result = {frozenset(c) for c in communities}
-    assert_equal(result, ground_truth)
+    def test_several_communities(self):
+        # This graph is the disjoint union of five triangles.
+        ground_truth = {frozenset(range(3 * i, 3 * (i + 1))) for i in range(5)}
+        edges = chain.from_iterable(combinations(c, 2) for c in ground_truth)
+        G = nx.Graph(edges)
+        self._check_communities(G, ground_truth)

--- a/networkx/algorithms/community/tests/test_centrality.py
+++ b/networkx/algorithms/community/tests/test_centrality.py
@@ -17,6 +17,7 @@ from nose.tools import assert_equal
 from nose.tools import assert_true
 
 import networkx as nx
+from networkx.algorithms.community import girvan_newman
 
 
 def set_of_sets(iterable):
@@ -40,14 +41,14 @@ class TestGirvanNewman(object):
 
     def test_no_edges(self):
         G = nx.empty_graph(3)
-        communities = list(nx.girvan_newman(G))
+        communities = list(girvan_newman(G))
         assert_equal(len(communities), 1)
         validate_communities(communities[0], [{0}, {1}, {2}])
 
     def test_undirected(self):
         # Start with the graph .-.-.-.
         G = nx.path_graph(4)
-        communities = list(nx.girvan_newman(G))
+        communities = list(girvan_newman(G))
         assert_equal(len(communities), 3)
         # After one removal, we get the graph .-. .-.
         validate_communities(communities[0], [{0, 1}, {2, 3}])
@@ -60,7 +61,7 @@ class TestGirvanNewman(object):
 
     def test_directed(self):
         G = nx.DiGraph(nx.path_graph(4))
-        communities = list(nx.girvan_newman(G))
+        communities = list(girvan_newman(G))
         assert_equal(len(communities), 3)
         validate_communities(communities[0], [{0, 1}, {2, 3}])
         validate_possible_communities(communities[1], [{0}, {1}, {2, 3}],
@@ -71,7 +72,7 @@ class TestGirvanNewman(object):
         G = nx.path_graph(4)
         G.add_edge(0, 0)
         G.add_edge(2, 2)
-        communities = list(nx.girvan_newman(G))
+        communities = list(girvan_newman(G))
         assert_equal(len(communities), 3)
         validate_communities(communities[0], [{0, 1}, {2, 3}])
         validate_possible_communities(communities[1], [{0}, {1}, {2, 3}],
@@ -83,7 +84,7 @@ class TestGirvanNewman(object):
         G.add_weighted_edges_from([(0, 1, 3), (1, 2, 2), (2, 3, 1)])
         # Let the most valuable edge be the one with the highest weight.
         heaviest = lambda G: max(G.edges(data='weight'), key=itemgetter(2))[:2]
-        communities = list(nx.girvan_newman(G, heaviest))
+        communities = list(girvan_newman(G, heaviest))
         assert_equal(len(communities), 3)
         validate_communities(communities[0], [{0}, {1, 2, 3}])
         validate_communities(communities[1], [{0}, {1}, {2, 3}])

--- a/networkx/algorithms/community/tests/test_generators.py
+++ b/networkx/algorithms/community/tests/test_generators.py
@@ -17,6 +17,7 @@ from nose.tools import assert_true
 from nose.tools import raises
 
 import networkx as nx
+from networkx.algorithms.community import LFR_benchmark_graph
 from networkx.algorithms.community.community_utils import is_partition
 
 
@@ -25,8 +26,8 @@ def test_generator():
     tau1 = 3
     tau2 = 1.5
     mu = 0.1
-    G = nx.LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=5,
-                               min_community=20, seed=10)
+    G = LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=5,
+                            min_community=20, seed=10)
     assert_equal(len(G), 250)
     C = {frozenset(G.node[v]['community']) for v in G}
     assert_true(is_partition(G.nodes(), C))
@@ -40,7 +41,7 @@ def test_invalid_tau1():
     tau1 = 2
     tau2 = 1
     mu = 0.1
-    nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
+    LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 @raises(nx.NetworkXError)
@@ -49,7 +50,7 @@ def test_invalid_tau2():
     tau1 = 1
     tau2 = 2
     mu = 0.1
-    nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
+    LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 @raises(nx.NetworkXError)
@@ -58,7 +59,7 @@ def test_mu_too_large():
     tau1 = 2
     tau2 = 2
     mu = 1.1
-    nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
+    LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 @raises(nx.NetworkXError)
@@ -67,7 +68,7 @@ def test_mu_too_small():
     tau1 = 2
     tau2 = 2
     mu = -1
-    nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
+    LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 @raises(nx.NetworkXError)
@@ -76,7 +77,7 @@ def test_both_degrees_none():
     tau1 = 2
     tau2 = 2
     mu = -1
-    nx.LFR_benchmark_graph(n, tau1, tau2, mu)
+    LFR_benchmark_graph(n, tau1, tau2, mu)
 
 
 @raises(nx.NetworkXError)
@@ -85,4 +86,4 @@ def test_neither_degrees_none():
     tau1 = 2
     tau2 = 2
     mu = -1
-    nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2, average_degree=5)
+    LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2, average_degree=5)

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -17,6 +17,7 @@ from nose.tools import assert_equal
 from nose.tools import raises
 
 import networkx as nx
+from networkx.algorithms.community import kernighan_lin_bisection
 
 
 def assert_partition_equal(x, y):
@@ -25,7 +26,7 @@ def assert_partition_equal(x, y):
 
 def test_partition():
     G = nx.barbell_graph(3, 0)
-    C = nx.kernighan_lin_bisection(G)
+    C = kernighan_lin_bisection(G)
     assert_partition_equal(C, [{0, 1, 2}, {3, 4, 5}])
 
 
@@ -33,14 +34,14 @@ def test_partition():
 def test_non_disjoint_partition():
     G = nx.barbell_graph(3, 0)
     partition = ({0, 1, 2}, {2, 3, 4, 5})
-    nx.kernighan_lin_bisection(G, partition)
+    kernighan_lin_bisection(G, partition)
 
 
 @raises(nx.NetworkXError)
 def test_too_many_blocks():
     G = nx.barbell_graph(3, 0)
     partition = ({0, 1}, {2}, {3, 4, 5})
-    nx.kernighan_lin_bisection(G, partition)
+    kernighan_lin_bisection(G, partition)
 
 
 def test_multigraph():
@@ -48,5 +49,5 @@ def test_multigraph():
     M = nx.MultiGraph(G.edges())
     M.add_edges_from(G.edges())
     M.remove_edge(1, 2)
-    A, B = nx.kernighan_lin_bisection(M)
+    A, B = kernighan_lin_bisection(M)
     assert_partition_equal([A, B], [{0, 1}, {2, 3}])

--- a/networkx/algorithms/community/tests/test_utils.py
+++ b/networkx/algorithms/community/tests/test_utils.py
@@ -1,0 +1,31 @@
+# test_utils.py - unit tests for the community utils module
+#
+# Copyright 2016 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.algorithms.community.utils` module.
+
+"""
+from nose.tools import assert_false
+from nose.tools import assert_true
+
+import networkx as nx
+from networkx.algorithms.community import is_partition
+
+
+def test_is_partition():
+    G = nx.empty_graph(3)
+    assert_true(is_partition(G, [{0, 1}, {2}]))
+
+
+def test_not_covering():
+    G = nx.empty_graph(3)
+    assert_false(is_partition(G, [{0}, {1}]))
+
+
+def test_not_disjoint():
+    G = nx.empty_graph(3)
+    assert_false(is_partition(G, [{0, 1}, {1, 2}]))


### PR DESCRIPTION
This makes the function `is_partition` public, and ensures that it only
appears in one place. This commit also changes the `community` package
so that it behaves like the `bipartite` package, and various others: its
functions are not exported to the top-level `networkx` namespace; the
functions must be accessed through `networkx.algorithms.community`.

Finally, this commit also simplifies some of the community tests and
makes them more readable.
