### PR TITLE
Use not_implemented_for() for in_degree_centrality() and out_degree_centrality()

### DIFF
--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -1,22 +1,21 @@
-"""
-Degree centrality measures.
-
-"""
 #    Copyright (C) 2004-2016 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-__author__ = "\n".join(['Aric Hagberg (hagberg@lanl.gov)',
-                        'Pieter Swart (swart@lanl.gov)',
-                        'Sasha Gutfraind (ag362@cornell.edu)'])
+#
+# Authors: Aric Hagberg (hagberg@lanl.gov)
+#          Pieter Swart (swart@lanl.gov)
+#          Sasha Gutfraind (ag362@cornell.edu)
+"""Degree centrality measures."""
+import networkx as nx
+from networkx.utils.decorators import not_implemented_for
 
 __all__ = ['degree_centrality',
            'in_degree_centrality',
            'out_degree_centrality']
 
-import networkx as nx
 
 def degree_centrality(G):
     """Compute the degree centrality for nodes.
@@ -27,7 +26,7 @@ def degree_centrality(G):
     Parameters
     ----------
     G : graph
-      A networkx graph 
+      A networkx graph
 
     Returns
     -------
@@ -40,22 +39,24 @@ def degree_centrality(G):
 
     Notes
     -----
-    The degree centrality values are normalized by dividing by the maximum 
+    The degree centrality values are normalized by dividing by the maximum
     possible degree in a simple graph n-1 where n is the number of nodes in G.
 
     For multigraphs or graphs with self loops the maximum degree might
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality={}
-    s=1.0/(len(G)-1.0)
-    centrality=dict((n,d*s) for n,d in G.degree())
+    centrality = {}
+    s = 1.0/(len(G)-1.0)
+    centrality = {n: d*s for n, d in G.degree()}
     return centrality
 
+
+@not_implemented_for('undirected')
 def in_degree_centrality(G):
     """Compute the in-degree centrality for nodes.
 
-    The in-degree centrality for a node v is the fraction of nodes its 
+    The in-degree centrality for a node v is the fraction of nodes its
     incoming edges are connected to.
 
     Parameters
@@ -70,8 +71,8 @@ def in_degree_centrality(G):
 
     Raises
     ------
-    NetworkXError
-       If the graph is undirected.
+    NetworkXNotImplemented:
+        If G is undirected.
 
     See Also
     --------
@@ -79,26 +80,24 @@ def in_degree_centrality(G):
 
     Notes
     -----
-    The degree centrality values are normalized by dividing by the maximum 
+    The degree centrality values are normalized by dividing by the maximum
     possible degree in a simple graph n-1 where n is the number of nodes in G.
 
     For multigraphs or graphs with self loops the maximum degree might
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    if not G.is_directed():
-        raise nx.NetworkXError(\
-            "in_degree_centrality() not defined for undirected graphs.")
-    centrality={}
-    s=1.0/(len(G)-1.0)
-    centrality=dict((n,d*s) for n,d in G.in_degree())
+    centrality = {}
+    s = 1.0/(len(G)-1.0)
+    centrality = {n: d*s for n, d in G.in_degree()}
     return centrality
 
 
+@not_implemented_for('undirected')
 def out_degree_centrality(G):
     """Compute the out-degree centrality for nodes.
 
-    The out-degree centrality for a node v is the fraction of nodes its 
+    The out-degree centrality for a node v is the fraction of nodes its
     outgoing edges are connected to.
 
     Parameters
@@ -113,8 +112,8 @@ def out_degree_centrality(G):
 
     Raises
     ------
-    NetworkXError
-       If the graph is undirected.
+    NetworkXNotImplemented:
+        If G is undirected.
 
     See Also
     --------
@@ -122,20 +121,14 @@ def out_degree_centrality(G):
 
     Notes
     -----
-    The degree centrality values are normalized by dividing by the maximum 
+    The degree centrality values are normalized by dividing by the maximum
     possible degree in a simple graph n-1 where n is the number of nodes in G.
 
     For multigraphs or graphs with self loops the maximum degree might
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    if not G.is_directed():
-        raise nx.NetworkXError(\
-            "out_degree_centrality() not defined for undirected graphs.")
-    centrality={}
-    s=1.0/(len(G)-1.0)
-    centrality=dict((n,d*s) for n,d in G.out_degree())
+    centrality = {}
+    s = 1.0/(len(G)-1.0)
+    centrality = {n: d*s for n, d in G.out_degree()}
     return centrality
-
-
-


### PR DESCRIPTION
Using `not_implemented_for()` from `networkx.utils.decorators` for `in_degree_centrality()` and `out_degree_centrality()`. Applying PEP8 (removing trailing whitespaces and adding missing whitespaces) and current top-of-the-module standards as well.