### PR TITLE
Add dominator tree

### DIFF
--- a/doc/source/reference/algorithms.dominance.rst
+++ b/doc/source/reference/algorithms.dominance.rst
@@ -8,3 +8,4 @@ Dominance
 
    immediate_dominators
    dominance_frontiers
+   dominator_tree

--- a/networkx/algorithms/dominance.py
+++ b/networkx/algorithms/dominance.py
@@ -11,7 +11,7 @@ from functools import reduce
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-__all__ = ['immediate_dominators', 'dominance_frontiers']
+__all__ = ['immediate_dominators', 'dominance_frontiers', 'dominator_tree']
 
 
 @not_implemented_for('undirected')
@@ -135,3 +135,37 @@ def dominance_frontiers(G, start):
                         df[v].add(u)
                         v = idom[v]
     return df
+
+
+def dominator_tree(G, start):
+    """Returns the dominator tree from a directed graph.
+
+
+    Parameters
+    ----------
+    G : a DiGraph or MultiDiGraph
+        The graph where dominance is to be computed.
+
+    start : node
+        The start node of dominance computation.
+
+    Returns
+    -------
+    T : DiGraph
+        Dominator tree where each node's children are those it immediately dominates
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is undirected.
+
+    NetworkXError
+        If `start` is not in `G`.
+
+    Notes
+    -----
+    Note that if a CFG has a single exit node,
+    then postdominance is equivalent to dominance if
+    flow is reversed (going from the exit node to the start node)
+    """
+    return nx.DiGraph(((v, u) for u, v in nx.immediate_dominators(G, start).items() if u != start))

--- a/networkx/algorithms/tests/test_dominance.py
+++ b/networkx/algorithms/tests/test_dominance.py
@@ -261,3 +261,37 @@ class TestDominanceFrontiers(object):
                   'exit': set()}
         for n in df:
             assert_equal(set(df[n]),set(answer[n]))
+
+
+class TestDominatorTree(object):
+
+    def test_dominator_tree(self):
+        # from page 5 (labeled as 388 in bottom right)
+        # http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.pdf
+        edges = [(1, 2), (2, 3), (2, 4), (3, 5), (4, 5), (5, 6), (6, 7),
+                (7, 6), (7, 8)]
+        G = nx.DiGraph(edges)
+        T = nx.dominator_tree(G, 1)
+        assert_equal(sorted(list(T.edges())),
+                sorted([(1, 2), (2, 3), (2, 4), (2, 5), (5, 6), (6, 7), (7, 8)]))
+
+    def test_post_dominator_tree(self):
+        # from page 17 (labeled as 400 in bottom right)
+        # http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.pdf
+        edges = [(1, 2), (2, 3), (2, 4), (3, 5), (4, 5), (5, 6), (6, 7),
+                (7, 6), (7, 8)]
+        G = nx.DiGraph(edges)
+        with nx.utils.reversed(G):
+            T = nx.dominator_tree(G, 8)
+            assert_equal(sorted(list(T.edges())),
+                sorted([(8, 7), (7, 6), (6, 5), (5, 4), (5, 3), (5, 2), (2, 1)]))
+
+    def test_dominator_tree2(self):
+        # from example on slide 9
+        # http://www.cs.cornell.edu/courses/cs412/2008sp/lectures/lec29.pdf
+        edges = [(1, 2), (2, 1), (2, 3), (2, 4), (2, 7), (3, 5), (4, 5),
+                (5, 6), (5, 4), (6, 2)]
+        G = nx.DiGraph(edges)
+        T = nx.dominator_tree(G, 1)
+        assert_equal(sorted(list(T.edges())),
+                sorted([(1, 2), (2, 7), (2, 3), (2, 4), (2, 5), (5, 6)]))


### PR DESCRIPTION
Hi,

This adds dominator trees using the already implemented immediate dominators

Addresses #1941 

This is my first contribution here so let me know if anything needs to be fixed.

Also, out of curiosity what's the consensus opinion on adding very small functions such as explicitly supporting post-dominator trees and immediate post-dominators which are handy, but trivial (too?) to add. In fact, they are already tested with the non-post functions.

Thanks!
