### PR TITLE
Add bipartite layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -869,7 +869,6 @@ def rescale_layout(pos, scale=1):
         scaled positions. Each row is a position.
 
     """
-    import numpy as np
     # Find max length over all dimensions
     lim = 0  # max coordinate for all axes
     for i in range(pos.shape[1]):

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -29,7 +29,8 @@ from __future__ import division
 import networkx as nx
 from networkx.utils import random_state
 
-__all__ = ['circular_layout',
+__all__ = ['bipartite_layout',
+           'circular_layout',
            'kamada_kawai_layout',
            'random_layout',
            'rescale_layout',
@@ -236,6 +237,92 @@ def shell_layout(G, nlist=None, scale=1, center=None, dim=2):
         radius += 1.0
 
     return npos
+
+
+def bipartite_layout(G, nodes, align='vertical', width=3, height=2):
+    """Position nodes in two straight lines.
+
+    Parameters
+    ----------
+    G : NetworkX graph or list of nodes
+        A position will be assigned to every node in G.
+
+    nodes : list or container
+            Nodes in one node set of the bipartite graph.
+            This set will be placed on left or top.
+
+    align : string (default='vertical')
+            The alignment of nodes. Vertical or horizontal.
+
+    width : number (default=3)
+            The width of the layout, measured by the distance between
+            the leftmost and the rightmost node.
+
+    height : number (default=2)
+             The height of the layout, measured by the distance between
+             the highest and the lowest node.
+
+    Returns
+    -------
+    pos : dict
+        A dictionary of positions keyed by node.
+
+    Examples
+    --------
+    >>> G = nx.bipartite.gnmk_random_graph(3, 5, 10)
+    >>> top = nx.bipartite.sets(G)[0]
+    >>> pos = nx.bipartite_layout(G, top)
+
+    Notes
+    -----
+    This algorithm currently only works in two dimensions and does not
+    try to minimize edge crossings.
+
+    """
+
+    import numpy as np
+
+    G, _ = _process_params(G, center=None, dim=2)
+
+    top = set(nodes)
+    bottom = set(G) - top
+
+    pos = {}
+
+    if align == 'vertical':
+        left_x = 0.0
+        right_x = width
+        left_ys = np.linspace(0, height, len(top))
+        right_ys = np.linspace(0, height, len(bottom))
+
+        top_pos = { node : (left_x, y)
+                    for node, y in zip(top, left_ys) }
+        bottom_pos = { node : (right_x, y)
+                       for node, y in zip(bottom, right_ys) }
+
+        pos.update(top_pos)
+        pos.update(bottom_pos)
+
+        return pos
+
+    if align == 'horizontal':
+        top_y = height
+        bottom_y = 0.0
+        top_xs = np.linspace(0, width, len(top))
+        bottom_xs = np.linspace(0, width, len(bottom))
+
+        top_pos = { node : (x, top_y)
+                    for node, x in zip(top, top_xs) }
+        bottom_pos = { node : (x, bottom_y)
+                       for node, x in zip(bottom, bottom_xs) }
+
+        pos.update(top_pos)
+        pos.update(bottom_pos)
+
+        return pos
+
+    msg = 'align must be either vertical or horizontal.'
+    raise ValueError(msg)
 
 
 @random_state(10)

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -460,11 +460,7 @@ def _fruchterman_reingold(A, k=None, pos=None, fixed=None, iterations=50,
                           threshold=1e-4, dim=2, random_state=None):
     # Position nodes in adjacency matrix A using Fruchterman-Reingold
     # Entry point for NetworkX graph is fruchterman_reingold_layout()
-    try:
-        import numpy as np
-    except ImportError:
-        msg = "_fruchterman_reingold() requires numpy: http://scipy.org/ "
-        raise ImportError(msg)
+    import numpy as np
 
     try:
         nnodes, _ = A.shape
@@ -531,11 +527,8 @@ def _sparse_fruchterman_reingold(A, k=None, pos=None, fixed=None,
     # Position nodes in adjacency matrix A using Fruchterman-Reingold
     # Entry point for NetworkX graph is fruchterman_reingold_layout()
     # Sparse version
-    try:
-        import numpy as np
-    except ImportError:
-        m = "_sparse_fruchterman_reingold() requires numpy: http://scipy.org/"
-        raise ImportError(m)
+    import numpy as np
+
     try:
         nnodes, _ = A.shape
     except AttributeError:
@@ -650,11 +643,7 @@ def kamada_kawai_layout(G, dist=None,
     >>> G = nx.path_graph(4)
     >>> pos = nx.kamada_kawai_layout(G)
     """
-    try:
-        import numpy as np
-    except ImportError:
-        msg = 'Kamada-Kawai layout requires numpy: http://scipy.org'
-        raise ImportError(msg)
+    import numpy as np
 
     G, center = _process_params(G, center, dim)
     nNodes = len(G)
@@ -687,11 +676,7 @@ def _kamada_kawai_solve(dist_mtx, pos_arr, dim):
     # and starting locations.
 
     import numpy as np
-    try:
-        from scipy.optimize import minimize
-    except ImportError:
-        msg = 'Kamada-Kawai layout requires scipy: http://scipy.org'
-        raise ImportError(msg)
+    from scipy.optimize import minimize
 
     meanwt = 1e-3
     costargs = (np, 1 / (dist_mtx + np.eye(dist_mtx.shape[0]) * 1e-3),
@@ -806,11 +791,8 @@ def spectral_layout(G, weight='weight', scale=1, center=None, dim=2):
 def _spectral(A, dim=2):
     # Input adjacency matrix A
     # Uses dense eigenvalue solver from numpy
-    try:
-        import numpy as np
-    except ImportError:
-        msg = "spectral_layout() requires numpy: http://scipy.org/ "
-        raise ImportError(msg)
+    import numpy as np
+
     try:
         nnodes, _ = A.shape
     except AttributeError:
@@ -834,13 +816,10 @@ def _sparse_spectral(A, dim=2):
     # Input adjacency matrix A
     # Uses sparse eigenvalue solver from scipy
     # Could use multilevel methods here, see Koren "On spectral graph drawing"
-    try:
-        import numpy as np
-        from scipy.sparse import spdiags
-        from scipy.sparse.linalg.eigen import eigsh
-    except ImportError:
-        msg = "_sparse_spectral() requires scipy & numpy: http://scipy.org/ "
-        raise ImportError(msg)
+    import numpy as np
+    from scipy.sparse import spdiags
+    from scipy.sparse.linalg.eigen import eigsh
+
     try:
         nnodes, _ = A.shape
     except AttributeError:

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -850,7 +850,7 @@ def rescale_layout(pos, scale=1):
     Each position is one row of the array. The dimension of the space
     equals the number of columns. Each coordinate in one column.
 
-    To rescale, the center is subtracted from each axis separately.
+    To rescale, the mean (center) is subtracted from each axis separately.
     Then all values are scaled so that the largest magnitude value
     from all axes equals `scale` (thus, the aspect ratio is preserved).
     The resulting NumPy Array is returned (order of rows unchanged).
@@ -872,8 +872,7 @@ def rescale_layout(pos, scale=1):
     # Find max length over all dimensions
     lim = 0  # max coordinate for all axes
     for i in range(pos.shape[1]):
-        center = (max(pos[:, i]) + min(pos[:, i])) / 2
-        pos[:, i] -= center
+        pos[:, i] -= pos[:, i].mean()
         lim = max(abs(pos[:, i]).max(), lim)
     # rescale to (-scale, scale) in all directions, preserves aspect
     if lim > 0:

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -47,6 +47,7 @@ class TestLayout(object):
         vpos = nx.fruchterman_reingold_layout(G)
         vpos = nx.spectral_layout(G)
         vpos = nx.shell_layout(G)
+        vpos = nx.bipartite_layout(G, G)
         if self.scipy is not None:
             vpos = nx.kamada_kawai_layout(G)
 
@@ -187,6 +188,8 @@ class TestLayout(object):
         assert_equal(vpos, {})
         vpos = nx.circular_layout(G, center=(1, 1))
         assert_equal(vpos, {})
+        vpos = nx.bipartite_layout(G, G)
+        assert_equal(vpos, {})
         vpos = nx.spring_layout(G, center=(1, 1))
         assert_equal(vpos, {})
         vpos = nx.fruchterman_reingold_layout(G, center=(1, 1))
@@ -195,6 +198,28 @@ class TestLayout(object):
         assert_equal(vpos, {})
         vpos = nx.shell_layout(G, center=(1, 1))
         assert_equal(vpos, {})
+
+    def test_bipartite_layout(self):
+        G = nx.complete_bipartite_graph(3,5)
+        top, bottom = nx.bipartite.sets(G)
+        vpos = nx.bipartite_layout(G, top)
+        assert_equal(len(vpos), len(G))
+        for node in top:
+            assert_equal(vpos[node][0], 0)
+        for node in bottom:
+            assert_equal(vpos[node][0], 3)
+
+        vpos = nx.bipartite_layout(G, top,
+                                   align='horizontal',
+                                   height=5,
+                                   width=3)
+        assert_equal(len(vpos), len(G))
+        for node in top:
+            assert_equal(vpos[node][1], 5)
+        for node in bottom:
+            assert_equal(vpos[node][1], 0)
+
+        assert_raises(ValueError, nx.bipartite_layout, G, top, align='foo')
 
     def test_kamada_kawai_costfn_1d(self):
         costfn = nx.drawing.layout._kamada_kawai_costfn

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -202,12 +202,16 @@ class TestLayout(object):
     def test_bipartite_layout(self):
         G = nx.complete_bipartite_graph(3,5)
         top, bottom = nx.bipartite.sets(G)
+
         vpos = nx.bipartite_layout(G, top)
         assert_equal(len(vpos), len(G))
+
+        top_x = vpos[list(top)[0]][0]
+        bottom_x = vpos[list(bottom)[0]][0]
         for node in top:
-            assert_equal(vpos[node][0], -1)
+            assert_equal(vpos[node][0], top_x)
         for node in bottom:
-            assert_equal(vpos[node][0], 1)
+            assert_equal(vpos[node][0], bottom_x)
 
         vpos = nx.bipartite_layout(G, top,
                                    align='horizontal',
@@ -215,10 +219,13 @@ class TestLayout(object):
                                    scale=2,
                                    aspect_ratio=1)
         assert_equal(len(vpos), len(G))
+
+        top_y = vpos[list(top)[0]][1]
+        bottom_y = vpos[list(bottom)[0]][1]
         for node in top:
-            assert_equal(vpos[node][1], 4)
+            assert_equal(vpos[node][1], top_y)
         for node in bottom:
-            assert_equal(vpos[node][1], 0)
+            assert_equal(vpos[node][1], bottom_y)
 
         assert_raises(ValueError, nx.bipartite_layout, G, top, align='foo')
 

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -205,17 +205,18 @@ class TestLayout(object):
         vpos = nx.bipartite_layout(G, top)
         assert_equal(len(vpos), len(G))
         for node in top:
-            assert_equal(vpos[node][0], 0)
+            assert_equal(vpos[node][0], -1)
         for node in bottom:
-            assert_equal(vpos[node][0], 3)
+            assert_equal(vpos[node][0], 1)
 
         vpos = nx.bipartite_layout(G, top,
                                    align='horizontal',
-                                   height=5,
-                                   width=3)
+                                   center=(2,2),
+                                   scale=2,
+                                   aspect_ratio=1)
         assert_equal(len(vpos), len(G))
         for node in top:
-            assert_equal(vpos[node][1], 5)
+            assert_equal(vpos[node][1], 4)
         for node in bottom:
             assert_equal(vpos[node][1], 0)
 


### PR DESCRIPTION
Add a simple layout for bipartite graph.

I also noticed that all the functions in layout.py used numpy but some checked if numpy is installed while others didn't. Shall we make them more consistent? Personally I don't think checking and raise a new error is necessary. If we remove all the checks we can bring up the code coverage a bit as well.