### PR TITLE
Bugfix for issue 3065

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -130,6 +130,7 @@ def circular_layout(G, scale=1, center=None, dim=2):
         Dimension of layout.
         If dim>2, the remaining dimensions are set to zero
         in the returned positions.
+        If dim<2, a ValueError is raised.
 
     Returns
     -------

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -674,7 +674,7 @@ def kamada_kawai_layout(G, dist=None,
     if pos is None and dim >= 2:
         pos = circular_layout(G, dim=dim)
     elif pos is None:
-        pos = {n: pt for n,pt in zip(G, np.linspace(0, 1, len(G)))}
+        pos = {n: pt for n, pt in zip(G, np.linspace(0, 1, len(G)))}
     pos_arr = np.array([pos[n] for n in G])
 
     pos = _kamada_kawai_solve(dist_mtx, pos_arr, dim)

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -629,7 +629,7 @@ def kamada_kawai_layout(G, dist=None,
     pos : dict or None  optional (default=None)
         Initial positions for nodes as a dictionary with node as keys
         and values as a coordinate list or tuple.  If None, then use
-        circular_layout().
+        circular_layout() for dim > 2 and a linear layout for dim == 1.
 
     weight : string or None   optional (default='weight')
         The edge attribute that holds the numerical value used for
@@ -671,8 +671,10 @@ def kamada_kawai_layout(G, dist=None,
                 continue
             dist_mtx[row][col] = rdist[nc]
 
-    if pos is None:
+    if pos is None and dim >= 2:
         pos = circular_layout(G, dim=dim)
+    elif pos is None:
+        pos = {n: pt for n,pt in zip(G, np.linspace(0, 1, len(G)))}
     pos_arr = np.array([pos[n] for n in G])
 
     pos = _kamada_kawai_solve(dist_mtx, pos_arr, dim)

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -136,6 +136,11 @@ def circular_layout(G, scale=1, center=None, dim=2):
     pos : dict
         A dictionary of positions keyed by node
 
+    Raises
+    -------
+    ValueError
+        If dim < 2
+
     Examples
     --------
     >>> G = nx.path_graph(4)
@@ -148,6 +153,9 @@ def circular_layout(G, scale=1, center=None, dim=2):
 
     """
     import numpy as np
+
+    if dim < 2:
+        raise ValueError('cannot handle dimensions < 2')
 
     G, center = _process_params(G, center, dim)
 

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -629,7 +629,7 @@ def kamada_kawai_layout(G, dist=None,
     pos : dict or None  optional (default=None)
         Initial positions for nodes as a dictionary with node as keys
         and values as a coordinate list or tuple.  If None, then use
-        circular_layout() for dim > 2 and a linear layout for dim == 1.
+        circular_layout() for dim >= 2 and a linear layout for dim == 1.
 
     weight : string or None   optional (default='weight')
         The edge attribute that holds the numerical value used for

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -671,10 +671,11 @@ def kamada_kawai_layout(G, dist=None,
                 continue
             dist_mtx[row][col] = rdist[nc]
 
-    if pos is None and dim >= 2:
-        pos = circular_layout(G, dim=dim)
-    elif pos is None:
-        pos = {n: pt for n, pt in zip(G, np.linspace(0, 1, len(G)))}
+    if pos is None:
+        if dim >= 2:
+            pos = circular_layout(G, dim=dim)
+        else:
+            pos = {n: pt for n, pt in zip(G, np.linspace(0, 1, len(G)))}
     pos_arr = np.array([pos[n] for n in G])
 
     pos = _kamada_kawai_solve(dist_mtx, pos_arr, dim)

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -197,11 +197,17 @@ def shell_layout(G, nlist=None, scale=1, center=None, dim=2):
 
     dim : int
         Dimension of layout, currently only dim=2 is supported.
+        Other dimension values result in a ValueError.
 
     Returns
     -------
     pos : dict
         A dictionary of positions keyed by node
+
+    Raises
+    -------
+    ValueError
+        If dim != 2
 
     Examples
     --------
@@ -216,6 +222,9 @@ def shell_layout(G, nlist=None, scale=1, center=None, dim=2):
 
     """
     import numpy as np
+
+    if dim != 2:
+        raise ValueError('can only handle 2 dimensions')
 
     G, center = _process_params(G, center, dim)
 

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -116,9 +116,11 @@ class TestLayout(object):
         if self.scipy is not None:
             sc(nx.kamada_kawai_layout(G), scale=1, center=c)
 
-    def test_circular_dim_error(self):
+    def test_circular_and_shell_dim_error(self):
         G = nx.path_graph(4)
         assert_raises(ValueError, nx.circular_layout, G, dim=1)
+        assert_raises(ValueError, nx.shell_layout, G, dim=1)
+        assert_raises(ValueError, nx.shell_layout, G, dim=3)
 
     def test_adjacency_interface_numpy(self):
         A = nx.to_numpy_matrix(self.Gs)

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -114,6 +114,10 @@ class TestLayout(object):
         if self.scipy is not None:
             sc(nx.kamada_kawai_layout(G), scale=1, center=c)
 
+    def test_circular_dim_error(self):
+        G = nx.path_graph(4)
+        assert_raises(ValueError, nx.circular_layout, G, dim=1)
+
     def test_adjacency_interface_numpy(self):
         A = nx.to_numpy_matrix(self.Gs)
         pos = nx.drawing.layout._fruchterman_reingold(A)

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -65,6 +65,7 @@ class TestLayout(object):
         vpos = nx.shell_layout(G)
         if self.scipy is not None:
             vpos = nx.kamada_kawai_layout(G)
+            vpos = nx.kamada_kawai_layout(G, dim=1)
 
     def test_smoke_string(self):
         G = self.Gs
@@ -76,6 +77,7 @@ class TestLayout(object):
         vpos = nx.shell_layout(G)
         if self.scipy is not None:
             vpos = nx.kamada_kawai_layout(G)
+            vpos = nx.kamada_kawai_layout(G, dim=1)
 
     def check_scale_and_center(self, pos, scale, center):
         center = numpy.array(center)


### PR DESCRIPTION
Fix #3065 

`circular_layout()` now raises an exception when `dim < 2`.

Also, `kamada_kawai_layout()` now uses a uniformly-spaced linear layout when `dim < 2` and `pos` hasn't been specified, rather than passing a bad parameter value to `circular_layout()`.