### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -19,7 +19,7 @@ Bibliography
 
 .. [choudum1986] S.A. Choudum. "A simple proof of the Erdős-Gallai theorem on 
    graph sequences." Bulletin of the Australian Mathematical Society, 33, 
-   pp 67-70, 1986. http://dx.doi.org/10.1017/S0004972700002872
+   pp 67-70, 1986. https://doi.org/10.1017/S0004972700002872
 
 .. [Diestel97] R. Diestel, "Graph Theory", Springer-Verlag, 1997. 
    http://diestel-graph-theory.com/index.html

--- a/examples/algorithms/plot_blockmodel.py
+++ b/examples/algorithms/plot_blockmodel.py
@@ -10,7 +10,7 @@ used is the Hartford, CT drug users network::
 
     @article{weeks2002social,
       title={Social networks of drug users in high-risk sites: Finding the connections},
-      url = {http://dx.doi.org/10.1023/A:1015457400897},
+      url = {https://doi.org/10.1023/A:1015457400897},
       doi = {10.1023/A:1015457400897},
       author={Weeks, Margaret R and Clair, Scott and Borgatti, Stephen P and Radda, Kim and Schensul, Jean J},
       journal={{AIDS and Behavior}},

--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -141,7 +141,7 @@ def large_clique_size(G):
        "Fast Algorithms for the Maximum Clique Problem on Massive Graphs
        with Applications to Overlapping Community Detection."
        *Internet Mathematics* 11.4-5 (2015): 421--448.
-       <https://dx.doi.org/10.1080/15427951.2014.986778>
+       <https://doi.org/10.1080/15427951.2014.986778>
 
     See also
     --------

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -403,7 +403,7 @@ def preferential_attachment_graph(aseq, p, create_using=None, seed=None):
     .. [1] Jean-Loup Guillaume and Matthieu Latapy,
        Bipartite structure of all complex networks,
        Inf. Process. Lett. 90, 2004, pg. 215-221
-       http://dx.doi.org/10.1016/j.ipl.2004.03.007
+       https://doi.org/10.1016/j.ipl.2004.03.007
 
     Notes
     -----

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -104,7 +104,7 @@ def hopcroft_karp_matching(G, top_nodes=None):
     ----------
     .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
        Maximum Matchings in Bipartite Graphs" In: **SIAM Journal of Computing**
-       2.4 (1973), pp. 225--231. <https://dx.doi.org/10.1137/0202019>.
+       2.4 (1973), pp. 225--231. <https://doi.org/10.1137/0202019>.
 
     """
     # First we define some auxiliary search functions.

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -68,7 +68,7 @@ def current_flow_closeness_centrality(G, weight=None,
     .. [2] Karen Stephenson and Marvin Zelen:
        Rethinking centrality: Methods and examples.
        Social Networks 11(1):1-37, 1989.
-       http://dx.doi.org/10.1016/0378-8733(89)90016-6
+       https://doi.org/10.1016/0378-8733(89)90016-6
     """
     import numpy as np
     import scipy

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -91,7 +91,7 @@ def global_reaching_centrality(G, weight=None, normalized=True):
     .. [1] Mones, Enys, Lilla Vicsek, and Tamás Vicsek.
            "Hierarchy Measure for Complex Networks."
            *PLoS ONE* 7.3 (2012): e33799.
-           https://dx.doi.org/10.1371/journal.pone.0033799
+           https://doi.org/10.1371/journal.pone.0033799
     """
     if nx.is_negatively_weighted(G, weight=weight):
         raise nx.NetworkXError('edge weights must be positive')
@@ -181,7 +181,7 @@ def local_reaching_centrality(G, v, paths=None, weight=None, normalized=True):
     .. [1] Mones, Enys, Lilla Vicsek, and Tamás Vicsek.
            "Hierarchy Measure for Complex Networks."
            *PLoS ONE* 7.3 (2012): e33799.
-           https://dx.doi.org/10.1371/journal.pone.0033799
+           https://doi.org/10.1371/journal.pone.0033799
     """
     if paths is None:
         if nx.is_negatively_weighted(G, weight=weight):

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -303,11 +303,11 @@ def estrada_index(G):
     ----------
     .. [1] E. Estrada, "Characterization of 3D molecular structure",
        Chem. Phys. Lett. 319, 713 (2000).
-       http://dx.doi.org/10.1016/S0009-2614(00)00158-5
+       https://doi.org/10.1016/S0009-2614(00)00158-5
     .. [2] José Antonio de la Peñaa, Ivan Gutman, Juan Rada,
        "Estimating the Estrada index",
        Linear Algebra and its Applications. 427, 1 (2007).
-       http://dx.doi.org/10.1016/j.laa.2007.06.020
+       https://doi.org/10.1016/j.laa.2007.06.020
 
     Examples
     --------

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -60,7 +60,7 @@ def chain_decomposition(G, root=None):
     ----------
     .. [1] Jens M. Schmidt (2013). "A simple test on 2-vertex-
        and 2-edge-connectivity." *Information Processing Letters*,
-       113, 241–244. Elsevier. <http://dx.doi.org/10.1016/j.ipl.2013.01.016>
+       113, 241–244. Elsevier. <https://doi.org/10.1016/j.ipl.2013.01.016>
 
     """
 

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -74,7 +74,7 @@ def enumerate_all_cliques(G):
            Applications in Systems Biology".
            *Supercomputing*, 2005. Proceedings of the ACM/IEEE SC 2005
            Conference, pp. 12, 12--18 Nov. 2005.
-           <http://dx.doi.org/10.1109/SC.2005.29>.
+           <https://doi.org/10.1109/SC.2005.29>.
 
     """
     index = {}
@@ -160,13 +160,13 @@ def find_cliques(G):
        Computing and Combinatorics,
        10th Annual International Conference on
        Computing and Combinatorics (COCOON 2004), 25 October 2006, Pages 28--42
-       <http://dx.doi.org/10.1016/j.tcs.2006.06.015>
+       <https://doi.org/10.1016/j.tcs.2006.06.015>
 
     .. [3] F. Cazals, C. Karande,
        "A note on the problem of reporting maximal cliques",
        *Theoretical Computer Science*,
        Volume 407, Issues 1--3, 6 November 2008, Pages 564--568,
-       <http://dx.doi.org/10.1016/j.tcs.2008.05.010>
+       <https://doi.org/10.1016/j.tcs.2008.05.010>
 
     """
     if len(G) == 0:
@@ -265,13 +265,13 @@ def find_cliques_recursive(G):
        Computing and Combinatorics,
        10th Annual International Conference on
        Computing and Combinatorics (COCOON 2004), 25 October 2006, Pages 28--42
-       <http://dx.doi.org/10.1016/j.tcs.2006.06.015>
+       <https://doi.org/10.1016/j.tcs.2006.06.015>
 
     .. [3] F. Cazals, C. Karande,
        "A note on the problem of reporting maximal cliques",
        *Theoretical Computer Science*,
        Volume 407, Issues 1--3, 6 November 2008, Pages 564--568,
-       <http://dx.doi.org/10.1016/j.tcs.2008.05.010>
+       <https://doi.org/10.1016/j.tcs.2008.05.010>
 
     """
     if len(G) == 0:

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -320,7 +320,7 @@ def greedy_color(G, strategy='largest_first', interchange=False):
        ISBN 0-8218-3458-4.
     .. [2] David W. Matula, and Leland L. Beck, "Smallest-last
        ordering and clustering and graph coloring algorithms." *J. ACM* 30,
-       3 (July 1983), 417–427. <http://dx.doi.org/10.1145/2402.322385>
+       3 (July 1983), 417–427. <https://doi.org/10.1145/2402.322385>
     .. [3] Maciej M. Sysło, Marsingh Deo, Janusz S. Kowalik,
        Discrete Optimization Algorithms with Pascal Programs, 415-424, 1983.
        ISBN 0-486-45353-7.

--- a/networkx/algorithms/cuts.py
+++ b/networkx/algorithms/cuts.py
@@ -311,7 +311,7 @@ def mixing_expansion(G, S, T=None, weight=None):
            "Pseudorandomness."
            *Foundations and Trends
            in Theoretical Computer Science* 7.1–3 (2011): 1–336.
-           <http://dx.doi.org/10.1561/0400000010>
+           <https://doi.org/10.1561/0400000010>
 
     """
     num_cut_edges = cut_size(G, S, T=T, weight=weight)
@@ -351,7 +351,7 @@ def node_expansion(G, S):
            "Pseudorandomness."
            *Foundations and Trends
            in Theoretical Computer Science* 7.1–3 (2011): 1–336.
-           <http://dx.doi.org/10.1561/0400000010>
+           <https://doi.org/10.1561/0400000010>
 
     """
     neighborhood = set(chain.from_iterable(G.neighbors(v) for v in S))
@@ -390,7 +390,7 @@ def boundary_expansion(G, S):
            "Pseudorandomness."
            *Foundations and Trends in Theoretical Computer Science*
            7.1–3 (2011): 1–336.
-           <http://dx.doi.org/10.1561/0400000010>
+           <https://doi.org/10.1561/0400000010>
 
     """
     return len(nx.node_boundary(G, S)) / len(S)

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -156,7 +156,7 @@ def simple_cycles(G):
     ----------
     .. [1] Finding all the elementary circuits of a directed graph.
        D. B. Johnson, SIAM Journal on Computing 4, no. 1, 77-84, 1975.
-       http://dx.doi.org/10.1137/0204007
+       https://doi.org/10.1137/0204007
     .. [2] Enumerating the cycles of a digraph: a new preprocessing strategy.
        G. Loizou and P. Thanish, Information Sciences, v. 27, 163-182, 1982.
     .. [3] A search strategy for the elementary cycles of a directed graph.
@@ -269,7 +269,7 @@ def recursive_simple_cycles(G):
     ----------
     .. [1] Finding all the elementary circuits of a directed graph.
        D. B. Johnson, SIAM Journal on Computing 4, no. 1, 77-84, 1975.
-       http://dx.doi.org/10.1137/0204007
+       https://doi.org/10.1137/0204007
 
     See Also
     --------

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -51,16 +51,16 @@ def extrema_bounding(G, compute="diameter"):
     F.W. Takes and W.A. Kosters, Determining the Diameter of Small World
     Networks, in Proceedings of the 20th ACM International Conference on
     Information and Knowledge Management (CIKM 2011), pp. 1191-1196, 2011.
-    doi: http://dx.doi.org/10.1145/2063576.2063748
+    doi: https://doi.org/10.1145/2063576.2063748
 
     F.W. Takes and W.A. Kosters, Computing the Eccentricity Distribution of
     Large Graphs, Algorithms 6(1): 100-118, 2013.
-    doi: http://dx.doi.org/10.3390/a6010100
+    doi: https://doi.org/10.3390/a6010100
 
     M. Borassi, P. Crescenzi, M. Habib, W.A. Kosters, A. Marino and F.W. Takes,
     Fast Graph Diameter and Radius BFS-Based Computation in (Weakly Connected)
     Real-World Graphs, Theoretical Computer Science 586: 59-80, 2015.
-    doi: http://dx.doi.org/10.1016/j.tcs.2015.02.033
+    doi: https://doi.org/10.1016/j.tcs.2015.02.033
     """
 
     # init variables

--- a/networkx/algorithms/efficiency.py
+++ b/networkx/algorithms/efficiency.py
@@ -52,7 +52,7 @@ def efficiency(G, u, v):
     .. [1] Latora, Vito, and Massimo Marchiori.
            "Efficient behavior of small-world networks."
            *Physical Review Letters* 87.19 (2001): 198701.
-           <http://dx.doi.org/10.1103/PhysRevLett.87.198701>
+           <https://doi.org/10.1103/PhysRevLett.87.198701>
 
     """
     try:
@@ -94,7 +94,7 @@ def global_efficiency(G):
     .. [1] Latora, Vito, and Massimo Marchiori.
            "Efficient behavior of small-world networks."
            *Physical Review Letters* 87.19 (2001): 198701.
-           <http://dx.doi.org/10.1103/PhysRevLett.87.198701>
+           <https://doi.org/10.1103/PhysRevLett.87.198701>
 
     """
     n = len(G)
@@ -143,7 +143,7 @@ def local_efficiency(G):
     .. [1] Latora, Vito, and Massimo Marchiori.
            "Efficient behavior of small-world networks."
            *Physical Review Letters* 87.19 (2001): 198701.
-           <http://dx.doi.org/10.1103/PhysRevLett.87.198701>
+           <https://doi.org/10.1103/PhysRevLett.87.198701>
 
     """
     # TODO This summation can be trivially parallelized.

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -469,7 +469,7 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community='community'):
        Link prediction in complex networks based on cluster information.
        In Proceedings of the 21st Brazilian conference on Advances in
        Artificial Intelligence (SBIA'12)
-       http://dx.doi.org/10.1007/978-3-642-34459-6_10
+       https://doi.org/10.1007/978-3-642-34459-6_10
     """
     if delta <= 0:
         raise nx.NetworkXAlgorithmError('Delta must be greater than zero')

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -19,7 +19,7 @@ This implementation is based on:
 #    doi={10.1007/BF02579168},
 #    title={Efficient algorithms for finding minimum spanning trees in
 #        undirected and directed graphs},
-#    url={http://dx.doi.org/10.1007/BF02579168},
+#    url={https://doi.org/10.1007/BF02579168},
 #    publisher={Springer-Verlag},
 #    keywords={68 B 15; 68 C 05},
 #    author={Gabow, Harold N. and Galil, Zvi and Spencer, Thomas and Tarjan,

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -270,7 +270,7 @@ def to_prufer_sequence(T):
     .. [1] Wang, Xiaodong, Lei Wang, and Yingjie Wu.
            "An optimal algorithm for Prufer codes."
            *Journal of Software Engineering and Applications* 2.02 (2009): 111.
-           <http://dx.doi.org/10.4236/jsea.2009.22016>
+           <https://doi.org/10.4236/jsea.2009.22016>
 
     Examples
     --------
@@ -354,7 +354,7 @@ def from_prufer_sequence(sequence):
     .. [1] Wang, Xiaodong, Lei Wang, and Yingjie Wu.
            "An optimal algorithm for Prufer codes."
            *Journal of Software Engineering and Applications* 2.02 (2009): 111.
-           <http://dx.doi.org/10.4236/jsea.2009.22016>
+           <https://doi.org/10.4236/jsea.2009.22016>
 
     See also
     --------

--- a/networkx/generators/duplication.py
+++ b/networkx/generators/duplication.py
@@ -68,7 +68,7 @@ def partial_duplication_graph(N, n, p, q, seed=None):
     ----------
     .. [1] Knudsen Michael, and Carsten Wiuf. "A Markov chain approach to
            randomly grown graphs." Journal of Applied Mathematics 2008.
-           <https://dx.doi.org/10.1155/2008/190836>
+           <https://doi.org/10.1155/2008/190836>
 
     """
     if p < 0 or p > 1 or q < 0 or q > 1:

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -336,7 +336,7 @@ def newman_watts_strogatz_graph(n, k, p, seed=None):
     .. [1] M. E. J. Newman and D. J. Watts,
        Renormalization group analysis of the small-world network model,
        Physics Letters A, 263, 341, 1999.
-       http://dx.doi.org/10.1016/S0375-9601(99)00757-4
+       https://doi.org/10.1016/S0375-9601(99)00757-4
     """
     if seed is not None:
         random.seed(seed)


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing all static DOI links to `https://doi.org/`, see diff.

If you agree and merge, I'll also update other repos, website, docu, etc. in the same manner.

Cheers :-)