### PR TITLE
add binary mode to open_file for view_pygraphviz.

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -301,7 +301,7 @@ def pygraphviz_layout(G, prog='neato', root=None, args=''):
     return node_pos
 
 
-@nx.utils.open_file(5, 'w')
+@nx.utils.open_file(5, 'w+b')
 def view_pygraphviz(G, edgelabel=None, prog='dot', args='',
                     suffix='', path=None):
     """Views the graph G using the specified layout algorithm.


### PR DESCRIPTION
This works on some OS as is, but adding the b-flag in mode makes it work for all.

Fixes #3060