### PR TITLE
Fix reading labels from gml files (#3184)

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -415,17 +415,18 @@ def parse_gml_lines(lines, label, destringizer):
 
     nodes = graph.get('node', [])
     mapping = {}
-    labels = set()
+    node_labels = set()
     for i, node in enumerate(nodes if isinstance(nodes, list) else [nodes]):
         id = pop_attr(node, 'node', 'id', i)
         if id in G:
             raise NetworkXError('node id %r is duplicated' % (id,))
-        if label != 'id':
-            label = pop_attr(node, 'node', 'label', i)
-            if label in labels:
-                raise NetworkXError('node label %r is duplicated' % (label,))
-            labels.add(label)
-            mapping[id] = label
+        if label is not None and label != 'id':
+            node_label = pop_attr(node, 'node', label, i)
+            if node_label in node_labels:
+                raise NetworkXError('node label %r is duplicated' %
+                                    (node_label,))
+            node_labels.add(node_label)
+            mapping[id] = node_label
         G.add_node(id, **node)
 
     edges = graph.get('edge', [])
@@ -455,7 +456,7 @@ Hint:  If this is a multigraph, add "multigraph 1" to the header of the file."""
                     (i, source, '->' if directed else '--', target, key))
             G.add_edge(source, target, key, **edge)
 
-    if label != 'id':
+    if label is not None and label != 'id':
         G = nx.relabel_nodes(G, mapping)
     return G
 

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -456,3 +456,14 @@ graph
         G.graph['data'] = []
         assert_generate_error(G)
         assert_generate_error(G, stringizer=len)
+
+    def test_label_kwarg(self):
+        G = nx.parse_gml(self.simple_data, label='id')
+        assert_equals(sorted(G.nodes), [1, 2, 3])
+        labels = [G.nodes[n]['label'] for n in sorted(G.nodes)]
+        assert_equals(labels, ['Node 1', 'Node 2', 'Node 3'])
+
+        G = nx.parse_gml(self.simple_data, label=None)
+        assert_equals(sorted(G.nodes), [1, 2, 3])
+        labels = [G.nodes[n]['label'] for n in sorted(G.nodes)]
+        assert_equals(labels, ['Node 1', 'Node 2', 'Node 3'])


### PR DESCRIPTION
This PR fixes issue #3184 in reading GML files, bringing the behavior in line with the documentation.