### PR TITLE
Adds partial_duplication_graph generator.

### DIFF
--- a/networkx/generators/__init__.py
+++ b/networkx/generators/__init__.py
@@ -6,6 +6,7 @@ from networkx.generators.classic import *
 from networkx.generators.community import *
 from networkx.generators.degree_seq import *
 from networkx.generators.directed import *
+from networkx.generators.duplication import *
 from networkx.generators.ego import *
 from networkx.generators.expanders import *
 from networkx.generators.geometric import *

--- a/networkx/generators/duplication.py
+++ b/networkx/generators/duplication.py
@@ -1,0 +1,176 @@
+# duplication.py - functions for generating graphs by duplicating nodes
+#
+# Copyright 2016 NetworkX developers.
+# Copyright (C) 2004-2016 by
+# Aric Hagberg <hagberg@lanl.gov>
+# Dan Schult <dschult@colgate.edu>
+# Pieter Swart <swart@lanl.gov>
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions for generating graphs based on the "duplication" method.
+
+These graph generators start with a small initial graph then duplicate
+nodes and (partially) duplicate their edges. These functions are
+generally inspired by biological networks.
+
+"""
+import random
+
+import networkx as nx
+from networkx.exception import NetworkXError
+
+__all__ = ['partial_duplication_graph', 'duplication_divergence_graph']
+
+
+def partial_duplication_graph(N, n, p, q, seed=None):
+    """Return a random graph using the partial duplication model.
+
+    Parameters
+    ----------
+    N : int
+        The total number of nodes in the final graph.
+
+    n : int
+        The number of nodes in the initial clique.
+
+    p : float
+        The probability of joining each neighbor of a node to the
+        duplicate node. Must be a number in the between zero and one,
+        inclusive.
+
+    q : float
+        The probability of joining the source node to the duplicate
+        node. Must be a number in the between zero and one, inclusive.
+
+    seed : int, optional
+        Seed for random number generator (default=None).
+
+    Notes
+    -----
+    A graph of nodes is grown by creating a fully connected graph
+    of size ``n``. The following procedure is then repeated until
+    a total of ``N`` nodes have been reached.
+
+    1. A random node, *u*, is picked and a new node, *v*, is created.
+    2. For each neighbor of *u* an edge from the neighbor to *v* is created
+       with probability ``p``.
+    3. An edge from *u* to *v* is created with probability ``q``.
+
+    This algorithm appears in [1].
+
+    This implementation allows the possibility of generating
+    disconnected graphs.
+
+    References
+    ----------
+    .. [1] Knudsen Michael, and Carsten Wiuf. "A Markov chain approach to
+           randomly grown graphs." Journal of Applied Mathematics 2008.
+           <https://dx.doi.org/10.1155/2008/190836>
+
+    """
+    if p < 0 or p > 1 or q < 0 or q > 1:
+        msg = "partial duplication graph must have 0 <= p, q <= 1."
+        raise NetworkXError(msg)
+    if n > N:
+        raise NetworkXError("partial duplication graph must have n <= N.")
+    if seed is not None:
+        random.seed(seed)
+
+    G = nx.complete_graph(n)
+    G.name = 'partial_duplication_graph({}, {}, {}, {})'.format(N, n, p, q)
+    for new_node in range(n, N):
+        # Add a new vertex, v, to the graph.
+        G.add_node(new_node)
+
+        # Pick a random vertex, u, already in the graph.
+        src_node = random.randint(0, new_node)
+
+        # Join v and u with probability q.
+        if random.random() < q:
+            G.add_edge(new_node, src_node)
+
+        # For each neighbor of u...
+        for neighbor_node in list(nx.all_neighbors(G, src_node)):
+            # Add the neighbor to v with probability p.
+            if random.random() < p:
+                G.add_edge(new_node, neighbor_node)
+    return G
+
+
+def duplication_divergence_graph(n, p, seed=None):
+    """Returns an undirected graph using the duplication-divergence model.
+
+    A graph of ``n`` nodes is created by duplicating the initial nodes
+    and retaining edges incident to the original nodes with a retention
+    probability ``p``.
+
+    Parameters
+    ----------
+    n : int
+        The desired number of nodes in the graph.
+    p : float
+        The probability for retaining the edge of the replicated node.
+    seed : int, optional
+        A seed for the random number generator of ``random`` (default=None).
+
+    Returns
+    -------
+    G : Graph
+
+    Raises
+    ------
+    NetworkXError
+        If `p` is not a valid probability.
+        If `n` is less than 2.
+
+    Notes
+    -----
+    This algorithm appears in [1].
+
+    This implementation disallows the possibility of generating
+    disconnected graphs.
+
+    References
+    ----------
+    .. [1] I. Ispolatov, P. L. Krapivsky, A. Yuryev,
+       "Duplication-divergence model of protein interaction network",
+       Phys. Rev. E, 71, 061911, 2005.
+
+    """
+    if p > 1 or p < 0:
+        msg = "NetworkXError p={0} is not in [0,1].".format(p)
+        raise nx.NetworkXError(msg)
+    if n < 2:
+        msg = 'n must be greater than or equal to 2'
+        raise nx.NetworkXError(msg)
+    if seed is not None:
+        random.seed(seed)
+
+    G = nx.Graph()
+    G.name = "duplication_divergence_graph({}, {})".format(n, p)
+
+    # Initialize the graph with two connected nodes.
+    G.add_edge(0, 1)
+    i = 2
+    while i < n:
+        # Choose a random node from current graph to duplicate.
+        random_node = random.choice(list(G))
+        # Make the replica.
+        G.add_node(i)
+        # flag indicates whether at least one edge is connected on the replica.
+        flag = False
+        for nbr in G.neighbors(random_node):
+            if random.random() < p:
+                # Link retention step.
+                G.add_edge(i, nbr)
+                flag = True
+        if not flag:
+            # Delete replica if no edges retained.
+            G.remove_node(i)
+        else:
+            # Successful duplication.
+            i += 1
+    return G

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -34,7 +34,6 @@ __all__ = ['fast_gnp_random_graph',
            'random_regular_graph',
            'barabasi_albert_graph',
            'powerlaw_cluster_graph',
-           'duplication_divergence_graph',
            'random_lobster',
            'random_shell_graph',
            'random_powerlaw_tree',
@@ -747,73 +746,6 @@ def powerlaw_cluster_graph(n, m, p, seed=None):
         source += 1
     return G
 
-def duplication_divergence_graph(n, p, seed=None):
-    """Returns an undirected graph using the duplication-divergence model.
-
-    A graph of ``n`` nodes is created by duplicating the initial nodes
-    and retaining edges incident to the original nodes with a retention
-    probability ``p``.
-
-    Parameters
-    ----------
-    n : int
-        The desired number of nodes in the graph.
-    p : float
-        The probability for retaining the edge of the replicated node.
-    seed : int, optional
-        A seed for the random number generator of ``random`` (default=None).
-
-    Returns
-    -------
-    G : Graph
-
-    Raises
-    ------
-    NetworkXError
-        If `p` is not a valid probability.
-        If `n` is less than 2.
-
-    References
-    ----------
-    .. [1] I. Ispolatov, P. L. Krapivsky, A. Yuryev,
-       "Duplication-divergence model of protein interaction network",
-       Phys. Rev. E, 71, 061911, 2005.
-
-    """
-    if p > 1 or p < 0:
-        msg = "NetworkXError p={0} is not in [0,1].".format(p)
-        raise nx.NetworkXError(msg)
-    if n < 2:
-        msg = 'n must be greater than or equal to 2'
-        raise nx.NetworkXError(msg)
-    if seed is not None:
-        random.seed(seed)
-
-    G = nx.Graph()
-    G.graph['name'] = "Duplication-Divergence Graph"
-
-    # Initialize the graph with two connected nodes.
-    G.add_edge(0,1)
-    i = 2
-    while i < n:
-        # Choose a random node from current graph to duplicate.
-        random_node = random.choice(list(G.nodes()))
-        # Make the replica.
-        G.add_node(i)
-        # flag indicates whether at least one edge is connected on the replica.
-        flag=False
-        for nbr in G.neighbors(random_node):
-            if random.random() < p:
-                # Link retention step.
-                G.add_edge(i, nbr)
-                flag = True
-        if not flag:
-            # Delete replica if no edges retained.
-            G.remove_node(i)
-        else:
-            # Successful duplication.
-            i += 1
-    return G
 
 def random_lobster(n, p1, p2, seed=None):
     """Returns a random lobster graph.

--- a/networkx/generators/tests/test_duplication.py
+++ b/networkx/generators/tests/test_duplication.py
@@ -1,0 +1,79 @@
+# -*- encoding: utf-8 -*-
+# test_duplication.py - unit tests for the generators.duplication module
+#
+# Copyright 2010–2016 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.generators.duplication` module.
+
+"""
+from nose.tools import assert_equal
+from nose.tools import assert_raises
+from nose.tools import raises
+
+from networkx.exception import NetworkXError
+from networkx.generators.duplication import duplication_divergence_graph
+from networkx.generators.duplication import partial_duplication_graph
+
+
+class TestDuplicationDivergenceGraph(object):
+    """Unit tests for the
+    :func:`networkx.generators.duplication.duplication_divergence_graph`
+    function.
+
+    """
+
+    def test_final_size(self):
+        G = duplication_divergence_graph(3, 1)
+        assert_equal(len(G), 3)
+
+    @raises(NetworkXError)
+    def test_probability_too_large(self):
+        duplication_divergence_graph(3, 2)
+
+    @raises(NetworkXError)
+    def test_probability_too_small(self):
+        duplication_divergence_graph(3, -1)
+
+
+class TestPartialDuplicationGraph(object):
+    """Unit tests for the
+    :func:`networkx.generators.duplication.partial_duplication_graph`
+    function.
+
+    """
+
+    def test_final_size(self):
+        N = 10
+        n = 5
+        p = 0.5
+        q = 0.5
+        G = partial_duplication_graph(N, n, p, q)
+        assert_equal(len(G), N)
+
+    def test_initial_clique_size(self):
+        N = 10
+        n = 10
+        p = 0.5
+        q = 0.5
+        G = partial_duplication_graph(N, n, p, q)
+        assert_equal(len(G), n)
+
+    @raises(NetworkXError)
+    def test_invalid_initial_size(self):
+        N = 5
+        n = 10
+        p = 0.5
+        q = 0.5
+        G = partial_duplication_graph(N, n, p, q)
+        assert_equal(len(G), n)
+
+    def test_invalid_probabilities(self):
+        N = 1
+        n = 1
+        for p, q in [(0.5, 2), (0.5, -1), (2, 0.5), (-1, 0.5)]:
+            args = (N, n, p, q)
+            assert_raises(NetworkXError, partial_duplication_graph, *args)

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -1,9 +1,40 @@
-#!/usr/bin/env python
-from nose.tools import *
-from networkx import *
-from networkx.generators.random_graphs import *
+# -*- encoding: utf-8 -*-
+# test_random_graphs.py - unit tests for random graph generators
+#
+# Copyright 2010–2016 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Unit tests for the :mod:`networkx.generators.random_graphs` module.
 
-class TestGeneratorsRandom():
+"""
+from nose.tools import assert_almost_equal
+from nose.tools import assert_equal
+from nose.tools import assert_raises
+from nose.tools import assert_true
+
+from networkx.exception import NetworkXError
+from networkx.generators.random_graphs import barabasi_albert_graph
+from networkx.generators.random_graphs import binomial_graph
+from networkx.generators.random_graphs import connected_watts_strogatz_graph
+from networkx.generators.random_graphs import dense_gnm_random_graph
+from networkx.generators.random_graphs import erdos_renyi_graph
+from networkx.generators.random_graphs import fast_gnp_random_graph
+from networkx.generators.random_graphs import gnm_random_graph
+from networkx.generators.random_graphs import gnp_random_graph
+from networkx.generators.random_graphs import newman_watts_strogatz_graph
+from networkx.generators.random_graphs import powerlaw_cluster_graph
+from networkx.generators.random_graphs import random_kernel_graph
+from networkx.generators.random_graphs import random_lobster
+from networkx.generators.random_graphs import random_regular_graph
+from networkx.generators.random_graphs import random_shell_graph
+from networkx.generators.random_graphs import watts_strogatz_graph
+
+
+class TestGeneratorsRandom(object):
+
     def smoke_test_random_graph(self):
         seed = 42
         G=gnp_random_graph(100,0.25,seed)
@@ -41,22 +72,14 @@ class TestGeneratorsRandom():
         G=powerlaw_cluster_graph(100,3,0.0,seed)
         assert_equal(G.number_of_edges(),(97*3))
 
-        G=duplication_divergence_graph(100,1.0,seed)
-        assert_equal(len(G), 100)
-        assert_raises(networkx.exception.NetworkXError,
-                      duplication_divergence_graph, 100, 2)
-        assert_raises(networkx.exception.NetworkXError,
-                      duplication_divergence_graph, 100, -1)
-
         G=random_regular_graph(10,20,seed)
 
-        assert_raises(networkx.exception.NetworkXError,
-                      random_regular_graph, 3, 21)
+        assert_raises(NetworkXError, random_regular_graph, 3, 21)
 
         constructor=[(10,20,0.8),(20,40,0.8)]
         G=random_shell_graph(constructor,seed)
 
-        G=nx.random_lobster(10,0.1,0.5,seed)
+        G=random_lobster(10,0.1,0.5,seed)
 
     def test_random_zero_regular_graph(self):
         """Tests that a 0-regular graph has the correct number of nodes and
@@ -127,10 +150,8 @@ class TestGeneratorsRandom():
         assert_equal(sum(1 for _ in G.edges()),0)
 
     def test_watts_strogatz_big_k(self):
-        assert_raises(networkx.exception.NetworkXError,
-                watts_strogatz_graph, 10, 10, 0.25)
-        assert_raises(networkx.exception.NetworkXError,
-                newman_watts_strogatz_graph, 10, 10, 0.25)
+        assert_raises(NetworkXError, watts_strogatz_graph, 10, 10, 0.25)
+        assert_raises(NetworkXError, newman_watts_strogatz_graph, 10, 10, 0.25)
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
         watts_strogatz_graph(10, 9, 0.25, seed=0)


### PR DESCRIPTION
This commit adds the `partial_duplication_graph` generator function in a
new module `networkx.generators.duplication`. It also moves the
`duplication_divergence_graph` function from the `random_graphs` module
to the `duplication` module.

Fixes issue #1368.