### PR TITLE
Correct error in minimum_spanning_arborescence

### DIFF
--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -615,7 +615,7 @@ def minimum_spanning_arborescence(G, attr='weight', default=1):
     ed = Edmonds(G)
     B = ed.find_optimum(attr, default, kind='min', style='arborescence')
     if not is_arborescence(B):
-        msg = 'No maximum spanning arborescence in G.'
+        msg = 'No minimum spanning arborescence in G.'
         raise nx.exception.NetworkXException(msg)
     return B
 


### PR DESCRIPTION
The error message appears to have been copied from `maximum_spanning_arborescence` to `minimum_spanning_arborescence` as the latter incorrectly reports "No maximum spanning arborescence in G". Fixed.
