### PR TITLE
Implement basic connectivity algorithms for directed graphs

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -11,7 +11,6 @@
 #          Christopher Ellison
 """Connected components."""
 import networkx as nx
-from networkx.utils.decorators import not_implemented_for
 from ...utils import arbitrary_element
 
 __all__ = [
@@ -23,7 +22,6 @@ __all__ = [
 ]
 
 
-@not_implemented_for('directed')
 def connected_components(G):
     """Generate connected components.
 
@@ -36,11 +34,6 @@ def connected_components(G):
     -------
     comp : generator of sets
        A generator of sets of nodes, one for each component of G.
-
-    Raises
-    ------
-    NetworkXNotImplemented:
-        If G is undirected.
 
     Examples
     --------
@@ -61,10 +54,6 @@ def connected_components(G):
     strongly_connected_components
     weakly_connected_components
 
-    Notes
-    -----
-    For undirected graphs only.
-
     """
     seen = set()
     for v in G:
@@ -74,7 +63,6 @@ def connected_components(G):
             seen.update(c)
 
 
-@not_implemented_for('directed')
 def connected_component_subgraphs(G, copy=True):
     """Generate connected components as subgraphs.
 
@@ -90,11 +78,6 @@ def connected_component_subgraphs(G, copy=True):
     -------
     comp : generator
       A generator of graphs, one for each connected component of G.
-
-    Raises
-    ------
-    NetworkXNotImplemented:
-        If G is undirected.
 
     Examples
     --------
@@ -115,7 +98,6 @@ def connected_component_subgraphs(G, copy=True):
 
     Notes
     -----
-    For undirected graphs only.
     Graph, node, and edge attributes are copied to the subgraphs by default.
 
     """
@@ -145,15 +127,10 @@ def number_connected_components(G):
     number_weakly_connected_components
     number_strongly_connected_components
 
-    Notes
-    -----
-    For undirected graphs only.
-
     """
     return len(list(connected_components(G)))
 
 
-@not_implemented_for('directed')
 def is_connected(G):
     """Return True if the graph is connected, false otherwise.
 
@@ -169,8 +146,8 @@ def is_connected(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
-        If G is undirected.
+    NetworkXPointlessConcept:
+        If G is the null graph.
 
     Examples
     --------
@@ -186,10 +163,6 @@ def is_connected(G):
     is_biconnected
     connected_components
 
-    Notes
-    -----
-    For undirected graphs only.
-
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept('Connectivity is undefined ',
@@ -197,7 +170,6 @@ def is_connected(G):
     return len(set(_plain_bfs(G, arbitrary_element(G)))) == len(G)
 
 
-@not_implemented_for('directed')
 def node_connected_component(G, n):
     """Return the nodes in the component of graph containing node n.
 
@@ -214,18 +186,9 @@ def node_connected_component(G, n):
     comp : set
        A set of nodes in the component of G containing node n.
 
-    Raises
-    ------
-    NetworkXNotImplemented:
-        If G is directed.
-
     See Also
     --------
     connected_components
-
-    Notes
-    -----
-    For undirected graphs only.
 
     """
     return set(_plain_bfs(G, n))
@@ -233,6 +196,7 @@ def node_connected_component(G, n):
 
 def _plain_bfs(G, source):
     """A fast BFS node generator"""
+    directed = G.is_directed()
     seen = set()
     nextlevel = {source}
     while nextlevel:
@@ -243,3 +207,5 @@ def _plain_bfs(G, source):
                 yield v
                 seen.add(v)
                 nextlevel.update(G[v])
+                if directed:
+                    nextlevel.update(G.pred[v])

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -7,12 +7,21 @@ from networkx import NetworkXError,NetworkXNotImplemented
 class TestConnected:
 
     def setUp(self):
-        G1 = cnlti(nx.grid_2d_graph(2, 2), first_label=0, ordering="sorted")
-        G2 = cnlti(nx.lollipop_graph(3, 3), first_label=4, ordering="sorted")
-        G3 = cnlti(nx.house_graph(), first_label=10, ordering="sorted")
-        self.G = nx.union(G1, G2)
-        self.G = nx.union(self.G, G3)
+        # Create union of three separate undirected graphs
+        components = [
+            nx.grid_2d_graph(2, 2),
+            nx.lollipop_graph(3, 3),
+            nx.house_graph()
+        ]
+        self.G = nx.Graph()
+        self.G_components = set()
+        for c in components:
+            c = cnlti(c, first_label=len(self.G) + 1, ordering="sorted")
+            self.G = nx.union(self.G, c)
+            self.G_components.add(frozenset(c.nodes()))
+
         self.DG = nx.DiGraph([(1, 2), (1, 3), (2, 3)])
+        # A larger connected grid
         self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1)
 
         self.gc = []
@@ -45,16 +54,12 @@ class TestConnected:
     def test_connected_components(self):
         cc = nx.connected_components
         G = self.G
-        C = {
-            frozenset([0, 1, 2, 3]),
-            frozenset([4, 5, 6, 7, 8, 9]),
-            frozenset([10, 11, 12, 13, 14])
-        }
+        C = self.G_components
         assert_equal({frozenset(g) for g in cc(G)}, C)
 
     def test_number_connected_components(self):
         ncc = nx.number_connected_components
-        assert_equal(ncc(self.G), 3)
+        assert_equal(ncc(self.G), len(self.G_components))
 
     def test_number_connected_components2(self):
         ncc = nx.number_connected_components
@@ -63,13 +68,13 @@ class TestConnected:
     def test_connected_components2(self):
         cc = nx.connected_components
         G = self.grid
-        C = {frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])}
+        C = {frozenset(G.nodes())}
         assert_equal({frozenset(g) for g in cc(G)}, C)
 
     def test_node_connected_components(self):
         ncc = nx.node_connected_component
         G = self.grid
-        C = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+        C = set(G.nodes())
         assert_equal(ncc(G, 1), C)
 
     def test_connected_component_subgraphs(self):

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -2,7 +2,24 @@
 from nose.tools import *
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
-from networkx import NetworkXError,NetworkXNotImplemented
+
+
+def to_directed(G):
+    """Convert an undirected graph to a directed one, alternating converting
+    undirected edges to directed edges in either or both directions.
+    """
+    DG = nx.DiGraph()
+
+    for i, (n1, n2) in enumerate(G.edges()):
+        # Alternate converting undirected edges to directed in either or
+        # both directions
+        if i % 3 != 0:
+            DG.add_edge(n1, n2)
+        if i % 3 != 1:
+            DG.add_edge(n2, n1)
+
+    return DG
+
 
 class TestConnected:
 
@@ -20,7 +37,6 @@ class TestConnected:
             self.G = nx.union(self.G, c)
             self.G_components.add(frozenset(c.nodes()))
 
-        self.DG = nx.DiGraph([(1, 2), (1, 3), (2, 3)])
         # A larger connected grid
         self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1)
 
@@ -56,20 +72,25 @@ class TestConnected:
         G = self.G
         C = self.G_components
         assert_equal({frozenset(g) for g in cc(G)}, C)
+        assert_equal({frozenset(g) for g in cc(to_directed(G))}, C)
 
     def test_number_connected_components(self):
         ncc = nx.number_connected_components
         assert_equal(ncc(self.G), len(self.G_components))
+        assert_equal(ncc(to_directed(self.G)), len(self.G_components))
 
     def test_number_connected_components2(self):
         ncc = nx.number_connected_components
-        assert_equal(ncc(self.grid), 1)
+        G = self.grid
+        assert_equal(ncc(G), 1)
+        assert_equal(ncc(to_directed(G)), 1)
 
     def test_connected_components2(self):
         cc = nx.connected_components
         G = self.grid
         C = {frozenset(G.nodes())}
         assert_equal({frozenset(g) for g in cc(G)}, C)
+        assert_equal({frozenset(g) for g in cc(to_directed(G))}, C)
 
     def test_node_connected_components(self):
         ncc = nx.node_connected_component
@@ -85,17 +106,17 @@ class TestConnected:
             w = {frozenset(g) for g in wcc(G)}
             c = {frozenset(g) for g in cc(U)}
             assert_equal(w, c)
+            d = {frozenset(g) for g in cc(G)}
+            assert_equal(c, d)
 
     def test_is_connected(self):
         assert_true(nx.is_connected(self.grid))
+        assert_true(nx.is_connected(to_directed(self.grid)))
+
         G = nx.Graph()
         G.add_nodes_from([1, 2])
         assert_false(nx.is_connected(G))
+        assert_false(nx.is_connected(G.to_directed()))
 
     def test_connected_raise(self):
-        assert_raises(NetworkXNotImplemented, nx.connected_components, self.DG)
-        assert_raises(NetworkXNotImplemented, nx.number_connected_components, self.DG)
-        assert_raises(NetworkXNotImplemented, nx.connected_component_subgraphs, self.DG)
-        assert_raises(NetworkXNotImplemented, nx.node_connected_component, self.DG,1)
-        assert_raises(NetworkXNotImplemented, nx.is_connected, self.DG)
         assert_raises(nx.NetworkXPointlessConcept, nx.is_connected, nx.Graph())

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -40,33 +40,6 @@ class TestConnected:
         # A larger connected grid
         self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1)
 
-        self.gc = []
-        G = nx.DiGraph()
-        G.add_edges_from([(1, 2), (2, 3), (2, 8), (3, 4), (3, 7), (4, 5),
-                          (5, 3), (5, 6), (7, 4), (7, 6), (8, 1), (8, 7)])
-        C = [[3, 4, 5, 7], [1, 2, 8], [6]]
-        self.gc.append((G, C))
-
-        G = nx.DiGraph()
-        G.add_edges_from([(1, 2), (1, 3), (1, 4), (4, 2), (3, 4), (2, 3)])
-        C = [[2, 3, 4],[1]]
-        self.gc.append((G, C))
-
-        G = nx.DiGraph()
-        G.add_edges_from([(1, 2), (2, 3), (3, 2), (2, 1)])
-        C = [[1, 2, 3]]
-        self.gc.append((G,C))
-
-        # Eppstein's tests
-        G = nx.DiGraph({0:[1], 1:[2, 3], 2:[4, 5], 3:[4, 5], 4:[6], 5:[], 6:[]})
-        C = [[0], [1], [2],[ 3], [4], [5], [6]]
-        self.gc.append((G,C))
-
-        G = nx.DiGraph({0:[1], 1:[2, 3, 4], 2:[0, 3], 3:[4], 4:[3]})
-        C = [[0, 1, 2], [3, 4]]
-        self.gc.append((G, C))
-
-
     def test_connected_components(self):
         cc = nx.connected_components
         G = self.G
@@ -99,15 +72,11 @@ class TestConnected:
         assert_equal(ncc(G, 1), C)
 
     def test_connected_component_subgraphs(self):
-        wcc = nx.weakly_connected_component_subgraphs
-        cc = nx.connected_component_subgraphs
-        for G, C in self.gc:
-            U = G.to_undirected()
-            w = {frozenset(g) for g in wcc(G)}
-            c = {frozenset(g) for g in cc(U)}
-            assert_equal(w, c)
-            d = {frozenset(g) for g in cc(G)}
-            assert_equal(c, d)
+        ccs = nx.connected_component_subgraphs
+        G = self.G
+        C = self.G_components
+        assert_equal({frozenset(g.nodes()) for g in ccs(G)}, C)
+        assert_equal({frozenset(g.nodes()) for g in ccs(to_directed(G))}, C)
 
     def test_is_connected(self):
         assert_true(nx.is_connected(self.grid))


### PR DESCRIPTION
* Changed functions in `networkx.algorithms.components.connected.py` to work with directed graphs and updated docstrings.
* Adapted tests for undirected graphs to also test directed ones.
* Cleaned up test code a bit, fixed broken test for `connected_component_subgraphs` that contained code that looks like it belonged to `test_weakly_connected.py`.