### PR TITLE
add Spectral Graph Forge generator

### DIFF
--- a/networkx/generators/__init__.py
+++ b/networkx/generators/__init__.py
@@ -21,6 +21,7 @@ from networkx.generators.random_clustered import *
 from networkx.generators.random_graphs import *
 from networkx.generators.small import *
 from networkx.generators.social import *
+from networkx.generators.spectral_graph_forge import *
 from networkx.generators.stochastic import *
 from networkx.generators.trees import *
 from networkx.generators.triads import *

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -183,3 +183,16 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     H = nx.from_numpy_matrix(B)
 
     return H
+
+
+# fixture for nose tests
+def setup_module(module):
+    from nose import SkipTest
+    try:
+        import numpy
+    except:
+        raise SkipTest("NumPy not available")
+    try:
+        import scipy
+    except:
+        raise SkipTest("SciPy not available")

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -1,0 +1,185 @@
+#    Copyright (C) 2017-2018 by
+#    Luca Baldesi
+#    BSD license.
+#
+# Author:  Luca Baldesi (luca.baldesi@unitn.it)
+"""Generates graphs with a given eigenvector structure"""
+
+
+import networkx as nx
+import numpy as np
+import scipy.stats as stats
+
+__all__ = ['spectral_graph_forge']
+
+
+def _truncate(x):
+    """ Returns the truncated value of x in the interval [0,1]
+    """
+
+    if x < 0:
+        return 0
+    if x > 1:
+        return 1
+    return x
+
+
+def _mat_spect_approx(A, level, sorteigs=True, reverse=False, absolute=True):
+    """ Returns the low-rank approximation of the given matrix A
+
+    Parameters
+    ----------
+    A : numpy matrix
+    level : integer
+        It represents the fixed rank for the output approximation matrix
+    sorteigs : boolean
+        Whether eigenvectors should be sorted according to their associated
+        eigenvalues before removing the firsts of them
+    reverse : boolean
+        Whether eigenvectors list should be reversed before removing the firsts
+        of them
+    absolute : boolean
+        Whether eigenvectors should be sorted considering the absolute values
+        of the corresponding eigenvalues
+
+    Returns
+    -------
+    B : numpy matrix
+        low-rank approximation of A
+
+    Notes
+    -----
+    Low-rank matrix approximation is about finding a fixed rank matrix close
+    enough to the input one with respect to a given norm (distance).
+    In the case of real symmetric input matrix and euclidean distance, the best
+    low-rank approximation is given by the sum of first eigenvector matrices.
+
+    References
+    ----------
+    ..  [1] G. Eckart and G. Young, The approximation of one matrix by another
+            of lower rank
+    ..  [2] L. Mirsky, Symmetric gauge functions and unitarily invariant norms
+
+    """
+
+    d, V = np.linalg.eigh(A)
+    d = np.ravel(d)
+    n = len(d)
+    if sorteigs:
+        if absolute:
+            k = np.argsort(np.abs(d))
+        else:
+            k = np.argsort(d)
+        # ordered from the lowest to the highest
+    else:
+        k = range(n)
+    if not reverse:
+        k = np.flipud(k)
+
+    z = np.zeros((n, 1))
+    for i in range(level, n):
+        V[:, k[i]] = z
+
+    B = V*np.diag(d)*np.transpose(V)
+    return B
+
+
+def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
+    """ Spectral Graph Forge (SGF) generates a random simple graph resembling
+        the global properties of the input one.
+
+    Parameters
+    ----------
+    G : Graph
+    alpha :  float
+        Ratio representing the percentage of eigenvectors of G to consider,
+        values in [0,1].
+    transformation : string, optional
+        Represents the intended matrix linear transformation, possible values
+        are 'identity' and 'modularity'
+    seed : integer, optional
+        Seed for random number generator.
+
+    Returns
+    -------
+    H : Graph
+        A graph with a similar eigenvector structure of the input one.
+
+    Raises
+    ------
+    NetworkXError
+        If transformation has a value different from 'identity' or 'modularity'.
+
+    Notes
+    -----
+    Spectral Graph Forge (SGF) generates a random simple graph resembling the
+    global properties of the given one.
+    It leverages the low-rank approximation of the associated adjacency matrix
+    driven by the *alpha* precision parameter.
+    SGF preserves the number of nodes of the input graph and their ordering.
+    This way, nodes of output graphs resemble the properties of the input one
+    and attributes can be directly mapped.
+
+    It considers the graph adjacency matrices which can optionally be
+    transformed to other symmetric real matrices (currently transformation
+    options include *identity* and *modularity*).
+    The *modularity* transformation, in the sense of Newman's modularity matrix
+    allows the focusing on community structure related properties of the graph.
+
+    SGF applies a low-rank approximation whose fixed rank is computed from the
+    ratio *alpha* of the input graph adjacency matrix dimension.
+    This step performs a filtering on the input eigenvectors similar to the low
+    pass filtering common in telecommunications.
+
+    The filtered values (after truncation) are used as input to a Bernoulli
+    sampling for constructing a random adjacency matrix.
+
+    References
+    ----------
+    ..  [1] L. Baldesi, C. T. Butts, A. Markopoulou, "Spectral Graph Forge:
+        Graph Generation Targeting Modularity", IEEE Infocom, '18.
+    ..  [2] M. Newman, "Networks: an introduction", Oxford university press,
+        2010
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.karate_club_graph()
+    >>> H = nx.spectral_graph_forge(G, 0.3)
+    >>>
+    """
+
+    available_transformations = ['identity', 'modularity']
+    alpha = _truncate(alpha)
+    A = nx.to_numpy_matrix(G)
+    n = A.shape[1]
+    level = int(round(n*alpha))
+    if seed:
+        np.random.seed(int(seed))
+
+    if transformation not in available_transformations:
+        msg = '\'{0}\' is not a valid transformation. '.format(transformation)
+        msg += 'Transformations: {0}'.format(available_transformations)
+        raise nx.NetworkXError(msg)
+
+    K = np.ones((1, n)) * A
+
+    B = A
+    if (transformation == 'modularity'):
+        B -= np.transpose(K) * K / float(sum(np.ravel(K)))
+
+    B = _mat_spect_approx(B, level, sorteigs=True, absolute=True)
+
+    if (transformation == 'modularity'):
+        B += np.transpose(K) * K / float(sum(np.ravel(K)))
+
+    B = np.vectorize(_truncate, otypes=[np.float])(B)
+    np.fill_diagonal(B, np.zeros((1, n)))
+
+    for i in range(n-1):
+        B[i, i+1:] = stats.bernoulli.rvs(B[i, i+1:])
+        B[i+1:, i] = np.transpose(B[i, i+1:])
+
+    H = nx.from_numpy_matrix(B)
+
+    return H

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -88,6 +88,13 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     """ Spectral Graph Forge (SGF) generates a random simple graph resembling
         the global properties of the input one.
 
+    This algorithm, called Spectral Graph Forge (SGF), computes the
+    eigenvectors of a given graph adjacency matrix, filters them and
+    builds a random graph with a similar eigenstructure.
+    SGF has been proved to be particularly useful for synthesizing
+    realistic social networks and it can also be used to anonymize
+    graph sensitive data.
+
     Parameters
     ----------
     G : Graph
@@ -108,7 +115,7 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     Raises
     ------
     NetworkXError
-        If transformation has a value different from 'identity' or 'modularity'.
+        If transformation has a value different from 'identity' or 'modularity'
 
     Notes
     -----
@@ -138,6 +145,7 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     ----------
     ..  [1] L. Baldesi, C. T. Butts, A. Markopoulou, "Spectral Graph Forge:
         Graph Generation Targeting Modularity", IEEE Infocom, '18.
+        https://arxiv.org/abs/1801.01715
     ..  [2] M. Newman, "Networks: an introduction", Oxford university press,
         2010
 

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -7,8 +7,6 @@
 
 
 import networkx as nx
-import numpy as np
-import scipy.stats as stats
 
 __all__ = ['spectral_graph_forge']
 
@@ -61,6 +59,8 @@ def _mat_spect_approx(A, level, sorteigs=True, reverse=False, absolute=True):
     ..  [2] L. Mirsky, Symmetric gauge functions and unitarily invariant norms
 
     """
+
+    import numpy as np
 
     d, V = np.linalg.eigh(A)
     d = np.ravel(d)
@@ -148,6 +148,9 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     >>> H = nx.spectral_graph_forge(G, 0.3)
     >>>
     """
+
+    import numpy as np
+    import scipy.stats as stats
 
     available_transformations = ['identity', 'modularity']
     alpha = _truncate(alpha)

--- a/networkx/generators/tests/test_spectral_graph_forge.py
+++ b/networkx/generators/tests/test_spectral_graph_forge.py
@@ -1,0 +1,46 @@
+import time
+from networkx import is_isomorphic
+from networkx.exception import NetworkXError
+from nose.tools import assert_true, assert_raises, assert_false
+from networkx.testing import assert_nodes_equal
+from networkx.generators.spectral_graph_forge import spectral_graph_forge
+from networkx.generators import karate_club_graph
+
+
+def test_spectral_graph_forge(ntimes=100):
+    G = karate_club_graph()
+
+    for _ in range(ntimes):
+        seed = time.time()
+
+        # common cases, just checking node number preserving and difference
+        # between identity and modularity cases
+        H = spectral_graph_forge(G, 0.1, transformation='identity', seed=seed)
+        assert_nodes_equal(G, H)
+
+        I = spectral_graph_forge(G, 0.1, transformation='identity', seed=seed)
+        assert_nodes_equal(G, H)
+        assert_true(is_isomorphic(I, H))
+
+        I = spectral_graph_forge(G, 0.1, transformation='modularity', seed=seed)
+        assert_nodes_equal(G, I)
+
+        assert_false(is_isomorphic(I, H))
+
+        # with all the eigenvectors, output graph is identical to the input one
+        H = spectral_graph_forge(G, 1, transformation='modularity', seed=seed)
+        assert_nodes_equal(G, H)
+        assert_true(is_isomorphic(G, H))
+
+        # invalid alpha input value, it is silently truncated in [0,1]
+        H = spectral_graph_forge(G, -1, transformation='identity', seed=seed)
+        assert_nodes_equal(G, H)
+
+        H = spectral_graph_forge(G, 10, transformation='identity', seed=seed)
+        assert_nodes_equal(G, H)
+        assert_true(is_isomorphic(G, H))
+
+        # invalid transformation mode, checking the error raising
+        assert_raises(NetworkXError,
+                      spectral_graph_forge, G, 0.1, transformation='unknown',
+                      seed=seed)

--- a/networkx/generators/tests/test_spectral_graph_forge.py
+++ b/networkx/generators/tests/test_spectral_graph_forge.py
@@ -1,13 +1,27 @@
+from nose import SkipTest
+from nose.tools import assert_true, assert_raises, assert_false
+
 import time
 from networkx import is_isomorphic
 from networkx.exception import NetworkXError
-from nose.tools import assert_true, assert_raises, assert_false
 from networkx.testing import assert_nodes_equal
 from networkx.generators.spectral_graph_forge import spectral_graph_forge
 from networkx.generators import karate_club_graph
 
 
 def test_spectral_graph_forge(ntimes=100):
+    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
+    scipy = 1
+
+    try:
+        import numpy
+    except ImportError:
+        raise SkipTest('NumPy not available.')
+    try:
+        import scipy
+    except ImportError:
+        raise SkipTest("SciPy not available")
+
     G = karate_club_graph()
 
     for _ in range(ntimes):

--- a/networkx/generators/tests/test_spectral_graph_forge.py
+++ b/networkx/generators/tests/test_spectral_graph_forge.py
@@ -1,7 +1,6 @@
 from nose import SkipTest
 from nose.tools import assert_true, assert_raises, assert_false
 
-import time
 from networkx import is_isomorphic
 from networkx.exception import NetworkXError
 from networkx.testing import assert_nodes_equal
@@ -9,7 +8,7 @@ from networkx.generators.spectral_graph_forge import spectral_graph_forge
 from networkx.generators import karate_club_graph
 
 
-def test_spectral_graph_forge(ntimes=100):
+def test_spectral_graph_forge():
     numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
     scipy = 1
 
@@ -24,37 +23,36 @@ def test_spectral_graph_forge(ntimes=100):
 
     G = karate_club_graph()
 
-    for _ in range(ntimes):
-        seed = time.time()
+    seed = 54321
 
-        # common cases, just checking node number preserving and difference
-        # between identity and modularity cases
-        H = spectral_graph_forge(G, 0.1, transformation='identity', seed=seed)
-        assert_nodes_equal(G, H)
+    # common cases, just checking node number preserving and difference
+    # between identity and modularity cases
+    H = spectral_graph_forge(G, 0.1, transformation='identity', seed=seed)
+    assert_nodes_equal(G, H)
 
-        I = spectral_graph_forge(G, 0.1, transformation='identity', seed=seed)
-        assert_nodes_equal(G, H)
-        assert_true(is_isomorphic(I, H))
+    I = spectral_graph_forge(G, 0.1, transformation='identity', seed=seed)
+    assert_nodes_equal(G, H)
+    assert_true(is_isomorphic(I, H))
 
-        I = spectral_graph_forge(G, 0.1, transformation='modularity', seed=seed)
-        assert_nodes_equal(G, I)
+    I = spectral_graph_forge(G, 0.1, transformation='modularity', seed=seed)
+    assert_nodes_equal(G, I)
 
-        assert_false(is_isomorphic(I, H))
+    assert_false(is_isomorphic(I, H))
 
-        # with all the eigenvectors, output graph is identical to the input one
-        H = spectral_graph_forge(G, 1, transformation='modularity', seed=seed)
-        assert_nodes_equal(G, H)
-        assert_true(is_isomorphic(G, H))
+    # with all the eigenvectors, output graph is identical to the input one
+    H = spectral_graph_forge(G, 1, transformation='modularity', seed=seed)
+    assert_nodes_equal(G, H)
+    assert_true(is_isomorphic(G, H))
 
-        # invalid alpha input value, it is silently truncated in [0,1]
-        H = spectral_graph_forge(G, -1, transformation='identity', seed=seed)
-        assert_nodes_equal(G, H)
+    # invalid alpha input value, it is silently truncated in [0,1]
+    H = spectral_graph_forge(G, -1, transformation='identity', seed=seed)
+    assert_nodes_equal(G, H)
 
-        H = spectral_graph_forge(G, 10, transformation='identity', seed=seed)
-        assert_nodes_equal(G, H)
-        assert_true(is_isomorphic(G, H))
+    H = spectral_graph_forge(G, 10, transformation='identity', seed=seed)
+    assert_nodes_equal(G, H)
+    assert_true(is_isomorphic(G, H))
 
-        # invalid transformation mode, checking the error raising
-        assert_raises(NetworkXError,
-                      spectral_graph_forge, G, 0.1, transformation='unknown',
-                      seed=seed)
+    # invalid transformation mode, checking the error raising
+    assert_raises(NetworkXError,
+                  spectral_graph_forge, G, 0.1, transformation='unknown',
+                  seed=seed)


### PR DESCRIPTION
Hi,
I am a PhD. student at the University of Trento, Italy and I would like to contribute to the NetworkX project adding a random graph generator algorithm that me and my co-authors have recently published in an international peer-reviewed conference.

This algorithm, called Spectral Graph Forge (SGF), computes the eigenvectors of a given graph adjacency matrix, filters them and build a random graph with a similar eigenstructure.
SGF has been proved to be particularly useful for synthesizing realistic social networks and it can also be used to anonymize graph sensitive data.
Our paper, L. Baldesi, C. T. Butts, A. Markopoulou, "Spectral Graph Forge: Graph Generation Targeting Modularity", [IEEE Infocom](http://infocom2018.ieee-infocom.org/), 2018, has a [pre-print version](https://arxiv.org/abs/1801.01715) available online.

I prepared the files as described in [the documentation](https://networkx.github.io/documentation/latest/developer/contribute.html) but I am obviously available for any needed changes.

Best,
Luca