### PR TITLE
Unravel subgraph chains

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1211,19 +1211,19 @@ class DiGraph(Graph):
 
         Returns
         -------
-        G : Graph
-            A subgraph of the graph with the same edge attributes.
+        G : SubGraph View
+            A subgraph view of the graph. The graph structure cannot be
+            changed but node/edge attributes can and are shared with the
+            original graph.
 
         Notes
         -----
-        The graph, edge, and node attributes in the returned subgraph
-        view are references to the corresponding attributes in the original
-        graph. The view is read-only.
+        The graph, edge and node attributes are shared with the original graph.
+        Changes to the graph structure is ruled out by the view, but changes
+        to attributes are reflected in the original graph.
 
-        To create a full graph version of the subgraph with its own copy
-        of the edge or node attributes, use::
-
-            >>> G.edge_subgraph(edges).copy()  # doctest: +SKIP
+        To create a subgraph with its own copy of the edge/node attributes use:
+        G.subgraph(nbunch).copy()
 
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nbunch)])
@@ -1236,7 +1236,11 @@ class DiGraph(Graph):
         [(0, 1), (1, 2)]
         """
         induced_nodes = nx.filters.show_nodes(self.nbunch_iter(nbunch))
-        return nx.graphviews.SubDiGraph(self, induced_nodes)
+        SubGraph = nx.graphviews.SubDiGraph
+        # if already a subgraph, don't make a chain
+        if hasattr(self, '_NODE_OK'):
+            return SubGraph(self._graph, induced_nodes, self._EDGE_OK)
+        return SubGraph(self, induced_nodes)
 
     def reverse(self, copy=True):
         """Return the reverse of the graph.

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -333,6 +333,14 @@ def induced_subgraph(G, nbunch):
     For an inplace reduction of a graph to a subgraph you can remove nodes:
     `G.remove_nodes_from(n in G if n not in set(nbunch))`
 
+    If you are going to compute subgraphs of your subgraphs you could
+    end up with a chain of views that can be very slow once the chain
+    has about 15 views in it. If they are all induced subgraphs, you
+    can short-cut the chain by making them all subgraphs of the original
+    graph. The graph class method `G.subgraph` does this when `G` is
+    a subgraph. In contrast, this function allows you to choose to build
+    chains or not, as you wish. The returned subgraph is a view on `G`.
+
     Examples
     --------
     >>> import networkx as nx
@@ -373,6 +381,14 @@ def edge_subgraph(G, edges):
     -----
     To create a mutable subgraph with its own copies of nodes
     edges and attributes use `subgraph.copy()` or `Graph(subgraph)`
+
+    If you create a subgraph of a subgraph recursively you can end up
+    with a chain of subgraphs that becomes very slow with about 15
+    nested subgraph views. Luckily the edge_subgraph filter nests
+    nicely so you can use the original graph (`subgraph.root_graph`)
+    as G in this function to avoid chains. We do not rule out chains
+    programmatically so that odd cases like an `edge_subgraph` of a
+    `restricted_view` can be created.
 
     Examples
     --------
@@ -428,6 +444,13 @@ def restricted_view(G, nodes, edges):
     -----
     To create a mutable subgraph with its own copies of nodes
     edges and attributes use `subgraph.copy()` or `Graph(subgraph)`
+
+    If you create a subgraph of a subgraph recursively you may end up
+    with a chain of subgraph views. Such chains can get quite slow
+    for lengths near 15. To avoid long chains, try to make your subgraph
+    based on the original graph (`subgraph.root_graph`). We do not
+    rule out chains programatically so that odd cases like an
+    `edge_subgraph` of a `restricted_view` can be created.
 
     Examples
     --------
@@ -1016,8 +1039,8 @@ def is_empty(G):
     Notes
     -----
     An empty graph can have nodes but not edges. The empty graph with zero
-    nodes is known as the null graph. This is an $O(n)$ operation where n is the
-    number of nodes in the graph.
+    nodes is known as the null graph. This is an $O(n)$ operation where n
+    is the number of nodes in the graph.
 
     """
     return not any(G.adj.values())

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1486,14 +1486,16 @@ class Graph(object):
 
         Returns
         -------
-        G : Graph
-            A subgraph of the graph with the same edge attributes.
+        G : SubGraph View
+            A subgraph view of the graph. The graph structure cannot be
+            changed but node/edge attributes can and are shared with the
+            original graph.
 
         Notes
         -----
-        The graph, edge or node attributes just point to the original graph.
-        So changes to the node or edge structure will not be reflected in
-        the original graph while changes to the attributes will.
+        The graph, edge and node attributes are shared with the original graph.
+        Changes to the graph structure is ruled out by the view, but changes
+        to attributes are reflected in the original graph.
 
         To create a subgraph with its own copy of the edge/node attributes use:
         G.subgraph(nbunch).copy()
@@ -1509,7 +1511,11 @@ class Graph(object):
         [(0, 1), (1, 2)]
         """
         induced_nodes = nx.filters.show_nodes(self.nbunch_iter(nbunch))
-        return nx.graphviews.SubGraph(self, induced_nodes)
+        SubGraph = nx.graphviews.SubGraph
+        # if already a subgraph, don't make a chain
+        if hasattr(self, '_NODE_OK'):
+            return SubGraph(self._graph, induced_nodes, self._EDGE_OK)
+        return SubGraph(self, induced_nodes)
 
     def edge_subgraph(self, edges):
         """Returns the subgraph induced by the specified edges.

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -32,6 +32,18 @@ attributes related to the underlying graph object.
         as the current view. This is similar to G.root_graph.__class__()
         but reflects the fact that (Un)DirectedView could make the
         type of data structure different from the root_graph.
+
+Note: Since graphviews look like graphs, one can end up with
+view-of-view-of-view chains. Be careful with chains because
+they become very slow with about 15 nested views.
+For the common simple case of node induced subgraphs created
+from the graph class, we short-cut the chain by returning a
+subgraph of the original graph directly rather than a subgraph
+of a subgraph. We are careful not to disrupt any edge filter in
+the middle subgraph. In general, determining how to short-cut
+the chain is tricky and much harder with restricted_views than
+with induced subgraphs.
+Often it is easiest to use `.copy()` to avoid chains.
 """
 from collections import Mapping
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -916,19 +916,19 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         Returns
         -------
-        G : Graph
-            A subgraph of the graph with the same edge attributes.
+        G : SubGraph View
+            A subgraph view of the graph. The graph structure cannot be
+            changed but node/edge attributes can and are shared with the
+            original graph.
 
         Notes
         -----
-        The graph, edge, and node attributes in the returned subgraph
-        view are references to the corresponding attributes in the original
-        graph. The view is read-only.
+        The graph, edge and node attributes are shared with the original graph.
+        Changes to the graph structure is ruled out by the view, but changes
+        to attributes are reflected in the original graph.
 
-        To create a full graph version of the subgraph with its own copy
-        of the edge or node attributes, use::
-
-            >>> G.edge_subgraph(edges).copy()  # doctest: +SKIP
+        To create a subgraph with its own copy of the edge/node attributes use:
+        G.subgraph(nbunch).copy()
 
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nbunch)])
@@ -941,7 +941,11 @@ class MultiDiGraph(MultiGraph, DiGraph):
         [(0, 1), (1, 2)]
         """
         induced_nodes = nx.filters.show_nodes(self.nbunch_iter(nbunch))
-        return nx.graphviews.SubMultiDiGraph(self, induced_nodes)
+        SubGraph = nx.graphviews.SubMultiDiGraph
+        # if already a subgraph, don't make a chain
+        if hasattr(self, '_NODE_OK'):
+            return SubGraph(self._graph, induced_nodes, self._EDGE_OK)
+        return SubGraph(self, induced_nodes)
 
     def reverse(self, copy=True):
         """Return the reverse of the graph.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -1047,19 +1047,19 @@ class MultiGraph(Graph):
 
         Returns
         -------
-        G : Graph
-            A subgraph of the graph with the same edge attributes.
+        G : SubGraph View
+            A subgraph view of the graph. The graph structure cannot be
+            changed but node/edge attributes can and are shared with the
+            original graph.
 
         Notes
         -----
-        The graph, edge, and node attributes in the returned subgraph
-        view are references to the corresponding attributes in the original
-        graph. The view is read-only.
+        The graph, edge and node attributes are shared with the original graph.
+        Changes to the graph structure is ruled out by the view, but changes
+        to attributes are reflected in the original graph.
 
-        To create a full graph version of the subgraph with its own copy
-        of the edge or node attributes, use::
-
-            >>> G.edge_subgraph(edges).copy()  # doctest: +SKIP
+        To create a subgraph with its own copy of the edge/node attributes use:
+        G.subgraph(nbunch).copy()
 
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nbunch)])
@@ -1073,7 +1073,11 @@ class MultiGraph(Graph):
         [(0, 1), (1, 2)]
         """
         induced_nodes = nx.filters.show_nodes(self.nbunch_iter(nbunch))
-        return nx.graphviews.SubMultiGraph(self, induced_nodes)
+        SubGraph = nx.graphviews.SubMultiGraph
+        # if already a subgraph, don't make a chain
+        if hasattr(self, '_NODE_OK'):
+            return SubGraph(self._graph, induced_nodes, self._EDGE_OK)
+        return SubGraph(self, induced_nodes)
 
     def number_of_edges(self, u=None, v=None):
         """Return the number of edges between two nodes.

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -105,6 +105,14 @@ class TestFunction(object):
                      nx.subgraph(self.G, [0, 1, 2, 4]).adj)
         assert_equal(self.DG.subgraph([0, 1, 2, 4]).adj,
                      nx.subgraph(self.DG, [0, 1, 2, 4]).adj)
+        assert_equal(self.G.subgraph([0, 1, 2, 4]).adj,
+                     nx.induced_subgraph(self.G, [0, 1, 2, 4]).adj)
+        assert_equal(self.DG.subgraph([0, 1, 2, 4]).adj,
+                     nx.induced_subgraph(self.DG, [0, 1, 2, 4]).adj)
+        # subgraph-subgraph chain is allowed in function interface
+        H = nx.induced_subgraph(self.G.subgraph([0, 1, 2, 4]), [0, 1, 4])
+        assert_is_not(H._graph, self.G)
+        assert_equal(H.adj, self.G.subgraph([0, 1, 4]).adj)
 
     def test_edge_subgraph(self):
         assert_equal(self.G.edge_subgraph([(1, 2), (0, 3)]).adj,

--- a/networkx/classes/tests/test_graphviews.py
+++ b/networkx/classes/tests/test_graphviews.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_in, assert_not_in, assert_equal
+from nose.tools import assert_in, assert_not_in, assert_equal, assert_is
 from nose.tools import assert_raises, assert_true, assert_false
 
 import networkx as nx
@@ -157,14 +157,18 @@ class TestChainsOfViews(object):
         self.G = nx.path_graph(9)
         self.DG = nx.path_graph(9, create_using=nx.DiGraph())
         self.Gv = nx.to_undirected(self.DG)
+        self.MG = nx.path_graph(9, create_using=nx.MultiGraph())
         self.DMG = nx.path_graph(9, create_using=nx.MultiDiGraph())
         self.MGv = nx.to_undirected(self.DMG)
 
     def test_subgraph_of_subgraph(self):
-        SG = nx.induced_subgraph(self.G, [4, 5, 6])
-        assert_equal(list(SG), [4, 5, 6])
-        SSG = SG.subgraph([6, 7])
-        assert_equal(list(SSG), [6])
+        for G in [self.G, self.DG, self.DMG, self.MG]:
+            SG = nx.induced_subgraph(G, [4, 5, 6])
+            assert_equal(list(SG), [4, 5, 6])
+            SSG = SG.subgraph([6, 7])
+            assert_equal(list(SSG), [6])
+            # subgraph-subgraph chain is short-cut in base class method
+            assert_is(SSG._graph, G)
 
     def test_subgraph_todirected(self):
         SG = nx.induced_subgraph(self.G, [4, 5, 6])


### PR DESCRIPTION
Chains of views are view-of-view-of-view constructs. For subgraphs, if they get long (about 15 views) simple node/edge reporting slows to a crawl.

There could be times when we want the flexibility provided by short chains of subgraphs, but many common cases used in recursive algorithms should avoid chains. 

I have changes the base class method ```subgraph``` to short-cut chains. That is, when the subgraph method of a subgraph view is called, it constructs a subgraph view of the original graph rather than of itself. 

For people who want chains, the function ```nx.induced_subgraph(G, nodes)``` does not short-cut. I also considered ```edge_subgraph``` and ```restricted_view```, but short-cuts are harder to figure out from introspection. In the end I added documentation to describe options. Let the user choose which way they want to go. 