### PR TITLE
Document integer-only numeric mixing

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -190,13 +190,15 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
 
     Assortativity measures the similarity of connections
     in the graph with respect to the given numeric attribute.
-    
+    The numeric attribute must be an integer.
+
     Parameters
     ----------
     G : NetworkX graph
 
     attribute : string 
-        Node attribute key
+        Node attribute key.  The corresponding attribute value must be an
+        integer.
 
     nodes: list or iterable (optional)
         Compute numeric assortativity only for attributes of nodes in 

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -166,13 +166,15 @@ def degree_mixing_matrix(G, x='out', y='in', weight=None,
 def numeric_mixing_matrix(G,attribute,nodes=None,normalized=True):
     """Return numeric mixing matrix for attribute.
 
+    The attribute must be an integer.
+
     Parameters
     ----------
     G : graph 
        NetworkX graph object.
 
     attribute : string 
-       Node attribute key.
+       Node attribute key.  The corresponding attribute must be an integer.
 
     nodes: list or iterable (optional)
         Build the matrix only with nodes in container. The default is all nodes.


### PR DESCRIPTION
The numeric mixing and assortativity algorithms only work for integers.
They could be implemented to work for floating point numbers too.

Fixes #1981 
