### PR TITLE
Sort centralities together and outsource dispersion

### DIFF
--- a/doc/source/reference/algorithms.centrality.rst
+++ b/doc/source/reference/algorithms.centrality.rst
@@ -1,6 +1,7 @@
 **********
 Centrality
 **********
+
 .. automodule:: networkx.algorithms.centrality
 
 Degree
@@ -12,41 +13,6 @@ Degree
    in_degree_centrality
    out_degree_centrality
 
-Closeness
----------
-.. autosummary::
-   :toctree: generated/
-
-   closeness_centrality
-
-Betweenness
------------
-.. autosummary::
-   :toctree: generated/
-
-   betweenness_centrality
-   edge_betweenness_centrality
-   betweenness_centrality_subset
-   edge_betweenness_centrality_subset
-
-Current Flow Closeness
-----------------------
-.. autosummary::
-   :toctree: generated/
-
-   current_flow_closeness_centrality
-
-Current-Flow Betweenness
-------------------------
-.. autosummary::
-   :toctree: generated/
-
-   current_flow_betweenness_centrality
-   edge_current_flow_betweenness_centrality
-   approximate_current_flow_betweenness_centrality
-   current_flow_betweenness_centrality_subset
-   edge_current_flow_betweenness_centrality_subset
-
 Eigenvector
 -----------
 .. autosummary::
@@ -57,15 +23,48 @@ Eigenvector
    katz_centrality
    katz_centrality_numpy
 
-Subgraph
---------
+Closeness
+---------
+.. autosummary::
+   :toctree: generated/
+
+   closeness_centrality
+
+Current Flow Closeness
+----------------------
+.. autosummary::
+   :toctree: generated/
+
+   current_flow_closeness_centrality
+
+(Shortest Path) Betweenness
+---------------------------
+.. autosummary::
+   :toctree: generated/
+
+   betweenness_centrality
+   edge_betweenness_centrality
+   betweenness_centrality_subset
+   edge_betweenness_centrality_subset
+
+
+Current Flow Betweenness
+------------------------
+.. autosummary::
+   :toctree: generated/
+
+   current_flow_betweenness_centrality
+   edge_current_flow_betweenness_centrality
+   approximate_current_flow_betweenness_centrality
+   current_flow_betweenness_centrality_subset
+   edge_current_flow_betweenness_centrality_subset
+
+Communicability Betweenness
+---------------------------
 .. autosummary::
    :toctree: generated/
 
    communicability_betweenness_centrality
-   estrada_index
-   subgraph_centrality
-   subgraph_centrality_exp
 
 Load
 ----
@@ -75,12 +74,14 @@ Load
    load_centrality
    edge_load_centrality
 
-Dispersion
-----------
+Subgraph
+--------
 .. autosummary::
    :toctree: generated/
 
-   dispersion
+   subgraph_centrality
+   subgraph_centrality_exp
+   estrada_index
 
 Harmonic Centrality
 -------------------

--- a/doc/source/reference/algorithms.dispersion.rst
+++ b/doc/source/reference/algorithms.dispersion.rst
@@ -1,0 +1,12 @@
+**********
+Dispersion
+**********
+
+.. automodule:: networkx.algorithms.dispersion
+
+   Dispersion
+----------
+.. autosummary::
+   :toctree: generated/
+
+   dispersion

--- a/doc/source/reference/algorithms.rst
+++ b/doc/source/reference/algorithms.rst
@@ -26,6 +26,7 @@ Algorithms
    algorithms.cycles
    algorithms.cuts
    algorithms.dag
+   algorithms.dispersion
    algorithms.distance_measures
    algorithms.distance_regular
    algorithms.dominance


### PR DESCRIPTION
This is to fix #1397.

Basically, there are three types of centralities: Based on paths, neighbors and the entire network. Those based on paths are usually betweenness centralities, while those based on neighbors (degree centrality, eigenvector centrality, katz centrality). The latter category are usually called closeness centralities. I ordered all the centralities in `algorithms.centrality.rst` by category.

Furthermore I outsourced `dispersion` into a new file/page because it's not a centrality.