### PR TITLE
Turan docs

### DIFF
--- a/doc/source/reference/generators.rst
+++ b/doc/source/reference/generators.rst
@@ -39,6 +39,7 @@ Classic
    path_graph
    star_graph
    trivial_graph
+   turan_graph
    wheel_graph
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -681,7 +681,7 @@ def trivial_graph(create_using=None):
     return G
 
 
-def turan_graph(n,r):
+def turan_graph(n, r):
     """ Return the Turan Graph
     
     The Turan Graph is a complete multipartite graph on `n` vertices
@@ -706,15 +706,12 @@ def turan_graph(n,r):
     The graph has :math:`(r-1)(n^2)/(2r)` edges, rounded down.
     """
 
-    if not isinstance(n,int) or not isinstance(r,int):
-        raise nx.NetworkXError("n and r must be type int") 
-
     if not 1 <= r <= n:
         raise nx.NetworkXError("Must satisfy 1 <= r <= n")
 
     partitions = [n//r]*(r-(n%r))+[n//r+1]*(n%r)
     G = complete_multipartite_graph(*partitions)
-    G.name = "turan_graph({},{})".format(n,r)
+    G.name = "turan_graph({},{})".format(n, r)
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -682,11 +682,11 @@ def trivial_graph(create_using=None):
 
 
 def turan_graph(n, r):
-    """ Return the Turan Graph
-    
+    r""" Return the Turan Graph
+
     The Turan Graph is a complete multipartite graph on `n` vertices
-    with `r` partitions with the property that it has the maximum number
-    of edges for any graph with the same number of vertices and partitions.
+    with `r` disjoint subsets. It is the graph with the edges for any graph with
+    `n` vertices and `r` disjoint subsets.
 
     Given `n` and `r`, we generate a complete multipartite graph with
     :math:`r-(n \mod r)` partitions of size :math:`n/r`, rounded down, and

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -688,9 +688,9 @@ def turan_graph(n,r):
     with `r` partitions with the property that it has the maximum number
     of edges for any graph with the same number of vertices and partitions.
 
-    Given n and r, we get a complete multipartite graph with `r-(n mod r)`
-    partitions of size `n/r`, rounded down, and `n mod r` partitions of size
-    `n/r+1`, rounded down.
+    Given `n` and `r`, we generate a complete multipartite graph with
+    :math:`r-(n \mod r)` partitions of size :math:`n/r`, rounded down, and
+    :math:`n \mod r` partitions of size :math:`n/r+1`, rounded down.
 
     Parameters
     ==========
@@ -702,8 +702,8 @@ def turan_graph(n,r):
 
     Notes
     =====
-    Must satisfy `1 <= r <= n`.
-    The graph has `(r-1)(n^2)/(2r)` edges, rounded down.
+    Must satisfy :math:`1 <= r <= n`.
+    The graph has :math:`(r-1)(n^2)/(2r)` edges, rounded down.
     """
 
     if not isinstance(n,int) or not isinstance(r,int):

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -437,8 +437,6 @@ class TestGeneratorClassic():
         assert_equal(number_of_nodes(trivial_graph()), 1)
 
     def test_turan_graph(self):
-        assert_raises(nx.NetworkXError, turan_graph,3,5)
-        assert_raises(nx.NetworkXError, turan_graph,1.0,1)
         assert_equal(number_of_edges(turan_graph(13,4)),63)
         assert_true(is_isomorphic(turan_graph(13,4),complete_multipartite_graph(3,4,3,3)))
 


### PR DESCRIPTION
The Turan Graph generator does not appear in the docs (it was not in the generator.rst file).

This pr also removes some unnecessary type checking from the Turan Graph code and fixes its documentation to include the :math: tag. It also fixes some spacing issues to comply with PEP8.
