### PR TITLE
Correct when we raise NetworkXNotImplemented

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -40,7 +40,7 @@ def connected_components(G):
     Raises
     ------
     NetworkXNotImplemented:
-        If G is undirected.
+        If G is directed.
 
     Examples
     --------
@@ -94,7 +94,7 @@ def connected_component_subgraphs(G, copy=True):
     Raises
     ------
     NetworkXNotImplemented:
-        If G is undirected.
+        If G is directed.
 
     Examples
     --------
@@ -170,7 +170,7 @@ def is_connected(G):
     Raises
     ------
     NetworkXNotImplemented:
-        If G is undirected.
+        If G is directed.
 
     Examples
     --------


### PR DESCRIPTION
`algorithms/components/connected.py` was littered with incorrect descriptions that we raise `NetworkXNotImplemented` for undirected graphs, when we meant to say directed.