### PR TITLE
Require strongly connected to compute average shortest path length.

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -353,7 +353,7 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
         If `G` is the null graph (that is, the graph on zero nodes).
 
     NetworkXError
-        If `G` is not connected (or not weakly connected, in the case
+        If `G` is not connected (or not strongly connected, in the case
         of a directed graph).
 
     ValueError
@@ -387,8 +387,8 @@ def average_shortest_path_length(G, weight=None, method='dijkstra'):
     if n == 1:
         return 0
     # Shortest path length is undefined if the graph is disconnected.
-    if G.is_directed() and not nx.is_weakly_connected(G):
-        raise nx.NetworkXError("Graph is not weakly connected.")
+    if G.is_directed() and not nx.is_strongly_connected(G):
+        raise nx.NetworkXError("Graph is not strongly connected.")
     if not G.is_directed() and not nx.is_connected(G):
         raise nx.NetworkXError("Graph is not connected.")
     # Compute all-pairs shortest paths.

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -318,6 +318,8 @@ class TestAverageShortestPathLength(object):
         assert_raises(nx.NetworkXError, nx.average_shortest_path_length, g)
         g = g.to_directed()
         assert_raises(nx.NetworkXError, nx.average_shortest_path_length, g)
+        g.add_edge(1, 2)
+        assert_raises(nx.NetworkXError, nx.average_shortest_path_length, g)
 
     def test_trivial_graph(self):
         """Tests that the trivial graph has average path length zero,


### PR DESCRIPTION
As mentioned in #3266 