### PR TITLE
Fix all_node_cuts corner cases: cycle and complete graphs.

### DIFF
--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -3,6 +3,7 @@
 Kanevsky all minimum node k cutsets algorithm.
 """
 from operator import itemgetter
+from itertools import combinations
 
 import networkx as nx
 from .utils import build_auxiliary_node_connectivity
@@ -86,6 +87,22 @@ def all_node_cuts(G, k=None, flow_func=None):
     if not nx.is_connected(G):
         raise nx.NetworkXError('Input graph is disconnected.')
 
+    # Addess some corner cases first.
+    # For cycle graphs
+    if G.order() == G.size():
+        if all(2 == d for n, d in G.degree()):
+            seen = set()
+            for u in G:
+                for v in nx.non_neighbors(G, u):
+                    if (u, v) not in seen and (v, u) not in seen:
+                        yield {v, u}
+                        seen.add((v, u))
+            return
+    # For complete Graphs
+    if nx.density(G) == 1:
+        for cut_set in combinations(G, len(G)-1):
+            yield set(cut_set)
+        return
     # Initialize data structures.
     # Keep track of the cuts already computed so we do not repeat them.
     seen = []

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -241,3 +241,27 @@ def test_non_repeated_cuts():
     assert_true(len(solution) == len(cuts))
     for cut in cuts:
         assert_true(cut in solution)
+
+
+def test_cycle_graph():
+    G = nx.cycle_graph(5)
+    solution = [{0, 2}, {0, 3}, {1, 3}, {1, 4}, {2, 4}]
+    cuts = list(nx.all_node_cuts(G))
+    assert_true(len(solution) == len(cuts))
+    for cut in cuts:
+        assert_true(cut in solution)
+
+
+def test_complete_graph():
+    G = nx.complete_graph(5)
+    solution = [
+        {0, 1, 2, 3},
+        {0, 1, 2, 4},
+        {0, 1, 3, 4},
+        {0, 2, 3, 4},
+        {1, 2, 3, 4},
+    ]
+    cuts = list(nx.all_node_cuts(G))
+    assert_true(len(solution) == len(cuts))
+    for cut in cuts:
+        assert_true(cut in solution)


### PR DESCRIPTION
This PR fixes #1875 . For cycle graphs and complete graphs all_node_cuts
was giving incorrect or incomplete results. The most tricky case is cycle
graphs because handling them as a part of the implementation of Kanevsky's
algorithm requires checks inside tight loops that would penalize the common
case.

Instead in this PR cycle and complete graphs are handled separately. It is
cheap to test if the input graph is any of both, and the solution of finding
all node cuts is a lot easier and faster than in the general case.

Also added tests for both cycle and complete graphs.