### PR TITLE
[DOC] Added blurb about set_edge/node_attributes

### DIFF
--- a/doc/release/migration_guide_from_1.x_to_2.0.rst
+++ b/doc/release/migration_guide_from_1.x_to_2.0.rst
@@ -108,3 +108,26 @@ Let's have a look on them.
 	[1]
 
 The same changes apply to MultiGraphs and MultiDiGraphs.
+
+
+The order of arguments to `set_edge_attributes` and `set_node_attributes` has
+changed.  The position of `name` and `values` has been swapped, and `name` now
+defaults to `None`.  The previous call signature of `(graph, name, value)` has
+been changed to `(graph, value, name=None)`. The new style allows for `name` to
+be ommitted in favor of passing a dictionary of dictionaries to `values`.
+
+A simple method for migrating existing code to the new version is to explicitly
+specify the keyword argument names. This method is backwards compatible and
+ensures the correct arguments are passed, regardless of the order. For example the old code
+
+    >>> G = nx.Graph([(1, 2), (1, 3)])
+    >>> nx.set_node_attributes(G, 'label', {1: 'one', 2: 'two', 3: 'three'})
+    >>> nx.set_edge_attributes(G, 'label', {(1, 2): 'path1', (2, 3): 'path2'})
+
+Will cause `TypeError: unhashable type: 'dict'` in the new version. The code
+can be refactored as
+
+    >>> G = nx.Graph([(1, 2), (1, 3)])
+    >>> nx.set_node_attributes(G, name='label', values={1: 'one', 2: 'two', 3: 'three'})
+    >>> nx.set_edge_attributes(G, name='label', values={(1, 2): 'path1', (2, 3): 'path2'})
+    

--- a/doc/release/migration_guide_from_1.x_to_2.0.rst
+++ b/doc/release/migration_guide_from_1.x_to_2.0.rst
@@ -109,6 +109,8 @@ Let's have a look on them.
 
 The same changes apply to MultiGraphs and MultiDiGraphs.
 
+ 
+-------
 
 The order of arguments to `set_edge_attributes` and `set_node_attributes` has
 changed.  The position of `name` and `values` has been swapped, and `name` now

--- a/doc/release/migration_guide_from_1.x_to_2.0.rst
+++ b/doc/release/migration_guide_from_1.x_to_2.0.rst
@@ -112,11 +112,11 @@ The same changes apply to MultiGraphs and MultiDiGraphs.
  
 -------
 
-The order of arguments to `set_edge_attributes` and `set_node_attributes` has
-changed.  The position of `name` and `values` has been swapped, and `name` now
-defaults to `None`.  The previous call signature of `(graph, name, value)` has
-been changed to `(graph, value, name=None)`. The new style allows for `name` to
-be ommitted in favor of passing a dictionary of dictionaries to `values`.
+The order of arguments to ``set_edge_attributes`` and ``set_node_attributes`` has
+changed.  The position of ``name`` and ``values`` has been swapped, and ``name`` now
+defaults to ``None``.  The previous call signature of ``(graph, name, value)`` has
+been changed to ``(graph, value, name=None)``. The new style allows for ``name`` to
+be ommitted in favor of passing a dictionary of dictionaries to ``values``.
 
 A simple method for migrating existing code to the new version is to explicitly
 specify the keyword argument names. This method is backwards compatible and
@@ -126,7 +126,7 @@ ensures the correct arguments are passed, regardless of the order. For example t
     >>> nx.set_node_attributes(G, 'label', {1: 'one', 2: 'two', 3: 'three'})
     >>> nx.set_edge_attributes(G, 'label', {(1, 2): 'path1', (2, 3): 'path2'})
 
-Will cause `TypeError: unhashable type: 'dict'` in the new version. The code
+Will cause ``TypeError: unhashable type: 'dict'`` in the new version. The code
 can be refactored as
 
     >>> G = nx.Graph([(1, 2), (1, 3)])


### PR DESCRIPTION
I noticed that after PR #2553 the new set_edge_attributes and get_edge_attribute API broke my codebase. 
I didn't see any documentation about the new API in the migration from 1.x.x to 2.0 doc, so after finding a fix, I added a write-up describing it. 