### PR TITLE
Fix #2880: Allow line_graph to apply to multigraph

### DIFF
--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -21,7 +21,6 @@ from networkx.utils.decorators import *
 __all__ = ['line_graph', 'inverse_line_graph']
 
 
-@not_implemented_for('multigraph')
 def line_graph(G, create_using=None):
     """Returns the line graph of the graph or digraph `G`.
 


### PR DESCRIPTION
Removed not_implemented_for decorator from line_graph function. See #2814 and #2880.