### PR TITLE
Ensure label in gml output is quoted

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -565,7 +565,7 @@ def generate_gml(G, stringizer=None):
     Notes
     -----
     Graph attributes named 'directed', 'multigraph', 'node' or
-    'edge',node attributes named 'id' or 'label', edge attributes
+    'edge', node attributes named 'id' or 'label', edge attributes
     named 'source' or 'target' (or 'key' if `G` is a multigraph)
     are ignored because these attribute names are used to encode the graph
     structure.
@@ -580,9 +580,9 @@ def generate_gml(G, stringizer=None):
         if not isinstance(key, str):
             key = str(key)
         if key not in ignored_keys:
-            if isinstance(value, (int, long)):
+            if isinstance(value, (int, long)) and key != 'label':
                 yield indent + key + ' ' + str(value)
-            elif isinstance(value, float):
+            elif isinstance(value, float) and key != 'label':
                 text = repr(value).upper()
                 # GML requires that a real literal contain a decimal point, but
                 # repr may not output a decimal point when the mantissa is
@@ -606,12 +606,15 @@ def generate_gml(G, stringizer=None):
             else:
                 if stringizer:
                     try:
+                        print(isinstance(value, unicode))
                         value = stringizer(value)
+                        print(isinstance(value, unicode))
                     except ValueError:
                         raise NetworkXError(
                             '%r cannot be converted into a string' % (value,))
                 if not isinstance(value, (str, unicode)):
                     raise NetworkXError('%r is not a string' % (value,))
+                print(indent + key + ' "' + escape(value) + '"')
                 yield indent + key + ' "' + escape(value) + '"'
 
     multigraph = G.is_multigraph()

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -580,9 +580,12 @@ def generate_gml(G, stringizer=None):
         if not isinstance(key, str):
             key = str(key)
         if key not in ignored_keys:
-            if isinstance(value, (int, long)) and key != 'label':
-                yield indent + key + ' ' + str(value)
-            elif isinstance(value, float) and key != 'label':
+            if isinstance(value, (int, long)):
+                if key == 'label':
+                    yield indent + key + ' "' + str(value) + '"'
+                else:
+                    yield indent + key + ' ' + str(value)
+            elif isinstance(value, float):
                 text = repr(value).upper()
                 # GML requires that a real literal contain a decimal point, but
                 # repr may not output a decimal point when the mantissa is
@@ -590,7 +593,10 @@ def generate_gml(G, stringizer=None):
                 epos = text.rfind('E')
                 if epos != -1 and text.find('.', 0, epos) == -1:
                     text = text[:epos] + '.' + text[epos:]
-                yield indent + key + ' ' + text
+                if key == 'label':
+                    yield indent + key + ' "' + test + '"'
+                else:
+                    yield indent + key + ' ' + text
             elif isinstance(value, dict):
                 yield indent + key + ' ['
                 next_indent = indent + '  '
@@ -606,15 +612,12 @@ def generate_gml(G, stringizer=None):
             else:
                 if stringizer:
                     try:
-                        print(isinstance(value, unicode))
                         value = stringizer(value)
-                        print(isinstance(value, unicode))
                     except ValueError:
                         raise NetworkXError(
                             '%r cannot be converted into a string' % (value,))
                 if not isinstance(value, (str, unicode)):
                     raise NetworkXError('%r is not a string' % (value,))
-                print(indent + key + ' "' + escape(value) + '"')
                 yield indent + key + ' "' + escape(value) + '"'
 
     multigraph = G.is_multigraph()

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -245,7 +245,7 @@ graph
         attr = 'This is "quoted" and this is a copyright: ' + unichr(169)
         G.node[0]['demo'] = attr
         fobj = tempfile.NamedTemporaryFile()
-        nx.write_gml(G, fobj, stringizer=literal_stringizer)
+        nx.write_gml(G, fobj)
         fobj.seek(0)
         # Should be bytes in 2.x and 3.x
         data = fobj.read().strip().decode('ascii')
@@ -255,6 +255,23 @@ graph
     id 0
     label "0"
     demo "This is &#34;quoted&#34; and this is a copyright: &#169;"
+  ]
+]"""
+        assert_equal(data, answer)
+
+    def test_unicode_node(self):
+        node = 'node' + unichr(169)
+        G = nx.Graph()
+        G.add_node(node)
+        fobj = tempfile.NamedTemporaryFile()
+        nx.write_gml(G, fobj)
+        fobj.seek(0)
+        # Should be bytes in 2.x and 3.x
+        data = fobj.read().strip().decode('ascii')
+        answer = """graph [
+  node [
+    id 0
+    label "node&#169;"
   ]
 ]"""
         assert_equal(data, answer)

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -181,7 +181,7 @@ graph   [
         os.unlink(fname)
 
     def test_labels_are_strings(self):
-        # GMl requires labels to be stings (i.e., in quotes)
+        # GML requires labels to be strings (i.e., in quotes)
         answer = """graph [
   node [
     id 0

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -180,6 +180,19 @@ graph   [
         os.close(fd)
         os.unlink(fname)
 
+    def test_labels_are_strings(self):
+        # GMl requires labels to be stings (i.e., in quotes)
+        answer = """graph [
+  node [
+    id 0
+    label "1203"
+  ]
+]"""
+        G = nx.Graph()
+        G.add_node(1203)
+        data = '\n'.join(nx.generate_gml(G, stringizer=literal_stringizer))
+        assert_equal(data, answer)
+
     def test_relabel_duplicate(self):
         data = """
 graph
@@ -232,7 +245,7 @@ graph
         attr = 'This is "quoted" and this is a copyright: ' + unichr(169)
         G.node[0]['demo'] = attr
         fobj = tempfile.NamedTemporaryFile()
-        nx.write_gml(G, fobj)
+        nx.write_gml(G, fobj, stringizer=literal_stringizer)
         fobj.seek(0)
         # Should be bytes in 2.x and 3.x
         data = fobj.read().strip().decode('ascii')
@@ -240,7 +253,7 @@ graph
   name "path_graph(1)"
   node [
     id 0
-    label 0
+    label "0"
     demo "This is &#34;quoted&#34; and this is a copyright: &#169;"
   ]
 ]"""
@@ -261,7 +274,7 @@ graph
                     gml += ' directed ' + str(int(directed))
                 if multigraph is not None:
                     gml += ' multigraph ' + str(int(multigraph))
-                gml += ' node [ id 0 label 0 ]'
+                gml += ' node [ id 0 label "0" ]'
                 gml += ' edge [ source 0 target 0 ]'
                 gml += ' ]'
                 G = nx.parse_gml(gml)
@@ -274,7 +287,7 @@ graph
                     gml += '  multigraph 1\n'
                 gml += """  node [
     id 0
-    label 0
+    label "0"
   ]
   edge [
     source 0


### PR DESCRIPTION
Attempting to fix #2362. 

@dschult  I am not confident that my approach is correct.  Would you take a quick look and let me know if this seems like a reasonable start.  Should I add `and key != 'label'` to the blocks of code handling dicts and lists in `stringize` as well?  I wasn't sure how we should handle labels that were more complex than just ints, longs, and floats.

If this seems like the correct approach, the problem I am running into is that the `literal_stringizer` function takes the unicode string
```
u'This is "quoted" and this is a copyright: \xa9'
``` 
and converts it to the text string
```
'u\'This is "quoted" and this is a copyright: \\xa9\''
```

The function `escape` handles the unicode string correctly producing
```
'This is &#34;quoted&#34; and this is a copyright: &#169;'
```
But the text string becomes
```
"u'This is &#34;quoted&#34; and this is a copyright: \\xa9'"
```

I left some print statements for debugging purposes in for now, but will remove them before finalizing the pull request.
Any thoughts?