### PR TITLE
Adds exception: failed power iteration convergence

### DIFF
--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -78,6 +78,11 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
     NetworkXError
         If each value in `nstart` is zero.
 
+    PowerIterationFailedConvergence
+        If the algorithm fails to converge to the specified tolerance
+        within the specified number of iterations of the power iteration
+        method.
+
     See Also
     --------
     eigenvector_centrality_numpy
@@ -141,8 +146,7 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
         # Check for convergence (in the L_1 norm).
         if sum(abs(x[n] - xlast[n]) for n in x) < nnodes * tol:
             return x
-    raise nx.NetworkXError('power iteration failed to converge within {}'
-                           ' iterations'.format(max_iter))
+    raise nx.PowerIterationFailedConvergence(max_iter)
 
 
 def eigenvector_centrality_numpy(G, weight='weight', max_iter=50, tol=0):

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -94,6 +94,11 @@ def katz_centrality(G, alpha=0.1, beta=1.0,
        If the parameter `beta` is not a scalar but lacks a value for at least
        one node
 
+    PowerIterationFailedConvergence
+        If the algorithm fails to converge to the specified tolerance
+        within the specified number of iterations of the power iteration
+        method.
+
     Examples
     --------
     >>> import math
@@ -190,9 +195,8 @@ def katz_centrality(G, alpha=0.1, beta=1.0,
             for n in x:
                 x[n] *= s
             return x
+    raise nx.PowerIterationFailedConvergence(max_iter)
 
-    raise nx.NetworkXError('Power iteration failed to converge in '
-                           '%d iterations.' % max_iter)
 
 @not_implemented_for('multigraph')
 def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -56,7 +56,7 @@ class TestEigenvectorCentrality(object):
 
 
 
-    @raises(nx.NetworkXError)
+    @raises(nx.PowerIterationFailedConvergence)
     def test_maxiter(self):
         G=nx.path_graph(3)
         b=nx.eigenvector_centrality(G,max_iter=0)

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -30,7 +30,7 @@ class TestKatzCentrality(object):
         for n in sorted(G):
             assert_almost_equal(b[n], b_answer[n], places=4)
 
-    @raises(nx.NetworkXError)
+    @raises(nx.PowerIterationFailedConvergence)
     def test_maxiter(self):
         alpha = 0.1
         G = nx.path_graph(3)

--- a/networkx/algorithms/community/community_generators.py
+++ b/networkx/algorithms/community/community_generators.py
@@ -77,7 +77,7 @@ def _powerlaw_sequence(gamma, low, high, condition, length, max_iters):
 
     ``max_iters`` indicates the number of times to generate a list
     satisfying ``length``. If the number of iterations exceeds this
-    value, :exc:`~networkx.exception.NetworkXError` is raised.
+    value, :exc:`~networkx.exception.ExceededMaxIterations` is raised.
 
     """
     for i in range(max_iters):
@@ -86,7 +86,7 @@ def _powerlaw_sequence(gamma, low, high, condition, length, max_iters):
             seq.append(_zipf_rv_below(gamma, low, high))
         if condition(seq):
             return seq
-    raise nx.NetworkXError("Could not create power law sequence")
+    raise nx.ExceededMaxIterations("Could not create power law sequence")
 
 
 # TODO Needs documentation.
@@ -100,7 +100,7 @@ def _generate_min_degree(gamma, average_degree, max_degree, tolerance,
     mid_avg_deg = 0
     while abs(mid_avg_deg - average_degree) > tolerance:
         if itrs > max_iters:
-            raise nx.NetworkXError("Could not match average_degree")
+            raise nx.ExceededMaxIterations("Could not match average_degree")
         mid_avg_deg = 0
         for x in range(int(min_deg_mid), max_degree + 1):
             mid_avg_deg += (x ** (-gamma + 1)) / zeta(gamma, min_deg_mid,
@@ -129,15 +129,11 @@ def _generate_communities(degree_sequence, community_sizes, mu, max_iters):
     ``mu`` is a float in the interval [0, 1] indicating the fraction of
     intra-community edges incident to each node.
 
-    ``max_iters`` indicates the number of times to generate a list
-    satisfying ``length``. If the number of iterations exceeds this
-    value, :exc:`~networkx.exception.NetworkXError` is raised.
-
     ``max_iters`` is the number of times to try to add a node to a
     community. This must be greater than the length of
     ``degree_sequence``, otherwise this function will always fail. If
     the number of iterations exceeds this value,
-    :exc:`~networkx.exception.NetworkXError` is raised.
+    :exc:`~networkx.exception.ExceededMaxIterations` is raised.
 
     The communities returned by this are sets of integers in the set {0,
     ..., *n* - 1}, where *n* is the length of ``degree_sequence``.
@@ -164,8 +160,8 @@ def _generate_communities(degree_sequence, community_sizes, mu, max_iters):
             free.append(result[c].pop())
         if not free:
             return result
-    raise nx.NetworkXError('Could not assign communities; try increasing'
-                           ' min_community')
+    msg = 'Could not assign communities; try increasing min_community'
+    raise nx.ExceededMaxIterations(msg)
 
 
 def LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=None,
@@ -284,6 +280,7 @@ def LFR_benchmark_graph(n, tau1, tau2, mu, average_degree=None,
         If ``min_degree`` is not specified and a suitable ``min_degree``
         cannot be found.
 
+    ExceededMaxIterations
         If a valid degree sequence cannot be created within
         ``max_iters`` number of iterations.
 

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -42,6 +42,13 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
        Two dictionaries keyed by node containing the hub and authority
        values.
 
+    Raises
+    ------
+    PowerIterationFailedConvergence
+        If the algorithm fails to converge to the specified tolerance
+        within the specified number of iterations of the power iteration
+        method.
+
     Examples
     --------
     >>> G=nx.path_graph(4)
@@ -107,8 +114,7 @@ def hits(G,max_iter=100,tol=1.0e-8,nstart=None,normalized=True):
         if err < tol:
             break
         if i>max_iter:
-            raise NetworkXError(\
-            "HITS: power iteration failed to converge in %d iterations."%(i+1))
+            raise nx.PowerIterationFailedConvergence(max_iter)
         i+=1
     if normalized:
         s = 1.0/sum(a.values())
@@ -247,6 +253,13 @@ def hits_scipy(G,max_iter=100,tol=1.0e-6,normalized=True):
     algorithm does not check if the input graph is directed and will
     execute on undirected graphs.
 
+    Raises
+    ------
+    PowerIterationFailedConvergence
+        If the algorithm fails to converge to the specified tolerance
+        within the specified number of iterations of the power iteration
+        method.
+
     References
     ----------
     .. [1] A. Langville and C. Meyer,
@@ -281,8 +294,7 @@ def hits_scipy(G,max_iter=100,tol=1.0e-6,normalized=True):
         if err < tol:
             break
         if i>max_iter:
-            raise NetworkXError(\
-            "HITS: power iteration failed to converge in %d iterations."%(i+1))
+            raise nx.PowerIterationFailedConvergence(max_iter)
         i+=1
 
     a=np.asarray(x).flatten()

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -72,9 +72,11 @@ def pagerank(G, alpha=0.85, personalization=None,
     Notes
     -----
     The eigenvector calculation is done by the power iteration method
-    and has no guarantee of convergence.  The iteration will stop
-    after max_iter iterations or an error tolerance of
-    number_of_nodes(G)*tol has been reached.
+    and has no guarantee of convergence.  The iteration will stop after
+    an error tolerance of ``len(G) * tol`` has been reached. If the
+    number of iterations exceed `max_iter`, a
+    :exc:`networkx.exception.PowerIterationFailedConvergence` exception
+    is raised.
 
     The PageRank algorithm was designed for directed graphs but this
     algorithm does not check if the input graph is directed and will
@@ -85,6 +87,13 @@ def pagerank(G, alpha=0.85, personalization=None,
     --------
     pagerank_numpy, pagerank_scipy, google_matrix
 
+    Raises
+    ------
+    PowerIterationFailedConvergence
+        If the algorithm fails to converge to the specified tolerance
+        within the specified number of iterations of the power iteration
+        method.
+
     References
     ----------
     .. [1] A. Langville and C. Meyer,
@@ -93,6 +102,7 @@ def pagerank(G, alpha=0.85, personalization=None,
     .. [2] Page, Lawrence; Brin, Sergey; Motwani, Rajeev and Winograd, Terry,
        The PageRank citation ranking: Bringing order to the Web. 1999
        http://dbpubs.stanford.edu:8090/pub/showDoc.Fulltext?lang=en&doc=1999-66&format=pdf
+
     """
     if len(G) == 0:
         return {}
@@ -154,8 +164,7 @@ def pagerank(G, alpha=0.85, personalization=None,
         err = sum([abs(x[n] - xlast[n]) for n in x])
         if err < N*tol:
             return x
-    raise NetworkXError('pagerank: power iteration failed to converge '
-                        'in %d iterations.' % max_iter)
+    raise nx.PowerIterationFailedConvergence(max_iter)
 
 
 def google_matrix(G, alpha=0.85, personalization=None,
@@ -405,6 +414,13 @@ def pagerank_scipy(G, alpha=0.85, personalization=None,
     --------
     pagerank, pagerank_numpy, google_matrix
 
+    Raises
+    ------
+    PowerIterationFailedConvergence
+        If the algorithm fails to converge to the specified tolerance
+        within the specified number of iterations of the power iteration
+        method.
+
     References
     ----------
     .. [1] A. Langville and C. Meyer,
@@ -468,8 +484,7 @@ def pagerank_scipy(G, alpha=0.85, personalization=None,
         err = scipy.absolute(x - xlast).sum()
         if err < N * tol:
             return dict(zip(nodelist, map(float, x)))
-    raise NetworkXError('pagerank_scipy: power iteration failed to converge '
-                        'in %d iterations.' % max_iter)
+    raise nx.PowerIterationFailedConvergence(max_iter)
 
 
 # fixture for nose tests

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -52,8 +52,9 @@ class TestPageRank(object):
         for n in G:
             assert_almost_equal(p[n], G.pagerank[n], places=4)
 
-        assert_raises(networkx.NetworkXError, networkx.pagerank, G,
-                      max_iter=0)
+    @raises(networkx.PowerIterationFailedConvergence)
+    def test_pagerank_max_iter(self):
+        networkx.pagerank(self.G, max_iter=0)
 
     def test_numpy_pagerank(self):
         G = self.G
@@ -147,8 +148,9 @@ class TestPageRankScipy(TestPageRank):
         p = networkx.pagerank_scipy(G, alpha=0.9, tol=1.e-08,
                                     personalization=personalize)
 
-        assert_raises(networkx.NetworkXError, networkx.pagerank_scipy, G,
-                      max_iter=0)
+    @raises(networkx.PowerIterationFailedConvergence)
+    def test_scipy_pagerank_max_iter(self):
+        networkx.pagerank_scipy(self.G, max_iter=0)
 
     def test_dangling_scipy_pagerank(self):
         pr = networkx.pagerank_scipy(self.G, dangling=self.dangling_edges)

--- a/networkx/exception.py
+++ b/networkx/exception.py
@@ -55,3 +55,29 @@ class NetworkXNotImplemented(NetworkXException):
 
 class NodeNotFound(NetworkXException):
     """Exception raised if requested node is not present in the graph"""
+
+
+class ExceededMaxIterations(NetworkXException):
+    """Raised if a loop iterates too many times without breaking.
+
+    This may occur, for example, in an algorithm that computes
+    progressively better approximations to a value but exceeds an
+    iteration bound specified by the user.
+
+    """
+
+
+class PowerIterationFailedConvergence(ExceededMaxIterations):
+    """Raised when the power iteration method fails to converge within a
+    specified iteration limit.
+
+    `num_iterations` is the number of iterations that have been
+    completed when this exception was raised.
+
+    """
+
+    def __init__(self, num_iterations, *args, **kw):
+        msg = 'power iteration failed to converge within {} iterations'
+        msg = msg.format(num_iterations)
+        superinit = super(PowerIterationFailedConvergence, self).__init__
+        superinit(self, msg, *args, **kw)


### PR DESCRIPTION
This commit adds two new exceptions, `ExceededMaxIterations` and its
subclass `PowerIterationFailedConvergence`, intended to be used by
algorithms that accept a `max_iter` keyword argument specifying the
maximum number of allowable iterations of a main loop. Several existing
algorithms have been modified to raise these more meaningful exceptions.

(This pull request was inspired by pull request #2142, and needs to be updated once that gets merged. Specifically, that pull request should be merged before this one.)

This pull request follows the suggestion of issue #1705 to remove the "NetworkX" prefix from exception names.