### PR TITLE
Read/write/generate a basic graph using UCINET DL format

### DIFF
--- a/networkx/readwrite/__init__.py
+++ b/networkx/readwrite/__init__.py
@@ -16,3 +16,4 @@ from networkx.readwrite.graphml import *
 from networkx.readwrite.gexf import *
 from networkx.readwrite.nx_shp import *
 from networkx.readwrite.json_graph import *
+from networkx.readwrite.ucinet import *

--- a/networkx/readwrite/tests/test_ucinet.py
+++ b/networkx/readwrite/tests/test_ucinet.py
@@ -20,8 +20,19 @@ class TestUcinet(object):
 
     def test_generate_ucinet(self):
         Gout = nx.readwrite.generate_ucinet(self.G)
+        s = ''
         for line in Gout:
-            print line
+            s += line + '\n'
+        s = s[:-1]
+        data = """\
+dl n=5 format=fullmatrix
+data:
+0 1 1 1 1
+1 0 1 1 0
+1 1 0 0 0
+1 1 0 0 0
+1 0 0 0 0"""
+        assert_equal(data, s)
 
     def test_parse_ucinet(self):
         data = """
@@ -35,7 +46,11 @@ Data:
         """
         graph = nx.MultiDiGraph()
         graph.add_nodes_from([0, 1, 2, 3, 4])
-        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 2), (2, 0), (2, 1), (2, 4), (3, 0), (4, 0), (4, 2)])
+        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4),
+                              (1, 0), (1, 2),
+                              (2, 0), (2, 1), (2, 4),
+                              (3, 0),
+                              (4, 0), (4, 2)])
         G = nx.readwrite.parse_ucinet(data)
         assert_equal(sorted(G.nodes()), sorted(graph.nodes()))
         assert_edges_equal(G.edges(), graph.edges())
@@ -57,7 +72,11 @@ data:
                 """
         G = nx.readwrite.parse_ucinet(data)
         assert_equal(sorted(G.nodes()), sorted(['russ', 'barry', 'lin', 'pat', 'david']))
-        assert_edges_equal(G.edges(), [('russ', 'pat'), ('russ', 'david'), ('barry', 'lin'), ('barry', 'pat'), ('barry', 'david'), ('lin', 'barry'), ('lin', 'pat'), ('pat', 'barry'), ('pat', 'lin'), ('pat', 'russ'), ('david', 'barry'), ('david', 'russ')])
+        assert_edges_equal(G.edges(), [('russ', 'pat'), ('russ', 'david'),
+                                       ('barry', 'lin'), ('barry', 'pat'), ('barry', 'david'),
+                                       ('lin', 'barry'), ('lin', 'pat'),
+                                       ('pat', 'barry'), ('pat', 'lin'), ('pat', 'russ'),
+                                       ('david', 'barry'), ('david', 'russ')])
         # print [n for n in G.nodes()]
         # print [e for e in G.edges()]
 
@@ -92,7 +111,11 @@ data:
 """
         graph = nx.MultiDiGraph()
         graph.add_nodes_from([0, 1, 2, 3, 4])
-        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 2), (2, 0), (2, 1), (2, 4), (3, 0), (4, 0), (4, 2)])
+        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4),
+                              (1, 0), (1, 2),
+                              (2, 0), (2, 1), (2, 4),
+                              (3, 0),
+                              (4, 0), (4, 2)])
         nx.readwrite.write_ucinet(graph, fh)
         fh.seek(0)
         assert_equal(fh.read(), data)

--- a/networkx/readwrite/tests/test_ucinet.py
+++ b/networkx/readwrite/tests/test_ucinet.py
@@ -147,8 +147,43 @@ data:
   2  1 4
         """
         G = nx.MultiDiGraph()
-        G.add_nodes_from([1, 2, 3, 4])
-        G.add_edges_from([(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 4), (4, 1), (4, 4)])
+        G.add_nodes_from([0, 1, 2, 3])
+        G.add_edges_from([(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 3), (3, 0), (3, 3)])
+        G1 = nx.readwrite.parse_ucinet(data1)
+        G2 = nx.readwrite.parse_ucinet(data2)
+        assert_equal(sorted(G1.nodes()), sorted(G.nodes()))
+        assert_equal(sorted(G2.nodes()), sorted(G.nodes()))
+        assert_edges_equal(G1.edges(), G.edges())
+        assert_edges_equal(G2.edges(), G.edges())
+
+    def test_parse_ucinet_nodelist1_labels(self):
+        data1 = """
+DL n=5
+format = nodelist1
+labels:
+george, sally, jim, billy, jane
+data:
+1 2 3
+2 3
+4 1
+5 3
+        """
+        data2 = """
+DL n=5
+format = nodelist1
+labels embedded:
+data:
+george sally jim
+sally jim
+billy george
+jane jim
+        """
+        G = nx.MultiDiGraph()
+        G.add_nodes_from(['george', 'sally', 'jim', 'billy', 'jane'])
+        G.add_edges_from([('billy', 'george'),
+                          ('jane', 'jim'),
+                          ('sally', 'jim'),
+                          ('george', 'jim'), ('george', 'sally')])
         G1 = nx.readwrite.parse_ucinet(data1)
         G2 = nx.readwrite.parse_ucinet(data2)
         assert_equal(sorted(G1.nodes()), sorted(G.nodes()))
@@ -199,3 +234,41 @@ data:
 
         assert_equal(sorted(G.nodes()), sorted(graph.nodes()))
         assert_edges_equal(G.edges(), graph.edges())
+
+    def test_parse_ucinet_edgelist1(self):
+        data1 = """
+DL n=5
+format = edgelist1
+labels:
+george, sally, jim, billy, jane
+data:
+1 2
+1 3
+2 3
+3 1
+5 4
+        """
+        data2 = """
+DL n=5
+format = edgelist1
+labels embedded:
+data:
+george sally
+george jim
+sally jim
+jim george
+jane billy
+        """
+        G = nx.MultiDiGraph()
+        G.add_nodes_from(['george', 'sally', 'jim', 'billy', 'jane'])
+        G.add_edges_from([('jim', 'george'),
+                          ('jane', 'billy'),
+                          ('sally', 'jim'),
+                          ('george', 'jim'), ('george', 'sally')])
+
+        G1 = nx.readwrite.parse_ucinet(data1)
+        G2 = nx.readwrite.parse_ucinet(data2)
+        assert_equal(sorted(G1.nodes()), sorted(G.nodes()))
+        assert_equal(sorted(G2.nodes()), sorted(G.nodes()))
+        assert_edges_equal(G1.edges(), G.edges())
+        assert_edges_equal(G2.edges(), G.edges())

--- a/networkx/readwrite/tests/test_ucinet.py
+++ b/networkx/readwrite/tests/test_ucinet.py
@@ -6,6 +6,7 @@ import io
 from nose.tools import *
 import networkx as nx
 from networkx.testing import *
+from nose import SkipTest
 
 
 class TestUcinet(object):
@@ -17,6 +18,10 @@ class TestUcinet(object):
                                 ('c', 'a'), ('c', 'b'),
                                 ('d', 'a'), ('d', 'b'),
                                 ('e', 'a')])
+        try:
+            import numpy
+        except ImportError:
+            raise SkipTest('NumPy not available.')
 
     def test_generate_ucinet(self):
         Gout = nx.readwrite.generate_ucinet(self.G)

--- a/networkx/readwrite/tests/test_ucinet.py
+++ b/networkx/readwrite/tests/test_ucinet.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+UCINET tests
+"""
+import io
+from nose.tools import *
+import networkx as nx
+from networkx.testing import *
+
+
+class TestUcinet(object):
+    def setUp(self):
+        self.G = nx.MultiDiGraph()
+        self.G.add_nodes_from(['a', 'b', 'c', 'd', 'e'])
+        self.G.add_edges_from([('a', 'b'), ('a', 'c'), ('a', 'd'), ('a', 'e'),
+                                ('b', 'a'), ('b', 'c'),
+                                ('c', 'a'), ('c', 'b'), ('c', 'e'),
+                                ('d', 'a'),
+                                ('e', 'a'), ('e', 'c')])
+
+    def test_generate_ucinet(self):
+        Gout = nx.readwrite.generate_ucinet(self.G)
+        for line in Gout:
+            print line
+
+    def test_parse_ucinet(self):
+        data = """
+DL N = 5
+Data:
+0 1 1 1 1
+1 0 1 0 0
+1 1 0 0 1
+1 0 0 0 0
+1 0 1 0 0
+        """
+        graph = nx.MultiDiGraph()
+        graph.add_nodes_from([0, 1, 2, 3, 4])
+        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 2), (2, 0), (2, 1), (2, 4), (3, 0), (4, 0), (4, 2)])
+        G = nx.readwrite.parse_ucinet(data)
+        assert_equal(sorted(G.nodes()), sorted(graph.nodes()))
+        assert_edges_equal(G.edges(), graph.edges())
+        # print [n for n in G.nodes(data=True)]
+        # print [e for e in G.edges()]
+
+    def test_parse_ucinet_labels(self):
+        data = """
+dl n=5
+format = fullmatrix
+labels:
+barry,david,lin,pat,russ
+data:
+0 1 1 1 0
+1 0 0 0 1
+1 0 0 1 0
+1 0 1 0 1
+0 1 0 1 0
+                """
+        G = nx.readwrite.parse_ucinet(data)
+        assert_equal(sorted(G.nodes()), sorted(['russ', 'barry', 'lin', 'pat', 'david']))
+        assert_edges_equal(G.edges(), [('russ', 'pat'), ('russ', 'david'), ('barry', 'lin'), ('barry', 'pat'), ('barry', 'david'), ('lin', 'barry'), ('lin', 'pat'), ('pat', 'barry'), ('pat', 'lin'), ('pat', 'russ'), ('david', 'barry'), ('david', 'russ')])
+        # print [n for n in G.nodes()]
+        # print [e for e in G.edges()]
+
+    def test_read_ucinet(self):
+        fh = io.BytesIO()
+        data = """
+DL N = 5
+Data:
+0 1 1 1 1
+1 0 1 0 0
+1 1 0 0 1
+1 0 0 0 0
+1 0 1 0 0
+        """
+        Gin = nx.readwrite.parse_ucinet(data)
+        fh.write(data.encode('UTF-8'))
+        fh.seek(0)
+        Gout = nx.readwrite.read_ucinet(fh)
+        assert_equal(sorted(Gout.nodes()), sorted(Gin.nodes()))
+        assert_equal(sorted(Gout.edges()), sorted(Gin.edges()))
+
+    def test_write_ucinet(self):
+        fh = io.BytesIO()
+        data = """\
+dl n=5 format=fullmatrix
+data:
+0 1 1 1 1
+1 0 1 0 0
+1 1 0 0 1
+1 0 0 0 0
+1 0 1 0 0
+"""
+        graph = nx.MultiDiGraph()
+        graph.add_nodes_from([0, 1, 2, 3, 4])
+        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 2), (2, 0), (2, 1), (2, 4), (3, 0), (4, 0), (4, 2)])
+        nx.readwrite.write_ucinet(graph, fh)
+        fh.seek(0)
+        assert_equal(fh.read(), data)

--- a/networkx/readwrite/tests/test_ucinet.py
+++ b/networkx/readwrite/tests/test_ucinet.py
@@ -58,7 +58,14 @@ Data:
         # print [e for e in G.edges()]
 
     def test_parse_ucinet_labels(self):
-        data = """
+        """
+        Test parsing of labels : single line (data1), multiple lines (data2), embedded (data3)
+
+        Labels must be separated by spaces, carriage returns, equal signs or commas.
+        Labels with embedded spaces are not advisable, but can be entered by
+        surrounding the label in quotes (e.g., "Humpty Dumpty").
+        """
+        data1 = """
 dl n=5
 format = fullmatrix
 labels:
@@ -70,15 +77,78 @@ data:
 1 0 1 0 1
 0 1 0 1 0
                 """
-        G = nx.readwrite.parse_ucinet(data)
-        assert_equal(sorted(G.nodes()), sorted(['russ', 'barry', 'lin', 'pat', 'david']))
-        assert_edges_equal(G.edges(), [('russ', 'pat'), ('russ', 'david'),
-                                       ('barry', 'lin'), ('barry', 'pat'), ('barry', 'david'),
-                                       ('lin', 'barry'), ('lin', 'pat'),
-                                       ('pat', 'barry'), ('pat', 'lin'), ('pat', 'russ'),
-                                       ('david', 'barry'), ('david', 'russ')])
+        data2 = """
+dl n=5
+format = fullmatrix
+labels:
+barry,david
+lin,pat
+russ
+data:
+0 1 1 1 0
+1 0 0 0 1
+1 0 0 1 0
+1 0 1 0 1
+0 1 0 1 0
+        """
+        data3 = """\
+dl n=5
+format = fullmatrix
+labels embedded
+data:
+barry david lin pat russ
+Barry 0 1 1 1 0
+david 1 0 0 0 1
+Lin 1 0 0 1 0
+Pat 1 0 1 0 1
+Russ 0 1 0 1 0
+        """
+        G = nx.MultiDiGraph()
+        G.add_nodes_from(['russ', 'barry', 'lin', 'pat', 'david'])
+        G.add_edges_from([('russ', 'pat'), ('russ', 'david'),
+                            ('barry', 'lin'), ('barry', 'pat'), ('barry', 'david'),
+                            ('lin', 'barry'), ('lin', 'pat'),
+                            ('pat', 'barry'), ('pat', 'lin'), ('pat', 'russ'),
+                            ('david', 'barry'), ('david', 'russ')])
+        G1 = nx.readwrite.parse_ucinet(data1)
+        G2 = nx.readwrite.parse_ucinet(data2)
+        G3 = nx.readwrite.parse_ucinet(data3)
+        assert_equal(sorted(G1.nodes()), sorted(G.nodes()))
+        assert_equal(sorted(G2.nodes()), sorted(G.nodes()))
+        assert_equal(sorted(G3.nodes()), sorted(G.nodes()))
+        assert_edges_equal(G1.edges(), G.edges())
+        assert_edges_equal(G2.edges(), G.edges())
+        assert_edges_equal(G3.edges(), G.edges())
         # print [n for n in G.nodes()]
         # print [e for e in G.edges()]
+
+    def test_parse_ucinet_nodelist1(self):
+        data1 = """
+DL n=4
+format = nodelist1
+data:
+  1  3 2 1
+  4  1 4
+  2  2 4 1
+        """
+        data2 = """
+DL n=4
+format = nodelist1b
+data:
+  3  1 2 3
+  3  1 2 4
+  0
+  2  1 4
+        """
+        G = nx.MultiDiGraph()
+        G.add_nodes_from([1, 2, 3, 4])
+        G.add_edges_from([(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 4), (4, 1), (4, 4)])
+        G1 = nx.readwrite.parse_ucinet(data1)
+        G2 = nx.readwrite.parse_ucinet(data2)
+        assert_equal(sorted(G1.nodes()), sorted(G.nodes()))
+        assert_equal(sorted(G2.nodes()), sorted(G.nodes()))
+        assert_edges_equal(G1.edges(), G.edges())
+        assert_edges_equal(G2.edges(), G.edges())
 
     def test_read_ucinet(self):
         fh = io.BytesIO()

--- a/networkx/readwrite/tests/test_ucinet.py
+++ b/networkx/readwrite/tests/test_ucinet.py
@@ -13,26 +13,32 @@ class TestUcinet(object):
         self.G = nx.MultiDiGraph()
         self.G.add_nodes_from(['a', 'b', 'c', 'd', 'e'])
         self.G.add_edges_from([('a', 'b'), ('a', 'c'), ('a', 'd'), ('a', 'e'),
-                                ('b', 'a'), ('b', 'c'),
-                                ('c', 'a'), ('c', 'b'), ('c', 'e'),
-                                ('d', 'a'),
-                                ('e', 'a'), ('e', 'c')])
+                                ('b', 'a'), ('b', 'c'), ('b', 'd'),
+                                ('c', 'a'), ('c', 'b'),
+                                ('d', 'a'), ('d', 'b'),
+                                ('e', 'a')])
 
     def test_generate_ucinet(self):
         Gout = nx.readwrite.generate_ucinet(self.G)
         s = ''
         for line in Gout:
             s += line + '\n'
-        s = s[:-1]
+        G_generated = nx.readwrite.parse_ucinet(s)
+
         data = """\
 dl n=5 format=fullmatrix
+labels:
+a,b,c,d,e
 data:
 0 1 1 1 1
 1 0 1 1 0
 1 1 0 0 0
 1 1 0 0 0
 1 0 0 0 0"""
-        assert_equal(data, s)
+        G = nx.readwrite.parse_ucinet(data)
+
+        assert_equal(sorted(G.nodes()), sorted(G_generated.nodes()))
+        assert_edges_equal(G.edges(), G_generated.edges())
 
     def test_parse_ucinet(self):
         data = """
@@ -186,6 +192,10 @@ data:
                               (2, 0), (2, 1), (2, 4),
                               (3, 0),
                               (4, 0), (4, 2)])
+
         nx.readwrite.write_ucinet(graph, fh)
         fh.seek(0)
-        assert_equal(fh.read(), data)
+        G = nx.readwrite.parse_ucinet(fh.readlines())
+
+        assert_equal(sorted(G.nodes()), sorted(graph.nodes()))
+        assert_edges_equal(G.edges(), graph.edges())

--- a/networkx/readwrite/ucinet.py
+++ b/networkx/readwrite/ucinet.py
@@ -33,7 +33,7 @@ import re
 import shlex
 import networkx as nx
 from networkx.utils import is_string_like, open_file, make_str
-from numpy import genfromtxt, reshape
+from numpy import genfromtxt, reshape, array_str
 
 __all__ = ['generate_ucinet', 'read_ucinet', 'parse_ucinet', 'write_ucinet']
 
@@ -60,19 +60,21 @@ def generate_ucinet(G):
     for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
     """
     n = G.number_of_nodes()
+    nodes = sorted(list(G.nodes()))
     yield 'dl n=%i format=fullmatrix' % n
+
+    # Labels
+    try:
+        int(nodes[0])
+    except ValueError:
+        s = 'labels:\n'
+        for label in nodes:
+            s += label + ' '
+        yield s
 
     yield 'data:'
 
-    for node in G:
-        neighbors = list(G.neighbors(node))
-        s = ''
-        for node2 in G:
-            if node2 in neighbors:
-                s += '1 '
-            else:
-                s += '0 '
-        yield s[:-1]  # Remove last space
+    yield str(nx.to_numpy_matrix(G, nodelist=nodes, dtype=int)).replace('[', ' ').replace(']', ' ').lstrip().rstrip()
 
 
 @open_file(0, mode='rb')

--- a/networkx/readwrite/ucinet.py
+++ b/networkx/readwrite/ucinet.py
@@ -187,7 +187,7 @@ def parse_ucinet(lines):
             token = next(lines).lower()
         except StopIteration:
             break
-        print "Token : %s" % token
+        # print "Token : %s" % token
         if token.startswith('n'):
             if token.startswith('nr'):
                 nr = int(get_param("\d+", token, lines))
@@ -201,7 +201,8 @@ def parse_ucinet(lines):
                 number_of_nodes = int(get_param("\d+", token, lines))
 
         elif token.startswith("format"):
-            ucinet_format = get_param("fullmatrix|upperhalf|lowerhalf|nodelist1|nodelist2|nodelist1b|edgelist1|edgelist2|blockmatrix|partition", token, lines)
+            ucinet_format = get_param("fullmatrix|upperhalf|lowerhalf|nodelist1|nodelist2|nodelist1b|\
+                                        edgelist1|edgelist2|blockmatrix|partition", token, lines)
 
         elif token.startswith("labels"):
             token = next(lines).lower()
@@ -238,7 +239,8 @@ def parse_ucinet(lines):
                         else:
                             G.add_edge(source, target)
                 else:
-                    raise NotImplementedError("UCINET DL data format %s not yet implemented in Networkx" % ucinet_format)
+                    raise NotImplementedError("UCINET DL data format %s not yet implemented in Networkx"
+                                            % ucinet_format)
                 j += 1
     return G
 

--- a/networkx/readwrite/ucinet.py
+++ b/networkx/readwrite/ucinet.py
@@ -170,9 +170,9 @@ def parse_ucinet(lines):
             s += line
         lines = s
 
-    lines = shlex.shlex(lines)
-    lines.whitespace += ','
-    lines.whitespace_split = True
+    lexer = shlex.shlex(lines.lower())
+    lexer.whitespace += ',='
+    lexer.whitespace_split = True
 
     number_of_nodes = 0
     number_of_matrices = 0
@@ -180,52 +180,94 @@ def parse_ucinet(lines):
     nc = 0  # number of columns (rectangular matrix)
     ucinet_format = 'fullmatrix'  # Format by default
     labels = {}  # Contains labels of nodes
+    row_labels_embedded = False  # Whether labels are embedded in data or not
+    cols_labels_embedded = False
 
     KEYWORDS = ('format', 'data:', 'labels:')  # TODO remove ':' in keywords
 
-    while lines:
+    while lexer:
         try:
-            token = next(lines).lower()
+            token = next(lexer)
         except StopIteration:
             break
         # print "Token : %s" % token
         if token.startswith('n'):
             if token.startswith('nr'):
-                nr = int(get_param("\d+", token, lines))
+                nr = int(get_param("\d+", token, lexer))
                 number_of_nodes = max(nr, nc)
             elif token.startswith('nc'):
-                nc = int(get_param("\d+", token, lines))
+                nc = int(get_param("\d+", token, lexer))
                 number_of_nodes = max(nr, nc)
             elif token.startswith('nm'):
-                number_of_matrices = int(get_param("\d+", token, lines))
+                number_of_matrices = int(get_param("\d+", token, lexer))
             else:
-                number_of_nodes = int(get_param("\d+", token, lines))
+                number_of_nodes = int(get_param("\d+", token, lexer))
+                nr = number_of_nodes
+                nc = number_of_nodes
 
         elif token.startswith("format"):
-            ucinet_format = get_param("fullmatrix|upperhalf|lowerhalf|nodelist1|nodelist2|nodelist1b|\
-                                        edgelist1|edgelist2|blockmatrix|partition", token, lines)
+            ucinet_format = get_param("^(fullmatrix|upperhalf|lowerhalf|nodelist1|nodelist2|nodelist1b|\
+                                        edgelist1|edgelist2|blockmatrix|partition)$", token, lexer)
+
+        # TODO : row and columns labels
+        elif token.startswith("row"):  # Row labels
+            pass
+        elif token.startswith("column"):  # Columns labels
+            pass
 
         elif token.startswith("labels"):
-            token = next(lines).lower()
+            token = next(lexer)
             i = 0
             while token not in KEYWORDS:
-                labels[i] = token
-                i += 1
-                try:
-                    token = next(lines).lower()
-                except StopIteration:
+                if token == 'embedded':
+                    row_labels_embedded = True
+                    cols_labels_embedded = True
                     break
+                else:
+                    labels[i] = token.replace('"', '')  # for labels with embedded spaces
+                    i += 1
+                    try:
+                        token = next(lexer)
+                    except StopIteration:
+                        break
+        elif token.startswith('data'):
+            break
 
-        if token.startswith('data'):  # data
-            # Generate edges
-            data = genfromtxt(list(lines))
-            if ucinet_format == 'fullmatrix':
-                mat = reshape(data, (max(number_of_nodes, nr), -1))
-                G = nx.from_numpy_matrix(mat, create_using=nx.MultiDiGraph())
+    data_lines = lines.lower().split("data:", 1)[1]
+    # Generate edges
+    params = {}
+    if cols_labels_embedded:
+        # params['names'] = True
+        labels = dict(zip(range(0, nc), data_lines.splitlines()[1].split()))
+        params['skip_header'] = 2  # First character is \n
+    if row_labels_embedded:  # Skip first column
+        # TODO rectangular case : labels can differ from rows to columns
+        params['usecols'] = range(1, nc + 1)
 
-            # Relabel nodes
-            if labels:
-                G = nx.relabel_nodes(G, labels)
+    if ucinet_format == 'fullmatrix':
+        data = genfromtxt(data_lines.splitlines(), case_sensitive=False, **params)
+        mat = reshape(data, (max(number_of_nodes, nr), -1))
+        G = nx.from_numpy_matrix(mat, create_using=nx.MultiDiGraph())
+
+    elif ucinet_format in ('nodelist1', 'nodelist1b'):  # Since genfromtxt only accepts square matrix...
+        s = ''
+        for i, line in enumerate(data_lines.splitlines()):
+            row = line.split()
+            if row:
+                if ucinet_format == 'nodelist1b' and row[0] == '0':
+                    pass
+                else:
+                    for neighbor in row[1:]:
+                        if ucinet_format == 'nodelist1':
+                            source = row[0]
+                        else:
+                            source = str(i)
+                        s += source + ' ' + neighbor + '\n'
+        G = nx.parse_edgelist(s.splitlines(), nodetype=int, create_using=nx.MultiDiGraph())
+
+    # Relabel nodes
+    if labels:
+        G = nx.relabel_nodes(G, labels)
     return G
 
 
@@ -240,6 +282,9 @@ def get_param(regex, token, lines):
     n = token
     query = re.search(regex, n)
     while query is None:
-        n = next(lines).lower()
+        try:
+            n = next(lines)
+        except StopIteration:
+            raise Exception("Parameter value not recognized")
         query = re.search(regex, n)
     return query.group()

--- a/networkx/readwrite/ucinet.py
+++ b/networkx/readwrite/ucinet.py
@@ -33,7 +33,6 @@ import re
 import shlex
 import networkx as nx
 from networkx.utils import is_string_like, open_file
-from numpy import genfromtxt, reshape, insert, isnan
 
 __all__ = ['generate_ucinet', 'read_ucinet', 'parse_ucinet', 'write_ucinet']
 
@@ -164,6 +163,7 @@ def parse_ucinet(lines):
     See UCINET User Guide or http://www.analytictech.com/ucinet/help/hs5000.htm
     for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
     """
+    from numpy import genfromtxt, reshape, insert, isnan
     G = nx.MultiDiGraph()
 
     if not is_string_like(lines):

--- a/networkx/readwrite/ucinet.py
+++ b/networkx/readwrite/ucinet.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+#
+# Authors: Laura Dominé (temigo@gmx.com)
+
+"""
+**************
+UCINET DL
+**************
+Read and write graphs in UCINET DL format.
+
+This implementation currently supports only the 'fullmatrix' data format.
+
+Format
+------
+The UCINET DL format is the most common file format used by UCINET package.
+
+Basic example:
+
+DL N = 5
+Data:
+0 1 1 1 1
+1 0 1 0 0
+1 1 0 0 1
+1 0 0 0 0
+1 0 1 0 0
+
+References
+----------
+    See UCINET User Guide or http://www.analytictech.com/ucinet/help/hs5000.htm
+    for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
+"""
+import re
+import shlex
+import networkx as nx
+from networkx.utils import is_string_like, open_file, make_str
+
+__all__ = ['generate_ucinet', 'read_ucinet', 'parse_ucinet', 'write_ucinet']
+
+
+def generate_ucinet(G):
+    """Generate lines in UCINET graph format.
+
+    Parameters
+    ----------
+    G : graph
+       A Networkx graph
+
+    Examples
+    --------
+
+
+    Notes
+    -----
+    The default format 'fullmatrix' is used (for UCINET DL format).
+    
+    References
+    ----------
+    See UCINET User Guide or http://www.analytictech.com/ucinet/help/hs5000.htm
+    for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
+    """
+    n = G.number_of_nodes()
+    yield 'dl n=%i format=fullmatrix' % n
+
+    yield 'data:'
+
+    for node in G:
+        neighbors = list(G.neighbors(node))
+        s = ''
+        for node2 in G:
+            if node2 in neighbors:
+                s += '1 '
+            else:
+                s += '0 '
+        yield s[:-1]  # Remove last space
+
+
+@open_file(0, mode='rb')
+def read_ucinet(path, encoding='UTF-8'):
+    """Read graph in UCINET format from path.
+
+    Parameters
+    ----------
+    path : file or string
+       File or filename to read.
+       Filenames ending in .gz or .bz2 will be uncompressed.
+
+    Returns
+    -------
+    G : NetworkX MultiGraph or MultiDiGraph.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(4)
+    >>> nx.write_ucinet(G, "test.dl")
+    >>> G=nx.read_ucinet("test.dl")
+
+    To create a Graph instead of a MultiGraph use
+
+    >>> G1=nx.Graph(G)
+
+    See Also
+    --------
+    parse_ucinet()
+
+    References
+    ----------
+    See UCINET User Guide or http://www.analytictech.com/ucinet/help/hs5000.htm
+    for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
+    """
+    lines = (line.decode(encoding) for line in path)
+    return parse_ucinet(lines)
+
+
+@open_file(1, mode='wb')
+def write_ucinet(G, path, encoding='UTF-8'):
+    """Write graph in UCINET format to path.
+
+    Parameters
+    ----------
+    G : graph
+       A Networkx graph
+    path : file or string
+       File or filename to write.
+       Filenames ending in .gz or .bz2 will be compressed.
+
+    Examples
+    --------
+    >>> G=nx.path_graph(4)
+    >>> nx.write_ucinet(G, "test.net")
+
+    References
+    ----------
+    See UCINET User Guide or http://www.analytictech.com/ucinet/help/hs5000.htm
+    for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
+    """
+    for line in generate_ucinet(G):
+        line += '\n'
+        path.write(line.encode(encoding))
+
+
+def parse_ucinet(lines):
+    """Parse UCINET format graph from string or iterable.
+
+    Currently only the 'fullmatrix' format is supported.
+
+    Parameters
+    ----------
+    lines : string or iterable
+       Data in UCINET format.
+
+    Returns
+    -------
+    G : NetworkX graph
+
+    See Also
+    --------
+    read_ucinet()
+
+    References
+    ----------
+    See UCINET User Guide or http://www.analytictech.com/ucinet/help/hs5000.htm
+    for full format information. Short version on http://www.analytictech.com/networks/dataentry.htm
+    """
+    G = nx.MultiDiGraph()
+
+    if not is_string_like(lines):
+        s = ''
+        for line in lines:
+            s += line
+        lines = s
+
+    lines = shlex.shlex(lines)
+    lines.whitespace += ','
+    lines.whitespace_split = True
+
+    number_of_nodes = 0
+    number_of_matrices = 0
+    nr = 0  # number of rows (rectangular matrix)
+    nc = 0  # number of columns (rectangular matrix)
+    ucinet_format = 'fullmatrix'  # Format by default
+    labels = []  # Contains labels of nodes
+
+    KEYWORDS = ('format', 'data:', 'labels:')  # TODO remove ':' in keywords
+
+    while lines:
+        try:
+            token = next(lines).lower()
+        except StopIteration:
+            break
+        print "Token : %s" % token
+        if token.startswith('n'):
+            if token.startswith('nr'):
+                nr = int(get_param("\d+", token, lines))
+                number_of_nodes = max(nr, nc)
+            elif token.startswith('nc'):
+                nc = int(get_param("\d+", token, lines))
+                number_of_nodes = max(nr, nc)
+            elif token.startswith('nm'):
+                number_of_matrices = int(get_param("\d+", token, lines))
+            else:
+                number_of_nodes = int(get_param("\d+", token, lines))
+
+        elif token.startswith("format"):
+            ucinet_format = get_param("fullmatrix|upperhalf|lowerhalf|nodelist1|nodelist2|nodelist1b|edgelist1|edgelist2|blockmatrix|partition", token, lines)
+
+        elif token.startswith("labels"):
+            token = next(lines).lower()
+            i = 0
+            while token not in KEYWORDS:
+                labels.append(token)
+                i += 1
+                try:
+                    token = next(lines).lower()
+                except StopIteration:
+                    break
+
+        if token.startswith('data'):  # data
+            # Generate nodes
+            if not labels:
+                labels = range(0, number_of_nodes)
+            G.add_nodes_from(labels)
+
+            # Generate edges
+            j = 0
+            while lines:
+                try:
+                    token = next(lines).lower()
+                except StopIteration:
+                    break
+                if ucinet_format == 'fullmatrix':
+                    i = j / number_of_nodes
+                    k = j % number_of_nodes
+                    source = labels[i]
+                    target = labels[k]
+                    if token != '0':
+                        if token != '1':  # Weighted edge
+                            G.add_weighted_edges_from([(source, target, float(token))])
+                        else:
+                            G.add_edge(source, target)
+                else:
+                    raise NotImplementedError("UCINET DL data format %s not yet implemented in Networkx" % ucinet_format)
+                j += 1
+    return G
+
+
+def get_param(regex, token, lines):
+    """
+    Get a parameter value in UCINET DL file
+    :param regex: string with the regex matching the parameter value
+    :param token: token (string) in which we search for the parameter
+    :param lines: to iterate through the next tokens
+    :return:
+    """
+    n = token
+    query = re.search(regex, n)
+    while query is None:
+        n = next(lines).lower()
+        query = re.search(regex, n)
+    return query.group()


### PR DESCRIPTION
Functions and tests for UCINET DL format. 
(Currently supports only 'fullmatrix' format for data. There are many variants for UCINET DL format, this implementation only covers the basic one for now.)

This is related to issue  #2051. Thanks !
