### PR TITLE
ENH: Added feature delete_edge_attributes and delete_node_attributes

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -28,9 +28,9 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'is_directed', 'info', 'freeze', 'is_frozen', 'subgraph',
            'add_star', 'add_path', 'add_cycle',
            'create_empty_copy', 'set_node_attributes',
-           'get_node_attributes', 'set_edge_attributes',
-           'get_edge_attributes', 'all_neighbors', 'non_neighbors',
-           'non_edges', 'common_neighbors', 'is_weighted',
+           'get_node_attributes', 'set_edge_attributes', 'get_edge_attributes',
+           'delete_edge_attributes', 'delete_node_attributes', 'all_neighbors',
+           'non_neighbors', 'non_edges', 'common_neighbors', 'is_weighted',
            'is_negatively_weighted', 'is_empty']
 
 
@@ -535,6 +535,120 @@ def get_edge_attributes(G, name):
     else:
         edges = G.edges(data=True)
     return {x[:-1]: x[-1][name] for x in edges if name in x[-1]}
+
+
+def delete_edge_attributes(G, key, edges=None):
+    """Remove edge attributes from graph
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+
+    name : string or list
+       Attribute name or list of attribute names
+
+    edges : list, optional
+       If specified removes attributes from all edges otherwise only removes
+       attributes from the subset of edges specified.
+
+    Returns
+    -------
+    The number of edge attributes removed
+
+    Examples
+    --------
+    >>> G=nx.Graph()
+    >>> nx.add_path(G, [1, 2, 3], color='red')
+    >>> nx.delete_edge_attributes(G, 'color', [(3, 2)])
+    1
+    >>> G.edge[1]
+    {2: {'color': u'red'}}
+    >>> G.edge[3]
+    {2: {}}
+
+    >>> G=nx.Graph()
+    >>> nx.add_path(G, [1, 2, 3], color='red')
+    >>> nx.delete_edge_attributes(G, 'color')
+    2
+    >>> G.edge[1]
+    {2: {}}
+    """
+    n_removed = 0
+    # Ensure keys are specified in a list
+    keys = [key] if not isinstance(key, list) else key
+    if edges is None:
+        # Get all edges if a subset is not specified
+        edges = list(G.edges(keys=G.is_multigraph()))
+    if G.is_multigraph():
+        for key in keys:
+            for edge in edges:
+                u, v, k = edge
+                try:
+                    del G[u][v][k][key]
+                    n_removed += 1
+                except KeyError:
+                    pass
+    else:
+        for key in keys:
+            for edge in edges:
+                u, v = edge
+                try:
+                    del G[u][v][key]
+                    n_removed += 1
+                except KeyError:
+                    pass
+    return n_removed
+
+
+def delete_node_attributes(graph, key, nodes=None):
+    """Remove node attributes from graph
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+
+    name : string or list
+       Attribute name or list of attribute names
+
+    nodes : list, optional
+       If specified removes attributes from all nodes otherwise only removes
+       attributes from the subset of nodes specified.
+
+    Returns
+    -------
+    The number of node attributes removed
+
+    Examples
+    --------
+    >>> G=nx.Graph()
+    >>> G.add_nodes_from([1, 2, 3], color='red')
+    >>> nx.delete_node_attributes(G, 'color', [2])
+    1
+    >>> G.node
+    {1: {'color': u'red'}, 2: {}, 3: {'color': u'red'}}
+
+    >>> G=nx.Graph()
+    >>> G.add_nodes_from([1, 2, 3], color='red')
+    >>> G.node
+    {1: {'color': u'red'}, 2: {'color': u'red'}, 3: {'color': u'red'}}
+    >>> nx.delete_node_attributes(G, 'color')
+    3
+    >>> G.node
+    {1: {}, 2: {}, 3: {}}
+    """
+    removed = 0
+    keys = [key] if not isinstance(key, list) else key
+    if nodes is None:
+        # Get all nodes if subset is not specified
+        nodes = list(graph.nodes())
+    for key in keys:
+        for node in nodes:
+            try:
+                del graph.node[node][key]
+                removed += 1
+            except KeyError:
+                pass
+    return removed
 
 
 def all_neighbors(graph, node):


### PR DESCRIPTION
In one of my projects I have to maintain a graph with lots of dynamic state. Its often convenient to be able to remove attributes entirely from a graph instead of having set the attribute to None. It makes debugging much easier as extra keys don't get in the way if they've been deleted.

I initially made an internal helper function to get this functionality following the discussion in https://groups.google.com/forum/#!topic/networkx-discuss/S-rIdrNNrUY 

It seems like this may be something that the official library would want to support, hence the pull request. 

The added functions work similarly to get_*_attributes and set_*_attributes. Except they are not delete_*_attributes. But perhaps they may be better named as del_*_attributes?

Also, there is a question of implementation in delete_edge_attributes. The implementation in my commit differentiates between the multigraph and non-multigraph inputs. However, the following code should be universal to both:

```python
    for edge in edges:
        d = G
        for p in edge[:-1]:
            d = d[p]
        del d[edge[-1]]
```

However, it seems a bit more obfuscated, which is why I went with the more explicit implementation. 


Any comments? If this feature is wanted I can make any requested changes and add the appropriate tests. If not, then feel free to close the PR. 