### PR TITLE
Makes write_graph6 less memory-intensive.

### DIFF
--- a/doc/source/reference/readwrite.sparsegraph6.rst
+++ b/doc/source/reference/readwrite.sparsegraph6.rst
@@ -23,9 +23,9 @@ Graph6
 .. autosummary::
    :toctree: generated/
 
-   parse_graph6
+   from_graph6_bytes
    read_graph6
-   generate_graph6
+   to_graph6_bytes
    write_graph6
 
 Sparse6
@@ -34,8 +34,7 @@ Sparse6
 .. autosummary::
    :toctree: generated/
 
-   parse_sparse6
+   from_sparse6_bytes
    read_sparse6
-   generate_sparse6
+   to_sparse6_bytes
    write_sparse6
-

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -20,20 +20,64 @@ For more information, see the `graph6`_ homepage.
 .. _graph6: http://users.cecs.anu.edu.au/~bdm/data/formats.html
 
 """
+from itertools import islice
+import sys
+
 import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils import open_file, not_implemented_for
 
-__all__ = ['read_graph6', 'parse_graph6', 'generate_graph6', 'write_graph6']
+__all__ = ['from_graph6_bytes', 'read_graph6', 'to_graph6_bytes',
+           'write_graph6']
 
 
-def parse_graph6(string):
+def _generate_graph6_bytes(G, nodes, header):
+    """Yield bytes in the graph6 encoding of a graph.
+
+    `G` is an undirected simple graph. `nodes` is the list of nodes for
+    which the node-induced subgraph will be encoded; if `nodes` is the
+    list of all nodes in the graph, the entire graph will be
+    encoded. `header` is a Boolean that specifies whether to generate
+    the header ``b'>>graph6<<'`` before the remaining data.
+
+    This function generates `bytes` objects in the following order:
+
+    1. the header (if requested),
+    2. the encoding of the number of nodes,
+    3. each character, one-at-a-time, in the encoding of the requested
+       node-induced subgraph,
+    4. a newline character.
+
+    This function raises :exc:`ValueError` if the graph is too large for
+    the graph6 format (that is, greater than ``2 ** 36`` nodes).
+
+    """
+    n = len(G)
+    if n >= 2 ** 36:
+        raise ValueError('graph6 is only defined if number of nodes is less '
+                         'than 2 ** 36')
+    if header:
+        yield b'>>graph6<<'
+    for d in n_to_data(n):
+        yield str.encode(chr(d + 63))
+    # This generates the same as `(v in G[u] for u, v in combinations(G, 2))`,
+    # but in "column-major" order instead of "row-major" order.
+    bits = (nodes[j] in G[nodes[i]] for j in range(1, n) for i in range(j))
+    chunk = list(islice(bits, 6))
+    while chunk:
+        d = sum(b << 5 - i for i, b in enumerate(chunk))
+        yield str.encode(chr(d + 63))
+        chunk = list(islice(bits, 6))
+    yield b'\n'
+
+
+def from_graph6_bytes(string):
     """Read a simple undirected graph in graph6 format from string.
 
     Parameters
     ----------
     string : string
-       Data in graph6 format
+       Data in graph6 format, without a trailing newline.
 
     Returns
     -------
@@ -44,15 +88,19 @@ def parse_graph6(string):
     NetworkXError
         If the string is unable to be parsed in graph6 format
 
+    ValueError
+        If any character ``c`` in the input string does not satisfy
+        ``63 <= ord(c) < 127``.
+
     Examples
     --------
-    >>> G = nx.parse_graph6('A_')
+    >>> G = nx.from_graph6_bytes(b'A_')
     >>> sorted(G.edges())
     [(0, 1)]
 
     See Also
     --------
-    generate_graph6, read_graph6, write_graph6
+    read_graph6, write_graph6
 
     References
     ----------
@@ -67,9 +115,16 @@ def parse_graph6(string):
             for i in [5,4,3,2,1,0]:
                 yield (d>>i)&1
 
-    if string.startswith('>>graph6<<'):
+    if string.startswith(b'>>graph6<<'):
         string = string[10:]
-    data = graph6_to_data(string)
+
+    if sys.version_info < (3, ):
+        data = [ord(c) - 63 for c in string]
+    else:
+        data = [c - 63 for c in string]
+    if any(c > 63 for c in data):
+        raise ValueError('each input character must be in range(63, 127)')
+
     n, data = data_to_n(data)
     nd = (n*(n-1)//2 + 5) // 6
     if len(data) != nd:
@@ -84,7 +139,60 @@ def parse_graph6(string):
 
     return G
 
-@open_file(0,mode='rt')
+
+def to_graph6_bytes(G, nodes=None, header=True):
+    """Convert a simple undirected graph to bytes in graph6 format.
+
+    Parameters
+    ----------
+    G : Graph (undirected)
+
+    nodes: list or iterable
+       Nodes are labeled 0...n-1 in the order provided.  If None the ordering
+       given by ``G.nodes()`` is used.
+
+    header: bool
+       If True add '>>graph6<<' bytes to head of data.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If the graph is directed or is a multigraph.
+
+    ValueError
+        If the graph has at least ``2 ** 36`` nodes; the graph6 format
+        is only defined for graphs of order less than ``2 ** 36``.
+
+    Examples
+    --------
+    >>> nx.to_graph6_bytes(nx.path_graph(2)) # doctest: +SKIP
+    b'>>graph6<<A_\\n'
+
+    See Also
+    --------
+    from_graph6_bytes, read_graph6, write_graph6_bytes
+
+    Notes
+    -----
+    The returned bytes end with a newline character.
+
+    The format does not support edge or node labels, parallel edges or
+    self loops. If self loops are present they are silently ignored.
+
+    References
+    ----------
+    .. [1] Graph6 specification
+           <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
+
+    """
+    if nodes is not None:
+        G = G.subgraph(nodes)
+    H = nx.convert_node_labels_to_integers(G)
+    nodes = sorted(H.nodes())
+    return b''.join(_generate_graph6_bytes(G, nodes, header))
+
+
+@open_file(0, mode='rb')
 def read_graph6(path):
     """Read simple undirected graphs in graph6 format from path.
 
@@ -105,14 +213,29 @@ def read_graph6(path):
 
     Examples
     --------
-    >>> nx.write_graph6(nx.Graph([(0,1)]), 'test.g6')
-    >>> G = nx.read_graph6('test.g6')
-    >>> sorted(G.edges())
-    [(0, 1)]
+    You can read a graph6 file by giving the path to the file::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     _ = f.write(b'>>graph6<<A_\\n')
+        ...     _ = f.seek(0)
+        ...     G = nx.read_graph6(f.name)
+        >>> list(G.edges())
+        [(0, 1)]
+
+    You can also read a graph6 file by giving an open file-like object::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     _ = f.write(b'>>graph6<<A_\\n')
+        ...     _ = f.seek(0)
+        ...     G = nx.read_graph6(f)
+        >>> list(G.edges())
+        [(0, 1)]
 
     See Also
     --------
-    generate_graph6, parse_graph6, write_graph6
+    from_graph6_bytes, write_graph6
 
     References
     ----------
@@ -125,49 +248,122 @@ def read_graph6(path):
         line = line.strip()
         if not len(line):
             continue
-        glist.append(parse_graph6(line))
+        glist.append(from_graph6_bytes(line))
     if len(glist) == 1:
         return glist[0]
     else:
         return glist
 
-@not_implemented_for('directed','multigraph')
-def generate_graph6(G, nodes = None, header=True):
-    """Generate graph6 format string from a simple undirected graph.
+
+@not_implemented_for('directed')
+@not_implemented_for('multigraph')
+@open_file(1, mode='wb')
+def write_graph6(G, path, nodes=None, header=True):
+    """Write a simple undirected graph to a path in graph6 format.
 
     Parameters
     ----------
     G : Graph (undirected)
 
+    path : str
+       The path naming the file to which to write the graph.
+
     nodes: list or iterable
        Nodes are labeled 0...n-1 in the order provided.  If None the ordering
-       given by G.nodes() is used.
+       given by ``G.nodes()`` is used.
 
     header: bool
        If True add '>>graph6<<' string to head of data
 
-    Returns
-    -------
-    s : string
-       String in graph6 format
-
     Raises
     ------
-    NetworkXError
-        If the graph is directed or has parallel edges
+    NetworkXNotImplemented
+        If the graph is directed or is a multigraph.
+
+    ValueError
+        If the graph has at least ``2 ** 36`` nodes; the graph6 format
+        is only defined for graphs of order less than ``2 ** 36``.
 
     Examples
     --------
-    >>> G = nx.Graph([(0, 1)])
-    >>> nx.generate_graph6(G)
-    '>>graph6<<A_'
+    You can write a graph6 file by giving the path to a file::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     nx.write_graph6(nx.path_graph(2), f.name)
+        ...     _ = f.seek(0)
+        ...     print(f.read())  # doctest: +SKIP
+        b'>>graph6<<A_\\n'
 
     See Also
     --------
-    read_graph6, parse_graph6, write_graph6
+    from_graph6_bytes, read_graph6
 
     Notes
     -----
+    The function writes a newline character after writing the encoding
+    of the graph.
+
+    The format does not support edge or node labels, parallel edges or
+    self loops.  If self loops are present they are silently ignored.
+
+    References
+    ----------
+    .. [1] Graph6 specification
+           <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
+
+    """
+    return write_graph6_file(G, path, nodes=nodes, header=header)
+
+
+@not_implemented_for('directed')
+@not_implemented_for('multigraph')
+def write_graph6_file(G, f, nodes=None, header=True):
+    """Write a simple undirected graph to a file-like object in graph6 format.
+
+    Parameters
+    ----------
+    G : Graph (undirected)
+
+    f : file-like object
+       The file to write.
+
+    nodes: list or iterable
+       Nodes are labeled 0...n-1 in the order provided.  If None the ordering
+       given by ``G.nodes()`` is used.
+
+    header: bool
+       If True add '>>graph6<<' string to head of data
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If the graph is directed or is a multigraph.
+
+    ValueError
+        If the graph has at least ``2 ** 36`` nodes; the graph6 format
+        is only defined for graphs of order less than ``2 ** 36``.
+
+    Examples
+    --------
+    You can write a graph6 file by giving an open file-like object::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     nx.write_graph6(nx.path_graph(2), f)
+        ...     _ = f.seek(0)
+        ...     print(f.read())  # doctest: +SKIP
+        b'>>graph6<<A_\\n'
+
+    See Also
+    --------
+    from_graph6_bytes, read_graph6
+
+    Notes
+    -----
+    The function writes a newline character after writing the encoding
+    of the graph.
+
     The format does not support edge or node labels, parallel edges or
     self loops.  If self loops are present they are silently ignored.
 
@@ -180,91 +376,10 @@ def generate_graph6(G, nodes = None, header=True):
     if nodes is not None:
         G = G.subgraph(nodes)
     H = nx.convert_node_labels_to_integers(G)
-    ns = sorted(H.nodes())
-    def bits():
-        for (i,j) in [(i,j) for j in range(1,n) for i in range(j)]:
-            yield G.has_edge(ns[i],ns[j])
+    nodes = sorted(H.nodes())
+    for b in _generate_graph6_bytes(G, nodes, header):
+        f.write(b)
 
-    n = G.order()
-    data = n_to_data(n)
-    d = 0
-    flush = False
-    for i, b in zip(range(n * n), bits()):
-        d |= b << (5 - (i % 6))
-        flush = True
-        if i % 6 == 5:
-            data.append(d)
-            d = 0
-            flush = False
-    if flush:
-        data.append(d)
-
-    string_data =  data_to_graph6(data)
-    if header:
-        string_data  =  '>>graph6<<' + string_data
-    return string_data
-
-
-@open_file(1, mode='wt')
-def write_graph6(G, path, nodes = None, header=True):
-    """Write a simple undirected graph to path in graph6 format.
-
-    Parameters
-    ----------
-    G : Graph (undirected)
-
-    path : file or string
-       File or filename to write.
-
-    nodes: list or iterable
-       Nodes are labeled 0...n-1 in the order provided.  If None the ordering
-       given by G.nodes() is used.
-
-    header: bool
-       If True add '>>graph6<<' string to head of data
-
-    Raises
-    ------
-    NetworkXError
-        If the graph is directed or has parallel edges
-
-    Examples
-    --------
-    >>> G = nx.Graph([(0, 1)])
-    >>> nx.write_graph6(G, 'test.g6')
-
-    See Also
-    --------
-    generate_graph6, parse_graph6, read_graph6
-
-    Notes
-    -----
-    The format does not support edge or node labels, parallel edges or
-    self loops.  If self loops are present they are silently ignored.
-
-    References
-    ----------
-    .. [1] Graph6 specification
-           <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
-
-    """
-    path.write(generate_graph6(G, nodes=nodes, header=header))
-    path.write('\n')
-
-# helper functions
-
-def graph6_to_data(string):
-    """Convert graph6 character sequence to 6-bit integers."""
-    v = [ord(c)-63 for c in string]
-    if len(v) > 0 and (min(v) < 0 or max(v) > 63):
-        return None
-    return v
-
-def data_to_graph6(data):
-    """Convert 6-bit integer sequence to graph6 character sequence."""
-    if len(data) > 0 and (min(data) < 0 or max(data) > 63):
-        raise NetworkXError("graph6 data units must be within 0..63")
-    return ''.join([chr(d+63) for d in data])
 
 def data_to_n(data):
     """Read initial one-, four- or eight-unit value from graph6
@@ -278,22 +393,18 @@ def data_to_n(data):
     return ((data[2]<<30) + (data[3]<<24) + (data[4]<<18) +
             (data[5]<<12) + (data[6]<<6) + data[7], data[8:])
 
+
 def n_to_data(n):
-    """Convert an integer to one-, four- or eight-unit graph6 sequence."""
-    if n < 0:
-        raise NetworkXError("Numbers in graph6 format must be non-negative.")
+    """Convert an integer to one-, four- or eight-unit graph6 sequence.
+
+    This function is undefined if `n` is not in ``range(2 ** 36)``.
+
+    """
     if n <= 62:
         return [n]
-    if n <= 258047:
+    elif n <= 258047:
         return [63, (n>>12) & 0x3f, (n>>6) & 0x3f, n & 0x3f]
-    if n <= 68719476735:
+    else:  # if n <= 68719476735:
         return [63, 63,
-            (n>>30) & 0x3f, (n>>24) & 0x3f, (n>>18) & 0x3f,
-            (n>>12) & 0x3f, (n>>6) & 0x3f, n & 0x3f]
-    raise NetworkXError("Numbers above 68719476735 are not supported by graph6")
-
-
-def teardown_module(module):
-    import os
-    if os.path.isfile('test.g6'):
-        os.unlink('test.g6')
+                (n>>30) & 0x3f, (n>>24) & 0x3f, (n>>18) & 0x3f,
+                (n>>12) & 0x3f, (n>>6) & 0x3f, n & 0x3f]

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -21,16 +21,94 @@ For more information, see the `sparse6`_ homepage.
 .. _sparse6: http://users.cecs.anu.edu.au/~bdm/data/formats.html
 
 """
+from itertools import chain
+import math
+import sys
+
 import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils import open_file, not_implemented_for
-from networkx.readwrite.graph6 import data_to_graph6, graph6_to_data,\
-    data_to_n, n_to_data
+from networkx.readwrite.graph6 import data_to_n, n_to_data
 
-__all__ = ['read_sparse6', 'parse_sparse6',
-           'generate_sparse6', 'write_sparse6']
+__all__ = ['from_sparse6_bytes', 'read_sparse6', 'to_sparse6_bytes',
+           'write_sparse6']
 
-def parse_sparse6(string):
+
+def _generate_sparse6_bytes(G, nodes, header):
+    """Yield bytes in the sparse6 encoding of a graph.
+
+    `G` is an undirected simple graph. `nodes` is the list of nodes for
+    which the node-induced subgraph will be encoded; if `nodes` is the
+    list of all nodes in the graph, the entire graph will be
+    encoded. `header` is a Boolean that specifies whether to generate
+    the header ``b'>>sparse6<<'`` before the remaining data.
+
+    This function generates `bytes` objects in the following order:
+
+    1. the header (if requested),
+    2. the encoding of the number of nodes,
+    3. each character, one-at-a-time, in the encoding of the requested
+       node-induced subgraph,
+    4. a newline character.
+
+    This function raises :exc:`ValueError` if the graph is too large for
+    the graph6 format (that is, greater than ``2 ** 36`` nodes).
+
+    """
+    n = len(G)
+    if n >= 2 ** 36:
+        raise ValueError('sparse6 is only defined if number of nodes is less '
+                         'than 2 ** 36')
+    if header:
+        yield b'>>sparse6<<'
+    yield b':'
+    for d in n_to_data(n):
+        yield str.encode(chr(d + 63))
+
+    k = 1
+    while 1<<k < n:
+        k += 1
+
+    def enc(x):
+        """Big endian k-bit encoding of x"""
+        return [1 if (x & 1 << (k-1-i)) else 0 for i in range(k)]
+
+    edges = sorted((max(u, v), min(u, v)) for u, v in G.edges())
+    bits = []
+    curv = 0
+    for (v, u) in edges:
+        if v == curv: # current vertex edge
+            bits.append(0)
+            bits.extend(enc(u))
+        elif v == curv + 1: # next vertex edge
+            curv += 1
+            bits.append(1)
+            bits.extend(enc(u))
+        else: # skip to vertex v and then add edge to u
+            curv = v
+            bits.append(1)
+            bits.extend(enc(v))
+            bits.append(0)
+            bits.extend(enc(u))
+    if k < 6 and n == (1 << k) and ((-len(bits)) % 6) >= k and curv < (n - 1):
+        # Padding special case: small k, n=2^k,
+        # more than k bits of padding needed,
+        # current vertex is not (n-1) --
+        # appending 1111... would add a loop on (n-1)
+        bits.append(0)
+        bits.extend([1] * ((-len(bits)) % 6))
+    else:
+        bits.extend([1] * ((-len(bits)) % 6))
+
+    data = [(bits[i+0]<<5) + (bits[i+1]<<4) + (bits[i+2]<<3) + (bits[i+3]<<2) +
+            (bits[i+4]<<1) + (bits[i+5]<<0) for i in range(0, len(bits), 6)]
+
+    for d in data:
+        yield str.encode(chr(d + 63))
+    yield b'\n'
+
+
+def from_sparse6_bytes(string):
     """Read an undirected graph in sparse6 format from string.
 
     Parameters
@@ -49,13 +127,13 @@ def parse_sparse6(string):
 
     Examples
     --------
-    >>> G = nx.parse_sparse6(':A_')
+    >>> G = nx.from_sparse6_bytes(b':A_')
     >>> sorted(G.edges())
     [(0, 1), (0, 1), (0, 1)]
 
     See Also
     --------
-    generate_sparse6, read_sparse6, write_sparse6
+    read_sparse6, write_sparse6
 
     References
     ----------
@@ -63,11 +141,16 @@ def parse_sparse6(string):
            <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
 
     """
-    if string.startswith('>>sparse6<<'):
+    if string.startswith(b'>>sparse6<<'):
         string = string[11:]
-    if not string.startswith(':'):
+    if not string.startswith(b':'):
         raise NetworkXError('Expected leading colon in sparse6')
-    n, data = data_to_n(graph6_to_data(string[1:]))
+
+    if sys.version_info < (3, ):
+        chars = [ord(c) - 63 for c in string[1:]]
+    else:
+        chars = [c - 63 for c in string[1:]]
+    n, data = data_to_n(chars)
     k = 1
     while 1<<k < n:
         k += 1
@@ -118,7 +201,58 @@ def parse_sparse6(string):
         G = nx.Graph(G)
     return G
 
-@open_file(0,mode='rt')
+
+def to_sparse6_bytes(G, nodes=None, header=True):
+    """Convert an undirected graph to bytes in sparse6 format.
+
+    Parameters
+    ----------
+    G : Graph (undirected)
+
+    nodes: list or iterable
+       Nodes are labeled 0...n-1 in the order provided.  If None the ordering
+       given by ``G.nodes()`` is used.
+
+    header: bool
+       If True add '>>sparse6<<' bytes to head of data.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If the graph is directed.
+
+    ValueError
+        If the graph has at least ``2 ** 36`` nodes; the sparse6 format
+        is only defined for graphs of order less than ``2 ** 36``.
+
+    Examples
+    --------
+    >>> nx.to_sparse6_bytes(nx.path_graph(2))  # doctest: +SKIP
+    b'>>sparse6<<:An\\n'
+
+    See Also
+    --------
+    to_sparse6_bytes, read_sparse6, write_sparse6_bytes
+
+    Notes
+    -----
+    The returned bytes end with a newline character.
+
+    The format does not support edge or node labels.
+
+    References
+    ----------
+    .. [1] Graph6 specification
+           <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
+
+    """
+    if nodes is not None:
+        G = G.subgraph(nodes)
+    G = nx.convert_node_labels_to_integers(G, ordering='sorted')
+    return b''.join(_generate_sparse6_bytes(G, nodes, header))
+
+
+@open_file(0,mode='rb')
 def read_sparse6(path):
     """Read an undirected graph in sparse6 format from path.
 
@@ -139,14 +273,29 @@ def read_sparse6(path):
 
     Examples
     --------
-    >>> nx.write_sparse6(nx.Graph([(0,1),(0,1),(0,1)]), 'test.s6')
-    >>> G = nx.read_sparse6('test.s6')
-    >>> sorted(G.edges())
-    [(0, 1)]
+    You can read a sparse6 file by giving the path to the file::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     _ = f.write(b'>>sparse6<<:An\\n')
+        ...     _ = f.seek(0)
+        ...     G = nx.read_sparse6(f.name)
+        >>> list(G.edges())
+        [(0, 1)]
+
+    You can also read a sparse6 file by giving an open file-like object::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     _ = f.write(b'>>sparse6<<:An\\n')
+        ...     _ = f.seek(0)
+        ...     G = nx.read_sparse6(f)
+        >>> list(G.edges())
+        [(0, 1)]
 
     See Also
     --------
-    generate_sparse6, read_sparse6, parse_sparse6
+    read_sparse6, from_sparse6_bytes
 
     References
     ----------
@@ -159,107 +308,15 @@ def read_sparse6(path):
         line = line.strip()
         if not len(line):
             continue
-        glist.append(parse_sparse6(line))
+        glist.append(from_sparse6_bytes(line))
     if len(glist) == 1:
         return glist[0]
     else:
         return glist
 
+
 @not_implemented_for('directed')
-def generate_sparse6(G, nodes=None, header=True):
-    """Generate sparse6 format string from an undirected graph.
-
-    Parameters
-    ----------
-    G : Graph (undirected)
-
-    nodes: list or iterable
-       Nodes are labeled 0...n-1 in the order provided.  If None the ordering
-       given by G.nodes() is used.
-
-    header: bool
-       If True add '>>sparse6<<' string to head of data
-
-    Returns
-    -------
-    s : string
-       String in sparse6 format
-
-    Raises
-    ------
-    NetworkXError
-        If the graph is directed
-
-    Examples
-    --------
-    >>> G = nx.MultiGraph([(0, 1), (0, 1), (0, 1)])
-    >>> nx.generate_sparse6(G)
-    '>>sparse6<<:A_'
-
-    See Also
-    --------
-    read_sparse6, parse_sparse6, write_sparse6
-
-    Notes
-    -----
-    The format does not support edge or node labels.
-
-    References
-    ----------
-    .. [1] Sparse6 specification
-           <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
-
-    """
-    n = G.order()
-    k = 1
-    while 1<<k < n:
-        k += 1
-
-    def enc(x):
-        """Big endian k-bit encoding of x"""
-        return [1 if (x & 1 << (k-1-i)) else 0 for i in range(k)]
-
-    if nodes is not None:
-        G = G.subgraph(nodes)
-    H = nx.convert_node_labels_to_integers(G,ordering='sorted')
-    edges = sorted(((max(u,v), min(u,v)) for (u, v) in H.edges()))
-    bits = []
-    curv = 0
-    for (v, u) in edges:
-        if v == curv: # current vertex edge
-            bits.append(0)
-            bits.extend(enc(u))
-        elif v == curv + 1: # next vertex edge
-            curv += 1
-            bits.append(1)
-            bits.extend(enc(u))
-        else: # skip to vertex v and then add edge to u
-            curv = v
-            bits.append(1)
-            bits.extend(enc(v))
-            bits.append(0)
-            bits.extend(enc(u))
-    if k < 6 and n == (1 << k) and ((-len(bits)) % 6) >= k and curv < (n - 1):
-        # Padding special case: small k, n=2^k,
-        # more than k bits of padding needed,
-        # current vertex is not (n-1) --
-        # appending 1111... would add a loop on (n-1)
-        bits.append(0)
-        bits.extend([1] * ((-len(bits)) % 6))
-    else:
-        bits.extend([1] * ((-len(bits)) % 6))
-
-    data = [(bits[i+0]<<5) + (bits[i+1]<<4) + (bits[i+2]<<3) + (bits[i+3]<<2) +
-            (bits[i+4]<<1) + (bits[i+5]<<0) for i in range(0, len(bits), 6)]
-
-    res = (':' + data_to_graph6(n_to_data(n)) +
-                data_to_graph6(data))
-    if header:
-        return '>>sparse6<<' + res
-    else:
-        return res
-
-@open_file(1, mode='wt')
+@open_file(1, mode='wb')
 def write_sparse6(G, path, nodes=None, header=True):
     """Write graph G to given path in sparse6 format.
 
@@ -284,12 +341,25 @@ def write_sparse6(G, path, nodes=None, header=True):
 
     Examples
     --------
-    >>> G = nx.Graph([(0, 1), (0, 1), (0, 1)])
-    >>> nx.write_sparse6(G, 'test.s6')
+    You can write a sparse6 file by giving the path to the file::
+
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     nx.write_sparse6(nx.path_graph(2), f.name)
+        ...     print(f.read())  # doctest: +SKIP
+        b'>>sparse6<<:An\\n'
+
+    You can also write a sparse6 file by giving an open file-like object::
+
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     nx.write_sparse6(nx.path_graph(2), f)
+        ...     _ = f.seek(0)
+        ...     print(f.read())  # doctest: +SKIP
+        b'>>sparse6<<:An\\n'
 
     See Also
     --------
-    read_sparse6, parse_sparse6, generate_sparse6
+    read_sparse6, from_sparse6_bytes
 
     Notes
     -----
@@ -301,11 +371,8 @@ def write_sparse6(G, path, nodes=None, header=True):
            <http://users.cecs.anu.edu.au/~bdm/data/formats.html>
 
     """
-    path.write(generate_sparse6(G, nodes=nodes, header=header))
-    path.write('\n')
-
-
-def teardown_module(test):
-    import os
-    if os.path.isfile('test.s6'):
-        os.unlink('test.s6')
+    if nodes is not None:
+        G = G.subgraph(nodes)
+    G = nx.convert_node_labels_to_integers(G, ordering='sorted')
+    for b in _generate_sparse6_bytes(G, nodes, header):
+        path.write(b)

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -1,12 +1,17 @@
-#!/usr/bin/env python
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-from nose.tools import *
+from __future__ import division
+
+from io import BytesIO
+import tempfile
+from unittest import TestCase
+
+from nose.tools import assert_equal
+
 import networkx as nx
 import networkx.readwrite.graph6 as g6
-from networkx.testing.utils import *
+from networkx.testing.utils import assert_edges_equal
+from networkx.testing.utils import assert_graphs_equal
+from networkx.testing.utils import assert_nodes_equal
+
 
 class TestGraph6Utils(object):
 
@@ -17,71 +22,98 @@ class TestGraph6Utils(object):
             assert_equal(g6.data_to_n(g6.n_to_data(i) + [42, 43])[1],
                          [42, 43])
 
-    def test_data_sparse6_data_conversion(self):
-        for data in [[], [0], [63], [63, 63], [0]*42,
-                     [0, 1, 62, 42, 3, 11, 0, 11]]:
-            assert_equal(g6.graph6_to_data(g6.data_to_graph6(data)), data)
-            assert_equal(len(g6.data_to_graph6(data)), len(data))
 
+class TestFromGraph6Bytes(TestCase):
 
-class TestGraph6(object):
-
-    def test_parse_graph6(self):
-        data="""DF{"""
-        G=nx.parse_graph6(data)
+    def test_from_graph6_bytes(self):
+        data = b'DF{'
+        G=nx.from_graph6_bytes(data)
         assert_nodes_equal(G.nodes(),[0, 1, 2, 3, 4])
         assert_edges_equal(G.edges(),
                      [(0, 3), (0, 4), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)])
 
-    def test_read_graph6(self):
-        data="""DF{"""
-        G=nx.parse_graph6(data)
-        fh = StringIO(data)
-        Gin=nx.read_graph6(fh)
-        assert_nodes_equal(G.nodes(),Gin.nodes())
-        assert_edges_equal(G.edges(),Gin.edges())
+    def test_read_equals_from_bytes(self):
+        data = b'DF{'
+        G = nx.from_graph6_bytes(data)
+        fh = BytesIO(data)
+        Gin = nx.read_graph6(fh)
+        assert_nodes_equal(G.nodes(), Gin.nodes())
+        assert_edges_equal(G.edges(), Gin.edges())
+
+
+class TestReadGraph6(TestCase):
 
     def test_read_many_graph6(self):
-        # Read many graphs into list
-        data="""DF{\nD`{\nDqK\nD~{\n"""
-        fh = StringIO(data)
-        glist=nx.read_graph6(fh)
-        assert_equal(len(glist),4)
+        """Test for reading many graphs from a file into a list."""
+        data = b'DF{\nD`{\nDqK\nD~{\n'
+        fh = BytesIO(data)
+        glist = nx.read_graph6(fh)
+        assert_equal(len(glist), 4)
         for G in glist:
-            assert_equal(sorted(G.nodes()),[0, 1, 2, 3, 4])
+            assert_equal(sorted(G), list(range(5)))
 
-    def test_generate_graph6(self):
-        assert_equal(nx.generate_graph6(nx.empty_graph(0)), '>>graph6<<?')
-        assert_equal(nx.generate_graph6(nx.empty_graph(1)), '>>graph6<<@')
 
-        G1 = nx.complete_graph(4)
-        assert_equal(nx.generate_graph6(G1, header=True), '>>graph6<<C~')
-        assert_equal(nx.generate_graph6(G1, header=False), 'C~')
+class TestWriteGraph6(TestCase):
+    """Unit tests for writing a graph to a file in graph6 format."""
 
-        G2 = nx.complete_bipartite_graph(6,9)
-        assert_equal(nx.generate_graph6(G2, header=False),
-                     'N??F~z{~Fw^_~?~?^_?') # verified by Sage
+    def test_null_graph(self):
+        result = BytesIO()
+        nx.write_graph6(nx.null_graph(), result)
+        self.assertEqual(result.getvalue(), b'>>graph6<<?\n')
 
-        G3 = nx.complete_graph(67)
-        assert_equal(nx.generate_graph6(G3, header=False),
-                     '~?@B' + '~' * 368 + 'w')
+    def test_trivial_graph(self):
+        result = BytesIO()
+        nx.write_graph6(nx.trivial_graph(), result)
+        self.assertEqual(result.getvalue(), b'>>graph6<<@\n')
 
-    def test_write_graph6(self):
-        fh = StringIO()
-        nx.write_graph6(nx.complete_bipartite_graph(6,9), fh)
-        fh.seek(0)
-        assert_equal(fh.read(), '>>graph6<<N??F~z{~Fw^_~?~?^_?\n')
+    def test_complete_graph(self):
+        result = BytesIO()
+        nx.write_graph6(nx.complete_graph(4), result)
+        self.assertEqual(result.getvalue(), b'>>graph6<<C~\n')
 
-    def test_generate_and_parse_graph6(self):
+    def test_large_complete_graph(self):
+        result = BytesIO()
+        nx.write_graph6(nx.complete_graph(67), result, header=False)
+        self.assertEqual(result.getvalue(), b'~?@B' + b'~' * 368 + b'w\n')
+
+    def test_no_header(self):
+        result = BytesIO()
+        nx.write_graph6(nx.complete_graph(4), result, header=False)
+        self.assertEqual(result.getvalue(), b'C~\n')
+
+    def test_complete_bipartite_graph(self):
+        result = BytesIO()
+        G = nx.complete_bipartite_graph(6, 9)
+        nx.write_graph6(G, result, header=False)
+        # The expected encoding here was verified by Sage.
+        self.assertEqual(result.getvalue(), b'N??F~z{~Fw^_~?~?^_?\n')
+
+    def no_directed_graphs(self):
+        with self.assertRaises(nx.NetworkXNotImplemented):
+            nx.write_graph6(nx.DiGraph(), BytesIO())
+
+    def test_length(self):
         for i in list(range(13)) + [31, 47, 62, 63, 64, 72]:
             g = nx.random_graphs.gnm_random_graph(i, i * i // 4, seed=i)
-            gstr = nx.generate_graph6(g, header=False)
+            gstr = BytesIO()
+            nx.write_graph6(g, gstr, header=False)
+            # Strip the trailing newline.
+            gstr = gstr.getvalue().rstrip()
             assert_equal(len(gstr),
                          ((i-1) * i // 2 + 5) // 6 + (1 if i < 63 else 4))
-            g2 = nx.parse_graph6(gstr)
-            assert_equal(g2.order(), g.order())
-            assert_edges_equal(g2.edges(), g.edges())
 
-    @raises(nx.NetworkXError)
-    def directed_raise(self):
-        nx.generate_graph6(nx.DiGraph())
+    def test_roundtrip(self):
+        for i in list(range(13)) + [31, 47, 62, 63, 64, 72]:
+            G = nx.random_graphs.gnm_random_graph(i, i * i // 4, seed=i)
+            f = BytesIO()
+            nx.write_graph6(G, f)
+            f.seek(0)
+            H = nx.read_graph6(f)
+            assert_nodes_equal(G.nodes(), H.nodes())
+            assert_edges_equal(G.edges(), H.edges())
+
+    def test_write_path(self):
+        with tempfile.NamedTemporaryFile() as f:
+            g6.write_graph6_file(nx.null_graph(), f)
+            f.seek(0)
+            self.assertEqual(f.read(), b'>>graph6<<?\n')

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -1,20 +1,21 @@
-#!/usr/bin/env python
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-from nose.tools import *
+from io import BytesIO
+import tempfile
+from unittest import TestCase
+
+from nose.tools import assert_equal
+from nose.tools import assert_true
+
 import networkx as nx
-from networkx.testing import *
-import networkx.readwrite.sparse6 as sg6
-import os,tempfile
+from networkx.testing.utils import assert_edges_equal
+from networkx.testing.utils import assert_nodes_equal
+
 
 class TestSparseGraph6(object):
 
-    def test_parse_sparse6(self):
-        data=""":Q___eDcdFcDeFcE`GaJ`IaHbKNbLM"""
-        G=nx.parse_sparse6(data)
-        assert_nodes_equal(G.nodes(),
+    def test_from_sparse6_bytes(self):
+        data = b':Q___eDcdFcDeFcE`GaJ`IaHbKNbLM'
+        G=nx.from_sparse6_bytes(data)
+        assert_nodes_equal(sorted(G.nodes()),
                      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                       10, 11, 12, 13, 14, 15, 16, 17])
         assert_edges_equal(G.edges(),
@@ -24,27 +25,27 @@ class TestSparseGraph6(object):
                       (7, 10), (8, 12), (9, 15), (10, 14), (11, 13),
                       (12, 16), (13, 17), (14, 17), (15, 16)])
 
-    def test_parse_multigraph_graph(self):
-        graph_data = ':An'
-        G = nx.parse_sparse6(graph_data)
+    def test_from_bytes_multigraph_graph(self):
+        graph_data = b':An'
+        G = nx.from_sparse6_bytes(graph_data)
         assert_true(type(G), nx.Graph)
-        multigraph_data = ':Ab'
-        M = nx.parse_sparse6(multigraph_data)
+        multigraph_data = b':Ab'
+        M = nx.from_sparse6_bytes(multigraph_data)
         assert_true(type(M), nx.MultiGraph)
 
     def test_read_sparse6(self):
-        data=""":Q___eDcdFcDeFcE`GaJ`IaHbKNbLM"""
-        G=nx.parse_sparse6(data)
-        fh = StringIO(data)
+        data = b':Q___eDcdFcDeFcE`GaJ`IaHbKNbLM'
+        G=nx.from_sparse6_bytes(data)
+        fh = BytesIO(data)
         Gin=nx.read_sparse6(fh)
         assert_nodes_equal(G.nodes(),Gin.nodes())
         assert_edges_equal(G.edges(),Gin.edges())
 
     def test_read_many_graph6(self):
         # Read many graphs into list
-        data=':Q___eDcdFcDeFcE`GaJ`IaHbKNbLM\n'+\
-            ':Q___dCfDEdcEgcbEGbFIaJ`JaHN`IM'
-        fh = StringIO(data)
+        data = (b':Q___eDcdFcDeFcE`GaJ`IaHbKNbLM\n'
+                b':Q___dCfDEdcEgcbEGbFIaJ`JaHN`IM')
+        fh = BytesIO(data)
         glist=nx.read_sparse6(fh)
         assert_equal(len(glist),2)
         for G in glist:
@@ -52,52 +53,89 @@ class TestSparseGraph6(object):
                          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                           10, 11, 12, 13, 14, 15, 16, 17])
 
-    def test_generate_sparse6(self):
-        # Checked against sage encoder
-        assert_equal(nx.generate_sparse6(nx.empty_graph(0)), '>>sparse6<<:?')
-        assert_equal(nx.generate_sparse6(nx.empty_graph(1)), '>>sparse6<<:@')
-        assert_equal(nx.generate_sparse6(nx.empty_graph(5)), '>>sparse6<<:D')
-        assert_equal(nx.generate_sparse6(nx.empty_graph(68)),
-                     '>>sparse6<<:~?@C')
-        assert_equal(nx.generate_sparse6(nx.empty_graph(258049)),
-                     '>>sparse6<<:~~???~?@')
 
-        G1 = nx.complete_graph(4)
-        assert_equal(nx.generate_sparse6(G1, header=True),
-                     '>>sparse6<<:CcKI')
-        assert_equal(nx.generate_sparse6(G1, header=False), ':CcKI')
+class TestWriteSparse6(TestCase):
+    """Unit tests for writing graphs in the sparse6 format.
 
-        # Padding testing
-        assert_equal(nx.generate_sparse6(nx.path_graph(4), header=False),
-                     ':Cdv')
-        assert_equal(nx.generate_sparse6(nx.path_graph(5), header=False),
-                     ':DaYn')
-        assert_equal(nx.generate_sparse6(nx.path_graph(6), header=False),
-                     ':EaYnN')
-        assert_equal(nx.generate_sparse6(nx.path_graph(7), header=False),
-                     ':FaYnL')
-        assert_equal(nx.generate_sparse6(nx.path_graph(8), header=False),
-                     ':GaYnLz')
+    Most of the test cases were checked against the sparse6 encoder in Sage.
 
-    def test_write_sparse6(self):
-        fh = StringIO()
-        nx.write_sparse6(nx.complete_bipartite_graph(6,9), fh)
-        fh.seek(0)
-        assert_equal(fh.read(),
-                     '>>sparse6<<:Nk?G`cJ?G`cJ?G`cJ?G`'+
-                     'cJ?G`cJ?G`cJ?G`cJ?G`cJ?G`cJ\n')
+    """
+
+    def test_null_graph(self):
+        G = nx.null_graph()
+        result = BytesIO()
+        nx.write_sparse6(G, result)
+        self.assertEqual(result.getvalue(), b'>>sparse6<<:?\n')
+
+    def test_trivial_graph(self):
+        G = nx.trivial_graph()
+        result = BytesIO()
+        nx.write_sparse6(G, result)
+        self.assertEqual(result.getvalue(), b'>>sparse6<<:@\n')
+
+    def test_empty_graph(self):
+        G = nx.empty_graph(5)
+        result = BytesIO()
+        nx.write_sparse6(G, result)
+        self.assertEqual(result.getvalue(), b'>>sparse6<<:D\n')
+
+    def test_large_empty_graph(self):
+        G = nx.empty_graph(68)
+        result = BytesIO()
+        nx.write_sparse6(G, result)
+        self.assertEqual(result.getvalue(), b'>>sparse6<<:~?@C\n')
+
+    def test_very_large_empty_graph(self):
+        G = nx.empty_graph(258049)
+        result = BytesIO()
+        nx.write_sparse6(G, result)
+        self.assertEqual(result.getvalue(), b'>>sparse6<<:~~???~?@\n')
+
+    def test_complete_graph(self):
+        G = nx.complete_graph(4)
+        result = BytesIO()
+        nx.write_sparse6(G, result)
+        self.assertEqual(result.getvalue(), b'>>sparse6<<:CcKI\n')
+
+    def test_no_header(self):
+        G = nx.complete_graph(4)
+        result = BytesIO()
+        nx.write_sparse6(G, result, header=False)
+        self.assertEqual(result.getvalue(), b':CcKI\n')
+
+    def test_padding(self):
+        codes = (b':Cdv', b':DaYn', b':EaYnN', b':FaYnL', b':GaYnLz')
+        for n, code in enumerate(codes, start=4):
+            G = nx.path_graph(n)
+            result = BytesIO()
+            nx.write_sparse6(G, result, header=False)
+            self.assertEqual(result.getvalue(), code + b'\n')
+
+    def test_complete_bipartite(self):
+        G = nx.complete_bipartite_graph(6, 9)
+        result = BytesIO()
+        nx.write_sparse6(G, result)
         # Compared with sage
+        expected = b'>>sparse6<<:Nk' + b'?G`cJ' * 9 + b'\n'
+        assert_equal(result.getvalue(), expected)
 
-
-    def test_generate_and_parse_sparse6(self):
+    def test_read_write_inverse(self):
         for i in list(range(13)) + [31, 47, 62, 63, 64, 72]:
             m = min(2 * i, i * i // 2)
             g = nx.random_graphs.gnm_random_graph(i, m, seed=i)
-            gstr = nx.generate_sparse6(g, header=False)
-            g2 = nx.parse_sparse6(gstr)
+            gstr = BytesIO()
+            nx.write_sparse6(g, gstr, header=False)
+            # Strip the trailing newline.
+            gstr = gstr.getvalue().rstrip()
+            g2 = nx.from_sparse6_bytes(gstr)
             assert_equal(g2.order(), g.order())
             assert_edges_equal(g2.edges(), g.edges())
 
-    @raises(nx.NetworkXError)
-    def directed_raises(self):
-        nx.generate_sparse6(nx.DiGraph())
+    def no_directed_graphs(self):
+        with self.assertRaises(nx.NetworkXNotImplemented):
+            nx.write_sparse6(nx.DiGraph(), BytesIO())
+
+    def test_write_path(self):
+        with tempfile.NamedTemporaryFile() as f:
+            nx.write_sparse6(nx.null_graph(), f.name)
+            self.assertEqual(f.read(), b'>>sparse6<<:?\n')


### PR DESCRIPTION
This commit changes the implementation of the `write_graph6` function so
that it makes better use of iterators and writes directly to file
instead of buffering the entire encoding of the graph as a string in
memory before writing. This commit also removes the `generate_graph6`
function, since it's functionality can be simulated by using the
`write_graph6` function to write to a file.

Fixes issue #2295.