### PR TITLE
Improve subgraph node iteration

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -286,9 +286,13 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         self.NODE_OK = NODE_OK
 
     def __len__(self):
+        if hasattr(self.NODE_OK, 'nodes'):
+            return len(self.NODE_OK.nodes & set(self._atlas.keys()))
         return sum(1 for n in self._atlas if self.NODE_OK(n))
 
     def __iter__(self):
+        if hasattr(self.NODE_OK, 'nodes'):
+            return iter(self.NODE_OK.nodes & set(self._atlas.keys()))
         return (n for n in self._atlas if self.NODE_OK(n))
 
     def __getitem__(self, key):


### PR DESCRIPTION
The show_nodes() filter creates a set from an iterable container.
However, FilterAtlas will always traverse the entire node set,
even though the set of nodes is available in this newly constructed
set.

This change dramatically speeds up node iteration when the subgraph
is much smaller than the graph.

I tested this with the following:
```
import networkx as nx

import time

# Make a large graph
GRAPH_SIZE=10000000

nodes = list(range(GRAPH_SIZE))
G = nx.Graph()
G.add_nodes_from(nodes)

# Make a small subgraph of the graph
SG = G.subgraph(nodes[:100])

# Make a list of nodes from the subgraph
t = time.clock()
node_list = list(SG)
elapsed = time.clock() - t

print('Time to make subgraph node list: {:.3f}'.format(elapsed))
```

Our use case in particular involved created lists of nodes from
connected component subgraphs of a large graph, which became
much slower when upgrading to 2.0. This returns the performance
to the levels we saw with 1.X.