### PR TITLE
Returns 0 for average path length of trivial graph

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -285,26 +285,37 @@ def average_shortest_path_length(G, weight=None):
 
     Raises
     ------
-    NetworkXError:
-       if the graph is not connected.
+    NetworkXPointlessConcept
+        If ``G`` is the null graph (that is, the graph on zero nodes).
+
+    NetworkXError
+        If ``G`` is not connected (or not weakly connected, in the case
+        of a directed graph).
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> print(nx.average_shortest_path_length(G))
+    >>> G = nx.path_graph(5)
+    >>> nx.average_shortest_path_length(G)
     2.0
 
-    For disconnected graphs you can compute the average shortest path
+    For disconnected graphs, you can compute the average shortest path
     length for each component:
-    >>> G=nx.Graph([(1,2),(3,4)])
-    >>> for g in nx.connected_component_subgraphs(G):
-    ...     print(nx.average_shortest_path_length(g))
+
+    >>> G = nx.Graph([(1, 2), (3, 4)])
+    >>> for C in nx.connected_component_subgraphs(G):
+    ...     print(nx.average_shortest_path_length(C))
     1.0
     1.0
 
     """
-    # For the special case of the trivial graph, return zero immediately.
     n = len(G)
+    # For the special case of the null graph, raise an exception, since
+    # there are no paths in the null graph.
+    if n == 0:
+        msg = ('the null graph has no paths, thus there is no average shortest'
+               ' path length')
+        raise nx.NetworkXPointlessConcept(msg)
+    # For the special case of the trivial graph, return zero immediately.
     if n == 1:
         return 0
     # Shortest path length is undefined if the graph is disconnected.

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -181,3 +181,7 @@ class TestAverageShortestPathLength(object):
         """
         G = nx.trivial_graph()
         assert_equal(nx.average_shortest_path_length(G), 0)
+
+    @raises(nx.NetworkXPointlessConcept)
+    def test_null_graph(self):
+        nx.average_shortest_path_length(nx.null_graph())

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -1,6 +1,15 @@
-#!/usr/bin/env python
-from nose.tools import *
+from __future__ import division
+
+from nose.tools import assert_almost_equal
+from nose.tools import assert_equal
+from nose.tools import assert_false
+from nose.tools import assert_true
+from nose.tools import assert_raises
+from nose.tools import ok_
+from nose.tools import raises
+
 import networkx as nx
+
 
 def validate_grid_path(r, c, s, t, p):
     ok_(isinstance(p, list))
@@ -112,32 +121,6 @@ class TestGenericPath:
         l = dict(nx.shortest_path_length(self.grid, weight='weight'))
         assert_equal(l[1][16], 6)
 
-    def test_average_shortest_path(self):
-        l=nx.average_shortest_path_length(self.cycle)
-        assert_almost_equal(l,2)
-        l=nx.average_shortest_path_length(nx.path_graph(5))
-        assert_almost_equal(l,2)
-
-
-    def test_weighted_average_shortest_path(self):
-        G=nx.Graph()
-        G.add_cycle(range(7),weight=2)
-        l=nx.average_shortest_path_length(G,weight='weight')
-        assert_almost_equal(l,4)
-        G=nx.Graph()
-        G.add_path(range(5),weight=2)
-        l=nx.average_shortest_path_length(G,weight='weight')
-        assert_almost_equal(l,4)
-
-
-    def test_average_shortest_disconnected(self):
-        g = nx.Graph()
-        g.add_nodes_from(range(3))
-        g.add_edge(0, 1)
-        assert_raises(nx.NetworkXError,nx.average_shortest_path_length,g)
-        g = g.to_directed()
-        assert_raises(nx.NetworkXError,nx.average_shortest_path_length,g)
-
     def test_has_path(self):
         G = nx.Graph()
         G.add_path(range(3))
@@ -158,3 +141,43 @@ class TestGenericPath:
         G.add_path([0,1,2,3])
         G.add_node(4)
         paths = list(nx.all_shortest_paths(G,0,4))
+
+
+class TestAverageShortestPathLength(object):
+
+    def test_cycle_graph(self):
+        l = nx.average_shortest_path_length(nx.cycle_graph(7))
+        assert_almost_equal(l, 2)
+
+    def test_path_graph(self):
+        l = nx.average_shortest_path_length(nx.path_graph(5))
+        assert_almost_equal(l, 2)
+
+    def test_weighted(self):
+        G = nx.Graph()
+        G.add_cycle(range(7), weight=2)
+        l = nx.average_shortest_path_length(G, weight='weight')
+        assert_almost_equal(l, 4)
+        G = nx.Graph()
+        G.add_path(range(5), weight=2)
+        l = nx.average_shortest_path_length(G, weight='weight')
+        assert_almost_equal(l, 4)
+
+    def test_disconnected(self):
+        g = nx.Graph()
+        g.add_nodes_from(range(3))
+        g.add_edge(0, 1)
+        assert_raises(nx.NetworkXError, nx.average_shortest_path_length, g)
+        g = g.to_directed()
+        assert_raises(nx.NetworkXError, nx.average_shortest_path_length, g)
+
+    def test_trivial_graph(self):
+        """Tests that the trivial graph has average path length zero,
+        since there is exactly one path of length zero in the trivial
+        graph.
+
+        For more information, see issue #1960.
+
+        """
+        G = nx.trivial_graph()
+        assert_equal(nx.average_shortest_path_length(G), 0)


### PR DESCRIPTION
This commit updates the `average_shortest_path_length` function to
return zero for the trivial graph (the graph with a single node).

This fixes issue #1960, if my understanding of Google's machine translation of the original Chinese text is correct.