### PR TITLE
Add absent source checks

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -143,6 +143,10 @@ class TestWeightedPath(WeightedTestBase):
         P = nx.single_source_dijkstra_path(self.XG, 's')['v']
         validate_path(self.XG, 's', 'v', sum(self.XG[u][v]['weight'] for u, v in zip(
             P[:-1], P[1:])), nx.dijkstra_path(self.XG, 's', 'v'))
+        
+        # check absent source
+        G = nx.path_graph(2)
+        assert_raises(nx.NodeNotFound, nx.bidirectional_dijkstra, G, 3, 0)
 
     @raises(nx.NetworkXNoPath)
     def test_bidirectional_dijkstra_no_path(self):
@@ -150,6 +154,19 @@ class TestWeightedPath(WeightedTestBase):
         nx.add_path(G, [1, 2, 3])
         nx.add_path(G, [4, 5, 6])
         path = nx.bidirectional_dijkstra(G, 1, 6)
+
+    def test_absent_source(self):
+        # the check is in _dijkstra_multisource, but this will provide
+        # regression testing against later changes to any of the "client"
+        # Dijkstra or Bellman-Ford functions
+        G = nx.path_graph(2)
+        for fn in (nx.dijkstra_path,
+                   nx.dijkstra_path_length,
+                   nx.single_source_dijkstra_path,
+                   nx.single_source_dijkstra_path_length,
+                   nx.single_source_dijkstra,
+                   nx.dijkstra_predecessor_and_distance,):
+            assert_raises(nx.NodeNotFound, fn, G, 3, 0)
 
     def test_dijkstra_predecessor1(self):
         G = nx.path_graph(4)
@@ -319,6 +336,13 @@ class TestMultiSourceDijkstra(object):
     def test_path_length_no_sources(self):
         nx.multi_source_dijkstra_path_length(nx.Graph(), {})
 
+    def test_absent_source(self):
+        G = nx.path_graph(2)
+        for fn in (nx.multi_source_dijkstra_path,
+                   nx.multi_source_dijkstra_path_length,
+                   nx.multi_source_dijkstra,):
+            assert_raises(nx.NodeNotFound, fn, G, [3], 0)
+
     def test_two_sources(self):
         edges = [(0, 1, 1), (1, 2, 1), (2, 3, 10), (3, 4, 1)]
         G = nx.Graph()
@@ -348,8 +372,23 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(nx.single_source_bellman_ford(G, 0), ({0: 0}, {0: [0]}))
         assert_equal(nx.bellman_ford_predecessor_and_distance(G, 0), ({0: []}, {0: 0}))
         assert_equal(nx.goldberg_radzik(G, 0), ({0: None}, {0: 0}))
-        assert_raises(nx.NodeNotFound, nx.bellman_ford_predecessor_and_distance, G, 1)
-        assert_raises(nx.NodeNotFound, nx.goldberg_radzik, G, 1)
+
+    def test_absent_source_bellman_ford(self):
+        # the check is in _bellman_ford; this provides regression testing
+        # against later changes to "client" Bellman-Ford functions
+        G = nx.path_graph(2)
+        for fn in (nx.bellman_ford_predecessor_and_distance,
+                   nx.bellman_ford_path,
+                   nx.bellman_ford_path_length,
+                   nx.single_source_bellman_ford_path,
+                   nx.single_source_bellman_ford_path_length,
+                   nx.single_source_bellman_ford,):
+            assert_raises(nx.NodeNotFound, fn, G, 3, 0)
+
+    @raises(nx.NodeNotFound)
+    def test_absent_source_goldberg_radzik(self):
+        G = nx.path_graph(2)
+        nx.goldberg_radzik(G, 3, 0)
 
     def test_negative_weight_cycle(self):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -143,7 +143,7 @@ class TestWeightedPath(WeightedTestBase):
         P = nx.single_source_dijkstra_path(self.XG, 's')['v']
         validate_path(self.XG, 's', 'v', sum(self.XG[u][v]['weight'] for u, v in zip(
             P[:-1], P[1:])), nx.dijkstra_path(self.XG, 's', 'v'))
-        
+
         # check absent source
         G = nx.path_graph(2)
         assert_raises(nx.NodeNotFound, nx.bidirectional_dijkstra, G, 3, 0)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -764,6 +764,11 @@ def _dijkstra_multisource(G, sources, weight, pred=None, paths=None,
         A mapping from node to shortest distance to that node from one
         of the source nodes.
 
+    Raises
+    ------
+    NodeNotFound
+        If any of `sources` is not in `G`.
+
     Notes
     -----
     The optional predecessor and path dictionaries can be accessed by
@@ -782,6 +787,8 @@ def _dijkstra_multisource(G, sources, weight, pred=None, paths=None,
     c = count()
     fringe = []
     for source in sources:
+        if source not in G:
+            raise nx.NodeNotFound("Source {} not in G".format(source))
         seen[source] = 0
         push(fringe, (0, next(c), source))
     while fringe:
@@ -1209,12 +1216,18 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
 
     Raises
     ------
+    NodeNotFound
+        If any of `source` is not in `G`.
+
     NetworkXUnbounded
        If the (di)graph contains a negative cost (di)cycle, the
        algorithm raises an exception to indicate the presence of the
        negative cost (di)cycle.  Note: any negative weight edge in an
        undirected graph is a negative cost cycle
     """
+    for s in source:
+        if s not in G:
+            raise nx.NodeNotFound("Source {} not in G".format(s))
 
     if pred is None:
         pred = {v: [] for v in source}

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -123,6 +123,9 @@ def dijkstra_path(G, source, target, weight='weight'):
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXNoPath
        If no path exists between source and target.
 
@@ -197,6 +200,9 @@ def dijkstra_path_length(G, source, target, weight='weight'):
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXNoPath
         If no path exists between source and target.
 
@@ -265,6 +271,11 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
     paths : dictionary
        Dictionary of shortest path lengths keyed by target.
 
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     Examples
     --------
     >>> G=nx.path_graph(5)
@@ -324,6 +335,11 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
     -------
     length : dict
         Dict keyed by node to shortest path length from source.
+
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
 
     Examples
     --------
@@ -404,6 +420,10 @@ def single_source_dijkstra(G, source, target=None, cutoff=None,
        distance is the distance from source to target and path is a list
        representing the path from source to target.
 
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
 
     Examples
     --------
@@ -512,6 +532,8 @@ def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
     ------
     ValueError
         If `sources` is empty.
+    NodeNotFound
+        If any of `sources` is not in `G`.
 
     See Also
     --------
@@ -587,6 +609,8 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
     ------
     ValueError
         If `sources` is empty.
+    NodeNotFound
+        If any of `sources` is not in `G`.
 
     See Also
     --------
@@ -689,6 +713,8 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     ------
     ValueError
         If `sources` is empty.
+    NodeNotFound
+        If any of `sources` is not in `G`.
 
     See Also
     --------
@@ -863,6 +889,11 @@ def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight='weight'):
        of a node and the distance to each node.
        Warning: If target is specified, the dicts are incomplete as they
        only contain information for the nodes along a path to target.
+
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
 
     Notes
     -----
@@ -1110,6 +1141,9 @@ def bellman_ford_predecessor_and_distance(G, source, target=None,
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXUnbounded
        If the (di)graph contains a negative cost (di)cycle, the
        algorithm raises an exception to indicate the presence of the
@@ -1315,6 +1349,9 @@ def bellman_ford_path(G, source, target, weight='weight'):
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXNoPath
        If no path exists between source and target.
 
@@ -1362,6 +1399,9 @@ def bellman_ford_path_length(G, source, target, weight='weight'):
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXNoPath
         If no path exists between source and target.
 
@@ -1416,6 +1456,11 @@ def single_source_bellman_ford_path(G, source, cutoff=None, weight='weight'):
     paths : dictionary
        Dictionary of shortest path lengths keyed by target.
 
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     Examples
     --------
     >>> G=nx.path_graph(5)
@@ -1460,6 +1505,11 @@ def single_source_bellman_ford_path_length(G, source,
     -------
     length : iterator
         (target, shortest path length) iterator
+
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
 
     Examples
     --------
@@ -1518,6 +1568,10 @@ def single_source_bellman_ford(G, source,
        distance is the distance from source to target and path is a list
        representing the path from source to target.
 
+    Raises
+    ------
+    NodeNotFound
+        If `source` is not in `G`.
 
     Examples
     --------
@@ -1694,6 +1748,9 @@ def goldberg_radzik(G, source, weight='weight'):
 
     Raises
     ------
+    NodeNotFound
+        If `source` is not in `G`.
+
     NetworkXUnbounded
        If the (di)graph contains a negative cost (di)cycle, the
        algorithm raises an exception to indicate the presence of the
@@ -1925,6 +1982,9 @@ def bidirectional_dijkstra(G, source, target, weight='weight'):
 
     Raises
     ------
+    NodeNotFound
+        If either `source` or `target` is not in `G`.
+
     NetworkXNoPath
         If no path exists between source and target.
 


### PR DESCRIPTION
Per discussion in #3098 

I added the `NodeNotFound` exceptions to the docstrings for the "client" functions of `_dijkstra_multisource()` and `_bellman_ford()` as well, since that has been done elsewhere in the file for other "pass-through" exceptions.