### PR TITLE
Improve Notes section on simplex and friends docs.

### DIFF
--- a/networkx/algorithms/flow/mincost.py
+++ b/networkx/algorithms/flow/mincost.py
@@ -81,6 +81,14 @@ def min_cost_flow_cost(G, demand = 'demand', capacity = 'capacity',
     --------
     cost_of_flow, max_flow_min_cost, min_cost_flow, network_simplex
 
+    Notes
+    -----
+    This algorithm is not guaranteed to work if edge weights or demands
+    are floating point numbers (overflows and roundoff errors can
+    cause problems). As a workaround you can use integer numbers by
+    multiplying the relevant edge attributes by a convenient
+    constant factor (eg 100).
+
     Examples
     --------
     A simple example of a min cost flow problem.
@@ -166,6 +174,14 @@ def min_cost_flow(G, demand = 'demand', capacity = 'capacity',
     --------
     cost_of_flow, max_flow_min_cost, min_cost_flow_cost, network_simplex
 
+    Notes
+    -----
+    This algorithm is not guaranteed to work if edge weights or demands
+    are floating point numbers (overflows and roundoff errors can
+    cause problems). As a workaround you can use integer numbers by
+    multiplying the relevant edge attributes by a convenient
+    constant factor (eg 100).
+
     Examples
     --------
     A simple example of a min cost flow problem.
@@ -216,6 +232,14 @@ def cost_of_flow(G, flowDict, weight = 'weight'):
     See also
     --------
     max_flow_min_cost, min_cost_flow, min_cost_flow_cost, network_simplex
+
+    Notes
+    -----
+    This algorithm is not guaranteed to work if edge weights or demands
+    are floating point numbers (overflows and roundoff errors can
+    cause problems). As a workaround you can use integer numbers by
+    multiplying the relevant edge attributes by a convenient
+    constant factor (eg 100).
     """
     return sum((flowDict[u][v] * d.get(weight, 0)
                 for u, v, d in G.edges(data = True)))
@@ -275,6 +299,14 @@ def max_flow_min_cost(G, s, t, capacity = 'capacity', weight = 'weight'):
     --------
     cost_of_flow, min_cost_flow, min_cost_flow_cost, network_simplex
 
+    Notes
+    -----
+    This algorithm is not guaranteed to work if edge weights or demands
+    are floating point numbers (overflows and roundoff errors can
+    cause problems). As a workaround you can use integer numbers by
+    multiplying the relevant edge attributes by a convenient
+    constant factor (eg 100).
+
     Examples
     --------
     >>> G = nx.DiGraph()
@@ -302,7 +334,6 @@ def max_flow_min_cost(G, s, t, capacity = 'capacity', weight = 'weight'):
     ...                     - sum((mincostFlow[7][v] for v in G.successors(7))))
     >>> mincostFlowValue == nx.maximum_flow_value(G, 1, 7)
     True
-
 
     """
     maxFlow = nx.maximum_flow_value(G, s, t, capacity = capacity)

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -96,7 +96,9 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
     -----
     This algorithm is not guaranteed to work if edge weights or demands
     are floating point numbers (overflows and roundoff errors can
-    cause problems).
+    cause problems). As a workaround you can use integer numbers by
+    multiplying the relevant edge attributes by a convenient
+    constant factor (eg 100).
 
     See also
     --------


### PR DESCRIPTION
Add a Notes section to functions that use network_simplex warning
users of the potential problems of using float edge weights. Also
mention the workaround of multiplying weights by a convenient constant
factor.

Fixes #2076

