### PR TITLE
Corrected eppstein matching

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_matching.py
+++ b/networkx/algorithms/bipartite/tests/test_matching.py
@@ -11,6 +11,8 @@ import itertools
 
 import networkx as nx
 
+from nose.tools import assert_true
+
 from networkx.algorithms.bipartite.matching import eppstein_matching
 from networkx.algorithms.bipartite.matching import hopcroft_karp_matching
 from networkx.algorithms.bipartite.matching import maximum_matching
@@ -82,3 +84,15 @@ class TestMatching():
         matching = maximum_matching(self.graph)
         vertex_cover = to_vertex_cover(self.graph, matching)
         self.check_vertex_cover(vertex_cover)
+
+
+def test_eppstein_matching():
+    """Test in accordance to issue #1927"""
+    G = nx.Graph()
+    G.add_nodes_from(['a', 2, 3, 4], bipartite=0)
+    G.add_nodes_from([1, 'b', 'c'], bipartite=1)
+    G.add_edges_from([('a', 1), ('a', 'b'), (2, 'b'),
+                      (2, 'c'), (3, 'c'), (4, 1)])
+    matching = eppstein_matching(G)
+    assert_true(len(matching)==len(maximum_matching(G)))
+    assert all(x in set(matching.keys()) for x in set(matching.values()))

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -43,11 +43,11 @@ def maximal_matching(G):
     """
     matching = set([])
     nodes = set([])
-    for u,v in G.edges():
+    for u, v in G.edges():
         # If the edge isn't covered, add it to the matching
         # then remove neighborhood of u and v from consideration.
-        if u not in nodes and v not in nodes and u!=v:
-            matching.add((u,v))
+        if u not in nodes and v not in nodes and u != v:
+            matching.add((u, v))
             nodes.add(u)
             nodes.add(v)
     return matching
@@ -127,7 +127,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     class Blossom:
         """Representation of a non-trivial blossom or sub-blossom."""
 
-        __slots__ = [ 'childs', 'edges', 'mybestedges' ]
+        __slots__ = ['childs', 'edges', 'mybestedges']
 
         # b.childs is an ordered list of b's sub-blossoms, starting with
         # the base and going round the blossom.
@@ -153,13 +153,13 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # Get a list of vertices.
     gnodes = list(G)
     if not gnodes:
-        return { }  # don't bother with empty graphs
+        return {}  # don't bother with empty graphs
 
     # Find the maximum edge weight.
     maxweight = 0
     allinteger = True
-    for i,j,d in G.edges(data=True):
-        wt=d.get(weight,1)
+    for i, j, d in G.edges(data=True):
+        wt = d.get(weight, 1)
         if i != j and wt > maxweight:
             maxweight = wt
         allinteger = allinteger and (str(type(wt)).split("'")[1]
@@ -168,7 +168,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # If v is a matched vertex, mate[v] is its partner vertex.
     # If v is a single vertex, v does not occur as a key in mate.
     # Initially all vertices are single; updated during augmentation.
-    mate = { }
+    mate = {}
 
     # If b is a top-level blossom,
     # label.get(b) is None if b is unlabeled (free),
@@ -179,7 +179,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # If v is a vertex inside a T-blossom, label[v] is 2 iff v is reachable
     # from an S-vertex outside the blossom.
     # Labels are assigned during a stage and reset after each augmentation.
-    label = { }
+    label = {}
 
     # If b is a labeled top-level blossom,
     # labeledge[b] = (v, w) is the edge through which b obtained its label
@@ -187,7 +187,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # If w is a vertex inside a T-blossom and label[w] == 2,
     # labeledge[w] = (v, w) is an edge through which w is reachable from
     # outside the blossom.
-    labeledge = { }
+    labeledge = {}
 
     # If v is a vertex, inblossom[v] is the top-level blossom to which v
     # belongs.
@@ -212,7 +212,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # bestedge[b] = (v, w) is the least-slack edge to a different S-blossom
     # (v inside b), or None if there is no such edge.
     # This is used for efficient computation of delta2 and delta3.
-    bestedge = { }
+    bestedge = {}
 
     # If v is a vertex,
     # dualvar[v] = 2 * u(v) where u(v) is the v's variable in the dual
@@ -224,19 +224,19 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # If b is a non-trivial blossom,
     # blossomdual[b] = z(b) where z(b) is b's variable in the dual
     # optimization problem.
-    blossomdual = { }
+    blossomdual = {}
 
     # If (v, w) in allowedge or (w, v) in allowedg, then the edge
     # (v, w) is known to have zero slack in the optimization problem;
     # otherwise the edge may or may not have zero slack.
-    allowedge = { }
+    allowedge = {}
 
     # Queue of newly discovered S-vertices.
-    queue = [ ]
+    queue = []
 
     # Return 2 * slack of edge (v, w) (does not work inside blossoms).
     def slack(v, w):
-        return dualvar[v] + dualvar[w] - 2 * G[v][w].get(weight,1)
+        return dualvar[v] + dualvar[w] - 2 * G[v][w].get(weight, 1)
 
     # Assign label t to the top-level blossom containing vertex w,
     # coming through an edge from vertex v.
@@ -267,7 +267,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
     # or NoNode if an augmenting path was found.
     def scanBlossom(v, w):
         # Trace back from v and w, placing breadcrumbs as we go.
-        path = [ ]
+        path = []
         base = NoNode
         while v is not NoNode:
             # Look for a breadcrumb in v's blossom or put a new breadcrumb.
@@ -293,7 +293,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             # Swap v and w so that we alternate between both paths.
             if w is not NoNode:
                 v, w = w, v
-       # Remove breadcrumbs.
+        # Remove breadcrumbs.
         for b in path:
             label[b] = 1
         # Return base vertex, if we found one.
@@ -312,15 +312,16 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         blossomparent[b] = None
         blossomparent[bb] = b
         # Make list of sub-blossoms and their interconnecting edge endpoints.
-        b.childs = path = [ ]
-        b.edges  = edgs = [ (v, w) ]
+        b.childs = path = []
+        b.edges = edgs = [(v, w)]
         # Trace back from v to base.
         while bv != bb:
             # Add bv to the new blossom.
             blossomparent[bv] = b
             path.append(bv)
             edgs.append(labeledge[bv])
-            assert label[bv] == 2 or (label[bv] == 1 and labeledge[bv][0] == mate[blossombase[bv]])
+            assert label[bv] == 2 or (label[bv] == 1 and labeledge[
+                                      bv][0] == mate[blossombase[bv]])
             # Trace one step back.
             v = labeledge[bv][0]
             bv = inblossom[v]
@@ -334,7 +335,8 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             blossomparent[bw] = b
             path.append(bw)
             edgs.append((labeledge[bw][1], labeledge[bw][0]))
-            assert label[bw] == 2 or (label[bw] == 1 and labeledge[bw][0] == mate[blossombase[bw]])
+            assert label[bw] == 2 or (label[bw] == 1 and labeledge[
+                                      bw][0] == mate[blossombase[bw]])
             # Trace one step back.
             w = labeledge[bw][0]
             bw = inblossom[w]
@@ -352,7 +354,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
                 queue.append(v)
             inblossom[v] = b
         # Compute b.mybestedges.
-        bestedgeto = { }
+        bestedgeto = {}
         for bv in path:
             if isinstance(bv, Blossom):
                 if bv.mybestedges is not None:
@@ -363,14 +365,14 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
                 else:
                     # This subblossom does not have a list of least-slack
                     # edges; get the information from the vertices.
-                    nblist = [ (v, w)
-                                for v in bv.leaves()
-                                for w in G.neighbors(v)
-                                if v != w ]
+                    nblist = [(v, w)
+                              for v in bv.leaves()
+                              for w in G.neighbors(v)
+                              if v != w]
             else:
-                nblist = [ (bv, w)
-                           for w in G.neighbors(bv)
-                           if bv != w ]
+                nblist = [(bv, w)
+                          for w in G.neighbors(bv)
+                          if bv != w]
             for k in nblist:
                 (i, j) = k
                 if inblossom[j] == b:
@@ -430,9 +432,9 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             while j != 0:
                 # Relabel the T-sub-blossom.
                 if jstep == 1:
-                    p, q  = b.edges[j]
+                    p, q = b.edges[j]
                 else:
-                    q, p = b.edges[j-1]
+                    q, p = b.edges[j - 1]
                 label[w] = None
                 label[q] = None
                 assignLabel(w, 2, v)
@@ -442,7 +444,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
                 if jstep == 1:
                     v, w = b.edges[j]
                 else:
-                    w, v = b.edges[j-1]
+                    w, v = b.edges[j - 1]
                 # Step to the next T-sub-blossom.
                 allowedge[(v, w)] = allowedge[(w, v)] = True
                 j += jstep
@@ -488,7 +490,8 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         del blossomdual[b]
 
     # Swap matched/unmatched edges over an alternating path through blossom b
-    # between vertex v and the base vertex. Keep blossom bookkeeping consistent.
+    # between vertex v and the base vertex. Keep blossom bookkeeping
+    # consistent.
     def augmentBlossom(b, v):
         # Bubble up through the blossom tree from vertex v to an immediate
         # sub-blossom of b.
@@ -515,7 +518,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             if jstep == 1:
                 w, x = b.edges[j]
             else:
-                x, w = b.edges[j-1]
+                x, w = b.edges[j - 1]
             if isinstance(t, Blossom):
                 augmentBlossom(t, w)
             # Step to the next sub-blossom and augment it recursively.
@@ -528,7 +531,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             mate[x] = w
         # Rotate the list of sub-blossoms to put the new base at the front.
         b.childs = b.childs[i:] + b.childs[:i]
-        b.edges  = b.edges[i:]  + b.edges[:i]
+        b.edges = b.edges[i:] + b.edges[:i]
         blossombase[b] = blossombase[b.childs[0]]
         assert blossombase[b] == v
 
@@ -542,7 +545,9 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             while 1:
                 bs = inblossom[s]
                 assert label[bs] == 1
-                assert (labeledge[bs] is None and blossombase[bs] not in mate) or (labeledge[bs][0] == mate[blossombase[bs]])
+                assert (
+                        labeledge[bs] is None and blossombase[bs] not in mate)\
+                    or (labeledge[bs][0] == mate[blossombase[bs]])
                 # Augment through the S-blossom from s to base.
                 if isinstance(bs, Blossom):
                     augmentBlossom(bs, s)
@@ -577,13 +582,13 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         assert len(blossomdual) == 0 or min(blossomdual.values()) >= 0
         # 0. all edges have non-negative slack and
         # 1. all matched edges have zero slack;
-        for i,j,d in G.edges(data=True):
-            wt=d.get(weight,1)
+        for i, j, d in G.edges(data=True):
+            wt = d.get(weight, 1)
             if i == j:
-                continue # ignore self-loops
+                continue  # ignore self-loops
             s = dualvar[i] + dualvar[j] - 2 * wt
-            iblossoms = [ i ]
-            jblossoms = [ j ]
+            iblossoms = [i]
+            jblossoms = [j]
             while blossomparent[iblossoms[-1]] is not None:
                 iblossoms.append(blossomparent[iblossoms[-1]])
             while blossomparent[jblossoms[-1]] is not None:
@@ -630,13 +635,12 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         allowedge.clear()
 
         # Make queue empty.
-        queue[:] = [ ]
+        queue[:] = []
 
         # Label single blossoms/vertices with S and put them in the queue.
         for v in gnodes:
             if (v not in mate) and label.get(inblossom[v]) is None:
                 assignLabel(v, 1, None)
-
 
         # Loop until we succeed in augmenting the matching.
         augmented = 0
@@ -660,7 +664,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
                 # Scan its neighbours:
                 for w in G.neighbors(v):
                     if w == v:
-                        continue # ignore self-loops
+                        continue  # ignore self-loops
                     # w is a neighbour to v
                     bv = inblossom[v]
                     bw = inblossom[w]
@@ -703,13 +707,15 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
                     elif label.get(bw) == 1:
                         # keep track of the least-slack non-allowable edge to
                         # a different S-blossom.
-                        if bestedge.get(bv) is None or kslack < slack(*bestedge[bv]):
+                        if bestedge.get(bv) is None or \
+                         kslack < slack(*bestedge[bv]):
                             bestedge[bv] = (v, w)
                     elif label.get(w) is None:
                         # w is a free vertex (or an unreached vertex inside
                         # a T-blossom) but we can not reach it yet;
                         # keep track of the least-slack edge that reaches w.
-                        if bestedge.get(w) is None or kslack < slack(*bestedge[w]):
+                        if bestedge.get(w) is None or \
+                         kslack < slack(*bestedge[w]):
                             bestedge[w] = (v, w)
 
             if augmented:
@@ -730,7 +736,8 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             # Compute delta2: the minimum slack on any edge between
             # an S-vertex and a free vertex.
             for v in G.nodes():
-                if label.get(inblossom[v]) is None and bestedge.get(v) is not None:
+                if label.get(inblossom[v]) is None and \
+                 bestedge.get(v) is not None:
                     d = slack(*bestedge[v])
                     if deltatype == -1 or d < delta:
                         delta = d
@@ -740,8 +747,8 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             # Compute delta3: half the minimum slack on any edge between
             # a pair of S-blossoms.
             for b in blossomparent:
-                if ( blossomparent[b] is None and label.get(b) == 1 and
-                     bestedge.get(b) is not None ):
+                if (blossomparent[b] is None and label.get(b) == 1 and
+                        bestedge.get(b) is not None):
                     kslack = slack(*bestedge[b])
                     if allinteger:
                         assert (kslack % 2) == 0
@@ -755,8 +762,8 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
 
             # Compute delta4: minimum z variable of any T-blossom.
             for b in blossomdual:
-                if ( blossomparent[b] is None and label.get(b) == 2 and
-                     (deltatype == -1 or blossomdual[b] < delta) ):
+                if (blossomparent[b] is None and label.get(b) == 2 and
+                        (deltatype == -1 or blossomdual[b] < delta)):
                     delta = blossomdual[b]
                     deltatype = 4
                     deltablossom = b
@@ -819,9 +826,9 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         # End of a stage; expand all S-blossoms which have zero dual.
         for b in list(blossomdual.keys()):
             if b not in blossomdual:
-                continue # already expanded
-            if ( blossomparent[b] is None and label.get(b) == 1 and
-                 blossomdual[b] == 0 ):
+                continue  # already expanded
+            if (blossomparent[b] is None and label.get(b) == 1 and
+                    blossomdual[b] == 0):
                 expandBlossom(b, True)
 
     # Verify that we reached the optimum solution (only for integer weights).
@@ -829,3 +836,4 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         verifyOptimum()
 
     return mate
+

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -3,6 +3,7 @@ import math
 from nose.tools import *
 import networkx as nx
 
+
 class TestMatching:
 
     def setUp(self):
@@ -11,13 +12,13 @@ class TestMatching:
     def test_trivial1(self):
         """Empty graph"""
         G = nx.Graph()
-        assert_equal(nx.max_weight_matching(G),{})
+        assert_equal(nx.max_weight_matching(G), {})
 
     def test_trivial2(self):
         """Self loop"""
         G = nx.Graph()
         G.add_edge(0, 0, weight=100)
-        assert_equal(nx.max_weight_matching(G),{})
+        assert_equal(nx.max_weight_matching(G), {})
 
     def test_trivial3(self):
         """Single edge"""
@@ -79,20 +80,20 @@ class TestMatching:
     def test_s_blossom(self):
         """Create S-blossom and use it for augmentation:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 8), (1, 3, 9),
-                                    (2, 3, 10), (3, 4, 7) ])
+        G.add_weighted_edges_from([(1, 2, 8), (1, 3, 9),
+                                   (2, 3, 10), (3, 4, 7)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 2, 2: 1, 3: 4, 4: 3})
 
-        G.add_weighted_edges_from([ (1, 6, 5), (4, 5, 6) ])
+        G.add_weighted_edges_from([(1, 6, 5), (4, 5, 6)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 6, 2: 3, 3: 2, 4: 5, 5: 4, 6: 1})
 
     def test_s_t_blossom(self):
         """Create S-blossom, relabel as T-blossom, use for augmentation:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 9), (1, 3, 8), (2, 3, 10),
-                                    (1, 4, 5), (4, 5, 4), (1, 6, 3) ])
+        G.add_weighted_edges_from([(1, 2, 9), (1, 3, 8), (2, 3, 10),
+                                   (1, 4, 5), (4, 5, 4), (1, 6, 3)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 6, 2: 3, 3: 2, 4: 5, 5: 4, 6: 1})
         G.add_edge(4, 5, weight=3)
@@ -108,60 +109,58 @@ class TestMatching:
         """Create nested S-blossom, use for augmentation:"""
 
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 9), (1, 3, 9), (2, 3, 10),
-                                    (2, 4, 8), (3, 5, 8), (4, 5, 10),
-                                    (5, 6, 6) ])
+        G.add_weighted_edges_from([(1, 2, 9), (1, 3, 9), (2, 3, 10),
+                                   (2, 4, 8), (3, 5, 8), (4, 5, 10),
+                                   (5, 6, 6)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 3, 2: 4, 3: 1, 4: 2, 5: 6, 6: 5})
 
     def test_nested_s_blossom_relabel(self):
         """Create S-blossom, relabel as S, include in nested S-blossom:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 10), (1, 7, 10), (2, 3, 12),
-                                    (3, 4, 20), (3, 5, 20), (4, 5, 25),
-                                    (5, 6, 10), (6, 7, 10), (7, 8, 8) ])
+        G.add_weighted_edges_from([(1, 2, 10), (1, 7, 10), (2, 3, 12),
+                                   (3, 4, 20), (3, 5, 20), (4, 5, 25),
+                                   (5, 6, 10), (6, 7, 10), (7, 8, 8)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 2, 2: 1, 3: 4, 4: 3, 5: 6, 6: 5, 7: 8, 8: 7})
 
     def test_nested_s_blossom_expand(self):
         """Create nested S-blossom, augment, expand recursively:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 8), (1, 3, 8), (2, 3, 10),
-                                    (2, 4, 12),(3, 5, 12), (4, 5, 14),
-                                    (4, 6, 12), (5, 7, 12), (6, 7, 14),
-                                    (7, 8, 12) ])
+        G.add_weighted_edges_from([(1, 2, 8), (1, 3, 8), (2, 3, 10),
+                                   (2, 4, 12), (3, 5, 12), (4, 5, 14),
+                                   (4, 6, 12), (5, 7, 12), (6, 7, 14),
+                                   (7, 8, 12)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 2, 2: 1, 3: 5, 4: 6, 5: 3, 6: 4, 7: 8, 8: 7})
-
 
     def test_s_blossom_relabel_expand(self):
         """Create S-blossom, relabel as T, expand:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 23), (1, 5, 22), (1, 6, 15),
-                                    (2, 3, 25), (3, 4, 22), (4, 5, 25),
-                                    (4, 8, 14), (5, 7, 13) ])
+        G.add_weighted_edges_from([(1, 2, 23), (1, 5, 22), (1, 6, 15),
+                                   (2, 3, 25), (3, 4, 22), (4, 5, 25),
+                                   (4, 8, 14), (5, 7, 13)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4})
 
     def test_nested_s_blossom_relabel_expand(self):
         """Create nested S-blossom, relabel as T, expand:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 19), (1, 3, 20), (1, 8, 8),
-                                    (2, 3, 25), (2, 4, 18), (3, 5, 18),
-                                    (4, 5, 13), (4, 7, 7), (5, 6, 7) ])
+        G.add_weighted_edges_from([(1, 2, 19), (1, 3, 20), (1, 8, 8),
+                                   (2, 3, 25), (2, 4, 18), (3, 5, 18),
+                                   (4, 5, 13), (4, 7, 7), (5, 6, 7)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1})
-
 
     def test_nasty_blossom1(self):
         """Create blossom, relabel as T in more than one way, expand,
         augment:
         """
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 45), (1, 5, 45), (2, 3, 50),
-                                    (3, 4, 45), (4, 5, 50), (1, 6, 30),
-                                    (3, 9, 35), (4, 8, 35), (5, 7, 26),
-                                    (9, 10, 5) ])
+        G.add_weighted_edges_from([(1, 2, 45), (1, 5, 45), (2, 3, 50),
+                                   (3, 4, 45), (4, 5, 50), (1, 6, 30),
+                                   (3, 9, 35), (4, 8, 35), (5, 7, 26),
+                                   (9, 10, 5)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 6, 2: 3, 3: 2, 4: 8, 5: 7,
                       6: 1, 7: 5, 8: 4, 9: 10, 10: 9})
@@ -169,10 +168,10 @@ class TestMatching:
     def test_nasty_blossom2(self):
         """Again but slightly different:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 45), (1, 5, 45), (2, 3, 50),
-                                    (3, 4, 45), (4, 5, 50), (1, 6, 30),
-                                    (3, 9, 35), (4, 8, 26), (5, 7, 40),
-                                    (9, 10, 5) ])
+        G.add_weighted_edges_from([(1, 2, 45), (1, 5, 45), (2, 3, 50),
+                                   (3, 4, 45), (4, 5, 50), (1, 6, 30),
+                                   (3, 9, 35), (4, 8, 26), (5, 7, 40),
+                                   (9, 10, 5)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 6, 2: 3, 3: 2, 4: 8, 5: 7,
                       6: 1, 7: 5, 8: 4, 9: 10, 10: 9})
@@ -182,10 +181,10 @@ class TestMatching:
         least-slack S-to-free dge is produced, augment:
         """
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 45), (1, 5, 45), (2, 3, 50),
-                                    (3, 4, 45), (4, 5, 50), (1, 6, 30),
-                                    (3, 9, 35), (4, 8, 28), (5, 7, 26),
-                                    (9, 10, 5) ])
+        G.add_weighted_edges_from([(1, 2, 45), (1, 5, 45), (2, 3, 50),
+                                   (3, 4, 45), (4, 5, 50), (1, 6, 30),
+                                   (3, 9, 35), (4, 8, 28), (5, 7, 26),
+                                   (9, 10, 5)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 6, 2: 3, 3: 2, 4: 8, 5: 7,
                       6: 1, 7: 5, 8: 4, 9: 10, 10: 9})
@@ -195,11 +194,11 @@ class TestMatching:
         # expand outer blossom such that inner blossom ends up on an
         # augmenting path:
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 45), (1, 7, 45), (2, 3, 50),
-                                    (3, 4, 45), (4, 5, 95), (4, 6, 94),
-                                    (5, 6, 94), (6, 7, 50), (1, 8, 30),
-                                    (3, 11, 35), (5, 9, 36), (7, 10, 26),
-                                    (11, 12, 5) ])
+        G.add_weighted_edges_from([(1, 2, 45), (1, 7, 45), (2, 3, 50),
+                                   (3, 4, 45), (4, 5, 95), (4, 6, 94),
+                                   (5, 6, 94), (6, 7, 50), (1, 8, 30),
+                                   (3, 11, 35), (5, 9, 36), (7, 10, 26),
+                                   (11, 12, 5)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 8, 2: 3, 3: 2, 4: 6, 5: 9, 6: 4,
                       7: 10, 8: 1, 9: 5, 10: 7, 11: 12, 12: 11})
@@ -207,13 +206,14 @@ class TestMatching:
     def test_nasty_blossom_expand_recursively(self):
         """Create nested S-blossom, relabel as S, expand recursively:"""
         G = nx.Graph()
-        G.add_weighted_edges_from([ (1, 2, 40), (1, 3, 40), (2, 3, 60),
-                                    (2, 4, 55), (3, 5, 55), (4, 5, 50),
-                                    (1, 8, 15), (5, 7, 30), (7, 6, 10),
-                                    (8, 10, 10), (4, 9, 30) ])
+        G.add_weighted_edges_from([(1, 2, 40), (1, 3, 40), (2, 3, 60),
+                                   (2, 4, 55), (3, 5, 55), (4, 5, 50),
+                                   (1, 8, 15), (5, 7, 30), (7, 6, 10),
+                                   (8, 10, 10), (4, 9, 30)])
         assert_equal(nx.max_weight_matching(G),
                      {1: 2, 2: 1, 3: 5, 4: 9, 5: 3,
                       6: 7, 7: 6, 8: 10, 9: 4, 10: 8})
+
 
 def test_maximal_matching():
     graph = nx.Graph()
@@ -230,8 +230,8 @@ def test_maximal_matching():
 
     for edge in graph.edges():
         u, v = edge
-        ok_(len(set([v]) & vset) > 0 or len(set([u]) & vset) > 0, \
-                "not a proper matching!")
+        ok_(len(set([v]) & vset) > 0 or len(set([u]) & vset) > 0,
+            "not a proper matching!")
 
     eq_(1, len(matching), "matching not length 1!")
     graph = nx.Graph()
@@ -249,37 +249,38 @@ def test_maximal_matching():
 
     for edge in graph.edges():
         u, v = edge
-        ok_(len(set([v]) & vset) > 0 or len(set([u]) & vset) > 0, \
-                "not a proper matching!")
+        ok_(len(set([v]) & vset) > 0 or len(set([u]) & vset) > 0,
+            "not a proper matching!")
     graph = nx.Graph()
     graph.add_edge(1, 1)
     graph.add_edge(1, 2)
     graph.add_edge(2, 2)
     graph.add_edge(2, 3)
     matching = nx.maximal_matching(graph)
-    assert(len(matching)==1)
+    assert(len(matching) == 1)
     vset = set(u for u, v in matching)
     vset = vset | set(v for u, v in matching)
 
     for edge in graph.edges():
         u, v = edge
-        ok_(len(set([v]) & vset) > 0 or len(set([u]) & vset) > 0, \
-                "not a proper matching!")
+        ok_(len(set([v]) & vset) > 0 or len(set([u]) & vset) > 0,
+            "not a proper matching!")
+
 
 def test_maximal_matching_ordering():
     # check edge ordering
     G = nx.Graph()
-    G.add_nodes_from([100,200,300])
-    G.add_edges_from([(100,200),(100,300)])
+    G.add_nodes_from([100, 200, 300])
+    G.add_edges_from([(100, 200), (100, 300)])
     matching = nx.maximal_matching(G)
     assert_equal(len(matching), 1)
     G = nx.Graph()
-    G.add_nodes_from([200,100,300])
-    G.add_edges_from([(100,200),(100,300)])
+    G.add_nodes_from([200, 100, 300])
+    G.add_edges_from([(100, 200), (100, 300)])
     matching = nx.maximal_matching(G)
     assert_equal(len(matching), 1)
     G = nx.Graph()
-    G.add_nodes_from([300,200,100])
-    G.add_edges_from([(100,200),(100,300)])
+    G.add_nodes_from([300, 200, 100])
+    G.add_edges_from([(100, 200), (100, 300)])
     matching = nx.maximal_matching(G)
     assert_equal(len(matching), 1)


### PR DESCRIPTION
Ref to #1927 
I contacted Prof. Eppstein. There, problem is with the input format. From [PADS/BipartiteMatching](http://www.ics.uci.edu/~eppstein/PADS/BipartiteMatching.py)'s documentation:
**The input format is a dictionary mapping members of U to lists of their neighbors in V.**
This PR solves this issue.
Along with it, I have implemented `is_max_cardinality_matching` and fixed some pep8 errors.
Will modify #1915's test cases soon.