### PR TITLE
Remove sorting from assert_nodes_equal, assert_edges_equal

### DIFF
--- a/networkx/testing/tests/test_utils.py
+++ b/networkx/testing/tests/test_utils.py
@@ -76,6 +76,19 @@ class TestEdgesEqual(_GenericTest):
         self._test_not_equal(G.edges(data=True, keys=True),
                              H.edges(data=True, keys=True))
 
+    def test_no_edges(self):
+        G = nx.MultiGraph()
+        H = nx.MultiGraph()
+        self._test_equal(G.edges(data=True, keys=True),
+                         H.edges(data=True, keys=True))
+
+
+    def test_duplicate_edges(self):
+        a = [(1,2),(5,4),(1,2)]
+        b = [(4,5),(1,2)]
+        self._test_not_equal(a,b)
+
+
 class TestGraphsEqual(_GenericTest):
     def setUp(self):
         self._assert_func = assert_graphs_equal

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -1,43 +1,39 @@
-import operator
-from nose.tools import *
+from nose.tools import assert_equal
 __all__ = ['assert_nodes_equal', 'assert_edges_equal','assert_graphs_equal']
 
-def assert_nodes_equal(nlist1, nlist2):
-    # Assumes lists are either nodes, or (node,datadict) tuples,
-    # and also that nodes are orderable/sortable.
+def assert_nodes_equal(nodes1, nodes2):
+    # Assumes iterables of nodes, or (node,datadict) tuples
+    nlist1 = list(nodes1)
+    nlist2 = list(nodes2)
     try:
-        n1 = sorted(nlist1,key=operator.itemgetter(0))
-        n2 = sorted(nlist2,key=operator.itemgetter(0))
-        assert_equal(len(n1),len(n2))
-        for a,b in zip(n1,n2):
-            assert_equal(a,b)
-    except TypeError:
-        assert_equal(set(nlist1),set(nlist2))
-    return
+        d1 = dict(nlist1)
+        d2 = dict(nlist2)
+    except (ValueError, TypeError):
+        d1 = dict.fromkeys(nlist1)
+        d2 = dict.fromkeys(nlist2)
+    assert_equal(d1, d2)
 
-def assert_edges_equal(elist1, elist2):
-    # Assumes lists with u,v nodes either as
-    # edge tuples (u,v)
-    # edge tuples with data dicts (u,v,d)
+def assert_edges_equal(edges1, edges2):
+    # Assumes iterables with u,v nodes as
+    # edge tuples (u,v), or
+    # edge tuples with data dicts (u,v,d), or
     # edge tuples with keys and data dicts (u,v,k, d)
-    # and also that nodes are orderable/sortable.
-    e1 = sorted(elist1,key=lambda x: sorted(x[0:2]))
-    e2 = sorted(elist2,key=lambda x: sorted(x[0:2]))
-    assert_equal(len(e1),len(e2))
-    if len(e1) == 0:
-        return True
-    if len(e1[0]) == 2:
-        for a,b in zip(e1,e2):
-            assert_equal(set(a[0:2]),set(b[0:2]))
-    elif len(e1[0]) == 3:
-        for a,b in zip(e1,e2):
-            assert_equal(set(a[0:2]),set(b[0:2]))
-            assert_equal(a[2],b[2])
-    elif len(e1[0]) == 4:
-        for a,b in zip(e1,e2):
-            assert_equal(set(a[0:2]),set(b[0:2]))
-            assert_equal(a[2],b[2])
-            assert_equal(a[3],b[3])
+    from collections import defaultdict
+    d1 = defaultdict(dict)
+    d2 = defaultdict(dict)
+    for e in edges1:
+        u,v = e[0],e[1]
+        data = e[2:]
+        d1[u][v] = data
+        d1[v][u] = data
+    for e in edges2:
+        u,v = e[0],e[1]
+        data = e[2:]
+        d2[u][v] = data
+        d2[v][u] = data
+    assert_equal(len(d1), len(d2))
+    for k in d1:
+        assert_equal(d1[k], d2[k])
 
 
 def assert_graphs_equal(graph1, graph2):

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -21,32 +21,23 @@ def assert_edges_equal(edges1, edges2):
     from collections import defaultdict
     d1 = defaultdict(dict)
     d2 = defaultdict(dict)
-    for e in edges1:
+    c1 = 0
+    for c1,e in enumerate(edges1):
         u,v = e[0],e[1]
         data = e[2:]
         d1[u][v] = data
         d1[v][u] = data
-    for e in edges2:
+    c2 = 0
+    for c2,e in enumerate(edges2):
         u,v = e[0],e[1]
         data = e[2:]
         d2[u][v] = data
         d2[v][u] = data
-    assert_equal(len(d1), len(d2))
-    for k in d1:
-        assert_equal(d1[k], d2[k])
+    assert_equal(c1, c2)
+    assert_equal(d1, d2)
 
 
 def assert_graphs_equal(graph1, graph2):
-    if graph1.is_multigraph():
-        edges1 = graph1.edges(data=True,keys=True)
-    else:
-        edges1 = graph1.edges(data=True)
-    if graph2.is_multigraph():
-        edges2 = graph2.edges(data=True,keys=True)
-    else:
-        edges2 = graph2.edges(data=True)
-    assert_nodes_equal(graph1.nodes(data=True),
-                       graph2.nodes(data=True))
-    assert_edges_equal(edges1, edges2)
-    assert_equal(graph1.graph,graph2.graph)
-    return
+    assert_equal(graph1.adj, graph2.adj)
+    assert_equal(graph1.node, graph2.node)
+    assert_equal(graph1.graph, graph2.graph)


### PR DESCRIPTION
Removes sorting requirement for nodes and edges in test for comparison.  This way builds dictionaries and compares the dictionaries.  Possibly not the most efficient way to do it but correct? Needs review @dschult?

Addresses #1911 
