### PR TITLE
See also-correction

### DIFF
--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
-"""
-Attracting components.
-"""
 #    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Christopher Ellison
+"""Attracting components."""
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
-__authors__ = "\n".join(['Christopher Ellison'])
+
 __all__ = ['number_attracting_components', 
            'attracting_components',
            'is_attracting_component', 
@@ -39,6 +39,11 @@ def attracting_components(G):
     attractors : generator of sets
         A generator of sets of nodes, one for each attracting component of G.
 
+    Raises
+    ------
+    NetworkXNotImplemented :
+        If the input graph is undirected.
+
     See Also
     --------
     number_attracting_components
@@ -66,6 +71,11 @@ def number_attracting_components(G):
     n : int
         The number of attracting components in G.
 
+    Raises
+    ------
+    NetworkXNotImplemented :
+        If the input graph is undirected.
+
     See Also
     --------
     attracting_components
@@ -90,6 +100,11 @@ def is_attracting_component(G):
     -------
     attracting : bool
         True if `G` has a single attracting component. Otherwise, False.
+
+    Raises
+    ------
+    NetworkXNotImplemented :
+        If the input graph is undirected.
 
     See Also
     --------
@@ -123,6 +138,11 @@ def attracting_component_subgraphs(G, copy=True):
     copy : bool
         If copy is True, graph, node, and edge attributes are copied to the 
         subgraphs.
+
+    Raises
+    ------
+    NetworkXNotImplemented :
+        If the input graph is undirected.
 
     See Also
     --------

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -11,11 +11,12 @@
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
-__all__ = ['number_attracting_components', 
+__all__ = ['number_attracting_components',
            'attracting_components',
-           'is_attracting_component', 
+           'is_attracting_component',
            'attracting_component_subgraphs',
            ]
+
 
 @not_implemented_for('undirected')
 def attracting_components(G):
@@ -47,7 +48,7 @@ def attracting_components(G):
     See Also
     --------
     number_attracting_components
-    is_attracting_component 
+    is_attracting_component
     attracting_component_subgraphs
 
     """
@@ -56,6 +57,7 @@ def attracting_components(G):
     for n in cG:
         if cG.out_degree(n) == 0:
             yield scc[n]
+
 
 @not_implemented_for('undirected')
 def number_attracting_components(G):
@@ -136,7 +138,7 @@ def attracting_component_subgraphs(G, copy=True):
         A list of node-induced subgraphs of the attracting components of `G`.
 
     copy : bool
-        If copy is True, graph, node, and edge attributes are copied to the 
+        If copy is True, graph, node, and edge attributes are copied to the
         subgraphs.
 
     Raises

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
-"""
-Biconnected components and articulation points.
-"""
-#    Copyright (C) 2011-2013 by
+#    Copyright (C) 2011-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Jordi Torrents (jtorrents@milnou.net)
+#          Dan Schult (dschult@colgate.edu)
+#          Aric Hagberg (aric.hagberg@gmail.com)
+"""Biconnected components and articulation points."""
 from itertools import chain
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
-
-__author__ = '\n'.join(['Jordi Torrents <jtorrents@milnou.net>',
-                        'Dan Schult <dschult@colgate.edu>',
-                        'Aric Hagberg <aric.hagberg@gmail.com>'])
 
 __all__ = [
     'biconnected_components',
@@ -30,7 +28,7 @@ def is_biconnected(G):
     """Return True if the graph is biconnected, False otherwise.
 
     A graph is biconnected if, and only if, it cannot be disconnected by
-    removing only one node (and all edges incident on that node). If
+    removing only one node (and all edges incident on that node).  If
     removing a node increases the number of disconnected components
     in the graph, that node is called an articulation point, or cut
     vertex.  A biconnected graph has no articulation points.
@@ -65,16 +63,20 @@ def is_biconnected(G):
     articulation_points
     biconnected_component_edges
     biconnected_component_subgraphs
+    components.is_strongly_connected
+    components.is_weakly_connected
+    components.is_connected
+    components.is_semiconnected
 
     Notes
     -----
     The algorithm to find articulation points and biconnected
     components is implemented using a non-recursive depth-first-search
     (DFS) that keeps track of the highest level that back edges reach
-    in the DFS tree. A node `n` is an articulation point if, and only
+    in the DFS tree.  A node `n` is an articulation point if, and only
     if, there exists a subtree rooted at `n` such that there is no
     back edge from any successor of `n` that links to a predecessor of
-    `n` in the DFS tree. By keeping track of all the edges traversed
+    `n` in the DFS tree.  By keeping track of all the edges traversed
     by the DFS we can obtain the biconnected components because all
     edges of a bicomponent will be traversed consecutively between
     articulation points.
@@ -99,9 +101,9 @@ def biconnected_component_edges(G):
 
     Biconnected components are maximal subgraphs such that the removal of a
     node (and all edges incident on that node) will not disconnect the
-    subgraph. Note that nodes may be part of more than one biconnected
-    component. Those nodes are articulation points, or cut vertices. However,
-    each edge belongs to one, and only one, biconnected component.
+    subgraph.  Note that nodes may be part of more than one biconnected
+    component.  Those nodes are articulation points, or cut vertices.
+    However, each edge belongs to one, and only one, biconnected component.
 
     Notice that by convention a dyad is considered a biconnected component.
 
@@ -147,10 +149,10 @@ def biconnected_component_edges(G):
     The algorithm to find articulation points and biconnected
     components is implemented using a non-recursive depth-first-search
     (DFS) that keeps track of the highest level that back edges reach
-    in the DFS tree. A node `n` is an articulation point if, and only
+    in the DFS tree.  A node `n` is an articulation point if, and only
     if, there exists a subtree rooted at `n` such that there is no
     back edge from any successor of `n` that links to a predecessor of
-    `n` in the DFS tree. By keeping track of all the edges traversed
+    `n` in the DFS tree.  By keeping track of all the edges traversed
     by the DFS we can obtain the biconnected components because all
     edges of a bicomponent will be traversed consecutively between
     articulation points.
@@ -174,7 +176,7 @@ def biconnected_components(G):
     Biconnected components are maximal subgraphs such that the removal of a
     node (and all edges incident on that node) will not disconnect the
     subgraph. Note that nodes may be part of more than one biconnected
-    component. Those nodes are articulation points, or cut vertices. The
+    component.  Those nodes are articulation points, or cut vertices.  The
     removal of articulation points will increase the number of connected
     components of the graph.
 
@@ -224,9 +226,9 @@ def biconnected_components(G):
 
     See Also
     --------
-    is_biconnected,
-    articulation_points,
-    biconnected_component_edges,
+    is_biconnected
+    articulation_points
+    biconnected_component_edges
     biconnected_component_subgraphs
 
     Notes
@@ -234,10 +236,10 @@ def biconnected_components(G):
     The algorithm to find articulation points and biconnected
     components is implemented using a non-recursive depth-first-search
     (DFS) that keeps track of the highest level that back edges reach
-    in the DFS tree. A node `n` is an articulation point if, and only
+    in the DFS tree.  A node `n` is an articulation point if, and only
     if, there exists a subtree rooted at `n` such that there is no
     back edge from any successor of `n` that links to a predecessor of
-    `n` in the DFS tree. By keeping track of all the edges traversed
+    `n` in the DFS tree.  By keeping track of all the edges traversed
     by the DFS we can obtain the biconnected components because all
     edges of a bicomponent will be traversed consecutively between
     articulation points.
@@ -259,8 +261,8 @@ def biconnected_component_subgraphs(G, copy=True):
 
     Biconnected components are maximal subgraphs such that the removal of a
     node (and all edges incident on that node) will not disconnect the
-    subgraph. Note that nodes may be part of more than one biconnected
-    component. Those nodes are articulation points, or cut vertices. The
+    subgraph.  Note that nodes may be part of more than one biconnected
+    component.  Those nodes are articulation points, or cut vertices.  The
     removal of articulation points will increase the number of connected
     components of the graph.
 
@@ -312,9 +314,9 @@ def biconnected_component_subgraphs(G, copy=True):
 
     See Also
     --------
-    is_biconnected,
-    articulation_points,
-    biconnected_component_edges,
+    is_biconnected
+    articulation_points
+    biconnected_component_edges
     biconnected_components
 
     Notes
@@ -322,10 +324,10 @@ def biconnected_component_subgraphs(G, copy=True):
     The algorithm to find articulation points and biconnected
     components is implemented using a non-recursive depth-first-search
     (DFS) that keeps track of the highest level that back edges reach
-    in the DFS tree. A node `n` is an articulation point if, and only
+    in the DFS tree.  A node `n` is an articulation point if, and only
     if, there exists a subtree rooted at `n` such that there is no
     back edge from any successor of `n` that links to a predecessor of
-    `n` in the DFS tree. By keeping track of all the edges traversed
+    `n` in the DFS tree.  By keeping track of all the edges traversed
     by the DFS we can obtain the biconnected components because all
     edges of a bicomponent will be traversed consecutively between
     articulation points.
@@ -352,7 +354,7 @@ def articulation_points(G):
 
     An articulation point or cut vertex is any node whose removal (along with
     all its incident edges) increases the number of connected components of
-    a graph. An undirected connected graph without articulation points is
+    a graph.  An undirected connected graph without articulation points is
     biconnected. Articulation points belong to more than one biconnected
     component of a graph.
 
@@ -389,9 +391,9 @@ def articulation_points(G):
 
     See Also
     --------
-    is_biconnected,
-    biconnected_components,
-    biconnected_component_edges,
+    is_biconnected
+    biconnected_components
+    biconnected_component_edges
     biconnected_component_subgraphs
 
     Notes
@@ -399,10 +401,10 @@ def articulation_points(G):
     The algorithm to find articulation points and biconnected
     components is implemented using a non-recursive depth-first-search
     (DFS) that keeps track of the highest level that back edges reach
-    in the DFS tree. A node `n` is an articulation point if, and only
+    in the DFS tree.  A node `n` is an articulation point if, and only
     if, there exists a subtree rooted at `n` such that there is no
     back edge from any successor of `n` that links to a predecessor of
-    `n` in the DFS tree. By keeping track of all the edges traversed
+    `n` in the DFS tree.  By keeping track of all the edges traversed
     by the DFS we can obtain the biconnected components because all
     edges of a bicomponent will be traversed consecutively between
     articulation points.

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -89,7 +89,7 @@ def is_biconnected(G):
 
     """
     bcc = list(biconnected_components(G))
-    if not bcc: # No bicomponents (it could be an empty graph)
+    if not bcc:  # No bicomponents (it could be an empty graph)
         return False
     return len(bcc[0]) == len(G)
 
@@ -253,6 +253,7 @@ def biconnected_components(G):
     """
     for comp in _biconnected_dfs(G, components=True):
         yield set(chain.from_iterable(comp))
+
 
 @not_implemented_for('directed')
 def biconnected_component_subgraphs(G, copy=True):
@@ -427,8 +428,8 @@ def _biconnected_dfs(G, components=True):
     for start in G:
         if start in visited:
             continue
-        discovery = {start:0} # "time" of first discovery of node during search
-        low = {start:0}
+        discovery = {start: 0}  # time of first discovery of node during search
+        low = {start: 0}
         root_children = 0
         visited.add(start)
         edge_stack = []
@@ -440,31 +441,31 @@ def _biconnected_dfs(G, components=True):
                 if grandparent == child:
                     continue
                 if child in visited:
-                    if discovery[child] <= discovery[parent]: # back edge
-                        low[parent] = min(low[parent],discovery[child])
+                    if discovery[child] <= discovery[parent]:  # back edge
+                        low[parent] = min(low[parent], discovery[child])
                         if components:
-                            edge_stack.append((parent,child))
+                            edge_stack.append((parent, child))
                 else:
                     low[child] = discovery[child] = len(discovery)
                     visited.add(child)
                     stack.append((parent, child, iter(G[child])))
                     if components:
-                        edge_stack.append((parent,child))
+                        edge_stack.append((parent, child))
             except StopIteration:
                 stack.pop()
                 if len(stack) > 1:
                     if low[parent] >= discovery[grandparent]:
                         if components:
-                            ind = edge_stack.index((grandparent,parent))
+                            ind = edge_stack.index((grandparent, parent))
                             yield edge_stack[ind:]
-                            edge_stack=edge_stack[:ind]
+                            edge_stack = edge_stack[:ind]
                         else:
                             yield grandparent
                     low[grandparent] = min(low[parent], low[grandparent])
-                elif stack: # length 1 so grandparent is root
+                elif stack:  # length 1 so grandparent is root
                     root_children += 1
                     if components:
-                        ind = edge_stack.index((grandparent,parent))
+                        ind = edge_stack.index((grandparent, parent))
                         yield edge_stack[ind:]
         if not components:
             # root node is articulation point if it has more than 1 child

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -1,20 +1,19 @@
 # -*- coding: utf-8 -*-
-"""
-Connected components.
-"""
-#    Copyright (C) 2004-2013 by
+#    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Eben Kenah
+#          Aric Hagberg (hagberg@lanl.gov)
+#          Christopher Ellison
+"""Connected components."""
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 from ...utils import arbitrary_element
 
-__authors__ = "\n".join(['Eben Kenah',
-                         'Aric Hagberg <aric.hagberg@gmail.com>'
-                         'Christopher Ellison'])
 __all__ = [
     'number_connected_components',
     'connected_components',
@@ -38,6 +37,11 @@ def connected_components(G):
     comp : generator of sets
        A generator of sets of nodes, one for each component of G.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     Examples
     --------
     Generate a sorted list of connected components, largest first.
@@ -54,7 +58,8 @@ def connected_components(G):
 
     See Also
     --------
-    strongly_connected_components
+    components.strongly_connected_components
+    components.weakly_connected_components
 
     Notes
     -----
@@ -86,6 +91,11 @@ def connected_component_subgraphs(G, copy=True):
     comp : generator
       A generator of graphs, one for each connected component of G.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     Examples
     --------
     >>> G = nx.path_graph(4)
@@ -93,13 +103,15 @@ def connected_component_subgraphs(G, copy=True):
     >>> graphs = list(nx.connected_component_subgraphs(G))
 
     If you only want the largest connected component, it's more
-    efficient to use max than sort.
+    efficient to use max instead of sort:
 
     >>> Gc = max(nx.connected_component_subgraphs(G), key=len)
 
     See Also
     --------
     connected_components
+    components.strongly_connected_component_subgraphs
+    components.weakly_connected_component_subgraphs
 
     Notes
     -----
@@ -130,6 +142,8 @@ def number_connected_components(G):
     See Also
     --------
     connected_components
+    components.number_weakly_connected_components
+    components.number_strongly_connected_components
 
     Notes
     -----
@@ -153,6 +167,11 @@ def is_connected(G):
     connected : bool
       True if the graph is connected, false otherwise.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     Examples
     --------
     >>> G = nx.path_graph(4)
@@ -161,6 +180,10 @@ def is_connected(G):
 
     See Also
     --------
+    components.is_strongly_connected
+    components.is_weakly_connected
+    components.is_semiconnected
+    components.is_biconnected
     connected_components
 
     Notes
@@ -190,6 +213,11 @@ def node_connected_component(G, n):
     -------
     comp : set
        A set of nodes in the component of G containing node n.
+
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
 
     See Also
     --------

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
-"""
-Semiconnectedness.
-"""
-
-__author__ = """ysitu <ysitu@users.noreply.github.com>"""
-# Copyright (C) 2014 ysitu <ysitu@users.noreply.github.com>
-# All rights reserved.
-# BSD license.
-
+#    Copyright (C) 2004-2016 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Authors: ysitu (ysitu@users.noreply.github.com)
+"""Semiconnectedness."""
 import networkx as nx
 from networkx.utils import not_implemented_for, pairwise
 
 __all__ = ['is_semiconnected']
+
 
 @not_implemented_for('undirected')
 def is_semiconnected(G):
@@ -33,7 +34,7 @@ def is_semiconnected(G):
     Raises
     ------
     NetworkXNotImplemented :
-        If the input graph is not directed.
+        If the input graph is undirected.
 
     NetworkXPointlessConcept :
         If the graph is empty.
@@ -49,8 +50,10 @@ def is_semiconnected(G):
 
     See Also
     --------
-    is_strongly_connected,
-    is_weakly_connected
+    components.is_strongly_connected
+    components.is_weakly_connected
+    components.is_connected
+    components.is_biconnected
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept(

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
-"""Strongly connected components.
-"""
 #    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Eben Kenah
+#          Aric Hagberg (hagberg@lanl.gov)
+#          Christopher Ellison
+#          Ben Edwards (bedwards@cs.unm.edu)
+"""Strongly connected components."""
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
-
-__authors__ = "\n".join(['Eben Kenah',
-                         'Aric Hagberg (hagberg@lanl.gov)'
-                         'Christopher Ellison',
-                         'Ben Edwards (bedwards@cs.unm.edu)'])
 
 __all__ = ['number_strongly_connected_components',
            'strongly_connected_components',
@@ -41,7 +40,7 @@ def strongly_connected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented :
         If G is undirected.
 
     Examples
@@ -61,12 +60,13 @@ def strongly_connected_components(G):
 
     See Also
     --------
-    connected_components,
-    weakly_connected_components
+    components.connected_components
+    components.weakly_connected_components
+    kosaraju_strongly_connected_components
 
     Notes
     -----
-    Uses Tarjan's algorithm with Nuutila's modifications.
+    Uses Tarjan's algorithm[1]_ with Nuutila's modifications[2]_.
     Nonrecursive version of algorithm.
 
     References
@@ -157,8 +157,7 @@ def kosaraju_strongly_connected_components(G, source=None):
 
     See Also
     --------
-    connected_components
-    weakly_connected_components
+    strongly_connected_components
 
     Notes
     -----
@@ -198,8 +197,8 @@ def strongly_connected_components_recursive(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
-        If G is undirected
+    NetworkXNotImplemented :
+        If G is undirected.
 
     Examples
     --------
@@ -222,7 +221,7 @@ def strongly_connected_components_recursive(G):
 
     Notes
     -----
-    Uses Tarjan's algorithm with Nuutila's modifications.
+    Uses Tarjan's algorithm[1]_ with Nuutila's modifications[2]_.
 
     References
     ----------
@@ -284,6 +283,11 @@ def strongly_connected_component_subgraphs(G, copy=True):
     comp : generator of graphs
       A generator of graphs, one for each strongly connected component of G.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     Examples
     --------
     Generate a sorted list of strongly connected components, largest first.
@@ -301,8 +305,9 @@ def strongly_connected_component_subgraphs(G, copy=True):
 
     See Also
     --------
-    connected_component_subgraphs
-    weakly_connected_component_subgraphs
+    strongly_connected_components
+    components.connected_component_subgraphs
+    components.weakly_connected_component_subgraphs
 
     """
     for comp in strongly_connected_components(G):
@@ -326,9 +331,16 @@ def number_strongly_connected_components(G):
     n : integer
        Number of strongly connected components
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     See Also
     --------
-    connected_components
+    strongly_connected_components
+    components.number_connected_components
+    components.number_weakly_connected_components
 
     Notes
     -----
@@ -351,8 +363,17 @@ def is_strongly_connected(G):
     connected : bool
       True if the graph is strongly connected, False otherwise.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     See Also
     --------
+    components.is_weakly_connected
+    components.is_semiconnected
+    components.is_connected
+    components.is_biconnected
     strongly_connected_components
 
     Notes
@@ -386,18 +407,18 @@ def condensation(G, scc=None):
     Returns
     -------
     C : NetworkX DiGraph
-       The condensation graph C of G. The node labels are integers
+       The condensation graph C of G.  The node labels are integers
        corresponding to the index of the component in the list of
-       strongly connected components of G. C has a graph attribute named
+       strongly connected components of G.  C has a graph attribute named
        'mapping' with a dictionary mapping the original nodes to the
-       nodes in C to which they belong. Each node in C also has a node
+       nodes in C to which they belong.  Each node in C also has a node
        attribute 'members' with the set of original nodes in G that
        form the SCC that the node in C represents.
 
     Raises
     ------
     NetworkXNotImplemented:
-        If G is not directed
+        If G is undirected.
 
     Notes
     -----

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
-"""Weakly connected components.
-"""
 #    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-
+#
+# Authors: Aric Hagberg (hagberg@lanl.gov)
+#          Christopher Ellison
+"""Weakly connected components."""
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
-
-__authors__ = "\n".join(['Aric Hagberg (hagberg@lanl.gov)'
-                         'Christopher Ellison'])
 
 __all__ = [
     'number_weakly_connected_components',
@@ -37,6 +35,11 @@ def weakly_connected_components(G):
         A generator of sets of nodes, one for each weakly connected
         component of G.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     Examples
     --------
     Generate a sorted list of weakly connected components, largest first.
@@ -48,13 +51,14 @@ def weakly_connected_components(G):
     [4, 3]
 
     If you only want the largest component, it's more efficient to
-    use max instead of sort.
+    use max instead of sort:
 
     >>> largest_cc = max(nx.weakly_connected_components(G), key=len)
 
     See Also
     --------
-    strongly_connected_components
+    components.connected_components
+    components.strongly_connected_components
 
     Notes
     -----
@@ -83,9 +87,16 @@ def number_weakly_connected_components(G):
     n : integer
         Number of weakly connected components
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     See Also
     --------
-    connected_components
+    weakly_connected_components
+    components.number_connected_components
+    components.number_strongly_connected_components
 
     Notes
     -----
@@ -112,6 +123,11 @@ def weakly_connected_component_subgraphs(G, copy=True):
     comp : generator
         A generator of graphs, one for each weakly connected component of G.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     Examples
     --------
     Generate a sorted list of weakly connected components, largest first.
@@ -123,14 +139,15 @@ def weakly_connected_component_subgraphs(G, copy=True):
     [4, 3]
 
     If you only want the largest component, it's more efficient to
-    use max instead of sort.
+    use max instead of sort:
 
     >>> Gc = max(nx.weakly_connected_component_subgraphs(G), key=len)
 
     See Also
     --------
-    strongly_connected_components
-    connected_components
+    weakly_connected_components
+    components.strongly_connected_component_subgraphs
+    components.connected_component_subgraphs
 
     Notes
     -----
@@ -162,11 +179,18 @@ def is_weakly_connected(G):
     connected : bool
         True if the graph is weakly connected, False otherwise.
 
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If G is undirected.
+
     See Also
     --------
-    is_strongly_connected
-    is_semiconnected
-    is_connected
+    components.is_strongly_connected
+    components.is_semiconnected
+    components.is_connected
+    components.is_biconnected
+    weakly_connected_components
 
     Notes
     -----


### PR DESCRIPTION
This is an attempt to fix #1176, which is about missing links to methods in other modules. Working on the docstrings, I added some references in text and added `raises` statements where they were missing.

Furthermore, I updated the tops of the modules to current standards and applied PEP8 in the code.