### PR TITLE
Typo in scale free network generator documentation

### DIFF
--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -219,7 +219,7 @@ def scale_free_graph(n, alpha=0.41, beta=0.54, gamma=0.05, delta_in=0.2,
         distribution and the other chosen randomly according to the out-degree
         distribution.
     gamma : float
-        Probability for adding a new node conecgted to an existing node
+        Probability for adding a new node connected to an existing node
         chosen randomly according to the out-degree distribution.
     delta_in : float
         Bias for choosing ndoes from in-degree distribution.


### PR DESCRIPTION
Fixed documentation of the scale free network generator: "conecgted" should be "connected".