### PR TITLE
Fixes some minor documentation issues (approximation algorithm subpackage)

### DIFF
--- a/networkx/algorithms/approximation/dominating_set.py
+++ b/networkx/algorithms/approximation/dominating_set.py
@@ -5,14 +5,14 @@
 #   BSD license.
 """Functions for finding node and edge dominating sets.
 
-A *`dominating set`_[1] for an undirected graph *G* with vertex set *V*
+A `dominating set`_ for an undirected graph *G* with vertex set *V*
 and edge set *E* is a subset *D* of *V* such that every vertex not in
-*D* is adjacent to at least one member of *D*. An *`edge dominating
-set`_[2] is a subset *F* of *E* such that every edge not in *F* is
+*D* is adjacent to at least one member of *D*. An `edge dominating set`_
+is a subset *F* of *E* such that every edge not in *F* is
 incident to an endpoint of at least one edge in *F*.
 
-.. [1] dominating set: https://en.wikipedia.org/wiki/Dominating_set
-.. [2] edge dominating set: https://en.wikipedia.org/wiki/Edge_dominating_set
+.. _dominating set: https://en.wikipedia.org/wiki/Dominating_set
+.. _edge dominating set: https://en.wikipedia.org/wiki/Edge_dominating_set
 
 """
 from __future__ import division

--- a/networkx/algorithms/approximation/independent_set.py
+++ b/networkx/algorithms/approximation/independent_set.py
@@ -14,7 +14,7 @@ the maximum independent set problem and is an NP-hard optimization problem.
 As such, it is unlikely that there exists an efficient algorithm for finding
 a maximum independent set of a graph.
 
-http://en.wikipedia.org/wiki/Independent_set_(graph_theory)
+`Wikipedia: Independent set <http://en.wikipedia.org/wiki/Independent_set_(graph_theory)>`_
 
 Independent set algorithm is based on the following paper:
 

--- a/networkx/algorithms/approximation/matching.py
+++ b/networkx/algorithms/approximation/matching.py
@@ -7,7 +7,7 @@ Graph Matching
 Given a graph G = (V,E), a matching M in G is a set of pairwise non-adjacent
 edges; that is, no two edges share a common vertex.
 
-http://en.wikipedia.org/wiki/Matching_(graph_theory)
+`Wikipedia: Matching <http://en.wikipedia.org/wiki/Matching_(graph_theory)>`_
 """
 #   Copyright (C) 2011-2012 by
 #   Nicholas Mancuso <nick.mancuso@gmail.com>


### PR DESCRIPTION
This changes some weird formatting in the documentation, mostly in the [`dominating_set` module docstring](http://networkx.readthedocs.io/en/latest/reference/algorithms.approximation.html#module-networkx.algorithms.approximation.dominating_set). But it also changes two links to Wikipedia that were missing the closing `)` in the link, for example [in `matching`](http://networkx.readthedocs.io/en/latest/reference/algorithms.approximation.html#graph-matching).

Preview:

![unnamed](https://user-images.githubusercontent.com/14200878/27333182-4edf001e-55c5-11e7-8c2d-98b992266dbd.png)
