### PR TITLE
removed list conversion from _triangles_and_degree_iter

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -83,8 +83,8 @@ def _triangles_and_degree_iter(G, nodes=None):
 
     for v, v_nbrs in nodes_nbrs:
         vs = set(v_nbrs) - {v}
-        gen_degree = Counter([len(vs & (set(G[w]) - {w})) for w in vs])
-        ntriangles = sum([k * val for k, val in gen_degree.items()])
+        gen_degree = Counter(len(vs & (set(G[w]) - {w})) for w in vs)
+        ntriangles = sum(k * val for k, val in gen_degree.items())
         yield (v, len(vs), ntriangles, gen_degree)
 
 


### PR DESCRIPTION
removed the explicit conversion to a list from the cluster._triangles_and_degree_iter function.