### PR TITLE
Refactor set_node_attributes() and set_edge_attributes()

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -165,12 +165,22 @@ API Changes
    expanding and pushing each other. The algorithm is completly described in 
    [`https://arxiv.org/pdf/1703.09307.pdf <https://arxiv.org/pdf/1703.09307.pdf>`_]. 
 
- * [`#2510 <https://github.com/networkx/networkx/pull/2510>`_ and
+* [`#2510 <https://github.com/networkx/networkx/pull/2510>`_ and
    `#2508 <https://github.com/networkx/networkx/pull/2508>`_]
    single_source_dijkstra, multi_source_dijkstra and functions that use these
    now have new behavior when `target` is specified. Instead of returning
    dicts for distances and paths a 2-tuple of (distance, path) is returned.
-   When `target` is not specified the return value is still 2 dicts. 
+   When `target` is not specified the return value is still 2 dicts.
+
+* [`#2553 <https://github.com/networkx/networkx/issues/2553>`_]
+   set_node_attributes() and set_edge_attributes() now accept dict-of-dict input
+   of shape {node/edge: {name: value}} in addition to previous valid inputs:
+   {node/edge: value} and value. The order of the parameters changed also: 
+   The second parameter "values" is the value argument and the third parameter
+   "name" is the name of the attribute. "name" has default value None in which
+   case "values" must be the newly allowed form containing names. Previously
+   "name" came second witout default, and "values" came third.
+
 
 Deprecations
 ------------

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -49,7 +49,7 @@ def color(G):
 
     You can use this to set a node attribute indicating the biparite set:
 
-    >>> nx.set_node_attributes(G, 'bipartite', c)
+    >>> nx.set_node_attributes(G, c, 'bipartite')
     >>> print(G.node[0]['bipartite'])
     1
     >>> print(G.node[1]['bipartite'])

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -594,5 +594,5 @@ def _add_nodes_with_bipartite_label(G, lena, lenb):
     G.add_nodes_from(range(0,lena+lenb))
     b=dict(zip(range(0,lena),[0]*lena))
     b.update(dict(zip(range(lena,lena+lenb),[1]*lenb)))
-    nx.set_node_attributes(G,'bipartite',b)
+    nx.set_node_attributes(G, b, 'bipartite')
     return G

--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -78,7 +78,7 @@ def girvan_newman(G, most_valuable_edge=None):
         >>> from operator import itemgetter
         >>> G = nx.path_graph(10)
         >>> edges = G.edges()
-        >>> nx.set_edge_attributes(G, 'weight', {(u, v): v for u, v in edges})
+        >>> nx.set_edge_attributes(G, {(u, v): v for u, v in edges}, 'weight')
         >>> def heaviest(G):
         ...     u, v, w = max(G.edges(data='weight'), key=itemgetter(2))
         ...     return (u, v)

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -440,7 +440,7 @@ def condensation(G, scc=None):
     C.add_edges_from((mapping[u], mapping[v]) for u, v in G.edges()
                      if mapping[u] != mapping[v])
     # Add a list of members (ie original nodes) to each node (ie scc) in C.
-    nx.set_node_attributes(C, 'members', members)
+    nx.set_node_attributes(C, members, 'members')
     # Add mapping dict as graph attribute
     C.graph['mapping'] = mapping
     return C

--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -182,7 +182,7 @@ def boykov_kolmogorov_impl(G, s, t, capacity, residual, cutoff):
 
     # Initialize/reset the residual network.
     # This is way too slow
-    #nx.set_edge_attributes(R, 'flow', 0)
+    #nx.set_edge_attributes(R, 0, 'flow')
     for u in R:
         for e in R[u].values():
             e['flow'] = 0

--- a/networkx/algorithms/flow/gomory_hu.py
+++ b/networkx/algorithms/flow/gomory_hu.py
@@ -79,7 +79,7 @@ def gomory_hu_tree(G, capacity='capacity', flow_func=None):
     Examples
     --------
     >>> G = nx.karate_club_graph()
-    >>> nx.set_edge_attributes(G, 'capacity', 1)
+    >>> nx.set_edge_attributes(G, 1, 'capacity')
     >>> T = nx.gomory_hu_tree(G)
     >>> # The value of the minimum cut between any pair
     ... # of nodes in G is the minimum edge weight in the

--- a/networkx/algorithms/flow/tests/test_gomory_hu.py
+++ b/networkx/algorithms/flow/tests/test_gomory_hu.py
@@ -33,7 +33,7 @@ class TestGomoryHuTree:
 
     def test_default_flow_function_karate_club_graph(self):
         G = nx.karate_club_graph()
-        nx.set_edge_attributes(G, 'capacity', 1)
+        nx.set_edge_attributes(G, 1, 'capacity')
         T = nx.gomory_hu_tree(G)
         assert_true(nx.is_tree(T))
         for u, v in combinations(G, 2):
@@ -43,7 +43,7 @@ class TestGomoryHuTree:
 
     def test_karate_club_graph(self):
         G = nx.karate_club_graph()
-        nx.set_edge_attributes(G, 'capacity', 1)
+        nx.set_edge_attributes(G, 1, 'capacity')
         for flow_func in flow_funcs:
             T = nx.gomory_hu_tree(G, flow_func=flow_func)
             assert_true(nx.is_tree(T))
@@ -54,7 +54,7 @@ class TestGomoryHuTree:
 
     def test_davis_southern_women_graph(self):
         G = nx.davis_southern_women_graph()
-        nx.set_edge_attributes(G, 'capacity', 1)
+        nx.set_edge_attributes(G, 1, 'capacity')
         for flow_func in flow_funcs:
             T = nx.gomory_hu_tree(G, flow_func=flow_func)
             assert_true(nx.is_tree(T))
@@ -65,7 +65,7 @@ class TestGomoryHuTree:
 
     def test_florentine_families_graph(self):
         G = nx.florentine_families_graph()
-        nx.set_edge_attributes(G, 'capacity', 1)
+        nx.set_edge_attributes(G, 1, 'capacity')
         for flow_func in flow_funcs:
             T = nx.gomory_hu_tree(G, flow_func=flow_func)
             assert_true(nx.is_tree(T))
@@ -76,7 +76,7 @@ class TestGomoryHuTree:
 
     def test_karate_club_graph_cutset(self):
         G = nx.karate_club_graph()
-        nx.set_edge_attributes(G, 'capacity', 1)
+        nx.set_edge_attributes(G, 1, 'capacity')
         T = nx.gomory_hu_tree(G)
         assert_true(nx.is_tree(T))
         u, v = 0, 33

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -502,8 +502,8 @@ class TestCutoff:
 
     def test_complete_graph_cutoff(self):
         G = nx.complete_graph(5)
-        nx.set_edge_attributes(G, 'capacity',
-                               dict(((u, v), 1) for u, v in G.edges()))
+        nx.set_edge_attributes(G, dict(((u, v), 1) for u, v in G.edges()),
+                               'capacity')
         for flow_func in [shortest_augmenting_path, edmonds_karp]:
             for cutoff in [3, 2, 1]:
                 result = nx.maximum_flow_value(G, 0, 4, flow_func=flow_func,

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -85,7 +85,7 @@ class TestMaxflowLargeGraph:
     def test_complete_graph(self):
         N = 50
         G = nx.complete_graph(N)
-        nx.set_edge_attributes(G, 'capacity', 5)
+        nx.set_edge_attributes(G, 5, 'capacity')
         R = build_residual_network(G, 'capacity')
         kwargs = dict(residual=R)
 

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -55,7 +55,7 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
     >>> print(nx.astar_path(G, 0, 4))
     [0, 1, 2, 3, 4]
     >>> G = nx.grid_graph(dim=[3, 3])  # nodes are two-tuples (x,y)
-    >>> nx.set_edge_attributes(G, 'cost', {e: e[1][0]*2 for e in G.edges()})
+    >>> nx.set_edge_attributes(G, {e: e[1][0]*2 for e in G.edges()}, 'cost')
     >>> def dist(a, b):
     ...    (x1, y1) = a
     ...    (x2, y2) = b

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -184,7 +184,7 @@ def test_weighted_shortest_simple_path():
         return sum(G.adj[u][v]['weight'] for (u, v) in zip(path, path[1:]))
     G = nx.complete_graph(5)
     weight = {(u, v): random.randint(1, 100) for (u, v) in G.edges()}
-    nx.set_edge_attributes(G, 'weight', weight)
+    nx.set_edge_attributes(G, weight, 'weight')
     cost = 0
     for path in nx.shortest_simple_paths(G, 0, 3, weight='weight'):
         this_cost = cost_func(path)
@@ -197,7 +197,7 @@ def test_directed_weighted_shortest_simple_path():
     G = nx.complete_graph(5)
     G = G.to_directed()
     weight = {(u, v): random.randint(1, 100) for (u, v) in G.edges()}
-    nx.set_edge_attributes(G, 'weight', weight)
+    nx.set_edge_attributes(G, weight, 'weight')
     cost = 0
     for path in nx.shortest_simple_paths(G, 0, 3, weight='weight'):
         this_cost = cost_func(path)
@@ -206,8 +206,8 @@ def test_directed_weighted_shortest_simple_path():
 
 def test_weight_name():
     G = nx.cycle_graph(7)
-    nx.set_edge_attributes(G, 'weight', 1)
-    nx.set_edge_attributes(G, 'foo', 1)
+    nx.set_edge_attributes(G, 1, 'weight')
+    nx.set_edge_attributes(G, 1, 'foo')
     G.adj[1][2]['foo'] = 7
     paths = list(nx.shortest_simple_paths(G, 0, 3, weight='foo'))
     solution = [[0, 6, 5, 4, 3], [0, 1, 2, 3]]

--- a/networkx/algorithms/tests/test_structuralholes.py
+++ b/networkx/algorithms/tests/test_structuralholes.py
@@ -55,7 +55,7 @@ class TestStructuralHoles(object):
 
     def test_constraint_weighted_directed(self):
         D = self.D.copy()
-        nx.set_edge_attributes(D, 'weight', self.D_weights)
+        nx.set_edge_attributes(D, self.D_weights, 'weight')
         constraint = nx.constraint(D, weight='weight')
         assert_almost_equal(round(constraint[0], 3), 0.840)
         assert_almost_equal(round(constraint[1], 3), 1.143)
@@ -63,7 +63,7 @@ class TestStructuralHoles(object):
 
     def test_effective_size_weighted_directed(self):
         D = self.D.copy()
-        nx.set_edge_attributes(D, 'weight', self.D_weights)
+        nx.set_edge_attributes(D, self.D_weights, 'weight')
         effective_size = nx.effective_size(D, weight='weight')
         assert_almost_equal(round(effective_size[0], 3), 1.567)
         assert_almost_equal(round(effective_size[1], 3), 1.083)
@@ -83,7 +83,7 @@ class TestStructuralHoles(object):
 
     def test_effective_size_undirected(self):
         G = self.G.copy()
-        nx.set_edge_attributes(G, 'weight', 1)
+        nx.set_edge_attributes(G, 1, 'weight')
         effective_size = nx.effective_size(G, weight='weight')
         assert_almost_equal(round(effective_size['G'], 2), 4.67)
         assert_almost_equal(round(effective_size['A'], 2), 2.50)
@@ -91,7 +91,7 @@ class TestStructuralHoles(object):
 
     def test_constraint_weighted_undirected(self):
         G = self.G.copy()
-        nx.set_edge_attributes(G, 'weight', self.G_weights)
+        nx.set_edge_attributes(G, self.G_weights, 'weight')
         constraint = nx.constraint(G, weight='weight')
         assert_almost_equal(round(constraint['G'], 3), 0.299)
         assert_almost_equal(round(constraint['A'], 3), 0.795)
@@ -99,7 +99,7 @@ class TestStructuralHoles(object):
 
     def test_effective_size_weighted_undirected(self):
         G = self.G.copy()
-        nx.set_edge_attributes(G, 'weight', self.G_weights)
+        nx.set_edge_attributes(G, self.G_weights, 'weight')
         effective_size = nx.effective_size(G, weight='weight')
         assert_almost_equal(round(effective_size['G'], 2), 5.47)
         assert_almost_equal(round(effective_size['A'], 2), 2.47)
@@ -114,7 +114,7 @@ class TestStructuralHoles(object):
     def test_effective_size_isolated(self):
         G = self.G.copy()
         G.add_node(1)
-        nx.set_edge_attributes(G, 'weight', self.G_weights)
+        nx.set_edge_attributes(G, self.G_weights, 'weight')
         effective_size = nx.effective_size(G, weight='weight')
         assert_true(math.isnan(effective_size[1]))
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -394,8 +394,8 @@ def set_node_attributes(G, values, name=None):
 
         >>> G = nx.path_graph(3)
         >>> bb = nx.betweenness_centrality(G)
-        >>> type(bb)
-        <class 'dict'>
+        >>> isinstance(bb, dict)
+        True
         >>> nx.set_node_attributes(G, bb, 'betweenness')
         >>> G.node[1]['betweenness']
         1.0
@@ -506,7 +506,7 @@ def set_edge_attributes(G, values, name=None):
 
         >>> G = nx.path_graph(3)
         >>> bb = nx.edge_betweenness_centrality(G, normalized=False)
-        >>> nx.set_edge_attributes(G, 'betweenness', bb)
+        >>> nx.set_edge_attributes(G, bb, 'betweenness')
         >>> G.edge[1, 2]['betweenness']
         2.0
 
@@ -514,7 +514,7 @@ def set_edge_attributes(G, values, name=None):
     will be reflected in the edge attribute for each edge::
 
         >>> labels = []
-        >>> nx.set_edge_attributes(G, 'labels', labels)
+        >>> nx.set_edge_attributes(G, labels, 'labels')
         >>> labels.append('foo')
         >>> G.edge[0, 1]['labels']
         ['foo']
@@ -525,7 +525,8 @@ def set_edge_attributes(G, values, name=None):
     the entire dictionary will be used to update edge attributes::
 
         >>> G = nx.path_graph(3)
-        >>> attrs = {(0, 1): {'attr1': 20, 'attr2': 'nothing'}, (1, 2): {'attr2': 3}}
+        >>> attrs = {(0, 1): {'attr1': 20, 'attr2': 'nothing'},
+        ...          (1, 2): {'attr2': 3}}
         >>> nx.set_edge_attributes(G, attrs)
         >>> G[0][1]['attr1']
         20
@@ -535,25 +536,29 @@ def set_edge_attributes(G, values, name=None):
         3
 
     """
-    if name is not None:  # `values` must not be a dict of dict
-        try:  # `values` must not be a dict of dict
+    if name is not None:
+        # `values` does not contain attribute names
+        try:
+            # if `values` is a dict using `.items()` => {edge: value}
             if G.is_multigraph():
                 for (u, v, key), value in values.items():
                     try:
                         G[u][v][key][name] = value
                     except KeyError:
                         pass
-            else:  # `values` must be dict of dict
+            else:
                 for (u, v), value in values.items():
                     try:
                         G[u][v][name] = value
                     except KeyError:
                         pass
-        except AttributeError:  # `values` is a constant
+        except AttributeError:
+            # treat `values` as a constant
             for u, v, data in G.edges(data=True):
                 data[name] = values
     else:
-        if G.is_multigraph():  # `values` must be dict of dict
+        # `values` consists of doct-of-dict {edge: {attr: value}} shape
+        if G.is_multigraph():
             for (u, v, key), d in values.items():
                 try:
                     G[u][v][key].update(d)
@@ -599,7 +604,7 @@ def get_edge_attributes(G, name):
 
 
 def all_neighbors(graph, node):
-    """ Returns all of the neighbors of a node in the graph.
+    """Returns all of the neighbors of a node in the graph.
 
     If the graph is directed returns predecessors as well as successors.
 

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -368,23 +368,33 @@ class TestCommonNeighbors():
 def test_set_node_attributes():
     graphs = [nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()]
     for G in graphs:
-        G = nx.path_graph(3, create_using=G)
-
         # Test single value
-        attr = 'hello'
+        G = nx.path_graph(3, create_using=G)
         vals = 100
-        nx.set_node_attributes(G, attr, vals)
+        attr = 'hello'
+        nx.set_node_attributes(G, vals, attr)
         assert_equal(G.node[0][attr], vals)
         assert_equal(G.node[1][attr], vals)
         assert_equal(G.node[2][attr], vals)
 
-        # Test multiple values
-        attr = 'hi'
+        # Test dictionary
+        G = nx.path_graph(3, create_using=G)
         vals = dict(zip(sorted(G.nodes()), range(len(G))))
-        nx.set_node_attributes(G, attr, vals)
+        attr = 'hi'
+        nx.set_node_attributes(G, vals, attr)
         assert_equal(G.node[0][attr], 0)
         assert_equal(G.node[1][attr], 1)
         assert_equal(G.node[2][attr], 2)
+
+        # Test dictionary of dictionaries
+        G = nx.path_graph(3, create_using=G)
+        d = {'hi': 0, 'hello': 200}
+        vals = dict.fromkeys(G.nodes(), d)
+        vals.pop(0)
+        nx.set_node_attributes(G, vals)
+        assert_equal(G.node[0], {})
+        assert_equal(G.node[1]["hi"], 0)
+        assert_equal(G.node[2]["hello"], 200)
 
 
 def test_set_edge_attributes():
@@ -435,7 +445,7 @@ def test_get_node_attributes():
         G = nx.path_graph(3, create_using=G)
         attr = 'hello'
         vals = 100
-        nx.set_node_attributes(G, attr, vals)
+        nx.set_node_attributes(G, vals, attr)
         attrs = nx.get_node_attributes(G, attr)
         assert_equal(attrs[0], vals)
         assert_equal(attrs[1], vals)

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -101,7 +101,8 @@ class TestFunction(object):
         assert_true(sorted(G.edges(nlist, data=True)) in oklists)
 
     def test_subgraph(self):
-        assert_equal(self.G.subgraph([0, 1, 2, 4]).adj, nx.subgraph(self.G, [0, 1, 2, 4]).adj)
+        assert_equal(self.G.subgraph([0, 1, 2, 4]).adj,
+                     nx.subgraph(self.G, [0, 1, 2, 4]).adj)
         assert_equal(self.DG.subgraph([0, 1, 2, 4]).adj,
                      nx.subgraph(self.DG, [0, 1, 2, 4]).adj)
 
@@ -279,8 +280,9 @@ class TestFunction(object):
         assert_true(nx.is_weighted(G, (3, 4)))
 
         G = nx.DiGraph()
-        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -5),
-                                   ('0', '2', 2), ('1', '2', 4), ('2', '3', 1)])
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5),
+                                   ('1', '0', -5), ('0', '2', 2),
+                                   ('1', '2', 4), ('2', '3', 1)])
         assert_true(nx.is_weighted(G))
         assert_true(nx.is_weighted(G, ('1', '0')))
 
@@ -311,8 +313,9 @@ class TestFunction(object):
         assert_true(nx.is_negatively_weighted(G))
 
         G = nx.DiGraph()
-        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5), ('1', '0', -2),
-                                   ('0', '2', 2), ('1', '2', -3), ('2', '3', 1)])
+        G.add_weighted_edges_from([('0', '3', 3), ('0', '1', -5),
+                                   ('1', '0', -2), ('0', '2', 2),
+                                   ('1', '2', -3), ('2', '3', 1)])
         assert_true(nx.is_negatively_weighted(G))
         assert_false(nx.is_negatively_weighted(G, ('0', '3')))
         assert_true(nx.is_negatively_weighted(G, ('1', '0')))

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -400,43 +400,63 @@ def test_set_node_attributes():
 def test_set_edge_attributes():
     graphs = [nx.Graph(), nx.DiGraph()]
     for G in graphs:
-        G = nx.path_graph(3, create_using=G)
-
         # Test single value
+        G = nx.path_graph(3, create_using=G)
         attr = 'hello'
         vals = 3
-        nx.set_edge_attributes(G, attr, vals)
+        nx.set_edge_attributes(G, vals, attr)
         assert_equal(G[0][1][attr], vals)
         assert_equal(G[1][2][attr], vals)
 
         # Test multiple values
+        G = nx.path_graph(3, create_using=G)
         attr = 'hi'
         edges = [(0, 1), (1, 2)]
         vals = dict(zip(edges, range(len(edges))))
-        nx.set_edge_attributes(G, attr, vals)
+        nx.set_edge_attributes(G, vals, attr)
         assert_equal(G[0][1][attr], 0)
         assert_equal(G[1][2][attr], 1)
+
+        # Test dictionary of dictionaries
+        G = nx.path_graph(3, create_using=G)
+        d = {'hi': 0, 'hello': 200}
+        edges = [(0, 1)]
+        vals = dict.fromkeys(edges, d)
+        nx.set_edge_attributes(G, vals)
+        assert_equal(G[0][1]['hi'], 0)
+        assert_equal(G[0][1]['hello'], 200)
+        assert_equal(G[1][2], {})
 
 
 def test_set_edge_attributes_multi():
     graphs = [nx.MultiGraph(), nx.MultiDiGraph()]
     for G in graphs:
-        G = nx.path_graph(3, create_using=G)
-
         # Test single value
+        G = nx.path_graph(3, create_using=G)
         attr = 'hello'
         vals = 3
-        nx.set_edge_attributes(G, attr, vals)
+        nx.set_edge_attributes(G, vals, attr)
         assert_equal(G[0][1][0][attr], vals)
         assert_equal(G[1][2][0][attr], vals)
 
         # Test multiple values
+        G = nx.path_graph(3, create_using=G)
         attr = 'hi'
         edges = [(0, 1, 0), (1, 2, 0)]
         vals = dict(zip(edges, range(len(edges))))
-        nx.set_edge_attributes(G, attr, vals)
+        nx.set_edge_attributes(G, vals, attr)
         assert_equal(G[0][1][0][attr], 0)
         assert_equal(G[1][2][0][attr], 1)
+
+        # Test dictionary of dictionaries
+        G = nx.path_graph(3, create_using=G)
+        d = {'hi': 0, 'hello': 200}
+        edges = [(0, 1, 0)]
+        vals = dict.fromkeys(edges, d)
+        nx.set_edge_attributes(G, vals)
+        assert_equal(G[0][1][0]['hi'], 0)
+        assert_equal(G[0][1][0]['hello'], 200)
+        assert_equal(G[1][2][0], {})
 
 
 def test_get_node_attributes():
@@ -458,7 +478,7 @@ def test_get_edge_attributes():
         G = nx.path_graph(3, create_using=G)
         attr = 'hello'
         vals = 100
-        nx.set_edge_attributes(G, attr, vals)
+        nx.set_edge_attributes(G, vals, attr)
         attrs = nx.get_edge_attributes(G, attr)
 
         assert_equal(len(attrs), 2)

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -153,7 +153,7 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2):
     # Euclidean space of the specified dimension.
     if pos is None:
         pos = {v: [random.random() for i in range(dim)] for v in nodes}
-    nx.set_node_attributes(G, 'pos', pos)
+    nx.set_node_attributes(G, pos, 'pos')
 
     if _is_scipy_available:
         _fast_construct_edges(G, radius, p)
@@ -276,8 +276,8 @@ def geographical_threshold_graph(n, theta, alpha=2, dim=2, pos=None,
     # If no distance metric is provided, use Euclidean distance.
     if metric is None:
         metric = euclidean
-    nx.set_node_attributes(G, 'weight', weight)
-    nx.set_node_attributes(G, 'pos', pos)
+    nx.set_node_attributes(G, weight, 'weight')
+    nx.set_node_attributes(G, pos, 'pos')
 
     # Returns ``True`` if and only if the nodes whose attributes are
     # ``du`` and ``dv`` should be joined, according to the threshold
@@ -381,7 +381,7 @@ def waxman_graph(n, beta=0.4, alpha=0.1, L=None, domain=(0, 0, 1, 1),
     (xmin, ymin, xmax, ymax) = domain
     # Each node gets a uniformly random position in the given rectangle.
     pos = {v: (uniform(xmin, xmax), uniform(ymin, ymax)) for v in G}
-    nx.set_node_attributes(G, 'pos', pos)
+    nx.set_node_attributes(G, pos, 'pos')
     # If no distance metric is provided, use Euclidean distance.
     if metric is None:
         metric = euclidean

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -280,7 +280,7 @@ def triangular_lattice_graph(m, n, periodic=False, with_positions=True,
             yy = (h * j for i in cols for j in rows)
         pos = {(i, j): (x, y) for i, j, x, y in zip(ii, jj, xx, yy)
                if (i, j) in H}
-        set_node_attributes(H, 'pos', pos)
+        set_node_attributes(H, pos, 'pos')
 
     # set the name
     H.name = 'triangular_lattice_graph({}, {})'.format(m, n)
@@ -382,7 +382,7 @@ def hexagonal_lattice_graph(m, n, periodic=False, with_positions=True,
         yy = (h * j for i in cols for j in rows)
     # exclude nodes not in G
     pos = {(i, j): (x, y) for i, j, x, y in zip(ii, jj, xx, yy) if (i, j) in G}
-    set_node_attributes(G, 'pos', pos)
+    set_node_attributes(G, pos, 'pos')
 
     # set the name
     G.name = 'hexagonal_lattice_graph({}, {})'.format(m, n)

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -223,6 +223,6 @@ def convert_node_labels_to_integers(G, first_label=0, ordering="default",
     H.name = "(" + G.name + ")_with_int_labels"
     # create node attribute with the old label
     if label_attribute is not None:
-        nx.set_node_attributes(H, label_attribute,
-                               dict((v, k) for k, v in mapping.items()))
+        nx.set_node_attributes(H, dict((v, k) for k, v in mapping.items()),
+                               label_attribute)
     return H


### PR DESCRIPTION
This is related to #2343:

- `set_node_attributes()` and `set_edge_attributes()` no longer throw KeyErrors when a key in the passed dict is not present in the graph
- `set_node_attributes()` and `set_edge_attributes()` both accept dictionary of dictionaries, conditional on parameters "values" and "name"
- parameter "name" now has a default value (`None`), and therefore parameter "name" now has to come last
- harmonized, corrected and extended documentation for `set_node_attributes()` and `set_edge_attributes()`