### PR TITLE
Add hint to duplicated edge error

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -423,7 +423,9 @@ def parse_gml_lines(lines, label, destringizer):
                 G.add_edge(source, target, **edge)
             else:
                 raise nx.NetworkXError(
-                    'edge #%d (%r%s%r) is duplicated' %
+                    """edge #%d (%r%s%r) is duplicated
+
+Hint:  If this is a multigraph, add "multigraph 1" to the header of the file.""" %
                     (i, source, '->' if directed else '--', target))
         else:
             key = edge.pop('key', None)


### PR DESCRIPTION
Fixes #2383 

It looked to me like modifying the code to automatically detecting a multigraph was a bit involved.  Given the (hopefully) imminent release of networkx-2.0, I decided that adding a hint to the error message would be sufficient for now.

```
In [1]: import networkx as nx

In [2]: nx.read_gml('polblogs.gml')
---------------------------------------------------------------------------
NetworkXError                             Traceback (most recent call last)
<ipython-input-2-83bca7fece32> in <module>()
----> 1 nx.read_gml('polblogs.gml')

<decorator-gen-455> in read_gml(path, label, destringizer)

/home/jarrod/src/networkx/networkx/utils/decorators.pyc in _open_file(func, *args, **kwargs)
    219         # Finally, we call the original function, making sure to close the fobj.
    220         try:
--> 221             result = func(*new_args, **kwargs)
    222         finally:
    223             if close_fobj:

/home/jarrod/src/networkx/networkx/readwrite/gml.py in read_gml(path, label, destringizer)
    203             yield line
    204 
--> 205     G = parse_gml_lines(filter_lines(path), label, destringizer)
    206     return G
    207 

/home/jarrod/src/networkx/networkx/readwrite/gml.py in parse_gml_lines(lines, label, destringizer)
    427 
    428 Hint:  If this is a multigraph, add "multigraph 1" to the header of the file.""" %
--> 429                     (i, source, '->' if directed else '--', target))
    430         else:
    431             key = edge.pop('key', None)

NetworkXError: edge #12757 (1047->1179) is duplicated

Hint:  If this is a multigraph, add "multigraph 1" to the header of the file.
```

Assuming this seems reasonable, this is ready to merge. @dschult 