### PR TITLE
Add some more files to gitignore related to doc builds on PyCharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 *~
 .DS_Store
 build/*
+dist/*
 networkx/version.py
 examples/*/*.png
 doc/networkx-documentation.zip
@@ -19,6 +20,10 @@ doc/reference/generated
 doc/reference/algorithms/generated
 doc/reference/classes/generated
 doc/reference/readwrite/generated
+doc/path.to.file
+
+examples/advanced/edgelist.utf-8
+examples/basic/grid.edgelist
 
 # Generated when 'python setup_egg.py'
 networkx.egg-info/
@@ -38,3 +43,6 @@ networkx.egg-info/
 
 #Spyder project file
 .spyderproject
+
+# PyCharm project file
+.idea


### PR DESCRIPTION
These files were untracked on my computer, some were created by PyCharm (`.idea`) while others were created during the documentation build.