### PR TITLE
Remove automatic assignment of G.name from many generators

### DIFF
--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -156,6 +156,7 @@ class TestFunction(object):
 
     def test_info(self):
         G = nx.path_graph(5)
+        G.name = "path_graph(5)"
         info = nx.info(G)
         expected_graph_info = '\n'.join(['Name: path_graph(5)',
                                          'Type: Graph',

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -183,7 +183,6 @@ def barbell_graph(m1, m2, create_using=None):
 
     # left barbell
     G = complete_graph(m1, create_using)
-    G.name = "barbell_graph(%d,%d)" % (m1, m2)
 
     # connecting path
     G.add_nodes_from(range(m1, m1 + m2 - 1))
@@ -229,7 +228,6 @@ def complete_graph(n, create_using=None):
     """
     n_name, nodes = n
     G = empty_graph(n_name, create_using)
-    G.name = "complete_graph(%s)" % (n_name,)
     if len(nodes) > 1:
         if G.is_directed():
             edges = itertools.permutations(nodes, 2)
@@ -249,7 +247,6 @@ def circular_ladder_graph(n, create_using=None):
 
     """
     G = ladder_graph(n, create_using)
-    G.name = "circular_ladder_graph(%d)" % n
     G.add_edge(0, n - 1)
     G.add_edge(n, 2 * n - 1)
     return G
@@ -302,8 +299,6 @@ def circulant_graph(n, offsets, create_using=None):
 
     """
     G = empty_graph(n, create_using)
-    template = 'circulant_graph(%d, [%s])'
-    G.name = template % (n, ', '.join(str(j) for j in offsets))
     for i in range(n):
         for j in offsets:
             G.add_edge(i, (i - j) % n)
@@ -333,7 +328,6 @@ def cycle_graph(n, create_using=None):
     """
     n_orig, nodes = n
     G = empty_graph(nodes, create_using)
-    G.name = "cycle_graph(%s)" % (n_orig,)
     G.add_edges_from(pairwise(nodes))
     G.add_edge(nodes[-1], nodes[0])
     return G
@@ -352,7 +346,6 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
         if create_using.is_multigraph():
             raise NetworkXError("Multigraph not supported")
     G = empty_graph(0, create_using)
-    G.name = "Dorogovtsev-Goltsev-Mendes Graph"
     G.add_edge(0, 1)
     if n == 0:
         return G
@@ -426,7 +419,6 @@ def empty_graph(n=0, create_using=None):
         G.clear()
 
     n_name, nodes = n
-    G.name = "empty_graph(%s)" % (n_name,)
     G.add_nodes_from(nodes)
     return G
 
@@ -443,7 +435,6 @@ def ladder_graph(n, create_using=None):
     if create_using is not None and create_using.is_directed():
         raise NetworkXError("Directed Graph not supported")
     G = empty_graph(2 * n, create_using)
-    G.name = "ladder_graph_(%d)" % n
     G.add_edges_from(pairwise(range(n)))
     G.add_edges_from(pairwise(range(n, 2 * n)))
     G.add_edges_from((v, v + n) for v in range(n))
@@ -501,7 +492,6 @@ def lollipop_graph(m, n, create_using=None):
     # connect ball to stick
     if M > 0 and N > 0:
         G.add_edge(m_nodes[-1], n_nodes[0])
-    G.name = "lollipop_graph(%s, %s)" % (m, n)
     return G
 
 
@@ -512,7 +502,6 @@ def null_graph(create_using=None):
 
     """
     G = empty_graph(0, create_using)
-    G.name = "null_graph()"
     return G
 
 
@@ -532,7 +521,6 @@ def path_graph(n, create_using=None):
     """
     n_name, nodes = n
     G = empty_graph(nodes, create_using)
-    G.name = "path_graph(%s)" % (n_name,)
     G.add_edges_from(pairwise(nodes))
     return G
 
@@ -565,7 +553,6 @@ def star_graph(n, create_using=None):
     if G.is_directed():
         raise NetworkXError("Directed Graph not supported")
     G.add_edges_from((first, v) for v in nodes[1:])
-    G.name = "star_graph(%s)" % (n_name,)
     return G
 
 
@@ -574,7 +561,6 @@ def trivial_graph(create_using=None):
 
     """
     G = empty_graph(1, create_using)
-    G.name = "trivial_graph()"
     return G
 
 
@@ -608,7 +594,6 @@ def turan_graph(n, r):
 
     partitions = [n//r]*(r-(n%r))+[n//r+1]*(n%r)
     G = complete_multipartite_graph(*partitions)
-    G.name = "turan_graph({},{})".format(n, r)
     return G
 
 
@@ -632,10 +617,8 @@ def wheel_graph(n, create_using=None):
     n_name, nodes = n
     if n_name == 0:
         G = empty_graph(0, create_using=create_using)
-        G.name = "wheel_graph(0)"
         return G
     G = star_graph(nodes, create_using)
-    G.name = "wheel_graph(%s)" % (n_name,)
     if len(G) > 2:
         G.add_edges_from(pairwise(nodes[1:]))
         G.add_edge(nodes[-1], nodes[1])
@@ -699,7 +682,6 @@ def complete_multipartite_graph(*subset_sizes):
     """
     # The complete multipartite graph is an undirected simple graph.
     G = Graph()
-    G.name = 'complete_multiparite_graph{}'.format(subset_sizes)
 
     if len(subset_sizes) == 0:
         return G

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -58,7 +58,6 @@ def caveman_graph(l, k):
     """
     # l disjoint cliques of size k
     G = nx.empty_graph(l*k)
-    G.name = "caveman_graph(%s,%s)" % (l*k, k)
     if k > 1:
         for start in range(0, l*k, k):
             edges = itertools.combinations(range(start, start+k), 2)
@@ -103,7 +102,6 @@ def connected_caveman_graph(l, k):
        Amer. J. Soc. 105, 493-527, 1999.
     """
     G = nx.caveman_graph(l, k)
-    G.name = "connected_caveman_graph(%s,%s)" % (l, k)
     for start in range(0, l*k, k):
         G.remove_edge(start, start+1)
         G.add_edge(start, (start-1) % (l*k))
@@ -151,7 +149,6 @@ def relaxed_caveman_graph(l, k, p, seed=None):
         random.seed(seed)
     G = nx.caveman_graph(l, k)
     nodes = list(G)
-    G.name = "relaxed_caveman_graph (%s,%s,%s)" % (l, k, p)
     for (u, v) in G.edges():
         if random.random() < p:  # rewire the edge
             x = random.choice(nodes)

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -242,7 +242,6 @@ def configuration_model(deg_sequence, create_using=None, seed=None):
 
     G = _configuration_model(deg_sequence, create_using, seed=seed)
 
-    G.name = "configuration_model %d nodes %d edges" % (G.order(), G.size())
     return G
 
 
@@ -338,7 +337,6 @@ def directed_configuration_model(in_degree_sequence,
                              in_deg_sequence=in_degree_sequence, seed=seed)
 
     name = "directed configuration_model {} nodes {} edges"
-    G.name = name.format(len(G), G.size())
     return G
 
 
@@ -540,7 +538,6 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
             num_degs[stubval].append(stubtarget)
             n += 1
 
-    G.name = "havel_hakimi_graph %d nodes %d edges" % (G.order(), G.size())
     return G
 
 
@@ -655,7 +652,6 @@ def directed_havel_hakimi_graph(in_deg_sequence,
         if freeout < 0:
             heapq.heappush(zeroheap, (freeout, target))
 
-    G.name = "directed_havel_hakimi_graph %d nodes %d edges" % (G.order(), G.size())
     return G
 
 

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -79,7 +79,6 @@ def gn_graph(n, kernel=None, create_using=None, seed=None):
         random.seed(seed)
 
     G = empty_graph(1, create_using)
-    G.name = "gn_graph({})".format(n)
 
     if n == 1:
         return G
@@ -143,7 +142,6 @@ def gnr_graph(n, p, create_using=None, seed=None):
         random.seed(seed)
 
     G = empty_graph(1, create_using)
-    G.name = "gnr_graph(%s,%s)" % (n, p)
 
     if n == 1:
         return G
@@ -188,7 +186,6 @@ def gnc_graph(n, create_using=None, seed=None):
         random.seed(seed)
 
     G = empty_graph(1, create_using)
-    G.name = "gnc_graph(%s)" % (n)
 
     if n == 1:
         return G
@@ -277,10 +274,6 @@ def scale_free_graph(n, alpha=0.41, beta=0.54, gamma=0.05, delta_in=0.2,
 
     if alpha + beta + gamma != 1.0:
         raise ValueError('alpha+beta+gamma must equal 1.')
-
-    G.name = ("directed_scale_free_graph(%s,alpha=%s,beta=%s,gamma=%s,"
-              "delta_in=%s,delta_out=%s)" % (n, alpha, beta, gamma, delta_in,
-                                             delta_out))
 
     # seed random number generated (uses None as default)
     random.seed(seed)
@@ -393,7 +386,6 @@ def random_uniform_k_out_graph(n, k, self_loops=True, with_replacement=True,
     nodes = set(G)
     for u in G:
         G.add_edges_from((u, v) for v in sample(u, nodes))
-    G.name = 'random_uniform_k_out_graph({}, {})'.format(n, k)
     return G
 
 
@@ -480,5 +472,4 @@ def random_k_out_graph(n, k, alpha, self_loops=True, seed=None):
         v = weighted_choice(weights - adjustment)
         G.add_edge(u, v)
         weights[v] += 1
-    G.name = 'random_k_out_graph({0}, {1}, {2})'.format(n, k, alpha)
     return G

--- a/networkx/generators/duplication.py
+++ b/networkx/generators/duplication.py
@@ -80,7 +80,6 @@ def partial_duplication_graph(N, n, p, q, seed=None):
         random.seed(seed)
 
     G = nx.complete_graph(n)
-    G.name = 'partial_duplication_graph({}, {}, {}, {})'.format(N, n, p, q)
     for new_node in range(n, N):
         # Add a new vertex, v, to the graph.
         G.add_node(new_node)
@@ -150,7 +149,6 @@ def duplication_divergence_graph(n, p, seed=None):
         random.seed(seed)
 
     G = nx.Graph()
-    G.name = "duplication_divergence_graph({}, {})".format(n, p)
 
     # Initialize the graph with two connected nodes.
     G.add_edge(0, 1)

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -147,7 +147,6 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2):
     #
     n_name, nodes = n
     G = nx.Graph()
-    G.name = 'random_geometric_graph({}, {}, {})'.format(n, radius, dim)
     G.add_nodes_from(nodes)
     # If no positions are provided, choose uniformly random vectors in
     # Euclidean space of the specified dimension.

--- a/networkx/generators/joint_degree_seq.py
+++ b/networkx/generators/joint_degree_seq.py
@@ -289,7 +289,4 @@ def joint_degree_graph(joint_degrees, seed=None):
                             k_unsat.discard(v)
                         if h_node_residual[w] == 0:
                             l_unsat.discard(w)
-
-
-    G.name = "joint_degree_graph %d nodes"%(G.order())
     return G

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -92,11 +92,6 @@ def grid_2d_graph(m, n, periodic=False, create_using=None):
     # both directions for directed
     if G.is_directed():
         G.add_edges_from((v, u) for u, v in G.edges())
-
-    # set name
-    G.name = "grid_2d_graph(%s, %s)" % (row_name, col_name)
-    if periodic is True:
-        G.name = "periodic_" + G.name
     return G
 
 
@@ -137,7 +132,6 @@ def grid_graph(dim, periodic=False):
     dlabel = "%s" % dim
     if not dim:
         G = empty_graph(0)
-        G.name = "grid_graph(%s)" % dlabel
         return G
 
     func = cycle_graph if periodic else path_graph
@@ -151,7 +145,6 @@ def grid_graph(dim, periodic=False):
         G = cartesian_product(Gnew, Gold)
     # graph G is done but has labels of the form (1, (2, (3, 1))) so relabel
     H = relabel_nodes(G, flatten)
-    H.name = "grid_graph(%s)" % dlabel
     return H
 
 
@@ -178,7 +171,6 @@ def hypercube_graph(n):
     """
     dim = n * [2]
     G = grid_graph(dim)
-    G.name = "hypercube_graph_(%d)" % n
     return G
 
 
@@ -281,11 +273,6 @@ def triangular_lattice_graph(m, n, periodic=False, with_positions=True,
         pos = {(i, j): (x, y) for i, j, x, y in zip(ii, jj, xx, yy)
                if (i, j) in H}
         set_node_attributes(H, pos, 'pos')
-
-    # set the name
-    H.name = 'triangular_lattice_graph({}, {})'.format(m, n)
-    if periodic:
-        H.name = 'periodic_' + H.name
     return H
 
 
@@ -383,9 +370,4 @@ def hexagonal_lattice_graph(m, n, periodic=False, with_positions=True,
     # exclude nodes not in G
     pos = {(i, j): (x, y) for i, j, x, y in zip(ii, jj, xx, yy) if (i, j) in G}
     set_node_attributes(G, pos, 'pos')
-
-    # set the name
-    G.name = 'hexagonal_lattice_graph({}, {})'.format(m, n)
-    if periodic:
-        G.name = 'periodic_' + G.name
     return G

--- a/networkx/generators/random_clustered.py
+++ b/networkx/generators/random_clustered.py
@@ -127,6 +127,4 @@ def random_clustered_graph(joint_degree_sequence, create_using=None,
         n2 = tlist.pop()
         n3 = tlist.pop()
         G.add_edges_from([(n1,n2),(n1,n3),(n2,n3)])
-    G.name = "random_clustered %d nodes %d edges"%(G.order(),G.size())
     return G
-

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -84,7 +84,6 @@ def fast_gnp_random_graph(n, p, seed=None, directed=False):
        Phys. Rev. E, 71, 036113, 2005.
     """
     G = empty_graph(n)
-    G.name="fast_gnp_random_graph(%s,%s)"%(n,p)
 
     if not seed is None:
         random.seed(seed)
@@ -165,7 +164,6 @@ def gnp_random_graph(n, p, seed=None, directed=False):
     else:
         G=nx.Graph()
     G.add_nodes_from(range(n))
-    G.name="gnp_random_graph(%s,%s)"%(n,p)
     if p<=0:
         return G
     if p>=1:
@@ -227,7 +225,6 @@ def dense_gnm_random_graph(n, m, seed=None):
         G=complete_graph(n)
     else:
         G=empty_graph(n)
-    G.name="dense_gnm_random_graph(%s,%s)"%(n,m)
 
     if n==1 or m>=mmax:
         return G
@@ -280,7 +277,6 @@ def gnm_random_graph(n, m, seed=None, directed=False):
     else:
         G=nx.Graph()
     G.add_nodes_from(range(n))
-    G.name="gnm_random_graph(%s,%s)"%(n,m)
 
     if seed is not None:
         random.seed(seed)
@@ -348,7 +344,6 @@ def newman_watts_strogatz_graph(n, k, p, seed=None):
     if k>=n:
         raise nx.NetworkXError("k>=n, choose smaller k or larger n")
     G=empty_graph(n)
-    G.name="newman_watts_strogatz_graph(%s,%s,%s)"%(n,k,p)
     nlist = list(G.nodes())
     fromv = nlist
     # connect the k/2 neighbors
@@ -418,7 +413,6 @@ def watts_strogatz_graph(n, k, p, seed=None):
         random.seed(seed)
 
     G = nx.Graph()
-    G.name="watts_strogatz_graph(%s,%s,%s)"%(n,k,p)
     nodes = list(range(n)) # nodes are labeled 0 to n-1
     # connect each node to k/2 neighbors
     for j in range(1, k // 2+1):
@@ -583,7 +577,6 @@ def random_regular_graph(d, n, seed=None):
         edges = _try_creation()
 
     G = nx.Graph()
-    G.name = "random_regular_graph(%s, %s)" % (d, n)
     G.add_edges_from(edges)
 
     return G
@@ -639,7 +632,6 @@ def barabasi_albert_graph(n, m, seed=None):
 
     # Add m initial nodes (m0 in barabasi-speak)
     G=empty_graph(m)
-    G.name="barabasi_albert_graph(%s,%s)"%(n,m)
     # Target nodes for new edges
     targets=list(range(m))
     # List of existing nodes, with nodes repeated once for each adjacent edge
@@ -718,7 +710,6 @@ def extended_barabasi_albert_graph(n, m, p, q, seed=None):
 
     # Add m initial nodes (m0 in barabasi-speak)
     G = empty_graph(m)
-    G.name = "extended_barabasi_albert_graph(%s, %s, %s, %s)" % (n, m, p, q)
 
     # List of nodes to represent the preferential attachment random selection.
     # At the creation of the graph, all nodes are added to the list
@@ -878,7 +869,6 @@ def powerlaw_cluster_graph(n, m, p, seed=None):
         random.seed(seed)
 
     G=empty_graph(m) # add m initial nodes (m0 in barabasi-speak)
-    G.name="Powerlaw-Cluster Graph"
     repeated_nodes = list(G.nodes()) # list of existing nodes to sample from
                            # with nodes repeated once for each adjacent edge
     source=m               # next node is m
@@ -934,7 +924,6 @@ def random_lobster(n, p1, p2, seed=None):
         random.seed(seed)
     llen=int(2*random.random()*n + 0.5)
     L=path_graph(llen)
-    L.name="random_lobster(%d,%s,%s)"%(n,p1,p2)
     # build caterpillar: add edges to path graph with probability p1
     current_node=llen-1
     for n in range(llen):
@@ -969,7 +958,6 @@ def random_shell_graph(constructor, seed=None):
 
     """
     G=empty_graph(0)
-    G.name="random_shell_graph(constructor)"
 
     if seed is not None:
         random.seed(seed)
@@ -1036,7 +1024,6 @@ def random_powerlaw_tree(n, gamma=3, seed=None, tries=100):
     # This call may raise a NetworkXError if the number of tries is succeeded.
     seq = random_powerlaw_tree_sequence(n, gamma=gamma, seed=seed, tries=tries)
     G = degree_sequence_tree(seq)
-    G.name = "random_powerlaw_tree(%s,%s)" % (n, gamma)
     return G
 
 

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -91,19 +91,16 @@ class TestGeneratorClassic():
         b=barbell_graph(m1,m2)
         assert_true(number_of_nodes(b)==2*m1+m2)
         assert_true(number_of_edges(b)==m1*(m1-1) + m2 + 1)
-        assert_equal(b.name, 'barbell_graph(3,5)')
 
         m1=4; m2=10
         b=barbell_graph(m1,m2)
         assert_true(number_of_nodes(b)==2*m1+m2)
         assert_true(number_of_edges(b)==m1*(m1-1) + m2 + 1)
-        assert_equal(b.name, 'barbell_graph(4,10)')
 
         m1=3; m2=20
         b=barbell_graph(m1,m2)
         assert_true(number_of_nodes(b)==2*m1+m2)
         assert_true(number_of_edges(b)==m1*(m1-1) + m2 + 1)
-        assert_equal(b.name, 'barbell_graph(3,20)')
 
         # Raise NetworkXError if m1<2
         m1=1; m2=20
@@ -229,7 +226,6 @@ class TestGeneratorClassic():
         G=empty_graph(42)
         assert_equal(number_of_nodes(G), 42)
         assert_equal(number_of_edges(G), 0)
-        assert_equal(G.name, 'empty_graph(42)')
 
         G=empty_graph("abc")
         assert_equal(len(G), 3)
@@ -239,14 +235,12 @@ class TestGeneratorClassic():
         G=empty_graph(42,create_using=DiGraph(name="duh"))
         assert_equal(number_of_nodes(G), 42)
         assert_equal(number_of_edges(G), 0)
-        assert_equal(G.name, 'empty_graph(42)')
         assert_true(isinstance(G,DiGraph))
 
         # create empty multigraph
         G=empty_graph(42,create_using=MultiGraph(name="duh"))
         assert_equal(number_of_nodes(G), 42)
         assert_equal(number_of_edges(G), 0)
-        assert_equal(G.name, 'empty_graph(42)')
         assert_true(isinstance(G,MultiGraph))
 
         # create empty graph from another
@@ -254,7 +248,6 @@ class TestGeneratorClassic():
         G=empty_graph(42,create_using=pete)
         assert_equal(number_of_nodes(G), 42)
         assert_equal(number_of_edges(G), 0)
-        assert_equal(G.name, 'empty_graph(42)')
         assert_true(isinstance(G,Graph))
 
     def test_ladder_graph(self):
@@ -276,8 +269,6 @@ class TestGeneratorClassic():
             b=lollipop_graph(m1,m2)
             assert_equal(number_of_nodes(b), m1+m2)
             assert_equal(number_of_edges(b), m1*(m1-1)/2 + m2)
-            assert_equal(b.name,
-                         'lollipop_graph(' + str(m1) + ', ' + str(m2) + ')')
 
         # Raise NetworkXError if m<2
         assert_raises(networkx.exception.NetworkXError,
@@ -308,11 +299,9 @@ class TestGeneratorClassic():
     def test_path_graph(self):
         p=path_graph(0)
         assert_true(is_isomorphic(p, null_graph()))
-        assert_equal(p.name, 'path_graph(0)')
 
         p=path_graph(1)
         assert_true(is_isomorphic( p, empty_graph(1)))
-        assert_equal(p.name, 'path_graph(1)')
 
         p=path_graph(10)
         assert_true(is_connected(p))
@@ -368,8 +357,6 @@ class TestGeneratorClassic():
                      (4, complete_graph(4))]:
             g=wheel_graph(n)
             assert_true(is_isomorphic( g, G))
-
-        assert_equal(g.name, 'wheel_graph(4)')
 
         g=wheel_graph(10)
         assert_equal(sorted(d for n, d in g.degree()),

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -243,6 +243,7 @@ graph
         # https://github.com/networkx/networkx/issues/1061
         # Encoding quotes as HTML entities.
         G = nx.path_graph(1)
+        G.name = "path_graph(1)"
         attr = 'This is "quoted" and this is a copyright: ' + unichr(169)
         G.node[0]['demo'] = attr
         fobj = tempfile.NamedTemporaryFile()

--- a/networkx/testing/tests/test_utils.py
+++ b/networkx/testing/tests/test_utils.py
@@ -97,28 +97,24 @@ class TestGraphsEqual(_GenericTest):
         G = nx.path_graph(4)
         H = nx.Graph()
         nx.add_path(H, range(4))
-        H.name='path_graph(4)'
         self._test_equal(G,H)
 
     def test_digraphs_equal(self):
         G = nx.path_graph(4, create_using=nx.DiGraph())
         H = nx.DiGraph()
         nx.add_path(H, range(4))
-        H.name='path_graph(4)'
         self._test_equal(G,H)
 
     def test_multigraphs_equal(self):
         G = nx.path_graph(4, create_using=nx.MultiGraph())
         H = nx.MultiGraph()
         nx.add_path(H, range(4))
-        H.name='path_graph(4)'
         self._test_equal(G,H)
 
     def test_multigraphs_equal(self):
         G = nx.path_graph(4, create_using=nx.MultiDiGraph())
         H = nx.MultiDiGraph()
         nx.add_path(H, range(4))
-        H.name='path_graph(4)'
         self._test_equal(G,H)
 
     def test_graphs_not_equal(self):
@@ -131,12 +127,11 @@ class TestGraphsEqual(_GenericTest):
         G = nx.path_graph(4)
         H = nx.Graph()
         nx.add_path(H, range(3))
-        H.name='path_graph(4)'
         self._test_not_equal(G,H)
 
     def test_graphs_not_equal3(self):
         G = nx.path_graph(4)
         H = nx.Graph()
         nx.add_path(H, range(4))
-        H.name='path_graph(foo)'
-        self._test_not_equal(G,H)
+        H.name = 'path_graph(4)'
+        self._test_not_equal(G, H)

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -12,14 +12,13 @@ class TestRelabel():
         # test that empty graph converts fine for all options
         G = empty_graph()
         H = convert_node_labels_to_integers(G, 100)
-        assert_equal(H.name, '(empty_graph(0))_with_int_labels')
+        assert_equal(H.name, '()_with_int_labels')
         assert_equal(list(H.nodes()), [])
         assert_equal(list(H.edges()), [])
 
         for opt in ["default", "sorted", "increasing degree", "decreasing degree"]:
             G = empty_graph()
             H = convert_node_labels_to_integers(G, 100, ordering=opt)
-            assert_equal(H.name, '(empty_graph(0))_with_int_labels')
             assert_equal(list(H.nodes()), [])
             assert_equal(list(H.edges()), [])
 
@@ -27,6 +26,7 @@ class TestRelabel():
         G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'C'), ('C', 'D')])
         G.name = "paw"
         H = convert_node_labels_to_integers(G)
+        assert_equal(H.name, '(paw)_with_int_labels')
         degH = (d for n, d in H.degree())
         degG = (d for n, d in G.degree())
         assert_equal(sorted(degH), sorted(degG))
@@ -74,7 +74,6 @@ class TestRelabel():
     def test_convert_to_integers2(self):
         G = empty_graph()
         G.add_edges_from([('C', 'D'), ('A', 'B'), ('A', 'C'), ('B', 'C')])
-        G.name = "paw"
         H = convert_node_labels_to_integers(G, ordering="sorted")
         degH = (d for n, d in H.degree())
         degG = (d for n, d in G.degree())


### PR DESCRIPTION
I left the names for atlas and small graphs as it seemed helpful in determining which graph was which. The other cases were sometimes incorrect or with incorrect parameter values (basically G.name doesn't always get updated when the graph gets updated).  So we'll put the user in charge of keeping it up-to-date.

Addresses #1906 