### PR TITLE
Added transitive_reduction in dag

### DIFF
--- a/doc/source/reference/algorithms.dag.rst
+++ b/doc/source/reference/algorithms.dag.rst
@@ -13,6 +13,7 @@ Directed Acyclic Graphs
    is_directed_acyclic_graph
    is_aperiodic
    transitive_closure
+   transitive_reduction
    antichains
    dag_longest_path
    dag_longest_path_length

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -24,6 +24,7 @@ __all__ = ['descendants',
            'is_directed_acyclic_graph',
            'is_aperiodic',
            'transitive_closure',
+           'transitive_reduction',
            'antichains',
            'dag_longest_path',
            'dag_longest_path_length']
@@ -352,6 +353,48 @@ def transitive_closure(G):
         TC.add_edges_from((v, u) for u in nx.dfs_preorder_nodes(G, source=v)
                           if v != u)
     return TC
+
+
+@not_implemented_for('undirected')
+def transitive_reduction(G):
+    """ Returns transitive reduction of a directed graph
+
+    The transitive reduction of G = (V,E) is a graph G- = (V,E-) such that
+    for all v,w in V there is an edge (v,w) in E- if and only if (v,w) is
+    in E and there is no path from v to w in G with length greater than 1.
+
+    Parameters
+    ----------
+    G : NetworkX DiGraph
+        Graph
+
+    Returns
+    -------
+    TR : NetworkX DiGraph
+        Graph
+
+    Raises
+    ------
+    NetworkXError
+        If G is not a directed acyclic graph (DAG) transitive reduction is
+        not uniquely defined and a NetworkXError exception is raised.
+
+    References 
+    ----------
+    https://en.wikipedia.org/wiki/Transitive_reduction
+
+    """   
+    if not is_directed_acyclic_graph(G):
+        raise nx.NetworkXError(
+            "Transitive reduction only uniquely defined on directed acyclic graphs.") 
+    TR = nx.DiGraph()
+    TR.add_nodes_from(G.nodes())
+    for u in G:
+        u_edges = set(G[u])
+        for v in G[u]:
+            u_edges -= {y for x, y in nx.dfs_edges(G, v)}
+        TR.add_edges_from((u,v) for v in u_edges)
+    return TR
 
 
 @not_implemented_for('undirected')

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -234,6 +234,18 @@ class TestDAG:
         G = nx.Graph([(1, 2), (2, 3), (3, 4)])
         assert_raises(nx.NetworkXNotImplemented, transitive_closure, G)
 
+    def test_transitive_reduction(self):
+        G = nx.DiGraph([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)])
+        transitive_reduction = nx.algorithms.dag.transitive_reduction
+        solution = [(1, 2), (2, 3), (3, 4)]
+        assert_edges_equal(transitive_reduction(G).edges(), solution)
+        G = nx.DiGraph([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)])
+        transitive_reduction = nx.algorithms.dag.transitive_reduction
+        solution = [(1, 2), (2, 3), (2, 4)]
+        assert_edges_equal(transitive_reduction(G).edges(), solution)        
+        G = nx.Graph([(1, 2), (2, 3), (3, 4)])
+        assert_raises(nx.NetworkXNotImplemented, transitive_reduction, G)
+
     def _check_antichains(self, solution, result):
         sol = [frozenset(a) for a in solution]
         res = [frozenset(a) for a in result]


### PR DESCRIPTION
I've added an initial implementation of [transitive reduction](https://en.wikipedia.org/wiki/Transitive_reduction) in the dag.py algorithms. It's a standard operation on directed acyclic graphs, basically the opposite of the transitive closure which is already implemented there.

This is my first attempt at contributing to this library but I'd like to get more involved if possible. I've tried to follow the development workflow in the docs but any feedback is welcome and apologies on anything that's been overlooked.

James