### PR TITLE
GraphView with hidden_nodes and hidden_edges

### DIFF
--- a/networkx/classes/__init__.py
+++ b/networkx/classes/__init__.py
@@ -3,6 +3,7 @@ from .digraph import DiGraph
 from .multigraph import MultiGraph
 from .multidigraph import MultiDiGraph
 from .views import *
+from .graphview import *
 from .ordered import *
 
 from .function import *

--- a/networkx/classes/graphview.py
+++ b/networkx/classes/graphview.py
@@ -1,0 +1,159 @@
+#    Copyright (C) 2004-2017 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Author:  Aric Hagberg (hagberg@lanl.gov),
+#          Pieter Swart (swart@lanl.gov),
+#          Dan Schult(dschult@colgate.edu)
+"""View of Graph with restricted nodes and edges.
+
+In some algorithms it is convenient to temporarily morph
+a graph to exclude some nodes or edges. It should be better
+to do that via a view than to remove and then re-add.
+"""
+from __future__ import division
+from collections import Mapping
+
+from networkx.classes import AtlasView, EdgeView
+from networkx.classes import Graph, DiGraph, MultiGraph, MultiDiGraph
+
+__all__ = ['HiddenAtlasView', 'HiddenAtlasView2', 'HiddenAtlasView3',
+           'GraphView', 'DiGraphView', 'MultiGraphView', 'MultiDiGraphView']
+
+
+class HiddenAtlasView(Mapping):
+    def __init__(self, d, hidden_keys):
+        self._atlas = d
+        self.hidden_keys = hidden_keys
+
+    def __len__(self):
+        return len(set(self._atlas) - self.hidden_keys)
+
+    def __iter__(self):
+        return (n for n in self._atlas if n not in self.hidden_keys)
+
+    def __getitem__(self, key):
+        if key in self._atlas and key not in self.hidden_keys:
+            return self._atlas[key]
+        raise KeyError("Key {} not found".format(key))
+
+    def copy(self):
+        return {u: d for u, d in self._atlas.items()
+                if u not in self.hidden_keys}
+
+    def __repr__(self):
+        return '%s(%r, %r)' % (self.__class__.__name__, self._atlas,
+                               self.hidden_keys)
+
+
+class HiddenAtlasView2(Mapping):
+    def __init__(self, d, hidden_nodes, hidden_edges):
+        self._atlas = d
+        self.hidden_nodes = hidden_nodes
+        self.hidden_edges = hidden_edges
+
+    def __len__(self):
+        return len(set(self._atlas) - self.hidden_nodes)
+
+    def __iter__(self):
+        return (n for n in self._atlas if n not in self.hidden_nodes)
+
+    def __getitem__(self, node):
+        if node in self._atlas and node not in self.hidden_nodes:
+            he = set(v for u, v in self.hidden_edges if u == node)
+            hn = he | self.hidden_nodes
+            return HiddenAtlasView(self._atlas[node], hn)
+        raise KeyError("Key {} not found".format(node))
+
+    def copy(self):
+        return {u: {v: d for v, d in nbrs.items() if v not in self.hidden_nodes
+                    if (u, v) not in self.hidden_edges}
+                for u, nbrs in self._atlas.items()
+                if u not in self.hidden_nodes}
+
+    def __repr__(self):
+        return '%s(%r, %r, %r)' % (self.__class__.__name__, self._atlas,
+                                   self.hidden_nodes, self.hidden_edges)
+
+
+class HiddenAtlasView2Multi(HiddenAtlasView2):
+    def __getitem__(self, node):
+        if node in self._atlas and node not in self.hidden_nodes:
+            hk = set(k for v, k in self.hidden_edges if v == node)
+            return HiddenAtlasView(self._atlas[node], hk)
+        raise KeyError("Key {} not found".format(node))
+
+    def copy(self):
+        return {v: {k: d for k, d in nbrs.items()
+                    if (v, k) not in self.hidden_edges}
+                for v, nbrs in self._atlas.items()
+                if v not in self.hidden_nodes}
+
+
+class HiddenAtlasView3(HiddenAtlasView2):
+    def __getitem__(self, key):
+        if key in self._atlas and key not in self.hidden_nodes:
+            he = set((v, k) for u, v, k in self.hidden_edges if u == key)
+            hn = self.hidden_nodes
+            return HiddenAtlasView2(self._atlas[key], hn, he)
+        raise KeyError("Key {} not found".format(key))
+
+    def copy(self):
+        return {u: {v: {k: d for k, d in kd.items()
+                        if (u, v, k) not in self.hidden_edges}
+                    for v, kd in nbrs.items() if v not in self.hidden_nodes}
+                for u, nbrs in self._atlas.items()
+                    if u not in self.hidden_nodes}
+
+
+class GraphView(Graph):
+    def __init__(self, graph, hidden_nodes, hidden_edges):
+        self._graph = graph
+        self.graph = graph.graph
+        hn = set(hidden_nodes)
+        # ensure 2-tuples and store undirected edges as both directed
+        he = set(hidden_edges) | set((v, u) for u, v in hidden_edges)
+        self._node = HiddenAtlasView(graph._node, hn)
+        self._adj = HiddenAtlasView2(graph._adj, hn, he)
+
+
+class DiGraphView(DiGraph):
+    def __init__(self, graph, hidden_nodes, hidden_edges):
+        self._graph = graph
+        self.graph = graph.graph
+        hn = set(hidden_nodes)
+        # ensure edges are all 2-tuples
+        he = set((u, v) for u, v in hidden_edges)
+        phe = set((v, u) for u, v in hidden_edges)
+        self._node = HiddenAtlasView(graph._node, hn)
+        self._adj = HiddenAtlasView2(graph._adj, hn, he)
+        self._pred = HiddenAtlasView2(graph._pred, hn, phe)
+        self._succ = self._adj
+
+
+class MultiGraphView(MultiGraph):
+    def __init__(self, graph, hidden_nodes, hidden_edges):
+        self._graph = graph
+        self.graph = graph.graph
+        hn = set(hidden_nodes)
+        # ensure 3-tuples and store undirected edges as both directed
+        he = set(hidden_edges) | set((v, u, k) for u, v, k in hidden_edges)
+        self._node = HiddenAtlasView(graph._node, hn)
+        self._adj = HiddenAtlasView3(graph._adj, hn, he)
+
+
+class MultiDiGraphView(MultiDiGraph):
+    def __init__(self, graph, hidden_nodes, hidden_edges):
+        self._graph = graph
+        self.graph = graph.graph
+        hn = set(hidden_nodes)
+        # ensure edges are all 3-tuples
+        he = set((u, v, k) for u, v, k in hidden_edges)
+        phe = set((v, u, k) for u, v, k in hidden_edges)
+        self._node = HiddenAtlasView(graph._node, hn)
+        self._adj = HiddenAtlasView3(graph._adj, hn, he)
+        self._pred = HiddenAtlasView3(graph._pred, hn, phe)
+        self._succ = self._adj

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -398,6 +398,7 @@ class MultiGraph(Graph):
 
                 - 2-tuples (u, v) or
                 - 3-tuples (u, v, d) for an edge attribute dict d, or
+                - 3-tuples (u, v, d) for an edge attribute dict d, or
                 - 4-tuples (u, v, k, d) for an edge identified by key k
 
         attr : keyword arguments, optional
@@ -440,13 +441,18 @@ class MultiGraph(Graph):
         keylist = []
         # process ebunch
         for e in ebunch:
-            ne = len(e)
-            if ne == 4:
+            numb_e = len(e)
+            if numb_e == 4:
                 u, v, key, dd = e
-            elif ne == 3:
+            elif numb_e == 3:
                 u, v, dd = e
-                key = None
-            elif ne == 2:
+                try:
+                    {dd}
+                    key = dd
+                    dd = {}
+                except TypeError:  # Not Hashable -- key!
+                    key = None
+            elif numb_e == 2:
                 u, v = e
                 dd = {}
                 key = None

--- a/networkx/classes/tests/test_graphview.py
+++ b/networkx/classes/tests/test_graphview.py
@@ -1,0 +1,123 @@
+from nose.tools import assert_equal, assert_not_equal, \
+        assert_true, assert_false, assert_raises
+
+import networkx as nx
+
+
+class test_graphview(object):
+    def setUp(self):
+        self.G = nx.path_graph(9)
+        self.gview = nx.GraphView
+        self.hide_nodes = [4, 5, 111]
+        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
+        self.out_nodes = {4, 5}
+        self.out_edges = {(3, 4), (4, 5), (5, 6)}
+
+    def test_hidden_nodes(self):
+        G = self.gview(self.G, self.hide_nodes, [])
+        assert_equal(self.G.nodes - G.nodes, self.out_nodes)
+        assert_equal(self.G.edges - G.edges, self.out_edges)
+        if G.is_directed():
+            assert_equal(list(G[3]), [])
+            assert_equal(list(G[2]), [3])
+        else:
+            assert_equal(list(G[3]), [2])
+            assert_equal(set(G[2]), {1, 3})
+        assert_raises(KeyError, G.__getitem__, 4)
+        assert_raises(KeyError, G.__getitem__, 112)
+        assert_raises(KeyError, G.__getitem__, 111)
+        assert_equal(G.degree(3), 1)
+        assert_equal(G.size(), 5)
+
+    def test_hidden_edges(self):
+        G = self.gview(self.G, [], self.hide_edges)
+        assert_equal(self.G.nodes, G.nodes)
+        if G.is_directed():
+            assert_equal(self.G.edges - G.edges, {(2, 3)})
+            assert_equal(list(G[3]), [4])
+            assert_equal(list(G[2]), [])
+            assert_equal(list(G.pred[3]), [])
+            assert_equal(list(G.pred[2]), [1])
+            assert_equal(G.size(), 7)
+        else:
+            assert_equal(self.G.edges - G.edges, {(2, 3), (7, 8)})
+            assert_equal(list(G[3]), [4])
+            assert_equal(list(G[2]), [1])
+            assert_equal(G.size(), 6)
+        assert_raises(KeyError, G.__getitem__, 221)
+        assert_raises(KeyError, G.__getitem__, 222)
+        assert_equal(G.degree(3), 1)
+
+
+class test_digraphview(test_graphview):
+    def setUp(self):
+        self.G = nx.path_graph(9, create_using=nx.DiGraph())
+        self.gview = nx.DiGraphView
+        self.hide_nodes = [4, 5, 111]
+        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
+        self.out_nodes = {4, 5}
+        self.out_edges = {(3, 4), (4, 5), (5, 6)}
+
+    def test_inoutedges(self):
+        G = self.gview(self.G, self.hide_nodes, self.hide_edges)
+        excluded = {(2, 3), (3, 4), (4, 5), (5, 6)}
+        assert_equal(self.G.in_edges - G.in_edges, excluded)
+        assert_equal(self.G.out_edges - G.out_edges, excluded)
+
+    def test_pred(self):
+        G = self.gview(self.G, self.hide_nodes, self.hide_edges)
+        assert_equal(list(G.pred[2]), [1])
+        assert_equal(list(G.pred[6]), [])
+
+    def test_inout_degree(self):
+        G = self.gview(self.G, self.hide_nodes, self.hide_edges)
+        assert_equal(G.degree(2), 1)
+        assert_equal(G.out_degree(2), 0)
+        assert_equal(G.in_degree(2), 1)
+        assert_equal(G.size(), 4)
+
+
+# multigraph
+class test_multigraphview(test_graphview):
+    def setUp(self):
+        self.G = nx.path_graph(9, create_using=nx.MultiGraph())
+        multiedges = {(2, 3, 4), (2, 3, 5)}
+        self.G.add_edges_from(multiedges)
+        self.gview = nx.MultiGraphView
+        self.hide_nodes = [4, 5, 111]
+        self.hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
+        self.out_nodes = {4, 5}
+        self.out_edges = multiedges | {(3, 4, 0), (4, 5, 0), (5, 6, 0)}
+
+    def test_hidden_edges(self):
+        G = self.gview(self.G, [], self.hide_edges)
+        assert_equal(self.G.nodes, G.nodes)
+        if G.is_directed():
+            assert_equal(self.G.edges - G.edges, {(2, 3, 4)})
+            assert_equal(list(G[3]), [4])
+            assert_equal(list(G[2]), [3])
+            assert_equal(list(G.pred[3]), [2])  # only one 2 but two edges
+            assert_equal(list(G.pred[2]), [1])
+            assert_equal(G.size(), 9)
+            assert_equal(G.degree(3), 3)
+        else:
+            assert_equal(self.G.edges - G.edges, {(2, 3, 4), (7, 8, 0)})
+            assert_equal(list(G[3]), [2, 4])
+            assert_equal(list(G[2]), [1, 3])
+            assert_equal(G.size(), 8)
+            assert_equal(G.degree(3), 3)
+        assert_raises(KeyError, G.__getitem__, 221)
+        assert_raises(KeyError, G.__getitem__, 222)
+
+
+# multidigraph
+class test_multidigraphview(test_multigraphview):
+    def setUp(self):
+        self.G = nx.path_graph(9, create_using=nx.MultiDiGraph())
+        multiedges = {(2, 3, 4), (2, 3, 5)}
+        self.G.add_edges_from(multiedges)
+        self.gview = nx.MultiDiGraphView
+        self.hide_nodes = [4, 5, 111]
+        self.hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
+        self.out_nodes = {4, 5}
+        self.out_edges = multiedges | {(3, 4, 0), (4, 5, 0), (5, 6, 0)}


### PR DESCRIPTION
This implements a restricted view on graphs where ```hidden_nodes``` and ```hidden_edges``` do not appear in the resulting graph.  This implementation is read-only though you could change the original graph and the restricted view would update accordingly. At this point you can't update the hidden_nodes and hidden_edges without creating a new view. I might add that feature if I can come up with a good way to do it. 

Related tickets include:   
#762
#1011 
#793
#335
and there are probably many other places where this feature has been discussed.

