### PR TITLE
Update harmonic centrality

### DIFF
--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -6,7 +6,7 @@
 #    Alessandro Luongo <alessandro.luongo@studenti.unimi.it>
 #
 """Functions for computing the harmonic centrality of a graph."""
-from __future__ import division
+from collections import Counter
 from functools import partial
 
 import networkx as nx
@@ -14,7 +14,7 @@ import networkx as nx
 __all__ = ['harmonic_centrality']
 
 
-def harmonic_centrality(G, nbunch=None, distance=None):
+def harmonic_centrality(G, u=None, distance=None, normalized=False, reverse=False):
     r"""Compute harmonic centrality for nodes.
 
     Harmonic centrality [1]_ of a node `u` is the sum of the reciprocal
@@ -33,13 +33,19 @@ def harmonic_centrality(G, nbunch=None, distance=None):
     G : graph
       A NetworkX graph
     
-    nbunch : container
-      Container of nodes. If provided harmonic centrality will be computed
-      only over the nodes in nbunch.
+    u : node, optional
+      Return only the value for node u
 
     distance : edge attribute key, optional (default=None)
       Use the specified edge attribute as the edge distance in shortest
       path calculations.  If `None`, then each edge will have distance equal to 1.
+      
+    normalized : bool, optional (default=False)
+      If True normalize by the number of nodes in the graph.
+
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, reverse the edges of G, using successors
+      instead of predecessors.
 
     Returns
     -------
@@ -62,7 +68,34 @@ def harmonic_centrality(G, nbunch=None, distance=None):
     .. [1] Boldi, Paolo, and Sebastiano Vigna. "Axioms for centrality."
            Internet Mathematics 10.3-4 (2014): 222-262.
     """
-    if G.is_directed():
-        G = G.reverse()
-    spl = partial(nx.shortest_path_length, G, weight=distance)
-    return {u: sum(1 / d if d > 0 else 0 for v, d in spl(source=u)) for u in G.nbunch_iter(nbunch)}
+    if distance is not None:
+        # use Dijkstra's algorithm with specified attribute as edge weight 
+        path_length = partial(nx.single_source_dijkstra_path_length, 
+                              weight=distance, reverse=not(reverse))
+    else: # handle either directed or undirected
+        if G.is_directed() and not reverse:
+            path_length = nx.single_target_shortest_path_length
+        else:
+            path_length = nx.single_source_shortest_path_length
+
+    if u is None:
+        nodes = G.nodes()
+    else:
+        nodes = [u]
+
+    if normalized:
+        normalize_denominator = float( len(G) - 1 )
+    else:
+        normalize_denominator = 1
+
+    harmonic_centrality = {}
+    for n in nodes:
+        counters = Counter(dict(path_length(G, n)).values())
+        if len(counters) > 1:
+            harmonic_centrality[n] = sum([count / float(distance) for distance, count in counters.most_common() if distance != 0]) / normalize_denominator
+        else:
+            harmonic_centrality[n] = 0.0
+    if u is not None:
+        return harmonic_centrality[u]
+    else:
+        return harmonic_centrality

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -232,7 +232,7 @@ def dijkstra_path_length(G, source, target, weight='weight'):
             "Node %s not reachable from %s" % (target, source))
 
 
-def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
+def single_source_dijkstra_path(G, source, cutoff=None, reverse=False, weight='weight'):
     """Find shortest weighted paths in G from a source node.
 
     Compute shortest path between source and all other reachable
@@ -247,6 +247,10 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
+       
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, compute shortest path to source instead
+      from source.
 
     weight : string or function
        If this is a string, then edge weights will be accessed via the
@@ -288,11 +292,11 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
 
     """
     return multi_source_dijkstra_path(G, {source}, cutoff=cutoff,
-                                      weight=weight)
+                                      reverse=reverse, weight=weight)
 
 
 def single_source_dijkstra_path_length(G, source, cutoff=None,
-                                       weight='weight'):
+                                       reverse=False, weight='weight'):
     """Find shortest weighted path lengths in G from a source node.
 
     Compute the shortest path length between source and all other
@@ -307,6 +311,10 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
+       
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, compute shortest path lengths to source
+      instead from source.
 
     weight : string or function
        If this is a string, then edge weights will be accessed via the
@@ -355,11 +363,11 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
 
     """
     return multi_source_dijkstra_path_length(G, {source}, cutoff=cutoff,
-                                             weight=weight)
+                                             reverse=reverse, weight=weight)
 
 
 def single_source_dijkstra(G, source, target=None, cutoff=None,
-                           weight='weight'):
+                           reverse=False, weight='weight'):
     """Find shortest weighted paths and lengths from a source node.
 
     Compute the shortest path length between source and all other
@@ -380,6 +388,10 @@ def single_source_dijkstra(G, source, target=None, cutoff=None,
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
+       
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, compute shortest path lengths to source
+      instead from source.
 
     weight : string or function
        If this is a string, then edge weights will be accessed via the
@@ -449,10 +461,11 @@ def single_source_dijkstra(G, source, target=None, cutoff=None,
     single_source_bellman_ford()
     """
     return multi_source_dijkstra(G, {source}, cutoff=cutoff, target=target,
-                                 weight=weight)
+                                 reverse=reverse, weight=weight)
 
 
-def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
+def multi_source_dijkstra_path(G, sources, cutoff=None, reverse=False,
+                               weight='weight'):
     """Find shortest weighted paths in G from a given set of source
     nodes.
 
@@ -471,6 +484,10 @@ def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
+       
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, compute shortest weighted paths to
+      a given set of source nodes instead from source.
 
     weight : string or function
        If this is a string, then edge weights will be accessed via the
@@ -519,12 +536,12 @@ def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
 
     """
     length, path = multi_source_dijkstra(G, sources, cutoff=cutoff,
-                                         weight=weight)
+                                         reverse=reverse, weight=weight)
     return path
 
 
 def multi_source_dijkstra_path_length(G, sources, cutoff=None,
-                                      weight='weight'):
+                                      reverse=False, weight='weight'):
     """Find shortest weighted path lengths in G from a given set of
     source nodes.
 
@@ -543,6 +560,10 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
+       
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, compute shortest weighted path lengths
+      to a given set of source nodes instead from source.
 
     weight : string or function
        If this is a string, then edge weights will be accessed via the
@@ -596,13 +617,14 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
     if not sources:
         raise ValueError('sources must not be empty')
     weight = _weight_function(G, weight)
-    dist = _dijkstra_multisource(G, sources, weight, cutoff=cutoff)
+    dist = _dijkstra_multisource(G, sources, weight, cutoff=cutoff, 
+                                 reverse=reverse)
     # TODO In Python 3.3+, this should be `yield from dist.items()`.
     return iter(dist.items())
 
 
 def multi_source_dijkstra(G, sources, target=None, cutoff=None,
-                          weight='weight'):
+                          reverse=False, weight='weight'):
     """Find shortest weighted paths and lengths from a given set of
     source nodes.
 
@@ -625,6 +647,10 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
+       
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, find shortest weighted paths and lengths
+      to a given set of source nodes instead from source.
 
     weight : string or function
        If this is a string, then edge weights will be accessed via the
@@ -705,7 +731,8 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     weight = _weight_function(G, weight)
     paths = {source: [source] for source in sources}  # dictionary of paths
     dist = _dijkstra_multisource(G, sources, weight, paths=paths,
-                                 cutoff=cutoff, target=target)
+                                 cutoff=cutoff, reverse=reverse, 
+                                 target=target)
     if target is None:
         return (dist, paths)
     try:
@@ -715,7 +742,7 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
 
 
 def _dijkstra(G, source, weight, pred=None, paths=None, cutoff=None,
-              target=None):
+              reverse=False, target=None):
     """Uses Dijkstra's algorithm to find shortest weighted paths from a
     single source.
 
@@ -725,11 +752,12 @@ def _dijkstra(G, source, weight, pred=None, paths=None, cutoff=None,
 
     """
     return _dijkstra_multisource(G, [source], weight, pred=pred, paths=paths,
-                                 cutoff=cutoff, target=target)
+                                 cutoff=cutoff, reverse=reverse, 
+                                 target=target)
 
 
 def _dijkstra_multisource(G, sources, weight, pred=None, paths=None,
-                          cutoff=None, target=None):
+                          cutoff=None, reverse=False, target=None):
     """Uses Dijkstra's algorithm to find shortest weighted paths
 
     Parameters
@@ -759,6 +787,10 @@ def _dijkstra_multisource(G, sources, weight, pred=None, paths=None,
 
     cutoff : integer or float, optional
         Depth to stop the search. Only return paths with length <= cutoff.
+        
+    reverse : bool, optional (default=False)
+      If True and G is a digraph, find shortest weighted paths to a 
+      given set of source nodes instead from source.
 
     Returns
     -------
@@ -773,7 +805,13 @@ def _dijkstra_multisource(G, sources, weight, pred=None, paths=None,
     as arguments. No need to explicitly return pred or paths.
 
     """
-    G_succ = G._succ if G.is_directed() else G._adj
+    if G.is_directed():
+        if reverse:
+            G_succ = G._pred
+        else:
+            G_succ = G._succ
+    else:
+        G_succ = G._adj
 
     push = heappush
     pop = heappop


### PR DESCRIPTION
I propose a new version of harmonic centrality that exploits the method nx.single_target_shortest_path_length (form pull request #2418) to avoid reversing the graph. 
Moreover, I made its signature similar to the other centrality algorithms, by adding "normalized" and "reverse", and by replacing "nbunch" (a container of nodes) with "u" (a single node).