### PR TITLE
Rename average_clustering

### DIFF
--- a/networkx/algorithms/approximation/clustering_coefficient.py
+++ b/networkx/algorithms/approximation/clustering_coefficient.py
@@ -7,12 +7,12 @@
 import random
 from networkx.utils import not_implemented_for
 
-__all__ = ['average_clustering']
+__all__ = ['estimate_average_clustering']
 __author__ = """\n""".join(['Fred Morstatter <fred.morstatter@asu.edu>',
                             'Jordi Torrents <jtorrents@milnou.net>'])
 
 @not_implemented_for('directed')
-def average_clustering(G, trials=1000):
+def estimate_average_clustering(G, trials=1000):
     r"""Estimates the average clustering coefficient of G.
 
     The local clustering of each node in `G` is the fraction of triangles
@@ -53,7 +53,7 @@ def average_clustering(G, trials=1000):
     for i in [int(random.random() * n) for i in range(trials)]:
         nbrs = list(G[nodes[i]])
         if len(nbrs) < 2:
-            continue
+          continue
         u, v = random.sample(nbrs, 2)
         if u in G[v]:
             triangles += 1


### PR DESCRIPTION
Should average_clustering be renamed to avoid collision with the function with the same name in https://github.com/networkx/networkx/blob/d7d906e1d16ef331da0bc1d149953e7532155acc/networkx/algorithms/cluster.py

(Sorry about the whitespace error in this PR; you probably don't want to merge this)