### PR TITLE
use gcd from math

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -20,7 +20,7 @@ to the user to check for that.
 """
 
 from collections import defaultdict, deque
-from fractions import gcd
+from math import gcd
 from functools import partial
 from itertools import chain
 from itertools import product


### PR DESCRIPTION
because gcd from fractions is deprecated in python 3.6