### PR TITLE
Add tests, fix my bugs for NotImplemented code in lowest_common_ancestor

### DIFF
--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -22,7 +22,8 @@ __all__ = ["all_pairs_lowest_common_ancestor",
            "lowest_common_ancestor"]
 
 
-@not_implemented_for("multigraph", "undirected")
+@not_implemented_for("undirected")
+@not_implemented_for("multigraph")
 def tree_all_pairs_lowest_common_ancestor(G, root=None, pairs=None):
     """Yield the lowest common ancestor for sets of pairs in a tree.
 
@@ -119,7 +120,8 @@ def tree_all_pairs_lowest_common_ancestor(G, root=None, pairs=None):
             ancestors[uf[parent]] = parent
 
 
-@not_implemented_for("multigraph", "undirected")
+@not_implemented_for("undirected")
+@not_implemented_for("multigraph")
 def lowest_common_ancestor(G, node1, node2, default=None):
     """Compute the lowest common ancestor of the given pair of nodes.
 
@@ -157,7 +159,8 @@ def lowest_common_ancestor(G, node1, node2, default=None):
         return default
 
 
-@not_implemented_for("multigraph", "undirected")
+@not_implemented_for("undirected")
+@not_implemented_for("multigraph")
 def all_pairs_lowest_common_ancestor(G, pairs=None):
     """Compute the lowest common ancestor for pairs of nodes.
 

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -129,6 +129,21 @@ class TestTreeLCA(object):
         G = nx.DiGraph([(3, 4), (5, 4)])
         assert_raises(nx.NetworkXError, list, tree_all_pairs_lca(G))
 
+    def test_not_implemented_for(self):
+        NNI = nx.NetworkXNotImplemented
+        G = nx.Graph([(0, 1)])
+        assert_raises(NNI, tree_all_pairs_lca, G)
+        assert_raises(NNI, all_pairs_lca, G)
+        assert_raises(NNI, nx.lowest_common_ancestor, G, 0, 1)
+        G = nx.MultiGraph([(0, 1)])
+        assert_raises(NNI, tree_all_pairs_lca, G)
+        assert_raises(NNI, all_pairs_lca, G)
+        assert_raises(NNI, nx.lowest_common_ancestor, G, 0, 1)
+        G = nx.MultiDiGraph([(0, 1)])
+        assert_raises(NNI, tree_all_pairs_lca, G)
+        assert_raises(NNI, all_pairs_lca, G)
+        assert_raises(NNI, nx.lowest_common_ancestor, G, 0, 1)
+
     def test_tree_all_pairs_lowest_common_ancestor13(self):
         """Test that it works on non-empty trees with no LCAs."""
         G = nx.DiGraph()


### PR DESCRIPTION
I introduced a bug into lowest common ancestor about using undirected or multigraph. 
This PR adds tests for that bug and fixes it.