### PR TITLE
Fix Pydot tests so works with new version 1.2.4

### DIFF
--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -53,7 +53,7 @@ class TestPydot(object):
 
         # Serialize this "pydot.Dot" instance to a temporary file in dot format.
         fname = tempfile.mktemp()
-        assert_true(P.write_raw(fname))
+        P.write_raw(fname)
 
         # Deserialize a list of new "pydot.Dot" instances back from this file.
         Pin_list = pydot.graph_from_dot_file(path=fname, encoding='utf-8')


### PR DESCRIPTION
I removed the check for "True" on P.write_raw because
now it returns None (nothing). We'll rely on exceptions
being raised is the write doesn't work. We actualy test
the written contents later by reading it in so should be OK.