### PR TITLE
Docs for compose now warn about MultiGraph edgekeys

### DIFF
--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -316,6 +316,10 @@ def compose(G, H, name=None):
     -----
     It is recommended that G and H be either both directed or both undirected.
     Attributes from H take precedent over attributes from G.
+
+    For MultiGraphs, the edges are identified by incident nodes AND edge-key.
+    This can cause surprises (i.e., edge `(1, 2)` may or may not be the same
+    in two graphs) if you use MultiGraph without keeping track of edge keys.
     """
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError('G and H must both be graphs or multigraphs.')


### PR DESCRIPTION
Fixes #1619 (doc changes only) while leaving #1654 to decide about whether edges
should have unique identifiers (UUID).