### PR TITLE
Tweak iteration logic of HITS

### DIFF
--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -89,8 +89,7 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
         s=1.0/sum(h.values())
         for k in h:
             h[k]*=s
-    i=1
-    while i<=max_iter:  # power iteration: make up to max_iter iterations
+    for i in range(max_iter):  # power iteration: make up to max_iter iterations
         hlast=h
         h=dict.fromkeys(hlast.keys(),0)
         a=dict.fromkeys(hlast.keys(),0)
@@ -113,7 +112,6 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
         err=sum([abs(h[n]-hlast[n]) for n in h])
         if err < tol:
             break
-        i+=1
     else:
         raise nx.PowerIterationFailedConvergence(max_iter)
     if normalized:

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -89,31 +89,31 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
         s=1.0/sum(h.values())
         for k in h:
             h[k]*=s
-    i = 1
-    while i <= max_iter:  # power iteration: make up to max_iter iterations
-        hlast = h
-        h = dict.fromkeys(hlast.keys(), 0)
-        a = dict.fromkeys(hlast.keys(), 0)
+    i=1
+    while i<=max_iter:  # power iteration: make up to max_iter iterations
+        hlast=h
+        h=dict.fromkeys(hlast.keys(),0)
+        a=dict.fromkeys(hlast.keys(),0)
         # this "matrix multiply" looks odd because it is
         # doing a left multiply a^T=hlast^T*G
         for n in h:
             for nbr in G[n]:
-                a[nbr] += hlast[n] * G[n][nbr].get('weight', 1)
+                a[nbr]+=hlast[n]*G[n][nbr].get('weight',1)
         # now multiply h=Ga
         for n in h:
             for nbr in G[n]:
-                h[n] += a[nbr] * G[n][nbr].get('weight', 1)
+                h[n]+=a[nbr]*G[n][nbr].get('weight',1)
         # normalize vector
-        s = 1.0 / max(h.values())
-        for n in h: h[n] *= s
+        s=1.0/max(h.values())
+        for n in h: h[n]*=s
         # normalize vector
-        s = 1.0 / max(a.values())
-        for n in a: a[n] *= s
+        s=1.0/max(a.values())
+        for n in a: a[n]*=s
         # check convergence, l1 norm
-        err = sum([abs(h[n] - hlast[n]) for n in h])
+        err=sum([abs(h[n]-hlast[n]) for n in h])
         if err < tol:
             break
-        i += 1
+        i+=1
     else:
         raise nx.PowerIterationFailedConvergence(max_iter)
     if normalized:

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -89,33 +89,33 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
         s=1.0/sum(h.values())
         for k in h:
             h[k]*=s
-    i=0
-    while True: # power iteration: make up to max_iter iterations
-        hlast=h
-        h=dict.fromkeys(hlast.keys(),0)
-        a=dict.fromkeys(hlast.keys(),0)
+    i = 1
+    while i <= max_iter:  # power iteration: make up to max_iter iterations
+        hlast = h
+        h = dict.fromkeys(hlast.keys(), 0)
+        a = dict.fromkeys(hlast.keys(), 0)
         # this "matrix multiply" looks odd because it is
         # doing a left multiply a^T=hlast^T*G
         for n in h:
             for nbr in G[n]:
-                a[nbr]+=hlast[n]*G[n][nbr].get('weight',1)
+                a[nbr] += hlast[n] * G[n][nbr].get('weight', 1)
         # now multiply h=Ga
         for n in h:
             for nbr in G[n]:
-                h[n]+=a[nbr]*G[n][nbr].get('weight',1)
+                h[n] += a[nbr] * G[n][nbr].get('weight', 1)
         # normalize vector
-        s=1.0/max(h.values())
-        for n in h: h[n]*=s
+        s = 1.0 / max(h.values())
+        for n in h: h[n] *= s
         # normalize vector
-        s=1.0/max(a.values())
-        for n in a: a[n]*=s
+        s = 1.0 / max(a.values())
+        for n in a: a[n] *= s
         # check convergence, l1 norm
-        err=sum([abs(h[n]-hlast[n]) for n in h])
+        err = sum([abs(h[n] - hlast[n]) for n in h])
         if err < tol:
             break
-        if i>max_iter:
-            raise nx.PowerIterationFailedConvergence(max_iter)
-        i+=1
+        i += 1
+    else:
+        raise nx.PowerIterationFailedConvergence(max_iter)
     if normalized:
         s = 1.0/sum(a.values())
         for n in a:

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -89,7 +89,7 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
         s=1.0/sum(h.values())
         for k in h:
             h[k]*=s
-    for i in range(max_iter):  # power iteration: make up to max_iter iterations
+    for _ in range(max_iter):  # power iteration: make up to max_iter iterations
         hlast=h
         h=dict.fromkeys(hlast.keys(),0)
         a=dict.fromkeys(hlast.keys(),0)

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -91,3 +91,9 @@ class TestHITS:
             raise SkipTest('scipy not available.')
         G=networkx.Graph()
         assert_equal(networkx.hits_scipy(G),({},{}))
+
+
+    @raises(networkx.PowerIterationFailedConvergence)
+    def test_hits_not_convergent(self):
+        G = self.G
+        networkx.hits(G, max_iter=0)


### PR DESCRIPTION
Refactor HITS convergence iteration logic so that exception message correctly states the number of iterations - iterate while the number of iterations is less than or equal to `max_iter`. If convergence is achieved within `max_iter` iterations, break out of the loop. If convergence is not achieved within `max_iter` iterations, raise a networkx error.

Create test `test_hits_not_convergent` to test for non-convergence of HITS by setting `max_iter` to 0 - test passes when error is raised and test fails when error is not raised.

https://github.com/networkx/networkx/issues/2140

cc: @dschult 