### PR TITLE
pydot read_dot now strips quotes from attributes

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -138,13 +138,14 @@ def from_pydot(P):
         n = p.get_name().strip('"')
         if n in ('node', 'graph', 'edge'):
             continue
-        N.add_node(n, **p.get_attributes())
+        N.add_node(n, **{k: v.strip('"')
+                         for k, v in p.get_attributes().items()})
 
     # add edges
     for e in P.get_edge_list():
         u = e.get_source()
         v = e.get_destination()
-        attr = e.get_attributes()
+        attr = {k: v.strip('"') for k, v in e.get_attributes().items()}
         s = []
         d = []
 
@@ -165,7 +166,7 @@ def from_pydot(P):
                 N.add_edge(source_node, destination_node, **attr)
 
     # add default attributes for graph, nodes, edges
-    pattr = P.get_attributes()
+    pattr = {k: v.strip('"') for k, v in P.get_attributes().items()}
     if pattr:
         N.graph['graph'] = pattr
     try:

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -106,3 +106,13 @@ class TestPydot(object):
         fh.seek(0)
         H = nx.nx_pydot.read_dot(fh)
         assert_graphs_equal(G, H)
+
+    def test_pydot_read_quoted_attributes(self):
+        """ Test attribute quotes are successfully stripped from dot files """
+        dot_data = StringIO("""
+        digraph G{
+            "A_0" [shape="ellipse" style=filled];
+        }
+        """)
+        G = nx.nx_pydot.read_dot(dot_data)
+        assert G.nodes(data=True)['A_0']['shape'] == 'ellipse'


### PR DESCRIPTION
.dot file node/edge/graph attributes which are double-quoted
are not stripped of their quotes when using `read_dot` via
pydot, but are stripped of their quotes when using pygraphviz.
This commit adds quote-stripping to `read_dot` when using pydot.

Fixes: #2832