### PR TITLE
Pandas accepts unhashables

### DIFF
--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -114,9 +114,6 @@ class TestConvertPandas(object):
                       self.df, 0, 'b', 'misspell')
         assert_raises(nx.NetworkXError, nx.from_pandas_edgelist,
                       self.df, 0, 'b', 1)
-        # unhashable attribute name
-        assert_raises(nx.NetworkXError, nx.from_pandas_edgelist,
-                      self.df, 0, 'b', {})
 
     def test_from_edgelist_no_attr(self):
         Gtrue = nx.Graph([('E', 'C', {}),


### PR DESCRIPTION
Pandas accepts unhashables as DataFrame containers of keys as of 0.24.0 so we cant test that unhashables cause an exception.

Fixes #3298 