### PR TITLE
added documentation for write_gexf viz attrs

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -46,11 +46,6 @@ def write_gexf(G, path, encoding='utf-8', prettyprint=True, version='1.1draft'):
     schemas used for parameters which are not user defined,
     e.g. visualization 'viz' [2]_. See example for usage.
 
-    # visualization data
-    >>> G[0]['viz'] = {'size' : 54}
-    >>> G[0]['viz']['position'] = {'x' : 0, 'y' : 1}}
-    >>> G[0]['viz']['color'] = {'r' : 0, 'g' : 0, 'b' : 256}
-
     Parameters
     ----------
     G : graph
@@ -67,6 +62,12 @@ def write_gexf(G, path, encoding='utf-8', prettyprint=True, version='1.1draft'):
     --------
     >>> G = nx.path_graph(4)
     >>> nx.write_gexf(G, "test.gexf")
+
+    # visualization data
+    >>> G[0]['viz'] = {'size' : 54}
+    >>> G[0]['viz']['position'] = {'x' : 0, 'y' : 1}}
+    >>> G[0]['viz']['color'] = {'r' : 0, 'g' : 0, 'b' : 256}
+
 
     Notes
     -----

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -42,6 +42,15 @@ def write_gexf(G, path, encoding='utf-8', prettyprint=True, version='1.1draft'):
     "GEXF (Graph Exchange XML Format) is a language for describing
     complex networks structures, their associated data and dynamics" [1]_.
 
+    Node attributes are checked according to the version of the GEXF
+    schemas used for parameters which are not user defined,
+    e.g. visualization 'viz' [2]_. See example for usage.
+
+    # visualization data
+    >>> G[0]['viz'] = {'size' : 54}
+    >>> G[0]['viz']['position'] = {'x' : 0, 'y' : 1}}
+    >>> G[0]['viz']['color'] = {'r' : 0, 'g' : 0, 'b' : 256}
+
     Parameters
     ----------
     G : graph
@@ -71,6 +80,8 @@ def write_gexf(G, path, encoding='utf-8', prettyprint=True, version='1.1draft'):
     References
     ----------
     .. [1] GEXF graph format, http://gexf.net/format/
+    .. [2] GEXF viz schema 1.1, http://www.gexf.net/1.1draft/viz
+
     """
     writer = GEXFWriter(encoding=encoding, prettyprint=prettyprint,
                         version=version)

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -65,7 +65,7 @@ def write_gexf(G, path, encoding='utf-8', prettyprint=True, version='1.1draft'):
 
     # visualization data
     >>> G[0]['viz'] = {'size' : 54}
-    >>> G[0]['viz']['position'] = {'x' : 0, 'y' : 1}}
+    >>> G[0]['viz']['position'] = {'x' : 0, 'y' : 1}
     >>> G[0]['viz']['color'] = {'r' : 0, 'g' : 0, 'b' : 256}
 
 


### PR DESCRIPTION
I added a sentence describing that networkx does indeed write
attributes like visualization parameters, "viz", correctly according
to the GEXF schema.

I added an example setting the size color and layout positions of a
node which was tested to work in Gephi 8.0.2.

There was a few questions on stackoverflow and some promoting
work-around behavior because it was not evident in the documentation.

I will note that beyond viz there are other behaviors that are not
documented and the user would not know they are available without
actually reading through the code.