### PR TITLE
Expand read/write_Graphml numeric type to support numpy numeric types

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -27,6 +27,11 @@ subclassing without memory leaks. Graphs no longer hold references to view.
 Cyclic references between a graph and itself have been removed by eliminating
 G.root_graph. It turns out this was an avoidable construct anyway.
 
+GraphML can now be written with attributes using numpy numeric types.
+In particular, np.float64 and np.int64 no longer need to convert to Python
+float and int to be written. They are still written as generic floats so
+reading them back in will not make the numpy values.
+
 API Changes
 -----------
 empty_graph has taken over the functionality from

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -334,6 +334,23 @@ class GraphML(object):
              (float, "float"), (float, "double"),
              (bool, "boolean")]
 
+    # These additions to types allow writing numpy types
+    try:
+        import numpy as np
+    except:
+        pass
+    else:
+        # prepend so that python types are created upon read (last entry wins)
+        types = [(np.float64, "float"), (np.float32, "float"),
+                 (np.float16, "float"), (np.float_, "float"),
+                 (np.int, "int"), (np.int8, "int"),
+                 (np.int16, "int"), (np.int32, "int"),
+                 (np.int64, "int"), (np.uint8, "int"),
+                 (np.uint16, "int"), (np.uint32, "int"),
+                 (np.uint64, "int"), (np.int_, "int"),
+                 (np.intc, "int"), (np.intp, "int"),
+                ] + types
+
     xml_type = dict(types)
     python_type = dict(reversed(a) for a in types)
 

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -960,8 +960,8 @@ class TestWriteGraphML(BaseGraphML):
         wtG = G[1][2]['weight']
         wtH = H[1][2]['weight']
         assert_almost_equal(wtG, wtH, places=6)
-        assert_equal(type(wtG), np.float32)
-        assert_equal(type(wtH), np.float32)
+        assert_equal(type(wtG), np.float64)
+        assert_equal(type(wtH), float)
         os.close(fd)
         os.unlink(fname)
 
@@ -980,7 +980,7 @@ class TestWriteGraphML(BaseGraphML):
         wtH = H[1][2]['weight']
         assert_almost_equal(wtG, wtH, places=6)
         assert_equal(type(wtG), np.float32)
-        assert_equal(type(wtH), np.float32)
+        assert_equal(type(wtH), float)
         os.close(fd)
         os.unlink(fname)
 

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -932,6 +932,58 @@ class TestWriteGraphML(BaseGraphML):
         os.close(fd)
         os.unlink(fname)
 
+    def test_numpy_float(self):
+        try:
+            import numpy as np
+        except:
+            return
+        wt = np.float(3.4)
+        G = nx.Graph([(1, 2, {'weight': wt})])
+        fd, fname = tempfile.mkstemp()
+        self.writer(G, fname)
+        H = nx.read_graphml(fname, node_type=int)
+        assert_equal(G._adj, H._adj)
+        os.close(fd)
+        os.unlink(fname)
+
+    def test_numpy_float64(self):
+        try:
+            import numpy as np
+        except:
+            return
+        wt = np.float64(3.4)
+        G = nx.Graph([(1, 2, {'weight': wt})])
+        fd, fname = tempfile.mkstemp()
+        self.writer(G, fname)
+        H = nx.read_graphml(fname, node_type=int)
+        assert_equal(G.edges, H.edges)
+        wtG = G[1][2]['weight']
+        wtH = H[1][2]['weight']
+        assert_almost_equal(wtG, wtH, places=6)
+        assert_equal(type(wtG), np.float32)
+        assert_equal(type(wtH), np.float32)
+        os.close(fd)
+        os.unlink(fname)
+
+    def test_numpy_float32(self):
+        try:
+            import numpy as np
+        except:
+            return
+        wt = np.float32(3.4)
+        G = nx.Graph([(1, 2, {'weight': wt})])
+        fd, fname = tempfile.mkstemp()
+        self.writer(G, fname)
+        H = nx.read_graphml(fname, node_type=int)
+        assert_equal(G.edges, H.edges)
+        wtG = G[1][2]['weight']
+        wtH = H[1][2]['weight']
+        assert_almost_equal(wtG, wtH, places=6)
+        assert_equal(type(wtG), np.float32)
+        assert_equal(type(wtH), np.float32)
+        os.close(fd)
+        os.unlink(fname)
+
     def test_unicode_attributes(self):
         G = nx.Graph()
         try:  # Python 3.x


### PR DESCRIPTION
Fixes #1556 