### PR TITLE
Fix closeness centrality for DiGraphs

### DIFF
--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -15,11 +15,11 @@ __author__ = "\n".join(['Aric Hagberg <aric.hagberg@gmail.com>',
 __all__ = ['closeness_centrality']
 
 
-def closeness_centrality(G, u=None, distance=None, normalized=True):
+def closeness_centrality(G, u=None, distance=None, normalized=True, reverse=False):
     r"""Compute closeness centrality for nodes.
 
     Closeness centrality [1]_ of a node `u` is the reciprocal of the
-    sum of the shortest path distances from `u` to all `n-1` other nodes.
+    sum of the shortest path distances to `u` from all `n-1` other nodes.
     Since the sum of distances depends on the number of nodes in the
     graph, closeness is normalized by the sum of minimum possible
     distances `n-1`.
@@ -45,6 +45,9 @@ def closeness_centrality(G, u=None, distance=None, normalized=True):
     normalized : bool, optional
       If True (default) normalize by the number of nodes in the connected
       part of the graph.
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, reverse the edges of G, using successors
+      instead of predecessors.
 
     Returns
     -------
@@ -78,8 +81,11 @@ def closeness_centrality(G, u=None, distance=None, normalized=True):
         # use Dijkstra's algorithm with specified attribute as edge weight 
         path_length = functools.partial(nx.single_source_dijkstra_path_length,
                                         weight=distance)
-    else:
-        path_length = nx.single_source_shortest_path_length
+    else: # handle either directed or undirected
+        if G.is_directed() and not reverse:
+            path_length = nx.single_target_shortest_path_length
+        else:
+            path_length = nx.single_source_shortest_path_length
 
     if u is None:
         nodes = G.nodes()

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -45,14 +45,34 @@ class TestUnweightedPath:
 
 
     def test_single_source_shortest_path(self):
-        p=nx.single_source_shortest_path(self.cycle,0)
-        assert_equal(p[3],[0,1,2,3])
-        p=nx.single_source_shortest_path(self.cycle,0, cutoff=0)
+        p = nx.single_source_shortest_path(self.directed_cycle, 3)
+        assert_equal(p[0], [3, 4, 5, 6, 0])
+        p = nx.single_source_shortest_path(self.cycle, 0)
+        assert_equal(p[3], [0, 1, 2, 3])
+        p = nx.single_source_shortest_path(self.cycle, 0, cutoff=0)
         assert_equal(p,{0 : [0]})
 
     def test_single_source_shortest_path_length(self):
-        assert_equal(dict(nx.single_source_shortest_path_length(self.cycle,0)),
-                     {0:0,1:1,2:2,3:3,4:3,5:2,6:1})
+        pl = nx.single_source_shortest_path_length
+        lengths = {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
+        assert_equal(dict(pl(self.cycle,0)), lengths)
+        lengths = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6}
+        assert_equal(dict(pl(self.directed_cycle,0)), lengths)
+
+    def test_single_target_shortest_path(self):
+        p = nx.single_target_shortest_path(self.directed_cycle, 0)
+        assert_equal(p[3], [3, 4, 5, 6, 0])
+        p = nx.single_target_shortest_path(self.cycle, 0)
+        assert_equal(p[3], [3, 2, 1, 0])
+        p = nx.single_target_shortest_path(self.cycle, 0, cutoff=0)
+        assert_equal(p,{0 : [0]})
+
+    def test_single_target_shortest_path_length(self):
+        pl = nx.single_target_shortest_path_length
+        lengths = {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
+        assert_equal(dict(pl(self.cycle, 0)), lengths)
+        lengths = {0: 0, 1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
+        assert_equal(dict(pl(self.directed_cycle, 0)), lengths)
 
     def test_all_pairs_shortest_path(self):
         p=nx.all_pairs_shortest_path(self.cycle)

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -357,6 +357,10 @@ def _single_shortest_path(adj, firstlevel, paths, cutoff, join):
             paths for starting nodes, e.g. {source: [source]}
         cutoff : int or float
             level at which we stop the process
+        join : function
+            function to construct a path from two partial paths. Requires two
+            list inputs `p1` and `p2`, and returns a list. Usually returns
+            `p1 + p2` (forward from source) or `p2 + p1` (backward from target)
     """
     level = 0                  # the current level
     nextlevel = firstlevel

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
-"""
-Shortest path algorithms for unweighted graphs.
-"""
-__author__ = """Aric Hagberg (hagberg@lanl.gov)"""
-#    Copyright (C) 2004-2016 by
+#    Copyright (C) 2004-2017 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Author:  Aric Hagberg <hagberg@lanl.gov>
+"""
+Shortest path algorithms for unweighted graphs.
+"""
+import networkx as nx
 
 __all__ = ['bidirectional_shortest_path',
            'single_source_shortest_path',
@@ -20,9 +22,7 @@ __all__ = ['bidirectional_shortest_path',
            'predecessor']
 
 
-import networkx as nx
-
-def single_source_shortest_path_length(G,source,cutoff=None):
+def single_source_shortest_path_length(G, source, cutoff=None):
     """Compute the shortest path lengths from source to all reachable nodes.
 
     Parameters
@@ -60,24 +60,42 @@ def single_source_shortest_path_length(G,source,cutoff=None):
     """
     if source not in G:
         raise nx.NodeNotFound('Source {} is not in G'.format(source))
+    if cutoff is None:
+        cutoff = float('inf')
+    nextlevel = {source: 1}
+    return _single_shortest_path_length(G.adj, nextlevel, cutoff)
+
+
+def _single_shortest_path_length(adj, firstlevel, cutoff):
+    """Yields (node, level) in a breadth first search
+
+    Shortest Path Length helper function
+    Parameters
+    ----------
+        adj : dict
+            Adjacency dict or view
+        firstlevel : dict
+            starting nodes, e.g. {source: 1} or {target: 1}
+        cutoff : int or float
+            level at which we stop the process
+    """
     seen = {}                  # level (number of hops) when seen in BFS
     level = 0                  # the current level
-    nextlevel = {source:1}  # dict of nodes to check at next level
+    nextlevel = firstlevel     # dict of nodes to check at next level
 
-    while nextlevel:
+    while nextlevel and cutoff >= level:
         thislevel = nextlevel  # advance to next level
         nextlevel = {}         # and start a new list (fringe)
         for v in thislevel:
             if v not in seen:
-                seen[v] = level # set the level of vertex v
-                nextlevel.update(G[v]) # add neighbors of v
+                seen[v] = level  # set the level of vertex v
+                nextlevel.update(adj[v])  # add neighbors of v
                 yield (v, level)
-        if (cutoff is not None and cutoff <= level):  break
-        level=level+1
+        level += 1
     del seen
 
 
-def single_target_shortest_path_length(G,target,cutoff=None):
+def single_target_shortest_path_length(G, target, cutoff=None):
     """Compute the shortest path lengths to target from all reachable nodes.
 
     Parameters
@@ -97,11 +115,11 @@ def single_target_shortest_path_length(G,target,cutoff=None):
 
     Examples
     --------
-    >>> G = nx.path_graph(5,create_using=nx.DiGraph())
-    >>> length = dict(nx.single_target_shortest_path_length(G,4))
+    >>> G = nx.path_graph(5, create_using=nx.DiGraph())
+    >>> length = dict(nx.single_target_shortest_path_length(G, 4))
     >>> length[0]
     4
-    >>> for node in [0, 1, 2, 3, 4]:
+    >>> for node in range(5):
     ...     print('{}: {}'.format(node, length[node]))
     0: 4
     1: 3
@@ -115,29 +133,13 @@ def single_target_shortest_path_length(G,target,cutoff=None):
     """
     if target not in G:
         raise nx.NodeNotFound('Target {} is not in G'.format(source))
-    
-    # handle either directed or undirected
-    if G.is_directed():
-        next_nodes=G.predecessors
-    else:
-        next_nodes=G.neighbors
-    
-    seen = {}                  # level (number of hops) when seen in BFS
-    level = 0                  # the current level
-    nextlevel = {target:1}     # dict of nodes to check at next level
 
-    while nextlevel:
-        thislevel = nextlevel  # advance to next level
-        nextlevel = {}         # and start a new list (fringe)
-        for v in thislevel:
-            if v not in seen:
-                seen[v] = level # set the level of vertex v
-                nextlevel.update({key: {} for key in next_nodes(v)})
-                yield (v, level)
-        if (cutoff is not None and cutoff <= level):  break
-        level=level+1
-    del seen    
-    
+    if cutoff is None:
+        cutoff = float('inf')
+    # handle either directed or undirected
+    adj = G.pred if G.is_directed() else G.adj
+    nextlevel = {target: 1}
+    return _single_shortest_path_length(adj, nextlevel, cutoff)
 
 
 def all_pairs_shortest_path_length(G, cutoff=None):
@@ -184,7 +186,7 @@ def all_pairs_shortest_path_length(G, cutoff=None):
         yield (n, dict(length(G, n, cutoff=cutoff)))
 
 
-def bidirectional_shortest_path(G,source,target):
+def bidirectional_shortest_path(G, source, target):
     """Return a list of nodes in a shortest path between source and target.
 
     Parameters
@@ -213,7 +215,7 @@ def bidirectional_shortest_path(G,source,target):
 
     Notes
     -----
-    This algorithm is used by shortest_path(G,source,target).
+    This algorithm is used by shortest_path(G, source, target).
     """
 
     if source not in G or target not in G:
@@ -221,75 +223,78 @@ def bidirectional_shortest_path(G,source,target):
         raise nx.NodeNotFound(msg.format(source, target))
 
     # call helper to do the real work
-    results=_bidirectional_pred_succ(G,source,target)
-    pred,succ,w=results
+    results = _bidirectional_pred_succ(G, source, target)
+    pred, succ, w = results
 
     # build path from pred+w+succ
-    path=[]
+    path = []
     # from source to w
     while w is not None:
         path.append(w)
-        w=pred[w]
+        w = pred[w]
     path.reverse()
     # from w to target
-    w=succ[path[-1]]
+    w = succ[path[-1]]
     while w is not None:
         path.append(w)
-        w=succ[w]
+        w = succ[w]
 
     return path
+
 
 def _bidirectional_pred_succ(G, source, target):
     """Bidirectional shortest path helper.
 
-       Returns (pred,succ,w) where
+       Returns (pred, succ, w) where
        pred is a dictionary of predecessors from w to the source, and
        succ is a dictionary of successors from w to the target.
     """
     # does BFS from both source and target and meets in the middle
     if target == source:
-        return ({target:None},{source:None},source)
+        return ({target: None}, {source: None}, source)
 
     # handle either directed or undirected
     if G.is_directed():
-        Gpred=G.predecessors
-        Gsucc=G.successors
+        Gpred = G.pred
+        Gsucc = G.succ
     else:
-        Gpred=G.neighbors
-        Gsucc=G.neighbors
+        Gpred = G.adj
+        Gsucc = G.adj
 
     # predecesssor and successors in search
-    pred={source:None}
-    succ={target:None}
+    pred = {source: None}
+    succ = {target: None}
 
     # initialize fringes, start with forward
-    forward_fringe=[source]
-    reverse_fringe=[target]
+    forward_fringe = [source]
+    reverse_fringe = [target]
 
     while forward_fringe and reverse_fringe:
         if len(forward_fringe) <= len(reverse_fringe):
-            this_level=forward_fringe
-            forward_fringe=[]
+            this_level = forward_fringe
+            forward_fringe = []
             for v in this_level:
-                for w in Gsucc(v):
+                for w in Gsucc[v]:
                     if w not in pred:
                         forward_fringe.append(w)
-                        pred[w]=v
-                    if w in succ:  return pred,succ,w # found path
+                        pred[w] = v
+                    if w in succ:  # path found
+                        return pred, succ, w
         else:
-            this_level=reverse_fringe
-            reverse_fringe=[]
+            this_level = reverse_fringe
+            reverse_fringe = []
             for v in this_level:
-                for w in Gpred(v):
+                for w in Gpred[v]:
                     if w not in succ:
-                        succ[w]=v
+                        succ[w] = v
                         reverse_fringe.append(w)
-                    if w in pred:  return pred,succ,w # found path
+                    if w in pred:  # found path
+                        return pred, succ, w
 
     raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
 
 
-def single_source_shortest_path(G,source,cutoff=None):
+def single_source_shortest_path(G, source, cutoff=None):
     """Compute shortest path between source
     and all other nodes reachable from source.
 
@@ -310,8 +315,8 @@ def single_source_shortest_path(G,source,cutoff=None):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> path=nx.single_source_shortest_path(G,0)
+    >>> G = nx.path_graph(5)
+    >>> path = nx.single_source_shortest_path(G, 0)
     >>> path[4]
     [0, 1, 2, 3, 4]
 
@@ -327,29 +332,48 @@ def single_source_shortest_path(G,source,cutoff=None):
     shortest_path
     """
     if source not in G:
-        raise nx.NodeNotFound("Source {} not in G".format(source));
+        raise nx.NodeNotFound("Source {} not in G".format(source))
 
-    level=0                  # the current level
-    nextlevel={source:1}       # list of nodes to check at next level
-    paths={source:[source]}  # paths dictionary  (paths to key from source)
-    if cutoff==0:
-        return paths
-    while nextlevel:
-        thislevel=nextlevel
-        nextlevel={}
+    def join(p1, p2):
+        return p1 + p2
+    if cutoff is None:
+        cutoff = float('inf')
+    nextlevel = {source: 1}     # list of nodes to check at next level
+    paths = {source: [source]}  # paths dictionary  (paths to key from source)
+    return _single_shortest_path(G.adj, nextlevel, paths, cutoff, join)
+
+
+def _single_shortest_path(adj, firstlevel, paths, cutoff, join):
+    """Returns shortest paths
+
+    Shortest Path helper function
+    Parameters
+    ----------
+        adj : dict
+            Adjacency dict or view
+        firstlevel : dict
+            starting nodes, e.g. {source: 1} or {target: 1}
+        paths : dict
+            paths for starting nodes, e.g. {source: [source]}
+        cutoff : int or float
+            level at which we stop the process
+    """
+    level = 0                  # the current level
+    nextlevel = firstlevel
+    while nextlevel and cutoff > level:
+        thislevel = nextlevel
+        nextlevel = {}
         for v in thislevel:
-            for w in G[v]:
+            for w in adj[v]:
                 if w not in paths:
-                    paths[w]=paths[v]+[w]
-                    nextlevel[w]=1
-        level=level+1
-        if (cutoff is not None and cutoff <= level):  break
+                    paths[w] = join(paths[v], [w])
+                    nextlevel[w] = 1
+        level += 1
     return paths
 
 
-def single_target_shortest_path(G,target,cutoff=None):
-    """Compute shortest path between all 
-    nodes that reach target and target.
+def single_target_shortest_path(G, target, cutoff=None):
+    """Compute shortest path to target from all nodes that reach target.
 
     Parameters
     ----------
@@ -368,10 +392,10 @@ def single_target_shortest_path(G,target,cutoff=None):
 
     Examples
     --------
-    >>> G=nx.path_graph(5,create_using=nx.DiGraph())
-    >>> path=nx.single_target_shortest_path(G,4)
+    >>> G = nx.path_graph(5, create_using=nx.DiGraph())
+    >>> path = nx.single_target_shortest_path(G, 4)
     >>> path[0]
-    [4, 3, 2, 1, 0]
+    [0, 1, 2, 3, 4]
 
     Notes
     -----
@@ -384,29 +408,18 @@ def single_target_shortest_path(G,target,cutoff=None):
     --------
     shortest_path, single_source_shortest_path
     """
-    # handle undirected graphs
-    if not G.is_directed():
-        return nx.single_source_shortest_path(G,target,cutoff=None)
-    
     if target not in G:
-        raise nx.NodeNotFound("Target {} not in G".format(source));
+        raise nx.NodeNotFound("Target {} not in G".format(source))
 
-    level=0                  # the current level
-    nextlevel={target:1}     # list of nodes to check at next level
-    paths={target:[target]}  # paths dictionary  (paths to key from source)
-    if cutoff==0:
-        return paths
-    while nextlevel:
-        thislevel=nextlevel
-        nextlevel={}
-        for v in thislevel:
-            for w in G.predecessors(v):
-                if w not in paths:
-                    paths[w]=paths[v]+[w]
-                    nextlevel[w]=1
-        level=level+1
-        if (cutoff is not None and cutoff <= level):  break
-    return paths
+    def join(p1, p2):
+        return p2 + p1
+    # handle undirected graphs
+    adj = G.pred if G.is_directed() else G.adj
+    if cutoff is None:
+        cutoff = float('inf')
+    nextlevel = {target: 1}     # list of nodes to check at next level
+    paths = {target: [target]}  # paths dictionary  (paths to key from source)
+    return _single_shortest_path(adj, nextlevel, paths, cutoff, join)
 
 
 def all_pairs_shortest_path(G, cutoff=None):
@@ -441,8 +454,8 @@ def all_pairs_shortest_path(G, cutoff=None):
     return {n: single_source_shortest_path(G, n, cutoff=cutoff) for n in G}
 
 
-def predecessor(G,source,target=None,cutoff=None,return_seen=None):
-    """ Returns dictionary of predecessors for the path from source to all nodes in G.
+def predecessor(G, source, target=None, cutoff=None, return_seen=None):
+    """Returns dict of predecessors for the path from source to all nodes in G
 
 
     Parameters
@@ -475,36 +488,38 @@ def predecessor(G,source,target=None,cutoff=None,return_seen=None):
 
     """
     if source not in G:
-        raise nx.NodeNotFound("Source {} not in G".format(source));
+        raise nx.NodeNotFound("Source {} not in G".format(source))
 
-    level=0                  # the current level
-    nextlevel=[source]       # list of nodes to check at next level
-    seen={source:level}      # level (number of hops) when seen in BFS
-    pred={source:[]}         # predecessor dictionary
+    level = 0                  # the current level
+    nextlevel = [source]       # list of nodes to check at next level
+    seen = {source: level}     # level (number of hops) when seen in BFS
+    pred = {source: []}        # predecessor dictionary
     while nextlevel:
-        level=level+1
-        thislevel=nextlevel
-        nextlevel=[]
+        level = level + 1
+        thislevel = nextlevel
+        nextlevel = []
         for v in thislevel:
             for w in G[v]:
                 if w not in seen:
-                    pred[w]=[v]
-                    seen[w]=level
+                    pred[w] = [v]
+                    seen[w] = level
                     nextlevel.append(w)
-                elif (seen[w]==level):# add v to predecessor list if it
-                    pred[w].append(v) # is at the correct level
+                elif (seen[w] == level):  # add v to predecessor list if it
+                    pred[w].append(v)     # is at the correct level
         if (cutoff and cutoff <= level):
             break
 
     if target is not None:
         if return_seen:
-            if not target in pred: return ([],-1)  # No predecessor
-            return (pred[target],seen[target])
+            if target not in pred:
+                return ([], -1)  # No predecessor
+            return (pred[target], seen[target])
         else:
-            if not target in pred: return []  # No predecessor
+            if target not in pred:
+                return []  # No predecessor
             return pred[target]
     else:
         if return_seen:
-            return (pred,seen)
+            return (pred, seen)
         else:
             return pred


### PR DESCRIPTION
Closeness centrality for a node u is calculated as C(u) = \frac{n - 1}{\sum_{v=1}^{n-1} d(v, u)}, that is the reciprocal of the sum of the shortest path distances from all n-1 other nodes to u, but in closeness_centrality method it is implemented as the reciprocal of the sum of the shortest path distances from u to all n-1 other nodes. For undirected graphs, using d(u,v) instead of d(v,u) is not a problem, but for directed graph it can produce totally different results. For this reason I have slightly modified the closeness centrality function, by using predecessors of a node instead of successors in case of undirected graph through the new method "single_target_shortest_path_length" added to the file _networkx/algorithms/shortest_paths/unweighted.py_: for the sake of completeness, I have also added the function "single_target_shortest_path" to the same file.

I really appreciate any feedback, and please feel free to modify any line of code ;)