### PR TITLE
Fix #2726: ensure add_path to add the first node

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -258,7 +258,13 @@ def add_path(G, nodes, **attr):
     >>> nx.add_path(G, [0, 1, 2, 3])
     >>> nx.add_path(G, [10, 11, 12], weight=7)
     """
-    G.add_edges_from(pairwise(nodes), **attr)
+    nlist = iter(nodes)
+    try:
+        first_node = next(nlist)
+    except StopIteration:
+        return
+    G.add_node(first_node)
+    G.add_edges_from(pairwise(chain((first_node,), nlist)), **attr)
 
 
 def add_cycle(G, nodes, **attr):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -81,6 +81,42 @@ class TestFunction(object):
                             (13, 14, {'weight': 2.}),
                             (14, 15, {'weight': 2.})])
 
+        G = self.G.copy()
+        nlist = [None]
+        nx.add_path(G, nlist)
+        assert_edges_equal(G.edges(nlist), [])
+        assert_nodes_equal(G, list(self.G) + [None])
+
+        G = self.G.copy()
+        nlist = iter([None])
+        nx.add_path(G, nlist)
+        assert_edges_equal(G.edges([None]), [])
+        assert_nodes_equal(G, list(self.G) + [None])
+
+        G = self.G.copy()
+        nlist = [12]
+        nx.add_path(G, nlist)
+        assert_edges_equal(G.edges(nlist), [])
+        assert_nodes_equal(G, list(self.G) + [12])
+
+        G = self.G.copy()
+        nlist = iter([12])
+        nx.add_path(G, nlist)
+        assert_edges_equal(G.edges([12]), [])
+        assert_nodes_equal(G, list(self.G) + [12])
+
+        G = self.G.copy()
+        nlist = []
+        nx.add_path(G, nlist)
+        assert_edges_equal(G.edges, self.G.edges)
+        assert_nodes_equal(G, list(self.G))
+
+        G = self.G.copy()
+        nlist = iter([])
+        nx.add_path(G, nlist)
+        assert_edges_equal(G.edges, self.G.edges)
+        assert_nodes_equal(G, list(self.G))
+
     def test_add_cycle(self):
         G = self.G.copy()
         nlist = [12, 13, 14, 15]


### PR DESCRIPTION
Fixes #2726 

If the given path (list of nodes) is of length one, `add_path` will add the first node.