### PR TITLE
Fix docstring formatting in richclub and generic

### DIFF
--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -1,4 +1,13 @@
 # -*- coding: utf-8 -*-
+#    Copyright (C) 2004-2016 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Authors: Ben Edwards (bedwards@cs.unm.edu)
+#          Aric Hagberg (hagberg@lanl.gov)
 """Functions for computing rich-club coefficients."""
 from __future__ import division
 
@@ -6,17 +15,15 @@ import networkx as nx
 from networkx.utils import accumulate
 from networkx.utils import not_implemented_for
 
-__author__ = """\n""".join(['Ben Edwards',
-                            'Aric Hagberg <hagberg@lanl.gov>'])
-
 __all__ = ['rich_club_coefficient']
+
 
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def rich_club_coefficient(G, normalized=True, Q=100):
     r"""Returns the rich-club coefficient of the graph ``G``.
 
-    For each degree *k, the *rich-club coefficient* is the ratio of the
+    For each degree *k*, the *rich-club coefficient* is the ratio of the
     number of actual to the number of potential edges for nodes with
     degree greater than *k*:
 
@@ -32,10 +39,10 @@ def rich_club_coefficient(G, normalized=True, Q=100):
     G : NetworkX graph
         Undirected graph with neither parallel edges nor self-loops.
     normalized : bool (optional)
-        Normalize using randomized network (see [1]_)
+        Normalize using randomized network as in [1]_
     Q : float (optional, default=100)
-        If ``normalized`` is ``True``, perform ``Q * m`` double-edge
-        swaps, where ``m`` is the number of edges in ``G``, to use as a
+        If ``normalized`` is ``True``, perform `Q * m` double-edge
+        swaps, where `m` is the number of edges in ``G``, to use as a
         null-model for normalization.
 
     Returns

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -299,7 +299,7 @@ def average_shortest_path_length(G, weight=None):
     2.0
 
     For disconnected graphs, you can compute the average shortest path
-    length for each component:
+    length for each component
 
     >>> G = nx.Graph([(1, 2), (3, 4)])
     >>> for C in nx.connected_component_subgraphs(G):

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -5,6 +5,9 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Aric Hagberg <aric.hagberg@gmail.com>
+#          Sérgio Nery Simões <sergionery@gmail.com>
 """
 Compute the shortest paths and path lengths between nodes in the graph.
 
@@ -15,16 +18,13 @@ from __future__ import division
 
 import networkx as nx
 
-__author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',
-                            'Sérgio Nery Simões <sergionery@gmail.com>'])
-
 __all__ = ['shortest_path', 'all_shortest_paths',
            'shortest_path_length', 'average_shortest_path_length',
            'has_path']
 
 
 def has_path(G, source, target):
-    """Return True if G has a path from source to target, False otherwise.
+    """Return *True* if *G* has a path from *source* to *target*.
 
     Parameters
     ----------
@@ -37,7 +37,7 @@ def has_path(G, source, target):
        Ending node for path
     """
     try:
-        sp = nx.shortest_path(G,source, target)
+        sp = nx.shortest_path(G, source, target)
     except nx.NetworkXNoPath:
         return False
     return True
@@ -51,12 +51,12 @@ def shortest_path(G, source=None, target=None, weight=None):
     G : NetworkX graph
 
     source : node, optional
-        Starting node for path.
-        If not specified, compute shortest paths using all nodes as source nodes.
+        Starting node for path. If not specified, compute shortest
+        paths for each possible starting node.
 
     target : node, optional
-        Ending node for path.
-        If not specified, compute shortest paths using all nodes as target nodes.
+        Ending node for path. If not specified, compute shortest
+        paths to all possible nodes.
 
     weight : None or string, optional (default = None)
         If None, every edge has weight/distance/cost 1.
@@ -84,16 +84,16 @@ def shortest_path(G, source=None, target=None, weight=None):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> print(nx.shortest_path(G,source=0,target=4))
+    >>> G = nx.path_graph(5)
+    >>> print(nx.shortest_path(G, source=0, target=4))
     [0, 1, 2, 3, 4]
-    >>> p=nx.shortest_path(G,source=0) # target not specified
+    >>> p = nx.shortest_path(G, source=0) # target not specified
     >>> p[4]
     [0, 1, 2, 3, 4]
-    >>> p=nx.shortest_path(G,target=4) # source not specified
+    >>> p = nx.shortest_path(G, target=4) # source not specified
     >>> p[0]
     [0, 1, 2, 3, 4]
-    >>> p=nx.shortest_path(G) # source,target not specified
+    >>> p = nx.shortest_path(G) # source, target not specified
     >>> p[0][4]
     [0, 1, 2, 3, 4]
 
@@ -111,35 +111,37 @@ def shortest_path(G, source=None, target=None, weight=None):
     """
     if source is None:
         if target is None:
-            ## Find paths between all pairs.
+            # Find paths between all pairs.
             if weight is None:
-                paths=nx.all_pairs_shortest_path(G)
+                paths = nx.all_pairs_shortest_path(G)
             else:
-                paths=nx.all_pairs_dijkstra_path(G,weight=weight)
+                paths = nx.all_pairs_dijkstra_path(G, weight=weight)
         else:
-            ## Find paths from all nodes co-accessible to the target.
+            # Find paths from all nodes co-accessible to the target.
             with nx.utils.reversed(G):
                 if weight is None:
-                    paths=nx.single_source_shortest_path(G, target)
+                    paths = nx.single_source_shortest_path(G, target)
                 else:
-                    paths=nx.single_source_dijkstra_path(G, target, weight=weight)
+                    paths = nx.single_source_dijkstra_path(G, target,
+                                                           weight=weight)
                 # Now flip the paths so they go from a source to the target.
                 for target in paths:
                     paths[target] = list(reversed(paths[target]))
 
     else:
         if target is None:
-            ## Find paths to all nodes accessible from the source.
+            # Find paths to all nodes accessible from the source.
             if weight is None:
-                paths=nx.single_source_shortest_path(G,source)
+                paths = nx.single_source_shortest_path(G, source)
             else:
-                paths=nx.single_source_dijkstra_path(G,source,weight=weight)
+                paths = nx.single_source_dijkstra_path(G, source,
+                                                       weight=weight)
         else:
-            ## Find shortest source-target path.
+            # Find shortest source-target path.
             if weight is None:
-                paths=nx.bidirectional_shortest_path(G,source,target)
+                paths = nx.bidirectional_shortest_path(G, source, target)
             else:
-                paths=nx.dijkstra_path(G,source,target,weight)
+                paths = nx.dijkstra_path(G, source, target, weight)
 
     return paths
 
@@ -193,16 +195,16 @@ def shortest_path_length(G, source=None, target=None, weight=None):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> nx.shortest_path_length(G,source=0,target=4)
+    >>> G = nx.path_graph(5)
+    >>> nx.shortest_path_length(G, source=0, target=4)
     4
-    >>> p=nx.shortest_path_length(G,source=0) # target not specified
+    >>> p = nx.shortest_path_length(G, source=0) # target not specified
     >>> dict(p)[4]
     4
-    >>> p=nx.shortest_path_length(G,target=4) # source not specified
+    >>> p = nx.shortest_path_length(G, target=4) # source not specified
     >>> dict(p)[0]
     4
-    >>> p=nx.shortest_path_length(G) # source,target not specified
+    >>> p = nx.shortest_path_length(G) # source,target not specified
     >>> dict(p)[0][4]
     4
 
@@ -225,35 +227,37 @@ def shortest_path_length(G, source=None, target=None, weight=None):
     """
     if source is None:
         if target is None:
-            ## Find paths between all pairs.
+            # Find paths between all pairs.
             if weight is None:
                 paths = nx.all_pairs_shortest_path_length(G)
             else:
-                paths=nx.all_pairs_dijkstra_path_length(G, weight=weight)
+                paths = nx.all_pairs_dijkstra_path_length(G, weight=weight)
         else:
-            ## Find paths from all nodes co-accessible to the target.
+            # Find paths from all nodes co-accessible to the target.
             with nx.utils.reversed(G):
                 if weight is None:
                     # We need to exhaust the iterator as Graph needs
                     # to be reversed.
-                    paths = list(nx.single_source_shortest_path_length(G, target))
+                    path_length = nx.single_source_shortest_path_length
+                    paths = list(path_length(G, target))
                 else:
-                    paths=nx.single_source_dijkstra_path_length(G, target,
-                                                                    weight=weight)
+                    path_length = nx.single_source_dijkstra_path_length
+                    paths = path_length(G, target, weight=weight)
     else:
         if target is None:
-            ## Find paths to all nodes accessible from the source.
+            # Find paths to all nodes accessible from the source.
             if weight is None:
-                paths = nx.single_source_shortest_path_length(G,source)
+                paths = nx.single_source_shortest_path_length(G, source)
             else:
-                paths=nx.single_source_dijkstra_path_length(G,source,weight=weight)
+                paths = nx.single_source_dijkstra_path_length(G, source,
+                                                              weight=weight)
         else:
-            ## Find shortest source-target path.
+            # Find shortest source-target path.
             if weight is None:
-                p=nx.bidirectional_shortest_path(G,source,target)
-                paths=len(p)-1
+                p = nx.bidirectional_shortest_path(G, source, target)
+                paths = len(p)-1
             else:
-                paths=nx.dijkstra_path_length(G,source,target,weight)
+                paths = nx.dijkstra_path_length(G, source, target, weight)
     return paths
 
 
@@ -308,8 +312,8 @@ def average_shortest_path_length(G, weight=None):
     # For the special case of the null graph, raise an exception, since
     # there are no paths in the null graph.
     if n == 0:
-        msg = ('the null graph has no paths, thus there is no average shortest'
-               ' path length')
+        msg = ('the null graph has no paths, thus there is no average'
+               'shortest path length')
         raise nx.NetworkXPointlessConcept(msg)
     # For the special case of the trivial graph, return zero immediately.
     if n == 1:
@@ -323,8 +327,8 @@ def average_shortest_path_length(G, weight=None):
     if weight is None:
         path_length = lambda v: nx.single_source_shortest_path_length(G, v)
     else:
-        path_length = lambda v: \
-            nx.single_source_dijkstra_path_length(G, v, weight=weight)
+        ssdpl = nx.single_source_dijkstra_path_length
+        path_length = lambda v: ssdpl(G, v, weight=weight)
     # Sum the distances for each (ordered) pair of source and target node.
     s = sum(l for u in G for v, l in path_length(u))
     return s / (n * (n - 1))
@@ -350,15 +354,15 @@ def all_shortest_paths(G, source, target, weight=None):
 
     Returns
     -------
-    paths: generator of lists
+    paths : generator of lists
         A generator of all paths between source and target.
 
     Examples
     --------
-    >>> G=nx.Graph()
-    >>> G.add_path([0,1,2])
-    >>> G.add_path([0,10,2])
-    >>> print([p for p in nx.all_shortest_paths(G,source=0,target=2)])
+    >>> G = nx.Graph()
+    >>> G.add_path([0, 1, 2])
+    >>> G.add_path([0, 10, 2])
+    >>> print([p for p in nx.all_shortest_paths(G, source=0, target=2)])
     [[0, 1, 2], [0, 10, 2]]
 
     Notes
@@ -372,23 +376,24 @@ def all_shortest_paths(G, source, target, weight=None):
     all_pairs_shortest_path()
     """
     if weight is not None:
-        pred,dist = nx.dijkstra_predecessor_and_distance(G,source,weight=weight)
+        pred, dist = nx.dijkstra_predecessor_and_distance(G, source,
+                                                          weight=weight)
     else:
-        pred = nx.predecessor(G,source)
+        pred = nx.predecessor(G, source)
     if target not in pred:
         raise nx.NetworkXNoPath()
-    stack = [[target,0]]
+    stack = [[target, 0]]
     top = 0
     while top >= 0:
-        node,i = stack[top]
+        node, i = stack[top]
         if node == source:
-            yield [p for p,n in reversed(stack[:top+1])]
+            yield [p for p, n in reversed(stack[:top+1])]
         if len(pred[node]) > i:
             top += 1
             if top == len(stack):
-                stack.append([pred[node][i],0])
+                stack.append([pred[node][i], 0])
             else:
-                stack[top] = [pred[node][i],0]
+                stack[top] = [pred[node][i], 0]
         else:
             stack[top-1][1] += 1
             top -= 1

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -13,8 +13,6 @@ These algorithms work with undirected and directed graphs.
 """
 from __future__ import division
 
-from itertools import chain
-
 import networkx as nx
 
 __author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',
@@ -23,8 +21,6 @@ __author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',
 __all__ = ['shortest_path', 'all_shortest_paths',
            'shortest_path_length', 'average_shortest_path_length',
            'has_path']
-
-chaini = chain.from_iterable
 
 
 def has_path(G, source, target):
@@ -324,9 +320,13 @@ def average_shortest_path_length(G, weight=None):
     if not G.is_directed() and not nx.is_connected(G):
         raise nx.NetworkXError("Graph is not connected.")
     # Compute all-pairs shortest paths.
-    path_lengths = shortest_path_length(G, weight=weight)
+    if weight is None:
+        path_length = lambda v: nx.single_source_shortest_path_length(G, v)
+    else:
+        path_length = lambda v: \
+            nx.single_source_dijkstra_path_length(G, v, weight=weight)
     # Sum the distances for each (ordered) pair of source and target node.
-    s = sum(chaini(dist.values() for s, dist in path_lengths))
+    s = sum(l for u in G for v, l in path_length(u))
     return s / (n * (n - 1))
 
 

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2006-2009 by
+# Copyright (C) 2006-2016 by
 #   Aric Hagberg <hagberg@lanl.gov>
 #   Dan Schult <dschult@colgate.edu>
 #   Pieter Swart <swart@lanl.gov>
 # Copyright (C) 2009 by Willem Ligtenberg <W.P.A.Ligtenberg@tue.nl>
-#
 # All rights reserved.
 # BSD license.
+#
+# Authors: Aric Hagberg (hagberg@lanl.gov)
+#          Willem Ligtenberg (W.P.A.Ligtenberg@tue.nl)
 """
 Generators for some directed graphs, including growing network (GN) graphs and
 scale-free graphs.


### PR DESCRIPTION
The richclub docstrings are a good candidate for pointing people to formatting choices in docstrings.

shortest_path/generic had some examples that didn't work, did pep8 on this one too--look at individual commits to avoid that it you need to.

added authors comment in generators/directed. 