### PR TITLE
Allow more flexible multigraph add_edges_from options

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -608,7 +608,6 @@ class DiGraph(Graph):
             ne = len(e)
             if ne == 3:
                 u, v, dd = e
-                assert hasattr(dd, "update")
             elif ne == 2:
                 u, v = e
                 dd = {}

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -16,6 +16,7 @@ from networkx.classes.graph import Graph
 from networkx.classes.views import AtlasView3
 from networkx.classes.views import MultiEdgeView, MultiDegreeView
 from networkx import NetworkXError
+from networkx.utils import iterable
 
 
 class MultiGraph(Graph):
@@ -370,8 +371,9 @@ class MultiGraph(Graph):
             graph. The edges can be:
 
                 - 2-tuples (u, v) or
-                - 3-tuples (u, v, d) for an edge attribute dict d, or
-                - 4-tuples (u, v, k, d) for an edge identified by key k
+                - 3-tuples (u, v, d) for an edge data dict d, or
+                - 3-tuples (u, v, k) for not iterable key k, or
+                - 4-tuples (u, v, k, d) for an edge with data and key k
 
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
@@ -428,7 +430,12 @@ class MultiGraph(Graph):
                 raise NetworkXError(msg.format(e))
             ddd = {}
             ddd.update(attr)
-            ddd.update(dd)
+            try:
+                ddd.update(dd)
+            except:
+                if ne != 3:
+                    raise
+                key = dd
             key = self.add_edge(u, v, key)
             self[u][v][key].update(ddd)
             keylist.append(key)

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -9,14 +9,16 @@ from test_multigraph import TestEdgeSubgraph as TestMultiGraphEdgeSubgraph
 class BaseMultiDiGraphTester(BaseMultiGraphTester):
     def test_edges(self):
         G = self.K3
-        assert_equal(sorted(G.edges()), [(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)])
+        edges = [(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+        assert_equal(sorted(G.edges()), edges)
         assert_equal(sorted(G.edges(0)), [(0, 1), (0, 2)])
         assert_raises((KeyError, nx.NetworkXError), G.edges, -1)
 
     def test_edges_data(self):
         G = self.K3
-        assert_equal(sorted(G.edges(data=True)),
-                     [(0, 1, {}), (0, 2, {}), (1, 0, {}), (1, 2, {}), (2, 0, {}), (2, 1, {})])
+        edges = [(0, 1, {}), (0, 2, {}), (1, 0, {}),
+                 (1, 2, {}), (2, 0, {}), (2, 1, {})]
+        assert_equal(sorted(G.edges(data=True)), edges)
         assert_equal(sorted(G.edges(0, data=True)), [(0, 1, {}), (0, 2, {})])
         assert_raises((KeyError, nx.NetworkXError), G.neighbors, -1)
 
@@ -51,8 +53,12 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(sorted(G.edges(0, data=True)), [(0, 1, {}), (0, 2, {})])
         G.remove_edge(0, 1)
         G.add_edge(0, 1, data=1)
-        assert_equal(sorted(G.edges(0, data=True)), [(0, 1, {'data': 1}), (0, 2, {})])
-        assert_equal(sorted(G.edges(0, data='data')), [(0, 1, 1), (0, 2, None)])
+        assert_equal(sorted(G.edges(0, data=True)),
+                     [(0, 1, {'data': 1}), (0, 2, {})])
+        assert_equal(sorted(G.edges(0, data='data')),
+                     [(0, 1, 1), (0, 2, None)])
+        assert_equal(sorted(G.edges(0, data='data', default=-1)),
+                     [(0, 1, 1), (0, 2, -1)])
 
     def test_in_edges(self):
         G = self.K3
@@ -75,16 +81,21 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
                      [(0, 1), (0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)])
 
         assert_equal(sorted(G.in_edges(data=True, keys=False)),
-                     [(0, 1, {}), (0, 1, {}), (0, 2, {}), (1, 0, {}), (1, 2, {}),
-                      (2, 0, {}), (2, 1, {})])
+                     [(0, 1, {}), (0, 1, {}), (0, 2, {}), (1, 0, {}),
+                      (1, 2, {}), (2, 0, {}), (2, 1, {})])
 
     def test_in_edges_data(self):
         G = self.K3
-        assert_equal(sorted(G.in_edges(0, data=True)), [(1, 0, {}), (2, 0, {})])
+        assert_equal(sorted(G.in_edges(0, data=True)),
+                     [(1, 0, {}), (2, 0, {})])
         G.remove_edge(1, 0)
         G.add_edge(1, 0, data=1)
-        assert_equal(sorted(G.in_edges(0, data=True)), [(1, 0, {'data': 1}), (2, 0, {})])
-        assert_equal(sorted(G.in_edges(0, data='data')), [(1, 0, 1), (2, 0, None)])
+        assert_equal(sorted(G.in_edges(0, data=True)),
+                     [(1, 0, {'data': 1}), (2, 0, {})])
+        assert_equal(sorted(G.in_edges(0, data='data')),
+                     [(1, 0, 1), (2, 0, None)])
+        assert_equal(sorted(G.in_edges(0, data='data', default=-1)),
+                     [(1, 0, 1), (2, 0, -1)])
 
     def is_shallow(self, H, G):
         # graph
@@ -121,8 +132,8 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         self.add_attributes(G)
         H = nx.MultiGraph(G)
         # self.is_shallow(H,G)
-        # the result is traversal order dependent so we can't use the is_shallow()
-        # test here.
+        # the result is traversal order dependent so we
+        # can't use the is_shallow() test here.
         try:
             assert_edges_equal(H.edges(), [(0, 1), (1, 2), (2, 0)])
         except AssertionError:
@@ -135,11 +146,6 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(G.has_successor(0, 1), True)
         assert_equal(G.has_successor(0, -1), False)
 
-    # def test_successors(self):
-    #     G=self.K3
-    #     assert_equal(sorted(G.successors(0)),[1,2])
-    #     assert_raises((KeyError,nx.NetworkXError), G.successors,-1)
-
     def test_successors(self):
         G = self.K3
         assert_equal(sorted(G.successors(0)), [1, 2])
@@ -149,11 +155,6 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         G = self.K3
         assert_equal(G.has_predecessor(0, 1), True)
         assert_equal(G.has_predecessor(0, -1), False)
-
-    # def test_predecessors(self):
-    #     G=self.K3
-    #     assert_equal(sorted(G.predecessors(0)),[1,2])
-    #     assert_raises((KeyError,nx.NetworkXError), G.predecessors,-1)
 
     def test_predecessors(self):
         G = self.K3
@@ -167,8 +168,10 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert_equal(G.degree(0), 4)
         assert_equal(list(G.degree(iter([0]))), [(0, 4)])
         G.add_edge(0, 1, weight=0.3, other=1.2)
-        assert_equal(sorted(G.degree(weight='weight')), [(0, 4.3), (1, 4.3), (2, 4)])
-        assert_equal(sorted(G.degree(weight='other')), [(0, 5.2), (1, 5.2), (2, 4)])
+        assert_equal(sorted(G.degree(weight='weight')),
+                     [(0, 4.3), (1, 4.3), (2, 4)])
+        assert_equal(sorted(G.degree(weight='other')),
+                     [(0, 5.2), (1, 5.2), (2, 4)])
 
     def test_in_degree(self):
         G = self.K3
@@ -270,10 +273,20 @@ class TestMultiDiGraph(BaseMultiDiGraphTester, TestMultiGraph):
                                               2: {'weight': 2},
                                               3: {'weight': 3}}}})
 
-        assert_raises(nx.NetworkXError, G.add_edges_from, [(0,)])  # too few in tuple
-        assert_raises(nx.NetworkXError, G.add_edges_from, [
-                      (0, 1, 2, 3, 4)])  # too many in tuple
-        assert_raises(TypeError, G.add_edges_from, [0])  # not a tuple
+        G = self.Graph()
+        edges = [(0, 1, {'weight': 3}), (0, 1, (('weight', 2),)),
+                 (0, 1, 5), (0, 1, 's')]
+        G.add_edges_from(edges)
+        keydict = {0: {'weight': 3}, 1: {'weight': 2}, 5: {}, 's': {}}
+        assert_equal(G._succ, {0: {1: keydict}, 1: {}})
+        assert_equal(G._pred, {1: {0: keydict}, 0: {}})
+
+        # too few in tuple
+        assert_raises(nx.NetworkXError, G.add_edges_from, [(0,)])
+        # too many in tuple
+        assert_raises(nx.NetworkXError, G.add_edges_from, [(0, 1, 2, 3, 4)])
+        # not a tuple
+        assert_raises(TypeError, G.add_edges_from, [0])
 
     def test_remove_edge(self):
         G = self.K3

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -136,8 +136,8 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
         G.adj[1][2][0]['listdata'] = [20, 200]
         G.adj[1][2][0]['weight'] = 20
         assert_edges_equal(G.edges(data=True),
-                           [(1, 2, {'data': 21, 'spam': 'bar',
-                                    'bar': 'foo', 'listdata': [20, 200], 'weight':20})])
+                           [(1, 2, {'data': 21, 'spam': 'bar', 'bar': 'foo',
+                            'listdata': [20, 200], 'weight':20})])
 
 
 class TestMultiGraph(BaseMultiGraphTester, TestGraph):
@@ -160,7 +160,8 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
     def test_data_input(self):
         G = self.Graph(data={1: [2], 2: [1]}, name="test")
         assert_equal(G.name, "test")
-        assert_equal(sorted(G.adj.items()), [(1, {2: {0: {}}}), (2, {1: {0: {}}})])
+        expected = [(1, {2: {0: {}}}), (2, {1: {0: {}}})]
+        assert_equal(sorted(G.adj.items()), expected)
 
     def test_getitem(self):
         G = self.K3
@@ -202,12 +203,19 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
                                      2: {'weight': 2}, 3: {'weight': 3}}},
                              1: {0: {0: {}, 1: {'weight': 3},
                                      2: {'weight': 2}, 3: {'weight': 3}}}})
+        G = self.Graph()
+        edges = [(0, 1, {'weight': 3}), (0, 1, (('weight', 2),)),
+                 (0, 1, 5), (0, 1, 's')]
+        G.add_edges_from(edges)
+        keydict = {0: {'weight': 3}, 1: {'weight': 2}, 5: {}, 's': {}}
+        assert_equal(G._adj, {0: {1: keydict}, 1: {0: keydict}})
 
         # too few in tuple
         assert_raises(nx.NetworkXError, G.add_edges_from, [(0,)])
         # too many in tuple
         assert_raises(nx.NetworkXError, G.add_edges_from, [(0, 1, 2, 3, 4)])
-        assert_raises(TypeError, G.add_edges_from, [0])  # not a tuple
+        # not a tuple
+        assert_raises(TypeError, G.add_edges_from, [0])
 
     def test_remove_edge(self):
         G = self.K3
@@ -224,7 +232,8 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
     def test_remove_edges_from(self):
         G = self.K3.copy()
         G.remove_edges_from([(0, 1)])
-        assert_equal(G.adj, {0: {2: {0: {}}}, 1: {2: {0: {}}}, 2: {0: {0: {}}, 1: {0: {}}}})
+        kd = {0: {}}
+        assert_equal(G.adj, {0: {2: kd}, 1: {2: kd}, 2: {0: kd, 1: kd}})
         G.remove_edges_from([(0, 0)])  # silent fail
         self.K3.add_edge(0, 1)
         G = self.K3.copy()
@@ -248,7 +257,8 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
                              1: {0: {0: {}}, 2: {0: {}}},
                              2: {0: {0: {}}, 1: {0: {}}}})
         G.remove_edge(0, 1)
-        assert_equal(G.adj, {0: {2: {0: {}}}, 1: {2: {0: {}}}, 2: {0: {0: {}}, 1: {0: {}}}})
+        kd = {0: {}}
+        assert_equal(G.adj, {0: {2: kd}, 1: {2: kd}, 2: {0: kd, 1: kd}})
         assert_raises((KeyError, nx.NetworkXError), G.remove_edge, -1, 0)
 
 


### PR DESCRIPTION
Can now do (u, v, d) or (u, v, k) with networkx deciding for k only when dict.update(d) raises an exception.  Basically if d is a dict or iterator of 2-tuples assume it is edge data. Otherwise assume it is a key.