### PR TITLE
Added dual-BA to docs

### DIFF
--- a/doc/reference/generators.rst
+++ b/doc/reference/generators.rst
@@ -115,6 +115,7 @@ Random Graphs
    connected_watts_strogatz_graph
    random_regular_graph
    barabasi_albert_graph
+   dual_barabasi_albert_graph
    extended_barabasi_albert_graph
    powerlaw_cluster_graph
    random_kernel_graph


### PR DESCRIPTION
I added the dual-BA model in https://github.com/networkx/networkx/pull/3194, but I forgot to add it to the `docs`. I have added it here