### PR TITLE
contracted nodes multiedges

### DIFF
--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -356,7 +356,6 @@ def contracted_nodes(G, u, v, self_loops=True):
         new_edges = ((u, w if w != v else u, d)
                      for x, w, d in G.edges(v, data=True)
                      if self_loops or w != u)
-    new_edges = list(new_edges)
     v_data = H.node[v]
     H.remove_node(v)
     H.add_edges_from(new_edges)

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -237,10 +237,31 @@ class TestContraction(object):
     def test_create_multigraph(self):
         """Tests that using a MultiGraph creates multiple edges."""
         G = nx.path_graph(3, create_using=nx.MultiGraph())
+        G.add_edge(0, 1)
+        G.add_edge(0, 0)
+        G.add_edge(0, 2)
         actual = nx.contracted_nodes(G, 0, 2)
-        expected = nx.MultiDiGraph()
+        expected = nx.MultiGraph()
         expected.add_edge(0, 1)
         expected.add_edge(0, 1)
+        expected.add_edge(0, 1)
+        expected.add_edge(0, 0)
+        expected.add_edge(0, 0)
+        assert_edges_equal(actual.edges, expected.edges)
+
+    def test_multigraph_keys(self):
+        """Tests that multiedge keys are reset in new graph."""
+        G = nx.path_graph(3, create_using=nx.MultiGraph())
+        G.add_edge(0, 1, 5)
+        G.add_edge(0, 0, 0)
+        G.add_edge(0, 2, 5)
+        actual = nx.contracted_nodes(G, 0, 2)
+        expected = nx.MultiGraph()
+        expected.add_edge(0, 1, 0)
+        expected.add_edge(0, 1, 5)
+        expected.add_edge(0, 1, 1)
+        expected.add_edge(0, 0, 0)
+        expected.add_edge(0, 0, 1)  # this comes from (0, 2, 5)
         assert_edges_equal(actual.edges, expected.edges)
 
     def test_node_attributes(self):
@@ -266,6 +287,21 @@ class TestContraction(object):
         actual = nx.contracted_nodes(G, 0, 1, self_loops=False)
         expected = nx.complete_graph(3)
         assert_true(nx.is_isomorphic(actual, expected))
+
+    def test_contract_selfloop_graph(self):
+        """Tests for node contraction when nodes have selfloops."""
+        G = nx.cycle_graph(4)
+        G.add_edge(0, 0)
+        actual = nx.contracted_nodes(G, 0, 1)
+        expected = nx.complete_graph([0, 2, 3])
+        expected.add_edge(0, 0)
+        expected.add_edge(0, 0)
+        assert_edges_equal(actual.edges, expected.edges)
+        actual = nx.contracted_nodes(G, 1, 0)
+        expected = nx.complete_graph([1, 2, 3])
+        expected.add_edge(1, 1)
+        expected.add_edge(1, 1)
+        assert_edges_equal(actual.edges, expected.edges)
 
     def test_undirected_edge_contraction(self):
         """Tests for edge contraction in an undirected graph."""

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -259,7 +259,7 @@ class TestContraction(object):
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, 0)
         expected.add_edge(0, 1, 5)
-        expected.add_edge(0, 1, 1)
+        expected.add_edge(0, 1, 2)  # keyed as 2 b/c 2 edges already in G
         expected.add_edge(0, 0, 0)
         expected.add_edge(0, 0, 1)  # this comes from (0, 2, 5)
         assert_edges_equal(actual.edges, expected.edges)


### PR DESCRIPTION
clean up docs, add tests, clarify multigraph treatment.

Found bug in ```assert_edges_equal``` for multiedge data comparison.
It doesn't seem to hav caused any errors elsewhere -- guess we don't tests multiedges this way often.