### PR TITLE
UnboundLocalError if called with an empty graph

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -410,6 +410,7 @@ def condensation(G, scc=None):
     mapping = {}
     members = {}
     C = nx.DiGraph()
+    i = 0  # required if G is empty
     for i, component in enumerate(scc):
         members[i] = component
         mapping.update((n, i) for n in component)


### PR DESCRIPTION
condensation(DiGraph()) currently crashes on line number_of_components = i + 1 with UnboundLocalError: local variable 'i' referenced before assignment