### PR TITLE
Add adjlist_outer_dict_factory.

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -176,14 +176,20 @@ class DiGraph(Graph):
     maintained but extra features can be added. To replace one of the
     dicts create a new graph class by changing the class(!) variable
     holding the factory for that dict-like structure. The variable names
-    are node_dict_factory, adjlist_dict_factory and edge_attr_dict_factory.
+    are node_dict_factory, adjlist_inner_dict_factory, adjlist_outer_dict_factory,
+    and edge_attr_dict_factory.
 
-    node_dict_factory : function, optional (default: dict)
+    node_dict_factory : function, (default: dict)
+        Factory function to be used to create the dict containing node
+        attributes, keyed by node id.
+        It should require no arguments and return a dict-like object
+
+    adjlist_outer_dict_factory : function, (default: dict)
         Factory function to be used to create the outer-most dict
         in the data structure that holds adjacency info keyed by node.
         It should require no arguments and return a dict-like object.
 
-    adjlist_dict_factory : function, optional (default: dict)
+    adjlist_inner_dict_factory : function, optional (default: dict)
         Factory function to be used to create the adjacency list
         dict which holds edge data keyed by neighbor.
         It should require no arguments and return a dict-like object
@@ -200,6 +206,7 @@ class DiGraph(Graph):
     >>> from collections import OrderedDict
     >>> class OrderedNodeGraph(nx.Graph):
     ...     node_dict_factory=OrderedDict
+    ...     adjlist_outer_dict_factory=OrderedDict
     >>> G=OrderedNodeGraph()
     >>> G.add_nodes_from( (2,1) )
     >>> list(G.nodes())
@@ -212,8 +219,9 @@ class DiGraph(Graph):
     and for each node track the order that neighbors are added.
 
     >>> class OrderedGraph(nx.Graph):
-    ...    node_dict_factory = OrderedDict
-    ...    adjlist_dict_factory = OrderedDict
+    ...     node_dict_factory = OrderedDict
+    ...     adjlist_outer_dict_factory=OrderedDict
+    ...     adjlist_inner_dict_factory = OrderedDict
     >>> G = OrderedGraph()
     >>> G.add_nodes_from( (2,1) )
     >>> list(G.nodes())
@@ -275,7 +283,8 @@ class DiGraph(Graph):
 
         """
         self.node_dict_factory = ndf = self.node_dict_factory
-        self.adjlist_dict_factory = self.adjlist_dict_factory
+        self.adjlist_outer_dict_factory = self.adjlist_outer_dict_factory
+        self.adjlist_inner_dict_factory = self.adjlist_inner_dict_factory
         self.edge_attr_dict_factory = self.edge_attr_dict_factory
 
         self.graph = {} # dictionary for graph attributes
@@ -336,8 +345,8 @@ class DiGraph(Graph):
         doesn't change on mutables.
         """
         if n not in self.succ:
-            self.succ[n] = self.adjlist_dict_factory()
-            self.pred[n] = self.adjlist_dict_factory()
+            self.succ[n] = self.adjlist_inner_dict_factory()
+            self.pred[n] = self.adjlist_inner_dict_factory()
             self.node[n] = attr
         else: # update attr even if node already exists
             self.node[n].update(attr)
@@ -394,16 +403,16 @@ class DiGraph(Graph):
             # while pre-2.7.5 ironpython throws on self.succ[n] 
             try:
                 if n not in self.succ:
-                    self.succ[n] = self.adjlist_dict_factory()
-                    self.pred[n] = self.adjlist_dict_factory()
+                    self.succ[n] = self.adjlist_inner_dict_factory()
+                    self.pred[n] = self.adjlist_inner_dict_factory()
                     self.node[n] = attr.copy()
                 else:
                     self.node[n].update(attr)
             except TypeError:
                 nn,ndict = n
                 if nn not in self.succ:
-                    self.succ[nn] = self.adjlist_dict_factory()
-                    self.pred[nn] = self.adjlist_dict_factory()
+                    self.succ[nn] = self.adjlist_inner_dict_factory()
+                    self.pred[nn] = self.adjlist_inner_dict_factory()
                     newdict = attr.copy()
                     newdict.update(ndict)
                     self.node[nn] = newdict
@@ -547,12 +556,12 @@ class DiGraph(Graph):
         """
         # add nodes
         if u not in self.succ:
-            self.succ[u]= self.adjlist_dict_factory()
-            self.pred[u]= self.adjlist_dict_factory()
+            self.succ[u]= self.adjlist_inner_dict_factory()
+            self.pred[u]= self.adjlist_inner_dict_factory()
             self.node[u] = {}
         if v not in self.succ:
-            self.succ[v]= self.adjlist_dict_factory()
-            self.pred[v]= self.adjlist_dict_factory()
+            self.succ[v]= self.adjlist_inner_dict_factory()
+            self.pred[v]= self.adjlist_inner_dict_factory()
             self.node[v] = {}
         # add the edge
         datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
@@ -611,12 +620,12 @@ class DiGraph(Graph):
                 raise NetworkXError(\
                     "Edge tuple %s must be a 2-tuple or 3-tuple."%(e,))
             if u not in self.succ:
-                self.succ[u] = self.adjlist_dict_factory()
-                self.pred[u] = self.adjlist_dict_factory()
+                self.succ[u] = self.adjlist_inner_dict_factory()
+                self.pred[u] = self.adjlist_inner_dict_factory()
                 self.node[u] = {}
             if v not in self.succ:
-                self.succ[v] = self.adjlist_dict_factory()
-                self.pred[v] = self.adjlist_dict_factory()
+                self.succ[v] = self.adjlist_inner_dict_factory()
+                self.pred[v] = self.adjlist_inner_dict_factory()
                 self.node[v] = {}
             datadict=self.adj[u].get(v,self.edge_attr_dict_factory())
             datadict.update(attr)
@@ -1250,8 +1259,8 @@ class DiGraph(Graph):
         self_succ=self.succ
         # add nodes
         for n in H:
-            H_succ[n]=H.adjlist_dict_factory()
-            H_pred[n]=H.adjlist_dict_factory()
+            H_succ[n]=H.adjlist_inner_dict_factory()
+            H_pred[n]=H.adjlist_inner_dict_factory()
         # add edges
         for u in H_succ:
             Hnbrs=H_succ[u]
@@ -1322,9 +1331,9 @@ class DiGraph(Graph):
             # Create an entry in the successors and predecessors
             # dictionary for the nodes u and v if they don't exist yet.
             if u not in H.succ:
-                H.succ[u] = H.adjlist_dict_factory()
+                H.succ[u] = H.adjlist_inner_dict_factory()
             if v not in H.pred:
-                H.pred[v] = H.adjlist_dict_factory()
+                H.pred[v] = H.adjlist_inner_dict_factory()
             # Copy the edge attributes.
             H.edge[u][v] = self.edge[u][v]
             H.pred[v][u] = self.pred[v][u]

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -188,15 +188,20 @@ class MultiDiGraph(MultiGraph,DiGraph):
     extra features can be added. To replace one of the dicts create
     a new graph class by changing the class(!) variable holding the
     factory for that dict-like structure. The variable names
-    are node_dict_factory, adjlist_dict_factory, edge_key_dict_factory
+    are node_dict_factory, adjlist_inner_dict_factory, adjlist_outer_dict_factory,
     and edge_attr_dict_factory.
 
     node_dict_factory : function, (default: dict)
+        Factory function to be used to create the dict containing node
+        attributes, keyed by node id.
+        It should require no arguments and return a dict-like object
+
+    adjlist_outer_dict_factory : function, (default: dict)
         Factory function to be used to create the outer-most dict
         in the data structure that holds adjacency info keyed by node.
         It should require no arguments and return a dict-like object.
 
-    adjlist_dict_factory : function, (default: dict)
+    adjlist_inner_dict_factory : function, (default: dict)
         Factory function to be used to create the adjacency list
         dict which holds multiedge key dicts keyed by neighbor.
         It should require no arguments and return a dict-like object.
@@ -218,6 +223,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
     >>> from collections import OrderedDict
     >>> class OrderedGraph(nx.MultiDiGraph):
     ...    node_dict_factory = OrderedDict
+    ...    adjlist_outer_dict_factory = OrderedDict
     >>> G = OrderedGraph()
     >>> G.add_nodes_from( (2,1) )
     >>> list(G.nodes())
@@ -232,7 +238,8 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
     >>> class OrderedGraph(nx.MultiDiGraph):
     ...    node_dict_factory = OrderedDict
-    ...    adjlist_dict_factory = OrderedDict
+    ...    adjlist_outer_dict_factory = OrderedDict
+    ...    adjlist_inner_dict_factory = OrderedDict
     ...    edge_key_dict_factory = OrderedDict
     >>> G = OrderedGraph()
     >>> G.add_nodes_from( (2,1) )
@@ -245,7 +252,8 @@ class MultiDiGraph(MultiGraph,DiGraph):
 
     """
     # node_dict_factory=dict    # already assigned in Graph
-    # adjlist_dict_factory=dict
+    # adjlist_outer_dict_factory=dict
+    # adjlist_inner_dict_factory=dict
     edge_key_dict_factory = dict
     # edge_attr_dict_factory=dict
 
@@ -321,12 +329,12 @@ class MultiDiGraph(MultiGraph,DiGraph):
         """
         # add nodes
         if u not in self.succ:
-            self.succ[u] = self.adjlist_dict_factory()
-            self.pred[u] = self.adjlist_dict_factory()
+            self.succ[u] = self.adjlist_inner_dict_factory()
+            self.pred[u] = self.adjlist_inner_dict_factory()
             self.node[u] = {}
         if v not in self.succ:
-            self.succ[v] = self.adjlist_dict_factory()
-            self.pred[v] = self.adjlist_dict_factory()
+            self.succ[v] = self.adjlist_inner_dict_factory()
+            self.pred[v] = self.adjlist_inner_dict_factory()
             self.node[v] = {}
         if key is None:
             key = self.new_edge_key(u, v)
@@ -932,8 +940,8 @@ class MultiDiGraph(MultiGraph,DiGraph):
         self_pred = self.pred
         # add nodes
         for n in H:
-            H_succ[n] = H.adjlist_dict_factory()
-            H_pred[n] = H.adjlist_dict_factory()
+            H_succ[n] = H.adjlist_inner_dict_factory()
+            H_pred[n] = H.adjlist_inner_dict_factory()
         # add edges
         for u in H_succ:
             Hnbrs = H_succ[u]
@@ -1017,9 +1025,9 @@ class MultiDiGraph(MultiGraph,DiGraph):
             # Create an entry in the successors and predecessors
             # dictionary for the nodes u and v if they don't exist yet.
             if u not in H.succ:
-                H.succ[u] = H.adjlist_dict_factory()
+                H.succ[u] = H.adjlist_inner_dict_factory()
             if v not in H.pred:
-                H.pred[v] = H.adjlist_dict_factory()
+                H.pred[v] = H.adjlist_inner_dict_factory()
             # Create an entry in the edge dictionary for the edges (u,
             # v) and (v, u) if the don't exist yet.
             if v not in H.succ[u]:

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -189,15 +189,20 @@ class MultiGraph(Graph):
     extra features can be added. To replace one of the dicts create
     a new graph class by changing the class(!) variable holding the
     factory for that dict-like structure. The variable names
-    are node_dict_factory, adjlist_dict_factory, edge_key_dict_factory
+    are node_dict_factory, adjlist_inner_dict_factory, adjlist_outer_dict_factory,
     and edge_attr_dict_factory.
 
     node_dict_factory : function, (default: dict)
+        Factory function to be used to create the dict containing node
+        attributes, keyed by node id.
+        It should require no arguments and return a dict-like object
+
+    adjlist_outer_dict_factory : function, (default: dict)
         Factory function to be used to create the outer-most dict
         in the data structure that holds adjacency info keyed by node.
         It should require no arguments and return a dict-like object.
 
-    adjlist_dict_factory : function, (default: dict)
+    adjlist_inner_dict_factory : function, (default: dict)
         Factory function to be used to create the adjacency list
         dict which holds multiedge key dicts keyed by neighbor.
         It should require no arguments and return a dict-like object.
@@ -219,6 +224,7 @@ class MultiGraph(Graph):
     >>> from collections import OrderedDict
     >>> class OrderedGraph(nx.MultiGraph):
     ...    node_dict_factory = OrderedDict
+    ...    adjlist_outer_dict_factory = OrderedDict
     >>> G = OrderedGraph()
     >>> G.add_nodes_from( (2,1) )
     >>> list(G.nodes())
@@ -233,7 +239,8 @@ class MultiGraph(Graph):
 
     >>> class OrderedGraph(nx.MultiGraph):
     ...    node_dict_factory = OrderedDict
-    ...    adjlist_dict_factory = OrderedDict
+    ...    adjlist_outer_dict_factory = OrderedDict
+    ...    adjlist_inner_dict_factory = OrderedDict
     ...    edge_key_dict_factory = OrderedDict
     >>> G = OrderedGraph()
     >>> G.add_nodes_from( (2,1) )
@@ -246,7 +253,8 @@ class MultiGraph(Graph):
 
     """
     # node_dict_factory=dict    # already assigned in Graph
-    # adjlist_dict_factory=dict
+    # adjlist_outer_dict_factory=dict
+    # adjlist_inner_dict_factory=dict
     edge_key_dict_factory = dict
     # edge_attr_dict_factory=dict
 
@@ -344,10 +352,10 @@ class MultiGraph(Graph):
         """
         # add nodes
         if u not in self.adj:
-            self.adj[u] = self.adjlist_dict_factory()
+            self.adj[u] = self.adjlist_inner_dict_factory()
             self.node[u] = {}
         if v not in self.adj:
-            self.adj[v] = self.adjlist_dict_factory()
+            self.adj[v] = self.adjlist_inner_dict_factory()
             self.node[v] = {}
         if key is None:
             key = self.new_edge_key(u, v)
@@ -1038,7 +1046,7 @@ class MultiGraph(Graph):
         self_adj = self.adj
         # add nodes and edges (undirected method)
         for n in H:
-            Hnbrs = H.adjlist_dict_factory()
+            Hnbrs = H.adjlist_inner_dict_factory()
             H_adj[n] = Hnbrs
             for nbr, edgedict in self_adj[n].items():
                 if nbr in H_adj:
@@ -1120,9 +1128,9 @@ class MultiGraph(Graph):
             # Create an entry in the adjacency dictionary for the
             # nodes u and v if they don't exist yet.
             if u not in H.adj:
-                H.adj[u] = H.adjlist_dict_factory()
+                H.adj[u] = H.adjlist_inner_dict_factory()
             if v not in H.adj:
-                H.adj[v] = H.adjlist_dict_factory()
+                H.adj[v] = H.adjlist_inner_dict_factory()
             # Create an entry in the edge dictionary for the edges (u,
             # v) and (v, u) if the don't exist yet.
             if v not in H.adj[u]:

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -21,25 +21,29 @@ __all__.extend([
 
 class OrderedGraph(Graph):
     node_dict_factory = OrderedDict
-    adjlist_dict_factory = OrderedDict
+    adjlist_outer_dict_factory = OrderedDict
+    adjlist_inner_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
 
 
 class OrderedDiGraph(DiGraph):
     node_dict_factory = OrderedDict
-    adjlist_dict_factory = OrderedDict
+    adjlist_outer_dict_factory = OrderedDict
+    adjlist_inner_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
 
 
 class OrderedMultiGraph(MultiGraph):
     node_dict_factory = OrderedDict
-    adjlist_dict_factory = OrderedDict
+    adjlist_outer_dict_factory = OrderedDict
+    adjlist_inner_dict_factory = OrderedDict
     edge_key_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
 
 
 class OrderedMultiDiGraph(MultiDiGraph):
     node_dict_factory = OrderedDict
-    adjlist_dict_factory = OrderedDict
+    adjlist_outer_dict_factory = OrderedDict
+    adjlist_inner_dict_factory = OrderedDict
     edge_key_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict

--- a/networkx/classes/tests/test_special.py
+++ b/networkx/classes/tests/test_special.py
@@ -25,7 +25,8 @@ class OrderedGraphTester(TestGraph):
         TestGraph.setUp(self)
         class MyGraph(nx.Graph):
             node_dict_factory = OrderedDict
-            adjlist_dict_factory = OrderedDict
+            adjlist_outer_dict_factory = OrderedDict
+            adjlist_inner_dict_factory = OrderedDict
             edge_attr_dict_factory = OrderedDict
         self.Graph=MyGraph
 
@@ -62,7 +63,8 @@ class OrderedDiGraphTester(TestDiGraph):
         TestGraph.setUp(self)
         class MyGraph(nx.DiGraph):
             node_dict_factory = OrderedDict
-            adjlist_dict_factory = OrderedDict
+            adjlist_outer_dict_factory = OrderedDict
+            adjlist_inner_dict_factory = OrderedDict
             edge_attr_dict_factory = OrderedDict
         self.Graph=MyGraph
 
@@ -98,7 +100,8 @@ class OrderedMultiGraphTester(TestMultiGraph):
         TestMultiGraph.setUp(self)
         class MyGraph(nx.MultiGraph):
             node_dict_factory = OrderedDict
-            adjlist_dict_factory = OrderedDict
+            adjlist_outer_dict_factory = OrderedDict
+            adjlist_inner_dict_factory = OrderedDict
             edge_key_dict_factory = OrderedDict
             edge_attr_dict_factory = OrderedDict
         self.Graph=MyGraph
@@ -114,7 +117,8 @@ class OrderedMultiDiGraphTester(TestMultiDiGraph):
         TestMultiDiGraph.setUp(self)
         class MyGraph(nx.MultiDiGraph):
             node_dict_factory = OrderedDict
-            adjlist_dict_factory = OrderedDict
+            adjlist_outer_dict_factory = OrderedDict
+            adjlist_inner_dict_factory = OrderedDict
             edge_key_dict_factory = OrderedDict
             edge_attr_dict_factory = OrderedDict
         self.Graph=MyGraph


### PR DESCRIPTION
* Rename adjlist_dict_factory to adjlist_inner_dict_factory
* Split node_dict_factory into node_dict_factory (and add its doc) and adjlist_inner_dict_factory (its previously documented purpose).


Motivation: in an application I am writing, I set `node_dict_factory` to a pseudo-dict that notifies a certain class when nodes are added to the graph.
Unfortunately, `node_dict_factory` is also used to create the outer dict of the adjacency list, so I have no way to patch one and not the other.