### PR TITLE
Fix graph_clique_number for clique-less graphs

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -423,7 +423,9 @@ def graph_clique_number(G, cliques=None):
     """
     if cliques is None:
         cliques = find_cliques(G)
-    return max([len(c) for c in cliques])
+    if len(G.nodes) < 1:
+        return 0
+    return max([len(c) for c in cliques] or [1])
 
 
 def graph_number_of_cliques(G, cliques=None):

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -40,6 +40,15 @@ class TestCliques:
         assert_equal(nx.graph_clique_number(G), 4)
         assert_equal(nx.graph_clique_number(G, cliques=self.cl), 4)
 
+    def test_clique_number2(self):
+        G = nx.Graph()
+        G.add_nodes_from([1, 2, 3])
+        assert_equal(nx.graph_clique_number(G), 1)
+
+    def test_clique_number3(self):
+        G = nx.Graph()
+        assert_equal(nx.graph_clique_number(G), 0)
+
     def test_number_of_cliques(self):
         G = self.G
         assert_equal(nx.graph_number_of_cliques(G), 5)


### PR DESCRIPTION
- empty graphs return 0
- graphs with at least one vertex and no cliques return 1

- add test cases for each

fixes https://github.com/networkx/networkx/issues/3050