### PR TITLE
Fix some examples for python 3 compatibility

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -199,8 +199,8 @@ latex_documents = [('reference/index', 'networkx_reference.tex',
 latex_appendices = ['tutorial']
 
 # Intersphinx mapping
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       'http://docs.scipy.org/doc/numpy/': None,
+intersphinx_mapping = {'https://docs.python.org/': None,
+                       'https://docs.scipy.org/doc/numpy/': None,
                        }
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/examples/drawing/plot_random_geometric_graph.py
+++ b/examples/drawing/plot_random_geometric_graph.py
@@ -28,9 +28,9 @@ p = dict(nx.single_source_shortest_path_length(G, ncenter))
 
 plt.figure(figsize=(8, 8))
 nx.draw_networkx_edges(G, pos, nodelist=[ncenter], alpha=0.4)
-nx.draw_networkx_nodes(G, pos, nodelist=p.keys(),
+nx.draw_networkx_nodes(G, pos, nodelist=list(p.keys()),
                        node_size=80,
-                       node_color=p.values(),
+                       node_color=list(p.values()),
                        cmap=plt.cm.Reds_r)
 
 plt.xlim(-0.05, 1.05)

--- a/examples/drawing/plot_sampson.py
+++ b/examples/drawing/plot_sampson.py
@@ -19,15 +19,18 @@ Shows how to read data from a zip file and plot multiple frames.
 #    BSD license.
 
 import zipfile
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import BytesIO as StringIO
 
 import matplotlib.pyplot as plt
 import networkx as nx
 
 zf = zipfile.ZipFile('sampson_data.zip')  # zipfile object
-e1 = cStringIO.StringIO(zf.read('samplike1.txt'))  # read info file
-e2 = cStringIO.StringIO(zf.read('samplike2.txt'))  # read info file
-e3 = cStringIO.StringIO(zf.read('samplike3.txt'))  # read info file
+e1 = StringIO(zf.read('samplike1.txt'))  # read info file
+e2 = StringIO(zf.read('samplike2.txt'))  # read info file
+e3 = StringIO(zf.read('samplike3.txt'))  # read info file
 G1 = nx.read_edgelist(e1, delimiter='\t')
 G2 = nx.read_edgelist(e2, delimiter='\t')
 G3 = nx.read_edgelist(e3, delimiter='\t')


### PR DESCRIPTION
Some of the examples threw errors at me, when I tried to build the documentation locally.

There are still two more failures, one related to `mailbox.UnixMailbox` and one regarding a not-pickable function in `advances/plot_parallel_betweenness`.

I also changed the intersphinx links to `https` to avoid these warnings:

```
loading intersphinx inventory from http://docs.scipy.org/doc/numpy/objects.inv...
intersphinx inventory has moved: http://docs.scipy.org/doc/numpy/objects.inv -> https://docs.scipy.org/doc/numpy/objects.inv
loading intersphinx inventory from http://docs.python.org/objects.inv...
intersphinx inventory has moved: http://docs.python.org/objects.inv -> https://docs.python.org/2/objects.inv
```

Also is there some documentation on how one should build the documentation? It was a bit of trial&error to get that working and I'm not sure I'm building them as "supposed".