### PR TITLE
Remove unused imports

### DIFF
--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -14,8 +14,6 @@ from networkx.utils import not_implemented_for
 from networkx.algorithms.approximation import local_node_connectivity
 from networkx.algorithms.connectivity import \
     local_node_connectivity as exact_local_node_connectivity
-from networkx.algorithms.connectivity import build_auxiliary_node_connectivity
-from networkx.algorithms.flow import build_residual_network
 
 
 __author__ = """\n""".join(['Jordi Torrents <jtorrents@milnou.net>'])

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -1,7 +1,6 @@
 #-*- coding: utf-8 -*-
 """Generators of  x-y pairs of node data."""
 import networkx as nx
-from networkx.utils import dict_to_numpy_array
 __author__ = ' '.join(['Aric Hagberg <aric.hagberg@gmail.com>'])
 __all__ = ['node_attribute_xy',
            'node_degree_xy']

--- a/networkx/algorithms/assortativity/tests/test_connectivity.py
+++ b/networkx/algorithms/assortativity/tests/test_connectivity.py
@@ -2,7 +2,6 @@ from itertools import permutations
 
 from nose.tools import assert_almost_equal
 from nose.tools import assert_equal
-from nose.tools import assert_true
 from nose.tools import raises
 
 import networkx as nx

--- a/networkx/algorithms/bipartite/covering.py
+++ b/networkx/algorithms/bipartite/covering.py
@@ -6,8 +6,7 @@
 
 """ Functions related to graph covers."""
 
-import networkx as nx
-from networkx.utils import not_implemented_for, arbitrary_element
+from networkx.utils import not_implemented_for
 from networkx.algorithms.bipartite.matching import hopcroft_karp_matching
 from networkx.algorithms.covering import min_edge_cover as _min_edge_cover
 

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -8,7 +8,6 @@
 # NetworkX is distributed under a BSD license; see LICENSE.txt for more
 # information.
 """Functions for finding chains in a graph."""
-from itertools import islice
 
 import networkx as nx
 from networkx.utils import not_implemented_for

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -13,7 +13,6 @@ from itertools import combinations
 from collections import Counter
 
 import networkx as nx
-from networkx import NetworkXError
 from networkx.utils import not_implemented_for
 
 __author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',

--- a/networkx/algorithms/coloring/greedy_coloring_with_interchange.py
+++ b/networkx/algorithms/coloring/greedy_coloring_with_interchange.py
@@ -1,4 +1,3 @@
-import networkx as nx
 import itertools
 
 __all__ = ['greedy_coloring_with_interchange']

--- a/networkx/algorithms/community/tests/test_asyn_fluidc.py
+++ b/networkx/algorithms/community/tests/test_asyn_fluidc.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_in
+from nose.tools import assert_equal
 from networkx import Graph
 from networkx.algorithms.community.asyn_fluidc import *
 import random

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -2,7 +2,7 @@
 from nose.tools import *
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
-from networkx import NetworkXError,NetworkXNotImplemented
+from networkx import NetworkXNotImplemented
 
 class TestConnected:
 

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -7,7 +7,7 @@ import networkx as nx
 
 # Define the default maximum flow function to use in all flow based
 # cut algorithms.
-from networkx.algorithms.flow import edmonds_karp, shortest_augmenting_path
+from networkx.algorithms.flow import edmonds_karp
 from networkx.algorithms.flow import build_residual_network
 default_flow_func = edmonds_karp
 

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -1,5 +1,5 @@
 import itertools
-from nose.tools import assert_equal, assert_true, assert_false, assert_raises
+from nose.tools import assert_equal, assert_true, assert_raises
 
 import networkx as nx
 from networkx.algorithms import flow

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -1,6 +1,5 @@
 # Jordi Torrents
 # Test for k-cutsets
-from operator import itemgetter
 from nose.tools import assert_equal, assert_false, assert_true, assert_raises
 
 import networkx as nx

--- a/networkx/algorithms/graphical.py
+++ b/networkx/algorithms/graphical.py
@@ -7,7 +7,6 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from collections import defaultdict
 import heapq
 import networkx as nx
 __author__ = "\n".join(['Aric Hagberg (hagberg@lanl.gov)',

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -1,8 +1,7 @@
 """
     Tests for the temporal aspect of the Temporal VF2 isomorphism algorithm.
 """
-from nose.tools import assert_true, assert_false, assert_equal
-from nose import SkipTest
+from nose.tools import assert_true, assert_false
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 from datetime import date, datetime, timedelta

--- a/networkx/algorithms/isomorphism/vf2userfunc.py
+++ b/networkx/algorithms/isomorphism/vf2userfunc.py
@@ -32,7 +32,6 @@
 """
 
 import networkx as nx
-
 from . import isomorphvf2 as vf2
 
 __all__ = ['GraphMatcher',

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -8,7 +8,6 @@
 #    BSD license.
 #    NetworkX:http://networkx.github.io/
 import networkx as nx
-from networkx.exception import NetworkXError
 __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
 __all__ = ['hits', 'hits_numpy', 'hits_scipy', 'authority_matrix', 'hub_matrix']
 

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -7,7 +7,6 @@
 #    BSD license.
 #    NetworkX:http://networkx.github.io/
 import networkx as nx
-from networkx.exception import NetworkXError
 from networkx.utils import not_implemented_for
 __author__ = """\n""".join(["Aric Hagberg <aric.hagberg@gmail.com>",
                             "Brandon Liu <brandon.k.liu@gmail.com"])

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -4,7 +4,6 @@ import random
 import networkx
 from nose.tools import *
 from nose import SkipTest
-from nose.plugins.attrib import attr
 
 # Example from
 # A. Langville and C. Meyer, "A survey of eigenvector methods of web

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -1,6 +1,6 @@
 import networkx as nx
 from networkx import tensor_product, cartesian_product, lexicographic_product, strong_product
-from nose.tools import assert_raises, assert_true, assert_equal, raises
+from nose.tools import assert_true, assert_equal, raises
 from networkx.testing import assert_edges_equal
 
 @raises(nx.NetworkXError)

--- a/networkx/algorithms/shortest_paths/tests/test_dense.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from nose.tools import *
-from nose import SkipTest
 import networkx as nx
 
 class TestFloyd:

--- a/networkx/algorithms/tests/test_efficiency.py
+++ b/networkx/algorithms/tests/test_efficiency.py
@@ -9,7 +9,6 @@
 """Unit tests for the :mod:`networkx.algorithms.efficiency` module."""
 
 from __future__ import division
-from unittest import TestCase
 from nose.tools import assert_equal
 import networkx as nx
 

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Original NetworkX graph tests"""
 from nose.tools import *
-import networkx
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
 from networkx.testing import *

--- a/networkx/classes/tests/test_filters.py
+++ b/networkx/classes/tests/test_filters.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equals, assert_true, assert_false, assert_raises
+from nose.tools import assert_true, assert_false, assert_raises
 import networkx as nx
 
 

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -2,7 +2,6 @@ from nose.tools import assert_equal
 from nose.tools import assert_is
 from nose.tools import assert_not_equal
 from nose.tools import assert_raises
-from nose.tools import assert_true
 from nose.tools import raises
 
 import networkx as nx

--- a/networkx/classes/tests/test_subgraphviews.py
+++ b/networkx/classes/tests/test_subgraphviews.py
@@ -1,5 +1,5 @@
 from nose.tools import assert_equal, assert_not_equal, \
-        assert_is, assert_true, assert_false, assert_raises
+        assert_is, assert_true, assert_raises
 
 import networkx as nx
 

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -26,7 +26,6 @@ Warning: Most layout routines have only been tested in 2-dimensions.
 
 """
 from __future__ import division
-import collections
 import networkx as nx
 
 __all__ = ['circular_layout',

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -24,7 +24,6 @@ See Also
 Pygraphviz: http://pygraphviz.github.io/
 """
 import os
-import sys
 import tempfile
 import networkx as nx
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -23,11 +23,9 @@ from __future__ import division
 import itertools
 
 import networkx as nx
-from networkx.algorithms.bipartite.generators import complete_bipartite_graph
 from networkx.classes import Graph
 from networkx.exception import NetworkXError
 from networkx.utils import accumulate
-from networkx.utils import flatten
 from networkx.utils import nodes_or_number
 from networkx.utils import pairwise
 

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -10,8 +10,6 @@ graph.
 """
 from __future__ import division
 
-from functools import partial
-
 from networkx.classes import DiGraph
 from networkx.classes import MultiDiGraph
 from networkx.utils import not_implemented_for

--- a/networkx/generators/tests/test_ego.py
+++ b/networkx/generators/tests/test_ego.py
@@ -4,7 +4,7 @@ ego graph
 ---------
 """
 
-from nose.tools import assert_true, assert_equal
+from nose.tools import assert_true
 import networkx as nx
 from networkx.testing.utils import *
 

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -1,5 +1,4 @@
 """Unit tests for the :mod:`networkx.generators.lattice` module."""
-import itertools
 
 from nose.tools import assert_equal
 from nose.tools import assert_true

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -15,8 +15,8 @@ from networkx.utils import reverse_cuthill_mckee_ordering
 from re import compile
 
 try:
-    from numpy import (array, asmatrix, asarray, dot, matrix, ndarray, ones,
-                       reshape, sqrt, zeros)
+    from numpy import (array, asmatrix, asarray, dot, ndarray, ones,
+                       sqrt, zeros)
     from numpy.linalg import norm, qr
     from numpy.random import normal
     from scipy.linalg import eigh, inv

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -4,7 +4,7 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from itertools import chain, count
+from itertools import chain
 import networkx as nx
 __author__ = """Aric Hagberg <aric.hagberg@gmail.com>"""
 __all__ = ['adjacency_data', 'adjacency_graph']

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -1,6 +1,5 @@
 #    BSD license.
-from itertools import chain, count
-import json
+
 import networkx as nx
 
 __all__ = ['cytoscape_data', 'cytoscape_graph']

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -8,10 +8,8 @@
 #    All rights reserved.
 #    BSD license.
 from itertools import chain, count
-import json
 import networkx as nx
 from networkx.utils import make_str, to_tuple
-from tempfile import NamedTemporaryFile
 __all__ = ['node_link_data', 'node_link_graph']
 
 

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -1,5 +1,5 @@
 import json
-from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_true, raises
+from nose.tools import assert_equal, assert_true, raises
 import networkx as nx
 from networkx.readwrite.json_graph import *
 

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -1,5 +1,5 @@
 import json
-from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_true, raises
+from nose.tools import assert_equal, assert_true, raises
 import networkx as nx
 from networkx.readwrite.json_graph import *
 

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -1,6 +1,6 @@
 #  -*- coding: utf-8 -*-
 import json
-from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_true, raises
+from nose.tools import assert_equal, assert_true, raises
 import networkx as nx
 from networkx.readwrite.json_graph import *
 

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -1,5 +1,5 @@
 import json
-from nose.tools import assert_equal, assert_raises, assert_not_equal, assert_true, raises
+from nose.tools import assert_equal, assert_true, raises
 import networkx as nx
 from networkx.readwrite.json_graph import *
 

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -4,7 +4,7 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from itertools import chain, count
+from itertools import chain
 import networkx as nx
 from networkx.utils import make_str
 __author__ = """Aric Hagberg (hagberg@lanl.gov))"""

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,5 +1,5 @@
 from nose import SkipTest
-from nose.tools import assert_true, assert_raises
+from nose.tools import assert_raises
 
 import networkx as nx
 from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -1,10 +1,9 @@
 from nose import SkipTest
-from nose.tools import assert_raises, assert_true, assert_equal, raises
+from nose.tools import assert_raises, assert_true, raises
 
 import networkx as nx
 from networkx.testing import assert_graphs_equal
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
-from networkx.testing.utils import assert_graphs_equal
 
 
 class TestConvertNumpy(object):

--- a/networkx/utils/union_find.py
+++ b/networkx/utils/union_find.py
@@ -8,7 +8,6 @@
 """
 Union-find data structure.
 """
-from itertools import groupby
 
 from networkx.utils import groups
 


### PR DESCRIPTION
Thank you for creating and maintaining this excellent module! I've really enjoyed using `networkx` so far. I wanted to learn more about the package so I spent some time looking through the source code tonight.

I found a few unused imports and decided that, to thank you, I'd try to root out more of them. Please consider this PR to remove unused imports. If you are worried that this PR is touching too much code, please let me know and I'd be happy to break it up into smaller, more targeted sets of changes.