### PR TITLE
Adding second order centrality algorithm to centrality/

### DIFF
--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -107,7 +107,7 @@ Percolation
    percolation_centrality
 
 Second Order Centrality
---------
+-----------------------
 .. autosummary::
    :toctree: generated/
 

--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -105,3 +105,10 @@ Percolation
    :toctree: generated/
 
    percolation_centrality
+
+Second Order Centrality
+--------
+.. autosummary::
+   :toctree: generated/
+
+   second_order_centrality

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -13,3 +13,4 @@ from .katz import *
 from .load import *
 from .reaching import *
 from .percolation import *
+from .second_order_centrality import *

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -13,4 +13,4 @@ from .katz import *
 from .load import *
 from .reaching import *
 from .percolation import *
-from .second_order_centrality import *
+from .second_order import *

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -32,7 +32,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 '''
 
 import networkx as nx
-import copy
 from networkx.utils import not_implemented_for
 
 # Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
@@ -124,7 +123,7 @@ def second_order_centrality(G):
     P = P / P.sum(axis=1)  # to transition probability matrix
 
     def _Qj(P, j):
-        P = copy.copy(P)
+        P = P.copy()
         P[:, j] = 0
         return P
 

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+'''Copyright (c) 2015 – Thomson Licensing, SAS
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+* Neither the name of Thomson Licensing, or Technicolor, nor the names
+of its contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+
+import networkx as nx
+import copy
+from networkx.utils import not_implemented_for
+
+# Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
+''' Second order centrality measure.'''
+
+__all__ = ['second_order_centrality']
+
+
+@not_implemented_for('directed')
+def second_order_centrality(G):
+    """Compute the second order centrality for nodes of G.
+
+    The second order centrality of a given node is the standard deviation of
+    the return times to that node of a perpetual random walk on G:
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX connected and undirected graph.
+
+    Returns
+    -------
+    nodes : dictionary
+       Dictionary keyed by node with second order centrality as the value.
+
+    Examples
+    --------
+    >>> G = nx.star_graph(10)
+    >>> soc = nx.second_order_centrality(G)
+    >>> print(sorted(soc.items(), key=lambda x:x[1])[0][0]) # pick first id
+    0
+
+    Raises
+    ------
+    NetworkXException
+        If the graph G is empty, non connected or has negative weights.
+
+    See Also
+    --------
+    betweenness_centrality
+
+    Notes
+    -----
+    Lower values of second order centrality indicate higher centrality.
+
+    The algorithm is from Kermarrec, Le Merrer, Sericola and Trédan [1]_.
+
+    This code implements the analytical version of the algorithm, i.e.,
+    there is no simulation of a random walk process involved. The random walk
+    is here unbiased (corresponding to eq 6 of the paper [1]_), thus the
+    centrality values are the standard deviations for random walk return times
+    on the transformed input graph G (equal in-degree at each nodes by adding
+    self-loops).
+
+    Complexity of this implementation, made to run locally on a single machine,
+    is O(n^3), with n the size of G, which makes it viable only for small
+    graphs.
+
+    References
+    ----------
+    .. [1] Anne-Marie Kermarrec, Erwan Le Merrer, Bruno Sericola, Gilles Trédan
+       "Second order centrality: Distributed assessment of nodes criticity in
+       complex networks", Elsevier Computer Communications 34(5):619-628, 2011.
+    """
+
+    try:
+        import numpy as np
+    except ImportError:
+        raise ImportError('Requires NumPy: http://scipy.org/')
+
+    n = len(G)
+
+    if n == 0:
+        raise nx.NetworkXException("Empty graph.")
+    if not nx.is_connected(G):
+        raise nx.NetworkXException("Non connected graph.")
+    if any(d.get('weight', 0) < 0 for u, v, d in G.edges(data=True)):
+        raise nx.NetworkXException("Graph has negative edge weights.")
+
+    # balancing G for Metropolis-Hastings random walks
+    G = nx.DiGraph(G)
+    in_deg = dict(G.in_degree(weight='weight'))
+    d_max = max(in_deg.values())
+    for i, deg in in_deg.items():
+        if deg < d_max:
+            G.add_edge(i, i, weight=d_max-deg)
+
+    P = nx.to_numpy_matrix(G)
+    P = P / P.sum(axis=1)  # to transition probability matrix
+
+    def _Qj(P, j):
+        P = copy.copy(P)
+        P[:, j] = 0
+        return P
+
+    M = np.empty([n, n])
+
+    for i in range(n):
+        M[:, i] = np.linalg.solve(np.identity(n) - _Qj(P, i),
+                                  np.ones([n, 1])[:, 0])  # eq 3
+
+    return dict(zip(G.nodes,
+                    [np.sqrt((2*np.sum(M[:, i])-n*(n+1))) for i in range(n)]
+                    ))  # eq 6
+
+
+# fixture for nose tests
+def setup_module(module):
+    from nose import SkipTest
+    try:
+        import numpy
+        import scipy
+    except:
+        raise SkipTest("NumPy not available")

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -132,5 +132,6 @@ def setup_module(module):
     from nose import SkipTest
     try:
         import numpy
+        import scipy
     except:
         raise SkipTest("NumPy not available")

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -124,5 +124,13 @@ def second_order_centrality(G):
                                   (np.identity(n) + _Qj(P, i)) *
                                   np.reshape(M[:, i], [n, 1]))[0]
 
-    return {k: v for k, v in enumerate(
-        np.sqrt(H - np.square(M))[0, :])}  # eq 4
+    return dict(zip(G.nodes, np.sqrt(H - np.square(M))[0, :]))  # eq 4
+
+
+# fixture for nose tests
+def setup_module(module):
+    from nose import SkipTest
+    try:
+        import numpy
+    except:
+        raise SkipTest("NumPy not available")

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -33,7 +33,11 @@
 
 __all__ = ['second_order_centrality']
 
-@nx.not_implemented_for('directed')
+import networkx as nx
+import copy
+from networkx.utils import not_implemented_for
+
+@not_implemented_for('directed')
 def second_order_centrality(G):
     """Compute the second order centrality for nodes of G.
 
@@ -81,9 +85,6 @@ def second_order_centrality(G):
        "Second order centrality: Distributed assessment of nodes criticity in
        complex networks", Elsevier Computer Communications 34(5):619-628, 2011.
     """
-
-    import networkx as nx
-    import copy
 
     try:
         import numpy as np

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -65,6 +65,21 @@ def second_order_centrality(G):
     >>> print(sorted(soc.items(), key=lambda x:x[1])[0][0]) # pick first id
     0
 
+    >>> G = nx.empty_graph()
+    >>> second_order_centrality(G)
+    networkx.exception.NetworkXException: Empty graph.
+
+    >>> G = nx.Graph()
+    >>> G.add_node(0)
+    >>> G.add_node(1)
+    >>> second_order_centrality(G)
+    networkx.exception.NetworkXException: Non connected graph.
+
+    Raises
+    ------
+    NetworkXException
+        If the graph ``G`` is empty or non connected.
+
     See Also
     --------
     betweenness_centrality
@@ -77,7 +92,7 @@ def second_order_centrality(G):
 
     This code implements the analytical version of the algorithm, i.e.,
     there is no simulation of a random walk process involved. The random walk
-    is here biased (corresponding to eq(4) of the paper [1]_).
+    is here biased (corresponding to eq 4 of the paper [1]_).
 
     Complexity of this implementation, made to run locally on a single machine,
     is O(n^3), with n the size of G, which makes it viable only for small

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 – Thomson Licensing, SAS
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted (subject to the limitations in the disclaimer below) provided that
+# the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of Thomson Licensing, or Technicolor, nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS 
+# LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
+''' Second order centrality measure.'''
+import networkx as nx
+import numpy as np
+import copy
+
+__all__ = ['second_order_centrality']
+
+@nx.not_implemented_for('directed')
+def second_order_centrality(G):
+    """Compute the second order centrality for nodes of G.
+
+    The second order centrality of a given node is the standard deviation of 
+    the return times to that node of a perpetual random walk on G:
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX connected and undirected graph.
+
+    Returns
+    -------
+    nodes : dictionary
+       Dictionary keyed by node with second order centrality as the value.
+
+    Examples
+    --------
+    >>> G = nx.star_graph(10)
+    >>> soc = second_order_centrality(G)
+    >>> print(sorted(soc.items(), key=lambda x:x[1])[0][0]) # pick first id
+    0  # most central node
+
+    See Also
+    --------
+    betweenness_centrality
+
+    Notes
+    -----
+    Lower values of second order centrality indicate higher centrality.
+    
+    The algorithm is from Kermarrec, Le Merrer, Sericola and Trédan [1]_.
+    
+    This code implements the analytical version of the algorithm, i.e., 
+    there is no simulation of a random walk process involved. The random walk
+    is here biased (corresponding to eq(4) of the paper [1]_).
+    
+    Complexity of this implementation, made to run locally on a single machine, 
+    is O(n^3), with n the size of G, which makes it viable only for small 
+    graphs.
+
+    References
+    ----------
+    .. [1] Anne-Marie Kermarrec, Erwan Le Merrer, Bruno Sericola, Gilles Trédan
+       "Second order centrality: Distributed assessment of nodes criticity in
+       complex networks", Elsevier Computer Communications 34(5):619-628, 2011.
+    """
+    n = len(G)
+
+    if n == 0:
+        raise nx.NetworkXException("Empty graph.")
+    if not nx.is_connected(G):
+        raise nx.NetworkXException("Non connected graph.")
+    
+    P = nx.to_numpy_matrix(G)
+    P = P / P.sum(axis=1)  # to transition probability matrix
+    
+    def _Qj(P, j):
+        P = copy.deepcopy(P)
+        P[:, j] = 0
+        return P
+    
+    M = np.empty([n, n])
+    H = np.empty([n, n])
+    for i in range(n):
+        M[:, i] = np.linalg.solve(np.identity(n) - _Qj(P, i),
+                                  np.ones([n, 1])
+                                 )[0]# eq(3)
+        H[:, i] = np.linalg.solve((np.identity(n) - _Qj(P, i)),
+                                 (np.identity(n) + _Qj(P, i)) * 
+                                    np.reshape(M[:, i], [n, 1])
+                                 )[0]
+        
+    return {k: v for k, v in enumerate(np.sqrt(H - np.square(M))[0, :])}# eq(4)
+
+
+if __name__ == '__main__':
+
+    G=nx.star_graph(10)
+    soc = second_order_centrality(G)
+    print("Most central node in the star graph is id: %d" % sorted(soc.items(), key=lambda x:x[1])[0][0])

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -34,6 +34,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import networkx as nx
 import copy
 from networkx.utils import not_implemented_for
+import unittest
 
 # Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
 ''' Second order centrality measure.'''
@@ -64,16 +65,6 @@ def second_order_centrality(G):
     >>> soc = second_order_centrality(G)
     >>> print(sorted(soc.items(), key=lambda x:x[1])[0][0]) # pick first id
     0
-
-    >>> G = nx.empty_graph()
-    >>> second_order_centrality(G)
-    networkx.exception.NetworkXException: Empty graph.
-
-    >>> G = nx.Graph()
-    >>> G.add_node(0)
-    >>> G.add_node(1)
-    >>> second_order_centrality(G)
-    networkx.exception.NetworkXException: Non connected graph.
 
     Raises
     ------
@@ -146,3 +137,22 @@ def setup_module(module):
         import numpy
     except:
         raise SkipTest("NumPy not available")
+
+# for codecov
+
+
+class AssumptionTests(unittest.TestCase):
+    def test_empty(self):
+        G = nx.empty_graph()
+        self.assertRaises(nx.NetworkXException,
+                          lambda: second_order_centrality(G))
+
+    def test_nonconnected(self):
+        G = nx.Graph()
+        G.add_node(0)
+        G.add_node(1)
+        self.assertRaises(nx.NetworkXException,
+                          lambda: second_order_centrality(G))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -154,5 +154,6 @@ class AssumptionTests(unittest.TestCase):
         self.assertRaises(nx.NetworkXException,
                           lambda: second_order_centrality(G))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -113,6 +113,17 @@ def second_order_centrality(G):
     return {k: v for k, v in enumerate(np.sqrt(H - np.square(M))[0, :])}# eq(4)
 
 
+
+# fixture for nose tests
+def setup_module(module):
+    from nose import SkipTest
+    try:
+        import numpy
+    except:
+        raise SkipTest("NumPy not available")
+
+
+
 if __name__ == '__main__':
 
     G=nx.star_graph(10)

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -34,7 +34,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import networkx as nx
 import copy
 from networkx.utils import not_implemented_for
-import unittest
 
 # Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
 ''' Second order centrality measure.'''
@@ -127,32 +126,3 @@ def second_order_centrality(G):
 
     return {k: v for k, v in enumerate(
         np.sqrt(H - np.square(M))[0, :])}  # eq 4
-
-# fixture for nose tests
-
-
-def setup_module(module):
-    from nose import SkipTest
-    try:
-        import numpy
-    except:
-        raise SkipTest("NumPy not available")
-
-# for codecov
-
-
-class AssumptionTests(unittest.TestCase):
-    def test_empty(self):
-        G = nx.empty_graph()
-        self.assertRaises(nx.NetworkXException,
-                          lambda: second_order_centrality(G))
-
-    def test_nonconnected(self):
-        G = nx.Graph()
-        G.add_node(0)
-        G.add_node(1)
-        self.assertRaises(nx.NetworkXException,
-                          lambda: second_order_centrality(G))
-
-
-unittest.main()

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -58,7 +58,7 @@ def second_order_centrality(G):
     >>> G = nx.star_graph(10)
     >>> soc = second_order_centrality(G)
     >>> print(sorted(soc.items(), key=lambda x:x[1])[0][0]) # pick first id
-    0  # most central node
+    0
 
     See Also
     --------

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -119,8 +119,6 @@ def second_order_centrality(G):
         
     return {k: v for k, v in enumerate(np.sqrt(H - np.square(M))[0, :])}# eq(4)
 
-
-
 # fixture for nose tests
 def setup_module(module):
     from nose import SkipTest
@@ -128,11 +126,3 @@ def setup_module(module):
         import numpy
     except:
         raise SkipTest("NumPy not available")
-
-
-
-if __name__ == '__main__':
-
-    G=nx.star_graph(10)
-    soc = second_order_centrality(G)
-    print("Most central node in the star graph is id: %d" % sorted(soc.items(), key=lambda x:x[1])[0][0])

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -30,9 +30,6 @@
 #
 # Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
 ''' Second order centrality measure.'''
-import networkx as nx
-import numpy as np
-import copy
 
 __all__ = ['second_order_centrality']
 
@@ -84,6 +81,15 @@ def second_order_centrality(G):
        "Second order centrality: Distributed assessment of nodes criticity in
        complex networks", Elsevier Computer Communications 34(5):619-628, 2011.
     """
+
+    import networkx as nx
+    import copy
+
+    try:
+        import numpy as np
+    except ImportError:
+        raise ImportError('Requires NumPy: http://scipy.org/')
+
     n = len(G)
 
     if n == 0:

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -1,47 +1,51 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015 – Thomson Licensing, SAS
-#
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted (subject to the limitations in the disclaimer below) provided that
-# the following conditions are met:
-#
-# * Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer.
-#
-# * Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# * Neither the name of Thomson Licensing, or Technicolor, nor the names of its
-# contributors may be used to endorse or promote products derived from this
-# software without specific prior written permission.
-#
-# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS 
-# LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
-# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-# Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
-''' Second order centrality measure.'''
+'''Copyright (c) 2015 – Thomson Licensing, SAS
 
-__all__ = ['second_order_centrality']
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+* Neither the name of Thomson Licensing, or Technicolor, nor the names
+of its contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
 
 import networkx as nx
 import copy
 from networkx.utils import not_implemented_for
 
+# Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
+''' Second order centrality measure.'''
+
+__all__ = ['second_order_centrality']
+
+
 @not_implemented_for('directed')
 def second_order_centrality(G):
     """Compute the second order centrality for nodes of G.
 
-    The second order centrality of a given node is the standard deviation of 
+    The second order centrality of a given node is the standard deviation of
     the return times to that node of a perpetual random walk on G:
 
     Parameters
@@ -68,15 +72,15 @@ def second_order_centrality(G):
     Notes
     -----
     Lower values of second order centrality indicate higher centrality.
-    
+
     The algorithm is from Kermarrec, Le Merrer, Sericola and Trédan [1]_.
-    
-    This code implements the analytical version of the algorithm, i.e., 
+
+    This code implements the analytical version of the algorithm, i.e.,
     there is no simulation of a random walk process involved. The random walk
     is here biased (corresponding to eq(4) of the paper [1]_).
-    
-    Complexity of this implementation, made to run locally on a single machine, 
-    is O(n^3), with n the size of G, which makes it viable only for small 
+
+    Complexity of this implementation, made to run locally on a single machine,
+    is O(n^3), with n the size of G, which makes it viable only for small
     graphs.
 
     References
@@ -97,29 +101,30 @@ def second_order_centrality(G):
         raise nx.NetworkXException("Empty graph.")
     if not nx.is_connected(G):
         raise nx.NetworkXException("Non connected graph.")
-    
+
     P = nx.to_numpy_matrix(G)
     P = P / P.sum(axis=1)  # to transition probability matrix
-    
+
     def _Qj(P, j):
         P = copy.deepcopy(P)
         P[:, j] = 0
         return P
-    
+
     M = np.empty([n, n])
     H = np.empty([n, n])
     for i in range(n):
         M[:, i] = np.linalg.solve(np.identity(n) - _Qj(P, i),
-                                  np.ones([n, 1])
-                                 )[0]# eq(3)
+                                  np.ones([n, 1]))[0]  # eq 3
         H[:, i] = np.linalg.solve((np.identity(n) - _Qj(P, i)),
-                                 (np.identity(n) + _Qj(P, i)) * 
-                                    np.reshape(M[:, i], [n, 1])
-                                 )[0]
-        
-    return {k: v for k, v in enumerate(np.sqrt(H - np.square(M))[0, :])}# eq(4)
+                                  (np.identity(n) + _Qj(P, i)) *
+                                  np.reshape(M[:, i], [n, 1]))[0]
+
+    return {k: v for k, v in enumerate(
+        np.sqrt(H - np.square(M))[0, :])}  # eq 4
 
 # fixture for nose tests
+
+
 def setup_module(module):
     from nose import SkipTest
     try:

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -155,5 +155,4 @@ class AssumptionTests(unittest.TestCase):
                           lambda: second_order_centrality(G))
 
 
-if __name__ == '__main__':
-    unittest.main()
+unittest.main()

--- a/networkx/algorithms/centrality/second_order_centrality.py
+++ b/networkx/algorithms/centrality/second_order_centrality.py
@@ -62,7 +62,7 @@ def second_order_centrality(G):
     Examples
     --------
     >>> G = nx.star_graph(10)
-    >>> soc = second_order_centrality(G)
+    >>> soc = nx.second_order_centrality(G)
     >>> print(sorted(soc.items(), key=lambda x:x[1])[0][0]) # pick first id
     0
 

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -4,7 +4,7 @@ Tests for second order centrality.
 
 import networkx as nx
 from nose import SkipTest
-from nose.tools import raises
+from nose.tools import raises, assert_almost_equal
 
 
 class TestSecondOrderCentrality(object):
@@ -25,8 +25,52 @@ class TestSecondOrderCentrality(object):
         nx.second_order_centrality(G)
 
     @raises(nx.NetworkXException)
-    def test_nonconnected(self):
+    def test_non_connected(self):
         G = nx.Graph()
         G.add_node(0)
         G.add_node(1)
         nx.second_order_centrality(G)
+
+    @raises(nx.NetworkXException)
+    def test_non_negative_edge_weights(self):
+        G = nx.path_graph(2)
+        G.add_edge(0, 1, weight=-1)
+        nx.second_order_centrality(G)
+
+    def test_one_node_graph(self):
+        """Second order centrality: single node"""
+        G = nx.Graph()
+        G.add_node(0)
+        G.add_edge(0, 0)
+        assert nx.second_order_centrality(G)[0] == 0
+
+    def test_P3(self):
+        """Second order centrality: line graph, as defined in paper"""
+        G = nx.path_graph(3)
+        b_answer = {0: 3.741, 1: 1.414, 2: 3.741}
+
+        b = nx.second_order_centrality(G)
+
+        for n in sorted(G):
+            assert_almost_equal(b[n], b_answer[n], places=2)
+
+    def test_K3(self):
+        """Second order centrality: complete graph, as defined in paper"""
+        G = nx.complete_graph(3)
+        b_answer = {0: 1.414, 1: 1.414, 2: 1.414}
+
+        b = nx.second_order_centrality(G)
+
+        for n in sorted(G):
+            assert_almost_equal(b[n], b_answer[n], places=2)
+
+    def test_ring_graph(self):
+        """Second order centrality: ring graph, as defined in paper"""
+        G = nx.cycle_graph(5)
+        b_answer = {0: 4.472, 1: 4.472, 2: 4.472,
+                    3: 4.472, 4: 4.472}
+
+        b = nx.second_order_centrality(G)
+
+        for n in sorted(G):
+            assert_almost_equal(b[n], b_answer[n], places=2)

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -4,10 +4,20 @@ Tests for second order centrality.
 
 import networkx as nx
 from nose import SkipTest
-from nose.tools import raises, assert_almost_equal
+from nose.tools import raises
 
 
 class TestSecondOrderCentrality(object):
+    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
+
+    @classmethod
+    def setupClass(cls):
+        global np
+        try:
+            import numpy as np
+            import scipy
+        except ImportError:
+            raise SkipTest('NumPy not available.')
 
     @raises(nx.NetworkXException)
     def test_empty(self):
@@ -20,27 +30,3 @@ class TestSecondOrderCentrality(object):
         G.add_node(0)
         G.add_node(1)
         nx.second_order_centrality(G)
-
-    def test_florentine_families_graph(self):
-        """Second order centrality: Florentine families graph"""
-        G = nx.florentine_families_graph()
-        b_answer = {'Acciaiuoli':    39.49,
-                    'Albizzi':       19.91,
-                    'Barbadori':     22.17,
-                    'Bischeri':      22.75,
-                    'Castellani':    23.67,
-                    'Ginori':        58.92,
-                    'Guadagni':      17.44,
-                    'Lamberteschi':  56.45,
-                    'Medici':        0.00,
-                    'Pazzi':         76.49,
-                    'Peruzzi':       25.90,
-                    'Ridolfi':       13.75,
-                    'Salviati':      37.49,
-                    'Strozzi':       18.85,
-                    'Tornabuoni':    13.80}
-
-        b = nx.second_order_centrality(G)
-
-        for n in sorted(G):
-            assert_almost_equal(b[n], b_answer[n], delta=0.01)

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -1,0 +1,28 @@
+"""
+Tests for second order centrality centrality.
+"""
+
+import networkx as nx
+from nose import SkipTest
+from nose.tools import raises
+
+
+class TestSecondOrderCentrality(object):
+
+    def setup_module(module):
+        try:
+            import numpy
+        except:
+            raise SkipTest("NumPy not available")
+
+    @raises(nx.NetworkXException)
+    def test_empty(self):
+        G = nx.empty_graph()
+        nx.second_order_centrality(G)
+
+    @raises(nx.NetworkXException)
+    def test_nonconnected(self):
+        G = nx.Graph()
+        G.add_node(0)
+        G.add_node(1)
+        nx.second_order_centrality(G)

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -1,19 +1,13 @@
 """
-Tests for second order centrality centrality.
+Tests for second order centrality.
 """
 
 import networkx as nx
 from nose import SkipTest
-from nose.tools import raises
+from nose.tools import raises, assert_almost_equal
 
 
 class TestSecondOrderCentrality(object):
-
-    def setup_module(module):
-        try:
-            import numpy
-        except:
-            raise SkipTest("NumPy not available")
 
     @raises(nx.NetworkXException)
     def test_empty(self):
@@ -26,3 +20,27 @@ class TestSecondOrderCentrality(object):
         G.add_node(0)
         G.add_node(1)
         nx.second_order_centrality(G)
+
+    def test_florentine_families_graph(self):
+        """Second order centrality: Florentine families graph"""
+        G = nx.florentine_families_graph()
+        b_answer = {'Acciaiuoli':    39.49,
+                    'Albizzi':       19.91,
+                    'Barbadori':     22.17,
+                    'Bischeri':      22.75,
+                    'Castellani':    23.67,
+                    'Ginori':        58.92,
+                    'Guadagni':      17.44,
+                    'Lamberteschi':  56.45,
+                    'Medici':        0.00,
+                    'Pazzi':         76.49,
+                    'Peruzzi':       25.90,
+                    'Ridolfi':       13.75,
+                    'Salviati':      37.49,
+                    'Strozzi':       18.85,
+                    'Tornabuoni':    13.80}
+
+        b = nx.second_order_centrality(G)
+
+        for n in sorted(G):
+            assert_almost_equal(b[n], b_answer[n], delta=0.01)


### PR DESCRIPTION
* Adds second_order_centrality module to networkx.algorithms.centrality package

Author implementation of "Second order centrality: Distributed assessment of nodes criticity in complex networks", Elsevier Computer Communications 34(5):619-628, 2011. Cited 96 times.
