### PR TITLE
Adds Voronoi cells algorithm

### DIFF
--- a/doc/source/reference/algorithms.rst
+++ b/doc/source/reference/algorithms.rst
@@ -53,4 +53,5 @@ Algorithms
    algorithms.tree
    algorithms.triads
    algorithms.vitality
+   algorithms.voronoi
    algorithms.wiener

--- a/doc/source/reference/algorithms.voronoi.rst
+++ b/doc/source/reference/algorithms.voronoi.rst
@@ -1,0 +1,9 @@
+*************
+Voronoi cells
+*************
+
+.. automodule:: networkx.algorithms.voronoi
+.. autosummary::
+   :toctree: generated/
+
+   voronoi_cells

--- a/doc/source/reference/utils.rst
+++ b/doc/source/reference/utils.rst
@@ -19,6 +19,8 @@ Helper Functions
    generate_unique_node
    default_opener
    pairwise
+   groups
+
 
 Data Structures and Algorithms
 ------------------------------

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -36,6 +36,7 @@ from networkx.algorithms.distance_regular import *
 from networkx.algorithms.swap import *
 from networkx.algorithms.graphical import *
 from networkx.algorithms.simple_paths import *
+from networkx.algorithms.voronoi import *
 from networkx.algorithms.wiener import *
 
 import networkx.algorithms.assortativity

--- a/networkx/algorithms/community/asyn_lpa.py
+++ b/networkx/algorithms/community/asyn_lpa.py
@@ -4,11 +4,10 @@
 #    BSD license.
 """Asynchronous label propagation algorithms for community detection."""
 
-import random
-from itertools import groupby
 from collections import Counter
+import random
 
-import networkx as nx
+from networkx.utils import groups
 
 
 def asyn_lpa_communities(G, weight=None):
@@ -85,5 +84,5 @@ def asyn_lpa_communities(G, weight=None):
             # neighbour labels (only one label has max_freq for each node).
             cont = cont or len(best_labels) > 1
 
-    return (set(v) for k, v in groupby(sorted(labels, key=labels.get),
-                                       key=labels.get))
+    # TODO In Python 3.3 or later, this should be `yield from ...`.
+    return iter(groups(labels).values())

--- a/networkx/algorithms/tests/test_voronoi.py
+++ b/networkx/algorithms/tests/test_voronoi.py
@@ -1,0 +1,106 @@
+# test_voronoi.py - unit tests for the networkx.algorithms.voronoi module
+#
+# Copyright 2016 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+from nose.tools import assert_equal
+
+import networkx as nx
+from networkx.utils import pairwise
+
+
+class TestVoronoiCells(object):
+    """Unit tests for the Voronoi cells function."""
+
+    def test_isolates(self):
+        """Tests that a graph with isolated nodes has all isolates in
+        one block of the partition.
+
+        """
+        G = nx.empty_graph(5)
+        cells = nx.voronoi_cells(G, {0, 2, 4})
+        expected = {0: {0}, 2: {2}, 4: {4}, 'unreachable': {1, 3}}
+        assert_equal(expected, cells)
+
+    def test_undirected_unweighted(self):
+        G = nx.cycle_graph(6)
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0, 1, 5}, 3: {2, 3, 4}}
+        assert_equal(expected, cells)
+
+    def test_directed_unweighted(self):
+        # This is the singly-linked directed cycle graph on six nodes.
+        G = nx.DiGraph(pairwise(range(6), cyclic=True))
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0, 1, 2}, 3: {3, 4, 5}}
+        assert_equal(expected, cells)
+
+    def test_directed_inward(self):
+        """Tests that reversing the graph gives the "inward" Voronoi
+        partition.
+
+        """
+        # This is the singly-linked reverse directed cycle graph on six nodes.
+        G = nx.DiGraph(pairwise(range(6), cyclic=True))
+        G.reverse(copy=False)
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0, 4, 5}, 3: {1, 2, 3}}
+        assert_equal(expected, cells)
+
+    def test_undirected_weighted(self):
+        edges = [(0, 1, 10), (1, 2, 1), (2, 3, 1)]
+        G = nx.Graph()
+        G.add_weighted_edges_from(edges)
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0}, 3: {1, 2, 3}}
+        assert_equal(expected, cells)
+
+    def test_directed_weighted(self):
+        edges = [(0, 1, 10), (1, 2, 1), (2, 3, 1), (3, 2, 1), (2, 1, 1)]
+        G = nx.DiGraph()
+        G.add_weighted_edges_from(edges)
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0}, 3: {1, 2, 3}}
+        assert_equal(expected, cells)
+
+    def test_multigraph_unweighted(self):
+        """Tests that the Voronoi cells for a multigraph are the same as
+        for a simple graph.
+
+        """
+        edges = [(0, 1), (1, 2), (2, 3)]
+        G = nx.MultiGraph(2 * edges)
+        H = nx.Graph(G)
+        G_cells = nx.voronoi_cells(G, {0, 3})
+        H_cells = nx.voronoi_cells(H, {0, 3})
+        assert_equal(G_cells, H_cells)
+
+    def test_multidigraph_unweighted(self):
+        # This is the twice-singly-linked directed cycle graph on six nodes.
+        edges = list(pairwise(range(6), cyclic=True))
+        G = nx.MultiDiGraph(2 * edges)
+        H = nx.DiGraph(G)
+        G_cells = nx.voronoi_cells(G, {0, 3})
+        H_cells = nx.voronoi_cells(H, {0, 3})
+        assert_equal(G_cells, H_cells)
+
+    def test_multigraph_weighted(self):
+        edges = [(0, 1, 10), (0, 1, 10), (1, 2, 1), (1, 2, 100), (2, 3, 1),
+                 (2, 3, 100)]
+        G = nx.MultiGraph()
+        G.add_weighted_edges_from(edges)
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0}, 3: {1, 2, 3}}
+        assert_equal(expected, cells)
+
+    def test_multidigraph_weighted(self):
+        edges = [(0, 1, 10), (0, 1, 10), (1, 2, 1), (2, 3, 1), (3, 2, 10),
+                 (3, 2, 1), (2, 1, 10), (2, 1, 1)]
+        G = nx.MultiDiGraph()
+        G.add_weighted_edges_from(edges)
+        cells = nx.voronoi_cells(G, {0, 3})
+        expected = {0: {0}, 3: {1, 2, 3}}
+        assert_equal(expected, cells)

--- a/networkx/algorithms/voronoi.py
+++ b/networkx/algorithms/voronoi.py
@@ -1,0 +1,93 @@
+# voronoi.py - functions for computing the Voronoi partition of a graph
+#
+# Copyright 2016 NetworkX developers.
+#
+# This file is part of NetworkX.
+#
+# NetworkX is distributed under a BSD license; see LICENSE.txt for more
+# information.
+"""Functions for computing the Voronoi cells of a graph."""
+import networkx as nx
+from networkx.utils import groups
+
+__all__ = ['voronoi_cells']
+
+
+def voronoi_cells(G, center_nodes, weight='weight'):
+    """Returns the Voronoi cells centered at `center_nodes` with respect
+    to the shortest-path distance metric.
+
+    If *C* is a set of nodes in the graph and *c* is an element of *C*,
+    the *Voronoi cell* centered at a node *c* is the set of all nodes
+    *v* that are closer to *c* than to any other center node in *C* with
+    respect to the shortest-path distance metric. [1]_
+
+    For directed graphs, this will compute the "outward" Voronoi cells,
+    as defined in [1]_, in which distance is measured from the center
+    nodes to the target node. For the "inward" Voronoi cells, use the
+    :meth:`DiGraph.reverse` method to reverse the orientation of the
+    edges before invoking this function on the directed graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    center_nodes : set
+        A nonempty set of nodes in the graph `G` that represent the
+        center of the Voronoi cells.
+
+    weight : string or function
+        The edge attribute (or an arbitrary function) representing the
+        weight of an edge. This keyword argument is as described in the
+        documentation for :func:`~networkx.multi_source_dijkstra_path`,
+        for example.
+
+    Returns
+    -------
+    dictionary
+        A mapping from center node to set of all nodes in the graph
+        closer to that center node than to any other center node. The
+        keys of the dictionary are the element of `center_nodes`, and
+        the values of the dictionary form a partition of the nodes of
+        `G`.
+
+    Examples
+    --------
+    To get only the partition of the graph induced by the Voronoi cells,
+    take the collection of all values in the returned dictionary::
+
+        >>> G = nx.path_graph(6)
+        >>> center_nodes = {0, 3}
+        >>> cells = nx.voronoi_cells(G, center_nodes)
+        >>> partition = set(map(frozenset, cells.values()))
+        >>> sorted(map(sorted, partition))
+        [[0, 1], [2, 3, 4, 5]]
+
+    Raises
+    ------
+    ValueError
+        If `center_nodes` is empty.
+
+    References
+    ----------
+    .. [1] Erwig, Martin. (2000),
+           "The graph Voronoi diagram with applications."
+           *Networks*, 36: 156--163.
+           <dx.doi.org/10.1002/1097-0037(200010)36:3<156::AID-NET2>3.0.CO;2-L>
+
+    """
+    # Determine the shortest paths from any one of the center nodes to
+    # every node in the graph.
+    #
+    # This raises `ValueError` if `center_nodes` is an empty set.
+    paths = nx.multi_source_dijkstra_path(G, center_nodes, weight=weight)
+    # Determine the center node from which the shortest path originates.
+    nearest = {v: p[0] for v, p in paths.items()}
+    # Get the mapping from center node to all nodes closer to it than to
+    # any other center node.
+    cells = groups(nearest)
+    # We collect all unreachable nodes under a special key, if there are any.
+    unreachable = set(G) - set(nearest)
+    if unreachable:
+        cells['unreachable'] = unreachable
+    return cells

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -18,7 +18,8 @@ True
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-import collections
+from collections import defaultdict
+from collections import deque
 import sys
 import uuid
 from itertools import tee, chain
@@ -219,7 +220,7 @@ def arbitrary_element(iterable):
 def consume(iterator):
     "Consume the iterator entirely."
     # Feed the entire iterator into a zero-length deque.
-    collections.deque(iterator, maxlen=0)
+    deque(iterator, maxlen=0)
 
 
 # Recipe from the itertools documentation.
@@ -230,6 +231,29 @@ def pairwise(iterable, cyclic=False):
     if cyclic is True:
         return zip(a, chain(b, (first,)))
     return zip(a, b)
+
+
+def groups(many_to_one):
+    """Converts a many-to-one mapping into a one-to-many mapping.
+
+    `many_to_one` must be a dictionary whose keys and values are all
+    :term:`hashable`.
+
+    The return value is a dictionary mapping values from `many_to_one`
+    to sets of keys from `many_to_one` that have that value.
+
+    For example::
+
+        >>> from networkx.utils import groups
+        >>> many_to_one = {'a': 1, 'b': 1, 'c': 2, 'd': 3, 'e': 3}
+        >>> groups(many_to_one)  # doctest: +SKIP
+        {1: {'a', 'b'}, 2: {'c'}, 3: {'d', 'e'}}
+
+    """
+    one_to_many = defaultdict(set)
+    for v, k in many_to_one.items():
+        one_to_many[k].add(v)
+    return dict(one_to_many)
 
 
 def is_path(G, *path):

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -130,3 +130,11 @@ def test_pairwise():
     assert_equal(list(pairwise(empty_iter)), [])
     empty_iter = iter(())
     assert_equal(list(pairwise(empty_iter, cyclic=True)), [])
+
+
+def test_groups():
+    many_to_one = dict(zip('abcde', [0, 0, 1, 1, 2]))
+    actual = groups(many_to_one)
+    expected = {0: {'a', 'b'}, 1: {'c', 'd'}, 2: {'e'}}
+    assert_equal(actual, expected)
+    assert_equal({}, groups({}))


### PR DESCRIPTION
This provides a new function, `voronoi_cells`, that computes the Voronoi partition of a graph with a given set of center nodes, with respect to the shortest-path distance metric.

This pull request uses the multi-source Dijkstra's algorithm from pull request #2073 and supercedes #2037.

The first commit refactors out a utility function, `groups()`, for "inverting" a many-to-one mapping which can be used in the `networkx.algorithms.community.asyn_lpa` module as well as in the `networkx.algorithms.voronoi` module.