### PR TITLE
Fix scale_free_graph restriction

### DIFF
--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -17,7 +17,6 @@ scale-free graphs.
 from __future__ import division
 
 from collections import Counter
-import math
 
 import networkx as nx
 from networkx.generators.classic import empty_graph
@@ -262,7 +261,7 @@ def scale_free_graph(n, alpha=0.41, beta=0.54, gamma=0.05, delta_in=0.2,
     if gamma <= 0:
         raise ValueError('beta must be >= 0.')
 
-    if not math.isclose(alpha + beta + gamma, 1.0):
+    if abs(alpha + beta + gamma - 1.0) < 1e-9:
         raise ValueError('alpha+beta+gamma must equal 1.')
 
     number_of_edges = G.number_of_edges()

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -261,7 +261,7 @@ def scale_free_graph(n, alpha=0.41, beta=0.54, gamma=0.05, delta_in=0.2,
     if gamma <= 0:
         raise ValueError('beta must be >= 0.')
 
-    if abs(alpha + beta + gamma - 1.0) < 1e-9:
+    if abs(alpha + beta + gamma - 1.0) >= 1e-9:
         raise ValueError('alpha+beta+gamma must equal 1.')
 
     number_of_edges = G.number_of_edges()

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -17,6 +17,7 @@ scale-free graphs.
 from __future__ import division
 
 from collections import Counter
+import math
 
 import networkx as nx
 from networkx.generators.classic import empty_graph
@@ -261,7 +262,7 @@ def scale_free_graph(n, alpha=0.41, beta=0.54, gamma=0.05, delta_in=0.2,
     if gamma <= 0:
         raise ValueError('beta must be >= 0.')
 
-    if alpha + beta + gamma != 1.0:
+    if not math.isclose(alpha + beta + gamma, 1.0):
         raise ValueError('alpha+beta+gamma must equal 1.')
 
     number_of_edges = G.number_of_edges()

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -47,10 +47,14 @@ class TestGeneratorsDirected(object):
         G = gnc_graph(100, seed=1)
         MG = gnc_graph(100, create_using=MultiDiGraph(), seed=1)
         assert_equal(sorted(G.edges()), sorted(MG.edges()))
+
         G = scale_free_graph(100, alpha=0.3, beta=0.4, gamma=0.3,
                              delta_in=0.3, delta_out=0.1,
                              create_using=MultiDiGraph, seed=1)
         assert_raises(ValueError, scale_free_graph, 100, 0.5, 0.4, 0.3)
+        assert_raises(ValueError, scale_free_graph, 100, alpha=-0.3)
+        assert_raises(ValueError, scale_free_graph, 100, beta=-0.3)
+        assert_raises(ValueError, scale_free_graph, 100, gamma=-0.3)
 
 
 class TestRandomKOutGraph(object):

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -47,6 +47,10 @@ class TestGeneratorsDirected(object):
         G = gnc_graph(100, seed=1)
         MG = gnc_graph(100, create_using=MultiDiGraph(), seed=1)
         assert_equal(sorted(G.edges()), sorted(MG.edges()))
+        G = scale_free_graph(100, alpha=0.3, beta=0.4, gamma=0.3,
+                             delta_in=0.3, delta_out=0.1,
+                             create_using=MultiDiGraph, seed=1)
+        assert_raises(ValueError, scale_free_graph, 100, 0.5, 0.4, 0.3)
 
 
 class TestRandomKOutGraph(object):


### PR DESCRIPTION
`scale_free_graph` generator has a restriction, that `alpha + beta + gamma` has to be equal to `1`.
However, while working with random graph parameters, it is often hard to satisfy this requirement, because   of the float representation.

Eg, this simple code doesn't work:
```python
from networkx import scale_free_graph
import numpy as np

np.random.seed(1)
t = np.random.random(3)
t = t / t.sum()
G = scale_free_graph(N, alpha=t[0], beta=t[1], gamma=t[2])
```
neither does that one
```python
from networkx import scale_free_graph
import numpy as np

np.random.seed(1)
t = np.random.random(3)
t = t / t.sum()
G = scale_free_graph(N, alpha=t[0], beta=t[1], gamma=(1 - t[0] - t[1]))
```
or that one
```python
from networkx import scale_free_graph
import numpy as np

t = np.random.dirichlet(np.ones(3, dtype=np.float32), size=1)[0]
G = scale_free_graph(10, alpha=t[0], beta=t[1], gamma=t[2])
```
So, that's why I think just checking if `math.isclose(alpha + beta + gamma, 1.0)` would be better.
 