### PR TITLE
don't assume nodes are sortable when running dag_longest_path

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -442,10 +442,10 @@ def dag_longest_path(G, weight='weight', default_weight=1):
         us = [(dist[u][0] + data.get(weight, default_weight), u)
             for u, data in G.pred[v].items()]
         # Use the best predecessor if there is one and its distance is non-negative, otherwise terminate.
-        maxu = max(us) if us else (0, v)
+        maxu = max(us, key=lambda x: x[0]) if us else (0, v)
         dist[v] = maxu if maxu[0] >= 0 else (0, v)
     u = None
-    v = max(dist, key=dist.get)
+    v = max(dist, key=lambda x: dist[x][0])
     path = []
     while u != v:
         path.append(v)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -10,7 +10,6 @@ from nose.tools import ok_
 import networkx as nx
 from networkx.testing.utils import assert_edges_equal
 from networkx.utils import consume
-from networkx.utils import pairwise
 
 
 class TestDagLongestPath(object):
@@ -30,10 +29,10 @@ class TestDagLongestPath(object):
 
     def test_weighted(self):
         G = nx.DiGraph()
-        edges = [(1, 2, -5), (2, 3, 0), (3, 4, 1), (4, 5, 2), (3, 5, 4),
-                 (5, 6, 0), (1, 6, 2)]
+        edges = [(1, 2, -5), (2, 3, 1), (3, 4, 1), (4, 5, 0), (3, 5, 4),
+                 (1, 6, 2)]
         G.add_weighted_edges_from(edges)
-        assert_equal(nx.dag_longest_path(G), [2, 3, 5, 6])
+        assert_equal(nx.dag_longest_path(G), [2, 3, 5])
 
     def test_undirected_not_implemented(self):
         G = nx.Graph()
@@ -53,20 +52,22 @@ class TestDagLongestPath(object):
         # support for Python 2 is dropped, this test can be simplified
         # by replacing `Unorderable()` by `object()`.
         class Unorderable(object):
+            def __lt__(self, other):
+                error_msg = "< not supported between instances of " \
+                  "{} and {}".format(type(self).__name__, type(other).__name__)
+                raise TypeError(error_msg)
 
-            def __le__(self):
-                raise NotImplemented
-
-            def __ge__(self):
-                raise NotImplemented
-
-        # Create the directed path graph on four nodes, with nodes
-        # represented as (unorderable) Python objects.
+        # Create the directed path graph on four nodes in a diamond shape,
+        # with nodes represented as (unorderable) Python objects.
         nodes = [Unorderable() for n in range(4)]
         G = nx.DiGraph()
-        G.add_edges_from(pairwise(nodes))
-        path = list(nx.dag_longest_path(G))
-        assert_equal(path, nodes)
+        G.add_edge(nodes[0], nodes[1])
+        G.add_edge(nodes[0], nodes[2])
+        G.add_edge(nodes[2], nodes[3])
+        G.add_edge(nodes[1], nodes[3])
+
+        # this will raise NotImplementedError when nodes need to be ordered
+        nx.dag_longest_path(G)
 
 
 class TestDagLongestPathLength(object):
@@ -89,11 +90,11 @@ class TestDagLongestPathLength(object):
         assert_raises(nx.NetworkXNotImplemented, nx.dag_longest_path_length, G)
 
     def test_weighted(self):
-        edges = [(1, 2, -5), (2, 3, 0), (3, 4, 1), (4, 5, 2), (3, 5, 4),
-                 (5, 6, 0), (1, 6, 2)]
+        edges = [(1, 2, -5), (2, 3, 1), (3, 4, 1), (4, 5, 0), (3, 5, 4),
+                 (1, 6, 2)]
         G = nx.DiGraph()
         G.add_weighted_edges_from(edges)
-        assert_equal(nx.dag_longest_path_length(G), 3)
+        assert_equal(nx.dag_longest_path_length(G), 2)
 
 
 class TestDAG:


### PR DESCRIPTION
The `dag_longest_path function` can raise an TypeError Exception when the nodes of the DiGraph passed to it aren't sortable (i.e. don't define the `__lt__` method). The algorithm creates a list of `(length, u)` tuples, where u is a node. It then runs the `max()` function on said list. Ordering of tuples is defined by comparing corresponding elements lexicographically. So if ever there's a case where two lengths are equal, the nodes will be compared a `TypeError: unorderable types` is raised. I suspect that this would occur for very frequently when using unsortable nodes considering how the algorithm works.