### PR TITLE
speedup of filters for induced subgraph

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -289,7 +289,11 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         return sum(1 for n in self)
 
     def __iter__(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 
@@ -299,7 +303,11 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         raise KeyError("Key {} not found".format(key))
 
     def copy(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return {u: self._atlas[u] for u in self.NODE_OK.nodes
                     if u in self._atlas}
         return {u: d for u, d in self._atlas.items()
@@ -323,7 +331,11 @@ class FilterAdjacency(Mapping):   # edgedict
         return sum(1 for n in self)
 
     def __iter__(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 
@@ -335,7 +347,11 @@ class FilterAdjacency(Mapping):   # edgedict
         raise KeyError("Key {} not found".format(node))
 
     def copy(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return {u: {v: d for v, d in self._atlas[u].items()
                         if self.NODE_OK(v) if self.EDGE_OK(u, v)}
                     for u in self.NODE_OK.nodes if u in self._atlas}
@@ -354,7 +370,11 @@ class FilterAdjacency(Mapping):   # edgedict
 
 class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
     def __iter__(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             my_nodes = (n for n in self.NODE_OK.nodes if n in self._atlas)
         else:
             my_nodes = (n for n in self._atlas if self.NODE_OK(n))
@@ -375,7 +395,11 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
         raise KeyError("Key {} not found".format(nbr))
 
     def copy(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return {v: {k: d for k, d in self._atlas[v].items()
                         if self.EDGE_OK(v, k)}
                     for v in self.NODE_OK.nodes if v in self._atlas}
@@ -392,7 +416,11 @@ class FilterMultiAdjacency(FilterAdjacency):  # multiedgedict
         raise KeyError("Key {} not found".format(node))
 
     def copy(self):
-        if hasattr(self.NODE_OK, 'nodes'):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             my_nodes = self.NODE_OK.nodes
             return {u: {v: {k: d for k, d in kd.items()
                             if self.EDGE_OK(u, v, k)}

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1243,6 +1243,26 @@ class DiGraph(Graph):
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nodes)])
 
+        Subgraph views are sometimes NOT what you want. In most cases where
+        you want to do more than simply look at the induced edges, it makes
+        more sense to just create the subgraph as its own graph with code like:
+
+        ::
+
+            # Create a subgraph SG based on a (possibly multigraph) G
+            SG = G.fresh_copy()
+            SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
+            if SG.is_multigraph:
+                SG.add_edges_from((n, nbr, key, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, keydict in nbrs.items() if nbr in largest_wcc
+                    for key, d in keydict.items())
+            else:
+                SG.add_edges_from((n, nbr, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, d in nbrs.items() if nbr in largest_wcc)
+            SG.graph.update(G.graph)
+
         Examples
         --------
         >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1551,19 +1551,21 @@ class Graph(object):
         you want to do more than simply look at the induced edges, it makes
         more sense to just create the subgraph as its own graph with code like:
 
-        # Create a subgraph SG based on a (possibly multigraph) G
-        SG = G.fresh_copy()
-        SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
-        if SG.is_multigraph:
-            SG.add_edges_from((n, nbr, key, d)
-                for n, nbrs in G.adj.items() if n in largest_wcc
-                for nbr, keydict in nbrs.items() if nbr in largest_wcc
-                for key, d in keydict.items())
-        else:
-            SG.add_edges_from((n, nbr, d)
-                for n, nbrs in G.adj.items() if n in largest_wcc
-                for nbr, d in nbrs.items() if nbr in largest_wcc)
-        SG.graph.update(G.graph)
+        ::
+
+            # Create a subgraph SG based on a (possibly multigraph) G
+            SG = G.fresh_copy()
+            SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
+            if SG.is_multigraph:
+                SG.add_edges_from((n, nbr, key, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, keydict in nbrs.items() if nbr in largest_wcc
+                    for key, d in keydict.items())
+            else:
+                SG.add_edges_from((n, nbr, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, d in nbrs.items() if nbr in largest_wcc)
+            SG.graph.update(G.graph)
 
         Examples
         --------

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1547,6 +1547,24 @@ class Graph(object):
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nodes)])
 
+        Subgraph views are sometimes NOT what you want. In most cases where
+        you want to do more than simply look at the induced edges, it makes
+        more sense to just create the subgraph as its own graph with code like:
+
+        # Create a subgraph SG based on a (possibly multigraph) G
+        SG = G.fresh_copy()
+        SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
+        if SG.is_multigraph:
+            SG.add_edges_from((n, nbr, key, d)
+                for n, nbrs in G.adj.items() if n in largest_wcc
+                for nbr, keydict in nbrs.items() if nbr in largest_wcc
+                for key, d in keydict.items())
+        else:
+            SG.add_edges_from((n, nbr, d)
+                for n, nbrs in G.adj.items() if n in largest_wcc
+                for nbr, d in nbrs.items() if nbr in largest_wcc)
+        SG.graph.update(G.graph)
+
         Examples
         --------
         >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -955,6 +955,26 @@ class MultiDiGraph(MultiGraph, DiGraph):
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nodes)])
 
+        Subgraph views are sometimes NOT what you want. In most cases where
+        you want to do more than simply look at the induced edges, it makes
+        more sense to just create the subgraph as its own graph with code like:
+
+        ::
+
+            # Create a subgraph SG based on a (possibly multigraph) G
+            SG = G.fresh_copy()
+            SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
+            if SG.is_multigraph:
+                SG.add_edges_from((n, nbr, key, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, keydict in nbrs.items() if nbr in largest_wcc
+                    for key, d in keydict.items())
+            else:
+                SG.add_edges_from((n, nbr, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, d in nbrs.items() if nbr in largest_wcc)
+            SG.graph.update(G.graph)
+
         Examples
         --------
         >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -1083,6 +1083,26 @@ class MultiGraph(Graph):
         For an inplace reduction of a graph to a subgraph you can remove nodes:
         G.remove_nodes_from([n for n in G if n not in set(nodes)])
 
+        Subgraph views are sometimes NOT what you want. In most cases where
+        you want to do more than simply look at the induced edges, it makes
+        more sense to just create the subgraph as its own graph with code like:
+
+        ::
+
+            # Create a subgraph SG based on a (possibly multigraph) G
+            SG = G.fresh_copy()
+            SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
+            if SG.is_multigraph:
+                SG.add_edges_from((n, nbr, key, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, keydict in nbrs.items() if nbr in largest_wcc
+                    for key, d in keydict.items())
+            else:
+                SG.add_edges_from((n, nbr, d)
+                    for n, nbrs in G.adj.items() if n in largest_wcc
+                    for nbr, d in nbrs.items() if nbr in largest_wcc)
+            SG.graph.update(G.graph)
+
         Examples
         --------
         >>> G = nx.Graph()   # or DiGraph, MultiGraph, MultiDiGraph, etc

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -312,3 +312,53 @@ class TestUnionMultiAdjacency(TestUnionAdjacency):
 
         assert_false(hasattr(self.adjview, '__setitem__'))
         assert_true(hasattr(avcopy, '__setitem__'))
+
+
+class TestFilteredGraphs(object):
+    def setup(self):
+        self.Graphs = [nx.Graph,
+                       nx.DiGraph,
+                       nx.MultiGraph,
+                       nx.MultiDiGraph]
+        self.SubGraphs = [nx.graphviews.SubGraph,
+                          nx.graphviews.SubDiGraph,
+                          nx.graphviews.SubMultiGraph,
+                          nx.graphviews.SubMultiDiGraph]
+
+    def test_hide_show_nodes(self):
+        for Graph, SubGraph in zip(self.Graphs, self.SubGraphs):
+            G = nx.path_graph(4, Graph)
+            SG = G.subgraph([2, 3])
+            RG = SubGraph(G, nx.filters.hide_nodes([0, 1]))
+            assert_equal(SG.nodes, RG.nodes)
+            assert_equal(SG.edges, RG.edges)
+            SGC = SG.copy()
+            RGC = RG.copy()
+            assert_equal(SGC.nodes, RGC.nodes)
+            assert_equal(SGC.edges, RGC.edges)
+
+    def test_str_repr(self):
+        for Graph, SubGraph in zip(self.Graphs, self.SubGraphs):
+            G = nx.path_graph(4, Graph)
+            SG = G.subgraph([2, 3])
+            RG = SubGraph(G, nx.filters.hide_nodes([0, 1]))
+            str(SG.adj)
+            str(RG.adj)
+            repr(SG.adj)
+            repr(RG.adj)
+            str(SG.adj[2])
+            str(RG.adj[2])
+            repr(SG.adj[2])
+            repr(RG.adj[2])
+
+    def test_copy(self):
+        for Graph, SubGraph in zip(self.Graphs, self.SubGraphs):
+            G = nx.path_graph(4, Graph)
+            SG = G.subgraph([2, 3])
+            RG = SubGraph(G, nx.filters.hide_nodes([0, 1]))
+            assert_equal(G.adj.copy(), G.adj)
+            assert_equal(G.adj[2].copy(), G.adj[2])
+            assert_equal(SG.adj.copy(), SG.adj)
+            assert_equal(SG.adj[2].copy(), SG.adj[2])
+            assert_equal(RG.adj.copy(), RG.adj)
+            assert_equal(RG.adj[2].copy(), RG.adj[2])


### PR DESCRIPTION
Check if induced node set is big or small to determine lookup method.
Also add subgraph docs to warn that building the subgraph from scratch
may be better and give alternate code to use for this.

Fixes #2887 
@gboeing :  This should help speed up the case when most nodes are in the subgraph.