### PR TITLE
Fix for issues #2328 and #2332

### DIFF
--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -1,10 +1,10 @@
 #    Copyright (C) 2011-2016 by
-# 
+#
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    Michael E. Rose <Michael.Ernst.Rose@gmail.com>
-#    
+#
 #    All rights reserved.
 #    BSD license.
 from itertools import chain, count
@@ -55,7 +55,7 @@ def node_link_data(G, attrs=None):
     >>> G = nx.Graph([('A', 'B')])
     >>> data1 = json_graph.node_link_data(G)
     >>> H = nx.gn_graph(2)
-    >>> data2 = json_graph.node_link_data(H, {'link': 'edges', 'source': 'from', 'target': 'to'})    
+    >>> data2 = json_graph.node_link_data(H, {'link': 'edges', 'source': 'from', 'target': 'to'})
 
     To serialize with json
 
@@ -174,23 +174,15 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
         nodedata = dict((make_str(k), v) for k, v in d.items() if k != name)
         graph.add_node(node, **nodedata)
     for d in data[links]:
-        src = d[source]
-        tgt = d[target]
+        src = tuple(d[source]) if isinstance(d[source], list) else d[source]
+        tgt = tuple(d[target]) if isinstance(d[target], list) else d[target]
         if not multigraph:
             edgedata = dict((make_str(k), v) for k, v in d.items()
                             if k != source and k != target)
-            if (isinstance(src, list)):
-                src = tuple(src)
-            if (isinstance(tgt, list)):
-                tgt = tuple(tgt)
             graph.add_edge(src, tgt, **edgedata)
         else:
             ky = d.get(key, None)
             edgedata = dict((make_str(k), v) for k, v in d.items()
                             if k != source and k != target and k != key)
-            if (isinstance(src, list)):
-                src = tuple(src)
-            if (isinstance(tgt, list)):
-                tgt = tuple(tgt)
             graph.add_edge(src, tgt, ky, **edgedata)
     return graph

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -179,10 +179,18 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
         if not multigraph:
             edgedata = dict((make_str(k), v) for k, v in d.items()
                             if k != source and k != target)
+            if (isinstance(src, list)):
+                src = tuple(src)
+            if (isinstance(tgt, list)):
+                tgt = tuple(tgt)
             graph.add_edge(src, tgt, **edgedata)
         else:
             ky = d.get(key, None)
             edgedata = dict((make_str(k), v) for k, v in d.items()
                             if k != source and k != target and k != key)
+            if (isinstance(src, list)):
+                src = tuple(src)
+            if (isinstance(tgt, list)):
+                tgt = tuple(tgt)
             graph.add_edge(src, tgt, ky, **edgedata)
     return graph

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -15,7 +15,7 @@ from tempfile import NamedTemporaryFile
 __all__ = ['node_link_data', 'node_link_graph']
 
 
-_attrs = dict(source='source', target='target', name='name',
+_attrs = dict(source='source', target='target', name='id',
               key='key', link='links')
 
 
@@ -33,7 +33,7 @@ def node_link_data(G, attrs=None):
         names for storing NetworkX-internal graph data.  The values should
         be unique.  Default value::
 
-            dict(source='source', target='target', name='name',
+            dict(source='source', target='target', name='id',
                  key='key', link='links')
 
         If some user-defined graph data use these attribute names as data keys,
@@ -88,7 +88,6 @@ def node_link_data(G, attrs=None):
     key = None if not multigraph else attrs['key']
     if len(set([source, target, key])) < 3:
         raise nx.NetworkXError('Attribute names are not unique.')
-    mapping = dict(zip(G, count()))
     data = {}
     data['directed'] = G.is_directed()
     data['multigraph'] = multigraph
@@ -97,12 +96,12 @@ def node_link_data(G, attrs=None):
     if multigraph:
         data[links] = [
             dict(chain(d.items(),
-                       [(source, mapping[u]), (target, mapping[v]), (key, k)]))
+                       [(source, u), (target, v), (key, k)]))
             for u, v, k, d in G.edges(keys=True, data=True)]
     else:
         data[links] = [
             dict(chain(d.items(),
-                       [(source, mapping[u]), (target, mapping[v])]))
+                       [(source, u), (target, v)]))
             for u, v, d in G.edges(data=True)]
     return data
 
@@ -126,7 +125,7 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
         'key' and 'link'.  The corresponding values provide the attribute
         names for storing NetworkX-internal graph data.  Default value:
 
-            dict(source='source', target='target', name='name',
+            dict(source='source', target='target', name='id',
                 key='key', link='links')
 
     Returns
@@ -168,12 +167,10 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
     links = attrs['link']
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
     key = None if not multigraph else attrs['key']
-    mapping = []
     graph.graph = data.get('graph', {})
     c = count()
     for d in data['nodes']:
         node = to_tuple(d.get(name, next(c)))
-        mapping.append(node)
         nodedata = dict((make_str(k), v) for k, v in d.items() if k != name)
         graph.add_node(node, **nodedata)
     for d in data[links]:
@@ -182,10 +179,10 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
         if not multigraph:
             edgedata = dict((make_str(k), v) for k, v in d.items()
                             if k != source and k != target)
-            graph.add_edge(mapping[src], mapping[tgt], **edgedata)
+            graph.add_edge(src, tgt, **edgedata)
         else:
             ky = d.get(key, None)
             edgedata = dict((make_str(k), v) for k, v in d.items()
                             if k != source and k != target and k != key)
-            graph.add_edge(mapping[src], mapping[tgt], ky, **edgedata)
+            graph.add_edge(src, tgt, ky, **edgedata)
     return graph

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -10,7 +10,7 @@ class TestNodeLink:
     def test_graph(self):
         G = nx.path_graph(4)
         H = node_link_graph(node_link_data(G))
-        nx.is_isomorphic(G, H)
+        assert_true(nx.is_isomorphic(G, H))
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
@@ -72,3 +72,19 @@ class TestNodeLink:
         G = nx.MultiDiGraph()
         attrs = dict(name='node', source='node', target='node', key='node')
         node_link_data(G, attrs)
+
+    def test_string_ids(self):
+        try:
+            q = unicode("qualité", 'utf-8')
+        except NameError:
+            q = "qualité"
+
+        G = nx.Graph()
+        G.add_node('A')
+        G.add_node(q)
+        G.add_edge('A', q)
+        data = node_link_data(G)
+        assert_equal(data['links'][0]['source'], 'A')
+        assert_equal(data['links'][0]['target'], q)
+        H = node_link_graph(data)
+        assert_true(nx.is_isomorphic(G, H))

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -79,7 +79,7 @@ class TestNodeLink:
         except NameError:
             q = "qualité"
 
-        G = nx.Graph()
+        G = nx.DiGraph()
         G.add_node('A')
         G.add_node(q)
         G.add_edge('A', q)


### PR DESCRIPTION
Fix for issues #2328 and #2332.

Changes JSON node-link format to no longer export or import expecting links to be by node index. Instead, it expects node IDs like D3's current examples.