### PR TITLE
Ensure nx.power preserves all original nodes

### DIFF
--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -413,6 +413,7 @@ def power(G, k):
     if k <= 0:
         raise ValueError('k must be a positive integer')
     H = nx.Graph()
+    H.add_nodes_from(G)
     # update BFS code to ignore self loops.
     for n in G:
         seen = {}                  # level (number of hops) when seen in BFS


### PR DESCRIPTION
Since the implementation was only adding nodes as a byproduct of adding edges, it ended up dropping zero-degree nodes. This fixes things by initializing the result to contain all original nodes. Fixes #2454.