### PR TITLE
Workaround for gdal python3.6 at travis and more doctests fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,10 @@ before_install:
 install:
   ### Install any prerequisites or dependencies necessary to run the build.
   - if [[ "${OPTIONAL_DEPS}" == miniconda ]]; then
-      DEPS="pyyaml numpy scipy matplotlib Cython pandas pip gdal";
+      DEPS="pyyaml numpy scipy matplotlib Cython pandas pip";
       conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $DEPS ;
       source activate test-environment;
+      conda install gdal;
       echo "Testing that gdal installed ok by if osgeo imports";
       python -c "from osgeo import ogr;print('importing ogr worked')";
       if [[ "${TRAVIS_PYTHON_VERSION}" =~ "2.7" ]]; then

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -70,7 +70,7 @@ def subgraph_centrality_exp(G):
     (from [1]_)
     >>> G = nx.Graph([(1,2),(1,5),(1,8),(2,3),(2,8),(3,4),(3,6),(4,5),(4,7),(5,6),(6,7),(7,8)])
     >>> sc = nx.subgraph_centrality_exp(G)
-    >>> print(['%s %0.2f'%(node,sc[node]) for node in sc])
+    >>> print(['%s %0.2f'%(node,sc[node]) for node in sorted(sc)])
     ['1 3.90', '2 3.90', '3 3.64', '4 3.71', '5 3.64', '6 3.71', '7 3.64', '8 3.90']
     """
     # alternative implementation that calculates the matrix exponential
@@ -132,7 +132,7 @@ def subgraph_centrality(G):
     --------
     >>> G = nx.Graph([(1,2),(1,5),(1,8),(2,3),(2,8),(3,4),(3,6),(4,5),(4,7),(5,6),(6,7),(7,8)])
     >>> sc = nx.subgraph_centrality(G)
-    >>> print(['%s %0.2f'%(node,sc[node]) for node in sc])
+    >>> print(['%s %0.2f'%(node,sc[node]) for node in sorted(sc)])
     ['1 3.90', '2 3.90', '3 3.64', '4 3.71', '5 3.64', '6 3.71', '7 3.64', '8 3.90']
 
     References

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -67,7 +67,7 @@ def subgraph_centrality_exp(G):
 
     Examples
     --------
-    (from [1]_)
+    (Example from [1]_)
     >>> G = nx.Graph([(1,2),(1,5),(1,8),(2,3),(2,8),(3,4),(3,6),(4,5),(4,7),(5,6),(6,7),(7,8)])
     >>> sc = nx.subgraph_centrality_exp(G)
     >>> print(['%s %0.2f'%(node,sc[node]) for node in sorted(sc)])
@@ -130,6 +130,7 @@ def subgraph_centrality(G):
 
     Examples
     --------
+    (Example from [1]_)
     >>> G = nx.Graph([(1,2),(1,5),(1,8),(2,3),(2,8),(3,4),(3,6),(4,5),(4,7),(5,6),(6,7),(7,8)])
     >>> sc = nx.subgraph_centrality(G)
     >>> print(['%s %0.2f'%(node,sc[node]) for node in sorted(sc)])


### PR DESCRIPTION
This PR fixes #2415 (well not really, but at least it doesn't kill the build for python 3.6 with optional dependencies).

This workaround still does not install gdal for python 3.6 but it doesn't kill the build, and gdal installation works for all other python versions. It seems that the problem is that conda for python 3.6 installs the latest version of gdal (2.1.3) which is not compatible with the package libgdal-dev provided by Travis version of Ubuntu.

Also more doctests fixes for python 3.6 at subgraph centrality. 