### PR TITLE
WIP: Install optional deps for osx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ matrix:
   include:
     - os: osx
       language: generic
+      env: TRAVIS_PYTHON_VERSION=3.6.0 OPTIONAL_DEPS=pip
+    - os: osx
+      language: generic
       env: TRAVIS_PYTHON_VERSION=3.6
-#    - os: osx
-#      language: generic
-#      env: TRAVIS_PYTHON_VERSION=3.6.0 OPTIONAL_DEPS=pip
 
 before_install:
   # prepare the system to install prerequisites or dependencies


### PR DESCRIPTION
This PR enables testing OSX with the optional requirements (see ``requirements/extras.txt``) installed.

@dschult Do you have any thoughts about how to fix the resulting error:

```
======================================================================

FAIL: test_agraph.TestAGraph.testMultiDirected

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/nose/case.py", line 198, in runTest

    self.test(*self.arg)

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/drawing/tests/test_agraph.py", line 69, in testMultiDirected

    self.agraph_checks(nx.MultiDiGraph())

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/drawing/tests/test_agraph.py", line 36, in agraph_checks

    self.assert_equal(G, H)

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/drawing/tests/test_agraph.py", line 29, in assert_equal

    assert_edges_equal(G1.edges(), G2.edges())

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/testing/utils.py", line 43, in assert_edges_equal

    assert_equal(c1, c2)

AssertionError: 4 != 3

    '4 != 3' = '%s != %s' % _common_shorten_repr(4, 3)

    '4 != 3' = self._formatMessage('4 != 3', '4 != 3')

>>  raise self.failureException('4 != 3')

    

======================================================================

FAIL: test_agraph.TestAGraph.testMultiUndirected

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/nose/case.py", line 198, in runTest

    self.test(*self.arg)

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/drawing/tests/test_agraph.py", line 66, in testMultiUndirected

    self.agraph_checks(nx.MultiGraph())

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/drawing/tests/test_agraph.py", line 36, in agraph_checks

    self.assert_equal(G, H)

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/drawing/tests/test_agraph.py", line 29, in assert_equal

    assert_edges_equal(G1.edges(), G2.edges())

  File "/Users/travis/build/networkx/networkx/venv/lib/python3.6/site-packages/networkx/testing/utils.py", line 43, in assert_edges_equal

    assert_equal(c1, c2)

AssertionError: 4 != 3

    '4 != 3' = '%s != %s' % _common_shorten_repr(4, 3)

    '4 != 3' = self._formatMessage('4 != 3', '4 != 3')

>>  raise self.failureException('4 != 3')
```

I am also not sure why the shapefile tests are being skipped:
```
SKIP: OGR not available
SKIP: ogr not available.
```
According to ``pip list``, 
```
GDAL (1.11.2)
```
is installed.  I'll look into this, but may need some help with the above tracebacks.