### PR TITLE
doc sphinx error removal

### DIFF
--- a/doc/source/reference/algorithms.rst
+++ b/doc/source/reference/algorithms.rst
@@ -30,6 +30,7 @@ Algorithms
    algorithms.distance_regular
    algorithms.dominance
    algorithms.dominating
+   algorithms.efficiency
    algorithms.euler
    algorithms.flow
    algorithms.graphical

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -60,9 +60,9 @@ def random_geometric_graph(n, radius, dim=2, pos=None, metric=None):
         A metric on vectors of numbers (represented as lists or
         tuples). This must be a function that accepts two lists (or
         tuples) as input and yields a number as output. The function
-        must also satisfy the four requirements of a
-        `metric`_. Specifically, if *d* is the function and *x*, *y*,
-        and *x* are vectors in the graph, then *d* must satisfy
+        must also satisfy the four requirements of a `metric`_.
+        Specifically, if *d* is the function and *x*, *y*,
+        and *z* are vectors in the graph, then *d* must satisfy
 
         1. *d*(*x*, *y*) ≥ 0,
         2. *d*(*x*, *y*) = 0 if and only if *x* = *y*,
@@ -71,8 +71,6 @@ def random_geometric_graph(n, radius, dim=2, pos=None, metric=None):
 
         If this argument is not specified, the Euclidean distance metric is
         used.
-
-    .. _metric: https://en.wikipedia.org/wiki/Metric_%28mathematics%29
 
     Returns
     -------
@@ -99,6 +97,8 @@ def random_geometric_graph(n, radius, dim=2, pos=None, metric=None):
 
     .. _taxicab metric: https://en.wikipedia.org/wiki/Taxicab_geometry
     .. _Euclidean metric: https://en.wikipedia.org/wiki/Euclidean_distance
+    .. _metric: https://en.wikipedia.org/wiki/Metric_%28mathematics%29
+
 
     Notes
     -----
@@ -193,9 +193,9 @@ def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
         A metric on vectors of numbers (represented as lists or
         tuples). This must be a function that accepts two lists (or
         tuples) as input and yields a number as output. The function
-        must also satisfy the four requirements of a
-        `metric`_. Specifically, if *d* is the function and *x*, *y*,
-        and *x* are vectors in the graph, then *d* must satisfy
+        must also satisfy the four requirements of a `metric`_.
+        Specifically, if *d* is the function and *x*, *y*,
+        and *z* are vectors in the graph, then *d* must satisfy
 
         1. *d*(*x*, *y*) ≥ 0,
         2. *d*(*x*, *y*) = 0 if and only if *x* = *y*,
@@ -204,8 +204,6 @@ def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
 
         If this argument is not specified, the Euclidean distance metric is
         used.
-
-    .. _metric: https://en.wikipedia.org/wiki/Metric_%28mathematics%29
 
     Returns
     -------
@@ -231,6 +229,8 @@ def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
 
     .. _taxicab metric: https://en.wikipedia.org/wiki/Taxicab_geometry
     .. _Euclidean metric: https://en.wikipedia.org/wiki/Euclidean_distance
+    .. _metric: https://en.wikipedia.org/wiki/Metric_%28mathematics%29
+
 
     Notes
     -----
@@ -326,9 +326,9 @@ def waxman_graph(n, alpha=0.4, beta=0.1, L=None, domain=(0, 0, 1, 1),
         A metric on vectors of numbers (represented as lists or
         tuples). This must be a function that accepts two lists (or
         tuples) as input and yields a number as output. The function
-        must also satisfy the four requirements of a
-        `metric`_. Specifically, if *d* is the function and *x*, *y*,
-        and *x* are vectors in the graph, then *d* must satisfy
+        must also satisfy the four requirements of a `metric`_.
+        Specifically, if *d* is the function and *x*, *y*,
+        and *z* are vectors in the graph, then *d* must satisfy
 
         1. *d*(*x*, *y*) ≥ 0,
         2. *d*(*x*, *y*) = 0 if and only if *x* = *y*,
@@ -337,8 +337,6 @@ def waxman_graph(n, alpha=0.4, beta=0.1, L=None, domain=(0, 0, 1, 1),
 
         If this argument is not specified, the Euclidean distance metric is
         used.
-
-    .. _metric: https://en.wikipedia.org/wiki/Metric_%28mathematics%29
 
     Returns
     -------
@@ -358,6 +356,8 @@ def waxman_graph(n, alpha=0.4, beta=0.1, L=None, domain=(0, 0, 1, 1),
 
     .. _taxicab metric: https://en.wikipedia.org/wiki/Taxicab_geometry
     .. _Euclidean metric: https://en.wikipedia.org/wiki/Euclidean_distance
+    .. _metric: https://en.wikipedia.org/wiki/Metric_%28mathematics%29
+
 
     References
     ----------


### PR DESCRIPTION
 - ```efficiency``` toc entry
 - link to definition of metric had to move out of parameters section. (in generators/geometric.py)