### PR TITLE
Generalize and improve docstrings of node_link.py

### DIFF
--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -4,49 +4,49 @@ from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_tru
 import networkx as nx
 from networkx.readwrite.json_graph import *
 
+
 class TestNodeLink:
 
     def test_graph(self):
         G = nx.path_graph(4)
         H = node_link_graph(node_link_data(G))
-        nx.is_isomorphic(G,H)
+        nx.is_isomorphic(G, H)
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
-        G.add_node(1,color='red')
-        G.add_edge(1,2,width=7)
-        G.graph[1]='one'
-        G.graph['foo']='bar'
+        G.add_node(1, color='red')
+        G.add_edge(1, 2, width=7)
+        G.graph[1] = 'one'
+        G.graph['foo'] = 'bar'
 
         H = node_link_graph(node_link_data(G))
-        assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.node[1]['color'],'red')
-        assert_equal(H[1][2]['width'],7)
+        assert_equal(H.graph['foo'], 'bar')
+        assert_equal(H.node[1]['color'], 'red')
+        assert_equal(H[1][2]['width'], 7)
 
         d = json.dumps(node_link_data(G))
         H = node_link_graph(json.loads(d))
-        assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.graph['1'],'one')
-        assert_equal(H.node[1]['color'],'red')
-        assert_equal(H[1][2]['width'],7)
+        assert_equal(H.graph['foo'], 'bar')
+        assert_equal(H.graph['1'], 'one')
+        assert_equal(H.node[1]['color'], 'red')
+        assert_equal(H[1][2]['width'], 7)
 
     def test_digraph(self):
         G = nx.DiGraph()
         H = node_link_graph(node_link_data(G))
         assert_true(H.is_directed())
 
-
     def test_multigraph(self):
         G = nx.MultiGraph()
-        G.add_edge(1,2,key='first')
-        G.add_edge(1,2,key='second',color='blue')
+        G.add_edge(1, 2, key='first')
+        G.add_edge(1, 2, key='second', color='blue')
         H = node_link_graph(node_link_data(G))
-        nx.is_isomorphic(G,H)
-        assert_equal(H[1][2]['second']['color'],'blue')
+        nx.is_isomorphic(G, H)
+        assert_equal(H[1][2]['second']['color'], 'blue')
 
     def test_unicode_keys(self):
         try:
-            q = unicode("qualité",'utf-8')
+            q = unicode("qualité", 'utf-8')
         except NameError:
             q = "qualité"
         G = nx.Graph()
@@ -60,5 +60,5 @@ class TestNodeLink:
     @raises(nx.NetworkXError)
     def test_exception(self):
         G = nx.MultiDiGraph()
-        attrs = dict(id='id', source='node', target='node', key='node')
+        attrs = dict(name='node', source='node', target='node', key='node')
         node_link_data(G, attrs)


### PR DESCRIPTION
This is related to issue #1951.

Changes: 
* Set default value of `id` to `name` and rename attribute key `id` to `name`
* Use `attrs` parameter to update `_attrs` such that default parameters don't need to be provided
* Add attribute key `link` with default value `links`
* Update docstrings (i.e. extend example, apply PEP8 and remove obsolete note)
* Apply PEP8 to `test_node_link.py`

Some questions remain:
1. Do we really need `make_str`? After all, it's just a wrapper and doesn't make things shorter. Removing it means to import one package less.
2. Should we get rid of all the blanks in the output? Especially for large graphs writing `{'source':0,'target':1}` instead of `{'source': 0, 'target': 1}` results in a good compression.
3. Should I remove `__author__` attribute according to #1728?