### PR TITLE
Allow community asyn_lpa test to have two answers

### DIFF
--- a/networkx/algorithms/community/tests/test_asyn_lpa.py
+++ b/networkx/algorithms/community/tests/test_asyn_lpa.py
@@ -106,4 +106,5 @@ def test_two_communities():
 
     communities = asyn_lpa.asyn_lpa_communities(test)
     result = {frozenset(c) for c in communities}
-    assert_equal(result, ground_truth)
+    # probabilitistic result could be all nodes in one community. So test result is either.
+    assert(result in [ground_truth, set(frozenset(range(16)))])


### PR DESCRIPTION
Alternate form of #2329 which should stop random test errors while leaving the test that came from the references.