### PR TITLE
Fix fruchterman reingold bug and add more tests to layouts.

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -139,7 +139,7 @@ def circular_layout(G, scale=1, center=None, dim=2):
     if len(G) == 0:
         pos = {}
     elif len(G) == 1:
-        pos = {G.nodes()[0]: center}
+        pos = {nx.utils.arbitrary_element(G): center}
     else:
         # Discard the extra angle since it matches 0 radians.
         theta = np.linspace(0, 1, len(G) + 1)[:-1] * 2 * np.pi
@@ -287,7 +287,7 @@ def fruchterman_reingold_layout(G, k=None,
 
     if pos is not None:
         # Determine size of existing domain to adjust initial positions
-        dom_size = max(coord for coord in pos_tup for pos_tup in pos.values())
+        dom_size = max(coord for pos_tup in pos.values() for coord in pos_tup)
         shape = (len(G), dim)
         pos_arr = np.random.random(shape) * dom_size + center
         for i, n in enumerate(G):

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -1,7 +1,7 @@
 """Unit tests for layout functions."""
 import sys
 from nose import SkipTest
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_false, assert_raises
 import networkx as nx
 
 
@@ -16,10 +16,10 @@ class TestLayout(object):
             raise SkipTest('numpy not available.')
 
     def setUp(self):
-        self.Gi = nx.grid_2d_graph(5,5)
+        self.Gi = nx.grid_2d_graph(5, 5)
         self.Gs = nx.Graph()
         nx.add_path(self.Gs, 'abcdef')
-        self.bigG = nx.grid_2d_graph(25,25) #bigger than 500 nodes for sparse
+        self.bigG = nx.grid_2d_graph(25, 25) #bigger than 500 nodes for sparse
 
     def test_smoke_int(self):
         G = self.Gi
@@ -27,6 +27,7 @@ class TestLayout(object):
         vpos = nx.circular_layout(G)
         vpos = nx.spring_layout(G)
         vpos = nx.fruchterman_reingold_layout(G)
+        vpos = nx.fruchterman_reingold_layout(self.bigG)
         vpos = nx.spectral_layout(G)
         vpos = nx.spectral_layout(self.bigG)
         vpos = nx.shell_layout(G)
@@ -43,8 +44,9 @@ class TestLayout(object):
     def test_adjacency_interface_numpy(self):
         A = nx.to_numpy_matrix(self.Gs)
         pos = nx.drawing.layout._fruchterman_reingold(A)
+        assert_equal(pos.shape, (6, 2))
         pos = nx.drawing.layout._fruchterman_reingold(A, dim=3)
-        assert_equal(pos.shape, (6,3))
+        assert_equal(pos.shape, (6, 3))
 
     def test_adjacency_interface_scipy(self):
         try:
@@ -53,14 +55,70 @@ class TestLayout(object):
             raise SkipTest('scipy not available.')
         A = nx.to_scipy_sparse_matrix(self.Gs, dtype='d')
         pos = nx.drawing.layout._sparse_fruchterman_reingold(A)
+        assert_equal(pos.shape, (6, 2))
         pos = nx.drawing.layout._sparse_spectral(A)
+        assert_equal(pos.shape, (6, 2))
         pos = nx.drawing.layout._sparse_fruchterman_reingold(A, dim=3)
-        assert_equal(pos.shape, (6,3))
+        assert_equal(pos.shape, (6, 3))
 
     def test_single_nodes(self):
         G = nx.path_graph(1)
         vpos = nx.shell_layout(G)
-        assert(vpos[0].any() == False)
+        assert_false(vpos[0].any())
         G = nx.path_graph(3)
-        vpos = nx.shell_layout(G, [[0], [1,2]])
-        assert(vpos[0].any() == False)
+        vpos = nx.shell_layout(G, [[0], [1, 2]])
+        assert_false(vpos[0].any())
+
+    def test_smoke_initial_pos_fruchterman_reingold(self):
+        pos = nx.circular_layout(self.Gi)
+        npos = nx.fruchterman_reingold_layout(self.Gi, pos=pos)
+
+    def test_fixed_node_fruchterman_reingold(self):
+        # Dense version (numpy based)
+        pos = nx.circular_layout(self.Gi)
+        npos = nx.fruchterman_reingold_layout(self.Gi, pos=pos, fixed=[(0, 0)])
+        assert_equal(tuple(pos[(0, 0)]), tuple(npos[(0, 0)]))
+        # Sparse version (scipy based)
+        pos = nx.circular_layout(self.bigG)
+        npos = nx.fruchterman_reingold_layout(self.bigG, pos=pos, fixed=[(0, 0)])
+        assert_equal(tuple(pos[(0, 0)]), tuple(npos[(0, 0)]))
+
+    def test_center_parameter(self):
+        G =  nx.path_graph(1)
+        vpos = nx.random_layout(G, center=(1, 1))
+        vpos = nx.circular_layout(G, center=(1, 1))
+        assert_equal(tuple(vpos[0]), (1, 1))
+        vpos = nx.spring_layout(G, center=(1, 1))
+        assert_equal(tuple(vpos[0]), (1, 1))
+        vpos = nx.fruchterman_reingold_layout(G, center=(1, 1))
+        assert_equal(tuple(vpos[0]), (1, 1))
+        vpos = nx.spectral_layout(G, center=(1, 1))
+        assert_equal(tuple(vpos[0]), (1, 1))
+        vpos = nx.shell_layout(G, center=(1, 1))
+        assert_equal(tuple(vpos[0]), (1, 1))
+
+    def test_center_wrong_dimensions(self):
+        G =  nx.path_graph(1)
+        assert_raises(ValueError, nx.random_layout, G, center=(1, 1, 1))
+        assert_raises(ValueError, nx.circular_layout, G, center=(1, 1, 1))
+        assert_raises(ValueError, nx.spring_layout, G, center=(1, 1, 1))
+        assert_raises(ValueError, nx.fruchterman_reingold_layout, G, center=(1, 1, 1))
+        assert_raises(ValueError, nx.fruchterman_reingold_layout, G, dim=3, center=(1, 1))
+        assert_raises(ValueError, nx.spectral_layout, G, center=(1, 1, 1))
+        assert_raises(ValueError, nx.spectral_layout, G, dim=3, center=(1, 1))
+        assert_raises(ValueError, nx.shell_layout, G, center=(1, 1, 1))
+
+    def test_empty_graph(self):
+        G =  nx.empty_graph()
+        vpos = nx.random_layout(G, center=(1, 1))
+        assert_equal(vpos, {})
+        vpos = nx.circular_layout(G, center=(1, 1))
+        assert_equal(vpos, {})
+        vpos = nx.spring_layout(G, center=(1, 1))
+        assert_equal(vpos, {})
+        vpos = nx.fruchterman_reingold_layout(G, center=(1, 1))
+        assert_equal(vpos, {})
+        vpos = nx.spectral_layout(G, center=(1, 1))
+        assert_equal(vpos, {})
+        vpos = nx.shell_layout(G, center=(1, 1))
+        assert_equal(vpos, {})


### PR DESCRIPTION
Incorrect generator expression syntax when evaluating the maximum of
the input pos dictionary. This bug only triggered when a pos dict
was passed as argument to fruchterman_reingold_layout. This commit
adds tests for this case.

Also added more tests for layouts, which are currently quite sparse.
When doing so I also found and fixed a bug in circular_layout
corner case (graph with only one node) that was using the old API
(expecting G.nodes() to be a list).