### PR TITLE
Minor bug in multi_source_dijkstra

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -654,7 +654,7 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     """
     if not sources:
         raise ValueError('sources must not be empty')
-    if target in sources:
+    if target != None and target in sources:
         return ({target: 0}, {target: [target]})
     weight = _weight_function(G, weight)
     paths = {source: [source] for source in sources}  # dictionary of paths


### PR DESCRIPTION
MINOR BUG

When no target nodes are provided in multi_source_dijkstra, Line 657 (https://github.com/networkx/networkx/blob/master/networkx/algorithms/shortest_paths/weighted.py#L657) gives the following TypeError.

TypeError: 'in <string>' requires string as left operand, not NoneType

Checking if target is None, before checking for target in sources, prevents the issue.