### PR TITLE
Expand documentation regarding strong connectivity

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -353,6 +353,9 @@ def number_strongly_connected_components(G):
 def is_strongly_connected(G):
     """Test directed graph for strong connectivity.
 
+    A directed graph is strongly connected if and only if every vertex in
+    the graph is reachable from every other vertex.
+
     Parameters
     ----------
     G : NetworkX Graph

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -166,8 +166,12 @@ def weakly_connected_component_subgraphs(G, copy=True):
 def is_weakly_connected(G):
     """Test directed graph for weak connectivity.
 
-    A directed graph is weakly connected if, and only if, the graph
+    A directed graph is weakly connected if and only if the graph
     is connected when the direction of the edge between nodes is ignored.
+
+    Note that if a graph is strongly connected (i.e. the graph is connected
+    even when we account for directionality), it is by definition weakly
+    connected as well.
 
     Parameters
     ----------


### PR DESCRIPTION
I liked the documentation for weak connectivity <a href="https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.is_weakly_connected.html">here</a>, but there wasn't anything similar for strong connectivity.  Thought I might as well add it.