### PR TITLE
feature: add_clique

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -13,7 +13,7 @@
 from __future__ import division
 
 from collections import Counter
-from itertools import chain
+from itertools import chain, combinations
 try:
     from itertools import zip_longest
 except ImportError:
@@ -27,7 +27,7 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'is_directed', 'info', 'freeze', 'is_frozen', 'subgraph',
            'induced_subgraph', 'edge_subgraph', 'restricted_view',
            'reverse_view', 'to_directed', 'to_undirected',
-           'add_star', 'add_path', 'add_cycle',
+           'add_star', 'add_path', 'add_cycle', 'add_clique',
            'create_empty_copy', 'set_node_attributes',
            'get_node_attributes', 'set_edge_attributes',
            'get_edge_attributes', 'all_neighbors', 'non_neighbors',
@@ -225,7 +225,7 @@ def add_star(G_to_add_to, nodes_for_star, **attr):
 
     See Also
     --------
-    add_path, add_cycle
+    add_path, add_cycle, add_clique
 
     Examples
     --------
@@ -254,7 +254,7 @@ def add_path(G_to_add_to, nodes_for_path, **attr):
 
     See Also
     --------
-    add_star, add_cycle
+    add_star, add_cycle, add_clique
 
     Examples
     --------
@@ -286,7 +286,7 @@ def add_cycle(G_to_add_to, nodes_for_cycle, **attr):
 
     See Also
     --------
-    add_path, add_star
+    add_path, add_star, add_clique
 
     Examples
     --------
@@ -295,6 +295,32 @@ def add_cycle(G_to_add_to, nodes_for_cycle, **attr):
     >>> nx.add_cycle(G, [10, 11, 12], weight=7)
     """
     G_to_add_to.add_edges_from(pairwise(nodes_for_cycle, cyclic=True), **attr)
+
+
+def add_clique(G_to_add_to, nodes_for_clique, **attr):
+    """Add a clique to the Graph G_to_add_to.
+
+    Parameters
+    ----------
+    G_to_add_to : graph
+        A NetworkX graph
+    nodes_for_clique: iterable container
+        A container of nodes.  A clique will be constructed from
+        the nodes (in order) and added to the graph.
+    attr : keyword arguments, optional (default= no attributes)
+        Attributes to add to every edge in clique.
+
+    See Also
+    --------
+    add_path, add_star, add_cycle
+
+    Examples
+    --------
+    >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc
+    >>> nx.add_clique(G, [0, 1, 2, 3])
+    >>> nx.add_clique(G, [10, 11, 12], weight=7)
+    """
+    G_to_add_to.add_edges_from(combinations(nodes_for_clique, 2), **attr)
 
 
 def subgraph(G, nbunch):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -136,6 +136,22 @@ class TestFunction(object):
         nx.add_cycle(G, nlist, weight=1.0)
         assert_true(sorted(G.edges(nlist, data=True)) in oklists)
 
+    def test_add_clique(self):
+        G = self.G.copy()
+        nlist = [12, 13, 14, 15]
+        okset = frozenset([(12, 13), (12, 14), (12, 15),
+                           (13, 14), (13, 15),
+                           (14, 15)])
+        nx.add_clique(G, nlist)
+        assert_true(frozenset(G.edges(nlist)) == okset)
+        G = self.G.copy()
+        okset = frozenset([(12, 13, 1.), (12, 14, 1.), (12, 15, 1.),
+                           (13, 14, 1.), (13, 15, 1.),
+                           (14, 15, 1.)])
+        nx.add_clique(G, nlist, weight=1.0)
+        comparedset = frozenset((s, t, d['weight']) for s, t, d in G.edges(nlist, data=True))
+        assert_true(comparedset == okset)
+
     def test_subgraph(self):
         assert_equal(self.G.subgraph([0, 1, 2, 4]).adj,
                      nx.subgraph(self.G, [0, 1, 2, 4]).adj)


### PR DESCRIPTION
Hello networkx team,

I am opening this PR as the basis for a discussion concerning the addition of a new function called `add_clique`, in the spirit of `add_path`, `add_star` etc. It basically adds a clique based on the iterable of nodes provided. What do you think?