### PR TITLE
Import ABCs from collections.abc

### DIFF
--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -6,12 +6,7 @@
 #    BSD license.
 import itertools
 from collections import defaultdict
-# Importing Abstract Base Classes directly from collections is deprecated
-# in pythn 3.8. There is no other option in python 2.7, though.
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
 import networkx as nx
 from networkx.exception import NetworkXError

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -5,7 +5,13 @@
 #    All rights reserved.
 #    BSD license.
 import itertools
-from collections import defaultdict, Mapping
+from collections import defaultdict
+# Importing Abstract Base Classes directly from collections is deprecated
+# in pythn 3.8. There is no other option in python 2.7, though.
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 import networkx as nx
 from networkx.exception import NetworkXError

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -10,7 +10,15 @@
 #
 # Author:  Alex Roper <aroper@umich.edu>
 """Algorithms for finding the lowest common ancestor of trees and DAGs."""
-from collections import defaultdict, Mapping, Set
+from collections import defaultdict
+
+# Importing Abstract Base Classes directly from collections is deprecated
+# in pythn 3.8. There is no other option in python 2.7, though.
+try:
+    from collections.abc import Mapping, Set
+except ImportError:
+    from collections import Mapping, Set
+
 from itertools import chain, count
 
 import networkx as nx

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -11,14 +11,7 @@
 # Author:  Alex Roper <aroper@umich.edu>
 """Algorithms for finding the lowest common ancestor of trees and DAGs."""
 from collections import defaultdict
-
-# Importing Abstract Base Classes directly from collections is deprecated
-# in pythn 3.8. There is no other option in python 2.7, though.
-try:
-    from collections.abc import Mapping, Set
-except ImportError:
-    from collections import Mapping, Set
-
+from collections.abc import Mapping, Set
 from itertools import chain, count
 
 import networkx as nx

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -10,7 +10,13 @@
 #          Dan Schult(dschult@colgate.edu)
 """
 """
-from collections import Mapping
+# Importing Abstract Base Classes directly from collections is deprecated
+# in pythn 3.8. There is no other option in python 2.7, though.
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 import networkx as nx
 
 __all__ = ['AtlasView', 'AdjacencyView', 'MultiAdjacencyView',

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -10,13 +10,7 @@
 #          Dan Schult(dschult@colgate.edu)
 """
 """
-# Importing Abstract Base Classes directly from collections is deprecated
-# in pythn 3.8. There is no other option in python 2.7, though.
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
-
+from collections.abc import Mapping
 import networkx as nx
 
 __all__ = ['AtlasView', 'AdjacencyView', 'MultiAdjacencyView',

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -20,12 +20,7 @@ For directed graphs see DiGraph and MultiDiGraph.
 from __future__ import division
 import warnings
 from copy import deepcopy
-# Importing Abstract Base Classes directly from collections is deprecated
-# in pythn 3.8. There is no other option in python 2.7, though.
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
 import networkx as nx
 from networkx.classes.coreviews import AtlasView, AdjacencyView

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -20,7 +20,12 @@ For directed graphs see DiGraph and MultiDiGraph.
 from __future__ import division
 import warnings
 from copy import deepcopy
-from collections import Mapping
+# Importing Abstract Base Classes directly from collections is deprecated
+# in pythn 3.8. There is no other option in python 2.7, though.
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 import networkx as nx
 from networkx.classes.coreviews import AtlasView, AdjacencyView

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -92,14 +92,7 @@ EdgeDataView
 
     The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 """
-
-# Importing Abstract Base Classes directly from collections is deprecated
-# in pythn 3.8. There is no other option in python 2.7, though.
-try:
-    from collections.abc import Mapping, Set, Iterable
-except ImportError:
-    from collections import Mapping, Set, Iterable
-
+from collections.abc import Mapping, Set, Iterable
 import networkx as nx
 
 __all__ = ['NodeView', 'NodeDataView',

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -92,7 +92,14 @@ EdgeDataView
 
     The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 """
-from collections import Mapping, Set, Iterable
+
+# Importing Abstract Base Classes directly from collections is deprecated
+# in pythn 3.8. There is no other option in python 2.7, though.
+try:
+    from collections.abc import Mapping, Set, Iterable
+except ImportError:
+    from collections import Mapping, Set, Iterable
+
 import networkx as nx
 
 __all__ = ['NodeView', 'NodeDataView',


### PR DESCRIPTION
Importing Abstract Base Classes directly from the collections module is
deprecated in python 3.8 in favour of the collections.abc module.
Importing from collections is the only option on python 2.7, though.

This PR tries to import ABCs from collections.abc, and fallback to
collections in case of failure.

Fixes #3170