### PR TITLE
Nose ignore docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,19 +97,20 @@ before_install:
 install:
   ### Install any prerequisites or dependencies necessary to run the build.
   - if [[ "${OPTIONAL_DEPS}" == miniconda ]]; then
-      DEPS="pyyaml numpy scipy matplotlib Cython pandas pip";
-      conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $DEPS gdal;
-      conda install -n test-environment --channel https://conda.binstar.org/patricksnape scikits-sparse;
+      DEPS="pyyaml numpy scipy matplotlib Cython pandas pip gdal";
+      conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $DEPS ;
       source activate test-environment;
+      echo "Testing that gdal installed ok by if osgeo imports";
+      python -c "from osgeo import ogr;print('importing ogr worked')";
       if [[ "${TRAVIS_PYTHON_VERSION}" =~ "3.3" ]]; then
           pip install https://pypi.python.org/packages/source/p/pydotplus/pydotplus-2.0.2.tar.gz#md5=0e2fc3dbdfd846819d4cd3769cb4595b;
       else
           pip install pydotplus;
       fi;
-      python -c "from osgeo import ogr;print('importing ogr worked')";
       if [[ "${TRAVIS_PYTHON_VERSION}" =~ "2.7" ]]; then
         pip install pygraphviz;
       fi;
+      pip install scikits.sparse;
     fi
   - if [[ "${PYTHON_VM}" != ipy ]]; then
       pip install --upgrade nose coverage coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ install:
     fi
   - if [[ "${PYTHON_VM}" != ipy ]]; then
       pip install --upgrade nose coverage coveralls;
+      pip install nose-ignore-docstring;
     fi
 
 script:
@@ -144,9 +145,9 @@ script:
       # Run nosetests.
   - if [[ "${PYTHON_VM}" != ipy ]]; then
       if [[ "${PYTHON_VM}" == pypy ]]; then
-          nosetests --verbosity=2;
+          nosetests --verbosity=2 --with-ignore-docstrings;
       else
-          nosetests --verbosity=2 --with-coverage --cover-package=networkx;
+          nosetests --verbosity=2 --with-ignore-docstrings --with-coverage --cover-package=networkx;
       fi;
     else
       mono "${IPY}" -X:ExceptionDetail -X:FullFrames -c 'from nose import main; main()' \--verbosity=2;

--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -7,7 +7,7 @@ import tempfile
 import os
 
 import networkx as nx
-from networkx.testing import (assert_edges_equal, assert_nodes_equal, 
+from networkx.testing import (assert_edges_equal, assert_nodes_equal,
                                 assert_graphs_equal)
 from networkx.algorithms import bipartite
 
@@ -117,7 +117,7 @@ class TestEdgelist:
         os.close(fd)
         os.unlink(fname)
 
-    def test_latin1_error(self):
+    def test_latin1_issue(self):
         G = nx.Graph()
         try: # Python 3.x
             name1 = chr(2344) + chr(123) + chr(6543)
@@ -157,7 +157,7 @@ class TestEdgelist:
     def test_edgelist_graph(self):
         G=self.G
         (fd,fname)=tempfile.mkstemp()
-        bipartite.write_edgelist(G,fname)  
+        bipartite.write_edgelist(G,fname)
         H=bipartite.read_edgelist(fname)
         H2=bipartite.read_edgelist(fname)
         assert_not_equal(H,H2) # they should be different graphs
@@ -170,7 +170,7 @@ class TestEdgelist:
     def test_edgelist_integers(self):
         G=nx.convert_node_labels_to_integers(self.G)
         (fd,fname)=tempfile.mkstemp()
-        bipartite.write_edgelist(G,fname)  
+        bipartite.write_edgelist(G,fname)
         H=bipartite.read_edgelist(fname,nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
@@ -182,7 +182,7 @@ class TestEdgelist:
     def test_edgelist_multigraph(self):
         G=self.MG
         (fd,fname)=tempfile.mkstemp()
-        bipartite.write_edgelist(G,fname) 
+        bipartite.write_edgelist(G,fname)
         H=bipartite.read_edgelist(fname,nodetype=int,create_using=nx.MultiGraph())
         H2=bipartite.read_edgelist(fname,nodetype=int,create_using=nx.MultiGraph())
         assert_not_equal(H,H2) # they should be different graphs
@@ -192,13 +192,13 @@ class TestEdgelist:
         os.unlink(fname)
 
     @raises(nx.NetworkXNotImplemented)
-    def test_digraph_fail(self):
+    def test_empty_digraph(self):
         bytesIO = io.BytesIO()
-        bipartite.write_edgelist(nx.DiGraph(),bytesIO) 
+        bipartite.write_edgelist(nx.DiGraph(),bytesIO)
 
     @raises(AttributeError)
-    def test_attribute_fail(self):
+    def test_raise_attribute(self):
         G = nx.path_graph(4)
         bytesIO = io.BytesIO()
-        bipartite.write_edgelist(G,bytesIO) 
+        bipartite.write_edgelist(G,bytesIO)
 

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -46,27 +46,27 @@ class TestBiadjacencyMatrix:
         assert_equal(M[1,2], 2)
 
     @raises(nx.NetworkXError)
-    def test_null_fail(self):
+    def test_null_graph(self):
         bipartite.biadjacency_matrix(nx.Graph(),[])
 
     @raises(nx.NetworkXError)
-    def test_empty_fail(self):
+    def test_empty_graph(self):
         bipartite.biadjacency_matrix(nx.Graph([(1,0)]),[])
 
     @raises(nx.NetworkXError)
-    def test_duplicate_row_fail(self):
+    def test_duplicate_row(self):
         bipartite.biadjacency_matrix(nx.Graph([(1,0)]),[1,1])
 
     @raises(nx.NetworkXError)
-    def test_duplicate_col_fail(self):
+    def test_duplicate_col(self):
         bipartite.biadjacency_matrix(nx.Graph([(1,0)]),[0],[1,1])
 
     @raises(nx.NetworkXError)
-    def test_duplicate_col_fail(self):
+    def test_duplicate_col(self):
         bipartite.biadjacency_matrix(nx.Graph([(1,0)]),[0],[1,1])
 
     @raises(nx.NetworkXError)
-    def test_format_keyword_fail(self):
+    def test_format_keyword(self):
         bipartite.biadjacency_matrix(nx.Graph([(1,0)]),[0],format='foo')
 
     def test_from_biadjacency_roundtrip(self):

--- a/networkx/algorithms/tests/test_dominating.py
+++ b/networkx/algorithms/tests/test_dominating.py
@@ -18,7 +18,7 @@ def test_complete():
     assert_equal(len(nx.dominating_set(K5)), 1)
 
 @raises(nx.NetworkXError)
-def test_dominating_set_error():
+def test_raise_dominating_set():
     G = nx.path_graph(4)
     D = nx.dominating_set(G, start_with=10)
 

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -462,7 +462,7 @@ class HistoricalTests(object):
         H=K5.subgraph([9])
         assert_true(nx.is_isomorphic(H,nullgraph))
 
-    def test_node_tuple_error(self):
+    def test_node_tuple_issue(self):
         H=self.G()
         # Test error handling of tuple as a node
         assert_raises(nx.NetworkXError,H.remove_node,(1,2))

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -86,14 +86,14 @@ class BaseGraphTester(object):
         assert_raises(networkx.NetworkXError,list,bunch)
 
     @raises(networkx.NetworkXError)
-    def test_nbunch_iter_node_fails_format(self):
-#        """Tests that a node that would have failed string formatting
-#        doesn't cause an error when attempting to raise a
-#        :exc:`networkx.NetworkXError`.
-#
-#        For more information, see pull request #1813.
-#
-#        """
+    def test_nbunch_iter_node_format_raise(self):
+        """Tests that a node that would have failed string formatting
+        doesn't cause an error when attempting to raise a
+        :exc:`networkx.NetworkXError`.
+
+        For more information, see pull request #1813.
+
+        """
         G = self.Graph()
         nbunch = [('x', set())]
         list(G.nbunch_iter(nbunch))

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -52,7 +52,7 @@ class TestAdjlist():
         os.close(fd)
         os.unlink(fname)
 
-    def test_latin1_error(self):
+    def test_latin1_err(self):
         G = nx.Graph()
         try: # Python 3.x
             name1 = chr(2344) + chr(123) + chr(6543)

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -116,7 +116,7 @@ class TestEdgelist:
         os.close(fd)
         os.unlink(fname)
 
-    def test_latin1_error(self):
+    def test_latin1_issue(self):
         G = nx.Graph()
         try: # Python 3.x
             name1 = chr(2344) + chr(123) + chr(6543)

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -216,7 +216,7 @@ class TestGEXF(object):
         assert_raises(nx.NetworkXError,nx.read_gexf,fh)
 
 
-    def test_key_error(self):
+    def test_key_raises(self):
         s="""<?xml version="1.0" encoding="UTF-8"?>
 <gexf xmlns="http://www.gexf.net/1.1draft" version="1.1">
     <graph mode="static" defaultedgetype="directed">

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -82,5 +82,5 @@ class TestGraph6(object):
             assert_equal(sorted(g2.edges()), sorted(g.edges()))
 
     @raises(nx.NetworkXError)
-    def directed_error(self):
+    def directed_raise(self):
         nx.generate_graph6(nx.DiGraph())

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -291,7 +291,7 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
         assert_raises(nx.NetworkXError,nx.read_graphml,fh)
         assert_raises(nx.NetworkXError,nx.parse_graphml,s)
 
-    def test_key_error(self):
+    def test_key_raise(self):
         s="""<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -319,7 +319,7 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
         assert_raises(nx.NetworkXError,nx.read_graphml,fh)
         assert_raises(nx.NetworkXError,nx.parse_graphml,s)
 
-    def test_hyperedge_error(self):
+    def test_hyperedge_raise(self):
         s="""<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -98,5 +98,5 @@ class TestSparseGraph6(object):
             assert_equal(sorted(g2.edges()), sorted(g.edges()))
 
     @raises(nx.NetworkXError)
-    def directed_error(self):
+    def directed_raises(self):
         nx.generate_sparse6(nx.DiGraph())

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -156,7 +156,7 @@ class TestConvertNumpy(object):
                         nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
 
     @raises(nx.NetworkXError)
-    def test_format_keyword_fail(self):
+    def test_format_keyword_raise(self):
         WP4 = nx.Graph()
         WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3))
                             for n in range(3) )
@@ -164,7 +164,7 @@ class TestConvertNumpy(object):
         nx.to_scipy_sparse_matrix(P4, format='any_other')
 
     @raises(nx.NetworkXError)
-    def test_null_fail(self):
+    def test_null_raise(self):
         nx.to_scipy_sparse_matrix(nx.Graph())
 
     def test_empty(self):

--- a/networkx/tests/test_exceptions.py
+++ b/networkx/tests/test_exceptions.py
@@ -4,11 +4,11 @@ import networkx as nx
 # smoke tests for exceptions
 
 @raises(nx.NetworkXException)
-def test_raises_networkx_exception():
+def test_raises_networkxexception():
     raise nx.NetworkXException
 
 @raises(nx.NetworkXError)
-def test_raises_networkx_error():
+def test_raises_networkxerr():
     raise nx.NetworkXError
 
 @raises(nx.NetworkXPointlessConcept)
@@ -16,7 +16,7 @@ def test_raises_networkx_pointless_concept():
     raise nx.NetworkXPointlessConcept
 
 @raises(nx.NetworkXAlgorithmError)
-def test_raises_networkx_algorithm_error():
+def test_raises_networkxalgorithmerr():
     raise nx.NetworkXAlgorithmError
 
 @raises(nx.NetworkXUnfeasible)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib
 scipy
 numpy
 nose
-nose-ignore-docstrings
+nose-ignore-docstring
 pandas
 gdal
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ matplotlib
 scipy
 numpy
 nose
+nose-ignore-docstrings
 pandas
 gdal
 pyyaml


### PR DESCRIPTION
This package makes nose report which test is being done in form: file.function
Without it the docstring of the test function is used and is not as helpful to find the problem.

I also switched installation of scikits-sparse from conda to pip because it is not being supported on conda anymore.  We still have a travis-ci issue with gdal/osgeo/ogr not being installed, but I'll try to figure that out in another pr.