### PR TITLE
Add miniconda osx test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ matrix:
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.6
-#    - os: osx
-#      language: generic
-#      env: TRAVIS_PYTHON_VERSION=3.6.0 OPTIONAL_DEPS=pip
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.6.0 OPTIONAL_DEPS=pip OSX_PKG_ENV=miniconda
 
 before_install:
   # prepare the system to install prerequisites or dependencies

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -1,14 +1,35 @@
 #!/usr/bin/env bash
 set -ex
 
-# set up Python and virtualenv on OSX
-git clone https://github.com/matthew-brett/multibuild
-source multibuild/osx_utils.sh
-get_macpython_environment $TRAVIS_PYTHON_VERSION venv
+# set up Miniconda on OSX
+if [[ "${OSX_PKG_ENV}" == miniconda ]]; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-MacOSX-x86_64.sh -O miniconda.sh
+    bash miniconda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    # Useful for debugging any issues with conda
+    conda info -a
+
+    conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION decorator
+    source activate testenv
+else
+    # set up Python and virtualenv on OSX
+    git clone https://github.com/matthew-brett/multibuild
+    source multibuild/osx_utils.sh
+    get_macpython_environment $TRAVIS_PYTHON_VERSION venv
+fi
 
 if [[ "${OPTIONAL_DEPS}" == pip ]]; then
-  brew install graphviz
-  sed -i "" 's/^gdal.*/gdal==1.11.2/' requirements/extras.txt
+    if [[ "${OSX_PKG_ENV}" == miniconda ]]; then
+        conda install graphviz
+        export PKG_CONFIG_PATH=/Users/travis/miniconda/envs/testenv/lib/pkgconfig
+    else
+        brew install graphviz
+    fi
+    dot -V
+    sed -i "" 's/^gdal.*/gdal==1.11.2/' requirements/extras.txt
 fi
 
 set +ex


### PR DESCRIPTION
Since Graphviz 2.40.1 from homebrew seems to have trouble with multiedges and it is not obvious how to get an older version of graphviz via homebrew, I put together this alternative where miniconda is used for the optional deps version of osx tests.

related to #2614