### PR TITLE
SubGraph filter on nodes/edges

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -98,9 +98,9 @@ from networkx.exception import *
 import networkx.external
 import networkx.utils
 
+import networkx.classes.filters
 import networkx.classes
 from networkx.classes import *
-
 
 import networkx.convert
 from networkx.convert import *

--- a/networkx/classes/__init__.py
+++ b/networkx/classes/__init__.py
@@ -3,6 +3,7 @@ from .digraph import DiGraph
 from .multigraph import MultiGraph
 from .multidigraph import MultiDiGraph
 from .views import *
+from .subgraph import *
 from .ordered import *
 
 from .function import *

--- a/networkx/classes/filters.py
+++ b/networkx/classes/filters.py
@@ -1,0 +1,75 @@
+#    Copyright (C) 2004-2017 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Author:  Aric Hagberg (hagberg@lanl.gov),
+#          Pieter Swart (swart@lanl.gov),
+#          Dan Schult(dschult@colgate.edu)
+"""Filter factories to hide or show sets of nodes and edges.
+
+These filters return the function used when creating `SubGraph`.
+"""
+__all__ = ['no_filter', 'hide_nodes',
+           'hide_edges', 'hide_multiedges',
+           'hide_diedges', 'hide_multidiedges',
+           'show_nodes',
+           'show_edges', 'show_multiedges',
+           'show_diedges', 'show_multidiedges',
+           ]
+
+
+def no_filter(*items):
+    return True
+
+
+def hide_nodes(nodes):
+    nodes = set(nodes)
+    return lambda node: node not in nodes
+
+
+def hide_diedges(edges):
+    edges = {(u, v) for u, v in edges}
+    return lambda u, v: (u, v) not in edges
+
+
+def hide_edges(edges):
+    alledges = set(edges) | {(v, u) for (u, v) in edges}
+    return lambda u, v: (u, v) not in alledges
+
+
+def hide_multidiedges(edges):
+    edges = {(u, v, k) for u, v, k in edges}
+    return lambda u, v, k: (u, v, k) not in edges
+
+
+def hide_multiedges(edges):
+    alledges = set(edges) | {(v, u, k) for (u, v, k) in edges}
+    return lambda u, v, k: (u, v, k) not in alledges
+
+
+def show_nodes(nodes):
+    nodes = set(nodes)
+    return lambda node: node in nodes
+
+
+def show_diedges(edges):
+    edges = {(u, v) for u, v in edges}
+    return lambda u, v: (u, v) in edges
+
+
+def show_edges(edges):
+    alledges = set(edges) | {(v, u) for (u, v) in edges}
+    return lambda u, v: (u, v) in alledges
+
+
+def show_multidiedges(edges):
+    edges = {(u, v, k) for u, v, k in edges}
+    return lambda u, v, k: (u, v, k) in edges
+
+
+def show_multiedges(edges):
+    alledges = set(edges) | {(v, u, k) for (u, v, k) in edges}
+    return lambda u, v, k: (u, v, k) in alledges

--- a/networkx/classes/subgraph.py
+++ b/networkx/classes/subgraph.py
@@ -16,10 +16,13 @@ to do that via a view than to remove and then re-add.
 """
 from collections import Mapping
 
+import networkx as nx
 from networkx.classes import Graph, DiGraph, MultiGraph, MultiDiGraph
-from networkx.classes.filters import no_filter
+from networkx.classes.filters import no_filter, show_nodes, show_edges
+from networkx.exception import NetworkXError
 
-__all__ = ['SubGraph', 'DiSubGraph', 'MultiSubGraph', 'MultiDiSubGraph']
+__all__ = ['SubGraph', 'DiSubGraph', 'MultiSubGraph', 'MultiDiSubGraph',
+           'induced_subgraph', 'edge_subgraph']
 
 
 class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
@@ -130,6 +133,23 @@ class SubGraph(Graph):
         self._node = FilterAtlas(graph._node, filter_node)
         self._adj = FilterAdjacency(graph._adj, filter_node, filter_edge)
 
+    def not_allowed(self, *args, **kwds):
+        msg = "SubGraph Views are readonly. Mutations not allowed"
+        raise NetworkXError(msg)
+
+    add_node = not_allowed
+    remove_node = not_allowed
+    add_nodes_from = not_allowed
+    remove_nodes_from = not_allowed
+
+    add_edge = not_allowed
+    remove_edge = not_allowed
+    add_edges_from = not_allowed
+    add_weighted_edges_from = not_allowed
+    remove_edges_from = not_allowed
+
+    clear = not_allowed
+
 
 class DiSubGraph(DiGraph):
     def __init__(self, graph, filter_node=no_filter, filter_edge=no_filter):
@@ -145,6 +165,23 @@ class DiSubGraph(DiGraph):
                                      lambda u, v: filter_edge(v, u))
         self._succ = self._adj
 
+    def not_allowed(self, *args, **kwds):
+        msg = "SubGraph Views are readonly. Mutations not allowed"
+        raise NetworkXError(msg)
+
+    add_node = not_allowed
+    remove_node = not_allowed
+    add_nodes_from = not_allowed
+    remove_nodes_from = not_allowed
+
+    add_edge = not_allowed
+    remove_edge = not_allowed
+    add_edges_from = not_allowed
+    add_weighted_edges_from = not_allowed
+    remove_edges_from = not_allowed
+
+    clear = not_allowed
+
 
 class MultiSubGraph(MultiGraph):
     def __init__(self, graph, filter_node=no_filter, filter_edge=no_filter):
@@ -156,6 +193,23 @@ class MultiSubGraph(MultiGraph):
         self.graph = graph.graph
         self._node = FilterAtlas(graph._node, filter_node)
         self._adj = FilterMultiAdjacency(graph._adj, filter_node, filter_edge)
+
+    def not_allowed(self, *args, **kwds):
+        msg = "SubGraph Views are readonly. Mutations not allowed"
+        raise NetworkXError(msg)
+
+    add_node = not_allowed
+    remove_node = not_allowed
+    add_nodes_from = not_allowed
+    remove_nodes_from = not_allowed
+
+    add_edge = not_allowed
+    remove_edge = not_allowed
+    add_edges_from = not_allowed
+    add_weighted_edges_from = not_allowed
+    remove_edges_from = not_allowed
+
+    clear = not_allowed
 
 
 class MultiDiSubGraph(MultiDiGraph):
@@ -172,3 +226,109 @@ class MultiDiSubGraph(MultiDiGraph):
         self._pred = FMA(graph._pred, filter_node,
                          lambda u, v, k: filter_edge(v, u, k))
         self._succ = self._adj
+
+    def not_allowed(self, *args, **kwds):
+        msg = "SubGraph Views are readonly. Mutations not allowed"
+        raise NetworkXError(msg)
+
+    add_node = not_allowed
+    remove_node = not_allowed
+    add_nodes_from = not_allowed
+    remove_nodes_from = not_allowed
+
+    add_edge = not_allowed
+    remove_edge = not_allowed
+    add_edges_from = not_allowed
+    add_weighted_edges_from = not_allowed
+    remove_edges_from = not_allowed
+
+    clear = not_allowed
+
+
+def induced_subgraph(G, nbunch):
+    """Return a SubGraph view of `G` showing only nodes in nbunch.
+
+    The induced subgraph of a graph on a set of nodes N is the
+    graph with nodes N and edges from G which have both ends in N.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    nbunch : node, container of nodes or None (for all nodes)
+
+    Returns
+    -------
+    subgraph : SubGraph View
+        A read-only view of the subgraph in `G` induced by the nodes.
+        Changes to the graph `G` will be reflected in the view.
+
+    Notes
+    -----
+    To create a mutable subgraph with its own copies of nodes
+    edges and attributes use `subgraph.copy()` or `nx.Graph(subgraph)`
+
+    For an inplace reduction of a graph to a subgraph you can remove nodes:
+    `G.remove_nodes_from(n in G if n not in set(nbunch))`
+
+    Examples
+    --------
+    >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc
+    >>> H = G.subgraph([0, 1, 2])
+    >>> list(H.edges)
+    [(0, 1), (1, 2)]
+    """
+    induced_nodes = show_nodes(G.nbunch_iter(nbunch))
+    if G.is_multigraph():
+        if G.is_directed():
+            return MultiDiSubGraph(G, induced_nodes)
+        return MultiSubGraph(G, induced_nodes)
+    if G.is_directed():
+        return DiSubGraph(G, induced_nodes)
+    return SubGraph(G, induced_nodes)
+
+
+def edge_subgraph(G, edges):
+    """Returns the subgraph induced by the specified edges.
+
+    The induced subgraph contains each edge in `edges` and each
+    node incident to any of those edges.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    edges : iterable
+        An iterable of edges. Edges not present in `G` are ignored.
+
+    Returns
+    -------
+    subgraph : SubGraph View
+        A read-only edge-induced subgraph of `G`.
+        Changes to `G` are reflected in the view.
+
+    Notes
+    -----
+    To create a mutable subgraph with its own copies of nodes
+    edges and attributes use `subgraph.copy()` or `nx.Graph(subgraph)`
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> H = G.edge_subgraph([(0, 1), (3, 4)])
+    >>> list(H.nodes)
+    [0, 1, 3, 4]
+    >>> list(H.edges)
+    [(0, 1), (3, 4)]
+    """
+    edges = set(edges)
+    nodes = set()
+    for e in edges:
+        nodes.update(e[:2])
+    induced_edges = show_edges(edges)
+    induced_nodes = show_nodes(nodes)
+    if G.is_multigraph():
+        if G.is_directed():
+            return MultiDiSubGraph(G, induced_nodes, induced_edges)
+        return MultiSubGraph(G, induced_nodes, induced_edges)
+    if G.is_directed():
+        return DiSubGraph(G, induced_nodes, induced_edges)
+    return SubGraph(G, induced_nodes, induced_edges)

--- a/networkx/classes/subgraph.py
+++ b/networkx/classes/subgraph.py
@@ -1,0 +1,171 @@
+#    Copyright (C) 2004-2017 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Author:  Aric Hagberg (hagberg@lanl.gov),
+#          Pieter Swart (swart@lanl.gov),
+#          Dan Schult(dschult@colgate.edu)
+"""View of Graph with restricted nodes and edges.
+
+In some algorithms it is convenient to temporarily morph
+a graph to exclude some nodes or edges. It should be better
+to do that via a view than to remove and then re-add.
+"""
+from __future__ import division
+from collections import Mapping
+
+from networkx.classes import AtlasView, EdgeView
+from networkx.classes import Graph, DiGraph, MultiGraph, MultiDiGraph
+
+__all__ = ['FilterAtlas', 'FilterAdjacency',
+           'FilterMultiInner', 'FilterMultiAdjacency',
+           'SubGraph', 'DiSubGraph',
+           'MultiSubGraph', 'MultiDiSubGraph']
+
+
+class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
+    def __init__(self, d, NODE_OK):
+        self._atlas = d
+        self.NODE_OK = NODE_OK
+
+    def __len__(self):
+        return sum(1 for n in self._atlas if self.NODE_OK(n))
+
+    def __iter__(self):
+        return (n for n in self._atlas if self.NODE_OK(n))
+
+    def __getitem__(self, key):
+        if key in self._atlas and self.NODE_OK(key):
+            return self._atlas[key]
+        raise KeyError("Key {} not found".format(key))
+
+    def copy(self):
+        return {u: d for u, d in self._atlas.items()
+                if self.NODE_OK(u)}
+
+    def __repr__(self):
+        return '%s(%r, %r)' % (self.__class__.__name__, self._atlas,
+                               self.NODE_OK)
+
+
+class FilterAdjacency(Mapping):   # edgedict
+    def __init__(self, d, NODE_OK, EDGE_OK):
+        self._atlas = d
+        self.NODE_OK = NODE_OK
+        self.EDGE_OK = EDGE_OK
+
+    def __len__(self):
+        return sum(1 for n in self._atlas if self.NODE_OK(n))
+
+    def __iter__(self):
+        return (n for n in self._atlas if self.NODE_OK(n))
+
+    def __getitem__(self, node):
+        if node in self._atlas and self.NODE_OK(node):
+            def new_node_ok(nbr):
+                return self.NODE_OK(nbr) and self.EDGE_OK(node, nbr)
+            return FilterAtlas(self._atlas[node], new_node_ok)
+        raise KeyError("Key {} not found".format(node))
+
+    def copy(self):
+        return {u: {v: d for v, d in nbrs.items() if self.NODE_OK(v)
+                    if self.EDGE_OK(u, v)}
+                for u, nbrs in self._atlas.items()
+                if self.NODE_OK(u)}
+
+    def __repr__(self):
+        return '%s(%r, %r, %r)' % (self.__class__.__name__, self._atlas,
+                                   self.NODE_OK, self.EDGE_OK)
+
+
+class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
+    def __getitem__(self, nbr):
+        if nbr in self._atlas and self.NODE_OK(nbr):
+            def new_node_ok(key):
+                return self.EDGE_OK(nbr, key)
+            return FilterAtlas(self._atlas[nbr], new_node_ok)
+        raise KeyError("Key {} not found".format(nbr))
+
+    def copy(self):
+        return {v: {k: d for k, d in nbrs.items() if self.EDGE_OK(v, k)}
+                for v, nbrs in self._atlas.items() if self.NODE_OK(v)}
+
+
+class FilterMultiAdjacency(FilterAdjacency):  # multiedgedict
+    def __getitem__(self, node):
+        if node in self._atlas and self.NODE_OK(node):
+            def edge_ok(nbr, key):
+                return self.NODE_OK(nbr) and self.EDGE_OK(node, nbr, key)
+            return FilterMultiInner(self._atlas[node], self.NODE_OK, edge_ok)
+        raise KeyError("Key {} not found".format(node))
+
+    def copy(self):
+        return {u: {v: {k: d for k, d in kd.items()
+                        if self.EDGE_OK(u, v, k)}
+                    for v, kd in nbrs.items() if self.NODE_OK(v)}
+                for u, nbrs in self._atlas.items() if self.NODE_OK(u)}
+
+
+def nofilter(*items):
+    return True
+
+
+class SubGraph(Graph):
+    def __init__(self, graph, filter_node=nofilter, filter_edge=nofilter):
+        self._graph = graph
+        self._NODE_OK = filter_node
+        self._EDGE_OK = filter_edge
+
+        # Set graph interface
+        self.graph = graph.graph
+        self._node = FilterAtlas(graph._node, filter_node)
+        self._adj = FilterAdjacency(graph._adj, filter_node, filter_edge)
+
+
+class DiSubGraph(DiGraph):
+    def __init__(self, graph, filter_node=nofilter, filter_edge=nofilter):
+        self._graph = graph
+        self._NODE_OK = filter_node
+        self._EDGE_OK = filter_edge
+
+        def filter_in_edge(u, v):
+            return filter_edge(v, u)
+
+        # Set graph interface
+        self.graph = graph.graph
+        self._node = FilterAtlas(graph._node, filter_node)
+        self._adj = FilterAdjacency(graph._adj, filter_node, filter_edge)
+        self._pred = FilterAdjacency(graph._pred, filter_node, filter_in_edge)
+        self._succ = self._adj
+
+
+class MultiSubGraph(MultiGraph):
+    def __init__(self, graph, filter_node=nofilter, filter_edge=nofilter):
+        self._graph = graph
+        self._NODE_OK = filter_node
+        self._EDGE_OK = filter_edge
+
+        # Set graph interface
+        self.graph = graph.graph
+        self._node = FilterAtlas(graph._node, filter_node)
+        self._adj = FilterMultiAdjacency(graph._adj, filter_node, filter_edge)
+
+
+class MultiDiSubGraph(MultiDiGraph):
+    def __init__(self, graph, filter_node=nofilter, filter_edge=nofilter):
+        self._graph = graph
+        self._NODE_OK = filter_node
+        self._EDGE_OK = filter_edge
+
+        def f_in_edge(u, v, k):
+            return filter_edge(v, u, k)
+
+        # Set graph interface
+        self.graph = graph.graph
+        self._node = FilterAtlas(graph._node, filter_node)
+        self._adj = FilterMultiAdjacency(graph._adj, filter_node, filter_edge)
+        self._pred = FilterMultiAdjacency(graph._pred, filter_node, f_in_edge)
+        self._succ = self._adj

--- a/networkx/classes/tests/test_subgraph.py
+++ b/networkx/classes/tests/test_subgraph.py
@@ -4,57 +4,21 @@ from nose.tools import assert_equal, assert_not_equal, \
 import networkx as nx
 
 
-def hide_nodes_filter(nodes):
-    def filter_node(node):
-        return node not in nodes
-    return filter_node
-
-
-def hide_diedges_filter(edges):
-    def filter_edge(u, v):
-        return (u, v) not in edges
-    return filter_edge
-
-
-def hide_edges_filter(edges):
-    alledges = set(edges) | {(v, u) for (u, v) in edges}
-
-    def filter_edge(u, v):
-        return (u, v) not in alledges
-    return filter_edge
-
-
-def hide_multidiedges_filter(edges):
-    def filter_multiedge(u, v, k):
-        return (u, v, k) not in edges
-    return filter_multiedge
-
-
-def hide_multiedges_filter(edges):
-    alledges = set(edges) | {(v, u, k) for (u, v, k) in edges}
-
-    def filter_multiedge(u, v, k):
-        return (u, v, k) not in alledges
-    return filter_multiedge
-
-
 class test_graphview(object):
+    hide_edges_filter = staticmethod(nx.filters.hide_edges)
+    show_edges_filter = staticmethod(nx.filters.show_edges)
+
     def setUp(self):
-        self.G = nx.path_graph(9)
         self.gview = nx.SubGraph
-
-        self.hide_nodes = [4, 5, 111]
-        self.node_ok = hide_nodes_filter(self.hide_nodes)
-        self.out_nodes = {4, 5}
-
-        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
-        self.edge_ok = hide_edges_filter(self.hide_edges)
-        self.out_edges = {(3, 4), (4, 5), (5, 6)}
+        self.G = nx.path_graph(9)
+        self.hide_edges_w_hide_nodes = {(3, 4), (4, 5), (5, 6)}
 
     def test_hidden_nodes(self):
-        G = self.gview(self.G, filter_node=self.node_ok)
-        assert_equal(self.G.nodes - G.nodes, self.out_nodes)
-        assert_equal(self.G.edges - G.edges, self.out_edges)
+        hide_nodes = [4, 5, 111]
+        nodes_gone = nx.filters.hide_nodes(hide_nodes)
+        G = self.gview(self.G, filter_node=nodes_gone)
+        assert_equal(self.G.nodes - G.nodes, {4, 5})
+        assert_equal(self.G.edges - G.edges, self.hide_edges_w_hide_nodes)
         if G.is_directed():
             assert_equal(list(G[3]), [])
             assert_equal(list(G[2]), [3])
@@ -68,51 +32,99 @@ class test_graphview(object):
         assert_equal(G.size(), 7 if G.is_multigraph() else 5)
 
     def test_hidden_edges(self):
-        G = self.gview(self.G, filter_edge=self.edge_ok)
+        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
+        self.edges_gone = self.hide_edges_filter(self.hide_edges)
+        G = self.gview(self.G, filter_edge=self.edges_gone)
         assert_equal(self.G.nodes, G.nodes)
         if G.is_directed():
             assert_equal(self.G.edges - G.edges, {(2, 3)})
-            assert_equal(list(G[3]), [4])
             assert_equal(list(G[2]), [])
             assert_equal(list(G.pred[3]), [])
             assert_equal(list(G.pred[2]), [1])
             assert_equal(G.size(), 7)
         else:
             assert_equal(self.G.edges - G.edges, {(2, 3), (7, 8)})
-            assert_equal(list(G[3]), [4])
             assert_equal(list(G[2]), [1])
             assert_equal(G.size(), 6)
+        assert_equal(list(G[3]), [4])
+        assert_raises(KeyError, G.__getitem__, 221)
+        assert_raises(KeyError, G.__getitem__, 222)
+        assert_equal(G.degree(3), 1)
+
+    def test_shown_node(self):
+        self.induced_subgraph = nx.filters.show_nodes([2, 3, 111])
+        G = self.gview(self.G, filter_node=self.induced_subgraph)
+        assert_equal(set(G.nodes), {2, 3})
+        if G.is_directed():
+            assert_equal(list(G[3]), [])
+        else:
+            assert_equal(list(G[3]), [2])
+        assert_equal(list(G[2]), [3])
+        assert_raises(KeyError, G.__getitem__, 4)
+        assert_raises(KeyError, G.__getitem__, 112)
+        assert_raises(KeyError, G.__getitem__, 111)
+        assert_equal(G.degree(3), 3 if G.is_multigraph() else 1)
+        assert_equal(G.size(), 3 if G.is_multigraph() else 1)
+
+    def test_shown_edges(self):
+        show_edges = [(2, 3), (8, 7), (222, 223)]
+        edge_subgraph = self.show_edges_filter(show_edges)
+        G = self.gview(self.G, filter_edge=edge_subgraph)
+        assert_equal(self.G.nodes, G.nodes)
+        if G.is_directed():
+            assert_equal(G.edges, {(2, 3)})
+            assert_equal(list(G[3]), [])
+            assert_equal(list(G[2]), [3])
+            assert_equal(list(G.pred[3]), [2])
+            assert_equal(list(G.pred[2]), [])
+            assert_equal(G.size(), 1)
+        else:
+            assert_equal(G.edges, {(2, 3), (7, 8)})
+            assert_equal(list(G[3]), [2])
+            assert_equal(list(G[2]), [3])
+            assert_equal(G.size(), 2)
         assert_raises(KeyError, G.__getitem__, 221)
         assert_raises(KeyError, G.__getitem__, 222)
         assert_equal(G.degree(3), 1)
 
 
 class test_digraphview(test_graphview):
+    hide_edges_filter = staticmethod(nx.filters.hide_diedges)
+    show_edges_filter = staticmethod(nx.filters.show_diedges)
+
     def setUp(self):
-        self.G = nx.path_graph(9, create_using=nx.DiGraph())
         self.gview = nx.DiSubGraph
-
-        self.hide_nodes = [4, 5, 111]
-        self.node_ok = hide_nodes_filter(self.hide_nodes)
-        self.out_nodes = {4, 5}
-
-        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
-        self.edge_ok = hide_diedges_filter(self.hide_edges)
-        self.out_edges = {(3, 4), (4, 5), (5, 6)}
+        self.G = nx.path_graph(9, create_using=nx.DiGraph())
+        self.hide_edges_w_hide_nodes = {(3, 4), (4, 5), (5, 6)}
 
     def test_inoutedges(self):
-        G = self.gview(self.G, self.node_ok, self.edge_ok)
+        hide_edges = [(2, 3), (8, 7), (222, 223)]
+        edges_gone = nx.filters.hide_diedges(hide_edges)
+        hide_nodes = [4, 5, 111]
+        nodes_gone = nx.filters.hide_nodes(hide_nodes)
+        G = self.gview(self.G, nodes_gone, edges_gone)
+
         excluded = {(2, 3), (3, 4), (4, 5), (5, 6)}
         assert_equal(self.G.in_edges - G.in_edges, excluded)
         assert_equal(self.G.out_edges - G.out_edges, excluded)
 
     def test_pred(self):
-        G = self.gview(self.G, self.node_ok, self.edge_ok)
+        hide_edges = [(2, 3), (8, 7), (222, 223)]
+        edges_gone = nx.filters.hide_diedges(hide_edges)
+        hide_nodes = [4, 5, 111]
+        nodes_gone = nx.filters.hide_nodes(hide_nodes)
+        G = self.gview(self.G, nodes_gone, edges_gone)
+
         assert_equal(list(G.pred[2]), [1])
         assert_equal(list(G.pred[6]), [])
 
     def test_inout_degree(self):
-        G = self.gview(self.G, self.node_ok, self.edge_ok)
+        hide_edges = [(2, 3), (8, 7), (222, 223)]
+        edges_gone = nx.filters.hide_diedges(hide_edges)
+        hide_nodes = [4, 5, 111]
+        nodes_gone = nx.filters.hide_nodes(hide_nodes)
+        G = self.gview(self.G, nodes_gone, edges_gone)
+
         assert_equal(G.degree(2), 1)
         assert_equal(G.out_degree(2), 0)
         assert_equal(G.in_degree(2), 1)
@@ -121,22 +133,21 @@ class test_digraphview(test_graphview):
 
 # multigraph
 class test_multigraphview(test_graphview):
+    gview = nx.MultiSubGraph
+    graph = nx.MultiGraph
+    hide_edges_filter = staticmethod(nx.filters.hide_multiedges)
+    show_edges_filter = staticmethod(nx.filters.show_multiedges)
+
     def setUp(self):
-        self.G = nx.path_graph(9, create_using=nx.MultiGraph())
+        self.G = nx.path_graph(9, create_using=self.graph())
         multiedges = {(2, 3, 4), (2, 3, 5)}
         self.G.add_edges_from(multiedges)
-        self.gview = nx.MultiSubGraph
-
-        self.hide_nodes = [4, 5, 111]
-        self.node_ok = hide_nodes_filter(self.hide_nodes)
-        self.out_nodes = {4, 5}
-
-        self.hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
-        self.edge_ok = hide_multiedges_filter(self.hide_edges)
-        self.out_edges = {(3, 4, 0), (4, 5, 0), (5, 6, 0)}
+        self.hide_edges_w_hide_nodes = {(3, 4, 0), (4, 5, 0), (5, 6, 0)}
 
     def test_hidden_edges(self):
-        G = self.gview(self.G, filter_edge=self.edge_ok)
+        hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
+        edges_gone = self.hide_edges_filter(hide_edges)
+        G = self.gview(self.G, filter_edge=edges_gone)
         assert_equal(self.G.nodes, G.nodes)
         if G.is_directed():
             assert_equal(self.G.edges - G.edges, {(2, 3, 4)})
@@ -145,29 +156,39 @@ class test_multigraphview(test_graphview):
             assert_equal(list(G.pred[3]), [2])  # only one 2 but two edges
             assert_equal(list(G.pred[2]), [1])
             assert_equal(G.size(), 9)
-            assert_equal(G.degree(3), 3)
         else:
             assert_equal(self.G.edges - G.edges, {(2, 3, 4), (7, 8, 0)})
             assert_equal(list(G[3]), [2, 4])
             assert_equal(list(G[2]), [1, 3])
             assert_equal(G.size(), 8)
-            assert_equal(G.degree(3), 3)
+        assert_equal(G.degree(3), 3)
+        assert_raises(KeyError, G.__getitem__, 221)
+        assert_raises(KeyError, G.__getitem__, 222)
+
+    def test_shown_edges(self):
+        show_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
+        edge_subgraph = self.show_edges_filter(show_edges)
+        G = self.gview(self.G, filter_edge=edge_subgraph)
+        assert_equal(self.G.nodes, G.nodes)
+        if G.is_directed():
+            assert_equal(G.edges, {(2, 3, 4)})
+            assert_equal(list(G[3]), [])
+            assert_equal(list(G.pred[3]), [2])
+            assert_equal(list(G.pred[2]), [])
+            assert_equal(G.size(), 1)
+        else:
+            assert_equal(G.edges, {(2, 3, 4), (7, 8, 0)})
+            assert_equal(G.size(), 2)
+            assert_equal(list(G[3]), [2])
+        assert_equal(G.degree(3), 1)
+        assert_equal(list(G[2]), [3])
         assert_raises(KeyError, G.__getitem__, 221)
         assert_raises(KeyError, G.__getitem__, 222)
 
 
 # multidigraph
 class test_multidigraphview(test_multigraphview):
-    def setUp(self):
-        self.G = nx.path_graph(9, create_using=nx.MultiDiGraph())
-        multiedges = {(2, 3, 4), (2, 3, 5)}
-        self.G.add_edges_from(multiedges)
-        self.gview = nx.MultiDiSubGraph
-
-        self.hide_nodes = [4, 5, 111]
-        self.node_ok = hide_nodes_filter(self.hide_nodes)
-        self.out_nodes = {4, 5}
-
-        self.hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
-        self.edge_ok = hide_multidiedges_filter(self.hide_edges)
-        self.out_edges = {(3, 4, 0), (4, 5, 0), (5, 6, 0)}
+    gview = nx.MultiDiSubGraph
+    graph = nx.MultiDiGraph
+    hide_edges_filter = staticmethod(nx.filters.hide_multidiedges)
+    show_edges_filter = staticmethod(nx.filters.show_multidiedges)

--- a/networkx/classes/tests/test_subgraph.py
+++ b/networkx/classes/tests/test_subgraph.py
@@ -1,0 +1,173 @@
+from nose.tools import assert_equal, assert_not_equal, \
+        assert_true, assert_false, assert_raises
+
+import networkx as nx
+
+
+def hide_nodes_filter(nodes):
+    def filter_node(node):
+        return node not in nodes
+    return filter_node
+
+
+def hide_diedges_filter(edges):
+    def filter_edge(u, v):
+        return (u, v) not in edges
+    return filter_edge
+
+
+def hide_edges_filter(edges):
+    alledges = set(edges) | {(v, u) for (u, v) in edges}
+
+    def filter_edge(u, v):
+        return (u, v) not in alledges
+    return filter_edge
+
+
+def hide_multidiedges_filter(edges):
+    def filter_multiedge(u, v, k):
+        return (u, v, k) not in edges
+    return filter_multiedge
+
+
+def hide_multiedges_filter(edges):
+    alledges = set(edges) | {(v, u, k) for (u, v, k) in edges}
+
+    def filter_multiedge(u, v, k):
+        return (u, v, k) not in alledges
+    return filter_multiedge
+
+
+class test_graphview(object):
+    def setUp(self):
+        self.G = nx.path_graph(9)
+        self.gview = nx.SubGraph
+
+        self.hide_nodes = [4, 5, 111]
+        self.node_ok = hide_nodes_filter(self.hide_nodes)
+        self.out_nodes = {4, 5}
+
+        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
+        self.edge_ok = hide_edges_filter(self.hide_edges)
+        self.out_edges = {(3, 4), (4, 5), (5, 6)}
+
+    def test_hidden_nodes(self):
+        G = self.gview(self.G, filter_node=self.node_ok)
+        assert_equal(self.G.nodes - G.nodes, self.out_nodes)
+        assert_equal(self.G.edges - G.edges, self.out_edges)
+        if G.is_directed():
+            assert_equal(list(G[3]), [])
+            assert_equal(list(G[2]), [3])
+        else:
+            assert_equal(list(G[3]), [2])
+            assert_equal(set(G[2]), {1, 3})
+        assert_raises(KeyError, G.__getitem__, 4)
+        assert_raises(KeyError, G.__getitem__, 112)
+        assert_raises(KeyError, G.__getitem__, 111)
+        assert_equal(G.degree(3), 3 if G.is_multigraph() else 1)
+        assert_equal(G.size(), 7 if G.is_multigraph() else 5)
+
+    def test_hidden_edges(self):
+        G = self.gview(self.G, filter_edge=self.edge_ok)
+        assert_equal(self.G.nodes, G.nodes)
+        if G.is_directed():
+            assert_equal(self.G.edges - G.edges, {(2, 3)})
+            assert_equal(list(G[3]), [4])
+            assert_equal(list(G[2]), [])
+            assert_equal(list(G.pred[3]), [])
+            assert_equal(list(G.pred[2]), [1])
+            assert_equal(G.size(), 7)
+        else:
+            assert_equal(self.G.edges - G.edges, {(2, 3), (7, 8)})
+            assert_equal(list(G[3]), [4])
+            assert_equal(list(G[2]), [1])
+            assert_equal(G.size(), 6)
+        assert_raises(KeyError, G.__getitem__, 221)
+        assert_raises(KeyError, G.__getitem__, 222)
+        assert_equal(G.degree(3), 1)
+
+
+class test_digraphview(test_graphview):
+    def setUp(self):
+        self.G = nx.path_graph(9, create_using=nx.DiGraph())
+        self.gview = nx.DiSubGraph
+
+        self.hide_nodes = [4, 5, 111]
+        self.node_ok = hide_nodes_filter(self.hide_nodes)
+        self.out_nodes = {4, 5}
+
+        self.hide_edges = [(2, 3), (8, 7), (222, 223)]
+        self.edge_ok = hide_diedges_filter(self.hide_edges)
+        self.out_edges = {(3, 4), (4, 5), (5, 6)}
+
+    def test_inoutedges(self):
+        G = self.gview(self.G, self.node_ok, self.edge_ok)
+        excluded = {(2, 3), (3, 4), (4, 5), (5, 6)}
+        assert_equal(self.G.in_edges - G.in_edges, excluded)
+        assert_equal(self.G.out_edges - G.out_edges, excluded)
+
+    def test_pred(self):
+        G = self.gview(self.G, self.node_ok, self.edge_ok)
+        assert_equal(list(G.pred[2]), [1])
+        assert_equal(list(G.pred[6]), [])
+
+    def test_inout_degree(self):
+        G = self.gview(self.G, self.node_ok, self.edge_ok)
+        assert_equal(G.degree(2), 1)
+        assert_equal(G.out_degree(2), 0)
+        assert_equal(G.in_degree(2), 1)
+        assert_equal(G.size(), 4)
+
+
+# multigraph
+class test_multigraphview(test_graphview):
+    def setUp(self):
+        self.G = nx.path_graph(9, create_using=nx.MultiGraph())
+        multiedges = {(2, 3, 4), (2, 3, 5)}
+        self.G.add_edges_from(multiedges)
+        self.gview = nx.MultiSubGraph
+
+        self.hide_nodes = [4, 5, 111]
+        self.node_ok = hide_nodes_filter(self.hide_nodes)
+        self.out_nodes = {4, 5}
+
+        self.hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
+        self.edge_ok = hide_multiedges_filter(self.hide_edges)
+        self.out_edges = {(3, 4, 0), (4, 5, 0), (5, 6, 0)}
+
+    def test_hidden_edges(self):
+        G = self.gview(self.G, filter_edge=self.edge_ok)
+        assert_equal(self.G.nodes, G.nodes)
+        if G.is_directed():
+            assert_equal(self.G.edges - G.edges, {(2, 3, 4)})
+            assert_equal(list(G[3]), [4])
+            assert_equal(list(G[2]), [3])
+            assert_equal(list(G.pred[3]), [2])  # only one 2 but two edges
+            assert_equal(list(G.pred[2]), [1])
+            assert_equal(G.size(), 9)
+            assert_equal(G.degree(3), 3)
+        else:
+            assert_equal(self.G.edges - G.edges, {(2, 3, 4), (7, 8, 0)})
+            assert_equal(list(G[3]), [2, 4])
+            assert_equal(list(G[2]), [1, 3])
+            assert_equal(G.size(), 8)
+            assert_equal(G.degree(3), 3)
+        assert_raises(KeyError, G.__getitem__, 221)
+        assert_raises(KeyError, G.__getitem__, 222)
+
+
+# multidigraph
+class test_multidigraphview(test_multigraphview):
+    def setUp(self):
+        self.G = nx.path_graph(9, create_using=nx.MultiDiGraph())
+        multiedges = {(2, 3, 4), (2, 3, 5)}
+        self.G.add_edges_from(multiedges)
+        self.gview = nx.MultiDiSubGraph
+
+        self.hide_nodes = [4, 5, 111]
+        self.node_ok = hide_nodes_filter(self.hide_nodes)
+        self.out_nodes = {4, 5}
+
+        self.hide_edges = [(2, 3, 4), (2, 3, 3), (8, 7, 0), (222, 223, 0)]
+        self.edge_ok = hide_multidiedges_filter(self.hide_edges)
+        self.out_edges = {(3, 4, 0), (4, 5, 0), (5, 6, 0)}


### PR DESCRIPTION
Here SubGraph means a view restricting (or enhancing) a graph. 
Two filters are possible: ```node_filter``` and ```edge_filter```
```node_filter``` takes a ```node``` argument and returns True to keep the node.
```edge_filter``` takes two nodes as arguments (or for multigraph,
an additional key argument) and returns True to keep the edge.

This seems cleaner than the ```GraphView``` of #2512 and can hide nodes easily by building a filter function: ```lambda n: n not in hidden_nodes```, but can be much more involved.

    def fish_nodes(n):
        return 'fish' in G.nodes[n]
    def red_edges(u,v):
        return 'red' == G.edges[u, v]['color']
    SG = nx.SubGraph(G, node_filter=fish_nodes, edge_filter=red_edges)

Related tickets include:
#2512 
#762
#1011
#793
#335
and there are probably many other places where this feature has been discussed.