### PR TITLE
Mathematics and rendering fixes to algorithms.cluster documentation

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -283,7 +283,7 @@ def clustering(G, nodes=None, weight=None):
     .. math::
 
        c_u = \frac{1}{deg(u)(deg(u)-1))}
-             \sum_{uv} (\hat{w}_{uv} \hat{w}_{uw} \hat{w}_{vw})^{1/3}.
+             \sum_{vw} (\hat{w}_{uv} \hat{w}_{uw} \hat{w}_{vw})^{1/3}.
 
     The edge weights `\hat{w}_{uv}` are normalized by the maximum weight in the
     network `\hat{w}_{uv} = w_{uv}/\max(w)`.

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -213,7 +213,7 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
 
        C = \frac{1}{n}\sum_{v \in G} c_v,
 
-    where `n` is the number of nodes in `G`.
+    where :math:`n` is the number of nodes in `G`.
 
     Parameters
     ----------
@@ -266,15 +266,15 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
 def clustering(G, nodes=None, weight=None):
     r"""Compute the clustering coefficient for nodes.
 
-    For unweighted graphs, the clustering of a node `u`
+    For unweighted graphs, the clustering of a node :math:`u`
     is the fraction of possible triangles through that node that exist,
 
     .. math::
 
       c_u = \frac{2 T(u)}{deg(u)(deg(u)-1)},
 
-    where `T(u)` is the number of triangles through node `u` and
-    `deg(u)` is the degree of `u`.
+    where :math:`T(u)` is the number of triangles through node :math:`u` and
+    :math:`deg(u)` is the degree of :math:`u`.
 
     For weighted graphs, there are several ways to define clustering [1]_.
     the one used here is defined
@@ -285,10 +285,10 @@ def clustering(G, nodes=None, weight=None):
        c_u = \frac{1}{deg(u)(deg(u)-1))}
              \sum_{vw} (\hat{w}_{uv} \hat{w}_{uw} \hat{w}_{vw})^{1/3}.
 
-    The edge weights `\hat{w}_{uv}` are normalized by the maximum weight in the
-    network `\hat{w}_{uv} = w_{uv}/\max(w)`.
+    The edge weights :math:`\hat{w}_{uv}` are normalized by the maximum weight
+    in the network :math:`\hat{w}_{uv} = w_{uv}/\max(w)`.
 
-    The value of `c_u` is assigned to 0 if `deg(u) < 2`.
+    The value of :math:`c_u` is assigned to 0 if :math:`deg(u) < 2`.
 
     For directed graphs, the clustering is similarly defined as the fraction
     of all possible directed triangles or geometric average of the subgraph
@@ -299,9 +299,10 @@ def clustering(G, nodes=None, weight=None):
        c_u = \frac{1}{deg^{tot}(u)(deg^{tot}(u)-1) - 2deg^{\leftrightarrow}(u)}
              T(u),
 
-    where `T(u)` is the number of directed triangles through node `u`,
-    `deg^{tot}(u)` is the sum of in degree and out degree of `u` and
-    `deg^{\leftrightarrow}(u)` is the reciprocal degree of `u`.
+    where :math:`T(u)` is the number of directed triangles through node
+    :math:`u`, :math:`deg^{tot}(u)` is the sum of in degree and out degree of
+    :math:`u` and :math:`deg^{\leftrightarrow}(u)` is the reciprocal degree of
+    :math:`u`.
 
     Parameters
     ----------
@@ -412,10 +413,11 @@ def square_clustering(G, nodes=None):
        \sum_{w=u+1}^{k_v} q_v(u,w) }{ \sum_{u=1}^{k_v}
        \sum_{w=u+1}^{k_v} [a_v(u,w) + q_v(u,w)]},
 
-    where `q_v(u,w)` are the number of common neighbors of `u` and `w`
-    other than `v` (ie squares), and
-    `a_v(u,w) = (k_u - (1+q_v(u,w)+\theta_{uv}))(k_w - (1+q_v(u,w)+\theta_{uw}))`,
-    where `\theta_{uw} = 1` if `u` and `w` are connected and 0 otherwise.
+    where :math:`q_v(u,w)` are the number of common neighbors of :math:`u` and
+    :math:`w` other than :math:`v` (ie squares), and :math:`a_v(u,w) = (k_u -
+    (1+q_v(u,w)+\theta_{uv}))(k_w - (1+q_v(u,w)+\theta_{uw}))`, where
+    :math:`\theta_{uw} = 1` if :math:`u` and :math:`w` are connected and 0
+    otherwise.
 
     Parameters
     ----------
@@ -439,8 +441,8 @@ def square_clustering(G, nodes=None):
 
     Notes
     -----
-    While `C_3(v)` (triangle clustering) gives the probability that
-    two neighbors of node v are connected with each other, `C_4(v)` is
+    While :math:`C_3(v)` (triangle clustering) gives the probability that
+    two neighbors of node v are connected with each other, :math:`C_4(v)` is
     the probability that two neighbors of node v share a common
     neighbor different from v. This algorithm can be applied to both
     bipartite and unipartite networks.
@@ -481,9 +483,10 @@ def generalized_degree(G, nodes=None):
     For each node, the generalized degree shows how many edges of given
     triangle multiplicity the node is connected to. The triangle multiplicity
     of an edge is the number of triangles an edge participates in. The
-    generalized degree of node `i` can be written as a vector
-    `\mathbf{k}_i=(k_i^{(0)}, \dotsc, k_i^{(N-2)})` where `k_i^{(j)}` is the
-    number of edges attached to node `i` that participate in `j` triangles.
+    generalized degree of node :math:`i` can be written as a vector
+    :math:`\mathbf{k}_i=(k_i^{(0)}, \dotsc, k_i^{(N-2)})` where
+    :math:`k_i^{(j)}` is the number of edges attached to node :math:`i` that
+    participate in :math:`j` triangles.
 
     Parameters
     ----------
@@ -521,9 +524,9 @@ def generalized_degree(G, nodes=None):
     The return value does not include a `zero` entry if no edges of a
     particular triangle multiplicity are present.
 
-    The number of triangles node `i` is attached to can be recovered from
-    the generalized degree `\mathbf{k}_i=(k_i^{(0)}, \dotsc, k_i^{(N-2)})` by
-    `(k_i^{(1)}+2k_i^{(2)}+\dotsc +(N-2)k_i^{(N-2)})/2`.
+    The number of triangles node :math:`i` is attached to can be recovered from
+    the generalized degree :math:`\mathbf{k}_i=(k_i^{(0)}, \dotsc,
+    k_i^{(N-2)})` by :math:`(k_i^{(1)}+2k_i^{(2)}+\dotsc +(N-2)k_i^{(N-2)})/2`.
 
     References
     ----------


### PR DESCRIPTION
- The documentation for `clustering` had `c_u = ... \sum_{uv}` but used `w` within the sum, so I think it was probably meant to be `c_u = ... \sum_{vw}`.

- The whole file used `` `...` `` instead ``:math:`...` `` for inline math, which meant it rendered as (semi-)raw LaTeX, 

Comparison showing both of these:

![image](https://user-images.githubusercontent.com/1203825/45003807-a1d46880-b029-11e8-9567-2c12cb044f10.png)


Rendered documentation at  https://huonw.github.io/networkx/reference/algorithms/clustering.html. Another comparison that's particularly heavy on inline math:

- old: https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.square_clustering.html#networkx.algorithms.cluster.square_clustering
- new: https://huonw.github.io/networkx/reference/algorithms/generated/networkx.algorithms.cluster.square_clustering.html#networkx.algorithms.cluster.square_clustering