### PR TITLE
Degree centrality bug fix.

### DIFF
--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -46,7 +46,9 @@ def degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality = {}
+    if len(G) == 1:
+        return {n: 1 for n in G.nodes()}
+
     s = 1.0 / (len(G) - 1.0)
     centrality = {n: d * s for n, d in G.degree()}
     return centrality
@@ -87,7 +89,9 @@ def in_degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality = {}
+    if len(G) == 1:
+        return {n: 1 for n in G.nodes()}
+
     s = 1.0 / (len(G) - 1.0)
     centrality = {n: d * s for n, d in G.in_degree()}
     return centrality
@@ -128,7 +132,9 @@ def out_degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    centrality = {}
+    if len(G) == 1:
+        return {n: 1 for n in G.nodes()}
+
     s = 1.0 / (len(G) - 1.0)
     centrality = {n: d * s for n, d in G.out_degree()}
     return centrality

--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -46,8 +46,8 @@ def degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    if len(G) == 1:
-        return {n: 1 for n in G.nodes()}
+    if len(G) <= 1:
+        return {n: 1 for n in G}
 
     s = 1.0 / (len(G) - 1.0)
     centrality = {n: d * s for n, d in G.degree()}
@@ -89,8 +89,8 @@ def in_degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    if len(G) == 1:
-        return {n: 1 for n in G.nodes()}
+    if len(G) <= 1:
+        return {n: 1 for n in G}
 
     s = 1.0 / (len(G) - 1.0)
     centrality = {n: d * s for n, d in G.in_degree()}
@@ -132,8 +132,8 @@ def out_degree_centrality(G):
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
     """
-    if len(G) == 1:
-        return {n: 1 for n in G.nodes()}
+    if len(G) <= 1:
+        return {n: 1 for n in G}
 
     s = 1.0 / (len(G) - 1.0)
     centrality = {n: d * s for n, d in G.out_degree()}

--- a/networkx/algorithms/centrality/tests/test_degree_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_degree_centrality.py
@@ -89,3 +89,14 @@ class TestDegreeCentrality:
                  4: 0.125, 5: 0.375, 6: 0.0, 7: 0.0, 8: 0.0}
         for n, dc in d.items():
             assert_almost_equal(exact[n], dc)
+
+    def test_small_graph_centrality(self):
+        G = nx.empty_graph(create_using=nx.DiGraph)
+        assert_equal({}, nx.degree_centrality(G))
+        assert_equal({}, nx.out_degree_centrality(G))
+        assert_equal({}, nx.in_degree_centrality(G))
+
+        G = nx.empty_graph(1, create_using=nx.DiGraph)
+        assert_equal({0: 1}, nx.degree_centrality(G))
+        assert_equal({0: 1}, nx.out_degree_centrality(G))
+        assert_equal({0: 1}, nx.in_degree_centrality(G))


### PR DESCRIPTION
1) Fixed a division by zero bug in the degree_centrality functions (division by zero was raised when len(G)==1), if there is one node in the graph it's centrality is set to 1.

2) Removed redundant dict initialization line.