### PR TITLE
Add deprecated methods for moved base class methods.

### DIFF
--- a/doc/release/migration_guide_from_1.x_to_2.0.rst
+++ b/doc/release/migration_guide_from_1.x_to_2.0.rst
@@ -183,11 +183,12 @@ can be refactored as
 
 -------
 
-Some methods have been removed from the base graph class and placed into the main
-networkx namespace. These are:  ``G.add_path``, ``G.add_star``, ``G.add_cycle``,
-``G.number_of_selfloops``, ``G.nodes_with_selfloops``, and ``G.selfloop_edges``.
-These are replaced by ``nx.path_graph(G, ...)`` ``nx.add_star(G, ...)``,
+Some methods have been moved from the base graph class into the main namespace.
+These are:  ``G.add_path``, ``G.add_star``, ``G.add_cycle``, ``G.number_of_selfloops``,
+``G.nodes_with_selfloops``, and ``G.selfloop_edges``.
+They are replaced by ``nx.path_graph(G, ...)`` ``nx.add_star(G, ...)``,
 ``nx.selfloop_edges(G)``, etc.
+For backward compatibility, we are leaving them as deprecated methods.
 
 -------
 
@@ -258,8 +259,9 @@ That code will cause an error in v2.x.  Replace it with one of the more safe ver
 -------
 
 The methods removed from the graph classes and put into the main package namespace
-are hard to get to work with both versions. One hack is to write your code for v2.x
-and add code to the v1 namespace in an ad hoc manner:
+can be used via the associated deprecated methods. If you want to update your code
+to the new functions, one hack to make that work with both versions is to write
+your code for v2.x and add code to the v1 namespace in an ad hoc manner:
 
     >>> if nx.__version__[0] == '1':
     ...     nx.add_path = lambda G, nodes: G.add_path(nodes)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -18,6 +18,7 @@ Self-loops are allowed but multiple edges are not (see MultiGraph).
 For directed graphs see DiGraph and MultiDiGraph.
 """
 from __future__ import division
+import warnings
 from copy import deepcopy
 from collections import Mapping
 
@@ -713,6 +714,39 @@ class Graph(object):
 
     # for backwards compatibility with 1.x, will be removed for 3.x
     node = nodes
+
+    def add_path(self, nodes, **attr):
+        msg = "add_path is deprecated. Use nx.add_path instead."
+        warnings.warn(msg, DeprecationWarning)
+        return nx.add_path(self, nodes, **attr)
+
+    def add_cycle(self, nodes, **attr):
+        msg = "add_cycle is deprecated. Use nx.add_cycle instead."
+        warnings.warn(msg, DeprecationWarning)
+        return nx.add_cycle(self, nodes, **attr)
+
+    def add_star(self, nodes, **attr):
+        msg = "add_star is deprecated. Use nx.add_star instead."
+        warnings.warn(msg, DeprecationWarning)
+        return nx.add_star(self, nodes, **attr)
+
+    def nodes_with_selfloops(self):
+        msg = "nodes_with_selfloops is deprecated." \
+              "Use nx.nodes_with_selfloops instead."
+        warnings.warn(msg, DeprecationWarning)
+        return nx.nodes_with_selfloops(self)
+
+    def number_of_selfloops(self):
+        msg = "number_of_selfloops is deprecated." \
+              "Use nx.number_of_selfloops instead."
+        warnings.warn(msg, DeprecationWarning)
+        return nx.number_of_selfloops(self)
+
+    def selfloop_edges(self, data=False, keys=False, default=None):
+        msg = "selfloop_edges is deprecated. Use nx.selfloop_edges instead."
+        warnings.warn(msg, DeprecationWarning)
+        return nx.selfloop_edges(self, data=False, keys=False, default=None)
+    # Done with backward compatibility methods for 1.x
 
     def number_of_nodes(self):
         """Return the number of nodes in the graph.

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -14,6 +14,23 @@ def test_deprecated():
     G = nx.complete_graph(3)
     assert_equal(G.node, {0: {}, 1: {}, 2: {}})
 
+    G = nx.DiGraph()
+    G.add_path([3, 4])
+    assert_equal(G.adj, {3: {4: {}}, 4: {}})
+
+    G = nx.DiGraph()
+    G.add_cycle([3, 4, 5])
+    assert_equal(G.adj, {3: {4: {}}, 4: {5: {}}, 5: {3: {}}})
+
+    G = nx.DiGraph()
+    G.add_star([3, 4, 5])
+    assert_equal(G.adj, {3: {4: {}, 5: {}}, 4: {}, 5: {}})
+
+    G = nx.DiGraph([(0, 0), (0, 1), (1, 2)])
+    assert_equal(G.number_of_selfloops(), 1)
+    assert_equal(list(G.nodes_with_selfloops()), [0])
+    assert_equal(list(G.selfloop_edges()), [(0, 0)])
+
 
 class BaseGraphTester(object):
     """ Tests for data-structure independent graph class features."""


### PR DESCRIPTION
This eases creating code that works for both v1 and v2.
It doesn't address the concerns of #2634 but it eases
the transition to v2.

What do people think about adding back the moved methods?