### PR TITLE
Handle negatively weighted edges in bellman-ford, fixes #3130

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -558,6 +558,17 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert_equal(pred[3], 0)
         assert_equal(dist, {0: 0, 1: 1, 2: 2, 3: 1})
 
+    def test_negative_weight(self):
+        G = nx.DiGraph()
+        G.add_nodes_from('abcd')
+        G.add_edge('a','d', weight = 0)
+        G.add_edge('a','b', weight = 1)
+        G.add_edge('b','c', weight = -3)
+        G.add_edge('c','d', weight = 1)
+
+        assert_equal(nx.bellman_ford_path(G, 'a', 'd'), ['a', 'b', 'c', 'd'])
+        assert_equal(nx.bellman_ford_path_length(G, 'a', 'd'), -1)
+
 
 class TestJohnsonAlgorithm(WeightedTestBase):
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1290,10 +1290,6 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
                     if dist_v > cutoff:
                         continue
 
-                if target is not None:
-                    if dist_v > dist.get(target, inf):
-                        continue
-
                 if dist_v < dist.get(v, inf):
                     if v not in in_q:
                         q.append(v)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1216,7 +1216,8 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
     G : NetworkX graph
 
     source: list
-        List of source nodes
+        List of source nodes. The shortest path from any of the source
+        nodes will be found if multiple sources are provided.
 
     weight : function
         The weight of an edge is the value returned by the function. The

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1101,7 +1101,7 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight='weight'):
 
 
 def bellman_ford_predecessor_and_distance(G, source, target=None,
-                                          cutoff=None, weight='weight'):
+                                          weight='weight'):
     """Compute shortest path lengths and predecessors on shortest paths
     in weighted graphs.
 
@@ -1200,12 +1200,12 @@ def bellman_ford_predecessor_and_distance(G, source, target=None,
     weight = _weight_function(G, weight)
 
     dist = _bellman_ford(G, [source], weight, pred=pred, dist=dist,
-                         cutoff=cutoff, target=target)
+                         target=target)
     return (pred, dist)
 
 
 def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
-                  cutoff=None, target=None):
+                  target=None):
     """Relaxation loop for Bellman–Ford algorithm
 
     Parameters
@@ -1233,9 +1233,6 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
         dict to store distance from source to the keyed node
         If None, returned dist dict contents default to 0 for every node in the
         source list
-
-    cutoff: integer or float, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned
 
     target: node label, optional
         Ending node for path. Path lengths to other destinations may (and
@@ -1283,10 +1280,6 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
             dist_u = dist[u]
             for v, e in G_succ[u].items():
                 dist_v = dist_u + weight(v, u, e)
-
-                if cutoff is not None:
-                    if dist_v > cutoff:
-                        continue
 
                 if dist_v < dist.get(v, inf):
                     if v not in in_q:
@@ -1428,7 +1421,7 @@ def bellman_ford_path_length(G, source, target, weight='weight'):
             "node %s not reachable from %s" % (source, target))
 
 
-def single_source_bellman_ford_path(G, source, cutoff=None, weight='weight'):
+def single_source_bellman_ford_path(G, source, weight='weight'):
     """Compute shortest path between source and all other reachable
     nodes for a weighted graph.
 
@@ -1441,9 +1434,6 @@ def single_source_bellman_ford_path(G, source, cutoff=None, weight='weight'):
 
     weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight
-
-    cutoff : integer or float, optional
-       Depth to stop the search. Only paths of length <= cutoff are returned.
 
     Returns
     -------
@@ -1473,12 +1463,11 @@ def single_source_bellman_ford_path(G, source, cutoff=None, weight='weight'):
 
     """
     (length, path) = single_source_bellman_ford(
-        G, source, cutoff=cutoff, weight=weight)
+        G, source, weight=weight)
     return path
 
 
-def single_source_bellman_ford_path_length(G, source,
-                                           cutoff=None, weight='weight'):
+def single_source_bellman_ford_path_length(G, source, weight='weight'):
     """Compute the shortest path length between source and all other
     reachable nodes for a weighted graph.
 
@@ -1491,9 +1480,6 @@ def single_source_bellman_ford_path_length(G, source,
 
     weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight.
-
-    cutoff : integer or float, optional
-       Depth to stop the search. Only paths of length <= cutoff are returned.
 
     Returns
     -------
@@ -1530,11 +1516,10 @@ def single_source_bellman_ford_path_length(G, source,
 
     """
     weight = _weight_function(G, weight)
-    return _bellman_ford(G, [source], weight, cutoff=cutoff)
+    return _bellman_ford(G, [source], weight)
 
 
-def single_source_bellman_ford(G, source,
-                               target=None, cutoff=None, weight='weight'):
+def single_source_bellman_ford(G, source, target=None, weight='weight'):
     """Compute shortest paths and lengths in a weighted graph G.
 
     Uses Bellman-Ford algorithm for shortest paths.
@@ -1548,9 +1533,6 @@ def single_source_bellman_ford(G, source,
 
     target : node label, optional
        Ending node for path
-
-    cutoff : integer or float, optional
-       Depth to stop the search. Only paths of length <= cutoff are returned.
 
     Returns
     -------
@@ -1605,8 +1587,7 @@ def single_source_bellman_ford(G, source,
     weight = _weight_function(G, weight)
 
     paths = {source: [source]}  # dictionary of paths
-    dist = _bellman_ford(G, [source], weight, paths=paths, cutoff=cutoff,
-                         target=target)
+    dist = _bellman_ford(G, [source], weight, paths=paths, target=target)
     if target is None:
         return (dist, paths)
     try:
@@ -1616,7 +1597,7 @@ def single_source_bellman_ford(G, source,
         raise nx.NetworkXNoPath(msg)
 
 
-def all_pairs_bellman_ford_path_length(G, cutoff=None, weight='weight'):
+def all_pairs_bellman_ford_path_length(G, weight='weight'):
     """ Compute shortest path lengths between all nodes in a weighted graph.
 
     Parameters
@@ -1625,9 +1606,6 @@ def all_pairs_bellman_ford_path_length(G, cutoff=None, weight='weight'):
 
     weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight
-
-    cutoff : integer or float, optional
-       Depth to stop the search. Only paths of length <= cutoff are returned.
 
     Returns
     -------
@@ -1660,10 +1638,10 @@ def all_pairs_bellman_ford_path_length(G, cutoff=None, weight='weight'):
     """
     length = single_source_bellman_ford_path_length
     for n in G:
-        yield (n, dict(length(G, n, cutoff=cutoff, weight=weight)))
+        yield (n, dict(length(G, n, weight=weight)))
 
 
-def all_pairs_bellman_ford_path(G, cutoff=None, weight='weight'):
+def all_pairs_bellman_ford_path(G, weight='weight'):
     """ Compute shortest paths between all nodes in a weighted graph.
 
     Parameters
@@ -1672,9 +1650,6 @@ def all_pairs_bellman_ford_path(G, cutoff=None, weight='weight'):
 
     weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight
-
-    cutoff : integer or float, optional
-       Depth to stop the search. Only paths of length <= cutoff are returned.
 
     Returns
     -------
@@ -1701,7 +1676,7 @@ def all_pairs_bellman_ford_path(G, cutoff=None, weight='weight'):
     path = single_source_bellman_ford_path
     # TODO This can be trivially parallelized.
     for n in G:
-        yield (n, path(G, n, cutoff=cutoff, weight=weight))
+        yield (n, path(G, n, weight=weight))
 
 
 def goldberg_radzik(G, source, weight='weight'):

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1206,7 +1206,10 @@ def bellman_ford_predecessor_and_distance(G, source, target=None,
 
 def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
                   target=None):
-    """Relaxation loop for Bellman–Ford algorithm
+    """Relaxation loop for Bellman–Ford algorithm.
+
+    This is an implementation of the SPFA variant.
+    See https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm
 
     Parameters
     ----------
@@ -1216,10 +1219,10 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
         List of source nodes
 
     weight : function
-       The weight of an edge is the value returned by the function. The
-       function must accept exactly three positional arguments: the two
-       endpoints of an edge and the dictionary of edge attributes for
-       that edge. The function must return a number.
+        The weight of an edge is the value returned by the function. The
+        function must accept exactly three positional arguments: the two
+        endpoints of an edge and the dictionary of edge attributes for
+        that edge. The function must return a number.
 
     pred: dict of lists, optional (default=None)
         dict to store a list of predecessors keyed by that node

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1136,8 +1136,6 @@ def bellman_ford_predecessor_and_distance(G, source, target=None,
     pred, dist : dictionaries
        Returns two dictionaries keyed by node to predecessor in the
        path and to the distance from the source respectively.
-       Warning: If target is specified, the dicts are incomplete as they
-       only contain information for the nodes along a path to target.
 
     Raises
     ------
@@ -1162,9 +1160,9 @@ def bellman_ford_predecessor_and_distance(G, source, target=None,
 
     >>> pred, dist = nx.bellman_ford_predecessor_and_distance(G, 0, 1)
     >>> sorted(pred.items())
-    [(0, []), (1, [0])]
+    [(0, []), (1, [0]), (2, [1]), (3, [2]), (4, [3])]
     >>> sorted(dist.items())
-    [(0, 0), (1, 1)]
+    [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
 
     >>> from nose.tools import assert_raises
     >>> G = nx.cycle_graph(5, create_using = nx.DiGraph())


### PR DESCRIPTION
When negatively weighted edges are present, skipping nodes with longer distance than destination could miss better path. See example added in test case.

This should fix #3130.