### PR TITLE
Fix dag_longest_path bug

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -489,6 +489,8 @@ def dag_longest_path(G, weight='weight', default_weight=1):
     --------
     dag_longest_path_length
     """
+    if not G:
+        return []
     dist = {}  # stores {v : (length, u)}
     for v in nx.topological_sort(G):
         us = [(dist[u][0] + data.get(weight, default_weight), u)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -18,6 +18,10 @@ class TestDagLongestPath(object):
 
     """
 
+    def test_empty(self):
+        G = nx.DiGraph()
+        assert_equal(nx.dag_longest_path(G), [])
+
     def test_unweighted1(self):
         edges = [(1, 2), (2, 3), (2, 4), (3, 5), (5, 6), (3, 7)]
         G = nx.DiGraph(edges)


### PR DESCRIPTION
Fix a bug in dag_longest_path that raises an exception when an empty
graph is given.