### PR TITLE
fix_duplicate_kwarg: Fix a duplicate kwarg that was causing to_agraph…

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -150,7 +150,7 @@ def to_agraph(N):
 
     if N.is_multigraph():
         for u,v,key,edgedata in N.edges(data=True,keys=True):
-            str_edgedata=dict((k,str(v)) for k,v in edgedata.items())
+            str_edgedata=dict((k,str(v)) for k,v in edgedata.items() if k != 'key')
             A.add_edge(u,v,key=str(key),**str_edgedata)
     else:
         for u,v,edgedata in N.edges(data=True):

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -204,7 +204,7 @@ def to_pydot(N, strict=True):
 
     if N.is_multigraph():
         for u,v,key,edgedata in N.edges(data=True,keys=True):
-            str_edgedata=dict((k,make_str(v)) for k,v in edgedata.items())
+            str_edgedata=dict((k,make_str(v)) for k,v in edgedata.items() if k != 'key')
             edge=pydotplus.Edge(make_str(u), make_str(v),
                     key=make_str(key), **str_edgedata)
             P.add_edge(edge)


### PR DESCRIPTION
… and to_pydot to fail on multigraphs.