### PR TITLE
nx_shp fixes

### DIFF
--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -280,13 +280,13 @@ def write_shp(G, outdir):
 
     # New edge attribute write support merged into edge loop
     fields = {}      # storage for field names and their data types
-    attributes = {}  # storage for attribute data (indexed by field names)
 
     # Conversion dict between python and ogr types
     OGRTypes = {int: ogr.OFTInteger, str: ogr.OFTString, float: ogr.OFTReal}
 
     # Edge loop
     for e in G.edges(data=True):
+        attributes = {}  # storage for attribute data (indexed by field names)
         data = G.get_edge_data(*e)
         g = netgeometry(e, data)
         # Loop through attribute data in edges

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -213,6 +213,10 @@ class TestShp(object):
 
 @raises(RuntimeError)
 def test_read_shp_nofile():
+    try:
+        from osgeo import ogr
+    except ImportError:
+        raise SkipTest('ogr not available.')
     G = nx.read_shp("hopefully_this_file_will_not_be_available")
 
 

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from nose import SkipTest
 from nose.tools import assert_equal
+from nose.tools import raises
 
 import networkx as nx
 
@@ -208,3 +209,47 @@ class TestShp(object):
 
     def tearDown(self):
         self.deletetmp(self.drv, self.testdir, self.shppath)
+
+
+@raises(RuntimeError)
+def test_read_shp_nofile():
+    G = nx.read_shp("hopefully_this_file_will_not_be_available")
+
+
+class TestMissingGeometry(object):
+    @classmethod
+    def setup_class(cls):
+        global ogr
+        try:
+            from osgeo import ogr
+        except ImportError:
+            raise SkipTest('ogr not available.')
+
+    def setUp(self):
+        self.setup_path()
+        self.delete_shapedir()
+        self.create_shapedir()
+
+    def tearDown(self):
+        self.delete_shapedir()
+
+    def setup_path(self):
+        self.path = os.path.join(tempfile.gettempdir(), 'missing_geometry')
+
+    def create_shapedir(self):
+        drv = ogr.GetDriverByName("ESRI Shapefile")
+        shp = drv.CreateDataSource(self.path)
+        lyr = shp.CreateLayer("nodes", None, ogr.wkbPoint)
+        feature = ogr.Feature(lyr.GetLayerDefn())
+        feature.SetGeometry(None)
+        lyr.CreateFeature(feature)
+        feature.Destroy()
+
+    def delete_shapedir(self):
+        drv = ogr.GetDriverByName("ESRI Shapefile")
+        if os.path.exists(self.path):
+            drv.DeleteDataSource(self.path)
+
+    @raises(nx.NetworkXError)
+    def test_missing_geometry(self):
+        G = nx.read_shp(self.path)


### PR DESCRIPTION
Hi, This PR fixes some minor bugs in nx_shp:
- Updates read_shp to raise RuntimeError when file cant be open or read.
- Adds new keyword `strict` to read_shp and implements suggestion #2451 , read_shp now raises NetworkXError when feature lacks geometry and `strict=True`. Conversely `strict=False` can be used to silently ignore features without geometry.
- Adds small change to write_shp, should fix #2432 .
- Some new tests which check this updates.

Update:
Some builds were failing because of no ogr module. Fixed testcase which was causing problems.