### PR TITLE
[WIP] edge connectivity algorithms

### DIFF
--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+import networkx as nx
+
+
+def one_edge_augmentation(G, avail=None):
+    """Finds minimum weight set of edges to connect G.
+
+    Adding these edges to G will make it connected.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    avail : list
+        available edges, if None nx.complement(G) is assumed.
+        if each item is a (u, v), the problem is unweighted.
+        if each item is a (u, v, d), the problem is weighted.
+        with d[weight] corresponding to the weight.
+    """
+    if avail is not None:
+        for edge in weighted_one_edge_augmentation(G, avail):
+            yield edge
+    else:
+        ccs1 = list(nx.connected_components(G))
+        C = collapse(G, ccs1)
+        mapping = C.graph['mapping']
+        # When we are not constrained, we can just make a meta graph tree.
+        meta_nodes = list(C.nodes())
+        # build a path in the metagraph
+        meta_aug = list(zip(meta_nodes, meta_nodes[1:]))
+        # map that path to the original graph
+        inverse = ut.group_pairs(C.graph['mapping'].items())
+        for mu, mv in meta_aug:
+            yield (inverse[mu][0], inverse[mv][0])
+
+
+def weighted_one_edge_augmentation(G, avail):
+    """ this is the MST problem """
+    ccs1 = list(nx.connected_components(G))
+    C = collapse(G, ccs1)
+    mapping = C.graph['mapping']
+
+    avail_uv = [tup[0:2] for tup in avail]
+    avail_w = [1 if len(tup) == 2 else tup[-1][weight] for tup in avail]
+    meta_avail_uv = [(mapping[u], mapping[v]) for u, v in avail_uv]
+
+    # only need exactly 1 edge at most between each CC, so choose lightest
+    avail_ew = zip(avail_uv, avail_w)
+    grouped_we = ut.group_items(avail_ew, meta_avail_uv)
+    candidates = []
+    for meta_edge, choices in grouped_we.items():
+        edge, w = min(choices, key=lambda t: t[1])
+        candidates.append((meta_edge, edge, w))
+    candidates = sorted(candidates, key=lambda t: t[2])
+
+    # kruskals algorithm on metagraph to find the best connecting edges
+    subtrees = nx.utils.UnionFind()
+    for (mu, mv), (u, v), w in candidates:
+        if subtrees[mu] != subtrees[mv]:
+            yield (u, v)
+        subtrees.union(mu, mv)
+    # G2 = G.copy()
+    # nx.set_edge_attributes(G2, 'weight', 0)
+    # G2.add_edges_from(avail, weight=1)
+    # mst = nx.minimum_spanning_tree(G2)
+    # aug_edges = [(u, v) for u, v in avail if mst.has_edge(u, v)]
+    # return aug_edges
+
+
+
+def bridge_augmentation(G, avail=None):
+    """Finds the a set of edges that bridge connects G.
+
+    Adding these edges to G will make it 2-edge-connected.
+    If no constraints are specified the returned set of edges is minimum an
+    optimal, otherwise the solution is approximated.
+
+    Notes
+    -----
+    This is an implementation of the algorithm from _[1].
+    If there are no constraints the solution can be computed in linear time.
+    When the available edges have weights the problem becomes NP-hard.
+    If G is connected the approximation ratio is 2, otherwise it is 3.
+
+    References
+    ----------
+    .. [1] Eswaran, Kapali P., and R. Endre Tarjan. Augmentation problems.
+        http://epubs.siam.org/doi/abs/10.1137/0205044
+    """
+    if G.number_of_nodes() < 3:
+        raise ValueError('impossible to bridge connect less than 3 verticies')
+    if avail is not None:
+        return weighted_bridge_augmentation(G, avail)
+    else:
+        # find the bridge-connected components of G
+        bridge_ccs = bridge_connected_compoments(G)
+        # condense G into an forest C
+        C = collapse(G, bridge_ccs)
+        # Connect each tree in the forest to construct an arborescence
+        # (I think) these must use nodes with minimum degree
+        roots = [min(cc, key=C.degree) for cc in nx.connected_components(C)]
+        forest_bridges = list(zip(roots, roots[1:]))
+        C.add_edges_from(forest_bridges)
+        # order the leaves of C by preorder
+        leafs = [n for n in nx.dfs_preorder_nodes(C) if C.degree(n) == 1]
+        # construct edges to bridge connect the tree
+        tree_bridges = list(zip(leafs, leafs[1:]))
+        # collect the edges used to augment the original forest
+        aug_tree_edges = tree_bridges + forest_bridges
+        # map these edges back to edges in the original graph
+        inverse = {v: k for k, v in C.graph['mapping'].items()}
+        bridge_edges = [(inverse[u], inverse[v]) for u, v in aug_tree_edges]
+        return bridge_edges
+
+
+def weighted_bridge_augmentation(G, avail):
+    """
+    Chooses a set of edges from avail to add to G that renders it
+    2-edge-connected if such a subset exists.
+
+    Because we are constrained by edges in avail this problem is NP-hard, and
+    this function is a 2-approximation if the input graph is connected, and a
+    3-approximation if it is not. Runs in O(m + nlog(n)) time
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    avail : set
+        candidate edges to choose from
+
+    Returns
+    -------
+    aug_edges (set): subset of avail chosen to augment G
+
+    References
+    ----------
+    .. [1] Khuller, Samir, and Ramakrishna Thurimella. Approximation
+        algorithms for graph augmentation.
+        http://www.sciencedirect.com/science/article/pii/S0196677483710102
+    """
+    def _most_recent_descendant(D, u, v):
+        # Find a closest common descendant
+        assert nx.is_directed_acyclic_graph(D), 'Must be DAG'
+        v_branch = nx.descendants(D, v).union({v})
+        u_branch = nx.descendants(D, u).union({u})
+        common = v_branch & u_branch
+        node_depth = (
+            ((c, (nx.shortest_path_length(D, u, c) +
+                  nx.shortest_path_length(D, v, c)))
+             for c in common))
+        mrd = min(node_depth, key=lambda t: t[1])[0]
+        return mrd
+
+    def _lowest_common_anscestor(D, u, v):
+        # Find a common ancestor furthest away
+        assert nx.is_directed_acyclic_graph(D), 'Must be DAG'
+        v_branch = nx.anscestors(D, v).union({v})
+        u_branch = nx.anscestors(D, u).union({u})
+        common = v_branch & u_branch
+        node_depth = (
+            ((c, (nx.shortest_path_length(D, c, u) +
+                  nx.shortest_path_length(D, c, v)))
+             for c in common))
+        mrd = max(node_depth, key=lambda t: t[1])[0]
+        return mrd
+
+    # If input G is not connected the approximation factor increases to 3
+    aug_edges = []
+    if not nx.is_connected(G):
+        H = G.copy()
+        connectors = one_connected_augmentation(H, avail)
+        H.add_edges_from(connectors)
+        aug_edges.extend(connectors)
+    else:
+        H = G
+    if not nx.is_connected(H):
+        raise ValueError('no augmentation possible')
+
+    uv_avail = [tup[0:2] for tup in avail]
+    uv_avail = [
+        (u, v) for u, v in uv_avail if (
+            H.has_node(u) and H.has_node(v) and not H.has_edge(u, v))
+    ]
+
+    # Collapse input into a metagraph. Meta nodes are bridge-ccs
+    bridge_ccs = bridge_connected_compoments(H)
+    C = collapse(H, bridge_ccs)
+
+    # Use the meta graph to filter out a small feasible subset of avail
+    # Choose the minimum weight edge from each group. TODO WEIGHTS
+    mapping = C.graph['mapping']
+    mapped_avail = [(mapping[u], mapping[v]) for u, v in uv_avail]
+    grouped_avail = ut.group_items(uv_avail, mapped_avail)
+    feasible_uv = [
+        group[0] for key, group in grouped_avail.items()
+        if key[0] != key[1]]
+    feasible_mapped_uv = {
+        e_(mapping[u], mapping[v]): e_(u, v) for u, v in feasible_uv
+    }
+
+    if len(feasible_mapped_uv) > 0:
+        """
+        Mapping of terms from (Khuller and Thurimella):
+            C         : G^0 = (V, E^0)
+            mapped_uv : E - E^0  # they group both avail and given edges in E
+            T         : \Gamma
+            D         : G^D = (V, E_D)
+
+            The paper uses ancestor because children point to parents,
+            in the networkx context this would be descendant.
+            So, lowest_common_ancestor = most_recent_descendant
+        """
+        # Pick an arbitrary leaf from C as the root
+        root = next(n for n in C.nodes() if C.degree(n) == 1)
+        # Root C into a tree T by directing all edges towards the root
+        T = nx.reverse(nx.dfs_tree(C, root))
+        # Add to D the directed edges of T and set their weight to zero
+        # This indicates that it costs nothing to use edges that were given.
+        D = T.copy()
+        nx.set_edge_attributes(D, 'weight', 0)
+        # Add in feasible edges with respective weights
+        for u, v in feasible_mapped_uv.keys():
+            mrd = _most_recent_descendant(T, u, v)
+            # print('(u, v)=({}, {})  mrd={}'.format(u, v, mrd))
+            if mrd == u:
+                # If u is descendant of v, then add edge u->v
+                D.add_edge(mrd, v, weight=1, implicit=True)
+            elif mrd == v:
+                # If v is descendant of u, then add edge v->u
+                D.add_edge(mrd, u, weight=1, implicit=True)
+            else:
+                # If neither u nor v is a descendant of the other
+                # let t = mrd(u, v) and add edges t->u and t->v
+                D.add_edge(mrd, u, weight=1, implicit=True)
+                D.add_edge(mrd, v, weight=1, implicit=True)
+
+        # root the graph by removing all predecessors to `root`.
+        D_ = D.copy()
+        D_.remove_edges_from([(u, root) for u in D.predecessors(root)])
+
+        # Then compute a minimum rooted branching
+        try:
+            A = nx.minimum_spanning_arborescence(D_)
+        except nx.NetworkXException:
+            # If there is no arborescence then augmentation is not possible
+            raise ValueError('There is no 2-edge-augmentation possible')
+        else:
+            edges = list(A.edges(data=True))
+
+        chosen_mapped = []
+        for u, v, d in edges:
+            edge = e_(u, v)
+            if edge in feasible_mapped_uv:
+                chosen_mapped.append(edge)
+
+        for edge in chosen_mapped:
+            orig_edge = feasible_mapped_uv[edge]
+            aug_edges.append(orig_edge)
+    return aug_edges
+
+
+@profile
+def edge_connected_augmentation(G, k, avail=None, hack=False, return_anyway=False):
+    r"""
+    Finds set of edges to k-edge-connect G. In the case of k=1
+    this is a minimum weight set. For k>2 it becomes exact only if avail is
+    None
+    """
+    if avail is not None and len(avail) == 0:
+        return []
+    if G.number_of_nodes() < k + 1:
+        if return_anyway:
+            if avail is None:
+                avail = list(complement_edges(G))
+            else:
+                avail = list(avail)
+            return avail
+        raise ValueError(
+            ('impossible to {} connect in graph with less than {} '
+             'verticies').format(k, k + 1))
+    # if is_edge_connected(G, k):
+    #     aug_edges = []
+    elif k == 1 and not hack:
+        aug_edges = one_connected_augmentation(G, avail)
+    elif k == 2 and avail is None and not hack:
+        aug_edges = bridge_connected_augmentation(G)
+    elif k == 2 and avail is not None:
+        aug_edges = weighted_bridge_connected_augmentation(G, avail,
+                                                           return_anyway)
+    else:
+        raise NotImplementedError('not implemented for k>2')
+    return aug_edges
+
+
+def collapse(G, grouped_nodes):
+    """Collapses each group of nodes into a single node.
+
+    This is similar to condensation, but works on undirected graphs.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+       A directed graph.
+
+    grouped_nodes:  list or generator
+       Grouping of nodes to collapse. The grouping must be disjoint.
+       If grouped_nodes are strongly_connected_components then this is
+       equivalent to condensation.
+
+    Returns
+    -------
+    C : NetworkX Graph
+       The collapsed graph C of G with respect to the node grouping.  The node
+       labels are integers corresponding to the index of the component in the
+       list of strongly connected components of G.  C has a graph attribute
+       named 'mapping' with a dictionary mapping the original nodes to the
+       nodes in C to which they belong.  Each node in C also has a node
+       attribute 'members' with the set of original nodes in G that form the
+       group that the node in C represents.
+
+    Examples
+    --------
+    Collapses a graph using disjoint groups, but not necesarilly connected
+    >>> G = nx.Graph([(1, 0), (2, 3), (3, 1), (3, 4), (4, 5), (5, 6), (5, 7)])
+    >>> G.add_node('A')
+    >>> grouped_nodes = [{0, 1, 2, 3}, {5, 6, 7}]
+    >>> C = collapse(G, grouped_nodes)
+    >>> assert nx.get_node_attributes(C, 'members') == {
+    >>>     0: {0, 1, 2, 3}, 1: {5, 6, 7}, 2: {4}, 3: {'A'}
+    >>> }
+    """
+    mapping = {}
+    members = {}
+    C = G.__class__()
+    i = 0  # required if G is empty
+    remaining = set(G.nodes())
+    for i, group in enumerate(grouped_nodes):
+        group = set(group)
+        assert remaining.issuperset(group), (
+            'grouped nodes must exist in G and be disjoint')
+        remaining.difference_update(group)
+        members[i] = group
+        mapping.update((n, i) for n in group)
+    # remaining nodes are in their own group
+    for i, node in enumerate(remaining, start=i + 1):
+        group = set([node])
+        members[i] = group
+        mapping.update((n, i) for n in group)
+    number_of_groups = i + 1
+    C.add_nodes_from(range(number_of_groups))
+    C.add_edges_from((mapping[u], mapping[v]) for u, v in G.edges()
+                     if mapping[u] != mapping[v])
+    # Add a list of members (ie original nodes) to each node (ie scc) in C.
+    nx.set_node_attributes(C, 'members', members)
+    # Add mapping dict as graph attribute
+    C.graph['mapping'] = mapping
+    return C
+
+
+def complement_edges(G):
+    return ((n, n2) for n, nbrs in G.adjacency()
+            for n2 in G if n2 not in nbrs if n != n2)

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+import networkx as nx
+from networkx.utils import arbitrary_element, pairwise, flatten
+
+__all__ = ['k_edge_components']
+
+
+@not_implemented_for('directed')
+@not_implemented_for('multi')
+def k_edge_components(G, k):
+    """Returns all the k-edge-connected-compoments in G.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    k : Integer
+        Desired edge connectivity
+
+    Returns
+    -------
+    k_edge_compoments : a generator of k-edge-connected-compoments
+        Each k-edge-cc is a maximal set of nodes in G with edge connectivity at
+        least `k`.
+
+    Raises
+    ------
+    NetworkXNotImplemented:
+        If the input graph is directed or a multigraph.
+
+    ValueError:
+        If k is less than 1
+
+    Notes
+    -----
+    If k=1, this is simply connected compoments.  If k=2, the an efficient
+    bridge connected compoment algorithm from _[1] is run based on the chain
+    decomposition. If k>2, then the algorithm from _[2] is used.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Bridge_(graph_theory)
+    .. [2] Wang, Tianhao, et al. A simple algorithm for finding all
+        k-edge-connected components.
+        http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0136264
+    """
+    if k < 1:
+        raise ValueError('k cannot be less than 1')
+    elif k == 1:
+        return nx.connected_components(G)
+    elif k == 2:
+        return bridge_connected_compoments(G)
+    else:
+        aux_graph = EdgeComponentAuxGraph.construct(G)
+        return aux_graph.k_edge_components(k)
+
+
+@not_implemented_for('directed')
+@not_implemented_for('multi')
+def find_bridges(G):
+    """Returns all bridge edges in G.
+
+    A bridge is an edge that, if removed, would diconnect a component in G.
+    Equivalently a bridge is an edge that does not belong to any cycle.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    Notes
+    -----
+    This is an implementation of the algorithm described in _[1]. Bridges can
+    be found using chain decomposition. An edge e in G is a bridge if and only
+    if e is not contained in any chain.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Bridge_(graph_theory)#Bridge-Finding_with_Chain_Decompositions
+
+    Example
+    -------
+    >>> G = demodata_bridge()
+    >>> bridges = set(find_bridges(G))
+    >>> assert bridges == {(3, 5), (4, 8), (20, 21), (22, 23), (23, 24)}
+    """
+    chains = nx.chain_decomposition(G)
+    H = G.copy(with_data=False)
+    H.remove_edges_from(it.chain.from_iterable(chains))
+    for edge in H.edges():
+        yield edge
+
+
+@not_implemented_for('directed')
+@not_implemented_for('multi')
+def bridge_compoments(G):
+    """Finds all bridge-connected-compoments G.
+
+    Notes
+    -----
+    bridge-connected compoments are also refered to as 2-edge-connected
+    compoments.
+    """
+    bridges = find_bridges(G)
+    H = G.copy()
+    H.remove_edges_from(bridges)
+    return list(nx.connected_components(H))
+
+
+class EdgeComponentAuxGraph(object):
+    """
+    A simple algorithm to find all k-edge-connected compoments in a graph.
+
+    Notes
+    -----
+    This implementation is based on [1]_. The idea is to construct an auxillary
+    graph from which the k-edge-connected compoments can be extracted in linear
+    time. The auxillary graph is constructed in O(|V|F) operations, where F is
+    the complexity of max flow. Querying the compoments takes an additional
+    O(|V|) operations. This algorithm can be slow for large graphs, but it
+    handles an arbitrary k and works for both directed, undirected, and
+    multigraph inputs.
+
+    References
+    ----------
+    .. [1] Wang, Tianhao, et al. A simple algorithm for finding all
+        k-edge-connected components.
+        http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0136264
+
+    Example
+    -------
+    >>> a, b, c, d, e, f, g = ut.chr_range(7)
+    >>> di_paths = [
+    >>>     (a, d, b, f, c),
+    >>>     (a, e, b),
+    >>>     (a, e, b, c, g, b, a),
+    >>>     (c, b),
+    >>>     (f, g, f),
+    >>> ]
+    >>> G = nx.DiGraph(flatten(pairwise(path) for path in di_paths))
+    >>> nx.set_edge_attributes(G, 'capacity', ut.dzip(G.edges(), [1]))
+    >>> A = aux_graph(G, source=a)
+    """
+
+    @classmethod
+    def construct(EdgeComponentAuxGraph, G):
+        """
+        Given G=(V, E), initialize an empty auxillary graph A.
+        Choose an arbitrary source vertex s.  Initialize a set N of available
+        vertices (that can be used as the sink). The algorithm picks an
+        arbitrary vertex t from N - {s}, and then computes the minimum st-cut
+        (S, T) with value w. If G is directed the the minimum of the st-cut or
+        the ts-cut is used instead. Then, the edge (s, t) is added to the
+        auxillary graph with weight w. The algorithm is called recursively
+        first using S as the available vertices and s as the source, and then
+        using T and t. Recusion stops when the source is the only available
+        node.
+        """
+
+        def _recursive_build(H, A, source, avail):
+            # Terminate once the flow has been compute to every node.
+            if {source} == avail:
+                return
+            # pick an arbitrary vertex as the sink
+            sink = arbitrary_element(avail - {source})
+            # find the minimum cut and its weight
+            value, (S, T) = nx.minimum_cut(H, source, sink)
+            if H.is_directed():
+                # check if the reverse direction has a smaller cut
+                value, (T_, S_) = nx.minimum_cut(H, source, sink)
+                if value_ < value:
+                    value, S, T = value, T_, S_
+            # add edge with weight of cut to the aux graph
+            A.add_edge(source, sink, weight=value)
+            # recursively call until all but one node is used
+            _recursive_build(H, A, source, avail.intersection(S))
+            _recursive_build(H, A, sink, avail.intersection(T))
+
+        # Copy input to ensure all edge have unit capacity
+        H = G.__class__()
+        H.add_nodes_from(G.nodes())
+        H.add_edges_from(G.edges(), capacity=1)
+
+        # Pick an arbitrary vertex as the source
+        source = next(H.nodes())
+
+        # Initialize a set of elements that can be chosen as the sink
+        avail = set(H.nodes())
+
+        A = G.__class__()
+        self = EdgeComponentAuxGraph()
+        self.A = A
+        return self
+
+    def k_edge_components(self, k):
+        """
+        Given the auxillary graph, the k-edge-connected components can be
+        determined in linear time by removing all edges with weights less than
+        k from the auxillary graph.  The resulting connected components are the
+        k-edge-connected compoments in the original graph.
+        """
+        aux_weights = nx.get_edge_attributes(A, 'weight')
+        # Create a relevant graph with the auxillary edges with weights >= k
+        R = nx.Graph()
+        R.add_nodes_from(A.nodes())
+        R.add_edges_from(e for e, w in aux_weights.items() if w >= k)
+        # Return the connected components of the relevant graph
+        return nx.connected_components(R)

--- a/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import networkx as nx
+from networkx.utils import arbitrary_element, pairwise, flatten
+
+
+def test_one_aug():
+    G = nx.Graph()
+    G.add_nodes_from([
+        1, 2, 3, 4, 5, 6, 7, 8, 9])
+    G.add_edges_from([(3, 8), (1, 2), (2, 3)])
+    impossible = {(6, 3), (3, 9)}
+    rng = np.random.RandomState(0)
+    avail = list(set(complement_edges(G)) - impossible)
+    avail_uvd = [(u, v, {'weight': rng.rand()}) for u, v in avail]
+    aug_edges1 = list(one_connected_augmentation(G))
+    aug_edges2 = list(one_connected_augmentation(G, avail))
+    aug_edges3 = list(one_connected_augmentation(G, avail_uvd))
+
+
+def test_bridge_aug():
+    G = demodata_tarjan_bridge()
+    bridge_edges = bridge_connected_augmentation(G)
+
+    G = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4])
+    bridge_edges = bridge_connected_augmentation(G)
+
+
+def test_weighted_bridge_augment():
+    G = demodata_tarjan_bridge()
+    avail = [(9, 7), (8, 5), (2, 10), (6, 13), (11, 18), (1, 17), (2, 3),
+             (16, 17), (18, 14), (15, 14)]
+    ut.assert_raises(ValueError, weighted_bridge_augmentation, G, [])
+    weighted_bridge_augmentation(G, [(9, 7)], return_anyway=True)
+    aug_edges = set(weighted_bridge_augmentation(G, avail))
+    assert aug_edges == {(6, 13), (2, 10), (1, 17)}
+    # test2
+    G = nx.Graph([(1, 2), (1, 3), (1, 4), (4, 2), (2, 5)])
+    avail = [(4, 5)]
+    ut.assert_raises(ValueError, weighted_bridge_augmentation, G, avail)
+    aug_edges = weighted_bridge_augmentation(G, avail, True)
+    avail = [(3, 5), (4, 5)]
+    aug_edges = weighted_bridge_augmentation(G, avail)
+
+
+def test_aug():
+    G = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4, 5, 6])
+    k = 4
+    aug_edges = edge_connected_augmentation(G, k)
+    G.add_edges_from(aug_edges)
+    print(nx.edge_connectivity(G))
+
+    G = nx.Graph()
+    G.add_nodes_from([
+        1, 2, 3, 4, 5, 6, 7, 8, 9])
+    G.add_edges_from([(3, 8)])
+    impossible = {(6, 3), (3, 9)}
+    avail = list(set(complement_edges(G)) - impossible)
+    aug_edges = edge_connected_augmentation(G, k=1)
+    aug_edges = edge_connected_augmentation(G, 1, avail)

--- a/networkx/algorithms/connectivity/tests/test_edge_kcompoments.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_kcompoments.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import networkx as nx
+from networkx.utils import arbitrary_element, pairwise, flatten
+import networkx as nx
+
+
+def demodata_bridge():
+    # define 2-connected compoments and bridges
+    cc2 = [(1, 2, 4, 3, 1, 4), (8, 9, 10, 8), (11, 12, 13, 11)]
+    bridges = [(4, 8), (3, 5), (20, 21), (22, 23, 24)]
+    G = nx.Graph(flatten(pairwise(path) for path in cc2 + bridges))
+    return G
+
+
+def demodata_tarjan_bridge():
+    """ graph from tarjan paper """
+    # define 2-connected compoments and bridges
+    ccs = [(1, 2, 4, 3, 1, 4), (5, 6, 7, 5), (8, 9, 10, 8),
+             (17, 18, 16, 15, 17), (11, 12, 14, 13, 11, 14)]
+    bridges = [(4, 8), (3, 5), (3, 17)]
+    G = nx.Graph(flatten(pairwise(path) for path in ccs + bridges))
+    return G
+
+
+def test_k_edge():
+    G = demodata_tarjan_bridge()
+    print(list(k_edge_components(G, k=1)))
+    print(list(k_edge_components(G, k=2)))
+    print(list(k_edge_components(G, k=3)))
+    print(list(k_edge_components(G, k=4)))
+
+
+def test_bridge_cc():
+    G = demodata_bridge()
+    bridge_ccs = bridge_connected_compoments(G)
+    assert bridge_ccs == [
+        {1, 2, 3, 4}, {5}, {8, 9, 10}, {11, 12, 13}, {20},
+        {21}, {22}, {23}, {24}
+    ]

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -139,6 +139,32 @@ def kruskal_mst_edges(G, minimum, weight='weight', keys=True, data=True):
                     yield (u, v)
                 subtrees.union(u, v)
 
+    if is_multigraph:
+        if keys:
+            for u, v, k, d in edges:
+                if subtrees[u] != subtrees[v]:
+                    if data:
+                        yield (u, v, k, d)
+                    else:
+                        yield (u, v, k)
+                subtrees.union(u, v)
+        else:
+            for u, v, k, d in edges:
+                if subtrees[u] != subtrees[v]:
+                    if data:
+                        yield (u, v, d)
+                    else:
+                        yield (u, v)
+                subtrees.union(u, v)
+    else:
+        for u, v, d in edges:
+            if subtrees[u] != subtrees[v]:
+                if data:
+                    yield (u, v, d)
+                else:
+                    yield (u, v)
+                subtrees.union(u, v)
+
 
 def prim_mst_edges(G, minimum, weight='weight', keys=True, data=True):
     is_multigraph = G.is_multigraph()

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -139,32 +139,6 @@ def kruskal_mst_edges(G, minimum, weight='weight', keys=True, data=True):
                     yield (u, v)
                 subtrees.union(u, v)
 
-    if is_multigraph:
-        if keys:
-            for u, v, k, d in edges:
-                if subtrees[u] != subtrees[v]:
-                    if data:
-                        yield (u, v, k, d)
-                    else:
-                        yield (u, v, k)
-                subtrees.union(u, v)
-        else:
-            for u, v, k, d in edges:
-                if subtrees[u] != subtrees[v]:
-                    if data:
-                        yield (u, v, d)
-                    else:
-                        yield (u, v)
-                subtrees.union(u, v)
-    else:
-        for u, v, d in edges:
-            if subtrees[u] != subtrees[v]:
-                if data:
-                    yield (u, v, d)
-                else:
-                    yield (u, v)
-                subtrees.union(u, v)
-
 
 def prim_mst_edges(G, minimum, weight='weight', keys=True, data=True):
     is_multigraph = G.is_multigraph()


### PR DESCRIPTION
This PR is a work in progress. I've submitted it to gauge interest in the proposed functionality. If interest exists, I'll do the work to conform it to networkx standards and test it. 

Preface
----------

In my research I've needed to compute properties of graphs based on edge-connectivity. Namely, I needed to find the k-edge-connected components in a graph, and given a graph I needed to compute a k-edge-connected augmentation.

k-edge-connected components are subgraphs of G, where it is impossible to disconnect the subgraph if less than k edges are removed.  

k-edge-augmentation takes a graph G that is not k-edge-connected and finds a small set of edges that would make G k-edge-connected if they were added. 

My work is primarily concerned with the case where k=2. This special case is also referred to as bridge-connected components, however I want to be able to compute the solutions for other values of k. 

Work So Far
-----------------

Given my problem, I checked to see if NetworkX had any out of the box solutions. I found a few tools. In the `nx.algorithms.connectivity` module I found the `edge_connectivity` and `local_edge_connectivity` functions to be quite useful. However, most other functions in this module were related to node connectivity. I concluded that NetworkX did not have this functionality (correct me if I'm wrong about that). 

Therefore I implemented the edge connectivity algorithms I needed myself internal to my project. Now that the implementation is done, I want to submit it to NetworkX in case anyone else wants to use them. 

I'm not sure what the guidelines for contributing are, so I haven't put much work into this PR other than copy pasting my implementations into `nx.algorithms.connectivity` and doing some minor cleanup. I haven't done any tests or even tried to import the modules yet. I'm sure it will error, but before I spend time fixing things up and writing in depth tests I wanted to make sure that this is a desirable PR. 

Whats Inside
-----------------

I've checked in two modules each with several algorithms.


### module 1
The first module is `edge_kconnectivity' to be consistent with the existing module `kconnectivity'

`EdgeComponentAuxGraph` finds k-edge connected components for arbitrary k. It takes |V| iterations of max-flow, so its a little slow, but its a simple algorithm that produces the right answer.

`bridge_compoments` solves the problem efficiently for k=2. There's not much too the function. It calls `find_bridges` which essentially find edges that aren't in the chain decomposition, and then removes them. I've had a previous PR rejected because it was essentially a one liner, so I'm not sure that is also the case for this. I think its conceptually different enough to warrant its own function though. 

`k_edge_components` combines the previous functions, essentially calling `bridge_compoments` if k is 2 and `EdgeComponentAuxGraph` otherwise. If more efficient algorithms are added (I'm aware of one where k=3) they could be added to this function. 


### module 2
The second module is `edge_augmentation`

I only have efficient algorithms for the case where k=1 and k=2 (although in my project I just wrote a greedy algorithm for k>=3). Each function has weighted and unweighted versions. I'm not sure what the best way to handle the API for that is yet. My working solution takes in a list of available edges that can have optional weights defaulted to 1. Otherwise it is assumed that the complement of G is available and those edges have weights 1.

This module probably needs more work than just cosmetics and it might be better handled as a separate PR. 

When k=1, `one_edge_augmentation` basically solves an MST problem, but my implementation solves it without constructing the complement of the graph. The weighted version is done in `weighted_one_edge_augmentation`. 

When k=2, `bridge_augmentation` performs an algorithm described by Eswaran and Tarjan. In the unweighted case it is exact. For the weighted case the problem becomes NP-hard. I'm not sure what the policy on approximation algorithms is, but `weighted_bridge_augmentation` solves the problem within an approximation ratio of 2. 

Lastly, I was surprised that I couldn't find a NetworkX function to collapse a set of nodes into a single node in a meta graph. There is the condense function for SCCs, but I implemented `collapse` for arbitrary groupings. Maybe I missed a way to do it that already exists. Currently I plan to keep it in this module as a private function, but I think it might be worth exposing in the NetworkX API.