### PR TITLE
Adds unit tests for using dtype with to_numpy_matrix

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -366,7 +366,7 @@ def to_numpy_matrix(G, nodelist=None, dtype=None, order=None,
 
     if G.is_multigraph():
         # Handle MultiGraphs and MultiDiGraphs
-        M = np.zeros((nlen, nlen), dtype=dtype, order=order) + np.nan
+        M = np.full((nlen, nlen), np.nan, order=order)
         # use numpy nan-aware operations
         operator={sum:np.nansum, min:np.nanmin, max:np.nanmax}
         try:
@@ -383,7 +383,7 @@ def to_numpy_matrix(G, nodelist=None, dtype=None, order=None,
                     M[j,i] = M[i,j]
     else:
         # Graph or DiGraph, this is much faster than above
-        M = np.zeros((nlen,nlen), dtype=dtype, order=order) + np.nan
+        M = np.full((nlen, nlen), np.nan, order=order)
         for u,nbrdict in G.adjacency():
             for v,d in nbrdict.items():
                 try:

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -218,3 +218,23 @@ class TestConvertNumpy(object):
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, weight=1)
         assert_graphs_equal(G, expected)
+
+    def test_dtype_int_graph(self):
+        """Test that setting dtype int actually gives an integer matrix.
+
+        For more information, see GitHub pull request #1363.
+
+        """
+        G = nx.complete_graph(3)
+        A = nx.to_numpy_matrix(G, dtype=int)
+        assert_equal(A.dtype, int)
+
+    def test_dtype_int_multigraph(self):
+        """Test that setting dtype int actually gives an integer matrix.
+
+        For more information, see GitHub pull request #1363.
+
+        """
+        G = nx.MultiGraph(nx.complete_graph(3))
+        A = nx.to_numpy_matrix(G, dtype=int)
+        assert_equal(A.dtype, int)


### PR DESCRIPTION
This commit incorporates the change from pull request #1363, which makes the `to_numpy_matrix` code a little easier to understand (just create a matrix full of NaNs instead of adding a NaN to a matrix of zeros). However, the issue reported in that pull request was already fixed in pull request #2038. The current pull request adds the missing unit tests for those pull requests.
