### PR TITLE
add_nodes_from fixed for custom hashable node_attr_dict.

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -562,28 +562,21 @@ class Graph(object):
 
         """
         for n in nodes_for_adding:
-            # keep all this inside try/except because
-            # CPython throws TypeError on n not in self._node,
-            # while pre-2.7.5 ironpython throws on self._adj[n]
-            try:
-                if n not in self._node:
-                    self._adj[n] = self.adjlist_inner_dict_factory()
-                    attr_dict = self._node[n] = self.node_attr_dict_factory()
-                    attr_dict.update(attr)
-                else:
-                    self._node[n].update(attr)
-            except TypeError:
-                nn, ndict = n
-                if nn not in self._node:
-                    self._adj[nn] = self.adjlist_inner_dict_factory()
-                    newdict = attr.copy()
-                    newdict.update(ndict)
-                    attr_dict = self._node[nn] = self.node_attr_dict_factory()
-                    attr_dict.update(newdict)
-                else:
-                    olddict = self._node[nn]
-                    olddict.update(attr)
-                    olddict.update(ndict)
+            if isinstance(n, (tuple, list)) and len(n) == 2 and isinstance(n[1], Mapping):
+                # check for (node, attribute dict) tuple.
+                # attribute dict may be hashable
+                new_attr_dict = attr.copy()
+                new_attr_dict.update(n[1])
+                n = n[0]
+            else:
+                new_attr_dict = attr
+
+            if n not in self._node:
+                self._adj[n] = self.adjlist_inner_dict_factory()
+                attr_dict = self._node[n] = self.node_attr_dict_factory()
+                attr_dict.update(new_attr_dict)
+            else:
+                self._node[n].update(new_attr_dict)
 
     def remove_node(self, n):
         """Remove node n.

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -571,6 +571,19 @@ class TestGraph(BaseAttrGraphTester):
         assert_equal(H.nodes[1]['c'], 'green')
         assert_equal(H.nodes[2]['c'], 'blue')
         assert_equal(H.nodes[3]['c'], 'cyan')
+        # test hashable node_attr_dict
+
+        class hashable_dict(dict):
+            # bad class, but enough to check add_nodes_from method
+            def __hash__(self):
+                return hash(tuple(self.items()))
+
+        R = self.Graph()
+        R.add_nodes_from([(1, hashable_dict(weight=1))])
+        R.add_nodes_from([(1, 2)])
+        assert 1 in R
+        assert R.nodes[1] == {'weight': 1}
+        assert (1, 2) in R
 
     def test_remove_node(self):
         G = self.K3


### PR DESCRIPTION
node_attr_dict may be hashable dict-like object and this example give unexpected result:

```
class hashable_dict(dict):
    # bad class, but enough to check add_nodes_from method
    def __hash__(self):
        return hash(tuple(self.items()))

class CustomGraph(nx.Graph):
    node_attr_dict_factory = hashable_dict

G = CustomGraph()
G.add_node(1, w=1)

H = nx.Graph()
H.add_nodes_from(G.nodes(data=True))
H.nodes[1]  # raise KeyError
H.nodes  # NodeView(((1, {'w': 1}),))
```

