### PR TITLE
Bugfix for generic_multiedge_match (Issue #2114)

### DIFF
--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -357,11 +357,16 @@ def generic_multiedge_match(attr, default, op):
                 x = tuple( data2.get(attr, d) for attr, d in attrs )
                 values2.append(x)
             for vals2 in permutations(values2):
-                for xi, yi, operator in zip(values1, vals2, op):
-                    if not operator(xi, yi):
-                        return False
+                for xi, yi in zip(values1, vals2):
+                    if not all(map(lambda x,y,z: z(x,y), xi, yi, op)):
+                        # This is not an isomorphism, go to next permutation.
+                        break
+                else:
+                    # Then we found an isomorphism.
+                    return True
             else:
-                return True
+                # Then there are no isomorphisms between the multiedges.
+                return False
     return match
 
 # Docstrings for numerical functions.

--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -331,42 +331,30 @@ def generic_multiedge_match(attr, default, op):
     # This is slow, but generic.
     # We must test every possible isomorphism between the edges.
     if nx.utils.is_string_like(attr):
-        def match(datasets1, datasets2):
-            values1 = [data.get(attr, default) for data in datasets1.values()]
-            values2 = [data.get(attr, default) for data in datasets2.values()]
-            for vals2 in permutations(values2):
-                for xi, yi in zip(values1, vals2):
-                    if not op(xi, yi):
-                        # This is not an isomorphism, go to next permutation.
-                        break
-                else:
-                    # Then we found an isomorphism.
-                    return True
+        attr = [attr]
+        default = [default]
+        op = [op]
+    attrs = list(zip(attr, default)) # Python 3
+    def match(datasets1, datasets2):
+        values1 = []
+        for data1 in datasets1.values():
+            x = tuple( data1.get(attr, d) for attr, d in attrs )
+            values1.append(x)
+        values2 = []
+        for data2 in datasets2.values():
+            x = tuple( data2.get(attr, d) for attr, d in attrs )
+            values2.append(x)
+        for vals2 in permutations(values2):
+            for xi, yi in zip(values1, vals2):
+                if not all(map(lambda x,y,z: z(x,y), xi, yi, op)):
+                    # This is not an isomorphism, go to next permutation.
+                    break
             else:
-                # Then there are no isomorphisms between the multiedges.
-                return False
-    else:
-        attrs = list(zip(attr, default)) # Python 3
-        def match(datasets1, datasets2):
-            values1 = []
-            for data1 in datasets1.values():
-                x = tuple( data1.get(attr, d) for attr, d in attrs )
-                values1.append(x)
-            values2 = []
-            for data2 in datasets2.values():
-                x = tuple( data2.get(attr, d) for attr, d in attrs )
-                values2.append(x)
-            for vals2 in permutations(values2):
-                for xi, yi in zip(values1, vals2):
-                    if not all(map(lambda x,y,z: z(x,y), xi, yi, op)):
-                        # This is not an isomorphism, go to next permutation.
-                        break
-                else:
-                    # Then we found an isomorphism.
-                    return True
-            else:
-                # Then there are no isomorphisms between the multiedges.
-                return False
+                # Then we found an isomorphism.
+                return True
+        else:
+            # Then there are no isomorphisms between the multiedges.
+            return False
     return match
 
 # Docstrings for numerical functions.

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -35,7 +35,13 @@ class TestGenericMultiEdgeMatch:
     def test_generic_multiedge_match(self):
         full_match = iso.generic_multiedge_match(['id', 'flowMin', 'flowMax'], [None]*3, [eq]*3)
         flow_match = iso.generic_multiedge_match(['flowMin', 'flowMax'], [None]*2, [eq]*2)
+        min_flow_match = iso.generic_multiedge_match('flowMin', None, eq)
+        id_match = iso.generic_multiedge_match('id', None, eq) 
         assert_true(flow_match(self.G1[1][2], self.G2[2][3]))
+        assert_true(min_flow_match(self.G1[1][2], self.G2[2][3]))
+        assert_true(id_match(self.G1[1][2], self.G2[2][3]))
         assert_true(full_match(self.G1[1][2], self.G2[2][3]))
         assert_true(flow_match(self.G3[3][4], self.G4[4][5]))
+        assert_true(min_flow_match(self.G3[3][4], self.G4[4][5]))
+        assert_false(id_match(self.G3[3][4], self.G4[4][5]))
         assert_false(full_match(self.G3[3][4], self.G4[4][5]))

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -1,4 +1,6 @@
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_false
+from operator import eq
+import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
 
@@ -6,3 +8,34 @@ def test_categorical_node_match():
     nm = iso.categorical_node_match(['x', 'y', 'z'], [None]*3)
     assert_true(nm(dict(x=1, y=2, z=3), dict(x=1, y=2, z=3)))
     assert_true(not nm(dict(x=1, y=2, z=2), dict(x=1, y=2, z=1)))
+    
+
+class TestGenericMultiEdgeMatch:
+    
+    def setup(self):
+        self.G1 = nx.MultiDiGraph()
+        self.G2 = nx.MultiDiGraph()
+        self.G3 = nx.MultiDiGraph()
+        self.G4 = nx.MultiDiGraph()
+        attr_dict1 = {'id': 'edge1', 'minFlow': 0, 'maxFlow': 10}
+        attr_dict2 = {'id': 'edge2', 'minFlow': -3, 'maxFlow': 7}
+        attr_dict3 = {'id': 'edge3', 'minFlow': 13, 'maxFlow': 117}
+        attr_dict4 = {'id': 'edge4', 'minFlow': 13, 'maxFlow': 117}
+        attr_dict5 = {'id': 'edge5', 'minFlow': 8, 'maxFlow': 12}
+        attr_dict6 = {'id': 'edge6', 'minFlow': 8, 'maxFlow': 12}
+        for attr_dict in [attr_dict1, attr_dict2, attr_dict3, attr_dict4, attr_dict5, attr_dict6]:
+            self.G1.add_edge(1 ,2, attr_dict=attr_dict)
+        for attr_dict in [attr_dict5, attr_dict3, attr_dict6, attr_dict1, attr_dict4, attr_dict2]:
+            self.G2.add_edge(2, 3, attr_dict=attr_dict)
+        for attr_dict in [attr_dict3, attr_dict5]:
+            self.G3.add_edge(3, 4, attr_dict=attr_dict)
+        for attr_dict in [attr_dict6, attr_dict4]:
+            self.G4.add_edge(4, 5, attr_dict=attr_dict)
+        
+    def test_generic_multiedge_match(self):
+        full_match = iso.generic_multiedge_match(['id', 'flowMin', 'flowMax'], [None]*3, [eq]*3)
+        flow_match = iso.generic_multiedge_match(['flowMin', 'flowMax'], [None]*2, [eq]*2)
+        assert_true(flow_match(self.G1[1][2], self.G2[2][3]))
+        assert_true(full_match(self.G1[1][2], self.G2[2][3]))
+        assert_true(flow_match(self.G3[3][4], self.G4[4][5]))
+        assert_false(full_match(self.G3[3][4], self.G4[4][5]))


### PR DESCRIPTION
generic_multiedge_match can be used to compare multiedges with multiple attributes. For this, one can give it a list of attributes, list of default values and a list of operators to be used for comparison of pairs of single attributes. There was a bug which caused the operators to instead compare tuples of attributes. I fixed this.
As discussed in https://github.com/networkx/networkx/issues/2114, I then also simplified the method to only one case, independent of the number of attributes that ought to be compared.