### PR TITLE
Added all_pairs_dijkstra, solving #2465

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -933,7 +933,7 @@ def all_pairs_dijkstra(G, cutoff=None, weight='weight'):
     >>> print(len_path[3]['distance'][1])
     2
     >>> for node in [0, 1, 2, 3, 4]:
-            print('3 - {}: {}'.format(node, len_path[3]['distance'][node]))
+    ...     print('3 - {}: {}'.format(node, len_path[3]['distance'][node]))
     3 - 0: 3
     3 - 1: 2
     3 - 2: 1
@@ -942,7 +942,7 @@ def all_pairs_dijkstra(G, cutoff=None, weight='weight'):
     >>> len_path[3]['path'][1]
     [3, 2, 1]
     >>> for pair in nx.all_pairs_dijkstra(G):
-            print(pair['path'][1])
+    ...     print(pair['path'][1])
     [0, 1]
     [1]
     [2, 1]


### PR DESCRIPTION
* Finds shortest weighted paths and lengths between all nodes.
* Returns an iterator of dictionaries, keyed by source nodes.
* Each dictionary essentially contains the value of
  single_source_dijkstra computed at the source node.
  The tuple that single_source_dijkstra returns is unpacked
  and saved as values to two keys: 'distance' and 'path'.
