### PR TITLE
Fixes issue #2710

### DIFF
--- a/networkx/algorithms/efficiency.py
+++ b/networkx/algorithms/efficiency.py
@@ -147,4 +147,4 @@ def local_efficiency(G):
 
     """
     # TODO This summation can be trivially parallelized.
-    return sum(global_efficiency(nx.ego_graph(G, v)) for v in G) / len(G)
+    return sum(global_efficiency(nx.ego_graph(G, v, center = False)) for v in G) / len(G)

--- a/networkx/algorithms/efficiency.py
+++ b/networkx/algorithms/efficiency.py
@@ -147,5 +147,5 @@ def local_efficiency(G):
 
     """
     # TODO This summation can be trivially parallelized.
-    efficiency_list = [global_efficiency(G.subgraph(G[v])) for v in G]
+    efficiency_list = (global_efficiency(G.subgraph(G[v])) for v in G)
     return sum(efficiency_list) / len(G)

--- a/networkx/algorithms/efficiency.py
+++ b/networkx/algorithms/efficiency.py
@@ -147,4 +147,5 @@ def local_efficiency(G):
 
     """
     # TODO This summation can be trivially parallelized.
-    return sum(global_efficiency(nx.ego_graph(G, v, center = False)) for v in G) / len(G)
+    efficiency_list = [global_efficiency(G.subgraph(G[v])) for v in G]
+    return sum(efficiency_list) / len(G)

--- a/networkx/algorithms/tests/test_efficiency.py
+++ b/networkx/algorithms/tests/test_efficiency.py
@@ -53,15 +53,15 @@ class TestEfficiency:
 
     def test_local_efficiency_complete_graph(self):
         """
-        Test that the local efficiency for a complete graph should be one.
+        Test that the local efficiency for a complete graph with at least 3 nodes should be one. For a graph with only 2 nodes, the induced subgraph has no edges.
         """
-        for n in range(2, 10):
+        for n in range(3, 10):
             G = nx.complete_graph(n)
             assert_equal(nx.local_efficiency(G), 1)
 
     def test_using_ego_graph(self):
         """
         Test that the ego graph is used when computing local efficiency.
-        For more information, see GitHub issue #2233.
+        For more information, see GitHub issue #2710.
         """
-        assert_equal(nx.local_efficiency(self.G3), 23 / 24)
+        assert_equal(nx.local_efficiency(self.G3), 7 / 12)

--- a/networkx/algorithms/tests/test_efficiency.py
+++ b/networkx/algorithms/tests/test_efficiency.py
@@ -53,7 +53,9 @@ class TestEfficiency:
 
     def test_local_efficiency_complete_graph(self):
         """
-        Test that the local efficiency for a complete graph with at least 3 nodes should be one. For a graph with only 2 nodes, the induced subgraph has no edges.
+        Test that the local efficiency for a complete graph with at least 3
+        nodes should be one. For a graph with only 2 nodes, the induced
+        subgraph has no edges.
         """
         for n in range(3, 10):
             G = nx.complete_graph(n)


### PR DESCRIPTION
Local efficiency should be computed on the subgraphs induced by *neighbors* of each node (ref: **Efficient Behavior of Small-World Networks**, Latora et al) - however, the node itself should not be included in this subgraph. Hence, `center = False`.

Thanks to @dschult and Vlado S.