### PR TITLE
Allow bipartite configuration model for empty graph

### DIFF
--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -129,7 +129,7 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
 
     G = _add_nodes_with_bipartite_label(G, lena, lenb)
 
-    if max(aseq) == 0:
+    if len(aseq) == 0 or max(aseq) == 0:
         return G  # done if no edges
 
     # build lists of degree-repeated vertex numbers

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -50,6 +50,17 @@ class TestGeneratorsBipartite():
         assert_equal(G.size(), 4)
 
     def test_configuration_model(self):
+        aseq = []
+        bseq = []
+        G = configuration_model(aseq, bseq)
+        assert_equal(len(G), 0)
+
+        aseq = [0, 0]
+        bseq = [0, 0]
+        G = configuration_model(aseq, bseq)
+        assert_equal(len(G), 4)
+        assert_equal(G.number_of_edges(), 0)
+
         aseq = [3, 3, 3, 3]
         bseq = [2, 2, 2, 2, 2]
         assert_raises(networkx.exception.NetworkXError,


### PR DESCRIPTION
Fix a bug when run bipartite configuration model with empty degree sequence.