### PR TITLE
Fix for inter_community_edges

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -114,7 +114,10 @@ def inter_community_edges(G, partition):
     #                                    for block in partition))
     #     return sum(1 for u, v in G.edges() if aff[u] != aff[v])
     #
-    return nx.quotient_graph(G, partition, create_using=nx.MultiGraph()).size()
+    if G.is_directed():
+        return nx.quotient_graph(G, partition, create_using=nx.MultiDiGraph()).size()
+    else:
+        return nx.quotient_graph(G, partition, create_using=nx.MultiGraph()).size()
 
 
 def inter_community_non_edges(G, partition):

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -12,6 +12,7 @@ module.
 """
 from __future__ import division
 
+from nose.tools import assert_equal
 from nose.tools import assert_almost_equal
 
 import networkx as nx
@@ -19,6 +20,7 @@ from networkx import barbell_graph
 from networkx.algorithms.community import coverage
 from networkx.algorithms.community import modularity
 from networkx.algorithms.community import performance
+from networkx.algorithms.community.quality import inter_community_edges
 
 
 class TestPerformance(object):
@@ -61,3 +63,17 @@ def test_modularity():
     assert_almost_equal(-16 / (14 ** 2), modularity(G, C))
     C = [{0, 1, 2}, {3, 4, 5}]
     assert_almost_equal((35 * 2) / (14 ** 2), modularity(G, C))
+
+
+def test_inter_community_edges_with_digraphs():
+    G = nx.complete_graph(2, create_using = nx.DiGraph())
+    partition = [{0}, {1}]
+    assert_equal(inter_community_edges(G, partition), 2)
+
+    G = nx.complete_graph(10, create_using = nx.DiGraph())
+    partition = [{0}, {1, 2}, {3, 4, 5}, {6, 7, 8, 9}]
+    assert_equal(inter_community_edges(G, partition), 70)
+
+    G = nx.cycle_graph(4, create_using = nx.DiGraph())
+    partition = [{0, 1}, {2, 3}]
+    assert_equal(inter_community_edges(G, partition), 2)


### PR DESCRIPTION
inter_community_edges sometimes returned wrong answer when working with digraphs. This patch should also fix #2600.