### PR TITLE
Misc. typos

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tools\\appveyor\\run_with_env.cmd"
 

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -76,7 +76,7 @@ Highlights
 
 - pyparsing dependence removed from GML reader/parser
 - improve flow algorithms
-- new generators releated to expander graphs.
+- new generators related to expander graphs.
 - new generators for multipartite graphs, nonisomorphic trees, 
   circulant graphs
 - allow graph subclasses to use dict-like objects in place of dicts
@@ -144,7 +144,7 @@ Highlights
 - Functions to generate all simple paths
 - Improved shapefile reader
 - More flexible weighted projection of bipartite graphs
-- Faster topological sort, decendents and ancestors of DAGs
+- Faster topological sort, descendants and ancestors of DAGs
 - Scaling parameter for force-directed layout
 
 Bug fixes

--- a/doc/release/api_1.5.rst
+++ b/doc/release/api_1.5.rst
@@ -11,7 +11,7 @@ Weighted graph algorithms
 -------------------------
 
 Many 'weighted' graph algorithms now take optional parameter to 
-specifiy which edge attribute should be used for the weight
+specify which edge attribute should be used for the weight
 (default='weight') (ticket https://networkx.lanl.gov/trac/ticket/509)
 
 In some cases the parameter name was changed from weighted_edges,
@@ -20,7 +20,7 @@ will be used in the algorithms:
 
 - Use weight=None to consider all weights equally (unweighted case)
 
-- Use weight=True or weight='weight' to use the 'weight' edge atribute
+- Use weight=True or weight='weight' to use the 'weight' edge attribute
 
 - Use weight='other' to use the 'other' edge attribute 
 

--- a/doc/release/api_1.6.rst
+++ b/doc/release/api_1.6.rst
@@ -20,7 +20,7 @@ Weighted graph algorithms
 -------------------------
 
 Many 'weighted' graph algorithms now take optional parameter to 
-specifiy which edge attribute should be used for the weight
+specify which edge attribute should be used for the weight
 (default='weight') (ticket https://networkx.lanl.gov/trac/ticket/573)
 
 In some cases the parameter name was changed from weighted, to weight.  Here is
@@ -28,7 +28,7 @@ how to specify which edge attribute will be used in the algorithms:
 
 - Use weight=None to consider all weights equally (unweighted case)
 
-- Use weight='weight' to use the 'weight' edge atribute
+- Use weight='weight' to use the 'weight' edge attribute
 
 - Use weight='other' to use the 'other' edge attribute 
 

--- a/doc/release/api_1.9.rst
+++ b/doc/release/api_1.9.rst
@@ -151,7 +151,7 @@ A few backwards *incompatible* changes were introduced.
   the Stoer–Wagner algorithm. This algorithm is not based on maximum flows.
   Several heap implementations are also added in the utility package
   (:samp:`networkx.utils`) for use in this function.
-  :class:`BinaryHeap` is recommeded over :class:`PairingHeap` for Python
+  :class:`BinaryHeap` is recommended over :class:`PairingHeap` for Python
   implementations without optimized attribute accesses (e.g., CPython)
   despite a slower asymptotic running time. For Python implementations
   with optimized attribute accesses (e.g., PyPy), :class:`PairingHeap`

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -6,7 +6,7 @@ Knuth Miles
 
 `miles_graph()` returns an undirected graph over the 128 US cities from
 the datafile `miles_dat.txt`. The cities each have location and population
-data.  The edges are labeled with the distance betwen the two cities.
+data.  The edges are labeled with the distance between the two cities.
 
 This example is described in Section 1.1 in Knuth's book (see [1]_ and [2]_).
 

--- a/examples/drawing/plot_unix_email.py
+++ b/examples/drawing/plot_unix_email.py
@@ -6,7 +6,7 @@ Unix Email
 
 Create a directed graph, allowing multiple edges and self loops, from
 a unix mailbox.  The nodes are email addresses with links
-that point from the sender to the recievers.  The edge data
+that point from the sender to the receivers.  The edge data
 is a Python email.Message object which contains all of
 the email message data.
 

--- a/examples/javascript/force/README
+++ b/examples/javascript/force/README
@@ -1,4 +1,4 @@
-Modifed from the example at of D3
+Modified from the example at of D3
 http://mbostock.github.com/d3/ex/force.html
 
 Run the file force.py to generate the force.json data file needed for this to work.

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -313,7 +313,7 @@ def _bidirectional_shortest_path(G, source, target, exclude):
 
     Notes
     -----
-    This function and its helper are originaly from
+    This function and its helper are originally from
     networkx.algorithms.shortest_paths.unweighted and are modified to 
     accept the extra parameter 'exclude', which is a container for nodes 
     already used in other paths that should be ignored.
@@ -374,7 +374,7 @@ def _bidirectional_pred_succ(G, source, target, exclude):
 
     while forward_fringe and reverse_fringe:
         # Make sure that we iterate one step forward and one step backwards
-        # thus source and target will only tigger "found path" when they are
+        # thus source and target will only trigger "found path" when they are
         # adjacent and then they can be safely included in the container 'exclude'
         level += 1
         if not level % 2 == 0:

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -35,7 +35,7 @@ def k_components(G, min_density=0.95):
     one or more 3-components, and so forth.
 
     This implementation is based on the fast heuristics to approximate
-    the `k`-component sturcture of a graph [1]_. Which, in turn, it is based on
+    the `k`-component structure of a graph [1]_. Which, in turn, it is based on
     a fast approximation algorithm for finding good lower bounds of the number
     of node independent paths between two nodes [2]_.
 
@@ -45,7 +45,7 @@ def k_components(G, min_density=0.95):
         Undirected graph
 
     min_density : Float
-        Density relaxation treshold. Default value 0.95
+        Density relaxation threshold. Default value 0.95
 
     Returns
     -------

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -40,7 +40,7 @@ def degree_centrality(G, nodes):
 
     Notes
     -----
-    The nodes input parameter must conatin all nodes in one bipartite node set,
+    The nodes input parameter must contain all nodes in one bipartite node set,
     but the dictionary returned contains all nodes from both bipartite node
     sets. See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
     for further details on how bipartite graphs are handled in NetworkX.
@@ -207,7 +207,7 @@ def closeness_centrality(G, nodes, normalized=True):
 
     Notes
     -----
-    The nodes input parameter must conatin all nodes in one bipartite node set,
+    The nodes input parameter must contain all nodes in one bipartite node set,
     but the dictionary returned contains all nodes from both node sets.
     See :mod:`bipartite documentation <networkx.algorithms.bipartite>`
     for further details on how bipartite graphs are handled in NetworkX.

--- a/networkx/algorithms/centrality/load.py
+++ b/networkx/algorithms/centrality/load.py
@@ -123,7 +123,7 @@ def _node_betweenness(G, source, cutoff=False, normalized=True,
     onodes.sort()
     onodes[:] = [vert for (l, vert) in onodes if l > 0]
 
-    # intialize betweenness
+    # initialize betweenness
     between = {}.fromkeys(length, 1.0)
 
     while onodes:
@@ -192,7 +192,7 @@ def _edge_betweenness(G, source, nodes=None, cutoff=False):
     (pred, length) = nx.predecessor(G, source, cutoff=cutoff, return_seen=True)
     # order the nodes by path length
     onodes = [n for n, d in sorted(length.items(), key=itemgetter(1))]
-    # intialize betweenness, doesn't account for any edge weights
+    # initialize betweenness, doesn't account for any edge weights
     between = {}
     for u, v in G.edges(nodes):
         between[(u, v)] = 1.0

--- a/networkx/algorithms/community/community_generators.py
+++ b/networkx/algorithms/community/community_generators.py
@@ -13,7 +13,7 @@ from __future__ import division
 
 import random
 
-# HACK In order to accomodate both SciPy and non-SciPy implementations,
+# HACK In order to accommodate both SciPy and non-SciPy implementations,
 # we need to wrap the SciPy implementation of the zeta function with an
 # extra parameter, `tolerance`, which will be ignored.
 try:

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -105,7 +105,7 @@ def kernighan_lin_bisection(G, partition=None, max_iter=10, weight='weight'):
     G : graph
 
     partition : tuple
-        Pair of iterables containing an intial partition. If not
+        Pair of iterables containing an initial partition. If not
         specified, a random balanced partition is used.
 
     max_iter : int

--- a/networkx/algorithms/community/tests/test_centrality.py
+++ b/networkx/algorithms/community/tests/test_centrality.py
@@ -53,10 +53,10 @@ class TestGirvanNewman(object):
         # After one removal, we get the graph .-. .-.
         validate_communities(communities[0], [{0, 1}, {2, 3}])
         # After the next, we get the graph .-. . ., but there are two
-        # symmetric possible verisons.
+        # symmetric possible versions.
         validate_possible_communities(communities[1], [{0}, {1}, {2, 3}],
                                       [{0, 1}, {2}, {3}])
-        # After the last removal, we alway get the empty graph.
+        # After the last removal, we always get the empty graph.
         validate_communities(communities[2], [{0}, {1}, {2}, {3}])
 
     def test_directed(self):

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -328,7 +328,7 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     -------
     cutset : set
         Set of nodes that, if removed, would disconnect G. If source
-        and target nodes are provided, the set contians the nodes that
+        and target nodes are provided, the set contains the nodes that
         if removed, would destroy all paths between source and target.
 
     Examples
@@ -401,7 +401,7 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
         return minimum_st_node_cut(G, s, t, flow_func=flow_func)
 
     # Global minimum node cut.
-    # Analog to the algoritm 11 for global node connectivity in [1].
+    # Analog to the algorithm 11 for global node connectivity in [1].
     if G.is_directed():
         if not nx.is_weakly_connected(G):
             raise nx.NetworkXError('Input graph is not connected')
@@ -473,7 +473,7 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
     -------
     cutset : set
         Set of edges that, if removed, would disconnect G. If source
-        and target nodes are provided, the set contians the edges that
+        and target nodes are provided, the set contains the edges that
         if removed, would destroy all paths between source and target.
 
     Examples
@@ -553,7 +553,7 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
         return minimum_st_edge_cut(H, s, t, **kwargs)
 
     # Global minimum edge cut
-    # Analog to the algoritm for global edge connectivity
+    # Analog to the algorithm for global edge connectivity
     if G.is_directed():
         # Based on algorithm 8 in [1]
         if not nx.is_weakly_connected(G):

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -13,7 +13,7 @@ Algorithms for finding k-edge-augmentations
 A k-edge-augmentation is a set of edges, that once added to a graph, ensures
 that the graph is k-edge-connected; i.e. the graph cannot be disconnected
 unless k or more edges are removed.  Typically, the goal is to find the
-augmentation with minimum weight.  In general, it is not gaurenteed that a
+augmentation with minimum weight.  In general, it is not guaranteed that a
 k-edge-augmentation exists.
 
 See Also
@@ -168,7 +168,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
         The available edges that can be used in the augmentation.
 
         If unspecified, then all edges in the complement of G are available.
-        Otherwise, each item is an available edge (with an optinal weight).
+        Otherwise, each item is an available edge (with an optional weight).
 
         In the unweighted case, each item is an edge ``(u, v)``.
 
@@ -216,7 +216,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
     Otherwise when k=2, this returns a 2-approximation of the optimal solution.
 
     For k>3, this problem is NP-hard and this uses a randomized algorithm that
-        produces a feasible solution, but provides no gaurentees on the
+        produces a feasible solution, but provides no guarantees on the
         solution weight.
 
     Example
@@ -287,7 +287,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
             if avail is None:
                 aug_edges = complement_edges(G)
             else:
-                # If we cant k-edge-connect the entire graph, try to
+                # If we can't k-edge-connect the entire graph, try to
                 # k-edge-connect as much as possible
                 aug_edges = partial_k_edge_augmentation(G, k=k, avail=avail,
                                                         weight=weight)
@@ -552,7 +552,7 @@ def _lightest_meta_edges(mapping, avail_uv, avail_w):
     Notes
     -----
     Each node in the metagraph is a k-edge-connected component in the original
-    graph.  We dont care about any edge within the same k-edge-connected
+    graph.  We don't care about any edge within the same k-edge-connected
     component, so we ignore self edges.  We also are only intereseted in the
     minimum weight edge bridging each k-edge-connected component so, we group
     the edges by meta-edge and take the lightest in each group.
@@ -716,7 +716,7 @@ def unconstrained_bridge_augmentation(G):
     -----
     Input: a graph G.
     First find the bridge components of G and collapse each bridge-cc into a
-    node of a metagraph graph C, which is gaurenteed to be a forest of trees.
+    node of a metagraph graph C, which is guaranteed to be a forest of trees.
 
     C contains p "leafs" --- nodes with exactly one incident edge.
     C contains q "isolated nodes" --- nodes with no incident edges.
@@ -995,7 +995,7 @@ def weighted_bridge_augmentation(G, avail, weight=None):
         raise nx.NetworkXUnfeasible('no 2-edge-augmentation possible')
 
     # For each edge e, in the branching that did not belong to the directed
-    # tree T, add the correponding edge that **GENERATED** it (this is not
+    # tree T, add the corresponding edge that **GENERATED** it (this is not
     # necesarilly e itself!)
 
     # ensure the third case does not generate edges twice
@@ -1164,7 +1164,7 @@ if sys.version_info[0] == 2:
             input[i], input[j] = input[j], input[i]
 else:
     def _compat_shuffle(rng, input):
-        """wraper around rng.shuffle for python 2 compatibility reasons"""
+        """wrapper around rng.shuffle for python 2 compatibility reasons"""
         rng.shuffle(input)
 
 
@@ -1202,7 +1202,7 @@ def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
     graph that are not yet locally k-edge-connected. Then edges are from the
     augmenting set are pruned as long as local-edge-connectivity is not broken.
 
-    This algorithm is greedy and does not provide optimiality gaurentees. It
+    This algorithm is greedy and does not provide optimality guarantees. It
     exists only to provide :func:`k_edge_augmentation` with the ability to
     generate a feasible solution for arbitrary k.
 
@@ -1267,7 +1267,7 @@ def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
     rng = random.Random(seed)
     _compat_shuffle(rng, aug_edges)
     for (u, v) in list(aug_edges):
-        # Dont remove if we know it would break connectivity
+        # Don't remove if we know it would break connectivity
         if H.degree(u) <= k or H.degree(v) <= k:
             continue
         H.remove_edge(u, v)

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -254,9 +254,9 @@ class EdgeComponentAuxGraph(object):
 
     Notes
     -----
-    This implementation is based on [1]_. The idea is to construct an auxillary
+    This implementation is based on [1]_. The idea is to construct an auxiliary
     graph from which the k-edge-ccs can be extracted in linear time. The
-    auxillary graph is constructed in $O(|V|\cdot F)$ operations, where F is the
+    auxiliary graph is constructed in $O(|V|\cdot F)$ operations, where F is the
     complexity of max flow. Querying the components takes an additional $O(|V|)$
     operations. This algorithm can be slow for large graphs, but it handles an
     arbitrary k and works for both directed and undirected inputs.
@@ -300,7 +300,7 @@ class EdgeComponentAuxGraph(object):
 
     Example
     -------
-    >>> # The auxillary graph is primarilly used for k-edge-ccs but it
+    >>> # The auxiliary graph is primarilly used for k-edge-ccs but it
     >>> # can also speed up the queries of k-edge-subgraphs by refining the
     >>> # search space.
     >>> import itertools as it
@@ -322,19 +322,19 @@ class EdgeComponentAuxGraph(object):
     # @not_implemented_for('multigraph')  # TODO: fix decor for classmethods
     @classmethod
     def construct(EdgeComponentAuxGraph, G):
-        """Builds an auxillary graph encoding edge-connectivity between nodes.
+        """Builds an auxiliary graph encoding edge-connectivity between nodes.
 
         Notes
         -----
-        Given G=(V, E), initialize an empty auxillary graph A.
+        Given G=(V, E), initialize an empty auxiliary graph A.
         Choose an arbitrary source node s.  Initialize a set N of available
         nodes (that can be used as the sink). The algorithm picks an
         arbitrary node t from N - {s}, and then computes the minimum st-cut
         (S, T) with value w. If G is directed the the minimum of the st-cut or
         the ts-cut is used instead. Then, the edge (s, t) is added to the
-        auxillary graph with weight w. The algorithm is called recursively
+        auxiliary graph with weight w. The algorithm is called recursively
         first using S as the available nodes and s as the source, and then
-        using T and t. Recusion stops when the source is the only available
+        using T and t. Recursion stops when the source is the only available
         node.
 
         Parameters
@@ -368,7 +368,7 @@ class EdgeComponentAuxGraph(object):
         H.add_nodes_from(G.nodes())
         H.add_edges_from(G.edges(), capacity=1)
 
-        # A is the auxillary graph to be constructed
+        # A is the auxiliary graph to be constructed
         # It is a weighted undirected tree
         A = nx.Graph()
 
@@ -381,7 +381,7 @@ class EdgeComponentAuxGraph(object):
             # This constructs A
             _recursive_build(H, A, source, avail)
 
-        # This class is a container the holds the auxillary graph A and
+        # This class is a container the holds the auxiliary graph A and
         # provides access the the k_edge_components function.
         self = EdgeComponentAuxGraph()
         self.A = A
@@ -389,7 +389,7 @@ class EdgeComponentAuxGraph(object):
         return self
 
     def k_edge_components(self, k):
-        """Queries the auxillary graph for k-edge-connected components.
+        """Queries the auxiliary graph for k-edge-connected components.
 
         Parameters
         ----------
@@ -402,9 +402,9 @@ class EdgeComponentAuxGraph(object):
 
         Notes
         -----
-        Given the auxillary graph, the k-edge-connected components can be
+        Given the auxiliary graph, the k-edge-connected components can be
         determined in linear time by removing all edges with weights less than
-        k from the auxillary graph.  The resulting connected components are the
+        k from the auxiliary graph.  The resulting connected components are the
         k-edge-ccs in the original graph.
         """
         if k < 1:
@@ -413,7 +413,7 @@ class EdgeComponentAuxGraph(object):
         # "traverse the auxiliary graph A and delete all edges with weights less
         # than k"
         aux_weights = nx.get_edge_attributes(A, 'weight')
-        # Create a relevant graph with the auxillary edges with weights >= k
+        # Create a relevant graph with the auxiliary edges with weights >= k
         R = nx.Graph()
         R.add_nodes_from(A.nodes())
         R.add_edges_from(e for e, w in aux_weights.items() if w >= k)
@@ -423,7 +423,7 @@ class EdgeComponentAuxGraph(object):
             yield cc
 
     def k_edge_subgraphs(self, k):
-        """Queries the auxillary graph for k-edge-connected subgraphs.
+        """Queries the auxiliary graph for k-edge-connected subgraphs.
 
         Parameters
         ----------
@@ -450,7 +450,7 @@ class EdgeComponentAuxGraph(object):
         # "traverse the auxiliary graph A and delete all edges with weights less
         # than k"
         aux_weights = nx.get_edge_attributes(A, 'weight')
-        # Create a relevant graph with the auxillary edges with weights >= k
+        # Create a relevant graph with the auxiliary edges with weights >= k
         R = nx.Graph()
         R.add_nodes_from(A.nodes())
         R.add_edges_from(e for e, w in aux_weights.items() if w >= k)
@@ -490,7 +490,7 @@ def _low_degree_nodes(G, k, nbunch=None):
 
 
 def _high_degree_components(G, k):
-    """Helper for filtering components that cant be k-edge-connected.
+    """Helper for filtering components that can't be k-edge-connected.
 
     Removes and generates each node with degree less than k.  Then generates
     remaining components where all nodes have degree at least k.
@@ -532,7 +532,7 @@ def general_k_edge_subgraphs(G, k):
     graph is a k-edge-connected subgraph and can be added to the results.
     Otherwise, the cut is used to split the graph in two and the procedure is
     applied recursively. If the graph is just a single node, then it is also
-    added to the results. At the end, each result is either gaurenteed to be
+    added to the results. At the end, each result is either guaranteed to be
     a single node or a subgraph of G that is k-edge-connected.
 
     This implementation contains optimizations for reducing the number of calls

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -88,7 +88,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     if not nx.is_connected(G):
         raise nx.NetworkXError('Input graph is disconnected.')
 
-    # Addess some corner cases first.
+    # Address some corner cases first.
     # For cycle graphs
     if G.order() == G.size():
         if all(2 == d for n, d in G.degree()):

--- a/networkx/algorithms/connectivity/stoerwagner.py
+++ b/networkx/algorithms/connectivity/stoerwagner.py
@@ -54,7 +54,7 @@ def stoer_wagner(G, weight='weight', heap=BinaryHeap):
         :class:`MinHeap` or implement a compatible interface.
 
         If a stock heap implementation is to be used, :class:`BinaryHeap` is
-        recommeded over :class:`PairingHeap` for Python implementations without
+        recommended over :class:`PairingHeap` for Python implementations without
         optimized attribute accesses (e.g., CPython) despite a slower
         asymptotic running time. For Python implementations with optimized
         attribute accesses (e.g., PyPy), :class:`PairingHeap` provides better

--- a/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
@@ -163,7 +163,7 @@ def test_tarjan():
 
     aug_edges = set(_augment_and_check(G, k=2)[0])
     print('aug_edges = {!r}'.format(aug_edges))
-    # cant assert edge exactly equality due to non-determenant edge order
+    # can't assert edge exactly equality due to non-determinant edge order
     # but we do know the size of the solution must be 3
     assert_equal(len(aug_edges), 3)
 
@@ -171,7 +171,7 @@ def test_tarjan():
              (16, 17), (18, 14), (15, 14)]
     aug_edges = set(_augment_and_check(G, avail=avail, k=2)[0])
 
-    # Can't assert exact length since approximation depnds on the order of a
+    # Can't assert exact length since approximation depends on the order of a
     # dict traversal.
     assert_less_equal(len(aug_edges), 3 * 2)
 
@@ -309,7 +309,7 @@ def _augment_and_check(G, k, avail=None, weight=None, verbose=False,
 
                 assert_less(max_aug_k, k, (
                     'avail should only be unfeasible if using all edges '
-                    'doesnt acheive k-edge-connectivity'))
+                    'does not achieve k-edge-connectivity'))
 
             # Test for a partial solution
             partial_edges = list(nx.k_edge_augmentation(

--- a/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py
@@ -83,7 +83,7 @@ def _check_edge_connectivity(G):
     both local and subgraph edge connectivity of each cc. Also checks that
     alternate methods of computing the k-edge-ccs generate the same result.
     """
-    # Construct the auxillary graph that can be used to make each k-cc or k-sub
+    # Construct the auxiliary graph that can be used to make each k-cc or k-sub
     aux_graph = EdgeComponentAuxGraph.construct(G)
 
     # memoize the local connectivity in this graph

--- a/networkx/algorithms/flow/capacityscaling.py
+++ b/networkx/algorithms/flow/capacityscaling.py
@@ -173,7 +173,7 @@ def capacity_scaling(G, demand='demand', capacity='capacity', weight='weight',
         :class:`MinHeap` or implement a compatible interface.
 
         If a stock heap implementation is to be used, :class:`BinaryHeap` is
-        recommeded over :class:`PairingHeap` for Python implementations without
+        recommended over :class:`PairingHeap` for Python implementations without
         optimized attribute accesses (e.g., CPython) despite a slower
         asymptotic running time. For Python implementations with optimized
         attribute accesses (e.g., PyPy), :class:`PairingHeap` provides better

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -96,7 +96,7 @@ def maximum_flow(flowG, _s, _t,
 
     Notes
     -----
-    The function used in the flow_func paramter has to return a residual
+    The function used in the flow_func parameter has to return a residual
     network that follows NetworkX conventions:
 
     The residual network :samp:`R` from an input graph :samp:`G` has the
@@ -237,7 +237,7 @@ def maximum_flow_value(flowG, _s, _t,
 
     Notes
     -----
-    The function used in the flow_func paramter has to return a residual
+    The function used in the flow_func parameter has to return a residual
     network that follows NetworkX conventions:
 
     The residual network :samp:`R` from an input graph :samp:`G` has the
@@ -375,7 +375,7 @@ def minimum_cut(flowG, _s, _t,
 
     Notes
     -----
-    The function used in the flow_func paramter has to return a residual
+    The function used in the flow_func parameter has to return a residual
     network that follows NetworkX conventions:
 
     The residual network :samp:`R` from an input graph :samp:`G` has the
@@ -468,7 +468,7 @@ def minimum_cut(flowG, _s, _t,
     # the minimum cut.
     non_reachable = set(dict(nx.shortest_path_length(R, target=_t)))
     partition = (set(flowG) - non_reachable, non_reachable)
-    # Finaly add again cutset edges to the residual network to make
+    # Finally add again cutset edges to the residual network to make
     # sure that it is reusable.
     if cutset is not None:
         R.add_edges_from(cutset)
@@ -537,7 +537,7 @@ def minimum_cut_value(flowG, _s, _t,
 
     Notes
     -----
-    The function used in the flow_func paramter has to return a residual
+    The function used in the flow_func parameter has to return a residual
     network that follows NetworkX conventions:
 
     The residual network :samp:`R` from an input graph :samp:`G` has the

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -30,7 +30,7 @@ def flow_hierarchy(G, weight=None):
     Returns
     -------
     h : float
-       Flow heirarchy value
+       Flow hierarchy value
 
     Notes
     -----

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -269,7 +269,7 @@ class GraphMatcher(object):
 
         self.state = GMState(self)
 
-        # Provide a convienient way to access the isomorphism mapping.
+        # Provide a convenient way to access the isomorphism mapping.
         self.mapping = self.core_1.copy()
 
     def is_isomorphic(self):
@@ -587,7 +587,7 @@ class DiGraphMatcher(GraphMatcher):
 
         self.state = DiGMState(self)
 
-        # Provide a convienient way to access the isomorphism mapping.
+        # Provide a convenient way to access the isomorphism mapping.
         self.mapping = self.core_1.copy()
 
     def syntactic_feasibility(self, G1_node, G2_node):

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -133,7 +133,7 @@ class TimeRespectingGraphMatcher(GraphMatcher):
             return False
         if not self.two_hop(self.G1, self.core_1, G1_node, neighbors):
             return False
-        # Otherwise, this node is sematically feasible!
+        # Otherwise, this node is semantically feasible!
         return True
 
 
@@ -266,5 +266,5 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
             return False
         if not self.two_hop_succ(self.G1, G1_node, self.core_1, succ):
             return False
-        # Otherwise, this node is sematically feasible!
+        # Otherwise, this node is semantically feasible!
         return True

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -24,7 +24,7 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
     G : graph
       A NetworkX graph
 
-    max_iter : interger, optional
+    max_iter : integer, optional
       Maximum number of iterations in power method.
 
     tol : float, optional
@@ -221,7 +221,7 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, normalized=True):
     G : graph
       A NetworkX graph
 
-    max_iter : interger, optional
+    max_iter : integer, optional
       Maximum number of iterations in power method.
 
     tol : float, optional

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -725,7 +725,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             b.mybestedges = None
 
         # Loss of labeling means that we can not be sure that currently
-        # allowable edges remain allowable througout this stage.
+        # allowable edges remain allowable throughout this stage.
         allowedge.clear()
 
         # Make queue empty.
@@ -822,7 +822,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
             deltatype = -1
             delta = deltaedge = deltablossom = None
 
-            # Compute delta1: the minumum value of any vertex dual.
+            # Compute delta1: the minimum value of any vertex dual.
             if not maxcardinality:
                 deltatype = 1
                 delta = min(dualvar.values())

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -53,7 +53,7 @@ def test_tensor_product_size():
 
 
 def test_tensor_product_combinations():
-    # basic smoke test, more realistic tests would be usefule
+    # basic smoke test, more realistic tests would be useful
     P5 = nx.path_graph(5)
     K3 = nx.complete_graph(3)
     G = nx.tensor_product(P5, K3)

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -85,7 +85,7 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
     # Uses Python heapq to keep in priority order.
     # Add a counter to the queue to prevent the underlying heap from
     # attempting to compare the nodes themselves. The hash breaks ties in the
-    # priority and is guarenteed unique for all nodes in the graph.
+    # priority and is guaranteed unique for all nodes in the graph.
     c = count()
     queue = [(0, next(c), source, 0, None)]
 

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -110,7 +110,7 @@ class TestAStar:
         assert_equal(nx.dijkstra_path(C, 0, 4), [0, 6, 5, 4])
 
     def test_unorderable_nodes(self):
-        """Tests that A* accomodates nodes that are not orderable.
+        """Tests that A* accommodates nodes that are not orderable.
 
         For more information, see issue #554.
 

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -525,7 +525,7 @@ def optimize_edit_paths(G1, G2, node_match=None, edge_match=None,
         Maximum edit distance to consider.
 
     strictly_decreasing : bool
-        If True, return consequtive approximations of strictly
+        If True, return consecutive approximations of strictly
         decreasing cost.  Otherwise, return all edit paths of cost
         less than or equal to the previous minimum cost.
 

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -436,7 +436,7 @@ def _bidirectional_shortest_path(G, source, target,
        edges to ignore, optional
 
     weight : None
-       This function accepts a weight argument for convinience of
+       This function accepts a weight argument for convenience of
        shortest_simple_paths function. It will be ignored.
 
     Returns

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -111,14 +111,14 @@ def effective_size(G, nodes=None, weight=None):
 
     Notes
     -----
-    Burt also defined the related concept of *efficency* of a node's ego
+    Burt also defined the related concept of *efficiency* of a node's ego
     network, which is its effective size divided by the degree of that
-    node [1]_. So you can easily compute efficencty:
+    node [1]_. So you can easily compute efficiency:
 
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(0, 1), (0, 2), (1, 0), (2, 1)])
     >>> esize = nx.effective_size(G)
-    >>> efficency = {n: v / G.degree(n) for n, v in esize.items()}
+    >>> efficiency = {n: v / G.degree(n) for n, v in esize.items()}
 
     See also
     --------

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -98,7 +98,7 @@ class TestCycles:
 
     def worst_case_graph(self, k):
         # see figure 1 in Johnson's paper
-        # this graph has excactly 3k simple cycles
+        # this graph has exactly 3k simple cycles
         G = nx.DiGraph()
         for n in range(2, k + 2):
             G.add_edge(1, n)

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -400,7 +400,7 @@ def triangles(creation_sequence):
     Compute number of triangles in the threshold graph with the
     given creation sequence.
     """
-    # shortcut algoritm that doesn't require computing number
+    # shortcut algorithm that doesn't require computing number
     # of triangles at each node.
     cs = creation_sequence    # alias
     dr = cs.count("d")        # number of d's in sequence
@@ -529,7 +529,7 @@ def shortest_path(creation_sequence, u, v):
     threshold graph G with the given creation_sequence.
 
     For an unlabeled creation_sequence, the vertices
-    u and v must be integers in (0,len(sequence)) refering
+    u and v must be integers in (0,len(sequence)) referring
     to the position of the desired vertices in the sequence.
 
     For a labeled creation_sequence, u and v are labels of veritices.

--- a/networkx/algorithms/vitality.py
+++ b/networkx/algorithms/vitality.py
@@ -37,7 +37,7 @@ def closeness_vitality(G, node=None, weight=None, wiener_index=None):
 
     node : object
         If specified, only the closeness vitality for this node will be
-        returned. Otherwise, a dictionary mappping each node to its
+        returned. Otherwise, a dictionary mapping each node to its
         closeness vitality will be returned.
 
     Other parameters
@@ -50,7 +50,7 @@ def closeness_vitality(G, node=None, weight=None, wiener_index=None):
     Returns
     -------
     dictionary or float
-        If `node` is None, this function returnes a dictionary
+        If `node` is None, this function returns a dictionary
         with nodes as keys and closeness vitality as the
         value. Otherwise, it returns only the closeness vitality for the
         specified `node`.

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -817,7 +817,7 @@ class DiGraph(Graph):
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
             If False, return 2-tuple (u, v).
         default : value, optional (default=None)
-            Value used for edges that dont have the requested attribute.
+            Value used for edges that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns
@@ -875,7 +875,7 @@ class DiGraph(Graph):
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
             If False, return 2-tuple (u, v).
         default : value, optional (default=None)
-            Value used for edges that dont have the requested attribute.
+            Value used for edges that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -54,7 +54,7 @@ def edges(G, nbunch=None):
 
 def degree(G, nbunch=None, weight=None):
     """Return a degree view of single node or of nbunch of nodes.
-    If nbunch is ommitted, then return degrees of *all* nodes.
+    If nbunch is omitted, then return degrees of *all* nodes.
     """
     return G.degree(nbunch, weight)
 
@@ -461,7 +461,7 @@ def restricted_view(G, nodes, edges):
     with a chain of subgraph views. Such chains can get quite slow
     for lengths near 15. To avoid long chains, try to make your subgraph
     based on the original graph (`subgraph.root_graph`). We do not
-    rule out chains programatically so that odd cases like an
+    rule out chains programmatically so that odd cases like an
     `edge_subgraph` of a `restricted_view` can be created.
 
     Examples
@@ -1099,7 +1099,7 @@ def selfloop_edges(G, data=False, keys=False, default=None):
     keys : bool, optional (default=False)
         If True, return edge keys with each edge.
     default : value, optional (default=None)
-        Value used for edges that dont have the requested attribute.
+        Value used for edges that don't have the requested attribute.
         Only relevant if data is not True or False.
 
     Returns

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -647,7 +647,7 @@ class Graph(object):
             If False, return just the nodes n.
 
         default : value, optional (default=None)
-            Value used for nodes that dont have the requested attribute.
+            Value used for nodes that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns
@@ -928,7 +928,7 @@ class Graph(object):
                 u, v, dd = e
             elif ne == 2:
                 u, v = e
-                dd = {}  # doesnt need edge_attr_dict_factory
+                dd = {}  # doesn't need edge_attr_dict_factory
             else:
                 raise NetworkXError(
                     "Edge tuple %s must be a 2-tuple or 3-tuple." % (e,))
@@ -1154,7 +1154,7 @@ class Graph(object):
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
             If False, return 2-tuple (u, v).
         default : value, optional (default=None)
-            Value used for edges that dont have the requested attribute.
+            Value used for edges that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -19,7 +19,7 @@ a graph to reverse directed edges, or treat a directed graph
 as undirected, etc. This module provides those graph views.
 
 The resulting views are essentially read-only graphs that
-report data from the orginal graph object. We provide three
+report data from the orignal graph object. We provide three
 attributes related to the underlying graph object.
 
     G._graph : the parent graph used for looking up graph data.

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -525,7 +525,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         keys : bool, optional (default=False)
             If True, return edge keys with each edge.
         default : value, optional (default=None)
-            Value used for edges that dont have the requested attribute.
+            Value used for edges that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns
@@ -590,7 +590,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         keys : bool, optional (default=False)
             If True, return edge keys with each edge.
         default : value, optional (default=None)
-            Value used for edges that dont have the requested attribute.
+            Value used for edges that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -693,7 +693,7 @@ class MultiGraph(Graph):
         keys : bool, optional (default=False)
             If True, return edge keys with each edge.
         default : value, optional (default=None)
-            Value used for edges that dont have the requested attribute.
+            Value used for edges that don't have the requested attribute.
             Only relevant if data is not True or False.
 
         Returns

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -302,7 +302,7 @@ class HistoricalTests(object):
         assert_equal(dict(d for n, d in P3.degree(['A', 'B'])), {})
         # nbunch can be a graph
         assert_equal(sorted(d for n, d in P5.degree(P3)), [1, 2, 2])
-        # nbunch can be a graph thats way to big
+        # nbunch can be a graph that's way too big
         assert_equal(sorted(d for n, d in P3.degree(P5)), [1, 1, 2])
         assert_equal(list(P5.degree([])), [])
         assert_equal(dict(P5.degree([])), {})

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -1,7 +1,7 @@
 """Functions to convert NetworkX graphs to and from other formats.
 
 The preferred way of converting data to a NetworkX graph is through the
-graph constuctor.  The constructor calls the to_networkx_graph() function
+graph constructor.  The constructor calls the to_networkx_graph() function
 which attempts to guess the input type and convert it automatically.
 
 Examples

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -7,7 +7,7 @@
 """Functions to convert NetworkX graphs to and from numpy/scipy matrices.
 
 The preferred way of converting data to a NetworkX graph is through the
-graph constuctor.  The constructor calls the to_networkx_graph() function
+graph constructor.  The constructor calls the to_networkx_graph() function
 which attempts to guess the input type and convert it automatically.
 
 Examples

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -1,4 +1,4 @@
-"""Unit tests for PyGraphviz inteface."""
+"""Unit tests for PyGraphviz interface."""
 import os
 import tempfile
 from nose import SkipTest

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -793,9 +793,9 @@ class DegreeSequenceRandomGraph(object):
         return self.graph
 
     def update_remaining(self, u, v, aux_graph=None):
-        # decrement remaining nodes, modify auxilliary graph if in phase3
+        # decrement remaining nodes, modify auxiliary graph if in phase3
         if aux_graph is not None:
-            # remove edges from auxilliary graph
+            # remove edges from auxiliary graph
             aux_graph.remove_edge(u, v)
         if self.remaining_degree[u] == 1:
             del self.remaining_degree[u]
@@ -855,7 +855,7 @@ class DegreeSequenceRandomGraph(object):
     def phase3(self):
         # build potential remaining edges and choose with rejection sampling
         potential_edges = combinations(self.remaining_degree, 2)
-        # build auxilliary graph of potential edges not already in graph
+        # build auxiliary graph of potential edges not already in graph
         H = nx.Graph([(u, v) for (u, v) in potential_edges
                       if not self.graph.has_edge(u, v)])
         while self.remaining_degree:

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -208,7 +208,7 @@ def soft_random_geometric_graph(n, radius, dim=2, pos=None, p=2, p_dist=None):
         be any function that takes the metric value as input
         and outputs a single probability value between 0-1. The scipy.stats
         package has many probability distribution functions implemented and tools
-        for custom probability distribution defintions [2], and passing the .pdf
+        for custom probability distribution definitions [2], and passing the .pdf
         method of scipy.stats distributions can be used here. If the probability
         function, `p_dist`, is not supplied, the default function is an exponential
         distribution with rate parameter :math:`\lambda=1`.
@@ -287,8 +287,8 @@ def soft_random_geometric_graph(n, radius, dim=2, pos=None, p=2, p_dist=None):
         u_pos, v_pos = pos[u], pos[v]
         dist = (sum(abs(a - b) ** p for a, b in zip(u_pos, v_pos)))**(1 / p)
         # Check if dist is <= radius parameter. This check is redundant if scipy
-        # is availible and _fast_edges routine is used, but provides the check incase
-        # scipy is not availible and all edge combinations need to be checked
+        # is available and _fast_edges routine is used, but provides the check in case
+        # scipy is not available and all edge combinations need to be checked
         if dist <= radius:
             return random.random() < p_dist(dist)
         else:
@@ -356,7 +356,7 @@ def geographical_threshold_graph(n, theta, dim=2, pos=None,
         be any function that takes the metric value as input
         and outputs a single probability value between 0-1. The scipy.stats
         package has many probability distribution functions implemented and tools
-        for custom probability distribution defintions [2], and passing the .pdf
+        for custom probability distribution definitions [2], and passing the .pdf
         method of scipy.stats distributions can be used here. If the probability
         function, `p_dist`, is not supplied, the default exponential function
         :math: `r^{-2}` is used.
@@ -531,7 +531,7 @@ def waxman_graph(n, beta=0.4, alpha=0.1, L=None, domain=(0, 0, 1, 1),
     -----
     Starting in NetworkX 2.0 the parameters alpha and beta align with their
     usual roles in the probability distribution. In earlier versions their
-    positions in the expresssion were reversed. Their position in the calling
+    positions in the expression were reversed. Their position in the calling
     sequence reversed as well to minimize backward incompatibility.
 
     References
@@ -648,7 +648,7 @@ def thresholded_random_geometric_graph(n, radius, theta, dim=2, pos=None, weight
     The thresholded random geometric graph [1] model places `n` nodes uniformly at
     random in the unit cube. Each node `u` is assigned a weight
     :math:`w_u`. Two nodes `u` and `v` are joined by an edge if they are within
-    the maximum conenction distance, `radius` computed by the `p`-Minkowski distance
+    the maximum connection distance, `radius` computed by the `p`-Minkowski distance
     and the summation of weights :math:`w_u` + :math:`w_v` is greater than or equal
     to the threshold parameter `theta`.
 
@@ -763,8 +763,8 @@ def thresholded_random_geometric_graph(n, radius, theta, dim=2, pos=None, weight
         u_pos, v_pos = pos[u], pos[v]
         dist = (sum(abs(a - b) ** p for a, b in zip(u_pos, v_pos)))**(1 / p)
         # Check if dist is <= radius parameter. This check is redundant if scipy
-        # is availible and _fast_edges routine is used, but provides the check incase
-        # scipy is not availible and all edge combinations need to be checked
+        # is available and _fast_edges routine is used, but provides the check in case
+        # scipy is not available and all edge combinations need to be checked
         if dist <= radius:
             return theta <= u_weight + v_weight
         else:

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -16,7 +16,7 @@ The :func:`grid_2d_graph`, :func:`triangular_lattice_graph`, and
 :func:`hexagonal_lattice_graph` functions correspond to the three
 `regular tilings of the plane`_, the square, triangular, and hexagonal
 tilings, respectively. :func:`grid_graph` and :func:`hypercube_graph`
-are similar for arbitrary dimensions. Useful relevent discussion can
+are similar for arbitrary dimensions. Useful relevant discussion can
 be found about `Triangular Tiling`_, and `Square, Hex and Triangle Grids`_
 
 .. _regular tilings of the plane: https://en.wikipedia.org/wiki/List_of_regular_polytopes_and_compounds#Euclidean_tilings

--- a/networkx/generators/mycielski.py
+++ b/networkx/generators/mycielski.py
@@ -47,7 +47,7 @@ def mycielskian(G, iterations=1):
         A simple, undirected NetworkX graph
     iterations : int
         The number of iterations of the Mycielski operation to
-        preform on G. Defaults to 1. Must be a non-negative integer.
+        perform on G. Defaults to 1. Must be a non-negative integer.
 
     Returns
     -------

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -648,7 +648,7 @@ def barabasi_albert_graph(n, m, seed=None):
         # And the new node "source" has m edges to add to the list.
         repeated_nodes.extend([source] * m)
         # Now choose m unique nodes from the existing nodes
-        # Pick uniformly from repeated_nodes (preferential attachement)
+        # Pick uniformly from repeated_nodes (preferential attachment)
         targets = _random_subset(repeated_nodes, m)
         source += 1
     return G
@@ -658,7 +658,7 @@ def extended_barabasi_albert_graph(n, m, p, q, seed=None):
     """Returns an extended Barabási–Albert model graph.
 
     An extended Barabási–Albert model graph is a random graph constructed
-    using preferential attachment. The extended model allows new egdes,
+    using preferential attachment. The extended model allows new edges,
     rewired edges or new nodes. Based on the probabilities $p$ and $q$
     with $p + q < 1$, the growing behavior of the graph is determined as:
 
@@ -666,7 +666,7 @@ def extended_barabasi_albert_graph(n, m, p, q, seed=None):
     starting from randomly chosen existing nodes and attached preferentially at the other end.
 
     2) With $q$ probability, $m$ existing edges are rewired
-    by randomly chosing an edge and rewiring one end to a preferentially chosen node.
+    by randomly choosing an edge and rewiring one end to a preferentially chosen node.
 
     3) With $(1 - p - q)$ probability, $m$ new nodes are added to the graph
     with edges attached preferentially.

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -100,7 +100,7 @@ class TestGeneratorsRandom(object):
 
     def test_extended_barabasi_albert(self, m=2):
         """
-        Tests that the extended BA random graph generated behaves consistenly.
+        Tests that the extended BA random graph generated behaves consistently.
 
         Tests the exceptions are raised as expected.
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -267,7 +267,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
     while True:
         # Orthonormalize X.
         X = qr(X)[0]
-        # Compute interation matrix H.
+        # Compute iteration matrix H.
         W[:, :] = L * X
         H = X.T * W
         sigma, Y = eigh(H, overwrite_a=True)

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -550,7 +550,7 @@ class GraphMLWriter(GraphML):
 class IncrementalElement(object):
     """Wrapper for _IncrementalWriter providing an Element like interface.
 
-    This wrapper does not intend to be a complete implemenation but rather to
+    This wrapper does not intend to be a complete implementation but rather to
     deal with those calls used in GraphMLWriter.
     """
 
@@ -852,7 +852,7 @@ class GraphMLReader(GraphML):
                 if node_label is not None:
                     data['label'] = node_label.text
 
-                # check all the diffrent types of edges avaivable in yEd.
+                # check all the different types of edges avaivable in yEd.
                 for e in ['PolyLineEdge', 'SplineEdge', 'QuadCurveEdge',
                           'BezierEdge', 'ArcEdge']:
                     pref = "{%s}%s/{%s}" % (self.NS_Y, e, self.NS_Y)

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -264,7 +264,7 @@ def read_sparse6(path):
     Returns
     -------
     G : Graph/Multigraph or list of Graphs/MultiGraphs
-       If the file contains multple lines then a list of graphs is returned
+       If the file contains multiple lines then a list of graphs is returned
 
     Raises
     ------


### PR DESCRIPTION
Found via `codespell -q 3 -I ../networkx-whitelist.txt` where whitelist consisted of:
```
ans
childs
iff
nd
te
```