### PR TITLE
rm arg `strict` from function `networkx.drawing.nx_pydot.to_pydot`

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -179,7 +179,7 @@ def from_pydot(P):
     return N
 
 
-def to_pydot(N, strict=True):
+def to_pydot(N):
     """Return a pydot graph from a NetworkX graph N.
 
     Parameters


### PR DESCRIPTION
This keyword argument is unused, because the value is overwritten in the function's body.