### PR TITLE
Add Dinitz' algorithm for maximum flow problems.

### DIFF
--- a/doc/source/reference/algorithms.flow.rst
+++ b/doc/source/reference/algorithms.flow.rst
@@ -40,6 +40,14 @@ Preflow-Push
    preflow_push
 
 
+Dinitz
+------
+.. autosummary::
+   :toctree: generated/
+
+   dinitz
+
+
 Utils
 -----
 .. autosummary::

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -10,7 +10,9 @@ from operator import itemgetter
 import networkx as nx
 # Define the default maximum flow function to use in all flow based
 # connectivity algorithms.
-from networkx.algorithms.flow import edmonds_karp, shortest_augmenting_path
+from networkx.algorithms.flow import dinitz
+from networkx.algorithms.flow import edmonds_karp
+from networkx.algorithms.flow import shortest_augmenting_path
 from networkx.algorithms.flow import build_residual_network
 default_flow_func = edmonds_karp
 
@@ -198,6 +200,8 @@ def local_node_connectivity(G, s, t, flow_func=None, auxiliary=None,
         kwargs['cutoff'] = cutoff
         kwargs['two_phase'] = True
     elif flow_func is edmonds_karp:
+        kwargs['cutoff'] = cutoff
+    elif flow_func is dinitz:
         kwargs['cutoff'] = cutoff
 
     return nx.maximum_flow_value(H, '%sB' % mapping[s], '%sA' % mapping[t], **kwargs)
@@ -631,6 +635,8 @@ def local_edge_connectivity(G, u, v, flow_func=None, auxiliary=None,
         kwargs['cutoff'] = cutoff
         kwargs['two_phase'] = True
     elif flow_func is edmonds_karp:
+        kwargs['cutoff'] = cutoff
+    elif flow_func is dinitz:
         kwargs['cutoff'] = cutoff
 
     return nx.maximum_flow_value(H, u, v, **kwargs)

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -1,15 +1,17 @@
 import itertools
 from nose.tools import assert_equal, assert_true, assert_false, assert_raises
+
 import networkx as nx
+from networkx.algorithms import flow
+from networkx.algorithms.connectivity import local_edge_connectivity
+from networkx.algorithms.connectivity import local_node_connectivity
 
-from networkx.algorithms.flow import (edmonds_karp, preflow_push,
-    shortest_augmenting_path) 
-
-flow_funcs = [edmonds_karp, preflow_push, shortest_augmenting_path]
-
-# connectivity functions not imported to the base namespace
-from networkx.algorithms.connectivity import (local_edge_connectivity,
-    local_node_connectivity)
+flow_funcs = [
+    flow.dinitz,
+    flow.edmonds_karp,
+    flow.preflow_push,
+    flow.shortest_augmenting_path,
+]
 
 
 msg = "Assertion failed in function: {0}"
@@ -246,7 +248,7 @@ def test_cutoff():
     G = nx.complete_graph(5)
     for local_func in [local_edge_connectivity, local_node_connectivity]:
         for flow_func in flow_funcs:
-            if flow_func is preflow_push:
+            if flow_func is flow.preflow_push:
                 # cutoff is not supported by preflow_push
                 continue
             for cutoff in [3, 2, 1]:

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -1,13 +1,17 @@
 from nose.tools import assert_equal, assert_true, assert_false, assert_raises
 
 import networkx as nx
-from networkx.algorithms.connectivity import (minimum_st_edge_cut,
-                                              minimum_st_node_cut)
-from networkx.algorithms.flow import (edmonds_karp, preflow_push,
-                                      shortest_augmenting_path)
+from networkx.algorithms import flow
+from networkx.algorithms.connectivity import minimum_st_edge_cut
+from networkx.algorithms.connectivity import minimum_st_node_cut
 from networkx.utils import arbitrary_element
 
-flow_funcs = [edmonds_karp, preflow_push, shortest_augmenting_path]
+flow_funcs = [
+    flow.dinitz,
+    flow.edmonds_karp,
+    flow.preflow_push,
+    flow.shortest_augmenting_path,
+]
 
 msg = "Assertion failed in function: {0}"
 

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -2,14 +2,18 @@
 # Test for k-cutsets
 from operator import itemgetter
 from nose.tools import assert_equal, assert_false, assert_true, assert_raises
+
 import networkx as nx
+from networkx.algorithms import flow
 from networkx.algorithms.connectivity.kcutsets import _is_separating_set
 
-from networkx.algorithms.flow import (
-    edmonds_karp,
-    shortest_augmenting_path,
-    preflow_push,
-)
+
+flow_funcs = [
+    flow.dinitz,
+    flow.edmonds_karp,
+    flow.preflow_push,
+    flow.shortest_augmenting_path,
+]
 
 
 ##
@@ -204,7 +208,6 @@ def test_disconnected_graph():
 
 
 def test_alternative_flow_functions():
-    flow_funcs = [edmonds_karp, shortest_augmenting_path, preflow_push]
     graph_funcs = [graph_example_1, nx.davis_southern_women_graph]
     for graph_func in graph_funcs:
         G = graph_func()

--- a/networkx/algorithms/flow/__init__.py
+++ b/networkx/algorithms/flow/__init__.py
@@ -1,5 +1,6 @@
 from .maxflow import *
 from .mincost import *
+from .dinitz_alg import *
 from .edmondskarp import *
 from .preflowpush import *
 from .shortestaugmentingpath import *

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -177,7 +177,7 @@ def dinitz_impl(G, s, t, capacity, residual, cutoff):
         target_in_previous_layer = False
         while queue and not target_in_previous_layer:
             u = queue.popleft()
-            for v in G[u]:
+            for v in R[u]:
                 attr = R.succ[u][v]
                 if v not in rank and attr['capacity'] - attr['flow'] > 0:
                     rank[v] = rank[u] + 1
@@ -188,7 +188,7 @@ def dinitz_impl(G, s, t, capacity, residual, cutoff):
     def depth_first_search(G, R, u, t, flow, rank):
         if u == t:
             return flow
-        for v in (n for n in G[u] if n in rank and rank[n] == rank[u] + 1):
+        for v in (n for n in R[u] if n in rank and rank[n] == rank[u] + 1):
             attr = R.succ[u][v]
             if attr['capacity'] > attr['flow']:
                 min_flow = min(flow, attr['capacity'] - attr['flow'])

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -207,7 +207,7 @@ def dinitz_impl(G, s, t, capacity, residual, cutoff):
         rank = breath_first_search(G, R, s, t)
         if t not in rank:
             break
-        while True:
+        while flow_value < cutoff:
             blocking_flow = depth_first_search(G, R, s, t, INF, rank)
             if blocking_flow == 0:
                 break

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -1,0 +1,217 @@
+# dinitz.py - Dinitz' algorithm for maximum flow problems.
+#
+# Copyright 2016 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""
+Dinitz' algorithm for maximum flow problems.
+"""
+from collections import deque
+
+import networkx as nx
+from networkx.algorithms.flow.utils import build_residual_network
+
+__all__ = ['dinitz']
+
+def dinitz(G, s, t, capacity='capacity', residual=None, value_only=False, cutoff=None):
+    """Find a maximum single-commodity flow using Dinitz' algorithm.
+
+    This function returns the residual network resulting after computing
+    the maximum flow. See below for details about the conventions
+    NetworkX uses for defining residual networks.
+
+    This algorithm has a running time of `O(n^2 m)` for `n` nodes and `m`
+    edges _[1].
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        Edges of the graph are expected to have an attribute called
+        'capacity'. If this attribute is not present, the edge is
+        considered to have infinite capacity.
+
+    s : node
+        Source node for the flow.
+
+    t : node
+        Sink node for the flow.
+
+    capacity : string
+        Edges of the graph G are expected to have an attribute capacity
+        that indicates how much flow the edge can support. If this
+        attribute is not present, the edge is considered to have
+        infinite capacity. Default value: 'capacity'.
+
+    residual : NetworkX graph
+        Residual network on which the algorithm is to be executed. If None, a
+        new residual network is created. Default value: None.
+
+    value_only : bool
+        If True compute only the value of the maximum flow. This parameter
+        will be ignored by this algorithm because it is not applicable.
+
+    cutoff : integer, float
+        If specified, the algorithm will terminate when the flow value reaches
+        or exceeds the cutoff. In this case, it may be unable to immediately
+        determine a minimum cut. Default value: None.
+
+    Returns
+    -------
+    R : NetworkX DiGraph
+        Residual network after computing the maximum flow.
+
+    Raises
+    ------
+    NetworkXError
+        The algorithm does not support MultiGraph and MultiDiGraph. If
+        the input graph is an instance of one of these two classes, a
+        NetworkXError is raised.
+
+    NetworkXUnbounded
+        If the graph has a path of infinite capacity, the value of a
+        feasible flow on the graph is unbounded above and the function
+        raises a NetworkXUnbounded.
+
+    See also
+    --------
+    :meth:`maximum_flow`
+    :meth:`minimum_cut`
+    :meth:`preflow_push`
+    :meth:`shortest_augmenting_path`
+
+    Notes
+    -----
+    The residual network :samp:`R` from an input graph :samp:`G` has the
+    same nodes as :samp:`G`. :samp:`R` is a DiGraph that contains a pair
+    of edges :samp:`(u, v)` and :samp:`(v, u)` iff :samp:`(u, v)` is not a
+    self-loop, and at least one of :samp:`(u, v)` and :samp:`(v, u)` exists
+    in :samp:`G`.
+
+    For each edge :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['capacity']`
+    is equal to the capacity of :samp:`(u, v)` in :samp:`G` if it exists
+    in :samp:`G` or zero otherwise. If the capacity is infinite,
+    :samp:`R[u][v]['capacity']` will have a high arbitrary finite value
+    that does not affect the solution of the problem. This value is stored in
+    :samp:`R.graph['inf']`. For each edge :samp:`(u, v)` in :samp:`R`,
+    :samp:`R[u][v]['flow']` represents the flow function of :samp:`(u, v)` and
+    satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
+
+    The flow value, defined as the total flow into :samp:`t`, the sink, is
+    stored in :samp:`R.graph['flow_value']`. If :samp:`cutoff` is not
+    specified, reachability to :samp:`t` using only edges :samp:`(u, v)` such
+    that :samp:`R[u][v]['flow'] < R[u][v]['capacity']` induces a minimum
+    :samp:`s`-:samp:`t` cut.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> from networkx.algorithms.flow import dinitz
+
+    The functions that implement flow algorithms and output a residual
+    network, such as this one, are not imported to the base NetworkX
+    namespace, so you have to explicitly import them from the flow package.
+
+    >>> G = nx.DiGraph()
+    >>> G.add_edge('x','a', capacity=3.0)
+    >>> G.add_edge('x','b', capacity=1.0)
+    >>> G.add_edge('a','c', capacity=3.0)
+    >>> G.add_edge('b','c', capacity=5.0)
+    >>> G.add_edge('b','d', capacity=4.0)
+    >>> G.add_edge('d','e', capacity=2.0)
+    >>> G.add_edge('c','y', capacity=2.0)
+    >>> G.add_edge('e','y', capacity=3.0)
+    >>> R = dinitz(G, 'x', 'y')
+    >>> flow_value = nx.maximum_flow_value(G, 'x', 'y')
+    >>> flow_value
+    3.0
+    >>> flow_value == R.graph['flow_value']
+    True
+
+    References
+    ----------
+    .. [1] Dinitz' Algorithm: The Original Version and Even's Version.
+           2006. Yefim Dinitz. In Theoretical Computer Science. Lecture
+           Notes in Computer Science. Volume 3895. pp 218-240.
+           http://www.cs.bgu.ac.il/~dinitz/Papers/Dinitz_alg.pdf
+
+    """
+    R = dinitz_impl(G, s, t, capacity, residual, cutoff)
+    R.graph['algorithm'] = 'dinitz'
+    return R
+
+
+def dinitz_impl(G, s, t, capacity, residual, cutoff):
+    if s not in G:
+        raise nx.NetworkXError('node %s not in graph' % str(s))
+    if t not in G:
+        raise nx.NetworkXError('node %s not in graph' % str(t))
+    if s == t:
+        raise nx.NetworkXError('source and sink are the same node')
+
+    if residual is None:
+        R = build_residual_network(G, capacity)
+    else:
+        R = residual
+
+    # Initialize/reset the residual network.
+    for u in R:
+        for e in R[u].values():
+            e['flow'] = 0
+
+    # Use an arbitrary high value as infinite. It is computed
+    # when building the residual network. Useful when checking
+    # for infinite capacity paths.
+    INF = R.graph['inf']
+
+    if cutoff is None:
+        cutoff = INF
+
+    def breath_first_search(G, R, s, t):
+        rank = {}
+        rank[s] = 0
+        queue = deque([s])
+        target_in_previous_layer = False
+        while queue and not target_in_previous_layer:
+            u = queue.popleft()
+            for v in G[u]:
+                attr = R.succ[u][v]
+                if v not in rank and attr['capacity'] - attr['flow'] > 0:
+                    rank[v] = rank[u] + 1
+                    queue.append(v)
+                    target_in_previous_layer = t in rank and rank[t] < rank[v]
+        return rank
+
+    def depth_first_search(G, R, u, t, flow, rank):
+        if u == t:
+            return flow
+        for v in (n for n in G[u] if n in rank and rank[n] == rank[u] + 1):
+            attr = R.succ[u][v]
+            if attr['capacity'] > attr['flow']:
+                min_flow = min(flow, attr['capacity'] - attr['flow'])
+                this_flow = depth_first_search(G, R, v, t, min_flow, rank)
+                if this_flow * 2 > INF:
+                    raise nx.NetworkXUnbounded(
+                        'Infinite capacity path, flow unbounded above.')
+                if this_flow > 0:
+                    R.succ[u][v]['flow'] += this_flow
+                    R.succ[v][u]['flow'] -= this_flow
+                    return this_flow
+        return 0
+
+    flow_value = 0
+    while flow_value < cutoff:
+        rank = breath_first_search(G, R, s, t)
+        if t not in rank:
+            break
+        while True:
+            blocking_flow = depth_first_search(G, R, s, t, INF, rank)
+            if blocking_flow == 0:
+                break
+            flow_value += blocking_flow
+
+    R.graph['flow_value'] = flow_value
+    return R

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -4,12 +4,15 @@ Maximum flow (and minimum cut) algorithms on capacitated graphs.
 """
 import networkx as nx
 
-# Define the default flow function for computing maximum flow.
+from .dinitz_alg import dinitz
 from .edmondskarp import edmonds_karp
 from .preflowpush import preflow_push
 from .shortestaugmentingpath import shortest_augmenting_path
 from .utils import build_flow_dict
+# Define the default flow function for computing maximum flow.
 default_flow_func = preflow_push
+# Functions that don't support cutoff for minimum cut computations.
+flow_funcs = [dinitz, edmonds_karp, preflow_push, shortest_augmenting_path]
 
 __all__ = ['maximum_flow',
            'maximum_flow_value',
@@ -441,8 +444,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    if (kwargs.get('cutoff') is not None and
-        flow_func in (edmonds_karp, preflow_push, shortest_augmenting_path)):
+    if kwargs.get('cutoff') is not None and flow_func in flow_funcs:
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)
@@ -592,8 +594,7 @@ def minimum_cut_value(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    if (kwargs.get('cutoff') is not None and
-        flow_func in (edmonds_karp, preflow_push, shortest_augmenting_path)):
+    if kwargs.get('cutoff') is not None and flow_func in flow_funcs:
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -5,9 +5,12 @@ from nose.tools import *
 
 import networkx as nx
 from networkx.algorithms.flow import build_flow_dict, build_residual_network
-from networkx.algorithms.flow import edmonds_karp, preflow_push, shortest_augmenting_path
+from networkx.algorithms.flow import edmonds_karp
+from networkx.algorithms.flow import preflow_push
+from networkx.algorithms.flow import shortest_augmenting_path
+from networkx.algorithms.flow import dinitz
 
-flow_funcs = [edmonds_karp, preflow_push, shortest_augmenting_path]
+flow_funcs = [dinitz, edmonds_karp, preflow_push, shortest_augmenting_path]
 max_min_funcs = [nx.maximum_flow, nx.minimum_cut]
 flow_value_funcs = [nx.maximum_flow_value, nx.minimum_cut_value]
 interface_funcs = sum([max_min_funcs, flow_value_funcs], [])
@@ -195,6 +198,28 @@ class TestMaxflowMinCutCommon:
              'y': {}}
 
         compare_flows_and_cuts(G, 'x', 'y', H, 3.0)
+
+    def test_wikipedia_dinitz_example(self):
+        # Nice example from https://en.wikipedia.org/wiki/Dinic's_algorithm
+        G = nx.DiGraph()
+        G.add_edge('s', 1, capacity=10)
+        G.add_edge('s', 2, capacity=10)
+        G.add_edge(1, 3, capacity=4)
+        G.add_edge(1, 4, capacity=8)
+        G.add_edge(1, 2, capacity=2)
+        G.add_edge(2, 4, capacity=9)
+        G.add_edge(3, 't', capacity=10)
+        G.add_edge(4, 3, capacity=6)
+        G.add_edge(4, 't', capacity=10)
+
+        solnFlows = {1: {2: 0, 3: 4, 4: 6},
+                     2: {4: 9},
+                     3: {'t': 9},
+                     4: {3: 5, 't': 10},
+                     's': {1: 10, 2: 9},
+                     't': {}}
+
+        compare_flows_and_cuts(G, 's', 't', solnFlows, 19)
 
     def test_optional_capacity(self):
         # Test optional capacity parameter.

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -11,8 +11,13 @@ from nose.tools import *
 
 import networkx as nx
 from networkx.algorithms.flow import build_flow_dict, build_residual_network
-from networkx.algorithms.flow import (edmonds_karp, preflow_push, shortest_augmenting_path)
+from networkx.algorithms.flow import edmonds_karp
+from networkx.algorithms.flow import preflow_push
+from networkx.algorithms.flow import shortest_augmenting_path
+from networkx.algorithms.flow import dinitz
 
+# Dinitz algorithm is too slow in big and dense networks to test it here.
+# It is alredy tested in test_maxflow.py
 flow_funcs = [edmonds_karp, preflow_push, shortest_augmenting_path]
 
 msg = "Assertion failed in function: {0}"


### PR DESCRIPTION
This implementation is based on Cherkassky's approach (see section 4 of
this very nice paper [1]). That is, do not explicitly construct the layered
network, just compute the layer number or rank of each node in the BFS tree
up to distance = dist(s, t). Then in the DFS, just ignore both edges between
nodes of incompatible ranks and saturated edges.

I've implemented this algorithm with hopes of speed up flow based connectivity
algorithms. Turns out that Edmonds Karp algorithm clearly outperforms this one.
Although this one outperforms clearly Preflow-push and Short-augmenting-paths
for very sparse networks with skewed degree distributions. The paper suggest
other improvements not implemented here.

[1] Dinitz' Algorithm: The Original Version and Even's Version.
    http://www.cs.bgu.ac.il/~dinitz/Papers/Dinitz_alg.pdf