### PR TITLE
[FIX] fixed divide by zero error in spring_layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -298,6 +298,8 @@ def fruchterman_reingold_layout(G, k=None,
     if pos is not None:
         # Determine size of existing domain to adjust initial positions
         dom_size = max(coord for pos_tup in pos.values() for coord in pos_tup)
+        if dom_size == 0:
+            dom_size = 1
         shape = (len(G), dim)
         pos_arr = np.random.random(shape) * dom_size + center
         for i, n in enumerate(G):

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -27,6 +27,18 @@ class TestLayout(object):
         nx.add_path(self.Gs, 'abcdef')
         self.bigG = nx.grid_2d_graph(25, 25) #bigger than 500 nodes for sparse
 
+    def test_spring_init_pos(self):
+        # Tests GH #2448
+        import math
+        G = nx.Graph()
+        G.add_edges_from([(0, 1), (1, 2), (2, 0), (2, 3)])
+
+        init_pos = {0: (0.0, 0.0)}
+        fixed_pos = [0]
+        pos = nx.fruchterman_reingold_layout(G, pos=init_pos, fixed=fixed_pos)
+        has_nan = any(math.isnan(c) for coords in pos.values() for c in coords)
+        assert_false(has_nan, 'values should not be nan')
+
     def test_smoke_int(self):
         G = self.Gi
         vpos = nx.random_layout(G)


### PR DESCRIPTION
Fixes #2448 where a spring layout with a single initial position got a dimension size of 0 when there was only one initial value. 

My fix simply checks to see if the domain size is zero, and if it is, then it sets it to one. This also addresses the case if multiple nodes are all set to the same (0, 0) position. I added a corresponding test that replicates and tests for the original error. 