### PR TITLE
Improve execution time of eigenvector centrality.

### DIFF
--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -126,7 +126,8 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
         raise nx.NetworkXError('initial vector cannot have all zero values')
     # Normalize the initial vector so that each entry is in [0, 1]. This is
     # guaranteed to never have a divide-by-zero error by the previous line.
-    x = {k: v / sum(nstart.values()) for k, v in nstart.items()}
+    nstart_sum = sum(nstart.values())
+    x = {k: v / nstart_sum for k, v in nstart.items()}
     nnodes = G.number_of_nodes()
     # make up to max_iter iterations
     for i in range(max_iter):
@@ -135,7 +136,8 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
         # do the multiplication y^T = x^T A (left eigenvector)
         for n in x:
             for nbr in G[n]:
-                x[nbr] += xlast[n] * G[n][nbr].get(weight, 1)
+                w = G[n][nbr].get(weight, 1) if weight else 1
+                x[nbr] += xlast[n] * w
         # Normalize the vector. The normalization denominator `norm`
         # should never be zero by the Perron--Frobenius
         # theorem. However, in case it is due to numerical error, we


### PR DESCRIPTION
Precompute sum for the normalization of the initial vector.
Only make dict lookup if there are edge weights, otherweise dict lookups
are prevented.


These changes make the computation of the eigenvector centrality significantly faster if  edge weights are not used. In other cases it is a little bit faster (especially for larger networks) since there are $number_of_nodes fewer calls to the sum function.

Quick benchmarks:

current stable version: 
```
~> python3 -m timeit -n 10 -r 5 -s "import networkx as nx; g = nx.barabasi_albert_graph(1000, 10)" -u msec "x = nx.eigenvector_centrality(g)"
10 loops, best of 5: 298 msec per loop
```

this commit
```
~> python3 -m timeit -n 10 -r 5 -s "import networkx as nx; g = nx.barabasi_albert_graph(1000, 10)" -u msec "x = nx.eigenvector_centrality(g)"
10 loops, best of 5: 44.9 msec per loop
```

