### PR TITLE
Fix compatibility issue with new version of scipy.

### DIFF
--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -108,7 +108,9 @@ def biadjacency_matrix(G, row_order, column_order=None,
                           shape=(nlen, mlen), dtype=dtype)
     try:
         return M.asformat(format)
-    except AttributeError:
+    # From Scipy 1.1.0, asformat will throw a ValueError instead of an
+    # AttributeError if the format if not recognized.
+    except (AttributeError, ValueError):
         raise nx.NetworkXError("Unknown sparse matrix format: %s" % format)
 
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -798,7 +798,9 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
         M = sparse.coo_matrix((d, (r, c)), shape=(nlen, nlen), dtype=dtype)
     try:
         return M.asformat(format)
-    except AttributeError:
+    # From Scipy 1.1.0, asformat will throw a ValueError instead of an
+    # AttributeError if the format if not recognized.
+    except (AttributeError, ValueError):
         raise nx.NetworkXError("Unknown sparse matrix format: %s" % format)
 
 


### PR DESCRIPTION
From Scipy 1.1.0, `asformat` will throw a ValueError instead of an AttributeError if the format if not recognized. For backward compatibility, both are captured now.