### PR TITLE
Add two generators for Harary graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ networkx.egg-info/
 
 # PyCharm project file
 .idea
-.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ networkx.egg-info/
 
 # PyCharm project file
 .idea
+.vscode/settings.json

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -8,14 +8,18 @@
 #
 """Generators for Harary graphs
 
-This module gives two generators for the Harary graph, which has 
-the maximum node connectivity among all graphs with given number of nodes
-and given number of edges. [1]_.
+This module gives two generators for the Harary graph, which was
+introduced by the famous mathematician Frank Harary in his 1962 work [1]_.
+The first generator gives the Harary graph that maximizes the node
+connectivity with given number of nodes and given number of edges.
+The second generator gives the Harary graph that minimizes
+the number of edges in the graph with given node connectivity and
+number of nodes.
 
 References
 ----------
-.. [1] F. T. Boesch, A. Satyanarayana, and C. L. Suffel,
-"A Survey of Some Network Reliability Analysis and Synthesis Results," Networks, pp. 99-107, 2009.
+.. [1] Harary, F. "The Maximum Connectivity of a Graph."
+       Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962.
 
 """
 
@@ -24,11 +28,10 @@ from networkx.exception import NetworkXError
 
 __all__ = ['hnm_harary_graph', 'hkn_harary_graph']
 
-def hnm_harary_graph(n, m, create_using=None):
-    """Returns the Harary graph $H_{n,m}$ with $n$ nodes and $m$ edges.
 
-    The Harary graph $H_{n,m}$ has the maximum node connectivity 
-    among all graphs with $n$ nodes and $m$ edges. 
+def hnm_harary_graph(n, m, create_using=None):
+    """Returns the Harary graph $H_{n,m}$ that maximizes the node
+    connectivity with $n$ nodes and $m$ edges.
     This maximum node connectivity is known to be $[2m/n]$. [1]_
 
     Parameters
@@ -37,36 +40,40 @@ def hnm_harary_graph(n, m, create_using=None):
        The number of nodes the generated graph is to contain
     m: integer
        The number of edges the generated graph is to contain
-    create_using : NetworkX graph constructor, optional (default=nx.Graph)
-       Graph type to create. If graph instance, then cleared before populated.
+    create_using : NetworkX graph constructor, optional Graph type
+     to create (default=nx.Graph). If graph instance, then cleared
+     before populated.
 
     Returns
     -------
     NetworkX graph
         The Harary graph $H_{n,m}$.
-    
+
     See Also
     --------
     hkn_harary_graph
 
     Notes
     -----
-    This algorithm runs in $O(m)$ time. It is implemented by following the Reference [2]_.
+    This algorithm runs in $O(m)$ time.
+    It is implemented by following the Reference [2]_.
 
     References
     ----------
     .. [1] F. T. Boesch, A. Satyanarayana, and C. L. Suffel,
-     "A Survey of Some Network Reliability Analysis and Synthesis Results," Networks, pp. 99-107, 2009.
+     "A Survey of Some Network Reliability Analysis and Synthesis Results,"
+      Networks, pp. 99-107, 2009.
 
-    .. [2] Harary, F. "The Maximum Connectivity of a Graph." Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962. 
+    .. [2] Harary, F. "The Maximum Connectivity of a Graph."
+      Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962.
     """
 
-    if n < 1 :
-        raise NetworkXError("The number of nodes must be no less than 1!")
-    if m < n - 1 : 
-        raise NetworkXError("The number of edges must be no less than n - 1 !")
-    if m > n*(n-1)//2 :
-        raise NetworkXError("The number of edges must be no more than n(n-1)/2")
+    if n < 1:
+        raise NetworkXError("The number of nodes must be >= 1!")
+    if m < n - 1:
+        raise NetworkXError("The number of edges must be >= n - 1 !")
+    if m > n*(n-1)//2:
+        raise NetworkXError("The number of edges must be <= n(n-1)/2")
 
     # Construct an empty graph with n nodes first
     H = nx.empty_graph(n, create_using)
@@ -74,32 +81,32 @@ def hnm_harary_graph(n, m, create_using=None):
     d = 2*m // n
 
     # Test the parity of n and d
-    if (n % 2 == 0) or (d % 2 == 0) :
+    if (n % 2 == 0) or (d % 2 == 0):
         # Start with a regular graph of d degrees
         offset = d // 2
         for i in range(n):
             for j in range(1, offset+1):
                 H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)        
-        if d & 1 : 
+                H.add_edge(i, (i + j) % n)
+        if d & 1:
             # in case d is odd; n must be even in this case
             half = n // 2
             for i in range(0, half):
                 # add edges diagonally
                 H.add_edge(i, i+half)
-        # Get the remainder of 2*m modulo n  
-        r = 2*m % n 
-        if r > 0 : 
+        # Get the remainder of 2*m modulo n
+        r = 2*m % n
+        if r > 0:
             # add remaining edges at offset+1
             for i in range(0, r//2):
                 H.add_edge(i, i+offset+1)
-    else :
+    else:
         # Start with a regular graph of (d - 1) degrees
         offset = (d - 1) // 2
         for i in range(n):
-            for j in range(1,offset+1):
+            for j in range(1, offset+1):
                 H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)        
+                H.add_edge(i, (i + j) % n)
         half = n // 2
         for i in range(0, m - n*offset):
             # add the remaining m - n*offset edges between i and i+half
@@ -107,11 +114,12 @@ def hnm_harary_graph(n, m, create_using=None):
 
     return H
 
-def hkn_harary_graph(k, n, create_using=None):
-    """Returns the Harary graph $H_{k,n}$ with node connectivity $k$ and node number $n$.
 
-    The Harary graph $H_{k,n}$ has the smallest number of edges among all graphs
-    with node connectivity $k$ and node number $n$ [1]_.
+def hkn_harary_graph(k, n, create_using=None):
+    """Returns the Harary graph $H_{k,n}$ that minimizes the number of
+    edges in the graph with node connectivity $k$ and node number $n$.
+    This smallest number of edges is known to be $kn/2$
+    [1]_.
 
     Parameters
     ----------
@@ -119,37 +127,40 @@ def hkn_harary_graph(k, n, create_using=None):
        The node connectivity of the generated graph
     n: integer
        The number of nodes the generated graph is to contain
-    create_using : NetworkX graph constructor, optional (default=nx.Graph)
-       Graph type to create. If graph instance, then cleared before populated.
+    create_using : NetworkX graph constructor, optional Graph type
+     to create (default=nx.Graph). If graph instance, then cleared
+     before populated.
 
     Returns
     -------
     NetworkX graph
         The Harary graph $H_{k,n}$.
-    
+
     See Also
     --------
     hnm_harary_graph
 
     Notes
     -----
-    This algorithm runs in $O(kn)$ time. It is implemented by following the Reference [2]_.
+    This algorithm runs in $O(kn)$ time.
+    It is implemented by following the Reference [2]_.
 
     References
     ----------
-    .. [1] Weisstein, Eric W. "Harary Graph." From MathWorld--A Wolfram Web Resource.
-    http://mathworld.wolfram.com/HararyGraph.html.
+    .. [1] Weisstein, Eric W. "Harary Graph." From MathWorld--A Wolfram Web
+     Resource. http://mathworld.wolfram.com/HararyGraph.html.
 
-    .. [2] Harary, F. "The Maximum Connectivity of a Graph." Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962. 
+    .. [2] Harary, F. "The Maximum Connectivity of a Graph."
+      Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962.
     """
 
-    if k < 1 :
-        raise NetworkXError("The node connectivity must be no less than 1!")
-    if n < k+1 : 
-        raise NetworkXError("The number of nodes must be no less than k+1 !")
+    if k < 1:
+        raise NetworkXError("The node connectivity must be >= 1!")
+    if n < k+1:
+        raise NetworkXError("The number of nodes must be >= k+1 !")
 
     # in case of connectivity 1, simply return the path graph
-    if k == 1 :
+    if k == 1:
         H = nx.path_graph(n, create_using)
         return H
 
@@ -157,26 +168,26 @@ def hkn_harary_graph(k, n, create_using=None):
     H = nx.empty_graph(n, create_using)
 
     # Test the parity of k and n
-    if (k % 2 == 0) or (n % 2 == 0) :
+    if (k % 2 == 0) or (n % 2 == 0):
         # Construct a regular graph with k degrees
         offset = k // 2
         for i in range(n):
-            for j in range(1,offset+1):
+            for j in range(1, offset+1):
                 H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)        
-        if k & 1 : 
+                H.add_edge(i, (i + j) % n)
+        if k & 1:
             # odd degree; n must be even in this case
             half = n // 2
             for i in range(0, half):
                 # add edges diagonally
                 H.add_edge(i, i+half)
-    else :
+    else:
         # Construct a regular graph with (k - 1) degrees
         offset = (k - 1) // 2
         for i in range(n):
             for j in range(1, offset+1):
                 H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)        
+                H.add_edge(i, (i + j) % n)
         half = n // 2
         for i in range(0, half+1):
             # add half+1 edges between i and i+half

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -30,16 +30,21 @@ __all__ = ['hnm_harary_graph', 'hkn_harary_graph']
 
 
 def hnm_harary_graph(n, m, create_using=None):
-    """Returns the Harary graph $H_{n,m}$ that maximizes the node
-    connectivity with $n$ nodes and $m$ edges.
-    This maximum node connectivity is known to be $[2m/n]$. [1]_
+    """Returns the Harary graph with given numbers of nodes and edges.
+
+    The Harary graph $H_{n,m}$ is the graph that maximizes node connectivity
+    with $n$ nodes and $m$ edges.
+
+    This maximum node connectivity is known to be floor($2m/n$). [1]_
 
     Parameters
     ----------
     n: integer
        The number of nodes the generated graph is to contain
+
     m: integer
        The number of edges the generated graph is to contain
+
     create_using : NetworkX graph constructor, optional Graph type
      to create (default=nx.Graph). If graph instance, then cleared
      before populated.
@@ -116,17 +121,21 @@ def hnm_harary_graph(n, m, create_using=None):
 
 
 def hkn_harary_graph(k, n, create_using=None):
-    """Returns the Harary graph $H_{k,n}$ that minimizes the number of
-    edges in the graph with node connectivity $k$ and node number $n$.
-    This smallest number of edges is known to be $kn/2$
-    [1]_.
+    """Returns the Harary graph with given node connectivity and node number.
+
+    The Harary graph $H_{k,n}$ is the graph that minimizes the number of
+    edges needed with given node connectivity $k$ and node number $n$.
+
+    This smallest number of edges is known to be ceil($kn/2$) [1]_.
 
     Parameters
     ----------
     k: integer
        The node connectivity of the generated graph
+
     n: integer
        The number of nodes the generated graph is to contain
+
     create_using : NetworkX graph constructor, optional Graph type
      to create (default=nx.Graph). If graph instance, then cleared
      before populated.

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+#    Copyright (C) 2018-2019 by
+#    Weisheng Si <w.si@westernsydney.edu.au>
+#    All rights reserved.
+#    BSD license.
+#
+# Authors: Weisheng Si (w.si@westernsydney.edu.au)
+#
+"""Generators for Harary graphs
+
+This module gives two generators for the Harary graph, which has 
+the maximum node connectivity among all graphs with given number of nodes
+and given number of edges. [1]_.
+
+References
+----------
+.. [1] F. T. Boesch, A. Satyanarayana, and C. L. Suffel,
+"A Survey of Some Network Reliability Analysis and Synthesis Results," Networks, pp. 99-107, 2009.
+
+"""
+
+import networkx as nx
+from networkx.exception import NetworkXError
+
+__all__ = ['hnm_harary_graph', 'hkn_harary_graph']
+
+def hnm_harary_graph(n, m, create_using=None):
+    """Returns the Harary graph $H_{n,m}$ with $n$ nodes and $m$ edges.
+
+    The Harary graph $H_{n,m}$ has the maximum node connectivity 
+    among all graphs with $n$ nodes and $m$ edges. 
+    This maximum node connectivity is known to be $[2m/n]$. [1]_
+
+    Parameters
+    ----------
+    n: integer
+       The number of nodes the generated graph is to contain
+    m: integer
+       The number of edges the generated graph is to contain
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    NetworkX graph
+        The Harary graph $H_{n,m}$.
+    
+    See Also
+    --------
+    hkn_harary_graph
+
+    Notes
+    -----
+    This algorithm runs in $O(m)$ time. It is implemented by following the Reference [2]_.
+
+    References
+    ----------
+    .. [1] F. T. Boesch, A. Satyanarayana, and C. L. Suffel,
+     "A Survey of Some Network Reliability Analysis and Synthesis Results," Networks, pp. 99-107, 2009.
+
+    .. [2] Harary, F. "The Maximum Connectivity of a Graph." Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962. 
+    """
+
+    if n < 1 :
+        raise NetworkXError("The number of nodes must be no less than 1!")
+    if m < n - 1 : 
+        raise NetworkXError("The number of edges must be no less than n - 1 !")
+    if m > n*(n-1)//2 :
+        raise NetworkXError("The number of edges must be no more than n(n-1)/2")
+
+    # Construct an empty graph with n nodes first
+    H = nx.empty_graph(n, create_using)
+    # Get the floor of average node degree
+    d = 2*m // n
+
+    # Test the parity of n and d
+    if (n % 2 == 0) or (d % 2 == 0) :
+        # Start with a regular graph of d degrees
+        offset = d // 2
+        for i in range(n):
+            for j in range(1, offset+1):
+                H.add_edge(i, (i - j) % n)
+                H.add_edge(i, (i + j) % n)        
+        if d & 1 : 
+            # in case d is odd; n must be even in this case
+            half = n // 2
+            for i in range(0, half):
+                # add edges diagonally
+                H.add_edge(i, i+half)
+        # Get the remainder of 2*m modulo n  
+        r = 2*m % n 
+        if r > 0 : 
+            # add remaining edges at offset+1
+            for i in range(0, r//2):
+                H.add_edge(i, i+offset+1)
+    else :
+        # Start with a regular graph of (d - 1) degrees
+        offset = (d - 1) // 2
+        for i in range(n):
+            for j in range(1,offset+1):
+                H.add_edge(i, (i - j) % n)
+                H.add_edge(i, (i + j) % n)        
+        half = n // 2
+        for i in range(0, m - n*offset):
+            # add the remaining m - n*offset edges between i and i+half
+            H.add_edge(i, (i+half) % n)
+
+    return H
+
+def hkn_harary_graph(k, n, create_using=None):
+    """Returns the Harary graph $H_{k,n}$ with node connectivity $k$ and node number $n$.
+
+    The Harary graph $H_{k,n}$ has the smallest number of edges among all graphs
+    with node connectivity $k$ and node number $n$ [1]_.
+
+    Parameters
+    ----------
+    k: integer
+       The node connectivity of the generated graph
+    n: integer
+       The number of nodes the generated graph is to contain
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    NetworkX graph
+        The Harary graph $H_{k,n}$.
+    
+    See Also
+    --------
+    hnm_harary_graph
+
+    Notes
+    -----
+    This algorithm runs in $O(kn)$ time. It is implemented by following the Reference [2]_.
+
+    References
+    ----------
+    .. [1] Weisstein, Eric W. "Harary Graph." From MathWorld--A Wolfram Web Resource.
+    http://mathworld.wolfram.com/HararyGraph.html.
+
+    .. [2] Harary, F. "The Maximum Connectivity of a Graph." Proc. Nat. Acad. Sci. USA 48, 1142-1146, 1962. 
+    """
+
+    if k < 1 :
+        raise NetworkXError("The node connectivity must be no less than 1!")
+    if n < k+1 : 
+        raise NetworkXError("The number of nodes must be no less than k+1 !")
+
+    # in case of connectivity 1, simply return the path graph
+    if k == 1 :
+        H = nx.path_graph(n, create_using)
+        return H
+
+    # Construct an empty graph with n nodes first
+    H = nx.empty_graph(n, create_using)
+
+    # Test the parity of k and n
+    if (k % 2 == 0) or (n % 2 == 0) :
+        # Construct a regular graph with k degrees
+        offset = k // 2
+        for i in range(n):
+            for j in range(1,offset+1):
+                H.add_edge(i, (i - j) % n)
+                H.add_edge(i, (i + j) % n)        
+        if k & 1 : 
+            # odd degree; n must be even in this case
+            half = n // 2
+            for i in range(0, half):
+                # add edges diagonally
+                H.add_edge(i, i+half)
+    else :
+        # Construct a regular graph with (k - 1) degrees
+        offset = (k - 1) // 2
+        for i in range(n):
+            for j in range(1, offset+1):
+                H.add_edge(i, (i - j) % n)
+                H.add_edge(i, (i + j) % n)        
+        half = n // 2
+        for i in range(0, half+1):
+            # add half+1 edges between i and i+half
+            H.add_edge(i, (i+half) % n)
+
+    return H

--- a/networkx/generators/tests/test_harary_graph.py
+++ b/networkx/generators/tests/test_harary_graph.py
@@ -1,4 +1,5 @@
-"""Unit tests for the :mod:`networkx.generators.harary_graph` module."""
+"""Unit tests for the :mod:`networkx.generators.harary_graph` module.
+"""
 
 from nose.tools import assert_equal
 from nose.tools import assert_true
@@ -14,7 +15,7 @@ from networkx.testing import assert_nodes_equal
 
 
 class TestHararyGraph:
-    """ 
+    """
         Suppose n nodes, m >= n-1 edges, d = 2m // n, r = 2m % n
     """
     def test_hnm_harary_graph(self):
@@ -36,8 +37,8 @@ class TestHararyGraph:
             assert_true(set(G2.edges) < set(G1.edges))
             assert_equal(G1.number_of_edges(), m)
 
-        # When d is odd and n is even and r = 0, the hnm_harary_graph(n,m) is
-        # the circulant_graph(n, list(range(1,(d+1)/2) plus [n//2])
+        # When d is odd and n is even and r = 0, the hnm_harary_graph(n,m)
+        # is the circulant_graph(n, list(range(1,(d+1)/2) plus [n//2])
         for (n, m) in [(6, 9), (8, 12), (10, 15)]:
             G1 = hnm_harary_graph(n, m)
             d = 2*m // n
@@ -46,8 +47,8 @@ class TestHararyGraph:
             G2 = circulant_graph(n, L)
             assert_true(is_isomorphic(G1, G2))
 
-        # When d is odd and n is even and r > 0, the hnm_harary_graph(n,m) is
-        # the circulant_graph(n, list(range(1,(d+1)/2) plus [n//2])
+        # When d is odd and n is even and r > 0, the hnm_harary_graph(n,m)
+        # is the circulant_graph(n, list(range(1,(d+1)/2) plus [n//2])
         # with r edges added arbitrarily
         for (n, m) in [(6, 10), (8, 13), (10, 17)]:
             G1 = hnm_harary_graph(n, m)
@@ -84,8 +85,8 @@ class TestHararyGraph:
         m = 16
         assert_raises(networkx.exception.NetworkXError, hnm_harary_graph, n, m)
 
-    """ 
-        Suppose connectivity k, number of nodes n 
+    """
+        Suppose connectivity k, number of nodes n
     """
     def test_hkn_harary_graph(self):
         # When k == 1, the hkn_harary_graph(k,n) is

--- a/networkx/generators/tests/test_harary_graph.py
+++ b/networkx/generators/tests/test_harary_graph.py
@@ -2,6 +2,7 @@
 
 from nose.tools import assert_equal
 from nose.tools import assert_true
+from nose.tools import assert_raises
 
 import networkx as nx
 from networkx import *
@@ -68,10 +69,32 @@ class TestHararyGraph:
             assert_true(set(G2.edges) < set(G1.edges))
             assert_equal(G1.number_of_edges(), m)
 
+        # Raise NetworkXError if n<1
+        n = 0
+        m = 0
+        assert_raises(networkx.exception.NetworkXError, hnm_harary_graph, n, m)
+
+        # Raise NetworkXError if m < n-1
+        n = 6
+        m = 4
+        assert_raises(networkx.exception.NetworkXError, hnm_harary_graph, n, m)
+
+        # Raise NetworkXError if m > n(n-1)/2
+        n = 6
+        m = 16
+        assert_raises(networkx.exception.NetworkXError, hnm_harary_graph, n, m)
+
     """ 
         Suppose connectivity k, number of nodes n 
     """
     def test_hkn_harary_graph(self):
+        # When k == 1, the hkn_harary_graph(k,n) is
+        # the path_graph(n)
+        for (k, n) in [(1, 6), (1, 7)]:
+            G1 = hkn_harary_graph(k, n)
+            G2 = path_graph(n)
+            assert_true(is_isomorphic(G1, G2))
+
         # When k is even, the hkn_harary_graph(k,n) is
         # the circulant_graph(n, list(range(1,k/2+1)))
         for (k, n) in [(2, 6), (2, 7), (4, 6), (4, 7)]:
@@ -102,3 +125,13 @@ class TestHararyGraph:
                 # add half+1 edges between i and i+half
                 eSet3.add((i, (i+half) % n))
             assert_equal(eSet1, eSet2 | eSet3)
+
+        # Raise NetworkXError if k<1
+        k = 0
+        n = 0
+        assert_raises(networkx.exception.NetworkXError, hkn_harary_graph, k, n)
+
+        # Raise NetworkXError if n<k+1
+        k = 6
+        n = 6
+        assert_raises(networkx.exception.NetworkXError, hkn_harary_graph, k, n)

--- a/networkx/generators/tests/test_harary_graph.py
+++ b/networkx/generators/tests/test_harary_graph.py
@@ -1,0 +1,104 @@
+"""Unit tests for the :mod:`networkx.generators.harary_graph` module."""
+
+from nose.tools import assert_equal
+from nose.tools import assert_true
+
+import networkx as nx
+from networkx import *
+from networkx.generators.harary_graph import hnm_harary_graph
+from networkx.generators.harary_graph import hkn_harary_graph
+from networkx.algorithms.isomorphism.isomorph import is_isomorphic
+from networkx.testing import assert_edges_equal
+from networkx.testing import assert_nodes_equal
+
+
+class TestHararyGraph:
+    """ 
+        Suppose n nodes, m >= n-1 edges, d = 2m // n, r = 2m % n
+    """
+    def test_hnm_harary_graph(self):
+        # When d is even and r = 0, the hnm_harary_graph(n,m) is
+        # the circulant_graph(n, list(range(1,d/2+1)))
+        for (n, m) in [(5, 5), (6, 12), (7, 14)]:
+            G1 = hnm_harary_graph(n, m)
+            d = 2*m // n
+            G2 = circulant_graph(n, list(range(1, d//2 + 1)))
+            assert_true(is_isomorphic(G1, G2))
+
+        # When d is even and r > 0, the hnm_harary_graph(n,m) is
+        # the circulant_graph(n, list(range(1,d/2+1)))
+        # with r edges added arbitrarily
+        for (n, m) in [(5, 7), (6, 13), (7, 16)]:
+            G1 = hnm_harary_graph(n, m)
+            d = 2*m // n
+            G2 = circulant_graph(n, list(range(1, d//2 + 1)))
+            assert_true(set(G2.edges) < set(G1.edges))
+            assert_equal(G1.number_of_edges(), m)
+
+        # When d is odd and n is even and r = 0, the hnm_harary_graph(n,m) is
+        # the circulant_graph(n, list(range(1,(d+1)/2) plus [n//2])
+        for (n, m) in [(6, 9), (8, 12), (10, 15)]:
+            G1 = hnm_harary_graph(n, m)
+            d = 2*m // n
+            L = list(range(1, (d+1)//2))
+            L.append(n//2)
+            G2 = circulant_graph(n, L)
+            assert_true(is_isomorphic(G1, G2))
+
+        # When d is odd and n is even and r > 0, the hnm_harary_graph(n,m) is
+        # the circulant_graph(n, list(range(1,(d+1)/2) plus [n//2])
+        # with r edges added arbitrarily
+        for (n, m) in [(6, 10), (8, 13), (10, 17)]:
+            G1 = hnm_harary_graph(n, m)
+            d = 2*m // n
+            L = list(range(1, (d+1)//2))
+            L.append(n//2)
+            G2 = circulant_graph(n, L)
+            assert_true(set(G2.edges) < set(G1.edges))
+            assert_equal(G1.number_of_edges(), m)
+
+        # When d is odd and n is odd, the hnm_harary_graph(n,m) is
+        # the circulant_graph(n, list(range(1,(d+1)/2))
+        # with m - n*(d-1)/2 edges added arbitrarily
+        for (n, m) in [(5, 4), (7, 12), (9, 14)]:
+            G1 = hnm_harary_graph(n, m)
+            d = 2*m // n
+            L = list(range(1, (d+1)//2))
+            G2 = circulant_graph(n, L)
+            assert_true(set(G2.edges) < set(G1.edges))
+            assert_equal(G1.number_of_edges(), m)
+
+    """ 
+        Suppose connectivity k, number of nodes n 
+    """
+    def test_hkn_harary_graph(self):
+        # When k is even, the hkn_harary_graph(k,n) is
+        # the circulant_graph(n, list(range(1,k/2+1)))
+        for (k, n) in [(2, 6), (2, 7), (4, 6), (4, 7)]:
+            G1 = hkn_harary_graph(k, n)
+            G2 = circulant_graph(n, list(range(1, k//2 + 1)))
+            assert_true(is_isomorphic(G1, G2))
+
+        # When k is odd and n is even, the hkn_harary_graph(k,n) is
+        # the circulant_graph(n, list(range(1,(k+1)/2)) plus [n/2])
+        for (k, n) in [(3, 6), (5, 8), (7, 10)]:
+            G1 = hkn_harary_graph(k, n)
+            L = list(range(1, (k+1)//2))
+            L.append(n//2)
+            G2 = circulant_graph(n, L)
+            assert_true(is_isomorphic(G1, G2))
+
+        # When k is odd and n is odd, the hkn_harary_graph(k,n) is
+        # the circulant_graph(n, list(range(1,(k+1)/2))) with
+        # n//2+1 edges added between node i and node i+n//2+1
+        for (k, n) in [(3, 5), (5, 9), (7, 11)]:
+            G1 = hkn_harary_graph(k, n)
+            G2 = circulant_graph(n, list(range(1, (k+1)//2)))
+            eSet1 = set(G1.edges)
+            eSet2 = set(G2.edges)
+            eSet3 = set()
+            half = n // 2
+            for i in range(0, half+1):
+                # add half+1 edges between i and i+half
+                eSet3.add((i, (i+half) % n))
+            assert_equal(eSet1, eSet2 | eSet3)


### PR DESCRIPTION
This pull request implements two generators for the Harary graph, which achieves the maximum node connectivity among all graphs of the same number of nodes and number of edges. The way of constructing Harary graph is described by the famous mathematician Frank Harary in his 1962 work "The Maximum Connectivity of a Graph." 

The two generators use different parameters to generate Harary graph. For more details about them, please refer to the comments for the code. Please review and feedback. Thank you.