### PR TITLE
MAYBE INCORRECT: fix links

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,11 +8,11 @@ NetworkX documentation
     :Release: |version|
     :Date: |today|
 
-    Tutorial :download:`[PDF]  <networkx_tutorial.pdf>`
+    Tutorial :download:`[PDF]  _<networkx_tutorial.pdf>`
 
-    Reference :download:`[PDF]  <networkx_reference.pdf>`
+    Reference :download:`[PDF]  _<networkx_reference.pdf>`
 
-    Tutorial+Reference :download:`[HTML zip]  <networkx-documentation.zip>`
+    Tutorial+Reference :download:`[HTML zip]  _<networkx-documentation.zip>`
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Sorry I'm not familiar with the docutils syntax but the links to the PDF's and downloads are broken / inactive when I view them from the main site: https://networkx.readthedocs.io/en/stable/

They do work from this page; https://github.com/networkx/networkx/blob/v1.11/doc/source/download.rst

However, that syntax is different / maybe-auto-generated ...
