### PR TITLE
Deleted tests that were hidden due to name clash.

### DIFF
--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -34,15 +34,15 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         r = nx.degree_assortativity_coefficient(self.M)
         npt.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
 
-    def test_degree_assortativity_undirected(self):
+    def test_degree_pearson_assortativity_undirected(self):
         r = nx.degree_pearson_correlation_coefficient(self.P4)
         npt.assert_almost_equal(r, -1.0 / 2, decimal=4)
 
-    def test_degree_assortativity_directed(self):
+    def test_degree_pearson_assortativity_directed(self):
         r = nx.degree_pearson_correlation_coefficient(self.D)
         npt.assert_almost_equal(r, -0.57735, decimal=4)
 
-    def test_degree_assortativity_multigraph(self):
+    def test_degree_pearson_assortativity_multigraph(self):
         r = nx.degree_pearson_correlation_coefficient(self.M)
         npt.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
 

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -131,7 +131,6 @@ class TestEigenvectorCentralityExceptions(object):
             import scipy
         except ImportError:
             raise SkipTest('SciPy not available.')
-    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
 
     @raises(nx.NetworkXException)
     def test_multigraph(self):

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -388,7 +388,7 @@ class TestAllPairsNodeConnectivity:
         assert_equal(sorted((k, sorted(v)) for k, v in A.items()),
                      sorted((k, sorted(v)) for k, v in C.items()))
 
-    def test_all_pairs_connectivity_nbunch(self):
+    def test_all_pairs_connectivity_nbunch_combinations(self):
         G = nx.complete_graph(5)
         nbunch = [0, 2, 3]
         A = {n: {} for n in nbunch}

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -226,15 +226,15 @@ class HistoricalTests(object):
                           ('C', 'B'), ('C', 'D')])
         # node not in nbunch should be quietly ignored
         assert_raises(nx.NetworkXError, G.edges, 6)
-        assert_equals(G.edges('Z'), [])  # iterable non-node
+        assert_equals(list(G.edges('Z')), [])  # iterable non-node
         # nbunch can be an empty list
-        assert_equals(G.edges([]), [])
+        assert_equals(list(G.edges([])), [])
         if G.is_directed():
             elist = [('A', 'B'), ('A', 'C'), ('B', 'D')]
         else:
             elist = [('A', 'B'), ('A', 'C'), ('B', 'C'), ('B', 'D')]
         # nbunch can be a list
-        assert_edges_equal(G.edges(['A', 'B']), elist)
+        assert_edges_equal(list(G.edges(['A', 'B'])), elist)
         # nbunch can be a set
         assert_edges_equal(G.edges(set(['A', 'B'])), elist)
         # nbunch can be a graph
@@ -245,39 +245,14 @@ class HistoricalTests(object):
         ndict = {'A': "thing1", 'B': "thing2"}
         assert_edges_equal(G.edges(ndict), elist)
         # nbunch can be a single node
-        assert_edges_equal(G.edges('A'), [('A', 'B'), ('A', 'C')])
+        assert_edges_equal(list(G.edges('A')), [('A', 'B'), ('A', 'C')])
         assert_nodes_equal(sorted(G), ['A', 'B', 'C', 'D'])
 
-    def test_edges_nbunch(self):
-        G = self.G()
-        G.add_edges_from([('A', 'B'), ('A', 'C'), ('B', 'D'),
-                          ('C', 'B'), ('C', 'D')])
-        # Test G.edges(nbunch) with various forms of nbunch
-        # node not in nbunch should be quietly ignored
-        assert_equals(list(G.edges('Z')), [])
-        # nbunch can be an empty list
-        assert_equals(sorted(G.edges([])), [])
-        if G.is_directed():
-            elist = [('A', 'B'), ('A', 'C'), ('B', 'D')]
-        else:
-            elist = [('A', 'B'), ('A', 'C'), ('B', 'C'), ('B', 'D')]
-        # nbunch can be a list
-        assert_edges_equal(G.edges(['A', 'B']), elist)
-        # nbunch can be a set
-        assert_edges_equal(G.edges(set(['A', 'B'])), elist)
-        # nbunch can be a graph
-        G1 = self.G()
-        G1.add_nodes_from(['A', 'B'])
-        assert_edges_equal(G.edges(G1), elist)
-        # nbunch can be a dict with nodes as keys
-        ndict = {'A': "thing1", 'B': "thing2"}
-        assert_edges_equal(G.edges(ndict), elist)
-        # nbunch can be a single node
-        assert_edges_equal(G.edges('A'), [('A', 'B'), ('A', 'C')])
-
         # nbunch can be nothing (whole graph)
-        assert_edges_equal(G.edges(), [('A', 'B'), ('A', 'C'), ('B', 'D'),
-                                       ('C', 'B'), ('C', 'D')])
+        assert_edges_equal(
+            list(G.edges()),
+            [('A', 'B'), ('A', 'C'), ('B', 'D'), ('C', 'B'), ('C', 'D')]
+        )
 
     def test_degree(self):
         G = self.G()

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -80,12 +80,6 @@ class TestAGraph(object):
         G.add_edge(2, 3, weight=8)
         nx.nx_agraph.view_pygraphviz(G, edgelabel='weight')
 
-    def test_from_agraph_name(self):
-        G = nx.Graph(name='test')
-        A = nx.nx_agraph.to_agraph(G)
-        H = nx.nx_agraph.from_agraph(A)
-        assert_equal(G.name, 'test')
-
     def test_graph_with_reserved_keywords(self):
         # test attribute/keyword clash case for #1582
         # node: n

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -207,18 +207,6 @@ class TestMultilineAdjlist():
         os.close(fd)
         os.unlink(fname)
 
-    def test_multiline_adjlist_digraph(self):
-        G = self.DG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
-        H2 = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
-        assert_not_equal(H, H2)  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
-
     def test_multiline_adjlist_multigraph(self):
         G = self.XG
         (fd, fname) = tempfile.mkstemp()


### PR DESCRIPTION
Second iteration of this clean-up. I noticed also this duplicated attribute: 

```
numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
```