### PR TITLE
Cherry pick missing commits

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -8,22 +8,37 @@ NetworkX 2.0
 ------------
 Release date: TBD
 
-
 See :doc:`release/migration_guide_from_1.x_to_2.0`.
    
 API changes
 ~~~~~~~~~~~
 See :doc:`release/release_2.0`.
 
+NetworkX 1.11
+-------------
+Release date: 30 January 2016
+
+Support for Python 3.5 added, drop support for Python 3.2.
+
+Highlights
+~~~~~~~~~~
+
+Pydot features now use pydotplus.
+Fixes installation on some machines and test with appveyor.
+Restores default center and scale of layout routines.
+Fixes various docs including no symbolic links in examples.
+Docs can now build using autosummary on readthedocs.org.
 
 NetworkX 1.10
 --------------
+
 Release date: 2 August 2015
 
 Support for Python 2.6 is dropped in this release.
 
 Highlights
 ~~~~~~~~~~
+
 - Connected components now return generators
 - new functions including
 
@@ -60,8 +75,6 @@ NetworkX 1.9.1
 Release date: 13 September 2014
 
 Bugfix release for minor installation and documentation issues.
-
-https://github.com/networkx/networkx/milestones/networkx-1.9.1
 
 NetworkX 1.9
 ------------

--- a/doc/release/api_1.11.rst
+++ b/doc/release/api_1.11.rst
@@ -1,0 +1,40 @@
+**********************************
+Version 1.11 notes and API changes
+**********************************
+
+This page includes more detailed release information and API changes from
+NetworkX 1.10 to NetworkX 1.11.
+
+Please send comments and questions to the networkx-discuss mailing list:
+<http://groups.google.com/group/networkx-discuss>.
+
+API changes
+-----------
+* [`#1930 <https://github.com/networkx/networkx/pull/1930>`_]
+  No longer import nx_agraph and nx_pydot into the top-level namespace.
+  They can be accessed within networkx as e.g. ``nx.nx_agraph.write_dot``
+  or imported as ``from networkx.drawing.nx_agraph import write_dot``.
+
+* [`#1750 <https://github.com/networkx/networkx/pull/1750>`_]
+  Arguments center and scale are now available for all layout functions.
+  The defaul values revert to the v1.9 values (center is the origin
+  for circular layouts and domain is [0, scale) for others.
+
+* [`#1924 <https://github.com/networkx/networkx/pull/1924>`_]
+  Replace pydot with pydotplus for drawing with the pydot interface.
+
+* [`#1888 <https://github.com/networkx/networkx/pull/1888>`_]
+  Replace support for Python3.2 with support for Python 3.5.
+
+Miscellaneous changes
+---------------------
+
+* [`#1763 <https://github.com/networkx/networkx/pull/1763>`_]
+  Set up appveyor to automatically test installation on Windows machines.
+  Remove symbolic links in examples to help such istallation.
+
+Change many doc_string typos to allow sphinx
+to build the docs without errors or warnings.
+
+Enable the docs to be automatically built on
+readthedocs.org by changing requirements.txt

--- a/doc/release/index.rst
+++ b/doc/release/index.rst
@@ -6,6 +6,7 @@ API changes
    :maxdepth: 2
 
    release_2.0
+   api_1.11
    api_1.10
    api_1.9
    api_1.8

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -456,8 +456,9 @@ PyGraphviz or pydot, are available on your system, you can also use
 ``nx_agraph.graphviz_layout(G)`` or ``nx_pydot.graphviz_layout(G)`` to get the
 node positions, or write the graph in dot format for further processing.
 
+>>> from networkx.drawing.nx_pydot import write_dot
 >>> pos = nx.nx_agraph.graphviz_layout(G)
 >>> nx.draw(G, pos=pos)
->>> nx.write_dot(G,'file.dot')
+>>> nx.write_dot(G, 'file.dot')
 
 See :doc:`/reference/drawing` for additional details.

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1126,3 +1126,7 @@ def setup_module(module):
         import scipy
     except:
         raise SkipTest("SciPy not available")
+    try:
+        import pandas
+    except:
+        raise SkipTest("Pandas not available")

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 from nose import SkipTest
 from nose.tools import assert_true, assert_equal
+from networkx.testing import assert_edges_equal, assert_nodes_equal
+
 import networkx as nx
 
 
@@ -23,8 +25,8 @@ class TestAGraph(object):
         return G
 
     def assert_equal(self, G1, G2):
-        assert_equal(sorted(G1.nodes()), sorted(G2.nodes()))
-        assert_equal(sorted(G1.edges()), sorted(G2.edges()))
+        assert_nodes_equal(G1.nodes(), G2.nodes())
+        assert_edges_equal(G1.edges(), G2.edges())
         assert_equal(G1.graph['metal'], G2.graph['metal'])
 
     def agraph_checks(self, G):


### PR DESCRIPTION
Fix #2531.  Do we want some of 79550da?  Or should I remove the tests cases added in a35b7ea to ``networkx/drawing/tests/test_layout.py``?

I also left out the move to ``pydotplus`` as it appears abandoned and development on ``pydot`` continued.  But I am not familiar with either.