### PR TITLE
Allow grid_graph generator to accept tuple dim argument

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -483,9 +483,9 @@ def grid_2d_graph(m, n, periodic=False, create_using=None):
 def grid_graph(dim, periodic=False):
     """ Return the n-dimensional grid graph.
 
-    'dim' is a list with the size in each dimension or an
+    'dim' is a tuple or list with the size in each dimension or an
     iterable of nodes for each dimension. The dimension of
-    the grid_graph is the length of the list 'dim'.
+    the grid_graph is the length of the tuple or list 'dim'.
 
     E.g. G=grid_graph(dim=[2, 3]) produces a 2x3 grid graph.
 
@@ -494,21 +494,18 @@ def grid_graph(dim, periodic=False):
     If periodic=True then join grid edges with periodic boundary conditions.
 
     """
-    dlabel = "%s" % dim
-    if dim == []:
+    dlabel = "%s" % str(dim)
+    if not dim:
         G = empty_graph(0)
-        G.name = "grid_graph(%s)" % dim
+        G.name = "grid_graph(%s)" % dlabel
         return G
     if periodic:
         func = cycle_graph
     else:
         func = path_graph
 
-    dim = list(dim)
-    current_dim = dim.pop()
-    G = func(current_dim)
-    while len(dim) > 0:
-        current_dim = dim.pop()
+    G = func(dim[0])
+    for current_dim in dim[1:]:
         # order matters: copy before it is cleared during the creation of Gnew
         Gold = G.copy()
         Gnew = func(current_dim)

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -297,6 +297,26 @@ class TestGeneratorClassic():
         assert_equal(number_of_nodes(g), 2*3)
         assert_true(is_isomorphic(g, grid_graph([2,3])))
 
+        """Tuple dim arguments of the above tests
+        """
+        for n, m in [(3, 5), (5, 3), (4, 5), (5, 4)]:
+            dim=(n,m)
+            g=grid_graph(dim)
+            assert_equal(number_of_nodes(g), n*m)
+            assert_equal(degree_histogram(g), [0,0,4,2*(n+m)-8,(n-2)*(m-2)])
+            assert_equal(dim,(n,m))
+
+        for n, m in [(1, 5), (5, 1)]:
+            dim=(n,m)
+            g=grid_graph(dim)
+            assert_equal(number_of_nodes(g), n*m)
+            assert_true(is_isomorphic(g,path_graph(5)))
+            assert_equal(dim,(n,m))
+
+        g=grid_graph((range(7,9), range(3,6)))
+        assert_equal(number_of_nodes(g), 2*3)
+        assert_true(is_isomorphic(g, grid_graph((2,3))))
+
     def test_hypercube_graph(self):
         for n, G in [(0, null_graph()), (1, path_graph(2)),
                      (2, cycle_graph(4)), (3, cubical_graph())]:


### PR DESCRIPTION
This refactors the grid_graph() generator to accept both a tuple as well as a list argument for its dimension argument.