### PR TITLE
shortest_path return types as discussed for #2510

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ NetworkX
    :target: https://ci.appveyor.com/project/dschult/networkx-pqott
 
 .. image:: https://readthedocs.org/projects/networkx/badge/?version=latest
-   :target: https://readthedocs.org/projects/networkx/?badge=latest
+   :target: https://networkx.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
 .. image:: https://codecov.io/gh/networkx/networkx/branch/master/graph/badge.svg

--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -65,4 +65,5 @@ def harmonic_centrality(G, nbunch=None, distance=None):
     if G.is_directed():
         G = G.reverse()
     spl = partial(nx.shortest_path_length, G, weight=distance)
-    return {u: sum(1 / d if d > 0 else 0 for v, d in spl(source=u)) for u in G.nbunch_iter(nbunch)}
+    return {u: sum(1 / d if d > 0 else 0 for v, d in spl(source=u).items())
+            for u in G.nbunch_iter(nbunch)}

--- a/networkx/algorithms/connectivity/stoerwagner.py
+++ b/networkx/algorithms/connectivity/stoerwagner.py
@@ -151,7 +151,7 @@ def stoer_wagner(G, weight='weight', heap=BinaryHeap):
     G = nx.Graph(islice(contractions, best_phase))
     v = contractions[best_phase][1]
     G.add_node(v)
-    reachable = set(n for n, d in nx.single_source_shortest_path_length(G, v))
+    reachable = set(nx.single_source_shortest_path_length(G, v))
     partition = (list(reachable), list(nodes - reachable))
 
     return cut_value, partition

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -51,7 +51,8 @@ def descendants(G, source):
     """
     if not G.has_node(source):
         raise nx.NetworkXError("The node %s is not in the graph." % source)
-    des = set(n for n, d in nx.shortest_path_length(G, source=source)) - set([source])
+    spl = nx.shortest_path_length(G, source=source)
+    des = set(spl) - set([source])
     return des
 
 
@@ -71,7 +72,8 @@ def ancestors(G, source):
     """
     if not G.has_node(source):
         raise nx.NetworkXError("The node %s is not in the graph." % source)
-    anc = set(n for n, d in nx.shortest_path_length(G, target=source)) - set([source])
+    spl = nx.shortest_path_length(G, target=source)
+    anc = set(spl) - set([source])
     return anc
 
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -223,7 +223,7 @@ def eccentricity(G, v=None, sp=None):
     e = {}
     for n in G.nbunch_iter(v):
         if sp is None:
-            length = dict(networkx.single_source_shortest_path_length(G, n))
+            length = networkx.single_source_shortest_path_length(G, n)
             L = len(length)
         else:
             try:

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -113,9 +113,9 @@ def shortest_path(G, source=None, target=None, weight=None):
         if target is None:
             # Find paths between all pairs.
             if weight is None:
-                paths = nx.all_pairs_shortest_path(G)
+                paths = dict(nx.all_pairs_shortest_path(G))
             else:
-                paths = nx.all_pairs_dijkstra_path(G, weight=weight)
+                paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
         else:
             # Find paths from all nodes co-accessible to the target.
             with nx.utils.reversed(G):
@@ -174,19 +174,15 @@ def shortest_path_length(G, source=None, target=None, weight=None):
         If the source and target are both specified, return the length of
         the shortest path from the source to the target.
 
-        If only the source is specified, return a tuple
-        (target, shortest path length) iterator, where shortest path lengths
-        are the lengths of the shortest path from the source to one of the
-        targets.
+        If only the source is specified, return a dict keyed by target
+        to the shortest path length from the source to that target.
 
-        If only the target is specified, return a tuple
-        (source, shortest path length) iterator, where shortest path lengths
-        are the lengths of the shortest path from one of the sources
-        to the target.
+        If only the target is specified, return a dict keyed by source
+        to the shortest path length from that source to the target.
 
-        If neither the source nor target are specified, return a
-        (source, dictionary) iterator with dictionary keyed by target and
-        shortest path length as the key value.
+        If neither the source nor target are specified, return an iterator
+        over (source, dictionary) where dictionary is keyed by target to
+        shortest path length from source to that target.
 
     Raises
     ------
@@ -199,13 +195,13 @@ def shortest_path_length(G, source=None, target=None, weight=None):
     >>> nx.shortest_path_length(G, source=0, target=4)
     4
     >>> p = nx.shortest_path_length(G, source=0) # target not specified
-    >>> dict(p)[4]
+    >>> p[4]
     4
     >>> p = nx.shortest_path_length(G, target=4) # source not specified
-    >>> dict(p)[0]
+    >>> p[0]
     4
-    >>> p = nx.shortest_path_length(G) # source,target not specified
-    >>> dict(p)[0][4]
+    >>> p = dict(nx.shortest_path_length(G)) # source,target not specified
+    >>> p[0][4]
     4
 
     Notes
@@ -239,7 +235,7 @@ def shortest_path_length(G, source=None, target=None, weight=None):
                     # We need to exhaust the iterator as Graph needs
                     # to be reversed.
                     path_length = nx.single_source_shortest_path_length
-                    paths = list(path_length(G, target))
+                    paths = path_length(G, target)
                 else:
                     path_length = nx.single_source_dijkstra_path_length
                     paths = path_length(G, target, weight=weight)
@@ -333,7 +329,7 @@ def average_shortest_path_length(G, weight=None):
         ssdpl = nx.single_source_dijkstra_path_length
         path_length = lambda v: ssdpl(G, v, weight=weight)
     # Sum the distances for each (ordered) pair of source and target node.
-    s = sum(l for u in G for v, l in path_length(u))
+    s = sum(l for u in G for l in path_length(u).values())
     return s / (n * (n - 1))
 
 

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -96,14 +96,14 @@ class TestGenericPath:
 
     def test_all_pairs_shortest_path(self):
         p=nx.shortest_path(self.cycle)
-        assert_equal(p[0][3],[0,1,2,3])
-        assert_equal(p,nx.all_pairs_shortest_path(self.cycle))
+        assert_equal(p[0][3], [0, 1, 2, 3])
+        assert_equal(p, dict(nx.all_pairs_shortest_path(self.cycle)))
         p=nx.shortest_path(self.grid)
         validate_grid_path(4, 4, 1, 12, p[1][12])
         # now with weights
         p=nx.shortest_path(self.cycle,weight='weight')
-        assert_equal(p[0][3],[0,1,2,3])
-        assert_equal(p,nx.all_pairs_dijkstra_path(self.cycle))
+        assert_equal(p[0][3],[0, 1, 2, 3])
+        assert_equal(p, dict(nx.all_pairs_dijkstra_path(self.cycle)))
         p=nx.shortest_path(self.grid,weight='weight')
         validate_grid_path(4, 4, 1, 12, p[1][12])
 

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -75,9 +75,9 @@ class TestUnweightedPath:
         assert_equal(dict(pl(self.directed_cycle, 0)), lengths)
 
     def test_all_pairs_shortest_path(self):
-        p=nx.all_pairs_shortest_path(self.cycle)
+        p=dict(nx.all_pairs_shortest_path(self.cycle))
         assert_equal(p[0][3],[0,1,2,3])
-        p=nx.all_pairs_shortest_path(self.grid)
+        p=dict(nx.all_pairs_shortest_path(self.grid))
         validate_grid_path(4, 4, 1, 12, p[1][12])
 
     def test_all_pairs_shortest_path_length(self):

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -298,6 +298,13 @@ class TestMultiSourceDijkstra(object):
         assert_equal(distances, expected_distances)
         assert_equal(paths, expected_paths)
 
+    def test_simple_paths(self):
+        G = nx.path_graph(4)
+        lengths = nx.multi_source_dijkstra_path_length(G, [0])
+        assert_equal(lengths, {n: n for n in G})
+        paths = nx.multi_source_dijkstra_path(G, [0])
+        assert_equal(paths, {n: list(range(n+1)) for n in G})
+
 
 class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
@@ -305,7 +312,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.DiGraph()
         G.add_node(0)
         assert_equal(nx.single_source_bellman_ford_path(G, 0), {0: [0]})
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)), {0: 0})
+        assert_equal(nx.single_source_bellman_ford_path_length(G, 0), {0: 0})
         assert_equal(nx.single_source_bellman_ford(G, 0), ({0: 0}, {0: [0]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: [None]}, {0: 0}))
         assert_equal(nx.goldberg_radzik(G, 0), ({0: None}, {0: 0}))
@@ -340,7 +347,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G.add_edge(1, 2, weight=-3)
         assert_equal(nx.single_source_bellman_ford_path(G, 0),
                      {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3], 4: [0, 1, 2, 3, 4]})
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)),
+        assert_equal(nx.single_source_bellman_ford_path_length(G, 0),
                      {0: 0, 1: 1, 2: -2, 3: -1, 4: 0})
         assert_equal(nx.single_source_bellman_ford(G, 0),
                      ({0: 0, 1: 1, 2: -2, 3: -1, 4: 0},
@@ -358,7 +365,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G.add_edge(10, 12)
         assert_equal(nx.single_source_bellman_ford_path(G, 0),
                      {0: [0], 1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 4], 5: [0, 5]})
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)),
+        assert_equal(nx.single_source_bellman_ford_path_length(G, 0),
                      {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1})
         assert_equal(nx.single_source_bellman_ford(G, 0),
                      ({0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1},
@@ -378,7 +385,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
                           ('C', 'A', {'load': 2})])
         assert_equal(nx.single_source_bellman_ford_path(G, 0, weight='load'),
                      {0: [0], 1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 4], 5: [0, 5]})
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0, weight='load')),
+        assert_equal(nx.single_source_bellman_ford_path_length(G, 0, weight='load'),
                      {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1})
         assert_equal(nx.single_source_bellman_ford(G, 0, weight='load'),
                      ({0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1},
@@ -394,7 +401,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(nx.bellman_ford_path(self.MXG, 's', 'v'), ['s', 'x', 'u', 'v'])
         assert_equal(nx.bellman_ford_path_length(self.MXG, 's', 'v'), 9)
         assert_equal(nx.single_source_bellman_ford_path(self.MXG, 's')['v'], ['s', 'x', 'u', 'v'])
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(self.MXG, 's'))['v'], 9)
+        assert_equal(nx.single_source_bellman_ford_path_length(self.MXG, 's')['v'], 9)
         D, P = nx.single_source_bellman_ford(self.MXG, 's', target='v')
         assert_equal(D, 9)
         assert_equal(P, ['s', 'x', 'u', 'v'])
@@ -407,7 +414,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(nx.bellman_ford_path(self.MXG4, 0, 2), [0, 1, 2])
         assert_equal(nx.bellman_ford_path_length(self.MXG4, 0, 2), 4)
         assert_equal(nx.single_source_bellman_ford_path(self.MXG4, 0)[2], [0, 1, 2])
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(self.MXG4, 0))[2], 4)
+        assert_equal(nx.single_source_bellman_ford_path_length(self.MXG4, 0)[2], 4)
         D, P = nx.single_source_bellman_ford(self.MXG4, 0, target=2)
         assert_equal(D, 4)
         assert_equal(P, [0, 1, 2])
@@ -422,7 +429,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(nx.bellman_ford_path(self.XG, 's', 'v'), ['s', 'x', 'u', 'v'])
         assert_equal(nx.bellman_ford_path_length(self.XG, 's', 'v'), 9)
         assert_equal(nx.single_source_bellman_ford_path(self.XG, 's')['v'], ['s', 'x', 'u', 'v'])
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(self.XG, 's'))['v'], 9)
+        assert_equal(nx.single_source_bellman_ford_path_length(self.XG, 's')['v'], 9)
         D, P = nx.single_source_bellman_ford(self.XG, 's', target='v')
         assert_equal(D, 9)
         assert_equal(P, ['s', 'x', 'u', 'v'])
@@ -437,7 +444,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         G = nx.path_graph(4)
         assert_equal(nx.single_source_bellman_ford_path(G, 0),
                      {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3]})
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 0)),
+        assert_equal(nx.single_source_bellman_ford_path_length(G, 0),
                      {0: 0, 1: 1, 2: 2, 3: 3})
         assert_equal(nx.single_source_bellman_ford(G, 0),
                      ({0: 0, 1: 1, 2: 2, 3: 3}, {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [0, 1, 2, 3]}))
@@ -447,7 +454,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
                      ({0: None, 1: 0, 2: 1, 3: 2}, {0: 0, 1: 1, 2: 2, 3: 3}))
         assert_equal(nx.single_source_bellman_ford_path(G, 3),
                      {0: [3, 2, 1, 0], 1: [3, 2, 1], 2: [3, 2], 3: [3]})
-        assert_equal(dict(nx.single_source_bellman_ford_path_length(G, 3)),
+        assert_equal(nx.single_source_bellman_ford_path_length(G, 3),
                      {0: 3, 1: 2, 2: 1, 3: 0})
         assert_equal(nx.single_source_bellman_ford(G, 3),
                      ({0: 3, 1: 2, 2: 1, 3: 0}, {0: [3, 2, 1, 0], 1: [3, 2, 1], 2: [3, 2], 3: [3]}))

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -239,6 +239,35 @@ class TestWeightedPath(WeightedTestBase):
         assert_equal(distance, 1 / 10)
         assert_equal(path, [0, 2])
 
+    def test_all_pairs_dijkstra_path(self):
+        cycle=nx.cycle_graph(7)
+        p=dict(nx.all_pairs_dijkstra_path(cycle))
+        assert_equal(p[0][3], [0, 1, 2, 3])
+
+        cycle[1][2]['weight'] = 10
+        p=dict(nx.all_pairs_dijkstra_path(cycle))
+        assert_equal(p[0][3], [0, 6, 5, 4, 3])
+
+    def test_all_pairs_dijkstra_path_length(self):
+        cycle=nx.cycle_graph(7)
+        pl = dict(nx.all_pairs_dijkstra_path_length(cycle))
+        assert_equal(pl[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+
+        cycle[1][2]['weight'] = 10
+        pl = dict(nx.all_pairs_dijkstra_path_length(cycle))
+        assert_equal(pl[0], {0: 0, 1: 1, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1})
+
+    def test_all_pairs_dijkstra(self):
+        cycle=nx.cycle_graph(7)
+        out = dict(nx.all_pairs_dijkstra(cycle))
+        assert_equal(out[0][0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(out[0][1][3], [0, 1, 2, 3])
+
+        cycle[1][2]['weight'] = 10
+        out = dict(nx.all_pairs_dijkstra(cycle))
+        assert_equal(out[0][0], {0: 0, 1: 1, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1})
+        assert_equal(out[0][1][3], [0, 6, 5, 4, 3])
+
 
 class TestDijkstraPathLength(object):
     """Unit tests for the :func:`networkx.dijkstra_path_length`

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -37,13 +37,13 @@ def single_source_shortest_path_length(G, source, cutoff=None):
 
     Returns
     -------
-    lengths : iterator
-        (target, shortest path length) iterator
+    lengths : dict
+        Dict keyed by node to shortest path length to source.
 
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> length = dict(nx.single_source_shortest_path_length(G, 0))
+    >>> length = nx.single_source_shortest_path_length(G, 0)
     >>> length[4]
     4
     >>> for node in length:
@@ -63,7 +63,7 @@ def single_source_shortest_path_length(G, source, cutoff=None):
     if cutoff is None:
         cutoff = float('inf')
     nextlevel = {source: 1}
-    return _single_shortest_path_length(G.adj, nextlevel, cutoff)
+    return dict(_single_shortest_path_length(G.adj, nextlevel, cutoff))
 
 
 def _single_shortest_path_length(adj, firstlevel, cutoff):
@@ -183,7 +183,7 @@ def all_pairs_shortest_path_length(G, cutoff=None):
     length = single_source_shortest_path_length
     # TODO This can be trivially parallelized.
     for n in G:
-        yield (n, dict(length(G, n, cutoff=cutoff)))
+        yield (n, length(G, n, cutoff=cutoff))
 
 
 def bidirectional_shortest_path(G, source, target):
@@ -340,7 +340,7 @@ def single_source_shortest_path(G, source, cutoff=None):
         cutoff = float('inf')
     nextlevel = {source: 1}     # list of nodes to check at next level
     paths = {source: [source]}  # paths dictionary  (paths to key from source)
-    return _single_shortest_path(G.adj, nextlevel, paths, cutoff, join)
+    return dict(_single_shortest_path(G.adj, nextlevel, paths, cutoff, join))
 
 
 def _single_shortest_path(adj, firstlevel, paths, cutoff, join):
@@ -423,7 +423,7 @@ def single_target_shortest_path(G, target, cutoff=None):
         cutoff = float('inf')
     nextlevel = {target: 1}     # list of nodes to check at next level
     paths = {target: [target]}  # paths dictionary  (paths to key from source)
-    return _single_shortest_path(adj, nextlevel, paths, cutoff, join)
+    return dict(_single_shortest_path(adj, nextlevel, paths, cutoff, join))
 
 
 def all_pairs_shortest_path(G, cutoff=None):
@@ -445,7 +445,7 @@ def all_pairs_shortest_path(G, cutoff=None):
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> path = nx.all_pairs_shortest_path(G)
+    >>> path = dict(nx.all_pairs_shortest_path(G))
     >>> print(path[0][4])
     [0, 1, 2, 3, 4]
 
@@ -455,7 +455,8 @@ def all_pairs_shortest_path(G, cutoff=None):
 
     """
     # TODO This can be trivially parallelized.
-    return {n: single_source_shortest_path(G, n, cutoff=cutoff) for n in G}
+    for n in G:
+        yield (n, single_source_shortest_path(G, n, cutoff=cutoff))
 
 
 def predecessor(G, source, target=None, cutoff=None, return_seen=None):

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -323,13 +323,13 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
 
     Returns
     -------
-    length : iterator
-        (target, shortest path length) iterator
+    length : dict
+        Dict keyed by node to shortest path length from source.
 
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> length = dict(nx.single_source_dijkstra_path_length(G, 0))
+    >>> length = nx.single_source_dijkstra_path_length(G, 0)
     >>> length[4]
     4
     >>> for node in [0, 1, 2, 3, 4]:
@@ -559,13 +559,13 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
 
     Returns
     -------
-    length : iterator
-        (target, shortest path length) iterator
+    length : dict
+        Dict keyed by node to shortest path length to nearest source.
 
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> length = dict(nx.multi_source_dijkstra_path_length(G, {0, 4}))
+    >>> length = nx.multi_source_dijkstra_path_length(G, {0, 4})
     >>> for node in [0, 1, 2, 3, 4]:
     ...     print('{}: {}'.format(node, length[node]))
     0: 0
@@ -596,9 +596,7 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
     if not sources:
         raise ValueError('sources must not be empty')
     weight = _weight_function(G, weight)
-    dist = _dijkstra_multisource(G, sources, weight, cutoff=cutoff)
-    # TODO In Python 3.3+, this should be `yield from dist.items()`.
-    return iter(dist.items())
+    return _dijkstra_multisource(G, sources, weight, cutoff=cutoff)
 
 
 def multi_source_dijkstra(G, sources, target=None, cutoff=None,
@@ -943,7 +941,7 @@ def all_pairs_dijkstra_path_length(G, cutoff=None, weight='weight'):
     """
     length = single_source_dijkstra_path_length
     for n in G:
-        yield (n, dict(length(G, n, cutoff=cutoff, weight=weight)))
+        yield (n, length(G, n, cutoff=cutoff, weight=weight))
 
 
 def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
@@ -976,8 +974,8 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> path=nx.all_pairs_dijkstra_path(G)
+    >>> G = nx.path_graph(5)
+    >>> path = dict(nx.all_pairs_dijkstra_path(G))
     >>> print(path[0][4])
     [0, 1, 2, 3, 4]
 
@@ -993,7 +991,7 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
     """
     path = single_source_dijkstra_path
     # TODO This can be trivially parallelized.
-    return {n: path(G, n, cutoff=cutoff, weight=weight) for n in G}
+    return ((n, path(G, n, cutoff=cutoff, weight=weight)) for n in G)
 
 
 def bellman_ford(G, source, weight='weight'):
@@ -1416,8 +1414,7 @@ def single_source_bellman_ford_path_length(G, source,
 
     """
     weight = _weight_function(G, weight)
-
-    return iter(_bellman_ford(G, [source], weight, cutoff=cutoff).items())
+    return _bellman_ford(G, [source], weight, cutoff=cutoff)
 
 
 def single_source_bellman_ford(G, source,

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -924,20 +924,20 @@ def all_pairs_dijkstra(G, cutoff=None, weight='weight'):
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> len_path = list(nx.all_pairs_dijkstra(G))
-    >>> print(len_path[3]['distance'][1])
+    >>> len_path = dict(nx.all_pairs_dijkstra(G))
+    >>> print(len_path[3][0][1])
     2
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('3 - {}: {}'.format(node, len_path[3]['distance'][node]))
+    ...     print('3 - {}: {}'.format(node, len_path[3][0][node]))
     3 - 0: 3
     3 - 1: 2
     3 - 2: 1
     3 - 3: 0
     3 - 4: 1
-    >>> len_path[3]['path'][1]
+    >>> len_path[3][1][1]
     [3, 2, 1]
-    >>> for pair in nx.all_pairs_dijkstra(G):
-    ...     print(pair['path'][1])
+    >>> for n, (dist, path) in nx.all_pairs_dijkstra(G):
+    ...     print(path[1])
     [0, 1]
     [1]
     [2, 1]
@@ -1633,8 +1633,8 @@ def all_pairs_bellman_ford_path(G, cutoff=None, weight='weight'):
 
     Examples
     --------
-    >>> G=nx.path_graph(5)
-    >>> path=nx.all_pairs_bellman_ford_path(G)
+    >>> G = nx.path_graph(5)
+    >>> path = dict(nx.all_pairs_bellman_ford_path(G))
     >>> print(path[0][4])
     [0, 1, 2, 3, 4]
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -912,17 +912,14 @@ def all_pairs_dijkstra(G, cutoff=None, weight='weight'):
        dictionary of edge attributes for that edge. The function must
        return a number.
 
-    Returns
-    -------
-    distance, path : iterator
-       {'distance': distance, 'path': path} iterator, keyed by source nodes.
-       Associated to each source node is a dictionary containing two dicts,
-       'distance' and 'path'. Both dictionaries are keyed by target nodes.
-       (See single_source_dijkstra for the source node / target_node
-       terminology.) The first dictionary, keyed 'distance', stores distances
-       to each target node. The second, keyed 'path', stores the path to each
-       target node.
-
+    Yields
+    ------
+    (node, (distance, path)) : (node obj, (dict, dict))
+        Each source node has two associated dicts. The first holds distance
+        keyed by target and the second holds paths keyed by target.
+        (See single_source_dijkstra for the source/target node terminology.)
+        If desired you can apply `dict()` to this function to create a dict
+        keyed by source node to the two dicts.
 
     Examples
     --------
@@ -952,12 +949,11 @@ def all_pairs_dijkstra(G, cutoff=None, weight='weight'):
     Edge weight attributes must be numerical.
     Distances are calculated as sums of weighted edges traversed.
 
-    The dictionary returned only has keys for reachable node pairs.
+    The yielded dicts only have keys for reachable nodes.
     """
     for n in G:
-        distance, path = single_source_dijkstra(
-            G, n, cutoff=cutoff, weight=weight)
-        yield {'distance': distance, 'path': path}
+        dist, path = single_source_dijkstra(G, n, cutoff=cutoff, weight=weight)
+        yield (n, (dist, path))
 
 
 def all_pairs_dijkstra_path_length(G, cutoff=None, weight='weight'):
@@ -1064,7 +1060,8 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
     """
     path = single_source_dijkstra_path
     # TODO This can be trivially parallelized.
-    return ((n, path(G, n, cutoff=cutoff, weight=weight)) for n in G)
+    for n in G:
+        yield (n, path(G, n, cutoff=cutoff, weight=weight))
 
 
 def bellman_ford(G, source, weight='weight'):
@@ -1653,7 +1650,8 @@ def all_pairs_bellman_ford_path(G, cutoff=None, weight='weight'):
     """
     path = single_source_bellman_ford_path
     # TODO This can be trivially parallelized.
-    return {n: path(G, n, cutoff=cutoff, weight=weight) for n in G}
+    for n in G:
+        yield (n, path(G, n, cutoff=cutoff, weight=weight))
 
 
 def goldberg_radzik(G, source, weight='weight'):

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -162,7 +162,7 @@ class TestDAGLCA:
         self.DG.add_edge(6, 2)
         self.DG.add_edge(7, 2)
 
-        self.root_distance = dict(nx.shortest_path_length(self.DG, source=0))
+        self.root_distance = nx.shortest_path_length(self.DG, source=0)
 
         self.gold = {(1, 1): 1,
                      (1, 2): 1,
@@ -212,7 +212,7 @@ class TestDAGLCA:
         else:
             roots = [n for n, deg in G.in_degree if deg == 0]
             assert(len(roots) == 1)
-            root_distance = dict(nx.shortest_path_length(G, source=roots[0]))
+            root_distance = nx.shortest_path_length(G, source=roots[0])
 
         for a, b in ((min(pair), max(pair)) for pair in chain(d1, d2)):
             assert_equal(root_distance[get_pair(d1, a, b)],

--- a/networkx/algorithms/tests/test_threshold.py
+++ b/networkx/algorithms/tests/test_threshold.py
@@ -69,7 +69,7 @@ class TestGeneratorThreshold():
         for j,pl in enumerate(spl):
             n=cs1[j][0]
             spld[n]=pl
-        assert_equal(spld, dict(nx.single_source_shortest_path_length(G, 3)))
+        assert_equal(spld, nx.single_source_shortest_path_length(G, 3))
 
     def test_weights_thresholds(self):
         wseq=[3,4,3,3,5,6,5,4,5,6]


### PR DESCRIPTION
This is a partial solution to #2510.  This commit only handles the following:

Changed to return a dict:
- multi_source_dijkstra_path_length
- single_source_bellman_ford_path_length

Changed to yield 2-tuples:
- all_pairs_shortest_path

changed to return dicts:
- single_source_shortest_path_length
- single_target_shortest_path_length

The following are in #2510:
Still need these to yield 2-tuples:
- all_pairs_dijkstra_path
- all_pairs_bellman_ford_path

Need to add this (and yield 2-tuple):
- all_pairs_dijkstra