### PR TITLE
Avoid unnecessary eigenval sort in pagerank_numpy

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -334,9 +334,9 @@ def pagerank_numpy(G, alpha=0.85, personalization=None, weight='weight',
                       weight=weight, dangling=dangling)
     # use numpy LAPACK solver
     eigenvalues, eigenvectors = np.linalg.eig(M.T)
-    ind = eigenvalues.argsort()
-    # eigenvector of largest eigenvalue at ind[-1], normalized
-    largest = np.array(eigenvectors[:, ind[-1]]).flatten().real
+    ind = np.argmax(eigenvalues)
+    # eigenvector of largest eigenvalue is at ind, normalized
+    largest = np.array(eigenvectors[:, ind]).flatten().real
     norm = float(largest.sum())
     return dict(zip(G, map(float, largest / norm)))
 


### PR DESCRIPTION
We are only after the largest value, so np.argmax is sufficient.