### PR TITLE
Fix UnionFind set extraction

### DIFF
--- a/networkx/utils/union_find.py
+++ b/networkx/utils/union_find.py
@@ -90,6 +90,10 @@ class UnionFind:
             [['x', 'y'], ['z']]
 
         """
+        # Ensure fully pruned paths
+        for x in self.parents.keys():
+            _ = self[x] # Evaluated for side-effect only
+
         # TODO In Python 3.3+, this should be `yield from ...`.
         for block in groups(self.parents).values():
             yield block


### PR DESCRIPTION
Paths are not guaranteed to be fully pruned by the current
implementation of Union-Find if subtrees are unioned, e.g.:
```Python
from networkx.utils.union_find import UnionFind

def print_parents(uf):
    for k, v in uf.parents.items():
        print "parent[{}] = {}".format(k, v)

uf = UnionFind()
uf.union(1, 2)
uf.union(3, 4)
uf.union(4, 5)

print "Before uf.union(1,5):"
print_parents(uf)

uf.union(1, 5)

print "After uf.union(1,5):"
print_parents(uf)

print list(uf.to_sets())
```

In the current implementation, parents[1]=3 and parents[2]=1.
Because subtree {1,2} is placed below node 3 which creates
a path of length 2:
```
# Before uf.union(1, 5)
parent[1] = 1
parent[2] = 1
parent[3] = 3
parent[4] = 3
parent[5] = 3
# After uf.union(1, 5):
parent[1] = 3
parent[2] = 1
parent[3] = 3
parent[4] = 3
parent[5] = 3
```

Thus, the mere call of `networkx.utils.groups(parents)` in `to_sets` will yield a
wrong result:
```
[set([2]), set([1, 3, 4, 5])]
```

This patch fixes this behavior by simply doing a "find" operation
(which, in turn, does full path pruning) on every key before calling
groups. So the result is:
```
[set([1, 2, 3, 4, 5])]
```
