### PR TITLE
Remove ticks and tick labels from draw_networkx(), close #3254.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -412,6 +412,13 @@ def draw_networkx_nodes(G, pos,
                                  linewidths=linewidths,
                                  edgecolors=edgecolors,
                                  label=label)
+    plt.tick_params(
+        axis='both',
+        which='both',
+        bottom=False,
+        left=False,
+        labelbottom=False,
+        labelleft=False)
 
     node_collection.set_zorder(2)
     return node_collection
@@ -702,6 +709,14 @@ def draw_networkx_edges(G, pos,
     ax.update_datalim(corners)
     ax.autoscale_view()
 
+    plt.tick_params(
+        axis='both',
+        which='both',
+        bottom=False,
+        left=False,
+        labelbottom=False,
+        labelleft=False)
+
     return arrow_collection
 
 
@@ -808,6 +823,14 @@ def draw_networkx_labels(G, pos,
                     clip_on=True,
                     )
         text_items[n] = t
+        
+    plt.tick_params(
+        axis='both',
+        which='both',
+        bottom=False,
+        left=False,
+        labelbottom=False,
+        labelleft=False)
 
     return text_items
 
@@ -953,6 +976,14 @@ def draw_networkx_edge_labels(G, pos,
                     clip_on=True,
                     )
         text_items[(n1, n2)] = t
+
+    plt.tick_params(
+        axis='both',
+        which='both',
+        bottom=False,
+        left=False,
+        labelbottom=False,
+        labelleft=False)
 
     return text_items
 


### PR DESCRIPTION
* Removes left and bottom ticks and tick labels for draw_networkx() and all related draw_networkx_*() functions.