### PR TITLE
adjust convergence condition in power method for pagerank

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -153,7 +153,7 @@ def pagerank(G, alpha=0.85, personalization=None,
             x[n] += danglesum * dangling_weights.get(n, 0) + (1.0 - alpha) * p.get(n, 0)
         # check convergence, l1 norm
         err = sum([abs(x[n] - xlast[n]) for n in x])
-        if err < N * tol:
+        if err < tol: # if N * tol, convergence will be relaxed because err is l1 norm
             return x
     raise nx.PowerIterationFailedConvergence(max_iter)
 


### PR DESCRIPTION
The err is computed using l1 norm, which can be equally represented by (N * \delta x[i]) ( \delta x[i] is the difference of the ranking value of the node x[i]).

However, if we have err < N * tol, it makes the condition close to \delta x[i] < tol. The problem here is that if we have a very large graph (more that 10^7 nodes), the initialized value for x[i] is already less than tol (i.e., 1e-6), so the change will be very possibly less than tol, therefore the loop will stop in just few iteration without convergence.

Thank you!