### PR TITLE
[WIP] Fix nx.effective_size() for nodes w/o outgoing ties

### DIFF
--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -155,12 +155,13 @@ def effective_size(G, nodes=None, weight=None):
             effective_size[v] = len(E) - (2 * E.size()) / len(E)
     else:
         for v in nodes:
+            neighbors = set(nx.all_neighbors(G, v))
             # Effective size is not defined for isolated nodes
-            if len(G[v]) == 0:
+            if len(neighbors) == 0:
                 effective_size[v] = float('nan')
                 continue
             effective_size[v] = sum(redundancy(G, v, u, weight)
-                                    for u in set(nx.all_neighbors(G, v)))
+                                    for u in neighbors)
     return effective_size
 
 


### PR DESCRIPTION
This PR is to fix the bug discussed in #2661. However, new test cases should be added that test against a directed graph which contains some nodes with no outgoing ties.