### PR TITLE
Raise ValueError when empty list is passed to functions in all.py, fixes #2973

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -119,6 +119,7 @@ is partially historical, and now, mostly arbitrary.
 - Mads Jensen, Github: `atombrella <https://github.com/atombrella>`_
 - Edward L. Platt, `elplatt <https://elplatt.com>`_
 - James Owen, Github: `leamingrad <https://github.com/leamingrad>`_
+- Robert Gmyr, Github: `gmyr <https://github.com/gmyr>`_
 
 Support
 -------

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -38,6 +38,11 @@ def union_all(graphs, rename=(None,)):
     -------
     U : a graph with the same type as the first graph in list
 
+    Raises
+    ------
+    ValueError
+       If `graphs` is an empty list.
+
     Notes
     -----
     To force a disjoint union with node relabeling, use
@@ -52,6 +57,8 @@ def union_all(graphs, rename=(None,)):
     union
     disjoint_union_all
     """
+    if not graphs:
+        raise ValueError('cannot apply union_all to an empty list')
     graphs_names = zip_longest(graphs, rename)
     U, gname = next(graphs_names)
     for H, hname in graphs_names:
@@ -75,6 +82,11 @@ def disjoint_union_all(graphs):
     -------
     U : A graph with the same type as the first graph in list
 
+    Raises
+    ------
+    ValueError
+       If `graphs` is an empty list.
+
     Notes
     -----
     It is recommended that the graphs be either all directed or all undirected.
@@ -83,6 +95,8 @@ def disjoint_union_all(graphs):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
     """
+    if not graphs:
+        raise ValueError('cannot apply disjoint_union_all to an empty list')
     graphs = iter(graphs)
     U = next(graphs)
     for H in graphs:
@@ -105,6 +119,11 @@ def compose_all(graphs):
     -------
     C : A graph with the same type as the first graph in list
 
+    Raises
+    ------
+    ValueError
+       If `graphs` is an empty list.
+
     Notes
     -----
     It is recommended that the supplied graphs be either all directed or all
@@ -114,6 +133,8 @@ def compose_all(graphs):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
     """
+    if not graphs:
+        raise ValueError('cannot apply compose_all to an empty list')
     graphs = iter(graphs)
     C = next(graphs)
     for H in graphs:
@@ -136,11 +157,18 @@ def intersection_all(graphs):
     -------
     R : A new graph with the same type as the first graph in list
 
+    Raises
+    ------
+    ValueError
+       If `graphs` is an empty list.
+
     Notes
     -----
     Attributes from the graph, nodes, and edges are not copied to the new
     graph.
     """
+    if not graphs:
+        raise ValueError('cannot apply intersection_all to an empty list')
     graphs = iter(graphs)
     R = next(graphs)
     for H in graphs:

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -199,3 +199,23 @@ def test_mixed_type_compose():
     H = nx.MultiGraph()
     I = nx.Graph()
     U = nx.compose_all([G, H, I])
+
+
+@raises(ValueError)
+def test_empty_union():
+    nx.union_all([])
+
+
+@raises(ValueError)
+def test_empty_disjoint_union():
+    nx.disjoint_union_all([])
+
+
+@raises(ValueError)
+def test_empty_compose_all():
+    nx.compose_all([])
+
+
+@raises(ValueError)
+def test_empty_intersection_all():
+    nx.intersection_all([])


### PR DESCRIPTION
I raise a ValueError when any of the functions in all.py (i.e., union_all, disjoint_union_all, compose_all, and intersection_all) receives an empty list as an argument.

Fixes #2973.