### PR TITLE
Fix several DeprecationWarning: invalid escape sequence

### DIFF
--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -68,7 +68,7 @@ def max_clique(G):
 
 
 def clique_removal(G):
-    """ Repeatedly remove cliques from the graph.
+    r""" Repeatedly remove cliques from the graph.
 
     Results in a $O(|V|/(\log |V|)^2)$ approximation of maximum clique
     and independent set. Returns the largest independent set found, along

--- a/networkx/algorithms/approximation/dominating_set.py
+++ b/networkx/algorithms/approximation/dominating_set.py
@@ -29,7 +29,7 @@ __author__ = """Nicholas Mancuso (nick.mancuso@gmail.com)"""
 # TODO Why doesn't this algorithm work for directed graphs?
 @not_implemented_for('directed')
 def min_weighted_dominating_set(G, weight=None):
-    """Returns a dominating set that approximates the minimum weight node
+    r"""Returns a dominating set that approximates the minimum weight node
     dominating set.
 
     Parameters

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -249,7 +249,7 @@ def current_flow_betweenness_centrality(G, normalized=True, weight=None,
 def edge_current_flow_betweenness_centrality(G, normalized=True,
                                              weight=None,
                                              dtype=float, solver='full'):
-    """Compute current-flow betweenness centrality for edges.
+    r"""Compute current-flow betweenness centrality for edges.
 
     Current-flow betweenness centrality uses an electrical current
     model for information spreading in contrast to betweenness

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -506,8 +506,8 @@ def generalized_degree(G, nodes=None):
     >>> G=nx.complete_graph(5)
     >>> print(nx.generalized_degree(G,0))
     Counter({3: 4})
-    >>> print(nx.generalized_degree(G))  # doctest: +ELLIPSIS
-    {0: Counter({3: 4}), 1: Counter({3: 4}), ..., 4: Counter({3: 4})}
+    >>> print(nx.generalized_degree(G))
+    {0: Counter({3: 4}), 1: Counter({3: 4}), 2: Counter({3: 4}), 3: Counter({3: 4}), 4: Counter({3: 4})}
 
     To recover the number of triangles attached to a node:
 

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -478,7 +478,7 @@ def square_clustering(G, nodes=None):
 
 @not_implemented_for('directed')
 def generalized_degree(G, nodes=None):
-    """ Compute the generalized degree for nodes.
+    r""" Compute the generalized degree for nodes.
 
     For each node, the generalized degree shows how many edges of given
     triangle multiplicity the node is connected to. The triangle multiplicity
@@ -506,9 +506,8 @@ def generalized_degree(G, nodes=None):
     >>> G=nx.complete_graph(5)
     >>> print(nx.generalized_degree(G,0))
     Counter({3: 4})
-    >>> print(nx.generalized_degree(G))
-    {0: Counter({3: 4}), 1: Counter({3: 4}), 2: Counter({3: 4}), \
-3: Counter({3: 4}), 4: Counter({3: 4})}
+    >>> print(nx.generalized_degree(G))  # doctest: +ELLIPSIS
+    {0: Counter({3: 4}), 1: Counter({3: 4}), ..., 4: Counter({3: 4})}
 
     To recover the number of triangles attached to a node:
 

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -211,7 +211,7 @@ def local_node_connectivity(G, s, t, flow_func=None, auxiliary=None,
 
 
 def node_connectivity(G, s=None, t=None, flow_func=None):
-    """Returns node connectivity for a graph or digraph G.
+    r"""Returns node connectivity for a graph or digraph G.
 
     Node connectivity is equal to the minimum number of nodes that
     must be removed to disconnect G or render it trivial. If source

--- a/networkx/algorithms/connectivity/stoerwagner.py
+++ b/networkx/algorithms/connectivity/stoerwagner.py
@@ -22,7 +22,7 @@ __all__ = ['stoer_wagner']
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def stoer_wagner(G, weight='weight', heap=BinaryHeap):
-    """Returns the weighted minimum edge cut using the Stoer-Wagner algorithm.
+    r"""Returns the weighted minimum edge cut using the Stoer-Wagner algorithm.
 
     Determine the minimum edge cut of a connected graph using the
     Stoer-Wagner algorithm. In weighted cases, all weights must be

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -296,7 +296,7 @@ def preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq,
 
 def preflow_push(G, s, t, capacity='capacity', residual=None,
                  global_relabel_freq=1, value_only=False):
-    """Find a maximum single-commodity flow using the highest-label
+    r"""Find a maximum single-commodity flow using the highest-label
     preflow-push algorithm.
 
     This function returns the residual network resulting after computing

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -175,7 +175,7 @@ def shortest_augmenting_path_impl(G, s, t, capacity, residual, two_phase,
 
 def shortest_augmenting_path(G, s, t, capacity='capacity', residual=None,
                              value_only=False, two_phase=False, cutoff=None):
-    """Find a maximum single-commodity flow using the shortest augmenting path
+    r"""Find a maximum single-commodity flow using the shortest augmenting path
     algorithm.
 
     This function returns the residual network resulting after computing

--- a/networkx/algorithms/reciprocity.py
+++ b/networkx/algorithms/reciprocity.py
@@ -16,7 +16,7 @@ __all__ = ['reciprocity', 'overall_reciprocity']
 
 @not_implemented_for('undirected', 'multigraph')
 def reciprocity(G, nodes=None):
-    """Compute the reciprocity in a directed graph.
+    r"""Compute the reciprocity in a directed graph.
 
     The reciprocity of a directed graph is defined as the ratio
     of the number of edges pointing in both directions to the total

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1922,7 +1922,7 @@ def negative_edge_cycle(G, weight='weight'):
 
 
 def bidirectional_dijkstra(G, source, target, weight='weight'):
-    """Dijkstra's algorithm for shortest paths using bidirectional search.
+    r"""Dijkstra's algorithm for shortest paths using bidirectional search.
 
     Parameters
     ----------

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -44,7 +44,7 @@ __all__ = ['margulis_gabber_galil_graph', 'chordal_cycle_graph']
 #     (x, (y + (2*x + 2)) % n),
 #
 def margulis_gabber_galil_graph(n, create_using=None):
-    """Return the Margulis-Gabber-Galil undirected MultiGraph on `n^2` nodes.
+    r"""Return the Margulis-Gabber-Galil undirected MultiGraph on `n^2` nodes.
 
     The undirected MultiGraph is regular with degree `8`. Nodes are integer
     pairs. The second-largest eigenvalue of the adjacency matrix of the graph

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -175,7 +175,7 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2, seed=None):
 @nodes_or_number(0)
 def soft_random_geometric_graph(n, radius, dim=2, pos=None, p=2, p_dist=None,
                                 seed=None):
-    """Returns a soft random geometric graph in the unit cube.
+    r"""Returns a soft random geometric graph in the unit cube.
 
     The soft random geometric graph [1] model places `n` nodes uniformly at
     random in the unit cube in dimension `dim`. Two nodes of distance, `dist`,
@@ -666,7 +666,7 @@ def navigable_small_world_graph(n, p=1, q=1, r=2, dim=2, seed=None):
 @nodes_or_number(0)
 def thresholded_random_geometric_graph(n, radius, theta, dim=2,
                                        pos=None, weight=None, p=2, seed=None):
-    """Returns a thresholded random geometric graph in the unit cube.
+    r"""Returns a thresholded random geometric graph in the unit cube.
 
     The thresholded random geometric graph [1] model places `n` nodes
     uniformly at random in the unit cube of dimensions `dim`. Each node

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -171,7 +171,7 @@ def hypercube_graph(n):
 
 def triangular_lattice_graph(m, n, periodic=False, with_positions=True,
                              create_using=None):
-    """Returns the $m$ by $n$ triangular lattice graph.
+    r"""Returns the $m$ by $n$ triangular lattice graph.
 
     The `triangular lattice graph`_ is a two-dimensional `grid graph`_ in
     which each square unit has a diagonal edge (each grid unit has a chord).

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -22,7 +22,7 @@ __all__ = ['line_graph', 'inverse_line_graph']
 
 
 def line_graph(G, create_using=None):
-    """Returns the line graph of the graph or digraph `G`.
+    r"""Returns the line graph of the graph or digraph `G`.
 
     The line graph of a graph `G` has a node for each edge in `G` and an
     edge joining those nodes if the two edges in `G` share a common node. For

--- a/networkx/linalg/modularitymatrix.py
+++ b/networkx/linalg/modularitymatrix.py
@@ -19,7 +19,7 @@ __all__ = ['modularity_matrix', 'directed_modularity_matrix']
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def modularity_matrix(G, nodelist=None, weight=None):
-    """Return the modularity matrix of G.
+    r"""Return the modularity matrix of G.
 
     The modularity matrix is the matrix B = A - <A>, where A is the adjacency
     matrix and <A> is the average adjacency matrix, assuming that the graph


### PR DESCRIPTION
Hello,

This is a little patch to fix warnings such as:
```python
networkx/networkx/algorithms/cluster.py:537: DeprecationWarning: invalid escape sequence \m
```

In one place, I had to shorten the output of a function to fix
```python
ValueError: line 31 of the docstring for networkx.algorithms.cluster.generalized_degree has inconsistent leading whitespace: '3: Counter({3: 4}), 4: Counter({3: 4})}'
```
Let me know if you are not OK with that :)

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>