### PR TITLE
WIP: Legacy array printing for NumPy 1.14+

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1048,6 +1048,10 @@ def to_numpy_array(G, nodelist=None, dtype=None, order=None,
     resulting NumPy array can be modified as follows:
 
     >>> import numpy as np
+    >>> try:
+    ...    np.set_printoptions(legacy="1.13")
+    ... except TypeError:
+    ...    pass
     >>> G = nx.Graph([(1, 1)])
     >>> A = nx.to_numpy_array(G)
     >>> A
@@ -1074,6 +1078,7 @@ def to_numpy_array(G, nodelist=None, dtype=None, order=None,
 
     """
     import numpy as np
+
     if nodelist is None:
         nodelist = list(G)
     nodeset = set(nodelist)

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -190,18 +190,23 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
     --------
     Construct an adjacency matrix:
 
+    >>> try:
+    ...    import numpy as np
+    ...    np.set_printoptions(legacy="1.13")
+    ... except TypeError:
+    ...    pass
     >>> G = nx.Graph()
-    >>> G.add_edge(0,1,thickness=1,weight=3)
-    >>> G.add_edge(0,2,thickness=2)
-    >>> G.add_edge(1,2,thickness=3)
-    >>> nx.attr_matrix(G, rc_order=[0,1,2])
+    >>> G.add_edge(0, 1, thickness=1, weight=3)
+    >>> G.add_edge(0, 2, thickness=2)
+    >>> G.add_edge(1, 2, thickness=3)
+    >>> nx.attr_matrix(G, rc_order=[0, 1, 2])
     matrix([[ 0.,  1.,  1.],
             [ 1.,  0.,  1.],
             [ 1.,  1.,  0.]])
 
     Alternatively, we can obtain the matrix describing edge thickness.
 
-    >>> nx.attr_matrix(G, edge_attr='thickness', rc_order=[0,1,2])
+    >>> nx.attr_matrix(G, edge_attr='thickness', rc_order=[0, 1, 2])
     matrix([[ 0.,  1.,  2.],
             [ 1.,  0.,  3.],
             [ 2.,  3.,  0.]])


### PR DESCRIPTION
https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst

This fixes a bunch of failures like:
```
File "/home/travis/venv/lib/python2.7/site-packages/networkx/convert_matrix.py", line 1053, in networkx.convert_matrix.to_numpy_array
Failed example:
    A
Expected:
    array([[ 1.]])
Got:
    array([[1.]])
```