### PR TITLE
Handle graph name attribute in relabel_nodes

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -435,10 +435,6 @@ def parse_gml_lines(lines, label, destringizer):
 
     if label != 'id':
         G = nx.relabel_nodes(G, mapping)
-        if 'name' in graph:
-            G.graph['name'] = graph['name']
-        else:
-            del G.graph['name']
     return G
 
 

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -147,7 +147,8 @@ def _relabel_inplace(G, mapping):
 
 def _relabel_copy(G, mapping):
     H = G.__class__()
-    H.name = "(%s)" % G.name
+    if G.name:
+        H.name = "(%s)" % G.name
     if G.is_multigraph():
         H.add_edges_from( (mapping.get(n1, n1),mapping.get(n2, n2),k,d.copy())
                           for (n1,n2,k,d) in G.edges(keys=True, data=True))

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -150,6 +150,17 @@ class TestRelabel():
         mapping={0:'aardvark'}
         G=relabel_nodes(G,mapping,copy=False)
 
+    def test_relabel_copy_name(self):
+        G=Graph()
+        H = relabel_nodes(G, {}, copy=True)
+        assert_equal(H.graph, G.graph)
+        H = relabel_nodes(G, {}, copy=False)
+        assert_equal(H.graph, G.graph)
+        G.name = "first"
+        H = relabel_nodes(G, {}, copy=True)
+        assert_equal(H.graph, G.graph)
+        H = relabel_nodes(G, {}, copy=False)
+        assert_equal(H.graph, G.graph)
 
     def test_relabel_toposort(self):
         K5=nx.complete_graph(4)


### PR DESCRIPTION
Fixes #2134
simplifies read_gml handling of "name" as well.