### PR TITLE
Support digraphs in approximate min vertex cover

### DIFF
--- a/networkx/algorithms/approximation/tests/test_vertex_cover.py
+++ b/networkx/algorithms/approximation/tests/test_vertex_cover.py
@@ -1,19 +1,39 @@
-#!/usr/bin/env python
-from nose.tools import *
+from nose.tools import assert_equals
+from nose.tools import ok_
 import networkx as nx
-from  networkx.algorithms import approximation as a
+from networkx.algorithms.approximation import min_weighted_vertex_cover
 
-class TestMWVC:
 
-    def test_min_vertex_cover(self):
+def is_cover(G, node_cover):
+    return all({u, v} & node_cover for u, v in G.edges())
+
+
+class TestMWVC(object):
+    """Unit tests for the approximate minimum weighted vertex cover
+    function,
+    :func:`~networkx.algorithms.approximation.vertex_cover.min_weighted_vertex_cover`.
+
+    """
+
+    def test_unweighted_directed(self):
+        # Create a star graph in which half the nodes are directed in
+        # and half are directed out.
+        G = nx.DiGraph()
+        G.add_edges_from((0, v) for v in range(1, 26))
+        G.add_edges_from((v, 0) for v in range(26, 51))
+        cover = min_weighted_vertex_cover(G)
+        assert_equals(2, len(cover))
+        ok_(is_cover(G, cover))
+
+    def test_unweighted_undirected(self):
         # create a simple star graph
         size = 50
         sg = nx.star_graph(size)
-        cover = a.min_weighted_vertex_cover(sg)
+        cover = min_weighted_vertex_cover(sg)
         assert_equals(2, len(cover))
-        for u, v in sg.edges():
-            ok_((u in cover or v in cover), "Node node covered!")
+        ok_(is_cover(sg, cover))
 
+    def test_weighted(self):
         wg = nx.Graph()
         wg.add_node(0, weight=10)
         wg.add_node(1, weight=1)
@@ -26,14 +46,12 @@ class TestMWVC:
         wg.add_edge(0, 3)
         wg.add_edge(0, 4)
 
-        wg.add_edge(1,2)
-        wg.add_edge(2,3)
-        wg.add_edge(3,4)
-        wg.add_edge(4,1)
+        wg.add_edge(1, 2)
+        wg.add_edge(2, 3)
+        wg.add_edge(3, 4)
+        wg.add_edge(4, 1)
 
-        cover = a.min_weighted_vertex_cover(wg, weight="weight")
+        cover = min_weighted_vertex_cover(wg, weight="weight")
         csum = sum(wg.node[node]["weight"] for node in cover)
         assert_equals(4, csum)
-
-        for u, v in wg.edges():
-            ok_((u in cover or v in cover), "Node node covered!")
+        ok_(is_cover(wg, cover))

--- a/networkx/algorithms/approximation/vertex_cover.py
+++ b/networkx/algorithms/approximation/vertex_cover.py
@@ -1,65 +1,82 @@
 # -*- coding: utf-8 -*-
-"""
-************
-Vertex Cover
-************
-
-Given an undirected graph `G = (V, E)` and a function w assigning nonnegative
-weights to its vertices, find a minimum weight subset of V such that each edge
-in E is incident to at least one vertex in the subset.
-
-http://en.wikipedia.org/wiki/Vertex_cover
-"""
 #   Copyright (C) 2011-2012 by
 #   Nicholas Mancuso <nick.mancuso@gmail.com>
 #   All rights reserved.
 #   BSD license.
-from networkx.utils import *
+#
+# Author:
+#   Nicholas Mancuso <nick.mancuso@gmail.com>
+"""Functions for computing an approximate minimum weight vertex cover.
+
+A |vertex cover|_ is a subset of nodes such that each edge in the graph
+is incident to at least one node in the subset.
+
+.. _vertex cover: https://en.wikipedia.org/wiki/Vertex_cover
+.. |vertex cover| replace:: *vertex cover*
+
+"""
+
 __all__ = ["min_weighted_vertex_cover"]
-__author__ = """Nicholas Mancuso (nick.mancuso@gmail.com)"""
 
-@not_implemented_for('directed')
+
 def min_weighted_vertex_cover(G, weight=None):
-    r"""2-OPT Local Ratio for Minimum Weighted Vertex Cover
+    r"""Returns an approximate minimum weighted vertex cover.
 
-    Find an approximate minimum weighted vertex cover of a graph.
+    The set of nodes returned by this function is guaranteed to be a
+    vertex cover, and the total weight of the set is guaranteed to be at
+    most twice the total weight of the minimum weight vertex cover. In
+    other words,
+
+    .. math::
+
+       w(S) \leq 2 * w(S^*),
+
+    where :math:`S` is the vertex cover returned by this function,
+    :math:`S^*` is the vertex cover of minimum weight out of all vertex
+    covers of the graph, and :math:`w` is the function that computes the
+    sum of the weights of each node in that given set.
 
     Parameters
     ----------
     G : NetworkX graph
-      Undirected graph
 
-    weight : None or string, optional (default = None)
-        If None, every edge has weight/distance/cost 1. If a string, use this
-        edge attribute as the edge weight. Any edge attribute not present
-        defaults to 1.
+    weight : string, optional (default = None)
+        If None, every edge has weight 1. If a string, use this node
+        attribute as the node weight. A node without this attribute is
+        assumed to have weight 1.
 
     Returns
     -------
     min_weighted_cover : set
-      Returns a set of vertices whose weight sum is no more than 2 * OPT.
+        Returns a set of nodes whose weight sum is no more than twice
+        the weight sum of the minimum weight vertex cover.
 
     Notes
     -----
-    Local-Ratio algorithm for computing an approximate vertex cover.
-    Algorithm greedily reduces the costs over edges and iteratively
-    builds a cover. Worst-case runtime is `O(|E|)`.
+    For a directed graph, a vertex cover has the same definition: a set
+    of nodes such that each edge in the graph is incident to at least
+    one node in the set. Whether the node is the head or tail of the
+    directed edge is ignored.
+
+    This is the local-ratio algorithm for computing an approximate
+    vertex cover. The algorithm greedily reduces the costs over edges,
+    iteratively building a cover. The worst-case runtime of this
+    implementation is :math:`O(m \log n)`, where :math:`n` is the number
+    of nodes and :math:`m` the number of edges in the graph.
 
     References
     ----------
-    .. [1] Bar-Yehuda, R., & Even, S. (1985). A local-ratio theorem for
-       approximating the weighted vertex cover problem.
-       Annals of Discrete Mathematics, 25, 27–46
-       http://www.cs.technion.ac.il/~reuven/PDF/vc_lr.pdf
-    """
-    weight_func = lambda nd: nd.get(weight, 1)
-    cost = dict((n, weight_func(nd)) for n, nd in G.nodes(data=True))
+    .. [1] Bar-Yehuda, R., and Even, S. (1985). "A local-ratio theorem for
+       approximating the weighted vertex cover problem."
+       *Annals of Discrete Mathematics*, 25, 27–46
+       <http://www.cs.technion.ac.il/~reuven/PDF/vc_lr.pdf>
 
-    # while there are edges uncovered, continue
-    for u,v in G.edges():
-        # select some uncovered edge
-        min_cost = min([cost[u], cost[v]])
+    """
+    cost = dict(G.nodes(data=weight, default=1))
+    # While there are uncovered edges, choose an uncovered and update
+    # the cost of the remaining edges.
+    for u, v in G.edges():
+        min_cost = min(cost[u], cost[v])
         cost[u] -= min_cost
         cost[v] -= min_cost
-
-    return set(u for u in cost if cost[u] == 0)
+    return {u for u, c in cost.items() if c == 0}


### PR DESCRIPTION
This commit removes the decorator that marked the approximate minimum
weighted vertex cover function as "not implemented" for directed graphs,
because it works for a reasonable definition of vertex cover in directed
graphs.

This also updates the documentation and tests.

This fixes issue #961.