### PR TITLE
Remove automatic processing of G.name attribute

### DIFF
--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -48,8 +48,6 @@ def graph_example_1():
         for nbr in nbrs:
             G.add_edge(new_node+17, nbr)
         G.add_edge(new_node+16, new_node+5)
-
-    G.name = 'Example graph for connectivity'
     return G
 
 def torrents_and_ferraro_graph():
@@ -110,8 +108,6 @@ def torrents_and_ferraro_graph():
         G.remove_node(new_node+9)
         for nbr in nbrs2:
             G.add_edge(new_node+18, nbr)
-
-    G.name = 'Example graph for connectivity'
     return G
 
 # Helper function

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -72,8 +72,6 @@ def torrents_and_ferraro_graph():
         G.remove_node(new_node + 9)
         for nbr in nbrs2:
             G.add_edge(new_node + 18, nbr)
-
-    G.name = 'Example graph for connectivity'
     return G
 
 

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -50,8 +50,6 @@ def graph_example_1():
         for nbr in nbrs:
             G.add_edge(new_node + 17, nbr)
         G.add_edge(new_node + 16, new_node + 5)
-
-    G.name = 'Example graph for connectivity'
     return G
 
 
@@ -113,8 +111,6 @@ def torrents_and_ferraro_graph():
         G.remove_node(new_node + 9)
         for nbr in nbrs2:
             G.add_edge(new_node + 18, nbr)
-
-    G.name = 'Example graph for connectivity'
     return G
 
 

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -19,7 +19,7 @@ __all__ = ['union_all', 'compose_all', 'disjoint_union_all',
            'intersection_all']
 
 
-def union_all(graphs, rename=(None,), name=None):
+def union_all(graphs, rename=(None,)):
     """Return the union of all graphs.
 
     The graphs must be disjoint, otherwise an exception is raised.
@@ -33,9 +33,6 @@ def union_all(graphs, rename=(None,), name=None):
        Node names of G and H can be changed by specifying the tuple
        rename=('G-','H-') (for example).  Node "u" in G is then renamed
        "G-u" and "v" in H is renamed "H-v".
-
-    name : string
-       Specify the name for the union graph@not_implemnted_for('direct
 
     Returns
     -------
@@ -58,7 +55,7 @@ def union_all(graphs, rename=(None,), name=None):
     graphs_names = zip_longest(graphs, rename)
     U, gname = next(graphs_names)
     for H, hname in graphs_names:
-        U = nx.union(U, H, (gname, hname), name=name)
+        U = nx.union(U, H, (gname, hname))
         gname = None
     return U
 
@@ -93,7 +90,7 @@ def disjoint_union_all(graphs):
     return U
 
 
-def compose_all(graphs, name=None):
+def compose_all(graphs):
     """Return the composition of all graphs.
 
     Composition is the simple union of the node sets and edge sets.
@@ -103,9 +100,6 @@ def compose_all(graphs, name=None):
     ----------
     graphs : list
        List of NetworkX graphs
-
-    name : string
-       Specify name for new graph
 
     Returns
     -------
@@ -123,7 +117,7 @@ def compose_all(graphs, name=None):
     graphs = iter(graphs)
     C = next(graphs)
     for H in graphs:
-        C = nx.compose(C, H, name=name)
+        C = nx.compose(C, H)
     return C
 
 

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -55,11 +55,9 @@ def union(G, H, rename=(None, None), name=None):
         raise nx.NetworkXError('G and H must both be graphs or multigraphs.')
     # Union is the same type as G
     R = G.fresh_copy()
-    # construct new name graph attribute
-    # FIXME this is overwritten by .graph.update below
-    if name is None:
-        name = "union( %s, %s )" % (G.name, H.name)
-    R.name = name
+    # add graph attributes, H attributes take precedent over G attributes
+    R.graph.update(G.graph)
+    R.graph.update(H.graph)
 
     # rename graph to obtain disjoint node labels
     def add_prefix(graph, prefix):
@@ -100,9 +98,6 @@ def union(G, H, rename=(None, None), name=None):
     for n in H:
         R.nodes[n].update(H.nodes[n])
 
-    # add graph attributes, H attributes take precedent over G attributes
-    R.graph.update(G.graph)
-    R.graph.update(H.graph)
     return R
 
 
@@ -135,7 +130,6 @@ def disjoint_union(G, H):
     R1 = nx.convert_node_labels_to_integers(G)
     R2 = nx.convert_node_labels_to_integers(H, first_label=len(R1))
     R = union(R1, R2)
-    R.name = "disjoint_union( %s, %s )" % (G.name, H.name)
     R.graph.update(G.graph)
     R.graph.update(H.graph)
     return R
@@ -171,7 +165,6 @@ def intersection(G, H):
     # create new graph
     R = nx.create_empty_copy(G)
 
-    R.name = "Intersection of (%s and %s)" % (G.name, H.name)
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError('G and H must both be graphs or multigraphs.')
     if set(G) != set(H):
@@ -193,7 +186,6 @@ def intersection(G, H):
         for e in edges:
             if G.has_edge(*e):
                 R.add_edge(*e)
-
     return R
 
 
@@ -227,7 +219,6 @@ def difference(G, H):
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError('G and H must both be graphs or multigraphs.')
     R = nx.create_empty_copy(G)
-    R.name = "Difference of (%s and %s)" % (G.name, H.name)
 
     if set(G) != set(H):
         raise nx.NetworkXError("Node sets of graphs not equal")
@@ -265,7 +256,6 @@ def symmetric_difference(G, H):
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError('G and H must both be graphs or multigraphs.')
     R = nx.create_empty_copy(G)
-    R.name = "Symmetric difference of (%s and %s)" % (G.name, H.name)
 
     if set(G) != set(H):
         raise nx.NetworkXError("Node sets of graphs not equal")
@@ -295,7 +285,7 @@ def symmetric_difference(G, H):
     return R
 
 
-def compose(G, H, name=None):
+def compose(G, H):
     """Return a new graph of G composed with H.
 
     Composition is the simple union of the node sets and edge sets.
@@ -303,11 +293,8 @@ def compose(G, H, name=None):
 
     Parameters
     ----------
-    G,H : graph
+    G, H : graph
        A NetworkX graph
-
-    name : string
-       Specify name for new graph
 
     Returns
     -------
@@ -325,11 +312,10 @@ def compose(G, H, name=None):
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError('G and H must both be graphs or multigraphs.')
 
-    if name is None:
-        name = "compose( %s, %s )" % (G.name, H.name)
     R = G.fresh_copy()
-    # FIXME this is overwritten by R.graph.update below
-    R.name = name
+    # add graph attributes, H attributes take precedent over G attributes
+    R.graph.update(G.graph)
+    R.graph.update(H.graph)
 
     R.add_nodes_from(G.nodes(data=True))
     R.add_nodes_from(H.nodes(data=True))
@@ -342,7 +328,4 @@ def compose(G, H, name=None):
         R.add_edges_from(H.edges(keys=True, data=True))
     else:
         R.add_edges_from(H.edges(data=True))
-    # add graph attributes, H attributes take precedent over G attributes
-    R.graph.update(G.graph)
-    R.graph.update(H.graph)
     return R

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -180,7 +180,6 @@ def tensor_product(G, H):
     GH.add_edges_from(_directed_edges_cross_edges(G, H))
     if not GH.is_directed():
         GH.add_edges_from(_undirected_edges_cross_edges(G, H))
-    GH.name = "Tensor product(" + G.name + "," + H.name + ")"
     return GH
 
 
@@ -235,7 +234,6 @@ def cartesian_product(G, H):
     GH.add_nodes_from(_node_product(G, H))
     GH.add_edges_from(_edges_cross_nodes(G, H))
     GH.add_edges_from(_nodes_cross_edges(G, H))
-    GH.name = "Cartesian product(" + G.name + "," + H.name + ")"
     return GH
 
 
@@ -288,7 +286,6 @@ def lexicographic_product(G, H):
     GH.add_edges_from(_edges_cross_nodes_and_nodes(G, H))
     # For each x in G, only if there is an edge in H
     GH.add_edges_from(_nodes_cross_edges(G, H))
-    GH.name = "Lexicographic product(" + G.name + "," + H.name + ")"
     return GH
 
 
@@ -344,7 +341,6 @@ def strong_product(G, H):
     GH.add_edges_from(_directed_edges_cross_edges(G, H))
     if not GH.is_directed():
         GH.add_edges_from(_undirected_edges_cross_edges(G, H))
-    GH.name = "Strong product(" + G.name + "," + H.name + ")"
     return GH
 
 

--- a/networkx/algorithms/operators/unary.py
+++ b/networkx/algorithms/operators/unary.py
@@ -13,16 +13,13 @@ __author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',
 __all__ = ['complement', 'reverse']
 
 
-def complement(G, name=None):
+def complement(G):
     """Return the graph complement of G.
 
     Parameters
     ----------
     G : graph
        A NetworkX graph
-
-    name : string
-       Specify name for new graph
 
     Returns
     -------
@@ -35,10 +32,7 @@ def complement(G, name=None):
 
     Graph, node, and edge data are not propagated to the new graph.
     """
-    if name is None:
-        name = "complement(%s)" % (G.name)
     R = G.fresh_copy()
-    R.name = name
     R.add_nodes_from(G)
     R.add_edges_from(((n, n2)
                       for n, nbrs in G.adjacency()

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1299,8 +1299,6 @@ class DiGraph(Graph):
         if copy:
             H = self.fresh_copy()
             H.graph.update(deepcopy(self.graph))
-            if 'name' in H.graph:
-                H.name = "Reverse of (%s)" % H.name
             H.add_nodes_from((n, deepcopy(d)) for n, d in self.node.items())
             H.add_edges_from((v, u, deepcopy(d)) for u, v, d
                              in self.edges(data=True))

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1309,7 +1309,6 @@ class Graph(object):
         []
 
         """
-        self.name = ''
         self._adj.clear()
         self._node.clear()
         self.graph.clear()

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -991,8 +991,6 @@ class MultiDiGraph(MultiGraph, DiGraph):
         if copy:
             H = self.fresh_copy()
             H.graph.update(deepcopy(self.graph))
-            if 'name' in H.graph:
-                H.name = "Reverse of (%s)" % H.name
             H.add_nodes_from((n, deepcopy(d)) for n, d in self._node.items())
             H.add_edges_from((v, u, k, deepcopy(d)) for u, v, k, d
                              in self.edges(keys=True, data=True))

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -80,7 +80,6 @@ def from_agraph(A, create_using=None):
 
     # assign defaults
     N = nx.empty_graph(0, create_using)
-    N.name = ''
     if A.name is not None:
         N.name = A.name
 

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -734,7 +734,8 @@ def thresholded_random_geometric_graph(n, radius, theta, dim=2, pos=None, weight
 
     n_name, nodes = n
     G = nx.Graph()
-    G.name = 'thresholded_random_geometric_graph({}, {}, {}, {})'.format(n, radius, theta, dim)
+    namestr = 'thresholded_random_geometric_graph({}, {}, {}, {})'
+    G.name = namestr.format(n, radius, theta, dim)
     G.add_nodes_from(nodes)
     # If no weights are provided, choose them from an exponential
     # distribution.

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -154,9 +154,6 @@ def _relabel_copy(G, mapping):
     H = G.fresh_copy()
     H.add_nodes_from(mapping.get(n, n) for n in G)
     H._node.update((mapping.get(n, n), d.copy()) for n, d in G.nodes.items())
-    # FIXME this is overwritten below when H.graph is updated
-    if G.name:
-        H.name = "(%s)" % G.name
     if G.is_multigraph():
         H.add_edges_from((mapping.get(n1, n1), mapping.get(n2, n2), k, d.copy())
                          for (n1, n2, k, d) in G.edges(keys=True, data=True))
@@ -217,7 +214,6 @@ def convert_node_labels_to_integers(G, first_label=0, ordering="default",
     else:
         raise nx.NetworkXError('Unknown node ordering: %s' % ordering)
     H = relabel_nodes(G, mapping)
-    H.name = "(" + G.name + ")_with_int_labels"
     # create node attribute with the old label
     if label_attribute is not None:
         nx.set_node_attributes(H, {v: k for k, v in mapping.items()},

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -12,7 +12,6 @@ class TestRelabel():
         # test that empty graph converts fine for all options
         G = empty_graph()
         H = convert_node_labels_to_integers(G, 100)
-        assert_equal(H.name, '()_with_int_labels')
         assert_equal(list(H.nodes()), [])
         assert_equal(list(H.edges()), [])
 
@@ -24,9 +23,7 @@ class TestRelabel():
 
         G = empty_graph()
         G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'C'), ('C', 'D')])
-        G.name = "paw"
         H = convert_node_labels_to_integers(G)
-        assert_equal(H.name, '(paw)_with_int_labels')
         degH = (d for n, d in H.degree())
         degG = (d for n, d in G.degree())
         assert_equal(sorted(degH), sorted(degG))


### PR DESCRIPTION
It's too hard to keep G.name consistently updated
throughout the codebase.  Let users do it.
This stops from deprecating G.name altogether, but
it is a first step toward that if we decide to go that route.

Fixes #2651