### PR TITLE
The graph6 generator fails when relabeling

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -181,15 +181,15 @@ def generate_graph6(G, nodes = None, header=True):
         G = G.subgraph(nodes)
     H = nx.convert_node_labels_to_integers(G)
     ns = sorted(H.nodes())
-    def bits():
+    def bits(graph):
         for (i,j) in [(i,j) for j in range(1,n) for i in range(j)]:
-            yield G.has_edge(ns[i],ns[j])
+            yield graph.has_edge(ns[i],ns[j])
 
     n = G.order()
     data = n_to_data(n)
     d = 0
     flush = False
-    for i, b in zip(range(n * n), bits()):
+    for i, b in zip(range(n * n), bits(H)):
         d |= b << (5 - (i % 6))
         flush = True
         if i % 6 == 5:

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -82,6 +82,16 @@ class TestGraph6(object):
             assert_equal(g2.order(), g.order())
             assert_edges_equal(g2.edges(), g.edges())
 
+    def test_relabeling(self):
+        G = nx.Graph([(0,1)])
+        assert_equal(nx.generate_graph6(G),">>graph6<<A_")
+        G = nx.Graph([(1,2)])
+        assert_equal(nx.generate_graph6(G),">>graph6<<A_")
+        G = nx.Graph([(1,42)])
+        assert_equal(nx.generate_graph6(G),">>graph6<<A_")
+
+
+
     @raises(nx.NetworkXError)
     def directed_raise(self):
         nx.generate_graph6(nx.DiGraph())


### PR DESCRIPTION
When relabeling for consecutive nodes 0,..,n-1 use the new (relabeled) graph to test for edges.