### PR TITLE
Remove circular references between graphs and views.

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -21,6 +21,8 @@ X contributors. Highlights include:
 Improvements
 ------------
 
+Cyclic references between graph classes and views have been removed to ease
+subclassing without memory leaks. Graphs no longer hold references to view.
 
 API Changes
 -----------

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -243,25 +243,6 @@ class DiGraph(Graph):
     a dictionary-like object.
     """
 
-    def __getstate__(self):
-        attr = self.__dict__.copy()
-        # remove lazy property attributes
-        if 'nodes' in attr:
-            del attr['nodes']
-        if 'edges' in attr:
-            del attr['edges']
-        if 'out_edges' in attr:
-            del attr['out_edges']
-        if 'in_edges' in attr:
-            del attr['in_edges']
-        if 'degree' in attr:
-            del attr['degree']
-        if 'in_degree' in attr:
-            del attr['in_degree']
-        if 'out_degree' in attr:
-            del attr['out_degree']
-        return attr
-
     def __init__(self, incoming_graph_data=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 
@@ -853,9 +834,7 @@ class DiGraph(Graph):
         OutEdgeDataView([(0, 1)])
 
         """
-        self.__dict__['edges'] = edges = OutEdgeView(self)
-        self.__dict__['out_edges'] = edges
-        return edges
+        return OutEdgeView(self)
 
     # alias out_edges to edges
     out_edges = edges
@@ -889,8 +868,7 @@ class DiGraph(Graph):
         --------
         edges
         """
-        self.__dict__['in_edges'] = in_edges = InEdgeView(self)
-        return in_edges
+        return InEdgeView(self)
 
     @property
     def degree(self):
@@ -937,8 +915,7 @@ class DiGraph(Graph):
         [(0, 1), (1, 2), (2, 2)]
 
         """
-        self.__dict__['degree'] = degree = DiDegreeView(self)
-        return degree
+        return DiDegreeView(self)
 
     @property
     def in_degree(self):
@@ -985,8 +962,7 @@ class DiGraph(Graph):
         [(0, 0), (1, 1), (2, 1)]
 
         """
-        self.__dict__['in_degree'] = in_degree = InDegreeView(self)
-        return in_degree
+        return InDegreeView(self)
 
     @property
     def out_degree(self):
@@ -1033,8 +1009,7 @@ class DiGraph(Graph):
         [(0, 1), (1, 1), (2, 1)]
 
         """
-        self.__dict__['out_degree'] = out_degree = OutDegreeView(self)
-        return out_degree
+        return OutDegreeView(self)
 
     def clear(self):
         """Remove all nodes and edges from the graph.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -256,17 +256,6 @@ class Graph(object):
     adjlist_inner_dict_factory = dict
     edge_attr_dict_factory = dict
 
-    def __getstate__(self):
-        attr = self.__dict__.copy()
-        # remove lazy property attributes
-        if 'nodes' in attr:
-            del attr['nodes']
-        if 'edges' in attr:
-            del attr['edges']
-        if 'degree' in attr:
-            del attr['degree']
-        return attr
-
     def __init__(self, incoming_graph_data=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 
@@ -1184,8 +1173,7 @@ class Graph(object):
         >>> G.edges(0)  # only edges incident to a single node (use G.adj[0]?)
         EdgeDataView([(0, 1)])
         """
-        self.__dict__['edges'] = edges = EdgeView(self)
-        return edges
+        return EdgeView(self)
 
     def get_edge_data(self, u, v, default=None):
         """Return the attribute dictionary associated with edge (u, v).
@@ -1291,8 +1279,7 @@ class Graph(object):
         >>> list(G.degree([0, 1, 2]))
         [(0, 1), (1, 2), (2, 2)]
         """
-        self.__dict__['degree'] = degree = DegreeView(self)
-        return degree
+        return DegreeView(self)
 
     def clear(self):
         """Remove all nodes and edges from the graph.

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -566,9 +566,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         --------
         in_edges, out_edges
         """
-        self.__dict__['edges'] = edges = OutMultiEdgeView(self)
-        self.__dict__['out_edges'] = edges
-        return edges
+        return OutMultiEdgeView(self)
 
     # alias out_edges to edges
     out_edges = edges
@@ -604,8 +602,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         --------
         edges
         """
-        self.__dict__['in_edges'] = in_edges = InMultiEdgeView(self)
-        return in_edges
+        return InMultiEdgeView(self)
 
     @property
     def degree(self):
@@ -652,8 +649,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         [(0, 1), (1, 2), (2, 2)]
 
         """
-        self.__dict__['degree'] = degree = DiMultiDegreeView(self)
-        return degree
+        return DiMultiDegreeView(self)
 
     @property
     def in_degree(self):
@@ -700,8 +696,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         [(0, 0), (1, 1), (2, 1)]
 
         """
-        self.__dict__['in_degree'] = in_degree = InMultiDegreeView(self)
-        return in_degree
+        return InMultiDegreeView(self)
 
     @property
     def out_degree(self):
@@ -747,8 +742,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         [(0, 1), (1, 1), (2, 1)]
 
         """
-        self.__dict__['out_degree'] = out_degree = OutMultiDegreeView(self)
-        return out_degree
+        return OutMultiDegreeView(self)
 
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -730,8 +730,7 @@ class MultiGraph(Graph):
         >>> G.edges(0)
         MultiEdgeDataView([(0, 1)])
         """
-        self.__dict__['edges'] = edges = MultiEdgeView(self)
-        return edges
+        return MultiEdgeView(self)
 
     def get_edge_data(self, u, v, key=None, default=None):
         """Return the attribute dictionary associated with edge (u, v).
@@ -836,8 +835,7 @@ class MultiGraph(Graph):
         [(0, 1), (1, 2)]
 
         """
-        self.__dict__['degree'] = degree = MultiDegreeView(self)
-        return degree
+        return MultiDegreeView(self)
 
     def is_multigraph(self):
         """Return True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -17,6 +17,9 @@ class TestAtlasView(object):
         pview = pickle.loads(pickle.dumps(view, -1))
         assert_equal(view, pview)
         assert_equal(view.__slots__, pview.__slots__)
+        pview = pickle.loads(pickle.dumps(view))
+        assert_equal(view, pview)
+        assert_equal(view.__slots__, pview.__slots__)
 
     def test_len(self):
         assert_equal(len(self.av), len(self.d))

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -3,6 +3,7 @@ from nose.tools import assert_is
 from nose.tools import assert_not_equal
 from nose.tools import assert_raises
 from nose.tools import raises
+import pickle
 
 import networkx as nx
 from networkx.testing.utils import *
@@ -468,6 +469,13 @@ class TestGraph(BaseAttrGraphTester):
         self.K3._node[0] = {}
         self.K3._node[1] = {}
         self.K3._node[2] = {}
+
+    def test_pickle(self):
+        G = self.K3
+        pg = pickle.loads(pickle.dumps(G, -1))
+        self.graphs_equal(pg, G)
+        pg = pickle.loads(pickle.dumps(G))
+        self.graphs_equal(pg, G)
 
     def test_data_input(self):
         G = self.Graph({1: [2], 2: [1]}, name="test")


### PR DESCRIPTION
Graphs no longer have references to views.
Views still have references to the graph.
This should ease subclassing the base graph classes
because you don't have to worry about creating memory leaks.

Fixes #2915