### PR TITLE
Fix PageRank personalize docstring

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -35,7 +35,8 @@ def pagerank(G, alpha=0.85, personalization=None,
 
     personalization: dict, optional
       The "personalization vector" consisting of a dictionary with a
-      key for every graph node and nonzero personalization value for each node.
+      key for every graph node and personalization value for each node.
+      At least one personalization value must be non-zero.
       By default, a uniform distribution is used.
 
     max_iter : integer, optional

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -81,8 +81,8 @@ class TestPageRank(object):
     def test_personalization(self):
         G = networkx.complete_graph(4)
         personalize = {0: 1, 1: 1, 2: 4, 3: 4}
-        answer = {0: 0.1, 1: 0.1, 2: 0.4, 3: 0.4}
-        p = networkx.pagerank(G, alpha=0.0, personalization=personalize)
+        answer = {0: 0.23246732615667579, 1: 0.23246732615667579, 2: 0.267532673843324, 3: 0.2675326738433241}
+        p = networkx.pagerank(G, alpha=0.85, personalization=personalize)
         for n in G:
             assert_almost_equal(p[n], answer[n], places=4)
         personalize.pop(0)

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -89,6 +89,20 @@ class TestPageRank(object):
         assert_raises(networkx.NetworkXError, networkx.pagerank, G,
                       personalization=personalize)
 
+    def test_zero_personalization_vector(self):
+        G = networkx.complete_graph(4)
+        personalize = {0: 0, 1: 0, 2: 0, 3: 0}
+        assert_raises(ZeroDivisionError, networkx.pagerank, G,
+                  personalization=personalize)
+
+    def test_one_nonzero_personalization_value(self):
+        G = networkx.complete_graph(4)
+        personalize = {0: 0, 1: 0, 2: 0, 3: 1}
+        answer = {0: 0.22077931820379187, 1: 0.22077931820379187, 2: 0.22077931820379187, 3: 0.3376620453886241}
+        p = networkx.pagerank(G, alpha=0.85, personalization=personalize)
+        for n in G:
+            assert_almost_equal(p[n], answer[n], places=4)
+
     def test_dangling_matrix(self):
         """
         Tests that the google_matrix doesn't change except for the dangling


### PR DESCRIPTION
Fix docstring for PageRank personalization vector - personalization vector must have at least one non-zero value (ie. personalization values for each node can be zero provided that at least one personalization value for one node is non-zero).

Add test for zero personalization vector.

Add test for at least one non-zero personalization value.

Fix `test_personalization` - set `alpha` to 0.85. If `alpha` is 0, personalization vector does not contribute to PageRank.