### PR TITLE
Digraph Arrows to fix #2757

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -513,7 +513,7 @@ def draw_networkx_edges(G, pos,
     >>> arcs = nx.draw_networkx_edges(G, pos=nx.spring(layout(G)))
     >>> alphas = [0.3, 0.4, 0.5]
     >>> for i, arc in enumerate(arcs):  # change alpha values of arcs
-            arc.set_alpha(alphas[i])
+    ...     arc.set_alpha(alphas[i])
 
     Also see the NetworkX drawing examples at
     https://networkx.github.io/documentation/latest/auto_examples/index.html

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -154,12 +154,12 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
        Note: Arrows will be the same color as edges.
 
     arrowstyle : str, optional (default='-|>')
-        For directed graphs, chose the style of the arrowsheads.
+        For directed graphs, choose the style of the arrowsheads.
         See :py:class: `matplotlib.patches.ArrowStyle` for more
         options.
 
     arrowsize : int, optional (default=10)
-       For directed graphs, chose the size of the arrow head head's length and
+       For directed graphs, choose the size of the arrow head head's length and
        width. See :py:class: `matplotlib.patches.FancyArrowPatch` for attribute
        `mutation_scale` for more info.
 
@@ -475,12 +475,12 @@ def draw_networkx_edges(G, pos,
        Note: Arrows will be the same color as edges.
 
     arrowstyle : str, optional (default='-|>')
-       For directed graphs, chose the style of the arrow heads.
+       For directed graphs, choose the style of the arrow heads.
        See :py:class: `matplotlib.patches.ArrowStyle` for more
        options.
 
     arrowsize : int, optional (default=10)
-       For directed graphs, chose the size of the arrow head head's length and
+       For directed graphs, choose the size of the arrow head head's length and
        width. See :py:class: `matplotlib.patches.FancyArrowPatch` for attribute
        `mutation_scale` for more info.
 
@@ -510,7 +510,7 @@ def draw_networkx_edges(G, pos,
 
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (1, 3), (2, 3)])
-    >>> arcs = nx.draw_networkx_edges(G, pos=nx.spring(layout(G)))
+    >>> arcs = nx.draw_networkx_edges(G, pos=nx.spring_layout(G))
     >>> alphas = [0.3, 0.4, 0.5]
     >>> for i, arc in enumerate(arcs):  # change alpha values of arcs
     ...     arc.set_alpha(alphas[i])
@@ -577,13 +577,13 @@ def draw_networkx_edges(G, pos,
                 # numbers (which are going to be mapped with a colormap)
                 edge_colors = None
         else:
-            raise ValueError('edge_color must consist of either color names or numbers')
+            raise ValueError('edge_color must contain color names or numbers')
     else:
         if is_string_like(edge_color) or len(edge_color) == 1:
             edge_colors = (colorConverter.to_rgba(edge_color, alpha), )
         else:
-            raise ValueError(
-                'edge_color must be a single color or list of exactly m colors where m is the number or edges')
+            msg = 'edge_color must be a color or list of one color per edge'
+            raise ValueError(msg)
 
     if (not G.is_directed() or not arrows):
         edge_collection = LineCollection(edge_pos,
@@ -598,11 +598,11 @@ def draw_networkx_edges(G, pos,
         edge_collection.set_label(label)
         ax.add_collection(edge_collection)
 
-        # Note: there was a bug in mpl regarding the handling of alpha values for
-        # each line in a LineCollection.  It was fixed in matplotlib in r7184 and
-        # r7189 (June 6 2009).  We should then not set the alpha value globally,
-        # since the user can instead provide per-edge alphas now.  Only set it
-        # globally if provided as a scalar.
+        # Note: there was a bug in mpl regarding the handling of alpha values
+        # for each line in a LineCollection. It was fixed in matplotlib by
+        # r7184 and r7189 (June 6 2009). We should then not set the alpha
+        # value globally, since the user can instead provide per-edge alphas
+        # now.  Only set it globally if provided as a scalar.
         if cb.is_numlike(alpha):
             edge_collection.set_alpha(alpha)
 
@@ -786,7 +786,7 @@ def draw_networkx_labels(G, pos,
     for n, label in labels.items():
         (x, y) = pos[n]
         if not is_string_like(label):
-            label = str(label)  # this will cause "1" and 1 to be labeled the same
+            label = str(label)  # this makes "1" and 1 labeled the same
         t = ax.text(x, y,
                     label,
                     size=font_size,
@@ -904,7 +904,8 @@ def draw_networkx_edge_labels(G, pos,
                   y1 * label_pos + y2 * (1.0 - label_pos))
 
         if rotate:
-            angle = np.arctan2(y2 - y1, x2 - x1) / (2.0 * np.pi) * 360  # degrees
+            # in degrees
+            angle = np.arctan2(y2 - y1, x2 - x1) / (2.0 * np.pi) * 360
             # make label orientation "right-side-up"
             if angle > 90:
                 angle -= 180
@@ -923,7 +924,7 @@ def draw_networkx_edge_labels(G, pos,
                         fc=(1.0, 1.0, 1.0),
                         )
         if not is_string_like(label):
-            label = str(label)  # this will cause "1" and 1 to be labeled the same
+            label = str(label)  # this makes "1" and 1 labeled the same
 
         # set optional alignment
         horizontalalignment = kwds.get('horizontalalignment', 'center')
@@ -1087,7 +1088,7 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
 
     """
     import numbers
-    import itertools
+    from itertools import islice, cycle
 
     try:
         import numpy as np
@@ -1109,8 +1110,9 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
         try:
             rgba_colors = np.array([colorConverter.to_rgba(colors)])
         except ValueError:
-            rgba_colors = np.array([colorConverter.to_rgba(color) for color in colors])
-    # Set the final column of the rgba_colors to have the relevant alpha values.
+            rgba_colors = np.array([colorConverter.to_rgba(color)
+                                    for color in colors])
+    # Set the final column of the rgba_colors to have the relevant alpha values
     try:
         # If alpha is longer than the number of colors, resize to the number of
         # elements.  Also, if rgba_colors.size (the number of elements of
@@ -1121,7 +1123,7 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
             rgba_colors[1:, 0] = rgba_colors[0, 0]
             rgba_colors[1:, 1] = rgba_colors[0, 1]
             rgba_colors[1:, 2] = rgba_colors[0, 2]
-        rgba_colors[:,  3] = list(itertools.islice(itertools.cycle(alpha), len(rgba_colors)))
+        rgba_colors[:,  3] = list(islice(cycle(alpha), len(rgba_colors)))
     except TypeError:
         rgba_colors[:, -1] = alpha
     return rgba_colors

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -602,6 +602,7 @@ def draw_networkx_edges(G, pos,
                 edge_collection.set_clim(edge_vmin, edge_vmax)
             else:
                 edge_collection.autoscale()
+        return edge_collection
 
     arrow_collection = None
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -152,6 +152,11 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
     arrows : bool, optional (default=True)
        For directed graphs, if True draw arrowheads.
 
+    arrowstyle : str, optional (default='-|>')
+        For directed graphs, chose the style of the arrowsheads.
+        See :py:class: `matplotlib.patches.ArrowStyle` for more
+        options.
+
     with_labels :  bool, optional (default=True)
        Set to True to draw labels on the nodes.
 
@@ -409,6 +414,7 @@ def draw_networkx_edges(G, pos,
                         edge_color='k',
                         style='solid',
                         alpha=1.0,
+                        arrowstyle='-|>',
                         edge_cmap=None,
                         edge_vmin=None,
                         edge_vmax=None,
@@ -458,6 +464,11 @@ def draw_networkx_edges(G, pos,
 
     arrows : bool, optional (default=True)
        For directed graphs, if True draw arrowheads.
+
+    arrowstyle : str, optional (default='-|>')
+       For directed graphs, chose the style of the arrow heads.
+       See :py:class: `matplotlib.patches.ArrowStyle` for more
+       options.
 
     label : [None| string]
        Label for legend
@@ -576,8 +587,6 @@ def draw_networkx_edges(G, pos,
         else:
             edge_collection.autoscale()
 
-    arrow_collection = None
-
     if G.is_directed() and arrows:
 
         # a directed graph hack
@@ -589,7 +598,7 @@ def draw_networkx_edges(G, pos,
             x2, y2 = dst
             if len(arrow_colors) > 1 and len(lw) > 1:
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
-                                        arrowstyle='-|>',
+                                        arrowstyle=arrowstyle,
                                         shrinkA=20,
                                         shrinkB=6,
                                         mutation_scale=20,
@@ -599,7 +608,7 @@ def draw_networkx_edges(G, pos,
                                         zorder=1)
             elif len(arrow_colors) > 1:
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
-                                        arrowstyle='-|>',
+                                        arrowstyle=arrowstyle,
                                         shrinkA=20,
                                         shrinkB=6,
                                         mutation_scale=20,
@@ -609,7 +618,7 @@ def draw_networkx_edges(G, pos,
                                         zorder=1)
             elif len(lw) > 1:
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
-                                        arrowstyle='-|>',
+                                        arrowstyle=arrowstyle,
                                         shrinkA=20,
                                         shrinkB=6,
                                         mutation_scale=20,
@@ -619,7 +628,7 @@ def draw_networkx_edges(G, pos,
                                         zorder=1)
             else:
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
-                                        arrowstyle='-|>',
+                                        arrowstyle=arrowstyle,
                                         shrinkA=20,
                                         shrinkB=6,
                                         mutation_scale=20,
@@ -844,7 +853,6 @@ def draw_networkx_edge_labels(G, pos,
     """
     try:
         import matplotlib.pyplot as plt
-        import matplotlib.cbook as cb
         import numpy as np
     except ImportError:
         raise ImportError("Matplotlib required for draw()")

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -587,9 +587,12 @@ def draw_networkx_edges(G, pos,
         else:
             edge_collection.autoscale()
 
+    arrow_collection = None
+
     if G.is_directed() and arrows:
 
         # Draw arrows with `matplotlib.patches.FancyarrowPatch`
+        arrow_collection = []
         arrow_colors = edge_colors
         mutation_scale = 10  # scale factor of arrow head
         shrink_source = 20  # leave space for arrow in opposite direction
@@ -607,7 +610,7 @@ def draw_networkx_edges(G, pos,
                                         mutation_scale=mutation_scale,
                                         color=arrow_colors[i],
                                         linewidth=lw[i],
-                                        zorder=1)
+                                        zorder=1)  # arrows go behind nodes
             elif len(arrow_colors) > 1:  # only individual colors
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
                                         arrowstyle=arrowstyle,
@@ -636,22 +639,9 @@ def draw_networkx_edges(G, pos,
                                         linewidth=lw[0],
                                         zorder=1)
 
+            arrow_collection.append(arrow)
             ax.add_patch(arrow)
 
-        #arrow_collection = PatchCollection(a_pos,
-                                         # color=arrow_colors,
-                                         # linewidths=[4 * ww for ww in lw],
-                                         # antialiaseds=(1,),
-                                         # transOffset=ax.transData,
-                                          #)
-
-
-        #arrow_collection.set_zorder(1)  # edges go behind nodes
-        #arrow_collection.set_label(label)
-        #ax.add_collection(arrow_collection)
-
-
-            
     # update view
     minx = np.amin(np.ravel(edge_pos[:, :, 0]))
     maxx = np.amax(np.ravel(edge_pos[:, :, 0]))
@@ -664,8 +654,6 @@ def draw_networkx_edges(G, pos,
     corners = (minx - padx, miny - pady), (maxx + padx, maxy + pady)
     ax.update_datalim(corners)
     ax.autoscale_view()
-
-#    if arrow_collection:
 
     return edge_collection
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -495,7 +495,8 @@ def draw_networkx_edges(G, pos,
         import matplotlib.pyplot as plt
         import matplotlib.cbook as cb
         from matplotlib.colors import colorConverter, Colormap
-        from matplotlib.collections import LineCollection, PatchCollection
+        from matplotlib.collections import LineCollection
+        from matplotlib.patches import FancyArrowPatch
         import numpy as np
     except ImportError:
         raise ImportError("Matplotlib required for draw()")
@@ -583,30 +584,49 @@ def draw_networkx_edges(G, pos,
         # draw thick line segments at head end of edge
         # waiting for someone else to implement arrows that will work
         arrow_colors = edge_colors
-        a_pos = []
-        p = 1.0 - 0.10  # make head segment 10 percent of edge length
-        for src, dst in edge_pos:
+        for i, (src, dst) in enumerate(edge_pos):
             x1, y1 = src
             x2, y2 = dst
-            dx = x2 - x1   # x offset
-            dy = y2 - y1   # y offset
-            d = np.sqrt(float(dx**2 + dy**2))  # length of edge
-            if d == 0:   # source and target at same position
-                continue
-            if dx == 0:  # vertical edge
-                xa = x2
-                ya = dy * p + y1
-            if dy == 0:  # horizontal edge
-                ya = y2
-                xa = dx * p + x1
+            if len(arrow_colors) > 1 and len(lw) > 1:
+                arrow = FancyArrowPatch((x1, y1), (x2, y2),
+                                        arrowstyle='-|>',
+                                        shrinkA=20,
+                                        shrinkB=6,
+                                        mutation_scale=20,
+                                        fc='w',
+                                        edgecolor=arrow_colors[i],
+                                        linewidth=lw[i],
+                                        zorder=1)
+            elif len(arrow_colors) > 1:
+                arrow = FancyArrowPatch((x1, y1), (x2, y2),
+                                        arrowstyle='-|>',
+                                        shrinkA=20,
+                                        shrinkB=6,
+                                        mutation_scale=20,
+                                        fc='w',
+                                        edgecolor=arrow_colors[i],
+                                        linewidth=lw[0],
+                                        zorder=1)
+            elif len(lw) > 1:
+                arrow = FancyArrowPatch((x1, y1), (x2, y2),
+                                        arrowstyle='-|>',
+                                        shrinkA=20,
+                                        shrinkB=6,
+                                        mutation_scale=20,
+                                        fc='w',
+                                        edgecolor=arrow_colors[0],
+                                        linewidth=lw[i],
+                                        zorder=1)
             else:
-                theta = np.arctan2(dy, dx)
-                xa = p * d * np.cos(theta) + x1
-                ya = p * d * np.sin(theta) + y1
-
-            arrow = matplotlib.patches.FancyArrowPatch((x1,y1),(x2,y2),
-                    arrowstyle='-|>', shrinkA=5, shrinkB=5, mutation_scale=20,
-                    fc='w', zorder=2)
+                arrow = FancyArrowPatch((x1, y1), (x2, y2),
+                                        arrowstyle='-|>',
+                                        shrinkA=20,
+                                        shrinkB=6,
+                                        mutation_scale=20,
+                                        fc='w',
+                                        edgecolor=arrow_colors[0],
+                                        linewidth=lw[0],
+                                        zorder=1)
             ax.add_patch(arrow)
 
         #arrow_collection = PatchCollection(a_pos,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -492,11 +492,16 @@ def draw_networkx_edges(G, pos,
     matplotlib.collection.LineCollection
         `LineCollection` of the edges
 
+    list of matplotlib.patches.FancyArrowPatch
+        `FancyArrowPatch` instances of the directed edges
+
+    Depending whether the drawing includes arrows or not.
+
     Notes
     -----
-    For directed graphs, arrows  are drawn at the head end.  Arrows can be
-    turned off with keyword arrows=False. Be sure to include `node_size' as
-    arrows are drawn considering the size of nodes.
+    For directed graphs, arrows are drawn at the head end.  Arrows can be
+    turned off with keyword arrows=False. Be sure to include `node_size' as a
+    keyword argument; arrows are drawn considering the size of nodes.
 
     Examples
     --------

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -421,6 +421,7 @@ def draw_networkx_edges(G, pos,
                         ax=None,
                         arrows=True,
                         label=None,
+                        node_size=300,
                         **kwds):
     """Draw the edges of the graph G. DRAFT____1
 
@@ -595,8 +596,10 @@ def draw_networkx_edges(G, pos,
         arrow_collection = []
         arrow_colors = edge_colors
         mutation_scale = 10  # scale factor of arrow head
-        shrink_source = 20  # leave space for arrow in opposite direction
-        shrink_target = 8  # arrow head next to node
+        # To UPDATE: Case example using a single node size
+        to_marker_edge = np.sqrt(node_size) / 2.  # only valid for circle
+        shrink_source = 0  # leave space for arrow in opposite direction
+        shrink_target = to_marker_edge  # arrow head next to node
 
         for i, (src, dst) in enumerate(edge_pos):
             x1, y1 = src

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -589,53 +589,53 @@ def draw_networkx_edges(G, pos,
 
     if G.is_directed() and arrows:
 
-        # a directed graph hack
-        # draw thick line segments at head end of edge
-        # waiting for someone else to implement arrows that will work
+        # Draw arrows with `matplotlib.patches.FancyarrowPatch`
         arrow_colors = edge_colors
+        mutation_scale = 10  # scale factor of arrow head
+        shrink_source = 20  # leave space for arrow in opposite direction
+        shrink_target = 8  # arrow head next to node
+
         for i, (src, dst) in enumerate(edge_pos):
             x1, y1 = src
             x2, y2 = dst
+            # indivual colors and linewidths
             if len(arrow_colors) > 1 and len(lw) > 1:
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
                                         arrowstyle=arrowstyle,
-                                        shrinkA=20,
-                                        shrinkB=6,
-                                        mutation_scale=20,
-                                        fc='w',
-                                        edgecolor=arrow_colors[i],
+                                        shrinkA=shrink_source,
+                                        shrinkB=shrink_target,
+                                        mutation_scale=mutation_scale,
+                                        color=arrow_colors[i],
                                         linewidth=lw[i],
                                         zorder=1)
-            elif len(arrow_colors) > 1:
+            elif len(arrow_colors) > 1:  # only individual colors
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
                                         arrowstyle=arrowstyle,
-                                        shrinkA=20,
-                                        shrinkB=6,
-                                        mutation_scale=20,
-                                        fc='w',
-                                        edgecolor=arrow_colors[i],
+                                        shrinkA=shrink_source,
+                                        shrinkB=shrink_target,
+                                        mutation_scale=mutation_scale,
+                                        color=arrow_colors[i],
                                         linewidth=lw[0],
                                         zorder=1)
-            elif len(lw) > 1:
+            elif len(lw) > 1:  # only individual linewidths
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
                                         arrowstyle=arrowstyle,
-                                        shrinkA=20,
-                                        shrinkB=6,
-                                        mutation_scale=20,
-                                        fc='w',
-                                        edgecolor=arrow_colors[0],
+                                        shrinkA=shrink_source,
+                                        shrinkB=shrink_target,
+                                        mutation_scale=mutation_scale,
+                                        color=arrow_colors[0],
                                         linewidth=lw[i],
                                         zorder=1)
             else:
                 arrow = FancyArrowPatch((x1, y1), (x2, y2),
                                         arrowstyle=arrowstyle,
-                                        shrinkA=20,
-                                        shrinkB=6,
-                                        mutation_scale=20,
-                                        fc='w',
-                                        edgecolor=arrow_colors[0],
+                                        shrinkA=shrink_source,
+                                        shrinkB=shrink_target,
+                                        mutation_scale=mutation_scale,
+                                        color=arrow_colors[0],
                                         linewidth=lw[0],
                                         zorder=1)
+
             ax.add_patch(arrow)
 
         #arrow_collection = PatchCollection(a_pos,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -430,7 +430,7 @@ def draw_networkx_edges(G, pos,
                         nodelist=None,
                         node_shape="o",
                         **kwds):
-    """Draw the edges of the graph G. DRAFT____1
+    """Draw the edges of the graph G.
 
     This draws only the edges of the graph G.
 
@@ -495,12 +495,20 @@ def draw_networkx_edges(G, pos,
     Notes
     -----
     For directed graphs, arrows  are drawn at the head end.  Arrows can be
-    turned off with keyword arrows=False.
+    turned off with keyword arrows=False. Be sure to include `node_size' as
+    arrows are drawn considering the size of nodes.
 
     Examples
     --------
     >>> G = nx.dodecahedral_graph()
     >>> edges = nx.draw_networkx_edges(G, pos=nx.spring_layout(G))
+
+    >>> G = nx.DiGraph()
+    >>> G.add_edges_from([(1, 2), (1, 3), (2, 3)])
+    >>> arcs = nx.draw_networkx_edges(G, pos=nx.spring(layout(G)))
+    >>> alphas = [0.3, 0.4, 0.5]
+    >>> for i, arc in enumerate(arcs):  # change alpha values of arcs
+            arc.set_alpha(alphas[i])
 
     Also see the NetworkX drawing examples at
     https://networkx.github.io/documentation/latest/auto_examples/index.html

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -583,7 +583,7 @@ def draw_networkx_edges(G, pos,
         # draw thick line segments at head end of edge
         # waiting for someone else to implement arrows that will work
         arrow_colors = edge_colors
-        arrow_collection = []
+        a_pos = []
         p = 1.0 - 0.10  # make head segment 10 percent of edge length
         for src, dst in edge_pos:
             x1, y1 = src
@@ -604,24 +604,25 @@ def draw_networkx_edges(G, pos,
                 xa = p * d * np.cos(theta) + x1
                 ya = p * d * np.sin(theta) + y1
 
-                if theta > np.pi / 2:
-                    marker_pairs = [
-                                    (0, 0),
-                                    (-np.cos(theta), np.sin(theta)),
-                                    (1, 0)]
-                else:
-                    marker_pairs = [
-                                    (0, 0),
-                                    (-np.cos(theta), -np.sin(theta)),
-                                    (1, 0)]
-            #marker_paris = [(0,0), (xa, ya)]
+            arrow = matplotlib.patches.FancyArrowPatch((x1,y1),(x2,y2),
+                    arrowstyle='-|>', shrinkA=5, shrinkB=5, mutation_scale=20,
+                    fc='w', zorder=2)
+            ax.add_patch(arrow)
 
-            arrow_collection.append(ax.scatter([x2],[y2],
-                                                zorder=2,
-                                                marker=marker_pairs,
-                                                s=4000))
+        #arrow_collection = PatchCollection(a_pos,
+                                         # color=arrow_colors,
+                                         # linewidths=[4 * ww for ww in lw],
+                                         # antialiaseds=(1,),
+                                         # transOffset=ax.transData,
+                                          #)
 
 
+        #arrow_collection.set_zorder(1)  # edges go behind nodes
+        #arrow_collection.set_label(label)
+        #ax.add_collection(arrow_collection)
+
+
+            
     # update view
     minx = np.amin(np.ravel(edge_pos[:, :, 0]))
     maxx = np.amax(np.ravel(edge_pos[:, :, 0]))

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -416,7 +416,7 @@ def draw_networkx_edges(G, pos,
                         arrows=True,
                         label=None,
                         **kwds):
-    """Draw the edges of the graph G.
+    """Draw the edges of the graph G. DRAFT____1
 
     This draws only the edges of the graph G.
 
@@ -495,7 +495,7 @@ def draw_networkx_edges(G, pos,
         import matplotlib.pyplot as plt
         import matplotlib.cbook as cb
         from matplotlib.colors import colorConverter, Colormap
-        from matplotlib.collections import LineCollection
+        from matplotlib.collections import LineCollection, PatchCollection
         import numpy as np
     except ImportError:
         raise ImportError("Matplotlib required for draw()")
@@ -583,13 +583,13 @@ def draw_networkx_edges(G, pos,
         # draw thick line segments at head end of edge
         # waiting for someone else to implement arrows that will work
         arrow_colors = edge_colors
-        a_pos = []
-        p = 1.0 - 0.25  # make head segment 25 percent of edge length
+        arrow_collection = []
+        p = 1.0 - 0.10  # make head segment 10 percent of edge length
         for src, dst in edge_pos:
             x1, y1 = src
             x2, y2 = dst
-            dx = x2 - x1   # x offset
-            dy = y2 - y1   # y offset
+            dx = x1 - x2   # x offset
+            dy = y1 - y2   # y offset
             d = np.sqrt(float(dx**2 + dy**2))  # length of edge
             if d == 0:   # source and target at same position
                 continue
@@ -601,20 +601,19 @@ def draw_networkx_edges(G, pos,
                 xa = dx * p + x1
             else:
                 theta = np.arctan2(dy, dx)
+                theta = min(theta, np.pi - theta)
                 xa = p * d * np.cos(theta) + x1
                 ya = p * d * np.sin(theta) + y1
+                print(theta)
+            epsilon = .000001
 
-            a_pos.append(((xa, ya), (x2, y2)))
+            marker_pairs = [(0, 0), (x1,y1),(x1+epsilon,y1+epsilon),(0,0)]
 
-        arrow_collection = LineCollection(a_pos,
-                                          colors=arrow_colors,
-                                          linewidths=[4 * ww for ww in lw],
-                                          antialiaseds=(1,),
-                                          transOffset=ax.transData,
-                                          )
+            arrow_collection.append(ax.scatter([x2],[y2],
+                                                zorder=2,
+                                                marker=(3,0,theta),
+                                                s=1000))
 
-        arrow_collection.set_zorder(1)  # edges go behind nodes
-        ax.add_collection(arrow_collection)
 
     # update view
     minx = np.amin(np.ravel(edge_pos[:, :, 0]))

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1063,15 +1063,16 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
        in order (cycling through alpha multiple times if necessary).
 
     elem_list : array of networkx objects
-       The list of elements which are being colored. These could be nodes, edges
-       or labels.
+       The list of elements which are being colored. These could be nodes,
+       edges or labels.
 
     cmap : matplotlib colormap
-       Color map for use if colors is a list of floats corresponding to points on
-       a color mapping.
+       Color map for use if colors is a list of floats corresponding to points
+       on a color mapping.
 
     vmin, vmax : float
-       Minimum and maximum values for normalizing colors if a color mapping is used.
+       Minimum and maximum values for normalizing colors if a color mapping is
+       used.
 
     Returns
     -------
@@ -1090,13 +1091,15 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
     except ImportError:
         raise ImportError("Matplotlib required for draw()")
 
-    # If we have been provided with a list of numbers as long as elem_list, apply the color mapping.
+    # If we have been provided with a list of numbers as long as elem_list,
+    # apply the color mapping.
     if len(colors) == len(elem_list) and isinstance(colors[0], numbers.Number):
         mapper = cm.ScalarMappable(cmap=cmap)
         mapper.set_clim(vmin, vmax)
         rgba_colors = mapper.to_rgba(colors)
-    # Otherwise, convert colors to matplotlib's RGB using the colorConverter object.
-    # These are converted to numpy ndarrays to be consistent with the to_rgba method of ScalarMappable.
+    # Otherwise, convert colors to matplotlib's RGB using the colorConverter
+    # object.  These are converted to numpy ndarrays to be consistent with the
+    # to_rgba method of ScalarMappable.
     else:
         try:
             rgba_colors = np.array([colorConverter.to_rgba(colors)])
@@ -1104,9 +1107,10 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
             rgba_colors = np.array([colorConverter.to_rgba(color) for color in colors])
     # Set the final column of the rgba_colors to have the relevant alpha values.
     try:
-        # If alpha is longer than the number of colors, resize to the number of elements.
-        # Also, if rgba_colors.size (the number of elements of rgba_colors) is the same as the number of
-        # elements, resize the array, to avoid it being interpreted as a colormap by scatter()
+        # If alpha is longer than the number of colors, resize to the number of
+        # elements.  Also, if rgba_colors.size (the number of elements of
+        # rgba_colors) is the same as the number of elements, resize the array,
+        # to avoid it being interpreted as a colormap by scatter()
         if len(alpha) > len(rgba_colors) or rgba_colors.size == len(elem_list):
             rgba_colors.resize((len(elem_list), 4))
             rgba_colors[1:, 0] = rgba_colors[0, 0]

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -588,8 +588,8 @@ def draw_networkx_edges(G, pos,
         for src, dst in edge_pos:
             x1, y1 = src
             x2, y2 = dst
-            dx = x1 - x2   # x offset
-            dy = y1 - y2   # y offset
+            dx = x2 - x1   # x offset
+            dy = y2 - y1   # y offset
             d = np.sqrt(float(dx**2 + dy**2))  # length of edge
             if d == 0:   # source and target at same position
                 continue
@@ -601,18 +601,25 @@ def draw_networkx_edges(G, pos,
                 xa = dx * p + x1
             else:
                 theta = np.arctan2(dy, dx)
-                theta = min(theta, np.pi - theta)
                 xa = p * d * np.cos(theta) + x1
                 ya = p * d * np.sin(theta) + y1
-                print(theta)
-            epsilon = .000001
 
-            marker_pairs = [(0, 0), (x1,y1),(x1+epsilon,y1+epsilon),(0,0)]
+                if theta > np.pi / 2:
+                    marker_pairs = [
+                                    (0, 0),
+                                    (-np.cos(theta), np.sin(theta)),
+                                    (1, 0)]
+                else:
+                    marker_pairs = [
+                                    (0, 0),
+                                    (-np.cos(theta), -np.sin(theta)),
+                                    (1, 0)]
+            #marker_paris = [(0,0), (xa, ya)]
 
             arrow_collection.append(ax.scatter([x2],[y2],
                                                 zorder=2,
-                                                marker=(3,0,theta),
-                                                s=1000))
+                                                marker=marker_pairs,
+                                                s=4000))
 
 
     # update view

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -684,7 +684,7 @@ def draw_networkx_edges(G, pos,
     ax.update_datalim(corners)
     ax.autoscale_view()
 
-    return None
+    return arrow_collection
 
 
 def draw_networkx_labels(G, pos,


### PR DESCRIPTION
This pull request targets to replace the thicker lines used to draw arcs (directed edges) used in the nx_pylab.py file with arrow heads.

The main idea is to replace the `matplotlib.collections.LineCollection` with a list of `matplotlib.patches.FancyArrowPatch`.

The implementation is a bit slower than the original, but adds some clarity when zooming on a a network, e.g. consider the following the network with N nodes and N*2 edges:

```
import matplotlib.pyplot as plt
import networkx as nx


G = nx.Digraph()
G = nx.generators.directed.random_uniform_k_out_graph(N, 2)
pos = nx.layout.spring_layout(G)
nx.draw_networkx(G, pos=pos, edge_color='g', arrowstyle='-|>')
plt.show()
```

For **N=100**, this normally draws:
![regular_100](https://user-images.githubusercontent.com/10630980/32992068-877bffb4-cd46-11e7-81e9-ce2aebd6834f.png)

With this pull request:
![arrows_100](https://user-images.githubusercontent.com/10630980/32992075-9ef38e64-cd46-11e7-988a-9c9b8fcc5f5d.png)

For **N=1000**

Zooming on the network gives:
![regular_1000_zoom](https://user-images.githubusercontent.com/10630980/32992091-bdc23278-cd46-11e7-8cf4-a0242f6175de.png)

With this pull request:
![arrows_1000_zoom](https://user-images.githubusercontent.com/10630980/32992101-cf66eb7c-cd46-11e7-9ffd-bac6115e056c.png)

I added the keyword `arrowstyle` to be able to use all the styles for `matplotlib.patches.FancyArrowPatch`, however, the drawing is chaotic for some of them.



