### PR TITLE
Deprecate component_subgraphs functions

### DIFF
--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -20,7 +20,7 @@ __all__ = ['number_attracting_components',
 
 @not_implemented_for('undirected')
 def attracting_components(G):
-    """Generates a list of attracting components in `G`.
+    """Generates the attracting components in `G`.
 
     An attracting component in a directed graph `G` is a strongly connected
     component with the property that a random walker on the graph will never
@@ -85,8 +85,7 @@ def number_attracting_components(G):
     attracting_component_subgraphs
 
     """
-    n = len(list(attracting_components(G)))
-    return n
+    return sum(1 for ac in attracting_components(G))
 
 
 @not_implemented_for('undirected')
@@ -116,11 +115,9 @@ def is_attracting_component(G):
 
     """
     ac = list(attracting_components(G))
-    if len(ac[0]) == len(G):
-        attracting = True
-    else:
-        attracting = False
-    return attracting
+    if len(ac) == 1:
+        return len(ac[0]) == len(G)
+    return False
 
 
 @not_implemented_for('undirected')

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -8,6 +8,7 @@
 #
 # Authors: Christopher Ellison
 """Attracting components."""
+import warnings as _warnings
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
@@ -49,7 +50,6 @@ def attracting_components(G):
     --------
     number_attracting_components
     is_attracting_component
-    attracting_component_subgraphs
 
     """
     scc = list(nx.strongly_connected_components(G))
@@ -82,7 +82,6 @@ def number_attracting_components(G):
     --------
     attracting_components
     is_attracting_component
-    attracting_component_subgraphs
 
     """
     return sum(1 for ac in attracting_components(G))
@@ -111,7 +110,6 @@ def is_attracting_component(G):
     --------
     attracting_components
     number_attracting_components
-    attracting_component_subgraphs
 
     """
     ac = list(attracting_components(G))
@@ -122,36 +120,15 @@ def is_attracting_component(G):
 
 @not_implemented_for('undirected')
 def attracting_component_subgraphs(G, copy=True):
-    """Generates a list of attracting component subgraphs from `G`.
+    """DEPRECATED: Use ``(G.subgraph(c) for c in attracting_components(G))``
 
-    Parameters
-    ----------
-    G : DiGraph, MultiDiGraph
-        The graph to be analyzed.
-
-    Returns
-    -------
-    subgraphs : list
-        A list of node-induced subgraphs of the attracting components of `G`.
-
-    copy : bool
-        If copy is True, graph, node, and edge attributes are copied to the
-        subgraphs.
-
-    Raises
-    ------
-    NetworkXNotImplemented :
-        If the input graph is undirected.
-
-    See Also
-    --------
-    attracting_components
-    number_attracting_components
-    is_attracting_component
-
+           Or ``(G.subgraph(c).copy() for c in attracting_components(G))``
     """
-    for ac in attracting_components(G):
+    msg = "attracting_component_subgraphs is deprecated and will be removed" \
+        "in 2.2. Use (G.subgraph(c).copy() for c in attracting_components(G))"
+    _warnings.warn(msg, DeprecationWarning)
+    for c in attracting_components(G):
         if copy:
-            yield G.subgraph(ac).copy()
+            yield G.subgraph(c).copy()
         else:
-            yield G.subgraph(ac)
+            yield G.subgraph(c)

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -10,6 +10,7 @@
 #          Dan Schult (dschult@colgate.edu)
 #          Aric Hagberg (aric.hagberg@gmail.com)
 """Biconnected components and articulation points."""
+import warnings as _warnings
 from itertools import chain
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
@@ -62,7 +63,6 @@ def is_biconnected(G):
     biconnected_components
     articulation_points
     biconnected_component_edges
-    biconnected_component_subgraphs
     is_strongly_connected
     is_weakly_connected
     is_connected
@@ -145,7 +145,6 @@ def biconnected_component_edges(G):
     is_biconnected,
     biconnected_components,
     articulation_points,
-    biconnected_component_subgraphs
 
     Notes
     -----
@@ -239,7 +238,6 @@ def biconnected_components(G):
     is_biconnected
     articulation_points
     biconnected_component_edges
-    biconnected_component_subgraphs
 
     Notes
     -----
@@ -267,96 +265,18 @@ def biconnected_components(G):
 
 @not_implemented_for('directed')
 def biconnected_component_subgraphs(G, copy=True):
-    """Return a generator of graphs, one graph for each biconnected component
-    of the input graph.
+    """DEPRECATED: Use ``(G.subgraph(c) for c in biconnected_components(G))``
 
-    Biconnected components are maximal subgraphs such that the removal of a
-    node (and all edges incident on that node) will not disconnect the
-    subgraph.  Note that nodes may be part of more than one biconnected
-    component.  Those nodes are articulation points, or cut vertices.  The
-    removal of articulation points will increase the number of connected
-    components of the graph.
-
-    Notice that by convention a dyad is considered a biconnected component.
-
-    Parameters
-    ----------
-    G : NetworkX Graph
-        An undirected graph.
-
-    Returns
-    -------
-    graphs : generator
-        Generator of graphs, one graph for each biconnected component.
-
-    Raises
-    ------
-    NetworkXNotImplemented :
-        If the input graph is not undirected.
-
-    Examples
-    --------
-
-    >>> G = nx.lollipop_graph(5, 1)
-    >>> print(nx.is_biconnected(G))
-    False
-    >>> bicomponents = list(nx.biconnected_component_subgraphs(G))
-    >>> len(bicomponents)
-    2
-    >>> G.add_edge(0, 5)
-    >>> print(nx.is_biconnected(G))
-    True
-    >>> bicomponents = list(nx.biconnected_component_subgraphs(G))
-    >>> len(bicomponents)
-    1
-
-    You can generate a sorted list of biconnected components, largest
-    first, using sort.
-
-    >>> G.remove_edge(0, 5)
-    >>> [len(c) for c in sorted(nx.biconnected_component_subgraphs(G),
-    ...                         key=len, reverse=True)]
-    [5, 2]
-
-    If you only want the largest connected component, it's more
-    efficient to use max instead of sort.
-
-    >>> Gc = max(nx.biconnected_component_subgraphs(G), key=len)
-
-    See Also
-    --------
-    is_biconnected
-    articulation_points
-    biconnected_component_edges
-    biconnected_components
-
-    Notes
-    -----
-    The algorithm to find articulation points and biconnected
-    components is implemented using a non-recursive depth-first-search
-    (DFS) that keeps track of the highest level that back edges reach
-    in the DFS tree.  A node `n` is an articulation point if, and only
-    if, there exists a subtree rooted at `n` such that there is no
-    back edge from any successor of `n` that links to a predecessor of
-    `n` in the DFS tree.  By keeping track of all the edges traversed
-    by the DFS we can obtain the biconnected components because all
-    edges of a bicomponent will be traversed consecutively between
-    articulation points.
-
-    Graph, node, and edge attributes are copied to the subgraphs.
-
-    References
-    ----------
-    .. [1] Hopcroft, J.; Tarjan, R. (1973).
-           "Efficient algorithms for graph manipulation".
-           Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
-
+           Or ``(G.subgraph(c).copy() for c in biconnected_components(G))``
     """
-    for comp_nodes in biconnected_components(G):
+    msg = "connected_component_subgraphs is deprecated and will be removed" \
+        "in 2.2. Use (G.subgraph(c).copy() for c in biconnected_components(G))"
+    _warnings.warn(msg, DeprecationWarning)
+    for c in biconnected_components(G):
         if copy:
-            yield G.subgraph(comp_nodes).copy()
+            yield G.subgraph(c).copy()
         else:
-            yield G.subgraph(comp_nodes)
+            yield G.subgraph(c)
 
 
 @not_implemented_for('directed')
@@ -405,7 +325,6 @@ def articulation_points(G):
     is_biconnected
     biconnected_components
     biconnected_component_edges
-    biconnected_component_subgraphs
 
     Notes
     -----

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -89,9 +89,12 @@ def is_biconnected(G):
 
     """
     bcc = list(biconnected_components(G))
-    if not bcc:  # No bicomponents (it could be an empty graph)
-        return False
-    return len(bcc[0]) == len(G)
+    if len(bcc) == 1:
+        return len(bcc[0]) == len(G)
+    return False  # Multiple bicomponents or No bicomponents (empty graph?)
+#    if len(bcc) == 0:  # No bicomponents (it could be an empty graph)
+#        return False
+#    return len(bcc[0]) == len(G)
 
 
 @not_implemented_for('directed')

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -150,12 +150,12 @@ def number_connected_components(G):
     For undirected graphs only.
 
     """
-    return len(list(connected_components(G)))
+    return sum(1 for cc in connected_components(G))
 
 
 @not_implemented_for('directed')
 def is_connected(G):
-    """Return True if the graph is connected, false otherwise.
+    """Return True if the graph is connected, False otherwise.
 
     Parameters
     ----------
@@ -194,12 +194,12 @@ def is_connected(G):
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept('Connectivity is undefined ',
                                           'for the null graph.')
-    return len(set(_plain_bfs(G, arbitrary_element(G)))) == len(G)
+    return sum(1 for node in _plain_bfs(G, arbitrary_element(G))) == len(G)
 
 
 @not_implemented_for('directed')
 def node_connected_component(G, n):
-    """Return the nodes in the component of graph containing node n.
+    """Return the set of nodes in the component of graph containing node n.
 
     Parameters
     ----------
@@ -233,7 +233,7 @@ def node_connected_component(G, n):
 
 def _plain_bfs(G, source):
     """A fast BFS node generator"""
-    G_adj = G.adj
+    G_adj = G._adj
     seen = set()
     nextlevel = {source}
     while nextlevel:

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -10,6 +10,7 @@
 #          Aric Hagberg (hagberg@lanl.gov)
 #          Christopher Ellison
 """Connected components."""
+import warnings as _warnings
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 from ...utils import arbitrary_element
@@ -76,49 +77,13 @@ def connected_components(G):
 
 @not_implemented_for('directed')
 def connected_component_subgraphs(G, copy=True):
-    """Generate connected components as subgraphs.
+    """DEPRECATED: Use ``(G.subgraph(c) for c in connected_components(G))``
 
-    Parameters
-    ----------
-    G : NetworkX graph
-       An undirected graph.
-
-    copy: bool (default=True)
-      If True make a copy of the graph attributes
-
-    Returns
-    -------
-    comp : generator
-      A generator of graphs, one for each connected component of G.
-
-    Raises
-    ------
-    NetworkXNotImplemented:
-        If G is directed.
-
-    Examples
-    --------
-    >>> G = nx.path_graph(4)
-    >>> G.add_edge(5,6)
-    >>> graphs = list(nx.connected_component_subgraphs(G))
-
-    If you only want the largest connected component, it's more
-    efficient to use max instead of sort:
-
-    >>> Gc = max(nx.connected_component_subgraphs(G), key=len)
-
-    See Also
-    --------
-    connected_components
-    strongly_connected_component_subgraphs
-    weakly_connected_component_subgraphs
-
-    Notes
-    -----
-    For undirected graphs only.
-    Graph, node, and edge attributes are copied to the subgraphs by default.
-
+           Or ``(G.subgraph(c).copy() for c in connected_components(G))``
     """
+    msg = "connected_component_subgraphs is deprecated and will be removed" \
+          "in 2.2. Use (G.subgraph(c).copy() for c in connected_components(G))"
+    _warnings.warn(msg, DeprecationWarning)
     for c in connected_components(G):
         if copy:
             yield G.subgraph(c).copy()

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -198,7 +198,7 @@ def node_connected_component(G, n):
 
 def _plain_bfs(G, source):
     """A fast BFS node generator"""
-    G_adj = G._adj
+    G_adj = G.adj
     seen = set()
     nextlevel = {source}
     while nextlevel:

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -346,7 +346,7 @@ def number_strongly_connected_components(G):
     -----
     For directed graphs only.
     """
-    return len(list(strongly_connected_components(G)))
+    return sum(1 for scc in strongly_connected_components(G))
 
 
 @not_implemented_for('undirected')
@@ -434,7 +434,10 @@ def condensation(G, scc=None):
     mapping = {}
     members = {}
     C = nx.DiGraph()
-    i = 0  # required if G is empty
+    # Add mapping dict as graph attribute
+    C.graph['mapping'] = mapping
+    if len(G) == 0:
+        return C
     for i, component in enumerate(scc):
         members[i] = component
         mapping.update((n, i) for n in component)
@@ -444,6 +447,4 @@ def condensation(G, scc=None):
                      if mapping[u] != mapping[v])
     # Add a list of members (ie original nodes) to each node (ie scc) in C.
     nx.set_node_attributes(C, members, 'members')
-    # Add mapping dict as graph attribute
-    C.graph['mapping'] = mapping
     return C

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -11,6 +11,7 @@
 #          Christopher Ellison
 #          Ben Edwards (bedwards@cs.unm.edu)
 """Strongly connected components."""
+import warnings as _warnings
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
@@ -267,54 +268,18 @@ def strongly_connected_components_recursive(G):
 
 @not_implemented_for('undirected')
 def strongly_connected_component_subgraphs(G, copy=True):
-    """Generate strongly connected components as subgraphs.
+    """DEPRECATED: Use ``(G.subgraph(c) for c in strongly_connected_components(G))``
 
-    Parameters
-    ----------
-    G : NetworkX Graph
-       A directed graph.
-
-    copy : boolean, optional
-        if copy is True, Graph, node, and edge attributes are copied to
-        the subgraphs.
-
-    Returns
-    -------
-    comp : generator of graphs
-      A generator of graphs, one for each strongly connected component of G.
-
-    Raises
-    ------
-    NetworkXNotImplemented:
-        If G is undirected.
-
-    Examples
-    --------
-    Generate a sorted list of strongly connected components, largest first.
-
-    >>> G = nx.cycle_graph(4, create_using=nx.DiGraph())
-    >>> nx.add_cycle(G, [10, 11, 12])
-    >>> [len(Gc) for Gc in sorted(nx.strongly_connected_component_subgraphs(G),
-    ...                         key=len, reverse=True)]
-    [4, 3]
-
-    If you only want the largest component, it's more efficient to
-    use max instead of sort.
-
-    >>> Gc = max(nx.strongly_connected_component_subgraphs(G), key=len)
-
-    See Also
-    --------
-    strongly_connected_components
-    connected_component_subgraphs
-    weakly_connected_component_subgraphs
-
+         Or ``(G.subgraph(c).copy() for c in strongly_connected_components(G))``
     """
-    for comp in strongly_connected_components(G):
+    msg = "strongly_connected_component_subgraphs is deprecated and will be removed in 2.2" \
+        "use (G.subgraph(c).copy() for c in strongly_connected_components(G))"
+    _warnings.warn(msg, DeprecationWarning)
+    for c in strongly_connected_components(G):
         if copy:
-            yield G.subgraph(comp).copy()
+            yield G.subgraph(c).copy()
         else:
-            yield G.subgraph(comp)
+            yield G.subgraph(c)
 
 
 @not_implemented_for('undirected')

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -15,6 +15,8 @@ class TestAttractingComponents(object):
         self.G3 = nx.DiGraph()
         self.G3.add_edges_from([(0, 1), (1, 2), (2, 1), (0, 3), (3, 4), (4, 3)])
 
+        self.G4 = nx.DiGraph()
+
     def test_attracting_components(self):
         ac = list(nx.attracting_components(self.G1))
         assert_true({2} in ac)
@@ -31,10 +33,14 @@ class TestAttractingComponents(object):
         assert_true((3, 4) in ac)
         assert_equal(len(ac), 2)
 
+        ac = list(nx.attracting_components(self.G4))
+        assert_equal(ac, [])
+
     def test_number_attacting_components(self):
         assert_equal(nx.number_attracting_components(self.G1), 3)
         assert_equal(nx.number_attracting_components(self.G2), 1)
         assert_equal(nx.number_attracting_components(self.G3), 2)
+        assert_equal(nx.number_attracting_components(self.G4), 0)
 
     def test_is_attracting_component(self):
         assert_false(nx.is_attracting_component(self.G1))
@@ -42,6 +48,7 @@ class TestAttractingComponents(object):
         assert_false(nx.is_attracting_component(self.G3))
         g2 = self.G3.subgraph([1, 2])
         assert_true(nx.is_attracting_component(g2))
+        assert_false(nx.is_attracting_component(self.G4))
 
     def test_connected_raise(self):
         G=nx.Graph()

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -55,4 +55,5 @@ class TestAttractingComponents(object):
         assert_raises(NetworkXNotImplemented, nx.attracting_components, G)
         assert_raises(NetworkXNotImplemented, nx.number_attracting_components, G)
         assert_raises(NetworkXNotImplemented, nx.is_attracting_component, G)
+        # deprecated
         assert_raises(NetworkXNotImplemented, nx.attracting_component_subgraphs, G)

--- a/networkx/algorithms/components/tests/test_biconnected.py
+++ b/networkx/algorithms/components/tests/test_biconnected.py
@@ -169,6 +169,13 @@ def test_biconnected_eppstein():
     bcc = list(nx.biconnected_components(G2))
     assert_components_equal(bcc, answer_G2)
 
+def test_null_graph():
+    G = nx.Graph()
+    assert_false(nx.is_biconnected(G))
+    assert_equal(list(nx.biconnected_components(G)), [])
+    assert_equal(list(nx.biconnected_component_edges(G)), [])
+    assert_equal(list(nx.articulation_points(G)), [])
+
 def test_connected_raise():
     DG = nx.DiGraph()
     assert_raises(NetworkXNotImplemented, nx.biconnected_components, DG)

--- a/networkx/algorithms/components/tests/test_biconnected.py
+++ b/networkx/algorithms/components/tests/test_biconnected.py
@@ -71,6 +71,7 @@ def test_biconnected_components_cycle():
     answer = [{0, 1, 2}, {1, 3, 4}]
     assert_components_equal(list(nx.biconnected_components(G)), answer)
 
+# deprecated
 def test_biconnected_component_subgraphs_cycle():
     G=nx.cycle_graph(3)
     nx.add_cycle(G, [1, 3, 4, 5])
@@ -179,7 +180,8 @@ def test_null_graph():
 def test_connected_raise():
     DG = nx.DiGraph()
     assert_raises(NetworkXNotImplemented, nx.biconnected_components, DG)
-    assert_raises(NetworkXNotImplemented, nx.biconnected_component_subgraphs, DG)
     assert_raises(NetworkXNotImplemented, nx.biconnected_component_edges, DG)
     assert_raises(NetworkXNotImplemented, nx.articulation_points, DG)
     assert_raises(NetworkXNotImplemented, nx.is_biconnected, DG)
+    # deprecated
+    assert_raises(NetworkXNotImplemented, nx.biconnected_component_subgraphs, DG)

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -41,6 +41,10 @@ class TestConnected:
         C = [[0, 1, 2], [3, 4]]
         self.gc.append((G, C))
 
+        G = nx.DiGraph()
+        C = []
+        self.gc.append((G, C))
+
 
     def test_connected_components(self):
         cc = nx.connected_components

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -76,6 +76,7 @@ class TestConnected:
         C = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
         assert_equal(ncc(G, 1), C)
 
+    # deprecated
     def test_connected_component_subgraphs(self):
         wcc = nx.weakly_connected_component_subgraphs
         cc = nx.connected_component_subgraphs
@@ -94,7 +95,8 @@ class TestConnected:
     def test_connected_raise(self):
         assert_raises(NetworkXNotImplemented, nx.connected_components, self.DG)
         assert_raises(NetworkXNotImplemented, nx.number_connected_components, self.DG)
-        assert_raises(NetworkXNotImplemented, nx.connected_component_subgraphs, self.DG)
         assert_raises(NetworkXNotImplemented, nx.node_connected_component, self.DG,1)
         assert_raises(NetworkXNotImplemented, nx.is_connected, self.DG)
         assert_raises(nx.NetworkXPointlessConcept, nx.is_connected, nx.Graph())
+        # deprecated
+        assert_raises(NetworkXNotImplemented, nx.connected_component_subgraphs, self.DG)

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -67,6 +67,7 @@ class TestStronglyConnected:
             else:
                 assert_false(nx.is_strongly_connected(G))
 
+    # deprecated
     def test_strongly_connected_component_subgraphs(self):
         scc = nx.strongly_connected_component_subgraphs
         for G, C in self.gc:
@@ -147,7 +148,8 @@ class TestStronglyConnected:
         assert_raises(NetworkXNotImplemented, nx.strongly_connected_components, G)
         assert_raises(NetworkXNotImplemented, nx.kosaraju_strongly_connected_components, G)
         assert_raises(NetworkXNotImplemented, nx.strongly_connected_components_recursive, G)
-        assert_raises(NetworkXNotImplemented, nx.strongly_connected_component_subgraphs, G)
         assert_raises(NetworkXNotImplemented, nx.is_strongly_connected, G)
         assert_raises(nx.NetworkXPointlessConcept, nx.is_strongly_connected, nx.DiGraph())
         assert_raises(NetworkXNotImplemented, nx.condensation, G)
+        # deprecated
+        assert_raises(NetworkXNotImplemented, nx.strongly_connected_component_subgraphs, G)

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -134,6 +134,14 @@ class TestStronglyConnected:
         for n, d in cG.nodes(data=True):
             assert_equal(set(C[n]), cG.nodes[n]['members'])
 
+    def test_null_graph(self):
+        G=nx.DiGraph()
+        assert_equal(list(nx.strongly_connected_components(G)), [])
+        assert_equal(list(nx.kosaraju_strongly_connected_components(G)), [])
+        assert_equal(list(nx.strongly_connected_components_recursive(G)), [])
+        assert_equal(len(nx.condensation(G)), 0)
+        assert_raises(nx.NetworkXPointlessConcept, nx.is_strongly_connected, nx.DiGraph())
+
     def test_connected_raise(self):
         G=nx.Graph()
         assert_raises(NetworkXNotImplemented, nx.strongly_connected_components, G)

--- a/networkx/algorithms/components/tests/test_subgraph_copies.py
+++ b/networkx/algorithms/components/tests/test_subgraph_copies.py
@@ -4,6 +4,9 @@ from copy import deepcopy
 from nose.tools import assert_equal
 import networkx as nx
 
+# deprecated in 2.1 for removal in 2.2
+
+
 class TestSubgraphAttributesDicts:
 
     def setUp(self):

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -47,6 +47,7 @@ class TestWeaklyConnected:
             c = nx.number_connected_components(U)
             assert_equal(w, c)
 
+    # deprecated
     def test_weakly_connected_component_subgraphs(self):
         wcc = nx.weakly_connected_component_subgraphs
         cc = nx.connected_component_subgraphs
@@ -71,5 +72,6 @@ class TestWeaklyConnected:
         G=nx.Graph()
         assert_raises(NetworkXNotImplemented,nx.weakly_connected_components, G)
         assert_raises(NetworkXNotImplemented,nx.number_weakly_connected_components, G)
-        assert_raises(NetworkXNotImplemented,nx.weakly_connected_component_subgraphs, G)
         assert_raises(NetworkXNotImplemented,nx.is_weakly_connected, G)
+        # deprecated
+        assert_raises(NetworkXNotImplemented,nx.weakly_connected_component_subgraphs, G)

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -61,6 +61,12 @@ class TestWeaklyConnected:
             U = G.to_undirected()
             assert_equal(nx.is_weakly_connected(G), nx.is_connected(U))
 
+    def test_null_graph(self):
+        G=nx.DiGraph()
+        assert_equal(list(nx.weakly_connected_components(G)), [])
+        assert_equal(nx.number_weakly_connected_components(G), 0)
+        assert_raises(nx.NetworkXPointlessConcept, nx.is_weakly_connected, G)
+
     def test_connected_raise(self):
         G=nx.Graph()
         assert_raises(NetworkXNotImplemented,nx.weakly_connected_components, G)

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -9,6 +9,7 @@
 # Authors: Aric Hagberg (hagberg@lanl.gov)
 #          Christopher Ellison
 """Weakly connected components."""
+import warnings as _warnings
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
@@ -108,58 +109,18 @@ def number_weakly_connected_components(G):
 
 @not_implemented_for('undirected')
 def weakly_connected_component_subgraphs(G, copy=True):
-    """Generate weakly connected components as subgraphs.
+    """DEPRECATED: Use ``(G.subgraph(c) for c in weakly_connected_components(G))``
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        A directed graph.
-
-    copy: bool (default=True)
-        If True make a copy of the graph attributes
-
-    Returns
-    -------
-    comp : generator
-        A generator of graphs, one for each weakly connected component of G.
-
-    Raises
-    ------
-    NetworkXNotImplemented:
-        If G is undirected.
-
-    Examples
-    --------
-    Generate a sorted list of weakly connected components, largest first.
-
-    >>> G = nx.path_graph(4, create_using=nx.DiGraph())
-    >>> nx.add_path(G, [10, 11, 12])
-    >>> [len(c) for c in sorted(nx.weakly_connected_component_subgraphs(G),
-    ...                         key=len, reverse=True)]
-    [4, 3]
-
-    If you only want the largest component, it's more efficient to
-    use max instead of sort:
-
-    >>> Gc = max(nx.weakly_connected_component_subgraphs(G), key=len)
-
-    See Also
-    --------
-    weakly_connected_components
-    strongly_connected_component_subgraphs
-    connected_component_subgraphs
-
-    Notes
-    -----
-    For directed graphs only.
-    Graph, node, and edge attributes are copied to the subgraphs by default.
-
+           Or ``(G.subgraph(c).copy() for c in weakly_connected_components(G))``
     """
-    for comp in weakly_connected_components(G):
+    msg = "weakly_connected_component_subgraphs is deprecated and will be removed in 2.2" \
+        "use (G.subgraph(c).copy() for c in weakly_connected_components(G))"
+    _warnings.warn(msg, DeprecationWarning)
+    for c in weakly_connected_components(G):
         if copy:
-            yield G.subgraph(comp).copy()
+            yield G.subgraph(c).copy()
         else:
-            yield G.subgraph(comp)
+            yield G.subgraph(c)
 
 
 @not_implemented_for('undirected')

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -103,7 +103,7 @@ def number_weakly_connected_components(G):
     For directed graphs only.
 
     """
-    return len(list(weakly_connected_components(G)))
+    return sum(1 for wcc in weakly_connected_components(G))
 
 
 @not_implemented_for('undirected')

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -19,7 +19,6 @@ from heapq import heappush, heappop
 from itertools import count
 import networkx as nx
 from networkx.utils import generate_unique_node
-import warnings as _warnings
 
 
 __all__ = ['dijkstra_path',

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -27,7 +27,6 @@ See Also
 nx_agraph, nx_pydot
 """
 
-import warnings as _warnings
 import itertools
 import networkx as nx
 from networkx.convert import _prep_create_using


### PR DESCRIPTION
Resolves #1431 

Also added tests for null graphs to component functions and 
avoided creating lists of components when counting is sufficient.