### PR TITLE
Add support for initializing pagerank_scipy

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -336,7 +336,7 @@ def pagerank_numpy(G, alpha=0.85, personalization=None, weight='weight',
 
 
 def pagerank_scipy(G, alpha=0.85, personalization=None,
-                   max_iter=100, tol=1.0e-6, weight='weight',
+                   max_iter=100, tol=1.0e-6, nstart=None, weight='weight',
                    dangling=None):
     """Return the PageRank of the nodes in the graph.
 
@@ -365,6 +365,9 @@ def pagerank_scipy(G, alpha=0.85, personalization=None,
 
     tol : float, optional
       Error tolerance used to check convergence in power method solver.
+
+    nstart : dictionary, optional
+      Starting value of PageRank iteration for each node.
 
     weight : key, optional
       Edge data key to use as weight.  If None weights are set to 1.
@@ -432,7 +435,11 @@ def pagerank_scipy(G, alpha=0.85, personalization=None,
     M = Q * M
 
     # initial vector
-    x = scipy.repeat(1.0 / N, N)
+    if nstart is None:
+        x = scipy.repeat(1.0 / N, N)
+    else:
+        x = scipy.array([nstart.get(n, 0) for n in nodelist], dtype=float)
+        x = x / x.sum()
 
     # Personalization vector
     if personalization is None:

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -157,6 +157,11 @@ class TestPageRankScipy(TestPageRank):
         p = networkx.pagerank_scipy(G, alpha=0.9, tol=1.e-08,
                                     personalization=personalize)
 
+        nstart = dict((n, random.random()) for n in G)
+        p = networkx.pagerank_scipy(G, alpha=0.9, tol=1.e-08, nstart=nstart)
+        for n in G:
+            assert_almost_equal(p[n], G.pagerank[n], places=4)
+
     @raises(networkx.PowerIterationFailedConvergence)
     def test_scipy_pagerank_max_iter(self):
         networkx.pagerank_scipy(self.G, max_iter=0)


### PR DESCRIPTION
This will add support for an initialization vector parameter 'nstart' to the ```pagerank_scipy``` method. Also includes relevant unit tests.