### PR TITLE
Adds multi-source Dijkstra's algorithm

### DIFF
--- a/doc/source/reference/algorithms.shortest_paths.rst
+++ b/doc/source/reference/algorithms.shortest_paths.rst
@@ -28,15 +28,18 @@ Advanced Interface
 .. autosummary::
    :toctree: generated/
 
+   dijkstra_predecessor_and_distance
    dijkstra_path
    dijkstra_path_length
+   single_source_dijkstra
    single_source_dijkstra_path
    single_source_dijkstra_path_length
+   multi_source_dijkstra_path
+   multi_source_dijkstra_path_length
    all_pairs_dijkstra_path
    all_pairs_dijkstra_path_length
-   single_source_dijkstra
    bidirectional_dijkstra
-   dijkstra_predecessor_and_distance
+
    bellman_ford_path
    bellman_ford_path_length
    single_source_bellman_ford_path
@@ -45,6 +48,7 @@ Advanced Interface
    all_pairs_bellman_ford_path_length
    single_source_bellman_ford
    bellman_ford_predecessor_and_distance
+
    negative_edge_cycle
    johnson
 

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -266,6 +266,36 @@ class TestDijkstraPathLength(object):
         assert_equal(length, 1 / 10)
 
 
+class TestMultiSourceDijkstra(object):
+    """Unit tests for the multi-source dialect of Dijkstra's shortest
+    path algorithms.
+
+    """
+
+    @raises(ValueError)
+    def test_no_sources(self):
+        nx.multi_source_dijkstra(nx.Graph(), {})
+
+    @raises(ValueError)
+    def test_path_no_sources(self):
+        nx.multi_source_dijkstra_path(nx.Graph(), {})
+
+    @raises(ValueError)
+    def test_path_length_no_sources(self):
+        nx.multi_source_dijkstra_path_length(nx.Graph(), {})
+
+    def test_two_sources(self):
+        edges = [(0, 1, 1), (1, 2, 1), (2, 3, 10), (3, 4, 1)]
+        G = nx.Graph()
+        G.add_weighted_edges_from(edges)
+        sources = {0, 4}
+        distances, paths = nx.multi_source_dijkstra(G, sources)
+        expected_distances = {0: 0, 1: 1, 2: 2, 3: 1, 4: 0}
+        expected_paths = {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [4, 3], 4: [4]}
+        assert_equal(distances, expected_distances)
+        assert_equal(paths, expected_paths)
+
+
 class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
     def test_single_node_graph(self):


### PR DESCRIPTION
This is a generalization of Dijkstra's algorithm that works for a set of
initial nodes instead of just a single initial node.

With this addition pull request #2037 can be implemented easily as follows:

```python
import networkx as nx

def groups(many_to_one):
    one_to_many = defaultdict(set)
    for v, k in many_to_one.items():
        one_to_many[k].add(v)
    return dict(one_to_many)


def voronoi_cells(G, center_nodes, weight='weight'):
    paths = nx.multi_source_dijkstra_path(G, center_nodes, weight=weight)
    nearest = {v: p[0] for v, p in paths.items()}
    return groups(nearest)