### PR TITLE
Add base class method `update`

### DIFF
--- a/doc/reference/classes/digraph.rst
+++ b/doc/reference/classes/digraph.rst
@@ -28,6 +28,7 @@ Adding and removing nodes and edges
    DiGraph.add_weighted_edges_from
    DiGraph.remove_edge
    DiGraph.remove_edges_from
+   DiGraph.update
    DiGraph.clear
 
 

--- a/doc/reference/classes/graph.rst
+++ b/doc/reference/classes/graph.rst
@@ -28,6 +28,7 @@ Adding and removing nodes and edges
    Graph.add_weighted_edges_from
    Graph.remove_edge
    Graph.remove_edges_from
+   Graph.update
    Graph.clear
 
 

--- a/doc/reference/classes/multidigraph.rst
+++ b/doc/reference/classes/multidigraph.rst
@@ -30,6 +30,7 @@ Adding and Removing Nodes and Edges
    MultiDiGraph.new_edge_key
    MultiDiGraph.remove_edge
    MultiDiGraph.remove_edges_from
+   MultiDiGraph.update
    MultiDiGraph.clear
 
 

--- a/doc/reference/classes/multigraph.rst
+++ b/doc/reference/classes/multigraph.rst
@@ -29,6 +29,7 @@ Adding and removing nodes and edges
    MultiGraph.new_edge_key
    MultiGraph.remove_edge
    MultiGraph.remove_edges_from
+   MultiGraph.update
    MultiGraph.clear
 
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -33,8 +33,15 @@ empty_graph has taken over the functionality from
 nx.convert._prep_create_using which was removed.
 
 create_using should now be a Graph Constructor like nx.Graph or nx.DiGraph.
-It can still be a graph class which will be cleared before use, but the
+It can still be a graph instance which will be cleared before use, but the
 preferred use is a constructor.
+
+New Base Class Method: update
+H.update(G) adds the nodes, edges and graph attributes of G to H.
+H.update(edges=e, nodes=n) add the edges and nodes from containers e and n.
+H.update(e), and H.update(nodes=n) are also allowed.
+First argument is a graph if it has `edges` and `nodes` attributes.
+Otherwise the first argument is treated as a list of edges.
 
 Deprecations
 ------------


### PR DESCRIPTION
Second part of #1393 : adding an update() method to the base classes.
Input parameters can be a graph or containers of edges and/or nodes.

As written this new method returns None like the `dict.update`.  Perhaps it should return the graph? That would allow `G.update(G1).update(G2).edges()` which some might think is/isn't a good thing.

I decided to exclude adjacency inputs for the update method because there are so many variations.
I include examples in the docstring for adjacency inputs.