### PR TITLE
Graph.add_node, Graph.add_edge, and Graph.add_edges_from modification

### DIFF
--- a/examples/graph/napoleon_russian_campaign.py
+++ b/examples/graph/napoleon_russian_campaign.py
@@ -113,7 +113,7 @@ def minard_graph():
             if last is None:
                 last=i
             else:
-                G.add_edge(i,last,{r:int(n)})
+                G.add_edge(i,last,**{r:int(n)})
                 last=i
             i=i+1
         g.append(G)

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -273,7 +273,7 @@ def parse_edgelist(lines, comments='#', delimiter=None,
                 edgedata.update({edge_key:edge_value})
         G.add_node(u, bipartite=0)
         G.add_node(v, bipartite=1)
-        G.add_edge(u, v, attr_dict=edgedata)
+        G.add_edge(u, v, **edgedata)
     return G
 
 

--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -107,7 +107,7 @@ class TestEdgelist:
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', attr_dict={name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         G.add_node(name1,bipartite=0)
         G.add_node('Radiohead',bipartite=1)
         fd, fname = tempfile.mkstemp()
@@ -125,7 +125,7 @@ class TestEdgelist:
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', attr_dict={name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         G.add_node(name1,bipartite=0)
         G.add_node('Radiohead',bipartite=1)
         fd, fname = tempfile.mkstemp()
@@ -144,7 +144,7 @@ class TestEdgelist:
         except ValueError: # Python 2.6+
             name1 = 'Bj' + unichr(246) + 'rk'
             name2 = unichr(220) + 'ber'
-        G.add_edge(name1, 'Radiohead', attr_dict={name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         G.add_node(name1,bipartite=0)
         G.add_node('Radiohead',bipartite=1)
         fd, fname = tempfile.mkstemp()

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
@@ -28,7 +28,7 @@ class TestFlowBetweennessCentrality(object):
         b_answer={0: 0.25, 1: 0.25, 2: 0.25, 3: 0.25}
         for n in sorted(G):
             assert_almost_equal(b[n],b_answer[n])
-        G.add_edge(0,1,{'weight':0.5,'other':0.3})
+        G.add_edge(0,1,weight=0.5,other=0.3)
         b=nx.current_flow_betweenness_centrality(G,normalized=True,weight=None)
         for n in sorted(G):
             assert_almost_equal(b[n],b_answer[n])

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
@@ -45,7 +45,7 @@ class TestFlowBetweennessCentrality(object):
         for n in sorted(G):
             assert_almost_equal(b[n],b_answer[n])
         # test weighted network
-        G.add_edge(0,1,{'weight':0.5,'other':0.3})
+        G.add_edge(0,1,weight=0.5,other=0.3)
         b=nx.current_flow_betweenness_centrality_subset(G,
                                                         list(G),
                                                         list(G),
@@ -140,7 +140,7 @@ class TestEdgeFlowBetweennessCentrality(object):
             v2=b.get((s,t),b.get((t,s)))
             assert_almost_equal(v1,v2)
         # test weighted network
-        G.add_edge(0,1,{'weight':0.5,'other':0.3})
+        G.add_edge(0,1,weight=0.5,other=0.3)
         b=edge_current_flow_subset(G,list(G),list(G),normalized=False,weight=None)
         # weight is None => same as unweighted network
         for (s,t),v1 in b_answer.items():

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -69,7 +69,7 @@ class TestGlobalReachingCentrality(TestCase):
 
     def test_cycle_undirected_weighted(self):
         G = nx.Graph()
-        G.add_edge(1, 2, {"weight": 1})
+        G.add_edge(1, 2, weight=1)
         grc = nx.global_reaching_centrality
         assert_equal(grc(G, weight="weight", normalized=False), 0)
 

--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -222,12 +222,18 @@ class TestMinCostFlow:
         by mfrasca."""
 
         G = nx.DiGraph()
-        G.add_edge('s', 'a', {0: 2, 1: 4})
-        G.add_edge('s', 'b', {0: 2, 1: 1})
-        G.add_edge('a', 'b', {0: 5, 1: 2})
-        G.add_edge('a', 't', {0: 1, 1: 5})
-        G.add_edge('b', 'a', {0: 1, 1: 3})
-        G.add_edge('b', 't', {0: 3, 1: 2})
+        G.add_edge('s', 'a')
+        G['s']['a'].update({0: 2, 1: 4}) 
+        G.add_edge('s', 'b')
+        G['s']['b'].update({0: 2, 1: 1}) 
+        G.add_edge('a', 'b')
+        G['a']['b'].update({0: 5, 1: 2}) 
+        G.add_edge('a', 't')
+        G['a']['t'].update({0: 1, 1: 5}) 
+        G.add_edge('b', 'a')
+        G['b']['a'].update({0: 1, 1: 3}) 
+        G.add_edge('b', 't')
+        G['b']['t'].update({0: 3, 1: 2}) 
 
         "PS.ex.7.1: testing main function"
         sol = nx.max_flow_min_cost(G, 's', 't', capacity=0, weight=1)
@@ -239,7 +245,8 @@ class TestMinCostFlow:
         assert_equal(sol['b'], {'a': 0, 't': 3})
         assert_equal(sol['t'], {})
 
-        G.add_edge('t', 's', {1: -100})
+        G.add_edge('t', 's')
+        G['t']['s'].update({1: -100})
         flowCost, sol = nx.capacity_scaling(G, capacity=0, weight=1)
         G.remove_edge('t', 's')
         flow = sum(v for v in sol['s'].values())

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -156,7 +156,7 @@ def shortest_path_length(G, source=None, target=None, weight=None):
     source : node, optional
         Starting node for path.
         If not specified, compute shortest path lengths using all nodes as
-        source nodes.i
+        source nodes.
 
     target : node, optional
         Ending node for path.

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -296,18 +296,15 @@ class DiGraph(Graph):
 
 
 
-    def add_node(self, n, attr_dict=None, **attr):
+    def add_node(self, n, **attr):
         """Add a single node n and update node attributes.
 
         Parameters
         ----------
         n : node
             A node can be any hashable Python object except None.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of node attributes.  Key/value pairs will
-            update existing data associated with the node.
         attr : keyword arguments, optional
-            Set or change attributes using key=value.
+            Set or change node attributes using key=value.
 
         See Also
         --------
@@ -338,22 +335,12 @@ class DiGraph(Graph):
         NetworkX Graphs, though one should be careful that the hash
         doesn't change on mutables.
         """
-        # set up attribute dict
-        node_attr = dict()
-        if attr_dict is not None:
-            try:
-                node_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-		       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        node_attr.update(attr)
         if n not in self.succ:
             self.succ[n] = self.adjlist_dict_factory()
             self.pred[n] = self.adjlist_dict_factory()
-            self.node[n] = node_attr
+            self.node[n] = attr
         else: # update attr even if node already exists
-            self.node[n].update(node_attr)
+            self.node[n].update(attr)
 
 
     def add_nodes_from(self, nodes, **attr):
@@ -507,23 +494,20 @@ class DiGraph(Graph):
                 pass # silent failure on remove
 
 
-    def add_edge(self, u, v, attr_dict=None, **attr):
+    def add_edge(self, u, v, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
         not already in the graph.
 
-        Edge attributes can be specified with keywords or by providing
-        a dictionary with key/value pairs.  See examples below.
+        Edge attributes can be specified with keywords or by directly
+        accessing the edge's attribute dictionary. See examples below.
 
         Parameters
         ----------
         u, v : nodes
             Nodes can be, for example, strings or numbers.
             Nodes must be hashable (and not None) Python objects.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of edge attributes.  Key/value pairs will
-            update existing data associated with the edge.
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
             keyword arguments.
@@ -554,17 +538,13 @@ class DiGraph(Graph):
 
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
+
+        For non-string associations, directly access the edge's attribute
+        dictionary.
+
+        >>> G.add_edge(1, 2)
+        >>> G[1][2].update({0: 5})
         """
-        # set up attribute dict
-        edge_attr = {}
-        if attr_dict is not None:
-            try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
         # add nodes
         if u not in self.succ:
             self.succ[u]= self.adjlist_dict_factory()
@@ -576,7 +556,7 @@ class DiGraph(Graph):
             self.node[v] = {}
         # add the edge
         datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
-        datadict.update(edge_attr)
+        datadict.update(attr)
         self.succ[u][v]=datadict
         self.pred[v][u]=datadict
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -560,7 +560,7 @@ class DiGraph(Graph):
         self.succ[u][v]=datadict
         self.pred[v][u]=datadict
 
-    def add_edges_from(self, ebunch, attr_dict=None, **attr):
+    def add_edges_from(self, ebunch, **attr):
         """Add all the edges in ebunch.
 
         Parameters
@@ -569,9 +569,6 @@ class DiGraph(Graph):
             Each edge given in the container will be added to the
             graph. The edges must be given as 2-tuples (u,v) or
             3-tuples (u,v,d) where d is a dictionary containing edge data.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of edge attributes.  Key/value pairs will
-            update existing data associated with each edge.
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
             keyword arguments.
@@ -601,16 +598,6 @@ class DiGraph(Graph):
         >>> G.add_edges_from([(1,2),(2,3)], weight=3)
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
-        # set up attribute dict
-        edge_attr = {}
-        if attr_dict is not None:
-            try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
         # process ebunch
         for e in ebunch:
             ne = len(e)
@@ -632,7 +619,7 @@ class DiGraph(Graph):
                 self.pred[v] = self.adjlist_dict_factory()
                 self.node[v] = {}
             datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
-            datadict.update(edge_attr)
+            datadict.update(attr)
             datadict.update(dd)
             self.succ[u][v] = datadict
             self.pred[v][u] = datadict

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -295,6 +295,7 @@ class DiGraph(Graph):
         self.edge=self.adj
 
 
+
     def add_node(self, n, attr_dict=None, **attr):
         """Add a single node n and update node attributes.
 
@@ -338,20 +339,21 @@ class DiGraph(Graph):
         doesn't change on mutables.
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict=attr
-        else:
+        node_attr = dict()
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(\
-                    "The attr_dict argument must be a dictionary.")
+                node_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+		       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        node_attr.update(attr)
         if n not in self.succ:
             self.succ[n] = self.adjlist_dict_factory()
             self.pred[n] = self.adjlist_dict_factory()
-            self.node[n] = attr_dict
+            self.node[n] = node_attr
         else: # update attr even if node already exists
-            self.node[n].update(attr_dict)
+            self.node[n].update(node_attr)
 
 
     def add_nodes_from(self, nodes, **attr):
@@ -554,14 +556,15 @@ class DiGraph(Graph):
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict=attr
-        else:
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(\
-                    "The attr_dict argument must be a dictionary.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # add nodes
         if u not in self.succ:
             self.succ[u]= self.adjlist_dict_factory()
@@ -573,7 +576,7 @@ class DiGraph(Graph):
             self.node[v] = {}
         # add the edge
         datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
-        datadict.update(attr_dict)
+        datadict.update(edge_attr)
         self.succ[u][v]=datadict
         self.pred[v][u]=datadict
 
@@ -619,14 +622,15 @@ class DiGraph(Graph):
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict=attr
-        else:
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(\
-                    "The attr_dict argument must be a dict.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # process ebunch
         for e in ebunch:
             ne = len(e)
@@ -648,11 +652,10 @@ class DiGraph(Graph):
                 self.pred[v] = self.adjlist_dict_factory()
                 self.node[v] = {}
             datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             datadict.update(dd)
             self.succ[u][v] = datadict
             self.pred[v][u] = datadict
-
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -355,8 +355,8 @@ class DiGraph(Graph):
             Node attributes are updated using the attribute dict.
         attr : keyword arguments, optional (default= no attributes)
             Update attributes for all nodes in nodes.
-            Node attributes specified in nodes as a tuple
-            take precedence over attributes specified generally.
+            Node attributes specified in nodes as a tuple take 
+            precedence over attributes specified via keyword arguments.
 
         See Also
         --------
@@ -583,8 +583,8 @@ class DiGraph(Graph):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
-        Edge attributes specified in edges take precedence
-        over attributes specified generally.
+        Edge attributes specified in an ebunch take precedence over 
+        attributes specified via keyword arguments.
 
         Examples
         --------

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -463,8 +463,8 @@ class Graph(object):
             Node attributes are updated using the attribute dict.
         attr : keyword arguments, optional (default= no attributes)
             Update attributes for all nodes in nodes.
-            Node attributes specified in nodes as a tuple
-            take precedence over attributes specified generally.
+            Node attributes specified in nodes as a tuple take 
+            precedence over attributes specified via keyword arguments.
 
         See Also
         --------
@@ -815,8 +815,8 @@ class Graph(object):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
-        Edge attributes specified in edges take precedence
-        over attributes specified generally.
+        Edge attributes specified in an ebunch take precedence over 
+        attributes specified via keyword arguments.
 
         Examples
         --------

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -406,18 +406,15 @@ class Graph(object):
         """
         return self.adj[n]
 
-    def add_node(self, n, attr_dict=None, **attr):
+    def add_node(self, n, **attr):
         """Add a single node n and update node attributes.
 
         Parameters
         ----------
         n : node
             A node can be any hashable Python object except None.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of node attributes.  Key/value pairs will
-            update existing data associated with the node.
         attr : keyword arguments, optional
-            Set or change attributes using key=value.
+            Set or change node attributes using key=value.
 
         See Also
         --------
@@ -449,20 +446,11 @@ class Graph(object):
         doesn't change on mutables.
         """
         # set up attribute dict
-        node_attr = {}
-        if attr_dict is None:
-            attr_dict = {}
-        try:
-                node_attr.update(attr_dict)
-        except TypeError:
-                raise NetworkXError(
-                        "The attr_dict argument must be a dictionary.")
-        node_attr.update(attr)
         if n not in self.node:
             self.adj[n] = self.adjlist_dict_factory()
-            self.node[n] = node_attr
+            self.node[n] = attr
         else:  # update attr even if node already exists
-            self.node[n].update(node_attr)
+            self.node[n].update(attr)
 
     def add_nodes_from(self, nodes, **attr):
         """Add multiple nodes.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -853,6 +853,47 @@ class Graph(object):
         >>> G.add_edges_from([(1,2),(2,3)], weight=3)
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
+    def add_edges_from(self, ebunch, attr_dict=None, **attr):
+        """Add all the edges in ebunch.
+
+        Parameters
+        ----------
+        ebunch : container of edges
+            Each edge given in the container will be added to the
+            graph. The edges must be given as as 2-tuples (u,v) or
+            3-tuples (u,v,d) where d is a dictionary containing edge data.
+        attr_dict : dictionary, optional (default= no attributes)
+            Dictionary of edge attributes.  Key/value pairs will
+            update existing data associated with each edge.
+        attr : keyword arguments, optional
+            Edge data (or labels or objects) can be assigned using
+            keyword arguments.
+
+        See Also
+        --------
+        add_edge : add a single edge
+        add_weighted_edges_from : convenient way to add weighted edges
+
+        Notes
+        -----
+        Adding the same edge twice has no effect but any edge data
+        will be updated when each duplicate edge is added.
+
+        Edge attributes specified in edges take precedence
+        over attributes specified generally.
+
+        Examples
+        --------
+        >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
+        >>> G.add_edges_from([(0,1),(1,2)]) # using a list of edge tuples
+        >>> e = zip(range(0,3),range(1,4))
+        >>> G.add_edges_from(e) # Add the path graph 0-1-2-3
+
+        Associate data to edges
+
+        >>> G.add_edges_from([(1,2),(2,3)], weight=3)
+        >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
+        """
         # set up attribute dict
         edge_attr = {}
         if attr_dict is not None:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -489,20 +489,7 @@ class Graph(object):
         >>> G.add_nodes_from('Hello')
         >>> K3 = nx.Graph([(0,1),(1,2),(2,0)])
         >>> G.add_nodes_from(K3)
-        >>> sorted(G.nodes(        # set up attribute dict
-        if attr_dict is None:
-            attr_dict = attr
-        else:
-            try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
-        if n not in self.node:
-            self.adj[n] = self.adjlist_dict_factory()
-            self.node[n] = attr_dict
-        else:  # update attr even if node already exists
-            self.node[n].update(attr_dict)),key=str)
+        >>> sorted(G.nodes(),key=str)
         [0, 1, 2, 'H', 'e', 'l', 'o']
 
         Use keywords to update specific node attributes for every node.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -803,14 +803,15 @@ class Graph(object):
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
         # set up attribute dictionary
+        edge_attr = {}
         if attr_dict is None:
-            attr_dict = attr
-        else:
-            try:
-                attr_dict.update(attr)
-            except AttributeError:
+            attr_dict = {}
+        try:
+                edge_attr.update(attr_dict)
+        except TypeError:
                 raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
+                        "The attr_dict argument must be a dictionary.")
+        edge_attr.update(attr)
         # add nodes
         if u not in self.node:
             self.adj[u] = self.adjlist_dict_factory()
@@ -820,7 +821,7 @@ class Graph(object):
             self.node[v] = {}
         # add the edge
         datadict = self.adj[u].get(v, self.edge_attr_dict_factory())
-        datadict.update(attr_dict)
+        datadict.update(edge_attr)
         self.adj[u][v] = datadict
         self.adj[v][u] = datadict
 
@@ -866,14 +867,15 @@ class Graph(object):
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
         # set up attribute dict
+        edge_attr = {}
         if attr_dict is None:
-            attr_dict = attr
-        else:
-            try:
-                attr_dict.update(attr)
-            except AttributeError:
+            attr_dict = {}
+        try:
+                edge_attr.update(attr_dict)
+        except TypeError:
                 raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
+                        "The attr_dict argument must be a dictionary.")
+        edge_attr.update(attr)
         # process ebunch
         for e in ebunch:
             ne = len(e)
@@ -892,7 +894,7 @@ class Graph(object):
                 self.adj[v] = self.adjlist_dict_factory()
                 self.node[v] = {}
             datadict = self.adj[u].get(v, self.edge_attr_dict_factory())
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             datadict.update(dd)
             self.adj[u][v] = datadict
             self.adj[v][u] = datadict

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -449,19 +449,20 @@ class Graph(object):
         doesn't change on mutables.
         """
         # set up attribute dict
+        node_attr = {}
         if attr_dict is None:
-            attr_dict = attr
-        else:
-            try:
-                attr_dict.update(attr)
-            except AttributeError:
+            attr_dict = {}
+        try:
+                node_attr.update(attr_dict)
+        except TypeError:
                 raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
+                        "The attr_dict argument must be a dictionary.")
+        node_attr.update(attr)
         if n not in self.node:
             self.adj[n] = self.adjlist_dict_factory()
-            self.node[n] = attr_dict
+            self.node[n] = node_attr
         else:  # update attr even if node already exists
-            self.node[n].update(attr_dict)
+            self.node[n].update(node_attr)
 
     def add_nodes_from(self, nodes, **attr):
         """Add multiple nodes.
@@ -488,7 +489,20 @@ class Graph(object):
         >>> G.add_nodes_from('Hello')
         >>> K3 = nx.Graph([(0,1),(1,2),(2,0)])
         >>> G.add_nodes_from(K3)
-        >>> sorted(G.nodes(),key=str)
+        >>> sorted(G.nodes(        # set up attribute dict
+        if attr_dict is None:
+            attr_dict = attr
+        else:
+            try:
+                attr_dict.update(attr)
+            except AttributeError:
+                raise NetworkXError(
+                    "The attr_dict argument must be a dictionary.")
+        if n not in self.node:
+            self.adj[n] = self.adjlist_dict_factory()
+            self.node[n] = attr_dict
+        else:  # update attr even if node already exists
+            self.node[n].update(attr_dict)),key=str)
         [0, 1, 2, 'H', 'e', 'l', 'o']
 
         Use keywords to update specific node attributes for every node.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -406,15 +406,18 @@ class Graph(object):
         """
         return self.adj[n]
 
-    def add_node(self, n, **attr):
+    def add_node(self, n, attr_dict=None, **attr):
         """Add a single node n and update node attributes.
 
         Parameters
         ----------
         n : node
             A node can be any hashable Python object except None.
+        attr_dict : dictionary, optional (default= no attributes)
+            Dictionary of node attributes.  Key/value pairs will
+            update existing data associated with the node.
         attr : keyword arguments, optional
-            Set or change node attributes using key=value.
+            Set or change attributes using key=value.
 
         See Also
         --------
@@ -446,11 +449,20 @@ class Graph(object):
         doesn't change on mutables.
         """
         # set up attribute dict
+        node_attr = dict()
+        if attr_dict is not None:
+            try:
+                node_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+		       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        node_attr.update(attr)
         if n not in self.node:
             self.adj[n] = self.adjlist_dict_factory()
-            self.node[n] = attr
+            self.node[n] = node_attr
         else:  # update attr even if node already exists
-            self.node[n].update(attr)
+            self.node[n].update(node_attr)
 
     def add_nodes_from(self, nodes, **attr):
         """Add multiple nodes.
@@ -777,15 +789,15 @@ class Graph(object):
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
-        # set up attribute dictionary
+        # set up attribute dict
         edge_attr = {}
-        if attr_dict is None:
-            attr_dict = {}
-        try:
+        if attr_dict is not None:
+            try:
                 edge_attr.update(attr_dict)
-        except TypeError:
-                raise NetworkXError(
-                        "The attr_dict argument must be a dictionary.")
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
         edge_attr.update(attr)
         # add nodes
         if u not in self.node:
@@ -841,15 +853,56 @@ class Graph(object):
         >>> G.add_edges_from([(1,2),(2,3)], weight=3)
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
+    def add_edges_from(self, ebunch, attr_dict=None, **attr):
+        """Add all the edges in ebunch.
+
+        Parameters
+        ----------
+        ebunch : container of edges
+            Each edge given in the container will be added to the
+            graph. The edges must be given as as 2-tuples (u,v) or
+            3-tuples (u,v,d) where d is a dictionary containing edge data.
+        attr_dict : dictionary, optional (default= no attributes)
+            Dictionary of edge attributes.  Key/value pairs will
+            update existing data associated with each edge.
+        attr : keyword arguments, optional
+            Edge data (or labels or objects) can be assigned using
+            keyword arguments.
+
+        See Also
+        --------
+        add_edge : add a single edge
+        add_weighted_edges_from : convenient way to add weighted edges
+
+        Notes
+        -----
+        Adding the same edge twice has no effect but any edge data
+        will be updated when each duplicate edge is added.
+
+        Edge attributes specified in edges take precedence
+        over attributes specified generally.
+
+        Examples
+        --------
+        >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
+        >>> G.add_edges_from([(0,1),(1,2)]) # using a list of edge tuples
+        >>> e = zip(range(0,3),range(1,4))
+        >>> G.add_edges_from(e) # Add the path graph 0-1-2-3
+
+        Associate data to edges
+
+        >>> G.add_edges_from([(1,2),(2,3)], weight=3)
+        >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
+        """
         # set up attribute dict
         edge_attr = {}
-        if attr_dict is None:
-            attr_dict = {}
-        try:
+        if attr_dict is not None:
+            try:
                 edge_attr.update(attr_dict)
-        except TypeError:
-                raise NetworkXError(
-                        "The attr_dict argument must be a dictionary.")
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
         edge_attr.update(attr)
         # process ebunch
         for e in ebunch:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -445,7 +445,6 @@ class Graph(object):
         NetworkX Graphs, though one should be careful that the hash
         doesn't change on mutables.
         """
-        # set up attribute dict
         if n not in self.node:
             self.adj[n] = self.adjlist_dict_factory()
             self.node[n] = attr
@@ -743,9 +742,6 @@ class Graph(object):
         u, v : nodes
             Nodes can be, for example, strings or numbers.
             Nodes must be hashable (and not None) Python objects.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of edge attributes.  Key/value pairs will
-            update existing data associated with the edge.
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
             keyword arguments.
@@ -777,17 +773,6 @@ class Graph(object):
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
-        # set up attribute dict
-        attr_dict = None
-        edge_attr = {}
-        if attr_dict is not None:
-            try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
         # add nodes
         if u not in self.node:
             self.adj[u] = self.adjlist_dict_factory()
@@ -797,11 +782,11 @@ class Graph(object):
             self.node[v] = {}
         # add the edge
         datadict = self.adj[u].get(v, self.edge_attr_dict_factory())
-        datadict.update(edge_attr)
+        datadict.update(attr)
         self.adj[u][v] = datadict
         self.adj[v][u] = datadict
 
-    def add_edges_from(self, ebunch, attr_dict=None, **attr):
+    def add_edges_from(self, ebunch, **attr):
         """Add all the edges in ebunch.
 
         Parameters
@@ -810,9 +795,6 @@ class Graph(object):
             Each edge given in the container will be added to the
             graph. The edges must be given as as 2-tuples (u,v) or
             3-tuples (u,v,d) where d is a dictionary containing edge data.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of edge attributes.  Key/value pairs will
-            update existing data associated with each edge.
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
             keyword arguments.
@@ -842,57 +824,6 @@ class Graph(object):
         >>> G.add_edges_from([(1,2),(2,3)], weight=3)
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
-    def add_edges_from(self, ebunch, attr_dict=None, **attr):
-        """Add all the edges in ebunch.
-
-        Parameters
-        ----------
-        ebunch : container of edges
-            Each edge given in the container will be added to the
-            graph. The edges must be given as as 2-tuples (u,v) or
-            3-tuples (u,v,d) where d is a dictionary containing edge data.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of edge attributes.  Key/value pairs will
-            update existing data associated with each edge.
-        attr : keyword arguments, optional
-            Edge data (or labels or objects) can be assigned using
-            keyword arguments.
-
-        See Also
-        --------
-        add_edge : add a single edge
-        add_weighted_edges_from : convenient way to add weighted edges
-
-        Notes
-        -----
-        Adding the same edge twice has no effect but any edge data
-        will be updated when each duplicate edge is added.
-
-        Edge attributes specified in edges take precedence
-        over attributes specified generally.
-
-        Examples
-        --------
-        >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
-        >>> G.add_edges_from([(0,1),(1,2)]) # using a list of edge tuples
-        >>> e = zip(range(0,3),range(1,4))
-        >>> G.add_edges_from(e) # Add the path graph 0-1-2-3
-
-        Associate data to edges
-
-        >>> G.add_edges_from([(1,2),(2,3)], weight=3)
-        >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
-        """
-        # set up attribute dict
-        edge_attr = {}
-        if attr_dict is not None:
-            try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
         # process ebunch
         for e in ebunch:
             ne = len(e)
@@ -911,7 +842,7 @@ class Graph(object):
                 self.adj[v] = self.adjlist_dict_factory()
                 self.node[v] = {}
             datadict = self.adj[u].get(v, self.edge_attr_dict_factory())
-            datadict.update(edge_attr)
+            datadict.update(attr)
             datadict.update(dd)
             self.adj[u][v] = datadict
             self.adj[v][u] = datadict

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -406,18 +406,15 @@ class Graph(object):
         """
         return self.adj[n]
 
-    def add_node(self, n, attr_dict=None, **attr):
+    def add_node(self, n, **attr):
         """Add a single node n and update node attributes.
 
         Parameters
         ----------
         n : node
             A node can be any hashable Python object except None.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of node attributes.  Key/value pairs will
-            update existing data associated with the node.
         attr : keyword arguments, optional
-            Set or change attributes using key=value.
+            Set or change node attributes using key=value.
 
         See Also
         --------
@@ -449,20 +446,11 @@ class Graph(object):
         doesn't change on mutables.
         """
         # set up attribute dict
-        node_attr = dict()
-        if attr_dict is not None:
-            try:
-                node_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-		       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        node_attr.update(attr)
         if n not in self.node:
             self.adj[n] = self.adjlist_dict_factory()
-            self.node[n] = node_attr
+            self.node[n] = attr
         else:  # update attr even if node already exists
-            self.node[n].update(node_attr)
+            self.node[n].update(attr)
 
     def add_nodes_from(self, nodes, **attr):
         """Add multiple nodes.
@@ -741,7 +729,7 @@ class Graph(object):
         except TypeError:
             return False
 
-    def add_edge(self, u, v, attr_dict=None, **attr):
+    def add_edge(self, u, v, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -790,6 +778,7 @@ class Graph(object):
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
         # set up attribute dict
+        attr_dict = None
         edge_attr = {}
         if attr_dict is not None:
             try:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -734,8 +734,8 @@ class Graph(object):
         The nodes u and v will be automatically added if they are
         not already in the graph.
 
-        Edge attributes can be specified with keywords or by providing
-        a dictionary with key/value pairs.  See examples below.
+        Edge attributes can be specified with keywords or by directly
+        accessing the edge's attribute dictionary. See examples below.
 
         Parameters
         ----------
@@ -772,6 +772,12 @@ class Graph(object):
 
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
+
+        For non-string associations, directly access the edge's attribute
+        dictionary.
+
+        >>> G.add_edge(1, 2)
+        >>> G[1][2].update({0: 5})
         """
         # add nodes
         if u not in self.node:

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -306,14 +306,15 @@ class MultiDiGraph(MultiGraph,DiGraph):
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict = attr
-        else:
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # add nodes
         if u not in self.succ:
             self.succ[u] = self.adjlist_dict_factory()
@@ -332,18 +333,19 @@ class MultiDiGraph(MultiGraph,DiGraph):
                 while key in keydict:
                     key += 1
             datadict = keydict.get(key, self.edge_key_dict_factory())
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
                 key = 0
             datadict = self.edge_attr_dict_factory()
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             keydict = self.edge_key_dict_factory()
             keydict[key] = datadict
             self.succ[u][v] = keydict
             self.pred[v][u] = keydict
+
 
     def remove_edge(self, u, v, key=None):
         """Remove an edge between u and v.

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -252,14 +252,14 @@ class MultiDiGraph(MultiGraph,DiGraph):
         self.edge_key_dict_factory = self.edge_key_dict_factory
         DiGraph.__init__(self, data, **attr)
 
-    def add_edge(self, u, v, key=None, attr_dict=None, **attr):
+    def add_edge(self, u, v, key=None, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
         not already in the graph.
 
-        Edge attributes can be specified with keywords or by providing
-        a dictionary with key/value pairs.  See examples below.
+        Edge attributes can be specified with keywords or by directly
+        accessing the edge's attribute dictionary. See examples below.
 
         Parameters
         ----------
@@ -304,17 +304,13 @@ class MultiDiGraph(MultiGraph,DiGraph):
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 2, key=0, weight=4)   # update data for key=0
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
+
+        For non-string associations, directly access the edge's attribute
+        dictionary.
+
+        >>> G.add_edge(1, 2, key=0)
+        >>> G[1][2][0].update({0: 5})
         """
-        # set up attribute dict
-        edge_attr = {}
-        if attr_dict is not None:
-            try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
         # add nodes
         if u not in self.succ:
             self.succ[u] = self.adjlist_dict_factory()
@@ -333,14 +329,14 @@ class MultiDiGraph(MultiGraph,DiGraph):
                 while key in keydict:
                     key += 1
             datadict = keydict.get(key, self.edge_key_dict_factory())
-            datadict.update(edge_attr)
+            datadict.update(attr)
             keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
                 key = 0
             datadict = self.edge_attr_dict_factory()
-            datadict.update(edge_attr)
+            datadict.update(attr)
             keydict = self.edge_key_dict_factory()
             keydict[key] = datadict
             self.succ[u][v] = keydict

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -307,9 +307,6 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
         For non-string associations, directly access the edge's attribute
         dictionary.
-
-        >>> G.add_edge(1, 2, key=0)
-        >>> G[1][2][0].update({0: 5})
         """
         # add nodes
         if u not in self.succ:

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -392,18 +392,15 @@ class MultiGraph(Graph):
             ddd = {}
             ddd.update(attr)
             ddd.update(dd)
-            if key is not None:
-                self.add_edge(u, v, key)
-                self[u][v][key].update(ddd)
-            else:
-                if u in self and v in self and v in self[u]:
-                    k = len(self[u][v])
+            if key is None:
+                k = 0
+                if u in self and v in self[u]:
                     while k in self[u][v]:
                         k += 1
-                else:
-                    k = 0
-                self.add_edge(u, v, k)
-                self[u][v][k].update(ddd)
+            else:
+                k = key
+            self.add_edge(u, v, k)
+            self[u][v][k].update(ddd)
 
     def remove_edge(self, u, v, key=None):
         """Remove an edge between u and v.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -331,7 +331,6 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self.adj[u][v] = keydict
             self.adj[v][u] = keydict
-        return self[u][v][key]
 
     def add_edges_from(self, ebunch, **attr):
         """Add all the edges in ebunch.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -392,7 +392,7 @@ class MultiGraph(Graph):
             ddd = {}
             ddd.update(attr)
             ddd.update(dd)
-            if key:
+            if key is not None:
                 self.add_edge(u, v, key)
                 self[u][v][key].update(ddd)
             else:

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -359,8 +359,8 @@ class MultiGraph(Graph):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
-        Edge attributes specified in edges take precedence
-        over attributes specified generally.
+        Edge attributes specified in an ebunch take precedence over 
+        attributes specified via keyword arguments.
 
         Examples
         --------

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -307,14 +307,15 @@ class MultiGraph(Graph):
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict = attr
-        else:
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # add nodes
         if u not in self.adj:
             self.adj[u] = self.adjlist_dict_factory()
@@ -331,14 +332,14 @@ class MultiGraph(Graph):
                 while key in keydict:
                     key += 1
             datadict = keydict.get(key, self.edge_attr_dict_factory())
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             keydict[key] = datadict
         else:
             # selfloops work this way without special treatment
             if key is None:
                 key = 0
             datadict = self.edge_attr_dict_factory()
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             keydict = self.edge_key_dict_factory()
             keydict[key] = datadict
             self.adj[u][v] = keydict
@@ -390,14 +391,15 @@ class MultiGraph(Graph):
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict = attr
-        else:
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(
-                    "The attr_dict argument must be a dictionary.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # process ebunch
         for e in ebunch:
             ne = len(e)
@@ -414,7 +416,7 @@ class MultiGraph(Graph):
                 raise NetworkXError(
                     "Edge tuple %s must be a 2-tuple, 3-tuple or 4-tuple." % (e,))
             ddd = {}
-            ddd.update(attr_dict)
+            ddd.update(edge_attr)
             ddd.update(dd)
             self.add_edge(u, v, key, ddd)
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -396,12 +396,14 @@ class MultiGraph(Graph):
                 self.add_edge(u, v, key)
                 self[u][v][key].update(ddd)
             else:
-                try:
-                    self.add_edge(u, v, key, **ddd)
-                except TypeError:
-                    unique_key = object()
-                    self.add_edge(u, v, key=unique_key)
-                    self[u][v][unique_key].update(ddd)
+                if u in self and v in self and v in self[u]:
+                    k = len(self[u][v])
+                    while k in self[u][v]:
+                        k += 1
+                else:
+                    k = 0
+                self.add_edge(u, v, k)
+                self[u][v][k].update(ddd)
 
     def remove_edge(self, u, v, key=None):
         """Remove an edge between u and v.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -331,6 +331,7 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self.adj[u][v] = keydict
             self.adj[v][u] = keydict
+        return self[u][v][key]
 
     def add_edges_from(self, ebunch, **attr):
         """Add all the edges in ebunch.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -302,12 +302,6 @@ class MultiGraph(Graph):
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 2, key=0, weight=4)   # update data for key=0
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
-
-        For non-string associations, directly access the edge's attribute
-        dictionary.
-
-        >>> G.add_edge(1, 2, key=0)
-        >>> G[1][2][0].update({9: 5})
         """
         # add nodes
         if u not in self.adj:

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -153,7 +153,7 @@ class BaseAttrGraphTester(BaseGraphTester):
         G.add_edge(1,2,foo=ll)
         G.add_edge(2,1,foo=ll)
         # attr_dict must be dict
-        assert_raises(networkx.NetworkXError,G.add_edge,0,1,attr_dict=[])
+        assert_raises(networkx.NetworkXError,G.add_edge,0,1,attr_dict=[1])
 
     def test_name(self):
         G=self.Graph(name='')
@@ -384,7 +384,7 @@ class BaseAttrGraphTester(BaseGraphTester):
         G=self.Graph()
         edges=[(1,2)]
         assert_raises(networkx.NetworkXError,G.add_edges_from,edges,
-                      attr_dict=[])
+                      attr_dict=[1])
 
     def test_to_undirected(self):
         G=self.K3

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -376,13 +376,6 @@ class BaseAttrGraphTester(BaseGraphTester):
                      [(1,2,{'data':20,'spam':'bar',
                             'bar':'foo','listdata':[20,200],'weight':20})])
 
-    def test_attr_dict_not_dict(self):
-        # attr_dict must be dict
-        G=self.Graph()
-        edges=[(1,2)]
-        assert_raises(networkx.NetworkXError,G.add_edges_from,edges,
-                      attr_dict=[1])
-
     def test_to_undirected(self):
         G=self.K3
         self.add_attributes(G)

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -324,14 +324,13 @@ class BaseAttrGraphTester(BaseGraphTester):
         assert_equal(list(G.nodes(data='foo', default='bar')),
                      [(0, 'bar'), (1, 'baz'), (2, 'bar')])
 
-
-#    def test_node_attr2(self):
-#        G=self.K3
-#        a={'foo':'bar'}
-#        G.add_node(3,attr_dict=a)
-#        assert_equal(list(G.nodes()), [0, 1, 2, 3])
-#        assert_equal(list(G.nodes(data=True)),
-#                     [(0, {}), (1, {}), (2, {}), (3, {'foo':'bar'})])
+    def test_node_attr2(self):
+        G=self.K3
+        a={'foo':'bar'}
+        G.add_node(3,attr_dict=a)
+        assert_equal(list(G.nodes()), [0, 1, 2, 3])
+        assert_equal(list(G.nodes(data=True)),
+                     [(0, {}), (1, {}), (2, {}), (3, {'foo':'bar'})])
 
     def test_edge_attr(self):
         G=self.Graph()

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -475,7 +475,7 @@ class TestGraph(BaseAttrGraphTester):
         G.add_node(1,c='red')
         G.add_node(2,{'c':'blue'})
         G.add_node(3,{'c':'blue'},c='red')
-        assert_raises(networkx.NetworkXError, G.add_node, 4, [])
+        assert_raises(networkx.NetworkXError, G.add_node, 4, [4])
         assert_raises(networkx.NetworkXError, G.add_node, 4, 4)
         assert_equal(G.node[1]['c'],'red')
         assert_equal(G.node[2]['c'],'blue')

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -152,8 +152,6 @@ class BaseAttrGraphTester(BaseGraphTester):
         ll=[]
         G.add_edge(1,2,foo=ll)
         G.add_edge(2,1,foo=ll)
-        # attr_dict must be dict
-        assert_raises(networkx.NetworkXError,G.add_edge,0,1,attr_dict=[1])
 
     def test_name(self):
         G=self.Graph(name='')
@@ -327,13 +325,13 @@ class BaseAttrGraphTester(BaseGraphTester):
                      [(0, 'bar'), (1, 'baz'), (2, 'bar')])
 
 
-    def test_node_attr2(self):
-        G=self.K3
-        a={'foo':'bar'}
-        G.add_node(3,attr_dict=a)
-        assert_equal(list(G.nodes()), [0, 1, 2, 3])
-        assert_equal(list(G.nodes(data=True)),
-                     [(0, {}), (1, {}), (2, {}), (3, {'foo':'bar'})])
+#    def test_node_attr2(self):
+#        G=self.K3
+#        a={'foo':'bar'}
+#        G.add_node(3,attr_dict=a)
+#        assert_equal(list(G.nodes()), [0, 1, 2, 3])
+#        assert_equal(list(G.nodes(data=True)),
+#                     [(0, {}), (1, {}), (2, {}), (3, {'foo':'bar'})])
 
     def test_edge_attr(self):
         G=self.Graph()
@@ -473,17 +471,15 @@ class TestGraph(BaseAttrGraphTester):
         assert_equal(G.adj,{0:{}})
         # test add attributes
         G.add_node(1,c='red')
-        G.add_node(2,{'c':'blue'})
-        G.add_node(3,{'c':'blue'},c='red')
-        assert_raises(networkx.NetworkXError, G.add_node, 4, [4])
-        assert_raises(networkx.NetworkXError, G.add_node, 4, 4)
+        G.add_node(2,c='blue')
+        G.add_node(3,c='red')
         assert_equal(G.node[1]['c'],'red')
         assert_equal(G.node[2]['c'],'blue')
         assert_equal(G.node[3]['c'],'red')
         # test updating attributes
         G.add_node(1,c='blue')
-        G.add_node(2,{'c':'red'})
-        G.add_node(3,{'c':'red'},c='blue')
+        G.add_node(2,c='red')
+        G.add_node(3,c='blue')
         assert_equal(G.node[1]['c'],'blue')
         assert_equal(G.node[2]['c'],'red')
         assert_equal(G.node[3]['c'],'blue')

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -327,7 +327,7 @@ class BaseAttrGraphTester(BaseGraphTester):
     def test_node_attr2(self):
         G=self.K3
         a={'foo':'bar'}
-        G.add_node(3,attr_dict=a)
+        G.add_node(3,**a)
         assert_equal(list(G.nodes()), [0, 1, 2, 3])
         assert_equal(list(G.nodes(data=True)),
                      [(0, {}), (1, {}), (2, {}), (3, {'foo':'bar'})])

--- a/networkx/classes/tests/timingclasses.py
+++ b/networkx/classes/tests/timingclasses.py
@@ -361,19 +361,20 @@ class TimingGraph(object):
         doesn't change on mutables.
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict=attr
-        else:
+        node_attr = dict()
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(\
-                    "The attr_dict argument must be a dictionary.")
+                node_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+		       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        node_attr.update(attr)
         if n not in self.node:
             self.adj[n] = {}
-            self.node[n] = attr_dict
+            self.node[n] = node_attr
         else: # update attr even if node already exists
-            self.node[n].update(attr_dict)
+            self.node[n].update(node_attr)
 
 
     def add_nodes_from(self, nodes, **attr):
@@ -690,15 +691,16 @@ class TimingGraph(object):
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
-        # set up attribute dictionary
-        if attr_dict is None:
-            attr_dict=attr
-        else:
+        # set up attribute dict
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(\
-                    "The attr_dict argument must be a dictionary.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # add nodes
         if u not in self.node:
             self.adj[u] = {}
@@ -708,7 +710,7 @@ class TimingGraph(object):
             self.node[v] = {}
         # add the edge
         datadict=self.adj[u].get(v,{})
-        datadict.update(attr_dict)
+        datadict.update(edge_attr)
         self.adj[u][v] = datadict
         self.adj[v][u] = datadict
 
@@ -757,14 +759,15 @@ class TimingGraph(object):
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
         # set up attribute dict
-        if attr_dict is None:
-            attr_dict=attr
-        else:
+        edge_attr = {}
+        if attr_dict is not None:
             try:
-                attr_dict.update(attr)
-            except AttributeError:
-                raise NetworkXError(\
-                    "The attr_dict argument must be a dictionary.")
+                edge_attr.update(attr_dict)
+            except TypeError:
+                msg = ("The attr_dict argument must be a dict or "
+                       "iterable of 2-tuples")
+                raise NetworkXError(msg)
+        edge_attr.update(attr)
         # process ebunch
         for e in ebunch:
             ne=len(e)
@@ -783,7 +786,7 @@ class TimingGraph(object):
                 self.adj[v] = {}
                 self.node[v] = {}
             datadict=self.adj[u].get(v,{})
-            datadict.update(attr_dict)
+            datadict.update(edge_attr)
             datadict.update(dd)
             self.adj[u][v] = datadict
             self.adj[v][u] = datadict

--- a/networkx/classes/tests/timingclasses.py
+++ b/networkx/classes/tests/timingclasses.py
@@ -361,20 +361,19 @@ class TimingGraph(object):
         doesn't change on mutables.
         """
         # set up attribute dict
-        node_attr = dict()
-        if attr_dict is not None:
+        if attr_dict is None:
+            attr_dict=attr
+        else:
             try:
-                node_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-		       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        node_attr.update(attr)
+                attr_dict.update(attr)
+            except AttributeError:
+                raise NetworkXError(\
+                    "The attr_dict argument must be a dictionary.")
         if n not in self.node:
             self.adj[n] = {}
-            self.node[n] = node_attr
+            self.node[n] = attr_dict
         else: # update attr even if node already exists
-            self.node[n].update(node_attr)
+            self.node[n].update(attr_dict)
 
 
     def add_nodes_from(self, nodes, **attr):
@@ -691,16 +690,15 @@ class TimingGraph(object):
         >>> G.add_edge(1, 2, weight=3)
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
-        # set up attribute dict
-        edge_attr = {}
-        if attr_dict is not None:
+        # set up attribute dictionary
+        if attr_dict is None:
+            attr_dict=attr
+        else:
             try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
+                attr_dict.update(attr)
+            except AttributeError:
+                raise NetworkXError(\
+                    "The attr_dict argument must be a dictionary.")
         # add nodes
         if u not in self.node:
             self.adj[u] = {}
@@ -710,7 +708,7 @@ class TimingGraph(object):
             self.node[v] = {}
         # add the edge
         datadict=self.adj[u].get(v,{})
-        datadict.update(edge_attr)
+        datadict.update(attr_dict)
         self.adj[u][v] = datadict
         self.adj[v][u] = datadict
 
@@ -759,15 +757,14 @@ class TimingGraph(object):
         >>> G.add_edges_from([(3,4),(1,4)], label='WN2898')
         """
         # set up attribute dict
-        edge_attr = {}
-        if attr_dict is not None:
+        if attr_dict is None:
+            attr_dict=attr
+        else:
             try:
-                edge_attr.update(attr_dict)
-            except TypeError:
-                msg = ("The attr_dict argument must be a dict or "
-                       "iterable of 2-tuples")
-                raise NetworkXError(msg)
-        edge_attr.update(attr)
+                attr_dict.update(attr)
+            except AttributeError:
+                raise NetworkXError(\
+                    "The attr_dict argument must be a dictionary.")
         # process ebunch
         for e in ebunch:
             ne=len(e)
@@ -786,7 +783,7 @@ class TimingGraph(object):
                 self.adj[v] = {}
                 self.node[v] = {}
             datadict=self.adj[u].get(v,{})
-            datadict.update(edge_attr)
+            datadict.update(attr_dict)
             datadict.update(dd)
             self.adj[u][v] = datadict
             self.adj[v][u] = datadict

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -355,7 +355,8 @@ def from_dict_of_dicts(d,create_using=None,multigraph_input=False):
             for u,nbrs in d.items():
                 for v,data in nbrs.items():
                     if (u,v) not in seen:
-                        G.add_edge(u,v,attr_dict=data)
+                        G.add_edge(u,v,key=0)
+                        G[u][v][0].update(data)
                     seen.add((v,u))
         else:
             G.add_edges_from( ( (u,v,data)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -211,8 +211,8 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
             if g.is_multigraph():
-                g.add_edge(row[src_i], row[tar_i], key=1)
-                g[row[src_i]][row[tar_i]][1].update((i, row[j]) for i, j in edge_i)                
+                g.add_edge(row[src_i], row[tar_i], key=0)
+                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
             else:
                 g.add_edge(row[src_i], row[tar_i])
                 g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -211,9 +211,8 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
             if g.is_multigraph():
-                edge_attr = g.add_edge(row[src_i], row[tar_i])
-                edge_attr.update((i, row[j]) for i, j in edge_i)
-#                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
+                g.add_edge(row[src_i], row[tar_i], key=0)
+                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
             else:
                 g.add_edge(row[src_i], row[tar_i])
                 g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -210,7 +210,8 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
 
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
-            g.add_edge(row[src_i], row[tar_i], **{i:row[j] for i, j in edge_i})
+            g.add_edge(row[src_i], row[tar_i])
+            g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)
     
     # If no column names are given, then just return the edges.
     else:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -210,8 +210,12 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
 
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
-            g.add_edge(row[src_i], row[tar_i])
-            g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)
+            if g.is_multigraph():
+                g.add_edge(row[src_i], row[tar_i], key=0)
+                g[row[src_i]][row[tar_i]][key].update((i, row[j]) for i, j in edge_i)                
+            else:
+                g.add_edge(row[src_i], row[tar_i])
+                g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)
     
     # If no column names are given, then just return the edges.
     else:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -212,7 +212,7 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
         for row in df.values:
             if g.is_multigraph():
                 g.add_edge(row[src_i], row[tar_i], key=0)
-                g[row[src_i]][row[tar_i]][key].update((i, row[j]) for i, j in edge_i)                
+                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
             else:
                 g.add_edge(row[src_i], row[tar_i])
                 g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -211,8 +211,8 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
             if g.is_multigraph():
-                g.add_edge(row[src_i], row[tar_i], key=0)
-                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
+                g.add_edge(row[src_i], row[tar_i], key=1)
+                g[row[src_i]][row[tar_i]][1].update((i, row[j]) for i, j in edge_i)                
             else:
                 g.add_edge(row[src_i], row[tar_i])
                 g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -210,7 +210,7 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
 
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
-            g.add_edge(row[src_i], row[tar_i], attr_dict={i:row[j] for i, j in edge_i})
+            g.add_edge(row[src_i], row[tar_i], **{i:row[j] for i, j in edge_i})
     
     # If no column names are given, then just return the edges.
     else:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -210,12 +210,14 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
 
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
+            s, t = row[src_i], row[tar_i]
             if g.is_multigraph():
-                g.add_edge(row[src_i], row[tar_i], key=0)
-                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
+                g.add_edge(s, t)
+                key = max(g[s][t])  # default keys just count, so max is most recent 
+                g[s][t][key].update((i, row[j]) for i, j in edge_i)
             else:
-                g.add_edge(row[src_i], row[tar_i])
-                g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)
+                g.add_edge(s, t)
+                g[s][t].update((i, row[j]) for i, j in edge_i)
     
     # If no column names are given, then just return the edges.
     else:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -211,8 +211,9 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
         # Iteration on values returns the rows as Numpy arrays
         for row in df.values:
             if g.is_multigraph():
-                g.add_edge(row[src_i], row[tar_i], key=0)
-                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
+                edge_attr = g.add_edge(row[src_i], row[tar_i])
+                edge_attr.update((i, row[j]) for i, j in edge_i)
+#                g[row[src_i]][row[tar_i]][0].update((i, row[j]) for i, j in edge_i)                
             else:
                 g.add_edge(row[src_i], row[tar_i])
                 g[row[src_i]][row[tar_i]].update((i, row[j]) for i, j in edge_i)

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -69,7 +69,7 @@ class TestGraphMatrix(object):
         assert_equal(nx.incidence_matrix(self.WG,oriented=True,weight='other').todense(),
                      0.3*self.OI)
         WMG=nx.MultiGraph(self.WG)
-        WMG.add_edge(0,1,attr_dict={'weight':0.5,'other':0.3})
+        WMG.add_edge(0,1,weight=0.5,other=0.3)
         assert_equal(nx.incidence_matrix(WMG,weight='weight').todense(),
                      numpy.abs(0.5*self.MGOI))
         assert_equal(nx.incidence_matrix(WMG,weight='weight',oriented=True).todense(),

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -293,7 +293,7 @@ def parse_edgelist(lines, comments='#', delimiter=None,
                         "Failed to convert %s data %s to type %s."
                         %(edge_key, edge_value, edge_type))
                 edgedata.update({edge_key:edge_value})
-        G.add_edge(u, v, attr_dict=edgedata)
+        G.add_edge(u, v, **edgedata)
     return G
 
 @open_file(0,mode='rb')

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -717,7 +717,7 @@ class GEXFReader(GEXF):
             for node_xml in subnodes.findall('{%s}node' % self.NS_GEXF):
                 self.add_node(G, node_xml, node_attr, node_pid=node_id)
 
-        G.add_node(node_id, data)
+        G.add_node(node_id, **data)
 
     def add_start_end(self, data, xml):
         # start and end times

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -406,7 +406,7 @@ def parse_gml_lines(lines, label, destringizer):
                 raise NetworkXError('node label %r is duplicated' % (label,))
             labels.add(label)
             mapping[id] = label
-        G.add_node(id, node)
+        G.add_node(id, **node)
 
     edges = graph.get('edge', [])
     for i, edge in enumerate(edges if isinstance(edges, list) else [edges]):

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -420,7 +420,7 @@ def parse_gml_lines(lines, label, destringizer):
                 'edge #%d has an undefined target %r' % (i, target))
         if not multigraph:
             if not G.has_edge(source, target):
-                G.add_edge(source, target, edge)
+                G.add_edge(source, target, **edge)
             else:
                 raise nx.NetworkXError(
                     'edge #%d (%r%s%r) is duplicated' %
@@ -431,7 +431,7 @@ def parse_gml_lines(lines, label, destringizer):
                 raise nx.NetworkXError(
                     'edge #%d (%r%s%r, %r) is duplicated' %
                     (i, source, '->' if directed else '--', target, key))
-            G.add_edge(source, target, key, edge)
+            G.add_edge(source, target, key, **edge)
 
     if label != 'id':
         G = nx.relabel_nodes(G, mapping)

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -510,7 +510,7 @@ class GraphMLReader(GraphML):
         node_id = self.node_type(node_xml.get("id"))
         # get data/attributes for node
         data = self.decode_data_elements(graphml_keys, node_xml)
-        G.add_node(node_id, data)
+        G.add_node(node_id, **data)
 
     def add_edge(self, G, edge_element, graphml_keys):
         """Add an edge to the graph.

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -145,15 +145,18 @@ def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
         node_data = d.copy()
         node = node_data.pop(id_)
         mapping.append(node)
-        graph.add_node(node, **node_data)
+        graph.add_node(node)
+        graph.node[node].update(node_data)
     for i, d in enumerate(data['adjacency']):
         source = mapping[i]
         for tdata in d:
             target_data = tdata.copy()
             target = target_data.pop(id_)
             if not multigraph:
-                graph.add_edge(source, target, attr_dict=tdata)
+                graph.add_edge(source, target)
+                graph[source][target].update(tdata)
             else:
                 ky = target_data.pop(key, None)
-                graph.add_edge(source, target, key=ky, attr_dict=tdata)
+                graph.add_edge(source, target, key=ky)
+                graph[source][target][ky].update(target_data)
     return graph

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -158,5 +158,5 @@ def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
             else:
                 ky = target_data.pop(key, None)
                 graph.add_edge(source, target, key=ky)
-                graph[source][target][ky].update(target_data)
+                graph[source][target][ky].update(tdata)
     return graph

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -145,7 +145,7 @@ def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
         node_data = d.copy()
         node = node_data.pop(id_)
         mapping.append(node)
-        graph.add_node(node, attr_dict=node_data)
+        graph.add_node(node, **node_data)
     for i, d in enumerate(data['adjacency']):
         source = mapping[i]
         for tdata in d:

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -60,7 +60,7 @@ class TestNodeLink:
         except NameError:
             q = "qualité"
         G = nx.Graph()
-        G.add_node(1, {q:q})
+        G.add_node(1, **{q:q})
         s = node_link_data(G)
         output = json.dumps(s, ensure_ascii=False)
         data = json.loads(output)

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -142,12 +142,12 @@ def tree_graph(data, attrs=_attrs):
                 add_children(child, grandchildren)
             nodedata = dict((make_str(k), v) for k, v in data.items()
                             if k != id_ and k != children)
-            graph.add_node(child, attr_dict=nodedata)
+            graph.add_node(child, **nodedata)
 
     root = data[id_]
     children_ = data.get(children, [])
     nodedata = dict((make_str(k), v) for k, v in data.items()
                     if k != id_ and k != children)
-    graph.add_node(root, attr_dict=nodedata)
+    graph.add_node(root, **nodedata)
     add_children(root, children_)
     return graph

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -292,7 +292,7 @@ def parse_multiline_adjlist(lines, comments='#', delimiter=None,
                     edgedata = literal_eval(data)
                 except:
                     edgedata = {}
-            G.add_edge(u, v, attr_dict=edgedata)
+            G.add_edge(u, v, **edgedata)
 
     return G
 

--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -90,7 +90,9 @@ def read_shp(path, simplify=True, geom_attrs=True):
                                          ogr.wkbMultiLineString):
                 for edge in edges_from_line(g, attributes, simplify,
                                             geom_attrs):
-                    net.add_edge(*edge)
+                    e1, e2, attr = edge
+                    net.add_edge(e1, e2)
+                    net[e1][e2].update(attr)
             else:
                 raise ImportError("GeometryType {} not supported".
                                   format(g.GetGeometryType()))

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -44,7 +44,7 @@ class TestAdjlist():
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', {name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         fd, fname = tempfile.mkstemp()
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname)
@@ -60,7 +60,7 @@ class TestAdjlist():
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', {name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         fd, fname = tempfile.mkstemp()
         assert_raises(UnicodeEncodeError,
                       nx.write_multiline_adjlist,
@@ -77,7 +77,7 @@ class TestAdjlist():
         except ValueError: # Python 2.6+
             name1 = 'Bj' + unichr(246) + 'rk'
             name2 = unichr(220) + 'ber'
-        G.add_edge(name1, 'Radiohead', {name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         fd, fname = tempfile.mkstemp()
         nx.write_multiline_adjlist(G, fname, encoding = 'latin-1')
         H = nx.read_multiline_adjlist(fname, encoding = 'latin-1')

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -108,7 +108,7 @@ class TestEdgelist:
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', attr_dict={name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         fd, fname = tempfile.mkstemp()
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname)
@@ -124,7 +124,7 @@ class TestEdgelist:
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', attr_dict={name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         fd, fname = tempfile.mkstemp()
         assert_raises(UnicodeEncodeError,
                       nx.write_edgelist,
@@ -141,7 +141,7 @@ class TestEdgelist:
         except ValueError: # Python 2.6+
             name1 = 'Bj' + unichr(246) + 'rk'
             name2 = unichr(220) + 'ber'
-        G.add_edge(name1, 'Radiohead', attr_dict={name2: 3})
+        G.add_edge(name1, 'Radiohead', **{name2: 3})
         fd, fname = tempfile.mkstemp()
         nx.write_edgelist(G, fname, encoding = 'latin-1')
         H = nx.read_edgelist(fname, encoding = 'latin-1')

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -452,7 +452,7 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
             node_type=unicode
-        G.add_edge(name1, 'Radiohead', attr_dict={'foo': name2})
+        G.add_edge(name1, 'Radiohead', foo=name2)
         fd, fname = tempfile.mkstemp()
         nx.write_graphml(G, fname)
         H = nx.read_graphml(fname,node_type=node_type)

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -65,7 +65,7 @@ class TestPajek(object):
         except ValueError: # Python 2.6+
             name1 = unichr(2344) + unichr(123) + unichr(6543)
             name2 = unichr(5543) + unichr(1543) + unichr(324)
-        G.add_edge(name1, 'Radiohead', attr_dict={'foo': name2})
+        G.add_edge(name1, 'Radiohead', foo=name2)
         fh = io.BytesIO()
         nx.write_pajek(G,fh)
         fh.seek(0)

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -124,7 +124,7 @@ def _relabel_inplace(G, mapping):
         if new == old:
             continue
         try:
-            G.add_node(new, attr_dict=G.node[old])
+            G.add_node(new, **G.node[old])
         except KeyError:
             raise KeyError("Node %s is not in the graph"%old)
         if multigraph:

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -39,7 +39,7 @@ class TestConvertPandas(object):
         self.assert_equal(G, Gtrue)
         # MultiGraph
         MGtrue = nx.MultiGraph(Gtrue)
-        MGtrue.add_edge('A', 'D', attr_dict={'cost': 16, 'weight': 4})
+        MGtrue.add_edge('A', 'D', cost=16, weight=4)
         MG=nx.from_pandas_dataframe(self.mdf, 0, 'b', True, nx.MultiGraph())
         self.assert_equal(MG, MGtrue)
 


### PR DESCRIPTION
For each respective method, I just snuck in an empty `node_attr` and `edge_attr` dictionary, updated it based on the supplied parameters (`attr_dict` and `attr`), then either plugged it in if no attribute dictionary existed -- or updated an existing attribute dictionary if it was there. That way, you avoid mutating attr_dict and don't end up accidentally sharing a dictionary across multiple nodes (or other objects). 

Notably, this caused some test failures -- because we're no longer invoking the `update` method on` attr_dict`. And since a Python dictionary's `update` method can accept an empty sequence, just passing an empty sequence through `attr_dict` no longer raised an exception. So I added an int to the sequences to make the exception raise.

This leads to an interesting positive trade-off, though: Since we're updating a dictionary with `attr_dict`, `attr_dict` doesn't _have_ to be a dictionary. It can be any value that the `update` method accepts: Including sequences of 2-d tuples. So this:

```
>>> import networkx
>>> g = networkx.Graph()
>>> g.add_node("node", [("weight", 5)])
>>> print(g.node["node"])
{'weight' : 5}
```

-- is perfectly acceptable. So is:

```
>>> import networkx
>>> g = networkx.Graph()
>>> my_dict = {"x": 0}
>>> g.add_node("node", my_dict.items())
>>> print(g.node["node"])
{'x' : 0}
```

And, of course, the old way works too, sans mutation or direct assignment:

```
>>> import networkx
>>> g = networkx.Graph()
>>> my_dict = {"x": 0}
>>> g.add_node("node", my_dict, x=1)
>>> print(g.node["node"])
{'x' : 1}
>>> print(my_dict)
{'x' : 0}
```

(As an aside, this is my first attempt at trying to help with a collaborative github project -- so if I've messed up anywhere in this process, please feel free to tell me!)