### PR TITLE
Add targets argument to all_simple_paths

### DIFF
--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -224,22 +224,22 @@ def all_simple_paths(G, source, target, cutoff=None):
     if source not in G:
         raise nx.NodeNotFound('source node %s not in graph' % source)
     if target in G:
-        target = {target}
+        targets = {target}
     else:
         try:
-            target = set(target)
+            targets = set(target)
         except TypeError:
             raise nx.NodeNotFound('target node %s not in graph' % target)
-    if source in target:
+    if source in targets:
         return []
     if cutoff is None:
         cutoff = len(G) - 1
     if cutoff < 1:
         return []
     if G.is_multigraph():
-        return _all_simple_paths_multigraph(G, source, target, cutoff)
+        return _all_simple_paths_multigraph(G, source, targets, cutoff)
     else:
-        return _all_simple_paths_graph(G, source, target, cutoff)
+        return _all_simple_paths_graph(G, source, targets, cutoff)
 
 
 def _all_simple_paths_graph(G, source, targets, cutoff):

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -8,8 +8,8 @@ from nose.tools import raises
 
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
-from networkx.algorithms.simple_paths import _bidirectional_shortest_path
 from networkx.algorithms.simple_paths import _bidirectional_dijkstra
+from networkx.algorithms.simple_paths import _bidirectional_shortest_path
 from networkx.utils import arbitrary_element
 
 
@@ -88,6 +88,33 @@ def test_all_simple_paths():
     assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3)})
 
 
+def test_all_simple_paths_with_two_targets_emits_two_paths():
+    G = nx.path_graph(4)
+    G.add_edge(2, 4)
+    paths = nx.all_simple_paths(G, 0, [3, 4])
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
+
+
+def test_all_simple_paths_with_two_targets_in_line_emits_one_path():
+    G = nx.path_graph(4)
+    paths = nx.all_simple_paths(G, 0, [2, 3])
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2)})
+
+
+def test_all_simple_paths_ignores_cycle():
+    G = nx.cycle_graph(3, create_using=nx.DiGraph())
+    G.add_edge(1, 3)
+    paths = nx.all_simple_paths(G, 0, 3)
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 3)})
+
+
+def test_all_simple_paths_with_two_targets_inside_cycle_emits_two_paths():
+    G = nx.cycle_graph(3, create_using=nx.DiGraph())
+    G.add_edge(1, 3)
+    paths = nx.all_simple_paths(G, 0, [2, 3])
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2), (0, 1, 3)})
+
+
 def test_all_simple_paths_source_target():
     G = nx.path_graph(4)
     paths = nx.all_simple_paths(G, 1, 1)
@@ -130,10 +157,12 @@ def test_all_simple_paths_empty():
     paths = nx.all_simple_paths(G, 0, 3, cutoff=2)
     assert_equal(list(list(p) for p in paths), [])
 
+
 def test_all_simple_paths_corner_cases():
     assert_equal(list(nx.all_simple_paths(nx.empty_graph(2), 0, 0)), [])
     assert_equal(list(nx.all_simple_paths(nx.empty_graph(2), 0, 1)), [])
     assert_equal(list(nx.all_simple_paths(nx.path_graph(9), 0, 8, 0)), [])
+
 
 def hamiltonian_path(G, source):
     source = arbitrary_element(G)
@@ -174,9 +203,8 @@ def test_target_missing():
     nx.add_path(G, [1, 2, 3])
     paths = list(nx.all_simple_paths(nx.MultiGraph(G), 1, 4))
 
+
 # Tests for shortest_simple_paths
-
-
 def test_shortest_simple_paths():
     G = cnlti(nx.grid_2d_graph(4, 4), first_label=1, ordering="sorted")
     paths = nx.shortest_simple_paths(G, 1, 12)
@@ -209,6 +237,7 @@ def test_Greg_Bernstein():
 def test_weighted_shortest_simple_path():
     def cost_func(path):
         return sum(G.adj[u][v]['weight'] for (u, v) in zip(path, path[1:]))
+
     G = nx.complete_graph(5)
     weight = {(u, v): random.randint(1, 100) for (u, v) in G.edges()}
     nx.set_edge_attributes(G, weight, 'weight')
@@ -222,6 +251,7 @@ def test_weighted_shortest_simple_path():
 def test_directed_weighted_shortest_simple_path():
     def cost_func(path):
         return sum(G.adj[u][v]['weight'] for (u, v) in zip(path, path[1:]))
+
     G = nx.complete_graph(5)
     G = G.to_directed()
     weight = {(u, v): random.randint(1, 100) for (u, v) in G.edges()}


### PR DESCRIPTION
If one is looking to find all simple paths to multiple targets with out-degree 0, then emitting paths for a set of targets instead of each target separately improves big O algorithmic complexity by a factor of m, where m is the number of targets.

Further clarification: Because we are using an exhaustive depth-first search to find all paths to a target, all other targets will also be encountered during that search.  This PR changes the algorithm so that those paths are also emitted.  

One might not want to use the `targets` argument if any of the targets have out-degree > 0.