### PR TITLE
Make PyDot Support Great Again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,15 +102,10 @@ install:
       source activate test-environment;
       echo "Testing that gdal installed ok by if osgeo imports";
       python -c "from osgeo import ogr;print('importing ogr worked')";
-      if [[ "${TRAVIS_PYTHON_VERSION}" =~ "3.3" ]]; then
-          pip install https://pypi.python.org/packages/source/p/pydotplus/pydotplus-2.0.2.tar.gz#md5=0e2fc3dbdfd846819d4cd3769cb4595b;
-      else
-          pip install pydotplus;
-      fi;
       if [[ "${TRAVIS_PYTHON_VERSION}" =~ "2.7" ]]; then
         pip install pygraphviz;
       fi;
-      pip install scikits.sparse;
+      pip install pydot scikits.sparse;
     fi
   - if [[ "${PYTHON_VM}" != ipy ]]; then
       pip install --upgrade nose coverage coveralls;

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@ ipython[nbconvert]
 numpy >= 1.6
 matplotlib
 pandas
-pydotplus
+pydot >= 1.2.3
 -e git://github.com/sphinx-doc/sphinx.git@stable#egg=Sphinx-origin_stable
 sphinxcontrib-bibtex
 sphinx_rtd_theme

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -166,7 +166,7 @@ In conjunction with either
 
       or
 
-      - pydotplus: https://github.com/carlos-jenkins/pydotplus
+      - pydot: https://github.com/erocarrera/pydot
 
 provides graph drawing and graph layout algorithms.
 

--- a/doc/source/tutorial/tutorial.rst
+++ b/doc/source/tutorial/tutorial.rst
@@ -467,7 +467,7 @@ To save drawings to a file, use, for example
 >>> plt.savefig("path.png")
 
 writes to the file "path.png" in the local directory. If Graphviz
-and PyGraphviz or pydotplus, are available on your system, you can also use
+and PyGraphviz or pydot, are available on your system, you can also use
 ``nx_agraph.graphviz_layout(G)`` or ``nx_pydot.graphviz_layout(G)`` to
 get the node positions, or write the graph in dot format for further
 processing.

--- a/examples/drawing/atlas.py
+++ b/examples/drawing/atlas.py
@@ -64,11 +64,11 @@ if __name__ == '__main__':
         from networkx.drawing.nx_agraph import graphviz_layout
     except ImportError:
         try:
-            import pydotplus
+            import pydot
             from networkx.drawing.nx_pydot import graphviz_layout
         except ImportError:
             raise ImportError("This example needs Graphviz and either "
-                              "PyGraphviz or PyDotPlus")
+                              "PyGraphviz or pydot")
 
     import matplotlib.pyplot as plt
     plt.figure(1, figsize=(8, 8))

--- a/examples/drawing/circular_tree.py
+++ b/examples/drawing/circular_tree.py
@@ -6,11 +6,11 @@ try:
     from networkx.drawing.nx_agraph import graphviz_layout
 except ImportError:
     try:
-        import pydotplus
+        import pydot
         from networkx.drawing.nx_pydot import graphviz_layout
     except ImportError:
         raise ImportError("This example needs Graphviz and either "
-                          "PyGraphviz or PyDotPlus")
+                          "PyGraphviz or pydot")
 
 G = nx.balanced_tree(3, 5)
 pos = graphviz_layout(G, prog='twopi', args='')

--- a/examples/drawing/giant_component.py
+++ b/examples/drawing/giant_component.py
@@ -27,11 +27,11 @@ try:
     layout = graphviz_layout
 except ImportError:
     try:
-        import pydotplus
+        import pydot
         from networkx.drawing.nx_pydot import graphviz_layout
         layout = graphviz_layout
     except ImportError:
-        print("PyGraphviz and PyDotPlus not found;\n"
+        print("PyGraphviz and pydot not found;\n"
               "drawing with spring layout;\n"
               "will be slow.")
         layout = nx.spring_layout

--- a/examples/drawing/lanl_routes.py
+++ b/examples/drawing/lanl_routes.py
@@ -2,7 +2,7 @@
 """
 Routes to LANL from 186 sites on the Internet.
 
-This uses Graphviz for layout so you need PyGraphviz or PyDotPlus.
+This uses Graphviz for layout so you need PyGraphviz or pydot.
 
 """
 # Author: Aric Hagberg (hagberg@lanl.gov)
@@ -50,11 +50,11 @@ if __name__ == '__main__':
         from networkx.drawing.nx_agraph import graphviz_layout
     except ImportError:
         try:
-            import pydotplus
+            import pydot
             from networkx.drawing.nx_pydot import graphviz_layout
         except ImportError:
             raise ImportError("This example needs Graphviz and either "
-                              "PyGraphviz or PyDotPlus")
+                              "PyGraphviz or pydot")
 
     G=lanl_graph()
 

--- a/examples/graph/atlas.py
+++ b/examples/graph/atlas.py
@@ -64,11 +64,11 @@ if __name__ == '__main__':
         from networkx.drawing.nx_agraph import graphviz_layout
     except ImportError:
         try:
-            import pydotplus
+            import pydot
             from networkx.drawing.nx_pydot import graphviz_layout
         except ImportError:
             raise ImportError("This example needs Graphviz and either "
-                              "PyGraphviz or PyDotPlus")
+                              "PyGraphviz or pydot")
 
     import matplotlib.pyplot as plt
     plt.figure(1, figsize=(8, 8))

--- a/examples/pygraphviz/write_dotfile.py
+++ b/examples/pygraphviz/write_dotfile.py
@@ -2,7 +2,7 @@
 """
 Write a dot file from a networkx graph for further processing with graphviz.
 
-You need to have either pygraphviz or pydotplus for this example.
+You need to have either pygraphviz or pydot for this example.
 
 See http://networkx.github.io/documentation/latest/reference/drawing.html
 for more info.
@@ -28,12 +28,12 @@ try:
     print("using package pygraphviz")
 except ImportError:
     try:
-        import pydotplus
+        import pydot
         from networkx.drawing.nx_pydot import write_dot
-        print("using package pydotplus")
+        print("using package pydot")
     except ImportError:
         print()
-        print("Both pygraphviz and pydotplus were not found ")
+        print("Both pygraphviz and pydot were not found ")
         print("see http://networkx.github.io/documentation"
               "/latest/reference/drawing.html for info")
         print()

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,8 +1,7 @@
 """Unit tests for pydot drawing functions."""
-import os
+import sys
 import tempfile
-from nose import SkipTest
-from nose.tools import assert_true
+from nose.tools import assert_equal, assert_is_instance, assert_true
 import networkx as nx
 from networkx.testing import assert_graphs_equal
 
@@ -10,37 +9,83 @@ from networkx.testing import assert_graphs_equal
 class TestPydot(object):
     @classmethod
     def setupClass(cls):
-        global pydotplus
-        try:
-            import pydotplus
-        except ImportError:
-            raise SkipTest('pydotplus not available.')
+        '''
+        Fixture defining the `pydot` global to be the `pydot` module if both
+        importable and of sufficient version _or_ skipping this test.
+        '''
+        global pydot
+        pydot = nx.nx_pydot.setup_module(sys.modules[__name__])
+        assert pydot is not None
 
-    def pydot_checks(self, G):
+    def pydot_checks(self, G, prog):
+        '''
+        Validate :mod:`pydot`-based usage of the passed NetworkX graph with the
+        passed basename of an external GraphViz command (e.g., `dot`, `neato`).
+        '''
+
+        # Set the name of this graph to... "G". Failing to do so will
+        # subsequently trip an assertion expecting this name.
+        G.graph['name'] = 'G'
+
+        # Add arbitrary nodes and edges to the passed empty graph.
         G.add_edges_from([('A','B'),('A','C'),('B','C'),('A','D')])
         G.add_node('E')
+
+        # Validate layout of this graph with the passed GraphViz command.
+        graph_layout = nx.nx_pydot.pydot_layout(G, prog=prog)
+        assert_is_instance(graph_layout, dict)
+
+        # Convert this graph into a "pydot.Dot" instance.
         P = nx.nx_pydot.to_pydot(G)
+
+        # Convert this "pydot.Dot" instance back into a graph of the same type.
         G2 = G.__class__(nx.nx_pydot.from_pydot(P))
+
+        # Validate the original and resulting graphs to be the same.
         assert_graphs_equal(G, G2)
 
+        # Serialize this "pydot.Dot" instance to a temporary file in dot format.
         fname = tempfile.mktemp()
         assert_true(P.write_raw(fname))
-        Pin = pydotplus.graph_from_dot_file(fname)
 
+        # Deserialize a list of new "pydot.Dot" instances back from this file.
+        Pin_list = pydot.graph_from_dot_file(path=fname, encoding='utf-8')
+
+        # Validate this file to contain only one graph.
+        assert_equal(len(Pin_list), 1)
+
+        # The single "pydot.Dot" instance deserialized from this file.
+        Pin = Pin_list[0]
+
+        # Sorted list of all nodes in the original "pydot.Dot" instance.
         n1 = sorted([p.get_name() for p in P.get_node_list()])
+
+        # Sorted list of all nodes in the deserialized "pydot.Dot" instance.
         n2 = sorted([p.get_name() for p in Pin.get_node_list()])
-        assert_true(n1 == n2)
 
-        e1 = [(e.get_source(),e.get_destination()) for e in P.get_edge_list()]
-        e2 = [(e.get_source(),e.get_destination()) for e in Pin.get_edge_list()]
-        assert_true(sorted(e1) == sorted(e2))
+        # Validate these instances to contain the same nodes.
+        assert_equal(n1, n2)
 
+        # Sorted list of all edges in the original "pydot.Dot" instance.
+        e1 = sorted([
+            (e.get_source(), e.get_destination()) for e in P.get_edge_list()])
+
+        # Sorted list of all edges in the original "pydot.Dot" instance.
+        e2 = sorted([
+            (e.get_source(), e.get_destination()) for e in Pin.get_edge_list()])
+
+        # Validate these instances to contain the same edges.
+        assert_equal(e1, e2)
+
+        # Deserialize a new graph of the same type back from this file.
         Hin = nx.nx_pydot.read_dot(fname)
         Hin = G.__class__(Hin)
+
+        # Validate the original and resulting graphs to be the same.
         assert_graphs_equal(G, Hin)
 
     def testUndirected(self):
-        self.pydot_checks(nx.Graph())
+        self.pydot_checks(nx.Graph(), prog='neato')
 
     def testDirected(self):
-        self.pydot_checks(nx.DiGraph())
+        self.pydot_checks(nx.DiGraph(), prog='dot')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pygraphviz
 sphinx
 sphinxcontrib-bibtex
 sphinx_rtd_theme
-pydotplus
+pydot >= 1.2.3


### PR DESCRIPTION
This pull request refactors the `networkx.drawing.nx_pydot` submodule to support the well-maintained [`pydot`](https://github.com/erocarrera/pydot) project in lieu of the effectively dead [`pydotplus`](https://github.com/carlos-jenkins/pydotplus) fork, resolving [issue #2235](https://github.com/networkx/networkx/issues/2235) (_Abandon All pydotplus, Ye Who Graph Here_) and restoring basic sanity.

See #2235 for full-frontal details. A brute-force **tl;dr** follows:

* The last commit for [`pydotplus`](https://github.com/carlos-jenkins/pydotplus) was at **[December 8th, 2014](https://github.com/carlos-jenkins/pydotplus/commits/master?page=1)** – nearly two years ago. Long-standing open issues and pull requests remain unresolved. `pydotplus` is a face-rotting zombie.
* The last commit for [`pydot`](https://github.com/erocarrera/pydot) was at **[July 2nd, 2016](https://github.com/erocarrera/pydot/commits/master)** – only a little over two months ago. Issues and pull requests are quickly dispatched with, as evidenced by a [closed issue](https://github.com/erocarrera/pydot/issues/133) I foolishly opened two days ago.

**`pydot` lives.**

## Not all that Glitters is PyDot Gold

`pydot` 1.2.0 recently broke [backward API compatibility](https://github.com/erocarrera/pydot/blob/master/ChangeLog) with pre-1.0.29 forks (like `pydotplus`) in mostly beneficial ways. Let's talk a bit about that.

### Dot File Deserialization Gone Wild

In `pydot` 1.2.0, the `pydot.graph_from_dot_data()` function now _unconditionally_ returns a list of all deserialized `pydot.Dot` objects rather than _conditionally_ returning a list if the passed data contains two or more graphs or a single `pydot.Dot` object otherwise.

This is a positive change. The prior approach complicated caller handling and encouraged caller errors. It didn't help that the prior approach was poorly documented and that everyone downstream made simplistic assumptions about that approach. How do we know this?

Because NetworkX currently assumes the `pydot.graph_from_dot_data()` function to _always_ return a single `pydot.Dot` object. Which was never the case. Maybe nobody cares about `pydot` integration with dot files containing multiple graphs? It is pretty edge-case. <sup>_Or maybe my tenuous deathgrip on sanity has slipped another notch lower._</sup>

NetworkX functionality calling the `pydot.graph_from_dot_data()` function includes:

* `networkx.drawing.nx_pydot.read_dot()`.
* `networkx.drawing.nx_pydot.pydot_layout()`.
* `networkx.drawing.tests.test_pydot.TestPydot.pydot_checks()`.

This functionality has all been refactored to accept lists of `pydot.Dot` objects. In the case of both `pydot_layout()` and `pydot_checks()`, a list of exactly one object is _always_ returned. Life is simple here.

In the case of `read_dot()`, however, a list of two or more objects are returned if the passed dot file contains two or more graphs. This was _always_ the case, of course. NetworkX currently ignores this discrepancy by returning "sight-unseen" whatever `pydot` returns _without_ documenting that a list of graphs rather than a single graph might be returned.

Two options exist here:

1. **Break NetworkX backwards compatibility.** Refactor `read_dot()` to unconditionally return a list of `pydot.Dot` objects – just like the underlying `pydot.graph_from_dot_data()`. Orthogonality is preserved, which is mildly good. All downstream logic is broken, which is strongly bad.
1. **Mostly preserve NetworkX backwards compatibility.** Refactor `read_dot()` to unconditionally return only a single `pydot.Dot` object if the passed dot file contains only one graph _or_ raise an exception otherwise.

Under the safe assumption that 99.9999% of all calls to `read_dot()` pass dot files containing only one graph, the latter _"Don't break everything!"_ approach is arguably the sane approach. I like sanity, so I went with that. 

If anyone ever requires deserialization of multiple `pydot.Dot` objects from a single dot file, subsequently adding a new NetworkX function (e.g., `read_dots()`) _or_ a new optional keyword argument to the existing `read_dot()` function (e.g., `return_list=False`) would be trivial. This is left as an exercise to the reader.

### String Decoding and What It Can Do for You

In `pydot` 1.2.0,<sup>..._maybe earlier?_</sup> the `pydot.Dot.create_dot()` method now returns an encoded byte array (`bytes` in Python 3) rather than a probably-incorrectly-decoded Unicode string (`str` in Python 3).

This is a positive change, too. The prior approach masked inevitable encoding errors with a Jedi handwave: _"These are the character-like bytes you might be looking for. No further questions!"_

This does require, however, that NetworkX functionality calling `create_dot()` explicitly decode its return value into a proper Unicode string. My simplistic assumption is that GraphViz encodes this return value via the current user's preferred locale (e.g., `LC_*` environment variables on POSIX-compatible platforms), which is safely decodable by NetworkX via the same encoding. This assumption appears to hold. May the [Spaghetti Monster](https://s-media-cache-ak0.pinimg.com/564x/66/68/18/6668181a59aaf6846cfcb90f2a780e18.jpg) preserve us all.

The `pydot.Dot.create_dot()` method is only called by the `networkx.drawing.nx_pydot.pydot_layout()`,  which has been refactored to decode the returned byte array via the current `locale.getpreferredencoding()`. <sup>..._which is probably just `utf-8`, in most cases._</sup>

## We Can Build a Better PyDot Integration

The newer 1.2.0 `pydot` API is a non-trivial departure from the older pre-1.0.29 `pydot` API. Since both cannot be reasonably supported at the same time, this pull request revises all `networkx.drawing.nx_pydot` functions to explicitly require `pydot >= 1.2.0`. To enforce this constraint in a human-readable manner:

* A new private `networkx.drawing.nx_pydot._import_pydot()` function has been defined, importing and returning the `pydot` module if the currently installed version of that module is `>= 1.2.0` _or_ raising an `ImportError` exception. For [robustness](https://stackoverflow.com/a/21065570/2809027), the ubiquitous `pkg_resources.parse_version()` function  is called to implement this version comparison. Since NetworkX requires setuptools at installation time, the setuptools-bundled `pkg_resources` package is assumed to be available at runtime. This assumption is almost certainly safe for most definitions of "almost," "certainly," and "safe."
* Most `import pydotplus` statements in the codebase now read `pydot = _import_pydot()`.

## Are You Quite Done Yet?

**Nope.** Unit tests have also been improved to explicitly test the `networkx.drawing.nx_pydot.pydot_layout()` function. Because this is a safety-first pull request. For maintainability, I also obsessively documented everything in these tests. Because obsessiveness.

Thanks for the hard volunteerism, fellow NetworkX-ers! This graph paper is for you. :chart_with_upwards_trend: 