### PR TITLE
Improve bipartite documentation.

### DIFF
--- a/doc/source/reference/exceptions.rst
+++ b/doc/source/reference/exceptions.rst
@@ -17,8 +17,16 @@ Exceptions
 
 .. autoclass:: networkx.NetworkXNoPath
 
+.. autoclass:: networkx.NetworkXNoCycle
+
 .. autoclass:: networkx.NodeNotFound
 
 .. autoclass:: networkx.NetworkXUnbounded
 
+.. autoclass:: networkx.NetworkXNotImplemented
 
+.. autoclass:: networkx.AmbiguousSolution
+
+.. autoclass:: networkx.ExceededMaxIterations
+
+.. autoclass:: networkx.PowerIterationFailedConvergence

--- a/networkx/algorithms/bipartite/__init__.py
+++ b/networkx/algorithms/bipartite/__init__.py
@@ -13,19 +13,24 @@ NetworkX does not have a custom bipartite graph class but the Graph()
 or DiGraph() classes can be used to represent bipartite graphs. However,
 you have to keep track of which set each node belongs to, and make
 sure that there is no edge between nodes of the same set. The convention used
-in NetworkX is to use a node attribute named "bipartite" with values 0 or 1 to
-identify the sets each node belongs to.
+in NetworkX is to use a node attribute named `bipartite` with values 0 or 1 to
+identify the sets each node belongs to. This convention is not enforced in
+the source code of bipartite functions, it's only a recommendation.
  
 For example:
 
 >>> B = nx.Graph()
->>> B.add_nodes_from([1,2,3,4], bipartite=0) # Add the node attribute "bipartite"
->>> B.add_nodes_from(['a','b','c'], bipartite=1)
->>> B.add_edges_from([(1,'a'), (1,'b'), (2,'b'), (2,'c'), (3,'c'), (4,'a')])
+>>> # Add nodes with the node attribute "bipartite"
+>>> B.add_nodes_from([1, 2, 3, 4], bipartite=0)
+>>> B.add_nodes_from(['a', 'b', 'c'], bipartite=1)
+>>> # Add edges only between nodes of opposite node sets
+>>> B.add_edges_from([(1, 'a'), (1, 'b'), (2, 'b'), (2, 'c'), (3, 'c'), (4, 'a')])
 
 Many algorithms of the bipartite module of NetworkX require, as an argument, a
 container with all the nodes that belong to one set, in addition to the bipartite
-graph `B`. If `B` is connected, you can find the node sets using a two-coloring 
+graph `B`. The functions in the bipartite package do not check that the node set
+is actually correct nor that the input graph is actually bipartite.
+If `B` is connected, you can find the two node sets using a two-coloring 
 algorithm: 
 
 >>> nx.is_connected(B)
@@ -33,34 +38,39 @@ True
 >>> bottom_nodes, top_nodes = bipartite.sets(B)
 
 However, if the input graph is not connected, there are more than one possible
-colorations. In the face of ambiguity, we refuse the temptation to guess and
-raise an exc:`AmbiguousSolution` Exception.
+colorations. This is the reason why we require the user to pass a container
+with all nodes of one bipartite node set as an argument to most bipartite
+functions. In the face of ambiguity, we refuse the temptation to guess and
+raise an :exc:`AmbiguousSolution <networkx.AmbiguousSolution>`
+Exception if the input graph for
+:func:`bipartite.sets <networkx.algorithms.bipartite.basic.sets>`
+is disconnected.
 
-Using the "bipartite" node attribute, you can easily get the two node sets:
+Using the `bipartite` node attribute, you can easily get the two node sets:
 
->>> top_nodes = set(n for n,d in B.nodes(data=True) if d['bipartite']==0)
+>>> top_nodes = {n for n, d in B.nodes(data=True) if d['bipartite']==0}
 >>> bottom_nodes = set(B) - top_nodes
 
 So you can easily use the bipartite algorithms that require, as an argument, a
 container with all nodes that belong to one node set:
 
->>> print(round(bipartite.density(B, bottom_nodes),2))
+>>> print(round(bipartite.density(B, bottom_nodes), 2))
 0.5
 >>> G = bipartite.projected_graph(B, top_nodes)
 
 All bipartite graph generators in NetworkX build bipartite graphs with the 
-"bipartite" node attribute. Thus, you can use the same approach:
+`bipartite` node attribute. Thus, you can use the same approach:
 
 >>> RB = bipartite.random_graph(5, 7, 0.2)
->>> RB_top = set(n for n,d in RB.nodes(data=True) if d['bipartite']==0)
+>>> RB_top = {n for n, d in RB.nodes(data=True) if d['bipartite']==0}
 >>> RB_bottom = set(RB) - RB_top
 >>> list(RB_top)
 [0, 1, 2, 3, 4]
 >>> list(RB_bottom)
 [5, 6, 7, 8, 9, 10, 11]
 
-For other bipartite graph generators see the bipartite section of
-:doc:`generators`.
+For other bipartite graph generators see
+:mod:`Generators <networkx.algorithms.bipartite.generators>`.
 
 """
 

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -144,6 +144,8 @@ def sets(G, top_nodes=None):
 
     Raises an exception if the graph is not bipartite or if the input
     graph is disconnected and thus more than one valid solution exists.
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     Parameters
     ----------
@@ -212,7 +214,7 @@ def density(B, nodes):
     G : NetworkX graph
 
     nodes: list or container
-      Nodes in one set of the bipartite graph.
+      Nodes in one node set of the bipartite graph.
 
     Returns
     -------
@@ -229,6 +231,14 @@ def density(B, nodes):
     >>> Y=set([3,4])
     >>> bipartite.density(G,Y)
     1.0
+
+    Notes
+    -----
+    The container of nodes passed as argument must contain all nodes
+    in one of the two bipartite node sets to avoid ambiguity in the
+    case of disconnected graphs.
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     See Also
     --------
@@ -255,7 +265,7 @@ def degrees(B, nodes, weight=None):
     G : NetworkX graph
 
     nodes: list or container
-      Nodes in one set of the bipartite graph.
+      Nodes in one node set of the bipartite graph.
 
     weight : string or None, optional (default=None)
        The edge attribute that holds the numerical value used as a weight.
@@ -275,6 +285,14 @@ def degrees(B, nodes, weight=None):
     >>> degX,degY=bipartite.degrees(G,Y)
     >>> dict(degX)
     {0: 2, 1: 2, 2: 2}
+
+    Notes
+    -----
+    The container of nodes passed as argument must contain all nodes
+    in one of the two bipartite node sets to avoid ambiguity in the
+    case of disconnected graphs.
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     See Also
     --------

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -41,7 +41,8 @@ def degree_centrality(G, nodes):
     -----
     The nodes input parameter must conatin all nodes in one bipartite node set,
     but the dictionary returned contains all nodes from both bipartite node
-    sets.
+    sets. See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     For unipartite networks, the degree centrality values are 
     normalized by dividing by the maximum possible degree (which is 
@@ -138,6 +139,9 @@ def betweenness_centrality(G, nodes):
     -----
     The nodes input parameter must contain all nodes in one bipartite node set,
     but the dictionary returned contains all nodes from both node sets.
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
+
 
     References
     ----------
@@ -203,6 +207,9 @@ def closeness_centrality(G, nodes, normalized=True):
     -----
     The nodes input parameter must conatin all nodes in one bipartite node set,
     but the dictionary returned contains all nodes from both node sets.
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
+
 
     Closeness centrality is normalized by the minimum distance possible. 
     In the bipartite case the minimum distance for a node in one bipartite 

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -188,6 +188,9 @@ def average_clustering(G, nodes=None, mode='dot'):
     The container of nodes passed to this function must contain all of the nodes
     in one of the bipartite sets ("top" or "bottom") in order to compute 
     the correct average bipartite clustering coefficients.
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
+
 
     References
     ----------

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -92,6 +92,9 @@ def hopcroft_karp_matching(G, top_nodes=None):
     <https://en.wikipedia.org/wiki/Hopcroft%E2%80%93Karp_algorithm>`_ for
     bipartite graphs.
 
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
+
     See Also
     --------
 
@@ -207,6 +210,9 @@ def eppstein_matching(G, top_nodes=None):
     Hopcroft--Karp algorithm (see :func:`hopcroft_karp_matching`), which
     originally appeared in the `Python Algorithms and Data Structures library
     (PADS) <http://www.ics.uci.edu/~eppstein/PADS/ABOUT-PADS.txt>`_.
+
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     See Also
     --------
@@ -454,6 +460,9 @@ def to_vertex_cover(G, matching, top_nodes=None):
     >>> independent_set = set(G) - vertex_cover
     >>> print(list(independent_set))
     [2, 3, 4]
+
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     """
     # This is a Python implementation of the algorithm described at

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -75,6 +75,9 @@ def projected_graph(B, nodes, multigraph=False):
 
     The graph and node properties are (shallow) copied to the projected graph.
 
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
+
     See Also
     --------
     is_bipartite, 
@@ -161,6 +164,9 @@ def weighted_projected_graph(B, nodes, ratio=False):
     -----
     No attempt is made to verify that the input graph B is bipartite.
     The graph and node properties are (shallow) copied to the projected graph.
+
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     See Also
     --------
@@ -256,6 +262,9 @@ def collaboration_weighted_projected_graph(B, nodes):
     No attempt is made to verify that the input graph B is bipartite.
     The graph and node properties are (shallow) copied to the projected graph.
 
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
+
     See Also
     --------
     is_bipartite, 
@@ -347,6 +356,9 @@ def overlap_weighted_projected_graph(B, nodes, jaccard=True):
     -----
     No attempt is made to verify that the input graph B is bipartite.
     The graph and node properties are (shallow) copied to the projected graph.
+
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     See Also
     --------
@@ -460,6 +472,9 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     -----
     No attempt is made to verify that the input graph B is bipartite.
     The graph and node properties are (shallow) copied to the projected graph.
+
+    See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
+    for further details on how bipartite graphs are handled in NetworkX.
 
     See Also
     --------


### PR DESCRIPTION
This PR addresses #2400

Improve bipartite documentation by clarifying that the use of a node
attribute named `bipartite` with values 0 and 1 in order to
distinguish bipartite node sets is only a convention which is not
enforced in the source code. Also state explicitly that bipartite
functions do not check that the input graph is actually bipartite
nor than the container with a bipartite node set contains all nodes
from that bipartite node set.

Added links form all relevant function docstring to the module
level documentation where all this is explained.

Also added links to some custom exceptions to the generated
documentation that were missing.