### PR TITLE
Update setup.py related Networkx test Error #2925

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ package_data = {
 
 install_requires = ['decorator>=4.1.0']
 extras_require = {'all': ['numpy', 'scipy', 'pandas', 'matplotlib',
-                          'pygraphviz', 'pydot', 'pyyaml', 'gdal', 'lxml']}
+                          'pygraphviz', 'pydot', 'pyyaml', 'gdal', 'lxml','nose']}
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
When we run 'networkx.test()', we need nose packages.
Turtorial from this web page
https://networkx.github.io/documentation/networkx-1.9.1/test.html.

so I add nose package to extras_require packages