### PR TITLE
Pass heuristic function full node object, not just names

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -127,7 +127,10 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
                 if qcost <= ncost:
                     continue
             else:
-                h = heuristic(neighbor, target)
+                try:
+                    h = heuristic(neighbor, target)
+                except:
+                    h = heuristic(G.node[neighbor], G.node[target])
             enqueued[neighbor] = ncost, h
             push(queue, (ncost + h, next(c), neighbor, ncost, curnode))
 


### PR DESCRIPTION
Currently only the node names are passed to the heuristic function, which is quite limiting (for example, to calculate distance function in your example you must name the nodes by the coordinates (x,y)). If the node object was passed it would be possible to write heuristic functions which can use all node properties to return the result. 

I have included my proposal with a try statement so as not to interfere with legacy code.