### PR TITLE
Add stochastic block models to generators

### DIFF
--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -520,17 +520,17 @@ def stochastic_block_model(sizes, p, nodelist=None, seed=None,
     450
     >>> H = nx.quotient_graph(g, g.graph['partition'], relabel=True)
     >>> for v in H.nodes(data=True):
-    ...     print(v[1]['density'])
+    ...     print(round(v[1]['density'], 3))
     ...
-    0.245045045045
-    0.348108108108
-    0.405105908584
+    0.245
+    0.348
+    0.405
     >>> for v in H.edges(data=True):
-    ...     print(v[2]['weight'] / (sizes[v[0]] * sizes[v[1]]))
+    ...     print(round(v[2]['weight'] / (sizes[v[0]] * sizes[v[1]]), 3))
     ...
-    0.0506666666667
-    0.0216
-    0.0699555555556
+    0.051
+    0.022
+    0.07
 
     See Also
     --------

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -1,22 +1,24 @@
-"""Generators for classes of graphs used in studying social networks."""
-import itertools
-import math
-import random
-import networkx as nx
-#    Copyright(C) 2011, 2015 by
+#    Copyright(C) 2011, 2015, 2018 by
 #    Ben Edwards <bedwards@cs.unm.edu>
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Konstantinos Karakatsanis <dinoskarakas@gmail.com>
 #    All rights reserved.
 #    BSD license.
-__author__ = """\n""".join(['Ben Edwards (bedwards@cs.unm.edu)',
-                            'Aric Hagberg (hagberg@lanl.gov)',
-                            'Konstantinos Karakatsanis '
-                            '<dinoskarakas@gmail.com>'])
+#
+# Authors:  Ben Edwards (bedwards@cs.unm.edu)
+#           Aric Hagberg (hagberg@lanl.gov)
+#           Konstantinos Karakatsanis (dinoskarakas@gmail.com)
+#           Jean-Gabriel Young (jean.gabriel.young@gmail.com)
+"""Generators for classes of graphs used in studying social networks."""
+import itertools
+import math
+import random
+import networkx as nx
+
 __all__ = ['caveman_graph', 'connected_caveman_graph',
            'relaxed_caveman_graph', 'random_partition_graph',
            'planted_partition_graph', 'gaussian_random_partition_graph',
-           'ring_of_cliques', 'windmill_graph']
+           'ring_of_cliques', 'windmill_graph', 'stochastic_block_model']
 
 
 def caveman_graph(l, k):
@@ -417,14 +419,14 @@ def ring_of_cliques(num_cliques, clique_size):
     Parameters
     ----------
     num_cliques : int
-      Number of cliques
+        Number of cliques
     clique_size : int
-      Size of cliques
+        Size of cliques
 
     Returns
     -------
     G : NetworkX Graph
-      ring of cliques graph
+        ring of cliques graph
 
     Raises
     ------
@@ -474,14 +476,14 @@ def windmill_graph(n, k):
     Parameters
     ----------
     n : int
-      Number of cliques
+        Number of cliques
     k : int
-      Size of cliques
+        Size of cliques
 
     Returns
     -------
     G : NetworkX Graph
-      windmill graph with n cliques of size k
+        windmill graph with n cliques of size k
 
     Raises
     ------
@@ -510,3 +512,177 @@ def windmill_graph(n, k):
                                                for _ in range(n - 1))))
     G.add_edges_from((0, i) for i in range(k, G.number_of_nodes()))
     return G
+
+def stochastic_block_model(sizes, p, nodelist=None, seed=None,
+                           directed=False, selfloops=False, sparse=True):
+    """Return a stochastic block model graph.
+
+    This model partitions the nodes in blocks of arbitrary sizes, and places
+    edges between pairs of nodes independently, with a probability that depends
+    on the blocks.
+
+    Parameters
+    ----------
+    sizes : list of ints
+        Sizes of blocks
+    p : list of list of floats
+        Element (r,s) gives the density of edges going from the nodes
+        of group r to nodes of group s.
+        p must match the number of groups (len(sizes) == len(p)),
+        and it must be symmetric if the graph is undirected.
+    nodelist : list, optional
+        The block tags are assigned according to the node identifiers
+        in nodelist. If nodelist is None, then the ordering is the
+        range [0,sum(sizes)-1].
+    seed : int, optional,  default=None
+        Seed for random number generator.
+    directed : boolean optional, default=False
+        Whether to create a directed graph or not.
+    selfloops : boolean optional, default=False
+        Whether to include self-loops or not.
+    sparse: boolean optional, default=True
+        Use the sparse heuristic to speed up the generator.
+
+    Returns
+    -------
+    g : NetworkX Graph or DiGraph
+        Stochastic block model graph of size sum(sizes)
+
+    Raises
+    ------
+    NetworkXError
+      If probabilities are not in [0,1].
+      If the probability matrix is not square (directed case).
+      If the probability matrix is not symmetric (undirected case).
+      If the sizes list does not match nodelist or the probability matrix.
+      If nodelist contains duplicate.
+
+    Examples
+    --------
+    >>> from __future__ import division
+    >>> import numpy as np
+    >>> import networkx as nx
+    >>>
+    >>> sizes = [75, 75, 300]
+    >>> probs = [[0.25, 0.05, 0.02],
+    ...          [0.05, 0.35, 0.07],
+    ...          [0.02, 0.07, 0.40]]
+    >>> g = nx.stochastic_block_model(sizes, probs)
+    >>> len(g)
+    450
+    >>> H = nx.algorithms.blockmodel(g, g.graph['partition'])
+    >>> for v in H.nodes_iter(data=True):
+    ...     print v[1]['density']
+    ...
+    0.254414414414
+    0.357477477477
+    0.401672240803
+    >>> for v in H.edges_iter(data=True):
+    ...     print v[2]['weight'] / (sizes[v[0]] * sizes[v[1]])
+    ...
+    0.0483555555556
+    0.0195555555556
+    0.0728888888889
+
+    See Also
+    --------
+    random_partition_graph
+    planted_partition_graph
+    gaussian_random_partition_graph
+    gnp_random_graph
+
+    References
+    ----------
+    .. [1] Holland, P. W., Laskey, K. B., & Leinhardt, S.,
+           "Stochastic blockmodels: First steps",
+           Social networks, 5(2), 109-137, 1983.
+    """
+    # Check if dimensions match
+    if len(sizes) != len(p):
+        raise nx.NetworkXException("'sizes' and 'p' do not match.")
+    # Check for probability symmetry (undirected) and shape (directed)
+    for row in p:
+        if len(p) != len(row):
+            raise nx.NetworkXException("'p' must be a square matrix.")
+    if not directed:
+        p_transpose = [list(i) for i in zip(*p)]
+        for i in zip(p, p_transpose):
+            for j in zip(i[0], i[1]):
+                if abs(j[0] - j[1]) > 1e-08:
+                    raise nx.NetworkXException("'p' must be symmetric.")
+    # Check for probability range
+    for row in p:
+        for prob in row:
+            if prob < 0 or prob > 1:
+                raise nx.NetworkXException("Entries of 'p' not in [0,1].")
+    # Check for nodelist consistency
+    if nodelist is not None:
+        if len(nodelist) != sum(sizes):
+            raise nx.NetworkXException("'nodelist' and 'sizes' do not match.")
+        if len(nodelist) != len(set(nodelist)):
+            raise nx.NetworkXException("nodelist contains duplicate.")
+    else:
+        nodelist = range(0, sum(sizes))
+
+    # Setup the graph conditionally to the directed switch.
+    block_range = range(len(sizes))
+    if directed:
+        g = nx.DiGraph()
+        block_iter = itertools.product(block_range, block_range)
+    else:
+        g = nx.Graph()
+        block_iter = itertools.combinations_with_replacement(block_range, 2)
+    # Split nodelist in a partition (list of sets).
+    size_cumsum = [sum(sizes[0:x]) for x in range(0, len(sizes) + 1)]
+    g.graph['partition'] = [set(nodelist[size_cumsum[x]:size_cumsum[x + 1]])
+                            for x in range(0, len(size_cumsum) - 1)]
+    # Setup nodes and graph name
+    for block_id, nodes in enumerate(g.graph['partition']):
+        for node in nodes:
+            g.add_node(node, block=block_id)
+
+    g.name = "stochastic_block_model"
+
+    # Test for edge existence
+    if seed is not None:
+        random.seed(seed)
+
+    for i, j in block_iter:
+        if i == j:
+            if directed:
+                if selfloops:
+                    edges = itertools.product(g.graph['partition'][i],
+                                              g.graph['partition'][i])
+                else:
+                    edges = itertools.permutations(g.graph['partition'][i], 2)
+            else:
+                edges = itertools.combinations(g.graph['partition'][i], 2)
+                if selfloops:
+                    edges = itertools.chain(edges, zip(g.graph['partition'][i],
+                                                       g.graph['partition'][i]))  # noqa
+            for e in edges:
+                if random.random() < p[i][j]:
+                    g.add_edge(*e)
+        else:
+            edges = itertools.product(g.graph['partition'][i],
+                                      g.graph['partition'][j])
+        if sparse:
+            consume = lambda it, n: next(itertools.islice(it, n, n), None)
+            geo = lambda p: math.floor(math.log(random.random()) / math.log(1 - p))  # noqa
+            if p[i][j] == 1:  # Test edges cases p_ij = 0 or 1
+                for e in edges:
+                    g.add_edge(*e)
+            elif p[i][j] > 0:
+                while True:
+                    try:
+                        skip = geo(p[i][j])
+                        consume(edges, skip)
+                        e = next(edges)
+                        g.add_edge(*e)  # __safe
+                    except StopIteration:
+                        break
+        else:
+            for e in edges:
+                if random.random() < p[i][j]:
+                    g.add_edge(*e)  # __safe
+    return g

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -10,6 +10,7 @@
 #           Konstantinos Karakatsanis (dinoskarakas@gmail.com)
 #           Jean-Gabriel Young (jean.gabriel.young@gmail.com)
 """Generators for classes of graphs used in studying social networks."""
+from __future__ import division
 import itertools
 import math
 import random
@@ -513,6 +514,7 @@ def windmill_graph(n, k):
     G.add_edges_from((0, i) for i in range(k, G.number_of_nodes()))
     return G
 
+
 def stochastic_block_model(sizes, p, nodelist=None, seed=None,
                            directed=False, selfloops=False, sparse=True):
     """Return a stochastic block model graph.
@@ -559,30 +561,26 @@ def stochastic_block_model(sizes, p, nodelist=None, seed=None,
 
     Examples
     --------
-    >>> from __future__ import division
-    >>> import numpy as np
-    >>> import networkx as nx
-    >>>
     >>> sizes = [75, 75, 300]
     >>> probs = [[0.25, 0.05, 0.02],
     ...          [0.05, 0.35, 0.07],
     ...          [0.02, 0.07, 0.40]]
-    >>> g = nx.stochastic_block_model(sizes, probs)
+    >>> g = nx.stochastic_block_model(sizes, probs, seed=0)
     >>> len(g)
     450
-    >>> H = nx.algorithms.blockmodel(g, g.graph['partition'])
-    >>> for v in H.nodes_iter(data=True):
+    >>> H = nx.quotient_graph(g, g.graph['partition'], relabel=True)
+    >>> for v in H.nodes(data=True):
     ...     print v[1]['density']
     ...
-    0.254414414414
-    0.357477477477
-    0.401672240803
-    >>> for v in H.edges_iter(data=True):
+    0.245045045045
+    0.348108108108
+    0.405105908584
+    >>> for v in H.edges(data=True):
     ...     print v[2]['weight'] / (sizes[v[0]] * sizes[v[1]])
     ...
-    0.0483555555556
-    0.0195555555556
-    0.0728888888889
+    0.0506666666667
+    0.0216
+    0.0699555555556
 
     See Also
     --------
@@ -667,16 +665,16 @@ def stochastic_block_model(sizes, p, nodelist=None, seed=None,
             edges = itertools.product(g.graph['partition'][i],
                                       g.graph['partition'][j])
         if sparse:
-            consume = lambda it, n: next(itertools.islice(it, n, n), None)
-            geo = lambda p: math.floor(math.log(random.random()) / math.log(1 - p))  # noqa
             if p[i][j] == 1:  # Test edges cases p_ij = 0 or 1
                 for e in edges:
                     g.add_edge(*e)
             elif p[i][j] > 0:
                 while True:
                     try:
-                        skip = geo(p[i][j])
-                        consume(edges, skip)
+                        logrand = math.log(random.random())
+                        skip = math.floor(logrand / math.log(1 - p[i][j]))
+                        # consume "skip" edges
+                        next(itertools.islice(edges, skip, skip), None)
                         e = next(edges)
                         g.add_edge(*e)  # __safe
                     except StopIteration:

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -230,7 +230,8 @@ def random_partition_graph(sizes, p_in, p_out, seed=None, directed=False):
         p[r][r] = p_in
 
     return stochastic_block_model(sizes, p, nodelist=None, seed=seed,
-                                  directed=directed, selfloops=False, sparse=True)
+                                  directed=directed, selfloops=False,
+                                  sparse=True)
 
 
 def planted_partition_graph(l, k, p_in, p_out, seed=None, directed=False):
@@ -595,25 +596,23 @@ def stochastic_block_model(sizes, p, nodelist=None, seed=None,
     if seed is not None:
         random.seed(seed)
 
+    parts = g.graph['partition']
     for i, j in block_iter:
         if i == j:
             if directed:
                 if selfloops:
-                    edges = itertools.product(g.graph['partition'][i],
-                                              g.graph['partition'][i])
+                    edges = itertools.product(parts[i], parts[i])
                 else:
-                    edges = itertools.permutations(g.graph['partition'][i], 2)
+                    edges = itertools.permutations(parts[i], 2)
             else:
-                edges = itertools.combinations(g.graph['partition'][i], 2)
+                edges = itertools.combinations(parts[i], 2)
                 if selfloops:
-                    edges = itertools.chain(edges, zip(g.graph['partition'][i],
-                                                       g.graph['partition'][i]))  # noqa
+                    edges = itertools.chain(edges, zip(parts[i], parts[i]))
             for e in edges:
                 if random.random() < p[i][j]:
                     g.add_edge(*e)
         else:
-            edges = itertools.product(g.graph['partition'][i],
-                                      g.graph['partition'][j])
+            edges = itertools.product(parts[i], parts[j])
         if sparse:
             if p[i][j] == 1:  # Test edges cases p_ij = 0 or 1
                 for e in edges:

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -570,13 +570,13 @@ def stochastic_block_model(sizes, p, nodelist=None, seed=None,
     450
     >>> H = nx.quotient_graph(g, g.graph['partition'], relabel=True)
     >>> for v in H.nodes(data=True):
-    ...     print v[1]['density']
+    ...     print(v[1]['density'])
     ...
     0.245045045045
     0.348108108108
     0.405105908584
     >>> for v in H.edges(data=True):
-    ...     print v[2]['weight'] / (sizes[v[0]] * sizes[v[1]])
+    ...     print(v[2]['weight'] / (sizes[v[0]] * sizes[v[1]]))
     ...
     0.0506666666667
     0.0216

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -188,5 +188,7 @@ def test_stochastic_block_model():
     # Extra keyword arguments test
     GG = nx.stochastic_block_model(sizes, probs, seed=0, selfloops=True)
     assert_equal(G.nodes, GG.nodes)
+    GG = nx.stochastic_block_model(sizes, probs, selfloops=True, directed=True)
+    assert_equal(G.nodes, GG.nodes)
     GG = nx.stochastic_block_model(sizes, probs, seed=0, sparse=False)
     assert_equal(G.nodes, GG.nodes)

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -161,20 +161,32 @@ def test_stochastic_block_model():
 
     # Test Exceptions
     sbm = nx.stochastic_block_model
+    badnodelist = list(range(400))  # not enough nodes to match sizes
     badprobs1 = [[0.25, 0.05, 1.02],
                  [0.05, 0.35, 0.07],
                  [0.02, 0.07, 0.40]]
     badprobs2 = [[0.25, 0.05, 0.02],
                  [0.05, -0.35, 0.07],
                  [0.02, 0.07, 0.40]]
-    probs_rect = [[0.25, 0.05, 0.02],
-                  [0.05, -0.35, 0.07]]
+    probs_rect1 = [[0.25, 0.05, 0.02],
+                   [0.05, -0.35, 0.07]]
+    probs_rect2 = [[0.25, 0.05],
+                   [0.05, -0.35],
+                   [0.02, 0.07]]
     asymprobs = [[0.25, 0.05, 0.01],
                  [0.05, -0.35, 0.07],
                  [0.02, 0.07, 0.40]]
     assert_raises(nx.NetworkXException, sbm, sizes, badprobs1)
     assert_raises(nx.NetworkXException, sbm, sizes, badprobs2)
-    assert_raises(nx.NetworkXException, sbm, sizes, probs_rect, directed=True)
+    assert_raises(nx.NetworkXException, sbm, sizes, probs_rect1, directed=True)
+    assert_raises(nx.NetworkXException, sbm, sizes, probs_rect2, directed=True)
     assert_raises(nx.NetworkXException, sbm, sizes, asymprobs, directed=False)
+    assert_raises(nx.NetworkXException, sbm, sizes, probs, badnodelist)
     nodelist = [0] + list(range(449))  # repeated node name in nodelist
     assert_raises(nx.NetworkXException, sbm, sizes, probs, nodelist)
+
+    # Extra keyword arguments test
+    GG = nx.stochastic_block_model(sizes, probs, seed=0, selfloops=True)
+    assert_equal(G.nodes, GG.nodes)
+    GG = nx.stochastic_block_model(sizes, probs, seed=0, sparse=False)
+    assert_equal(G.nodes, GG.nodes)

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -33,10 +33,11 @@ def test_random_partition_graph():
                      set([6, 7, 8, 9]), set([10, 11, 12, 13, 14])])
     assert_equal(len(G), 15)
 
-    assert_raises(nx.NetworkXError, nx.random_partition_graph, [1, 2, 3], 1.1, 0.1)
-    assert_raises(nx.NetworkXError, nx.random_partition_graph, [1, 2, 3], -0.1, 0.1)
-    assert_raises(nx.NetworkXError, nx.random_partition_graph, [1, 2, 3], 0.1, 1.1)
-    assert_raises(nx.NetworkXError, nx.random_partition_graph, [1, 2, 3], 0.1, -0.1)
+    rpg = nx.random_partition_graph
+    assert_raises(nx.NetworkXError, rpg, [1, 2, 3], 1.1, 0.1)
+    assert_raises(nx.NetworkXError, rpg, [1, 2, 3], -0.1, 0.1)
+    assert_raises(nx.NetworkXError, rpg, [1, 2, 3], 0.1, 1.1)
+    assert_raises(nx.NetworkXError, rpg, [1, 2, 3], 0.1, -0.1)
 
 
 def test_planted_partition_graph():
@@ -77,10 +78,11 @@ def test_planted_partition_graph():
     assert_equal(len(G), 40)
     assert_equal(len(list(G.edges())), 218)
 
-    assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3, 1.1, 0.1)
-    assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3, -0.1, 0.1)
-    assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3, 0.1, 1.1)
-    assert_raises(nx.NetworkXError, nx.planted_partition_graph, 3, 3, 0.1, -0.1)
+    ppg = nx.planted_partition_graph
+    assert_raises(nx.NetworkXError, ppg, 3, 3, 1.1, 0.1)
+    assert_raises(nx.NetworkXError, ppg, 3, 3, -0.1, 0.1)
+    assert_raises(nx.NetworkXError, ppg, 3, 3, 0.1, 1.1)
+    assert_raises(nx.NetworkXError, ppg, 3, 3, 0.1, -0.1)
 
 
 def test_relaxed_caveman_graph():
@@ -119,8 +121,8 @@ def test_gaussian_random_partition_graph():
 
 
 def test_ring_of_cliques():
-    for i in range(2, 20):
-        for j in range(2, 20):
+    for i in range(2, 20, 3):
+        for j in range(2, 20, 3):
             G = nx.ring_of_cliques(i, j)
             assert_equal(G.number_of_nodes(), i * j)
             if i != 2 or j != 1:
@@ -134,8 +136,8 @@ def test_ring_of_cliques():
 
 
 def test_windmill_graph():
-    for n in range(2, 20):
-        for k in range(2, 20):
+    for n in range(2, 20, 3):
+        for k in range(2, 20, 3):
             G = nx.windmill_graph(n, k)
             assert_equal(G.number_of_nodes(), (k - 1) * n + 1)
             assert_equal(G.number_of_edges(), n * k * (k - 1) / 2)
@@ -144,3 +146,38 @@ def test_windmill_graph():
                 assert_equal(G.degree(i), k - 1)
     assert_raises(nx.NetworkXError, nx.ring_of_cliques, 1, 3)
     assert_raises(nx.NetworkXError, nx.ring_of_cliques, 15, 0)
+
+
+def test_stochastic_block_model():
+    sizes = [75, 75, 300]
+    probs = [[0.25, 0.05, 0.02],
+             [0.05, 0.35, 0.07],
+             [0.02, 0.07, 0.40]]
+    G = nx.stochastic_block_model(sizes, probs, seed=0)
+    C = G.graph['partition']
+    assert_equal(len(C), 3)
+    assert_equal(len(G), 450)
+    assert_equal(G.size(), 22160)
+
+    GG = nx.stochastic_block_model(sizes, probs, range(450), seed=0)
+    assert_equal(G.nodes, GG.nodes)
+
+    # Test Exceptions
+    sbm = nx.stochastic_block_model
+    badprobs1 = [[0.25, 0.05, 1.02],
+                 [0.05, 0.35, 0.07],
+                 [0.02, 0.07, 0.40]]
+    badprobs2 = [[0.25, 0.05, 0.02],
+                 [0.05, -0.35, 0.07],
+                 [0.02, 0.07, 0.40]]
+    probs_rect = [[0.25, 0.05, 0.02],
+                  [0.05, -0.35, 0.07]]
+    asymprobs = [[0.25, 0.05, 0.01],
+                 [0.05, -0.35, 0.07],
+                 [0.02, 0.07, 0.40]]
+    assert_raises(nx.NetworkXException, sbm, sizes, badprobs1)
+    assert_raises(nx.NetworkXException, sbm, sizes, badprobs2)
+    assert_raises(nx.NetworkXException, sbm, sizes, probs_rect, directed=True)
+    assert_raises(nx.NetworkXException, sbm, sizes, asymprobs, directed=False)
+    nodelist = [0] + list(range(449))  # repeated node name in nodelist
+    assert_raises(nx.NetworkXException, sbm, sizes, probs, nodelist)

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -57,8 +57,6 @@ def test_planted_partition_graph():
     C = G.graph['partition']
     assert_equal(len(C), 10)
     assert_equal(len(G), 40)
-    # number of edges is random, so can't be tested for exact value?
-    # assert_equal(len(list(G.edges())),108)
 
     G = nx.planted_partition_graph(4, 3, 1, 0, directed=True)
     C = G.graph['partition']
@@ -76,7 +74,6 @@ def test_planted_partition_graph():
     C = G.graph['partition']
     assert_equal(len(C), 10)
     assert_equal(len(G), 40)
-    assert_equal(len(list(G.edges())), 218)
 
     ppg = nx.planted_partition_graph
     assert_raises(nx.NetworkXError, ppg, 3, 3, 1.1, 0.1)


### PR DESCRIPTION
This is fairly straightforward PR, I've implemented the classical "binomial" SBM in `generators/community.py`.

There's a sparse switch that will create edges by jumping ahead by a random number of  non-edges,
drawn from a geometric distribution. This is the default. In the dense case, I use a Bernoulli test on each edges.

Note that with this PR,  `random_partition_graph` could be refactored as a call to `stochastic_block_model` (as well as `gnp_random_graph` and other Erdos Renyi type graphs).

