### PR TITLE
t domain proportionality in _sparse_fruchterman

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -481,7 +481,7 @@ def _sparse_fruchterman_reingold(A, k=None, pos=None, fixed=None,
         k = np.sqrt(1.0 / nnodes)
     # the initial "temperature"  is about .1 of domain area (=1x1)
     # this is the largest step allowed in the dynamics.
-    t = 0.1
+    t = max(max(pos.T[0]) - min(pos.T[0]), max(pos.T[1]) - min(pos.T[1])) * 0.1
     # simple cooling scheme.
     # linearly step down by dt on each iteration so last iteration is size dt.
     dt = t / float(iterations + 1)


### PR DESCRIPTION
Unlike the regular version of fruchterman reingold, the sparse version doesn't calculate temperature proportionality to domain size.
I propose to make the exact same calculation for t in the sparse version, too. If this calculation is not carried out, unsatisfying behavior is shown when plotting graphs with nodes with fixed, faraway position.