### PR TITLE
WIP: Enable doctests for timingclasses module

### DIFF
--- a/networkx/classes/tests/timingclasses.py
+++ b/networkx/classes/tests/timingclasses.py
@@ -4793,11 +4793,3 @@ class TimingMultiDiGraph(TimingMultiGraph, TimingDiGraph):
             self.adj = self.succ
             H = self
         return H
-
-# Temporarily skip doctests for timingclasses.py till the changes in *iter
-# functions are finalized.
-
-
-def setup_module(module):
-    from nose import SkipTest
-    raise SkipTest("Skip nose doctests for timingclasses module")


### PR DESCRIPTION
Enabling doctests, which were skipped per fdc906e4.