### PR TITLE
add new function rescale_layout_dict

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -894,6 +894,24 @@ def rescale_layout(pos, scale=1):
             pos[:, i] *= scale / lim
     return pos
 
+def rescale_layout_dict(pos, scale=1):
+    """Return a dictionary of scaled positions keyed by node 
+
+    Parameters
+    ----------
+    pos : A dictionary of positions keyed by node
+
+    scale : number (default: 1)
+        The size of the resulting extent in all directions.
+
+    Returns
+    -------
+    pos : A dictionary of positions keyed by node
+
+    """
+    pos_v = np.array([(px, py) for px, py in pos.values()])
+    pos_v = rescale_layout(pos_v, scale=scale)
+    return {k: tuple(v) for k, v in zip(pos.keys(), pos_v)}
 
 # fixture for nose tests
 def setup_module(module):


### PR DESCRIPTION
the issue was uploaded in [#3129](https://github.com/networkx/networkx/issues/3129)

in function `networkx.drawing.layout.rescale_layout`, input is fixed to `np.array`.
In fact, other layouts (`nx.spring_layout`, `nx.spectral_layout`, etc.) return a dictionary (key: node label, value: pos tuple (x, y)).

So, I think it would be useful to add new function(the input is dictionary(key: node label, value: pos tuple (x, y)). 
