### PR TITLE
Add tests for pickle of each view and fix where needed

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -240,6 +240,25 @@ class DiGraph(Graph):
     creating graph subclasses by overwriting the base class `dict` with
     a dictionary-like object.
     """
+    def __getstate__(self):
+        attr = self.__dict__.copy()
+        # remove lazy property attributes
+        if 'nodes' in attr:
+            del attr['nodes']
+        if 'edges' in attr:
+            del attr['edges']
+        if 'out_edges' in attr:
+            del attr['out_edges']
+        if 'in_edges' in attr:
+            del attr['in_edges']
+        if 'degree' in attr:
+            del attr['degree']
+        if 'in_degree' in attr:
+            del attr['in_degree']
+        if 'out_degree' in attr:
+            del attr['out_degree']
+        return attr
+
     def __init__(self, data=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 

--- a/networkx/classes/filters.py
+++ b/networkx/classes/filters.py
@@ -50,9 +50,13 @@ def hide_multiedges(edges):
     return lambda u, v, k: (u, v, k) not in alledges
 
 
-def show_nodes(nodes):
-    nodes = set(nodes)
-    return lambda node: node in nodes
+# write show_nodes as a class to make SubGraph pickleable
+class show_nodes(object):
+    def __init__(self, nodes):
+        self.nodes = set(nodes)
+
+    def __call__(self, node):
+        return node in self.nodes
 
 
 def show_diedges(edges):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -254,6 +254,17 @@ class Graph(object):
     adjlist_inner_dict_factory = dict
     edge_attr_dict_factory = dict
 
+    def __getstate__(self):
+        attr = self.__dict__.copy()
+        # remove lazy property attributes
+        if 'nodes' in attr:
+            del attr['nodes']
+        if 'edges' in attr:
+            del attr['edges']
+        if 'degree' in attr:
+            del attr['degree']
+        return attr
+
     def __init__(self, data=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -331,26 +331,26 @@ class DiDegreeView(object):
     >>> assert(len(list(DVnbunch)) == 2)  # iteration over nbunch only
     """
     def __init__(self, G, nbunch=None, weight=None):
-        self.nbunch_iter = G.nbunch_iter
+        self._graph = G
         self._succ = G._succ if hasattr(G, "_succ") else G._adj
         self._pred = G._pred if hasattr(G, "_pred") else G._adj
         self._nodes = self._succ if nbunch is None \
-            else list(self.nbunch_iter(nbunch))
+            else list(G.nbunch_iter(nbunch))
         self._weight = weight
 
     def __call__(self, nbunch=None, weight=None):
         if nbunch is None:
             if weight == self._weight:
                 return self
-            return self.__class__(self, None, weight)
+            return self.__class__(self._graph, None, weight)
         try:
             if nbunch in self._nodes:
                 if weight == self._weight:
                     return self[nbunch]
-                return self.__class__(self, None, weight)[nbunch]
+                return self.__class__(self._graph, None, weight)[nbunch]
         except TypeError:
             pass
-        return self.__class__(self, nbunch, weight)
+        return self.__class__(self._graph, nbunch, weight)
 
     def __getitem__(self, n):
         weight = self._weight
@@ -619,28 +619,29 @@ class OutMultiDegreeView(DiDegreeView):
 # EdgeDataViews
 class OutEdgeDataView(object):
     """EdgeDataView for outward edges of DiGraph; See EdgeDataView"""
-    __slots__ = ('_adjdict', 'nbunch_iter', '_nodes_nbrs', '_report')
+    __slots__ = ('_viewer', '_nbunch', '_data', '_default',
+                 '_adjdict', '_nodes_nbrs', '_report')
 
     def __getstate__(self):
-        return {'_adjdict': self._adjdict,
-                'nbunch_iter': self.nbunch_iter,
-                '_nodes_nbrs': self._nodes_nbrs,
-                '_report': self._report}
+        return {'viewer': self._viewer,
+                'nbunch': self._nbunch,
+                'data': self._data,
+                'default': self._default}
 
     def __setstate__(self, state):
-        self._adjdict = state['_nodes']
-        self.nbunch_iter = state['_nbunch_iter']
-        self._nodes_nbrs = state['_nodes_nbrs']
-        self._report = state['_report']
+        self.__init__(**state)
 
     def __init__(self, viewer, nbunch=None, data=False, default=None):
-        self.nbunch_iter = viewer.nbunch_iter
+        self._viewer = viewer
         self._adjdict = viewer._adjdict
         if nbunch is None:
             self._nodes_nbrs = self._adjdict.items
         else:
-            nbunch = list(viewer.nbunch_iter(nbunch))
+            nbunch = list(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, self._adjdict[n]) for n in nbunch]
+        self._nbunch = nbunch
+        self._data = data
+        self._default = default
         # Set _report based on data and default
         if data is True:
             self._report = lambda n, nbr, dd: (n, nbr, dd)
@@ -747,16 +748,29 @@ class OutMultiEdgeDataView(OutEdgeDataView):
     """An EdgeDataView for outward edges of MultiDiGraph; See EdgeDataView"""
     __slots__ = ('keys',)
 
+    def __getstate__(self):
+        return {'viewer': self._viewer,
+                'nbunch': self._nbunch,
+                'keys': self.keys,
+                'data': self._data,
+                'default': self._default}
+
+    def __setstate__(self, state):
+        self.__init__(**state)
+
     def __init__(self, viewer, nbunch=None,
                  data=False, keys=False, default=None):
-        self.nbunch_iter = viewer.nbunch_iter
+        self._viewer = viewer
         self._adjdict = viewer._adjdict
         self.keys = keys
         if nbunch is None:
             self._nodes_nbrs = self._adjdict.items
         else:
-            nbunch = list(viewer.nbunch_iter(nbunch))
+            nbunch = list(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, self._adjdict[n]) for n in nbunch]
+        self._nbunch = nbunch
+        self._data = data
+        self._default = default
         # Set _report based on data and default
         if data is True:
             if keys is True:
@@ -870,17 +884,15 @@ class InMultiEdgeDataView(OutMultiEdgeDataView):
 # EdgeViews    have set operations and no data reported
 class OutEdgeView(Set, Mapping):
     """A EdgeView class for outward edges of a DiGraph"""
-    __slots__ = ('_adjdict', 'nbunch_iter', '_nodes_nbrs')
+    __slots__ = ('_adjdict', '_graph', '_nodes_nbrs')
 
     def __getstate__(self):
-        return {'_adjdict': self._adjdict,
-                'nbunch_iter': self.nbunch_iter,
-                '_nodes_nbrs': self._nodes_nbrs}
+        return {'_graph': self._graph}
 
     def __setstate__(self, state):
-        self._adjdict = state['_adjdict']
-        self.nbunch_iter = state['nbunch_iter']
-        self._nodes_nbrs = state['_nodes_nbrs']
+        self._graph = G = state['_graph']
+        self._adjdict = G._succ if hasattr(G, "succ") else G._adj
+        self._nodes_nbrs = self._adjdict.items
 
     @classmethod
     def _from_iterable(self, it):
@@ -889,10 +901,9 @@ class OutEdgeView(Set, Mapping):
     dataview = OutEdgeDataView
 
     def __init__(self, G):
-        succ = G._succ if hasattr(G, "succ") else G._adj
-        self.nbunch_iter = G.nbunch_iter
-        self._adjdict = succ
-        self._nodes_nbrs = succ.items
+        self._graph = G
+        self._adjdict = G._succ if hasattr(G, "succ") else G._adj
+        self._nodes_nbrs = self._adjdict.items
 
     # Set methods
     def __len__(self):
@@ -1028,13 +1039,17 @@ class InEdgeView(OutEdgeView):
     """A EdgeView class for inward edges of a DiGraph"""
     __slots__ = ()
 
+    def __setstate__(self, state):
+        self._graph = G = state['_graph']
+        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
+        self._nodes_nbrs = self._adjdict.items
+
     dataview = InEdgeDataView
 
     def __init__(self, G):
-        pred = G._pred if hasattr(G, "pred") else G._adj
-        self.nbunch_iter = G.nbunch_iter
-        self._adjdict = pred
-        self._nodes_nbrs = pred.items
+        self._graph = G
+        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
+        self._nodes_nbrs = self._adjdict.items
 
     def __iter__(self):
         for n, nbrs in self._nodes_nbrs():
@@ -1123,13 +1138,17 @@ class InMultiEdgeView(OutMultiEdgeView):
     """A EdgeView class for inward edges of a MultiDiGraph"""
     __slots__ = ()
 
+    def __setstate__(self, state):
+        self._graph = G = state['_graph']
+        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
+        self._nodes_nbrs = self._adjdict.items
+
     dataview = InMultiEdgeDataView
 
     def __init__(self, G):
-        pred = G._pred if hasattr(G, "pred") else G._adj
-        self.nbunch_iter = G.nbunch_iter
-        self._adjdict = pred
-        self._nodes_nbrs = pred.items
+        self._graph = G
+        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
+        self._nodes_nbrs = self._adjdict.items
 
     def __iter__(self):
         for n, nbrs in self._nodes_nbrs():

--- a/networkx/classes/tests/test_graphviews.py
+++ b/networkx/classes/tests/test_graphviews.py
@@ -3,7 +3,7 @@ from nose.tools import assert_is, assert_is_not
 from nose.tools import assert_raises, assert_true, assert_false
 
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.testing import assert_edges_equal, assert_nodes_equal
 
 # Note: SubGraph views are not tested here. They have their own testing file
 
@@ -157,13 +157,33 @@ class TestChainsOfViews(object):
     def setUp(self):
         self.G = nx.path_graph(9)
         self.DG = nx.path_graph(9, create_using=nx.DiGraph())
-        self.Gv = nx.to_undirected(self.DG)
         self.MG = nx.path_graph(9, create_using=nx.MultiGraph())
         self.MDG = nx.path_graph(9, create_using=nx.MultiDiGraph())
+        self.Gv = nx.to_undirected(self.DG)
+        self.DGv = nx.to_directed(self.G)
         self.MGv = nx.to_undirected(self.MDG)
+        self.MDGv = nx.to_directed(self.MG)
+        self.Rv = self.DG.reverse()
+        self.MRv = self.MDG.reverse()
+        self.graphs = [self.G, self.DG, self.MG, self.MDG,
+                       self.Gv, self.DGv, self.MGv, self.MDGv,
+                       self.Rv, self.MRv]
+        for G in self.graphs:
+            G.edges, G.nodes, G.degree
+
+    def test_pickle(self):
+        import pickle
+        for G in self.graphs:
+            H = pickle.loads(pickle.dumps(G, -1))
+            assert_edges_equal(H.edges, G.edges)
+            assert_nodes_equal(H.nodes, G.nodes)
 
     def test_subgraph_of_subgraph(self):
-        for G in [self.G, self.DG, self.MDG, self.MG]:
+        SGv = nx.subgraph(self.G, range(3, 7))
+        SDGv = nx.subgraph(self.DG, range(3, 7))
+        SMGv = nx.subgraph(self.MG, range(3, 7))
+        SMDGv = nx.subgraph(self.MDG, range(3, 7))
+        for G in self.graphs + [SGv, SDGv, SMGv, SMDGv]:
             SG = nx.induced_subgraph(G, [4, 5, 6])
             assert_equal(list(SG), [4, 5, 6])
             SSG = SG.subgraph([6, 7])

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -238,6 +238,13 @@ class TestEdgeDataView(object):
         self.G = nx.path_graph(9)
         self.eview = nx.reportviews.EdgeView
 
+    def test_pickle(self):
+        import pickle
+        ev = self.eview(self.G)(data=True)
+        pev = pickle.loads(pickle.dumps(ev, -1))
+        assert_equal(list(ev), list(pev))
+        assert_equal(ev.__slots__, pev.__slots__)
+
     def modify_edge(self, G, e, **kwds):
         self.G._adj[e[0]][e[1]].update(kwds)
 
@@ -412,6 +419,13 @@ class TestEdgeView(object):
     def setup(self):
         self.G = nx.path_graph(9)
         self.eview = nx.reportviews.EdgeView
+
+    def test_pickle(self):
+        import pickle
+        ev = self.eview(self.G)
+        pev = pickle.loads(pickle.dumps(ev, -1))
+        assert_equal(ev, pev)
+        assert_equal(ev.__slots__, pev.__slots__)
 
     def modify_edge(self, G, e, **kwds):
         self.G._adj[e[0]][e[1]].update(kwds)
@@ -745,6 +759,12 @@ class TestDegreeView(object):
         self.G = nx.path_graph(6, self.GRAPH())
         self.G.add_edge(1, 3, foo=2)
         self.G.add_edge(1, 3, foo=3)
+
+    def test_pickle(self):
+        import pickle
+        deg = self.G.degree
+        pdeg = pickle.loads(pickle.dumps(deg, -1))
+        assert_equal(dict(deg), dict(pdeg))
 
     def test_str(self):
         dv = self.dview(self.G)


### PR DESCRIPTION
Fixes #2652 

The EdgeViews have attributes that refer (without context) to graph methods like ```G.nbunch_iter``` and ```G._adj.items```.  Even worse, the EdgeDataViews store lambda functions on the ```_report``` attribute. In any case, these objects are thus not picklable. The graph would probably still be pickleable if it didn't use lazy properties to store the ```edges``` object. But the edge views would not be.  I decided it would be better to make them all pickleable rather than just fix the graph classes and then run into the same trouble later with the views.

I'm sure there are many methods to fix the pickles. The one I use here is to store enough context to recreate the troublesome attribute methods/iterators on Unpickling. That adds a couple of slots to the views which is not a problem. The graph classes also have to remove the lazy properties from the pickle (in ```__getstate__```). They get lazily recreated after unpickling.