### PR TITLE
mention `doc.txt` in `requirements/README.md`

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -2,11 +2,11 @@
 
 ## Index
 
-- [default.txt](default.txt)
+- [`default.txt`](default.txt)
   Default requirements
-- [extras.txt](extras.txt)
+- [`extras.txt`](extras.txt)
   Optional requirements
-- [test.txt](test.txt)
+- [`test.txt`](test.txt)
   Requirements for running test suite
 
 ## Examples

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -8,6 +8,8 @@
   Optional requirements
 - [`test.txt`](test.txt)
   Requirements for running test suite
+- [`doc.txt`](doc.txt)
+  Requirements for building the documentation (see `../doc/`)
 
 ## Examples
 


### PR DESCRIPTION
The file `requirements/doc.txt` was recently added, and was not described in the README file of that directory.