### PR TITLE
Speed up simple_cycles

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -181,9 +181,20 @@ def simple_cycles(G):
     # Also we save the actual graph so we can mutate it. We only take the
     # edges because we do not want to copy edge and node attributes here.
     subG = type(G)(G.edges())
-    sccs = list(nx.strongly_connected_components(subG))
+    sccs = [scc for scc in nx.strongly_connected_components(subG)
+            if len(scc) > 1]
+
+    # Johnson's algorithm exclude self cycle edges like (v, v)
+    # To be backward compatible, we record those cycles in advance
+    # and then remove from subG
+    for v in subG:
+        if subG.has_edge(v, v):
+            yield [v]
+            subG.remove_edge(v, v)
+
     while sccs:
         scc = sccs.pop()
+        sccG = subG.subgraph(scc)
         # order of scc determines ordering of nodes
         startnode = scc.pop()
         # Processing node runs "circuit" routine from recursive version
@@ -192,7 +203,7 @@ def simple_cycles(G):
         closed = set()   # nodes involved in a cycle
         blocked.add(startnode)
         B = defaultdict(set)  # graph portions that yield no elementary circuit
-        stack = [(startnode, list(subG[startnode]))]  # subG gives comp nbrs
+        stack = [(startnode, list(sccG[startnode]))]  # sccG gives comp nbrs
         while stack:
             thisnode, nbrs = stack[-1]
             if nbrs:
@@ -203,7 +214,7 @@ def simple_cycles(G):
 #                        print "Found a cycle", path, closed
                 elif nextnode not in blocked:
                     path.append(nextnode)
-                    stack.append((nextnode, list(subG[nextnode])))
+                    stack.append((nextnode, list(sccG[nextnode])))
                     closed.discard(nextnode)
                     blocked.add(nextnode)
                     continue
@@ -212,16 +223,16 @@ def simple_cycles(G):
                 if thisnode in closed:
                     _unblock(thisnode, blocked, B)
                 else:
-                    for nbr in subG[thisnode]:
+                    for nbr in sccG[thisnode]:
                         if thisnode not in B[nbr]:
                             B[nbr].add(thisnode)
                 stack.pop()
 #                assert path[-1] == thisnode
                 path.pop()
         # done processing this node
-        subG.remove_node(startnode)
         H = subG.subgraph(scc)  # make smaller to avoid work in SCC routine
-        sccs.extend(list(nx.strongly_connected_components(H)))
+        sccs.extend(scc for scc in nx.strongly_connected_components(H)
+                    if len(scc) > 1)
 
 
 @not_implemented_for('undirected')
@@ -251,7 +262,7 @@ def recursive_simple_cycles(G):
     >>> edges = [(0, 0), (0, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)]
     >>> G = nx.DiGraph(edges)
     >>> nx.recursive_simple_cycles(G)
-    [[0], [0, 1, 2], [0, 2], [1, 2], [2]]
+    [[0], [2], [0, 1, 2], [0, 2], [1, 2]]
 
     See Also
     --------
@@ -306,6 +317,15 @@ def recursive_simple_cycles(G):
     blocked = defaultdict(bool)  # vertex: blocked from search?
     B = defaultdict(list)  # graph portions that yield no elementary circuit
     result = []            # list to accumulate the circuits found
+
+    # Johnson's algorithm exclude self cycle edges like (v, v)
+    # To be backward compatible, we record those cycles in advance
+    # and then remove from subG
+    for v in G:
+        if G.has_edge(v, v):
+            result.append([v])
+            G.remove_edge(v, v)
+
     # Johnson's algorithm requires some ordering of the nodes.
     # They might not be sortable so we assign an arbitrary ordering.
     ordering = dict(zip(G, range(len(G))))
@@ -318,7 +338,7 @@ def recursive_simple_cycles(G):
         strongcomp = nx.strongly_connected_components(subgraph)
         mincomp = min(strongcomp, key=lambda ns: min(ordering[n] for n in ns))
         component = G.subgraph(mincomp)
-        if component:
+        if len(component) > 1:
             # smallest node in the component according to the ordering
             startnode = min(component, key=ordering.__getitem__)
             for node in component:

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -24,7 +24,7 @@ class TestCycles:
         if len(b) != n:
             return False
         l = a + a
-        return any(l[i:i + n] == b for i in range(2 * n - n + 1))
+        return any(l[i:i + n] == b for i in range(n))
 
     def test_cycle_basis(self):
         G = self.G
@@ -59,6 +59,7 @@ class TestCycles:
         G = nx.DiGraph(edges)
         cc = sorted(nx.simple_cycles(G))
         ca = [[0], [0, 1, 2], [0, 2], [1, 2], [2]]
+        assert_equal(len(cc), len(ca))
         for c in cc:
             assert_true(any(self.is_cyclic_permutation(c, rc) for rc in ca))
 
@@ -81,6 +82,7 @@ class TestCycles:
         assert_true(self.is_cyclic_permutation(c[0], [1, 2, 3]))
         nx.add_cycle(G, [10, 20, 30])
         cc = sorted(nx.simple_cycles(G))
+        assert_equal(len(cc), 2)
         ca = [[1, 2, 3], [10, 20, 30]]
         for c in cc:
             assert_true(any(self.is_cyclic_permutation(c, rc) for rc in ca))


### PR DESCRIPTION
Really appreciate your work on this wonderful lib. These are codes written by genius!

And, I found below example,
```
import networkx as nx
g = nx.DiGraph()
for i in range(10000):
    g.add_edge(i, i + 1)
g.add_path([10005, 10007, 10005])
g.add_path([10014, 10016, 10014])
list(nx.simple_cycles(g))
```
runs surprisingly slow. 
After I look into this, I would like to make 2 changes.

In Johnson's paper,
>  Our definitions exclude graphs with loops (edges of the form (v, v)) and multiple edges between the same vertices. 

So I would like to remove self-cycle edges out. This reduces huge amount of time. If you really want to do this (to be back compatible, although not consistent with its raw paper def), it would still be faster to check it in advance within O(n) time (I would add it if needed).

Another one is the component subgraph can be induced by `scc` nodes, which will also reduce some meaningless operation related with stack/blocked compared to subgraph `subG`.

Hope to make this lib even better! Would appreciate hearing your thoughts.