### PR TITLE
Floyd Warshall rebuild path

### DIFF
--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -14,6 +14,7 @@ import networkx as nx
 
 __all__ = ['floyd_warshall',
            'floyd_warshall_predecessor_and_distance',
+           'reconstruct_path',
            'floyd_warshall_numpy']
 
 

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -84,10 +84,8 @@ def floyd_warshall_predecessor_and_distance(G, weight='weight'):
     --------
     >>> G = nx.DiGraph()
     >>> G.add_weighted_edges_from([('s', 'u', 10), ('s', 'x', 5),
-                                ('u', 'v', 1), ('u', 'x', 2),
-                                ('v', 'y', 1), ('x', 'u', 3),
-                                ('x', 'v', 5), ('x', 'y', 2),
-                                ('y', 's', 7), ('y', 'v', 6)])
+    ...     ('u', 'v', 1), ('u', 'x', 2), ('v', 'y', 1), ('x', 'u', 3),
+    ...     ('x', 'v', 5), ('x', 'y', 2), ('y', 's', 7), ('y', 'v', 6)])
     >>> predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
     >>> print(reconstruct_path('s', 'v', predecessors))
     ['s', 'x', 'u', 'v']

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -81,7 +81,7 @@ def floyd_warshall_predecessor_and_distance(G, weight='weight'):
 
     Examples
     --------
-    >>> G = nx.gnm_random_graph(10, 20)
+    >>> G = nx.gnm_random_graph(10, 20) # results could differ
     >>> predecessors, distances = nx.floyd_warshall_predecessor_and_distance(G)
     >>> print(reconstruct_path(1, 2, predecessors))
     [1, 3, 2]

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -7,8 +7,11 @@
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Aric Hagberg <aric.hagberg@gmail.com>
+#          Miguel Sozinho Ramalho <m.ramalho@fe.up.pt>
 import networkx as nx
-__author__ = """Aric Hagberg <aric.hagberg@gmail.com>"""
+
 __all__ = ['floyd_warshall',
            'floyd_warshall_predecessor_and_distance',
            'floyd_warshall_numpy']
@@ -76,6 +79,15 @@ def floyd_warshall_predecessor_and_distance(G, weight='weight'):
        Dictionaries, keyed by source and target, of predecessors and distances
        in the shortest path.
 
+    Examples
+    --------
+    >>> G = nx.gnm_random_graph(10, 20)
+    >>> predecessors, distances = nx.floyd_warshall_predecessor_and_distance(G)
+    >>> print(reconstruct_path(1, 2, predecessors))
+    [1, 3, 2]
+    >>> print(reconstruct_path(1, 1, predecessors))
+    []
+
     Notes
     ------
     Floyd's algorithm is appropriate for finding shortest paths
@@ -115,6 +127,49 @@ def floyd_warshall_predecessor_and_distance(G, weight='weight'):
                     dist[u][v] = dist[u][w] + dist[w][v]
                     pred[u][v] = pred[w][v]
     return dict(pred), dict(dist)
+
+
+def reconstruct_path(source, target, predecessors):
+    """Reconstruct a path from source to target using the predecessors
+    dict as returned by floyd_warshall_predecessor_and_distance
+
+    Parameters
+    ----------
+    source : node
+       Starting node for path
+
+    target : node
+       Ending node for path
+
+    predecessors: dictionary
+       Dictionary, keyed by source and target, of predecessors in the
+       shortest path, as returned by floyd_warshall_predecessor_and_distance
+
+    Returns
+    -------
+    path : list
+       A list of nodes containing the shortest path from source to target
+
+       If source and target are the same, an empty list is returned
+
+    Notes
+    ------
+    This function is meant to give more applicability to the
+    floyd_warshall_predecessor_and_distance function
+
+    See Also
+    --------
+    floyd_warshall_predecessor_and_distance
+    """
+    if source == target:
+        return []
+    prev = predecessors[source]
+    curr = prev[target]
+    path = [target, curr]
+    while curr != source:
+        curr = prev[curr]
+        path.append(curr)
+    return list(reversed(path))
 
 
 def floyd_warshall(G, weight='weight'):

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -86,7 +86,7 @@ def floyd_warshall_predecessor_and_distance(G, weight='weight'):
     >>> G.add_weighted_edges_from([('s', 'u', 10), ('s', 'x', 5),
     ...     ('u', 'v', 1), ('u', 'x', 2), ('v', 'y', 1), ('x', 'u', 3),
     ...     ('x', 'v', 5), ('x', 'y', 2), ('y', 's', 7), ('y', 'v', 6)])
-    >>> predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
+    >>> predecessors, _ = nx.floyd_warshall_predecessor_and_distance(G)
     >>> print(reconstruct_path('s', 'v', predecessors))
     ['s', 'x', 'u', 'v']
 

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -81,12 +81,15 @@ def floyd_warshall_predecessor_and_distance(G, weight='weight'):
 
     Examples
     --------
-    >>> G = nx.gnm_random_graph(10, 20) # results could differ
-    >>> predecessors, distances = nx.floyd_warshall_predecessor_and_distance(G)
-    >>> print(reconstruct_path(1, 2, predecessors))
-    [1, 3, 2]
-    >>> print(reconstruct_path(1, 1, predecessors))
-    []
+    >>> G = nx.DiGraph()
+    >>> G.add_weighted_edges_from([('s', 'u', 10), ('s', 'x', 5),
+                                ('u', 'v', 1), ('u', 'x', 2),
+                                ('v', 'y', 1), ('x', 'u', 3),
+                                ('x', 'v', 5), ('x', 'y', 2),
+                                ('y', 's', 7), ('y', 'v', 6)])
+    >>> predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
+    >>> print(reconstruct_path('s', 'v', predecessors))
+    ['s', 'x', 'u', 'v']
 
     Notes
     ------

--- a/networkx/algorithms/shortest_paths/tests/test_dense.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense.py
@@ -48,8 +48,28 @@ class TestFloyd:
         dist = nx.floyd_warshall(G)
         assert_equal(dist['s']['v'], 2)
 
+    @raises(KeyError)
+    def test_reconstruct_path(self):
+        XG = nx.DiGraph()
+        XG.add_weighted_edges_from([('s', 'u', 10), ('s', 'x', 5),
+                                    ('u', 'v', 1), ('u', 'x', 2),
+                                    ('v', 'y', 1), ('x', 'u', 3),
+                                    ('x', 'v', 5), ('x', 'y', 2),
+                                    ('y', 's', 7), ('y', 'v', 6)])
+        predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
+
+        path = reconstruct_path('s', 'v', predecessors)
+        assert_equal(path, ['s', 'x', 'u', 'v'])
+
+        path = reconstruct_path('s', 's', predecessors)
+        assert_equal(path, [])
+
+        # this part raises the keyError
+        reconstruct_path('1', '2', predecessors)
+
     def test_cycle(self):
-        path, dist = nx.floyd_warshall_predecessor_and_distance(nx.cycle_graph(7))
+        path, dist = nx.floyd_warshall_predecessor_and_distance(
+            nx.cycle_graph(7))
         assert_equal(dist[0][3], 3)
         assert_equal(path[0][3], 2)
         assert_equal(dist[0][4], 3)
@@ -105,7 +125,8 @@ class TestFloyd:
 
     def test_zero_weight(self):
         G = nx.DiGraph()
-        edges = [(1, 2, -2), (2, 3, -4), (1, 5, 1), (5, 4, 0), (4, 3, -5), (2, 5, -7)]
+        edges = [(1, 2, -2), (2, 3, -4), (1, 5, 1),
+                 (5, 4, 0), (4, 3, -5), (2, 5, -7)]
         G.add_weighted_edges_from(edges)
         dist = nx.floyd_warshall(G)
         assert_equal(dist[1][3], -14)

--- a/networkx/algorithms/shortest_paths/tests/test_dense.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense.py
@@ -58,14 +58,14 @@ class TestFloyd:
                                     ('y', 's', 7), ('y', 'v', 6)])
         predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
 
-        path = reconstruct_path('s', 'v', predecessors)
+        path = nx.reconstruct_path('s', 'v', predecessors)
         assert_equal(path, ['s', 'x', 'u', 'v'])
 
-        path = reconstruct_path('s', 's', predecessors)
+        path = nx.reconstruct_path('s', 's', predecessors)
         assert_equal(path, [])
 
         # this part raises the keyError
-        reconstruct_path('1', '2', predecessors)
+        nx.reconstruct_path('1', '2', predecessors)
 
     def test_cycle(self):
         path, dist = nx.floyd_warshall_predecessor_and_distance(


### PR DESCRIPTION
In this PR I have implemented a simple function to reconstruct the path from a node `source` to a node `target` with the result of executing: `floyd_warshall_predecessor_and_distance`

The code is being properly tested:
 . Expected behavior
 . Abnormal behavior: `source == target`
 . KeyError exception (this test is optional)