### PR TITLE
Arrows as a plot example.

### DIFF
--- a/examples/drawing/plot_directed.py
+++ b/examples/drawing/plot_directed.py
@@ -1,0 +1,17 @@
+import matplotlib.pyplot as plt
+import networkx as nx
+
+G = nx.generators.directed.random_k_out_graph(10, 3, 0.5)
+pos = nx.layout.spring_layout(G)
+
+node_sizes = range(10)
+edge_colors = range(10)
+edge_colors = range(len(G.edges))
+
+nodes = nx.draw_networkx_nodes(G, pos, node_size=node_sizes, node_color='blue')
+edges = nx.draw_networkx_edges(G, pos, node_size=node_sizes, arrowstyle='->',
+                               arrowsize=10, edge_color=edge_colors,
+                               edge_cmap=plt.cm.Blues)
+ax = plt.gca()
+ax.set_axis_off()
+plt.show()

--- a/examples/drawing/plot_directed.py
+++ b/examples/drawing/plot_directed.py
@@ -1,17 +1,26 @@
+#! /usr/bin/env python
+"""
+Directed Graph
+
+Draw a graph with directed edges or arcs using a colormap and different node sizes.
+
+Arcs have different colors.
+"""
+# Author: Rodrigo Dorantes-Gilardi (rodgdor@gmail.com)
+
 import matplotlib.pyplot as plt
 import networkx as nx
 
 G = nx.generators.directed.random_k_out_graph(10, 3, 0.5)
 pos = nx.layout.spring_layout(G)
 
-node_sizes = range(10)
-edge_colors = range(10)
+node_sizes = range(20, 20 + len(G.nodes))
 edge_colors = range(len(G.edges))
 
 nodes = nx.draw_networkx_nodes(G, pos, node_size=node_sizes, node_color='blue')
 edges = nx.draw_networkx_edges(G, pos, node_size=node_sizes, arrowstyle='->',
                                arrowsize=10, edge_color=edge_colors,
-                               edge_cmap=plt.cm.Blues)
+                               edge_cmap=plt.cm.Blues, width=2)
 ax = plt.gca()
 ax.set_axis_off()
 plt.show()

--- a/examples/drawing/plot_directed.py
+++ b/examples/drawing/plot_directed.py
@@ -1,26 +1,35 @@
 #! /usr/bin/env python
 """
+==============
 Directed Graph
+==============
 
-Draw a graph with directed edges or arcs using a colormap and different node sizes.
+Draw a graph with directed edges using a colormap and different node sizes.
 
-Arcs have different colors.
+Edges have different colors and alphas (opacity). Drawn using matplotlib.
 """
 # Author: Rodrigo Dorantes-Gilardi (rodgdor@gmail.com)
 
+from __future__ import division
 import matplotlib.pyplot as plt
 import networkx as nx
 
 G = nx.generators.directed.random_k_out_graph(10, 3, 0.5)
 pos = nx.layout.spring_layout(G)
 
-node_sizes = [5*i for i in range(len(G.nodes))]
-edge_colors = range(len(G.edges))
+node_sizes = [3 + 10 * i for i in range(len(G))]
+M = G.number_of_edges()
+edge_colors = range(2, M + 2)
+edge_alphas = [(5 + i) / (M + 4) for i in range(M)]
 
 nodes = nx.draw_networkx_nodes(G, pos, node_size=node_sizes, node_color='blue')
 edges = nx.draw_networkx_edges(G, pos, node_size=node_sizes, arrowstyle='->',
                                arrowsize=10, edge_color=edge_colors,
                                edge_cmap=plt.cm.Blues, width=2)
+# set alpha value for each edge
+for i in range(M):
+    edges[i].set_alpha(edge_alphas[i])
+
 ax = plt.gca()
 ax.set_axis_off()
 plt.show()

--- a/examples/drawing/plot_directed.py
+++ b/examples/drawing/plot_directed.py
@@ -14,7 +14,7 @@ import networkx as nx
 G = nx.generators.directed.random_k_out_graph(10, 3, 0.5)
 pos = nx.layout.spring_layout(G)
 
-node_sizes = range(20, 20 + len(G.nodes))
+node_sizes = [5*i for i in range(len(G.nodes))]
 edge_colors = range(len(G.edges))
 
 nodes = nx.draw_networkx_nodes(G, pos, node_size=node_sizes, node_color='blue')


### PR DESCRIPTION
This Pull request gives an example of usage of the newly added arrows heads for directed edges or arcs.

Is a simple plot where node sizes differ from node to node, and `arrowstyle` and `arrowsize` are different from default. It should output something like:

![arrows](https://user-images.githubusercontent.com/10630980/34104380-788c3706-e3f0-11e7-846e-2ab68ebfc9a0.png)
