### PR TITLE
Refactor travis tests and deploy docs with travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ doc/networkx-documentation.zip
 doc/networkx_reference.pdf
 doc/networkx_tutorial.pdf
 doc/build
+doc/doc_build
 .coverage
 *.class
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,42 +5,70 @@ sudo: false
 
 language: python
 
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-
 cache:
   directories:
     - $HOME/.cache/pip
 
-addons:
-  apt:
-    packages:
-    - libgdal-dev
-    - graphviz
-
-env:
-  matrix:
-    - OPTIONAL_DEPS=pip
-    - OPTIONAL_DEPS=no
-
 matrix:
   include:
+    - os: linux
+      python: 2.7
+      env:
+      - OPTIONAL_DEPS=1
+      - MINIMUM_REQUIREMENTS=1
+      - REPORT_COVERAGE=1
+      addons:
+        apt:
+          packages:
+          - libgdal-dev
+          - graphviz
+    - os: linux
+      python: 2.7
+      env:
+      - OPTIONAL_DEPS=1
+      addons:
+        apt:
+          packages:
+          - libgdal-dev
+          - graphviz
+    - os: linux
+      python: 3.6
+      env: OPTIONAL_DEPS=1
+      addons:
+        apt:
+          packages:
+          - libgdal-dev
+          - graphviz
+    - os: linux
+      python: 3.6
+      env:
+      - OPTIONAL_DEPS=1
+      - MINIMUM_REQUIREMENTS=1
+      addons:
+        apt:
+          packages:
+          - libgdal-dev
+          - graphviz
+    - os: osx
+      language: generic
+      env:
+      - TRAVIS_PYTHON_VERSION=3.6.0
+      - OPTIONAL_DEPS=1
+      - OSX_PKG_ENV=miniconda
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.6
-    - os: osx
-      language: generic
-      env: TRAVIS_PYTHON_VERSION=3.6.0 OPTIONAL_DEPS=pip OSX_PKG_ENV=miniconda
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
 
 before_install:
   # prepare the system to install prerequisites or dependencies
   - source tools/travis/before_install.sh
   - uname -a
   - printenv
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       source tools/travis/osx_install.sh;
     else
       source tools/travis/linux_install.sh;
@@ -50,7 +78,7 @@ install:
   # install required packages
   - pip install --upgrade pip
   - pip install --retries 3 -r requirements.txt
-  - if [[ "${OPTIONAL_DEPS}" == pip ]]; then
+  - if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
       pip install --retries 3 -r requirements/extras.txt;
     fi
   # install networkx
@@ -64,8 +92,7 @@ script:
   - source tools/travis/script.sh
 
 after_success:
-  # Report coverage for 2.7 miniconda runs only.
-  - if [[ "${TRAVIS_PYTHON_VERSION}${OPTIONAL_DEPS}" == 2\.7pip ]]; then
+  - if [[ "${REPORT_COVERAGE}" == 1 ]]; then
       codecov;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,15 @@ matrix:
       python: 2.7
       env:
       - OPTIONAL_DEPS=1
+      - BUILD_DOCS=1
       addons:
         apt:
           packages:
           - libgdal-dev
           - graphviz
+          - texlive
+          - texlive-latex-extra
+          - latexmk
     - os: linux
       python: 3.6
       env: OPTIONAL_DEPS=1
@@ -89,6 +93,9 @@ install:
   - pip list
 
 script:
+  - if [[ "${BUILD_DOCS}" == 1 ]]; then
+      source tools/travis/build_docs.sh;
+    fi
   - source tools/travis/script.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
       env:
       - OPTIONAL_DEPS=1
       - BUILD_DOCS=1
+      - DEPLOY_DOCS=1
       addons:
         apt:
           packages:
@@ -101,6 +102,9 @@ script:
 after_success:
   - if [[ "${REPORT_COVERAGE}" == 1 ]]; then
       codecov;
+    fi
+  - if [[ "${BUILD_DOCS}" == 1 && "${DEPLOY_DOCS}" == 1 ]]; then
+      source tools/travis/deploy_docs.sh;
     fi
 
 notifications:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -105,6 +105,11 @@ doctest:
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in build/doctest/output.txt."
 
+latexpdf: latex
+	@echo "Running LaTeX files through latexmk..."
+	$(MAKE) -C build/latex all-pdf
+	@echo "latexmk finished; the PDF files are in build/latex."
+
 gitwash-update:
 	python ../tools/gitwash_dumper.py developer networkx \
 	--project-url=http://networkx.github.io \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -199,7 +199,7 @@ latex_documents = [('reference/index', 'networkx_reference.tex',
 latex_appendices = ['tutorial']
 
 # Intersphinx mapping
-intersphinx_mapping = {'https://docs.python.org/': None,
+intersphinx_mapping = {'https://docs.python.org/2/': None,
                        'https://docs.scipy.org/doc/numpy/': None,
                        }
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,0 +1,6 @@
+sphinx>=1.6.3
+sphinx_rtd_theme>=0.2.4
+sphinx-gallery>=0.1.12
+pillow>=4.2.1
+nb2plots>=0.5.2
+texext>=0.5

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,6 +1,6 @@
 numpy>=1.12.0
 scipy>=0.19.0
-pandas>=0.20.0
+pandas>=0.20.1
 matplotlib>=2.0.2
 pygraphviz>=1.3.1
 pydot>=1.2.3

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 section () {
     echo -en "travis_fold:start:$1\r"
@@ -12,4 +12,10 @@ section_end () {
 export -f section
 export -f section_end
 
-set +ex
+if [[ "${MINIMUM_REQUIREMENTS}" == 1 ]]; then
+    sed -i 's/>=/==/g' requirements/default.txt
+    sed -i 's/>=/==/g' requirements/extras.txt
+    sed -i 's/>=/==/g' requirements/test.txt
+fi
+
+set +e

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -16,6 +16,7 @@ if [[ "${MINIMUM_REQUIREMENTS}" == 1 ]]; then
     sed -i 's/>=/==/g' requirements/default.txt
     sed -i 's/>=/==/g' requirements/extras.txt
     sed -i 's/>=/==/g' requirements/test.txt
+    sed -i 's/>=/==/g' requirements/doc.txt
 fi
 
 set +e

--- a/tools/travis/build_docs.sh
+++ b/tools/travis/build_docs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+pip install --retries 3 -q -r requirements/doc.txt
+export SPHINXCACHE=$HOME/.cache/sphinx
+cd doc
+make html
+make doctest
+make latexpdf
+cd ..
+
+set +e

--- a/tools/travis/deploy-key.enc
+++ b/tools/travis/deploy-key.enc
@@ -1,0 +1,4 @@
+_'NXNòg£	Æ…Õ„Ë}¡LÖbÌ§Ë¶¶‹¢=÷îÆ>ßÈÛ÷Éµˆf\Î<XäO6ÑœZ>Z€cÕùŸ{ïãÇªNÏÒ±É$R‰¡Œ¶KcÃ¤µø5í#ác#0Í`Kì•.ï£×ãQqD'ý‡UÆÚˆœ˜"_rÇQà’¬¤¢IRnhM¨€×€˜ëÿú›¡™Ï}†ÙÏ0ÉQ˜¬Ës™\‡¯î–:i•)Ž¾Ú&´)$û§Þf(o)æ.õ#ø¦ãCŸ–ô»
+µŸŸ4‡ŠÖIŽ…€á>Ý—ÄÓœ’Ú­$ÿ£Vå2uªáœo«ØDŽÉ0`$­¯*ŒŸ
+¦‰	¯F–s¦à…!Æ}_D,×X0©¡çVH±õ,þ¦†
+£EH8ÈðŒ¶˜0©â.ŒYæ²ù–<‘~m‚&¤baæ>]†gÇ„Œlúï²U’ÐX¹®ÿìßZð˜IØˆ\½änH¯^ós&ŠHŒ†•,Ÿµ: f@çñh“R”ÛÕËåµÌû­´2h6¾²«3»

--- a/tools/travis/deploy_docs.sh
+++ b/tools/travis/deploy_docs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+
+section "Deploy docs"
+if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_BRANCH == "master" && $BUILD_DOCS == 1 && $DEPLOY_DOCS == 1 ]]
+then
+    # "A deploy key is an SSH key that is stored on your server and grants access to a single GitHub repository.
+    # This key is attached directly to the repository instead of to a personal user account."
+    # -- https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys
+    #
+    # $ ssh-keygen -t ed25519 -C "Networkx Travis Bot" -f deploy-key
+    # Your identification has been saved in deploy-key.
+    # Your public key has been saved in deploy-key.pub.
+    #
+    # Add the deploy-key.pub contents to your repo's settings under Settings -> Deploy Keys.
+    # Encrypt the private deploy-key for Travis-CI and commit it to the repo
+    #
+    # $ gem install travis
+    # $ travis login
+    # $ travis encrypt-file deploy-key
+    # storing result as deploy-key.enc
+    #
+    # The ``travis encrypt-file deploy-key`` command provides the ``openssl`` command below.
+
+    # Decrypt the deploy-key with the Travis-CI key
+    openssl aes-256-cbc -K $encrypted_64abb7a9cf51_key -iv $encrypted_64abb7a9cf51_iv -in tools/travis/deploy-key.enc -out deploy-key -d
+    chmod 600 deploy-key
+    eval `ssh-agent -s`
+    ssh-add deploy-key
+
+    # Push the docs to the gh-pages branch of the networkx/dev-docs repo
+    GH_REF=git@github.com:networkx/dev-docs.git
+    echo "-- pushing docs --"
+    (
+    git config --global user.email "travis@travis-ci.com"
+    git config --global user.name "NetworkX Travis Bot"
+
+    cd doc
+    git clone --quiet --branch=gh-pages ${GH_REF} doc_build
+    cd doc_build
+
+    # Overwrite previous commit
+    git rm -rf .
+    cp -a ../build/html/* .
+    cp -a ../build/latex/networkx_reference.pdf _downloads/.
+    touch .nojekyll
+    git add -A
+    git commit --amend --no-edit
+
+    git push --force --quiet "${GH_REF}" gh-pages > /dev/null 2>&1
+    cd ../..
+    )
+else
+    echo "-- will only push docs from master --"
+fi
+section_end "Deploy docs"
+
+set +e

--- a/tools/travis/linux_install.sh
+++ b/tools/travis/linux_install.sh
@@ -5,7 +5,7 @@ set -ex
 virtualenv -p python ~/venv
 source ~/venv/bin/activate
 
-if [[ "${OPTIONAL_DEPS}" == pip ]]; then
+if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
 
   # needed to build Python binding for GDAL
   export CPLUS_INCLUDE_PATH=/usr/include/gdal

--- a/tools/travis/linux_install.sh
+++ b/tools/travis/linux_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # create new empty venv
 virtualenv -p python ~/venv
@@ -29,4 +29,4 @@ EOF
 
 fi
 
-set +ex
+set +e

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -21,7 +21,7 @@ else
     get_macpython_environment $TRAVIS_PYTHON_VERSION venv
 fi
 
-if [[ "${OPTIONAL_DEPS}" == pip ]]; then
+if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
     if [[ "${OSX_PKG_ENV}" == miniconda ]]; then
         conda install graphviz
         export PKG_CONFIG_PATH=/Users/travis/miniconda/envs/testenv/lib/pkgconfig

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
-section "Script section"
-set -ex
+set -e
 
-export NX_INSTALL=`pip show networkx | grep Location | awk '{print $2"/networkx"}'`;
+section "Script section"
+
+export NX_SOURCE=$PWD
+export NX_INSTALL=$(pip show networkx | grep Location | awk '{print $2"/networkx"}')
 
 # nose 1.3.0 does not tell coverage to only cover the requested
 # package (except during the report).  So to restrict coverage, we must
 # inform coverage through the .coveragerc file.
-cp .coveragerc $NX_INSTALL;
-cp setup.cfg $NX_INSTALL;
+cp .coveragerc $NX_INSTALL
+cp setup.cfg $NX_INSTALL
 
 # Move to new directory so that networkx is not imported from repository.
 # Why? Because we want the tests to make sure that NetworkX was installed
@@ -17,11 +19,19 @@ cp setup.cfg $NX_INSTALL;
 # Testing from the git repository cannot catch a mistake like that.
 #
 # Export current directory for logs.
-cd $NX_INSTALL;
-printenv PWD;
+cd $NX_INSTALL
+printenv PWD
 
 # Run nosetests.
-nosetests --verbosity=2 --with-ignore-docstrings --with-coverage --cover-package=networkx;
+if [[ "${REPORT_COVERAGE}" == 1 ]]; then
+  nosetests --verbosity=2 --with-ignore-docstrings --with-coverage --cover-package=networkx
+  cp -a .coverage $NX_SOURCE
+else
+  nosetests --verbosity=2 --with-ignore-docstrings
+fi
 
-set +ex
+cd $NX_SOURCE
+
 section_end "Script section"
+
+set +e


### PR DESCRIPTION
See
- https://travis-ci.org/networkx/networkx/builds/271948102
- https://networkx.github.io/dev-docs/

This PR accomplishes two main goals:

1. Travis-ci now tests that our documentation builds without error.
2. Travis-ci can now push the built docs to GitHub pages when a
   build is triggered on the master branch.

I also changed the travis-ci tests so that we only install packages
when necessary and only generate a coverage report when it will
be uploaded via codecov.
This substantial speeds up the tests so that we are able to test more
things now (e.g., whether the docs build).
Generating the coverage reports, in particular, was costly (i.e., it roughly
doubled or tripled the time it takes the test suite to run).
I no longer test extra dependencies on 3.4 and 3.5 (since I suspect they
aren't often as useful and I suspect that most folks on Python 3 are using
3.6 anyway), but I can easily add them back
(though they will slightly increase the testing time).

To deploy the built docs on GitHub pages, I generated an ed25519
deploy key using ``ssh-keygen``.
I added the ``deploy-key.pub`` contents to the ``networkx/dev-docs`` repo’s
settings under ``Settings -> Deploy Keys``.
I encrypted the private deploy key with the travis-ci symmetric key
using ``travis encrypt-file deploy-key``.
You can see how I use it in ``tools/travis/deploy_docs.sh``.

I haven't been able to directly test this without triggering a
build on the master branch (however, I could temporarily have
it deploy from the PR by changing the conditional at the top
of ``tools/travis/deploy_docs.sh``).
If we merge this, we should leave ReadTheDocs working
until we are certain this pushes the docs to GitHub pages
and that we like the results.
(We will need to update a few links on
http://networkx.github.io/documentation/ and
https://networkx.github.io/ as well.)
I tested it by hand and you can see the results here:
  https://networkx.github.io/dev-docs/
Once we verify this PR works as I intended, we can shut down the ReadTheDocs site
and clean up a few things I left behind (e.g., ``doc/requirements.txt``).

Initially I looked into pushing to the ``gh-pages`` branch of this repo:
  http://networkx.github.io/documentation/
But that repo is huge and takes a long time to clone.
We can add the stable 2.0 docs (and any other missing builds) there.
Alternatively, we could create a new repo (e.g., networkx/docs)
for 1.11 and future docs.
This would leave the networkx/documentation repo as it is.

(There were other options, I looked into and that we could still use.
Travis-ci has builtin  support: https://docs.travis-ci.com/user/deployment/pages/
However, they use a personal ``GITHUB_TOKEN``, which has
access to all of the repositories that that person has access to
(and it isn't as flexible as the approach I used). 
If we want to use that method, I would recommend creating a new
machine user account on GitHub that only has access to one repo.
However, that seems like overkill to me.
There is also this project (developed by the sympy folks):
https://drdoctr.github.io/doctr/
That seems like a big project for the little bit of work
necessary to accomplish what we want and it isn't as flexible
as the current approach.)

This isn't exactly what I did, but this blog post describes
something similar to what I did:
https://djw8605.github.io/2017/02/08/deploying-docs-on-github-with-travisci/
If this PR seems reasonable, I will write up something similar
except with the steps I followed.
(That could be useful as documentation for us and might be
helpful for other projects.)
Setting up the keys is a one-time deal, which we won't need to
bother with again.
The key pair I generated will only allow travis-ci (or someone
with the travis-ci key) to push to ``networkx/dev-docs``.
We don't need to keep a copy of the private key, so I could
delete it once we verify that this works.

If we go with this method, then we can control the documentation
build by modifying ``tools/travis/deploy_docs.sh``.
It is a pretty straightforward bash script and it should
be obvious how you could do whatever you want
(e.g., we could use the various text editing command-line
tools on Linux to correct or modify anything we want,
we could grab additional files from anywhere on the web
and copy them into any directory we want, etc.).

I've spent some time reorganizing the commits into somewhat
reasonable chunks of work, so you may want to review the
changes commit by commit.
However, I suspect looking at the full changes will be
reasonable as well.

This is a fairly big change to our doc system and one
we probably don't want to immediately change again.
So I would be happy to get a lot of tough feedback.

Thoughts?

Fix #2646.