### PR TITLE
Use ego graph when computing local efficiency

### DIFF
--- a/networkx/algorithms/efficiency.py
+++ b/networkx/algorithms/efficiency.py
@@ -137,4 +137,4 @@ def local_efficiency(G):
 
     """
     # TODO This summation can be trivially parallelized.
-    return sum(global_efficiency(G.subgraph(G[v])) for v in G) / len(G)
+    return sum(global_efficiency(nx.ego_graph(G, v)) for v in G) / len(G)

--- a/networkx/algorithms/tests/test_efficiency.py
+++ b/networkx/algorithms/tests/test_efficiency.py
@@ -8,6 +8,7 @@
 # information.
 """Unit tests for the :mod:`networkx.algorithms.efficiency` module."""
 from __future__ import division
+from unittest import TestCase
 
 from nose.tools import assert_equal
 
@@ -18,11 +19,6 @@ def test_efficiency():
     G = nx.cycle_graph(4)
     assert_equal(nx.efficiency(G, 0, 1), 1)
     assert_equal(nx.efficiency(G, 0, 2), 1 / 2)
-
-
-def test_local_efficiency():
-    G = nx.complete_graph(4)
-    assert_equal(nx.local_efficiency(G), 1)
 
 
 def test_global_efficiency():
@@ -38,3 +34,21 @@ def test_complete_graph_global_efficiency():
     for n in range(10):
         G = nx.complete_graph(5)
         assert_equal(nx.global_efficiency(G), 1)
+
+
+class TestLocalEfficiency(TestCase):
+    """Unit tests for the local efficiency function."""
+
+    def test_complete_graph(self):
+        G = nx.complete_graph(4)
+        assert_equal(nx.local_efficiency(G), 1)
+
+    def test_using_ego_graph(self):
+        """Test that the ego graph is used when computing local efficiency.
+
+        For more information, see GitHub issue #2233.
+
+        """
+        # This is the triangle graph with one additional edge.
+        G = nx.lollipop_graph(3, 1)
+        assert_equal(nx.local_efficiency(G), 23 / 24)


### PR DESCRIPTION
This commit fixes a bug in the `local_efficiency()` function in which
the central node was being excluded from the computation of global
efficiency.

This fixes issue #2233.