### PR TITLE
Use faster random geometric graph implementation.

### DIFF
--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -69,7 +69,7 @@ def _slow_construct_edges(G, radius, p):
         pu = du['pos']
         for v, dv in nodes:
             pv = dv['pos']
-            d = sum(((a - b) ** p for a, b in zip(pu, pv)))
+            d = sum((abs(a - b) ** p for a, b in zip(pu, pv)))
             if d <= radius ** p:
                 G.add_edge(u, v)
 

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -63,15 +63,10 @@ def _slow_construct_edges(G, radius, p):
 
     Works without scipy, but in `O(n^2)` time.
     """
-    nodes = list(G.nodes(data=True))
-    while nodes:
-        u, du = nodes.pop()
-        pu = du['pos']
-        for v, dv in nodes:
-            pv = dv['pos']
-            d = sum((abs(a - b) ** p for a, b in zip(pu, pv)))
-            if d <= radius ** p:
-                G.add_edge(u, v)
+    # TODO This can be parallelized.
+    for (u, pu), (v, pv) in combinations(G.nodes(data='pos'), 2):
+        if sum(abs(a - b) ** p for a, b in zip(pu, pv)) <= radius ** p:
+            G.add_edge(u, v)
 
 
 @nodes_or_number(0)
@@ -81,6 +76,9 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2):
     The random geometric graph model places `n` nodes uniformly at
     random in the unit cube. Two nodes are joined by an edge if the
     distance between the nodes is at most `radius`.
+
+    Edges are determined using a KDTree when SciPy is available.
+    This reduces the time complexity from :math:`O(n^2)` to :math:`O(n)`.
 
     Parameters
     ----------

--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -37,14 +37,14 @@ class TestRandomGeometricGraph(object):
             else:
                 assert_false(dist(G.node[u]['pos'], G.node[v]['pos']) <= 0.25)
 
-    def test_norm(self):
+    def test_p(self):
         """Tests for providing an alternate distance metric to the
         generator.
 
         """
         # Use the L1 metric.
         dist = lambda x, y: sum(abs(a - b) for a, b in zip(x, y))
-        G = nx.random_geometric_graph(50, 0.25, norm=1)
+        G = nx.random_geometric_graph(50, 0.25, p=1)
         for u, v in combinations(G, 2):
             # Adjacent vertices must be within the given distance.
             if v in G[u]:

--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -7,6 +7,7 @@ from nose.tools import assert_true
 
 import networkx as nx
 
+
 class TestRandomGeometricGraph(object):
     """Unit tests for the :func:`~networkx.random_geometric_graph`
     function.
@@ -36,14 +37,32 @@ class TestRandomGeometricGraph(object):
             else:
                 assert_false(dist(G.node[u]['pos'], G.node[v]['pos']) <= 0.25)
 
-    def test_metric(self):
+    def test_norm(self):
         """Tests for providing an alternate distance metric to the
         generator.
 
         """
         # Use the L1 metric.
         dist = lambda x, y: sum(abs(a - b) for a, b in zip(x, y))
-        G = nx.random_geometric_graph(50, 0.25, metric=dist)
+        G = nx.random_geometric_graph(50, 0.25, norm=1)
+        for u, v in combinations(G, 2):
+            # Adjacent vertices must be within the given distance.
+            if v in G[u]:
+                assert_true(dist(G.node[u]['pos'], G.node[v]['pos']) <= 0.25)
+            # Nonadjacent vertices must be at greater distance.
+            else:
+                assert_false(dist(G.node[u]['pos'], G.node[v]['pos']) <= 0.25)
+
+    def test_node_names(self):
+        """Tests using values other than sequential numbers as node IDs.
+
+        """
+        import string
+        nodes = list(string.ascii_lowercase)
+        G = nx.random_geometric_graph(nodes, 0.25)
+        assert_equal(len(G), len(nodes))
+
+        dist = lambda x, y: sqrt(sum((a - b) ** 2 for a, b in zip(x, y)))
         for u, v in combinations(G, 2):
             # Adjacent vertices must be within the given distance.
             if v in G[u]:
@@ -145,14 +164,14 @@ class TestWaxmanGraph(object):
 class TestNavigableSmallWorldGraph(object):
 
     def test_navigable_small_world(self):
-        G = nx.navigable_small_world_graph(5,p=1,q=0)
-        gg = nx.grid_2d_graph(5,5).to_directed()
-        assert_true(nx.is_isomorphic(G,gg))
+        G = nx.navigable_small_world_graph(5, p=1, q=0)
+        gg = nx.grid_2d_graph(5, 5).to_directed()
+        assert_true(nx.is_isomorphic(G, gg))
 
-        G = nx.navigable_small_world_graph(5,p=1,q=0,dim=3)
-        gg = nx.grid_graph([5,5,5]).to_directed()
-        assert_true(nx.is_isomorphic(G,gg))
+        G = nx.navigable_small_world_graph(5, p=1, q=0, dim=3)
+        gg = nx.grid_graph([5, 5, 5]).to_directed()
+        assert_true(nx.is_isomorphic(G, gg))
 
-        G = nx.navigable_small_world_graph(5,p=1,q=0,dim=1)
+        G = nx.navigable_small_world_graph(5, p=1, q=0, dim=1)
         gg = nx.grid_graph([5]).to_directed()
-        assert_true(nx.is_isomorphic(G,gg))
+        assert_true(nx.is_isomorphic(G, gg))


### PR DESCRIPTION
Replace the existing random geometric graph generator with one
that uses a k-d tree to efficiently determine which nodes are
adjacent, so the algorithm is now `O(n)` instead of `O(n^2)`.

Use p-norm number as parameter instead of function. The
scipy KDTree requires a number instead of distance function.