### PR TITLE
Pull back graphviz version on osx_install to v2.38

### DIFF
--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -23,7 +23,7 @@ fi
 
 if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
     if [[ "${OSX_PKG_ENV}" == miniconda ]]; then
-        conda install graphviz
+        conda install graphviz=2.38
         export PKG_CONFIG_PATH=/Users/travis/miniconda/envs/testenv/lib/pkgconfig
     else
         brew install graphviz


### PR DESCRIPTION
temporarily fixes #2852 
There's a problem with graphviz 2.40 that is fixed in the development version 2.41
Hopefully that will be released soon so that the latest version no longer gives the error.
This change just makes our tests use the old version. It doesn't make NetworkX work with v2.40.