### PR TITLE
Create separate functions for df as edge-lists and adjacency matrices

### DIFF
--- a/doc/reference/convert.rst
+++ b/doc/reference/convert.rst
@@ -54,5 +54,7 @@ Pandas
 .. autosummary::
    :toctree: generated/
 
-   to_pandas_dataframe
-   from_pandas_dataframe
+   to_pandas_adjacency
+   from_pandas_adjacency
+   to_pandas_edgelist
+   from_pandas_edgelist

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -192,6 +192,14 @@ API Changes
 Deprecations
 ------------
 
+The following deprecated functions will be removed in 2.1.
+
+- The function ``bellman_ford`` has been deprecated in favor of
+  ``bellman_ford_predecessor_and_distance``.
+
+- The functions ``to_pandas_dataframe`` and ``from_pandas_dataframe`` have been
+  deprecated in favor of ``to_pandas_adjacency``, ``from_pandas_adjacency``,
+  ``to_pandas_edgelist``, and ``from_pandas_edgelist``.
 
 Contributors to this release
 ----------------------------

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -55,12 +55,12 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     The preferred way to call this is automatically
     from the class constructor
 
-    >>> d={0: {1: {'weight':1}}} # dict-of-dicts single edge (0,1)
-    >>> G=nx.Graph(d)
+    >>> d = {0: {1: {'weight':1}}} # dict-of-dicts single edge (0,1)
+    >>> G = nx.Graph(d)
 
     instead of the equivalent
 
-    >>> G=nx.from_dict_of_dicts(d)
+    >>> G = nx.from_dict_of_dicts(d)
 
     Parameters
     ----------
@@ -179,8 +179,6 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     raise nx.NetworkXError(
         "Input is not a known data type for conversion.")
 
-    return
-
 
 def to_dict_of_lists(G, nodelist=None):
     """Return adjacency representation of graph as a dictionary of lists.
@@ -220,11 +218,12 @@ def from_dict_of_lists(d, create_using=None):
 
     Examples
     --------
-    >>> dol= {0:[1]} # single edge (0,1)
-    >>> G=nx.from_dict_of_lists(dol)
+    >>> dol = {0: [1]} # single edge (0,1)
+    >>> G = nx.from_dict_of_lists(dol)
 
     or
-    >>> G=nx.Graph(dol) # use Graph constructor
+
+    >>> G = nx.Graph(dol) # use Graph constructor
 
     """
     G = _prep_create_using(create_using)
@@ -303,11 +302,12 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
 
     Examples
     --------
-    >>> dod= {0: {1:{'weight':1}}} # single edge (0,1)
-    >>> G=nx.from_dict_of_dicts(dod)
+    >>> dod = {0: {1: {'weight': 1}}} # single edge (0,1)
+    >>> G = nx.from_dict_of_dicts(dod)
 
     or
-    >>> G=nx.Graph(dod) # use Graph constructor
+
+    >>> G = nx.Graph(dod) # use Graph constructor
 
     """
     G = _prep_create_using(create_using)
@@ -397,11 +397,12 @@ def from_edgelist(edgelist, create_using=None):
 
     Examples
     --------
-    >>> edgelist= [(0,1)] # single edge (0,1)
-    >>> G=nx.from_edgelist(edgelist)
+    >>> edgelist = [(0, 1)] # single edge (0,1)
+    >>> G = nx.from_edgelist(edgelist)
 
     or
-    >>> G=nx.Graph(edgelist) # use Graph constructor
+
+    >>> G = nx.Graph(edgelist) # use Graph constructor
 
     """
     G = _prep_create_using(create_using)

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -134,11 +134,18 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     try:
         import pandas as pd
         if isinstance(data, pd.DataFrame):
-            try:
-                return nx.from_pandas_dataframe(data, edge_attr=True, create_using=create_using)
-            except:
-                msg = "Input is not a correct Pandas DataFrame."
-                raise nx.NetworkXError(msg)
+            if data.shape[0] == data.shape[1]:
+                try:
+                    return nx.from_pandas_adjacency(data, create_using=create_using)
+                except:
+                    msg = "Input is not a correct Pandas DataFrame adjacency matrix."
+                    raise nx.NetworkXError(msg)
+            else:
+                try:
+                    return nx.from_pandas_edgelist(data, edge_attr=True, create_using=create_using)
+                except:
+                    msg = "Input is not a correct Pandas DataFrame edge-list."
+                    raise nx.NetworkXError(msg)
     except ImportError:
         msg = 'pandas not found, skipping conversion test.'
         warnings.warn(msg, ImportWarning)

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -120,11 +120,9 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                 raise TypeError("Input is not known type.")
 
     # list or generator of edges
-    if (isinstance(data, list) or
-        isinstance(data, tuple) or
-        hasattr(data, '_adjdict') or
-        hasattr(data, 'next') or
-        hasattr(data, '__next__')):
+
+    if (isinstance(data, (list, tuple)) or
+            any(hasattr(data, attr) for attr in ['_adjdict', 'next', '__next__'])):
         try:
             return from_edgelist(data, create_using=create_using)
         except:
@@ -153,7 +151,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     # numpy matrix or ndarray
     try:
         import numpy
-        if isinstance(data, numpy.matrix) or isinstance(data, numpy.ndarray):
+        if isinstance(data, (numpy.matrix, numpy.ndarray)):
             try:
                 return nx.from_numpy_matrix(data, create_using=create_using)
             except:
@@ -321,13 +319,13 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
                                  for u, nbrs in d.items()
                                  for v, datadict in nbrs.items()
                                  for key, data in datadict.items()
-                                 )
+                                )
             else:
                 G.add_edges_from((u, v, data)
                                  for u, nbrs in d.items()
                                  for v, datadict in nbrs.items()
                                  for key, data in datadict.items()
-                                 )
+                                )
         else:  # Undirected
             if G.is_multigraph():
                 seen = set()   # don't add both directions of undirected graph
@@ -336,7 +334,7 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
                         if (u, v) not in seen:
                             G.add_edges_from((u, v, key, data)
                                              for key, data in datadict.items()
-                                             )
+                                            )
                             seen.add((v, u))
             else:
                 seen = set()   # don't add both directions of undirected graph
@@ -380,8 +378,7 @@ def to_edgelist(G, nodelist=None):
     """
     if nodelist is None:
         return G.edges(data=True)
-    else:
-        return G.edges(nodelist, data=True)
+    return G.edges(nodelist, data=True)
 
 
 def from_edgelist(edgelist, create_using=None):

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -191,8 +191,8 @@ def from_pandas_adjacency(df, create_using=None):
     try:
         df = df[df.index]
     except:
-        raise nx.NetworkXError("Columns must match Indices.",
-                "%s not in columns"%list(set(df.index).difference(set(df.columns))))
+        raise nx.NetworkXError("Columns must match Indices.", "%s not in columns" %
+                               list(set(df.index).difference(set(df.columns))))
 
     nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=False)
     return G
@@ -258,7 +258,7 @@ def from_pandas_dataframe(df, source='source', target='target', edge_attr=None,
 
 
 def from_pandas_edgelist(df, source='source', target='target', edge_attr=None,
-                          create_using=None):
+                         create_using=None):
     """Return a graph from Pandas DataFrame containing an edge list.
 
     The Pandas DataFrame should contain at least two columns of node names and

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -103,7 +103,7 @@ def to_pandas_adjacency(G, nodelist=None, dtype=None, order=None,
 
     >>> import pandas as pd
     >>> import numpy as np
-    >>> G = nx.Graph([(1,1)])
+    >>> G = nx.Graph([(1, 1)])
     >>> df = nx.to_pandas_adjacency(G, dtype=int)
     >>> df
        1
@@ -116,19 +116,20 @@ def to_pandas_adjacency(G, nodelist=None, dtype=None, order=None,
     Examples
     --------
     >>> G = nx.MultiDiGraph()
-    >>> G.add_edge(0,1,weight=2)
+    >>> G.add_edge(0, 1, weight=2)
     0
-    >>> G.add_edge(1,0)
+    >>> G.add_edge(1, 0)
     0
-    >>> G.add_edge(2,2,weight=3)
+    >>> G.add_edge(2, 2, weight=3)
     0
-    >>> G.add_edge(2,2)
+    >>> G.add_edge(2, 2)
     1
-    >>> nx.to_pandas_adjacency(G, nodelist=[0,1,2], dtype=int)
+    >>> nx.to_pandas_adjacency(G, nodelist=[0, 1, 2], dtype=int)
        0  1  2
     0  0  2  0
     1  1  0  0
     2  0  0  4
+
     """
     import pandas as pd
     M = to_numpy_matrix(G, nodelist=nodelist, dtype=dtype, order=order,
@@ -177,11 +178,12 @@ def from_pandas_adjacency(df, create_using=None):
     1  2  1
     >>> G = nx.from_pandas_adjacency(df)
     >>> print(nx.info(G))
-    Name:
+    Name: 
     Type: Graph
     Number of nodes: 2
     Number of edges: 3
     Average degree:   3.0000
+
     """
 
     A = df.values
@@ -230,6 +232,7 @@ def to_pandas_edgelist(G, source='source', target='target', nodelist=None,
        cost source target  weight
     0     1      A      B       7
     1     9      C      E      10
+
     """
     import pandas as pd
     if nodelist is None:
@@ -323,6 +326,7 @@ def from_pandas_edgelist(df, source='source', target='target', edge_attr=None,
     >>> G = nx.from_pandas_edgelist(edges, edge_attr=True)
     >>> G[0][2]['color']
     'red'
+
     """
 
     g = _prep_create_using(create_using)
@@ -442,18 +446,19 @@ def to_numpy_matrix(G, nodelist=None, dtype=None, order=None,
     Examples
     --------
     >>> G = nx.MultiDiGraph()
-    >>> G.add_edge(0,1,weight=2)
+    >>> G.add_edge(0, 1, weight=2)
     0
-    >>> G.add_edge(1,0)
+    >>> G.add_edge(1, 0)
     0
-    >>> G.add_edge(2,2,weight=3)
+    >>> G.add_edge(2, 2, weight=3)
     0
-    >>> G.add_edge(2,2)
+    >>> G.add_edge(2, 2)
     1
-    >>> nx.to_numpy_matrix(G, nodelist=[0,1,2])
+    >>> nx.to_numpy_matrix(G, nodelist=[0, 1, 2])
     matrix([[ 0.,  2.,  0.],
             [ 1.,  0.,  0.],
             [ 0.,  0.,  4.]])
+
     """
     import numpy as np
 
@@ -652,14 +657,15 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
     Examples
     --------
     >>> G = nx.Graph()
-    >>> G.add_edge(1,2,weight=7.0,cost=5)
-    >>> A=nx.to_numpy_recarray(G,dtype=[('weight',float),('cost',int)])
+    >>> G.add_edge(1, 2, weight=7.0, cost=5)
+    >>> A = nx.to_numpy_recarray(G, dtype=[('weight', float), ('cost', int)])
     >>> print(A.weight)
     [[ 0.  7.]
      [ 7.  0.]]
     >>> print(A.cost)
     [[0 5]
      [5 0]]
+
     """
     if dtype is None:
         dtype = [('weight', float)]
@@ -739,26 +745,26 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
     resulting Scipy sparse matrix can be modified as follows:
 
     >>> import scipy as sp
-    >>> G = nx.Graph([(1,1)])
+    >>> G = nx.Graph([(1, 1)])
     >>> A = nx.to_scipy_sparse_matrix(G)
     >>> print(A.todense())
     [[1]]
-    >>> A.setdiag(A.diagonal()*2)
+    >>> A.setdiag(A.diagonal() * 2)
     >>> print(A.todense())
     [[2]]
 
     Examples
     --------
     >>> G = nx.MultiDiGraph()
-    >>> G.add_edge(0,1,weight=2)
+    >>> G.add_edge(0, 1, weight=2)
     0
-    >>> G.add_edge(1,0)
+    >>> G.add_edge(1, 0)
     0
-    >>> G.add_edge(2,2,weight=3)
+    >>> G.add_edge(2, 2, weight=3)
     0
-    >>> G.add_edge(2,2)
+    >>> G.add_edge(2, 2)
     1
-    >>> S = nx.to_scipy_sparse_matrix(G, nodelist=[0,1,2])
+    >>> S = nx.to_scipy_sparse_matrix(G, nodelist=[0, 1, 2])
     >>> print(S.todense())
     [[0 2 0]
      [1 0 0]
@@ -914,7 +920,7 @@ def from_scipy_sparse_matrix(A, parallel_edges=False, create_using=None,
     Examples
     --------
     >>> import scipy as sp
-    >>> A = sp.sparse.eye(2,2,1)
+    >>> A = sp.sparse.eye(2, 2, 1)
     >>> G = nx.from_scipy_sparse_matrix(A)
 
     If `create_using` is a multigraph and the matrix has only integer entries,
@@ -1052,18 +1058,19 @@ def to_numpy_array(G, nodelist=None, dtype=None, order=None,
     Examples
     --------
     >>> G = nx.MultiDiGraph()
-    >>> G.add_edge(0,1,weight=2)
+    >>> G.add_edge(0, 1, weight=2)
     0
-    >>> G.add_edge(1,0)
+    >>> G.add_edge(1, 0)
     0
-    >>> G.add_edge(2,2,weight=3)
+    >>> G.add_edge(2, 2, weight=3)
     0
-    >>> G.add_edge(2,2)
+    >>> G.add_edge(2, 2)
     1
-    >>> nx.to_numpy_array(G, nodelist=[0,1,2])
+    >>> nx.to_numpy_array(G, nodelist=[0, 1, 2])
     array([[ 0.,  2.,  0.],
            [ 1.,  0.,  0.],
            [ 0.,  0.,  4.]])
+
     """
     import numpy as np
     if nodelist is None:
@@ -1226,6 +1233,7 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
     2
     >>> G[0][0]['weight']
     1.0
+
     """
     return from_numpy_matrix(A, parallel_edges=parallel_edges,
                              create_using=create_using)

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-from nose.tools import assert_equal, assert_not_equal, assert_true, assert_false
+from nose.tools import (assert_equal, assert_not_equal,
+                        assert_true, assert_false,
+                        assert_raises)
 
 import networkx as nx
 from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
@@ -38,6 +40,38 @@ class TestConvert():
             dod = dest(P4, nodelist=[0, 1, 2])
             Gdod = nx.Graph(dod)
             assert_graphs_equal(Gdod, P3)
+
+    def test_exceptions(self):
+        # _prep_create_using
+        G = {"a": "a"}
+        H = nx.to_networkx_graph(G)
+        assert_graphs_equal(H, nx.Graph([('a', 'a')]))
+        assert_raises(TypeError, to_networkx_graph, G, create_using=0.0)
+
+        # NX graph
+        class G(object):
+            adj = None
+
+        assert_raises(nx.NetworkXError, to_networkx_graph, G)
+
+        # pygraphviz  agraph
+        class G(object):
+            is_strict = None
+
+        assert_raises(nx.NetworkXError, to_networkx_graph, G)
+
+        # Dict of [dicts, lists]
+        G = {"a": 0}
+        assert_raises(TypeError, to_networkx_graph, G)
+
+        # list or generator of edges
+        class G(object):
+            next = None
+
+        assert_raises(nx.NetworkXError, to_networkx_graph, G)
+
+        # no match
+        assert_raises(nx.NetworkXError, to_networkx_graph, "a")
 
     def test_digraphs(self):
         for dest, source in [(to_dict_of_dicts, from_dict_of_dicts),
@@ -225,3 +259,8 @@ class TestConvert():
         assert_equal(list(H.nodes), list(G.nodes))
         H = nx.OrderedDiGraph(G)
         assert_equal(list(H.nodes), list(G.nodes))
+
+    def test_to_edgelist(self):
+        G = nx.Graph([(1, 1)])
+        elist = nx.to_edgelist(G, nodelist=list(G))
+        assert_edges_equal(G.edges(data=True), elist)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -2,19 +2,20 @@ from nose import SkipTest
 from nose.tools import assert_raises, assert_true, assert_equal
 
 import networkx as nx
-from networkx.generators.classic import barbell_graph,cycle_graph,path_graph
+from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 from networkx.testing.utils import assert_graphs_equal
 
 
 class TestConvertNumpy(object):
-    numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
+
     @classmethod
     def setupClass(cls):
         global np
         global np_assert_equal
         try:
             import numpy as np
-            np_assert_equal=np.testing.assert_equal
+            np_assert_equal = np.testing.assert_equal
         except ImportError:
             raise SkipTest('NumPy not available.')
 
@@ -25,7 +26,6 @@ class TestConvertNumpy(object):
         self.G3 = self.create_weighted(nx.Graph())
         self.G4 = self.create_weighted(nx.DiGraph())
 
-
     def test_exceptions(self):
         G = np.array("a")
         assert_raises(nx.NetworkXError, nx.to_networkx_graph, G)
@@ -33,12 +33,12 @@ class TestConvertNumpy(object):
     def create_weighted(self, G):
         g = cycle_graph(4)
         G.add_nodes_from(g)
-        G.add_weighted_edges_from( (u,v,10+u) for u,v in g.edges())
+        G.add_weighted_edges_from((u, v, 10 + u) for u, v in g.edges())
         return G
 
     def assert_equal(self, G1, G2):
-        assert_true( sorted(G1.nodes())==sorted(G2.nodes()) )
-        assert_true( sorted(G1.edges())==sorted(G2.edges()) )
+        assert_true(sorted(G1.nodes()) == sorted(G2.nodes()))
+        assert_true(sorted(G1.edges()) == sorted(G2.edges()))
 
     def identity_conversion(self, G, A, create_using):
         assert(A.sum() > 0)
@@ -51,7 +51,7 @@ class TestConvertNumpy(object):
 
     def test_shape(self):
         "Conversion from non-square array."
-        A=np.array([[1,2,3],[4,5,6]])
+        A = np.array([[1, 2, 3], [4, 5, 6]])
         assert_raises(nx.NetworkXError, nx.from_numpy_matrix, A)
 
     def test_identity_graph_matrix(self):
@@ -113,66 +113,66 @@ class TestConvertNumpy(object):
 
     def test_weight_keyword(self):
         WP4 = nx.Graph()
-        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3)) for n in range(3) )
+        WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3)) for n in range(3))
         P4 = path_graph(4)
         A = nx.to_numpy_matrix(P4)
-        np_assert_equal(A, nx.to_numpy_matrix(WP4,weight=None))
-        np_assert_equal(0.5*A, nx.to_numpy_matrix(WP4))
-        np_assert_equal(0.3*A, nx.to_numpy_matrix(WP4,weight='other'))
+        np_assert_equal(A, nx.to_numpy_matrix(WP4, weight=None))
+        np_assert_equal(0.5 * A, nx.to_numpy_matrix(WP4))
+        np_assert_equal(0.3 * A, nx.to_numpy_matrix(WP4, weight='other'))
 
     def test_from_numpy_matrix_type(self):
-        A=np.matrix([[1]])
-        G=nx.from_numpy_matrix(A)
-        assert_equal(type(G[0][0]['weight']),int)
+        A = np.matrix([[1]])
+        G = nx.from_numpy_matrix(A)
+        assert_equal(type(G[0][0]['weight']), int)
 
-        A=np.matrix([[1]]).astype(np.float)
-        G=nx.from_numpy_matrix(A)
-        assert_equal(type(G[0][0]['weight']),float)
+        A = np.matrix([[1]]).astype(np.float)
+        G = nx.from_numpy_matrix(A)
+        assert_equal(type(G[0][0]['weight']), float)
 
-        A=np.matrix([[1]]).astype(np.str)
-        G=nx.from_numpy_matrix(A)
-        assert_equal(type(G[0][0]['weight']),str)
+        A = np.matrix([[1]]).astype(np.str)
+        G = nx.from_numpy_matrix(A)
+        assert_equal(type(G[0][0]['weight']), str)
 
-        A=np.matrix([[1]]).astype(np.bool)
-        G=nx.from_numpy_matrix(A)
-        assert_equal(type(G[0][0]['weight']),bool)
+        A = np.matrix([[1]]).astype(np.bool)
+        G = nx.from_numpy_matrix(A)
+        assert_equal(type(G[0][0]['weight']), bool)
 
-        A=np.matrix([[1]]).astype(np.complex)
-        G=nx.from_numpy_matrix(A)
-        assert_equal(type(G[0][0]['weight']),complex)
+        A = np.matrix([[1]]).astype(np.complex)
+        G = nx.from_numpy_matrix(A)
+        assert_equal(type(G[0][0]['weight']), complex)
 
-        A=np.matrix([[1]]).astype(np.object)
-        assert_raises(TypeError,nx.from_numpy_matrix,A)
+        A = np.matrix([[1]]).astype(np.object)
+        assert_raises(TypeError, nx.from_numpy_matrix, A)
 
     def test_from_numpy_matrix_dtype(self):
-        dt=[('weight',float),('cost',int)]
-        A=np.matrix([[(1.0,2)]],dtype=dt)
-        G=nx.from_numpy_matrix(A)
-        assert_equal(type(G[0][0]['weight']),float)
-        assert_equal(type(G[0][0]['cost']),int)
-        assert_equal(G[0][0]['cost'],2)
-        assert_equal(G[0][0]['weight'],1.0)
+        dt = [('weight', float), ('cost', int)]
+        A = np.matrix([[(1.0, 2)]], dtype=dt)
+        G = nx.from_numpy_matrix(A)
+        assert_equal(type(G[0][0]['weight']), float)
+        assert_equal(type(G[0][0]['cost']), int)
+        assert_equal(G[0][0]['cost'], 2)
+        assert_equal(G[0][0]['weight'], 1.0)
 
     def test_to_numpy_recarray(self):
-        G=nx.Graph()
-        G.add_edge(1,2,weight=7.0,cost=5)
-        A=nx.to_numpy_recarray(G,dtype=[('weight',float),('cost',int)])
-        assert_equal(sorted(A.dtype.names),['cost','weight'])
-        assert_equal(A.weight[0,1],7.0)
-        assert_equal(A.weight[0,0],0.0)
-        assert_equal(A.cost[0,1],5)
-        assert_equal(A.cost[0,0],0)
+        G = nx.Graph()
+        G.add_edge(1, 2, weight=7.0, cost=5)
+        A = nx.to_numpy_recarray(G, dtype=[('weight', float), ('cost', int)])
+        assert_equal(sorted(A.dtype.names), ['cost', 'weight'])
+        assert_equal(A.weight[0, 1], 7.0)
+        assert_equal(A.weight[0, 0], 0.0)
+        assert_equal(A.cost[0, 1], 5)
+        assert_equal(A.cost[0, 0], 0)
 
     def test_numpy_multigraph(self):
-        G=nx.MultiGraph()
-        G.add_edge(1,2,weight=7)
-        G.add_edge(1,2,weight=70)
-        A=nx.to_numpy_matrix(G)
-        assert_equal(A[1,0],77)
-        A=nx.to_numpy_matrix(G,multigraph_weight=min)
-        assert_equal(A[1,0],7)
-        A=nx.to_numpy_matrix(G,multigraph_weight=max)
-        assert_equal(A[1,0],70)
+        G = nx.MultiGraph()
+        G.add_edge(1, 2, weight=7)
+        G.add_edge(1, 2, weight=70)
+        A = nx.to_numpy_matrix(G)
+        assert_equal(A[1, 0], 77)
+        A = nx.to_numpy_matrix(G, multigraph_weight=min)
+        assert_equal(A[1, 0], 7)
+        A = nx.to_numpy_matrix(G, multigraph_weight=max)
+        assert_equal(A[1, 0], 70)
 
     def test_from_numpy_matrix_parallel_edges(self):
         """Tests that the :func:`networkx.from_numpy_matrix` function
@@ -243,14 +243,15 @@ class TestConvertNumpy(object):
 
 
 class TestConvertNumpyArray(object):
-    numpy=1 # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
+
     @classmethod
     def setupClass(cls):
         global np
         global np_assert_equal
         try:
             import numpy as np
-            np_assert_equal=np.testing.assert_equal
+            np_assert_equal = np.testing.assert_equal
         except ImportError:
             raise SkipTest('NumPy not available.')
 
@@ -264,12 +265,12 @@ class TestConvertNumpyArray(object):
     def create_weighted(self, G):
         g = cycle_graph(4)
         G.add_nodes_from(g)
-        G.add_weighted_edges_from( (u,v,10+u) for u,v in g.edges())
+        G.add_weighted_edges_from((u, v, 10 + u) for u, v in g.edges())
         return G
 
     def assert_equal(self, G1, G2):
-        assert_true( sorted(G1.nodes())==sorted(G2.nodes()) )
-        assert_true( sorted(G1.edges())==sorted(G2.edges()) )
+        assert_true(sorted(G1.nodes()) == sorted(G2.nodes()))
+        assert_true(sorted(G1.edges()) == sorted(G2.edges()))
 
     def identity_conversion(self, G, A, create_using):
         assert(A.sum() > 0)
@@ -282,7 +283,7 @@ class TestConvertNumpyArray(object):
 
     def test_shape(self):
         "Conversion from non-square array."
-        A=np.array([[1,2,3],[4,5,6]])
+        A = np.array([[1, 2, 3], [4, 5, 6]])
         assert_raises(nx.NetworkXError, nx.from_numpy_array, A)
 
     def test_identity_graph_array(self):
@@ -320,66 +321,66 @@ class TestConvertNumpyArray(object):
 
     def test_weight_keyword(self):
         WP4 = nx.Graph()
-        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3)) for n in range(3) )
+        WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3)) for n in range(3))
         P4 = path_graph(4)
         A = nx.to_numpy_array(P4)
-        np_assert_equal(A, nx.to_numpy_array(WP4,weight=None))
-        np_assert_equal(0.5*A, nx.to_numpy_array(WP4))
-        np_assert_equal(0.3*A, nx.to_numpy_array(WP4,weight='other'))
+        np_assert_equal(A, nx.to_numpy_array(WP4, weight=None))
+        np_assert_equal(0.5 * A, nx.to_numpy_array(WP4))
+        np_assert_equal(0.3 * A, nx.to_numpy_array(WP4, weight='other'))
 
     def test_from_numpy_array_type(self):
-        A=np.array([[1]])
-        G=nx.from_numpy_array(A)
-        assert_equal(type(G[0][0]['weight']),int)
+        A = np.array([[1]])
+        G = nx.from_numpy_array(A)
+        assert_equal(type(G[0][0]['weight']), int)
 
-        A=np.array([[1]]).astype(np.float)
-        G=nx.from_numpy_array(A)
-        assert_equal(type(G[0][0]['weight']),float)
+        A = np.array([[1]]).astype(np.float)
+        G = nx.from_numpy_array(A)
+        assert_equal(type(G[0][0]['weight']), float)
 
-        A=np.array([[1]]).astype(np.str)
-        G=nx.from_numpy_array(A)
-        assert_equal(type(G[0][0]['weight']),str)
+        A = np.array([[1]]).astype(np.str)
+        G = nx.from_numpy_array(A)
+        assert_equal(type(G[0][0]['weight']), str)
 
-        A=np.array([[1]]).astype(np.bool)
-        G=nx.from_numpy_array(A)
-        assert_equal(type(G[0][0]['weight']),bool)
+        A = np.array([[1]]).astype(np.bool)
+        G = nx.from_numpy_array(A)
+        assert_equal(type(G[0][0]['weight']), bool)
 
-        A=np.array([[1]]).astype(np.complex)
-        G=nx.from_numpy_array(A)
-        assert_equal(type(G[0][0]['weight']),complex)
+        A = np.array([[1]]).astype(np.complex)
+        G = nx.from_numpy_array(A)
+        assert_equal(type(G[0][0]['weight']), complex)
 
-        A=np.array([[1]]).astype(np.object)
-        assert_raises(TypeError,nx.from_numpy_array,A)
+        A = np.array([[1]]).astype(np.object)
+        assert_raises(TypeError, nx.from_numpy_array, A)
 
     def test_from_numpy_array_dtype(self):
-        dt=[('weight',float),('cost',int)]
-        A=np.array([[(1.0,2)]],dtype=dt)
-        G=nx.from_numpy_array(A)
-        assert_equal(type(G[0][0]['weight']),float)
-        assert_equal(type(G[0][0]['cost']),int)
-        assert_equal(G[0][0]['cost'],2)
-        assert_equal(G[0][0]['weight'],1.0)
+        dt = [('weight', float), ('cost', int)]
+        A = np.array([[(1.0, 2)]], dtype=dt)
+        G = nx.from_numpy_array(A)
+        assert_equal(type(G[0][0]['weight']), float)
+        assert_equal(type(G[0][0]['cost']), int)
+        assert_equal(G[0][0]['cost'], 2)
+        assert_equal(G[0][0]['weight'], 1.0)
 
     def test_to_numpy_recarray(self):
-        G=nx.Graph()
-        G.add_edge(1,2,weight=7.0,cost=5)
-        A=nx.to_numpy_recarray(G,dtype=[('weight',float),('cost',int)])
-        assert_equal(sorted(A.dtype.names),['cost','weight'])
-        assert_equal(A.weight[0,1],7.0)
-        assert_equal(A.weight[0,0],0.0)
-        assert_equal(A.cost[0,1],5)
-        assert_equal(A.cost[0,0],0)
+        G = nx.Graph()
+        G.add_edge(1, 2, weight=7.0, cost=5)
+        A = nx.to_numpy_recarray(G, dtype=[('weight', float), ('cost', int)])
+        assert_equal(sorted(A.dtype.names), ['cost', 'weight'])
+        assert_equal(A.weight[0, 1], 7.0)
+        assert_equal(A.weight[0, 0], 0.0)
+        assert_equal(A.cost[0, 1], 5)
+        assert_equal(A.cost[0, 0], 0)
 
     def test_numpy_multigraph(self):
-        G=nx.MultiGraph()
-        G.add_edge(1,2,weight=7)
-        G.add_edge(1,2,weight=70)
-        A=nx.to_numpy_array(G)
-        assert_equal(A[1,0],77)
-        A=nx.to_numpy_array(G,multigraph_weight=min)
-        assert_equal(A[1,0],7)
-        A=nx.to_numpy_array(G,multigraph_weight=max)
-        assert_equal(A[1,0],70)
+        G = nx.MultiGraph()
+        G.add_edge(1, 2, weight=7)
+        G.add_edge(1, 2, weight=70)
+        A = nx.to_numpy_array(G)
+        assert_equal(A[1, 0], 77)
+        A = nx.to_numpy_array(G, multigraph_weight=min)
+        assert_equal(A[1, 0], 7)
+        A = nx.to_numpy_array(G, multigraph_weight=max)
+        assert_equal(A[1, 0], 70)
 
     def test_from_numpy_array_parallel_edges(self):
         """Tests that the :func:`networkx.from_numpy_array` function
@@ -395,10 +396,10 @@ class TestConvertNumpyArray(object):
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
         expected.add_edge(1, 1, weight=2)
         actual = nx.from_numpy_array(A, parallel_edges=True,
-                                      create_using=nx.DiGraph())
+                                     create_using=nx.DiGraph())
         assert_graphs_equal(actual, expected)
         actual = nx.from_numpy_array(A, parallel_edges=False,
-                                      create_using=nx.DiGraph())
+                                     create_using=nx.DiGraph())
         assert_graphs_equal(actual, expected)
         # Now each integer entry in the adjacency matrix is interpreted as the
         # number of parallel edges in the graph if the appropriate keyword
@@ -407,14 +408,14 @@ class TestConvertNumpyArray(object):
         expected = nx.MultiDiGraph()
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
         actual = nx.from_numpy_array(A, parallel_edges=True,
-                                      create_using=nx.MultiDiGraph())
+                                     create_using=nx.MultiDiGraph())
         assert_graphs_equal(actual, expected)
         expected = nx.MultiDiGraph()
         expected.add_edges_from(set(edges), weight=1)
         # The sole self-loop (edge 0) on vertex 1 should have weight 2.
         expected[1][1][0]['weight'] = 2
         actual = nx.from_numpy_array(A, parallel_edges=False,
-                                      create_using=nx.MultiDiGraph())
+                                     create_using=nx.MultiDiGraph())
         assert_graphs_equal(actual, expected)
 
     def test_symmetric(self):

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -25,6 +25,11 @@ class TestConvertNumpy(object):
         self.G3 = self.create_weighted(nx.Graph())
         self.G4 = self.create_weighted(nx.DiGraph())
 
+
+    def test_exceptions(self):
+        G = np.array("a")
+        assert_raises(nx.NetworkXError, nx.to_networkx_graph, G)
+
     def create_weighted(self, G):
         g = cycle_graph(4)
         G.add_nodes_from(g)

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,8 +1,8 @@
 from nose import SkipTest
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_raises
 
 import networkx as nx
-from networkx.testing import assert_nodes_equal, assert_edges_equal
+from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
 
 
 class TestConvertPandas(object):
@@ -15,7 +15,7 @@ class TestConvertPandas(object):
         except ImportError:
             raise SkipTest('Pandas not available.')
 
-    def __init__(self, ):
+    def __init__(self):
         global pd
         import pandas as pd
 
@@ -31,43 +31,80 @@ class TestConvertPandas(object):
                            columns=['weight', 'cost', 0, 'b'])
         self.mdf = df.append(mdf)
 
-    def assert_equal(self, G1, G2):
-        assert_true(nx.is_isomorphic(G1, G2, edge_match=lambda x, y: x == y))
+    def test_exceptions(self):
+        G = pd.DataFrame(["a"])  # adj
+        assert_raises(nx.NetworkXError, nx.to_networkx_graph, G)
+        G = pd.DataFrame(["a", 0.0])  # elist
+        assert_raises(nx.NetworkXError, nx.to_networkx_graph, G)
+        df = pd.DataFrame([[1, 1], [1, 0]], dtype=int, index=[1, 2], columns=["a", "b"])
+        assert_raises(nx.NetworkXError, nx.from_pandas_adjacency, df)
 
-    def test_from_edgelist_all_attr(self, ):
+    def test_from_edgelist_all_attr(self):
         Gtrue = nx.Graph([('E', 'C', {'cost': 9, 'weight': 10}),
                           ('B', 'A', {'cost': 1, 'weight': 7}),
                           ('A', 'D', {'cost': 7, 'weight': 4})])
         G = nx.from_pandas_edgelist(self.df, 0, 'b', True)
-        self.assert_equal(G, Gtrue)
+        assert_graphs_equal(G, Gtrue)
+        # deprecated
+        G = nx.from_pandas_dataframe(self.df, 0, 'b', True)
+        assert_graphs_equal(G, Gtrue)
         # MultiGraph
         MGtrue = nx.MultiGraph(Gtrue)
         MGtrue.add_edge('A', 'D', cost=16, weight=4)
         MG = nx.from_pandas_edgelist(self.mdf, 0, 'b', True, nx.MultiGraph())
-        self.assert_equal(MG, MGtrue)
+        assert_graphs_equal(MG, MGtrue)
 
-    def test_from_edgelist_multi_attr(self, ):
+    def test_from_edgelist_multi_attr(self):
         Gtrue = nx.Graph([('E', 'C', {'cost': 9, 'weight': 10}),
                           ('B', 'A', {'cost': 1, 'weight': 7}),
                           ('A', 'D', {'cost': 7, 'weight': 4})])
         G = nx.from_pandas_edgelist(self.df, 0, 'b', ['weight', 'cost'])
-        self.assert_equal(G, Gtrue)
+        assert_graphs_equal(G, Gtrue)
 
-    def test_from_edgelist_one_attr(self, ):
+    def test_from_edgelist_multidigraph_and_edge_attr(self):
+        # example from issue #2374
+        Gtrue = nx.MultiDiGraph([('X1', 'X4', {'Co': 'zA', 'Mi': 0, 'St': 'X1'}),
+                                 ('X1', 'X4', {'Co': 'zB', 'Mi': 54, 'St': 'X2'}),
+                                 ('X1', 'X4', {'Co': 'zB', 'Mi': 49, 'St': 'X3'}),
+                                 ('X1', 'X4', {'Co': 'zB', 'Mi': 44, 'St': 'X4'}),
+                                 ('Y1', 'Y3', {'Co': 'zC', 'Mi': 0, 'St': 'Y1'}),
+                                 ('Y1', 'Y3', {'Co': 'zC', 'Mi': 34, 'St': 'Y2'}),
+                                 ('Y1', 'Y3', {'Co': 'zC', 'Mi': 29, 'St': 'X2'}),
+                                 ('Y1', 'Y3', {'Co': 'zC', 'Mi': 24, 'St': 'Y3'}),
+                                 ('Z1', 'Z3', {'Co': 'zD', 'Mi': 0, 'St': 'Z1'}),
+                                 ('Z1', 'Z3', {'Co': 'zD', 'Mi': 14, 'St': 'X3'}),
+                                 ('Z1', 'Z3', {'Co': 'zE', 'Mi': 9, 'St': 'Z2'}),
+                                 ('Z1', 'Z3', {'Co': 'zE', 'Mi': 4, 'St': 'Z3'})])
+        df = pd.DataFrame.from_items([
+                ('O', ['X1', 'X1', 'X1', 'X1', 'Y1', 'Y1', 'Y1', 'Y1', 'Z1', 'Z1', 'Z1', 'Z1']),
+                ('D', ['X4', 'X4', 'X4', 'X4', 'Y3', 'Y3', 'Y3', 'Y3', 'Z3', 'Z3', 'Z3', 'Z3']),
+                ('St', ['X1', 'X2', 'X3', 'X4', 'Y1', 'Y2', 'X2', 'Y3', 'Z1', 'X3', 'Z2', 'Z3']),
+                ('Co', ['zA', 'zB', 'zB', 'zB', 'zC', 'zC', 'zC', 'zC', 'zD', 'zD', 'zE', 'zE']),
+                ('Mi', [0,   54,   49,   44,    0,   34,   29,   24,    0,   14,    9,   4])])
+        G1 = nx.from_pandas_edgelist(df, source='O', target='D',
+                                     edge_attr=True,
+                                     create_using=nx.MultiDiGraph())
+        G2 = nx.from_pandas_edgelist(df, source='O', target='D',
+                                     edge_attr=['St', 'Co', 'Mi'],
+                                     create_using=nx.MultiDiGraph())
+        assert_graphs_equal(G1, Gtrue)
+        assert_graphs_equal(G2, Gtrue)
+
+    def test_from_edgelist_one_attr(self):
         Gtrue = nx.Graph([('E', 'C', {'weight': 10}),
                           ('B', 'A', {'weight': 7}),
                           ('A', 'D', {'weight': 4})])
         G = nx.from_pandas_edgelist(self.df, 0, 'b', 'weight')
-        self.assert_equal(G, Gtrue)
+        assert_graphs_equal(G, Gtrue)
 
-    def test_from_edgelist_no_attr(self, ):
+    def test_from_edgelist_no_attr(self):
         Gtrue = nx.Graph([('E', 'C', {}),
                           ('B', 'A', {}),
                           ('A', 'D', {})])
         G = nx.from_pandas_edgelist(self.df, 0, 'b',)
-        self.assert_equal(G, Gtrue)
+        assert_graphs_equal(G, Gtrue)
 
-    def test_from_edgelist(self, ):
+    def test_from_edgelist(self):
         # Pandas DataFrame
         g = nx.cycle_graph(10)
         G = nx.Graph()
@@ -77,13 +114,34 @@ class TestConvertPandas(object):
         source = [s for s, t, d in edgelist]
         target = [t for s, t, d in edgelist]
         weight = [d['weight'] for s, t, d in edgelist]
-        import pandas as pd
         edges = pd.DataFrame({'source': source,
                               'target': target,
                               'weight': weight})
         GG = nx.from_pandas_edgelist(edges, edge_attr='weight')
-        assert_nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GG.edges()))
+        assert_nodes_equal(G.nodes(), GG.nodes())
+        assert_edges_equal(G.edges(), GG.edges())
         GW = nx.to_networkx_graph(edges, create_using=nx.Graph())
-        assert_nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GW.edges()))
+        assert_nodes_equal(G.nodes(), GW.nodes())
+        assert_edges_equal(G.edges(), GW.edges())
+
+    def test_from_adjacency(self):
+        nodelist = [1, 2]
+        dftrue = pd.DataFrame([[1, 1], [1, 0]], dtype=int, index=nodelist, columns=nodelist)
+        G = nx.Graph([(1, 1), (1, 2)])
+        df = nx.to_pandas_adjacency(G, dtype=int)
+        pd.testing.assert_frame_equal(df, dftrue)
+        # deprecated
+        df = nx.to_pandas_dataframe(G, dtype=int)
+        pd.testing.assert_frame_equal(df, dftrue)
+
+    def test_roundtrip(self):
+        # edgelist
+        Gtrue = nx.Graph([(1, 1), (1, 2)])
+        df = nx.to_pandas_edgelist(Gtrue)
+        G = nx.from_pandas_edgelist(df)
+        assert_graphs_equal(Gtrue, G)
+        # adjacency
+        Gtrue = nx.Graph(({1: {1: {'weight': 1}, 2: {'weight': 1}}, 2: {1: {'weight': 1}}}))
+        df = nx.to_pandas_adjacency(Gtrue, dtype=int)
+        G = nx.from_pandas_adjacency(df)
+        assert_graphs_equal(Gtrue, G)

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -34,40 +34,40 @@ class TestConvertPandas(object):
     def assert_equal(self, G1, G2):
         assert_true(nx.is_isomorphic(G1, G2, edge_match=lambda x, y: x == y))
 
-    def test_from_dataframe_all_attr(self, ):
+    def test_from_edgelist_all_attr(self, ):
         Gtrue = nx.Graph([('E', 'C', {'cost': 9, 'weight': 10}),
                           ('B', 'A', {'cost': 1, 'weight': 7}),
                           ('A', 'D', {'cost': 7, 'weight': 4})])
-        G = nx.from_pandas_dataframe(self.df, 0, 'b', True)
+        G = nx.from_pandas_edgelist(self.df, 0, 'b', True)
         self.assert_equal(G, Gtrue)
         # MultiGraph
         MGtrue = nx.MultiGraph(Gtrue)
         MGtrue.add_edge('A', 'D', cost=16, weight=4)
-        MG = nx.from_pandas_dataframe(self.mdf, 0, 'b', True, nx.MultiGraph())
+        MG = nx.from_pandas_edgelist(self.mdf, 0, 'b', True, nx.MultiGraph())
         self.assert_equal(MG, MGtrue)
 
-    def test_from_dataframe_multi_attr(self, ):
+    def test_from_edgelist_multi_attr(self, ):
         Gtrue = nx.Graph([('E', 'C', {'cost': 9, 'weight': 10}),
                           ('B', 'A', {'cost': 1, 'weight': 7}),
                           ('A', 'D', {'cost': 7, 'weight': 4})])
-        G = nx.from_pandas_dataframe(self.df, 0, 'b', ['weight', 'cost'])
+        G = nx.from_pandas_edgelist(self.df, 0, 'b', ['weight', 'cost'])
         self.assert_equal(G, Gtrue)
 
-    def test_from_dataframe_one_attr(self, ):
+    def test_from_edgelist_one_attr(self, ):
         Gtrue = nx.Graph([('E', 'C', {'weight': 10}),
                           ('B', 'A', {'weight': 7}),
                           ('A', 'D', {'weight': 4})])
-        G = nx.from_pandas_dataframe(self.df, 0, 'b', 'weight')
+        G = nx.from_pandas_edgelist(self.df, 0, 'b', 'weight')
         self.assert_equal(G, Gtrue)
 
-    def test_from_dataframe_no_attr(self, ):
+    def test_from_edgelist_no_attr(self, ):
         Gtrue = nx.Graph([('E', 'C', {}),
                           ('B', 'A', {}),
                           ('A', 'D', {})])
-        G = nx.from_pandas_dataframe(self.df, 0, 'b',)
+        G = nx.from_pandas_edgelist(self.df, 0, 'b',)
         self.assert_equal(G, Gtrue)
 
-    def test_from_datafram(self, ):
+    def test_from_edgelist(self, ):
         # Pandas DataFrame
         g = nx.cycle_graph(10)
         G = nx.Graph()
@@ -81,7 +81,7 @@ class TestConvertPandas(object):
         edges = pd.DataFrame({'source': source,
                               'target': target,
                               'weight': weight})
-        GG = nx.from_pandas_dataframe(edges, edge_attr='weight')
+        GG = nx.from_pandas_edgelist(edges, edge_attr='weight')
         assert_nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
         assert_edges_equal(sorted(G.edges()), sorted(GG.edges()))
         GW = nx.to_networkx_graph(edges, create_using=nx.Graph())

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -26,6 +26,12 @@ class TestConvertNumpy(object):
         self.G3 = self.create_weighted(nx.Graph())
         self.G4 = self.create_weighted(nx.DiGraph())
 
+    def test_exceptions(self):
+        class G(object):
+            format = None
+
+        assert_raises(nx.NetworkXError, nx.to_networkx_graph, G)
+
     def create_weighted(self, G):
         g = cycle_graph(4)
         e = list(g.edges())

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -3,7 +3,7 @@ from nose.tools import assert_raises, assert_true, assert_equal, raises
 
 import networkx as nx
 from networkx.testing import assert_graphs_equal
-from networkx.generators.classic import barbell_graph,cycle_graph,path_graph
+from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 from networkx.testing.utils import assert_graphs_equal
 
 
@@ -15,7 +15,7 @@ class TestConvertNumpy(object):
             import numpy as np
             import scipy as sp
             import scipy.sparse as sparse
-            np_assert_equal=np.testing.assert_equal
+            np_assert_equal = np.testing.assert_equal
         except ImportError:
             raise SkipTest('SciPy sparse library not available.')
 
@@ -35,15 +35,15 @@ class TestConvertNumpy(object):
     def create_weighted(self, G):
         g = cycle_graph(4)
         e = list(g.edges())
-        source = [u for u,v in e]
-        dest = [v for u,v in e]
-        weight = [s+10 for s in source]
+        source = [u for u, v in e]
+        dest = [v for u, v in e]
+        weight = [s + 10 for s in source]
         ex = zip(source, dest, weight)
         G.add_weighted_edges_from(ex)
         return G
 
     def assert_isomorphic(self, G1, G2):
-        assert_true(nx.is_isomorphic(G1,G2))
+        assert_true(nx.is_isomorphic(G1, G2))
 
     def identity_conversion(self, G, A, create_using):
         GG = nx.from_scipy_sparse_matrix(A, create_using=create_using)
@@ -77,7 +77,7 @@ class TestConvertNumpy(object):
 
     def test_shape(self):
         "Conversion from non-square sparse array."
-        A = sp.sparse.lil_matrix([[1,2,3],[4,5,6]])
+        A = sp.sparse.lil_matrix([[1, 2, 3], [4, 5, 6]])
         assert_raises(nx.NetworkXError, nx.from_scipy_sparse_matrix, A)
 
     def test_identity_graph_matrix(self):
@@ -111,60 +111,60 @@ class TestConvertNumpy(object):
 
         # Make nodelist ambiguous by containing duplicates.
         nodelist += [nodelist[0]]
-        assert_raises(nx.NetworkXError, nx.to_numpy_matrix, P3, 
+        assert_raises(nx.NetworkXError, nx.to_numpy_matrix, P3,
                       nodelist=nodelist)
 
     def test_weight_keyword(self):
         WP4 = nx.Graph()
-        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3)) 
-                            for n in range(3) )
+        WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3))
+                           for n in range(3))
         P4 = path_graph(4)
         A = nx.to_scipy_sparse_matrix(P4)
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
-        np_assert_equal(0.5*A.todense(),
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
+        np_assert_equal(0.5 * A.todense(),
                         nx.to_scipy_sparse_matrix(WP4).todense())
-        np_assert_equal(0.3*A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight='other').todense())
+        np_assert_equal(0.3 * A.todense(),
+                        nx.to_scipy_sparse_matrix(WP4, weight='other').todense())
 
     def test_format_keyword(self):
         WP4 = nx.Graph()
-        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3))
-                            for n in range(3) )
+        WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3))
+                           for n in range(3))
         P4 = path_graph(4)
         A = nx.to_scipy_sparse_matrix(P4, format='csr')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
         A = nx.to_scipy_sparse_matrix(P4, format='csc')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
         A = nx.to_scipy_sparse_matrix(P4, format='coo')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
         A = nx.to_scipy_sparse_matrix(P4, format='bsr')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
         A = nx.to_scipy_sparse_matrix(P4, format='lil')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
         A = nx.to_scipy_sparse_matrix(P4, format='dia')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
         A = nx.to_scipy_sparse_matrix(P4, format='dok')
         np_assert_equal(A.todense(),
-                        nx.to_scipy_sparse_matrix(WP4,weight=None).todense())
+                        nx.to_scipy_sparse_matrix(WP4, weight=None).todense())
 
     @raises(nx.NetworkXError)
     def test_format_keyword_raise(self):
         WP4 = nx.Graph()
-        WP4.add_edges_from( (n,n+1,dict(weight=0.5,other=0.3))
-                            for n in range(3) )
+        WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3))
+                           for n in range(3))
         P4 = path_graph(4)
         nx.to_scipy_sparse_matrix(P4, format='any_other')
 
@@ -180,19 +180,19 @@ class TestConvertNumpy(object):
 
     def test_ordering(self):
         G = nx.DiGraph()
-        G.add_edge(1,2)
-        G.add_edge(2,3)
-        G.add_edge(3,1)
-        M = nx.to_scipy_sparse_matrix(G,nodelist=[3,2,1])
-        np_assert_equal(M.todense(), np.matrix([[0,0,1],[1,0,0],[0,1,0]]))
+        G.add_edge(1, 2)
+        G.add_edge(2, 3)
+        G.add_edge(3, 1)
+        M = nx.to_scipy_sparse_matrix(G, nodelist=[3, 2, 1])
+        np_assert_equal(M.todense(), np.matrix([[0, 0, 1], [1, 0, 0], [0, 1, 0]]))
 
     def test_selfloop_graph(self):
-        G = nx.Graph([(1,1)])
+        G = nx.Graph([(1, 1)])
         M = nx.to_scipy_sparse_matrix(G)
         np_assert_equal(M.todense(), np.matrix([[1]]))
 
     def test_selfloop_digraph(self):
-        G = nx.DiGraph([(1,1)])
+        G = nx.DiGraph([(1, 1)])
         M = nx.to_scipy_sparse_matrix(G)
         np_assert_equal(M.todense(), np.matrix([[1]]))
 


### PR DESCRIPTION
Fixes #2464.

Some related commits:
52eb3d3: from_pandas_dataframe and to_pandas_dataframe were added to work with adjacency matrix.
f0c22dd: from_pandas_dataframe was changed to work with edge-lists, but to_pandas_dataframe was not changed.