### PR TITLE
This seems to fix the shadow import for version

### DIFF
--- a/networkx/release.py
+++ b/networkx/release.py
@@ -101,9 +101,9 @@ vcs_info = %(vcs_info)r
             # This is *good*, and the most likely place users will be when
             # running setup.py. We do not want to overwrite version.py.
             # Grab the version so that setup can use it.
-            sys.path.insert(0, basedir)
+            #sys.path.insert(0, basedir)
             from version import version
-            del sys.path[0]
+            #del sys.path[0]
         else:
             # This is *bad*.  It means the user might have a tarball that
             # does not include version.py.  Let this error raise so we can
@@ -152,7 +152,7 @@ def get_info(dynamic=True):
         # This is where most final releases of NetworkX will be.
         # All info should come from version.py. If it does not exist, then
         # no vcs information will be provided.
-        sys.path.insert(0, basedir)
+        #sys.path.insert(0, basedir)
         try:
             from version import date, date_info, version, version_info, vcs_info
         except ImportError:
@@ -160,7 +160,7 @@ def get_info(dynamic=True):
             vcs_info = (None, (None, None))
         else:
             revision = vcs_info[1][0]
-        del sys.path[0]
+        #del sys.path[0]
 
     if import_failed or (dynamic and not dynamic_failed):
         # We are here if:


### PR DESCRIPTION
It works when I make this change to release.py in
already installed v1.11 site-packages. It makes sense
that it would fix it for all future releases too.

Don't add the current directory to sys.path
and then removing it again in release.py. Just import version.

We can still play with sys.path in setup.py.  That gets run 
from the base directory. But release.py runs in the same directory as version.py
So this is the only change needed.

I'm writing all this out because I know very little about this code and I'm hoping to either justify it to myself, or give someone else enough info to tell me I'm wrong (or right).

Fixes #2546