### PR TITLE
Avoid loosing the order of the nodes in subraphs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -117,6 +117,7 @@ is partially historical, and now, mostly arbitrary.
 - Lewis Robbins
 - Mads Jensen, Github: `atombrella <https://github.com/atombrella>`_
 - Edward L. Platt, `elplatt <https://elplatt.com>`_
+- Jonathan Barnoud, `jbarnoud <https://github.com/jbarnoud>`_
 
 Support
 -------

--- a/networkx/classes/filters.py
+++ b/networkx/classes/filters.py
@@ -53,7 +53,15 @@ def hide_multiedges(edges):
 # write show_nodes as a class to make SubGraph pickleable
 class show_nodes(object):
     def __init__(self, nodes):
-        self.nodes = set(nodes)
+        # Remove duplicates in the selection,
+        # but keep the order in case it matters.
+        seen = set()
+        unique_nodes = []
+        for node in nodes:
+            if node not in seen:
+                unique_nodes.append(node)
+                seen.add(node)
+        self.nodes = tuple(unique_nodes)
 
     def __call__(self, node):
         return node in self.nodes

--- a/networkx/classes/tests/test_ordered.py
+++ b/networkx/classes/tests/test_ordered.py
@@ -20,19 +20,22 @@ class SmokeTestOrdered(object):
 class TestOrderedFeatures(object):
     def setUp(self):
         self.G = nx.OrderedDiGraph()
-        self.G.add_nodes_from([1, 2, 3])
+        # The nodes should not be in numerical order, some operations may
+        # sort the keys and expecting them sorted masks this unwanted
+        # behavior.
+        self.G.add_nodes_from([2, 3, 1])
         self.G.add_edges_from([(2, 3), (1, 3)])
 
     def test_subgraph_order(self):
         G = self.G
-        G_sub = G.subgraph([1, 2, 3])
+        G_sub = G.subgraph([2, 3, 1, 3])
         assert_equals(list(G.nodes), list(G_sub.nodes))
         assert_equals(list(G.edges), list(G_sub.edges))
         assert_equals(list(G.pred[3]), list(G_sub.pred[3]))
         assert_equals([2, 1], list(G_sub.pred[3]))
         assert_equals([], list(G_sub.succ[3]))
 
-        G_sub = nx.induced_subgraph(G, [1, 2, 3])
+        G_sub = nx.induced_subgraph(G, [2, 3, 1, 3])
         assert_equals(list(G.nodes), list(G_sub.nodes))
         assert_equals(list(G.edges), list(G_sub.edges))
         assert_equals(list(G.pred[3]), list(G_sub.pred[3]))


### PR DESCRIPTION
* Make sure the tests catch the issue. The order of the nodes was
  already tested for subgraphs of OrderGraph. However, the nodes in the
  reference were sorted integer; as the faulty behavior was happened to
  be sorting the keys, the issue was not reported.
* Fix `classes.filters.show_nodes` to keep the order of the selection.

Fixes #2911