### PR TITLE
Check alternating paths using iterative DFS in to_vertex_cover.

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_matching.py
+++ b/networkx/algorithms/bipartite/tests/test_matching.py
@@ -166,6 +166,25 @@ class TestMatching():
         independent_set = set(G) - {v for _, v in vertex_cover}
         assert_equal({'B', 'D', 'F', 'I', 'H'}, independent_set)
 
+    def test_vertex_cover_issue_2384(self):
+        G = nx.Graph([(0, 3), (1, 3), (1, 4), (2, 3)])
+        matching = maximum_matching(G)
+        vertex_cover = to_vertex_cover(G, matching)
+        for u, v in G.edges():
+            assert_true(u in vertex_cover or v in vertex_cover)
+
+    def test_unorderable_nodes(self):
+        a = object()
+        b = object()
+        c = object()
+        d = object()
+        e = object()
+        G = nx.Graph([(a, d), (b, d), (b, e), (c, d)])
+        matching = maximum_matching(G)
+        vertex_cover = to_vertex_cover(G, matching)
+        for u, v in G.edges():
+            assert_true(u in vertex_cover or v in vertex_cover)
+
 
 def test_eppstein_matching():
     """Test in accordance to issue #1927"""


### PR DESCRIPTION
This PR fixes #2384.

Reimplement iteratively the inner function `_alternative_dfs` in
`_is_connected_by_alternating_path`. This function checks if nodes
in the graph are linked to target nodes by alternating paths, that
is, paths that alternate between matched and unmatched edges.

This PR also delegates to `_connected_by_alternating_paths`
computing the matched and unmatched edges because these are the same
for a given maximum matching and we do not need to recompute them
each time that we check if a node is linked to targets by an
alternating path.

I also changed the implementation of the computation of matched and
unmatched edges in order to avoid assuming orderable nodes.

Added a test with the example given in #2384 and another test with
unorderable nodes.