### PR TITLE
Make tests deterministic in connectivity/

### DIFF
--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -23,7 +23,7 @@ msg = "Assertion failed in function: {0}"
 def _generate_no_biconnected(max_attempts=50):
     attempts = 0
     while True:
-        G = nx.fast_gnp_random_graph(100, 0.0575)
+        G = nx.fast_gnp_random_graph(100, 0.0575, seed=42)
         if nx.is_connected(G) and not nx.is_biconnected(G):
             attempts = 0
             yield G
@@ -316,14 +316,14 @@ class TestAllPairsNodeConnectivity:
         self.directed_path = nx.path_graph(7, create_using=nx.DiGraph())
         self.cycle = nx.cycle_graph(7)
         self.directed_cycle = nx.cycle_graph(7, create_using=nx.DiGraph())
-        self.gnp = nx.gnp_random_graph(30, 0.1)
-        self.directed_gnp = nx.gnp_random_graph(30, 0.1, directed=True)
+        self.gnp = nx.gnp_random_graph(30, 0.1, seed=42)
+        self.directed_gnp = nx.gnp_random_graph(30, 0.1, directed=True, seed=42)
         self.K20 = nx.complete_graph(20)
         self.K10 = nx.complete_graph(10)
         self.K5 = nx.complete_graph(5)
         self.G_list = [self.path, self.directed_path, self.cycle,
-                       self.directed_cycle, self.gnp, self.directed_gnp, self.K10,
-                       self.K5, self.K20]
+                       self.directed_cycle, self.gnp, self.directed_gnp,
+                       self.K10, self.K5, self.K20]
 
     def test_cycles(self):
         K_undir = nx.all_pairs_node_connectivity(self.cycle)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -22,7 +22,7 @@ msg = "Assertion failed in function: {0}"
 def _generate_no_biconnected(max_attempts=50):
     attempts = 0
     while True:
-        G = nx.fast_gnp_random_graph(100, 0.0575)
+        G = nx.fast_gnp_random_graph(100, 0.0575, seed=42)
         if nx.is_connected(G) and not nx.is_biconnected(G):
             attempts = 0
             yield G
@@ -168,7 +168,7 @@ def test_node_cutset_exception():
 def test_node_cutset_random_graphs():
     for flow_func in flow_funcs:
         for i in range(3):
-            G = nx.fast_gnp_random_graph(50, 0.25)
+            G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
             if not nx.is_connected(G):
                 ccs = iter(nx.connected_components(G))
                 start = arbitrary_element(next(ccs))
@@ -183,7 +183,7 @@ def test_node_cutset_random_graphs():
 def test_edge_cutset_random_graphs():
     for flow_func in flow_funcs:
         for i in range(3):
-            G = nx.fast_gnp_random_graph(50, 0.25)
+            G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
             if not nx.is_connected(G):
                 ccs = iter(nx.connected_components(G))
                 start = arbitrary_element(next(ccs))

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -77,7 +77,7 @@ def torrents_and_ferraro_graph():
 
 @raises(nx.NetworkXNotImplemented)
 def test_directed():
-    G = nx.gnp_random_graph(10, 0.2, directed=True)
+    G = nx.gnp_random_graph(10, 0.2, directed=True, seed=42)
     nx.k_components(G)
 
 
@@ -109,20 +109,20 @@ def test_torrents_and_ferraro_graph():
 
 
 def test_random_gnp():
-    G = nx.gnp_random_graph(50, 0.2)
+    G = nx.gnp_random_graph(50, 0.2, seed=42)
     result = nx.k_components(G)
     _check_connectivity(G, result)
 
 
 def test_shell():
     constructor = [(20, 80, 0.8), (80, 180, 0.6)]
-    G = nx.random_shell_graph(constructor)
+    G = nx.random_shell_graph(constructor, seed=42)
     result = nx.k_components(G)
     _check_connectivity(G, result)
 
 
 def test_configuration():
-    deg_seq = nx.random_powerlaw_tree_sequence(100, tries=5000)
+    deg_seq = nx.random_powerlaw_tree_sequence(100, tries=5, seed=72)
     G = nx.Graph(nx.configuration_model(deg_seq))
     G.remove_edges_from(nx.selfloop_edges(G))
     result = nx.k_components(G)

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -141,18 +141,18 @@ def test_example_1():
 
 
 def test_random_gnp():
-    G = nx.gnp_random_graph(100, 0.1)
+    G = nx.gnp_random_graph(100, 0.1, seed=42)
     _check_separating_sets(G)
 
 
 def test_shell():
     constructor = [(20, 80, 0.8), (80, 180, 0.6)]
-    G = nx.random_shell_graph(constructor)
+    G = nx.random_shell_graph(constructor, seed=42)
     _check_separating_sets(G)
 
 
 def test_configuration():
-    deg_seq = nx.random_powerlaw_tree_sequence(100, tries=5000)
+    deg_seq = nx.random_powerlaw_tree_sequence(100, tries=5, seed=72)
     G = nx.Graph(nx.configuration_model(deg_seq))
     G.remove_edges_from(nx.selfloop_edges(G))
     _check_separating_sets(G)
@@ -166,7 +166,7 @@ def test_karate():
 def _generate_no_biconnected(max_attempts=50):
     attempts = 0
     while True:
-        G = nx.fast_gnp_random_graph(100, 0.0575)
+        G = nx.fast_gnp_random_graph(100, 0.0575, seed=42)
         if nx.is_connected(G) and not nx.is_biconnected(G):
             attempts = 0
             yield G
@@ -203,7 +203,7 @@ def test_grid_2d_graph():
 
 
 def test_disconnected_graph():
-    G = nx.fast_gnp_random_graph(100, 0.01)
+    G = nx.fast_gnp_random_graph(100, 0.01, seed=42)
     cuts = nx.all_node_cuts(G)
     assert_raises(nx.NetworkXError, next, cuts)
 


### PR DESCRIPTION
This is an attempt to stop the tests from occasionally failing when random degree sequences take too many iterations to find a valid degree sequence. This PR sets a seed on the RNG for those tests making them deterministic.