### PR TITLE
Add method .data() on Nodeview and Edgeview

### DIFF
--- a/networkx/classes/tests/test_views.py
+++ b/networkx/classes/tests/test_views.py
@@ -221,6 +221,12 @@ class test_edgeview(object):
         assert_not_equal(id(ev), id(ev(data=True)))
         assert_not_equal(id(ev), id(ev(nbunch=1)))
 
+    def test_data(self):
+        ev = self.eview(self.G)
+        assert_equal(id(ev), id(ev.data()))
+        assert_not_equal(id(ev), id(ev.data(data=True)))
+        assert_not_equal(id(ev), id(ev.data(nbunch=1)))
+
     def test_iter(self):
         ev = self.eview(self.G)
         for u, v in ev:
@@ -353,6 +359,12 @@ class test_multiedges(test_edgeview):
         assert_equal(id(ev), id(ev(keys=True)))
         assert_not_equal(id(ev), id(ev(data=True)))
         assert_not_equal(id(ev), id(ev(nbunch=1)))
+
+    def test_data(self):
+        ev = self.eview(self.G)
+        assert_equal(id(ev), id(ev.data(keys=True)))
+        assert_not_equal(id(ev), id(ev.data(data=True)))
+        assert_not_equal(id(ev), id(ev.data(nbunch=1)))
 
     def test_iter(self):
         ev = self.eview(self.G)

--- a/networkx/classes/views.py
+++ b/networkx/classes/views.py
@@ -186,6 +186,11 @@ class NodeView(Mapping, Set):
             return self
         return NodeDataView(self._nodes, data, default)
 
+    def data(self, data=False, default=None):
+        if data is False:
+            return self
+        return NodeDataView(self._nodes, data, default)
+
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, tuple(self))
 
@@ -885,6 +890,12 @@ class OutEdgeView(Set, Mapping):
             return self
         return self.view(self, nbunch, data, default)
 
+    def data(self, nbunch=None, data=False, default=None):
+        if nbunch is None and data is False:
+            return self
+        return self.view(self, nbunch, data, default)
+
+    # String Methods
     def __str__(self):
         return 'EdgeView(%r)' % list(self)
 
@@ -1059,6 +1070,11 @@ class OutMultiEdgeView(OutEdgeView):
         return self._adjdict[u][v][k]
 
     def __call__(self, nbunch=None, data=False, keys=False, default=None):
+        if nbunch is None and data is False and keys is True:
+            return self
+        return self.view(self, nbunch, data, keys, default)
+
+    def data(self, nbunch=None, data=False, keys=False, default=None):
         if nbunch is None and data is False and keys is True:
             return self
         return self.view(self, nbunch, data, keys, default)


### PR DESCRIPTION
```G.nodes``` and ```G.edges``` objects now have methods ```keys/values/items/data``` where ```data``` allows you to extract a particular data attribute rather than the entire data dict.  I'm not sure that we need all of these methods. Even for dicts, the ```keys``` method seems superfluous. But ```keys/values/items``` come with the Mapping ABC class, and could theoretically be useful to someone.

Thoughts?