### PR TITLE
Fix broken links and remove pdf files from Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -45,17 +45,10 @@ dist: html
 	make -C build/latex all-pdf
 	-rm -rf build/dist
 	(cd build/html; cp -r . ../../build/dist)
-	-rm -f build/dist/_downloads/*
-	(cd build/html && zip -9r ../dist/_downloads/networkx-documentation.zip .)
-	cp build/latex/*.pdf build/dist/_downloads
-#	(cd build/dist && ln -s _downloads/* .)
 	(cd build/dist && tar czf ../dist.tar.gz .)
 
 
 html: generate
-	touch source/networkx_tutorial.pdf	
-	touch source/networkx_reference.pdf	
-	touch source/networkx-documentation.zip
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -12,12 +12,6 @@ Github (latest development): https://github.com/networkx/networkx/
 
 Documentation
 ~~~~~~~~~~~~~
-*PDF*
+As .pdf file: https://media.readthedocs.org/pdf/networkx/stable/networkx.pdf
 
-http://networkx.github.io/documentation/latest/_downloads/networkx_tutorial.pdf
-
-http://networkx.github.io/documentation/latest/_downloads/networkx_reference.pdf
-
-*HTML in zip file*
-
-http://networkx.github.io/documentation/latest/_downloads/networkx-documentation.zip
+As html in .zip file: https://readthedocs.org/projects/networkx/downloads/htmlzip/stable/


### PR DESCRIPTION
This addresses #2281

1. Fix (or remove) broken links to documentation files
2. Remove obsolete calls in `Makefile`