### PR TITLE
Fix a typo in install.rst

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -73,7 +73,7 @@ Source archive file
 GitHub
 ------
 
-  1. Clone the networkx repostitory
+  1. Clone the networkx repository
      (see https://github.com/networkx/networkx/ for options)
      ::
 


### PR DESCRIPTION
`repostitory` → `repository`