### PR TITLE
Update `connected_components` example in tutorial

### DIFF
--- a/doc/source/tutorial/tutorial.rst
+++ b/doc/source/tutorial/tutorial.rst
@@ -388,8 +388,8 @@ functions such as:
 >>> G.add_edges_from([(1,2),(1,3)])
 >>> G.add_node("spam")       # adds node "spam"
 
->>> nx.connected_components(G)
-[[1, 2, 3], ['spam']]
+>>> list(nx.connected_components(G))
+[{1, 2, 3}, {'spam'}]
 
 >>> sorted(d for n, d in G.degree())
 [0, 1, 1, 2]


### PR DESCRIPTION
With version 1.10, `connected_components` returns a generator of sets of nodes. This PR updates the tutorial accordingly.