### PR TITLE
Added dynamic graph attribute field `start` into `node element` in gexf utils.

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -326,6 +326,18 @@ class GEXFWriter(GEXF):
                 kw['pid'] = make_str(pid)
             except KeyError:
                 pass
+            try:
+                start = node_data.pop('start')
+                kw['start'] = make_str(start)
+                self.alter_graph_mode_timeformat(start)
+            except KeyError:
+                pass
+            try:
+                end = node_data.pop('end')
+                kw['end'] = make_str(end)
+                self.alter_graph_mode_timeformat(end)
+            except KeyError:
+                pass
             # add node element with attributes
             node_element = Element('node', **kw)
             # add node element and attr subelements

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -290,16 +290,16 @@ class TestGEXF(object):
             G.nodes[i]['pid'] = i
 
         expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance">
-  <graph defaultedgetype="undirected" mode="static" name="">
+  <graph defaultedgetype="undirected" mode="dynamic" name="" timeformat="long">
     <meta>
       <creator>NetworkX {}</creator>
       <lastmodified>{}</lastmodified>
     </meta>
     <nodes>
-      <node id="0" label="0" pid="0" />
-      <node id="1" label="1" pid="1" />
-      <node id="2" label="2" pid="2" />
-      <node id="3" label="3" pid="3" />
+      <node end="1" id="0" label="0" pid="0" start="0" />
+      <node end="2" id="1" label="1" pid="1" start="1" />
+      <node end="3" id="2" label="2" pid="2" start="2" />
+      <node end="4" id="3" label="3" pid="3" start="3" />
     </nodes>
     <edges>
       <edge id="0" source="0" target="1" />


### PR DESCRIPTION
Hi,
I am sending a pull request which adds dynamic graph attribute field `start`/`end` into `node` element in gexf utils and tests that.

(Based on https://github.com/networkx/networkx/pull/1797)