### PR TITLE
Improve drawing test scripts (typos, newlines, methods)

### DIFF
--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -1,12 +1,10 @@
-"""Unit tests for PyGraphviz intefaace.
-"""
+"""Unit tests for PyGraphviz inteface."""
 import os
 import tempfile
-
 from nose import SkipTest
 from nose.tools import assert_true,assert_equal
-
 import networkx as nx
+
 
 class TestAGraph(object):
     @classmethod
@@ -18,18 +16,13 @@ class TestAGraph(object):
             raise SkipTest('PyGraphviz not available.')
 
     def build_graph(self, G):
-        G.add_edge('A','B')
-        G.add_edge('A','C')
-        G.add_edge('A','C')
-        G.add_edge('B','C')
-        G.add_edge('A','D')
+        G.add_edges_from([('A','B'),('A','C'),('A','C'),('B','C'),('A','D')])
         G.add_node('E')
         return G
 
     def assert_equal(self, G1, G2):
-        assert_true( sorted(G1.nodes())==sorted(G2.nodes()) )
-        assert_true( sorted(G1.edges())==sorted(G2.edges()) )
-
+        assert_true( sorted(G1.nodes()) == sorted(G2.nodes()) )
+        assert_true( sorted(G1.edges()) == sorted(G2.edges()) )
 
     def agraph_checks(self, G):
         G = self.build_graph(G)
@@ -37,30 +30,26 @@ class TestAGraph(object):
         H = nx.nx_agraph.from_agraph(A)
         self.assert_equal(G, H)
 
-        fname=tempfile.mktemp()
-        nx.drawing.nx_agraph.write_dot(H,fname)
+        fname = tempfile.mktemp()
+        nx.drawing.nx_agraph.write_dot(H, fname)
         Hin = nx.nx_agraph.read_dot(fname)
         os.unlink(fname)
-        self.assert_equal(H,Hin)
+        self.assert_equal(H, Hin)
 
+        (fd,fname) = tempfile.mkstemp()
+        with open(fname, 'w') as fh:
+            nx.drawing.nx_agraph.write_dot(H, fh)
 
-        (fd,fname)=tempfile.mkstemp()
-        fh=open(fname,'w')
-        nx.drawing.nx_agraph.write_dot(H,fh)
-        fh.close()
-
-        fh=open(fname,'r')
-        Hin = nx.nx_agraph.read_dot(fh)
-        fh.close()
+        with open(fname, 'r') as fh:
+            Hin = nx.nx_agraph.read_dot(fh)
         os.unlink(fname)
-        self.assert_equal(H,Hin)
+        self.assert_equal(H, Hin)
 
     def test_from_agraph_name(self):
         G = nx.Graph(name='test')
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A)
-        assert_equal(G.name,'test')
-
+        assert_equal(G.name, 'test')
 
     def testUndirected(self):
         self.agraph_checks(nx.Graph())

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -4,8 +4,9 @@ from nose import SkipTest
 from nose.tools import assert_equal
 import networkx as nx
 
+
 class TestLayout(object):
-    numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    numpy = 1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
     @classmethod
     def setupClass(cls):
         global numpy
@@ -14,56 +15,52 @@ class TestLayout(object):
         except ImportError:
             raise SkipTest('numpy not available.')
 
-
     def setUp(self):
-        self.Gi=nx.grid_2d_graph(5,5)
-        self.Gs=nx.Graph()
+        self.Gi = nx.grid_2d_graph(5,5)
+        self.Gs = nx.Graph()
         nx.add_path(self.Gs, 'abcdef')
-        self.bigG=nx.grid_2d_graph(25,25) #bigger than 500 nodes for sparse
+        self.bigG = nx.grid_2d_graph(25,25) #bigger than 500 nodes for sparse
 
     def test_smoke_int(self):
-        G=self.Gi
-        vpos=nx.random_layout(G)
-        vpos=nx.circular_layout(G)
-        vpos=nx.spring_layout(G)
-        vpos=nx.fruchterman_reingold_layout(G)
-        vpos=nx.spectral_layout(G)
-        vpos=nx.spectral_layout(self.bigG)
-        vpos=nx.shell_layout(G)
+        G = self.Gi
+        vpos = nx.random_layout(G)
+        vpos = nx.circular_layout(G)
+        vpos = nx.spring_layout(G)
+        vpos = nx.fruchterman_reingold_layout(G)
+        vpos = nx.spectral_layout(G)
+        vpos = nx.spectral_layout(self.bigG)
+        vpos = nx.shell_layout(G)
 
     def test_smoke_string(self):
-        G=self.Gs
-        vpos=nx.random_layout(G)
-        vpos=nx.circular_layout(G)
-        vpos=nx.spring_layout(G)
-        vpos=nx.fruchterman_reingold_layout(G)
-        vpos=nx.spectral_layout(G)
-        vpos=nx.shell_layout(G)
-
+        G = self.Gs
+        vpos = nx.random_layout(G)
+        vpos = nx.circular_layout(G)
+        vpos = nx.spring_layout(G)
+        vpos = nx.fruchterman_reingold_layout(G)
+        vpos = nx.spectral_layout(G)
+        vpos = nx.shell_layout(G)
 
     def test_adjacency_interface_numpy(self):
-        A=nx.to_numpy_matrix(self.Gs)
-        pos=nx.drawing.layout._fruchterman_reingold(A)
-        pos=nx.drawing.layout._fruchterman_reingold(A,dim=3)
-        assert_equal(pos.shape,(6,3))
+        A = nx.to_numpy_matrix(self.Gs)
+        pos = nx.drawing.layout._fruchterman_reingold(A)
+        pos = nx.drawing.layout._fruchterman_reingold(A, dim=3)
+        assert_equal(pos.shape, (6,3))
 
     def test_adjacency_interface_scipy(self):
         try:
             import scipy
         except ImportError:
             raise SkipTest('scipy not available.')
-
-        A=nx.to_scipy_sparse_matrix(self.Gs,dtype='d')
-        pos=nx.drawing.layout._sparse_fruchterman_reingold(A)
-        pos=nx.drawing.layout._sparse_spectral(A)
-
-        pos=nx.drawing.layout._sparse_fruchterman_reingold(A,dim=3)
-        assert_equal(pos.shape,(6,3))
+        A = nx.to_scipy_sparse_matrix(self.Gs, dtype='d')
+        pos = nx.drawing.layout._sparse_fruchterman_reingold(A)
+        pos = nx.drawing.layout._sparse_spectral(A)
+        pos = nx.drawing.layout._sparse_fruchterman_reingold(A, dim=3)
+        assert_equal(pos.shape, (6,3))
 
     def test_single_nodes(self):
-        G=nx.path_graph(1)
+        G = nx.path_graph(1)
         vpos = nx.shell_layout(G)
         assert(vpos[0].any() == False)
-        G=nx.path_graph(3)
+        G = nx.path_graph(3)
         vpos = nx.shell_layout(G, [[0], [1,2]])
         assert(vpos[0].any() == False)

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,14 +1,11 @@
-"""
-    Unit tests for pydot drawing functions.
-"""
+"""Unit tests for pydot drawing functions."""
 import os
 import tempfile
-
 from nose import SkipTest
 from nose.tools import assert_true
-
 import networkx as nx
 from networkx.testing import assert_graphs_equal
+
 
 class TestPydot(object):
     @classmethod
@@ -20,34 +17,27 @@ class TestPydot(object):
             raise SkipTest('pydotplus not available.')
 
     def pydot_checks(self, G):
-        G.add_edge('A','B')
-        G.add_edge('A','C')
-        G.add_edge('B','C')
-        G.add_edge('A','D')
+        G.add_edges_from([('A','B'),('A','C'),('B','C'),('A','D')])
         G.add_node('E')
         P = nx.nx_pydot.to_pydot(G)
         G2 = G.__class__(nx.nx_pydot.from_pydot(P))
         assert_graphs_equal(G, G2)
 
         fname = tempfile.mktemp()
-        assert_true( P.write_raw(fname) )
-
+        assert_true(P.write_raw(fname))
         Pin = pydotplus.graph_from_dot_file(fname)
 
         n1 = sorted([p.get_name() for p in P.get_node_list()])
         n2 = sorted([p.get_name() for p in Pin.get_node_list()])
-        assert_true( n1 == n2 )
+        assert_true(n1 == n2)
 
-        e1=[(e.get_source(),e.get_destination()) for e in P.get_edge_list()]
-        e2=[(e.get_source(),e.get_destination()) for e in Pin.get_edge_list()]
-        assert_true( sorted(e1)==sorted(e2) )
+        e1 = [(e.get_source(),e.get_destination()) for e in P.get_edge_list()]
+        e2 = [(e.get_source(),e.get_destination()) for e in Pin.get_edge_list()]
+        assert_true(sorted(e1) == sorted(e2))
 
         Hin = nx.nx_pydot.read_dot(fname)
         Hin = G.__class__(Hin)
         assert_graphs_equal(G, Hin)
-
-#        os.unlink(fname)
-
 
     def testUndirected(self):
         self.pydot_checks(nx.Graph())

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -1,12 +1,8 @@
-"""
-    Unit tests for matplotlib drawing functions.
-"""
-
+"""Unit tests for matplotlib drawing functions."""
 import os
-
 from nose import SkipTest
-
 import networkx as nx
+
 
 class TestPylab(object):
     @classmethod
@@ -14,7 +10,7 @@ class TestPylab(object):
         global plt
         try:
             import matplotlib as mpl
-            mpl.use('PS',warn=False)
+            mpl.use('PS', warn=False)
             import matplotlib.pyplot as plt
             plt.rcParams['text.usetex'] = False
         except ImportError:
@@ -23,22 +19,21 @@ class TestPylab(object):
             raise SkipTest('matplotlib not available.')
 
     def setUp(self):
-        self.G=nx.barbell_graph(5,10)
-
+        self.G = nx.barbell_graph(5,10)
 
     def test_draw(self):
         try:
-            N=self.G
+            N = self.G
             nx.draw_spring(N)
-            plt.savefig("test.ps")
+            plt.savefig('test.ps')
             nx.draw_random(N)
-            plt.savefig("test.ps")
+            plt.savefig('test.ps')
             nx.draw_circular(N)
-            plt.savefig("test.ps")
+            plt.savefig('test.ps')
             nx.draw_spectral(N)
-            plt.savefig("test.ps")
+            plt.savefig('test.ps')
             nx.draw_spring(N.to_directed())
-            plt.savefig("test.ps")
+            plt.savefig('test.ps')
         finally:
             try:
                 os.unlink('test.ps')


### PR DESCRIPTION
First, I wanted to remove the typo in `test_agraph.py` (intefaace). Then I saw that the list of `.add_edge()` can be collapsed to `.add_edges_from()`. I did the same in `test_pydot.py`, where I additionally entered `with open() as` statements. Finally, I ended up harmonizing all four test files: remove whitespaces around `=`, remove redundant newlines, collapse title to one-line.