### PR TITLE
make filter view work for unicode node name in py2.

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -278,7 +278,7 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     def __getitem__(self, key):
         if key in self._atlas and self.NODE_OK(key):
             return self._atlas[key]
-        raise KeyError("Key {} not found".format(key))
+        raise KeyError(u"Key {} not found".format(key))
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -322,7 +322,7 @@ class FilterAdjacency(Mapping):   # edgedict
             def new_node_ok(nbr):
                 return self.NODE_OK(nbr) and self.EDGE_OK(node, nbr)
             return FilterAtlas(self._atlas[node], new_node_ok)
-        raise KeyError("Key {} not found".format(node))
+        raise KeyError(u"Key {} not found".format(node))
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -370,7 +370,7 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
             def new_node_ok(key):
                 return self.EDGE_OK(nbr, key)
             return FilterAtlas(self._atlas[nbr], new_node_ok)
-        raise KeyError("Key {} not found".format(nbr))
+        raise KeyError(u"Key {} not found".format(nbr))
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -391,7 +391,7 @@ class FilterMultiAdjacency(FilterAdjacency):  # multiedgedict
             def edge_ok(nbr, key):
                 return self.NODE_OK(nbr) and self.EDGE_OK(node, nbr, key)
             return FilterMultiInner(self._atlas[node], self.NODE_OK, edge_ok)
-        raise KeyError("Key {} not found".format(node))
+        raise KeyError(u"Key {} not found".format(node))
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -362,3 +362,22 @@ class TestFilteredGraphs(object):
             assert_equal(SG.adj[2].copy(), SG.adj[2])
             assert_equal(RG.adj.copy(), RG.adj)
             assert_equal(RG.adj[2].copy(), RG.adj[2])
+
+    def test_unicode(self):
+        for Graph, SubGraph in zip(self.Graphs, self.SubGraphs):
+            G = Graph()
+            a, b, c = (u'\u4e59', u'\u4e19', u'\u7532')
+            G.add_nodes_from([a, b, c])
+            G.add_edge(a, b)
+            SG = G.subgraph([a, b])
+            RG = SubGraph(G, nx.filters.hide_nodes([c]))
+            assert_true(a in SG)
+            assert_false(c in SG)
+            assert_true(a in RG)
+            assert_false(c in RG)
+            assert_equal(G.adj.copy(), G.adj)
+            assert_equal(G.adj[a].copy(), G.adj[a])
+            assert_equal(SG.adj.copy(), SG.adj)
+            assert_equal(SG.adj[b].copy(), SG.adj[b])
+            assert_equal(RG.adj.copy(), RG.adj)
+            assert_equal(RG.adj[b].copy(), RG.adj[b])


### PR DESCRIPTION
This fixes #3180.

However I'm worrying there might be other places that trying to format a unicode character may cause problems. I did a quick search for `format` and didn't find other spots like this but I might no be thorough.