### PR TITLE
Fix location of graphviz_layout in draw_graphviz

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -981,7 +981,7 @@ def draw_graphviz(G, prog="neato", **kwargs):
     kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords.
     """
-    pos = nx.drawing.graphviz_layout(G, prog)
+    pos = nx.drawing.nx_pydot.graphviz_layout(G, prog)
     draw(G, pos, **kwargs)
 
 

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -44,3 +44,14 @@ class TestPylab(object):
                 os.unlink('test.ps')
             except OSError:
                 pass
+
+
+    def test_smoke_draw_graphviz(self):
+        try:
+            nx.drawing.draw_graphviz(self.G)
+        except AttributeError as e:
+            if "graphviz_layout" in str(e):
+                raise
+        except ImportError as e:
+            if "pygraphviz" in str(e):
+                raise SkipTest('pygraphviz not available.')


### PR DESCRIPTION
Lost in a rename/rearrange? Added a basic smoke-test that just calls the function with a graph to verify names are valid.