### PR TITLE
replace deprecated fresh_copy with __class__

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1192,7 +1192,7 @@ class DiGraph(Graph):
             the original graph.
         """
         if copy:
-            H = self.fresh_copy()
+            H = self.__class__()
             H.graph.update(deepcopy(self.graph))
             H.add_nodes_from((n, deepcopy(d)) for n, d in self.node.items())
             H.add_edges_from((v, u, deepcopy(d)) for u, v, d

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -528,7 +528,7 @@ def create_empty_copy(G, with_data=True):
     empty_graph
 
     """
-    H = G.fresh_copy()
+    H = G.__class__()
     H.add_nodes_from(G.nodes(data=with_data))
     if with_data:
         H.graph.update(G.graph)


### PR DESCRIPTION
Related to #3230

All the mentioned depredations were already fixed. I did find two more (if they're relevant)