### PR TITLE
custom object composition in graphml

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -462,9 +462,12 @@ class GraphMLWriter(GraphML):
         type in the keys table.
         """
         if element_type not in self.xml_type:
-            msg = 'GraphML writer does not support %s as data values.'
-            raise nx.NetworkXError(msg % element_type)
-        keyid = self.get_key(name, self.xml_type[element_type], scope, default)
+            # If element_type is unknown we fall back to a string representation
+            keyid = self.get_key(name, "string", scope, default)
+            # msg = 'GraphML writer does not support %s as data values.'
+            # raise nx.NetworkXError(msg % element_type)
+        else:
+            keyid = self.get_key(name, self.xml_type[element_type], scope, default)
         data_element = self.myElement("data", key=keyid)
         data_element.text = make_str(value)
         return data_element


### PR DESCRIPTION
Hi, i realized that is not possible to write graph with custom object as attribute.
I was replacing them by their str representation just before saving, but I think this could be a cleaner and more general solution for the problem.
I already had open an issue #3237.

I'm not sure whether should be use str or repr. As a first try i used str, because it was much cleaner and linear than redefining make_str()
But I'm hear for your feedback.

