### PR TITLE
Help ensure **kwargs doesn't clobber by using specific argument names

### DIFF
--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -117,7 +117,7 @@ def projected_graph(B, nodes, multigraph=False):
                     links = set(B[u]) & set(B[n])
                 for l in links:
                     if not G.has_edge(u, n, l):
-                        G.add_edge(u, n, key=l)
+                        G.add_edge(u, n, ekey=l)
         else:
             G.add_edges_from((u, n) for n in nbrs2)
     return G

--- a/networkx/algorithms/flow/capacityscaling.py
+++ b/networkx/algorithms/flow/capacityscaling.py
@@ -86,8 +86,8 @@ def _build_residual_network(G, demand, capacity, weight):
         # Add both (u, v) and (v, u) into the residual network marked with the
         # original key. (key[1] == True) indicates the (u, v) is in the
         # original network.
-        R.add_edge(u, v, key=(k, True), capacity=r, weight=w, flow=0)
-        R.add_edge(v, u, key=(k, False), capacity=0, weight=-w, flow=0)
+        R.add_edge(u, v, ekey=(k, True), capacity=r, weight=w, flow=0)
+        R.add_edge(v, u, ekey=(k, False), capacity=0, weight=-w, flow=0)
 
     # Record the value simulating infinity.
     R.graph['inf'] = inf

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -466,7 +466,7 @@ def minimum_cut(flowG, _s, _t,
     # Then, reachable and non reachable nodes from source in the
     # residual network form the node partition that defines
     # the minimum cut.
-    non_reachable = set(dict(nx.shortest_path_length(R, target=t)))
+    non_reachable = set(dict(nx.shortest_path_length(R, target=_t)))
     partition = (set(flowG) - non_reachable, non_reachable)
     # Finaly add again cutset edges to the residual network to make
     # sure that it is reusable.

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -27,20 +27,21 @@ __all__ = ['maximum_flow',
            'minimum_cut_value']
 
 
-def maximum_flow(G, s, t, capacity='capacity', flow_func=None, **kwargs):
+def maximum_flow(flowG, _s, _t,
+                 capacity='capacity', flow_func=None, **kwargs):
     """Find a maximum single-commodity flow.
 
     Parameters
     ----------
-    G : NetworkX graph
+    flowG : NetworkX graph
         Edges of the graph are expected to have an attribute called
         'capacity'. If this attribute is not present, the edge is
         considered to have infinite capacity.
 
-    s : node
+    _s : node
         Source node for the flow.
 
-    t : node
+    _t : node
         Sink node for the flow.
 
     capacity : string
@@ -165,26 +166,27 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    R = flow_func(G, s, t, capacity=capacity, value_only=False, **kwargs)
-    flow_dict = build_flow_dict(G, R)
+    R = flow_func(flowG, _s, _t, capacity=capacity, value_only=False, **kwargs)
+    flow_dict = build_flow_dict(flowG, R)
 
     return (R.graph['flow_value'], flow_dict)
 
 
-def maximum_flow_value(G, s, t, capacity='capacity', flow_func=None, **kwargs):
+def maximum_flow_value(flowG, _s, _t,
+                       capacity='capacity', flow_func=None, **kwargs):
     """Find the value of maximum single-commodity flow.
 
     Parameters
     ----------
-    G : NetworkX graph
+    flowG : NetworkX graph
         Edges of the graph are expected to have an attribute called
         'capacity'. If this attribute is not present, the edge is
         considered to have infinite capacity.
 
-    s : node
+    _s : node
         Source node for the flow.
 
-    t : node
+    _t : node
         Sink node for the flow.
 
     capacity : string
@@ -303,12 +305,13 @@ def maximum_flow_value(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)
+    R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
 
     return R.graph['flow_value']
 
 
-def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
+def minimum_cut(flowG, _s, _t,
+                capacity='capacity', flow_func=None, **kwargs):
     """Compute the value and the node partition of a minimum (s, t)-cut.
 
     Use the max-flow min-cut theorem, i.e., the capacity of a minimum
@@ -316,15 +319,15 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
 
     Parameters
     ----------
-    G : NetworkX graph
+    flowG : NetworkX graph
         Edges of the graph are expected to have an attribute called
         'capacity'. If this attribute is not present, the edge is
         considered to have infinite capacity.
 
-    s : node
+    _s : node
         Source node for the flow.
 
-    t : node
+    _t : node
         Sink node for the flow.
 
     capacity : string
@@ -454,7 +457,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     if kwargs.get('cutoff') is not None and flow_func in flow_funcs:
         raise nx.NetworkXError("cutoff should not be specified.")
 
-    R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)
+    R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
     # Remove saturated edges from the residual network 
     cutset = [(u, v, d) for u, v, d in R.edges(data=True)
               if d['flow'] == d['capacity']]
@@ -464,7 +467,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     # residual network form the node partition that defines
     # the minimum cut.
     non_reachable = set(dict(nx.shortest_path_length(R, target=t)))
-    partition = (set(G) - non_reachable, non_reachable)
+    partition = (set(flowG) - non_reachable, non_reachable)
     # Finaly add again cutset edges to the residual network to make
     # sure that it is reusable.
     if cutset is not None:
@@ -472,7 +475,8 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     return (R.graph['flow_value'], partition)
 
 
-def minimum_cut_value(G, s, t, capacity='capacity', flow_func=None, **kwargs):
+def minimum_cut_value(flowG, _s, _t,
+                      capacity='capacity', flow_func=None, **kwargs):
     """Compute the value of a minimum (s, t)-cut.
 
     Use the max-flow min-cut theorem, i.e., the capacity of a minimum
@@ -480,15 +484,15 @@ def minimum_cut_value(G, s, t, capacity='capacity', flow_func=None, **kwargs):
 
     Parameters
     ----------
-    G : NetworkX graph
+    flowG : NetworkX graph
         Edges of the graph are expected to have an attribute called
         'capacity'. If this attribute is not present, the edge is
         considered to have infinite capacity.
 
-    s : node
+    _s : node
         Source node for the flow.
 
-    t : node
+    _t : node
         Sink node for the flow.
 
     capacity : string
@@ -604,6 +608,6 @@ def minimum_cut_value(G, s, t, capacity='capacity', flow_func=None, **kwargs):
     if kwargs.get('cutoff') is not None and flow_func in flow_funcs:
         raise nx.NetworkXError("cutoff should not be specified.")
 
-    R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)
+    R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
 
     return R.graph['flow_value']

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -70,12 +70,12 @@ def test_intersection_all_attributes():
 
 def test_intersection_all_multigraph_attributes():
     g = nx.MultiGraph()
-    g.add_edge(0, 1, key=0)
-    g.add_edge(0, 1, key=1)
-    g.add_edge(0, 1, key=2)
+    g.add_edge(0, 1, ekey=0)
+    g.add_edge(0, 1, ekey=1)
+    g.add_edge(0, 1, ekey=2)
     h = nx.MultiGraph()
-    h.add_edge(0, 1, key=0)
-    h.add_edge(0, 1, key=3)
+    h.add_edge(0, 1, ekey=0)
+    h.add_edge(0, 1, ekey=3)
     gh = nx.intersection_all([g, h])
     assert_equal( set(gh.nodes()) , set(g.nodes()) )
     assert_equal( set(gh.nodes()) , set(h.nodes()) )
@@ -145,11 +145,11 @@ def test_union_all_and_compose_all():
 
 def test_union_all_multigraph():
     G=nx.MultiGraph()
-    G.add_edge(1,2,key=0)
-    G.add_edge(1,2,key=1)
+    G.add_edge(1, 2, ekey=0)
+    G.add_edge(1, 2, ekey=1)
     H=nx.MultiGraph()
-    H.add_edge(3,4,key=0)
-    H.add_edge(3,4,key=1)
+    H.add_edge(3, 4, ekey=0)
+    H.add_edge(3, 4, ekey=1)
     GH=nx.union_all([G,H])
     assert_equal( set(GH) , set(G)|set(H))
     assert_equal( set(GH.edges(keys=True)) ,

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -3,6 +3,7 @@ import networkx as nx
 from networkx import *
 from networkx.testing import *
 
+
 def test_union_attributes():
     g = nx.Graph()
     g.add_node(0, x=4)
@@ -16,26 +17,27 @@ def test_union_attributes():
     h.node[0]['x'] = 7
 
     gh = nx.union(g, h, rename=('g', 'h'))
-    assert_equal( set(gh.nodes()) , set(['h0', 'h1', 'g0', 'g1']) )
+    assert_equal(set(gh.nodes()), set(['h0', 'h1', 'g0', 'g1']))
     for n in gh:
         graph, node = n
-        assert_equal( gh.node[n], eval(graph).node[int(node)] )
+        assert_equal(gh.node[n], eval(graph).node[int(node)])
 
-    assert_equal(gh.graph['attr'],'attr')
-    assert_equal(gh.graph['name'],'h') # h graph attributes take precendent
+    assert_equal(gh.graph['attr'], 'attr')
+    assert_equal(gh.graph['name'], 'h')  # h graph attributes take precendent
+
 
 def test_intersection():
-    G=nx.Graph()
-    H=nx.Graph()
-    G.add_nodes_from([1,2,3,4])
-    G.add_edge(1,2)
-    G.add_edge(2,3)
-    H.add_nodes_from([1,2,3,4])
-    H.add_edge(2,3)
-    H.add_edge(3,4)
-    I=nx.intersection(G,H)
-    assert_equal( set(I.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(I.edges()) , [(2,3)] )    
+    G = nx.Graph()
+    H = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4])
+    G.add_edge(1, 2)
+    G.add_edge(2, 3)
+    H.add_nodes_from([1, 2, 3, 4])
+    H.add_edge(2, 3)
+    H.add_edge(3, 4)
+    I = nx.intersection(G, H)
+    assert_equal(set(I.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(I.edges()), [(2, 3)])
 
 
 def test_intersection_attributes():
@@ -51,68 +53,67 @@ def test_intersection_attributes():
     h.node[0]['x'] = 7
 
     gh = nx.intersection(g, h)
-    assert_equal( set(gh.nodes()) , set(g.nodes()) )
-    assert_equal( set(gh.nodes()) , set(h.nodes()) )
-    assert_equal( sorted(gh.edges()) , sorted(g.edges()) )
+    assert_equal(set(gh.nodes()), set(g.nodes()))
+    assert_equal(set(gh.nodes()), set(h.nodes()))
+    assert_equal(sorted(gh.edges()), sorted(g.edges()))
 
     h.remove_node(0)
     assert_raises(nx.NetworkXError, nx.intersection, g, h)
 
 
-
 def test_intersection_multigraph_attributes():
     g = nx.MultiGraph()
-    g.add_edge(0, 1, key=0)
-    g.add_edge(0, 1, key=1)
-    g.add_edge(0, 1, key=2)
+    g.add_edge(0, 1, ekey=0)
+    g.add_edge(0, 1, ekey=1)
+    g.add_edge(0, 1, ekey=2)
     h = nx.MultiGraph()
-    h.add_edge(0, 1, key=0)
-    h.add_edge(0, 1, key=3)
+    h.add_edge(0, 1, ekey=0)
+    h.add_edge(0, 1, ekey=3)
     gh = nx.intersection(g, h)
-    assert_equal( set(gh.nodes()) , set(g.nodes()) )
-    assert_equal( set(gh.nodes()) , set(h.nodes()) )
-    assert_equal( sorted(gh.edges()) , [(0,1)] )
-    assert_equal( sorted(gh.edges(keys=True)) , [(0,1,0)] )
+    assert_equal(set(gh.nodes()), set(g.nodes()))
+    assert_equal(set(gh.nodes()), set(h.nodes()))
+    assert_equal(sorted(gh.edges()), [(0, 1)])
+    assert_equal(sorted(gh.edges(keys=True)), [(0, 1, 0)])
 
 
 def test_difference():
-    G=nx.Graph()
-    H=nx.Graph()
-    G.add_nodes_from([1,2,3,4])
-    G.add_edge(1,2)
-    G.add_edge(2,3)
-    H.add_nodes_from([1,2,3,4])
-    H.add_edge(2,3)
-    H.add_edge(3,4)
-    D=nx.difference(G,H)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(1,2)] )    
-    D=nx.difference(H,G)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(3,4)] )    
-    D=nx.symmetric_difference(G,H)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(1,2),(3,4)] )    
+    G = nx.Graph()
+    H = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4])
+    G.add_edge(1, 2)
+    G.add_edge(2, 3)
+    H.add_nodes_from([1, 2, 3, 4])
+    H.add_edge(2, 3)
+    H.add_edge(3, 4)
+    D = nx.difference(G, H)
+    assert_equal(set(D.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(D.edges()), [(1, 2)])
+    D = nx.difference(H, G)
+    assert_equal(set(D.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(D.edges()), [(3, 4)])
+    D = nx.symmetric_difference(G, H)
+    assert_equal(set(D.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(D.edges()), [(1, 2), (3, 4)])
 
 
 def test_difference2():
-    G=nx.Graph()
-    H=nx.Graph()
-    G.add_nodes_from([1,2,3,4])
-    H.add_nodes_from([1,2,3,4])
-    G.add_edge(1,2)
-    H.add_edge(1,2)
-    G.add_edge(2,3)
-    D=nx.difference(G,H)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(2,3)] )    
-    D=nx.difference(H,G)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [] )    
-    H.add_edge(3,4)
-    D=nx.difference(H,G)
-    assert_equal( set(D.nodes()) , set([1,2,3,4]) )    
-    assert_equal( sorted(D.edges()) , [(3,4)] )    
+    G = nx.Graph()
+    H = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4])
+    H.add_nodes_from([1, 2, 3, 4])
+    G.add_edge(1, 2)
+    H.add_edge(1, 2)
+    G.add_edge(2, 3)
+    D = nx.difference(G, H)
+    assert_equal(set(D.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(D.edges()), [(2, 3)])
+    D = nx.difference(H, G)
+    assert_equal(set(D.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(D.edges()), [])
+    H.add_edge(3, 4)
+    D = nx.difference(H, G)
+    assert_equal(set(D.nodes()), set([1, 2, 3, 4]))
+    assert_equal(sorted(D.edges()), [(3, 4)])
 
 
 def test_difference_attributes():
@@ -128,26 +129,27 @@ def test_difference_attributes():
     h.node[0]['x'] = 7
 
     gh = nx.difference(g, h)
-    assert_equal( set(gh.nodes()) , set(g.nodes()) )
-    assert_equal( set(gh.nodes()) , set(h.nodes()) )
-    assert_equal( sorted(gh.edges()) , [])
+    assert_equal(set(gh.nodes()), set(g.nodes()))
+    assert_equal(set(gh.nodes()), set(h.nodes()))
+    assert_equal(sorted(gh.edges()), [])
 
     h.remove_node(0)
     assert_raises(nx.NetworkXError, nx.intersection, g, h)
 
+
 def test_difference_multigraph_attributes():
     g = nx.MultiGraph()
-    g.add_edge(0, 1, key=0)
-    g.add_edge(0, 1, key=1)
-    g.add_edge(0, 1, key=2)
+    g.add_edge(0, 1, ekey=0)
+    g.add_edge(0, 1, ekey=1)
+    g.add_edge(0, 1, ekey=2)
     h = nx.MultiGraph()
-    h.add_edge(0, 1, key=0)
-    h.add_edge(0, 1, key=3)
+    h.add_edge(0, 1, ekey=0)
+    h.add_edge(0, 1, ekey=3)
     gh = nx.difference(g, h)
-    assert_equal( set(gh.nodes()) , set(g.nodes()) )
-    assert_equal( set(gh.nodes()) , set(h.nodes()) )
-    assert_equal( sorted(gh.edges()) , [(0,1),(0,1)] )
-    assert_equal( sorted(gh.edges(keys=True)) , [(0,1,1),(0,1,2)] )
+    assert_equal(set(gh.nodes()), set(g.nodes()))
+    assert_equal(set(gh.nodes()), set(h.nodes()))
+    assert_equal(sorted(gh.edges()), [(0, 1), (0, 1)])
+    assert_equal(sorted(gh.edges(keys=True)), [(0, 1, 1), (0, 1, 2)])
 
 
 @raises(nx.NetworkXError)
@@ -156,20 +158,22 @@ def test_difference_raise():
     H = nx.path_graph(3)
     GH = nx.difference(G, H)
 
+
 def test_symmetric_difference_multigraph():
     g = nx.MultiGraph()
-    g.add_edge(0, 1, key=0)
-    g.add_edge(0, 1, key=1)
-    g.add_edge(0, 1, key=2)
+    g.add_edge(0, 1, ekey=0)
+    g.add_edge(0, 1, ekey=1)
+    g.add_edge(0, 1, ekey=2)
     h = nx.MultiGraph()
-    h.add_edge(0, 1, key=0)
-    h.add_edge(0, 1, key=3)
+    h.add_edge(0, 1, ekey=0)
+    h.add_edge(0, 1, ekey=3)
     gh = nx.symmetric_difference(g, h)
-    assert_equal( set(gh.nodes()) , set(g.nodes()) )
-    assert_equal( set(gh.nodes()) , set(h.nodes()) )
-    assert_equal( sorted(gh.edges()) , 3*[(0,1)] )
-    assert_equal( sorted(sorted(e) for e in gh.edges(keys=True)), 
-                  [[0,1,1],[0,1,2],[0,1,3]] )
+    assert_equal(set(gh.nodes()), set(g.nodes()))
+    assert_equal(set(gh.nodes()), set(h.nodes()))
+    assert_equal(sorted(gh.edges()), 3 * [(0, 1)])
+    assert_equal(sorted(sorted(e) for e in gh.edges(keys=True)),
+                 [[0, 1, 1], [0, 1, 2], [0, 1, 3]])
+
 
 @raises(nx.NetworkXError)
 def test_symmetric_difference_raise():
@@ -177,54 +181,55 @@ def test_symmetric_difference_raise():
     H = nx.path_graph(3)
     GH = nx.symmetric_difference(G, H)
 
+
 def test_union_and_compose():
-    K3=complete_graph(3)
-    P3=path_graph(3)
+    K3 = complete_graph(3)
+    P3 = path_graph(3)
 
-    G1=nx.DiGraph()
-    G1.add_edge('A','B')
-    G1.add_edge('A','C')
-    G1.add_edge('A','D')
-    G2=nx.DiGraph()
-    G2.add_edge('1','2')
-    G2.add_edge('1','3')
-    G2.add_edge('1','4')
+    G1 = nx.DiGraph()
+    G1.add_edge('A', 'B')
+    G1.add_edge('A', 'C')
+    G1.add_edge('A', 'D')
+    G2 = nx.DiGraph()
+    G2.add_edge('1', '2')
+    G2.add_edge('1', '3')
+    G2.add_edge('1', '4')
 
-    G=union(G1,G2)
-    H=compose(G1,G2)
-    assert_edges_equal(G.edges(),H.edges())
-    assert_false(G.has_edge('A',1))
+    G = union(G1, G2)
+    H = compose(G1, G2)
+    assert_edges_equal(G.edges(), H.edges())
+    assert_false(G.has_edge('A', 1))
     assert_raises(nx.NetworkXError, nx.union, K3, P3)
-    H1=union(H,G1,rename=('H','G1'))
+    H1 = union(H, G1, rename=('H', 'G1'))
     assert_equal(sorted(H1.nodes()),
-                 ['G1A', 'G1B', 'G1C', 'G1D', 
+                 ['G1A', 'G1B', 'G1C', 'G1D',
                   'H1', 'H2', 'H3', 'H4', 'HA', 'HB', 'HC', 'HD'])
 
-    H2=union(H,G2,rename=("H",""))
+    H2 = union(H, G2, rename=("H", ""))
     assert_equal(sorted(H2.nodes()),
-                 ['1', '2', '3', '4', 
+                 ['1', '2', '3', '4',
                   'H1', 'H2', 'H3', 'H4', 'HA', 'HB', 'HC', 'HD'])
 
-    assert_false(H1.has_edge('NB','NA'))
+    assert_false(H1.has_edge('NB', 'NA'))
 
-    G=compose(G,G)
-    assert_edges_equal(G.edges(),H.edges())
+    G = compose(G, G)
+    assert_edges_equal(G.edges(), H.edges())
 
-    G2=union(G2,G2,rename=('','copy'))
+    G2 = union(G2, G2, rename=('', 'copy'))
     assert_equal(sorted(G2.nodes()),
                  ['1', '2', '3', '4', 'copy1', 'copy2', 'copy3', 'copy4'])
 
-    assert_equal(sorted(G2.neighbors('copy4')),[])
-    assert_equal(sorted(G2.neighbors('copy1')),['copy2', 'copy3', 'copy4'])
-    assert_equal(len(G),8)
-    assert_equal(number_of_edges(G),6)
+    assert_equal(sorted(G2.neighbors('copy4')), [])
+    assert_equal(sorted(G2.neighbors('copy1')), ['copy2', 'copy3', 'copy4'])
+    assert_equal(len(G), 8)
+    assert_equal(number_of_edges(G), 6)
 
-    E=disjoint_union(G,G)
-    assert_equal(len(E),16)
-    assert_equal(number_of_edges(E),12)
+    E = disjoint_union(G, G)
+    assert_equal(len(E), 16)
+    assert_equal(number_of_edges(E), 12)
 
-    E=disjoint_union(G1,G2)
-    assert_equal(sorted(E.nodes()),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    E = disjoint_union(G1, G2)
+    assert_equal(sorted(E.nodes()), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
 
     G = nx.Graph()
     H = nx.Graph()
@@ -235,81 +240,86 @@ def test_union_and_compose():
 
 
 def test_union_multigraph():
-    G=nx.MultiGraph()
-    G.add_edge(1,2,key=0)
-    G.add_edge(1,2,key=1)
-    H=nx.MultiGraph()
-    H.add_edge(3,4,key=0)
-    H.add_edge(3,4,key=1)
-    GH=nx.union(G,H)
-    assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
-                  set(G.edges(keys=True))|set(H.edges(keys=True)))
+    G = nx.MultiGraph()
+    G.add_edge(1, 2, ekey=0)
+    G.add_edge(1, 2, ekey=1)
+    H = nx.MultiGraph()
+    H.add_edge(3, 4, ekey=0)
+    H.add_edge(3, 4, ekey=1)
+    GH = nx.union(G, H)
+    assert_equal(set(GH), set(G) | set(H))
+    assert_equal(set(GH.edges(keys=True)),
+                 set(G.edges(keys=True)) | set(H.edges(keys=True)))
+
 
 def test_disjoint_union_multigraph():
-    G=nx.MultiGraph()
-    G.add_edge(0,1,key=0)
-    G.add_edge(0,1,key=1)
-    H=nx.MultiGraph()
-    H.add_edge(2,3,key=0)
-    H.add_edge(2,3,key=1)
-    GH=nx.disjoint_union(G,H)
-    assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
-                  set(G.edges(keys=True))|set(H.edges(keys=True)))
+    G = nx.MultiGraph()
+    G.add_edge(0, 1, ekey=0)
+    G.add_edge(0, 1, ekey=1)
+    H = nx.MultiGraph()
+    H.add_edge(2, 3, ekey=0)
+    H.add_edge(2, 3, ekey=1)
+    GH = nx.disjoint_union(G, H)
+    assert_equal(set(GH), set(G) | set(H))
+    assert_equal(set(GH.edges(keys=True)),
+                 set(G.edges(keys=True)) | set(H.edges(keys=True)))
 
 
 def test_compose_multigraph():
-    G=nx.MultiGraph()
-    G.add_edge(1,2,key=0)
-    G.add_edge(1,2,key=1)
-    H=nx.MultiGraph()
-    H.add_edge(3,4,key=0)
-    H.add_edge(3,4,key=1)
-    GH=nx.compose(G,H)
-    assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
-                  set(G.edges(keys=True))|set(H.edges(keys=True)))
-    H.add_edge(1,2,key=2)
-    GH=nx.compose(G,H)
-    assert_equal( set(GH) , set(G)|set(H))
-    assert_equal( set(GH.edges(keys=True)) , 
-                  set(G.edges(keys=True))|set(H.edges(keys=True)))    
+    G = nx.MultiGraph()
+    G.add_edge(1, 2, ekey=0)
+    G.add_edge(1, 2, ekey=1)
+    H = nx.MultiGraph()
+    H.add_edge(3, 4, ekey=0)
+    H.add_edge(3, 4, ekey=1)
+    GH = nx.compose(G, H)
+    assert_equal(set(GH), set(G) | set(H))
+    assert_equal(set(GH.edges(keys=True)),
+                 set(G.edges(keys=True)) | set(H.edges(keys=True)))
+    H.add_edge(1, 2, ekey=2)
+    GH = nx.compose(G, H)
+    assert_equal(set(GH), set(G) | set(H))
+    assert_equal(set(GH.edges(keys=True)),
+                 set(G.edges(keys=True)) | set(H.edges(keys=True)))
 
 
 @raises(nx.NetworkXError)
 def test_mixed_type_union():
     G = nx.Graph()
     H = nx.MultiGraph()
-    U = nx.union(G,H)
+    U = nx.union(G, H)
+
 
 @raises(nx.NetworkXError)
 def test_mixed_type_disjoint_union():
     G = nx.Graph()
     H = nx.MultiGraph()
-    U = nx.disjoint_union(G,H)
+    U = nx.disjoint_union(G, H)
+
 
 @raises(nx.NetworkXError)
 def test_mixed_type_intersection():
     G = nx.Graph()
     H = nx.MultiGraph()
-    U = nx.intersection(G,H)
+    U = nx.intersection(G, H)
+
 
 @raises(nx.NetworkXError)
 def test_mixed_type_difference():
     G = nx.Graph()
     H = nx.MultiGraph()
-    U = nx.difference(G,H)
+    U = nx.difference(G, H)
 
 
 @raises(nx.NetworkXError)
 def test_mixed_type_symmetric_difference():
     G = nx.Graph()
     H = nx.MultiGraph()
-    U = nx.symmetric_difference(G,H)
+    U = nx.symmetric_difference(G, H)
+
 
 @raises(nx.NetworkXError)
 def test_mixed_type_compose():
     G = nx.Graph()
     H = nx.MultiGraph()
-    U = nx.compose(G,H)
+    U = nx.compose(G, H)

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -99,11 +99,11 @@ def test_tensor_product_random():
 
 def test_cartesian_product_multigraph():
     G = nx.MultiGraph()
-    G.add_edge(1, 2, key=0)
-    G.add_edge(1, 2, key=1)
+    G.add_edge(1, 2, ekey=0)
+    G.add_edge(1, 2, ekey=1)
     H = nx.MultiGraph()
-    H.add_edge(3, 4, key=0)
-    H.add_edge(3, 4, key=1)
+    H.add_edge(3, 4, ekey=0)
+    H.add_edge(3, 4, ekey=1)
     GH = cartesian_product(G, H)
     assert_equal(set(GH), {(1, 3), (2, 3), (2, 4), (1, 4)})
     assert_equal({(frozenset([u, v]), k) for u, v, k in GH.edges(keys=True)},

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -193,8 +193,8 @@ class TestWeightedPath(WeightedTestBase):
 
     def test_dijkstra_pred_distance_multigraph(self):
         G = nx.MultiGraph()
-        G.add_edge('a', 'b', key='short', foo=5, weight=100)
-        G.add_edge('a', 'b', key='long', bar=1, weight=110)
+        G.add_edge('a', 'b', ekey='short', foo=5, weight=100)
+        G.add_edge('a', 'b', ekey='long', bar=1, weight=110)
         p, d = nx.dijkstra_predecessor_and_distance(G, 'a')
         assert_equal(p, {'a': [], 'b': ['a']})
         assert_equal(d, {'a': 0, 'b': 100})

--- a/networkx/algorithms/traversal/edgedfs.py
+++ b/networkx/algorithms/traversal/edgedfs.py
@@ -24,14 +24,14 @@ def helper_funcs(G, orientation):
     if ignore_orientation:
         # When we ignore the orientation, we still need to know how the edge
         # was traversed, so we add an object representing the direction.
-        def out_edges(u, **kwds):
-            for edge in G.out_edges(u, **kwds):
+        def out_edges(u_for_edges, **kwds):
+            for edge in G.out_edges(u_for_edges, **kwds):
                 yield edge + (FORWARD,)
-            for edge in G.in_edges(u, **kwds):
+            for edge in G.in_edges(u_for_edges, **kwds):
                 yield edge + (REVERSE,)
     elif reverse_orientation:
-        def out_edges(u, **kwds):
-            for edge in G.in_edges(u, **kwds):
+        def out_edges(u_for_edges, **kwds):
+            for edge in G.in_edges(u_for_edges, **kwds):
                 yield edge + (REVERSE,)
     else:
         # If "yield from" were an option, we could pass kwds automatically.

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -165,9 +165,9 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
     of edges. We must reliably track edges across graph mutations.
 
     """
-    def __init__(self, data=None, **attr):
+    def __init__(self, incoming_graph_data=None, **attr):
         cls = super(MultiDiGraph_EdgeKey, self)
-        cls.__init__(data=data, **attr)
+        cls.__init__(incoming_graph_data=incoming_graph_data, **attr)
 
         self._cls = cls
         self.edge_index = {}
@@ -188,20 +188,21 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
         for n in nbunch:
             self.remove_node(n)
 
-    def add_edge(self, u, v, key, **attr):
+    def add_edge(self, u_for_edge, v_for_edge, key_for_edge, **attr):
         """
         Key is now required.
 
         """
+        u, v, key = u_for_edge, v_for_edge, key_for_edge
         if key in self.edge_index:
             uu, vv, _ = self.edge_index[key]
             if (u != uu) or (v != vv):
                 raise Exception("Key {0!r} is already in use.".format(key))
 
-        self._cls.add_edge(u, v, key=key, **attr)
+        self._cls.add_edge(u, v, key, **attr)
         self.edge_index[key] = (u, v, self.succ[u][v][key])
 
-    def add_edges_from(self, ebunch, **attr):
+    def add_edges_from(self, ebunch_to_add, **attr):
         raise NotImplementedError
 
     def remove_edge_with_key(self, key):
@@ -428,7 +429,7 @@ class Edmonds(object):
                 #print("Edge is acceptable: {0}".format(acceptable))
                 if acceptable:
                     dd = {attr: weight}
-                    B.add_edge(u, v, key=edge[2], **dd)
+                    B.add_edge(u, v, edge[2], **dd)
                     G[u][v][edge[2]]['candidate'] = True
                     uf.union(u, v)
                     if Q_edges is not None:

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -160,8 +160,8 @@ class MultigraphMSTTestBase(MinimumSpanningTreeTestBase):
 
         """
         G = nx.MultiGraph()
-        G.add_edge(0, 1, key='a', weight=2)
-        G.add_edge(0, 1, key='b', weight=1)
+        G.add_edge(0, 1, ekey='a', weight=2)
+        G.add_edge(0, 1, ekey='b', weight=1)
         min_edges = nx.minimum_spanning_edges
         mst_edges = min_edges(G, algorithm=self.algo, data=False)
         assert_edges_equal([(0, 1, 'b')], list(mst_edges))
@@ -172,8 +172,8 @@ class MultigraphMSTTestBase(MinimumSpanningTreeTestBase):
 
         """
         G = nx.MultiGraph()
-        G.add_edge(0, 1, key='a', weight=2)
-        G.add_edge(0, 1, key='b', weight=1)
+        G.add_edge(0, 1, ekey='a', weight=2)
+        G.add_edge(0, 1, ekey='b', weight=1)
         max_edges = nx.maximum_spanning_edges
         mst_edges = max_edges(G, algorithm=self.algo, data=False)
         assert_edges_equal([(0, 1, 'a')], list(mst_edges))
@@ -196,14 +196,14 @@ class TestPrim(MultigraphMSTTestBase, TestCase):
 
     def test_multigraph_keys_tree(self):
         G = nx.MultiGraph()
-        G.add_edge(0, 1, key='a', weight=2)
-        G.add_edge(0, 1, key='b', weight=1)
+        G.add_edge(0, 1, ekey='a', weight=2)
+        G.add_edge(0, 1, ekey='b', weight=1)
         T = nx.minimum_spanning_tree(G)
         assert_edges_equal([(0, 1, 1)], list(T.edges(data='weight')))
 
     def test_multigraph_keys_tree_max(self):
         G = nx.MultiGraph()
-        G.add_edge(0, 1, key='a', weight=2)
-        G.add_edge(0, 1, key='b', weight=1)
+        G.add_edge(0, 1, ekey='a', weight=2)
+        G.add_edge(0, 1, ekey='b', weight=1)
         T = nx.maximum_spanning_tree(G)
         assert_edges_equal([(0, 1, 2)], list(T.edges(data='weight')))

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -36,8 +36,8 @@ class DiGraph(Graph):
 
     Parameters
     ----------
-    data : input graph
-        Data to initialize graph. If data=None (default) an empty
+    incoming_graph_data : input graph (optional, default: None)
+        Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
         dict of dicts, dict of lists, NetworkX graph, NumPy matrix
@@ -239,8 +239,8 @@ class DiGraph(Graph):
 
         Parameters
         ----------
-        incoming_graph_data : input graph
-            Data to initialize graph.  If data=None (default) an empty
+        incoming_graph_data : input graph (optional, default: None)
+            Data to initialize graph.  If None (default) an empty
             graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
             packages are installed the data can also be a NumPy matrix

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -234,12 +234,12 @@ class DiGraph(Graph):
     creating graph subclasses by overwriting the base class `dict` with
     a dictionary-like object.
     """
-    def __init__(self, data=None, **attr):
+    def __init__(self, incoming_graph_data=None, **attr):
         """Initialize a graph with edges, name, graph attributes.
 
         Parameters
         ----------
-        data : input graph
+        incoming_graph_data : input graph
             Data to initialize graph.  If data=None (default) an empty
             graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
@@ -283,8 +283,8 @@ class DiGraph(Graph):
         self._succ = self._adj  # successor
 
         # attempt to load graph with data
-        if data is not None:
-            convert.to_networkx_graph(data, create_using=self)
+        if incoming_graph_data is not None:
+            convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 
@@ -304,12 +304,12 @@ class DiGraph(Graph):
     def pred(self):
         return AtlasView2(self._pred)
 
-    def add_node(self, n, **attr):
-        """Add a single node n and update node attributes.
+    def add_node(self, node_for_adding, **attr):
+        """Add a single node `node_for_adding` and update node attributes.
 
         Parameters
         ----------
-        n : node
+        node_for_adding : node
             A node can be any hashable Python object except None.
         attr : keyword arguments, optional
             Set or change node attributes using key=value.
@@ -343,19 +343,19 @@ class DiGraph(Graph):
         NetworkX Graphs, though one should be careful that the hash
         doesn't change on mutables.
         """
-        if n not in self._succ:
-            self._succ[n] = self.adjlist_inner_dict_factory()
-            self._pred[n] = self.adjlist_inner_dict_factory()
-            self._node[n] = attr
+        if node_for_adding not in self._succ:
+            self._succ[node_for_adding] = self.adjlist_inner_dict_factory()
+            self._pred[node_for_adding] = self.adjlist_inner_dict_factory()
+            self._node[node_for_adding] = attr
         else:  # update attr even if node already exists
-            self._node[n].update(attr)
+            self._node[node_for_adding].update(attr)
 
-    def add_nodes_from(self, nodes, **attr):
+    def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
 
         Parameters
         ----------
-        nodes : iterable container
+        nodes_for_adding : iterable container
             A container of nodes (list, dict, set, etc.).
             OR
             A container of (node, attribute dict) tuples.
@@ -395,7 +395,7 @@ class DiGraph(Graph):
         11
 
         """
-        for n in nodes:
+        for n in nodes_for_adding:
             # keep all this inside try/except because
             # CPython throws TypeError on n not in self._succ,
             # while pre-2.7.5 ironpython throws on self._succ[n]
@@ -499,7 +499,7 @@ class DiGraph(Graph):
             except KeyError:
                 pass  # silent failure on remove
 
-    def add_edge(self, u, v, **attr):
+    def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -550,6 +550,7 @@ class DiGraph(Graph):
         >>> G.add_edge(1, 2)
         >>> G[1][2].update({0: 5})
         """
+        u, v = u_of_edge, v_of_edge
         # add nodes
         if u not in self._succ:
             self._succ[u] = self.adjlist_inner_dict_factory()
@@ -565,12 +566,12 @@ class DiGraph(Graph):
         self._succ[u][v] = datadict
         self._pred[v][u] = datadict
 
-    def add_edges_from(self, ebunch, **attr):
-        """Add all the edges in ebunch.
+    def add_edges_from(self, ebunch_to_add, **attr):
+        """Add all the edges in ebunch_to_add.
 
         Parameters
         ----------
-        ebunch : container of edges
+        ebunch_to_add : container of edges
             Each edge given in the container will be added to the
             graph. The edges must be given as 2-tuples (u, v) or
             3-tuples (u, v, d) where d is a dictionary containing edge data.
@@ -603,8 +604,7 @@ class DiGraph(Graph):
         >>> G.add_edges_from([(1, 2), (2, 3)], weight=3)
         >>> G.add_edges_from([(3, 4), (1, 4)], label='WN2898')
         """
-        # process ebunch
-        for e in ebunch:
+        for e in ebunch_to_add:
             ne = len(e)
             if ne == 3:
                 u, v, dd = e

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -204,15 +204,15 @@ def is_frozen(G):
         return False
 
 
-def add_star(G, nodes, **attr):
-    """Add a star to Graph G.
+def add_star(G_to_add_to, nodes_for_star, **attr):
+    """Add a star to Graph G_to_add_to.
 
-    The first node in nodes is the middle of the star.
+    The first node in `nodes_for_star` is the middle of the star.
     It is connected to all other nodes.
 
     Parameters
     ----------
-    nodes : iterable container
+    nodes_for_star : iterable container
         A container of nodes.
     attr : keyword arguments, optional (default= no attributes)
         Attributes to add to every edge in star.
@@ -227,18 +227,18 @@ def add_star(G, nodes, **attr):
     >>> nx.add_star(G, [0, 1, 2, 3])
     >>> nx.add_star(G, [10, 11, 12], weight=2)
     """
-    nlist = iter(nodes)
+    nlist = iter(nodes_for_star)
     v = next(nlist)
     edges = ((v, n) for n in nlist)
-    G.add_edges_from(edges, **attr)
+    G_to_add_to.add_edges_from(edges, **attr)
 
 
-def add_path(G, nodes, **attr):
-    """Add a path to the Graph G.
+def add_path(G_to_add_to, nodes_for_path, **attr):
+    """Add a path to the Graph G_to_add_to.
 
     Parameters
     ----------
-    nodes : iterable container
+    nodes_for_path : iterable container
         A container of nodes.  A path will be constructed from
         the nodes (in order) and added to the graph.
     attr : keyword arguments, optional (default= no attributes)
@@ -254,15 +254,15 @@ def add_path(G, nodes, **attr):
     >>> nx.add_path(G, [0, 1, 2, 3])
     >>> nx.add_path(G, [10, 11, 12], weight=7)
     """
-    G.add_edges_from(pairwise(nodes), **attr)
+    G_to_add_to.add_edges_from(pairwise(nodes_for_path), **attr)
 
 
-def add_cycle(G, nodes, **attr):
-    """Add a cycle to the Graph G.
+def add_cycle(G_to_add_to, nodes_for_cycle, **attr):
+    """Add a cycle to the Graph G_to_add_to.
 
     Parameters
     ----------
-    nodes: iterable container
+    nodes_for_cycle: iterable container
         A container of nodes.  A cycle will be constructed from
         the nodes (in order) and added to the graph.
     attr : keyword arguments, optional (default= no attributes)
@@ -278,7 +278,7 @@ def add_cycle(G, nodes, **attr):
     >>> nx.add_cycle(G, [0, 1, 2, 3])
     >>> nx.add_cycle(G, [10, 11, 12], weight=7)
     """
-    G.add_edges_from(pairwise(nodes, cyclic=True), **attr)
+    G_to_add_to.add_edges_from(pairwise(nodes_for_cycle, cyclic=True), **attr)
 
 
 def subgraph(G, nbunch):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -491,8 +491,8 @@ def set_edge_attributes(G, values, name=None):
 
         If `values` is a dict or a dict of dict, the corresponding edge'
         attributes will be updated to `values`.  For multigraphs, the tuples
-        must be of the form ``(u, v, key)``, where `u` and `v` are nodes
-        and `key` is the key corresponding to the edge.  For non-multigraphs,
+        must be of the form ``(u, v, ekey)``, where `u` and `v` are nodes
+        and `ekey` is the key corresponding to the edge.  For non-multigraphs,
         the keys must be tuples of the form ``(u, v)``.
 
     name : string (optional, default=None)
@@ -541,9 +541,9 @@ def set_edge_attributes(G, values, name=None):
         try:
             # if `values` is a dict using `.items()` => {edge: value}
             if G.is_multigraph():
-                for (u, v, key), value in values.items():
+                for (u, v, ekey), value in values.items():
                     try:
-                        G[u][v][key][name] = value
+                        G[u][v][ekey][name] = value
                     except KeyError:
                         pass
             else:
@@ -559,9 +559,9 @@ def set_edge_attributes(G, values, name=None):
     else:
         # `values` consists of doct-of-dict {edge: {attr: value}} shape
         if G.is_multigraph():
-            for (u, v, key), d in values.items():
+            for (u, v, ekey), d in values.items():
                 try:
-                    G[u][v][key].update(d)
+                    G[u][v][ekey].update(d)
                 except KeyError:
                     pass
         else:
@@ -586,7 +586,7 @@ def get_edge_attributes(G, name):
     -------
     Dictionary of attributes keyed by edge. For (di)graphs, the keys are
     2-tuples of the form: (u, v). For multi(di)graphs, the keys are 3-tuples of
-    the form: (u, v, key).
+    the form: (u, v, ekey).
 
     Examples
     --------

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -252,12 +252,12 @@ class Graph(object):
     adjlist_inner_dict_factory = dict
     edge_attr_dict_factory = dict
 
-    def __init__(self, data=None, **attr):
+    def __init__(self, incoming_graph_data=None, **attr):
         """Initialize a graph with edges, name, graph attributes.
 
         Parameters
         ----------
-        data : input graph
+        incoming_graph_data : input graph
             Data to initialize graph.  If data=None (default) an empty
             graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
@@ -295,8 +295,8 @@ class Graph(object):
         self._node = ndf()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
         # attempt to load graph with data
-        if data is not None:
-            convert.to_networkx_graph(data, create_using=self)
+        if incoming_graph_data is not None:
+            convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 
@@ -413,12 +413,12 @@ class Graph(object):
         """
         return self.adj[n]
 
-    def add_node(self, n, **attr):
-        """Add a single node n and update node attributes.
+    def add_node(self, node_for_adding, **attr):
+        """Add a single node `node_for_adding` and update node attributes.
 
         Parameters
         ----------
-        n : node
+        node_for_adding : node
             A node can be any hashable Python object except None.
         attr : keyword arguments, optional
             Set or change node attributes using key=value.
@@ -452,18 +452,18 @@ class Graph(object):
         NetworkX Graphs, though one should be careful that the hash
         doesn't change on mutables.
         """
-        if n not in self._node:
-            self._adj[n] = self.adjlist_inner_dict_factory()
-            self._node[n] = attr
+        if node_for_adding not in self._node:
+            self._adj[node_for_adding] = self.adjlist_inner_dict_factory()
+            self._node[node_for_adding] = attr
         else:  # update attr even if node already exists
-            self._node[n].update(attr)
+            self._node[node_for_adding].update(attr)
 
-    def add_nodes_from(self, nodes, **attr):
+    def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
 
         Parameters
         ----------
-        nodes : iterable container
+        nodes_for_adding : iterable container
             A container of nodes (list, dict, set, etc.).
             OR
             A container of (node, attribute dict) tuples.
@@ -503,7 +503,7 @@ class Graph(object):
         11
 
         """
-        for n in nodes:
+        for n in nodes_for_adding:
             # keep all this inside try/except because
             # CPython throws TypeError on n not in self._node,
             # while pre-2.7.5 ironpython throws on self._adj[n]
@@ -740,7 +740,7 @@ class Graph(object):
         except TypeError:
             return False
 
-    def add_edge(self, u, v, **attr):
+    def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -791,6 +791,7 @@ class Graph(object):
         >>> G.add_edge(1, 2)
         >>> G[1][2].update({0: 5})
         """
+        u, v = u_of_edge, v_of_edge
         # add nodes
         if u not in self._node:
             self._adj[u] = self.adjlist_inner_dict_factory()
@@ -804,12 +805,12 @@ class Graph(object):
         self._adj[u][v] = datadict
         self._adj[v][u] = datadict
 
-    def add_edges_from(self, ebunch, **attr):
-        """Add all the edges in ebunch.
+    def add_edges_from(self, ebunch_to_add, **attr):
+        """Add all the edges in ebunch_to_add.
 
         Parameters
         ----------
-        ebunch : container of edges
+        ebunch_to_add : container of edges
             Each edge given in the container will be added to the
             graph. The edges must be given as as 2-tuples (u, v) or
             3-tuples (u, v, d) where d is a dictionary containing edge data.
@@ -842,8 +843,7 @@ class Graph(object):
         >>> G.add_edges_from([(1, 2), (2, 3)], weight=3)
         >>> G.add_edges_from([(3, 4), (1, 4)], label='WN2898')
         """
-        # process ebunch
-        for e in ebunch:
+        for e in ebunch_to_add:
             ne = len(e)
             if ne == 3:
                 u, v, dd = e
@@ -865,13 +865,13 @@ class Graph(object):
             self._adj[u][v] = datadict
             self._adj[v][u] = datadict
 
-    def add_weighted_edges_from(self, ebunch, weight='weight', **attr):
+    def add_weighted_edges_from(self, ebunch_to_add, weight='weight', **attr):
         """Add all the edges in ebunch as weighted edges with specified
         weights.
 
         Parameters
         ----------
-        ebunch : container of edges
+        ebunch_to_add : container of edges
             Each edge given in the list or container will be added
             to the graph. The edges must be given as 3-tuples (u, v, w)
             where w is a number.
@@ -896,7 +896,7 @@ class Graph(object):
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
         >>> G.add_weighted_edges_from([(0, 1, 3.0), (1, 2, 7.5)])
         """
-        self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch),
+        self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch_to_add),
                             **attr)
 
     def remove_edge(self, u, v):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -46,8 +46,8 @@ class Graph(object):
 
     Parameters
     ----------
-    data : input graph
-        Data to initialize graph. If data=None (default) an empty
+    incoming_graph_data : input graph (optional, default: None)
+        Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
         dict of dicts, dict of lists, NetworkX graph, NumPy matrix
@@ -148,7 +148,7 @@ class Graph(object):
 
     Warning: assigning to `G.edge[u]` or `G.edge[u][v]` will almost certainly
     corrupt the graph data structure. Use 3 sets of brackets as shown above.
-    (4 for multigraphs: `MG.edge[u][v][key][name] = value`)
+    (4 for multigraphs: `MG.edge[u][v][ekey][name] = value`)
 
     **Shortcuts:**
 
@@ -258,7 +258,7 @@ class Graph(object):
         Parameters
         ----------
         incoming_graph_data : input graph
-            Data to initialize graph.  If data=None (default) an empty
+            Data to initialize graph.  If None (default) an empty
             graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
             packages are installed the data can also be a NumPy matrix

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -238,9 +238,9 @@ class MultiDiGraph(MultiGraph, DiGraph):
     edge_key_dict_factory = dict
     # edge_attr_dict_factory = dict
 
-    def __init__(self, data=None, **attr):
+    def __init__(self, incoming_graph_data=None, **attr):
         self.edge_key_dict_factory = self.edge_key_dict_factory
-        DiGraph.__init__(self, data, **attr)
+        DiGraph.__init__(self, incoming_graph_data, **attr)
 
     @property
     def edge(self):
@@ -258,7 +258,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
     def pred(self):
         return AtlasView3(self._pred)
 
-    def add_edge(self, u, v, key=None, **attr):
+    def add_edge(self, u_for_edge, v_for_edge, key_for_edge=None, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -324,6 +324,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         For non-string associations, directly access the edge's attribute
         dictionary.
         """
+        u, v, key = u_for_edge, v_for_edge, key_for_edge
         # add nodes
         if u not in self._succ:
             self._succ[u] = self.adjlist_inner_dict_factory()

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -37,8 +37,8 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
     Parameters
     ----------
-    data : input graph
-        Data to initialize graph. If data=None (default) an empty
+    incoming_graph_data : input graph (optional, default: None)
+        Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
         dict of dicts, dict of lists, NetworkX graph, NumPy matrix
@@ -89,22 +89,22 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
     Add one edge,
 
-    >>> key = G.add_edge(1, 2)
+    >>> ekey = G.add_edge(1, 2)
 
     a list of edges,
 
-    >>> keys = G.add_edges_from([(1, 2), (1, 3)])
+    >>> ekeys = G.add_edges_from([(1, 2), (1, 3)])
 
     or a collection of edges,
 
-    >>> keys = G.add_edges_from(H.edges())
+    >>> ekeys = G.add_edges_from(H.edges())
 
     If some edges connect nodes not yet in the graph, the nodes
     are added automatically.  If an edge already exists, an additional
-    edge is created and stored using a key to identify the edge.
-    By default the key is the lowest unused integer.
+    edge is created and stored using ekey to identify the edge.
+    By default the ekey is the lowest unused integer.
 
-    >>> keys = G.add_edges_from([(4,5,dict(route=282)), (4,5,dict(route=37))])
+    >>> ekeys = G.add_edges_from([(4,5,dict(route=282)), (4,5,dict(route=37))])
     >>> G[4]
     AtlasView2({5: {0: {}, 1: {'route': 282}, 2: {'route': 37}}})
 
@@ -136,9 +136,9 @@ class MultiDiGraph(MultiGraph, DiGraph):
     Add edge attributes using add_edge(), add_edges_from(), subscript
     notation, or G.edge.
 
-    >>> key = G.add_edge(1, 2, weight=4.7 )
-    >>> keys = G.add_edges_from([(3, 4), (4, 5)], color='red')
-    >>> keys = G.add_edges_from([(1,2,{'color':'blue'}), (2,3,{'weight':8})])
+    >>> ekey = G.add_edge(1, 2, weight=4.7 )
+    >>> ekeys = G.add_edges_from([(3, 4), (4, 5)], color='red')
+    >>> ekeys = G.add_edges_from([(1,2,{'color':'blue'}), (2,3,{'weight':8})])
     >>> G[1][2][0]['weight'] = 4.7
     >>> G.edge[1, 2, 0]['weight'] = 4
 
@@ -160,7 +160,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
     >>> for n, nbrsdict in G.adjacency():
     ...     for nbr, keydict in nbrsdict.items():
-    ...        for key, eattr in keydict.items():
+    ...        for ekey, eattr in keydict.items():
     ...            if 'weight' in eattr:
     ...                # Do something useful with the edges
     ...                pass
@@ -258,7 +258,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
     def pred(self):
         return AtlasView3(self._pred)
 
-    def add_edge(self, u_for_edge, v_for_edge, key_for_edge=None, **attr):
+    def add_edge(self, u_for_edge, v_for_edge, ekey=None, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -272,7 +272,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         u, v : nodes
             Nodes can be, for example, strings or numbers.
             Nodes must be hashable (and not None) Python objects.
-        key : hashable identifier, optional (default=lowest unused integer)
+        ekey : hashable identifier, optional (default=lowest unused integer)
             Used to distinguish multiedges between a pair of nodes.
         attr_dict : dictionary, optional (default= no attributes)
             Dictionary of edge attributes.  Key/value pairs will
@@ -283,7 +283,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         Returns
         -------
-        The edge key assigned to the edge.
+        The edge ekey assigned to the edge.
 
         See Also
         --------
@@ -291,7 +291,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         Notes
         -----
-        To replace/update edge data, use the optional key argument
+        To replace/update edge data, use the optional ekey argument
         to identify a unique edge.  Otherwise a new edge will be created.
 
         NetworkX algorithms designed for weighted graphs cannot use
@@ -309,7 +309,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         >>> G = nx.MultiDiGraph()
         >>> e = (1, 2)
-        >>> key = G.add_edge(1, 2)     # explicit two-node form
+        >>> ekey = G.add_edge(1, 2)    # explicit two-node form
         >>> G.add_edge(*e)             # single edge as tuple of two nodes
         1
         >>> G.add_edges_from( [(1, 2)] ) # add edges from iterable container
@@ -317,14 +317,14 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         Associate data to edges using keywords:
 
-        >>> key = G.add_edge(1, 2, weight=3)
-        >>> key = G.add_edge(1, 2, key=0, weight=4)  # update data for key=0
-        >>> key = G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
+        >>> ekey = G.add_edge(1, 2, weight=3)
+        >>> ekey = G.add_edge(1, 2, ekey=0, weight=4)  # update data for edge
+        >>> ekey = G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
 
         For non-string associations, directly access the edge's attribute
         dictionary.
         """
-        u, v, key = u_for_edge, v_for_edge, key_for_edge
+        u, v = u_for_edge, v_for_edge
         # add nodes
         if u not in self._succ:
             self._succ[u] = self.adjlist_inner_dict_factory()
@@ -334,31 +334,31 @@ class MultiDiGraph(MultiGraph, DiGraph):
             self._succ[v] = self.adjlist_inner_dict_factory()
             self._pred[v] = self.adjlist_inner_dict_factory()
             self._node[v] = {}
-        if key is None:
-            key = self.new_edge_key(u, v)
+        if ekey is None:
+            ekey = self.new_edge_key(u, v)
         if v in self._succ[u]:
             keydict = self._adj[u][v]
-            datadict = keydict.get(key, self.edge_key_dict_factory())
+            datadict = keydict.get(ekey, self.edge_key_dict_factory())
             datadict.update(attr)
-            keydict[key] = datadict
+            keydict[ekey] = datadict
         else:
             # selfloops work this way without special treatment
             datadict = self.edge_attr_dict_factory()
             datadict.update(attr)
             keydict = self.edge_key_dict_factory()
-            keydict[key] = datadict
+            keydict[ekey] = datadict
             self._succ[u][v] = keydict
             self._pred[v][u] = keydict
-        return key
+        return ekey
 
-    def remove_edge(self, u, v, key=None):
+    def remove_edge(self, u, v, ekey=None):
         """Remove an edge between u and v.
 
         Parameters
         ----------
         u, v : nodes
             Remove an edge between nodes u and v.
-        key : hashable identifier, optional (default=None)
+        ekey : hashable identifier, optional (default=None)
             Used to distinguish multiple edges between a pair of nodes.
             If None remove a single (arbitrary) edge between u and v.
 
@@ -390,11 +390,11 @@ class MultiDiGraph(MultiGraph, DiGraph):
         For edges with keys
 
         >>> G = nx.MultiDiGraph()
-        >>> G.add_edge(1, 2, key='first')
+        >>> G.add_edge(1, 2, ekey='first')
         'first'
-        >>> G.add_edge(1, 2, key='second')
+        >>> G.add_edge(1, 2, ekey='second')
         'second'
-        >>> G.remove_edge(1, 2, key='second')
+        >>> G.remove_edge(1, 2, ekey='second')
 
         """
         try:
@@ -403,16 +403,16 @@ class MultiDiGraph(MultiGraph, DiGraph):
             raise NetworkXError(
                 "The edge %s-%s is not in the graph." % (u, v))
         # remove the edge with specified data
-        if key is None:
+        if ekey is None:
             d.popitem()
         else:
             try:
-                del d[key]
+                del d[ekey]
             except KeyError:
-                msg = "The edge %s-%s with key %s is not in the graph."
-                raise NetworkXError(msg % (u, v, key))
+                msg = "The edge %s-%s with ekey %s is not in the graph."
+                raise NetworkXError(msg % (u, v, ekey))
         if len(d) == 0:
-            # remove the key entries if last edge
+            # remove the entries if last edge
             del self._succ[u][v]
             del self._pred[v][u]
 
@@ -423,7 +423,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         edges(self, nbunch=None, data=False, keys=False, default=None)
 
         Edges are returned as tuples with optional data and keys
-        in the order (node, neighbor, key, data).
+        in the order (node, neighbor, ekey, data).
 
         Parameters
         ----------
@@ -443,7 +443,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         Returns
         -------
         edge : iterator
-            An iterator over (u, v), (u, v, d) or (u, v, key, d) edge tuples.
+            An iterator over (u, v), (u, v, d) or (u, v, ekey, d) edge tuples.
 
         Notes
         -----
@@ -454,7 +454,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         --------
         >>> G = nx.MultiDiGraph()
         >>> nx.add_path(G, [0, 1, 2])
-        >>> key = G.add_edge(2, 3, weight=5)
+        >>> ekey = G.add_edge(2, 3, weight=5)
         >>> [e for e in G.edges()]
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges(data=True)) # default data is {} (empty dict)
@@ -507,7 +507,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         Returns
         -------
         in_edge : iterator
-            An iterator over (u, v), (u, v, d) or (u, v, key, d) edge tuples.
+            An iterator over (u, v), (u, v, d) or (u, v, ekey, d) edge tuples.
 
         See Also
         --------
@@ -705,7 +705,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         If already directed, return a (deep) copy
 
         >>> G = nx.MultiDiGraph()
-        >>> key = G.add_edge(0, 1)
+        >>> ekey = G.add_edge(0, 1)
         >>> H = G.to_directed()
         >>> list(H.edges())
         [(0, 1)]
@@ -752,16 +752,16 @@ class MultiDiGraph(MultiGraph, DiGraph):
         H.name = self.name
         H.add_nodes_from(self)
         if reciprocal is True:
-            H.add_edges_from((u, v, key, deepcopy(data))
+            H.add_edges_from((u, v, ekey, deepcopy(data))
                              for u, nbrs in self.adjacency()
                              for v, keydict in nbrs.items()
-                             for key, data in keydict.items()
-                             if self.has_edge(v, u, key))
+                             for ekey, data in keydict.items()
+                             if self.has_edge(v, u, ekey))
         else:
-            H.add_edges_from((u, v, key, deepcopy(data))
+            H.add_edges_from((u, v, ekey, deepcopy(data))
                              for u, nbrs in self.adjacency()
                              for v, keydict in nbrs.items()
-                             for key, data in keydict.items())
+                             for ekey, data in keydict.items())
         H.graph = deepcopy(self.graph)
         H._node = deepcopy(self._node)
         return H
@@ -874,10 +874,10 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
             >>> # Create a graph in which some edges are "good" and some "bad".
             >>> G = nx.MultiDiGraph()
-            >>> key = G.add_edge(0, 1, key=0, good=True)
-            >>> key = G.add_edge(0, 1, key=1, good=False)
-            >>> key = G.add_edge(1, 2, key=0, good=False)
-            >>> key = G.add_edge(1, 2, key=1, good=True)
+            >>> ekey = G.add_edge(0, 1, ekey=0, good=True)
+            >>> ekey = G.add_edge(0, 1, ekey=1, good=False)
+            >>> ekey = G.add_edge(1, 2, ekey=0, good=False)
+            >>> ekey = G.add_edge(1, 2, ekey=1, good=True)
             >>> # Keep only those edges that are marked as "good".
             >>> edges = G.edges(keys=True, data='good')
             >>> edges = ((u, v, k) for (u, v, k, good) in edges if good)

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -237,9 +237,9 @@ class MultiGraph(Graph):
     edge_key_dict_factory = dict
     # edge_attr_dict_factory = dict
 
-    def __init__(self, data=None, **attr):
+    def __init__(self, incoming_graph_data=None, **attr):
         self.edge_key_dict_factory = self.edge_key_dict_factory
-        Graph.__init__(self, data, **attr)
+        Graph.__init__(self, incoming_graph_data, **attr)
 
     @property
     def edge(self):
@@ -279,7 +279,7 @@ class MultiGraph(Graph):
             key += 1
         return key
 
-    def add_edge(self, u, v, key=None, **attr):
+    def add_edge(self, u_for_edge, v_for_edge, key_for_edge=None, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -337,6 +337,7 @@ class MultiGraph(Graph):
         >>> G.add_edge(1, 2, key=0, weight=4)   # update data for key=0
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
+        u, v, key = u_for_edge, v_for_edge, key_for_edge
         # add nodes
         if u not in self._adj:
             self._adj[u] = self.adjlist_inner_dict_factory()
@@ -361,12 +362,12 @@ class MultiGraph(Graph):
             self._adj[v][u] = keydict
         return key
 
-    def add_edges_from(self, ebunch, **attr):
-        """Add all the edges in ebunch.
+    def add_edges_from(self, ebunch_to_add, **attr):
+        """Add all the edges in ebunch_to_add.
 
         Parameters
         ----------
-        ebunch : container of edges
+        ebunch_to_add : container of edges
             Each edge given in the container will be added to the
             graph. The edges can be:
 
@@ -413,8 +414,7 @@ class MultiGraph(Graph):
         >>> G.add_edges_from([(3, 4), (1, 4)], label='WN2898')
         """
         keylist = []
-        # process ebunch
-        for e in ebunch:
+        for e in ebunch_to_add:
             ne = len(e)
             if ne == 4:
                 u, v, key, dd = e

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -36,8 +36,8 @@ class MultiGraph(Graph):
 
     Parameters
     ----------
-    data : input graph
-        Data to initialize graph. If data=None (default) an empty
+    incoming_graph_data : input graph (optional, default=None)
+        Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
         dict of dicts, dict of lists, NetworkX graph, NumPy matrix
@@ -88,22 +88,22 @@ class MultiGraph(Graph):
 
     Add one edge,
 
-    >>> key = G.add_edge(1, 2)
+    >>> ekey = G.add_edge(1, 2)
 
     a list of edges,
 
-    >>> keys = G.add_edges_from([(1, 2), (1, 3)])
+    >>> ekeys = G.add_edges_from([(1, 2), (1, 3)])
 
     or a collection of edges,
 
-    >>> keys = G.add_edges_from(list(H.edges()))
+    >>> ekeys = G.add_edges_from(list(H.edges()))
 
     If some edges connect nodes not yet in the graph, the nodes
     are added automatically.  If an edge already exists, an additional
-    edge is created and stored using a key to identify the edge.
-    By default the key is the lowest unused integer.
+    edge is created and stored using a ekey to identify the edge.
+    By default the ekey is the lowest unused integer.
 
-    >>> keys = G.add_edges_from([(4,5,{'route':282}), (4,5,{'route':37})])
+    >>> ekeys = G.add_edges_from([(4,5,{'route':282}), (4,5,{'route':37})])
     >>> G[4]
     AtlasView2({3: {0: {}}, 5: {0: {}, 1: {'route': 282}, 2: {'route': 37}}})
 
@@ -135,9 +135,9 @@ class MultiGraph(Graph):
     Add edge attributes using add_edge(), add_edges_from(), subscript
     notation, or G.edge.
 
-    >>> key = G.add_edge(1, 2, weight=4.7 )
-    >>> keys = G.add_edges_from([(3, 4), (4, 5)], color='red')
-    >>> keys = G.add_edges_from([(1,2,{'color':'blue'}), (2,3,{'weight':8})])
+    >>> ekey = G.add_edge(1, 2, weight=4.7 )
+    >>> ekeys = G.add_edges_from([(3, 4), (4, 5)], color='red')
+    >>> ekeys = G.add_edges_from([(1,2,{'color':'blue'}), (2,3,{'weight':8})])
     >>> G[1][2][0]['weight'] = 4.7
     >>> G.edge[1, 2, 0]['weight'] = 4
 
@@ -159,14 +159,14 @@ class MultiGraph(Graph):
 
     >>> for n, nbrsdict in G.adjacency():
     ...     for nbr, keydict in nbrsdict.items():
-    ...        for key, eattr in keydict.items():
+    ...        for ekey, eattr in keydict.items():
     ...            if 'weight' in eattr:
     ...                # Do something useful with the edges
     ...                pass
 
     But the edges() method is often more convenient:
 
-    >>> for u, v, keys, weight in G.edges(data='weight', keys=True):
+    >>> for u, v, ekey, weight in G.edges(data='weight', keys=True):
     ...     if weight is not None:
     ...         # Do something useful with the edges
     ...         pass
@@ -250,16 +250,16 @@ class MultiGraph(Graph):
         return AtlasView3(self._adj)
 
     def new_edge_key(self, u, v):
-        """Return an unused key for edges between nodes `u` and `v`.
+        """Return an unused ekey for edges between nodes `u` and `v`.
 
         The nodes `u` and `v` do not need to be already in the graph.
 
         Notes
         -----
 
-        In the standard MultiGraph class the new key is the number of existing
+        In the standard MultiGraph class the new ekey is the number of existing
         edges between `u` and `v` (increased if necessary to ensure unused).
-        The first edge will have key 0, then 1, etc. If an edge is removed
+        The first edge will have ekey 0, then 1, etc. If an edge is removed
         further new_edge_keys may not be in this order.
 
         Parameters
@@ -268,18 +268,18 @@ class MultiGraph(Graph):
 
         Returns
         -------
-        key : int
+        ekey : int
         """
         try:
             keydict = self._adj[u][v]
         except KeyError:
             return 0
-        key = len(keydict)
-        while key in keydict:
-            key += 1
-        return key
+        ekey = len(keydict)
+        while ekey in keydict:
+            ekey += 1
+        return ekey
 
-    def add_edge(self, u_for_edge, v_for_edge, key_for_edge=None, **attr):
+    def add_edge(self, u_for_edge, v_for_edge, ekey=None, **attr):
         """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
@@ -293,7 +293,7 @@ class MultiGraph(Graph):
         u, v : nodes
             Nodes can be, for example, strings or numbers.
             Nodes must be hashable (and not None) Python objects.
-        key : hashable identifier, optional (default=lowest unused integer)
+        ekey : hashable identifier, optional (default=lowest unused integer)
             Used to distinguish multiedges between a pair of nodes.
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
@@ -301,7 +301,7 @@ class MultiGraph(Graph):
 
         Returns
         -------
-        The edge key assigned to the edge.
+        The edge ekey assigned to the edge.
 
         See Also
         --------
@@ -309,7 +309,7 @@ class MultiGraph(Graph):
 
         Notes
         -----
-        To replace/update edge data, use the optional key argument
+        To replace/update edge data, use the optional ekey argument
         to identify a unique edge.  Otherwise a new edge will be created.
 
         NetworkX algorithms designed for weighted graphs cannot use
@@ -317,7 +317,7 @@ class MultiGraph(Graph):
         multiedge weights.  Convert to Graph using edge attribute
         'weight' to enable weighted graph algorithms.
 
-        Default keys are generated using the method `new_edge_key()`.
+        Default ekeys are generated using the method `new_edge_key()`.
         This method can be overridden by subclassing the base class and
         providing a custom `new_edge_key()` method.
 
@@ -334,10 +334,10 @@ class MultiGraph(Graph):
         Associate data to edges using keywords:
 
         >>> G.add_edge(1, 2, weight=3)
-        >>> G.add_edge(1, 2, key=0, weight=4)   # update data for key=0
+        >>> G.add_edge(1, 2, ekey=0, weight=4)   # update data for edge
         >>> G.add_edge(1, 3, weight=7, capacity=15, length=342.7)
         """
-        u, v, key = u_for_edge, v_for_edge, key_for_edge
+        u, v = u_for_edge, v_for_edge
         # add nodes
         if u not in self._adj:
             self._adj[u] = self.adjlist_inner_dict_factory()
@@ -345,22 +345,22 @@ class MultiGraph(Graph):
         if v not in self._adj:
             self._adj[v] = self.adjlist_inner_dict_factory()
             self._node[v] = {}
-        if key is None:
-            key = self.new_edge_key(u, v)
+        if ekey is None:
+            ekey = self.new_edge_key(u, v)
         if v in self._adj[u]:
             keydict = self._adj[u][v]
-            datadict = keydict.get(key, self.edge_attr_dict_factory())
+            datadict = keydict.get(ekey, self.edge_attr_dict_factory())
             datadict.update(attr)
-            keydict[key] = datadict
+            keydict[ekey] = datadict
         else:
             # selfloops work this way without special treatment
             datadict = self.edge_attr_dict_factory()
             datadict.update(attr)
             keydict = self.edge_key_dict_factory()
-            keydict[key] = datadict
+            keydict[ekey] = datadict
             self._adj[u][v] = keydict
             self._adj[v][u] = keydict
-        return key
+        return ekey
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -373,8 +373,8 @@ class MultiGraph(Graph):
 
                 - 2-tuples (u, v) or
                 - 3-tuples (u, v, d) for an edge data dict d, or
-                - 3-tuples (u, v, k) for not iterable key k, or
-                - 4-tuples (u, v, k, d) for an edge with data and key k
+                - 3-tuples (u, v, k) for not iterable ekey k, or
+                - 4-tuples (u, v, k, d) for an edge with data and ekey k
 
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
@@ -382,7 +382,7 @@ class MultiGraph(Graph):
 
         Returns
         -------
-        A list of edge keys assigned to the edges in `ebunch`.
+        A list of edge ekeys assigned to the edges in `ebunch`.
 
         See Also
         --------
@@ -397,7 +397,7 @@ class MultiGraph(Graph):
         Edge attributes specified in an ebunch take precedence over
         attributes specified via keyword arguments.
 
-        Default keys are generated using the method ``new_edge_key()``.
+        Default ekeys are generated using the method ``new_edge_key()``.
         This method can be overridden by subclassing the base class and
         providing a custom ``new_edge_key()`` method.
 
@@ -413,18 +413,18 @@ class MultiGraph(Graph):
         >>> G.add_edges_from([(1, 2), (2, 3)], weight=3)
         >>> G.add_edges_from([(3, 4), (1, 4)], label='WN2898')
         """
-        keylist = []
+        ekeylist = []
         for e in ebunch_to_add:
             ne = len(e)
             if ne == 4:
-                u, v, key, dd = e
+                u, v, ekey, dd = e
             elif ne == 3:
                 u, v, dd = e
-                key = None
+                ekey = None
             elif ne == 2:
                 u, v = e
                 dd = {}
-                key = None
+                ekey = None
             else:
                 msg = "Edge tuple {} must be a 2-tuple, 3-tuple or 4-tuple."
                 raise NetworkXError(msg.format(e))
@@ -435,20 +435,20 @@ class MultiGraph(Graph):
             except:
                 if ne != 3:
                     raise
-                key = dd
-            key = self.add_edge(u, v, key)
-            self[u][v][key].update(ddd)
-            keylist.append(key)
-        return keylist
+                ekey = dd
+            ekey = self.add_edge(u, v, ekey)
+            self[u][v][ekey].update(ddd)
+            ekeylist.append(ekey)
+        return ekeylist
 
-    def remove_edge(self, u, v, key=None):
+    def remove_edge(self, u, v, ekey=None):
         """Remove an edge between u and v.
 
         Parameters
         ----------
         u, v : nodes
             Remove an edge between nodes u and v.
-        key : hashable identifier, optional (default=None)
+        ekey : hashable identifier, optional (default=None)
             Used to distinguish multiple edges between a pair of nodes.
             If None remove a single (arbitrary) edge between u and v.
 
@@ -456,7 +456,7 @@ class MultiGraph(Graph):
         ------
         NetworkXError
             If there is not an edge between u and v, or
-            if there is no edge with the specified key.
+            if there is no edge with the specified ekey.
 
         See Also
         --------
@@ -473,18 +473,18 @@ class MultiGraph(Graph):
         For multiple edges
 
         >>> G = nx.MultiGraph()   # or MultiDiGraph, etc
-        >>> G.add_edges_from([(1, 2), (1, 2), (1, 2)])  # key_list returned
+        >>> G.add_edges_from([(1, 2), (1, 2), (1, 2)])  # ekey_list returned
         [0, 1, 2]
         >>> G.remove_edge(1, 2) # remove a single (arbitrary) edge
 
-        For edges with keys
+        For edges with ekeys
 
         >>> G = nx.MultiGraph()   # or MultiDiGraph, etc
-        >>> G.add_edge(1, 2, key='first')
+        >>> G.add_edge(1, 2, ekey='first')
         'first'
-        >>> G.add_edge(1, 2, key='second')
+        >>> G.add_edge(1, 2, ekey='second')
         'second'
-        >>> G.remove_edge(1, 2, key='second')
+        >>> G.remove_edge(1, 2, ekey='second')
 
         """
         try:
@@ -493,16 +493,16 @@ class MultiGraph(Graph):
             raise NetworkXError(
                 "The edge %s-%s is not in the graph." % (u, v))
         # remove the edge with specified data
-        if key is None:
+        if ekey is None:
             d.popitem()
         else:
             try:
-                del d[key]
+                del d[ekey]
             except KeyError:
-                msg = "The edge %s-%s with key %s is not in the graph."
-                raise NetworkXError(msg % (u, v, key))
+                msg = "The edge %s-%s with ekey %s is not in the graph."
+                raise NetworkXError(msg % (u, v, ekey))
         if len(d) == 0:
-            # remove the key entries if last edge
+            # remove the ekey entries if last edge
             del self._adj[u][v]
             if u != v:  # check for selfloop
                 del self._adj[v][u]
@@ -517,8 +517,8 @@ class MultiGraph(Graph):
             from the graph. The edges can be:
 
                 - 2-tuples (u, v) All edges between u and v are removed.
-                - 3-tuples (u, v, key) The edge identified by key is removed.
-                - 4-tuples (u, v, key, data) where data is ignored.
+                - 3-tuples (u, v, ekey) The edge identified by ekey is removed.
+                - 4-tuples (u, v, ekey, data) where data is ignored.
 
         See Also
         --------
@@ -537,7 +537,7 @@ class MultiGraph(Graph):
         Removing multiple copies of edges
 
         >>> G = nx.MultiGraph()
-        >>> keys = G.add_edges_from([(1, 2), (1, 2), (1, 2)])
+        >>> ekeys = G.add_edges_from([(1, 2), (1, 2), (1, 2)])
         >>> G.remove_edges_from([(1, 2), (1, 2)])
         >>> list(G.edges())
         [(1, 2)]
@@ -551,7 +551,7 @@ class MultiGraph(Graph):
             except NetworkXError:
                 pass
 
-    def has_edge(self, u, v, key=None):
+    def has_edge(self, u, v, ekey=None):
         """Return True if the graph has an edge between nodes u and v.
 
         Parameters
@@ -559,9 +559,9 @@ class MultiGraph(Graph):
         u, v : nodes
             Nodes can be, for example, strings or numbers.
 
-        key : hashable identifier, optional (default=None)
+        ekey : hashable identifier, optional (default=None)
             If specified return True only if the edge with
-            key is found.
+            ekey is found.
 
         Returns
         -------
@@ -571,7 +571,7 @@ class MultiGraph(Graph):
         Examples
         --------
         Can be called either using two nodes u, v, an edge tuple (u, v),
-        or an edge tuple (u, v, key).
+        or an edge tuple (u, v, ekey).
 
         >>> G = nx.MultiGraph()   # or MultiDiGraph
         >>> nx.add_path(G, [0, 1, 2, 3])
@@ -580,9 +580,9 @@ class MultiGraph(Graph):
         >>> e = (0, 1)
         >>> G.has_edge(*e)  #  e is a 2-tuple (u, v)
         True
-        >>> G.add_edge(0, 1, key='a')
+        >>> G.add_edge(0, 1, ekey='a')
         'a'
-        >>> G.has_edge(0, 1, key='a')  # specify key
+        >>> G.has_edge(0, 1, ekey='a')  # specify ekey
         True
         >>> e=(0, 1, 'a')
         >>> G.has_edge(*e) # e is a 3-tuple (u, v, 'a')
@@ -599,10 +599,10 @@ class MultiGraph(Graph):
 
         """
         try:
-            if key is None:
+            if ekey is None:
                 return v in self._adj[u]
             else:
-                return key in self._adj[u][v]
+                return ekey in self._adj[u][v]
         except KeyError:
             return False
 
@@ -613,7 +613,7 @@ class MultiGraph(Graph):
         edges(self, nbunch=None, data=False, keys=False, default=None)
 
         Edges are returned as tuples with optional data and keys
-        in the order (node, neighbor, key, data).
+        in the order (node, neighbor, ekey, data).
 
         Parameters
         ----------
@@ -633,7 +633,7 @@ class MultiGraph(Graph):
         Returns
         -------
         edge : iterator
-            An iterator over (u, v), (u, v, d) or (u, v, key, d) edge tuples
+            An iterator over (u, v), (u, v, d) or (u, v, ekey, d) edge tuples
 
         Notes
         -----
@@ -644,7 +644,7 @@ class MultiGraph(Graph):
         --------
         >>> G = nx.MultiGraph()   # or MultiDiGraph
         >>> nx.add_path(G, [0, 1, 2])
-        >>> key = G.add_edge(2, 3, weight=5)
+        >>> ekey = G.add_edge(2, 3, weight=5)
         >>> [e for e in G.edges()]
         [(0, 1), (1, 2), (2, 3)]
         >>> list(G.edges(data=True)) # default data is {} (empty dict)
@@ -665,7 +665,7 @@ class MultiGraph(Graph):
         self.__dict__['edges'] = edges = MultiEdgeView(self)
         return edges
 
-    def get_edge_data(self, u, v, key=None, default=None):
+    def get_edge_data(self, u, v, ekey=None, default=None):
         """Return the attribute dictionary associated with edge (u, v).
 
         Parameters
@@ -675,8 +675,8 @@ class MultiGraph(Graph):
         default :  any Python object (default=None)
             Value to return if the edge (u, v) is not found.
 
-        key : hashable identifier, optional (default=None)
-            Return data only for the edge with specified key.
+        ekey : hashable identifier, optional (default=None)
+            Return data only for the edge with specified ekey.
 
         Returns
         -------
@@ -685,14 +685,14 @@ class MultiGraph(Graph):
 
         Notes
         -----
-        It is faster to use G[u][v][key].
+        It is faster to use G[u][v][ekey].
 
         >>> G = nx.MultiGraph() # or MultiDiGraph
-        >>> key = G.add_edge(0, 1, key='a', weight=7)
-        >>> G[0][1]['a']  # key='a'
+        >>> ekey = G.add_edge(0, 1, ekey='a', weight=7)
+        >>> G[0][1]['a']  # ekey='a'
         {'weight': 7}
 
-        Warning: Assigning G[u][v][key] corrupts the graph data structure.
+        Warning: Assigning G[u][v][ekey] corrupts the graph data structure.
         But it is safe to assign attributes to that dictionary,
 
         >>> G[0][1]['a']['weight'] = 10
@@ -714,10 +714,10 @@ class MultiGraph(Graph):
         0
         """
         try:
-            if key is None:
+            if ekey is None:
                 return self._adj[u][v]
             else:
-                return self._adj[u][v][key]
+                return self._adj[u][v][ekey]
         except KeyError:
             return default
 
@@ -818,10 +818,10 @@ class MultiGraph(Graph):
         from networkx.classes.multidigraph import MultiDiGraph
         G = MultiDiGraph()
         G.add_nodes_from(self)
-        G.add_edges_from((u, v, key, deepcopy(datadict))
+        G.add_edges_from((u, v, ekey, deepcopy(datadict))
                          for u, nbrs in self.adjacency()
                          for v, keydict in nbrs.items()
-                         for key, datadict in keydict.items())
+                         for ekey, datadict in keydict.items())
         G.graph = deepcopy(self.graph)
         G._node = deepcopy(self._node)
         return G
@@ -1058,10 +1058,10 @@ class MultiGraph(Graph):
 
             >>> # Create a graph in which some edges are "good" and some "bad".
             >>> G = nx.MultiGraph()
-            >>> key = G.add_edge(0, 1, key=0, good=True)
-            >>> key = G.add_edge(0, 1, key=1, good=False)
-            >>> key = G.add_edge(1, 2, key=0, good=False)
-            >>> key = G.add_edge(1, 2, key=1, good=True)
+            >>> ekey = G.add_edge(0, 1, ekey=0, good=True)
+            >>> ekey = G.add_edge(0, 1, ekey=1, good=False)
+            >>> ekey = G.add_edge(1, 2, ekey=0, good=False)
+            >>> ekey = G.add_edge(1, 2, ekey=1, good=True)
             >>> # Keep only those edges that are marked as "good".
             >>> edges = G.edges(keys=True, data='good')
             >>> edges = ((u, v, k) for (u, v, k, good) in edges if good)

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -197,7 +197,7 @@ class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
         self.P3._node[2] = {}
 
     def test_data_input(self):
-        G = self.Graph(data={1: [2], 2: [1]}, name="test")
+        G = self.Graph({1: [2], 2: [1]}, name="test")
         assert_equal(G.name, "test")
         assert_equal(sorted(G.adj.items()), [(1, {2: {}}), (2, {1: {}})])
         assert_equal(sorted(G.succ.items()), [(1, {2: {}}), (2, {1: {}})])

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -449,7 +449,7 @@ class TestGraph(BaseAttrGraphTester):
         self.K3._node[2] = {}
 
     def test_data_input(self):
-        G = self.Graph(data={1: [2], 2: [1]}, name="test")
+        G = self.Graph({1: [2], 2: [1]}, name="test")
         assert_equal(G.name, "test")
         assert_equal(sorted(G.adj.items()), [(1, {2: {}}), (2, {1: {}})])
         G = self.Graph({1: [2], 2: [1]}, name="test")

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -299,12 +299,12 @@ class TestMultiDiGraph(BaseMultiDiGraphTester, TestMultiGraph):
                                2: {0: {0: {}}, 1: {0: {}}}})
         assert_raises((KeyError, nx.NetworkXError), G.remove_edge, -1, 0)
         assert_raises((KeyError, nx.NetworkXError), G.remove_edge, 0, 2,
-                      key=1)
+                      ekey=1)
 
     def test_remove_multiedge(self):
         G = self.K3
-        G.add_edge(0, 1, key='parallel edge')
-        G.remove_edge(0, 1, key='parallel edge')
+        G.add_edge(0, 1, ekey='parallel edge')
+        G.remove_edge(0, 1, ekey='parallel edge')
         assert_equal(G._adj, {0: {1: {0: {}}, 2: {0: {}}},
                               1: {0: {0: {}}, 2: {0: {}}},
                               2: {0: {0: {}}, 1: {0: {}}}})

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -105,8 +105,8 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
         G = self.K3
         G.add_edge(0, 0)
         G.add_edge(0, 0)
-        G.add_edge(0, 0, key='parallel edge')
-        G.remove_edge(0, 0, key='parallel edge')
+        G.add_edge(0, 0, ekey='parallel edge')
+        G.remove_edge(0, 0, ekey='parallel edge')
         assert_equal(G.number_of_edges(0, 0), 2)
         G.remove_edge(0, 0)
         assert_equal(G.number_of_edges(0, 0), 1)
@@ -114,13 +114,13 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
     def test_edge_lookup(self):
         G = self.Graph()
         G.add_edge(1, 2, foo='bar')
-        G.add_edge(1, 2, 'key', foo='biz')
+        G.add_edge(1, 2, 'ekey', foo='biz')
         assert_edges_equal(G.edges[1, 2, 0], {'foo': 'bar'})
-        assert_edges_equal(G.edges[1, 2, 'key'], {'foo': 'biz'})
+        assert_edges_equal(G.edges[1, 2, 'ekey'], {'foo': 'biz'})
 
     def test_edge_attr4(self):
         G = self.Graph()
-        G.add_edge(1, 2, key=0, data=7, spam='bar', bar='foo')
+        G.add_edge(1, 2, ekey=0, data=7, spam='bar', bar='foo')
         assert_edges_equal(G.edges(data=True),
                            [(1, 2, {'data': 7, 'spam': 'bar', 'bar': 'foo'})])
         G[1][2][0]['data'] = 10  # OK to set data like this
@@ -158,7 +158,7 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
         self.K3._node[2] = {}
 
     def test_data_input(self):
-        G = self.Graph(data={1: [2], 2: [1]}, name="test")
+        G = self.Graph({1: [2], 2: [1]}, name="test")
         assert_equal(G.name, "test")
         expected = [(1, {2: {0: {}}}), (2, {1: {0: {}}})]
         assert_equal(sorted(G.adj.items()), expected)
@@ -185,7 +185,7 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
 
     def test_add_edge_conflicting_key(self):
         G = self.Graph()
-        G.add_edge(0, 1, key=1)
+        G.add_edge(0, 1, ekey=1)
         G.add_edge(0, 1)
         assert_equal(G.number_of_edges(), 2)
         G = self.Graph()
@@ -227,7 +227,7 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
 
         assert_raises((KeyError, nx.NetworkXError), G.remove_edge, -1, 0)
         assert_raises((KeyError, nx.NetworkXError), G.remove_edge, 0, 2,
-                      key=1)
+                      ekey=1)
 
     def test_remove_edges_from(self):
         G = self.K3.copy()
@@ -251,8 +251,8 @@ class TestMultiGraph(BaseMultiGraphTester, TestGraph):
 
     def test_remove_multiedge(self):
         G = self.K3
-        G.add_edge(0, 1, key='parallel edge')
-        G.remove_edge(0, 1, key='parallel edge')
+        G.add_edge(0, 1, ekey='parallel edge')
+        G.remove_edge(0, 1, ekey='parallel edge')
         assert_equal(G.adj, {0: {1: {0: {}}, 2: {0: {}}},
                              1: {0: {0: {}}, 2: {0: {}}},
                              2: {0: {0: {}}, 1: {0: {}}}})

--- a/networkx/classes/tests/test_views.py
+++ b/networkx/classes/tests/test_views.py
@@ -338,7 +338,7 @@ class test_inedges(test_edgeview):
 class test_multiedges(test_edgeview):
     def setup(self):
         self.G = nx.path_graph(9, nx.MultiGraph())
-        self.G.add_edge(1, 2, key=3, foo='bar')
+        self.G.add_edge(1, 2, ekey=3, foo='bar')
         self.eview = nx.MultiEdgeView
 
         def modify_edge(G, e, **kwds):
@@ -477,7 +477,7 @@ class test_multiedges(test_edgeview):
 class test_directed_multiedges(test_multiedges):
     def setup(self):
         self.G = nx.path_graph(9, nx.MultiDiGraph())
-        self.G.add_edge(1, 2, key=3, foo='bar')
+        self.G.add_edge(1, 2, ekey=3, foo='bar')
         self.eview = nx.OutMultiEdgeView
 
         def modify_edge(G, e, **kwds):
@@ -496,7 +496,7 @@ class test_directed_multiedges(test_multiedges):
 class test_in_multiedges(test_multiedges):
     def setup(self):
         self.G = nx.path_graph(9, nx.MultiDiGraph())
-        self.G.add_edge(1, 2, key=3, foo='bar')
+        self.G.add_edge(1, 2, ekey=3, foo='bar')
         self.eview = nx.InMultiEdgeView
 
         def modify_edge(G, e, **kwds):

--- a/networkx/classes/views.py
+++ b/networkx/classes/views.py
@@ -65,7 +65,7 @@ EdgeView
     `V = G.edges` or `V = G.edges()` allows iteration over edges as well as
     `e in V`, set operations and edge data lookup `dd = G.edge[2, 3]`.
     Iteration is over 2-tuples `(u, v)` for Graph/DiGraph. For multigraphs
-    edges 3-tuples `(u, v, key)` are the default but 2-tuples can be obtained
+    edges 3-tuples `(u, v, ekey)` are the default but 2-tuples can be obtained
     via `V = G.edges(keys=False)`.
 
     Set operations for directed graphs treat the edges as a set of 2-tuples.
@@ -897,7 +897,7 @@ class EdgeView(OutEdgeView):
     like a dict and set operations on edges represented by node-tuples.
     In addition, edge data can be controlled by calling this object
     possibly creating an EdgeDataView. Typically edges are iterated over
-    and reported as `(u, v)` node tuples or `(u, v, key)` node/key tuples
+    and reported as `(u, v)` node tuples or `(u, v, ekey)` node/ekey tuples
     for multigraphs. Those edge representations can also be using to
     lookup the data dict for any edge. Set operations also are available
     where those tuples are the elements of the set.
@@ -914,7 +914,7 @@ class EdgeView(OutEdgeView):
     ==========
     graph : NetworkX graph-like class
     nbunch : (default= all nodes in graph) only report edges with these nodes
-    keys : (only for MultiGraph. default=False) report edge key in tuple
+    keys : (only for MultiGraph. default=False) report edge ekey in tuple
     data : bool or string (default=False) see above
     default : object (default=None)
 
@@ -949,7 +949,7 @@ class EdgeView(OutEdgeView):
     True
     >>> (2, 3) in EVmulti   # 2-tuples work even when keys is True
     True
-    >>> key = MG.add_edge(2, 3)
+    >>> ekey = MG.add_edge(2, 3)
     >>> for u, v, k in EVmulti: print((u, v, k))
     (0, 1, 0)
     (1, 2, 0)
@@ -1022,8 +1022,8 @@ class OutMultiEdgeView(OutEdgeView):
     def __iter__(self):
         for n, nbrs in self._nodes_nbrs():
             for nbr, kdict in nbrs.items():
-                for key in kdict:
-                    yield (n, nbr, key)
+                for ekey in kdict:
+                    yield (n, nbr, ekey)
 
     def __contains__(self, e):
         N = len(e)
@@ -1090,8 +1090,8 @@ class InMultiEdgeView(OutMultiEdgeView):
     def __iter__(self):
         for n, nbrs in self._nodes_nbrs():
             for nbr, kdict in nbrs.items():
-                for key in kdict:
-                    yield (nbr, n, key)
+                for ekey in kdict:
+                    yield (nbr, n, ekey)
 
     def __contains__(self, e):
         N = len(e)
@@ -1135,8 +1135,8 @@ class AtlasView(Mapping):
     def __iter__(self):
         return iter(self._atlas)
 
-    def __getitem__(self, key):
-        return self._atlas[key]
+    def __getitem__(self, ekey):
+        return self._atlas[ekey]
 
     def copy(self):
         return self._atlas.copy()

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -349,7 +349,7 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
             for u, nbrs in d.items():
                 for v, data in nbrs.items():
                     if (u, v) not in seen:
-                        G.add_edge(u, v, key=0)
+                        G.add_edge(u, v, ekey=0)
                         G[u][v][0].update(data)
                     seen.add((v, u))
         else:

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -103,7 +103,7 @@ def from_agraph(A, create_using=None):
                 str_attr['key'] = e.name
             N.add_edge(u, v, **str_attr)
         else:
-            N.add_edge(u, v, key=e.name, **str_attr)
+            N.add_edge(u, v, ekey=e.name, **str_attr)
 
     # add default attributes for graph, nodes, and edges
     # hang them on N.graph_attr

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -283,7 +283,7 @@ def draw_networkx_nodes(G, pos,
                         ax=None,
                         linewidths=None,
                         label=None,
-                        **kwds):
+                        ):
     """Draw the nodes of the graph G.
 
     This draws only the nodes of the graph G.
@@ -411,7 +411,7 @@ def draw_networkx_edges(G, pos,
                         ax=None,
                         arrows=True,
                         label=None,
-                        **kwds):
+                        ):
     """Draw the edges of the graph G.
 
     This draws only the edges of the graph G.
@@ -642,7 +642,9 @@ def draw_networkx_labels(G, pos,
                          alpha=1.0,
                          bbox=None,
                          ax=None,
-                         **kwds):
+                         horizontalalignment='center',
+                         verticalalignment='center',
+                         ):
     """Draw node labels on the graph G.
 
     Parameters
@@ -674,6 +676,13 @@ def draw_networkx_labels(G, pos,
 
     ax : Matplotlib Axes object, optional
        Draw the graph in the specified Matplotlib axes.
+
+    horizontalalignment : string (default: 'center')
+       How to horizontally align text.
+       Can be: 'center', 'top', 'bottom' or 'baseline'.
+
+    verticalalignment : string (default: 'center')
+       How to vertically align text. Can be: 'center', 'right', or 'left'.
 
     Returns
     -------
@@ -711,10 +720,6 @@ def draw_networkx_labels(G, pos,
     if labels is None:
         labels = dict((n, n) for n in G.nodes())
 
-    # set optional alignment
-    horizontalalignment = kwds.get('horizontalalignment', 'center')
-    verticalalignment = kwds.get('verticalalignment', 'center')
-
     text_items = {}  # there is no text collection so we'll fake one
     for n, label in labels.items():
         (x, y) = pos[n]
@@ -739,17 +744,20 @@ def draw_networkx_labels(G, pos,
 
 
 def draw_networkx_edge_labels(G, pos,
+                              ax=None,
+                              alpha=1.0,
                               edge_labels=None,
                               label_pos=0.5,
                               font_size=10,
                               font_color='k',
                               font_family='sans-serif',
                               font_weight='normal',
-                              alpha=1.0,
                               bbox=None,
-                              ax=None,
                               rotate=True,
-                              **kwds):
+                              clip_on=True,
+                              horizontalalignment='center',
+                              verticalalignment='center',
+                              ):
     """Draw edge labels.
 
     Parameters
@@ -781,17 +789,27 @@ def draw_networkx_edge_labels(G, pos,
     font_color : string
        Font color string (default='k' black)
 
-    font_weight : string
-       Font weight (default='normal')
-
     font_family : string
        Font family (default='sans-serif')
+
+    font_weight : string
+       Font weight (default='normal')
 
     bbox : Matplotlib bbox
        Specify text box shape and colors.
 
+    rotate : bool
+       Turn on clipping at axis boundaries (default=True)
+
     clip_on : bool
        Turn on clipping at axis boundaries (default=True)
+
+    horizontalalignment : string (default: 'center')
+       How to horizontally align text.
+       Can be: 'center', 'top', 'bottom' or 'baseline'.
+
+    verticalalignment : string (default: 'center')
+       How to vertically align text. Can be: 'center', 'right', or 'left'.
 
     Returns
     -------
@@ -859,10 +877,6 @@ def draw_networkx_edge_labels(G, pos,
         if not cb.is_string_like(label):
             label = str(label)  # this will cause "1" and 1 to be labeled the same
 
-        # set optional alignment
-        horizontalalignment = kwds.get('horizontalalignment', 'center')
-        verticalalignment = kwds.get('verticalalignment', 'center')
-
         t = ax.text(x, y,
                     label,
                     size=font_size,
@@ -876,7 +890,7 @@ def draw_networkx_edge_labels(G, pos,
                     transform=ax.transData,
                     bbox=bbox,
                     zorder=1,
-                    clip_on=True,
+                    clip_on=clip_on,
                     )
         text_items[(n1, n2)] = t
 

--- a/networkx/exception.py
+++ b/networkx/exception.py
@@ -89,6 +89,6 @@ class PowerIterationFailedConvergence(ExceededMaxIterations):
 
     def __init__(self, num_iterations, *args, **kw):
         msg = 'power iteration failed to converge within {} iterations'
-        msg = msg.format(num_iterations)
+        exception_message = msg.format(num_iterations)
         superinit = super(PowerIterationFailedConvergence, self).__init__
-        superinit(self, msg, *args, **kw)
+        superinit(self, exception_message, *args, **kw)

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -871,9 +871,9 @@ class GEXFReader(GEXF):
         if G.has_edge(source, target):
             # seen this edge before - this is a multigraph
             self.simple_graph = False
-        G.add_edge(source, target, key=edge_id, **data)
+        G.add_edge(source, target, ekey=edge_id, **data)
         if edge_direction == 'mutual':
-            G.add_edge(target, source, key=edge_id, **data)
+            G.add_edge(target, source, ekey=edge_id, **data)
 
     def decode_attr_elements(self, gexf_keys, obj_xml):
         # Use the key information to decode the attr XML

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -157,6 +157,6 @@ def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
                 graph[source][target].update(tdata)
             else:
                 ky = target_data.pop(key, None)
-                graph.add_edge(source, target, key=ky)
+                graph.add_edge(source, target, ekey=ky)
                 graph[source][target][ky].update(tdata)
     return graph

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -104,7 +104,7 @@ def cytoscape_graph(data, attrs=None):
         targ = d["data"].pop("target")
         if multigraph:
             key = d["data"].get("key", 0)
-            graph.add_edge(sour, targ, key=key)
+            graph.add_edge(sour, targ, ekey=key)
             graph.edge[sour, targ, key].update(edge_data)
         else:
             graph.add_edge(sour, targ)

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -1,40 +1,41 @@
 import json
-from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_true, raises
+from nose.tools import assert_equal, assert_raises, assert_not_equal, \
+                       assert_true, raises
 import networkx as nx
 from networkx.readwrite.json_graph import *
 
-class TestAdjacency:
 
+class TestAdjacency:
     def test_graph(self):
         G = nx.path_graph(4)
         H = adjacency_graph(adjacency_data(G))
-        nx.is_isomorphic(G,H)
+        nx.is_isomorphic(G, H)
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
-        G.add_node(1,color='red')
-        G.add_edge(1,2,width=7)
-        G.graph['foo']='bar'
-        G.graph[1]='one'
+        G.add_node(1, color='red')
+        G.add_edge(1, 2, width=7)
+        G.graph['foo'] = 'bar'
+        G.graph[1] = 'one'
 
         H = adjacency_graph(adjacency_data(G))
-        assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.node[1]['color'],'red')
-        assert_equal(H[1][2]['width'],7)
+        assert_equal(H.graph['foo'], 'bar')
+        assert_equal(H.node[1]['color'], 'red')
+        assert_equal(H[1][2]['width'], 7)
 
         d = json.dumps(adjacency_data(G))
         H = adjacency_graph(json.loads(d))
-        assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.graph[1],'one')
-        assert_equal(H.node[1]['color'],'red')
-        assert_equal(H[1][2]['width'],7)
+        assert_equal(H.graph['foo'], 'bar')
+        assert_equal(H.graph[1], 'one')
+        assert_equal(H.node[1]['color'], 'red')
+        assert_equal(H[1][2]['width'], 7)
 
     def test_digraph(self):
         G = nx.DiGraph()
         nx.add_path(G, [1, 2, 3])
         H = adjacency_graph(adjacency_data(G))
         assert_true(H.is_directed())
-        nx.is_isomorphic(G,H)
+        nx.is_isomorphic(G, H)
 
     def test_multidigraph(self):
         G = nx.MultiDiGraph()
@@ -45,11 +46,11 @@ class TestAdjacency:
 
     def test_multigraph(self):
         G = nx.MultiGraph()
-        G.add_edge(1,2,key='first')
-        G.add_edge(1,2,key='second',color='blue')
+        G.add_edge(1, 2, ekey='first')
+        G.add_edge(1, 2, ekey='second', color='blue')
         H = adjacency_graph(adjacency_data(G))
-        nx.is_isomorphic(G,H)
-        assert_equal(H[1][2]['second']['color'],'blue')
+        nx.is_isomorphic(G, H)
+        assert_equal(H[1][2]['second']['color'], 'blue')
 
     @raises(nx.NetworkXError)
     def test_exception(self):

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -1,49 +1,46 @@
 import json
-from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_true, raises
+from nose.tools import assert_equal, assert_raises, assert_not_equal, \
+                       assert_true, raises
 import networkx as nx
 from networkx.readwrite.json_graph import *
 
+
 class TestCytoscape:
-    
     def test_graph(self):
         G = nx.path_graph(4)
         H = cytoscape_graph(cytoscape_data(G))
-        nx.is_isomorphic(G,H)
+        nx.is_isomorphic(G, H)
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
-        G.add_node(1,color='red')
-        G.add_edge(1,2,width=7)
-        G.graph['foo']='bar'
-        G.graph[1]='one'
+        G.add_node(1, color='red')
+        G.add_edge(1, 2, width=7)
+        G.graph['foo'] = 'bar'
+        G.graph[1] = 'one'
         G.add_node(3, name="node", id="123")
-        
+
         H = cytoscape_graph(cytoscape_data(G))
-        assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.node[1]['color'],'red')
-        assert_equal(H[1][2]['width'],7)
-        assert_equal(H.node[3]['name'],'node')
-        assert_equal(H.node[3]['id'],'123')
-        
+        assert_equal(H.graph['foo'], 'bar')
+        assert_equal(H.node[1]['color'], 'red')
+        assert_equal(H[1][2]['width'], 7)
+        assert_equal(H.node[3]['name'], 'node')
+        assert_equal(H.node[3]['id'], '123')
 
         d = json.dumps(cytoscape_data(G))
         H = cytoscape_graph(json.loads(d))
-        assert_equal(H.graph['foo'],'bar')
-        assert_equal(H.graph[1],'one')
-        assert_equal(H.node[1]['color'],'red')
-        assert_equal(H[1][2]['width'],7)
-        assert_equal(H.node[3]['name'],'node')
-        assert_equal(H.node[3]['id'],'123')
-        
-        
-        
-        
+        assert_equal(H.graph['foo'], 'bar')
+        assert_equal(H.graph[1], 'one')
+        assert_equal(H.node[1]['color'], 'red')
+        assert_equal(H[1][2]['width'], 7)
+        assert_equal(H.node[3]['name'], 'node')
+        assert_equal(H.node[3]['id'], '123')
+
     def test_digraph(self):
         G = nx.DiGraph()
         nx.add_path(G, [1, 2, 3])
         H = cytoscape_graph(cytoscape_data(G))
         assert_true(H.is_directed())
-        nx.is_isomorphic(G,H)
+        nx.is_isomorphic(G, H)
 
     def test_multidigraph(self):
         G = nx.MultiDiGraph()
@@ -54,11 +51,11 @@ class TestCytoscape:
 
     def test_multigraph(self):
         G = nx.MultiGraph()
-        G.add_edge(1,2,key='first')
-        G.add_edge(1,2,key='second',color='blue')
+        G.add_edge(1, 2, ekey='first')
+        G.add_edge(1, 2, ekey='second', color='blue')
         H = cytoscape_graph(cytoscape_data(G))
-        assert_true(nx.is_isomorphic(G,H))
-        assert_equal(H[1][2]['second']['color'],'blue')
+        assert_true(nx.is_isomorphic(G, H))
+        assert_equal(H[1][2]['second']['color'], 'blue')
 
     @raises(nx.NetworkXError)
     def test_exception(self):

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -38,8 +38,8 @@ class TestNodeLink:
 
     def test_multigraph(self):
         G = nx.MultiGraph()
-        G.add_edge(1, 2, key='first')
-        G.add_edge(1, 2, key='second', color='blue')
+        G.add_edge(1, 2, ekey='first')
+        G.add_edge(1, 2, ekey='second', color='blue')
         H = node_link_graph(node_link_data(G))
         nx.is_isomorphic(G, H)
         assert_equal(H[1][2]['second']['color'], 'blue')

--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -27,7 +27,7 @@ import networkx as nx
 from networkx.utils import open_file
 
 @open_file(1,mode='w')
-def write_yaml(G, path, encoding='UTF-8', **kwds):
+def write_yaml(G_to_be_yaml, path_for_yaml_output, **kwds):
     """Write graph G in YAML format to path. 
 
     YAML is a data serialization format designed for human readability 
@@ -40,8 +40,11 @@ def write_yaml(G, path, encoding='UTF-8', **kwds):
     path : file or string
        File or filename to write. 
        Filenames ending in .gz or .bz2 will be compressed.
-    encoding: string, optional
-       Specify which encoding to use when writing file.
+
+    Notes
+    -----
+    To use encoding on the output file include e.g. `encoding='utf-8'`
+    in the keyword arguments.
 
     Examples
     --------
@@ -56,7 +59,7 @@ def write_yaml(G, path, encoding='UTF-8', **kwds):
         import yaml
     except ImportError:
         raise ImportError("write_yaml() requires PyYAML: http://pyyaml.org/")
-    yaml.dump(G, path, **kwds)
+    yaml.dump(G_to_be_yaml, path_for_yaml_output, **kwds)
     
 @open_file(0,mode='r')
 def read_yaml(path):

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -49,12 +49,12 @@ def not_implemented_for(*graph_types):
            pass
     """
     @decorator
-    def _not_implemented_for(f,*args,**kwargs):
+    def _not_implemented_for(not_implement_for_func, *args, **kwargs):
         graph = args[0]
-        terms= {'directed':graph.is_directed(),
-                'undirected':not graph.is_directed(),
-                'multigraph':graph.is_multigraph(),
-                'graph':not graph.is_multigraph()}
+        terms= {'directed': graph.is_directed(),
+                'undirected': not graph.is_directed(),
+                'multigraph': graph.is_multigraph(),
+                'graph': not graph.is_multigraph()}
         match = True
         try:
             for t in graph_types:
@@ -63,10 +63,10 @@ def not_implemented_for(*graph_types):
             raise KeyError('use one or more of ',
                            'directed, undirected, multigraph, graph')
         if match:
-            raise nx.NetworkXNotImplemented('not implemented for %s type'%
-                                            ' '.join(graph_types))
+            msg = 'not implemented for %s type' % ' '.join(graph_types)
+            raise nx.NetworkXNotImplemented(msg)
         else:
-            return f(*args,**kwargs)
+            return not_implement_for_func(*args, **kwargs)
     return _not_implemented_for
 
 
@@ -154,7 +154,7 @@ def open_file(path_arg, mode='r'):
     # be closed, if it should be, by the decorator.
 
     @decorator
-    def _open_file(func, *args, **kwargs):
+    def _open_file(func_to_be_decorated, *args, **kwargs):
 
         # Note that since we have used @decorator, *args, and **kwargs have
         # already been resolved to match the function signature of func. This
@@ -218,7 +218,7 @@ def open_file(path_arg, mode='r'):
 
         # Finally, we call the original function, making sure to close the fobj.
         try:
-            result = func(*new_args, **kwargs)
+            result = func_to_be_decorated(*new_args, **kwargs)
         finally:
             if close_fobj:
                 fobj.close()
@@ -262,7 +262,7 @@ def nodes_or_number(which_args):
            pass
     """
     @decorator
-    def _nodes_or_number(f, *args, **kw):
+    def _nodes_or_number(func_to_be_decorated, *args, **kw):
         # form tuple of arg positions to be converted.
         try:
             iter_wa = iter(which_args)
@@ -281,5 +281,5 @@ def nodes_or_number(which_args):
                     msg = "Negative number of nodes not valid: %i" % n
                     raise nx.NetworkXError(msg)
             new_args[i] = (n, nodes)
-        return f(*new_args, **kw)
+        return func_to_be_decorated(*new_args, **kw)
     return _nodes_or_number


### PR DESCRIPTION
ekey is the new name for the edge key. That is the change with the biggest backward compatibility impact.  Code that says ```G.add_edge(0, 1, key=3)``` will not do what it used to do for a multigraph.

Just think of multiedges as 3-tuples (u, v, ekey) and don't use the keyword for the 3rd argument.

Other changes like changing ```n``` to ```node_to_add``` will have minimal impact because not many people used those names anyway.

Fixes #1583 
Addresses #1582 but doesn't solve it completely without changes on pygraphviz side (which were turned down when proposed almost 2 years ago). Perhaps this change should be turned down too. :)

Feedback welcome.