### PR TITLE
Set default source=None for dfs_tree

### DIFF
--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -69,7 +69,7 @@ def dfs_edges(G, source=None):
             except StopIteration:
                 stack.pop()
 
-def dfs_tree(G, source):
+def dfs_tree(G, source=None):
     """Return oriented tree constructed from a depth-first-search from source.
 
     Parameters

--- a/networkx/algorithms/traversal/tests/test_dfs.py
+++ b/networkx/algorithms/traversal/tests/test_dfs.py
@@ -36,9 +36,20 @@ class TestDFS:
         assert_equal(nx.dfs_predecessors(self.D), {1: 0, 3: 2})
 
     def test_dfs_tree(self):
+        exp_nodes = sorted(self.G.nodes())
+        exp_edges = [(0, 1), (1, 2), (2, 4), (4, 3)]
+        # Search from first node
         T=nx.dfs_tree(self.G,source=0)
-        assert_equal(sorted(T.nodes()),sorted(self.G.nodes()))
-        assert_equal(sorted(T.edges()),[(0, 1), (1, 2), (2, 4), (4, 3)])
+        assert_equal(sorted(T.nodes()), exp_nodes)
+        assert_equal(sorted(T.edges()), exp_edges)
+        # Check source=None
+        T = nx.dfs_tree(self.G, source=None)
+        assert_equal(sorted(T.nodes()), exp_nodes)
+        assert_equal(sorted(T.edges()), exp_edges)
+        # Check source=None is the default
+        T = nx.dfs_tree(self.G)
+        assert_equal(sorted(T.nodes()), exp_nodes)
+        assert_equal(sorted(T.edges()), exp_edges)
 
     def test_dfs_edges(self):
         edges=nx.dfs_edges(self.G,source=0)


### PR DESCRIPTION
Docstring for `dfs_tree` states that `source` parameter is optional,
None is a valid value for `source`, and other functions in the same
module default to source=None.  Set `source=None` default and test.