### PR TITLE
Fix SOURCE_DATE_EPOCH ignored bug (#2735)

### DIFF
--- a/networkx/release.py
+++ b/networkx/release.py
@@ -135,7 +135,7 @@ def get_revision():
 
 def get_info(dynamic=True):
     # Date information
-    date_info = datetime.datetime.now()
+    date_info = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
     date = time.asctime(date_info.timetuple())
 
     revision, version, version_info, vcs_info = None, None, None, None


### PR DESCRIPTION
* Fix SOURCE_DATE_EPOCH ignored bug

Fix a bug in networkx/release.py that makes build
non-reproducible.