### PR TITLE
Add option to use Bellman-Ford in generic shortest-path functions

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -57,6 +57,10 @@ Functions for Clauset-Newman-Moore modularity-max community detection.
 
 Functions for small world analysis, directed clustering and perfect matchings.
 
+The shortest_path generic and convenience functions now have a `method`
+parameter to choose between dijkstra and bellmon-ford in the weighted case.
+Default is dijkstra (which was the only option before).
+
 API Changes
 -----------
 empty_graph has taken over the functionality from

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -154,8 +154,6 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
                 for target in paths:
                     paths[target] = list(reversed(paths[target]))
     else:
-        if source not in G:
-            raise nx.NodeNotFound("Source {} not in G".format(source))
         if target is None:
             # Find paths to all nodes accessible from the source.
             if method == 'unweighted':
@@ -298,8 +296,6 @@ def shortest_path_length(G,
                     path_length = nx.single_source_bellman_ford_path_length
                     paths = path_length(G, target, weight=weight)
     else:
-        if source not in G:
-            raise nx.NodeNotFound("Source {} not in G".format(source))
         if target is None:
             # Find paths to all nodes accessible from the source.
             if method == 'unweighted':

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -22,6 +22,7 @@ __all__ = ['shortest_path', 'all_shortest_paths',
            'shortest_path_length', 'average_shortest_path_length',
            'has_path']
 
+
 def has_path(G, source, target):
     """Return *True* if *G* has a path from *source* to *target*.
 
@@ -36,7 +37,7 @@ def has_path(G, source, target):
        Ending node for path
     """
     try:
-        sp = nx.shortest_path(G, source, target)
+        nx.shortest_path(G, source, target)
     except nx.NetworkXNoPath:
         return False
     return True
@@ -61,7 +62,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
         If None, every edge has weight/distance/cost 1.
         If a string, use this edge attribute as the edge weight.
         Any edge attribute not present defaults to 1.
-    
+
     method : string, optional (default = 'dijkstra')
         The algorithm to use to compute the path.
         Supported options: 'dijkstra', 'bellman-ford'.
@@ -334,7 +335,7 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
        If None, every edge has weight/distance/cost 1.
        If a string, use this edge attribute as the edge weight.
        Any edge attribute not present defaults to 1.
-    
+
     method : string, optional (default = 'dijkstra')
         The algorithm to use to compute the path lengths.
         Supported options: 'dijkstra', 'bellman-ford'.
@@ -350,7 +351,7 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
     NetworkXError
         If `G` is not connected (or not weakly connected, in the case
         of a directed graph).
-    
+
     ValueError
         If `method` is not among the supported options.
 
@@ -387,6 +388,7 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
     if not G.is_directed() and not nx.is_connected(G):
         raise nx.NetworkXError("Graph is not connected.")
     # Compute all-pairs shortest paths.
+
     def path_length(v):
         if method == 'unweighted':
             return nx.single_source_shortest_path_length(G, v)

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -91,6 +91,9 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     ValueError
         If `method` is not among the supported options.
 
@@ -151,6 +154,8 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
                 for target in paths:
                     paths[target] = list(reversed(paths[target]))
     else:
+        if source not in G:
+            raise nx.NodeNotFound("Source {} not in G".format(source))
         if target is None:
             # Find paths to all nodes accessible from the source.
             if method == 'unweighted':
@@ -223,6 +228,9 @@ def shortest_path_length(G,
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXNoPath
         If no path exists between source and target.
 

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -22,7 +22,6 @@ __all__ = ['shortest_path', 'all_shortest_paths',
            'shortest_path_length', 'average_shortest_path_length',
            'has_path']
 
-
 def has_path(G, source, target):
     """Return *True* if *G* has a path from *source* to *target*.
 
@@ -43,7 +42,7 @@ def has_path(G, source, target):
     return True
 
 
-def shortest_path(G, source=None, target=None, weight=None):
+def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
     """Compute shortest paths in the graph.
 
     Parameters
@@ -62,6 +61,13 @@ def shortest_path(G, source=None, target=None, weight=None):
         If None, every edge has weight/distance/cost 1.
         If a string, use this edge attribute as the edge weight.
         Any edge attribute not present defaults to 1.
+    
+    method : string, optional (default = 'dijkstra')
+        The algorithm to use to compute the path.
+        Supported options: 'dijkstra', 'bellman-ford'.
+        Other inputs produce a ValueError.
+        If *weight* is None, unweighted graph methods are used, and this
+        suggestion is ignored.
 
     Returns
     -------
@@ -81,6 +87,10 @@ def shortest_path(G, source=None, target=None, weight=None):
 
         If neither the source nor target are specified return a dictionary
         of dictionaries with path[source][target]=[list of nodes in path].
+
+    Raises
+    ------
+    ValueError: if method is not among the supported options
 
     Examples
     --------
@@ -106,24 +116,36 @@ def shortest_path(G, source=None, target=None, weight=None):
     --------
     all_pairs_shortest_path()
     all_pairs_dijkstra_path()
+    all_pairs_bellman_ford_path()
     single_source_shortest_path()
     single_source_dijkstra_path()
+    single_source_bellman_ford_path()
     """
+    if method not in ('dijkstra', 'bellman-ford'):
+        # so we don't need to check in each branch later
+        raise ValueError('method not supported: {}'.format(method))
     if source is None:
         if target is None:
             # Find paths between all pairs.
             if weight is None:
                 paths = dict(nx.all_pairs_shortest_path(G))
             else:
-                paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
+                if method == 'dijkstra':
+                    paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
+                elif method == 'bellman-ford':
+                    paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
         else:
             # Find paths from all nodes co-accessible to the target.
             with nx.utils.reversed(G):
                 if weight is None:
                     paths = nx.single_source_shortest_path(G, target)
                 else:
-                    paths = nx.single_source_dijkstra_path(G, target,
-                                                           weight=weight)
+                    if method == 'dijkstra':
+                        paths = nx.single_source_dijkstra_path(G, target,
+                                                               weight=weight)
+                    elif method == 'bellman-ford':
+                        paths = nx.single_source_bellman_ford_path(G, target,
+                                                                   weight=weight)
                 # Now flip the paths so they go from a source to the target.
                 for target in paths:
                     paths[target] = list(reversed(paths[target]))
@@ -134,14 +156,21 @@ def shortest_path(G, source=None, target=None, weight=None):
             if weight is None:
                 paths = nx.single_source_shortest_path(G, source)
             else:
-                paths = nx.single_source_dijkstra_path(G, source,
-                                                       weight=weight)
+                if method == 'dijkstra':
+                    paths = nx.single_source_dijkstra_path(G, source,
+                                                           weight=weight)
+                elif method == 'bellman-ford':
+                    paths = nx.single_source_bellman_ford_path(G, source,
+                                                               weight=weight)
         else:
             # Find shortest source-target path.
             if weight is None:
                 paths = nx.bidirectional_shortest_path(G, source, target)
             else:
-                paths = nx.dijkstra_path(G, source, target, weight)
+                if method == 'dijkstra':
+                    paths = nx.dijkstra_path(G, source, target, weight)
+                elif method == 'bellman-ford':
+                    paths = nx.bellman_ford_path(G, source, target, weight)
 
     return paths
 

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -66,7 +66,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
         The algorithm to use to compute the path.
         Supported options: 'dijkstra', 'bellman-ford'.
         Other inputs produce a ValueError.
-        If *weight* is None, unweighted graph methods are used, and this
+        If `weight` is None, unweighted graph methods are used, and this
         suggestion is ignored.
 
     Returns
@@ -91,7 +91,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
     Raises
     ------
     ValueError
-        If method is not among the supported options.
+        If `method` is not among the supported options.
 
     Examples
     --------
@@ -206,7 +206,7 @@ def shortest_path_length(G,
         The algorithm to use to compute the path length.
         Supported options: 'dijkstra', 'bellman-ford'.
         Other inputs produce a ValueError.
-        If *weight* is None, unweighted graph methods are used, and this
+        If `weight` is None, unweighted graph methods are used, and this
         suggestion is ignored.
 
     Returns
@@ -231,7 +231,7 @@ def shortest_path_length(G,
         If no path exists between source and target.
 
     ValueError
-        If method is not among the supported options.
+        If `method` is not among the supported options.
 
     Examples
     --------
@@ -261,9 +261,10 @@ def shortest_path_length(G,
     --------
     all_pairs_shortest_path_length()
     all_pairs_dijkstra_path_length()
+    all_pairs_bellman_ford_path_length()
     single_source_shortest_path_length()
     single_source_dijkstra_path_length()
-
+    single_source_bellman_ford_path_length()
     """
     if method not in ('dijkstra', 'bellman-ford'):
         # so we don't need to check in each branch later
@@ -321,7 +322,7 @@ def shortest_path_length(G,
     return paths
 
 
-def average_shortest_path_length(G, weight=None):
+def average_shortest_path_length(G, weight=None, method='dijkstra'):
     r"""Return the average shortest path length.
 
     The average shortest path length is
@@ -342,6 +343,13 @@ def average_shortest_path_length(G, weight=None):
        If None, every edge has weight/distance/cost 1.
        If a string, use this edge attribute as the edge weight.
        Any edge attribute not present defaults to 1.
+    
+    method : string, optional (default = 'dijkstra')
+        The algorithm to use to compute the path lengths.
+        Supported options: 'dijkstra', 'bellman-ford'.
+        Other inputs produce a ValueError.
+        If `weight` is None, unweighted graph methods are used, and this
+        suggestion is ignored.
 
     Raises
     ------
@@ -351,6 +359,9 @@ def average_shortest_path_length(G, weight=None):
     NetworkXError
         If `G` is not connected (or not weakly connected, in the case
         of a directed graph).
+    
+    ValueError
+        If `method` is not among the supported options.
 
     Examples
     --------
@@ -387,9 +398,14 @@ def average_shortest_path_length(G, weight=None):
     if weight is None:
         def path_length(v): return nx.single_source_shortest_path_length(G, v)
     else:
-        ssdpl = nx.single_source_dijkstra_path_length
+        if method == 'dijkstra':
+            path_len_fn = nx.single_source_dijkstra_path_length
+        elif method == 'bellman-ford':
+            path_len_fn = nx.single_source_bellman_ford_path_length
+        else:
+            raise ValueError('method not supported: {}'.format(method))
 
-        def path_length(v): return ssdpl(G, v, weight=weight)
+        def path_length(v): return path_len_fn(G, v, weight=weight)
     # Sum the distances for each (ordered) pair of source and target node.
     s = sum(l for u in G for l in path_length(u).values())
     return s / (n * (n - 1))

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -125,54 +125,49 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
     if method not in ('dijkstra', 'bellman-ford'):
         # so we don't need to check in each branch later
         raise ValueError('method not supported: {}'.format(method))
+    method = 'unweighted' if weight is None else method
     if source is None:
         if target is None:
             # Find paths between all pairs.
-            if weight is None:
+            if method == 'unweighted':
                 paths = dict(nx.all_pairs_shortest_path(G))
-            else:
-                if method == 'dijkstra':
-                    paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
-                elif method == 'bellman-ford':
-                    paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
+            elif method == 'dijkstra':
+                paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
+            elif method == 'bellman-ford':
+                paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
         else:
             # Find paths from all nodes co-accessible to the target.
             with nx.utils.reversed(G):
-                if weight is None:
+                if method == 'unweighted':
                     paths = nx.single_source_shortest_path(G, target)
-                else:
-                    if method == 'dijkstra':
-                        paths = nx.single_source_dijkstra_path(G, target,
+                elif method == 'dijkstra':
+                    paths = nx.single_source_dijkstra_path(G, target,
+                                                           weight=weight)
+                elif method == 'bellman-ford':
+                    paths = nx.single_source_bellman_ford_path(G, target,
                                                                weight=weight)
-                    elif method == 'bellman-ford':
-                        paths = nx.single_source_bellman_ford_path(G, target,
-                                                                   weight=weight)
                 # Now flip the paths so they go from a source to the target.
                 for target in paths:
                     paths[target] = list(reversed(paths[target]))
-
     else:
         if target is None:
             # Find paths to all nodes accessible from the source.
-            if weight is None:
+            if method == 'unweighted':
                 paths = nx.single_source_shortest_path(G, source)
-            else:
-                if method == 'dijkstra':
-                    paths = nx.single_source_dijkstra_path(G, source,
+            elif method == 'dijkstra':
+                paths = nx.single_source_dijkstra_path(G, source,
+                                                       weight=weight)
+            elif method == 'bellman-ford':
+                paths = nx.single_source_bellman_ford_path(G, source,
                                                            weight=weight)
-                elif method == 'bellman-ford':
-                    paths = nx.single_source_bellman_ford_path(G, source,
-                                                               weight=weight)
         else:
             # Find shortest source-target path.
-            if weight is None:
+            if method == 'unweighted':
                 paths = nx.bidirectional_shortest_path(G, source, target)
-            else:
-                if method == 'dijkstra':
-                    paths = nx.dijkstra_path(G, source, target, weight)
-                elif method == 'bellman-ford':
-                    paths = nx.bellman_ford_path(G, source, target, weight)
-
+            elif method == 'dijkstra':
+                paths = nx.dijkstra_path(G, source, target, weight)
+            elif method == 'bellman-ford':
+                paths = nx.bellman_ford_path(G, source, target, weight)
     return paths
 
 
@@ -269,56 +264,52 @@ def shortest_path_length(G,
     if method not in ('dijkstra', 'bellman-ford'):
         # so we don't need to check in each branch later
         raise ValueError('method not supported: {}'.format(method))
+    method = 'unweighted' if weight is None else method
     if source is None:
         if target is None:
             # Find paths between all pairs.
-            if weight is None:
+            if method == 'unweighted':
                 paths = nx.all_pairs_shortest_path_length(G)
-            else:
-                if method == 'dijkstra':
-                    paths = nx.all_pairs_dijkstra_path_length(G, weight=weight)
-                elif method == 'bellman-ford':
-                    paths = nx.all_pairs_bellman_ford_path_length(G,
-                                                                  weight=weight)
+            elif method == 'dijkstra':
+                paths = nx.all_pairs_dijkstra_path_length(G, weight=weight)
+            elif method == 'bellman-ford':
+                paths = nx.all_pairs_bellman_ford_path_length(G, weight=weight)
         else:
             # Find paths from all nodes co-accessible to the target.
             with nx.utils.reversed(G):
-                if weight is None:
+                if method == 'unweighted':
                     # We need to exhaust the iterator as Graph needs
                     # to be reversed.
                     path_length = nx.single_source_shortest_path_length
                     paths = path_length(G, target)
-                else:
-                    if method == 'dijkstra':
-                        path_length = nx.single_source_dijkstra_path_length
-                    elif method == 'bellman-ford':
-                        path_length = nx.single_source_bellman_ford_path_length
+                elif method == 'dijkstra':
+                    path_length = nx.single_source_dijkstra_path_length
+                    paths = path_length(G, target, weight=weight)
+                elif method == 'bellman-ford':
+                    path_length = nx.single_source_bellman_ford_path_length
                     paths = path_length(G, target, weight=weight)
     else:
         if source not in G:
             raise nx.NodeNotFound("Source {} not in G".format(source))
-
         if target is None:
             # Find paths to all nodes accessible from the source.
-            if weight is None:
+            if method == 'unweighted':
                 paths = nx.single_source_shortest_path_length(G, source)
-            else:
-                if method == 'dijkstra':
-                    path_length = nx.single_source_dijkstra_path_length
-                elif method == 'bellman-ford':
-                    path_length = nx.single_source_bellman_ford_path_length
+            elif method == 'dijkstra':
+                path_length = nx.single_source_dijkstra_path_length
+                paths = path_length(G, source, weight=weight)
+            elif method == 'bellman-ford':
+                path_length = nx.single_source_bellman_ford_path_length
                 paths = path_length(G, source, weight=weight)
         else:
             # Find shortest source-target path.
-            if weight is None:
+            if method == 'unweighted':
                 p = nx.bidirectional_shortest_path(G, source, target)
                 paths = len(p) - 1
-            else:
-                if method == 'dijkstra':
-                    paths = nx.dijkstra_path_length(G, source, target, weight)
-                elif method == 'bellman-ford':
-                    paths = nx.bellman_ford_path_length(G, source, target,
-                                                        weight)
+            elif method == 'dijkstra':
+                paths = nx.dijkstra_path_length(G, source, target, weight)
+            elif method == 'bellman-ford':
+                paths = nx.bellman_ford_path_length(G, source, target, weight)
     return paths
 
 
@@ -379,6 +370,7 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
     1.0
 
     """
+    method = 'unweighted' if weight is None else method
     n = len(G)
     # For the special case of the null graph, raise an exception, since
     # there are no paths in the null graph.
@@ -395,17 +387,16 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
     if not G.is_directed() and not nx.is_connected(G):
         raise nx.NetworkXError("Graph is not connected.")
     # Compute all-pairs shortest paths.
-    if weight is None:
-        def path_length(v): return nx.single_source_shortest_path_length(G, v)
-    else:
-        if method == 'dijkstra':
-            path_len_fn = nx.single_source_dijkstra_path_length
+    def path_length(v):
+        if method == 'unweighted':
+            return nx.single_source_shortest_path_length(G, v)
+        elif method == 'dijkstra':
+            return nx.single_source_dijkstra_path_length(G, v, weight=weight)
         elif method == 'bellman-ford':
-            path_len_fn = nx.single_source_bellman_ford_path_length
+            return nx.single_source_bellman_ford_path_length(G, v,
+                                                             weight=weight)
         else:
             raise ValueError('method not supported: {}'.format(method))
-
-        def path_length(v): return path_len_fn(G, v, weight=weight)
     # Sum the distances for each (ordered) pair of source and target node.
     s = sum(l for u in G for l in path_length(u).values())
     return s / (n * (n - 1))
@@ -464,17 +455,17 @@ def all_shortest_paths(G, source, target, weight=None, method='dijkstra'):
     single_source_shortest_path()
     all_pairs_shortest_path()
     """
-    if weight is not None:
-        if method == 'dijkstra':
-            pred, dist = nx.dijkstra_predecessor_and_distance(G, source,
-                                                              weight=weight)
-        elif method == 'bellman-ford':
-            pred, dist = nx.bellman_ford_predecessor_and_distance(G, source,
-                                                                  weight=weight)
-        else:
-            raise ValueError('method not supported: {}'.format(method))
-    else:
+    method = 'unweighted' if weight is None else method
+    if method == 'unweighted':
         pred = nx.predecessor(G, source)
+    elif method == 'dijkstra':
+        pred, dist = nx.dijkstra_predecessor_and_distance(G, source,
+                                                          weight=weight)
+    elif method == 'bellman-ford':
+        pred, dist = nx.bellman_ford_predecessor_and_distance(G, source,
+                                                              weight=weight)
+    else:
+        raise ValueError('method not supported: {}'.format(method))
 
     if source not in G:
         raise nx.NodeNotFound('Source {} is not in G'.format(source))

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -137,7 +137,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
                 paths = dict(nx.all_pairs_shortest_path(G))
             elif method == 'dijkstra':
                 paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
-            elif method == 'bellman-ford':
+            else:  # method == 'bellman-ford':
                 paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
         else:
             # Find paths from all nodes co-accessible to the target.
@@ -147,7 +147,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
                 elif method == 'dijkstra':
                     paths = nx.single_source_dijkstra_path(G, target,
                                                            weight=weight)
-                elif method == 'bellman-ford':
+                else:  # method == 'bellman-ford':
                     paths = nx.single_source_bellman_ford_path(G, target,
                                                                weight=weight)
                 # Now flip the paths so they go from a source to the target.
@@ -163,7 +163,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
             elif method == 'dijkstra':
                 paths = nx.single_source_dijkstra_path(G, source,
                                                        weight=weight)
-            elif method == 'bellman-ford':
+            else:  # method == 'bellman-ford':
                 paths = nx.single_source_bellman_ford_path(G, source,
                                                            weight=weight)
         else:
@@ -172,7 +172,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
                 paths = nx.bidirectional_shortest_path(G, source, target)
             elif method == 'dijkstra':
                 paths = nx.dijkstra_path(G, source, target, weight)
-            elif method == 'bellman-ford':
+            else:  # method == 'bellman-ford':
                 paths = nx.bellman_ford_path(G, source, target, weight)
     return paths
 
@@ -281,7 +281,7 @@ def shortest_path_length(G,
                 paths = nx.all_pairs_shortest_path_length(G)
             elif method == 'dijkstra':
                 paths = nx.all_pairs_dijkstra_path_length(G, weight=weight)
-            elif method == 'bellman-ford':
+            else:  # method == 'bellman-ford':
                 paths = nx.all_pairs_bellman_ford_path_length(G, weight=weight)
         else:
             # Find paths from all nodes co-accessible to the target.
@@ -294,7 +294,7 @@ def shortest_path_length(G,
                 elif method == 'dijkstra':
                     path_length = nx.single_source_dijkstra_path_length
                     paths = path_length(G, target, weight=weight)
-                elif method == 'bellman-ford':
+                else:  # method == 'bellman-ford':
                     path_length = nx.single_source_bellman_ford_path_length
                     paths = path_length(G, target, weight=weight)
     else:
@@ -307,7 +307,7 @@ def shortest_path_length(G,
             elif method == 'dijkstra':
                 path_length = nx.single_source_dijkstra_path_length
                 paths = path_length(G, source, weight=weight)
-            elif method == 'bellman-ford':
+            else:  # method == 'bellman-ford':
                 path_length = nx.single_source_bellman_ford_path_length
                 paths = path_length(G, source, weight=weight)
         else:
@@ -317,7 +317,7 @@ def shortest_path_length(G,
                 paths = len(p) - 1
             elif method == 'dijkstra':
                 paths = nx.dijkstra_path_length(G, source, target, weight)
-            elif method == 'bellman-ford':
+            else:  # method == 'bellman-ford':
                 paths = nx.bellman_ford_path_length(G, source, target, weight)
     return paths
 

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -290,8 +290,6 @@ def shortest_path_length(G,
                     path_length = nx.single_source_bellman_ford_path_length
                     paths = path_length(G, target, weight=weight)
     else:
-        if source not in G:
-            raise nx.NodeNotFound("Source {} not in G".format(source))
         if target is None:
             # Find paths to all nodes accessible from the source.
             if method == 'unweighted':

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -290,6 +290,8 @@ def shortest_path_length(G,
                     path_length = nx.single_source_bellman_ford_path_length
                     paths = path_length(G, target, weight=weight)
     else:
+        if source not in G:
+            raise nx.NodeNotFound("Source {} not in G".format(source))
         if target is None:
             # Find paths to all nodes accessible from the source.
             if method == 'unweighted':

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -411,7 +411,7 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
     return s / (n * (n - 1))
 
 
-def all_shortest_paths(G, source, target, weight=None):
+def all_shortest_paths(G, source, target, weight=None, method='dijkstra'):
     """Compute all shortest paths in the graph.
 
     Parameters
@@ -429,10 +429,22 @@ def all_shortest_paths(G, source, target, weight=None):
        If a string, use this edge attribute as the edge weight.
        Any edge attribute not present defaults to 1.
 
+    method : string, optional (default = 'dijkstra')
+       The algorithm to use to compute the path lengths.
+       Supported options: 'dijkstra', 'bellman-ford'.
+       Other inputs produce a ValueError.
+       If `weight` is None, unweighted graph methods are used, and this
+       suggestion is ignored.
+
     Returns
     -------
     paths : generator of lists
         A generator of all paths between source and target.
+
+    Raises
+    ------
+    ValueError
+        If `method` is not among the supported options.
 
     Examples
     --------
@@ -453,8 +465,14 @@ def all_shortest_paths(G, source, target, weight=None):
     all_pairs_shortest_path()
     """
     if weight is not None:
-        pred, dist = nx.dijkstra_predecessor_and_distance(G, source,
-                                                          weight=weight)
+        if method == 'dijkstra':
+            pred, dist = nx.dijkstra_predecessor_and_distance(G, source,
+                                                              weight=weight)
+        elif method == 'bellman-ford':
+            pred, dist = nx.bellman_ford_predecessor_and_distance(G, source,
+                                                                  weight=weight)
+        else:
+            raise ValueError('method not supported: {}'.format(method))
     else:
         pred = nx.predecessor(G, source)
 

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -439,6 +439,9 @@ def all_shortest_paths(G, source, target, weight=None, method='dijkstra'):
     ValueError
         If `method` is not among the supported options.
 
+    NetworkXNoPath
+        If `target` cannot be reached from `source`.
+
     Examples
     --------
     >>> G = nx.Graph()

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -469,9 +469,6 @@ def all_shortest_paths(G, source, target, weight=None, method='dijkstra'):
     else:
         raise ValueError('method not supported: {}'.format(method))
 
-    if source not in G:
-        raise nx.NodeNotFound('Source {} is not in G'.format(source))
-
     if target not in pred:
         raise nx.NetworkXNoPath('Target {} cannot be reached'
                                 'from Source {}'.format(target, source))

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -218,6 +218,25 @@ class TestGenericPath:
         nx.add_path(G, [0, 10, 20, 3])
         assert_equal([[0, 1, 2, 3], [0, 10, 20, 3]],
                      sorted(nx.all_shortest_paths(G, 0, 3)))
+        # with weights
+        G = nx.Graph()
+        nx.add_path(G, [0, 1, 2, 3])
+        nx.add_path(G, [0, 10, 20, 3])
+        assert_equal([[0, 1, 2, 3], [0, 10, 20, 3]],
+                     sorted(nx.all_shortest_paths(G, 0, 3, weight='weight')))
+        # weights and method specified
+        G = nx.Graph()
+        nx.add_path(G, [0, 1, 2, 3])
+        nx.add_path(G, [0, 10, 20, 3])
+        assert_equal([[0, 1, 2, 3], [0, 10, 20, 3]],
+                     sorted(nx.all_shortest_paths(G, 0, 3, weight='weight',
+                                                  method='dijkstra')))
+        G = nx.Graph()
+        nx.add_path(G, [0, 1, 2, 3])
+        nx.add_path(G, [0, 10, 20, 3])
+        assert_equal([[0, 1, 2, 3], [0, 10, 20, 3]],
+                     sorted(nx.all_shortest_paths(G, 0, 3, weight='weight',
+                                                  method='bellman-ford')))
 
     @raises(nx.NetworkXNoPath)
     def test_all_shortest_paths_raise(self):

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -30,7 +30,8 @@ class TestGenericPath:
 
     def setUp(self):
         from networkx import convert_node_labels_to_integers as cnlti
-        self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1, ordering="sorted")
+        self.grid = cnlti(nx.grid_2d_graph(4, 4), first_label=1,
+                          ordering="sorted")
         self.cycle = nx.cycle_graph(7)
         self.directed_cycle = nx.cycle_graph(7, create_using=nx.DiGraph())
         self.neg_weights = nx.DiGraph()
@@ -45,10 +46,14 @@ class TestGenericPath:
         validate_grid_path(4, 4, 1, 12, nx.shortest_path(self.grid, 1, 12))
         assert_equal(nx.shortest_path(self.directed_cycle, 0, 3), [0, 1, 2, 3])
         # now with weights
-        assert_equal(nx.shortest_path(self.cycle, 0, 3, weight='weight'), [0, 1, 2, 3])
-        assert_equal(nx.shortest_path(self.cycle, 0, 4, weight='weight'), [0, 6, 5, 4])
-        validate_grid_path(4, 4, 1, 12, nx.shortest_path(self.grid, 1, 12, weight='weight'))
-        assert_equal(nx.shortest_path(self.directed_cycle, 0, 3, weight='weight'),
+        assert_equal(nx.shortest_path(self.cycle, 0, 3, weight='weight'),
+                     [0, 1, 2, 3])
+        assert_equal(nx.shortest_path(self.cycle, 0, 4, weight='weight'),
+                     [0, 6, 5, 4])
+        validate_grid_path(4, 4, 1, 12, nx.shortest_path(self.grid, 1, 12,
+                                                         weight='weight'))
+        assert_equal(nx.shortest_path(self.directed_cycle, 0, 3,
+                                      weight='weight'),
                      [0, 1, 2, 3])
         # weights and method specified
         assert_equal(nx.shortest_path(self.directed_cycle, 0, 3,
@@ -85,9 +90,15 @@ class TestGenericPath:
         assert_equal(nx.shortest_path_length(self.grid, 1, 12), 5)
         assert_equal(nx.shortest_path_length(self.directed_cycle, 0, 4), 4)
         # now with weights
-        assert_equal(nx.shortest_path_length(self.cycle, 0, 3, weight='weight'), 3)
-        assert_equal(nx.shortest_path_length(self.grid, 1, 12, weight='weight'), 5)
-        assert_equal(nx.shortest_path_length(self.directed_cycle, 0, 4, weight='weight'), 4)
+        assert_equal(nx.shortest_path_length(self.cycle, 0, 3,
+                                             weight='weight'),
+                     3)
+        assert_equal(nx.shortest_path_length(self.grid, 1, 12,
+                                             weight='weight'),
+                     5)
+        assert_equal(nx.shortest_path_length(self.directed_cycle, 0, 4,
+                                             weight='weight'),
+                     4)
         # weights and method specified
         assert_equal(nx.shortest_path_length(self.cycle, 0, 3, weight='weight',
                                              method='dijkstra'),
@@ -139,28 +150,30 @@ class TestGenericPath:
         assert_equal(p, nx.single_source_shortest_path(self.cycle, 0))
 
     def test_single_source_shortest_path_length(self):
-        l = dict(nx.shortest_path_length(self.cycle, 0))
-        assert_equal(l, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.single_source_shortest_path_length(self.cycle, 0)))
-        l = dict(nx.shortest_path_length(self.grid, 1))
-        assert_equal(l[16], 6)
+        ans = dict(nx.shortest_path_length(self.cycle, 0))
+        assert_equal(ans, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans,
+                     dict(nx.single_source_shortest_path_length(self.cycle,
+                                                                0)))
+        ans = dict(nx.shortest_path_length(self.grid, 1))
+        assert_equal(ans[16], 6)
         # now with weights
-        l = dict(nx.shortest_path_length(self.cycle, 0, weight='weight'))
-        assert_equal(l, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.single_source_dijkstra_path_length(
+        ans = dict(nx.shortest_path_length(self.cycle, 0, weight='weight'))
+        assert_equal(ans, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans, dict(nx.single_source_dijkstra_path_length(
             self.cycle, 0)))
-        l = dict(nx.shortest_path_length(self.grid, 1, weight='weight'))
-        assert_equal(l[16], 6)
+        ans = dict(nx.shortest_path_length(self.grid, 1, weight='weight'))
+        assert_equal(ans[16], 6)
         # weights and method specified
-        l = dict(nx.shortest_path_length(self.cycle, 0, weight='weight',
-                                         method='dijkstra'))
-        assert_equal(l, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.single_source_dijkstra_path_length(
+        ans = dict(nx.shortest_path_length(self.cycle, 0, weight='weight',
+                                           method='dijkstra'))
+        assert_equal(ans, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans, dict(nx.single_source_dijkstra_path_length(
             self.cycle, 0)))
-        l = dict(nx.shortest_path_length(self.cycle, 0, weight='weight',
-                                         method='bellman-ford'))
-        assert_equal(l, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.single_source_bellman_ford_path_length(
+        ans = dict(nx.shortest_path_length(self.cycle, 0, weight='weight',
+                                           method='bellman-ford'))
+        assert_equal(ans, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans, dict(nx.single_source_bellman_ford_path_length(
             self.cycle, 0)))
 
     def test_all_pairs_shortest_path(self):
@@ -179,31 +192,33 @@ class TestGenericPath:
         p = nx.shortest_path(self.cycle, weight='weight', method='dijkstra')
         assert_equal(p[0][3], [0, 1, 2, 3])
         assert_equal(p, dict(nx.all_pairs_dijkstra_path(self.cycle)))
-        p = nx.shortest_path(self.cycle, weight='weight', method='bellman-ford')
+        p = nx.shortest_path(self.cycle, weight='weight',
+                             method='bellman-ford')
         assert_equal(p[0][3], [0, 1, 2, 3])
         assert_equal(p, dict(nx.all_pairs_bellman_ford_path(self.cycle)))
 
     def test_all_pairs_shortest_path_length(self):
-        l = dict(nx.shortest_path_length(self.cycle))
-        assert_equal(l[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.all_pairs_shortest_path_length(self.cycle)))
-        l = dict(nx.shortest_path_length(self.grid))
-        assert_equal(l[1][16], 6)
+        ans = dict(nx.shortest_path_length(self.cycle))
+        assert_equal(ans[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans, dict(nx.all_pairs_shortest_path_length(self.cycle)))
+        ans = dict(nx.shortest_path_length(self.grid))
+        assert_equal(ans[1][16], 6)
         # now with weights
-        l = dict(nx.shortest_path_length(self.cycle, weight='weight'))
-        assert_equal(l[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.all_pairs_dijkstra_path_length(self.cycle)))
-        l = dict(nx.shortest_path_length(self.grid, weight='weight'))
-        assert_equal(l[1][16], 6)
+        ans = dict(nx.shortest_path_length(self.cycle, weight='weight'))
+        assert_equal(ans[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans, dict(nx.all_pairs_dijkstra_path_length(self.cycle)))
+        ans = dict(nx.shortest_path_length(self.grid, weight='weight'))
+        assert_equal(ans[1][16], 6)
         # weights and method specified
-        l = dict(nx.shortest_path_length(self.cycle, weight='weight',
-                                         method='dijkstra'))
-        assert_equal(l[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.all_pairs_dijkstra_path_length(self.cycle)))
-        l = dict(nx.shortest_path_length(self.cycle, weight='weight',
-                                         method='bellman-ford'))
-        assert_equal(l[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
-        assert_equal(l, dict(nx.all_pairs_bellman_ford_path_length(self.cycle)))
+        ans = dict(nx.shortest_path_length(self.cycle, weight='weight',
+                                           method='dijkstra'))
+        assert_equal(ans[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans, dict(nx.all_pairs_dijkstra_path_length(self.cycle)))
+        ans = dict(nx.shortest_path_length(self.cycle, weight='weight',
+                                           method='bellman-ford'))
+        assert_equal(ans[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(ans,
+                     dict(nx.all_pairs_bellman_ford_path_length(self.cycle)))
 
     def test_has_path(self):
         G = nx.Graph()
@@ -242,50 +257,50 @@ class TestGenericPath:
     def test_all_shortest_paths_raise(self):
         G = nx.path_graph(4)
         G.add_node(4)
-        paths = list(nx.all_shortest_paths(G, 0, 4))
+        nx.all_shortest_paths(G, 0, 4)
 
 
 class TestAverageShortestPathLength(object):
 
     def test_cycle_graph(self):
-        l = nx.average_shortest_path_length(nx.cycle_graph(7))
-        assert_almost_equal(l, 2)
+        ans = nx.average_shortest_path_length(nx.cycle_graph(7))
+        assert_almost_equal(ans, 2)
 
     def test_path_graph(self):
-        l = nx.average_shortest_path_length(nx.path_graph(5))
-        assert_almost_equal(l, 2)
+        ans = nx.average_shortest_path_length(nx.path_graph(5))
+        assert_almost_equal(ans, 2)
 
     def test_weighted(self):
         G = nx.Graph()
         nx.add_cycle(G, range(7), weight=2)
-        l = nx.average_shortest_path_length(G, weight='weight')
-        assert_almost_equal(l, 4)
+        ans = nx.average_shortest_path_length(G, weight='weight')
+        assert_almost_equal(ans, 4)
         G = nx.Graph()
         nx.add_path(G, range(5), weight=2)
-        l = nx.average_shortest_path_length(G, weight='weight')
-        assert_almost_equal(l, 4)
-    
+        ans = nx.average_shortest_path_length(G, weight='weight')
+        assert_almost_equal(ans, 4)
+
     def test_specified_methods(self):
         G = nx.Graph()
         nx.add_cycle(G, range(7), weight=2)
-        l = nx.average_shortest_path_length(G,
-                                            weight='weight',
-                                            method='dijkstra')
-        assert_almost_equal(l, 4)
-        l = nx.average_shortest_path_length(G,
-                                            weight='weight',
-                                            method='bellman-ford')
-        assert_almost_equal(l, 4)
+        ans = nx.average_shortest_path_length(G,
+                                              weight='weight',
+                                              method='dijkstra')
+        assert_almost_equal(ans, 4)
+        ans = nx.average_shortest_path_length(G,
+                                              weight='weight',
+                                              method='bellman-ford')
+        assert_almost_equal(ans, 4)
         G = nx.Graph()
         nx.add_path(G, range(5), weight=2)
-        l = nx.average_shortest_path_length(G,
-                                            weight='weight',
-                                            method='dijkstra')
-        assert_almost_equal(l, 4)
-        l = nx.average_shortest_path_length(G,
-                                            weight='weight',
-                                            method='bellman-ford')
-        assert_almost_equal(l, 4)
+        ans = nx.average_shortest_path_length(G,
+                                              weight='weight',
+                                              method='dijkstra')
+        assert_almost_equal(ans, 4)
+        ans = nx.average_shortest_path_length(G,
+                                              weight='weight',
+                                              method='bellman-ford')
+        assert_almost_equal(ans, 4)
 
     def test_disconnected(self):
         g = nx.Graph()

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -245,6 +245,28 @@ class TestAverageShortestPathLength(object):
         nx.add_path(G, range(5), weight=2)
         l = nx.average_shortest_path_length(G, weight='weight')
         assert_almost_equal(l, 4)
+    
+    def test_specified_methods(self):
+        G = nx.Graph()
+        nx.add_cycle(G, range(7), weight=2)
+        l = nx.average_shortest_path_length(G,
+                                            weight='weight',
+                                            method='dijkstra')
+        assert_almost_equal(l, 4)
+        l = nx.average_shortest_path_length(G,
+                                            weight='weight',
+                                            method='bellman-ford')
+        assert_almost_equal(l, 4)
+        G = nx.Graph()
+        nx.add_path(G, range(5), weight=2)
+        l = nx.average_shortest_path_length(G,
+                                            weight='weight',
+                                            method='dijkstra')
+        assert_almost_equal(l, 4)
+        l = nx.average_shortest_path_length(G,
+                                            weight='weight',
+                                            method='bellman-ford')
+        assert_almost_equal(l, 4)
 
     def test_disconnected(self):
         g = nx.Graph()

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -257,7 +257,7 @@ class TestGenericPath:
     def test_all_shortest_paths_raise(self):
         G = nx.path_graph(4)
         G.add_node(4)
-        nx.all_shortest_paths(G, 0, 4)
+        list(nx.all_shortest_paths(G, 0, 4))
 
 
 class TestAverageShortestPathLength(object):

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -88,12 +88,34 @@ class TestGenericPath:
         assert_equal(nx.shortest_path_length(self.cycle, 0, 3, weight='weight'), 3)
         assert_equal(nx.shortest_path_length(self.grid, 1, 12, weight='weight'), 5)
         assert_equal(nx.shortest_path_length(self.directed_cycle, 0, 4, weight='weight'), 4)
+        # weights and method specified
+        assert_equal(nx.shortest_path_length(self.cycle, 0, 3, weight='weight',
+                                             method='dijkstra'),
+                     3)
+        assert_equal(nx.shortest_path_length(self.cycle, 0, 3, weight='weight',
+                                             method='bellman-ford'),
+                     3)
+        # confirm bad method rejection
+        assert_raises(ValueError,
+                      nx.shortest_path_length,
+                      self.cycle,
+                      method='SPAM')
 
     def test_shortest_path_length_target(self):
+        answer = {0: 1, 1: 0, 2: 1}
         sp = dict(nx.shortest_path_length(nx.path_graph(3), target=1))
-        assert_equal(sp[0], 1)
-        assert_equal(sp[1], 0)
-        assert_equal(sp[2], 1)
+        assert_equal(sp, answer)
+        # with weights
+        sp = nx.shortest_path_length(nx.path_graph(3), target=1,
+                                     weight='weight')
+        assert_equal(sp, answer)
+        # weights and method specified
+        sp = nx.shortest_path_length(nx.path_graph(3), target=1,
+                                     weight='weight', method='dijkstra')
+        assert_equal(sp, answer)
+        sp = nx.shortest_path_length(nx.path_graph(3), target=1,
+                                     weight='weight', method='bellman-ford')
+        assert_equal(sp, answer)
 
     def test_single_source_shortest_path(self):
         p = nx.shortest_path(self.cycle, 0)
@@ -129,6 +151,17 @@ class TestGenericPath:
             self.cycle, 0)))
         l = dict(nx.shortest_path_length(self.grid, 1, weight='weight'))
         assert_equal(l[16], 6)
+        # weights and method specified
+        l = dict(nx.shortest_path_length(self.cycle, 0, weight='weight',
+                                         method='dijkstra'))
+        assert_equal(l, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(l, dict(nx.single_source_dijkstra_path_length(
+            self.cycle, 0)))
+        l = dict(nx.shortest_path_length(self.cycle, 0, weight='weight',
+                                         method='bellman-ford'))
+        assert_equal(l, {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(l, dict(nx.single_source_bellman_ford_path_length(
+            self.cycle, 0)))
 
     def test_all_pairs_shortest_path(self):
         p = nx.shortest_path(self.cycle)
@@ -162,6 +195,15 @@ class TestGenericPath:
         assert_equal(l, dict(nx.all_pairs_dijkstra_path_length(self.cycle)))
         l = dict(nx.shortest_path_length(self.grid, weight='weight'))
         assert_equal(l[1][16], 6)
+        # weights and method specified
+        l = dict(nx.shortest_path_length(self.cycle, weight='weight',
+                                         method='dijkstra'))
+        assert_equal(l[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(l, dict(nx.all_pairs_dijkstra_path_length(self.cycle)))
+        l = dict(nx.shortest_path_length(self.cycle, weight='weight',
+                                         method='bellman-ford'))
+        assert_equal(l[0], {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1})
+        assert_equal(l, dict(nx.all_pairs_bellman_ford_path_length(self.cycle)))
 
     def test_has_path(self):
         G = nx.Graph()

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -69,6 +69,8 @@ class TestGenericPath:
                      [0, 2, 3])
         # confirm bad method rejection
         assert_raises(ValueError, nx.shortest_path, self.cycle, method='SPAM')
+        # confirm absent source rejection
+        assert_raises(nx.NodeNotFound, nx.shortest_path, self.cycle, 8)
 
     def test_shortest_path_target(self):
         answer = {0: [0, 1], 1: [1], 2: [2, 1]}
@@ -111,6 +113,8 @@ class TestGenericPath:
                       nx.shortest_path_length,
                       self.cycle,
                       method='SPAM')
+        # confirm absent source rejection
+        assert_raises(nx.NodeNotFound, nx.shortest_path_length, self.cycle, 8)
 
     def test_shortest_path_length_target(self):
         answer = {0: 1, 1: 0, 2: 1}

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -259,6 +259,11 @@ class TestGenericPath:
         G.add_node(4)
         list(nx.all_shortest_paths(G, 0, 4))
 
+    @raises(ValueError)
+    def test_bad_method(self):
+        G = nx.path_graph(2)
+        list(nx.all_shortest_paths(G, 0, 1, weight='weight', method='SPAM'))
+
 
 class TestAverageShortestPathLength(object):
 
@@ -324,3 +329,8 @@ class TestAverageShortestPathLength(object):
     @raises(nx.NetworkXPointlessConcept)
     def test_null_graph(self):
         nx.average_shortest_path_length(nx.null_graph())
+
+    @raises(ValueError)
+    def test_bad_method(self):
+        G = nx.path_graph(2)
+        nx.average_shortest_path_length(G, weight='weight', method='SPAM')


### PR DESCRIPTION
Addresses #2346 

This is one possible way to do this. I reworked some of the machinery to reduce conditional nesting, but there's still redundant code.

Some verbosity is inevitable - we're trying to value-dispatch on multiple parameters, which isn't usually elegant.

Another approach would be a more dramatic refactor in favor of a more functional style of passing functions around and closing them over values as needed. I've briefly sketched this out for myself, and I can share it in a gist if there's interest. My concern is that it would add complexity (at least for the casual reader) for somewhat questionable gain - how likely is it that the generic shortest-path functions will need to be extended similarly soon?

Finally: this module raises `NetworkXNoPath`, `NetworkXPointlessConcept`, and `NetworkXError` exceptions - should I factor them out, per #1705 ? It's not entirely clear to me from that issue when such refactors should occur, since they're potentially interface-breaking.