### PR TITLE
Edited Doc Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ help:
 
 
 clean:
-	-rm -rf build/* source/reference/generated/* source/examples/* source/static/examples doc/source/*.pdf doc/source/*.zip 
+	-rm -rf build/* source/reference/generated/* source/examples/* source/static/examples/* doc/source/*.pdf doc/source/*.zip 
 	-rm -rf ../examples/*/*.png
 
 generate: build/generate-stamp


### PR DESCRIPTION
Probably the smallest pull-request ever. I edited the Makefile in the doc-directory to remove the contents of the folder source/static/examples instead of the folder itself when `make clean` is called, as was already the case with the other generated folders. I also use other types of file synchronization tools and it is difficult to exclude non-existent folders, or the exclusion gets deleted together with the deleted folder, hence it gets included again at the next make.