### PR TITLE
Unused variables in list comprehensions replaced by a wildcard

### DIFF
--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         except CalledProcessError:
             print("using development as label")
             tag = "development"   # Fallback
-    
+
     startdir = os.getcwdu()
     if not os.path.exists(pages_dir):
         # init the repo

--- a/doc/gitwash_dumper.py
+++ b/doc/gitwash_dumper.py
@@ -177,7 +177,7 @@ def main():
                       metavar="MAIN_GH_USER")
     parser.add_option("--gitwash-url", dest="gitwash_url",
                       help="URL to gitwash repository - default %s"
-                      % GITWASH_CENTRAL, 
+                      % GITWASH_CENTRAL,
                       default=GITWASH_CENTRAL,
                       metavar="GITWASH_URL")
     parser.add_option("--gitwash-branch", dest="gitwash_branch",

--- a/doc/sphinxext/customroles.py
+++ b/doc/sphinxext/customroles.py
@@ -11,7 +11,7 @@ from sphinx.util import ws_re, caption_ref_re
 # http://www.doughellmann.com/articles/how-tos/sphinx-custom-roles/index.html
 def sample_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Custom role.
-   
+
     Parameters
     ----------
     name : str
@@ -28,21 +28,21 @@ def sample_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         Directive options for customizatoin.
     content : list
         The directive content for customization.
-        
+
     Returns
     -------
     nodes : list
         The list of nodes to insert into the document.
     msgs : list
         The list of system messages, perhaps an error message.
-        
+
     """
     pass
-    
-    
-##################   
-    
-    
+
+
+##################
+
+
 prefixed_roles = {
     # name: (prefix, baseuri)
     'arxiv': ('arXiv:', 'http://arxiv.org/abs/'),
@@ -62,15 +62,15 @@ def prefixed_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     ref = nodes.reference(rawtext, display, refuri=uri, **options)
     node += ref # keep it in the 'literal' background
     return [node], []
-    
+
 def url_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     uri = text
     display = 'url'
     node = nodes.literal('', '')
     node += nodes.reference(rawtext, name, refuri=uri, **options)
     return [node], []
-    
-def trac_ticket_role(name, rawtext, text, lineno, inliner, 
+
+def trac_ticket_role(name, rawtext, text, lineno, inliner,
                      options={}, content=[]):
     app = inliner.document.settings.env.app
     try:
@@ -87,9 +87,9 @@ def trac_ticket_role(name, rawtext, text, lineno, inliner,
     display = utils.unescape(text)
     uri = base + slash + 'ticket/' + text
     node += nodes.reference(rawtext, display, refuri=uri, **options)
-    return [node], []  
+    return [node], []
 
-def trac_changeset_role(name, rawtext, text, lineno, inliner, 
+def trac_changeset_role(name, rawtext, text, lineno, inliner,
                         options={}, content=[]):
     app = inliner.document.settings.env.app
     try:
@@ -98,7 +98,7 @@ def trac_changeset_role(name, rawtext, text, lineno, inliner,
             raise AttributeError
     except AttributeError as err:
         msg = 'trac_url configuration value is not set (%s)'
-        raise ValueError(msg % str(err))    
+        raise ValueError(msg % str(err))
 
     slash = '/' if base[-1] != '/' else ''
     unescaped = utils.unescape(text)
@@ -112,7 +112,7 @@ def trac_changeset_role(name, rawtext, text, lineno, inliner,
     else:
         # hg: use the first 12 hash characters
         display = unescaped[:12]
-        
+
     uri = base + slash + 'changeset/' + text
     node += nodes.reference(rawtext, display, refuri=uri, **options)
     return [node], []
@@ -134,5 +134,5 @@ def setup(app):
     for role, func in active_roles.items():
         roles.register_local_role(role, func)
     app.add_config_value('trac_url', None, 'env')
-        
+
 

--- a/examples/3d_drawing/mayavi2_spring.py
+++ b/examples/3d_drawing/mayavi2_spring.py
@@ -1,4 +1,4 @@
-# needs mayavi2 
+# needs mayavi2
 # run with ipython -wthread
 import networkx as nx
 import numpy as np
@@ -28,7 +28,7 @@ pts = mlab.points3d(xyz[:,0], xyz[:,1], xyz[:,2],
                     scale_mode='none',
                     colormap='Blues',
                     resolution=20)
-                                   
+
 pts.mlab_source.dataset.lines = np.array(list(G.edges()))
 tube = mlab.pipeline.tube(pts, tube_radius=0.01)
 mlab.pipeline.surface(tube, color=(0.8, 0.8, 0.8))

--- a/examples/advanced/iterated_dynamical_systems.py
+++ b/examples/advanced/iterated_dynamical_systems.py
@@ -41,7 +41,7 @@ The smallest number that requires 13 iterations to reach 153, is 177, i.e.,
 
 177->687->1071->345->216->225->141->66->432->99->1458->702->351->153
 
-The resulting large digraphs are useful for testing network software. 
+The resulting large digraphs are useful for testing network software.
 
 The general problem
 -------------------
@@ -69,13 +69,13 @@ The 3n+1 problem
 ----------------
 
 There is a rich history of mathematical recreations
-associated with discrete dynamical systems.  The most famous 
-is the Collatz 3n+1 problem. See the function 
+associated with discrete dynamical systems.  The most famous
+is the Collatz 3n+1 problem. See the function
 collatz_problem_digraph below. The Collatz conjecture
---- that every orbit returrns to the fixed point 1 in finite time 
+--- that every orbit returrns to the fixed point 1 in finite time
 --- is still unproven. Even the great Paul Erdos said "Mathematics
-is not yet ready for such problems", and offered $500 
-for its solution. 
+is not yet ready for such problems", and offered $500
+for its solution.
 
 keywords: "3n+1", "3x+1", "Collatz problem", "Thwaite's conjecture"
 
@@ -135,11 +135,11 @@ def squaring_cycle_graph_old(n,b=10):
         G.add_node(k1) # case k1==knext, at least add node
         knext=powersum(k1,2,b)
         G.add_edge(k1,knext)
-        while k1!=knext: # stop if fixed point 
+        while k1!=knext: # stop if fixed point
              k1=knext
              knext=powersum(k1,2,b)
              G.add_edge(k1,knext)
-             if G.out_degree(knext) >=1: 
+             if G.out_degree(knext) >=1:
                  # knext has already been iterated in and out
                  break
     return G
@@ -163,12 +163,12 @@ def discrete_dynamics_digraph(nmax,f,itermax=50000):
         G.add_node(kold)
         knew=f(kold)
         G.add_edge(kold,knew)
-        while kold!=knew and kold<<itermax: 
+        while kold!=knew and kold<<itermax:
         # iterate until fixed point reached or itermax is exceeded
             kold=knew
             knew=f(kold)
             G.add_edge(kold,knew)
-            if G.out_degree(knew) >=1: 
+            if G.out_degree(knew) >=1:
                # knew has already been iterated in and out
                break
     return G
@@ -182,12 +182,12 @@ def collatz_problem_digraph(nmax):
     return discrete_dynamics_digraph(nmax,f)
 
 def fixed_points(G):
-    """Return a list of fixed points for the discrete dynamical 
+    """Return a list of fixed points for the discrete dynamical
     system represented by the digraph G.
     """
     return [n for n in G if G.out_degree(n)==0]
 
-    
+
 if __name__ == "__main__":
     nmax=10000
     print("Building cubing_153_digraph(%d)"% nmax)

--- a/examples/algorithms/davis_club.py
+++ b/examples/algorithms/davis_club.py
@@ -5,8 +5,8 @@ Davis Southern Club Women
 Shows how to make unipartite projections of the graph and compute the
 properties of those graphs.
 
-These data were collected by Davis et al. in the 1930s.  
-They represent observed attendance at 14 social events by 18 Southern women.  
+These data were collected by Davis et al. in the 1930s.
+They represent observed attendance at 14 social events by 18 Southern women.
 The graph is bipartite (clubs, women).
 """
 import networkx as nx
@@ -21,7 +21,7 @@ print(bipartite.biadjacency_matrix(G,women,clubs))
 
 # project bipartite graph onto women nodes
 W = bipartite.projected_graph(G, women)
-print('') 
+print('')
 print("#Friends, Member")
 for w in women:
     print('%d %s' % (W.degree(w),w))
@@ -29,7 +29,7 @@ for w in women:
 # project bipartite graph onto women nodes keeping number of co-occurence
 # the degree computed is weighted and counts the total number of shared contacts
 W = bipartite.weighted_projected_graph(G, women)
-print('') 
+print('')
 print("#Friend meetings, Member")
 for w in women:
     print('%d %s' % (W.degree(w,weight='weight'),w))

--- a/examples/drawing/ego_graph.py
+++ b/examples/drawing/ego_graph.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Example using the NetworkX ego_graph() function to return the main egonet of 
+Example using the NetworkX ego_graph() function to return the main egonet of
 the largest hub in a Barabási-Albert network.
 """
 # Author:  Drew Conway (drew.conway@nyu.edu)

--- a/examples/drawing/house_with_colors.py
+++ b/examples/drawing/house_with_colors.py
@@ -8,7 +8,7 @@ try:
     import matplotlib.pyplot as plt
 except:
     raise
-    
+
 import networkx as nx
 
 G=nx.house_graph()

--- a/examples/drawing/simple_path.py
+++ b/examples/drawing/simple_path.py
@@ -6,8 +6,8 @@ You must have matplotlib for this to work.
 try:
     import matplotlib.pyplot as plt
 except:
-    raise 
-    
+    raise
+
 import networkx as nx
 
 G=nx.path_graph(8)

--- a/examples/graph/erdos_renyi.py
+++ b/examples/graph/erdos_renyi.py
@@ -30,7 +30,7 @@ print("node degree clustering")
 for v in nodes(G):
     print('%s %d %f' % (v,degree(G,v),clustering(G,v)))
 
-# print the adjacency list to terminal 
+# print the adjacency list to terminal
 try:
     write_adjlist(G,sys.stdout)
 except TypeError: # Python 3.x

--- a/examples/subclass/antigraph.py
+++ b/examples/subclass/antigraph.py
@@ -58,7 +58,7 @@ class AntiGraph(nx.Graph):
 
 
     def neighbors(self, n):
-        """Return an iterator over all neighbors of node n in the 
+        """Return an iterator over all neighbors of node n in the
            dense graph.
 
         """

--- a/fixcoverage.py
+++ b/fixcoverage.py
@@ -16,7 +16,7 @@ def main(argv):
         new_filename = re.sub(source, dest, filename)
         if new_filename != filename:
             coverage_data._lines[new_filename] = coverage_data._lines.pop(filename)
-        
+
     coverage_data.write_file('.coverage')
 
 if __name__ == '__main__':

--- a/networkx/algorithms/approximation/__init__.py
+++ b/networkx/algorithms/approximation/__init__.py
@@ -1,6 +1,6 @@
 '''
     .. warning:: The approximation submodule is not imported automatically with networkx.
-    
+
     Approximate algorithms can be imported with ``from networkx.algorithms import approximation``.
 '''
 from networkx.algorithms.approximation.clustering_coefficient import *

--- a/networkx/algorithms/approximation/clustering_coefficient.py
+++ b/networkx/algorithms/approximation/clustering_coefficient.py
@@ -50,7 +50,7 @@ def average_clustering(G, trials=1000):
     n = len(G)
     triangles = 0
     nodes = list(G)
-    for i in [int(random.random() * n) for i in range(trials)]:
+    for i in [int(random.random() * n) for _ in range(trials)]:
         nbrs = list(G[nodes[i]])
         if len(nbrs) < 2:
             continue

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -1,6 +1,6 @@
 """ Fast approximation for node connectivity
 """
-#    Copyright (C) 2015 by 
+#    Copyright (C) 2015 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    All rights reserved.
 #    BSD license.
@@ -20,15 +20,15 @@ INF = float('inf')
 
 def local_node_connectivity(G, source, target, cutoff=None):
     """Compute node connectivity between source and target.
-    
-    Pairwise or local node connectivity between two distinct and nonadjacent 
-    nodes is the minimum number of nodes that must be removed (minimum 
-    separating cutset) to disconnect them. By Menger's theorem, this is equal 
+
+    Pairwise or local node connectivity between two distinct and nonadjacent
+    nodes is the minimum number of nodes that must be removed (minimum
+    separating cutset) to disconnect them. By Menger's theorem, this is equal
     to the number of node independent paths (paths that share no nodes other
     than source and target). Which is what we compute in this function.
 
     This algorithm is a fast approximation that gives an strict lower
-    bound on the actual number of node independent paths between two nodes [1]_. 
+    bound on the actual number of node independent paths between two nodes [1]_.
     It works for both directed and undirected graphs.
 
     Parameters
@@ -53,24 +53,24 @@ def local_node_connectivity(G, source, target, cutoff=None):
 
     Examples
     --------
-    >>> # Platonic icosahedral graph has node connectivity 5 
+    >>> # Platonic icosahedral graph has node connectivity 5
     >>> # for each non adjacent node pair
     >>> from networkx.algorithms import approximation as approx
     >>> G = nx.icosahedral_graph()
     >>> approx.local_node_connectivity(G, 0, 6)
     5
 
-    Notes 
+    Notes
     -----
-    This algorithm [1]_ finds node independents paths between two nodes by 
-    computing their shortest path using BFS, marking the nodes of the path 
-    found as 'used' and then searching other shortest paths excluding the 
-    nodes marked as used until no more paths exist. It is not exact because 
+    This algorithm [1]_ finds node independents paths between two nodes by
+    computing their shortest path using BFS, marking the nodes of the path
+    found as 'used' and then searching other shortest paths excluding the
+    nodes marked as used until no more paths exist. It is not exact because
     a shortest path could use nodes that, if the path were longer, may belong
     to two different node independent paths. Thus it only guarantees an
     strict lower bound on node connectivity.
 
-    Note that the authors propose a further refinement, losing accuracy and 
+    Note that the authors propose a further refinement, losing accuracy and
     gaining speed, which is not implemented yet.
 
     See also
@@ -80,10 +80,10 @@ def local_node_connectivity(G, source, target, cutoff=None):
 
     References
     ----------
-    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for
         Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
         http://eclectic.ss.uci.edu/~drwhite/working.pdf
- 
+
     """
     if target == source:
         raise nx.NetworkXError("source and target have to be different nodes.")
@@ -97,7 +97,7 @@ def local_node_connectivity(G, source, target, cutoff=None):
     K = 0
     if not possible:
         return K
-    
+
     if cutoff is None:
         cutoff = INF
 
@@ -118,17 +118,17 @@ def node_connectivity(G, s=None, t=None):
 
     Node connectivity is equal to the minimum number of nodes that
     must be removed to disconnect G or render it trivial. By Menger's theorem,
-    this is equal to the number of node independent paths (paths that 
+    this is equal to the number of node independent paths (paths that
     share no nodes other than source and target).
 
-    If source and target nodes are provided, this function returns the 
-    local node connectivity: the minimum number of nodes that must be 
+    If source and target nodes are provided, this function returns the
+    local node connectivity: the minimum number of nodes that must be
     removed to break all paths from source to target in G.
 
     This algorithm is based on a fast approximation that gives an strict lower
-    bound on the actual number of node independent paths between two nodes [1]_. 
+    bound on the actual number of node independent paths between two nodes [1]_.
     It works for both directed and undirected graphs.
-   
+
     Parameters
     ----------
     G : NetworkX graph
@@ -148,18 +148,18 @@ def node_connectivity(G, s=None, t=None):
 
     Examples
     --------
-    >>> # Platonic icosahedral graph is 5-node-connected 
+    >>> # Platonic icosahedral graph is 5-node-connected
     >>> from networkx.algorithms import approximation as approx
     >>> G = nx.icosahedral_graph()
     >>> approx.node_connectivity(G)
     5
-    
+
     Notes
     -----
-    This algorithm [1]_ finds node independents paths between two nodes by 
-    computing their shortest path using BFS, marking the nodes of the path 
-    found as 'used' and then searching other shortest paths excluding the 
-    nodes marked as used until no more paths exist. It is not exact because 
+    This algorithm [1]_ finds node independents paths between two nodes by
+    computing their shortest path using BFS, marking the nodes of the path
+    found as 'used' and then searching other shortest paths excluding the
+    nodes marked as used until no more paths exist. It is not exact because
     a shortest path could use nodes that, if the path were longer, may belong
     to two different node independent paths. Thus it only guarantees an
     strict lower bound on node connectivity.
@@ -171,7 +171,7 @@ def node_connectivity(G, s=None, t=None):
 
     References
     ----------
-    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for
         Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
         http://eclectic.ss.uci.edu/~drwhite/working.pdf
 
@@ -219,14 +219,14 @@ def node_connectivity(G, s=None, t=None):
 def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
     """ Compute node connectivity between all pairs of nodes.
 
-    Pairwise or local node connectivity between two distinct and nonadjacent 
-    nodes is the minimum number of nodes that must be removed (minimum 
-    separating cutset) to disconnect them. By Menger's theorem, this is equal 
+    Pairwise or local node connectivity between two distinct and nonadjacent
+    nodes is the minimum number of nodes that must be removed (minimum
+    separating cutset) to disconnect them. By Menger's theorem, this is equal
     to the number of node independent paths (paths that share no nodes other
     than source and target). Which is what we compute in this function.
 
     This algorithm is a fast approximation that gives an strict lower
-    bound on the actual number of node independent paths between two nodes [1]_. 
+    bound on the actual number of node independent paths between two nodes [1]_.
     It works for both directed and undirected graphs.
 
 
@@ -255,7 +255,7 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
 
     References
     ----------
-    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for
         Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
         http://eclectic.ss.uci.edu/~drwhite/working.pdf
     """
@@ -313,16 +313,16 @@ def _bidirectional_shortest_path(G, source, target, exclude):
     Notes
     -----
     This function and its helper are originaly from
-    networkx.algorithms.shortest_paths.unweighted and are modified to 
-    accept the extra parameter 'exclude', which is a container for nodes 
+    networkx.algorithms.shortest_paths.unweighted and are modified to
+    accept the extra parameter 'exclude', which is a container for nodes
     already used in other paths that should be ignored.
 
     References
     ----------
-    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for 
+    .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for
         Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
         http://eclectic.ss.uci.edu/~drwhite/working.pdf
-    
+
     """
     # call helper to do the real work
     results = _bidirectional_pred_succ(G, source, target, exclude)
@@ -370,7 +370,7 @@ def _bidirectional_pred_succ(G, source, target, exclude):
     reverse_fringe = [target]
 
     level = 0
-    
+
     while forward_fringe and reverse_fringe:
         # Make sure that we iterate one step forward and one step backwards
         # thus source and target will only tigger "found path" when they are
@@ -398,7 +398,7 @@ def _bidirectional_pred_succ(G, source, target, exclude):
                     if w not in succ:
                         succ[w] = v
                         reverse_fringe.append(w)
-                    if w in pred: 
+                    if w in pred:
                         return pred, succ, w # found path
 
     raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -1,6 +1,6 @@
 """ Fast approximation for k-component structure
 """
-#    Copyright (C) 2015 by 
+#    Copyright (C) 2015 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    All rights reserved.
 #    BSD license.
@@ -26,19 +26,19 @@ __all__ = ['k_components']
 not_implemented_for('directed')
 def k_components(G, min_density=0.95):
     r"""Returns the approximate k-component structure of a graph G.
-    
-    A `k`-component is a maximal subgraph of a graph G that has, at least, 
+
+    A `k`-component is a maximal subgraph of a graph G that has, at least,
     node connectivity `k`: we need to remove at least `k` nodes to break it
     into more components. `k`-components have an inherent hierarchical
-    structure because they are nested in terms of connectivity: a connected 
-    graph can contain several 2-components, each of which can contain 
+    structure because they are nested in terms of connectivity: a connected
+    graph can contain several 2-components, each of which can contain
     one or more 3-components, and so forth.
 
     This implementation is based on the fast heuristics to approximate
     the `k`-component sturcture of a graph [1]_. Which, in turn, it is based on
-    a fast approximation algorithm for finding good lower bounds of the number 
+    a fast approximation algorithm for finding good lower bounds of the number
     of node independent paths between two nodes [2]_.
-  
+
     Parameters
     ----------
     G : NetworkX graph
@@ -52,39 +52,39 @@ def k_components(G, min_density=0.95):
     k_components : dict
         Dictionary with connectivity level `k` as key and a list of
         sets of nodes that form a k-component of level `k` as values.
-        
+
 
     Examples
     --------
-    >>> # Petersen graph has 10 nodes and it is triconnected, thus all 
+    >>> # Petersen graph has 10 nodes and it is triconnected, thus all
     >>> # nodes are in a single component on all three connectivity levels
     >>> from networkx.algorithms import approximation as apxa
     >>> G = nx.petersen_graph()
     >>> k_components = apxa.k_components(G)
-    
+
     Notes
     -----
-    The logic of the approximation algorithm for computing the `k`-component 
-    structure [1]_ is based on repeatedly applying simple and fast algorithms 
-    for `k`-cores and biconnected components in order to narrow down the 
+    The logic of the approximation algorithm for computing the `k`-component
+    structure [1]_ is based on repeatedly applying simple and fast algorithms
+    for `k`-cores and biconnected components in order to narrow down the
     number of pairs of nodes over which we have to compute White and Newman's
     approximation algorithm for finding node independent paths [2]_. More
-    formally, this algorithm is based on Whitney's theorem, which states 
-    an inclusion relation among node connectivity, edge connectivity, and 
-    minimum degree for any graph G. This theorem implies that every 
-    `k`-component is nested inside a `k`-edge-component, which in turn, 
+    formally, this algorithm is based on Whitney's theorem, which states
+    an inclusion relation among node connectivity, edge connectivity, and
+    minimum degree for any graph G. This theorem implies that every
+    `k`-component is nested inside a `k`-edge-component, which in turn,
     is contained in a `k`-core. Thus, this algorithm computes node independent
     paths among pairs of nodes in each biconnected part of each `k`-core,
-    and repeats this procedure for each `k` from 3 to the maximal core number 
+    and repeats this procedure for each `k` from 3 to the maximal core number
     of a node in the input graph.
 
-    Because, in practice, many nodes of the core of level `k` inside a 
-    bicomponent actually are part of a component of level k, the auxiliary 
-    graph needed for the algorithm is likely to be very dense. Thus, we use 
-    a complement graph data structure (see `AntiGraph`) to save memory. 
-    AntiGraph only stores information of the edges that are *not* present 
-    in the actual auxiliary graph. When applying algorithms to this 
-    complement graph data structure, it behaves as if it were the dense 
+    Because, in practice, many nodes of the core of level `k` inside a
+    bicomponent actually are part of a component of level k, the auxiliary
+    graph needed for the algorithm is likely to be very dense. Thus, we use
+    a complement graph data structure (see `AntiGraph`) to save memory.
+    AntiGraph only stores information of the edges that are *not* present
+    in the actual auxiliary graph. When applying algorithms to this
+    complement graph data structure, it behaves as if it were the dense
     version.
 
     See also
@@ -93,16 +93,16 @@ def k_components(G, min_density=0.95):
 
     References
     ----------
-    .. [1]  Torrents, J. and F. Ferraro (2015) Structural Cohesion: 
+    .. [1]  Torrents, J. and F. Ferraro (2015) Structural Cohesion:
             Visualization and Heuristics for Fast Computation.
             http://arxiv.org/pdf/1503.04476v1
 
-    .. [2]  White, Douglas R., and Mark Newman (2001) A Fast Algorithm for 
+    .. [2]  White, Douglas R., and Mark Newman (2001) A Fast Algorithm for
             Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
             http://eclectic.ss.uci.edu/~drwhite/working.pdf
 
-    .. [3]  Moody, J. and D. White (2003). Social cohesion and embeddedness: 
-            A hierarchical conception of social groups. 
+    .. [3]  Moody, J. and D. White (2003). Social cohesion and embeddedness:
+            A hierarchical conception of social groups.
             American Sociological Review 68(1), 103--28.
             http://www2.asanet.org/journals/ASRFeb03MoodyWhite.pdf
 
@@ -207,7 +207,7 @@ class _AntiGraph(nx.Graph):
     a low memory foodprint.
 
     In this class you add the edges that *do not exist* in the dense graph,
-    the report methods of the class return the neighbors, the edges and 
+    the report methods of the class return the neighbors, the edges and
     the degree as if it was the dense graph. Thus it's possible to use
     an instance of this class with some of NetworkX functions. In this
     case we only use k-core, connected_components, and biconnected_components.
@@ -233,11 +233,11 @@ class _AntiGraph(nx.Graph):
 
         """
         all_edge_dict = self.all_edge_dict
-        return dict((node, all_edge_dict) for node in 
+        return dict((node, all_edge_dict) for node in
                     set(self.adj) - set(self.adj[n]) - set([n]))
 
     def neighbors(self, n):
-        """Return an iterator over all neighbors of node n in the 
+        """Return an iterator over all neighbors of node n in the
            dense graph.
 
         """
@@ -258,7 +258,7 @@ class _AntiGraph(nx.Graph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 

--- a/networkx/algorithms/approximation/tests/test_approx_clust_coeff.py
+++ b/networkx/algorithms/approximation/tests/test_approx_clust_coeff.py
@@ -2,7 +2,7 @@ from nose.tools import assert_equal
 import networkx as nx
 from networkx.algorithms.approximation import average_clustering
 
-# This approximation has to be be exact in regular graphs 
+# This approximation has to be be exact in regular graphs
 # with no triangles or with all possible triangles.
 def test_petersen():
     # Actual coefficient is 0

--- a/networkx/algorithms/approximation/tests/test_connectivity.py
+++ b/networkx/algorithms/approximation/tests/test_connectivity.py
@@ -111,7 +111,7 @@ class TestAllPairsNodeConnectivityApprox:
         self.K10 = nx.complete_graph(10)
         self.K5 = nx.complete_graph(5)
         self.G_list = [self.path, self.directed_path, self.cycle,
-            self.directed_cycle, self.gnp, self.directed_gnp, self.K10, 
+            self.directed_cycle, self.gnp, self.directed_gnp, self.K10,
             self.K5, self.K20]
 
     def test_cycles(self):

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -13,7 +13,7 @@ __all__ = ['degree_pearson_correlation_coefficient',
            'attribute_assortativity_coefficient',
            'numeric_assortativity_coefficient']
 
-def degree_assortativity_coefficient(G, x='out', y='in', weight=None, 
+def degree_assortativity_coefficient(G, x='out', y='in', weight=None,
                                      nodes=None):
     """Compute degree assortativity of graph.
 
@@ -26,24 +26,24 @@ def degree_assortativity_coefficient(G, x='out', y='in', weight=None,
 
     x: string ('in','out')
        The degree type for source node (directed graphs only).
-    
+
     y: string ('in','out')
        The degree type for target node (directed graphs only).
 
     weight: string or None, optional (default=None)
-       The edge attribute that holds the numerical value used 
+       The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
 
     nodes: list or iterable (optional)
-        Compute degree assortativity only for nodes in container. 
+        Compute degree assortativity only for nodes in container.
         The default is all nodes.
 
     Returns
     -------
     r : float
        Assortativity of graph by degree.
-    
+
     Examples
     --------
     >>> G=nx.path_graph(4)
@@ -63,28 +63,28 @@ def degree_assortativity_coefficient(G, x='out', y='in', weight=None,
     -----
     This computes Eq. (21) in Ref. [1]_ , where e is the joint
     probability distribution (mixing matrix) of the degrees.  If G is
-    directed than the matrix e is the joint probability of the 
+    directed than the matrix e is the joint probability of the
     user-specified degree type for the source and target.
 
     References
     ----------
     .. [1] M. E. J. Newman, Mixing patterns in networks,
        Physical Review E, 67 026126, 2003
-    .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M. 
+    .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
     M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight)
     return numeric_ac(M)
 
 
-def degree_pearson_correlation_coefficient(G, x='out', y='in', 
+def degree_pearson_correlation_coefficient(G, x='out', y='in',
                                            weight=None, nodes=None):
-    """Compute degree assortativity of graph. 
+    """Compute degree assortativity of graph.
 
     Assortativity measures the similarity of connections
     in the graph with respect to the node degree.
 
-    This is the same as degree_assortativity_coefficient but uses the 
+    This is the same as degree_assortativity_coefficient but uses the
     potentially faster scipy.stats.pearsonr function.
 
     Parameters
@@ -98,7 +98,7 @@ def degree_pearson_correlation_coefficient(G, x='out', y='in',
        The degree type for target node (directed graphs only).
 
     weight: string or None, optional (default=None)
-       The edge attribute that holds the numerical value used 
+       The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
 
@@ -110,11 +110,11 @@ def degree_pearson_correlation_coefficient(G, x='out', y='in',
     -------
     r : float
        Assortativity of graph by degree.
-    
+
     Examples
     --------
     >>> G=nx.path_graph(4)
-    >>> r=nx.degree_pearson_correlation_coefficient(G) 
+    >>> r=nx.degree_pearson_correlation_coefficient(G)
     >>> print("%3.1f"%r)
     -0.5
 
@@ -126,7 +126,7 @@ def degree_pearson_correlation_coefficient(G, x='out', y='in',
     ----------
     .. [1] M. E. J. Newman, Mixing patterns in networks
            Physical Review E, 67 026126, 2003
-    .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M. 
+    .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
     try:
@@ -144,23 +144,23 @@ def attribute_assortativity_coefficient(G,attribute,nodes=None):
 
     Assortativity measures the similarity of connections
     in the graph with respect to the given attribute.
-    
+
     Parameters
     ----------
     G : NetworkX graph
 
-    attribute : string 
+    attribute : string
         Node attribute key
 
     nodes: list or iterable (optional)
-        Compute attribute assortativity for nodes in container. 
-        The default is all nodes. 
+        Compute attribute assortativity for nodes in container.
+        The default is all nodes.
 
     Returns
     -------
     r: float
        Assortativity of graph for given attribute
-    
+
     Examples
     --------
     >>> G=nx.Graph()
@@ -196,19 +196,19 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     ----------
     G : NetworkX graph
 
-    attribute : string 
+    attribute : string
         Node attribute key.  The corresponding attribute value must be an
         integer.
 
     nodes: list or iterable (optional)
-        Compute numeric assortativity only for attributes of nodes in 
+        Compute numeric assortativity only for attributes of nodes in
         container. The default is all nodes.
 
     Returns
     -------
     r: float
        Assortativity of graph for given attribute
-    
+
     Examples
     --------
     >>> G=nx.Graph()
@@ -220,7 +220,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
 
     Notes
     -----
-    This computes Eq. (21) in Ref. [1]_ , for the mixing matrix of 
+    This computes Eq. (21) in Ref. [1]_ , for the mixing matrix of
     of the specified attribute.
 
     References

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -19,10 +19,10 @@ def attribute_mixing_dict(G,attribute,nodes=None,normalized=False):
 
     Parameters
     ----------
-    G : graph 
+    G : graph
        NetworkX graph object.
 
-    attribute : string 
+    attribute : string
        Node attribute key.
 
     nodes: list or iterable (optional)
@@ -58,20 +58,20 @@ def attribute_mixing_matrix(G,attribute,nodes=None,mapping=None,
 
     Parameters
     ----------
-    G : graph 
+    G : graph
        NetworkX graph object.
 
-    attribute : string 
+    attribute : string
        Node attribute key.
 
     nodes: list or iterable (optional)
-        Use only nodes in container to build the matrix. The default is 
+        Use only nodes in container to build the matrix. The default is
         all nodes.
 
-    mapping : dictionary, optional        
-       Mapping from node attribute to integer index in matrix.  
-       If not specified, an arbitrary ordering will be used. 
-    
+    mapping : dictionary, optional
+       Mapping from node attribute to integer index in matrix.
+       If not specified, an arbitrary ordering will be used.
+
     normalized : bool (default=False)
        Return counts if False or probabilities if True.
 
@@ -87,13 +87,13 @@ def attribute_mixing_matrix(G,attribute,nodes=None,mapping=None,
     return a
 
 
-def degree_mixing_dict(G, x='out', y='in', weight=None, 
+def degree_mixing_dict(G, x='out', y='in', weight=None,
                        nodes=None, normalized=False):
     """Return dictionary representation of mixing matrix for degree.
 
     Parameters
     ----------
-    G : graph 
+    G : graph
         NetworkX graph object.
 
     x: string ('in','out')
@@ -103,7 +103,7 @@ def degree_mixing_dict(G, x='out', y='in', weight=None,
        The degree type for target node (directed graphs only).
 
     weight: string or None, optional (default=None)
-       The edge attribute that holds the numerical value used 
+       The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
 
@@ -120,13 +120,13 @@ def degree_mixing_dict(G, x='out', y='in', weight=None,
 
 
 
-def degree_mixing_matrix(G, x='out', y='in', weight=None, 
+def degree_mixing_matrix(G, x='out', y='in', weight=None,
                          nodes=None, normalized=True):
     """Return mixing matrix for attribute.
 
     Parameters
     ----------
-    G : graph 
+    G : graph
        NetworkX graph object.
 
     x: string ('in','out')
@@ -136,11 +136,11 @@ def degree_mixing_matrix(G, x='out', y='in', weight=None,
        The degree type for target node (directed graphs only).
 
     nodes: list or iterable (optional)
-        Build the matrix using only nodes in container. 
+        Build the matrix using only nodes in container.
         The default is all nodes.
 
     weight: string or None, optional (default=None)
-       The edge attribute that holds the numerical value used 
+       The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
 
@@ -156,7 +156,7 @@ def degree_mixing_matrix(G, x='out', y='in', weight=None,
     s=set(d.keys())
     for k,v in d.items():
         s.update(v.keys())
-    m=max(s)            
+    m=max(s)
     mapping=dict(zip(range(m+1),range(m+1)))
     a=dict_to_numpy_array(d,mapping=mapping)
     if normalized:
@@ -170,15 +170,15 @@ def numeric_mixing_matrix(G,attribute,nodes=None,normalized=True):
 
     Parameters
     ----------
-    G : graph 
+    G : graph
        NetworkX graph object.
 
-    attribute : string 
+    attribute : string
        Node attribute key.  The corresponding attribute must be an integer.
 
     nodes: list or iterable (optional)
         Build the matrix only with nodes in container. The default is all nodes.
-    
+
     normalized : bool (default=False)
        Return counts if False or probabilities if True.
 
@@ -191,7 +191,7 @@ def numeric_mixing_matrix(G,attribute,nodes=None,normalized=True):
     s=set(d.keys())
     for k,v in d.items():
         s.update(v.keys())
-    m=max(s)            
+    m=max(s)
     mapping=dict(zip(range(m+1),range(m+1)))
     a=dict_to_numpy_array(d,mapping=mapping)
     if normalized:
@@ -204,10 +204,10 @@ def mixing_dict(xy,normalized=False):
     Parameters
     ----------
     xy : list or container of two-tuples
-       Pairs of (x,y) items. 
+       Pairs of (x,y) items.
 
-    attribute : string 
-       Node attribute key 
+    attribute : string
+       Node attribute key
 
     normalized : bool (default=False)
        Return counts if False or probabilities if True.

--- a/networkx/algorithms/assortativity/neighbor_degree.py
+++ b/networkx/algorithms/assortativity/neighbor_degree.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    Aric Hagberg <hagberg@lanl.gov>
 #    All rights reserved.
@@ -21,7 +21,7 @@ def _average_nbr_deg(G, source_degree, target_degree, nodes=None, weight=None):
         if weight is None:
             avg[n] = sum(d for n, d in nbrdeg) / float(deg)
         else:
-            avg[n] = sum((G[n][nbr].get(weight,1)*d 
+            avg[n] = sum((G[n][nbr].get(weight,1)*d
                           for nbr,d in nbrdeg)) / float(deg)
     return avg
 
@@ -36,7 +36,7 @@ def average_neighbor_degree(G, source='out', target='out',
         k_{nn,i} = \frac{1}{|N(i)|} \sum_{j \in N(i)} k_j
 
     where `N(i)` are the neighbors of node `i` and `k_j` is
-    the degree of node `j` which belongs to `N(i)`. For weighted 
+    the degree of node `j` which belongs to `N(i)`. For weighted
     graphs, an analogous measure can be defined [1]_,
 
     .. math::
@@ -54,13 +54,13 @@ def average_neighbor_degree(G, source='out', target='out',
 
     source : string ("in"|"out")
        Directed graphs only.
-       Use "in"- or "out"-degree for source node.  
+       Use "in"- or "out"-degree for source node.
 
     target : string ("in"|"out")
        Directed graphs only.
        Use "in"- or "out"-degree for target node.
 
-    nodes : list or iterable, optional 
+    nodes : list or iterable, optional
         Compute neighbor degree for specified nodes.  The default is
         all nodes in the graph.
 
@@ -91,20 +91,20 @@ def average_neighbor_degree(G, source='out', target='out',
 
     >>> nx.average_neighbor_degree(G, source='out', target='out')
     {0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0}
- 
+
     Notes
     -----
-    For directed graphs you can also specify in-degree or out-degree 
+    For directed graphs you can also specify in-degree or out-degree
     by passing keyword arguments.
 
     See Also
     --------
-    average_degree_connectivity 
-    
+    average_degree_connectivity
+
     References
-    ----------    
-    .. [1] A. Barrat, M. Barthélemy, R. Pastor-Satorras, and A. Vespignani, 
-       "The architecture of complex weighted networks". 
+    ----------
+    .. [1] A. Barrat, M. Barthélemy, R. Pastor-Satorras, and A. Vespignani,
+       "The architecture of complex weighted networks".
        PNAS 101 (11): 3747–3752 (2004).
     """
     source_degree = G.degree
@@ -114,7 +114,7 @@ def average_neighbor_degree(G, source='out', target='out',
                      'in':G.in_degree}
         source_degree = direction[source]
         target_degree = direction[target]
-    return _average_nbr_deg(G, source_degree, target_degree, 
+    return _average_nbr_deg(G, source_degree, target_degree,
                             nodes=nodes, weight=weight)
 
 # obsolete

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -36,22 +36,22 @@ def node_attribute_xy(G, attribute, nodes=None):
 
     Notes
     -----
-    For undirected graphs each edge is produced twice, once for each edge 
-    representation (u,v) and (v,u), with the exception of self-loop edges 
+    For undirected graphs each edge is produced twice, once for each edge
+    representation (u,v) and (v,u), with the exception of self-loop edges
     which only appear once.
     """
     if nodes is None:
         nodes = set(G)
     else:
         nodes = set(nodes)
-    node = G.node 
+    node = G.node
     for u,nbrsdict in G.adjacency():
         if u not in nodes:
             continue
         uattr = node[u].get(attribute,None)
         if G.is_multigraph():
             for v,keys in nbrsdict.items():
-                vattr = node[v].get(attribute,None)                
+                vattr = node[v].get(attribute,None)
                 for k,d in keys.items():
                     yield (uattr,vattr)
         else:
@@ -74,7 +74,7 @@ def node_degree_xy(G, x='out', y='in', weight=None, nodes=None):
        The degree type for target node (directed graphs only).
 
     weight: string or None, optional (default=None)
-       The edge attribute that holds the numerical value used 
+       The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
 
@@ -99,8 +99,8 @@ def node_degree_xy(G, x='out', y='in', weight=None, nodes=None):
 
     Notes
     -----
-    For undirected graphs each edge is produced twice, once for each edge 
-    representation (u,v) and (v,u), with the exception of self-loop edges 
+    For undirected graphs each edge is produced twice, once for each edge
+    representation (u,v) and (v,u), with the exception of self-loop edges
     which only appear once.
     """
     if nodes is None:
@@ -119,7 +119,7 @@ def node_degree_xy(G, x='out', y='in', weight=None, nodes=None):
         neighbors = (nbr for _,nbr in G.edges(u) if nbr in nodes)
         for v,degv in ydeg(neighbors, weight=weight):
             yield degu,degv
- 
+
 
 # fixture for nose tests
 def setup_module(module):

--- a/networkx/algorithms/assortativity/tests/test_connectivity.py
+++ b/networkx/algorithms/assortativity/tests/test_connectivity.py
@@ -15,7 +15,7 @@ class TestNeighborConnectivity(object):
         answer={1:2.0,2:1.5}
         nd = nx.average_degree_connectivity(G)
         assert_equal(nd,answer)
-        
+
         D=G.to_directed()
         answer={2:2.0,4:1.5}
         nd = nx.average_degree_connectivity(D)
@@ -39,7 +39,7 @@ class TestNeighborConnectivity(object):
         answer={1:2.0,2:1.5}
         nd = nx.average_degree_connectivity(G)
         assert_equal(nd,answer)
-        
+
         D=G.to_directed()
         answer={2:2.0,4:1.8}
         nd = nx.average_degree_connectivity(D,weight='weight')
@@ -65,7 +65,7 @@ class TestNeighborConnectivity(object):
         answer={1:2.0,2:1.5}
         nd = nx.average_degree_connectivity(G,weight=None)
         assert_equal(nd,answer)
-        
+
         D=G.to_directed()
         answer={2:2.0,4:1.8}
         nd = nx.average_degree_connectivity(D,weight='other')

--- a/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
+++ b/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
@@ -9,7 +9,7 @@ class TestAverageNeighbor(object):
         answer={0:2,1:1.5,2:1.5,3:2}
         nd = nx.average_neighbor_degree(G)
         assert_equal(nd,answer)
-        
+
         D=G.to_directed()
         nd = nx.average_neighbor_degree(D)
         assert_equal(nd,answer)
@@ -28,7 +28,7 @@ class TestAverageNeighbor(object):
         answer={0:2,1:1.8,2:1.8,3:2}
         nd = nx.average_neighbor_degree(G,weight='weight')
         assert_equal(nd,answer)
-        
+
         D=G.to_directed()
         nd = nx.average_neighbor_degree(D,weight='weight')
         assert_equal(nd,answer)
@@ -51,7 +51,7 @@ class TestAverageNeighbor(object):
         answer={0:3,1:3,2:3,3:3}
         nd = nx.average_neighbor_degree(G)
         assert_equal(nd,answer)
-        
+
         D=G.to_directed()
         nd = nx.average_neighbor_degree(D)
         assert_equal(nd,answer)
@@ -79,4 +79,4 @@ class TestAverageNeighbor(object):
         nd = nx.average_neighbor_degree(G,weight='weight')[5]
         assert_almost_equal(nd,3.222222,places=5)
 
-    
+

--- a/networkx/algorithms/bipartite/__init__.py
+++ b/networkx/algorithms/bipartite/__init__.py
@@ -15,7 +15,7 @@ you have to keep track of which set each node belongs to, and make
 sure that there is no edge between nodes of the same set. The convention used
 in NetworkX is to use a node attribute named "bipartite" with values 0 or 1 to
 identify the sets each node belongs to.
- 
+
 For example:
 
 >>> B = nx.Graph()
@@ -25,8 +25,8 @@ For example:
 
 Many algorithms of the bipartite module of NetworkX require, as an argument, a
 container with all the nodes that belong to one set, in addition to the bipartite
-graph `B`. If `B` is connected, you can find the node sets using a two-coloring 
-algorithm: 
+graph `B`. If `B` is connected, you can find the node sets using a two-coloring
+algorithm:
 
 >>> nx.is_connected(B)
 True
@@ -69,7 +69,7 @@ container with all nodes that belong to one node set:
 >>> list(G.edges())
 [(1, 2), (1, 4)]
 
-All bipartite graph generators in NetworkX build bipartite graphs with the 
+All bipartite graph generators in NetworkX build bipartite graphs with the
 "bipartite" node attribute. Thus, you can use the same approach:
 
 >>> RB = bipartite.random_graph(5, 7, 0.2)

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    Aric Hagberg <hagberg@lanl.gov>
 #    All rights reserved.
@@ -14,7 +14,7 @@ __all__=['degree_centrality',
 def degree_centrality(G, nodes):
     r"""Compute the degree centrality for nodes in a bipartite network.
 
-    The degree centrality for a node `v` is the fraction of nodes 
+    The degree centrality for a node `v` is the fraction of nodes
     connected to it.
 
     Parameters
@@ -43,9 +43,9 @@ def degree_centrality(G, nodes):
     but the dictionary returned contains all nodes from both bipartite node
     sets.
 
-    For unipartite networks, the degree centrality values are 
-    normalized by dividing by the maximum possible degree (which is 
-    `n-1` where `n` is the number of nodes in G). 
+    For unipartite networks, the degree centrality values are
+    normalized by dividing by the maximum possible degree (which is
+    `n-1` where `n` is the number of nodes in G).
 
     In the bipartite case, the maximum possible degree of a node in a
     bipartite node set is the number of nodes in the opposite node set
@@ -59,12 +59,12 @@ def degree_centrality(G, nodes):
         d_{v} = \frac{deg(v)}{n}, \mbox{for} v \in V ,
 
 
-    where `deg(v)` is the degree of node `v`.        
+    where `deg(v)` is the degree of node `v`.
 
     References
     ----------
-    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation 
-        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook 
+    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
+        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
         http://www.steveborgatti.com/papers/bhaffiliations.pdf
     """
@@ -81,34 +81,34 @@ def betweenness_centrality(G, nodes):
     r"""Compute betweenness centrality for nodes in a bipartite network.
 
     Betweenness centrality of a node `v` is the sum of the
-    fraction of all-pairs shortest paths that pass through `v`. 
+    fraction of all-pairs shortest paths that pass through `v`.
 
     Values of betweenness are normalized by the maximum possible
-    value which for bipartite graphs is limited by the relative size 
+    value which for bipartite graphs is limited by the relative size
     of the two node sets [1]_.
 
     Let `n` be the number of nodes in the node set `U` and
     `m` be the number of nodes in the node set `V`, then
-    nodes in `U` are normalized by dividing by 
+    nodes in `U` are normalized by dividing by
 
     .. math::
 
        \frac{1}{2} [m^2 (s + 1)^2 + m (s + 1)(2t - s - 1) - t (2s - t + 3)] ,
 
     where
-    
+
     .. math::
-        
+
         s = (n - 1) \div m , t = (n - 1) \mod m ,
-    
+
     and nodes in `V` are normalized by dividing by
 
-    .. math::    
+    .. math::
 
         \frac{1}{2} [n^2 (p + 1)^2 + n (p + 1)(2r - p - 1) - r (2p - r + 3)] ,
 
     where,
-    
+
     .. math::
 
         p = (m - 1) \div n , r = (m - 1) \mod n .
@@ -124,7 +124,7 @@ def betweenness_centrality(G, nodes):
     Returns
     -------
     betweenness : dictionary
-        Dictionary keyed by node with bipartite betweenness centrality 
+        Dictionary keyed by node with bipartite betweenness centrality
         as the value.
 
     See Also
@@ -141,8 +141,8 @@ def betweenness_centrality(G, nodes):
 
     References
     ----------
-    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation 
-        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook 
+    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
+        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
         http://www.steveborgatti.com/papers/bhaffiliations.pdf
     """
@@ -160,7 +160,7 @@ def betweenness_centrality(G, nodes):
     bet_max_bot = (((n**2)*((p+1)**2))+
                    (n*(p+1)*(2*r-p-1))-
                    (r*((2*p)-r+3)))/2.0
-    betweenness = nx.betweenness_centrality(G, normalized=False, 
+    betweenness = nx.betweenness_centrality(G, normalized=False,
                                             weight=None)
     for node in top:
         betweenness[node]/=bet_max_top
@@ -171,7 +171,7 @@ def betweenness_centrality(G, nodes):
 def closeness_centrality(G, nodes, normalized=True):
     r"""Compute the closeness centrality for nodes in a bipartite network.
 
-    The closeness of a node is the distance to all other nodes in the 
+    The closeness of a node is the distance to all other nodes in the
     graph or in the case that the graph is not connected to all other nodes
     in the connected component containing that node.
 
@@ -183,13 +183,13 @@ def closeness_centrality(G, nodes, normalized=True):
     nodes : list or container
         Container with all nodes in one bipartite node set.
 
-    normalized : bool, optional      
+    normalized : bool, optional
       If True (default) normalize by connected component size.
 
     Returns
     -------
     closeness : dictionary
-        Dictionary keyed by node with bipartite closeness centrality 
+        Dictionary keyed by node with bipartite closeness centrality
         as the value.
 
     See Also
@@ -204,13 +204,13 @@ def closeness_centrality(G, nodes, normalized=True):
     The nodes input parameter must conatin all nodes in one bipartite node set,
     but the dictionary returned contains all nodes from both node sets.
 
-    Closeness centrality is normalized by the minimum distance possible. 
-    In the bipartite case the minimum distance for a node in one bipartite 
-    node set is 1 from all nodes in the other node set and 2 from all 
+    Closeness centrality is normalized by the minimum distance possible.
+    In the bipartite case the minimum distance for a node in one bipartite
+    node set is 1 from all nodes in the other node set and 2 from all
     other nodes in its own set [1]_. Thus the closeness centrality
-    for node `v`  in the two bipartite sets `U` with 
-    `n` nodes and `V` with `m` nodes is 
- 
+    for node `v`  in the two bipartite sets `U` with
+    `n` nodes and `V` with `m` nodes is
+
     .. math::
 
         c_{v} = \frac{m + 2(n - 1)}{d}, \mbox{for} v \in U,
@@ -231,8 +231,8 @@ def closeness_centrality(G, nodes, normalized=True):
 
     References
     ----------
-    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation 
-        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook 
+    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
+        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
         http://www.steveborgatti.com/papers/bhaffiliations.pdf
     """

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Jordi Torrents <jtorrents@milnou.net>
 #    Aric Hagberg <hagberg@lanl.gov>
 #    All rights reserved.
@@ -22,7 +22,7 @@ def cc_max(nu,nv):
 
 def cc_min(nu,nv):
     return float(len(nu & nv))/min(len(nu),len(nv))
-    
+
 modes={'dot':cc_dot,
        'min':cc_min,
        'max':cc_max}
@@ -32,30 +32,30 @@ def latapy_clustering(G, nodes=None, mode='dot'):
 
     The bipartie clustering coefficient is a measure of local density
     of connections defined as [1]_:
-    
+
     .. math::
 
        c_u = \frac{\sum_{v \in N(N(v))} c_{uv} }{|N(N(u))|}
 
-    where `N(N(u))` are the second order neighbors of `u` in `G` excluding `u`, 
-    and `c_{uv}` is the pairwise clustering coefficient between nodes 
+    where `N(N(u))` are the second order neighbors of `u` in `G` excluding `u`,
+    and `c_{uv}` is the pairwise clustering coefficient between nodes
     `u` and `v`.
 
     The mode selects the function for `c_{uv}` which can be:
 
-    `dot`: 
+    `dot`:
 
     .. math::
 
        c_{uv}=\frac{|N(u)\cap N(v)|}{|N(u) \cup N(v)|}
 
-    `min`: 
+    `min`:
 
     .. math::
 
        c_{uv}=\frac{|N(u)\cap N(v)|}{min(|N(u)|,|N(v)|)}
 
-    `max`: 
+    `max`:
 
     .. math::
 
@@ -68,13 +68,13 @@ def latapy_clustering(G, nodes=None, mode='dot'):
         A bipartite graph
 
     nodes : list or iterable (optional)
-        Compute bipartite clustering for these nodes. The default 
+        Compute bipartite clustering for these nodes. The default
         is all nodes in G.
 
     mode : string
         The pariwise bipartite clustering method to be used in the computation.
-        It must be "dot", "max", or "min". 
-    
+        It must be "dot", "max", or "min".
+
     Returns
     -------
     clustering : dictionary
@@ -85,10 +85,10 @@ def latapy_clustering(G, nodes=None, mode='dot'):
     --------
     >>> from networkx.algorithms import bipartite
     >>> G = nx.path_graph(4) # path graphs are bipartite
-    >>> c = bipartite.clustering(G) 
+    >>> c = bipartite.clustering(G)
     >>> c[0]
     0.5
-    >>> c = bipartite.clustering(G,mode='min') 
+    >>> c = bipartite.clustering(G,mode='min')
     >>> c[0]
     1.0
 
@@ -97,16 +97,16 @@ def latapy_clustering(G, nodes=None, mode='dot'):
     robins_alexander_clustering
     square_clustering
     average_clustering
-    
+
     References
     ----------
     .. [1] Latapy, Matthieu, Clémence Magnien, and Nathalie Del Vecchio (2008).
-       Basic notions for the analysis of large two-mode networks. 
+       Basic notions for the analysis of large two-mode networks.
        Social Networks 30(1), 31--48.
     """
     if not nx.algorithms.bipartite.is_bipartite(G):
         raise nx.NetworkXError("Graph is not bipartite")
-    
+
     try:
         cc_func = modes[mode]
     except KeyError:
@@ -131,20 +131,20 @@ clustering = latapy_clustering
 def average_clustering(G, nodes=None, mode='dot'):
     r"""Compute the average bipartite clustering coefficient.
 
-    A clustering coefficient for the whole graph is the average, 
+    A clustering coefficient for the whole graph is the average,
 
     .. math::
 
        C = \frac{1}{n}\sum_{v \in G} c_v,
-       
+
     where `n` is the number of nodes in `G`.
 
     Similar measures for the two bipartite sets can be defined [1]_
-    
+
     .. math::
 
        C_X = \frac{1}{|X|}\sum_{v \in X} c_v,
-       
+
     where `X` is a bipartite set of `G`.
 
     Parameters
@@ -153,46 +153,46 @@ def average_clustering(G, nodes=None, mode='dot'):
         a bipartite graph
 
     nodes : list or iterable, optional
-        A container of nodes to use in computing the average.  
-        The nodes should be either the entire graph (the default) or one of the 
+        A container of nodes to use in computing the average.
+        The nodes should be either the entire graph (the default) or one of the
         bipartite sets.
 
     mode : string
-        The pariwise bipartite clustering method. 
-        It must be "dot", "max", or "min" 
-    
+        The pariwise bipartite clustering method.
+        It must be "dot", "max", or "min"
+
     Returns
     -------
     clustering : float
-       The average bipartite clustering for the given set of nodes or the 
+       The average bipartite clustering for the given set of nodes or the
        entire graph if no nodes are specified.
 
     Examples
     --------
     >>> from networkx.algorithms import bipartite
     >>> G=nx.star_graph(3) # star graphs are bipartite
-    >>> bipartite.average_clustering(G) 
+    >>> bipartite.average_clustering(G)
     0.75
     >>> X,Y=bipartite.sets(G)
-    >>> bipartite.average_clustering(G,X) 
+    >>> bipartite.average_clustering(G,X)
     0.0
-    >>> bipartite.average_clustering(G,Y) 
+    >>> bipartite.average_clustering(G,Y)
     1.0
 
     See Also
     --------
     clustering
-   
-    Notes    
+
+    Notes
     -----
     The container of nodes passed to this function must contain all of the nodes
-    in one of the bipartite sets ("top" or "bottom") in order to compute 
+    in one of the bipartite sets ("top" or "bottom") in order to compute
     the correct average bipartite clustering coefficients.
 
     References
     ----------
     .. [1] Latapy, Matthieu, Clémence Magnien, and Nathalie Del Vecchio (2008).
-        Basic notions for the analysis of large two-mode networks. 
+        Basic notions for the analysis of large two-mode networks.
         Social Networks 30(1), 31--48.
     """
     if nodes is None:
@@ -210,7 +210,7 @@ def robins_alexander_clustering(G):
     .. math::
 
        CC_4 = \frac{4 * C_4}{L_3}
-       
+
     Parameters
     ----------
     G : graph
@@ -232,11 +232,11 @@ def robins_alexander_clustering(G):
     --------
     latapy_clustering
     square_clustering
-   
+
     References
     ----------
-    .. [1] Robins, G. and M. Alexander (2004). Small worlds among interlocking 
-           directors: Network structure and distance in bipartite graphs. 
+    .. [1] Robins, G. and M. Alexander (2004). Small worlds among interlocking
+           directors: Network structure and distance in bipartite graphs.
            Computational & Mathematical Organization Theory 10(1), 69–94.
 
     """

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -140,7 +140,7 @@ def generate_edgelist(G, delimiter=' ', data=True):
     try:
         part0 = [n for n,d in G.node.items() if d['bipartite'] == 0]
     except:
-        raise AttributeError("Missing node attribute `bipartite`") 
+        raise AttributeError("Missing node attribute `bipartite`")
     if data is True or data is False:
         for n in part0:
             for e in G.edges(n, data=data):

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -134,12 +134,10 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
     # build lists of degree-repeated vertex numbers
     stubs=[]
     stubs.extend([[v]*aseq[v] for v in range(0,lena)])
-    astubs=[]
     astubs=[x for subseq in stubs for x in subseq]
 
     stubs=[]
     stubs.extend([[v]*bseq[v-lena] for v in range(lena,lena+lenb)])
-    bstubs=[]
     bstubs=[x for subseq in stubs for x in subseq]
 
     # shuffle lists

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -2,7 +2,7 @@
 """One-mode (unipartite) projections of bipartite graphs.
 """
 import networkx as nx
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -20,14 +20,14 @@ __all__ = ['project',
 def projected_graph(B, nodes, multigraph=False):
     r"""Returns the projection of B onto one of its node sets.
 
-    Returns the graph G that is the projection of the bipartite graph B 
+    Returns the graph G that is the projection of the bipartite graph B
     onto the specified nodes. They retain their attributes and are connected
     in G if they have a common neighbor in B.
 
     Parameters
     ----------
-    B : NetworkX graph 
-      The input graph should be bipartite. 
+    B : NetworkX graph
+      The input graph should be bipartite.
 
     nodes : list or iterable
       Nodes to project onto (the "bottom" nodes).
@@ -46,14 +46,14 @@ def projected_graph(B, nodes, multigraph=False):
     --------
     >>> from networkx.algorithms import bipartite
     >>> B = nx.path_graph(4)
-    >>> G = bipartite.projected_graph(B, [1,3]) 
+    >>> G = bipartite.projected_graph(B, [1,3])
     >>> list(G)
     [1, 3]
     >>> list(G.edges())
     [(1, 3)]
-    
+
     If nodes `a`, and `b` are connected through both nodes 1 and 2 then
-    building a multigraph results in two edges in the projection onto 
+    building a multigraph results in two edges in the projection onto
     [`a`,`b`]:
 
     >>> B = nx.Graph()
@@ -77,9 +77,9 @@ def projected_graph(B, nodes, multigraph=False):
 
     See Also
     --------
-    is_bipartite, 
-    is_bipartite_node_set, 
-    sets, 
+    is_bipartite,
+    is_bipartite_node_set,
+    sets,
     weighted_projected_graph,
     collaboration_weighted_projected_graph,
     overlap_weighted_projected_graph,
@@ -128,20 +128,20 @@ def weighted_projected_graph(B, nodes, ratio=False):
 
     Parameters
     ----------
-    B : NetworkX graph 
-        The input graph should be bipartite. 
+    B : NetworkX graph
+        The input graph should be bipartite.
 
     nodes : list or iterable
         Nodes to project onto (the "bottom" nodes).
 
     ratio: Bool (default=False)
-        If True, edge weight is the ratio between actual shared neighbors 
-        and possible shared neighbors. If False, edges weight is the number 
+        If True, edge weight is the ratio between actual shared neighbors
+        and possible shared neighbors. If False, edges weight is the number
         of shared neighbors.
 
     Returns
     -------
-    Graph : NetworkX graph 
+    Graph : NetworkX graph
        A graph that is the projection onto the given nodes.
 
     Examples
@@ -156,7 +156,7 @@ def weighted_projected_graph(B, nodes, ratio=False):
     >>> G = bipartite.weighted_projected_graph(B, [1,3], ratio=True)
     >>> list(G.edges(data=True))
     [(1, 3, {'weight': 0.5})]
-    
+
     Notes
     -----
     No attempt is made to verify that the input graph B is bipartite.
@@ -164,18 +164,18 @@ def weighted_projected_graph(B, nodes, ratio=False):
 
     See Also
     --------
-    is_bipartite, 
-    is_bipartite_node_set, 
-    sets, 
+    is_bipartite,
+    is_bipartite_node_set,
+    sets,
     collaboration_weighted_projected_graph,
     overlap_weighted_projected_graph,
     generic_weighted_projected_graph
-    projected_graph 
+    projected_graph
 
     References
     ----------
-    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation 
-        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook 
+    .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
+        Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
     """
     if B.is_multigraph():
@@ -210,30 +210,30 @@ def collaboration_weighted_projected_graph(B, nodes):
     using Newman's collaboration model [1]_:
 
     .. math::
-        
+
         w_{v,u} = \sum_k \frac{\delta_{v}^{w} \delta_{w}^{k}}{k_w - 1}
 
     where `v` and `u` are nodes from the same bipartite node set,
-    and `w` is a node of the opposite node set. 
+    and `w` is a node of the opposite node set.
     The value `k_w` is the degree of node `w` in the bipartite
     network and `\delta_{v}^{w}` is 1 if node `v` is
     linked to node `w` in the original bipartite graph or 0 otherwise.
- 
+
     The nodes retain their attributes and are connected in the resulting
     graph if have an edge to a common node in the original bipartite
     graph.
 
     Parameters
     ----------
-    B : NetworkX graph 
-      The input graph should be bipartite. 
+    B : NetworkX graph
+      The input graph should be bipartite.
 
     nodes : list or iterable
       Nodes to project onto (the "bottom" nodes).
 
     Returns
     -------
-    Graph : NetworkX graph 
+    Graph : NetworkX graph
        A graph that is the projection onto the given nodes.
 
     Examples
@@ -245,12 +245,12 @@ def collaboration_weighted_projected_graph(B, nodes):
     >>> list(G)
     [0, 2, 4, 5]
     >>> for edge in G.edges(data=True): print(edge)
-    ... 
+    ...
     (0, 2, {'weight': 0.5})
     (0, 5, {'weight': 0.5})
     (2, 4, {'weight': 1.0})
     (2, 5, {'weight': 0.5})
-    
+
     Notes
     -----
     No attempt is made to verify that the input graph B is bipartite.
@@ -258,18 +258,18 @@ def collaboration_weighted_projected_graph(B, nodes):
 
     See Also
     --------
-    is_bipartite, 
-    is_bipartite_node_set, 
-    sets, 
+    is_bipartite,
+    is_bipartite_node_set,
+    sets,
     weighted_projected_graph,
     overlap_weighted_projected_graph,
     generic_weighted_projected_graph,
-    projected_graph 
+    projected_graph
 
     References
     ----------
-    .. [1] Scientific collaboration networks: II. 
-        Shortest paths, weighted networks, and centrality, 
+    .. [1] Scientific collaboration networks: II.
+        Shortest paths, weighted networks, and centrality,
         M. E. J. Newman, Phys. Rev. E 64, 016132 (2001).
     """
     if B.is_multigraph():
@@ -295,30 +295,30 @@ def collaboration_weighted_projected_graph(B, nodes):
 def overlap_weighted_projected_graph(B, nodes, jaccard=True):
     r"""Overlap weighted projection of B onto one of its node sets.
 
-    The overlap weighted projection is the projection of the bipartite 
-    network B onto the specified nodes with weights representing 
+    The overlap weighted projection is the projection of the bipartite
+    network B onto the specified nodes with weights representing
     the Jaccard index between the neighborhoods of the two nodes in the
-    original bipartite network [1]_: 
+    original bipartite network [1]_:
 
     .. math::
-        
+
         w_{v,u} = \frac{|N(u) \cap N(v)|}{|N(u) \cup N(v)|}
 
-    or if the parameter 'jaccard' is False, the fraction of common 
-    neighbors by minimum of both nodes degree in the original 
+    or if the parameter 'jaccard' is False, the fraction of common
+    neighbors by minimum of both nodes degree in the original
     bipartite graph [1]_:
-    
+
     .. math::
 
         w_{v,u} = \frac{|N(u) \cap N(v)|}{min(|N(u)|,|N(v)|)}
-    
+
     The nodes retain their attributes and are connected in the resulting
     graph if have an edge to a common node in the original bipartite graph.
 
     Parameters
     ----------
-    B : NetworkX graph 
-        The input graph should be bipartite. 
+    B : NetworkX graph
+        The input graph should be bipartite.
 
     nodes : list or iterable
         Nodes to project onto (the "bottom" nodes).
@@ -327,7 +327,7 @@ def overlap_weighted_projected_graph(B, nodes, jaccard=True):
 
     Returns
     -------
-    Graph : NetworkX graph 
+    Graph : NetworkX graph
        A graph that is the projection onto the given nodes.
 
     Examples
@@ -342,7 +342,7 @@ def overlap_weighted_projected_graph(B, nodes, jaccard=True):
     >>> G = bipartite.overlap_weighted_projected_graph(B, [0, 2, 4], jaccard=False)
     >>> list(G.edges(data=True))
     [(0, 2, {'weight': 1.0}), (2, 4, {'weight': 1.0})]
-    
+
     Notes
     -----
     No attempt is made to verify that the input graph B is bipartite.
@@ -350,20 +350,20 @@ def overlap_weighted_projected_graph(B, nodes, jaccard=True):
 
     See Also
     --------
-    is_bipartite, 
-    is_bipartite_node_set, 
-    sets, 
+    is_bipartite,
+    is_bipartite_node_set,
+    sets,
     weighted_projected_graph,
     collaboration_weighted_projected_graph,
     generic_weighted_projected_graph,
-    projected_graph 
+    projected_graph
 
     References
     ----------
-    .. [1] Borgatti, S.P. and Halgin, D. In press. Analyzing Affiliation 
-        Networks. In Carrington, P. and Scott, J. (eds) The Sage Handbook 
+    .. [1] Borgatti, S.P. and Halgin, D. In press. Analyzing Affiliation
+        Networks. In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
-    
+
     """
     if B.is_multigraph():
         raise nx.NetworkXError("not defined for multigraphs")
@@ -395,25 +395,25 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     must accept as a parameter the neighborhood sets of two nodes and
     return an integer or a float.
 
-    The nodes retain their attributes and are connected in the resulting graph 
+    The nodes retain their attributes and are connected in the resulting graph
     if they have an edge to a common node in the original graph.
 
     Parameters
     ----------
-    B : NetworkX graph 
-        The input graph should be bipartite. 
+    B : NetworkX graph
+        The input graph should be bipartite.
 
     nodes : list or iterable
         Nodes to project onto (the "bottom" nodes).
 
     weight_function: function
-        This function must accept as parameters the same input graph 
+        This function must accept as parameters the same input graph
         that this function, and two nodes; and return an integer or a float.
         The default function computes the number of shared neighbors.
 
     Returns
     -------
-    Graph : NetworkX graph 
+    Graph : NetworkX graph
        A graph that is the projection onto the given nodes.
 
     Examples
@@ -424,22 +424,22 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     ...     unbrs = set(G[u])
     ...     vnbrs = set(G[v])
     ...     return float(len(unbrs & vnbrs)) / len(unbrs | vnbrs)
-    ... 
+    ...
     >>> def my_weight(G, u, v, weight='weight'):
     ...     w = 0
     ...     for nbr in set(G[u]) & set(G[v]):
     ...         w += G.edge[u][nbr].get(weight, 1) + G.edge[v][nbr].get(weight, 1)
     ...     return w
-    ... 
+    ...
     >>> # A complete bipartite graph with 4 nodes and 4 edges
     >>> B = nx.complete_bipartite_graph(2,2)
     >>> # Add some arbitrary weight to the edges
     >>> for i,(u,v) in enumerate(B.edges()):
     ...     B.edge[u][v]['weight'] = i + 1
-    ... 
+    ...
     >>> for edge in B.edges(data=True):
     ...     print(edge)
-    ... 
+    ...
     (0, 2, {'weight': 1})
     (0, 3, {'weight': 2})
     (1, 2, {'weight': 3})
@@ -455,7 +455,7 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     >>> G = bipartite.generic_weighted_projected_graph(B, [0, 1], weight_function=my_weight)
     >>> print(list(G.edges(data=True)))
     [(0, 1, {'weight': 10})]
-    
+
     Notes
     -----
     No attempt is made to verify that the input graph B is bipartite.
@@ -463,13 +463,13 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
 
     See Also
     --------
-    is_bipartite, 
-    is_bipartite_node_set, 
-    sets, 
+    is_bipartite,
+    is_bipartite_node_set,
+    sets,
     weighted_projected_graph,
     collaboration_weighted_projected_graph,
     overlap_weighted_projected_graph,
-    projected_graph 
+    projected_graph
 
     """
     if B.is_multigraph():

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -4,7 +4,7 @@ Spectral bipartivity measure.
 """
 import networkx as nx
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -17,7 +17,7 @@ def spectral_bipartivity(G, nodes=None, weight='weight'):
 
     Parameters
     ----------
-    G : NetworkX graph 
+    G : NetworkX graph
 
     nodes : list or container  optional(default is all nodes)
       Nodes to return value of spectral bipartivity contribution.
@@ -31,7 +31,7 @@ def spectral_bipartivity(G, nodes=None, weight='weight'):
        A single number if the keyword nodes is not specified, or
        a dictionary keyed by node with the spectral bipartivity contribution
        of that node as the value.
-       
+
     Examples
     --------
     >>> from networkx.algorithms import bipartite
@@ -42,7 +42,7 @@ def spectral_bipartivity(G, nodes=None, weight='weight'):
     Notes
     -----
     This implementation uses Numpy (dense) matrices which are not efficient
-    for storing large sparse graphs.  
+    for storing large sparse graphs.
 
     See Also
     --------

--- a/networkx/algorithms/bipartite/tests/test_centrality.py
+++ b/networkx/algorithms/bipartite/tests/test_centrality.py
@@ -9,7 +9,7 @@ class TestBipartiteCentrality(object):
         self.K3 = nx.complete_bipartite_graph(3,3)
         self.C4 = nx.cycle_graph(4)
         self.davis = nx.davis_southern_women_graph()
-        self.top_nodes = [n for n,d in self.davis.nodes(data=True) 
+        self.top_nodes = [n for n,d in self.davis.nodes(data=True)
                           if d['bipartite']==0]
 
     def test_degree_centrality(self):

--- a/networkx/algorithms/bipartite/tests/test_cluster.py
+++ b/networkx/algorithms/bipartite/tests/test_cluster.py
@@ -5,13 +5,13 @@ import networkx.algorithms.bipartite as bipartite
 
 def test_pairwise_bipartite_cc_functions():
     # Test functions for different kinds of bipartite clustering coefficients
-    # between pairs of nodes using 3 example graphs from figure 5 p. 40 
+    # between pairs of nodes using 3 example graphs from figure 5 p. 40
     # Latapy et al (2008)
     G1 = nx.Graph([(0,2),(0,3),(0,4),(0,5),(0,6),(1,5),(1,6),(1,7)])
     G2 = nx.Graph([(0,2),(0,3),(0,4),(1,3),(1,4),(1,5)])
     G3 = nx.Graph([(0,2),(0,3),(0,4),(0,5),(0,6),(1,5),(1,6),(1,7),(1,8),(1,9)])
-    result = {0:[1/3.0, 2/3.0, 2/5.0], 
-              1:[1/2.0, 2/3.0, 2/3.0], 
+    result = {0:[1/3.0, 2/3.0, 2/5.0],
+              1:[1/2.0, 2/3.0, 2/3.0],
               2:[2/8.0, 2/5.0, 2/5.0]}
     for i, G in enumerate([G1, G2, G3]):
         assert(bipartite.is_bipartite(G))

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -54,7 +54,7 @@ class TestGeneratorsBipartite():
         bseq=[2,2,2,2,2]
         assert_raises(networkx.exception.NetworkXError,
                       configuration_model, aseq, bseq)
-        
+
         aseq=[3,3,3,3]
         bseq=[2,2,2,2,2,2]
         G=configuration_model(aseq,bseq)
@@ -88,7 +88,7 @@ class TestGeneratorsBipartite():
         bseq=[2,2,2,2,2]
         assert_raises(networkx.exception.NetworkXError,
                       havel_hakimi_graph, aseq, bseq)
-        
+
         bseq=[2,2,2,2,2,2]
         G=havel_hakimi_graph(aseq,bseq)
         assert_equal(sorted(d for n,d in G.degree()),
@@ -108,13 +108,13 @@ class TestGeneratorsBipartite():
         assert_raises(networkx.exception.NetworkXError,
                       havel_hakimi_graph, aseq, bseq,
                       create_using=DiGraph())
-            
+
     def test_reverse_havel_hakimi_graph(self):
         aseq=[3,3,3,3]
         bseq=[2,2,2,2,2]
         assert_raises(networkx.exception.NetworkXError,
                       reverse_havel_hakimi_graph, aseq, bseq)
-        
+
         bseq=[2,2,2,2,2,2]
         G=reverse_havel_hakimi_graph(aseq,bseq)
         assert_equal(sorted(d for n,d in G.degree()),
@@ -140,13 +140,13 @@ class TestGeneratorsBipartite():
         assert_raises(networkx.exception.NetworkXError,
                       reverse_havel_hakimi_graph, aseq, bseq,
                       create_using=DiGraph())
-        
+
     def test_alternating_havel_hakimi_graph(self):
         aseq=[3,3,3,3]
         bseq=[2,2,2,2,2]
         assert_raises(networkx.exception.NetworkXError,
                       alternating_havel_hakimi_graph, aseq, bseq)
-        
+
         bseq=[2,2,2,2,2,2]
         G=alternating_havel_hakimi_graph(aseq,bseq)
         assert_equal(sorted(d for n,d in G.degree()),
@@ -173,7 +173,7 @@ class TestGeneratorsBipartite():
         assert_raises(networkx.exception.NetworkXError,
                       alternating_havel_hakimi_graph, aseq, bseq,
                       create_using=DiGraph())
-        
+
     def test_preferential_attachment(self):
         aseq=[3,2,1,1]
         G=preferential_attachment_graph(aseq,0.5)

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -40,7 +40,7 @@ def closeness_centrality(G, u=None, distance=None, normalized=True):
     u : node, optional
       Return only the value for node u
     distance : edge attribute key, optional (default=None)
-      Use the specified edge attribute as the edge distance in shortest 
+      Use the specified edge attribute as the edge distance in shortest
       path calculations
     normalized : bool, optional
       If True (default) normalize by the number of nodes in the connected
@@ -75,7 +75,7 @@ def closeness_centrality(G, u=None, distance=None, normalized=True):
        http://leonidzhukov.ru/hse/2013/socialnetworks/papers/freeman79-centrality.pdf
     """
     if distance is not None:
-        # use Dijkstra's algorithm with specified attribute as edge weight 
+        # use Dijkstra's algorithm with specified attribute as edge weight
         path_length = functools.partial(nx.single_source_dijkstra_path_length,
                                         weight=distance)
     else:

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -1,7 +1,7 @@
 """
 Current-flow betweenness centrality measures for subsets of nodes.
 """
-#    Copyright (C) 2010-2011 by 
+#    Copyright (C) 2010-2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -33,7 +33,7 @@ def current_flow_betweenness_centrality_subset(G,sources,targets,
     Parameters
     ----------
     G : graph
-      A NetworkX graph 
+      A NetworkX graph
 
     sources: list of nodes
       Nodes to use as sources for current
@@ -55,14 +55,14 @@ def current_flow_betweenness_centrality_subset(G,sources,targets,
 
     solver: string (default='lu')
        Type of linear solver to use for computing the flow matrix.
-       Options are "full" (uses most memory), "lu" (recommended), and 
+       Options are "full" (uses most memory), "lu" (recommended), and
        "cg" (uses least memory).
 
     Returns
     -------
     nodes : dictionary
        Dictionary of nodes with betweenness centrality as the value.
-        
+
     See Also
     --------
     approximate_current_flow_betweenness_centrality
@@ -73,36 +73,36 @@ def current_flow_betweenness_centrality_subset(G,sources,targets,
     Notes
     -----
     Current-flow betweenness can be computed in `O(I(n-1)+mn \log n)`
-    time [1]_, where `I(n-1)` is the time needed to compute the 
+    time [1]_, where `I(n-1)` is the time needed to compute the
     inverse Laplacian.  For a full matrix this is `O(n^3)` but using
     sparse methods you can achieve `O(nm{\sqrt k})` where `k` is the
-    Laplacian matrix condition number.  
+    Laplacian matrix condition number.
 
     The space required is `O(nw) where `w` is the width of the sparse
     Laplacian matrix.  Worse case is `w=n` for `O(n^2)`.
 
-    If the edges have a 'weight' attribute they will be used as 
+    If the edges have a 'weight' attribute they will be used as
     weights in this algorithm.  Unspecified weights are set to 1.
 
     References
     ----------
-    .. [1] Centrality Measures Based on Current Flow. 
+    .. [1] Centrality Measures Based on Current Flow.
        Ulrik Brandes and Daniel Fleischer,
-       Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05). 
-       LNCS 3404, pp. 533-544. Springer-Verlag, 2005. 
+       Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
+       LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
        http://www.inf.uni-konstanz.de/algo/publications/bf-cmbcf-05.pdf
 
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    from networkx.utils import reverse_cuthill_mckee_ordering 
+    from networkx.utils import reverse_cuthill_mckee_ordering
     try:
         import numpy as np
     except ImportError:
         raise ImportError('current_flow_betweenness_centrality requires NumPy ',
                           'http://scipy.org/')
     try:
-        import scipy 
+        import scipy
     except ImportError:
         raise ImportError('current_flow_betweenness_centrality requires SciPy ',
                           'http://scipy.org/')
@@ -118,14 +118,14 @@ def current_flow_betweenness_centrality_subset(G,sources,targets,
     mapping=dict(zip(ordering,range(n)))
     H = nx.relabel_nodes(G,mapping)
     betweenness = dict.fromkeys(H,0.0) # b[v]=0 for v in H
-    for row,(s,t) in flow_matrix_row(H, weight=weight, dtype=dtype, 
+    for row,(s,t) in flow_matrix_row(H, weight=weight, dtype=dtype,
                                      solver=solver):
         for ss in sources:
             i=mapping[ss]
             for tt in targets:
                 j=mapping[tt]
-                betweenness[s]+=0.5*np.abs(row[i]-row[j]) 
-                betweenness[t]+=0.5*np.abs(row[i]-row[j]) 
+                betweenness[s]+=0.5*np.abs(row[i]-row[j])
+                betweenness[t]+=0.5*np.abs(row[i]-row[j])
     if normalized:
         nb=(n-1.0)*(n-2.0) # normalization factor
     else:
@@ -136,10 +136,10 @@ def current_flow_betweenness_centrality_subset(G,sources,targets,
 
 
 def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
-                                                    normalized=True, 
+                                                    normalized=True,
                                                     weight='weight',
                                                     dtype=float, solver='lu'):
-    """Compute current-flow betweenness centrality for edges using subsets 
+    """Compute current-flow betweenness centrality for edges using subsets
     of nodes.
 
     Current-flow betweenness centrality uses an electrical current
@@ -152,7 +152,7 @@ def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
     Parameters
     ----------
     G : graph
-      A NetworkX graph 
+      A NetworkX graph
 
     sources: list of nodes
       Nodes to use as sources for current
@@ -174,14 +174,14 @@ def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
 
     solver: string (default='lu')
        Type of linear solver to use for computing the flow matrix.
-       Options are "full" (uses most memory), "lu" (recommended), and 
+       Options are "full" (uses most memory), "lu" (recommended), and
        "cg" (uses least memory).
 
     Returns
     -------
     nodes : dictionary
        Dictionary of edge tuples with betweenness centrality as the value.
-        
+
     See Also
     --------
     betweenness_centrality
@@ -191,36 +191,36 @@ def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
     Notes
     -----
     Current-flow betweenness can be computed in `O(I(n-1)+mn \log n)`
-    time [1]_, where `I(n-1)` is the time needed to compute the 
+    time [1]_, where `I(n-1)` is the time needed to compute the
     inverse Laplacian.  For a full matrix this is `O(n^3)` but using
     sparse methods you can achieve `O(nm{\sqrt k})` where `k` is the
-    Laplacian matrix condition number.  
+    Laplacian matrix condition number.
 
     The space required is `O(nw) where `w` is the width of the sparse
     Laplacian matrix.  Worse case is `w=n` for `O(n^2)`.
 
-    If the edges have a 'weight' attribute they will be used as 
+    If the edges have a 'weight' attribute they will be used as
     weights in this algorithm.  Unspecified weights are set to 1.
 
     References
     ----------
-    .. [1] Centrality Measures Based on Current Flow. 
+    .. [1] Centrality Measures Based on Current Flow.
        Ulrik Brandes and Daniel Fleischer,
-       Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05). 
-       LNCS 3404, pp. 533-544. Springer-Verlag, 2005. 
+       Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
+       LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
        http://www.inf.uni-konstanz.de/algo/publications/bf-cmbcf-05.pdf
 
-    .. [2] A measure of betweenness centrality based on random walks, 
+    .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    from networkx.utils import reverse_cuthill_mckee_ordering 
+    from networkx.utils import reverse_cuthill_mckee_ordering
     try:
         import numpy as np
     except ImportError:
         raise ImportError('current_flow_betweenness_centrality requires NumPy ',
                           'http://scipy.org/')
     try:
-        import scipy 
+        import scipy
     except ImportError:
         raise ImportError('current_flow_betweenness_centrality requires SciPy ',
                           'http://scipy.org/')
@@ -240,15 +240,15 @@ def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
         nb=(n-1.0)*(n-2.0) # normalization factor
     else:
         nb=2.0
-    for row,(e) in flow_matrix_row(H, weight=weight, dtype=dtype, 
+    for row,(e) in flow_matrix_row(H, weight=weight, dtype=dtype,
                                    solver=solver):
         for ss in sources:
             i=mapping[ss]
             for tt in targets:
                 j=mapping[tt]
-                betweenness[e]+=0.5*np.abs(row[i]-row[j]) 
+                betweenness[e]+=0.5*np.abs(row[i]-row[j])
         betweenness[e]/=nb
-    return dict(((ordering[s],ordering[t]),v) 
+    return dict(((ordering[s],ordering[t]),v)
                 for (s,t),v in betweenness.items())
 
 

--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -46,7 +46,6 @@ def degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality = {}
     s = 1.0/(len(G)-1.0)
     centrality = {n: d*s for n, d in G.degree()}
     return centrality
@@ -87,7 +86,6 @@ def in_degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality = {}
     s = 1.0/(len(G)-1.0)
     centrality = {n: d*s for n, d in G.in_degree()}
     return centrality
@@ -128,7 +126,6 @@ def out_degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality = {}
     s = 1.0/(len(G)-1.0)
     centrality = {n: d*s for n, d in G.out_degree()}
     return centrality

--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -11,7 +11,7 @@ def flow_matrix_row(G, weight='weight', dtype=float, solver='lu'):
                 "lu": SuperLUInverseLaplacian,
                 "cg": CGInverseLaplacian}
     n = G.number_of_nodes()
-    L = laplacian_sparse_matrix(G, nodelist=range(n), weight=weight, 
+    L = laplacian_sparse_matrix(G, nodelist=range(n), weight=weight,
                                 dtype=dtype, format='csc')
     C = solvername[solver](L, dtype=dtype) # initialize solver
     w = C.w # w is the Laplacian matrix width
@@ -21,10 +21,10 @@ def flow_matrix_row(G, weight='weight', dtype=float, solver='lu'):
         c = d.get(weight,1.0)
         B[u%w] = c
         B[v%w] = -c
-        # get only the rows needed in the inverse laplacian 
+        # get only the rows needed in the inverse laplacian
         # and multiply to get the flow matrix row
-        row = np.dot(B, C.get_rows(u,v))  
-        yield row,(u,v) 
+        row = np.dot(B, C.get_rows(u,v))
+        yield row,(u,v)
 
 
 # Class to compute the inverse laplacian only for specified rows
@@ -131,7 +131,7 @@ def laplacian_sparse_matrix(G, nodelist=None, weight='weight', dtype=None,
                             format='csr'):
     import numpy as np
     import scipy.sparse
-    A = nx.to_scipy_sparse_matrix(G, nodelist=nodelist, weight=weight, 
+    A = nx.to_scipy_sparse_matrix(G, nodelist=nodelist, weight=weight,
                                   dtype=dtype, format=format)
     (n,n) = A.shape
     data = np.asarray(A.sum(axis=1).T)

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -19,7 +19,7 @@ def weighted_G():
 
 
 class TestBetweennessCentrality(object):
-        
+
     def test_K5(self):
         """Betweenness centrality: K5"""
         G=nx.complete_graph(5)
@@ -133,7 +133,7 @@ class TestBetweennessCentrality(object):
     def test_ladder_graph(self):
         """Betweenness centrality: Ladder graph"""
         G = nx.Graph() # ladder_graph(3)
-        G.add_edges_from([(0,1), (0,2), (1,3), (2,3), 
+        G.add_edges_from([(0,1), (0,2), (1,3), (2,3),
                           (2,4), (4,5), (3,5)])
         b_answer={0:1.667,1: 1.667,2: 6.667,
                   3: 6.667,4: 1.667,5: 1.667}
@@ -196,7 +196,7 @@ class TestBetweennessCentrality(object):
 
 
 class TestWeightedBetweennessCentrality(object):
-        
+
     def test_K5(self):
         """Weighted betweenness centrality: K5"""
         G=nx.complete_graph(5)
@@ -245,7 +245,7 @@ class TestWeightedBetweennessCentrality(object):
 
 
     def test_krackhardt_kite_graph_normalized(self):
-        """Weighted betweenness centrality: 
+        """Weighted betweenness centrality:
         Krackhardt kite graph normalized
         """
         G=nx.krackhardt_kite_graph()
@@ -260,7 +260,7 @@ class TestWeightedBetweennessCentrality(object):
 
 
     def test_florentine_families_graph(self):
-        """Weighted betweenness centrality: 
+        """Weighted betweenness centrality:
         Florentine families graph"""
         G=nx.florentine_families_graph()
         b_answer=\
@@ -290,7 +290,7 @@ class TestWeightedBetweennessCentrality(object):
     def test_ladder_graph(self):
         """Weighted betweenness centrality: Ladder graph"""
         G = nx.Graph() # ladder_graph(3)
-        G.add_edges_from([(0,1), (0,2), (1,3), (2,3), 
+        G.add_edges_from([(0,1), (0,2), (1,3), (2,3),
                           (2,4), (4,5), (3,5)])
         b_answer={0:1.667,1: 1.667,2: 6.667,
                   3: 6.667,4: 1.667,5: 1.667}
@@ -303,8 +303,8 @@ class TestWeightedBetweennessCentrality(object):
             assert_almost_equal(b[n],b_answer[n],places=3)
 
     def test_G(self):
-        """Weighted betweenness centrality: G"""                   
-        G = weighted_G()               
+        """Weighted betweenness centrality: G"""
+        G = weighted_G()
         b_answer={0: 2.0, 1: 0.0, 2: 4.0, 3: 3.0, 4: 4.0, 5: 0.0}
         b=nx.betweenness_centrality(G,
                                           weight='weight',
@@ -313,7 +313,7 @@ class TestWeightedBetweennessCentrality(object):
             assert_almost_equal(b[n],b_answer[n])
 
     def test_G2(self):
-        """Weighted betweenness centrality: G2"""                   
+        """Weighted betweenness centrality: G2"""
         G=nx.DiGraph()
         G.add_weighted_edges_from([('s','u',10) ,('s','x',5) ,
                                    ('u','v',1) ,('u','x',2) ,
@@ -331,7 +331,7 @@ class TestWeightedBetweennessCentrality(object):
 
 
 class TestEdgeBetweennessCentrality(object):
-        
+
     def test_K5(self):
         """Edge betweenness centrality: K5"""
         G=nx.complete_graph(5)
@@ -384,7 +384,7 @@ class TestEdgeBetweennessCentrality(object):
             assert_almost_equal(b[n],b_answer[n])
 
 class TestWeightedEdgeBetweennessCentrality(object):
-        
+
     def test_K5(self):
         """Edge betweenness centrality: K5"""
         G=nx.complete_graph(5)
@@ -420,8 +420,8 @@ class TestWeightedEdgeBetweennessCentrality(object):
             assert_almost_equal(b[n],b_answer[n])
 
     def test_weighted_graph(self):
-        eList = [(0, 1, 5), (0, 2, 4), (0, 3, 3), 
-                 (0, 4, 2), (1, 2, 4), (1, 3, 1), 
+        eList = [(0, 1, 5), (0, 2, 4), (0, 3, 3),
+                 (0, 4, 2), (1, 2, 4), (1, 3, 1),
                  (1, 4, 3), (2, 4, 5), (3, 4, 4)]
         G = nx.Graph()
         G.add_weighted_edges_from(eList)
@@ -440,8 +440,8 @@ class TestWeightedEdgeBetweennessCentrality(object):
             assert_almost_equal(b[n],b_answer[n])
 
     def test_normalized_weighted_graph(self):
-        eList = [(0, 1, 5), (0, 2, 4), (0, 3, 3), 
-                 (0, 4, 2), (1, 2, 4), (1, 3, 1), 
+        eList = [(0, 1, 5), (0, 2, 4), (0, 3, 3),
+                 (0, 4, 2), (1, 2, 4), (1, 3, 1),
                  (1, 4, 3), (2, 4, 5), (3, 4, 4)]
         G = nx.Graph()
         G.add_weighted_edges_from(eList)

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
@@ -124,11 +124,11 @@ class TestBetweennessCentralitySources:
         for n in sorted(G):
             assert_almost_equal(b[n],b_answer[n])
 
-    
+
 
 
 class TestEdgeSubsetBetweennessCentrality:
-    
+
     def test_K5(self):
         """Edge betweenness centrality: K5"""
         G=nx.complete_graph(5)

--- a/networkx/algorithms/centrality/tests/test_closeness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_closeness_centrality.py
@@ -15,7 +15,7 @@ class TestClosenessCentrality:
         self.C4=nx.cycle_graph(4)
         self.T=nx.balanced_tree(r=2, h=2)
         self.Gb = nx.Graph()
-        self.Gb.add_edges_from([(0,1), (0,2), (1,3), (2,3), 
+        self.Gb.add_edges_from([(0,1), (0,2), (1,3), (2,3),
                                 (2,4), (4,5), (3,5)])
 
 

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
@@ -21,7 +21,7 @@ class TestFlowBetweennessCentrality(object):
         except ImportError:
             raise SkipTest('NumPy not available.')
 
-        
+
     def test_K4_normalized(self):
         """Betweenness centrality: K4"""
         G=nx.complete_graph(4)
@@ -121,7 +121,7 @@ class TestEdgeFlowBetweennessCentrality(object):
             import scipy
         except ImportError:
             raise SkipTest('NumPy not available.')
-      
+
     def test_K4_normalized(self):
         """Betweenness centrality: K4"""
         G=nx.complete_graph(4)

--- a/networkx/algorithms/centrality/tests/test_current_flow_closeness.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_closeness.py
@@ -13,8 +13,8 @@ class TestFlowClosenessCentrality(object):
             import scipy
         except ImportError:
             raise SkipTest('NumPy not available.')
-        
-        
+
+
     def test_K4(self):
         """Closeness centrality: K4"""
         G=nx.complete_graph(4)

--- a/networkx/algorithms/centrality/tests/test_degree_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_degree_centrality.py
@@ -34,7 +34,7 @@ class TestDegreeCentrality:
         F.add_edge('Albizzi','Ginori')
         F.add_edge('Albizzi','Guadagni')
         F.add_edge('Bischeri','Guadagni')
-        F.add_edge('Guadagni','Lamberteschi')    
+        F.add_edge('Guadagni','Lamberteschi')
         self.F = F
 
         G = nx.DiGraph()
@@ -70,7 +70,7 @@ class TestDegreeCentrality:
     def test_degree_centrality_4(self):
         d = nx.degree_centrality(self.F)
         names = sorted(self.F.nodes())
-        dcs = [0.071, 0.214, 0.143, 0.214, 0.214, 0.071, 0.286, 
+        dcs = [0.071, 0.214, 0.143, 0.214, 0.214, 0.071, 0.286,
                0.071, 0.429, 0.071, 0.214, 0.214, 0.143, 0.286, 0.214]
         exact = dict(zip(names, dcs))
         for n,dc in d.items():
@@ -78,14 +78,14 @@ class TestDegreeCentrality:
 
     def test_indegree_centrality(self):
         d = nx.in_degree_centrality(self.G)
-        exact = {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 
+        exact = {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0,
                  5: 0.625, 6: 0.125, 7: 0.125, 8: 0.125}
         for n,dc in d.items():
             assert_almost_equal(exact[n], dc)
 
     def test_outdegree_centrality(self):
         d = nx.out_degree_centrality(self.G)
-        exact = {0: 0.125, 1: 0.125, 2: 0.125, 3: 0.125,    
+        exact = {0: 0.125, 1: 0.125, 2: 0.125, 3: 0.125,
                  4: 0.125, 5: 0.375, 6: 0.0, 7: 0.0, 8: 0.0}
         for n,dc in d.items():
             assert_almost_equal(exact[n], dc)

--- a/networkx/algorithms/centrality/tests/test_dispersion.py
+++ b/networkx/algorithms/centrality/tests/test_dispersion.py
@@ -3,7 +3,7 @@ from nose.tools import *
 
 def small_ego_G():
     """The sample network from http://arxiv.org/pdf/1310.6753v1.pdf"""
-    edges=[('a','b'), ('a','c'), ('b','c'), ('b','d'), 
+    edges=[('a','b'), ('a','c'), ('b','c'), ('b','d'),
            ('b', 'e'),('b','f'),('c','d'),('c','f'),('c','h'),('d','f'), ('e','f'),
            ('f','h'),('h','j'), ('h','k'),('i','j'), ('i','k'), ('j','k'), ('u','a'),
            ('u','b'), ('u','c'), ('u','d'), ('u','e'), ('u','f'), ('u','g'), ('u','h'),
@@ -14,7 +14,7 @@ def small_ego_G():
     return G
 
 class TestDispersion(object):
-    
+
     def test_article(self):
         """our algorithm matches article's"""
         G = small_ego_G()
@@ -27,8 +27,8 @@ class TestDispersion(object):
         """there is a result for every node"""
         G = small_ego_G()
         disp = nx.dispersion(G)
-        disp_Gu = nx.dispersion(G, 'u') 
-        disp_uv = nx.dispersion(G, 'u', 'h') 
+        disp_Gu = nx.dispersion(G, 'u')
+        disp_uv = nx.dispersion(G, 'u', 'h')
         assert len(disp) == len(G)
         assert len(disp_Gu) == len(G) - 1
         assert type(disp_uv) is float

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -35,13 +35,13 @@ def triangles(G, nodes=None):
     G : graph
        A networkx graph
     nodes : container of nodes, optional (default= all nodes in G)
-       Compute triangles for nodes in this container. 
+       Compute triangles for nodes in this container.
 
     Returns
     -------
     out : dictionary
        Number of triangles keyed by node label.
-    
+
     Examples
     --------
     >>> G=nx.complete_graph(5)
@@ -54,13 +54,13 @@ def triangles(G, nodes=None):
 
     Notes
     -----
-    When computing triangles for the entire graph each triangle is counted 
+    When computing triangles for the entire graph each triangle is counted
     three times, once at each node.  Self loops are ignored.
 
     """
     # If `nodes` represents a single node in the graph, return only its number
     # of triangles.
-    if nodes in G: 
+    if nodes in G:
         return next(_triangles_and_degree_iter(G,nodes))[2] // 2
     # Otherwise, `nodes` represents an iterable of nodes, so return a
     # dictionary mapping node to number of triangles.
@@ -69,7 +69,7 @@ def triangles(G, nodes=None):
 
 @not_implemented_for('multigraph')
 def _triangles_and_degree_iter(G, nodes=None):
-    """ Return an iterator of (node, degree, triangles).  
+    """ Return an iterator of (node, degree, triangles).
 
     This double counts triangles so you may want to divide by 2.
     See degree() and triangles() for definitions and details.
@@ -88,8 +88,8 @@ def _triangles_and_degree_iter(G, nodes=None):
 
 @not_implemented_for('multigraph')
 def _weighted_triangles_and_degree_iter(G, nodes=None, weight='weight'):
-    """ Return an iterator of (node, degree, weighted_triangles).  
-    
+    """ Return an iterator of (node, degree, weighted_triangles).
+
     Used for weighted clustering.
 
     """
@@ -124,12 +124,12 @@ def _weighted_triangles_and_degree_iter(G, nodes=None, weight='weight'):
 def average_clustering(G, nodes=None, weight=None, count_zeros=True):
     r"""Compute the average clustering coefficient for the graph G.
 
-    The clustering coefficient for the graph is the average, 
+    The clustering coefficient for the graph is the average,
 
     .. math::
 
        C = \frac{1}{n}\sum_{v \in G} c_v,
-       
+
     where `n` is the number of nodes in `G`.
 
     Parameters
@@ -137,7 +137,7 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
     G : graph
 
     nodes : container of nodes, optional (default=all nodes in G)
-       Compute average clustering for nodes in this container. 
+       Compute average clustering for nodes in this container.
 
     weight : string or None, optional (default=None)
        The edge attribute that holds the numerical value used as a weight.
@@ -150,7 +150,7 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
     -------
     avg : float
        Average clustering
-    
+
     Examples
     --------
     >>> G=nx.complete_graph(5)
@@ -166,11 +166,11 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
 
     References
     ----------
-    .. [1] Generalizations of the clustering coefficient to weighted 
-       complex networks by J. Saramäki, M. Kivelä, J.-P. Onnela, 
-       K. Kaski, and J. Kertész, Physical Review E, 75 027105 (2007).  
+    .. [1] Generalizations of the clustering coefficient to weighted
+       complex networks by J. Saramäki, M. Kivelä, J.-P. Onnela,
+       K. Kaski, and J. Kertész, Physical Review E, 75 027105 (2007).
        http://jponnela.com/web_documents/a9.pdf
-    .. [2] Marcus Kaiser,  Mean clustering coefficients: the role of isolated 
+    .. [2] Marcus Kaiser,  Mean clustering coefficients: the role of isolated
        nodes and leafs on clustering measures for small-world networks.
        http://arxiv.org/abs/0802.2512
     """
@@ -201,7 +201,7 @@ def clustering(G, nodes=None, weight=None):
 
        c_u = \frac{1}{deg(u)(deg(u)-1))}
             \sum_{uv} (\hat{w}_{uv} \hat{w}_{uw} \hat{w}_{vw})^{1/3}.
-      
+
     The edge weights `\hat{w}_{uv}` are normalized by the maximum weight in the
     network `\hat{w}_{uv} = w_{uv}/\max(w)`.
 
@@ -212,7 +212,7 @@ def clustering(G, nodes=None, weight=None):
     G : graph
 
     nodes : container of nodes, optional (default=all nodes in G)
-       Compute clustering for nodes in this container. 
+       Compute clustering for nodes in this container.
 
     weight : string or None, optional (default=None)
        The edge attribute that holds the numerical value used as a weight.
@@ -237,9 +237,9 @@ def clustering(G, nodes=None, weight=None):
 
     References
     ----------
-    .. [1] Generalizations of the clustering coefficient to weighted 
-       complex networks by J. Saramäki, M. Kivelä, J.-P. Onnela, 
-       K. Kaski, and J. Kertész, Physical Review E, 75 027105 (2007).  
+    .. [1] Generalizations of the clustering coefficient to weighted
+       complex networks by J. Saramäki, M. Kivelä, J.-P. Onnela,
+       K. Kaski, and J. Kertész, Physical Review E, 75 027105 (2007).
        http://jponnela.com/web_documents/a9.pdf
     """
     if weight is not None:
@@ -247,17 +247,17 @@ def clustering(G, nodes=None, weight=None):
     else:
         td_iter = _triangles_and_degree_iter(G, nodes)
     clusterc = {v: 0 if t == 0 else t / (d * (d - 1)) for v, d, t in td_iter}
-    if nodes in G: 
+    if nodes in G:
         # Return the value of the sole entry in the dictionary.
         return clusterc[nodes]
     return clusterc
 
 
 def transitivity(G):
-    r"""Compute graph transitivity, the fraction of all possible triangles 
+    r"""Compute graph transitivity, the fraction of all possible triangles
     present in G.
 
-    Possible triangles are identified by the number of "triads" 
+    Possible triangles are identified by the number of "triads"
     (two edges with a shared vertex).
 
     The transitivity is
@@ -292,12 +292,12 @@ def square_clustering(G, nodes=None):
     the node [1]_
 
     .. math::
-       C_4(v) = \frac{ \sum_{u=1}^{k_v} 
-       \sum_{w=u+1}^{k_v} q_v(u,w) }{ \sum_{u=1}^{k_v} 
+       C_4(v) = \frac{ \sum_{u=1}^{k_v}
+       \sum_{w=u+1}^{k_v} q_v(u,w) }{ \sum_{u=1}^{k_v}
        \sum_{w=u+1}^{k_v} [a_v(u,w) + q_v(u,w)]},
-    
-    where `q_v(u,w)` are the number of common neighbors of `u` and `w` 
-    other than `v` (ie squares), and 
+
+    where `q_v(u,w)` are the number of common neighbors of `u` and `w`
+    other than `v` (ie squares), and
     `a_v(u,w) = (k_u - (1+q_v(u,w)+\theta_{uv}))(k_w - (1+q_v(u,w)+\theta_{uw}))`,
     where `\theta_{uw} = 1` if `u` and `w` are connected and 0 otherwise.
 
@@ -306,12 +306,12 @@ def square_clustering(G, nodes=None):
     G : graph
 
     nodes : container of nodes, optional (default=all nodes in G)
-       Compute clustering for nodes in this container. 
-        
+       Compute clustering for nodes in this container.
+
     Returns
     -------
     c4 : dictionary
-       A dictionary keyed by node with the square clustering coefficient value. 
+       A dictionary keyed by node with the square clustering coefficient value.
 
     Examples
     --------
@@ -328,7 +328,7 @@ def square_clustering(G, nodes=None):
     the probability that two neighbors of node v share a common
     neighbor different from v. This algorithm can be applied to both
     bipartite and unipartite networks.
- 
+
     References
     ----------
     .. [1] Pedro G. Lind, Marta C. González, and Hans J. Herrmann. 2005
@@ -352,7 +352,7 @@ def square_clustering(G, nodes=None):
             potential += (len(G[u]) - degm) * (len(G[w]) - degm) + squares
         if potential > 0:
             clustering[v] /= potential
-    if nodes in G: 
+    if nodes in G:
         # Return the value of the sole entry in the dictionary.
         return clustering[nodes]
     return clustering

--- a/networkx/algorithms/coloring/tests/test_coloring.py
+++ b/networkx/algorithms/coloring/tests/test_coloring.py
@@ -30,7 +30,7 @@ INTERCHANGE_INVALID = [
     'saturation_largest_first',
     'DSATUR'
 ]
-    
+
 
 class TestColoring:
     def test_basic_cases(self):
@@ -61,7 +61,7 @@ class TestColoring:
             assert_true(any(verify_length(coloring, n_colors)
                             for n_colors in colors))
             assert_true(verify_coloring(graph, coloring))
-            
+
         for strategy, arglist in SPECIAL_TEST_CASES.items():
             for args in arglist:
                 yield (check_special_case, strategy, args[0], args[1], args[2])
@@ -192,9 +192,9 @@ def slf_hc():
         (5,8),
         (6,7),
         (6,8),
-        (7,8)  
+        (7,8)
     ])
-    return graph    
+    return graph
 
 def lf_shc():
     graph = nx.Graph()
@@ -225,7 +225,7 @@ def lf_hc():
         (4, 3)
     ])
     return graph
-    
+
 def sl_shc():
     graph = nx.Graph()
     graph.add_nodes_from([1, 2, 3, 4, 5, 6])

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Conrad Lee <conradlee@gmail.com>
 #    Aric Hagberg <hagberg@lanl.gov>
 #    All rights reserved.
@@ -23,7 +23,7 @@ def k_clique_communities(G, k, cliques=None):
     k : int
        Size of smallest clique
 
-    cliques: list or generator       
+    cliques: list or generator
        Precomputed cliques (use networkx.find_cliques(G))
 
     Returns
@@ -44,7 +44,7 @@ def k_clique_communities(G, k, cliques=None):
     References
     ----------
     .. [1] Gergely Palla, Imre Derényi, Illés Farkas1, and Tamás Vicsek,
-       Uncovering the overlapping community structure of complex networks 
+       Uncovering the overlapping community structure of complex networks
        in nature and society Nature 435, 814-818, 2005,
        doi:10.1038/nature03607
     """

--- a/networkx/algorithms/community/tests/test_kclique.py
+++ b/networkx/algorithms/community/tests/test_kclique.py
@@ -24,8 +24,8 @@ def test_zachary():
     z = nx.karate_club_graph()
     # clique percolation with k=2 is just connected components
     zachary_k2_ground_truth = set([frozenset(z.nodes())])
-    zachary_k3_ground_truth = set([frozenset([0, 1, 2, 3, 7, 8, 12, 13, 14, 
-                                              15, 17, 18, 19, 20, 21, 22, 23, 
+    zachary_k3_ground_truth = set([frozenset([0, 1, 2, 3, 7, 8, 12, 13, 14,
+                                              15, 17, 18, 19, 20, 21, 22, 23,
                                               26, 27, 28, 29, 30, 31, 32, 33]),
                                    frozenset([0, 4, 5, 6, 10, 16]),
                                    frozenset([24, 25, 31])])

--- a/networkx/algorithms/components/tests/test_subgraph_copies.py
+++ b/networkx/algorithms/components/tests/test_subgraph_copies.py
@@ -17,7 +17,7 @@ class TestSubgraphAttributesDicts:
             nx.attracting_component_subgraphs,
         ]
         self.subgraph_funcs = self.undirected + self.directed
-        
+
         self.D = nx.DiGraph()
         self.D.add_edge(1, 2, eattr='red')
         self.D.add_edge(2, 1, eattr='red')
@@ -30,7 +30,7 @@ class TestSubgraphAttributesDicts:
         self.G.graph['gattr'] = 'green'
 
     def test_subgraphs_default_copy_behavior(self):
-        # Test the default behavior of subgraph functions 
+        # Test the default behavior of subgraph functions
         # For the moment (1.10) the default is to copy
         for subgraph_func in self.subgraph_funcs:
             G = deepcopy(self.G if subgraph_func in self.undirected else self.D)

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -471,7 +471,6 @@ def all_pairs_node_connectivity(G, nbunch=None, flow_func=None):
 
     # Reuse auxiliary digraph and residual network
     H = build_auxiliary_node_connectivity(G)
-    mapping = H.graph['mapping']
     R = build_residual_network(H, 'capacity')
     kwargs = dict(flow_func=flow_func, auxiliary=H, residual=R)
 

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -49,10 +49,10 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes.
-        The function has to accept at least three parameters: a Digraph, 
-        a source node, and a target node. And return a residual network 
-        that follows NetworkX conventions (see :meth:`maximum_flow` for 
-        details). If flow_func is None, the default maximum flow function 
+        The function has to accept at least three parameters: a Digraph,
+        a source node, and a target node. And return a residual network
+        that follows NetworkX conventions (see :meth:`maximum_flow` for
+        details). If flow_func is None, the default maximum flow function
         (:meth:`edmonds_karp`) is used. See :meth:`node_connectivity` for
         details. The choice of the default function may change from version
         to version and should not be relied on. Default value: None.
@@ -95,16 +95,16 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
 
     If you need to compute local edge cuts on several pairs of
     nodes in the same graph, it is recommended that you reuse the
-    data structures that NetworkX uses in the computation: the 
+    data structures that NetworkX uses in the computation: the
     auxiliary digraph for edge connectivity, and the residual
     network for the underlying maximum flow computation.
 
     Example of how to compute local edge cuts among all pairs of
-    nodes of the platonic icosahedral graph reusing the data 
+    nodes of the platonic icosahedral graph reusing the data
     structures.
 
     >>> import itertools
-    >>> # You also have to explicitly import the function for 
+    >>> # You also have to explicitly import the function for
     >>> # building the auxiliary digraph from the connectivity package
     >>> from networkx.algorithms.connectivity import (
     ...     build_auxiliary_edge_connectivity)
@@ -147,7 +147,7 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None,
 
     cut_value, partition = nx.minimum_cut(H, s, t, **kwargs)
     reachable, non_reachable = partition
-    # Any edge in the original graph linking the two sets in the 
+    # Any edge in the original graph linking the two sets in the
     # partition is part of the edge cutset
     cutset = set()
     for u, nbrs in ((n, G[n]) for n in reachable):
@@ -175,12 +175,12 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes.
-        The function has to accept at least three parameters: a Digraph, 
-        a source node, and a target node. And return a residual network 
-        that follows NetworkX conventions (see :meth:`maximum_flow` for 
-        details). If flow_func is None, the default maximum flow function 
+        The function has to accept at least three parameters: a Digraph,
+        a source node, and a target node. And return a residual network
+        that follows NetworkX conventions (see :meth:`maximum_flow` for
+        details). If flow_func is None, the default maximum flow function
         (:meth:`edmonds_karp`) is used. See below for details. The choice
-        of the default function may change from version to version and 
+        of the default function may change from version to version and
         should not be relied on. Default value: None.
 
     auxiliary : NetworkX DiGraph
@@ -222,7 +222,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     Example of how to compute local st node cuts reusing the data
     structures:
 
-    >>> # You also have to explicitly import the function for 
+    >>> # You also have to explicitly import the function for
     >>> # building the auxiliary digraph from the connectivity package
     >>> from networkx.algorithms.connectivity import (
     ...     build_auxiliary_node_connectivity)
@@ -254,7 +254,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     is based in solving a number of maximum flow computations to determine
     the capacity of the minimum cut on an auxiliary directed network that
     corresponds to the minimum node cut of G. It handles both directed
-    and undirected graphs. This implementation is based on algorithm 11 
+    and undirected graphs. This implementation is based on algorithm 11
     in [1]_.
 
     See also
@@ -316,10 +316,10 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes.
-        The function has to accept at least three parameters: a Digraph, 
-        a source node, and a target node. And return a residual network 
-        that follows NetworkX conventions (see :meth:`maximum_flow` for 
-        details). If flow_func is None, the default maximum flow function 
+        The function has to accept at least three parameters: a Digraph,
+        a source node, and a target node. And return a residual network
+        that follows NetworkX conventions (see :meth:`maximum_flow` for
+        details). If flow_func is None, the default maximum flow function
         (:meth:`edmonds_karp`) is used. See below for details. The
         choice of the default function may change from version
         to version and should not be relied on. Default value: None.
@@ -358,7 +358,7 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
 
     If you need to perform several local st cuts among different
     pairs of nodes on the same graph, it is recommended that you reuse
-    the data structures used in the maximum flow computations. See 
+    the data structures used in the maximum flow computations. See
     :meth:`minimum_st_node_cut` for details.
 
     Notes
@@ -367,7 +367,7 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     is based in solving a number of maximum flow computations to determine
     the capacity of the minimum cut on an auxiliary directed network that
     corresponds to the minimum node cut of G. It handles both directed
-    and undirected graphs. This implementation is based on algorithm 11 
+    and undirected graphs. This implementation is based on algorithm 11
     in [1]_.
 
     See also
@@ -460,10 +460,10 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes.
-        The function has to accept at least three parameters: a Digraph, 
-        a source node, and a target node. And return a residual network 
-        that follows NetworkX conventions (see :meth:`maximum_flow` for 
-        details). If flow_func is None, the default maximum flow function 
+        The function has to accept at least three parameters: a Digraph,
+        a source node, and a target node. And return a residual network
+        that follows NetworkX conventions (see :meth:`maximum_flow` for
+        details). If flow_func is None, the default maximum flow function
         (:meth:`edmonds_karp`) is used. See below for details. The
         choice of the default function may change from version
         to version and should not be relied on. Default value: None.
@@ -482,10 +482,10 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
     >>> len(nx.minimum_edge_cut(G))
     5
 
-    You can use alternative flow algorithms for the underlying 
-    maximum flow computation. In dense networks the algorithm 
-    :meth:`shortest_augmenting_path` will usually perform better 
-    than the default :meth:`edmonds_karp`, which is faster for 
+    You can use alternative flow algorithms for the underlying
+    maximum flow computation. In dense networks the algorithm
+    :meth:`shortest_augmenting_path` will usually perform better
+    than the default :meth:`edmonds_karp`, which is faster for
     sparse networks with highly skewed degree distributions.
     Alternative flow functions have to be explicitly imported
     from the flow package.
@@ -502,7 +502,7 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
 
     If you need to perform several local computations among different
     pairs of nodes on the same graph, it is recommended that you reuse
-    the data structures used in the maximum flow computations. See 
+    the data structures used in the maximum flow computations. See
     :meth:`local_edge_connectivity` for details.
 
     Notes
@@ -511,7 +511,7 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
     undirected graphs the algorithm works by finding a 'small' dominating
     set of nodes of G (see algorithm 7 in [1]_) and computing the maximum
     flow between an arbitrary node in the dominating set and the rest of
-    nodes in it. This is an implementation of algorithm 6 in [1]_. For 
+    nodes in it. This is an implementation of algorithm 6 in [1]_. For
     directed graphs, the algorithm does n calls to the max flow function.
     The function raises an error if the directed graph is not weakly
     connected and returns an empty set if it is weakly connected.

--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -20,7 +20,7 @@ __all__ = ['k_components']
 @not_implemented_for('directed')
 def k_components(G, flow_func=None):
     r"""Returns the k-component structure of a graph G.
-    
+
     A `k`-component is a maximal subgraph of a graph G that has, at least,
     node connectivity `k`: we need to remove at least `k` nodes to break it
     into more components. `k`-components have an inherent hierarchical
@@ -56,7 +56,7 @@ def k_components(G, flow_func=None):
     >>> # nodes are in a single component on all three connectivity levels
     >>> G = nx.petersen_graph()
     >>> k_components = nx.k_components(G)
-   
+
     Notes
     -----
     Moody and White [1]_ (appendix A) provide an algorithm for identifying
@@ -76,7 +76,7 @@ def k_components(G, flow_func=None):
         4. If the graph is neither complete nor trivial, return to 1;
            else end.
 
-    This implementation also uses some heuristics (see [3]_ for details) 
+    This implementation also uses some heuristics (see [3]_ for details)
     to speed up the computation.
 
     See also
@@ -101,7 +101,7 @@ def k_components(G, flow_func=None):
 
     """
     # Dictionary with connectivity level (k) as keys and a list of
-    # sets of nodes that form a k-component as values. Note that 
+    # sets of nodes that form a k-component as values. Note that
     # k-compoents can overlap (but only k - 1 nodes).
     k_components = defaultdict(list)
     # Define default flow function

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -20,20 +20,20 @@ __author__ = '\n'.join(['Jordi Torrents <jtorrents@milnou.net>'])
 __all__ = ['all_node_cuts']
 
 def all_node_cuts(G, k=None, flow_func=None):
-    r"""Returns all minimum k cutsets of an undirected graph G. 
+    r"""Returns all minimum k cutsets of an undirected graph G.
 
     This implementation is based on Kanevsky's algorithm [1]_ for finding all
-    minimum-size node cut-sets of an undirected graph G; ie the set (or sets) 
-    of nodes of cardinality equal to the node connectivity of G. Thus if 
+    minimum-size node cut-sets of an undirected graph G; ie the set (or sets)
+    of nodes of cardinality equal to the node connectivity of G. Thus if
     removed, would break G into two or more connected components.
-   
+
     Parameters
     ----------
     G : NetworkX graph
         Undirected graph
 
     k : Integer
-        Node connectivity of the input graph. If k is None, then it is 
+        Node connectivity of the input graph. If k is None, then it is
         computed. Default value: None.
 
     flow_func : function
@@ -41,7 +41,7 @@ def all_node_cuts(G, k=None, flow_func=None):
         edmonds_karp. This function performs better in sparse graphs with
         right tailed degree distributions. shortest_augmenting_path will
         perform better in denser graphs.
-        
+
 
     Returns
     -------
@@ -65,10 +65,10 @@ def all_node_cuts(G, k=None, flow_func=None):
     -----
     This implementation is based on the sequential algorithm for finding all
     minimum-size separating vertex sets in a graph [1]_. The main idea is to
-    compute minimum cuts using local maximum flow computations among a set 
+    compute minimum cuts using local maximum flow computations among a set
     of nodes of highest degree and all other non-adjacent nodes in the Graph.
     Once we find a minimum cut, we add an edge between the high degree
-    node and the target node of the local maximum flow computation to make 
+    node and the target node of the local maximum flow computation to make
     sure that we will not find that minimum cut again.
 
     See also
@@ -79,7 +79,7 @@ def all_node_cuts(G, k=None, flow_func=None):
 
     References
     ----------
-    .. [1]  Kanevsky, A. (1993). Finding all minimum-size separating vertex 
+    .. [1]  Kanevsky, A. (1993). Finding all minimum-size separating vertex
             sets in a graph. Networks 23(6), 533--541.
             http://onlinelibrary.wiley.com/doi/10.1002/net.3230230604/abstract
 
@@ -106,7 +106,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     # Initialize data structures.
     # Keep track of the cuts already computed so we do not repeat them.
     seen = []
-    # Even-Tarjan reduction is what we call auxiliary digraph 
+    # Even-Tarjan reduction is what we call auxiliary digraph
     # for node connectivity.
     H = build_auxiliary_node_connectivity(G)
     mapping = H.graph['mapping']
@@ -121,7 +121,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     # step 1: Find node connectivity k of G
     if k is None:
         k = nx.node_connectivity(G, flow_func=flow_func)
-    # step 2: 
+    # step 2:
     # Find k nodes with top degree, call it X:
     X = {n for n, d in sorted(G.degree(), key=itemgetter(1), reverse=True)[:k]}
     # Check if X is a k-node-cutset
@@ -145,7 +145,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                                     R.edges(data=True)
                                     if d['capacity'] == d['flow']]
                 R.remove_edges_from(saturated_edges)
-                # step 6: shrink the strongly connected components of 
+                # step 6: shrink the strongly connected components of
                 # residual flow network R and call it L
                 L = nx.condensation(R)
                 cmap = L.graph['mapping']
@@ -170,7 +170,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                             seen.append(node_cut)
                         # Add an edge (x, v) to make sure that we do not
                         # find this cutset again. This is equivalent
-                        # of adding the edge in the input graph 
+                        # of adding the edge in the input graph
                         # G.add_edge(x, v) and then regenerate H and R:
                         # Add edges to the auxiliary digraph.
                         H.add_edge('%sB' % mapping[x], '%sA' % mapping[v],

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -35,7 +35,7 @@ def _generate_no_biconnected(max_attempts=50):
 
 def test_average_connectivity():
     # figure 1 from:
-    # Beineke, L., O. Oellermann, and R. Pippert (2002). The average 
+    # Beineke, L., O. Oellermann, and R. Pippert (2002). The average
     # connectivity of a graph. Discrete mathematics 252(1-3), 31-45
     # http://www.sciencedirect.com/science/article/pii/S0012365X01001807
     G1 = nx.path_graph(3)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -30,7 +30,7 @@ def _generate_no_biconnected(max_attempts=50):
                 raise Exception(msg % max_attempts)
             else:
                 attempts += 1
- 
+
 def test_articulation_points():
     Ggen = _generate_no_biconnected()
     for flow_func in flow_funcs:

--- a/networkx/algorithms/connectivity/utils.py
+++ b/networkx/algorithms/connectivity/utils.py
@@ -24,7 +24,7 @@ def build_auxiliary_node_connectivity(G):
     For a directed graph having `n` nodes and `m` arcs we derive a
     directed graph D with `2n` nodes and `m+n` arcs by replacing each
     original node `v` with two nodes `vA`, `vB` linked by an (internal)
-    arc (`vA`, `vB`) in D. Then for each arc (`u`, `v`) in G we add one 
+    arc (`vA`, `vB`) in D. Then for each arc (`u`, `v`) in G we add one
     arc (`uB`, `vA`) in D. Finally we set the attribute capacity = 1 for
     each arc in D.
 
@@ -43,7 +43,7 @@ def build_auxiliary_node_connectivity(G):
 
     mapping = {}
     H = nx.DiGraph()
-    
+
     for i, node in enumerate(G):
         mapping[node] = i
         H.add_node('%dA' % i, id=node)

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -362,7 +362,7 @@ def find_cycle(G, source=None, orientation='original'):
         direction. When the direction is forward, the value of `direction`
         is 'forward'. When the direction is reverse, the value of `direction`
         is 'reverse'.
-        
+
     Raises
     ------
     NetworkXNoCycle

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -379,14 +379,14 @@ def transitive_reduction(G):
         If G is not a directed acyclic graph (DAG) transitive reduction is
         not uniquely defined and a NetworkXError exception is raised.
 
-    References 
+    References
     ----------
     https://en.wikipedia.org/wiki/Transitive_reduction
 
-    """   
+    """
     if not is_directed_acyclic_graph(G):
         raise nx.NetworkXError(
-            "Transitive reduction only uniquely defined on directed acyclic graphs.") 
+            "Transitive reduction only uniquely defined on directed acyclic graphs.")
     TR = nx.DiGraph()
     TR.add_nodes_from(G.nodes())
     for u in G:

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -27,9 +27,9 @@ def eccentricity(G, v=None, sp=None):
        A graph
 
     v : node, optional
-       Return value of specified node       
+       Return value of specified node
 
-    sp : dict of dicts, optional       
+    sp : dict of dicts, optional
        All pairs shortest path lengths as a dictionary of dictionaries
 
     Returns
@@ -39,7 +39,7 @@ def eccentricity(G, v=None, sp=None):
     """
 #    nodes=
 #    nodes=[]
-#    if v is None:                # none, use entire graph 
+#    if v is None:                # none, use entire graph
 #        nodes=G.nodes()
 #    elif v in G:               # is v a single node
 #        nodes=[v]
@@ -102,9 +102,9 @@ def diameter(G, e=None):
     return max(e.values())
 
 def periphery(G, e=None):
-    """Return the periphery of the graph G. 
+    """Return the periphery of the graph G.
 
-    The periphery is the set of nodes with eccentricity equal to the diameter. 
+    The periphery is the set of nodes with eccentricity equal to the diameter.
 
     Parameters
     ----------
@@ -149,9 +149,9 @@ def radius(G, e=None):
     return min(e.values())
 
 def center(G, e=None):
-    """Return the center of the graph G. 
+    """Return the center of the graph G.
 
-    The center is the set of nodes with eccentricity equal to radius. 
+    The center is the set of nodes with eccentricity equal to radius.
 
     Parameters
     ----------

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -455,7 +455,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)
-    # Remove saturated edges from the residual network 
+    # Remove saturated edges from the residual network
     cutset = [(u, v, d) for u, v, d in R.edges(data=True)
               if d['flow'] == d['capacity']]
     R.remove_edges_from(cutset)

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -108,7 +108,7 @@ def preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq,
             push(s, u, flow)
 
     # Partition nodes into levels.
-    levels = [Level() for i in range(2 * n)]
+    levels = [Level() for _ in range(2 * n)]
     for u in R:
         if u != s and u != t:
             level = levels[R_node[u]['height']]

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -404,7 +404,7 @@ class TestMaxFlowMinCutInterface:
                     result = result[0]
                 assert_equal(fv, result, msg=msgi.format(flow_func.__name__,
                                                     interface_func.__name__))
- 
+
     def test_minimum_cut_no_cutoff(self):
         G = self.G
         for flow_func in flow_funcs:

--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -223,17 +223,17 @@ class TestMinCostFlow:
 
         G = nx.DiGraph()
         G.add_edge('s', 'a')
-        G['s']['a'].update({0: 2, 1: 4}) 
+        G['s']['a'].update({0: 2, 1: 4})
         G.add_edge('s', 'b')
-        G['s']['b'].update({0: 2, 1: 1}) 
+        G['s']['b'].update({0: 2, 1: 1})
         G.add_edge('a', 'b')
-        G['a']['b'].update({0: 5, 1: 2}) 
+        G['a']['b'].update({0: 5, 1: 2})
         G.add_edge('a', 't')
-        G['a']['t'].update({0: 1, 1: 5}) 
+        G['a']['t'].update({0: 1, 1: 5})
         G.add_edge('b', 'a')
-        G['b']['a'].update({0: 1, 1: 3}) 
+        G['b']['a'].update({0: 1, 1: 3})
         G.add_edge('b', 't')
-        G['b']['t'].update({0: 3, 1: 2}) 
+        G['b']['t'].update({0: 3, 1: 2})
 
         "PS.ex.7.1: testing main function"
         sol = nx.max_flow_min_cost(G, 's', 't', capacity=0, weight=1)

--- a/networkx/algorithms/graphical.py
+++ b/networkx/algorithms/graphical.py
@@ -112,7 +112,7 @@ def is_valid_degree_sequence_havel_hakimi(deg_sequence):
     Notes
     -----
     The ZZ condition says that for the sequence d if
-    
+
     .. math::
         |d| >= \frac{(\max(d) + \min(d) + 1)^2}{4*\min(d)}
 
@@ -200,7 +200,7 @@ def is_valid_degree_sequence_erdos_gallai(deg_sequence):
     This particular rearrangement comes from the proof of Theorem 3 in [2]_.
 
     The ZZ condition says that for the sequence d if
-    
+
     .. math::
         |d| >= \frac{(\max(d) + \min(d) + 1)^2}{4*\min(d)}
 
@@ -308,7 +308,7 @@ def is_pseudographical(sequence):
     return sum(s)%2 == 0 and min(s) >= 0
 
 def is_digraphical(in_sequence, out_sequence):
-    r"""Returns True if some directed graph can realize the in- and out-degree 
+    r"""Returns True if some directed graph can realize the in- and out-degree
     sequences.
 
     Parameters

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -4,34 +4,34 @@
 Time-respecting VF2 Algorithm
 *****************************
 
-An extension of the VF2 algorithm for time-respecting graph ismorphism 
+An extension of the VF2 algorithm for time-respecting graph ismorphism
 testing in temporal graphs.
 
-A temporal graph is one in which edges contain a datetime attribute, 
-denoting when interaction occurred between the incident nodes. A 
-time-respecting subgraph of a temporal graph is a subgraph such that 
-all interactions incident to a node occurred within a time threshold, 
-delta, of each other. A directed time-respecting subgraph has the 
-added constraint that incoming interactions to a node must precede 
-outgoing interactions from the same node - this enforces a sense of 
+A temporal graph is one in which edges contain a datetime attribute,
+denoting when interaction occurred between the incident nodes. A
+time-respecting subgraph of a temporal graph is a subgraph such that
+all interactions incident to a node occurred within a time threshold,
+delta, of each other. A directed time-respecting subgraph has the
+added constraint that incoming interactions to a node must precede
+outgoing interactions from the same node - this enforces a sense of
 directed flow.
 
 Introduction
 ------------
 
-The TimeRespectingGraphMatcher and TimeRespectingDiGraphMatcher 
-extend the GraphMatcher and DiGraphMatcher classes, respectively, 
-to include temporal constraints on matches. This is achieved through 
+The TimeRespectingGraphMatcher and TimeRespectingDiGraphMatcher
+extend the GraphMatcher and DiGraphMatcher classes, respectively,
+to include temporal constraints on matches. This is achieved through
 a semantic check, via the semantic_feasibility() function.
 
-As well as including G1 (the graph in which to seek embeddings) and 
-G2 (the subgraph structure of interest), the name of the temporal 
-attribute on the edges and the time threshold, delta, must be supplied 
+As well as including G1 (the graph in which to seek embeddings) and
+G2 (the subgraph structure of interest), the name of the temporal
+attribute on the edges and the time threshold, delta, must be supplied
 as arguments to the matching constructors.
 
-A delta of zero is the strictest temporal constraint on the match - 
-only embeddings in which all interactions occur at the same time will 
-be returned. A delta of one day will allow embeddings in which 
+A delta of zero is the strictest temporal constraint on the match -
+only embeddings in which all interactions occur at the same time will
+be returned. A delta of one day will allow embeddings in which
 adjacent interactions occur up to a day apart.
 
 Examples
@@ -43,20 +43,20 @@ Examples will be provided when the datetime type has been incorporated.
 Temporal Subgraph Isomorphism
 -----------------------------
 
-A brief discussion of the somewhat diverse current literature will be 
+A brief discussion of the somewhat diverse current literature will be
 included here.
 
 References
 ----------
 
-[1] Redmond, U. and Cunningham, P. Temporal subgraph isomorphism. In: 
-The 2013 IEEE/ACM International Conference on Advances in Social 
-Networks Analysis and Mining (ASONAM). Niagara Falls, Canada; 2013: 
+[1] Redmond, U. and Cunningham, P. Temporal subgraph isomorphism. In:
+The 2013 IEEE/ACM International Conference on Advances in Social
+Networks Analysis and Mining (ASONAM). Niagara Falls, Canada; 2013:
 pages 1451 - 1452. [65]
 
 For a discussion of the literature on temporal networks:
 
-[3] P. Holme and J. Saramaki. Temporal networks. Physics Reports, 
+[3] P. Holme and J. Saramaki. Temporal networks. Physics Reports,
 519(3):97–125, 2012.
 
 Notes
@@ -84,7 +84,7 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         Examples
         --------
-        To create a TimeRespectingGraphMatcher which checks for 
+        To create a TimeRespectingGraphMatcher which checks for
         syntactic and semantic feasibility:
 
         >>> from networkx.algorithms import isomorphism
@@ -97,10 +97,10 @@ class TimeRespectingGraphMatcher(GraphMatcher):
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
         super(TimeRespectingGraphMatcher, self).__init__(G1, G2)
-    
+
     def one_hop(self, Gx, Gx_node, neighbors):
         """
-        Edges one hop out from a node in the mapping should be 
+        Edges one hop out from a node in the mapping should be
         time-respecting with respect to each other.
         """
         dates = []
@@ -113,7 +113,7 @@ class TimeRespectingGraphMatcher(GraphMatcher):
         if any(x is None for x in dates):
             raise ValueError('Datetime not supplied for at least one edge.')
         return not dates or max(dates) - min(dates) <= self.delta
-    
+
     def two_hop(self, Gx, core_x, Gx_node, neighbors):
         """
         Paths of length 2 from Gx_node should be time-respecting.
@@ -121,11 +121,11 @@ class TimeRespectingGraphMatcher(GraphMatcher):
         return all(self.one_hop(Gx, v, [n for n in Gx[v] if n in core_x] + [Gx_node]) for v in neighbors)
 
     def semantic_feasibility(self, G1_node, G2_node):
-        """Returns True if adding (G1_node, G2_node) is semantically 
+        """Returns True if adding (G1_node, G2_node) is semantically
         feasible.
 
-        Any subclass which redefines semantic_feasibility() must 
-        maintain the self.tests if needed, to keep the match() method 
+        Any subclass which redefines semantic_feasibility() must
+        maintain the self.tests if needed, to keep the match() method
         functional. Implementations should consider multigraphs.
         """
         neighbors = [n for n in self.G1[G1_node] if n in self.core_1]
@@ -146,7 +146,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         Examples
         --------
-        To create a TimeRespectingDiGraphMatcher which checks for 
+        To create a TimeRespectingDiGraphMatcher which checks for
         syntactic and semantic feasibility:
 
         >>> from networkx.algorithms import isomorphism
@@ -159,7 +159,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
         super(TimeRespectingDiGraphMatcher, self).__init__(G1, G2)
-    
+
     def get_pred_dates(self, Gx, Gx_node, core_x, pred):
         """
         Get the dates of edges from predecessors.
@@ -173,7 +173,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
                 for edge in Gx[n][Gx_node].values(): # Iterates all edge data between node pair.
                     pred_dates.append(edge[self.temporal_attribute_name])
         return pred_dates
-    
+
     def get_succ_dates(self, Gx, Gx_node, core_x, succ):
         """
         Get the dates of edges to successors.
@@ -195,7 +195,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         pred_dates = self.get_pred_dates(Gx, Gx_node, core_x, pred)
         succ_dates = self.get_succ_dates(Gx, Gx_node, core_x, succ)
         return self.test_one(pred_dates, succ_dates) and self.test_two(pred_dates, succ_dates)
-    
+
     def two_hop_pred(self, Gx, Gx_node, core_x, pred):
         """
         The predeccessors of the ego node.
@@ -207,39 +207,39 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         The successors of the ego node.
         """
         return all(self.one_hop(Gx, s, core_x, self.preds(Gx, core_x, s, Gx_node), self.succs(Gx, core_x, s)) for s in succ)
-   
+
     def preds(self, Gx, core_x, v, Gx_node=None):
         pred = [n for n in Gx.predecessors(v) if n in core_x]
         if Gx_node:
             pred.append(Gx_node)
         return pred
-    
+
     def succs(self, Gx, core_x, v, Gx_node=None):
         succ = [n for n in Gx.successors(v) if n in core_x]
         if Gx_node:
             succ.append(Gx_node)
         return succ
- 
+
     def test_one(self, pred_dates, succ_dates):
         """
-        Edges one hop out from Gx_node in the mapping should be 
-        time-respecting with respect to each other, regardless of 
+        Edges one hop out from Gx_node in the mapping should be
+        time-respecting with respect to each other, regardless of
         direction.
         """
         time_respecting = True
         dates = pred_dates + succ_dates
-        
+
         if any(x is None for x in dates):
             raise ValueError('Date or datetime not supplied for at least one edge.')
-        
+
         dates.sort() # Small to large.
         if 0 < len(dates) and not (dates[-1] - dates[0] <= self.delta):
             time_respecting = False
         return time_respecting
-    
+
     def test_two(self, pred_dates, succ_dates):
         """
-        Edges from a dual Gx_node in the mapping should be ordered in 
+        Edges from a dual Gx_node in the mapping should be ordered in
         a time-respecting manner.
         """
         time_respecting = True
@@ -251,11 +251,11 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         return time_respecting
 
     def semantic_feasibility(self, G1_node, G2_node):
-        """Returns True if adding (G1_node, G2_node) is semantically 
+        """Returns True if adding (G1_node, G2_node) is semantically
         feasible.
 
-        Any subclass which redefines semantic_feasibility() must 
-        maintain the self.tests if needed, to keep the match() method 
+        Any subclass which redefines semantic_feasibility() must
+        maintain the self.tests if needed, to keep the match() method
         functional. Implementations should consider multigraphs.
         """
         pred, succ = [n for n in self.G1.predecessors(G1_node) if n in self.core_1], [n for n in self.G1.successors(G1_node) if n in self.core_1]

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -16,15 +16,15 @@ class TestWikipediaExample(object):
 
     # Nodes 'a', 'b', 'c' and 'd' form a column.
     # Nodes 'g', 'h', 'i' and 'j' form a column.
-    g1edges = [['a','g'], ['a','h'], ['a','i'], 
-               ['b','g'], ['b','h'], ['b','j'], 
-               ['c','g'], ['c','i'], ['c','j'], 
+    g1edges = [['a','g'], ['a','h'], ['a','i'],
+               ['b','g'], ['b','h'], ['b','j'],
+               ['c','g'], ['c','i'], ['c','j'],
                ['d','h'], ['d','i'], ['d','j']]
 
     # Nodes 1,2,3,4 form the clockwise corners of a large square.
-    # Nodes 5,6,7,8 form the clockwise corners of a small square 
-    g2edges = [[1,2], [2,3], [3,4], [4,1], 
-               [5,6], [6,7], [7,8], [8,5], 
+    # Nodes 5,6,7,8 form the clockwise corners of a small square
+    g2edges = [[1,2], [2,3], [3,4], [4,1],
+               [5,6], [6,7], [7,8], [8,5],
                [1,5], [2,6], [3,7], [4,8]]
 
     def test_graph(self):
@@ -36,12 +36,12 @@ class TestWikipediaExample(object):
         assert_true(gm.is_isomorphic())
 
         mapping = sorted(gm.mapping.items())
-# this mapping is only one of the possibilies 
-# so this test needs to be reconsidered 
-#        isomap = [('a', 1), ('b', 6), ('c', 3), ('d', 8), 
+# this mapping is only one of the possibilies
+# so this test needs to be reconsidered
+#        isomap = [('a', 1), ('b', 6), ('c', 3), ('d', 8),
 #                  ('g', 2), ('h', 5), ('i', 4), ('j', 7)]
 #        assert_equal(mapping, isomap)
-        
+
     def test_subgraph(self):
         g1 = nx.Graph()
         g2 = nx.Graph()
@@ -109,7 +109,7 @@ class TestAtlas(object):
         if platform.python_implementation()=='Jython':
             raise SkipTest('graph atlas not available under Jython.')
         import networkx.generators.atlas as atlas
-            
+
     def setUp(self):
         self.GAG=atlas.graph_atlas_g()
 
@@ -130,12 +130,12 @@ class TestAtlas(object):
 def test_multiedge():
     # Simple test for multigraphs
     # Need something much more rigorous
-    edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), 
-             (5, 6), (6, 7), (7, 8), (8, 9), (9, 10), 
-             (10, 11), (10, 11), (11, 12), (11, 12), 
-             (12, 13), (12, 13), (13, 14), (13, 14), 
-             (14, 15), (14, 15), (15, 16), (15, 16), 
-             (16, 17), (16, 17), (17, 18), (17, 18), 
+    edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5),
+             (5, 6), (6, 7), (7, 8), (8, 9), (9, 10),
+             (10, 11), (10, 11), (11, 12), (11, 12),
+             (12, 13), (12, 13), (13, 14), (13, 14),
+             (14, 15), (14, 15), (15, 16), (15, 16),
+             (16, 17), (16, 17), (17, 18), (17, 18),
              (18, 19), (18, 19), (19, 0), (19, 0)]
     nodes = list(range(20))
 
@@ -154,7 +154,7 @@ def test_multiedge():
 
 def test_selfloop():
     # Simple test for graphs with selfloops
-    edges = [(0, 1), (0, 2), (1, 2), (1, 3), (2, 2), 
+    edges = [(0, 1), (0, 2), (1, 2), (1, 3), (2, 2),
              (2, 4), (3, 1), (3, 2), (4, 2), (4, 5), (5, 4)]
     nodes = list(range(6))
 

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -8,10 +8,10 @@ def test_categorical_node_match():
     nm = iso.categorical_node_match(['x', 'y', 'z'], [None]*3)
     assert_true(nm(dict(x=1, y=2, z=3), dict(x=1, y=2, z=3)))
     assert_true(not nm(dict(x=1, y=2, z=2), dict(x=1, y=2, z=1)))
-    
+
 
 class TestGenericMultiEdgeMatch:
-    
+
     def setup(self):
         self.G1 = nx.MultiDiGraph()
         self.G2 = nx.MultiDiGraph()
@@ -31,7 +31,7 @@ class TestGenericMultiEdgeMatch:
             self.G3.add_edge(3, 4, **attr_dict)
         for attr_dict in [attr_dict6, attr_dict4]:
             self.G4.add_edge(4, 5, **attr_dict)
-        
+
     def test_generic_multiedge_match(self):
         full_match = iso.generic_multiedge_match(['id', 'flowMin', 'flowMax'], [None]*3, [eq]*3)
         flow_match = iso.generic_multiedge_match(['flowMin', 'flowMax'], [None]*2, [eq]*2)

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -128,7 +128,7 @@ class TestTimeRespectingGraphMatcher(object):
         gm = iso.TimeRespectingGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 4)
-    
+
     def test_timdelta_one_config2_returns_ten_embeddings(self):
         G1 = self.provide_g1_topology()
         temporal_name = 'date'
@@ -139,7 +139,7 @@ class TestTimeRespectingGraphMatcher(object):
         L = list(gm.subgraph_isomorphisms_iter())
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 10)
-    
+
 
 class TestDiTimeRespectingGraphMatcher(object):
     """
@@ -193,7 +193,7 @@ class TestDiTimeRespectingGraphMatcher(object):
         gm = iso.TimeRespectingDiGraphMatcher(G1, G2, temporal_name, d)
         count_match = len(list(gm.subgraph_isomorphisms_iter()))
         assert_true(count_match == 1)
-    
+
     def test_timdelta_one_config2_returns_two_embeddings(self):
         G1 = self.provide_g1_topology()
         temporal_name = 'date'

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -12,7 +12,7 @@ import networkx
 class TestHITS:
 
     def setUp(self):
-        
+
         G=networkx.DiGraph()
 
         edges=[(1,3),(1,5),\
@@ -20,12 +20,12 @@ class TestHITS:
            (3,5),\
            (5,4),(5,3),\
            (6,5)]
-           
+
         G.add_edges_from(edges,weight=1)
         self.G=G
         self.G.a=dict(zip(G,[0.000000, 0.000000, 0.366025,
                              0.133975, 0.500000, 0.000000]))
-        self.G.h=dict(zip(G,[ 0.366025, 0.000000, 0.211325, 
+        self.G.h=dict(zip(G,[ 0.366025, 0.000000, 0.211325,
                               0.000000, 0.211325, 0.211325]))
 
 

--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -27,10 +27,10 @@ def maximal_independent_set(G, nodes=None):
     of G induced by these nodes contains no edges. A maximal
     independent set is an independent set such that it is not possible
     to add a new node and still get an independent set.
-    
+
     Parameters
     ----------
-    G : NetworkX graph 
+    G : NetworkX graph
 
     nodes : list or iterable
        Nodes that must be part of the independent set. This set of nodes
@@ -38,7 +38,7 @@ def maximal_independent_set(G, nodes=None):
 
     Returns
     -------
-    indep_nodes : list 
+    indep_nodes : list
        List of nodes that are part of a maximal independent set.
 
     Raises
@@ -54,7 +54,7 @@ def maximal_independent_set(G, nodes=None):
     [4, 0, 2]
     >>> nx.maximal_independent_set(G, [1]) # doctest: +SKIP
     [1, 3]
-    
+
     Notes
     -----
     This algorithm does not solve the maximum independent set problem.

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -142,7 +142,7 @@ def tensor_product(G, H):
     Parameters
     ----------
     G, H: graphs
-     Networkx graphs. 
+     Networkx graphs.
 
     Returns
     -------

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -34,8 +34,8 @@ def test_intersection():
     H.add_edge(2,3)
     H.add_edge(3,4)
     I=nx.intersection(G,H)
-    assert_equal( set(I.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(I.edges()) , [(2,3)] )    
+    assert_equal( set(I.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(I.edges()) , [(2,3)] )
 
 
 def test_intersection_attributes():
@@ -85,14 +85,14 @@ def test_difference():
     H.add_edge(2,3)
     H.add_edge(3,4)
     D=nx.difference(G,H)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(1,2)] )    
+    assert_equal( set(D.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(D.edges()) , [(1,2)] )
     D=nx.difference(H,G)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(3,4)] )    
+    assert_equal( set(D.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(D.edges()) , [(3,4)] )
     D=nx.symmetric_difference(G,H)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(1,2),(3,4)] )    
+    assert_equal( set(D.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(D.edges()) , [(1,2),(3,4)] )
 
 
 def test_difference2():
@@ -104,15 +104,15 @@ def test_difference2():
     H.add_edge(1,2)
     G.add_edge(2,3)
     D=nx.difference(G,H)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(2,3)] )    
+    assert_equal( set(D.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(D.edges()) , [(2,3)] )
     D=nx.difference(H,G)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [] )    
+    assert_equal( set(D.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(D.edges()) , [] )
     H.add_edge(3,4)
     D=nx.difference(H,G)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(3,4)] )    
+    assert_equal( set(D.nodes()) , set([1,2,3,4]) )
+    assert_equal( sorted(D.edges()) , [(3,4)] )
 
 
 def test_difference_attributes():
@@ -168,7 +168,7 @@ def test_symmetric_difference_multigraph():
     assert_equal( set(gh.nodes()) , set(g.nodes()) )
     assert_equal( set(gh.nodes()) , set(h.nodes()) )
     assert_equal( sorted(gh.edges()) , 3*[(0,1)] )
-    assert_equal( sorted(sorted(e) for e in gh.edges(keys=True)), 
+    assert_equal( sorted(sorted(e) for e in gh.edges(keys=True)),
                   [[0,1,1],[0,1,2],[0,1,3]] )
 
 @raises(nx.NetworkXError)
@@ -197,12 +197,12 @@ def test_union_and_compose():
     assert_raises(nx.NetworkXError, nx.union, K3, P3)
     H1=union(H,G1,rename=('H','G1'))
     assert_equal(sorted(H1.nodes()),
-                 ['G1A', 'G1B', 'G1C', 'G1D', 
+                 ['G1A', 'G1B', 'G1C', 'G1D',
                   'H1', 'H2', 'H3', 'H4', 'HA', 'HB', 'HC', 'HD'])
 
     H2=union(H,G2,rename=("H",""))
     assert_equal(sorted(H2.nodes()),
-                 ['1', '2', '3', '4', 
+                 ['1', '2', '3', '4',
                   'H1', 'H2', 'H3', 'H4', 'HA', 'HB', 'HC', 'HD'])
 
     assert_false(H1.has_edge('NB','NA'))
@@ -243,7 +243,7 @@ def test_union_multigraph():
     H.add_edge(3,4,key=1)
     GH=nx.union(G,H)
     assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
+    assert_equal( set(GH.edges(keys=True)) ,
                   set(G.edges(keys=True))|set(H.edges(keys=True)))
 
 def test_disjoint_union_multigraph():
@@ -255,7 +255,7 @@ def test_disjoint_union_multigraph():
     H.add_edge(2,3,key=1)
     GH=nx.disjoint_union(G,H)
     assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
+    assert_equal( set(GH.edges(keys=True)) ,
                   set(G.edges(keys=True))|set(H.edges(keys=True)))
 
 
@@ -268,13 +268,13 @@ def test_compose_multigraph():
     H.add_edge(3,4,key=1)
     GH=nx.compose(G,H)
     assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
+    assert_equal( set(GH.edges(keys=True)) ,
                   set(G.edges(keys=True))|set(H.edges(keys=True)))
     H.add_edge(1,2,key=2)
     GH=nx.compose(G,H)
     assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
-                  set(G.edges(keys=True))|set(H.edges(keys=True)))    
+    assert_equal( set(GH.edges(keys=True)) ,
+                  set(G.edges(keys=True))|set(H.edges(keys=True)))
 
 
 @raises(nx.NetworkXError)

--- a/networkx/algorithms/reciprocity.py
+++ b/networkx/algorithms/reciprocity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-#    Copyright (C) 2015 by 
+#    Copyright (C) 2015 by
 #    Haochen Wu <wuhaochen42@gmail.com>
 #    All rights reserved.
 #    BSD license.
@@ -41,7 +41,7 @@ def reciprocity(G, nodes=None):
     -----
     The reciprocity is not defined for isolated nodes.
     In such cases this function will return None.
-    
+
     """
     # If `nodes` is not specified, calculate the reciprocity of the graph.
     if nodes is None:
@@ -61,7 +61,7 @@ def reciprocity(G, nodes=None):
     return dict(_reciprocity_iter(G,nodes))
 
 def _reciprocity_iter(G,nodes):
-    """ Return an iterator of (node, reciprocity).  
+    """ Return an iterator of (node, reciprocity).
 
     """
     n = G.nbunch_iter(nodes)
@@ -78,7 +78,7 @@ def _reciprocity_iter(G,nodes):
         else:
             reciprocity = 2.0*float(len(overlap))/float(n_total)
             yield (node,reciprocity)
-        
+
 @not_implemented_for('undirected','multigraph')
 def overall_reciprocity(G):
     """Compute the reciprocity for the whole graph.
@@ -89,7 +89,7 @@ def overall_reciprocity(G):
     ----------
     G : graph
        A networkx graph
-    
+
     """
     n_all_edge = G.number_of_edges()
     n_overlap_edge = (n_all_edge - G.to_undirected().number_of_edges()) *2

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -400,7 +400,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(D['v'], 9)
         P, D = nx.goldberg_radzik(self.MXG, 's')
         assert_equal(P['v'], 'u')
-        assert_equal(D['v'], 9)        
+        assert_equal(D['v'], 9)
         assert_equal(nx.bellman_ford_path(self.MXG4, 0, 2), [0, 1, 2])
         assert_equal(nx.bellman_ford_path_length(self.MXG4, 0, 2), 4)
         assert_equal(nx.single_source_bellman_ford_path(self.MXG4, 0)[2], [0, 1, 2])

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -926,9 +926,9 @@ def bellman_ford(G, source, weight='weight'):
     """
     _warnings.warn("Function bellman_ford() is deprecated, use function bellman_ford_predecessor_and_distance() instead.",
                    DeprecationWarning)
-                   
-    return bellman_ford_predecessor_and_distance(G, source, weight=weight) 
-    
+
+    return bellman_ford_predecessor_and_distance(G, source, weight=weight)
+
 def bellman_ford_predecessor_and_distance(G, source, target=None, cutoff=None, weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths
     in weighted graphs.
@@ -1015,7 +1015,7 @@ def bellman_ford_predecessor_and_distance(G, source, target=None, cutoff=None, w
         return pred, dist
 
     weight = _weight_function(G, weight)
-        
+
     return (pred, _bellman_ford(G, [source], weight,pred=pred, dist=dist, cutoff=cutoff, target=target))
 
 
@@ -1026,7 +1026,7 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
     Parameters
     ----------
     G : NetworkX graph
-    
+
     source: list
         List of source nodes
 
@@ -1051,7 +1051,7 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
 
     cutoff: integer or float, optional
         Depth to stop the search. Only paths of length <= cutoff are returned
-        
+
     target: node label, optional
         Ending node for path. Path lengths to other destinations may (and
         probably will) be incorrect.
@@ -1072,7 +1072,7 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
 
     if pred is None:
         pred = {v: [None] for v in source}
-    
+
     if dist is None:
         dist = {v: 0 for v in source}
 
@@ -1096,11 +1096,11 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
                 if cutoff is not None:
                     if dist_v > cutoff:
                         continue
-                                    
+
                 if target is not None:
                     if dist_v > dist.get(target, inf):
                         continue
-                    
+
                 if dist_v < dist.get(v, inf):
                     if v not in in_q:
                         q.append(v)
@@ -1112,24 +1112,24 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
                         count[v] = count_v
                     dist[v] = dist_v
                     pred[v] = [u]
-                    
+
                 elif dist.get(v) is not None and dist_v == dist.get(v):
                     pred[v].append(u)
 
     if paths is not None:
         dsts = [target] if target is not None else pred
         for dst in dsts:
-        
+
             path = [dst]
             cur = dst
-            
+
             while pred[cur][0] is not None:
                 cur = pred[cur][0]
                 path.append(cur)
-            
+
             path.reverse()
             paths[dst] = path
-    
+
 
     return dist
 
@@ -1180,7 +1180,7 @@ def bellman_ford_path(G, source, target, weight='weight'):
     except KeyError:
         raise nx.NetworkXNoPath(
             "node %s not reachable from %s" % (source, target))
-            
+
 def bellman_ford_path_length(G, source, target, weight='weight'):
     """Returns the shortest path length from source to target
     in a weighted graph.
@@ -1227,9 +1227,9 @@ def bellman_ford_path_length(G, source, target, weight='weight'):
         return 0
 
     weight = _weight_function(G, weight)
-    
+
     length =  _bellman_ford(G, [source], weight, target=target)
-    
+
     try:
         return length[target]
     except KeyError:

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -17,7 +17,7 @@ def s_metric(G, normalized=True):
            Normalize the value.
 
     Returns
-    -------       
+    -------
     s : float
         The s-metric of the graph.
 
@@ -32,6 +32,6 @@ def s_metric(G, normalized=True):
         raise nx.NetworkXError("Normalization not implemented")
 #        Gmax = li_smax_graph(list(G.degree().values()))
 #        return s_metric(G,normalized=False)/s_metric(Gmax,normalized=False)
-#    else:    
+#    else:
     return float(sum([G.degree(u)*G.degree(v) for (u,v) in G.edges()]))
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -249,7 +249,7 @@ class TestDAG:
         G = nx.DiGraph([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)])
         transitive_reduction = nx.algorithms.dag.transitive_reduction
         solution = [(1, 2), (2, 3), (2, 4)]
-        assert_edges_equal(transitive_reduction(G).edges(), solution)        
+        assert_edges_equal(transitive_reduction(G).edges(), solution)
         G = nx.Graph([(1, 2), (2, 3), (3, 4)])
         assert_raises(nx.NetworkXNotImplemented, transitive_reduction, G)
 

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -37,7 +37,7 @@ class TestDistance:
 
 
 
-        
+
     def test_diameter(self):
         assert_equal(networkx.diameter(self.G),6)
 

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -37,7 +37,7 @@ class TestEuler:
         G.add_edge(3,1)
         assert_false(is_eulerian(G))
 
-        
+
 
     def test_eulerian_circuit_cycle(self):
         G=nx.cycle_graph(4)
@@ -53,17 +53,17 @@ class TestEuler:
         assert_equal(edges,[(1,2),(2,3),(3,0),(0,1)])
 
         G=nx.complete_graph(3)
-        
+
         edges=list(eulerian_circuit(G,source=0))
         nodes=[u for u,v in edges]
         assert_equal(nodes,[0,2,1])
         assert_equal(edges,[(0,2),(2,1),(1,0)])
-        
+
         edges=list(eulerian_circuit(G,source=1))
         nodes=[u for u,v in edges]
         assert_equal(nodes,[1,2,0])
         assert_equal(edges,[(1,2),(2,0),(0,1)])
-        
+
 
 
     def test_eulerian_circuit_digraph(self):

--- a/networkx/algorithms/tests/test_graphical.py
+++ b/networkx/algorithms/tests/test_graphical.py
@@ -10,7 +10,7 @@ def test_valid_degree_sequence1():
         G = nx.erdos_renyi_graph(n,p)
         deg = (d for n, d in G.degree())
         assert_true( nx.is_valid_degree_sequence(deg, method='eg') )
-        assert_true( nx.is_valid_degree_sequence(deg, method='hh') )        
+        assert_true( nx.is_valid_degree_sequence(deg, method='hh') )
 
 def test_valid_degree_sequence2():
     n = 100
@@ -18,7 +18,7 @@ def test_valid_degree_sequence2():
         G = nx.barabasi_albert_graph(n,1)
         deg = (d for n, d in G.degree())
         assert_true( nx.is_valid_degree_sequence(deg, method='eg') )
-        assert_true( nx.is_valid_degree_sequence(deg, method='hh') )        
+        assert_true( nx.is_valid_degree_sequence(deg, method='hh') )
 
 @raises(nx.NetworkXException)
 def test_string_input():
@@ -40,23 +40,23 @@ class TestAtlas(object):
 
     def setUp(self):
         self.GAG=atlas.graph_atlas_g()
-        
+
     def test_atlas(self):
         for graph in self.GAG:
             deg = (d for n, d in graph.degree())
             assert_true( nx.is_valid_degree_sequence(deg, method='eg') )
-            assert_true( nx.is_valid_degree_sequence(deg, method='hh') )        
-        
+            assert_true( nx.is_valid_degree_sequence(deg, method='hh') )
+
 def test_small_graph_true():
         z=[5,3,3,3,3,2,2,2,1,1,1]
         assert_true(nx.is_valid_degree_sequence(z, method='hh'))
-        assert_true(nx.is_valid_degree_sequence(z, method='eg'))       
+        assert_true(nx.is_valid_degree_sequence(z, method='eg'))
         z=[10,3,3,3,3,2,2,2,2,2,2]
         assert_true(nx.is_valid_degree_sequence(z, method='hh'))
-        assert_true(nx.is_valid_degree_sequence(z, method='eg'))        
+        assert_true(nx.is_valid_degree_sequence(z, method='eg'))
         z=[1, 1, 1, 1, 1, 2, 2, 2, 3, 4]
         assert_true(nx.is_valid_degree_sequence(z, method='hh'))
-        assert_true(nx.is_valid_degree_sequence(z, method='eg'))        
+        assert_true(nx.is_valid_degree_sequence(z, method='eg'))
 
 
 
@@ -69,7 +69,7 @@ def test_small_graph_false():
     assert_false(nx.is_valid_degree_sequence(z, method='eg'))
     z=[1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 4]
     assert_false(nx.is_valid_degree_sequence(z, method='hh'))
-    assert_false(nx.is_valid_degree_sequence(z, method='eg'))        
+    assert_false(nx.is_valid_degree_sequence(z, method='eg'))
 
 def test_directed_degree_sequence():
     # Test a range of valid directed degree sequences
@@ -113,7 +113,7 @@ def test_multi_sequence():
     # Test for sequence with odd sum
     seq=[1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 4]
     assert_false(nx.is_multigraphical(seq))
-        
+
 def test_pseudo_sequence():
     # Test small valid pseudo sequence
     seq=[1000,3,3,3,3,2,2,2,1,1]

--- a/networkx/algorithms/tests/test_hybrid.py
+++ b/networkx/algorithms/tests/test_hybrid.py
@@ -2,7 +2,7 @@ from nose.tools import *
 import networkx as nx
 
 def test_2d_grid_graph():
-    # FC article claims 2d grid graph of size n is (3,3)-connected 
+    # FC article claims 2d grid graph of size n is (3,3)-connected
     # and (5,9)-connected, but I don't think it is (5,9)-connected
     G=nx.grid_2d_graph(8,8,periodic=True)
     assert_true(nx.is_kl_connected(G,3,3))
@@ -21,4 +21,4 @@ def test_small_graph():
                                          low_memory=True,
                                          same_as_graph=True)
     assert_true(graphOK)
-    
+

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -42,7 +42,7 @@ class TestMaximalIndependantSet(object):
         self.florentine.add_edge('Albizzi','Guadagni')
         self.florentine.add_edge('Bischeri','Guadagni')
         self.florentine.add_edge('Guadagni','Lamberteschi')
-        
+
     def test_K5(self):
         """Maximal independent set: K5"""
         G = nx.complete_graph(5)

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -6,7 +6,7 @@ def test_richclub():
     G = nx.Graph([(0,1),(0,2),(1,2),(1,3),(1,4),(4,5)])
     rc = nx.richclub.rich_club_coefficient(G,normalized=False)
     assert_equal(rc,{0: 12.0/30,1:8.0/12})
-    
+
     # test single value
     rc0 = nx.richclub.rich_club_coefficient(G,normalized=False)[0]
     assert_equal(rc0,12.0/30.0)
@@ -43,7 +43,7 @@ def test_richclub3():
                      13:0.0,
                      14:0.0,
                      15:0.0,})
-    
+
 def test_richclub4():
     G = nx.Graph()
     G.add_edges_from([(0,1),(0,2),(0,3),(0,4),(4,5),(5,9),(6,9),(7,9),(8,9)])

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -21,7 +21,7 @@ def is_threshold_graph(G):
     Returns True if G is a threshold graph.
     """
     return is_threshold_sequence(list(d for n, d in G.degree()))
-    
+
 def is_threshold_sequence(degree_sequence):
     """
     Returns True if the sequence is a threshold degree seqeunce.
@@ -312,7 +312,7 @@ def threshold_graph(creation_sequence, create_using=None):
             # the loop. Hence using an iterator will result in
             # `RuntimeError: dictionary changed size during iteration`
             for u in list(G):
-                G.add_edge(v, u) 
+                G.add_edge(v, u)
         G.add_node(v)
     return G
 

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -157,7 +157,7 @@ def random_tournament(n):
 
     """
     # Flip an unbiased coin for each pair of distinct nodes.
-    coins = (random.random() for i in range((n * (n - 1)) // 2))
+    coins = (random.random() for _ in range((n * (n - 1)) // 2))
     pairs = combinations(range(n), 2)
     edges = ((u, v) if r < 0.5 else (v, u) for (u, v), r in zip(pairs, coins))
     return nx.DiGraph(edges)

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -171,7 +171,7 @@ class DiGraph(Graph):
     edge data keyed by neighbor.  The inner dict (edge_attr_dict) represents
     the edge data and holds edge attribute values keyed by attribute names.
 
-    Each of these three dicts can be replaced in a subclass by a user defined 
+    Each of these three dicts can be replaced in a subclass by a user defined
     dict-like object. In general, the dict-like features should be
     maintained but extra features can be added. To replace one of the
     dicts create a new graph class by changing the class(!) variable
@@ -364,7 +364,7 @@ class DiGraph(Graph):
             Node attributes are updated using the attribute dict.
         attr : keyword arguments, optional (default= no attributes)
             Update attributes for all nodes in nodes.
-            Node attributes specified in nodes as a tuple take 
+            Node attributes specified in nodes as a tuple take
             precedence over attributes specified via keyword arguments.
 
         See Also
@@ -400,7 +400,7 @@ class DiGraph(Graph):
         for n in nodes:
             # keep all this inside try/except because
             # CPython throws TypeError on n not in self.succ,
-            # while pre-2.7.5 ironpython throws on self.succ[n] 
+            # while pre-2.7.5 ironpython throws on self.succ[n]
             try:
                 if n not in self.succ:
                     self.succ[n] = self.adjlist_inner_dict_factory()
@@ -592,7 +592,7 @@ class DiGraph(Graph):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
-        Edge attributes specified in an ebunch take precedence over 
+        Edge attributes specified in an ebunch take precedence over
         attributes specified via keyword arguments.
 
         Examples
@@ -748,7 +748,7 @@ class DiGraph(Graph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         default : value, optional (default=None)
             Value used for edges that dont have the requested attribute.
             Only relevant if data is not True or False.
@@ -776,7 +776,7 @@ class DiGraph(Graph):
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges(data=True)) # default data is {} (empty dict)
         [(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})]
-        >>> list(G.edges(data='weight', default=1)) 
+        >>> list(G.edges(data='weight', default=1))
         [(0, 1, 1), (1, 2, 1), (2, 3, 5)]
         >>> list(G.edges([0,2]))
         [(0, 1), (2, 3)]
@@ -816,7 +816,7 @@ class DiGraph(Graph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
         default : value, optional (default=None)
             Value used for edges that dont have the requested attribute.
             Only relevant if data is not True or False.
@@ -1161,7 +1161,7 @@ class DiGraph(Graph):
         See the Python copy module for more information on shallow
         and deep copies, http://docs.python.org/library/copy.html.
 
-        Warning: If you have subclassed DiGraph to use dict-like objects 
+        Warning: If you have subclassed DiGraph to use dict-like objects
         in the data structure, those changes do not transfer to the Graph
         created by this method.
         """

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -473,7 +473,7 @@ class Graph(object):
             Node attributes are updated using the attribute dict.
         attr : keyword arguments, optional (default= no attributes)
             Update attributes for all nodes in nodes.
-            Node attributes specified in nodes as a tuple take 
+            Node attributes specified in nodes as a tuple take
             precedence over attributes specified via keyword arguments.
 
         See Also
@@ -825,7 +825,7 @@ class Graph(object):
         Adding the same edge twice has no effect but any edge data
         will be updated when each duplicate edge is added.
 
-        Edge attributes specified in an ebunch take precedence over 
+        Edge attributes specified in an ebunch take precedence over
         attributes specified via keyword arguments.
 
         Examples

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -512,7 +512,7 @@ class MultiDiGraph(MultiGraph,DiGraph):
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u,v,ddict[data]).
             If True, return edge attribute dict in 3-tuple (u,v,ddict).
-            If False, return 2-tuple (u,v). 
+            If False, return 2-tuple (u,v).
 
         keys : bool, optional (default=False)
             If True, return edge keys with each edge.

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -63,7 +63,7 @@ class HistoricalTests(object):
         G.add_node('A')
         assert_true('A' in G)
         assert_false([] in G)  # never raise a Key or TypeError in this test
-        assert_false({1:1} in G) 
+        assert_false({1:1} in G)
 
     def test_add_remove(self):
         # Test add_node and remove_node acting for various nbunch
@@ -77,7 +77,7 @@ class HistoricalTests(object):
 
     def test_nbunch_is_list(self):
         G=self.G()
-        G.add_nodes_from(list("ABCD")) 
+        G.add_nodes_from(list("ABCD"))
         G.add_nodes_from(self.P3) # add nbunch of nodes (nbunch=Graph)
         assert_equal(sorted(G.nodes(),key=str),
                      [1, 2, 3, 'A', 'B', 'C', 'D'])
@@ -135,20 +135,20 @@ class HistoricalTests(object):
         assert_false(G.has_edge('A','C'))
         assert_true(G.has_edge( *('A','B') ))
         if G.is_directed():
-            assert_false(G.has_edge('B','A')) 
+            assert_false(G.has_edge('B','A'))
         else:
             # G is undirected, so B->A is an edge
-            assert_true(G.has_edge('B','A')) 
+            assert_true(G.has_edge('B','A'))
 
 
         G.add_edge('A','C')  # test directedness
         G.add_edge('C','A')
         G.remove_edge('C','A')
         if G.is_directed():
-            assert_true(G.has_edge('A','C')) 
+            assert_true(G.has_edge('A','C'))
         else:
-            assert_false(G.has_edge('A','C')) 
-        assert_false(G.has_edge('C','A')) 
+            assert_false(G.has_edge('A','C'))
+        assert_false(G.has_edge('C','A'))
 
 
     def test_self_loop(self):
@@ -157,7 +157,7 @@ class HistoricalTests(object):
         assert_true(G.has_edge('A','A'))
         G.remove_edge('A','A')
         G.add_edge('X','X')
-        assert_true(G.has_node('X')) 
+        assert_true(G.has_node('X'))
         G.remove_node('X')
         G.add_edge('A','Z') # should add the node silently
         assert_true(G.has_node('Z'))
@@ -167,7 +167,7 @@ class HistoricalTests(object):
         G.add_edges_from([('B','C')])   # test add_edges_from()
         assert_true(G.has_edge('B','C'))
         if G.is_directed():
-            assert_false(G.has_edge('C','B')) 
+            assert_false(G.has_edge('C','B'))
         else:
             assert_true(G.has_edge('C','B'))  # undirected
 
@@ -176,14 +176,14 @@ class HistoricalTests(object):
         assert_true(G.has_edge('B','D'))
 
         if G.is_directed():
-            assert_false(G.has_edge('D','B')) 
+            assert_false(G.has_edge('D','B'))
         else:
             assert_true(G.has_edge('D','B'))  # undirected
 
     def test_add_edges_from2(self):
         G=self.G()
         # after failing silently, should add 2nd edge
-        G.add_edges_from([tuple('IJ'),list('KK'),tuple('JK')]) 
+        G.add_edges_from([tuple('IJ'),list('KK'),tuple('JK')])
         assert_true(G.has_edge(*('I','J')))
         assert_true(G.has_edge(*('K','K')))
         assert_true(G.has_edge(*('J','K')))
@@ -191,10 +191,10 @@ class HistoricalTests(object):
             assert_false(G.has_edge(*('K','J')))
         else:
             assert_true(G.has_edge(*('K','J')))
-            
+
     def test_add_edges_from3(self):
         G=self.G()
-        G.add_edges_from(zip(list('ACD'),list('CDE'))) 
+        G.add_edges_from(zip(list('ACD'),list('CDE')))
         assert_true(G.has_edge('D','E'))
         assert_false(G.has_edge('E','C'))
 
@@ -209,14 +209,14 @@ class HistoricalTests(object):
         assert_false(G.has_edge('P','M'))
         assert_raises(TypeError,G.remove_edge,'M')
 
-        G.add_edge('N','M')  
+        G.add_edge('N','M')
         assert_true(G.has_edge('M','N'))
         G.remove_edge('M','N')
         assert_false(G.has_edge('M','N'))
-                        
+
         # self loop fails silently
         G.remove_edges_from([list('HI'),list('DF'),
-                             tuple('KK'),tuple('JK')]) 
+                             tuple('KK'),tuple('JK')])
         assert_false(G.has_edge('H','I'))
         assert_false(G.has_edge('J','K'))
         G.remove_edges_from([list('IJ'),list('KK'),list('JK')])
@@ -228,7 +228,7 @@ class HistoricalTests(object):
     def test_edges_nbunch(self):
         # Test G.edges(nbunch) with various forms of nbunch
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
         # node not in nbunch should be quietly ignored
         assert_raises(nx.NetworkXError,G.edges,6)
@@ -256,7 +256,7 @@ class HistoricalTests(object):
 
     def test_edges_nbunch(self):
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
         # Test G.edges(nbunch) with various forms of nbunch
         # node not in nbunch should be quietly ignored
@@ -282,13 +282,13 @@ class HistoricalTests(object):
         assert_edges_equal(G.edges('A'), [('A', 'B'), ('A', 'C')])
 
         # nbunch can be nothing (whole graph)
-        assert_edges_equal(G.edges(), [('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        assert_edges_equal(G.edges(), [('A', 'B'), ('A', 'C'), ('B', 'D'),
                            ('C', 'B'), ('C', 'D')])
 
 
     def test_degree(self):
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
         assert_equal(G.degree('A'),2)
 
@@ -321,7 +321,7 @@ class HistoricalTests(object):
 
     def test_order_size(self):
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
         assert_equal(G.order(),4)
         assert_equal(G.size(),5)
@@ -338,16 +338,16 @@ class HistoricalTests(object):
 
     def test_subgraph(self):
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
-        SG=G.subgraph(['A','B','D']) 
+        SG=G.subgraph(['A','B','D'])
         assert_nodes_equal(list(SG), ['A', 'B', 'D'])
         assert_edges_equal(list(SG.edges()), [('A', 'B'), ('B', 'D')])
 
     def test_to_directed(self):
         G=self.G()
         if not G.is_directed():
-            G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+            G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                               ('C', 'B'), ('C', 'D')])
 
             DG=G.to_directed()
@@ -357,7 +357,7 @@ class HistoricalTests(object):
             assert_equal(DG.name,G.name)
             assert_equal(DG.adj,G.adj)
             assert_equal(sorted(DG.out_edges(list('AB'))),
-                         [('A', 'B'), ('A', 'C'), ('B', 'A'), 
+                         [('A', 'B'), ('A', 'C'), ('B', 'A'),
                           ('B', 'C'), ('B', 'D')])
             DG.remove_edge('A','B')
             assert_true(DG.has_edge('B','A')) # this removes B-A but not  A-B
@@ -366,7 +366,7 @@ class HistoricalTests(object):
     def test_to_undirected(self):
         G=self.G()
         if G.is_directed():
-            G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+            G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                               ('C', 'B'), ('C', 'D')])
             UG=G.to_undirected()       # to_undirected
             assert_not_equal(UG,G)
@@ -386,7 +386,7 @@ class HistoricalTests(object):
 
     def test_neighbors(self):
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
         G.add_nodes_from('GJK')
         assert_equal(sorted(G['A']),['B', 'C'])
@@ -397,7 +397,7 @@ class HistoricalTests(object):
 
     def test_iterators(self):
         G=self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('C', 'B'), ('C', 'D')])
         G.add_nodes_from('GJK')
         assert_equal(sorted(G.nodes()),
@@ -408,7 +408,7 @@ class HistoricalTests(object):
         assert_equal(sorted([v for k,v in G.degree()]),
                      [0, 0, 0, 2, 2, 3, 3])
         assert_equal(sorted(G.degree(), key=str),
-                     [('A', 2), ('B', 3), ('C', 3), ('D', 2), 
+                     [('A', 2), ('B', 3), ('C', 3), ('D', 2),
                       ('G', 0), ('J', 0), ('K', 0)])
         assert_equal(sorted(G.neighbors('A')),['B', 'C'])
         assert_raises(nx.NetworkXError,G.neighbors,'X')
@@ -425,7 +425,7 @@ class HistoricalTests(object):
         assert_true(nx.is_isomorphic(H,nullgraph))
 
     def test_empty_subgraph(self):
-        # Subgraph of an empty graph is an empty graph. test 1 
+        # Subgraph of an empty graph is an empty graph. test 1
         nullgraph=nx.null_graph()
         E5=nx.empty_graph(5)
         E10=nx.empty_graph(10)

--- a/networkx/classes/tests/test_digraph_historical.py
+++ b/networkx/classes/tests/test_digraph_historical.py
@@ -17,7 +17,7 @@ class TestDiGraphHistorical(HistoricalTests):
     def test_in_degree(self):
         G=self.G()
         G.add_nodes_from('GJK')
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('B', 'C'), ('C', 'D')])
 
         assert_equal(sorted(d for n, d in G.in_degree()),[0, 0, 0, 0, 1, 2, 2])
@@ -27,7 +27,7 @@ class TestDiGraphHistorical(HistoricalTests):
     def test_out_degree(self):
         G=self.G()
         G.add_nodes_from('GJK')
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('B', 'C'), ('C', 'D')])
         assert_equal(sorted([v for k,v in G.in_degree()]),
                      [0, 0, 0, 0, 1, 2, 2])
@@ -46,7 +46,7 @@ class TestDiGraphHistorical(HistoricalTests):
     def test_neighbors(self):
         G=self.G()
         G.add_nodes_from('GJK')
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('B', 'C'), ('C', 'D')])
 
         assert_equal(sorted(G.neighbors('C')),['D'])
@@ -58,7 +58,7 @@ class TestDiGraphHistorical(HistoricalTests):
     def test_successors(self):
         G=self.G()
         G.add_nodes_from('GJK')
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('B', 'C'), ('C', 'D')])
         assert_equal(sorted(G.successors('A')),['B', 'C'])
         assert_equal(sorted(G.successors('A')),['B', 'C'])
@@ -67,12 +67,12 @@ class TestDiGraphHistorical(HistoricalTests):
         assert_equal(sorted(G.successors('G')),[])
         assert_raises(nx.NetworkXError,G.successors,'j')
         assert_raises(nx.NetworkXError,G.successors,'j')
-        
+
 
     def test_predecessors(self):
         G=self.G()
         G.add_nodes_from('GJK')
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'), 
+        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
                           ('B', 'C'), ('C', 'D')])
         assert_equal(sorted(G.predecessors('C')),['A', 'B'])
         assert_equal(sorted(G.predecessors('C')),['A', 'B'])

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -24,7 +24,7 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
         assert_equal(G[0][1][0],{})
         assert_equal(G.get_edge_data(10,20),None)
         assert_equal(G.get_edge_data(0,1,0),{})
-        
+
 
     def test_adjacency(self):
         G=self.K3
@@ -171,7 +171,7 @@ class TestMultiGraph(BaseMultiGraphTester,TestGraph):
         G=self.Graph()
         G.add_edge(*(0,1))
         assert_equal(G.adj,{0: {1: {0:{}}}, 1: {0: {0:{}}}})
-        
+
     def test_add_edge_conflicting_key(self):
         G=self.Graph()
         G.add_edge(0,1,key=1)
@@ -210,7 +210,7 @@ class TestMultiGraph(BaseMultiGraphTester,TestGraph):
         assert_raises((KeyError,nx.NetworkXError), G.remove_edge,-1,0)
         assert_raises((KeyError,nx.NetworkXError), G.remove_edge,0,2,
                       key=1)
-        
+
     def test_remove_edges_from(self):
         G=self.K3.copy()
         G.remove_edges_from([(0,1)])

--- a/networkx/classes/tests/timingclasses.py
+++ b/networkx/classes/tests/timingclasses.py
@@ -3,7 +3,7 @@
 The idea is to use these classes to compare timing with the
 current classes to see if adding features has slowed any methods.
 
-The classes are named TimingGraph, TimingDiGraph, 
+The classes are named TimingGraph, TimingDiGraph,
 TimingMultiGraph and TimingMultiDiGraph
 """
 #    Copyright (C) 2004-2016 by
@@ -3735,7 +3735,7 @@ class TimingMultiGraph(TimingGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -3832,7 +3832,7 @@ class TimingMultiGraph(TimingGraph):
         G.add_edges_from( (u,v,key,deepcopy(datadict))
                            for u,nbrs in self.adjacency_iter()
                            for v,keydict in nbrs.items()
-                           for key,datadict in keydict.items() ) 
+                           for key,datadict in keydict.items() )
         G.graph=deepcopy(self.graph)
         G.node=deepcopy(self.node)
         return G
@@ -3876,22 +3876,22 @@ class TimingMultiGraph(TimingGraph):
         """
         if data:
             if keys:
-                return [ (n,n,k,d) 
-                         for n,nbrs in self.adj.items() 
+                return [ (n,n,k,d)
+                         for n,nbrs in self.adj.items()
                          if n in nbrs for k,d in nbrs[n].items()]
             else:
-                return [ (n,n,d) 
-                         for n,nbrs in self.adj.items() 
+                return [ (n,n,d)
+                         for n,nbrs in self.adj.items()
                          if n in nbrs for d in nbrs[n].values()]
         else:
             if keys:
                 return [ (n,n,k)
-                     for n,nbrs in self.adj.items() 
+                     for n,nbrs in self.adj.items()
                      if n in nbrs for k in nbrs[n].keys()]
 
             else:
                 return [ (n,n)
-                     for n,nbrs in self.adj.items() 
+                     for n,nbrs in self.adj.items()
                      if n in nbrs for d in nbrs[n].values()]
 
 
@@ -4490,7 +4490,7 @@ class TimingMultiDiGraph(TimingMultiGraph,TimingDiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -4549,7 +4549,7 @@ class TimingMultiDiGraph(TimingMultiGraph,TimingDiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights adjacent to the node.
 
@@ -4601,7 +4601,7 @@ class TimingMultiDiGraph(TimingMultiGraph,TimingDiGraph):
             through once.
 
         weight : string or None, optional (default=None)
-           The edge attribute that holds the numerical value used 
+           The edge attribute that holds the numerical value used
            as a weight.  If None, then each edge has weight 1.
            The degree is the sum of the edge weights.
 
@@ -4697,8 +4697,8 @@ class TimingMultiDiGraph(TimingMultiGraph,TimingDiGraph):
         Parameters
         ----------
         reciprocal : bool (optional)
-          If True only keep edges that appear in both directions 
-          in the original digraph. 
+          If True only keep edges that appear in both directions
+          in the original digraph.
 
         Returns
         -------
@@ -4823,7 +4823,7 @@ class TimingMultiDiGraph(TimingMultiGraph,TimingDiGraph):
         if copy:
             H = self.__class__(name="Reverse of (%s)"%self.name)
             H.add_nodes_from(self)
-            H.add_edges_from( (v,u,k,deepcopy(d)) for u,v,k,d 
+            H.add_edges_from( (v,u,k,deepcopy(d)) for u,v,k,d
                               in self.edges(keys=True, data=True) )
             H.graph=deepcopy(self.graph)
             H.node=deepcopy(self.node)

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -166,11 +166,8 @@ def to_networkx_graph(data,create_using=None,multigraph_input=False):
         warnings.warn('scipy not found, skipping conversion test.',
                       ImportWarning)
 
-
     raise nx.NetworkXError(\
           "Input is not a known data type for conversion.")
-
-    return
 
 
 def convert_to_undirected(G):

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -39,7 +39,7 @@ __all__ = ['from_numpy_matrix', 'to_numpy_matrix',
            'to_numpy_recarray',
            'from_scipy_sparse_matrix', 'to_scipy_sparse_matrix']
 
-def to_pandas_dataframe(G, nodelist=None, dtype=None, order=None, 
+def to_pandas_dataframe(G, nodelist=None, dtype=None, order=None,
                         multigraph_weight=sum, weight='weight', nonedge=0.0):
     """Return the graph adjacency matrix as a Pandas DataFrame.
 
@@ -119,8 +119,8 @@ def to_pandas_dataframe(G, nodelist=None, dtype=None, order=None,
     2  0  0  4
     """
     import pandas as pd
-    M = to_numpy_matrix(G, nodelist=nodelist, dtype=dtype, order=order, 
-                        multigraph_weight=multigraph_weight, weight=weight, 
+    M = to_numpy_matrix(G, nodelist=nodelist, dtype=dtype, order=order,
+                        multigraph_weight=multigraph_weight, weight=weight,
                         nonedge=nonedge)
     if nodelist is None:
         nodelist = list(G)
@@ -217,12 +217,12 @@ def from_pandas_dataframe(df, source, target, edge_attr=None,
             s, t = row[src_i], row[tar_i]
             if g.is_multigraph():
                 g.add_edge(s, t)
-                key = max(g[s][t])  # default keys just count, so max is most recent 
+                key = max(g[s][t])  # default keys just count, so max is most recent
                 g[s][t][key].update((i, row[j]) for i, j in edge_i)
             else:
                 g.add_edge(s, t)
                 g[s][t].update((i, row[j]) for i, j in edge_i)
-    
+
     # If no column names are given, then just return the edges.
     else:
         for row in df.values:

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -12,7 +12,6 @@ Generators for the small graph atlas.
 """
 import gzip
 from itertools import islice
-import os
 import os.path
 
 import networkx as nx

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -165,8 +165,8 @@ def barbell_graph(m1, m2, create_using=None):
         `m1, ..., m1+m2-1` for the path,
         and `m1+m2, ..., 2*m1+m2-1` for the right barbell.
 
-    The 3 subgraphs are joined via the edges `(m1-1, m1)` and 
-    `(m1+m2-1, m1+m2)`. If `m2=0`, this is merely two complete 
+    The 3 subgraphs are joined via the edges `(m1-1, m1)` and
+    `(m1+m2-1, m1+m2)`. If `m2=0`, this is merely two complete
     graphs joined together.
 
     This graph is an extremal example in David Aldous
@@ -435,7 +435,7 @@ def empty_graph(n=0, create_using=None):
 @nodes_or_number([0, 1])
 def grid_2d_graph(m, n, periodic=False, create_using=None):
     """ Return the 2d grid graph of mxn nodes
-    
+
     The grid graph has each node connected to its four nearest neighbors.
 
     Parameters
@@ -573,7 +573,7 @@ def lollipop_graph(m, n, create_using=None):
 
     Notes
     =====
-    The 2 subgraphs are joined via an edge (m-1, m).  
+    The 2 subgraphs are joined via an edge (m-1, m).
     If n=0, this is merely a complete graph.
 
     (This graph is an extremal example in David Aldous and Jim
@@ -643,7 +643,7 @@ def path_graph(n, create_using=None):
 @nodes_or_number(0)
 def star_graph(n, create_using=None):
     """ Return the star graph
-    
+
     The star graph consists of one center node connected to n outer nodes.
 
     Parameters
@@ -683,7 +683,7 @@ def trivial_graph(create_using=None):
 
 def turan_graph(n,r):
     """ Return the Turan Graph
-    
+
     The Turan Graph is a complete multipartite graph on `n` vertices
     with `r` partitions with the property that it has the maximum number
     of edges for any graph with the same number of vertices and partitions.
@@ -707,7 +707,7 @@ def turan_graph(n,r):
     """
 
     if not isinstance(n,int) or not isinstance(r,int):
-        raise nx.NetworkXError("n and r must be type int") 
+        raise nx.NetworkXError("n and r must be type int")
 
     if not 1 <= r <= n:
         raise nx.NetworkXError("Must satisfy 1 <= r <= n")
@@ -721,7 +721,7 @@ def turan_graph(n,r):
 @nodes_or_number(0)
 def wheel_graph(n, create_using=None):
     """ Return the wheel graph
-    
+
     The wheel graph consists of a hub node connected to a cycle of (n-1) nodes.
 
     Parameters

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -76,16 +76,16 @@ def configuration_model(deg_sequence,create_using=None,seed=None):
     This configuration model construction process can lead to
     duplicate edges and loops.  You can remove the self-loops and
     parallel edges (see below) which will likely result in a graph
-    that doesn't have the exact degree sequence specified.  
-    
-    The density of self-loops and parallel edges tends to decrease 
-    as the number of nodes increases. However, typically the number 
-    of self-loops will approach a Poisson distribution with a nonzero 
-    mean, and similarly for the number of parallel edges.   Consider a 
-    node with k stubs. The probability of being joined to another stub of 
-    the same node is basically (k-1)/N where k is the degree and N is 
-    the number of nodes. So the probability of a self-loop  scales like c/N 
-    for some constant c.  As N grows, this means we expect c self-loops. 
+    that doesn't have the exact degree sequence specified.
+
+    The density of self-loops and parallel edges tends to decrease
+    as the number of nodes increases. However, typically the number
+    of self-loops will approach a Poisson distribution with a nonzero
+    mean, and similarly for the number of parallel edges.   Consider a
+    node with k stubs. The probability of being joined to another stub of
+    the same node is basically (k-1)/N where k is the degree and N is
+    the number of nodes. So the probability of a self-loop  scales like c/N
+    for some constant c.  As N grows, this means we expect c self-loops.
     Similarly for parallel edges.
 
     References
@@ -126,7 +126,7 @@ def configuration_model(deg_sequence,create_using=None,seed=None):
     G=nx.empty_graph(N,create_using)
 
     if N==0 or max(deg_sequence)==0: # done if no edges
-        return G 
+        return G
 
     # build stublist, a list of available degree-repeated stubs
     # e.g. for deg_sequence=[3,2,1,1,1]
@@ -416,12 +416,12 @@ def havel_hakimi_graph(deg_sequence,create_using=None):
 
     References
     ----------
-    .. [1] Hakimi S., On Realizability of a Set of Integers as 
+    .. [1] Hakimi S., On Realizability of a Set of Integers as
        Degrees of the Vertices of a Linear Graph. I,
        Journal of SIAM, 10(3), pp. 496-506 (1962)
     .. [2] Kleitman D.J. and Wang D.L.
        Algorithms for Constructing Graphs and Digraphs with Given Valences
-       and Factors  Discrete Mathematics, 6(1), pp. 79-88 (1973) 
+       and Factors  Discrete Mathematics, 6(1), pp. 79-88 (1973)
     """
     if not nx.is_valid_degree_sequence(deg_sequence):
         raise nx.NetworkXError('Invalid degree sequence')
@@ -486,9 +486,9 @@ def directed_havel_hakimi_graph(in_deg_sequence,
 
     Parameters
     ----------
-    in_deg_sequence :  list of integers 
+    in_deg_sequence :  list of integers
        Each list entry corresponds to the in-degree of a node.
-    out_deg_sequence : list of integers 
+    out_deg_sequence : list of integers
        Each list entry corresponds to the out-degree of a node.
     create_using : graph, optional (default DiGraph)
        Return graph of this type. The instance will be cleared.
@@ -508,7 +508,7 @@ def directed_havel_hakimi_graph(in_deg_sequence,
     See Also
     --------
     configuration_model
-    
+
     Notes
     -----
     Algorithm as described by Kleitman and Wang [1]_.
@@ -517,7 +517,7 @@ def directed_havel_hakimi_graph(in_deg_sequence,
     ----------
     .. [1] D.J. Kleitman and D.L. Wang
        Algorithms for Constructing Graphs and Digraphs with Given Valences
-       and Factors Discrete Mathematics, 6(1), pp. 79-88 (1973) 
+       and Factors Discrete Mathematics, 6(1), pp. 79-88 (1973)
     """
     assert(nx.utils.is_list_of_ints(in_deg_sequence))
     assert(nx.utils.is_list_of_ints(out_deg_sequence))
@@ -528,7 +528,7 @@ def directed_havel_hakimi_graph(in_deg_sequence,
     # Process the sequences and form two heaps to store degree pairs with
     # either zero or nonzero out degrees
     sumin, sumout, nin, nout = 0, 0, len(in_deg_sequence), len(out_deg_sequence)
-    maxn = max(nin, nout) 
+    maxn = max(nin, nout)
     G = nx.empty_graph(maxn,create_using)
     if maxn==0:
         return G
@@ -545,9 +545,9 @@ def directed_havel_hakimi_graph(in_deg_sequence,
                 'Invalid degree sequences. Sequence values must be positive.')
         sumin, sumout, maxin = sumin+in_deg, sumout+out_deg, max(maxin, in_deg)
         if in_deg > 0:
-            stubheap.append((-1*out_deg, -1*in_deg,n)) 
+            stubheap.append((-1*out_deg, -1*in_deg,n))
         elif out_deg > 0:
-            zeroheap.append((-1*out_deg,n)) 
+            zeroheap.append((-1*out_deg,n))
     if sumin != sumout:
         raise nx.NetworkXError(
             'Invalid degree sequences. Sequences must have equal sums.')
@@ -555,11 +555,11 @@ def directed_havel_hakimi_graph(in_deg_sequence,
     heapq.heapify(zeroheap)
 
     modstubs = [(0,0,0)]*(maxin+1)
-    # Successively reduce degree sequence by removing the maximum 
+    # Successively reduce degree sequence by removing the maximum
     while stubheap:
         # Remove first value in the sequence with a non-zero in degree
         (freeout, freein, target) =  heapq.heappop(stubheap)
-        freein *= -1   
+        freein *= -1
         if freein > len(stubheap)+len(zeroheap):
             raise nx.NetworkXError('Non-digraphical integer sequence')
 

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -379,7 +379,7 @@ def random_uniform_k_out_graph(n, k, self_loops=True, with_replacement=True,
         def sample(v, nodes):
             if not self_loops:
                 nodes = nodes - {v}
-            return (random.choice(list(nodes)) for i in range(k))
+            return (random.choice(list(nodes)) for _ in range(k))
 
     else:
         create_using = nx.DiGraph()

--- a/networkx/generators/ego.py
+++ b/networkx/generators/ego.py
@@ -1,7 +1,7 @@
 """
 Ego graph.
 """
-#    Copyright (C) 2010 by 
+#    Copyright (C) 2010 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -16,25 +16,25 @@ import networkx as nx
 def ego_graph(G,n,radius=1,center=True,undirected=False,distance=None):
     """Returns induced subgraph of neighbors centered at node n within
     a given radius.
-    
+
     Parameters
     ----------
     G : graph
       A NetworkX Graph or DiGraph
 
-    n : node 
-      A single node 
+    n : node
+      A single node
 
     radius : number, optional
       Include all neighbors of distance<=radius from n.
-      
-    center : bool, optional
-      If False, do not include center node in graph 
 
-    undirected : bool, optional      
+    center : bool, optional
+      If False, do not include center node in graph
+
+    undirected : bool, optional
       If True use both in- and out-neighbors of directed graphs.
 
-    distance : key, optional      
+    distance : key, optional
       Use specified edge data key as distance.  For example, setting
       distance='weight' will use the edge weight to measure the
       distance from the node n.

--- a/networkx/generators/intersection.py
+++ b/networkx/generators/intersection.py
@@ -2,7 +2,7 @@
 """
 Generators for random intersection graphs.
 """
-#    Copyright (C) 2011 by 
+#    Copyright (C) 2011 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
@@ -29,9 +29,9 @@ def uniform_random_intersection_graph(n, m, p, seed=None):
     m : int
         The number of nodes in the second bipartite set (attributes)
     p : float
-        Probability of connecting nodes between bipartite sets  
+        Probability of connecting nodes between bipartite sets
     seed : int, optional
-        Seed for random number generator (default=None). 
+        Seed for random number generator (default=None).
 
     See Also
     --------
@@ -41,17 +41,17 @@ def uniform_random_intersection_graph(n, m, p, seed=None):
     ----------
     .. [1] K.B. Singer-Cohen, Random Intersection Graphs, 1995,
        PhD thesis, Johns Hopkins University
-    .. [2] Fill, J. A., Scheinerman, E. R., and Singer-Cohen, K. B., 
-       Random intersection graphs when m = !(n): 
+    .. [2] Fill, J. A., Scheinerman, E. R., and Singer-Cohen, K. B.,
+       Random intersection graphs when m = !(n):
        An equivalence theorem relating the evolution of the g(n, m, p)
        and g(n, p) models. Random Struct. Algorithms 16, 2 (2000), 156–176.
     """
     G=bipartite.random_graph(n, m, p, seed=seed)
-    return nx.projected_graph(G, range(n)) 
+    return nx.projected_graph(G, range(n))
 
 def k_random_intersection_graph(n,m,k):
     """Return a intersection graph with randomly chosen attribute sets for
-    each node that are of equal size (k). 
+    each node that are of equal size (k).
 
     Parameters
     ----------
@@ -62,7 +62,7 @@ def k_random_intersection_graph(n,m,k):
     k : float
         Size of attribute set to assign to each node.
     seed : int, optional
-        Seed for random number generator (default=None). 
+        Seed for random number generator (default=None).
 
     See Also
     --------
@@ -94,17 +94,17 @@ def general_random_intersection_graph(n,m,p):
     p : list of floats of length m
         Probabilities for connecting nodes to each attribute
     seed : int, optional
-        Seed for random number generator (default=None). 
-    
+        Seed for random number generator (default=None).
+
     See Also
     --------
     gnp_random_graph, uniform_random_intersection_graph
 
     References
     ----------
-    .. [1] Nikoletseas, S. E., Raptopoulos, C., and Spirakis, P. G. 
-       The existence and efficient construction of large independent sets 
-       in general random intersection graphs. In ICALP (2004), J. D´ıaz, 
+    .. [1] Nikoletseas, S. E., Raptopoulos, C., and Spirakis, P. G.
+       The existence and efficient construction of large independent sets
+       in general random intersection graphs. In ICALP (2004), J. D´ıaz,
        J. Karhum¨aki, A. Lepist¨o, and D. Sannella, Eds., vol. 3142
        of Lecture Notes in Computer Science, Springer, pp. 1029–1040.
     """

--- a/networkx/generators/random_clustered.py
+++ b/networkx/generators/random_clustered.py
@@ -30,8 +30,8 @@ def random_clustered_graph(joint_degree_sequence, create_using=None,
     edges. The number `d_{u,t}` is the *triangle degree* of `u` and the number
     `d_{u,i}` is the *independent edge degree*.
 
-    Parameters 
-    ---------- 
+    Parameters
+    ----------
     joint_degree_sequence : list of integer pairs
         Each list entry corresponds to the independent edge degree and
         triangle degree of a node.

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -936,8 +936,8 @@ def random_kernel_graph(n, kernel_integral, kernel_root=None, seed=None):
     """Return an random graph based on the specified kernel.
 
     The algorithm chooses each of the `[n(n-1)]/2` possible edges with
-    probability specified by a kernel `\kappa(x,y)` [1]_.  The kernel 
-    `\kappa(x,y)` must be a symmetric (in `x,y`), non-negative, 
+    probability specified by a kernel `\kappa(x,y)` [1]_.  The kernel
+    `\kappa(x,y)` must be a symmetric (in `x,y`), non-negative,
     bounded function.
 
     Parameters
@@ -949,16 +949,16 @@ def random_kernel_graph(n, kernel_integral, kernel_root=None, seed=None):
         `F(y,a,b) := \int_a^b \kappa(x,y)dx`
     kernel_root: function (optional)
         Function that returns the root `b` of the equation `F(y,a,b) = r`.
-        If None, the root is found using :func:`scipy.optimize.brentq` 
+        If None, the root is found using :func:`scipy.optimize.brentq`
         (this requires SciPy).
     seed : int, optional
         Seed for random number generator (default=None)
 
     Notes
     -----
-    The kernel is specified through its definite integral which must be 
-    provided as one of the arguments. If the integral and root of the 
-    kernel integral can be found in `O(1)` time then this algorithm runs in 
+    The kernel is specified through its definite integral which must be
+    provided as one of the arguments. If the integral and root of the
+    kernel integral can be found in `O(1)` time then this algorithm runs in
     time `O(n+m)` where m is the expected number of edges [2]_.
 
     The nodes are set to integers from 0 to n-1.

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -61,7 +61,7 @@ def make_small_graph(graph_description, create_using=None):
     Here ltype is one of "adjacencylist" or "edgelist",
     name is the name of the graph and n the number of nodes.
     This constructs a graph of n nodes with integer labels 0,..,n-1.
-    
+
     If ltype="adjacencylist"  then xlist is an adjacency list
     with exactly n entries, in with the j'th entry (which can be empty)
     specifies the nodes connected to vertex j.
@@ -70,17 +70,17 @@ def make_small_graph(graph_description, create_using=None):
     >>> G=nx.make_small_graph(["adjacencylist","C_4",4,[[2,4],[1,3],[2,4],[1,3]]])
 
     or, since we do not need to add edges twice,
-    
+
     >>> G=nx.make_small_graph(["adjacencylist","C_4",4,[[2,4],[3],[4],[]]])
-    
-    If ltype="edgelist" then xlist is an edge list 
+
+    If ltype="edgelist" then xlist is an edge list
     written as [[v1,w2],[v2,w2],...,[vk,wk]],
     where vj and wj integers in the range 1,..,n
     e.g. the "square" graph C_4 can be obtained by
- 
+
     >>> G=nx.make_small_graph(["edgelist","C_4",4,[[1,2],[3,4],[2,3],[4,1]]])
 
-    Use the create_using argument to choose the graph class/type. 
+    Use the create_using argument to choose the graph class/type.
     """
     ltype=graph_description[0]
     name=graph_description[1]
@@ -115,7 +115,7 @@ def LCF_graph(n,shift_list,repeats,create_using=None):
     notation used in the generation of various cubic Hamiltonian
     graphs of high symmetry. See, for example, dodecahedral_graph,
     desargues_graph, heawood_graph and pappus_graph below.
-    
+
     n (number of nodes)
       The starting graph is the n-cycle with nodes 0,...,n-1.
       (The null graph is returned if n < 0.)
@@ -130,18 +130,18 @@ def LCF_graph(n,shift_list,repeats,create_using=None):
     For v1 cycling through the n-cycle a total of k*repeats
     with shift cycling through shiftlist repeats times connect
     v1 with v1+shift mod n
-          
+
     The utility graph K_{3,3}
 
     >>> G=nx.LCF_graph(6,[3,-3],3)
-    
+
     The Heawood graph
 
     >>> G=nx.LCF_graph(14,[5,-5],7)
 
     See http://mathworld.wolfram.com/LCFNotation.html for a description
     and references.
-    
+
     """
     if create_using is not None and create_using.is_directed():
         raise NetworkXError("Directed Graph not supported")
@@ -154,7 +154,7 @@ def LCF_graph(n,shift_list,repeats,create_using=None):
     G.name="LCF_graph"
     nodes = list(G)
 
-    n_extra_edges=repeats*len(shift_list)    
+    n_extra_edges=repeats*len(shift_list)
     # edges are added n_extra_edges times
     # (not all of these need be new)
     if n_extra_edges < 1:
@@ -285,18 +285,18 @@ def icosahedral_graph(create_using=None):
         ]
     G=make_small_undirected_graph(description, create_using)
     return G
-    
+
 
 def krackhardt_kite_graph(create_using=None):
     """
     Return the Krackhardt Kite Social Network.
- 
+
     A 10 actor social network introduced by David Krackhardt
-    to illustrate: degree, betweenness, centrality, closeness, etc. 
+    to illustrate: degree, betweenness, centrality, closeness, etc.
     The traditional labeling is:
     Andre=1, Beverley=2, Carol=3, Diane=4,
     Ed=5, Fernando=6, Garth=7, Heather=8, Ike=9, Jane=10.
-    
+
     """
     description=[
         "adjacencylist",
@@ -312,7 +312,7 @@ def moebius_kantor_graph(create_using=None):
     """Return the Moebius-Kantor graph."""
     G=LCF_graph(16, [5,-5], 8, create_using)
     G.name="Moebius-Kantor Graph"
-    return G    
+    return G
 
 def octahedral_graph(create_using=None):
     """Return the Platonic Octahedral graph."""
@@ -324,7 +324,7 @@ def octahedral_graph(create_using=None):
         ]
     G=make_small_undirected_graph(description, create_using)
     return G
-    
+
 def pappus_graph():
     """ Return the Pappus graph."""
     G=LCF_graph(18,[5,7,-7,7,-7,-5],3)
@@ -351,7 +351,7 @@ def sedgewick_maze_graph(create_using=None):
     This is the maze used in Sedgewick,3rd Edition, Part 5, Graph
     Algorithms, Chapter 18, e.g. Figure 18.2 and following.
     Nodes are numbered 0,..,7
-    """ 
+    """
     G=empty_graph(0, create_using)
     G.add_nodes_from(range(8))
     G.add_edges_from([[0,2],[0,7],[0,5]])

--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -101,7 +101,7 @@ def davis_southern_women_graph():
 
     References
     ----------
-    .. [1] A. Davis, Gardner, B. B., Gardner, M. R., 1941. Deep South.    
+    .. [1] A. Davis, Gardner, B. B., Gardner, M. R., 1941. Deep South.
         University of Chicago Press, Chicago, IL.
     """
     G = nx.Graph()
@@ -237,12 +237,12 @@ def davis_southern_women_graph():
 
 def florentine_families_graph():
     """Return Florentine families graph.
-    
+
     References
     ----------
     .. [1] Ronald L. Breiger and Philippa E. Pattison
        Cumulated social roles: The duality of persons and their algebras,1
-       Social Networks, Volume 8, Issue 3, September 1986, Pages 215-256 
+       Social Networks, Volume 8, Issue 3, September 1986, Pages 215-256
     """
     G=nx.Graph()
     G.add_edge('Acciaiuoli','Medici')

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -3,31 +3,31 @@ from nose.tools import *
 
 def test_random_partition_graph():
     G = nx.random_partition_graph([3,3,3],1,0)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(C,[set([0,1,2]), set([3,4,5]), set([6,7,8])])
     assert_equal(len(G),9)
     assert_equal(len(list(G.edges())),9)
 
     G = nx.random_partition_graph([3,3,3],0,1)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(C,[set([0,1,2]), set([3,4,5]), set([6,7,8])])
     assert_equal(len(G),9)
     assert_equal(len(list(G.edges())),27)
 
     G = nx.random_partition_graph([3,3,3],1,0,directed=True)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(C,[set([0,1,2]), set([3,4,5]), set([6,7,8])])
     assert_equal(len(G),9)
     assert_equal(len(list(G.edges())),18)
 
     G = nx.random_partition_graph([3,3,3],0,1,directed=True)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(C,[set([0,1,2]), set([3,4,5]), set([6,7,8])])
     assert_equal(len(G),9)
     assert_equal(len(list(G.edges())),54)
 
     G = nx.random_partition_graph([1,2,3,4,5], 0.5, 0.1)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(C,[set([0]), set([1,2]), set([3,4,5]),
                     set([6,7,8,9]), set([10,11,12,13,14])])
     assert_equal(len(G),15)
@@ -39,13 +39,13 @@ def test_random_partition_graph():
 
 def test_planted_partition_graph():
     G = nx.planted_partition_graph(4,3,1,0)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(len(C),4)
     assert_equal(len(G),12)
     assert_equal(len(list(G.edges())),12)
 
     G = nx.planted_partition_graph(4,3,0,1)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(len(C),4)
     assert_equal(len(G),12)
     assert_equal(len(list(G.edges())),54)
@@ -57,19 +57,19 @@ def test_planted_partition_graph():
     assert_equal(len(list(G.edges())),108)
 
     G = nx.planted_partition_graph(4,3,1,0,directed=True)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(len(C),4)
     assert_equal(len(G),12)
     assert_equal(len(list(G.edges())),24)
 
     G = nx.planted_partition_graph(4,3,0,1,directed=True)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(len(C),4)
     assert_equal(len(G),12)
     assert_equal(len(list(G.edges())),108)
 
     G = nx.planted_partition_graph(10,4,.5,.1,seed=42,directed=True)
-    C = G.graph['partition'] 
+    C = G.graph['partition']
     assert_equal(len(C),10)
     assert_equal(len(G),40)
     assert_equal(len(list(G.edges())),218)
@@ -78,7 +78,7 @@ def test_planted_partition_graph():
     assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3,-0.1, 0.1)
     assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3, 0.1, 1.1)
     assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3, 0.1,-0.1)
-    
+
 def test_relaxed_caveman_graph():
     G = nx.relaxed_caveman_graph(4, 3, 0)
     assert_equal(len(G), 12)
@@ -90,7 +90,7 @@ def test_relaxed_caveman_graph():
 def test_connected_caveman_graph():
     G = nx.connected_caveman_graph(4,3)
     assert_equal(len(G),12)
-    
+
     G = nx.connected_caveman_graph(1,5)
     K5 = nx.complete_graph(5)
     K5.remove_edge(3,4)
@@ -99,7 +99,7 @@ def test_connected_caveman_graph():
 def test_caveman_graph():
     G = nx.caveman_graph(4,3)
     assert_equal(len(G),12)
-    
+
     G = nx.caveman_graph(1,5)
     K5 = nx.complete_graph(5)
     assert_true(nx.is_isomorphic(G,K5))

--- a/networkx/generators/tests/test_ego.py
+++ b/networkx/generators/tests/test_ego.py
@@ -28,10 +28,10 @@ class TestGeneratorEgo():
 
 
     def test_ego_distance(self):
-        G=nx.Graph()                                                            
+        G=nx.Graph()
         G.add_edge(0,1,weight=2,distance=1)
         G.add_edge(1,2,weight=2,distance=2)
-        G.add_edge(2,3,weight=2,distance=1) 
+        G.add_edge(2,3,weight=2,distance=1)
         assert_nodes_equal(nx.ego_graph(G,0,radius=3).nodes(),[0,1,2,3])
         eg=nx.ego_graph(G,0,radius=3,distance='weight')
         assert_nodes_equal(eg.nodes(),[0,1])

--- a/networkx/generators/tests/test_random_clustered.py
+++ b/networkx/generators/tests/test_random_clustered.py
@@ -6,15 +6,15 @@ class TestRandomClusteredGraph:
 
     def test_valid(self):
         node=[1,1,1,2,1,2,0,0]
-        tri=[0,0,0,0,0,1,1,1]  
+        tri=[0,0,0,0,0,1,1,1]
         joint_degree_sequence=zip(node,tri)
         G = networkx.random_clustered_graph(joint_degree_sequence)
         assert_equal(G.number_of_nodes(),8)
         assert_equal(G.number_of_edges(),7)
-        
+
     def test_valid2(self):
         G = networkx.random_clustered_graph(\
-            [(1,2),(2,1),(1,1),(1,1),(1,1),(2,0)])        
+            [(1,2),(2,1),(1,1),(1,1),(1,1),(2,0)])
         assert_equal(G.number_of_nodes(),6)
         assert_equal(G.number_of_edges(),10)
 
@@ -25,4 +25,4 @@ class TestRandomClusteredGraph:
     def test_invalid2(self):
         assert_raises((TypeError,networkx.NetworkXError),
                       networkx.random_clustered_graph,[[1,1],[1,2],[0,1]])
-    
+

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -64,7 +64,7 @@ class TestGeneratorsSmall():
         assert_equal(G.number_of_nodes(), 20)
         assert_equal(G.number_of_edges(), 30)
         assert_equal(list(d for n, d in G.degree()), 20 * [3])
-        
+
         G=diamond_graph()
         assert_equal(G.number_of_nodes(), 4)
         assert_equal(sorted(d for n, d in G.degree()), [2, 2, 3, 3])

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -8,19 +8,19 @@ import networkx as nx
 
 def _node_value(G, node_attr):
     """Returns a function that returns a value from G.node[u].
-    
+
     We return a function expecting a node as its sole argument. Then, in the
     simplest scenario, the returned function will return G.node[u][node_attr].
-    However, we also handle the case when `node_attr` is None or when it is a 
+    However, we also handle the case when `node_attr` is None or when it is a
     function itself.
 
     Parameters
     ----------
     G : graph
-        A NetworkX graph 
+        A NetworkX graph
 
     node_attr : {None, str, callable}
-        Specification of how the value of the node attribute should be obtained 
+        Specification of how the value of the node attribute should be obtained
         from the node attribute dictionary.
 
     Returns
@@ -49,8 +49,8 @@ def _edge_value(G, edge_attr):
     """Returns a function that returns a value from G[u][v].
 
     Suppose there exists an edge between u and v.  Then we return a function
-    expecting u and v as arguments.  For Graph and DiGraph, G[u][v] is 
-    the edge attribute dictionary, and the function (essentially) returns 
+    expecting u and v as arguments.  For Graph and DiGraph, G[u][v] is
+    the edge attribute dictionary, and the function (essentially) returns
     G[u][v][edge_attr].  However, we also handle cases when `edge_attr` is None
     and when it is a function itself. For MultiGraph and MultiDiGraph, G[u][v]
     is a dictionary of all edges between u and v.  In this case, the returned
@@ -59,18 +59,18 @@ def _edge_value(G, edge_attr):
     Parameters
     ----------
     G : graph
-       A NetworkX graph 
+       A NetworkX graph
 
     edge_attr : {None, str, callable}
-        Specification of how the value of the edge attribute should be obtained 
+        Specification of how the value of the edge attribute should be obtained
         from the edge attribute dictionary, G[u][v].  For multigraphs, G[u][v]
-        is a dictionary of all the edges between u and v.  This allows for 
+        is a dictionary of all the edges between u and v.  This allows for
         special treatment of multiedges.
 
     Returns
     -------
     value : function
-        A function expecting two nodes as parameters. The nodes should 
+        A function expecting two nodes as parameters. The nodes should
         represent the from- and to- node of an edge. The function will
         return a value from G[u][v] that depends on `edge_attr`.
 
@@ -99,11 +99,11 @@ def _edge_value(G, edge_attr):
                 value = lambda u,v: sum([d[edge_attr] for d in G[u][v].values()])
             else:
                 value = lambda u,v: G[u][v][edge_attr]
-            
+
     else:
         # Advanced:  Allow users to specify something else.
         #
-        # Alternative default value:  
+        # Alternative default value:
         #     edge_attr = lambda u,v: G[u][v].get('thickness', .5)
         #
         # Function on an attribute:
@@ -119,7 +119,7 @@ def _edge_value(G, edge_attr):
 
     return value
 
-def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False, 
+def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
                 rc_order=None, dtype=None, order=None):
     """Returns a NumPy matrix using attributes from G.
 
@@ -128,9 +128,9 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
     Let A be a discrete set of values for the node attribute `node_attr`. Then
     the elements of A represent the rows and columns of the constructed matrix.
     Now, iterate through every edge e=(u,v) in `G` and consider the value
-    of the edge attribute `edge_attr`.  If ua and va are the values of the 
+    of the edge attribute `edge_attr`.  If ua and va are the values of the
     node attribute `node_attr` for u and v, respectively, then the value of
-    the edge attribute is added to the matrix element at (ua, va). 
+    the edge attribute is added to the matrix element at (ua, va).
 
     Parameters
     ----------
@@ -140,26 +140,26 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
     edge_attr : str, optional
         Each element of the matrix represents a running total of the
         specified edge attribute for edges whose node attributes correspond
-        to the rows/cols of the matirx. The attribute must be present for 
+        to the rows/cols of the matirx. The attribute must be present for
         all edges in the graph. If no attribute is specified, then we
         just count the number of edges whose node attributes correspond
-        to the matrix element.        
+        to the matrix element.
 
     node_attr : str, optional
         Each row and column in the matrix represents a particular value
         of the node attribute.  The attribute must be present for all nodes
         in the graph. Note, the values of this attribute should be reliably
-        hashable. So, float values are not recommended. If no attribute is 
+        hashable. So, float values are not recommended. If no attribute is
         specified, then the rows and columns will be the nodes of the graph.
 
     normalized : bool, optional
         If True, then each row is normalized by the summation of its values.
 
     rc_order : list, optional
-        A list of the node attribute values. This list specifies the ordering 
+        A list of the node attribute values. This list specifies the ordering
         of rows and columns of the array. If no ordering is provided, then
         the ordering will be random (and also, a return value).
-    
+
     Other Parameters
     ----------------
     dtype : NumPy data-type, optional
@@ -180,7 +180,7 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
 
     ordering : list
         If `rc_order` was specified, then only the matrix is returned.
-        However, if `rc_order` was None, then the ordering used to construct 
+        However, if `rc_order` was None, then the ordering used to construct
         the matrix is returned as well.
 
     Examples
@@ -204,10 +204,10 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
             [ 2.,  3.,  0.]])
 
     We can also color the nodes and ask for the probability distribution over
-    all edges (u,v) describing:  
-            
+    all edges (u,v) describing:
+
         Pr(v has color Y | u has color X)
-    
+
     >>> G.node[0]['color'] = 'red'
     >>> G.node[1]['color'] = 'red'
     >>> G.node[2]['color'] = 'blue'
@@ -253,7 +253,7 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
         ordering = rc_order
 
     N = len(ordering)
-    undirected = not G.is_directed()   
+    undirected = not G.is_directed()
     index = dict(zip(ordering, range(N)))
     M = np.zeros((N,N), dtype=dtype, order=order)
 
@@ -268,7 +268,7 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
                     M[j,i] = M[i,j]
 
         if undirected:
-            seen.add(u)    
+            seen.add(u)
 
     if normalized:
         M /= M.sum(axis=1).reshape((N,1))
@@ -280,7 +280,7 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
     else:
         return M
 
-def attr_sparse_matrix(G, edge_attr=None, node_attr=None, 
+def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
                        normalized=False, rc_order=None, dtype=None):
     """Returns a SciPy sparse matrix using attributes from G.
 
@@ -289,9 +289,9 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
     Let A be a discrete set of values for the node attribute `node_attr`. Then
     the elements of A represent the rows and columns of the constructed matrix.
     Now, iterate through every edge e=(u,v) in `G` and consider the value
-    of the edge attribute `edge_attr`.  If ua and va are the values of the 
+    of the edge attribute `edge_attr`.  If ua and va are the values of the
     node attribute `node_attr` for u and v, respectively, then the value of
-    the edge attribute is added to the matrix element at (ua, va). 
+    the edge attribute is added to the matrix element at (ua, va).
 
     Parameters
     ----------
@@ -301,26 +301,26 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
     edge_attr : str, optional
         Each element of the matrix represents a running total of the
         specified edge attribute for edges whose node attributes correspond
-        to the rows/cols of the matirx. The attribute must be present for 
+        to the rows/cols of the matirx. The attribute must be present for
         all edges in the graph. If no attribute is specified, then we
         just count the number of edges whose node attributes correspond
-        to the matrix element.        
+        to the matrix element.
 
     node_attr : str, optional
         Each row and column in the matrix represents a particular value
         of the node attribute.  The attribute must be present for all nodes
         in the graph. Note, the values of this attribute should be reliably
-        hashable. So, float values are not recommended. If no attribute is 
+        hashable. So, float values are not recommended. If no attribute is
         specified, then the rows and columns will be the nodes of the graph.
 
     normalized : bool, optional
         If True, then each row is normalized by the summation of its values.
 
     rc_order : list, optional
-        A list of the node attribute values. This list specifies the ordering 
+        A list of the node attribute values. This list specifies the ordering
         of rows and columns of the array. If no ordering is provided, then
         the ordering will be random (and also, a return value).
-    
+
     Other Parameters
     ----------------
     dtype : NumPy data-type, optional
@@ -336,7 +336,7 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
 
     ordering : list
         If `rc_order` was specified, then only the matrix is returned.
-        However, if `rc_order` was None, then the ordering used to construct 
+        However, if `rc_order` was None, then the ordering used to construct
         the matrix is returned as well.
 
     Examples
@@ -362,10 +362,10 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
             [ 2.,  3.,  0.]])
 
     We can also color the nodes and ask for the probability distribution over
-    all edges (u,v) describing:  
-            
+    all edges (u,v) describing:
+
         Pr(v has color Y | u has color X)
-    
+
     >>> G.node[0]['color'] = 'red'
     >>> G.node[1]['color'] = 'red'
     >>> G.node[2]['color'] = 'blue'
@@ -416,7 +416,7 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
         ordering = rc_order
 
     N = len(ordering)
-    undirected = not G.is_directed()   
+    undirected = not G.is_directed()
     index = dict(zip(ordering, range(N)))
     M = sparse.lil_matrix((N,N), dtype=dtype)
 
@@ -431,12 +431,12 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
                     M[j,i] = M[i,j]
 
         if undirected:
-            seen.add(u)    
+            seen.add(u)
 
     if normalized:
         norms = np.asarray(M.sum(axis=1)).ravel()
         for i,norm in enumerate(norms):
-            M[i,:] /= norm 
+            M[i,:] /= norm
 
     if rc_order is None:
         return M, ordering

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -127,7 +127,7 @@ def adjacency_matrix(G, nodelist=None, weight='weight'):
     Notes
     -----
     For directed graphs, entry i,j corresponds to an edge from i to j.
-    
+
     If you want a pure Python adjacency matrix representation try
     networkx.convert.to_dict_of_dicts which will return a
     dictionary-of-dictionaries format that can be addressed as a

--- a/networkx/linalg/modularitymatrix.py
+++ b/networkx/linalg/modularitymatrix.py
@@ -28,8 +28,8 @@ def modularity_matrix(G, nodelist=None, weight=None):
     More specifically, the element B_ij of B is defined as
         A_ij - k_i k_j / 2 * m
     where k_i(in) is the degree of node i, and were m is the number of edges
-    in the graph. When weight is set to a name of an attribute edge, Aij, k_i, 
-    k_j and m are computed using its value. 
+    in the graph. When weight is set to a name of an attribute edge, Aij, k_i,
+    k_j and m are computed using its value.
 
     Parameters
     ----------
@@ -39,7 +39,7 @@ def modularity_matrix(G, nodelist=None, weight=None):
     nodelist : list, optional
        The rows and columns are ordered according to the nodes in nodelist.
        If nodelist is None, then the ordering is produced by G.nodes().
-    
+
     weight : string or None, optional (default=None)
        The edge attribute that holds the numerical value used for
        the edge weight.  If None then all edge weights are 1.
@@ -138,7 +138,7 @@ def directed_modularity_matrix(G, nodelist=None, weight=None):
 
     References
     ----------
-    .. [1] E. A. Leicht, M. E. J. Newman, 
+    .. [1] E. A. Leicht, M. E. J. Newman,
        "Community structure in directed networks",
         Phys. Rev Lett., vol. 100, no. 11, p. 118703, 2008.
     """

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -82,7 +82,7 @@ def generate_adjlist(G, delimiter=' '):
             if not directed and t in seen:
                 continue
             if G.is_multigraph():
-                for d in data.values():
+                for _ in data.values():
                     line += make_str(t) + delimiter
             else:
                 line += make_str(t) + delimiter

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -4,7 +4,7 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from itertools import chain, count
+from itertools import chain
 import networkx as nx
 __author__ = """Aric Hagberg <aric.hagberg@gmail.com>"""
 __all__ = ['adjacency_data', 'adjacency_graph']

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -1,10 +1,10 @@
 #    Copyright (C) 2011-2016 by
-# 
+#
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    Michael E. Rose <Michael.Ernst.Rose@gmail.com>
-#    
+#
 #    All rights reserved.
 #    BSD license.
 from itertools import chain, count
@@ -55,7 +55,7 @@ def node_link_data(G, attrs=None):
     >>> G = nx.Graph([('A', 'B')])
     >>> data1 = json_graph.node_link_data(G)
     >>> H = nx.gn_graph(2)
-    >>> data2 = json_graph.node_link_data(H, {'link': 'edges', 'source': 'from', 'target': 'to'})    
+    >>> data2 = json_graph.node_link_data(H, {'link': 'edges', 'source': 'from', 'target': 'to'})
 
     To serialize with json
 

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -20,7 +20,7 @@ __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
 
 __all__ = ['read_leda', 'parse_leda']
 
-import networkx as nx 
+import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils import open_file, is_string_like
 
@@ -31,7 +31,7 @@ def read_leda(path, encoding='UTF-8'):
     Parameters
     ----------
     path : file or string
-       File or filename to read.  Filenames ending in .gz or .bz2  will be 
+       File or filename to read.  Filenames ending in .gz or .bz2  will be
        uncompressed.
 
     Returns
@@ -41,7 +41,7 @@ def read_leda(path, encoding='UTF-8'):
     Examples
     --------
     G=nx.read_leda('file.leda')
- 
+
     References
     ----------
     .. [1] http://www.algorithmic-solutions.info/leda_guide/graphs/leda_native_graph_fileformat.html
@@ -66,7 +66,7 @@ def parse_leda(lines):
     Examples
     --------
     G=nx.parse_leda(string)
- 
+
     References
     ----------
     .. [1] http://www.algorithmic-solutions.info/leda_guide/graphs/leda_native_graph_fileformat.html
@@ -82,7 +82,7 @@ def parse_leda(lines):
         G = nx.DiGraph()
     else:
         G = nx.Graph()
-        
+
     # Nodes
     n =int(next(lines)) # number of nodes
     node={}
@@ -92,7 +92,7 @@ def parse_leda(lines):
         node[i]=symbol
 
     G.add_nodes_from([s for i,s in node.items()])
-	
+
     # Edges
     m = int(next(lines)) # number of edges
     for i in range(m):
@@ -103,4 +103,3 @@ def parse_leda(lines):
         # BEWARE: no handling of reversal edges
         G.add_edge(node[int(s)],node[int(t)],label=label[2:-2])
     return G
-

--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -4,7 +4,7 @@ YAML
 ****
 Read and write NetworkX graphs in YAML format.
 
-"YAML is a data serialization format designed for human readability 
+"YAML is a data serialization format designed for human readability
 and interaction with scripting languages."
 See http://www.yaml.org for documentation.
 
@@ -28,9 +28,9 @@ from networkx.utils import open_file
 
 @open_file(1,mode='w')
 def write_yaml(G, path, encoding='UTF-8', **kwds):
-    """Write graph G in YAML format to path. 
+    """Write graph G in YAML format to path.
 
-    YAML is a data serialization format designed for human readability 
+    YAML is a data serialization format designed for human readability
     and interaction with scripting languages [1]_.
 
     Parameters
@@ -38,7 +38,7 @@ def write_yaml(G, path, encoding='UTF-8', **kwds):
     G : graph
        A NetworkX graph
     path : file or string
-       File or filename to write. 
+       File or filename to write.
        Filenames ending in .gz or .bz2 will be compressed.
     encoding: string, optional
        Specify which encoding to use when writing file.
@@ -57,18 +57,18 @@ def write_yaml(G, path, encoding='UTF-8', **kwds):
     except ImportError:
         raise ImportError("write_yaml() requires PyYAML: http://pyyaml.org/")
     yaml.dump(G, path, **kwds)
-    
+
 @open_file(0,mode='r')
 def read_yaml(path):
     """Read graph in YAML format from path.
 
-    YAML is a data serialization format designed for human readability 
+    YAML is a data serialization format designed for human readability
     and interaction with scripting languages [1]_.
 
     Parameters
     ----------
     path : file or string
-       File or filename to read.  Filenames ending in .gz or .bz2 
+       File or filename to read.  Filenames ending in .gz or .bz2
        will be uncompressed.
 
     Returns
@@ -80,7 +80,7 @@ def read_yaml(path):
     >>> G=nx.path_graph(4)
     >>> nx.write_yaml(G,'test.yaml')
     >>> G=nx.read_yaml('test.yaml')
- 
+
     References
     ----------
     .. [1] http://www.yaml.org

--- a/networkx/readwrite/p2g.py
+++ b/networkx/readwrite/p2g.py
@@ -1,5 +1,5 @@
 """
-This module provides the following: read and write of p2g format 
+This module provides the following: read and write of p2g format
 used in metabolic pathway studies.
 
 See http://www.cs.purdue.edu/homes/koyuturk/pathway/ for a description.
@@ -31,18 +31,21 @@ edges. Observe that node labeled "c" has an outgoing edge to
 itself. Indeed, self-loops are allowed. Node index starts from 0.
 
 """
-#    Copyright (C) 2008-2012 by 
+#    Copyright (C) 2008-2012 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-import networkx
-from networkx.utils import is_string_like,open_file
-__author__ = '\n'.join(['Willem Ligtenberg (w.p.a.ligtenberg@tue.nl)',
-                      'Aric Hagberg (aric.hagberg@gmail.com)'])
 
-@open_file(1,mode='w')
+from __future__ import print_function
+
+import networkx
+from networkx.utils import open_file
+__author__ = '\n'.join(['Willem Ligtenberg (w.p.a.ligtenberg@tue.nl)',
+                        'Aric Hagberg (aric.hagberg@gmail.com)'])
+
+@open_file(1, mode='w')
 def write_p2g(G, path, encoding = 'utf-8'):
     """Write NetworkX graph in p2g format.
 
@@ -51,20 +54,20 @@ def write_p2g(G, path, encoding = 'utf-8'):
     This format is meant to be used with directed graphs with
     possible self loops.
     """
-    path.write(("%s\n"%G.name).encode(encoding))
-    path.write(("%s %s\n"%(G.order(),G.size())).encode(encoding))
+    path.write(("%s\n" % G.name).encode(encoding))
+    path.write(("%s %s\n" % (G.order(), G.size())).encode(encoding))
     nodes = list(G)
     # make dictionary mapping nodes to integers
-    nodenumber=dict(zip(nodes,range(len(nodes)))) 
+    nodenumber = dict(zip(nodes, range(len(nodes))))
     for n in nodes:
-        path.write(("%s\n"%n).encode(encoding))
+        path.write(("%s\n" % n).encode(encoding))
         for nbr in G.neighbors(n):
-            path.write(("%s "%nodenumber[nbr]).encode(encoding))
+            path.write(("%s" % nodenumber[nbr]).encode(encoding))
         path.write("\n".encode(encoding))
 
-@open_file(0,mode='r')
+@open_file(0, mode='r')
 def read_p2g(path, encoding='utf-8'):
-    """Read graph in p2g format from path. 
+    """Read graph in p2g format from path.
 
     Returns
     -------
@@ -76,11 +79,11 @@ def read_p2g(path, encoding='utf-8'):
     use D=networkx.DiGraph(read_p2g(path))
     """
     lines = (line.decode(encoding) for line in path)
-    G=parse_p2g(lines)
+    G = parse_p2g(lines)
     return G
 
 def parse_p2g(lines):
-    """Parse p2g format graph from string or iterable. 
+    """Parse p2g format graph from string or iterable.
 
     Returns
     -------
@@ -88,20 +91,21 @@ def parse_p2g(lines):
     """
     description = next(lines).strip()
     # are multiedges (parallel edges) allowed?
-    G=networkx.MultiDiGraph(name=description,selfloops=True)
-    nnodes,nedges=map(int,next(lines).split())
-    nodelabel={}
-    nbrs={}
+    G = networkx.MultiDiGraph(name=description, selfloops=True)
+    nnodes, nedges = map(int, next(lines).split())
+    nodelabel = {}
+    nbrs = {}
     # loop over the nodes keeping track of node labels and out neighbors
     # defer adding edges until all node labels are known
     for i in range(nnodes):
-        n=next(lines).strip()
-        nodelabel[i]=n
+        n = next(lines).strip()
+        nodelabel[i] = n
         G.add_node(n)
-        nbrs[n]=map(int,next(lines).split())
+        nbrs[n] = map(int, next(lines).split())
+        print(nbrs[n])
     # now we know all of the node labels so we can add the edges
-    # with the correct labels        
+    # with the correct labels
     for n in G:
         for nbr in nbrs[n]:
-            G.add_edge(n,nodelabel[nbr])
+            G.add_edge(n, nodelabel[nbr])
     return G

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -7,7 +7,7 @@ from nose.tools import assert_equal, assert_raises, assert_not_equal
 import os
 import tempfile
 import networkx as nx
-from networkx.testing import (assert_nodes_equal, assert_edges_equal, 
+from networkx.testing import (assert_nodes_equal, assert_edges_equal,
                                 assert_graphs_equal)
 
 

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -7,7 +7,7 @@ import tempfile
 import os
 
 import networkx as nx
-from networkx.testing import (assert_edges_equal, assert_nodes_equal, 
+from networkx.testing import (assert_edges_equal, assert_nodes_equal,
                                 assert_graphs_equal)
 
 
@@ -152,7 +152,7 @@ class TestEdgelist:
     def test_edgelist_graph(self):
         G=self.G
         (fd,fname)=tempfile.mkstemp()
-        nx.write_edgelist(G,fname)  
+        nx.write_edgelist(G,fname)
         H=nx.read_edgelist(fname)
         H2=nx.read_edgelist(fname)
         assert_not_equal(H,H2) # they should be different graphs
@@ -165,7 +165,7 @@ class TestEdgelist:
     def test_edgelist_digraph(self):
         G=self.DG
         (fd,fname)=tempfile.mkstemp()
-        nx.write_edgelist(G,fname) 
+        nx.write_edgelist(G,fname)
         H=nx.read_edgelist(fname,create_using=nx.DiGraph())
         H2=nx.read_edgelist(fname,create_using=nx.DiGraph())
         assert_not_equal(H,H2) # they should be different graphs
@@ -178,7 +178,7 @@ class TestEdgelist:
     def test_edgelist_integers(self):
         G=nx.convert_node_labels_to_integers(self.G)
         (fd,fname)=tempfile.mkstemp()
-        nx.write_edgelist(G,fname)  
+        nx.write_edgelist(G,fname)
         H=nx.read_edgelist(fname,nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
@@ -190,7 +190,7 @@ class TestEdgelist:
     def test_edgelist_digraph(self):
         G=self.DG
         (fd,fname)=tempfile.mkstemp()
-        nx.write_edgelist(G,fname)  
+        nx.write_edgelist(G,fname)
         H=nx.read_edgelist(fname,create_using=nx.DiGraph())
         G.remove_node('g') # isolated nodes are not written in edgelist
         H2=nx.read_edgelist(fname,create_using=nx.DiGraph())
@@ -203,7 +203,7 @@ class TestEdgelist:
     def test_edgelist_multigraph(self):
         G=self.XG
         (fd,fname)=tempfile.mkstemp()
-        nx.write_edgelist(G,fname) 
+        nx.write_edgelist(G,fname)
         H=nx.read_edgelist(fname,nodetype=int,create_using=nx.MultiGraph())
         H2=nx.read_edgelist(fname,nodetype=int,create_using=nx.MultiGraph())
         assert_not_equal(H,H2) # they should be different graphs
@@ -215,7 +215,7 @@ class TestEdgelist:
     def test_edgelist_multidigraph(self):
         G=self.XDG
         (fd,fname)=tempfile.mkstemp()
-        nx.write_edgelist(G,fname) 
+        nx.write_edgelist(G,fname)
         H=nx.read_edgelist(fname,nodetype=int,create_using=nx.MultiDiGraph())
         H2=nx.read_edgelist(fname,nodetype=int,create_using=nx.MultiDiGraph())
         assert_not_equal(H,H2) # they should be different graphs

--- a/networkx/readwrite/tests/test_leda.py
+++ b/networkx/readwrite/tests/test_leda.py
@@ -12,12 +12,12 @@ class TestLEDA(object):
         assert_equal(sorted(G.nodes()),
                      ['v1', 'v2', 'v3', 'v4', 'v5'])
         assert_equal(sorted(G.edges(data=True)),
-                     [('v1', 'v2', {'label': '4'}), 
-                      ('v1', 'v3', {'label': '3'}), 
-                      ('v2', 'v3', {'label': '2'}), 
-                      ('v3', 'v4', {'label': '3'}), 
-                      ('v3', 'v5', {'label': '7'}), 
-                      ('v4', 'v5', {'label': '6'}), 
+                     [('v1', 'v2', {'label': '4'}),
+                      ('v1', 'v3', {'label': '3'}),
+                      ('v2', 'v3', {'label': '2'}),
+                      ('v3', 'v4', {'label': '3'}),
+                      ('v3', 'v5', {'label': '7'}),
+                      ('v4', 'v5', {'label': '6'}),
                       ('v5', 'v1', {'label': 'foo'})])
 
 

--- a/networkx/readwrite/tests/test_p2g.py
+++ b/networkx/readwrite/tests/test_p2g.py
@@ -1,8 +1,6 @@
-from nose.tools import assert_equal, assert_raises, assert_not_equal
+from nose.tools import assert_equal
 import networkx as nx
 import io
-import tempfile
-import os
 from networkx.readwrite.p2g import *
 from networkx.testing import *
 
@@ -10,11 +8,11 @@ from networkx.testing import *
 class TestP2G:
 
     def setUp(self):
-        self.G=nx.Graph(name="test")
-        e=[('a','b'),('b','c'),('c','d'),('d','e'),('e','f'),('a','f')]
+        self.G = nx.Graph(name="test")
+        e = [('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'e'), ('e', 'f'), ('a', 'f')]
         self.G.add_edges_from(e)
         self.G.add_node('g')
-        self.DG=nx.DiGraph(self.G)
+        self.DG = nx.DiGraph(self.G)
 
     def test_read_p2g(self):
         s = b"""\
@@ -29,36 +27,35 @@ c
 """
         bytesIO = io.BytesIO(s)
         G = read_p2g(bytesIO)
-        assert_equal(G.name,'name')
-        assert_equal(sorted(G),['a','b','c'])
-        edges = [(str(u),str(v)) for u,v in G.edges()]
-        assert_edges_equal(G.edges(),[('a','c'),('a','b'),('c','a'),('c','c')])
+        assert_equal(G.name, 'name')
+        assert_equal(sorted(G), ['a', 'b', 'c'])
+        assert_edges_equal(G.edges(), [('a', 'c'), ('a', 'b'), ('c', 'a'), ('c', 'c')])
 
     def test_write_p2g(self):
-        s=b"""foo
+        s = b"""foo
 3 2
 1
-1 
+1
 2
-2 
+2
 3
 
 """
-        fh=io.BytesIO()
-        G=nx.DiGraph()
-        G.name='foo'
-        G.add_edges_from([(1,2),(2,3)])
-        write_p2g(G,fh)
+        fh = io.BytesIO()
+        G = nx.DiGraph()
+        G.name = 'foo'
+        G.add_edges_from([(1, 2), (2, 3)])
+        write_p2g(G, fh)
         fh.seek(0)
-        r=fh.read()
-        assert_equal(r,s)
+        r = fh.read()
+        assert_equal(r, s)
 
     def test_write_read_p2g(self):
-        fh=io.BytesIO()
-        G=nx.DiGraph()
-        G.name='foo'
-        G.add_edges_from([('a','b'),('b','c')])
-        write_p2g(G,fh)
+        fh = io.BytesIO()
+        G = nx.DiGraph()
+        G.name = 'foo'
+        G.add_edges_from([('a', 'b'), ('b', 'c')])
+        write_p2g(G, fh)
         fh.seek(0)
-        H=read_p2g(fh)
-        assert_edges_equal(G.edges(),H.edges())
+        H = read_p2g(fh)
+        assert_edges_equal(G.edges(), H.edges())

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -54,7 +54,7 @@ class TestShp(object):
 
         shp = drv.CreateDataSource(shppath)
         lyr = createlayer(shp)
- 
+
         for path, name in zip(self.paths, self.names):
             feat = ogr.Feature(lyr.GetLayerDefn())
             g = ogr.Geometry(ogr.wkbLineString)
@@ -67,10 +67,10 @@ class TestShp(object):
         # create single record multiline shapefile for testing
         multi_shp = drv.CreateDataSource(multi_shppath)
         multi_lyr = createlayer(multi_shp, ogr.wkbMultiLineString)
-         
+
         multi_g = ogr.Geometry(ogr.wkbMultiLineString)
         for path in self.paths:
-            
+
             g = ogr.Geometry(ogr.wkbLineString)
             for p in path:
                 g.AddPoint_2D(*p)
@@ -79,7 +79,7 @@ class TestShp(object):
 
         multi_feat = ogr.Feature(multi_lyr.GetLayerDefn())
         multi_feat.SetGeometry(multi_g)
-        multi_feat.SetField("Name", 'a') 
+        multi_feat.SetField("Name", 'a')
         multi_lyr.CreateFeature(multi_feat)
 
         self.shppath = shppath
@@ -97,12 +97,12 @@ class TestShp(object):
             assert_equal(sorted(expected.edges()), sorted(g.edges()))
             g_names = [g.get_edge_data(s, e)['Name'] for s, e in g.edges()]
             assert_equal(names, sorted(g_names))
-                
+
         # simplified
         G = nx.read_shp(self.shppath)
         compare_graph_paths_names(G, self.simplified_paths, \
                                     self.simplified_names)
-       
+
         # unsimplified
         G = nx.read_shp(self.shppath, simplify=False)
         compare_graph_paths_names(G, self.paths, self.names)
@@ -155,8 +155,8 @@ class TestShp(object):
         self.checkgeom(shpdir.GetLayerByName("nodes"), expectedpoints_simple)
         self.checkgeom(shpdir.GetLayerByName("edges"), expectedlines_simple)
 
-        # Test unsimplified 
-        # Nodes should have additional point, 
+        # Test unsimplified
+        # Nodes should have additional point,
         # edges should be 'flattened'
         G = nx.read_shp(self.shppath, simplify=False)
         nx.write_shp(G, tpath)

--- a/networkx/readwrite/tests/test_yaml.py
+++ b/networkx/readwrite/tests/test_yaml.py
@@ -42,7 +42,7 @@ class TestYaml(object):
 
         os.close(fd)
         os.unlink(fname)
-   
+
     def testUndirected(self):
         self.assert_equal(self.G, False)
 

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -1,6 +1,7 @@
 from nose.tools import assert_equal
 __all__ = ['assert_nodes_equal', 'assert_edges_equal','assert_graphs_equal']
 
+
 def assert_nodes_equal(nodes1, nodes2):
     # Assumes iterables of nodes, or (node,datadict) tuples
     nlist1 = list(nodes1)
@@ -13,6 +14,7 @@ def assert_nodes_equal(nodes1, nodes2):
         d2 = dict.fromkeys(nlist2)
     assert_equal(d1, d2)
 
+
 def assert_edges_equal(edges1, edges2):
     # Assumes iterables with u,v nodes as
     # edge tuples (u,v), or
@@ -22,14 +24,14 @@ def assert_edges_equal(edges1, edges2):
     d1 = defaultdict(dict)
     d2 = defaultdict(dict)
     c1 = 0
-    for c1,e in enumerate(edges1):
-        u,v = e[0],e[1]
+    for c1, e in enumerate(edges1):
+        u, v = e[0],e[1]
         data = e[2:]
         d1[u][v] = data
         d1[v][u] = data
     c2 = 0
     for c2,e in enumerate(edges2):
-        u,v = e[0],e[1]
+        u,v = e[0], e[1]
         data = e[2:]
         d2[u][v] = data
         d2[v][u] = data

--- a/networkx/tests/test.py
+++ b/networkx/tests/test.py
@@ -8,7 +8,7 @@ def run(verbosity=1,doctest=False,numpy=True):
     Parameters
     ----------
     verbosity: integer, optional
-      Level of detail in test reports.  Higher numbers provide  more detail.  
+      Level of detail in test reports.  Higher numbers provide  more detail.
 
     doctest: bool, optional
       True to run doctests in code modules

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -217,7 +217,7 @@ class TestConvert():
         assert_true(self.edgelists_equal(nx.Graph(nx.MultiDiGraph(edges2)).edges(),edges1))
 
     def test_attribute_dict_integrity(self):
-        # we must not replace dict-like graph data structures with dicts 
+        # we must not replace dict-like graph data structures with dicts
         G=OrderedGraph()
         G.add_nodes_from("abc")
         H=to_networkx_graph(G, create_using=OrderedGraph())

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -106,12 +106,12 @@ class TestConvertNumpy(object):
 
         # Make nodelist ambiguous by containing duplicates.
         nodelist += [nodelist[0]]
-        assert_raises(nx.NetworkXError, nx.to_numpy_matrix, P3, 
+        assert_raises(nx.NetworkXError, nx.to_numpy_matrix, P3,
                       nodelist=nodelist)
 
     def test_weight_keyword(self):
         WP4 = nx.Graph()
-        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3)) 
+        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3))
                             for n in range(3) )
         P4 = path_graph(4)
         A = nx.to_scipy_sparse_matrix(P4)

--- a/networkx/utils/random_sequence.py
+++ b/networkx/utils/random_sequence.py
@@ -1,5 +1,5 @@
 """
-Utilities for generating random numbers, random sequences, and 
+Utilities for generating random numbers, random sequences, and
 random selections.
 """
 #    Copyright (C) 2004-2016 by
@@ -37,7 +37,7 @@ def create_degree_sequence(n, sfunction=None, max_tries=50, **kwds):
     Repeatedly create a degree sequence by calling sfunction(n,**kwds)
     until achieving a valid degree sequence. If unsuccessful after
     max_tries attempts, raise an exception.
-    
+
     For examples of sfunctions that return sequences of random numbers,
     see networkx.Utils.
 
@@ -85,11 +85,11 @@ def zipf_rv(alpha, xmin=1, seed=None):
 
         p(x)=\frac{x^{-\alpha}}{\zeta(\alpha,x_{min})},
 
-    where `\zeta(\alpha,x_{min})` is the Hurwitz zeta function.        
+    where `\zeta(\alpha,x_{min})` is the Hurwitz zeta function.
 
     Parameters
     ----------
-    alpha : float 
+    alpha : float
       Exponent value of the distribution
     xmin : int
       Minimum value
@@ -119,7 +119,7 @@ def zipf_rv(alpha, xmin=1, seed=None):
 
     References
     ----------
-    ..[1] Luc Devroye, Non-Uniform Random Variate Generation, 
+    ..[1] Luc Devroye, Non-Uniform Random Variate Generation,
        Springer-Verlag, New York, 1986.
     """
     if xmin < 1:
@@ -163,18 +163,18 @@ def cumulative_distribution(distribution):
     psum=float(sum(distribution))
     for i in range(0,len(distribution)):
         cdf.append(cdf[i]+distribution[i]/psum)
-    return cdf        
+    return cdf
 
 
 def discrete_sequence(n, distribution=None, cdistribution=None):
     """
     Return sample sequence of length n from a given discrete distribution
-    or discrete cumulative distribution. 
+    or discrete cumulative distribution.
 
-    One of the following must be specified.  
+    One of the following must be specified.
 
     distribution = histogram of values, will be normalized
-    
+
     cdistribution = normalized discrete cumulative distribution
 
     """
@@ -187,7 +187,7 @@ def discrete_sequence(n, distribution=None, cdistribution=None):
     else:
         raise nx.NetworkXError(
                 "discrete_sequence: distribution or cdistribution missing")
-        
+
 
     # get a uniform random number
     inputseq=[random.random() for i in range(n)]

--- a/tools/gh_api.py
+++ b/tools/gh_api.py
@@ -23,28 +23,28 @@ class Obj(dict):
             return self[name]
         except KeyError:
             raise AttributeError(name)
-    
+
     def __setattr__(self, name, val):
         self[name] = val
 
 token = None
 def get_auth_token():
     global token
-    
+
     if token is not None:
         return token
-    
+
     import keyring
     token = keyring.get_password('github', fake_username)
     if token is not None:
         return token
-    
+
     print("Please enter your github username and password. These are not "
            "stored, only used to get an oAuth token. You can revoke this at "
            "any time on Github.")
     user = input("Username: ")
     pw = getpass.getpass("Password: ")
-    
+
     auth_request = {
       "scopes": [
         "public_repo",
@@ -79,13 +79,13 @@ def post_gist(content, description='', filename='file', auth=False):
         }
       }
     }).encode('utf-8')
-    
+
     headers = make_auth_header() if auth else {}
     response = requests.post("https://api.github.com/gists", data=post_data, headers=headers)
     response.raise_for_status()
     response_data = json.loads(response.text)
     return response_data['html_url']
-    
+
 def get_pull_request(project, num):
     """get pull request info  by number
     """
@@ -175,16 +175,16 @@ def post_download(project, filename, name=None, description=""):
         name = os.path.basename(filename)
     with open(filename, 'rb') as f:
         filedata = f.read()
-    
+
     url = "https://api.github.com/repos/{project}/downloads".format(project=project)
-    
+
     payload = json.dumps(dict(name=name, size=len(filedata),
                     description=description))
     response = requests.post(url, data=payload, headers=make_auth_header())
     response.raise_for_status()
     reply = json.loads(response.content)
     s3_url = reply['s3_url']
-    
+
     fields = dict(
         key=reply['path'],
         acl=reply['acl'],


### PR DESCRIPTION
Variables initialized and immediately reassigned

Unused imports

PyCharm generates quite a lot of warnings with the introspection. This pull requests addresses a tiny fraction of them to determine. Would it be feasible to include something like `flake8` in the CI test suites?
