### PR TITLE
 Replacing `Return` to `Returns` in docs for functions

### DIFF
--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -283,7 +283,7 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
 
 
 def _bidirectional_shortest_path(G, source, target, exclude):
-    """Return shortest path between source and target ignoring nodes in the
+    """Returns shortest path between source and target ignoring nodes in the
     container 'exclude'.
 
     Parameters

--- a/networkx/algorithms/approximation/dominating_set.py
+++ b/networkx/algorithms/approximation/dominating_set.py
@@ -109,7 +109,7 @@ def min_weighted_dominating_set(G, weight=None):
 
 
 def min_edge_dominating_set(G):
-    r"""Return minimum cardinality edge dominating set.
+    r"""Returns minimum cardinality edge dominating set.
 
     Parameters
     ----------

--- a/networkx/algorithms/approximation/independent_set.py
+++ b/networkx/algorithms/approximation/independent_set.py
@@ -36,7 +36,7 @@ __author__ = """Nicholas Mancuso (nick.mancuso@gmail.com)"""
 
 
 def maximum_independent_set(G):
-    """Return an approximate maximum independent set.
+    """Returns an approximate maximum independent set.
 
     Parameters
     ----------

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -222,7 +222,7 @@ class _AntiGraph(nx.Graph):
     edge_attr_dict_factory = single_edge_dict
 
     def __getitem__(self, n):
-        """Return a dict of neighbors of node n in the dense graph.
+        """Returns a dict of neighbors of node n in the dense graph.
 
         Parameters
         ----------
@@ -240,7 +240,7 @@ class _AntiGraph(nx.Graph):
                 set(self._adj) - set(self._adj[n]) - set([n])}
 
     def neighbors(self, n):
-        """Return an iterator over all neighbors of node n in the
+        """Returns an iterator over all neighbors of node n in the
            dense graph.
         """
         try:
@@ -319,7 +319,7 @@ class _AntiGraph(nx.Graph):
 
     @property
     def degree(self):
-        """Return an iterator for (node, degree) and degree for single node.
+        """Returns an iterator for (node, degree) and degree for single node.
 
         The node degree is the number of edges adjacent to the node.
 
@@ -357,7 +357,7 @@ class _AntiGraph(nx.Graph):
         return self.AntiDegreeView(self)
 
     def adjacency(self):
-        """Return an iterator of (node, adjacency set) tuples for all nodes
+        """Returns an iterator of (node, adjacency set) tuples for all nodes
            in the dense graph.
 
         This is the fastest way to look at every edge.

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -16,7 +16,7 @@ __all__ = ['attribute_mixing_matrix',
 
 
 def attribute_mixing_dict(G, attribute, nodes=None, normalized=False):
-    """Return dictionary representation of mixing matrix for attribute.
+    """Returns dictionary representation of mixing matrix for attribute.
 
     Parameters
     ----------
@@ -55,7 +55,7 @@ def attribute_mixing_dict(G, attribute, nodes=None, normalized=False):
 
 def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None,
                             normalized=True):
-    """Return mixing matrix for attribute.
+    """Returns mixing matrix for attribute.
 
     Parameters
     ----------
@@ -90,7 +90,7 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None,
 
 def degree_mixing_dict(G, x='out', y='in', weight=None,
                        nodes=None, normalized=False):
-    """Return dictionary representation of mixing matrix for degree.
+    """Returns dictionary representation of mixing matrix for degree.
 
     Parameters
     ----------
@@ -122,7 +122,7 @@ def degree_mixing_dict(G, x='out', y='in', weight=None,
 
 def degree_mixing_matrix(G, x='out', y='in', weight=None,
                          nodes=None, normalized=True):
-    """Return mixing matrix for attribute.
+    """Returns mixing matrix for attribute.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def degree_mixing_matrix(G, x='out', y='in', weight=None,
 
 
 def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
-    """Return numeric mixing matrix for attribute.
+    """Returns numeric mixing matrix for attribute.
 
     The attribute must be an integer.
 
@@ -201,7 +201,7 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
 
 
 def mixing_dict(xy, normalized=False):
-    """Return a dictionary representation of mixing matrix.
+    """Returns a dictionary representation of mixing matrix.
 
     Parameters
     ----------

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -7,7 +7,7 @@ __all__ = ['node_attribute_xy',
 
 
 def node_attribute_xy(G, attribute, nodes=None):
-    """Return iterator of node-attribute pairs for all edges in G.
+    """Returns iterator of node-attribute pairs for all edges in G.
 
     Parameters
     ----------

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -211,7 +211,7 @@ def sets(G, top_nodes=None):
 
 
 def density(B, nodes):
-    """Return density of bipartite graph B.
+    """Returns density of bipartite graph B.
 
     Parameters
     ----------
@@ -263,7 +263,7 @@ def density(B, nodes):
 
 
 def degrees(B, nodes, weight=None):
-    """Return the degrees of the two node sets in the bipartite graph B.
+    """Returns the degrees of the two node sets in the bipartite graph B.
 
     Parameters
     ----------

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -32,7 +32,7 @@ __all__ = ['configuration_model',
 
 @nodes_or_number([0, 1])
 def complete_bipartite_graph(n1, n2, create_using=None):
-    """Return the complete bipartite graph `K_{n_1,n_2}`.
+    """Returns the complete bipartite graph `K_{n_1,n_2}`.
 
     Composed of two partitions with `n_1` nodes in the first
     and `n_2` nodes in the second. Each node in the first is
@@ -71,7 +71,7 @@ def complete_bipartite_graph(n1, n2, create_using=None):
 
 @py_random_state(3)
 def configuration_model(aseq, bseq, create_using=None, seed=None):
-    """Return a random bipartite graph from two given degree sequences.
+    """Returns a random bipartite graph from two given degree sequences.
 
     Parameters
     ----------
@@ -144,7 +144,7 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
 
 
 def havel_hakimi_graph(aseq, bseq, create_using=None):
-    """Return a bipartite graph from two given degree sequences using a
+    """Returns a bipartite graph from two given degree sequences using a
     Havel-Hakimi style construction.
 
     Nodes from the set A are connected to nodes in the set B by
@@ -216,7 +216,7 @@ def havel_hakimi_graph(aseq, bseq, create_using=None):
 
 
 def reverse_havel_hakimi_graph(aseq, bseq, create_using=None):
-    """Return a bipartite graph from two given degree sequences using a
+    """Returns a bipartite graph from two given degree sequences using a
     Havel-Hakimi style construction.
 
     Nodes from set A are connected to nodes in the set B by connecting
@@ -287,7 +287,7 @@ def reverse_havel_hakimi_graph(aseq, bseq, create_using=None):
 
 
 def alternating_havel_hakimi_graph(aseq, bseq, create_using=None):
-    """Return a bipartite graph from two given degree sequences using
+    """Returns a bipartite graph from two given degree sequences using
     an alternating Havel-Hakimi style construction.
 
     Nodes from the set A are connected to nodes in the set B by
@@ -424,7 +424,7 @@ def preferential_attachment_graph(aseq, p, create_using=None, seed=None):
 
 @py_random_state(3)
 def random_graph(n, m, p, seed=None, directed=False):
-    """Return a bipartite random graph.
+    """Returns a bipartite random graph.
 
     This is a bipartite version of the binomial (Erdős-Rényi) graph.
 
@@ -508,7 +508,7 @@ def random_graph(n, m, p, seed=None, directed=False):
 
 @py_random_state(3)
 def gnmk_random_graph(n, m, k, seed=None, directed=False):
-    """Return a random bipartite graph G_{n,m,k}.
+    """Returns a random bipartite graph G_{n,m,k}.
 
     Produces a bipartite graph chosen randomly out of the set of all graphs
     with n top nodes, m bottom nodes, and k edges.

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -20,7 +20,7 @@ __all__ = ['biadjacency_matrix', 'from_biadjacency_matrix']
 
 def biadjacency_matrix(G, row_order, column_order=None,
                        dtype=None, weight='weight',  format='csr'):
-    r"""Return the biadjacency matrix of the bipartite graph G.
+    r"""Returns the biadjacency matrix of the bipartite graph G.
 
     Let `G = (U, V, E)` be a bipartite graph with node sets
     `U = u_{1},...,u_{r}` and `V = v_{1},...,v_{s}`. The biadjacency

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -22,7 +22,7 @@ __all__ = ['subgraph_centrality_exp',
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def subgraph_centrality_exp(G):
-    r"""Return the subgraph centrality for each node of G.
+    r"""Returns the subgraph centrality for each node of G.
 
     Subgraph centrality  of a node `n` is the sum of weighted closed
     walks of all lengths starting and ending at node `n`. The weights
@@ -89,7 +89,7 @@ def subgraph_centrality_exp(G):
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def subgraph_centrality(G):
-    r"""Return subgraph centrality for each node in G.
+    r"""Returns subgraph centrality for each node in G.
 
     Subgraph centrality  of a node `n` is the sum of weighted closed
     walks of all lengths starting and ending at node `n`. The weights
@@ -164,7 +164,7 @@ def subgraph_centrality(G):
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def communicability_betweenness_centrality(G, normalized=True):
-    r"""Return subgraph communicability for all pairs of nodes in G.
+    r"""Returns subgraph communicability for all pairs of nodes in G.
 
     Communicability betweenness measure makes use of the number of walks
     connecting every pair of nodes as the basis of a betweenness centrality
@@ -272,7 +272,7 @@ def _rescale(cbc, normalized):
 
 
 def estrada_index(G):
-    r"""Return the Estrada index of a the graph G.
+    r"""Returns the Estrada index of a the graph G.
 
     The Estrada Index is a topological index of folding or 3D "compactness" ([1]_).
 

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -16,7 +16,7 @@ from networkx.utils import not_implemented_for
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def chain_decomposition(G, root=None):
-    """Return the chain decomposition of a graph.
+    """Returns the chain decomposition of a graph.
 
     The *chain decomposition* of a graph with respect a depth-first
     search tree is a set of cycles or paths derived from the set of

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -318,7 +318,7 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
 
 
 def _connected_chordal_graph_cliques(G):
-    """Return the set of maximal cliques of a connected chordal graph."""
+    """Returns the set of maximal cliques of a connected chordal graph."""
     if G.number_of_nodes() == 1:
         x = frozenset(G.nodes())
         return set([x])

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -21,7 +21,7 @@ __all__ = ['communicability',
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def communicability(G):
-    r"""Return communicability between all pairs of nodes in G.
+    r"""Returns communicability between all pairs of nodes in G.
 
     The communicability between pairs of nodes in G is the sum of
     closed walks of different lengths starting at node u and ending at node v.
@@ -102,7 +102,7 @@ def communicability(G):
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def communicability_exp(G):
-    r"""Return communicability between all pairs of nodes in G.
+    r"""Returns communicability between all pairs of nodes in G.
 
     Communicability between pair of node (u,v) of node in G is the sum of
     closed walks of different lengths starting at node u and ending at node v.

--- a/networkx/algorithms/community/community_utils.py
+++ b/networkx/algorithms/community/community_utils.py
@@ -16,7 +16,7 @@ __all__ = ['is_partition']
 
 
 def is_partition(G, communities):
-    """Return True if and only if `communities` is a partition of
+    """Returns True if and only if `communities` is a partition of
     the nodes of `G`.
 
     A partition of a universe set is a family of pairwise disjoint sets

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -26,7 +26,7 @@ __all__ = [
 
 @not_implemented_for('directed')
 def is_biconnected(G):
-    """Return True if the graph is biconnected, False otherwise.
+    """Returns True if the graph is biconnected, False otherwise.
 
     A graph is biconnected if, and only if, it cannot be disconnected by
     removing only one node (and all edges incident on that node).  If
@@ -99,7 +99,7 @@ def is_biconnected(G):
 
 @not_implemented_for('directed')
 def biconnected_component_edges(G):
-    """Return a generator of lists of edges, one list for each biconnected
+    """Returns a generator of lists of edges, one list for each biconnected
     component of the input graph.
 
     Biconnected components are maximal subgraphs such that the removal of a
@@ -172,7 +172,7 @@ def biconnected_component_edges(G):
 
 @not_implemented_for('directed')
 def biconnected_components(G):
-    """Return a generator of sets of nodes, one set for each biconnected
+    """Returns a generator of sets of nodes, one set for each biconnected
     component of the graph
 
     Biconnected components are maximal subgraphs such that the removal of a

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -92,7 +92,7 @@ def connected_component_subgraphs(G, copy=True):
 
 
 def number_connected_components(G):
-    """Return the number of connected components.
+    """Returns the number of connected components.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def number_connected_components(G):
 
 @not_implemented_for('directed')
 def is_connected(G):
-    """Return True if the graph is connected, False otherwise.
+    """Returns True if the graph is connected, False otherwise.
 
     Parameters
     ----------
@@ -164,7 +164,7 @@ def is_connected(G):
 
 @not_implemented_for('directed')
 def node_connected_component(G, n):
-    """Return the set of nodes in the component of graph containing node n.
+    """Returns the set of nodes in the component of graph containing node n.
 
     Parameters
     ----------

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -16,7 +16,7 @@ __all__ = ['is_semiconnected']
 
 @not_implemented_for('undirected')
 def is_semiconnected(G):
-    """Return True if the graph is semiconnected, False otherwise.
+    """Returns True if the graph is semiconnected, False otherwise.
 
     A graph is semiconnected if, and only if, for any pair of nodes, either one
     is reachable from the other, or they are mutually reachable.

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -287,7 +287,7 @@ def strongly_connected_component_subgraphs(G, copy=True):
 
 @not_implemented_for('undirected')
 def number_strongly_connected_components(G):
-    """Return number of strongly connected components in graph.
+    """Returns number of strongly connected components in graph.
 
     Parameters
     ----------

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -76,7 +76,7 @@ def weakly_connected_components(G):
 
 @not_implemented_for('undirected')
 def number_weakly_connected_components(G):
-    """Return the number of weakly connected components in G.
+    """Returns the number of weakly connected components in G.
 
     Parameters
     ----------

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -41,7 +41,7 @@ __all__ = ['core_number', 'find_cores', 'k_core',
 
 @not_implemented_for('multigraph')
 def core_number(G):
-    """Return the core number for each vertex.
+    """Returns the core number for each vertex.
 
     A k-core is a maximal subgraph that contains nodes of degree k or more.
 
@@ -139,7 +139,7 @@ def _core_subgraph(G, k_filter, k=None, core=None):
 
 
 def k_core(G, k=None, core_number=None):
-    """Return the k-core of G.
+    """Returns the k-core of G.
 
     A k-core is a maximal subgraph that contains nodes of degree k or more.
 
@@ -189,7 +189,7 @@ def k_core(G, k=None, core_number=None):
 
 
 def k_shell(G, k=None, core_number=None):
-    """Return the k-shell of G.
+    """Returns the k-shell of G.
 
     The k-shell is the subgraph induced by nodes with core number k.
     That is, nodes in the k-core that are not in the (k+1)-core.
@@ -246,7 +246,7 @@ def k_shell(G, k=None, core_number=None):
 
 
 def k_crust(G, k=None, core_number=None):
-    """Return the k-crust of G.
+    """Returns the k-crust of G.
 
     The k-crust is the graph G with the k-core removed.
 
@@ -304,7 +304,7 @@ def k_crust(G, k=None, core_number=None):
 
 
 def k_corona(G, k, core_number=None):
-    """Return the k-corona of G.
+    """Returns the k-corona of G.
 
     The k-corona is the subgraph of nodes in the k-core which have
     exactly k neighbours in the k-core.

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -53,7 +53,7 @@ chaini = chain.from_iterable
 
 
 def descendants(G, source):
-    """Return all nodes reachable from `source` in `G`.
+    """Returns all nodes reachable from `source` in `G`.
 
     Parameters
     ----------
@@ -73,7 +73,7 @@ def descendants(G, source):
 
 
 def ancestors(G, source):
-    """Return all nodes having a path to `source` in `G`.
+    """Returns all nodes having a path to `source` in `G`.
 
     Parameters
     ----------
@@ -103,7 +103,7 @@ def has_cycle(G):
 
 
 def is_directed_acyclic_graph(G):
-    """Return True if the graph `G` is a directed acyclic graph (DAG) or
+    """Returns True if the graph `G` is a directed acyclic graph (DAG) or
     False if not.
 
     Parameters
@@ -119,7 +119,7 @@ def is_directed_acyclic_graph(G):
 
 
 def topological_sort(G):
-    """Return a generator of nodes in topologically sorted order.
+    """Returns a generator of nodes in topologically sorted order.
 
     A topological sort is a nonunique permutation of the nodes such that an
     edge from u to v implies that u appears before v in the topological sort
@@ -210,7 +210,7 @@ def topological_sort(G):
 
 
 def lexicographical_topological_sort(G, key=None):
-    """Return a generator of nodes in lexicographically topologically sorted
+    """Returns a generator of nodes in lexicographically topologically sorted
     order.
 
     A topological sort is a nonunique permutation of the nodes such that an
@@ -416,7 +416,7 @@ def all_topological_sorts(G):
 
 
 def is_aperiodic(G):
-    """Return True if `G` is aperiodic.
+    """Returns True if `G` is aperiodic.
 
     A directed graph is aperiodic if there is no integer k > 1 that
     divides the length of every cycle in the graph.

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -191,7 +191,7 @@ def extrema_bounding(G, compute="diameter"):
 
 
 def eccentricity(G, v=None, sp=None):
-    """Return the eccentricity of nodes in G.
+    """Returns the eccentricity of nodes in G.
 
     The eccentricity of a node v is the maximum distance from v to
     all other nodes in G.
@@ -249,7 +249,7 @@ def eccentricity(G, v=None, sp=None):
 
 
 def diameter(G, e=None, usebounds=False):
-    """Return the diameter of the graph G.
+    """Returns the diameter of the graph G.
 
     The diameter is the maximum eccentricity.
 
@@ -278,7 +278,7 @@ def diameter(G, e=None, usebounds=False):
 
 
 def periphery(G, e=None, usebounds=False):
-    """Return the periphery of the graph G.
+    """Returns the periphery of the graph G.
 
     The periphery is the set of nodes with eccentricity equal to the diameter.
 
@@ -305,7 +305,7 @@ def periphery(G, e=None, usebounds=False):
 
 
 def radius(G, e=None, usebounds=False):
-    """Return the radius of the graph G.
+    """Returns the radius of the graph G.
 
     The radius is the minimum eccentricity.
 
@@ -330,7 +330,7 @@ def radius(G, e=None, usebounds=False):
 
 
 def center(G, e=None, usebounds=False):
-    """Return the center of the graph G.
+    """Returns the center of the graph G.
 
     The center is the set of nodes with eccentricity equal to radius.
 

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -68,7 +68,7 @@ def is_distance_regular(G):
 
 
 def global_parameters(b, c):
-    """Return global parameters for a given intersection array.
+    """Returns global parameters for a given intersection array.
 
     Given a distance-regular graph G with integers b_i, c_i,i = 0,....,d
     such that for any 2 vertices x,y in G at a distance i=d(x,y), there

--- a/networkx/algorithms/flow/mincost.py
+++ b/networkx/algorithms/flow/mincost.py
@@ -111,7 +111,7 @@ def min_cost_flow_cost(G, demand='demand', capacity='capacity',
 
 def min_cost_flow(G, demand='demand', capacity='capacity',
                   weight='weight'):
-    r"""Return a minimum cost flow satisfying all demands in digraph G.
+    r"""Returns a minimum cost flow satisfying all demands in digraph G.
 
     G is a digraph with edge costs and capacities and in which nodes
     have demand, i.e., they want to send or receive some amount of
@@ -246,7 +246,7 @@ def cost_of_flow(G, flowDict, weight='weight'):
 
 
 def max_flow_min_cost(G, s, t, capacity='capacity', weight='weight'):
-    """Return a maximum (s, t)-flow of minimum cost.
+    """Returns a maximum (s, t)-flow of minimum cost.
 
     G is a digraph with edge costs and capacities. There is a source
     node s and a sink node t. This function finds a maximum flow from

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -293,7 +293,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
     ###########################################################################
 
     def reduced_cost(i):
-        """Return the reduced cost of an edge i.
+        """Returns the reduced cost of an edge i.
         """
         c = C[i] - pi[S[i]] + pi[T[i]]
         return c if x[i] == 0 else -c
@@ -364,7 +364,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
                     return p
 
     def trace_path(p, w):
-        """Return the nodes and edges on the path from node p to its ancestor
+        """Returns the nodes and edges on the path from node p to its ancestor
         w.
         """
         Wn = [p]
@@ -376,7 +376,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
         return Wn, We
 
     def find_cycle(i, p, q):
-        """Return the nodes and edges on the cycle containing edge i == (p, q)
+        """Returns the nodes and edges on the cycle containing edge i == (p, q)
         when the latter is added to the spanning tree.
 
         The cycle is oriented in the direction from p to q.
@@ -394,13 +394,13 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
         return Wn, We
 
     def residual_capacity(i, p):
-        """Return the residual capacity of an edge i in the direction away
+        """Returns the residual capacity of an edge i in the direction away
         from its endpoint p.
         """
         return U[i] - x[i] if S[i] == p else x[i]
 
     def find_leaving_edge(Wn, We):
-        """Return the leaving edge in a cycle represented by Wn and We.
+        """Returns the leaving edge in a cycle represented by Wn and We.
         """
         j, s = min(zip(reversed(We), reversed(Wn)),
                    key=lambda i_p: residual_capacity(*i_p))

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -13,7 +13,7 @@ __all__ = ['hits', 'hits_numpy', 'hits_scipy', 'authority_matrix', 'hub_matrix']
 
 
 def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
-    """Return HITS hubs and authorities values for nodes.
+    """Returns HITS hubs and authorities values for nodes.
 
     The HITS algorithm computes two numbers for a node.
     Authorities estimates the node value based on the incoming links.
@@ -127,19 +127,19 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
 
 
 def authority_matrix(G, nodelist=None):
-    """Return the HITS authority matrix."""
+    """Returns the HITS authority matrix."""
     M = nx.to_numpy_matrix(G, nodelist=nodelist)
     return M.T * M
 
 
 def hub_matrix(G, nodelist=None):
-    """Return the HITS hub matrix."""
+    """Returns the HITS hub matrix."""
     M = nx.to_numpy_matrix(G, nodelist=nodelist)
     return M * M.T
 
 
 def hits_numpy(G, normalized=True):
-    """Return HITS hubs and authorities values for nodes.
+    """Returns HITS hubs and authorities values for nodes.
 
     The HITS algorithm computes two numbers for a node.
     Authorities estimates the node value based on the incoming links.
@@ -210,7 +210,7 @@ def hits_numpy(G, normalized=True):
 
 
 def hits_scipy(G, max_iter=100, tol=1.0e-6, normalized=True):
-    """Return HITS hubs and authorities values for nodes.
+    """Returns HITS hubs and authorities values for nodes.
 
     The HITS algorithm computes two numbers for a node.
     Authorities estimates the node value based on the incoming links.

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -17,7 +17,7 @@ __all__ = ['pagerank', 'pagerank_numpy', 'pagerank_scipy', 'google_matrix']
 def pagerank(G, alpha=0.85, personalization=None,
              max_iter=100, tol=1.0e-6, nstart=None, weight='weight',
              dangling=None):
-    """Return the PageRank of the nodes in the graph.
+    """Returns the PageRank of the nodes in the graph.
 
     PageRank computes a ranking of the nodes in the graph G based on
     the structure of the incoming links. It was originally designed as
@@ -160,7 +160,7 @@ def pagerank(G, alpha=0.85, personalization=None,
 
 def google_matrix(G, alpha=0.85, personalization=None,
                   nodelist=None, weight='weight', dangling=None):
-    """Return the Google matrix of the graph.
+    """Returns the Google matrix of the graph.
 
     Parameters
     ----------
@@ -254,7 +254,7 @@ def google_matrix(G, alpha=0.85, personalization=None,
 
 def pagerank_numpy(G, alpha=0.85, personalization=None, weight='weight',
                    dangling=None):
-    """Return the PageRank of the nodes in the graph.
+    """Returns the PageRank of the nodes in the graph.
 
     PageRank computes a ranking of the nodes in the graph G based on
     the structure of the incoming links. It was originally designed as
@@ -338,7 +338,7 @@ def pagerank_numpy(G, alpha=0.85, personalization=None, weight='weight',
 def pagerank_scipy(G, alpha=0.85, personalization=None,
                    max_iter=100, tol=1.0e-6, weight='weight',
                    dangling=None):
-    """Return the PageRank of the nodes in the graph.
+    """Returns the PageRank of the nodes in the graph.
 
     PageRank computes a ranking of the nodes in the graph G based on
     the structure of the incoming links. It was originally designed as

--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -23,7 +23,7 @@ __all__ = ['maximal_independent_set']
 @py_random_state(2)
 @not_implemented_for('directed')
 def maximal_independent_set(G, nodes=None, seed=None):
-    """Return a random maximal independent set guaranteed to contain
+    """Returns a random maximal independent set guaranteed to contain
     a given set of nodes.
 
     An independent set is a set of nodes such that the subgraph

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -20,7 +20,7 @@ __all__ = ['union_all', 'compose_all', 'disjoint_union_all',
 
 
 def union_all(graphs, rename=(None,)):
-    """Return the union of all graphs.
+    """Returns the union of all graphs.
 
     The graphs must be disjoint, otherwise an exception is raised.
 
@@ -68,7 +68,7 @@ def union_all(graphs, rename=(None,)):
 
 
 def disjoint_union_all(graphs):
-    """Return the disjoint union of all graphs.
+    """Returns the disjoint union of all graphs.
 
     This operation forces distinct integer node labels starting with 0
     for the first graph in the list and numbering consecutively.
@@ -105,7 +105,7 @@ def disjoint_union_all(graphs):
 
 
 def compose_all(graphs):
-    """Return the composition of all graphs.
+    """Returns the composition of all graphs.
 
     Composition is the simple union of the node sets and edge sets.
     The node sets of the supplied graphs need not be disjoint.
@@ -143,7 +143,7 @@ def compose_all(graphs):
 
 
 def intersection_all(graphs):
-    """Return a new graph that contains only the edges that exist in
+    """Returns a new graph that contains only the edges that exist in
     all graphs.
 
     All supplied graphs must have the same node set.

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -136,7 +136,7 @@ def disjoint_union(G, H):
 
 
 def intersection(G, H):
-    """Return a new graph that contains only the edges that exist in
+    """Returns a new graph that contains only the edges that exist in
     both G and H.
 
     The node sets of H and G must be the same.
@@ -190,7 +190,7 @@ def intersection(G, H):
 
 
 def difference(G, H):
-    """Return a new graph that contains the edges that exist in G but not in H.
+    """Returns a new graph that contains the edges that exist in G but not in H.
 
     The node sets of H and G must be the same.
 
@@ -234,7 +234,7 @@ def difference(G, H):
 
 
 def symmetric_difference(G, H):
-    """Return new graph with edges that exist in either G or H but not both.
+    """Returns new graph with edges that exist in either G or H but not both.
 
     The node sets of H and G must be the same.
 
@@ -286,7 +286,7 @@ def symmetric_difference(G, H):
 
 
 def compose(G, H):
-    """Return a new graph of G composed with H.
+    """Returns a new graph of G composed with H.
 
     Composition is the simple union of the node sets and edge sets.
     The node sets of G and H do not need to be disjoint.

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -129,7 +129,7 @@ def _init_product_graph(G, H):
 
 
 def tensor_product(G, H):
-    r"""Return the tensor product of G and H.
+    r"""Returns the tensor product of G and H.
 
     The tensor product $P$ of the graphs $G$ and $H$ has a node set that
     is the tensor product of the node sets, $V(P)=V(G) \times V(H)$.
@@ -184,7 +184,7 @@ def tensor_product(G, H):
 
 
 def cartesian_product(G, H):
-    r"""Return the Cartesian product of G and H.
+    r"""Returns the Cartesian product of G and H.
 
     The Cartesian product $P$ of the graphs $G$ and $H$ has a node set that
     is the Cartesian product of the node sets, $V(P)=V(G) \times V(H)$.
@@ -235,7 +235,7 @@ def cartesian_product(G, H):
 
 
 def lexicographic_product(G, H):
-    r"""Return the lexicographic product of G and H.
+    r"""Returns the lexicographic product of G and H.
 
     The lexicographical product $P$ of the graphs $G$ and $H$ has a node set
     that is the Cartesian product of the node sets, $V(P)=V(G) \times V(H)$.
@@ -287,7 +287,7 @@ def lexicographic_product(G, H):
 
 
 def strong_product(G, H):
-    r"""Return the strong product of G and H.
+    r"""Returns the strong product of G and H.
 
     The strong product $P$ of the graphs $G$ and $H$ has a node set that
     is the Cartesian product of the node sets, $V(P)=V(G) \times V(H)$.

--- a/networkx/algorithms/operators/unary.py
+++ b/networkx/algorithms/operators/unary.py
@@ -14,7 +14,7 @@ __all__ = ['complement', 'reverse']
 
 
 def complement(G):
-    """Return the graph complement of G.
+    """Returns the graph complement of G.
 
     Parameters
     ----------
@@ -42,7 +42,7 @@ def complement(G):
 
 
 def reverse(G, copy=True):
-    """Return the reverse directed graph of G.
+    """Returns the reverse directed graph of G.
 
     Parameters
     ----------

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -155,11 +155,11 @@ class Interval(object):
         return self.low is None and self.high is None
 
     def copy(self):
-        """Return a copy of this interval"""
+        """Returns a copy of this interval"""
         return Interval(self.low, self.high)
 
     def conflicting(self, b, planarity_state):
-        """Return True if interval I conflicts with edge b"""
+        """Returns True if interval I conflicts with edge b"""
         return (not self.empty() and
                 planarity_state.lowpt[self.high] > planarity_state.lowpt[b])
 
@@ -182,7 +182,7 @@ class ConflictPair(object):
         self.right = temp
 
     def lowest(self, planarity_state):
-        """Return the lowest lowpoint of a conflict pair"""
+        """Returns the lowest lowpoint of a conflict pair"""
         if self.left.empty():
             return planarity_state.lowpt[self.right.low]
         if self.right.empty():

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -21,7 +21,7 @@ __all__ = ['astar_path', 'astar_path_length']
 
 @not_implemented_for('multigraph')
 def astar_path(G, source, target, heuristic=None, weight='weight'):
-    """Return a list of nodes in a shortest path between source and target
+    """Returns a list of nodes in a shortest path between source and target
     using the A* ("A-star") algorithm.
 
     There may be more than one shortest path.  This returns only one.
@@ -135,7 +135,7 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
 
 
 def astar_path_length(G, source, target, heuristic=None, weight='weight'):
-    """Return the length of the shortest path between source and target using
+    """Returns the length of the shortest path between source and target using
     the A* ("A-star") algorithm.
 
     Parameters

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -24,7 +24,7 @@ __all__ = ['shortest_path', 'all_shortest_paths',
 
 
 def has_path(G, source, target):
-    """Return *True* if *G* has a path from *source* to *target*.
+    """Returns *True* if *G* has a path from *source* to *target*.
 
     Parameters
     ----------
@@ -319,7 +319,7 @@ def shortest_path_length(G,
 
 
 def average_shortest_path_length(G, weight=None, method='dijkstra'):
-    r"""Return the average shortest path length.
+    r"""Returns the average shortest path length.
 
     The average shortest path length is
 

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -187,7 +187,7 @@ def all_pairs_shortest_path_length(G, cutoff=None):
 
 
 def bidirectional_shortest_path(G, source, target):
-    """Return a list of nodes in a shortest path between source and target.
+    """Returns a list of nodes in a shortest path between source and target.
 
     Parameters
     ----------

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1865,7 +1865,7 @@ def goldberg_radzik(G, source, weight='weight'):
 
 
 def negative_edge_cycle(G, weight='weight'):
-    """Return True if there exists a negative edge cycle anywhere in G.
+    """Returns True if there exists a negative edge cycle anywhere in G.
 
     Parameters
     ----------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -446,7 +446,7 @@ def _bidirectional_shortest_path(G, source, target,
                                  ignore_nodes=None,
                                  ignore_edges=None,
                                  weight=None):
-    """Return the shortest path between source and target ignoring
+    """Returns the shortest path between source and target ignoring
        nodes and edges in the containers ignore_nodes and ignore_edges.
 
     This is a custom modification of the standard bidirectional shortest

--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -243,7 +243,7 @@ def lattice_reference(G, niter=1, D=None, connectivity=True, seed=None):
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def sigma(G, niter=100, nrand=10, seed=None):
-    """Return the small-world coefficient (sigma) of the given graph.
+    """Returns the small-world coefficient (sigma) of the given graph.
 
     The small-world coefficient is defined as:
     sigma = C/Cr / L/Lr
@@ -311,7 +311,7 @@ def sigma(G, niter=100, nrand=10, seed=None):
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def omega(G, niter=100, nrand=10, seed=None):
-    """Return the small-world coefficient (omega) of a graph
+    """Returns the small-world coefficient (omega) of a graph
 
     The small-world coefficient of a graph G is:
 

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -3,7 +3,7 @@ import networkx as nx
 
 
 def s_metric(G, normalized=True):
-    """Return the s-metric of graph.
+    """Returns the s-metric of graph.
 
     The s-metric is defined as the sum of the products deg(u)*deg(v)
     for every edge (u,v) in G. If norm is provided construct the

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -147,7 +147,7 @@ def bfs_edges(G, source, reverse=False, depth_limit=None):
 
 
 def bfs_tree(G, source, reverse=False, depth_limit=None):
-    """Return an oriented tree constructed from of a breadth-first-search
+    """Returns an oriented tree constructed from of a breadth-first-search
     starting at source.
 
     Parameters

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -97,7 +97,7 @@ def dfs_edges(G, source=None, depth_limit=None):
 
 
 def dfs_tree(G, source=None, depth_limit=None):
-    """Return oriented tree constructed from a depth-first-search from source.
+    """Returns oriented tree constructed from a depth-first-search from source.
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ def dfs_tree(G, source=None, depth_limit=None):
 
 
 def dfs_predecessors(G, source=None, depth_limit=None):
-    """Return dictionary of predecessors in depth-first-search from source.
+    """Returns dictionary of predecessors in depth-first-search from source.
 
     Parameters
     ----------
@@ -178,7 +178,7 @@ def dfs_predecessors(G, source=None, depth_limit=None):
 
 
 def dfs_successors(G, source=None, depth_limit=None):
-    """Return dictionary of successors in depth-first-search from source.
+    """Returns dictionary of successors in depth-first-search from source.
 
     Parameters
     ----------

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -768,21 +768,21 @@ class DiGraph(Graph):
                 del self._pred[v][u]
 
     def has_successor(self, u, v):
-        """Return True if node u has successor v.
+        """Returns True if node u has successor v.
 
         This is true if graph has the edge u->v.
         """
         return (u in self._succ and v in self._succ[u])
 
     def has_predecessor(self, u, v):
-        """Return True if node u has predecessor v.
+        """Returns True if node u has predecessor v.
 
         This is true if graph has the edge u<-v.
         """
         return (u in self._pred and v in self._pred[u])
 
     def successors(self, n):
-        """Return an iterator over successor nodes of n.
+        """Returns an iterator over successor nodes of n.
 
         A successor of n is a node m such that there exists a directed
         edge from n to m.
@@ -814,7 +814,7 @@ class DiGraph(Graph):
     neighbors = successors
 
     def predecessors(self, n):
-        """Return an iterator over predecessor nodes of n.
+        """Returns an iterator over predecessor nodes of n.
 
         A predecessor of n is a node m such that there exists a directed
         edge from m to n.
@@ -1096,15 +1096,15 @@ class DiGraph(Graph):
         self.graph.clear()
 
     def is_multigraph(self):
-        """Return True if graph is a multigraph, False otherwise."""
+        """Returns True if graph is a multigraph, False otherwise."""
         return False
 
     def is_directed(self):
-        """Return True if graph is directed, False otherwise."""
+        """Returns True if graph is directed, False otherwise."""
         return True
 
     def to_undirected(self, reciprocal=False, as_view=False):
-        """Return an undirected representation of the digraph.
+        """Returns an undirected representation of the digraph.
 
         Parameters
         ----------
@@ -1179,7 +1179,7 @@ class DiGraph(Graph):
         return G
 
     def reverse(self, copy=True):
-        """Return the reverse of the graph.
+        """Returns the reverse of the graph.
 
         The reverse is a graph with the same nodes and edges
         but with the directions of the edges reversed.

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -38,12 +38,12 @@ __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
 
 
 def nodes(G):
-    """Return an iterator over the graph nodes."""
+    """Returns an iterator over the graph nodes."""
     return G.nodes()
 
 
 def edges(G, nbunch=None):
-    """Return an edge view of edges incident to nodes in nbunch.
+    """Returns an edge view of edges incident to nodes in nbunch.
 
     Return all edges if nbunch is unspecified or nbunch=None.
 
@@ -53,29 +53,29 @@ def edges(G, nbunch=None):
 
 
 def degree(G, nbunch=None, weight=None):
-    """Return a degree view of single node or of nbunch of nodes.
+    """Returns a degree view of single node or of nbunch of nodes.
     If nbunch is omitted, then return degrees of *all* nodes.
     """
     return G.degree(nbunch, weight)
 
 
 def neighbors(G, n):
-    """Return a list of nodes connected to node n. """
+    """Returns a list of nodes connected to node n. """
     return G.neighbors(n)
 
 
 def number_of_nodes(G):
-    """Return the number of nodes in the graph."""
+    """Returns the number of nodes in the graph."""
     return G.number_of_nodes()
 
 
 def number_of_edges(G):
-    """Return the number of edges in the graph. """
+    """Returns the number of edges in the graph. """
     return G.number_of_edges()
 
 
 def density(G):
-    r"""Return the density of a graph.
+    r"""Returns the density of a graph.
 
     The density for undirected graphs is
 
@@ -110,7 +110,7 @@ def density(G):
 
 
 def degree_histogram(G):
-    """Return a list of the frequency of each degree value.
+    """Returns a list of the frequency of each degree value.
 
     Parameters
     ----------
@@ -192,7 +192,7 @@ def freeze(G):
 
 
 def is_frozen(G):
-    """Return True if graph is frozen.
+    """Returns True if graph is frozen.
 
     Parameters
     ----------
@@ -309,7 +309,7 @@ def add_cycle(G_to_add_to, nodes_for_cycle, **attr):
 
 
 def subgraph(G, nbunch):
-    """Return the subgraph induced on nodes in nbunch.
+    """Returns the subgraph induced on nodes in nbunch.
 
     Parameters
     ----------
@@ -332,7 +332,7 @@ def subgraph(G, nbunch):
 
 
 def induced_subgraph(G, nbunch):
-    """Return a SubGraph view of `G` showing only nodes in nbunch.
+    """Returns a SubGraph view of `G` showing only nodes in nbunch.
 
     The induced subgraph of a graph on a set of nodes N is the
     graph with nodes N and edges from G which have both ends in N.
@@ -503,7 +503,7 @@ def reverse_view(digraph):
 
 
 def to_directed(graph):
-    """Return a directed view of the graph `graph`.
+    """Returns a directed view of the graph `graph`.
 
     Identical to graph.to_directed(as_view=True)
     Note that graph.to_directed defaults to `as_view=False`
@@ -513,7 +513,7 @@ def to_directed(graph):
 
 
 def to_undirected(graph):
-    """Return an undirected view of the graph `graph`.
+    """Returns an undirected view of the graph `graph`.
 
     Identical to graph.to_undirected(as_view=True)
     Note that graph.to_undirected defaults to `as_view=False`
@@ -523,7 +523,7 @@ def to_undirected(graph):
 
 
 def create_empty_copy(G, with_data=True):
-    """Return a copy of the graph G with all of the edges removed.
+    """Returns a copy of the graph G with all of the edges removed.
 
     Parameters
     ----------
@@ -902,7 +902,7 @@ def non_edges(graph):
 
 @not_implemented_for('directed')
 def common_neighbors(G, u, v):
-    """Return the common neighbors of two nodes in a graph.
+    """Returns the common neighbors of two nodes in a graph.
 
     Parameters
     ----------
@@ -1175,7 +1175,7 @@ def selfloop_edges(G, data=False, keys=False, default=None):
 
 
 def number_of_selfloops(G):
-    """Return the number of selfloop edges.
+    """Returns the number of selfloop edges.
 
     A selfloop edge has the same node at both ends.
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -381,7 +381,7 @@ class Graph(object):
         self.graph['name'] = s
 
     def __str__(self):
-        """Return the graph name.
+        """Returns the graph name.
 
         Returns
         -------
@@ -415,7 +415,7 @@ class Graph(object):
         return iter(self._node)
 
     def __contains__(self, n):
-        """Return True if n is a node, False otherwise. Use: 'n in G'.
+        """Returns True if n is a node, False otherwise. Use: 'n in G'.
 
         Examples
         --------
@@ -429,7 +429,7 @@ class Graph(object):
             return False
 
     def __len__(self):
-        """Return the number of nodes. Use: 'len(G)'.
+        """Returns the number of nodes. Use: 'len(G)'.
 
         Returns
         -------
@@ -446,7 +446,7 @@ class Graph(object):
         return len(self._node)
 
     def __getitem__(self, n):
-        """Return a dict of neighbors of node n.  Use: 'G[n]'.
+        """Returns a dict of neighbors of node n.  Use: 'G[n]'.
 
         Parameters
         ----------
@@ -795,7 +795,7 @@ class Graph(object):
     # Done with backward compatibility methods for 1.x
 
     def number_of_nodes(self):
-        """Return the number of nodes in the graph.
+        """Returns the number of nodes in the graph.
 
         Returns
         -------
@@ -815,7 +815,7 @@ class Graph(object):
         return len(self._node)
 
     def order(self):
-        """Return the number of nodes in the graph.
+        """Returns the number of nodes in the graph.
 
         Returns
         -------
@@ -830,7 +830,7 @@ class Graph(object):
         return len(self._node)
 
     def has_node(self, n):
-        """Return True if the graph contains the node n.
+        """Returns True if the graph contains the node n.
 
         Identical to `n in G`
 
@@ -1183,7 +1183,7 @@ class Graph(object):
             raise NetworkXError("update needs nodes or edges input")
 
     def has_edge(self, u, v):
-        """Return True if the edge (u, v) is in the graph.
+        """Returns True if the edge (u, v) is in the graph.
 
         This is the same as `v in G[u]` without KeyError exceptions.
 
@@ -1224,7 +1224,7 @@ class Graph(object):
             return False
 
     def neighbors(self, n):
-        """Return an iterator over all neighbors of node n.
+        """Returns an iterator over all neighbors of node n.
 
         This is identical to `iter(G[n])`
 
@@ -1325,7 +1325,7 @@ class Graph(object):
         return EdgeView(self)
 
     def get_edge_data(self, u, v, default=None):
-        """Return the attribute dictionary associated with edge (u, v).
+        """Returns the attribute dictionary associated with edge (u, v).
 
         This is identical to `G[u][v]` except the default is returned
         instead of an exception is the edge doesn't exist.
@@ -1371,7 +1371,7 @@ class Graph(object):
             return default
 
     def adjacency(self):
-        """Return an iterator over (node, adjacency dict) tuples for all nodes.
+        """Returns an iterator over (node, adjacency dict) tuples for all nodes.
 
         For directed graphs, only outgoing neighbors/adjacencies are included.
 
@@ -1450,11 +1450,11 @@ class Graph(object):
         self.graph.clear()
 
     def is_multigraph(self):
-        """Return True if graph is a multigraph, False otherwise."""
+        """Returns True if graph is a multigraph, False otherwise."""
         return False
 
     def is_directed(self):
-        """Return True if graph is directed, False otherwise."""
+        """Returns True if graph is directed, False otherwise."""
         return False
 
     def fresh_copy(self):
@@ -1464,7 +1464,7 @@ class Graph(object):
         return self.__class__()
 
     def copy(self, as_view=False):
-        """Return a copy of the graph.
+        """Returns a copy of the graph.
 
         The copy method by default returns an independent shallow copy
         of the graph and attributes. That is, if an attribute is a
@@ -1551,7 +1551,7 @@ class Graph(object):
         return G
 
     def to_directed(self, as_view=False):
-        """Return a directed representation of the graph.
+        """Returns a directed representation of the graph.
 
         Returns
         -------
@@ -1605,7 +1605,7 @@ class Graph(object):
         return G
 
     def to_undirected(self, as_view=False):
-        """Return an undirected copy of the graph.
+        """Returns an undirected copy of the graph.
 
         Parameters
         ----------
@@ -1660,7 +1660,7 @@ class Graph(object):
         return G
 
     def subgraph(self, nodes):
-        """Return a SubGraph view of the subgraph induced on `nodes`.
+        """Returns a SubGraph view of the subgraph induced on `nodes`.
 
         The induced subgraph of the graph contains the nodes in `nodes`
         and the edges between those nodes.
@@ -1764,7 +1764,7 @@ class Graph(object):
         return nx.edge_subgraph(self, edges)
 
     def size(self, weight=None):
-        """Return the number of edges or total of all edge weights.
+        """Returns the number of edges or total of all edge weights.
 
         Parameters
         ----------
@@ -1807,7 +1807,7 @@ class Graph(object):
         return s // 2 if weight is None else s / 2
 
     def number_of_edges(self, u=None, v=None):
-        """Return the number of edges between two nodes.
+        """Returns the number of edges between two nodes.
 
         Parameters
         ----------
@@ -1859,7 +1859,7 @@ class Graph(object):
         return 0
 
     def nbunch_iter(self, nbunch=None):
-        """Return an iterator over nodes contained in nbunch that are
+        """Returns an iterator over nodes contained in nbunch that are
         also in the graph.
 
         The nodes in nbunch are checked for membership in the graph

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -725,7 +725,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
     @property
     def out_degree(self):
-        """Return an iterator for (node, out-degree) or out-degree for single node.
+        """Returns an iterator for (node, out-degree) or out-degree for single node.
 
         out_degree(self, nbunch=None, weight=None)
 
@@ -770,15 +770,15 @@ class MultiDiGraph(MultiGraph, DiGraph):
         return OutMultiDegreeView(self)
 
     def is_multigraph(self):
-        """Return True if graph is a multigraph, False otherwise."""
+        """Returns True if graph is a multigraph, False otherwise."""
         return True
 
     def is_directed(self):
-        """Return True if graph is directed, False otherwise."""
+        """Returns True if graph is directed, False otherwise."""
         return True
 
     def to_undirected(self, reciprocal=False, as_view=False):
-        """Return an undirected representation of the digraph.
+        """Returns an undirected representation of the digraph.
 
         Parameters
         ----------
@@ -849,7 +849,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         return G
 
     def reverse(self, copy=True):
-        """Return the reverse of the graph.
+        """Returns the reverse of the graph.
 
         The reverse is a graph with the same nodes and edges
         but with the directions of the edges reversed.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -341,7 +341,7 @@ class MultiGraph(Graph):
         return MultiAdjacencyView(self._adj)
 
     def new_edge_key(self, u, v):
-        """Return an unused key for edges between nodes `u` and `v`.
+        """Returns an unused key for edges between nodes `u` and `v`.
 
         The nodes `u` and `v` do not need to be already in the graph.
 
@@ -650,7 +650,7 @@ class MultiGraph(Graph):
                 pass
 
     def has_edge(self, u, v, key=None):
-        """Return True if the graph has an edge between nodes u and v.
+        """Returns True if the graph has an edge between nodes u and v.
 
         This is the same as `v in G[u] or key in G[u][v]`
         without KeyError exceptions.
@@ -707,7 +707,7 @@ class MultiGraph(Graph):
 
     @property
     def edges(self):
-        """Return an iterator over the edges.
+        """Returns an iterator over the edges.
 
         edges(self, nbunch=None, data=False, keys=False, default=None)
 
@@ -774,7 +774,7 @@ class MultiGraph(Graph):
         return MultiEdgeView(self)
 
     def get_edge_data(self, u, v, key=None, default=None):
-        """Return the attribute dictionary associated with edge (u, v).
+        """Returns the attribute dictionary associated with edge (u, v).
 
         This is identical to `G[u][v][key]` except the default is returned
         instead of an exception is the edge doesn't exist.
@@ -879,15 +879,15 @@ class MultiGraph(Graph):
         return MultiDegreeView(self)
 
     def is_multigraph(self):
-        """Return True if graph is a multigraph, False otherwise."""
+        """Returns True if graph is a multigraph, False otherwise."""
         return True
 
     def is_directed(self):
-        """Return True if graph is directed, False otherwise."""
+        """Returns True if graph is directed, False otherwise."""
         return False
 
     def copy(self, as_view=False):
-        """Return a copy of the graph.
+        """Returns a copy of the graph.
 
         The copy method by default returns an independent shallow copy
         of the graph and attributes. That is, if an attribute is a
@@ -975,7 +975,7 @@ class MultiGraph(Graph):
         return G
 
     def to_directed(self, as_view=False):
-        """Return a directed representation of the graph.
+        """Returns a directed representation of the graph.
 
         Returns
         -------
@@ -1030,7 +1030,7 @@ class MultiGraph(Graph):
         return G
 
     def to_undirected(self, as_view=False):
-        """Return an undirected copy of the graph.
+        """Returns an undirected copy of the graph.
 
         Returns
         -------
@@ -1081,7 +1081,7 @@ class MultiGraph(Graph):
         return G
 
     def number_of_edges(self, u=None, v=None):
-        """Return the number of edges between two nodes.
+        """Returns the number of edges between two nodes.
 
         Parameters
         ----------

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -166,7 +166,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
 
 
 def to_dict_of_lists(G, nodelist=None):
-    """Return adjacency representation of graph as a dictionary of lists.
+    """Returns adjacency representation of graph as a dictionary of lists.
 
     Parameters
     ----------
@@ -191,7 +191,7 @@ def to_dict_of_lists(G, nodelist=None):
 
 
 def from_dict_of_lists(d, create_using=None):
-    """Return a graph from a dictionary of lists.
+    """Returns a graph from a dictionary of lists.
 
     Parameters
     ----------
@@ -230,7 +230,7 @@ def from_dict_of_lists(d, create_using=None):
 
 
 def to_dict_of_dicts(G, nodelist=None, edge_data=None):
-    """Return adjacency representation of graph as a dictionary of dictionaries.
+    """Returns adjacency representation of graph as a dictionary of dictionaries.
 
     Parameters
     ----------
@@ -270,7 +270,7 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
 
 
 def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
-    """Return a graph from a dictionary of dictionaries.
+    """Returns a graph from a dictionary of dictionaries.
 
     Parameters
     ----------
@@ -349,7 +349,7 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
 
 
 def to_edgelist(G, nodelist=None):
-    """Return a list of edges in the graph.
+    """Returns a list of edges in the graph.
 
     Parameters
     ----------
@@ -366,7 +366,7 @@ def to_edgelist(G, nodelist=None):
 
 
 def from_edgelist(edgelist, create_using=None):
-    """Return a graph from a list of edges.
+    """Returns a graph from a list of edges.
 
     Parameters
     ----------

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -41,7 +41,7 @@ __all__ = ['from_numpy_matrix', 'to_numpy_matrix',
 
 def to_pandas_adjacency(G, nodelist=None, dtype=None, order=None,
                         multigraph_weight=sum, weight='weight', nonedge=0.0):
-    """Return the graph adjacency matrix as a Pandas DataFrame.
+    """Returns the graph adjacency matrix as a Pandas DataFrame.
 
     Parameters
     ----------
@@ -130,7 +130,7 @@ def to_pandas_adjacency(G, nodelist=None, dtype=None, order=None,
 
 
 def from_pandas_adjacency(df, create_using=None):
-    r"""Return a graph from Pandas DataFrame.
+    r"""Returns a graph from Pandas DataFrame.
 
     The Pandas DataFrame is interpreted as an adjacency matrix for the graph.
 
@@ -193,7 +193,7 @@ def from_pandas_adjacency(df, create_using=None):
 
 def to_pandas_edgelist(G, source='source', target='target', nodelist=None,
                        dtype=None, order=None):
-    """Return the graph edge list as a Pandas DataFrame.
+    """Returns the graph edge list as a Pandas DataFrame.
 
     Parameters
     ----------
@@ -244,7 +244,7 @@ def to_pandas_edgelist(G, source='source', target='target', nodelist=None,
 
 def from_pandas_edgelist(df, source='source', target='target', edge_attr=None,
                          create_using=None):
-    """Return a graph from Pandas DataFrame containing an edge list.
+    """Returns a graph from Pandas DataFrame containing an edge list.
 
     The Pandas DataFrame should contain at least two columns of node names and
     zero or more columns of edge attributes. Each row will be processed as one
@@ -348,7 +348,7 @@ def from_pandas_edgelist(df, source='source', target='target', edge_attr=None,
 
 def to_numpy_matrix(G, nodelist=None, dtype=None, order=None,
                     multigraph_weight=sum, weight='weight', nonedge=0.0):
-    """Return the graph adjacency matrix as a NumPy matrix.
+    """Returns the graph adjacency matrix as a NumPy matrix.
 
     Parameters
     ----------
@@ -451,7 +451,7 @@ def to_numpy_matrix(G, nodelist=None, dtype=None, order=None,
 
 
 def from_numpy_matrix(A, parallel_edges=False, create_using=None):
-    """Return a graph from numpy matrix.
+    """Returns a graph from numpy matrix.
 
     The numpy matrix is interpreted as an adjacency matrix for the graph.
 
@@ -605,7 +605,7 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
 
 @not_implemented_for('multigraph')
 def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
-    """Return the graph adjacency matrix as a NumPy recarray.
+    """Returns the graph adjacency matrix as a NumPy recarray.
 
     Parameters
     ----------
@@ -677,7 +677,7 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
 
 def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
                            weight='weight', format='csr'):
-    """Return the graph adjacency matrix as a SciPy sparse matrix.
+    """Returns the graph adjacency matrix as a SciPy sparse matrix.
 
     Parameters
     ----------
@@ -967,7 +967,7 @@ def from_scipy_sparse_matrix(A, parallel_edges=False, create_using=None,
 
 def to_numpy_array(G, nodelist=None, dtype=None, order=None,
                    multigraph_weight=sum, weight='weight', nonedge=0.0):
-    """Return the graph adjacency matrix as a NumPy array.
+    """Returns the graph adjacency matrix as a NumPy array.
 
     Parameters
     ----------
@@ -1140,7 +1140,7 @@ def to_numpy_array(G, nodelist=None, dtype=None, order=None,
 
 
 def from_numpy_array(A, parallel_edges=False, create_using=None):
-    """Return a graph from NumPy array.
+    """Returns a graph from NumPy array.
 
     The NumPy array is interpreted as an adjacency matrix for the graph.
 

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -863,7 +863,7 @@ def _sparse_spectral(A, dim=2):
 
 
 def rescale_layout(pos, scale=1):
-    """Return scaled position array to (-scale, scale) in all axes.
+    """Returns scaled position array to (-scale, scale) in all axes.
 
     The function acts on NumPy arrays which hold position information.
     Each position is one row of the array. The dimension of the space

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -35,7 +35,7 @@ __all__ = ['from_agraph', 'to_agraph',
 
 
 def from_agraph(A, create_using=None):
-    """Return a NetworkX Graph or DiGraph from a PyGraphviz graph.
+    """Returns a NetworkX Graph or DiGraph from a PyGraphviz graph.
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ def from_agraph(A, create_using=None):
 
 
 def to_agraph(N):
-    """Return a pygraphviz graph from a NetworkX graph N.
+    """Returns a pygraphviz graph from a NetworkX graph N.
 
     Parameters
     ----------
@@ -196,7 +196,7 @@ def write_dot(G, path):
 
 
 def read_dot(path):
-    """Return a NetworkX graph from a dot file on path.
+    """Returns a NetworkX graph from a dot file on path.
 
     Parameters
     ----------

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -50,7 +50,7 @@ def write_dot(G, path):
 
 @open_file(0, mode='r')
 def read_dot(path):
-    """Return a NetworkX :class:`MultiGraph` or :class:`MultiDiGraph` from the
+    """Returns a NetworkX :class:`MultiGraph` or :class:`MultiDiGraph` from the
     dot file with the passed path.
 
     If this file contains multiple graphs, only the first such graph is
@@ -82,7 +82,7 @@ def read_dot(path):
 
 
 def from_pydot(P):
-    """Return a NetworkX graph from a Pydot graph.
+    """Returns a NetworkX graph from a Pydot graph.
 
     Parameters
     ----------
@@ -172,7 +172,7 @@ def from_pydot(P):
 
 
 def to_pydot(N):
-    """Return a pydot graph from a NetworkX graph N.
+    """Returns a pydot graph from a NetworkX graph N.
 
     Parameters
     ----------

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -136,7 +136,7 @@ def graph_atlas(i):
 
 
 def graph_atlas_g():
-    """Return the list of all graphs with up to seven nodes named in the
+    """Returns the list of all graphs with up to seven nodes named in the
     Graph Atlas.
 
     The graphs are listed in increasing order by

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -105,7 +105,7 @@ def full_rary_tree(r, n, create_using=None):
 
 
 def balanced_tree(r, h, create_using=None):
-    """Return the perfectly balanced `r`-ary tree of height `h`.
+    """Returns the perfectly balanced `r`-ary tree of height `h`.
 
     Parameters
     ----------
@@ -150,7 +150,7 @@ def balanced_tree(r, h, create_using=None):
 
 
 def barbell_graph(m1, m2, create_using=None):
-    """Return the Barbell Graph: two complete graphs connected by a path.
+    """Returns the Barbell Graph: two complete graphs connected by a path.
 
     For $m1 > 1$ and $m2 >= 0$.
 
@@ -235,7 +235,7 @@ def complete_graph(n, create_using=None):
 
 
 def circular_ladder_graph(n, create_using=None):
-    """Return the circular ladder graph $CL_n$ of length n.
+    """Returns the circular ladder graph $CL_n$ of length n.
 
     $CL_n$ consists of two concentric n-cycles in which
     each of the n pairs of concentric nodes are joined by an edge.
@@ -304,7 +304,7 @@ def circulant_graph(n, offsets, create_using=None):
 
 @nodes_or_number(0)
 def cycle_graph(n, create_using=None):
-    """Return the cycle graph $C_n$ of cyclically connected nodes.
+    """Returns the cycle graph $C_n$ of cyclically connected nodes.
 
     $C_n$ is a path with its two end-nodes connected.
 
@@ -329,7 +329,7 @@ def cycle_graph(n, create_using=None):
 
 
 def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
-    """Return the hierarchically constructed Dorogovtsev-Goltsev-Mendes graph.
+    """Returns the hierarchically constructed Dorogovtsev-Goltsev-Mendes graph.
 
     n is the generation.
     See: arXiv:/cond-mat/0112143 by Dorogovtsev, Goltsev and Mendes.
@@ -357,7 +357,7 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
 
 @nodes_or_number(0)
 def empty_graph(n=0, create_using=None, default=nx.Graph):
-    """Return the empty graph with n nodes and zero edges.
+    """Returns the empty graph with n nodes and zero edges.
 
     Parameters
     ----------
@@ -449,7 +449,7 @@ def empty_graph(n=0, create_using=None, default=nx.Graph):
 
 
 def ladder_graph(n, create_using=None):
-    """Return the Ladder graph of length n.
+    """Returns the Ladder graph of length n.
 
     This is two paths of n nodes, with
     each pair connected by a single edge.
@@ -468,7 +468,7 @@ def ladder_graph(n, create_using=None):
 
 @nodes_or_number([0, 1])
 def lollipop_graph(m, n, create_using=None):
-    """Return the Lollipop Graph; `K_m` connected to `P_n`.
+    """Returns the Lollipop Graph; `K_m` connected to `P_n`.
 
     This is the Barbell Graph without the right barbell.
 
@@ -520,7 +520,7 @@ def lollipop_graph(m, n, create_using=None):
 
 
 def null_graph(create_using=None):
-    """Return the Null graph with no nodes or edges.
+    """Returns the Null graph with no nodes or edges.
 
     See empty_graph for the use of create_using.
 
@@ -531,7 +531,7 @@ def null_graph(create_using=None):
 
 @nodes_or_number(0)
 def path_graph(n, create_using=None):
-    """Return the Path graph `P_n` of linearly connected nodes.
+    """Returns the Path graph `P_n` of linearly connected nodes.
 
     Parameters
     ----------

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -113,7 +113,7 @@ def connected_caveman_graph(l, k):
 
 @py_random_state(3)
 def relaxed_caveman_graph(l, k, p, seed=None):
-    """Return a relaxed caveman graph.
+    """Returns a relaxed caveman graph.
 
     A relaxed caveman graph starts with `l` cliques of size `k`.  Edges are
     then randomly rewired with probability `p` to link different cliques.
@@ -164,7 +164,7 @@ def relaxed_caveman_graph(l, k, p, seed=None):
 
 @py_random_state(3)
 def random_partition_graph(sizes, p_in, p_out, seed=None, directed=False):
-    """Return the random partition graph with a partition of sizes.
+    """Returns the random partition graph with a partition of sizes.
 
     A partition graph is a graph of communities with sizes defined by
     s in sizes. Nodes in the same group are connected with probability
@@ -236,7 +236,7 @@ def random_partition_graph(sizes, p_in, p_out, seed=None, directed=False):
 
 @py_random_state(4)
 def planted_partition_graph(l, k, p_in, p_out, seed=None, directed=False):
-    """Return the planted l-partition graph.
+    """Returns the planted l-partition graph.
 
     This model partitions a graph with n=l*k vertices in
     l groups with k vertices each. Vertices of the same
@@ -473,7 +473,7 @@ def windmill_graph(n, k):
 @py_random_state(3)
 def stochastic_block_model(sizes, p, nodelist=None, seed=None,
                            directed=False, selfloops=False, sparse=True):
-    """Return a stochastic block model graph.
+    """Returns a stochastic block model graph.
 
     This model partitions the nodes in blocks of arbitrary sizes, and places
     edges between pairs of nodes independently, with a probability that depends

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -143,7 +143,7 @@ def _configuration_model(deg_sequence, create_using, directed=False,
 
 @py_random_state(2)
 def configuration_model(deg_sequence, create_using=None, seed=None):
-    """Return a random graph with the given degree sequence.
+    """Returns a random graph with the given degree sequence.
 
     The configuration model generates a random pseudograph (graph with
     parallel edges and self loops) by randomly assigning edges to
@@ -247,7 +247,7 @@ def configuration_model(deg_sequence, create_using=None, seed=None):
 def directed_configuration_model(in_degree_sequence,
                                  out_degree_sequence,
                                  create_using=None, seed=None):
-    """Return a directed_random graph with the given degree sequences.
+    """Returns a directed_random graph with the given degree sequences.
 
     The configuration model generates a random directed pseudograph
     (graph with parallel edges and self loops) by randomly assigning
@@ -342,7 +342,7 @@ def directed_configuration_model(in_degree_sequence,
 
 @py_random_state(1)
 def expected_degree_graph(w, seed=None, selfloops=True):
-    r"""Return a random graph with given expected degrees.
+    r"""Returns a random graph with given expected degrees.
 
     Given a sequence of expected degrees $W=(w_0,w_1,\ldots,w_{n-1})$
     of length $n$ this algorithm assigns an edge between node $u$ and
@@ -450,7 +450,7 @@ def expected_degree_graph(w, seed=None, selfloops=True):
 
 
 def havel_hakimi_graph(deg_sequence, create_using=None):
-    """Return a simple graph with given degree sequence constructed
+    """Returns a simple graph with given degree sequence constructed
     using the Havel-Hakimi algorithm.
 
     Parameters
@@ -544,7 +544,7 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
 def directed_havel_hakimi_graph(in_deg_sequence,
                                 out_deg_sequence,
                                 create_using=None):
-    """Return a directed graph with the given degree sequences.
+    """Returns a directed graph with the given degree sequences.
 
     Parameters
     ----------
@@ -697,7 +697,7 @@ def degree_sequence_tree(deg_sequence, create_using=None):
 
 @py_random_state(1)
 def random_degree_sequence_graph(sequence, seed=None, tries=10):
-    r"""Return a simple random graph with the given degree sequence.
+    r"""Returns a simple random graph with the given degree sequence.
 
     If the maximum degree $d_m$ in the sequence is $O(m^{1/4})$ then the
     algorithm produces almost uniform random graphs in $O(m d_m)$ time

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -30,7 +30,7 @@ __all__ = ['gn_graph', 'gnc_graph', 'gnr_graph', 'random_k_out_graph',
 
 @py_random_state(3)
 def gn_graph(n, kernel=None, create_using=None, seed=None):
-    """Return the growing network (GN) digraph with `n` nodes.
+    """Returns the growing network (GN) digraph with `n` nodes.
 
     The GN graph is built by adding nodes one at a time with a link to one
     previously added node.  The target node for the link is chosen with
@@ -95,7 +95,7 @@ def gn_graph(n, kernel=None, create_using=None, seed=None):
 
 @py_random_state(3)
 def gnr_graph(n, p, create_using=None, seed=None):
-    """Return the growing network with redirection (GNR) digraph with `n`
+    """Returns the growing network with redirection (GNR) digraph with `n`
     nodes and redirection probability `p`.
 
     The GNR graph is built by adding nodes one at a time with a link to one
@@ -148,7 +148,7 @@ def gnr_graph(n, p, create_using=None, seed=None):
 
 @py_random_state(2)
 def gnc_graph(n, create_using=None, seed=None):
-    """Return the growing network with copying (GNC) digraph with `n` nodes.
+    """Returns the growing network with copying (GNC) digraph with `n` nodes.
 
     The GNC graph is built by adding nodes one at a time with a link to one
     previously added node (chosen uniformly at random) and to all of that

--- a/networkx/generators/duplication.py
+++ b/networkx/generators/duplication.py
@@ -26,7 +26,7 @@ __all__ = ['partial_duplication_graph', 'duplication_divergence_graph']
 
 @py_random_state(4)
 def partial_duplication_graph(N, n, p, q, seed=None):
-    """Return a random graph using the partial duplication model.
+    """Returns a random graph using the partial duplication model.
 
     Parameters
     ----------

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -44,7 +44,7 @@ __all__ = ['margulis_gabber_galil_graph', 'chordal_cycle_graph']
 #     (x, (y + (2*x + 2)) % n),
 #
 def margulis_gabber_galil_graph(n, create_using=None):
-    r"""Return the Margulis-Gabber-Galil undirected MultiGraph on `n^2` nodes.
+    r"""Returns the Margulis-Gabber-Galil undirected MultiGraph on `n^2` nodes.
 
     The undirected MultiGraph is regular with degree `8`. Nodes are integer
     pairs. The second-largest eigenvalue of the adjacency matrix of the graph
@@ -82,7 +82,7 @@ def margulis_gabber_galil_graph(n, create_using=None):
 
 
 def chordal_cycle_graph(p, create_using=None):
-    """Return the chordal cycle graph on `p` nodes.
+    """Returns the chordal cycle graph on `p` nodes.
 
     The returned graph is a cycle graph on `p` nodes with chords joining each
     vertex `x` to its inverse modulo `p`. This graph is a (mildly explicit)

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -475,7 +475,7 @@ def geographical_threshold_graph(n, theta, dim=2, pos=None, weight=None,
 @nodes_or_number(0)
 def waxman_graph(n, beta=0.4, alpha=0.1, L=None, domain=(0, 0, 1, 1),
                  metric=None, seed=None):
-    r"""Return a Waxman random graph.
+    r"""Returns a Waxman random graph.
 
     The Waxman random graph model places `n` nodes uniformly at random
     in a rectangular domain. Each pair of nodes at distance `d` is
@@ -592,7 +592,7 @@ def waxman_graph(n, beta=0.4, alpha=0.1, L=None, domain=(0, 0, 1, 1),
 
 @py_random_state(5)
 def navigable_small_world_graph(n, p=1, q=1, r=2, dim=2, seed=None):
-    r"""Return a navigable small-world graph.
+    r"""Returns a navigable small-world graph.
 
     A navigable small-world graph is a directed grid with additional long-range
     connections that are chosen randomly.

--- a/networkx/generators/intersection.py
+++ b/networkx/generators/intersection.py
@@ -23,7 +23,7 @@ __all__ = ['uniform_random_intersection_graph',
 
 @py_random_state(3)
 def uniform_random_intersection_graph(n, m, p, seed=None):
-    """Return a uniform random intersection graph.
+    """Returns a uniform random intersection graph.
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ def uniform_random_intersection_graph(n, m, p, seed=None):
 
 @py_random_state(3)
 def k_random_intersection_graph(n, m, k, seed=None):
-    """Return a intersection graph with randomly chosen attribute sets for
+    """Returns a intersection graph with randomly chosen attribute sets for
     each node that are of equal size (k).
 
     Parameters
@@ -91,7 +91,7 @@ def k_random_intersection_graph(n, m, k, seed=None):
 
 @py_random_state(3)
 def general_random_intersection_graph(n, m, p, seed=None):
-    """Return a random intersection graph with independent probabilities
+    """Returns a random intersection graph with independent probabilities
     for connections between node and attribute sets.
 
     Parameters

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -162,7 +162,7 @@ def _sorted_edge(u, v):
 
 
 def _lg_directed(G, create_using=None):
-    """Return the line graph L of the (multi)digraph G.
+    """Returns the line graph L of the (multi)digraph G.
 
     Edges in G appear as nodes in L, represented as tuples of the form (u,v)
     or (u,v,key) if G is a multidigraph. A node in L corresponding to the edge
@@ -192,7 +192,7 @@ def _lg_directed(G, create_using=None):
 
 
 def _lg_undirected(G, selfloops=False, create_using=None):
-    """Return the line graph L of the (multi)graph G.
+    """Returns the line graph L of the (multi)graph G.
 
     Edges in G appear as nodes in L, represented as sorted tuples of the form
     (u,v), or (u,v,key) if G is a multigraph. A node in L corresponding to

--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -138,7 +138,7 @@ def _next_tree(candidate):
 
 
 def _split_tree(layout):
-    """Return a tuple of two layouts, one containing the left
+    """Returns a tuple of two layouts, one containing the left
     subtree of the root vertex, and one containing the original tree
     with the left subtree removed."""
 

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -298,7 +298,7 @@ def gnm_random_graph(n, m, seed=None, directed=False):
 
 @py_random_state(3)
 def newman_watts_strogatz_graph(n, k, p, seed=None):
-    """Return a Newman–Watts–Strogatz small-world graph.
+    """Returns a Newman–Watts–Strogatz small-world graph.
 
     Parameters
     ----------
@@ -363,7 +363,7 @@ def newman_watts_strogatz_graph(n, k, p, seed=None):
 
 @py_random_state(3)
 def watts_strogatz_graph(n, k, p, seed=None):
-    """Return a Watts–Strogatz small-world graph.
+    """Returns a Watts–Strogatz small-world graph.
 
     Parameters
     ----------
@@ -1187,7 +1187,7 @@ def random_powerlaw_tree_sequence(n, gamma=3, seed=None, tries=100):
 
 @py_random_state(3)
 def random_kernel_graph(n, kernel_integral, kernel_root=None, seed=None):
-    r"""Return an random graph based on the specified kernel.
+    r"""Returns an random graph based on the specified kernel.
 
     The algorithm chooses each of the $[n(n-1)]/2$ possible edges with
     probability specified by a kernel $\kappa(x,y)$ [1]_.  The kernel

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -177,7 +177,7 @@ def LCF_graph(n, shift_list, repeats, create_using=None):
 #-------------------------------------------------------------------------------
 
 def bull_graph(create_using=None):
-    """Return the Bull graph. """
+    """Returns the Bull graph. """
     description = [
         "adjacencylist",
         "Bull Graph",
@@ -189,7 +189,7 @@ def bull_graph(create_using=None):
 
 
 def chvatal_graph(create_using=None):
-    """Return the Chvátal graph."""
+    """Returns the Chvátal graph."""
     description = [
         "adjacencylist",
         "Chvatal Graph",
@@ -203,7 +203,7 @@ def chvatal_graph(create_using=None):
 
 
 def cubical_graph(create_using=None):
-    """Return the 3-regular Platonic Cubical graph."""
+    """Returns the 3-regular Platonic Cubical graph."""
     description = [
         "adjacencylist",
         "Platonic Cubical Graph",
@@ -223,7 +223,7 @@ def desargues_graph(create_using=None):
 
 
 def diamond_graph(create_using=None):
-    """Return the Diamond graph. """
+    """Returns the Diamond graph. """
     description = [
         "adjacencylist",
         "Diamond Graph",
@@ -242,7 +242,7 @@ def dodecahedral_graph(create_using=None):
 
 
 def frucht_graph(create_using=None):
-    """Return the Frucht Graph.
+    """Returns the Frucht Graph.
 
     The Frucht Graph is the smallest cubical graph whose
     automorphism group consists only of the identity element.
@@ -281,7 +281,7 @@ def hoffman_singleton_graph():
 
 
 def house_graph(create_using=None):
-    """Return the House graph (square with triangle on top)."""
+    """Returns the House graph (square with triangle on top)."""
     description = [
         "adjacencylist",
         "House Graph",
@@ -293,7 +293,7 @@ def house_graph(create_using=None):
 
 
 def house_x_graph(create_using=None):
-    """Return the House graph with a cross inside the house square."""
+    """Returns the House graph with a cross inside the house square."""
     description = [
         "adjacencylist",
         "House-with-X-inside Graph",
@@ -305,7 +305,7 @@ def house_x_graph(create_using=None):
 
 
 def icosahedral_graph(create_using=None):
-    """Return the Platonic Icosahedral graph."""
+    """Returns the Platonic Icosahedral graph."""
     description = [
         "adjacencylist",
         "Platonic Icosahedral Graph",
@@ -341,14 +341,14 @@ def krackhardt_kite_graph(create_using=None):
 
 
 def moebius_kantor_graph(create_using=None):
-    """Return the Moebius-Kantor graph."""
+    """Returns the Moebius-Kantor graph."""
     G = LCF_graph(16, [5, -5], 8, create_using)
     G.name = "Moebius-Kantor Graph"
     return G
 
 
 def octahedral_graph(create_using=None):
-    """Return the Platonic Octahedral graph."""
+    """Returns the Platonic Octahedral graph."""
     description = [
         "adjacencylist",
         "Platonic Octahedral Graph",
@@ -367,7 +367,7 @@ def pappus_graph():
 
 
 def petersen_graph(create_using=None):
-    """Return the Petersen graph."""
+    """Returns the Petersen graph."""
     description = [
         "adjacencylist",
         "Petersen Graph",
@@ -405,7 +405,7 @@ def tetrahedral_graph(create_using=None):
 
 
 def truncated_cube_graph(create_using=None):
-    """Return the skeleton of the truncated cube."""
+    """Returns the skeleton of the truncated cube."""
     description = [
         "adjacencylist",
         "Truncated Cube Graph",
@@ -422,7 +422,7 @@ def truncated_cube_graph(create_using=None):
 
 
 def truncated_tetrahedron_graph(create_using=None):
-    """Return the skeleton of the truncated Platonic tetrahedron."""
+    """Returns the skeleton of the truncated Platonic tetrahedron."""
     G = path_graph(12, create_using)
 #    G.add_edges_from([(1,3),(1,10),(2,7),(4,12),(5,12),(6,8),(9,11)])
     G.add_edges_from([(0, 2), (0, 9), (1, 6), (3, 11), (4, 11), (5, 7), (8, 10)])
@@ -431,7 +431,7 @@ def truncated_tetrahedron_graph(create_using=None):
 
 
 def tutte_graph(create_using=None):
-    """Return the Tutte graph."""
+    """Returns the Tutte graph."""
     description = [
         "adjacencylist",
         "Tutte's Graph",

--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -12,7 +12,7 @@ __all__ = ['karate_club_graph', 'davis_southern_women_graph',
 
 
 def karate_club_graph():
-    """Return Zachary's Karate Club graph.
+    """Returns Zachary's Karate Club graph.
 
     Each node in the returned graph has a node attribute 'club' that
     indicates the name of the club to which the member represented by that node
@@ -96,7 +96,7 @@ def karate_club_graph():
 
 
 def davis_southern_women_graph():
-    """Return Davis Southern women social network.
+    """Returns Davis Southern women social network.
 
     This is a bipartite graph.
 
@@ -238,7 +238,7 @@ def davis_southern_women_graph():
 
 
 def florentine_families_graph():
-    """Return Florentine families graph.
+    """Returns Florentine families graph.
 
     References
     ----------
@@ -271,7 +271,7 @@ def florentine_families_graph():
 
 
 def les_miserables_graph():
-    """Return coappearance network of characters in the novel Les Miserables.
+    """Returns coappearance network of characters in the novel Les Miserables.
 
     References
     ----------

--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -276,8 +276,8 @@ def les_miserables_graph():
     References
     ----------
     .. [1] D. E. Knuth, 1993.
-    The Stanford GraphBase: a platform for combinatorial computing,
-    pp. 74-87. New York: AcM Press.
+       The Stanford GraphBase: a platform for combinatorial computing,
+       pp. 74-87. New York: AcM Press.
     """
     G = nx.Graph()
     G.add_edge('Napoleon', 'Myriel', weight=1)

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -87,7 +87,7 @@ def _mat_spect_approx(A, level, sorteigs=True, reverse=False, absolute=True):
 
 @np_random_state(3)
 def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
-    """Return a random simple graph with spectrum resembling that of `G`
+    """Returns a random simple graph with spectrum resembling that of `G`
 
     This algorithm, called Spectral Graph Forge (SGF), computes the
     eigenvectors of a given graph adjacency matrix, filters them and

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -289,7 +289,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
 
 
 def _get_fiedler_func(method):
-    """Return a function that solves the Fiedler eigenvalue problem.
+    """Returns a function that solves the Fiedler eigenvalue problem.
     """
     if method == "tracemin":  # old style keyword <v2.1
         method = "tracemin_pcg"
@@ -332,7 +332,7 @@ def _get_fiedler_func(method):
 @not_implemented_for('directed')
 def algebraic_connectivity(G, weight='weight', normalized=False, tol=1e-8,
                            method='tracemin_pcg', seed=None):
-    """Return the algebraic connectivity of an undirected graph.
+    """Returns the algebraic connectivity of an undirected graph.
 
     The algebraic connectivity of a connected undirected graph is the second
     smallest eigenvalue of its Laplacian matrix.
@@ -417,7 +417,7 @@ def algebraic_connectivity(G, weight='weight', normalized=False, tol=1e-8,
 @not_implemented_for('directed')
 def fiedler_vector(G, weight='weight', normalized=False, tol=1e-8,
                    method='tracemin_pcg', seed=None):
-    """Return the Fiedler vector of a connected undirected graph.
+    """Returns the Fiedler vector of a connected undirected graph.
 
     The Fiedler vector of a connected undirected graph is the eigenvector
     corresponding to the second smallest eigenvalue of the Laplacian matrix of

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -19,7 +19,7 @@ __all__ = ['incidence_matrix',
 
 def incidence_matrix(G, nodelist=None, edgelist=None,
                      oriented=False, weight=None):
-    """Return incidence matrix of G.
+    """Returns incidence matrix of G.
 
     The incidence matrix assigns each row to a node and each column to an edge.
     For a standard incidence matrix a 1 appears wherever a row's node is
@@ -106,7 +106,7 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
 
 
 def adjacency_matrix(G, nodelist=None, weight='weight'):
-    """Return adjacency matrix of G.
+    """Returns adjacency matrix of G.
 
     Parameters
     ----------

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -19,7 +19,7 @@ __all__ = ['laplacian_matrix',
 
 @not_implemented_for('directed')
 def laplacian_matrix(G, nodelist=None, weight='weight'):
-    """Return the Laplacian matrix of G.
+    """Returns the Laplacian matrix of G.
 
     The graph Laplacian is the matrix L = D - A, where
     A is the adjacency matrix and D is the diagonal matrix of node degrees.
@@ -64,7 +64,7 @@ def laplacian_matrix(G, nodelist=None, weight='weight'):
 
 @not_implemented_for('directed')
 def normalized_laplacian_matrix(G, nodelist=None, weight='weight'):
-    r"""Return the normalized Laplacian matrix of G.
+    r"""Returns the normalized Laplacian matrix of G.
 
     The normalized graph Laplacian is the matrix
 
@@ -138,7 +138,7 @@ def normalized_laplacian_matrix(G, nodelist=None, weight='weight'):
 @not_implemented_for('multigraph')
 def directed_laplacian_matrix(G, nodelist=None, weight='weight',
                               walk_type=None, alpha=0.95):
-    r"""Return the directed Laplacian matrix of G.
+    r"""Returns the directed Laplacian matrix of G.
 
     The graph directed Laplacian is the matrix
 

--- a/networkx/linalg/modularitymatrix.py
+++ b/networkx/linalg/modularitymatrix.py
@@ -19,7 +19,7 @@ __all__ = ['modularity_matrix', 'directed_modularity_matrix']
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
 def modularity_matrix(G, nodelist=None, weight=None):
-    r"""Return the modularity matrix of G.
+    r"""Returns the modularity matrix of G.
 
     The modularity matrix is the matrix B = A - <A>, where A is the adjacency
     matrix and <A> is the average adjacency matrix, assuming that the graph
@@ -86,7 +86,7 @@ def modularity_matrix(G, nodelist=None, weight=None):
 @not_implemented_for('undirected')
 @not_implemented_for('multigraph')
 def directed_modularity_matrix(G, nodelist=None, weight=None):
-    """Return the directed modularity matrix of G.
+    """Returns the directed modularity matrix of G.
 
     The modularity matrix is the matrix B = A - <A>, where A is the adjacency
     matrix and <A> is the expected adjacency matrix, assuming that the graph

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -17,7 +17,7 @@ __all__ = ['laplacian_spectrum', 'adjacency_spectrum', 'modularity_spectrum']
 
 
 def laplacian_spectrum(G, weight='weight'):
-    """Return eigenvalues of the Laplacian of G
+    """Returns eigenvalues of the Laplacian of G
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ def laplacian_spectrum(G, weight='weight'):
 
 
 def adjacency_spectrum(G, weight='weight'):
-    """Return eigenvalues of the adjacency matrix of G.
+    """Returns eigenvalues of the adjacency matrix of G.
 
     Parameters
     ----------
@@ -77,7 +77,7 @@ def adjacency_spectrum(G, weight='weight'):
 
 
 def modularity_spectrum(G):
-    """Return eigenvalues of the modularity matrix of G.
+    """Returns eigenvalues of the modularity matrix of G.
 
     Parameters
     ----------

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -109,7 +109,7 @@ def from_graph6_bytes(string):
 
     """
     def bits():
-        """Return sequence of individual bits from 6-bit-per-value
+        """Returns sequence of individual bits from 6-bit-per-value
         list of data values."""
         for d in data:
             for i in [5, 4, 3, 2, 1, 0]:

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -13,7 +13,7 @@ _attrs = dict(id='id', key='key')
 
 
 def adjacency_data(G, attrs=_attrs):
-    """Return data in adjacency format that is suitable for JSON serialization
+    """Returns data in adjacency format that is suitable for JSON serialization
     and use in Javascript documents.
 
     Parameters
@@ -89,7 +89,7 @@ def adjacency_data(G, attrs=_attrs):
 
 
 def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
-    """Return graph from adjacency data format.
+    """Returns graph from adjacency data format.
 
     Parameters
     ----------

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -8,7 +8,7 @@ _attrs = dict(name='name', ident='id')
 
 
 def cytoscape_data(G, attrs=None):
-    """Return data in Cytoscape JSON format (cyjs).
+    """Returns data in Cytoscape JSON format (cyjs).
 
     Parameters
     ----------

--- a/networkx/readwrite/json_graph/jit.py
+++ b/networkx/readwrite/json_graph/jit.py
@@ -70,7 +70,7 @@ def jit_graph(data, create_using=None):
 
 @not_implemented_for('multigraph')
 def jit_data(G, indent=None):
-    """Return data in JIT JSON format.
+    """Returns data in JIT JSON format.
 
     Parameters
     ----------

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -18,7 +18,7 @@ _attrs = dict(source='source', target='target', name='id',
 
 
 def node_link_data(G, attrs=None):
-    """Return data in node-link format that is suitable for JSON serialization
+    """Returns data in node-link format that is suitable for JSON serialization
     and use in Javascript documents.
 
     Parameters
@@ -102,7 +102,7 @@ def node_link_data(G, attrs=None):
 
 
 def node_link_graph(data, directed=False, multigraph=True, attrs=None):
-    """Return graph from node-link data format.
+    """Returns graph from node-link data format.
 
     Parameters
     ----------

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -14,7 +14,7 @@ _attrs = dict(id='id', children='children')
 
 
 def tree_data(G, root, attrs=_attrs):
-    """Return data in tree format that is suitable for JSON serialization
+    """Returns data in tree format that is suitable for JSON serialization
     and use in Javascript documents.
 
     Parameters
@@ -97,7 +97,7 @@ def tree_data(G, root, attrs=_attrs):
 
 
 def tree_graph(data, attrs=_attrs):
-    """Return graph from tree data format.
+    """Returns graph from tree data format.
 
     Parameters
     ----------

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -270,7 +270,7 @@ def parse_pajek(lines):
 
 
 def make_qstr(t):
-    """Return the string representation of t.
+    """Returns the string representation of t.
     Add outer double-quotes if the string has a space.
     """
     if not is_string_like(t):

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -156,7 +156,7 @@ def from_sparse6_bytes(string):
         k += 1
 
     def parseData():
-        """Return stream of pairs b[i], x[i] for sparse6 format."""
+        """Returns stream of pairs b[i], x[i] for sparse6 format."""
         chunks = iter(data)
         d = None  # partial data word
         dLen = 0  # how many unparsed bits are left in d

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -166,7 +166,7 @@ def _relabel_copy(G, mapping):
 
 def convert_node_labels_to_integers(G, first_label=0, ordering="default",
                                     label_attribute=None):
-    """Return a copy of the graph G with the nodes relabeled using
+    """Returns a copy of the graph G with the nodes relabeled using
     consecutive integers.
 
     Parameters

--- a/networkx/utils/heaps.py
+++ b/networkx/utils/heaps.py
@@ -70,7 +70,7 @@ class MinHeap(object):
         raise NotImplementedError
 
     def get(self, key, default=None):
-        """Return the value associated with a key.
+        """Returns the value associated with a key.
 
         Parameters
         ----------
@@ -112,22 +112,22 @@ class MinHeap(object):
         raise NotImplementedError
 
     def __nonzero__(self):
-        """Return whether the heap if empty.
+        """Returns whether the heap if empty.
         """
         return bool(self._dict)
 
     def __bool__(self):
-        """Return whether the heap if empty.
+        """Returns whether the heap if empty.
         """
         return bool(self._dict)
 
     def __len__(self):
-        """Return the number of key-value pairs in the heap.
+        """Returns the number of key-value pairs in the heap.
         """
         return len(self._dict)
 
     def __contains__(self, key):
-        """Return whether a key exists in the heap.
+        """Returns whether a key exists in the heap.
 
         Parameters
         ----------

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -104,7 +104,7 @@ def is_list_of_ints(intlist):
 PY2 = sys.version_info[0] == 2
 if PY2:
     def make_str(x):
-        """Return the string representation of t."""
+        """Returns the string representation of t."""
         if isinstance(x, unicode):
             return x
         else:
@@ -119,7 +119,7 @@ if PY2:
             return unicode(str(x), 'unicode-escape')
 else:
     def make_str(x):
-        """Return the string representation of t."""
+        """Returns the string representation of t."""
         return str(x)
 
 

--- a/networkx/utils/random_sequence.py
+++ b/networkx/utils/random_sequence.py
@@ -33,7 +33,7 @@ def powerlaw_sequence(n, exponent=2.0, seed=None):
 
 @py_random_state(2)
 def zipf_rv(alpha, xmin=1, seed=None):
-    r"""Return a random value chosen from the Zipf distribution.
+    r"""Returns a random value chosen from the Zipf distribution.
 
     The return value is an integer drawn from the probability distribution
 
@@ -96,7 +96,7 @@ def zipf_rv(alpha, xmin=1, seed=None):
 
 
 def cumulative_distribution(distribution):
-    """Return normalized cumulative distribution from discrete distribution."""
+    """Returns normalized cumulative distribution from discrete distribution."""
 
     cdf = [0.0]
     psum = float(sum(distribution))
@@ -138,7 +138,7 @@ def discrete_sequence(n, distribution=None, cdistribution=None, seed=None):
 
 @py_random_state(2)
 def random_weighted_sample(mapping, k, seed=None):
-    """Return k items without replacement from a weighted sample.
+    """Returns k items without replacement from a weighted sample.
 
     The input is a dictionary of items with weights as values.
     """
@@ -152,7 +152,7 @@ def random_weighted_sample(mapping, k, seed=None):
 
 @py_random_state(1)
 def weighted_choice(mapping, seed=None):
-    """Return a single element from a weighted sample.
+    """Returns a single element from a weighted sample.
 
     The input is a dictionary of items with weights as values.
     """


### PR DESCRIPTION
There are some inconsistencies in explaining functions in documentations. Some of them used `Return`, while most of them are using `Returns`. Examples [here](https://networkx.github.io/documentation/latest/reference/generators.html)
I think the latter is correct, so I changed them all.
Also, I made a mistake in my previous PR in doc indents which I fixed here.