### PR TITLE
In 'from_pandas_adjacency', use column names rather than column order.

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -177,14 +177,15 @@ def from_pandas_adjacency(df, create_using=None):
 
     """
 
-    A = df.values
-    G = from_numpy_matrix(A, create_using=create_using)
     try:
         df = df[df.index]
     except:
         msg = "%s not in columns"
         missing = list(set(df.index).difference(set(df.columns)))
         raise nx.NetworkXError("Columns must match Indices.", msg % missing)
+
+    A = df.values
+    G = from_numpy_matrix(A, create_using=create_using)
 
     nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=False)
     return G

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -163,3 +163,14 @@ class TestConvertPandas(object):
         df = nx.to_pandas_adjacency(Gtrue, dtype=int)
         G = nx.from_pandas_adjacency(df)
         assert_graphs_equal(Gtrue, G)
+
+    def test_from_adjacency_named(self):
+        # example from issue #3105
+        data = {"A": {"A": 0, "B": 0, "C": 0},
+                "B": {"A": 1, "B": 0, "C": 0},
+                "C": {"A": 0, "B": 1, "C": 0}}
+        dftrue = pd.DataFrame(data)
+        df = dftrue[["A", "C", "B"]]
+        G = nx.from_pandas_adjacency(df, create_using=nx.DiGraph())
+        df = nx.to_pandas_adjacency(G, dtype=int)
+        pd.testing.assert_frame_equal(df, dftrue)


### PR DESCRIPTION
Fixes #3105.