### PR TITLE
Refactor Dinitz' algorithm implementation.

### DIFF
--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -12,14 +12,18 @@ from nose.tools import *
 import networkx as nx
 from networkx.algorithms.flow import build_flow_dict, build_residual_network
 from networkx.algorithms.flow import boykov_kolmogorov
+from networkx.algorithms.flow import dinitz
 from networkx.algorithms.flow import edmonds_karp
 from networkx.algorithms.flow import preflow_push
 from networkx.algorithms.flow import shortest_augmenting_path
-from networkx.algorithms.flow import dinitz
 
-# Dinitz algorithm is too slow in big and dense networks to test it here.
-# It is alredy tested in test_maxflow.py
-flow_funcs = [boykov_kolmogorov, edmonds_karp, preflow_push, shortest_augmenting_path]
+flow_funcs = [
+    boykov_kolmogorov,
+    dinitz,
+    edmonds_karp,
+    preflow_push,
+    shortest_augmenting_path,
+]
 
 msg = "Assertion failed in function: {0}"
 


### PR DESCRIPTION
Reimplemented the DFS iteratively instead of recursively. This
speeds up the running time considerably, specially for problems
in which the paths between source and sink are long, such as big
and sparse networks (eg social networks). For dense networks, in
which the paths are typically short, the running time is very
simmilar to the recursive implementation.

The speed up in the running time makes now possible to use Dinitz'
algorithm for testing the large graphs in `test_maxflow_large_graph.py`.
Thus we are now using all flow algorithms in all flow tests.