### PR TITLE
Make clear to NOT assign to G.edge[u] or G.edge[u][v]

### DIFF
--- a/doc/source/tutorial/tutorial.rst
+++ b/doc/source/tutorial/tutorial.rst
@@ -263,6 +263,8 @@ notation, or G.edge.
 
 The special attribute 'weight'
 should be numeric and holds values used by algorithms requiring weighted edges.
+Warning: Do not assign anything to `G.edge[u]` or `G.edge[u][v]` as it will 
+corrupt the graph data structure. Change the edge dict as shown above. 
 
 
 Directed graphs

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -141,6 +141,10 @@ class Graph(object):
     >>> G[1][2]['weight'] = 4.7
     >>> G.edge[1][2]['weight'] = 4
 
+    Warning: assigning to `G.edge[u]` or `G.edge[u][v]` will almost certainly 
+    corrupt the graph data structure. Use 3 sets of brackets as shown above.
+    (4 for multigraphs: `MG.edge[u][v][key][name] = value`)
+
     **Shortcuts:**
 
     Many common graph features allow python syntax to speed reporting.


### PR DESCRIPTION
Fixes #2271 
Could be made unnecessary if we move G.edge to G._edge and create read-only G.edge (see #2469)