### PR TITLE
Fix 1568: Pydot - GraphViz visualization for complex objects

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -23,7 +23,7 @@ DOT Language:  http://www.graphviz.org/doc/info/lang.html
 #    All rights reserved.
 #    BSD license.
 from locale import getpreferredencoding
-from networkx.utils import open_file, make_str
+from networkx.utils import open_file, make_str, make_id
 from pkg_resources import parse_version
 import networkx as nx
 
@@ -224,20 +224,19 @@ def to_pydot(N):
 
     for n, nodedata in N.nodes(data=True):
         str_nodedata = dict((k, make_str(v)) for k, v in nodedata.items())
-        p = pydot.Node(make_str(n), **str_nodedata)
+        p = pydot.Node(make_id(n), label=make_str(n), **str_nodedata)
         P.add_node(p)
 
     if N.is_multigraph():
         for u, v, key, edgedata in N.edges(data=True, keys=True):
             str_edgedata = dict((k, make_str(v)) for k, v in edgedata.items() if k != 'key')
-            edge = pydot.Edge(make_str(u), make_str(v),
+            edge = pydot.Edge(make_id(u), make_id(v),
                               key=make_str(key), **str_edgedata)
             P.add_edge(edge)
-
     else:
         for u, v, edgedata in N.edges(data=True):
             str_edgedata = dict((k, make_str(v)) for k, v in edgedata.items())
-            edge = pydot.Edge(make_str(u), make_str(v), **str_edgedata)
+            edge = pydot.Edge(make_id(u), make_id(v), **str_edgedata)
             P.add_edge(edge)
     return P
 
@@ -316,7 +315,7 @@ def pydot_layout(G, prog='neato', root=None, **kwds):
 
     node_pos = {}
     for n in G.nodes():
-        pydot_node = pydot.Node(make_str(n)).get_name()
+        pydot_node = pydot.Node(make_id(n), label=make_str(n)).get_name()
         node = Q.get_node(pydot_node)
 
         if isinstance(node, list):

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -121,6 +121,13 @@ else:
         return str(x)
 
 
+def make_id(x):
+    """returns ID string of x"""
+    if type(x) in (str, unicode):
+        return x
+    return str(id(x))
+
+
 def generate_unique_node():
     """ Generate a unique node label."""
     return str(uuid.uuid1())


### PR DESCRIPTION
As reported in #1568, GraphViz breaks down when the nodes are complex python objects (especially when string representation of two nodes in the graph are same). See comments https://github.com/networkx/networkx/issues/1568#issuecomment-341931155 
## After this fix:
![screen shot 2017-11-07 at 5 27 21 pm](https://user-images.githubusercontent.com/1865964/32526982-fd0af06a-c3e0-11e7-9ad9-b64b3f7c94d7.png)


## Without this fix:
<img width="952" alt="screen shot 2017-11-04 at 3 42 53 pm" src="https://user-images.githubusercontent.com/1865964/32527017-1f5d34de-c3e1-11e7-8110-b997a6d5f43d.png">


- Closes #1568 
- Please merge this, or let me know if any changes are to be made. This is crucial for my use, otherwise I will have to keep track of 2 versions of networkx.
- Tested on Python 3.6