### PR TITLE
TravisCI fix

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -470,6 +470,11 @@ def connected_watts_strogatz_graph(n, k, p, tries=100, seed=None):
     newman_watts_strogatz_graph()
     watts_strogatz_graph()
 
+    References
+    ----------
+    .. [1] Duncan J. Watts and Steven H. Strogatz,
+       Collective dynamics of small-world networks,
+       Nature, 393, pp. 440--442, 1998.
     """
     for i in range(tries):
         G = watts_strogatz_graph(n, k, p, seed)

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -4,6 +4,6 @@ pandas>=0.20.1
 matplotlib>=2.0.2
 pygraphviz>=1.3.1
 pydot>=1.2.3
-pyyaml>=3.12
+pyyaml==3.12
 gdal==1.10.0
 lxml>=3.7.3

--- a/tools/travis/build_docs.sh
+++ b/tools/travis/build_docs.sh
@@ -3,6 +3,7 @@
 set -e
 
 pip install --retries 3 -q -r requirements/doc.txt
+pip list
 export SPHINXCACHE=$HOME/.cache/sphinx
 cd doc
 make html


### PR DESCRIPTION
Fixes #3030.

I couldn't reproduce the nbconvert / libpng error.  But it looks like it may no longer be a problem.

However, a couple of days ago pyyaml 4.1 was released and it is breaking things.  I am going to merge this now, so that there is less ci noise.  I will look into the 4.1 issue soon.