### PR TITLE
Temporarily disable sphinx doctests

### DIFF
--- a/tools/travis/build_docs.sh
+++ b/tools/travis/build_docs.sh
@@ -6,7 +6,6 @@ pip install --retries 3 -q -r requirements/doc.txt
 export SPHINXCACHE=$HOME/.cache/sphinx
 cd doc
 make html
-make doctest
 make latexpdf
 cd ..
 


### PR DESCRIPTION
See Legacy array printing for NumPy 1.14+ (#2810)

That fix worked for nose, but doesn't seem to work for sphinx.