### PR TITLE
provides with_data options for shallow copies in G.copy

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1299,13 +1299,47 @@ class Graph(object):
     def copy(self, with_data=True):
         """Return a copy of the graph.
 
+        All copies reproduce the graph structure, but data attributes
+        may be handled in different ways. There are four types of copies
+        of a graph that people might want.
+
+        Deepcopy -- The default behavior is a "deepcopy" where the graph
+        structure as well as all data attributes and any objects they might
+        contain are copied. The entire graph object is new so that changes
+        in the copy do not affect the original object.
+
+        Data Reference (Shallow) -- For a shallow copy (with_data=False)
+        the graph structure is copied but the edge, node and graph attribute
+        dicts are references to those in the original graph. This saves
+        time and memory but could cause confusion if you change an attribute
+        in one graph and it changes the attribute in the other.
+
+        Independent Shallow -- This copy creates new independent attribute
+        dicts and then does a shallow copy of the attributes. That is, any
+        attributes that are containers are shared between the new graph
+        and the original. This type of copy is not enabled. Instead use:
+
+            >>> G = nx.path_graph(5)
+            >>> H = G.__class__(G)
+
+        Fresh Data-- For fresh data, the graph structure is copied while
+        new empty data attribute dicts are created. The resulting graph
+        is independent of the original and it has no edge, node or graph
+        attributes. Fresh copies are not enabled. Instead use:
+
+            >>> H = G.__class__()
+            >>> H.add_nodes_from(G)
+            >>> H.add_edges_from(G.edges())
+
+        See the Python copy module for more information on shallow
+        and deep copies, http://docs.python.org/library/copy.html.
+
         Parameters
         ----------
         with_data : bool, optional (default=True)
             If True, the returned graph will have a deep copy of the
             graph, node, and edge attributes of this object. Otherwise,
-            the returned graph will only have a copy of the nodes and
-            edges of this object.
+            the returned graph will be a shallow copy.
 
         Returns
         -------
@@ -1325,10 +1359,7 @@ class Graph(object):
         """
         if with_data:
             return deepcopy(self)
-        G = nx.Graph()
-        G.add_nodes_from(self)
-        G.add_edges_from(self.edges())
-        return G
+        return self.subgraph(self)
 
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""
@@ -1477,6 +1508,7 @@ class Graph(object):
         H_adj = H.adj
         self_adj = self.adj
         # add nodes and edges (undirected method)
+        # Note that changing this may affect the deep-ness of self.copy()
         for n in H.node:
             Hnbrs = H.adjlist_dict_factory()
             H_adj[n] = Hnbrs


### PR DESCRIPTION
providing one style of shallow copies
with other styles described in the docstrings
Addresses #1916 and supercedes #1917 also related to #1876 