### PR TITLE
Fix bug and add checks for non-convergent fiedler_vector

### DIFF
--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
-Algebraic connectivity and Fiedler vectors of undirected graphs.
-"""
-
-__author__ = """ysitu <ysitu@users.noreply.github.com>"""
 # Copyright (C) 2014 ysitu <ysitu@users.noreply.github.com>
 # All rights reserved.
 # BSD license.
+#
+# Author: ysitu <ysitu@users.noreply.github.com>
+"""
+Algebraic connectivity and Fiedler vectors of undirected graphs.
+"""
 
 from functools import partial
 import networkx as nx
@@ -236,6 +236,9 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         # Depending on the linear solver to be used, two mathematically
         # equivalent formulations are used.
         if method == 'pcg':
+            if abs(W[:, 1]).sum() < 1e-10:
+                msg = "No Convergence. Try a different method"
+                raise nx.NetworkXError(msg)
             # Compute X = X - (P * L * P) \ (P * L * X) where
             # P = I - [e X] * [e X]' is a projection onto the orthogonal
             # complement of [e X].

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -7,16 +7,13 @@
 """
 Algebraic connectivity and Fiedler vectors of undirected graphs.
 """
-
 from functools import partial
 import networkx as nx
 from networkx.utils import not_implemented_for
 from networkx.utils import reverse_cuthill_mckee_ordering
-from re import compile
 
 try:
-    from numpy import (array, asmatrix, asarray, dot, matrix, ndarray, ones,
-                       reshape, sqrt, zeros)
+    from numpy import array, asmatrix, asarray, dot, ndarray, ones, sqrt, zeros
     from numpy.linalg import norm, qr
     from numpy.random import normal
     from scipy.linalg import eigh, inv
@@ -29,10 +26,8 @@ except ImportError:
 try:
     from scipy.linalg.blas import dasum, daxpy, ddot
 except ImportError:
-
     if __all__:
         # Make sure the imports succeeded.
-
         # Use minimal replacements if BLAS is unavailable from SciPy.
         dasum = partial(norm, ord=1)
         ddot = dot
@@ -41,13 +36,22 @@ except ImportError:
             y += a * x
             return y
 
-_tracemin_method = compile('^tracemin(?:_(.*))?$')
-
 
 class _PCGSolver(object):
     """Preconditioned conjugate gradient method.
-    """
 
+    To solve Ax = b:
+        M = A.diagonal() # or some other preconditioner
+        solver = _PCGSolver(lambda x: A * x, lambda x: M * x)
+        x = solver.solve(b)
+
+    The inputs A and M are functions which compute
+    matrix multiplication on the argument.
+    A - multiply by the matrix A in Ax=b
+    M - multiply by M, the preconditioner surragate for A
+
+    Warning: There is no limit on number of iterations.
+    """
     def __init__(self, A, M):
         self._A = A
         self._M = M or (lambda x: x.copy())
@@ -85,14 +89,20 @@ class _PCGSolver(object):
 
 class _CholeskySolver(object):
     """Cholesky factorization.
-    """
 
+    To solve Ax = b:
+        solver = _CholeskySolver(A)
+        x = solver.solve(b)
+
+    optional argument `tol` on solve method is ignored but included
+    to match _PCGsolver API.
+    """
     def __init__(self, A):
         if not self._cholesky:
             raise nx.NetworkXError('Cholesky solver unavailable.')
         self._chol = self._cholesky(A)
 
-    def solve(self, B):
+    def solve(self, B, tol=None):
         return self._chol(B)
 
     try:
@@ -104,14 +114,20 @@ class _CholeskySolver(object):
 
 class _LUSolver(object):
     """LU factorization.
-    """
 
+    To solve Ax = b:
+        solver = _LUSolver(A)
+        x = solver.solve(b)
+
+    optional argument `tol` on solve method is ignored but included
+    to match _PCGsolver API.
+    """
     def __init__(self, A):
         if not self._splu:
             raise nx.NetworkXError('LU solver unavailable.')
         self._LU = self._splu(A)
 
-    def solve(self, B):
+    def solve(self, B, tol=None):
         B = asarray(B)
         X = ndarray(B.shape, order='F')
         for j in range(B.shape[1]):
@@ -164,6 +180,37 @@ def _rcm_estimate(G, nodelist):
 
 def _tracemin_fiedler(L, X, normalized, tol, method):
     """Compute the Fiedler vector of L using the TraceMIN-Fiedler algorithm.
+
+    The Fiedler vector of a connected undirected graph is the eigenvector
+    corresponding to the second smallest eigenvalue of the Laplacian matrix of
+    of the graph. This function starts with the Laplacian L, not the Graph.
+
+    Parameters
+    ----------
+    L : Laplacian of a possibly weighted or normalized, but undirected graph
+
+    X : Initial guess for a solution. Usually a matrix of random numbers.
+        This function allows more than one column in X to identify more than
+        one eigenvector if desired.
+
+    normalized : bool
+        Whether the normalized Laplacian matrix is used.
+
+    tol : float
+        Tolerance of relative residual in eigenvalue computation.
+        Warning: There is no limit on number of iterations.
+
+    method : string
+        Should be 'tracemin_pcg', 'tracemin_chol' or 'tracemin_lu'.
+        Otherwise exception is raised.
+
+    Returns
+    -------
+    sigma, X : Two NumPy arrays of floats.
+        The lowest eigenvalues and corresponding eigenvectors of L.
+        The size of input X determines the size of these outputs.
+        As this is for Fiedler vectors, the zero eigenvalue (and
+        constant eigenvector) are avoided.
     """
     n = X.shape[0]
 
@@ -175,34 +222,25 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         L = D * L * D
         e *= 1. / norm(e, 2)
 
-    if not normalized:
-        def project(X):
-            """Make X orthogonal to the nullspace of L.
-            """
-            X = asarray(X)
-            for j in range(X.shape[1]):
-                X[:, j] -= X[:, j].sum() / n
-    else:
+    if normalized:
         def project(X):
             """Make X orthogonal to the nullspace of L.
             """
             X = asarray(X)
             for j in range(X.shape[1]):
                 X[:, j] -= dot(X[:, j], e) * e
+    else:
+        def project(X):
+            """Make X orthogonal to the nullspace of L.
+            """
+            X = asarray(X)
+            for j in range(X.shape[1]):
+                X[:, j] -= X[:, j].sum() / n
 
-    if method is None:
-        method = 'pcg'
-    if method == 'pcg':
-        # See comments below for the semantics of P and D.
-        def P(x):
-            x -= asarray(x * X * X.T)[0, :]
-            if not normalized:
-                x -= x.sum() / n
-            else:
-                x = daxpy(e, x, a=-ddot(x, e))
-            return x
-        solver = _PCGSolver(lambda x: P(L * P(x)), lambda x: D * x)
-    elif method == 'chol' or method == 'lu':
+    if method == 'tracemin_pcg':
+        D = L.diagonal().astype(float)
+        solver = _PCGSolver(lambda x: L * x, lambda x: D * x)
+    elif method == 'tracemin_chol' or method == 'tracemin_lu':
         # Convert A to CSC to suppress SparseEfficiencyWarning.
         A = csc_matrix(L, dtype=float, copy=True)
         # Force A to be nonsingular. Since A is the Laplacian matrix of a
@@ -211,9 +249,12 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         # corresponding element in the solution.
         i = (A.indptr[1:] - A.indptr[:-1]).argmax()
         A[i, i] = float('inf')
-        solver = (_CholeskySolver if method == 'chol' else _LUSolver)(A)
+        if method == 'tracemin_chol':
+            solver = _CholeskySolver(A)
+        else:
+            solver = _LUSolver(A)
     else:
-        raise nx.NetworkXError('unknown linear system solver.')
+        raise nx.NetworkXError('Unknown linear system solver: ' + method)
 
     # Initialize.
     Lnorm = abs(L).sum(axis=1).flatten().max()
@@ -233,33 +274,12 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         res = dasum(W * asmatrix(Y)[:, 0] - sigma[0] * X[:, 0]) / Lnorm
         if res < tol:
             break
-        # Depending on the linear solver to be used, two mathematically
-        # equivalent formulations are used.
-        if method == 'pcg':
-            if abs(W[:, 1]).sum() < 1e-10:
-                msg = "No Convergence. Try a different method"
-                raise nx.NetworkXError(msg)
-            # Compute X = X - (P * L * P) \ (P * L * X) where
-            # P = I - [e X] * [e X]' is a projection onto the orthogonal
-            # complement of [e X].
-            W *= Y  # L * X == W * Y
-            W -= (W.T * X * X.T).T
-            project(W)
-            # Compute the diagonal of P * L * P as a Jacobi preconditioner.
-            D = L.diagonal().astype(float)
-            D += 2. * (asarray(X) * asarray(W)).sum(axis=1)
-            D += (asarray(X) * asarray(X * (W.T * X))).sum(axis=1)
-            D[D < tol * Lnorm] = 1.
-            D = 1. / D
-            # Since TraceMIN is globally convergent, the relative residual can
-            # be loose.
-            X -= solver.solve(W, 0.1)
-        else:
-            # Compute X = L \ X / (X' * (L \ X)). L \ X can have an arbitrary
-            # projection on the nullspace of L, which will be eliminated.
-            W[:, :] = solver.solve(X)
-            project(W)
-            X = (inv(W.T * X) * W.T).T  # Preserves Fortran storage order.
+        # Compute X = L \ X / (X' * (L \ X)).
+        # L \ X can have an arbitrary projection on the nullspace of L,
+        # which will be eliminated.
+        W[:, :] = solver.solve(X, tol)
+        X = (inv(W.T * X) * W.T).T  # Preserves Fortran storage order.
+        project(X)
 
     return sigma, asarray(X)
 
@@ -267,14 +287,11 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
 def _get_fiedler_func(method):
     """Return a function that solves the Fiedler eigenvalue problem.
     """
-    match = _tracemin_method.match(method)
-    if match:
-        method = match.group(1)
-        if method is None:
-            method = 'pcg'
-
+    if method == "tracemin":  # old style keyword <v2.1
+        method = "tracemin_pcg"
+    if method in ("tracemin_pcg", "tracemin_chol", "tracemin_lu"):
         def find_fiedler(L, x, normalized, tol):
-            q = 2 if method == 'pcg' else min(4, L.shape[0] - 1)
+            q = 1 if method == 'tracemin_pcg' else min(4, L.shape[0] - 1)
             X = asmatrix(normal(size=(q, L.shape[0]))).T
             sigma, X = _tracemin_fiedler(L, X, normalized, tol, method)
             return sigma[0], X[:, 0]
@@ -309,7 +326,7 @@ def _get_fiedler_func(method):
 
 @not_implemented_for('directed')
 def algebraic_connectivity(G, weight='weight', normalized=False, tol=1e-8,
-                           method='tracemin'):
+                           method='tracemin_pcg'):
     """Return the algebraic connectivity of an undirected graph.
 
     The algebraic connectivity of a connected undirected graph is the second
@@ -320,21 +337,20 @@ def algebraic_connectivity(G, weight='weight', normalized=False, tol=1e-8,
     G : NetworkX graph
         An undirected graph.
 
-    weight : object, optional
+    weight : object, optional (default: None)
         The data key used to determine the weight of each edge. If None, then
-        each edge has unit weight. Default value: None.
+        each edge has unit weight.
 
-    normalized : bool, optional
-        Whether the normalized Laplacian matrix is used. Default value: False.
+    normalized : bool, optional (default: False)
+        Whether the normalized Laplacian matrix is used.
 
-    tol : float, optional
-        Tolerance of relative residual in eigenvalue computation. Default
-        value: 1e-8.
+    tol : float, optional (default: 1e-8)
+        Tolerance of relative residual in eigenvalue computation.
 
-    method : string, optional
-        Method of eigenvalue computation. It should be one of 'tracemin'
-        (TraceMIN), 'lanczos' (Lanczos iteration) and 'lobpcg' (LOBPCG).
-        Default value: 'tracemin'.
+    method : string, optional (default: 'tracemin_pcg')
+        Method of eigenvalue computation. It must be one of the tracemin
+        options shown below (TraceMIN), 'lanczos' (Lanczos iteration)
+        or 'lobpcg' (LOBPCG).
 
         The TraceMIN algorithm uses a linear system solver. The following
         values allow specifying the solver to be used.
@@ -384,12 +400,13 @@ def algebraic_connectivity(G, weight='weight', normalized=False, tol=1e-8,
 
     find_fiedler = _get_fiedler_func(method)
     x = None if method != 'lobpcg' else _rcm_estimate(G, G)
-    return find_fiedler(L, x, normalized, tol)[0]
+    sigma, fiedler = find_fiedler(L, x, normalized, tol)
+    return sigma
 
 
 @not_implemented_for('directed')
 def fiedler_vector(G, weight='weight', normalized=False, tol=1e-8,
-                   method='tracemin'):
+                   method='tracemin_pcg'):
     """Return the Fiedler vector of a connected undirected graph.
 
     The Fiedler vector of a connected undirected graph is the eigenvector
@@ -401,21 +418,20 @@ def fiedler_vector(G, weight='weight', normalized=False, tol=1e-8,
     G : NetworkX graph
         An undirected graph.
 
-    weight : object, optional
+    weight : object, optional (default: None)
         The data key used to determine the weight of each edge. If None, then
-        each edge has unit weight. Default value: None.
+        each edge has unit weight.
 
-    normalized : bool, optional
-        Whether the normalized Laplacian matrix is used. Default value: False.
+    normalized : bool, optional (default: False)
+        Whether the normalized Laplacian matrix is used.
 
-    tol : float, optional
-        Tolerance of relative residual in eigenvalue computation. Default
-        value: 1e-8.
+    tol : float, optional (default: 1e-8)
+        Tolerance of relative residual in eigenvalue computation.
 
-    method : string, optional
-        Method of eigenvalue computation. It should be one of 'tracemin'
-        (TraceMIN), 'lanczos' (Lanczos iteration) and 'lobpcg' (LOBPCG).
-        Default value: 'tracemin'.
+    method : string, optional (default: 'tracemin_pcg')
+        Method of eigenvalue computation. It must be one of the tracemin
+        options shown below (TraceMIN), 'lanczos' (Lanczos iteration)
+        or 'lobpcg' (LOBPCG).
 
         The TraceMIN algorithm uses a linear system solver. The following
         values allow specifying the solver to be used.
@@ -465,11 +481,12 @@ def fiedler_vector(G, weight='weight', normalized=False, tol=1e-8,
     find_fiedler = _get_fiedler_func(method)
     L = nx.laplacian_matrix(G)
     x = None if method != 'lobpcg' else _rcm_estimate(G, G)
-    return find_fiedler(L, x, normalized, tol)[1]
+    sigma, fiedler = find_fiedler(L, x, normalized, tol)
+    return fiedler
 
 
 def spectral_ordering(G, weight='weight', normalized=False, tol=1e-8,
-                      method='tracemin'):
+                      method='tracemin_pcg'):
     """Compute the spectral_ordering of a graph.
 
     The spectral ordering of a graph is an ordering of its nodes where nodes
@@ -481,21 +498,20 @@ def spectral_ordering(G, weight='weight', normalized=False, tol=1e-8,
     G : NetworkX graph
         A graph.
 
-    weight : object, optional
+    weight : object, optional (default: None)
         The data key used to determine the weight of each edge. If None, then
-        each edge has unit weight. Default value: None.
+        each edge has unit weight.
 
-    normalized : bool, optional
-        Whether the normalized Laplacian matrix is used. Default value: False.
+    normalized : bool, optional (default: False)
+        Whether the normalized Laplacian matrix is used.
 
-    tol : float, optional
-        Tolerance of relative residual in eigenvalue computation. Default
-        value: 1e-8.
+    tol : float, optional (default: 1e-8)
+        Tolerance of relative residual in eigenvalue computation.
 
-    method : string, optional
-        Method of eigenvalue computation. It should be one of 'tracemin'
-        (TraceMIN), 'lanczos' (Lanczos iteration) and 'lobpcg' (LOBPCG).
-        Default value: 'tracemin'.
+    method : string, optional (default: 'tracemin_pcg')
+        Method of eigenvalue computation. It must be one of the tracemin
+        options shown below (TraceMIN), 'lanczos' (Lanczos iteration)
+        or 'lobpcg' (LOBPCG).
 
         The TraceMIN algorithm uses a linear system solver. The following
         values allow specifying the solver to be used.
@@ -541,9 +557,9 @@ def spectral_ordering(G, weight='weight', normalized=False, tol=1e-8,
         if size > 2:
             L = nx.laplacian_matrix(G, component)
             x = None if method != 'lobpcg' else _rcm_estimate(G, component)
-            fiedler = find_fiedler(L, x, normalized, tol)[1]
-            order.extend(
-                u for x, c, u in sorted(zip(fiedler, range(size), component)))
+            sigma, fiedler = find_fiedler(L, x, normalized, tol)
+            sort_info = zip(fiedler, range(size), component)
+            order.extend(u for x, c, u in sorted(sort_info))
         else:
             order.extend(component)
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -267,6 +267,8 @@ def _get_fiedler_func(method):
     match = _tracemin_method.match(method)
     if match:
         method = match.group(1)
+        if method is None:
+            method = 'pcg'
 
         def find_fiedler(L, x, normalized, tol):
             q = 2 if method == 'pcg' else min(4, L.shape[0] - 1)

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -1,5 +1,4 @@
 from math import sqrt
-from numpy.random import shuffle
 import networkx as nx
 from nose import SkipTest
 from nose.tools import *
@@ -230,6 +229,8 @@ class TestSpectralOrdering(object):
             ok_(set([2, 3]) in (set(order[:-1]), set(order[1:])))
 
     def test_path(self):
+        # based on setupClass numpy is installed if we get here
+        from numpy.random import shuffle
         path = list(range(10))
         shuffle(path)
         G = nx.Graph()

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -130,8 +130,8 @@ class TestAlgebraicConnectivity(object):
         A = nx.laplacian_matrix(G)
         sigma = 2 - sqrt(2 + sqrt(2))
         for method in self._methods:
-            assert_almost_equal(nx.algebraic_connectivity(
-                G, tol=1e-12, method=method), sigma)
+            ac = nx.algebraic_connectivity(G, tol=1e-12, method=method)
+            assert_almost_equal(ac, sigma)
             x = nx.fiedler_vector(G, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
 
@@ -142,8 +142,8 @@ class TestAlgebraicConnectivity(object):
         A = nx.laplacian_matrix(G)
         sigma = 0.438447187191
         for method in self._methods:
-            assert_almost_equal(nx.algebraic_connectivity(
-                G, tol=1e-12, method=method), sigma)
+            ac = nx.algebraic_connectivity(G, tol=1e-12, method=method)
+            assert_almost_equal(ac, sigma)
             x = nx.fiedler_vector(G, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
 
@@ -153,8 +153,8 @@ class TestAlgebraicConnectivity(object):
         A = nx.laplacian_matrix(G)
         sigma = 2 - sqrt(2)
         for method in self._methods:
-            assert_almost_equal(nx.algebraic_connectivity(
-                G, tol=1e-12, method=method), sigma)
+            ac = nx.algebraic_connectivity(G, tol=1e-12, method=method)
+            assert_almost_equal(ac, sigma)
             x = nx.fiedler_vector(G, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
 

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -1,36 +1,19 @@
-from contextlib import contextmanager
 from math import sqrt
+from numpy.random import shuffle
 import networkx as nx
 from nose import SkipTest
 from nose.tools import *
 
-methods = ('tracemin_pcg', 'tracemin_chol', 'tracemin_lu', 'lanczos', 'lobpcg')
-
 try:
-    from numpy.random import get_state, seed, set_state, shuffle
-
-    @contextmanager
-    def save_random_state():
-        state = get_state()
-        try:
-            yield
-        finally:
-            set_state(state)
-
-    def preserve_random_state(func):
-        def wrapper(*args, **kwargs):
-            with save_random_state():
-                seed(1234567890)
-                return func(*args, **kwargs)
-        wrapper.__name__ = func.__name__
-        return wrapper
+    from scikits.sparse.cholmod import cholesky
+    _cholesky = cholesky
 except ImportError:
-    @contextmanager
-    def save_random_state():
-        yield
+    _cholesky = None
 
-    def preserve_random_state(func):
-        return func
+if _cholesky is None:
+    methods = ('tracemin_pcg', 'tracemin_lu', 'lanczos', 'lobpcg')
+else:
+    methods = ('tracemin_pcg', 'tracemin_chol', 'tracemin_lu', 'lanczos', 'lobpcg')
 
 
 def check_eigenvector(A, l, x):
@@ -58,7 +41,6 @@ class TestAlgebraicConnectivity(object):
         except ImportError:
             raise SkipTest('SciPy not available.')
 
-    @preserve_random_state
     def test_directed(self):
         G = nx.DiGraph()
         for method in self._methods:
@@ -67,7 +49,6 @@ class TestAlgebraicConnectivity(object):
             assert_raises(nx.NetworkXNotImplemented, nx.fiedler_vector, G,
                           method=method)
 
-    @preserve_random_state
     def test_null_and_singleton(self):
         G = nx.Graph()
         for method in self._methods:
@@ -82,7 +63,6 @@ class TestAlgebraicConnectivity(object):
             assert_raises(nx.NetworkXError, nx.fiedler_vector, G,
                           method=method)
 
-    @preserve_random_state
     def test_disconnected(self):
         G = nx.Graph()
         G.add_nodes_from(range(2))
@@ -96,14 +76,12 @@ class TestAlgebraicConnectivity(object):
             assert_raises(nx.NetworkXError, nx.fiedler_vector, G,
                           method=method)
 
-    @preserve_random_state
     def test_unrecognized_method(self):
         G = nx.path_graph(4)
         assert_raises(nx.NetworkXError, nx.algebraic_connectivity, G,
                       method='unknown')
         assert_raises(nx.NetworkXError, nx.fiedler_vector, G, method='unknown')
 
-    @preserve_random_state
     def test_two_nodes(self):
         G = nx.Graph()
         G.add_edge(0, 1, weight=1)
@@ -124,7 +102,6 @@ class TestAlgebraicConnectivity(object):
             x = nx.fiedler_vector(G, weight='spam', tol=1e-12, method=method)
             check_eigenvector(A, 6, x)
 
-    @preserve_random_state
     def test_abbreviation_of_method(self):
         G = nx.path_graph(8)
         A = nx.laplacian_matrix(G)
@@ -134,7 +111,6 @@ class TestAlgebraicConnectivity(object):
         x = nx.fiedler_vector(G, tol=1e-12, method='tracemin')
         check_eigenvector(A, sigma, x)
 
-    @preserve_random_state
     def test_path(self):
         G = nx.path_graph(8)
         A = nx.laplacian_matrix(G)
@@ -145,7 +121,6 @@ class TestAlgebraicConnectivity(object):
             x = nx.fiedler_vector(G, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
 
-    @preserve_random_state
     def test_problematic_graph_issue_2381(self):
         G = nx.path_graph(4)
         G.add_edges_from([(4, 2), (5, 1)])
@@ -157,7 +132,6 @@ class TestAlgebraicConnectivity(object):
             x = nx.fiedler_vector(G, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
 
-    @preserve_random_state
     def test_cycle(self):
         G = nx.cycle_graph(8)
         A = nx.laplacian_matrix(G)
@@ -168,7 +142,6 @@ class TestAlgebraicConnectivity(object):
             x = nx.fiedler_vector(G, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
 
-    @preserve_random_state
     def test_buckminsterfullerene(self):
         G = nx.Graph(
             [(1, 10), (1, 41), (1, 59), (2, 12), (2, 42), (2, 60), (3, 6),
@@ -206,7 +179,7 @@ class TestAlgebraicConnectivity(object):
                                       ('LU solver unavailable.',)):
                         raise
 
-    _methods = ('tracemin', 'lanczos', 'lobpcg')
+    _methods = methods
 
 
 class TestSpectralOrdering(object):
@@ -222,13 +195,11 @@ class TestSpectralOrdering(object):
         except ImportError:
             raise SkipTest('SciPy not available.')
 
-    @preserve_random_state
     def test_nullgraph(self):
         for graph in (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph):
             G = graph()
             assert_raises(nx.NetworkXError, nx.spectral_ordering, G)
 
-    @preserve_random_state
     def test_singleton(self):
         for graph in (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph):
             G = graph()
@@ -238,13 +209,11 @@ class TestSpectralOrdering(object):
             G.add_edge('x', 'x', weight=33)
             assert_equal(nx.spectral_ordering(G), ['x'])
 
-    @preserve_random_state
     def test_unrecognized_method(self):
         G = nx.path_graph(4)
         assert_raises(nx.NetworkXError, nx.spectral_ordering, G,
                       method='unknown')
 
-    @preserve_random_state
     def test_three_nodes(self):
         G = nx.Graph()
         G.add_weighted_edges_from([(1, 2, 1), (1, 3, 2), (2, 3, 1)],
@@ -260,7 +229,6 @@ class TestSpectralOrdering(object):
             assert_equal(set(order), set(G))
             ok_(set([2, 3]) in (set(order[:-1]), set(order[1:])))
 
-    @preserve_random_state
     def test_path(self):
         path = list(range(10))
         shuffle(path)
@@ -270,7 +238,6 @@ class TestSpectralOrdering(object):
             order = nx.spectral_ordering(G, method=method)
             ok_(order in [path, list(reversed(path))])
 
-    @preserve_random_state
     def test_disconnected(self):
         G = nx.Graph()
         nx.add_path(G, range(0, 10, 2))
@@ -283,7 +250,6 @@ class TestSpectralOrdering(object):
             ok_(order[:5] in seqs)
             ok_(order[5:] in seqs)
 
-    @preserve_random_state
     def test_cycle(self):
         path = list(range(10))
         G = nx.Graph()
@@ -307,4 +273,4 @@ class TestSpectralOrdering(object):
                         ok_(order in [[1, 2, 3, 0, 4, 5, 9, 6, 7, 8],
                                       [8, 7, 6, 9, 5, 4, 0, 3, 2, 1]])
 
-    _methods = ('tracemin', 'lanczos', 'lobpcg')
+    _methods = methods

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -125,6 +125,16 @@ class TestAlgebraicConnectivity(object):
             check_eigenvector(A, 6, x)
 
     @preserve_random_state
+    def test_abbreviation_of_method(self):
+        G = nx.path_graph(8)
+        A = nx.laplacian_matrix(G)
+        sigma = 2 - sqrt(2 + sqrt(2))
+        ac = nx.algebraic_connectivity(G, tol=1e-12, method='tracemin')
+        assert_almost_equal(ac, sigma)
+        x = nx.fiedler_vector(G, tol=1e-12, method='tracemin')
+        check_eigenvector(A, sigma, x)
+
+    @preserve_random_state
     def test_path(self):
         G = nx.path_graph(8)
         A = nx.laplacian_matrix(G)

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -136,6 +136,18 @@ class TestAlgebraicConnectivity(object):
             check_eigenvector(A, sigma, x)
 
     @preserve_random_state
+    def test_problematic_graph_issue_2381(self):
+        G = nx.path_graph(4)
+        G.add_edges_from([(4, 2), (5, 1)])
+        A = nx.laplacian_matrix(G)
+        sigma = 0.438447187191
+        for method in self._methods:
+            assert_almost_equal(nx.algebraic_connectivity(
+                G, tol=1e-12, method=method), sigma)
+            x = nx.fiedler_vector(G, tol=1e-12, method=method)
+            check_eigenvector(A, sigma, x)
+
+    @preserve_random_state
     def test_cycle(self):
         G = nx.cycle_graph(8)
         A = nx.laplacian_matrix(G)

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -5,6 +5,7 @@ from nose.tools import *
 
 import networkx as nx
 from networkx.utils.decorators import open_file, not_implemented_for
+from networkx.utils.decorators import nodes_or_number, preserve_random_state
 
 
 def test_not_implemented_decorator():
@@ -109,8 +110,8 @@ class TestOpenFileDecorator(object):
         self.writer_arg2default(0, path=None)
 
     def test_writer_arg4default_fobj(self):
-        self.writer_arg4default(0, 1, dog='dog', other='other2')
-        self.writer_arg4default(0, 1, dog='dog', other='other2', path=self.name)
+        self.writer_arg4default(0, 1, dog='dog', other='other')
+        self.writer_arg4default(0, 1, dog='dog', other='other', path=self.name)
         assert_equal(self.read(self.name), ''.join(self.text))
 
     def test_writer_kwarg_str(self):
@@ -128,3 +129,13 @@ class TestOpenFileDecorator(object):
     def tearDown(self):
         self.fobj.close()
         os.unlink(self.name)
+
+
+@preserve_random_state
+def test_random_state():
+    try:
+        import numpy.random
+        r = numpy.random.random()
+    except ImportError:
+        return
+    assert(abs(r - 0.61879477158568) < 1e-16)


### PR DESCRIPTION
Addresses #2381 

There was a bug (default method didn't set method to 'pcg') that made the algorithm not converge consistently for any network which required more than one iteration to converge.  Even with the bug fixed, the algorithm doesn't always converge. The initial conditions are random, so restarting could work. I put in a check for non-convergence that simply raises a NetworkXError. The user would have to check this to restart with new random conditions.

It would be nice if we could make one of the other methods the default, but they have optional dependencies. Perhaps we would check if those optional dependencies are present and if so switch the default.

To be clear: the non-convergence is not a fault of the algorithm. That is apparently guaranteed to converge. But up to roundoff error the matrix W becomes singular -- specifically the second column becomes entirely zeros up to round-off.

Suggestions?