### PR TITLE
Improves test coverage for A* shortest path.

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -1,24 +1,26 @@
 # -*- coding: utf-8 -*-
-"""Shortest paths and path lengths using A* ("A star") algorithm.
-"""
-
 #    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-
+#
+# Authors: Salim Fadhley <salimfadhley@gmail.com>
+#          Matteo Dell'Amico <matteodellamico@gmail.com>
+"""Shortest paths and path lengths using the A* ("A star") algorithm.
+"""
 from heapq import heappush, heappop
 from itertools import count
-from networkx import NetworkXError
-import networkx as nx
 
-__author__ = "\n".join(["Salim Fadhley <salimfadhley@gmail.com>",
-                        "Matteo Dell'Amico <matteodellamico@gmail.com>"])
+import networkx as nx
+from networkx import NetworkXError
+from networkx.utils import not_implemented_for
+
 __all__ = ['astar_path', 'astar_path_length']
 
 
+@not_implemented_for('multigraph')
 def astar_path(G, source, target, heuristic=None, weight='weight'):
     """Return a list of nodes in a shortest path between source and target
     using the A* ("A-star") algorithm.
@@ -67,9 +69,6 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
     shortest_path, dijkstra_path
 
     """
-    if G.is_multigraph():
-        raise NetworkXError("astar_path() not implemented for Multi(Di)Graphs")
-
     if heuristic is None:
         # The default heuristic is h=0 - same as Dijkstra's algorithm
         def heuristic(u, v):

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -1,36 +1,40 @@
-#!/usr/bin/env python
-from nose.tools import *
-import networkx as nx
+from nose.tools import assert_equal
+from nose.tools import assert_raises
+from nose.tools import raises
+
+from math import sqrt
 from random import random, choice
+
+import networkx as nx
+from networkx.utils import pairwise
+
+
+def dist(a, b):
+    """Returns the Euclidean distance between points ``a`` and ``b``."""
+    return sqrt(sum((x1 - x2) ** 2 for x1, x2 in zip(a, b)))
+
 
 class TestAStar:
 
     def setUp(self):
-        self.XG=nx.DiGraph()
-        self.XG.add_edges_from([('s','u',{'weight':10}),
-                                ('s','x',{'weight':5}),
-                                ('u','v',{'weight':1}),
-                                ('u','x',{'weight':2}),
-                                ('v','y',{'weight':1}),
-                                ('x','u',{'weight':3}),
-                                ('x','v',{'weight':5}),
-                                ('x','y',{'weight':2}),
-                                ('y','s',{'weight':7}),
-                                ('y','v',{'weight':6})])
+        edges = [('s', 'u', 10), ('s', 'x', 5), ('u', 'v', 1), ('u', 'x', 2),
+                 ('v', 'y', 1), ('x', 'u', 3), ('x', 'v', 5), ('x', 'y', 2),
+                 ('y', 's', 7), ('y', 'v', 6)]
+        self.XG = nx.DiGraph()
+        self.XG.add_weighted_edges_from(edges)
 
     def test_random_graph(self):
+        """Tests that the A* shortest path agrees with Dijkstra's
+        shortest path for a random graph.
 
-        def dist(a, b):
-            (x1, y1) = a
-            (x2, y2) = b
-            return ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
+        """
 
         G = nx.Graph()
 
         points = [(random(), random()) for _ in range(100)]
 
         # Build a path from points[0] to points[-1] to be sure it exists
-        for p1, p2 in zip(points[:-1], points[1:]):
+        for p1, p2 in pairwise(points):
             G.add_edge(p1, p2, weight=dist(p1, p2))
 
         # Add other random edges
@@ -39,64 +43,49 @@ class TestAStar:
             G.add_edge(p1, p2, weight=dist(p1, p2))
 
         path = nx.astar_path(G, points[0], points[-1], dist)
-        assert path == nx.dijkstra_path(G, points[0], points[-1])
+        assert_equal(path, nx.dijkstra_path(G, points[0], points[-1]))
 
     def test_astar_directed(self):
-        assert nx.astar_path(self.XG,'s','v')==['s', 'x', 'u', 'v']
-        assert nx.astar_path_length(self.XG,'s','v')==9
+        assert_equal(nx.astar_path(self.XG, 's', 'v'), ['s', 'x', 'u', 'v'])
+        assert_equal(nx.astar_path_length(self.XG, 's', 'v'), 9)
 
     def test_astar_multigraph(self):
-         G=nx.MultiDiGraph(self.XG)
-         assert_raises((TypeError,nx.NetworkXError),
-                      nx.astar_path, [G,'s','v'])
-         assert_raises((TypeError,nx.NetworkXError),
-                      nx.astar_path_length, [G,'s','v'])
+        G = nx.MultiDiGraph(self.XG)
+        assert_raises(nx.NetworkXNotImplemented, nx.astar_path, G, 's', 'v')
+        assert_raises(nx.NetworkXNotImplemented, nx.astar_path_length,
+                      G, 's', 'v')
 
     def test_astar_undirected(self):
-        GG=self.XG.to_undirected()
+        GG = self.XG.to_undirected()
         # make sure we get lower weight
         # to_undirected might choose either edge with weight 2 or weight 3
-        GG['u']['x']['weight']=2
+        GG['u']['x']['weight'] = 2
         GG['y']['v']['weight'] = 2
-        assert_equal(nx.astar_path(GG,'s','v'),['s', 'x', 'u', 'v'])
-        assert_equal(nx.astar_path_length(GG,'s','v'),8)
+        assert_equal(nx.astar_path(GG, 's', 'v'), ['s', 'x', 'u', 'v'])
+        assert_equal(nx.astar_path_length(GG, 's', 'v'), 8)
 
     def test_astar_directed2(self):
-        XG2=nx.DiGraph()
-        XG2.add_edges_from([[1,4,{'weight':1}],
-                            [4,5,{'weight':1}],
-                            [5,6,{'weight':1}],
-                            [6,3,{'weight':1}],
-                            [1,3,{'weight':50}],
-                            [1,2,{'weight':100}],
-                            [2,3,{'weight':100}]])
-        assert nx.astar_path(XG2,1,3)==[1, 4, 5, 6, 3]
+        XG2 = nx.DiGraph()
+        edges = [(1, 4, 1), (4, 5, 1), (5, 6, 1), (6, 3, 1), (1, 3, 50),
+                 (1, 2, 100), (2, 3, 100)]
+        XG2.add_weighted_edges_from(edges)
+        assert_equal(nx.astar_path(XG2, 1, 3), [1, 4, 5, 6, 3])
 
     def test_astar_undirected2(self):
-        XG3=nx.Graph()
-        XG3.add_edges_from([ [0,1,{'weight':2}],
-                             [1,2,{'weight':12}],
-                             [2,3,{'weight':1}],
-                             [3,4,{'weight':5}],
-                             [4,5,{'weight':1}],
-                             [5,0,{'weight':10}] ])
-        assert nx.astar_path(XG3,0,3)==[0, 1, 2, 3]
-        assert nx.astar_path_length(XG3,0,3)==15
-
+        XG3 = nx.Graph()
+        edges = [(0, 1, 2), (1, 2, 12), (2, 3, 1), (3, 4, 5), (4, 5, 1),
+                 (5, 0, 10)]
+        XG3.add_weighted_edges_from(edges)
+        assert_equal(nx.astar_path(XG3, 0, 3), [0, 1, 2, 3])
+        assert_equal(nx.astar_path_length(XG3, 0, 3), 15)
 
     def test_astar_undirected3(self):
-        XG4=nx.Graph()
-        XG4.add_edges_from([ [0,1,{'weight':2}],
-                             [1,2,{'weight':2}],
-                             [2,3,{'weight':1}],
-                             [3,4,{'weight':1}],
-                             [4,5,{'weight':1}],
-                             [5,6,{'weight':1}],
-                             [6,7,{'weight':1}],
-                             [7,0,{'weight':1}] ])
-        assert nx.astar_path(XG4,0,2)==[0, 1, 2]
-        assert nx.astar_path_length(XG4,0,2)==4
-
+        XG4 = nx.Graph()
+        edges = [(0, 1, 2), (1, 2, 2), (2, 3, 1), (3, 4, 1), (4, 5, 1),
+                 (5, 6, 1), (6, 7, 1), (7, 0, 1)]
+        XG4.add_weighted_edges_from(edges)
+        assert_equal(nx.astar_path(XG4, 0, 2), [0, 1, 2])
+        assert_equal(nx.astar_path_length(XG4, 0, 2), 4)
 
 # >>> MXG4=NX.MultiGraph(XG4)
 # >>> MXG4.add_edge(0,1,3)
@@ -104,34 +93,46 @@ class TestAStar:
 # [0, 1, 2]
 
     def test_astar_w1(self):
-        G=nx.DiGraph()
-        G.add_edges_from([('s','u'), ('s','x'), ('u','v'), ('u','x'),
-            ('v','y'), ('x','u'), ('x','w'), ('w', 'v'), ('x','y'),
-            ('y','s'), ('y','v')])
-        assert nx.astar_path(G,'s','v')==['s', 'u', 'v']
-        assert nx.astar_path_length(G,'s','v')== 2
+        G = nx.DiGraph()
+        G.add_edges_from([('s', 'u'), ('s', 'x'), ('u', 'v'), ('u', 'x'),
+                          ('v', 'y'), ('x', 'u'), ('x', 'w'), ('w', 'v'),
+                          ('x', 'y'), ('y', 's'), ('y', 'v')])
+        assert_equal(nx.astar_path(G, 's', 'v'), ['s', 'u', 'v'])
+        assert_equal(nx.astar_path_length(G, 's', 'v'), 2)
 
     @raises(nx.NetworkXNoPath)
     def test_astar_nopath(self):
-        p = nx.astar_path(self.XG,'s','moon')
+        nx.astar_path(self.XG, 's', 'moon')
 
     def test_cycle(self):
-        C=nx.cycle_graph(7)
-        assert nx.astar_path(C,0,3)==[0, 1, 2, 3]
-        assert nx.dijkstra_path(C,0,4)==[0, 6, 5, 4]
+        C = nx.cycle_graph(7)
+        assert_equal(nx.astar_path(C, 0, 3), [0, 1, 2, 3])
+        assert_equal(nx.dijkstra_path(C, 0, 4), [0, 6, 5, 4])
 
+    def test_unorderable_nodes(self):
+        """Tests that A* accomodates nodes that are not orderable.
 
-    def test_orderable(self):
-        class UnorderableClass: pass
-        node_1 = UnorderableClass()
-        node_2 = UnorderableClass()
-        node_3 = UnorderableClass()
-        node_4 = UnorderableClass()
+        For more information, see issue #554.
+
+        """
+        # TODO In Python 3, instances of the `object` class are
+        # unorderable by default, so we wouldn't need to define our own
+        # class here, we could just instantiate an instance of the
+        # `object` class. However, we still support Python 2; when
+        # support for Python 2 is dropped, this test can be simplified
+        # by replacing `Unorderable()` by `object()`.
+        class Unorderable(object):
+
+            def __le__(self):
+                raise NotImplemented
+
+            def __ge__(self):
+                raise NotImplemented
+
+        # Create the cycle graph on four nodes, with nodes represented
+        # as (unorderable) Python objects.
+        nodes = [Unorderable() for n in range(4)]
         G = nx.Graph()
-        G.add_edge(node_1, node_2)
-        G.add_edge(node_1, node_3)
-        G.add_edge(node_2, node_4)
-        G.add_edge(node_3, node_4)
-        path=nx.algorithms.shortest_paths.astar.astar_path(G, node_1, node_4)
-
-
+        G.add_edges_from(pairwise(nodes, cyclic=True))
+        path = nx.astar_path(G, nodes[0], nodes[2])
+        assert_equal(len(path), 3)


### PR DESCRIPTION
This commit improves test coverage by 1. using the `not_implemented_for` decorator and 2. updating a unit test to ensure it runs correctly on both Python 2 and Python 3. This commit also simplifies the unit tests and applies PEP8 to make them more readable.