### PR TITLE
Avoid keyword and attribute clash

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -150,18 +150,29 @@ def to_agraph(N):
 
     # add nodes
     for n, nodedata in N.nodes(data=True):
-        A.add_node(n, **nodedata)
+        A.add_node(n)
+        if nodedata is not None:
+            a = A.get_node(n)
+            a.attr.update({k: str(v) for k, v in nodedata.items()})
 
     # loop over edges
-
     if N.is_multigraph():
         for u, v, key, edgedata in N.edges(data=True, keys=True):
-            str_edata = {k: str(v) for k, v in edgedata.items() if k != 'key'}
-            A.add_edge(u, v, key=str(key), **str_edata)
+            str_edgedata = {k: str(v) for k, v in edgedata.items() if k != 'key'}
+            A.add_edge(u, v, key=str(key))
+            if edgedata is not None:
+                a = A.get_edge(u,v)
+                a.attr.update(str_edgedata)
+
+
     else:
         for u, v, edgedata in N.edges(data=True):
             str_edgedata = {k: str(v) for k, v in edgedata.items()}
-            A.add_edge(u, v, **str_edgedata)
+            A.add_edge(u, v)
+            if edgedata is not None:
+                a = A.get_edge(u,v)
+                a.attr.update(str_edgedata)
+
 
     return A
 

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -24,6 +24,7 @@ class TestAGraph(object):
         G.graph['metal'] = 'bronze'
         return G
 
+
     def assert_equal(self, G1, G2):
         assert_nodes_equal(G1.nodes(), G2.nodes())
         assert_edges_equal(G1.edges(), G2.edges())
@@ -79,3 +80,21 @@ class TestAGraph(object):
         G.add_edge(1, 2, weight=7)
         G.add_edge(2, 3, weight=8)
         nx.nx_agraph.view_pygraphviz(G, edgelabel='weight')
+
+    def test_from_agraph_name(self):
+        G = nx.Graph(name='test')
+        A = nx.nx_agraph.to_agraph(G)
+        H = nx.nx_agraph.from_agraph(A)
+        assert_equal(G.name, 'test')
+
+
+    def test_graph_with_reserved_keywords(self):
+        # test attribute/keyword clash case for #1582
+        # node: n
+        # edges: u,v
+        G = nx.Graph()
+        G = self.build_graph(G)
+        G.node['E']['n']='keyword'
+        G.edge[('A','B')]['u']='keyword'
+        G.edge[('A','B')]['v']='keyword'
+        A = nx.nx_agraph.to_agraph(G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -95,6 +95,6 @@ class TestAGraph(object):
         G = nx.Graph()
         G = self.build_graph(G)
         G.node['E']['n']='keyword'
-        G.edge[('A','B')]['u']='keyword'
-        G.edge[('A','B')]['v']='keyword'
+        G.edges[('A','B')]['u']='keyword'
+        G.edges[('A','B')]['v']='keyword'
         A = nx.nx_agraph.to_agraph(G)


### PR DESCRIPTION
Avoid keyword/attribute clash for
nodes: n
edges: u,v

Fixes #1582