### PR TITLE
Fix `simple_paths` targets parameter

### DIFF
--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -156,9 +156,15 @@ def all_simple_paths(G, source, target, cutoff=None):
         ...     print(path)
         ...
         [0, 1, 2]
+        [0, 1, 2, 3]
         [0, 1, 3]
+        [0, 1, 3, 2]
         [0, 2]
+        [0, 2, 1, 3]
+        [0, 2, 3]
         [0, 3]
+        [0, 3, 1, 2]
+        [0, 3, 2]
 
     Iterate over each path from the root nodes to the leaf nodes in a
     directed acyclic graph using a functional programming approach::
@@ -252,17 +258,18 @@ def _all_simple_paths_graph(G, source, targets, cutoff):
             stack.pop()
             visited.popitem()
         elif len(visited) < cutoff:
+            if child in visited:
+                continue
             if child in targets:
                 yield list(visited) + [child]
-            elif child not in visited:
-                visited[child] = None
+            visited[child] = None
+            if targets - set(visited.keys()):  # expand stack until find all targets
                 stack.append(iter(G[child]))
-        else:  # len(visited) == cutoff:
-            if child in targets:
-                yield list(visited) + [child]
             else:
-                for target in targets & set(children):
-                    yield list(visited) + [target]
+                visited.popitem()  # maybe other ways to child
+        else:  # len(visited) == cutoff:
+            for target in (targets & (set(children) | {child})) - set(visited.keys()):
+                yield list(visited) + [target]
             stack.pop()
             visited.popitem()
 
@@ -277,13 +284,17 @@ def _all_simple_paths_multigraph(G, source, targets, cutoff):
             stack.pop()
             visited.popitem()
         elif len(visited) < cutoff:
+            if child in visited:
+                continue
             if child in targets:
                 yield list(visited) + [child]
-            elif child not in visited:
-                visited[child] = None
+            visited[child] = None
+            if targets - set(visited.keys()):
                 stack.append((v for u, v in G.edges(child)))
+            else:
+                visited.popitem()
         else:  # len(visited) == cutoff:
-            for target in targets:
+            for target in targets - set(visited.keys()):
                 count = ([child] + list(children)).count(target)
                 for i in range(count):
                     yield list(visited) + [target]

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -95,10 +95,31 @@ def test_all_simple_paths_with_two_targets_emits_two_paths():
     assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
 
 
-def test_all_simple_paths_with_two_targets_in_line_emits_one_path():
+def test_digraph_all_simple_paths_with_two_targets_emits_two_paths():
+    G = nx.path_graph(4, create_using=nx.DiGraph())
+    G.add_edge(2, 4)
+    paths = nx.all_simple_paths(G, 0, [3, 4])
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
+
+
+def test_all_simple_paths_with_two_targets_cutoff():
+    G = nx.path_graph(4)
+    G.add_edge(2, 4)
+    paths = nx.all_simple_paths(G, 0, [3, 4], cutoff=3)
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
+
+
+def test_digraph_all_simple_paths_with_two_targets_cutoff():
+    G = nx.path_graph(4, create_using=nx.DiGraph())
+    G.add_edge(2, 4)
+    paths = nx.all_simple_paths(G, 0, [3, 4], cutoff=3)
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
+
+
+def test_all_simple_paths_with_two_targets_in_line_emits_two_paths():
     G = nx.path_graph(4)
     paths = nx.all_simple_paths(G, 0, [2, 3])
-    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2)})
+    assert_equal(set(tuple(p) for p in paths), {(0, 1, 2), (0, 1, 2, 3)})
 
 
 def test_all_simple_paths_ignores_cycle():
@@ -129,18 +150,35 @@ def test_all_simple_paths_cutoff():
     assert_equal(set(tuple(p) for p in paths), {(0, 1), (0, 2, 1), (0, 3, 1)})
 
 
+def test_all_simple_paths_on_non_trivial_graph():
+    ''' you may need to draw this graph to make sure it is reasonable '''
+    G = nx.path_graph(5, create_using=nx.DiGraph())
+    G.add_edges_from([(0, 5), (1, 5), (1, 3), (5, 4), (4, 2), (4, 3)])
+    paths = nx.all_simple_paths(G, 1, [2, 3])
+    assert_equal(set(tuple(p) for p in paths), {
+        (1, 2), (1, 3, 4, 2), (1, 5, 4, 2), (1, 3), (1, 2, 3), (1, 5, 4, 3),
+        (1, 5, 4, 2, 3)})
+    paths = nx.all_simple_paths(G, 1, [2, 3], cutoff=3)
+    assert_equal(set(tuple(p) for p in paths), {
+        (1, 2), (1, 3, 4, 2), (1, 5, 4, 2), (1, 3), (1, 2, 3), (1, 5, 4, 3)})
+    paths = nx.all_simple_paths(G, 1, [2, 3], cutoff=2)
+    assert_equal(set(tuple(p) for p in paths), {(1, 2), (1, 3), (1, 2, 3)})
+
+
 def test_all_simple_paths_multigraph():
     G = nx.MultiGraph([(1, 2), (1, 2)])
     paths = nx.all_simple_paths(G, 1, 1)
     assert_equal(paths, [])
     nx.add_path(G, [3, 1, 10, 2])
-    paths = nx.all_simple_paths(G, 1, 2)
+    paths = list(nx.all_simple_paths(G, 1, 2))
+    assert_equal(len(paths), 3)
     assert_equal(set(tuple(p) for p in paths), {(1, 2), (1, 2), (1, 10, 2)})
 
 
 def test_all_simple_paths_multigraph_with_cutoff():
     G = nx.MultiGraph([(1, 2), (1, 2), (1, 10), (10, 2)])
-    paths = nx.all_simple_paths(G, 1, 2, cutoff=1)
+    paths = list(nx.all_simple_paths(G, 1, 2, cutoff=1))
+    assert_equal(len(paths), 2)
     assert_equal(set(tuple(p) for p in paths), {(1, 2), (1, 2)})
 
 
@@ -155,7 +193,7 @@ def test_all_simple_paths_directed():
 def test_all_simple_paths_empty():
     G = nx.path_graph(4)
     paths = nx.all_simple_paths(G, 0, 3, cutoff=2)
-    assert_equal(list(list(p) for p in paths), [])
+    assert_equal(list(paths), [])
 
 
 def test_all_simple_paths_corner_cases():


### PR DESCRIPTION


Hey, I've recently use `simple_paths` function. I found https://github.com/networkx/networkx/pull/3074 which replaces `list` to `OrderedDict` speeds up it a lot. Thanks to that. But after that, I found https://github.com/networkx/networkx/pull/3138/ a little misleading.

In the doc, there is no warning about it when we pass in parameters as targets, those should be **out-degree 0**. Otherwise it may not return all_simple_paths as this function name indicates.

Actually, I noticed the added doc itself is likely a misuse.
```
        >>> G = nx.complete_graph(4)
        >>> for path in nx.all_simple_paths(G, source=0, target=[3, 2]):
        ...     print(path)
        [0, 1, 2]
        [0, 1, 3]
        [0, 2]
        [0, 3]
```
in this complete_graph, nodes [2, 3] are not out-degree 0. So the result paths miss some simple path like [0, 1, 2, 3], [0, 2, 1, 3] ...

There also exists same mistakes in the test.  `path_graph` used in the test not creating using `DiGraph` do not have out-degree 0 nodes.

there is also a bug for the cutoff part in if branch (`# len(visited) == cutoff`)
```
G = nx.DiGraph()
G.add_edges_from([(0,1), (1,2), (1,3)])
list(nx.all_simple_paths(G, source=0, target=[2, 3], cutoff=2))
```
in this example, pervious code would only get 1 path (which should be 2 paths of course).

However, I think in one pass of DFS, we could enumerate `all_simple_paths` to many targets, **including but not limit to** leaf nodes (as out-degree 0). pls check the code below. 

If that is OK, we do not need to restrict targets to be leaf nodes when we pass in more than one targets parameters.