### PR TITLE
Make harmonic centrality more memory-efficient

### DIFF
--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -1,12 +1,16 @@
 #    Copyright (C) 2015 by
 #    Alessandro Luongo
 #    BSD license.
+#
+# Authors:
+#    Alessandro Luongo <alessandro.luongo@studenti.unimi.it>
+#
 """Functions for computing the harmonic centrality of a graph."""
 from __future__ import division
+from functools import partial
 
 import networkx as nx
 
-__author__ = "\n".join(['Alessandro Luongo (alessandro.luongo@studenti.unimi.it'])
 __all__ = ['harmonic_centrality']
 
 
@@ -56,5 +60,5 @@ def harmonic_centrality(G, distance=None):
     """
     if G.is_directed():
         G = G.reverse()
-    sp = nx.shortest_path_length(G, weight=distance)
-    return {n: sum(1 / d if d > 0 else 0 for d in dd.values()) for n, dd in sp}
+    spl = partial(nx.shortest_path_length, G, weight=distance)
+    return {u: sum(1 / d if d > 0 else 0 for v, d in spl(source=u)) for u in G}


### PR DESCRIPTION
This commit changes the implementation of harmonic centrality to compute
single-source shortest path length in the body of a loop instead of
computing all-pairs shortest path lengths outside of the loop, in order
to make the implementation more memory efficient.

Fixes issue #2238.