### PR TITLE
Switch to xcode 7.3 for osx_image in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
           - libgdal-dev
           - graphviz
     - os: osx
+      osx_image: xcode7.3
       language: generic
       env:
       - TRAVIS_PYTHON_VERSION=3.6.0


### PR DESCRIPTION
Looks like the latest Travis image change on OSX broke our testing system there.
This makes it work again by using the older xcode (7.3) instead of the new default (8.3) but even the version 9 code gives the same error so we will have to deal with this more seriously at some point. 