### PR TITLE
Add percolation centrality

### DIFF
--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -97,3 +97,10 @@ Reaching
 
    local_reaching_centrality
    global_reaching_centrality
+
+Percolation
+-----------
+.. autosummary::
+   :toctree: generated/
+
+   percolation_centrality

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -12,3 +12,4 @@ from .harmonic import *
 from .katz import *
 from .load import *
 from .reaching import *
+from .percolation import *

--- a/networkx/algorithms/centrality/percolation.py
+++ b/networkx/algorithms/centrality/percolation.py
@@ -1,0 +1,131 @@
+# coding=utf8
+#    Copyright (C) 2018 by
+#    Pranay Kanwar <pranay.kanwar@gmail.com>
+#    All rights reserved.
+#    BSD license.
+#
+"""Percolation centrality measures."""
+from __future__ import division
+
+__author__ = """\n""".join(['Pranay Kanwar <pranay.kanwar@gmail.com>'])
+
+import networkx as nx
+
+from networkx.algorithms.centrality.betweenness import\
+    _single_source_dijkstra_path_basic as dijkstra
+from networkx.algorithms.centrality.betweenness import\
+    _single_source_shortest_path_basic as shortest_path
+
+__all__ = ['percolation_centrality']
+
+
+def percolation_centrality(G, attribute='percolation',
+                           states=None, weight=None):
+    r"""Compute the percolation centrality for nodes.
+
+    Percolation centrality of a node $v$, at a given time, is defined
+    as the proportion of ‘percolated paths’ that go through that node.
+
+    This measure quantifies relative impact of nodes based on their
+    topological connectivity, as well as their percolation states.
+
+    Percolation states of nodes are used to depict network percolation
+    scenarios (such as during infection transmission in a social network
+    of individuals, spreading of computer viruses on computer networks, or
+    transmission of disease over a network of towns) over time. In this
+    measure usually the percolation state is expressed as a decimal
+    between 0.0 and 1.0.
+
+    When all nodes are in the same percolated state this measure is
+    equivalent to betweenness centrality.
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX graph.
+
+    attribute : None or string, optional (default='percolation')
+      Name of the node attribute to use for percolation state, used
+      if `states` is None.
+
+    states : None or dict, optional (default=None)
+      Specify percolation states for the nodes, nodes as keys states
+      as values.
+
+    weight : None or string, optional (default=None)
+      If None, all edge weights are considered equal.
+      Otherwise holds the name of the edge attribute used as weight.
+
+    Returns
+    -------
+    nodes : dictionary
+       Dictionary of nodes with percolation centrality as the value.
+
+    See Also
+    --------
+    betweenness_centrality
+
+    Notes
+    -----
+    The algorithm is from Mahendra Piraveenan, Mikhail Prokopenko, and
+    Liaquat Hossain [1]_
+    Pair dependecies are calculated and accumulated using [2]_
+
+    For weighted graphs the edge weights must be greater than zero.
+    Zero edge weights can produce an infinite number of equal length
+    paths between pairs of nodes.
+
+    References
+    ----------
+    .. [1] Mahendra Piraveenan, Mikhail Prokopenko, Liaquat Hossain
+       Percolation Centrality: Quantifying Graph-Theoretic Impact of Nodes
+       during Percolation in Networks
+       http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0053095
+    .. [2] Ulrik Brandes:
+       A Faster Algorithm for Betweenness Centrality.
+       Journal of Mathematical Sociology 25(2):163-177, 2001.
+       http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+    """
+    percolation = dict.fromkeys(G, 0.0)  # b[v]=0 for v in G
+
+    nodes = G
+
+    if states is None:
+        states = nx.get_node_attributes(nodes, attribute)
+
+    # sum of all percolation states
+    p_sigma_x_t = 0.0
+    for v in states.values():
+        p_sigma_x_t += v
+
+    for s in nodes:
+        # single source shortest paths
+        if weight is None:  # use BFS
+            S, P, sigma = shortest_path(G, s)
+        else:  # use Dijkstra's algorithm
+            S, P, sigma = dijkstra(G, s, weight)
+        # accumulation
+        percolation = _accumulate_percolation(percolation, G, S, P, sigma, s,
+                                              states, p_sigma_x_t)
+
+    n = len(G)
+
+    for v in percolation:
+        percolation[v] *= 1 / (n - 2)
+
+    return percolation
+
+
+def _accumulate_percolation(percolation, G, S, P, sigma, s,
+                            states, p_sigma_x_t):
+    delta = dict.fromkeys(S, 0)
+    while S:
+        w = S.pop()
+        coeff = (1 + delta[w]) / sigma[w]
+        for v in P[w]:
+            delta[v] += sigma[v] * coeff
+        if w != s:
+            # percolation weight
+            pw_s_w = states[s] / (p_sigma_x_t - states[w])
+            percolation[w] += delta[w] * pw_s_w
+    return percolation

--- a/networkx/algorithms/centrality/tests/test_percolation_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_percolation_centrality.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+from __future__ import division
+from nose.tools import *
+import networkx as nx
+
+
+def example1a_G():
+    G = nx.Graph()
+    G.add_node(1, percolation=0.1)
+    G.add_node(2, percolation=0.2)
+    G.add_node(3, percolation=0.2)
+    G.add_node(4, percolation=0.2)
+    G.add_node(5, percolation=0.3)
+    G.add_node(6, percolation=0.2)
+    G.add_node(7, percolation=0.5)
+    G.add_node(8, percolation=0.5)
+    G.add_edges_from([(1, 4), (2, 4), (3, 4), (4, 5), (5, 6), (6, 7), (6, 8)])
+    return G
+
+
+def example1b_G():
+    G = nx.Graph()
+    G.add_node(1, percolation=0.3)
+    G.add_node(2, percolation=0.5)
+    G.add_node(3, percolation=0.5)
+    G.add_node(4, percolation=0.2)
+    G.add_node(5, percolation=0.3)
+    G.add_node(6, percolation=0.2)
+    G.add_node(7, percolation=0.1)
+    G.add_node(8, percolation=0.1)
+    G.add_edges_from([(1, 4), (2, 4), (3, 4), (4, 5), (5, 6), (6, 7), (6, 8)])
+    return G
+
+
+class TestPercolationCentrality(object):
+    def test_percolation_example1a(self):
+        """percolation centrality: example 1a"""
+        G = example1a_G()
+        p = nx.percolation_centrality(G)
+        p_answer = {4: 0.625, 6: 0.667}
+        for n in p_answer:
+            assert_almost_equal(p[n], p_answer[n], places=3)
+
+    def test_percolation_example1b(self):
+        """percolation centrality: example 1a"""
+        G = example1b_G()
+        p = nx.percolation_centrality(G)
+        p_answer = {4: 0.825, 6: 0.4}
+        for n in p_answer:
+            assert_almost_equal(p[n], p_answer[n], places=3)
+
+    def test_converge_to_betweenness(self):
+        """percolation centrality: should converge to betweenness
+        centrality when all nodes are percolated the same"""
+        # taken from betweenness test test_florentine_families_graph
+        G = nx.florentine_families_graph()
+        b_answer =\
+            {'Acciaiuoli':    0.000,
+             'Albizzi':       0.212,
+             'Barbadori':     0.093,
+             'Bischeri':      0.104,
+             'Castellani':    0.055,
+             'Ginori':        0.000,
+             'Guadagni':      0.255,
+             'Lamberteschi':  0.000,
+             'Medici':        0.522,
+             'Pazzi':         0.000,
+             'Peruzzi':       0.022,
+             'Ridolfi':       0.114,
+             'Salviati':      0.143,
+             'Strozzi':       0.103,
+             'Tornabuoni':    0.092}
+
+        p_states = {k: 1.0 for k, v in b_answer.items()}
+        p_answer = nx.percolation_centrality(G, states=p_states)
+        for n in sorted(G):
+            assert_almost_equal(p_answer[n], b_answer[n], places=3)
+
+        p_states = {k: 0.3 for k, v in b_answer.items()}
+        p_answer = nx.percolation_centrality(G, states=p_states)
+        for n in sorted(G):
+            assert_almost_equal(p_answer[n], b_answer[n], places=3)


### PR DESCRIPTION
Percolation centrality for a given node, at a given time, as the proportion of ‘percolated paths’ that go through that node. A ‘percolated path’ is a shortest path between a pair of nodes, where the source node is percolated (e.g., infected).

Ref. http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0053095