### PR TITLE
[WIP] Steiner multigraph

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -50,7 +50,7 @@ def metric_closure(G, weight='weight'):
 
 
 @not_implemented_for('directed')
-def steiner_tree(G, terminal_nodes, weight='weight'):
+def steiner_tree(G, terminal_nodes, weight='weight', metric_closure=None):
     """ Return an approximation to the minimum Steiner tree of a graph.
 
     Parameters
@@ -60,6 +60,12 @@ def steiner_tree(G, terminal_nodes, weight='weight'):
     terminal_nodes : list
          A list of terminal nodes for which minimum steiner tree is
          to be found.
+
+    weight :
+         The weight to be used for calculating the shortest path
+
+    metric_closure:
+         A precalculated metric_closure of the graph
 
     Returns
     -------
@@ -81,7 +87,7 @@ def steiner_tree(G, terminal_nodes, weight='weight'):
     """
     # M is the subgraph of the metric closure induced by the terminal nodes of
     # G.
-    M = metric_closure(G, weight=weight)
+    M = metric_closure if metric_closure else metric_closure(G, weight=weight)
     # Use the 'distance' attribute of each edge provided by the metric closure
     # graph.
     H = M.subgraph(terminal_nodes)

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -25,27 +25,30 @@ class TestSteinerTree:
 
     def test_metric_closure(self):
         M = metric_closure(self.G)
-        mc = [(1, 2, {'distance': 10, 'path': [1, 2]}),
-              (1, 3, {'distance': 20, 'path': [1, 2, 3]}),
-              (1, 4, {'distance': 22, 'path': [1, 2, 7, 5, 4]}),
-              (1, 5, {'distance': 12, 'path': [1, 2, 7, 5]}),
-              (1, 6, {'distance': 22, 'path': [1, 2, 7, 5, 6]}),
-              (1, 7, {'distance': 11, 'path': [1, 2, 7]}),
-              (2, 3, {'distance': 10, 'path': [2, 3]}),
-              (2, 4, {'distance': 12, 'path': [2, 7, 5, 4]}),
-              (2, 5, {'distance': 2, 'path': [2, 7, 5]}),
-              (2, 6, {'distance': 12, 'path': [2, 7, 5, 6]}),
-              (2, 7, {'distance': 1, 'path': [2, 7]}),
-              (3, 4, {'distance': 10, 'path': [3, 4]}),
-              (3, 5, {'distance': 12, 'path': [3, 2, 7, 5]}),
-              (3, 6, {'distance': 22, 'path': [3, 2, 7, 5, 6]}),
-              (3, 7, {'distance': 11, 'path': [3, 2, 7]}),
-              (4, 5, {'distance': 10, 'path': [4, 5]}),
-              (4, 6, {'distance': 20, 'path': [4, 5, 6]}),
-              (4, 7, {'distance': 11, 'path': [4, 5, 7]}),
-              (5, 6, {'distance': 10, 'path': [5, 6]}),
-              (5, 7, {'distance': 1, 'path': [5, 7]}),
-              (6, 7, {'distance': 11, 'path': [6, 5, 7]})]
+        mc = [(1, 2, {'distance': 10, 'path': [1, 2], 'keys': None, }),
+              (1, 3, {'distance': 20, 'path': [1, 2, 3], 'keys': None, }),
+              (1, 4, {'distance': 22, 'path': [1, 2, 7, 5, 4], 'keys': None, }),
+              (1, 5, {'distance': 12, 'path': [1, 2, 7, 5], 'keys': None, }),
+              (1, 6, {'distance': 22, 'path': [1, 2, 7, 5, 6], 'keys': None, }),
+              (1, 7, {'distance': 11, 'path': [1, 2, 7], 'keys': None, }),
+              (2, 3, {'distance': 10, 'path': [2, 3], 'keys': None, }),
+              (2, 4, {'distance': 12, 'path': [2, 7, 5, 4], 'keys': None, }),
+              (2, 5, {'distance': 2, 'path': [2, 7, 5], 'keys': None, }),
+              (2, 6, {'distance': 12, 'path': [2, 7, 5, 6], 'keys': None, }),
+              (2, 7, {'distance': 1, 'path': [2, 7], 'keys': None, }),
+              (3, 4, {'distance': 10, 'path': [3, 4], 'keys': None, }),
+              (3, 5, {'distance': 12, 'path': [3, 2, 7, 5], 'keys': None, }),
+              (3, 6, {'distance': 22, 'path': [3, 2, 7, 5, 6], 'keys': None, }),
+              (3, 7, {'distance': 11, 'path': [3, 2, 7], 'keys': None, }),
+              (4, 5, {'distance': 10, 'path': [4, 5], 'keys': None, }),
+              (4, 6, {'distance': 20, 'path': [4, 5, 6], 'keys': None, }),
+              (4, 7, {'distance': 11, 'path': [4, 5, 7], 'keys': None, }),
+              (5, 6, {'distance': 10, 'path': [5, 6], 'keys': None, }),
+              (5, 7, {'distance': 1, 'path': [5, 7], 'keys': None, }),
+              (6, 7, {'distance': 11, 'path': [6, 5, 7], 'keys': None, })]
+
+        import pprint
+        pprint.pprint([M.edges(data=True)])
         assert_edges_equal(list(M.edges(data=True)), mc)
 
     def test_steiner_tree(self):

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -57,21 +57,26 @@ class TestSteinerTree:
                                  (5, 7, {'weight': 1})]
         assert_edges_equal(list(S.edges(data=True)), expected_steiner_tree)
 
-    @raises(nx.NetworkXNotImplemented)
+    # @raises(nx.NetworkXNotImplemented)
     def test_multigraph_steiner_tree(self):
         G = nx.MultiGraph()
+
         G.add_edges_from([
-            (1, 2, 0, {'weight': 1}),
-            (2, 3, 0, {'weight': 999}),
-            (2, 3, 1, {'weight': 1}),
-            (3, 4, 0, {'weight': 1}),
-            (3, 5, 0, {'weight': 1})
+            ('A', 'B', 'k1', {'weight': 1}),
+            ('A', 'B', 'k2', {'weight': 999}),
+            ('B', 'C', 'k3', {'weight': 999}),
+            ('B', 'C', 'k4', {'weight': 1}),
+            ('B', 'C', 'k5', {'weight': 1}),
+            ('C', 'D', 'k6', {'weight': 1}),
+            ('C', 'E', 'k7', {'weight': 1}),
+            # ('Q', 'W', 'k8', {'weight': 1}),
         ])
-        terminal_nodes = [2, 4, 5]
+        terminal_nodes = ['A', 'D']
         expected_edges = [
-            (2, 3, 1, {'weight': 1}),  # edge with key 1 has lower weight
-            (3, 4, 0, {'weight': 1}),
-            (3, 5, 0, {'weight': 1})
+            ('A', 'B', 'k1', {'weight': 1}),  # edge with key 1 has lower weight
+            ('B', 'C', 'k4', {'weight': 1}),
+            ('C', 'D', 'k6', {'weight': 1})
         ]
-        # not implemented
         T = steiner_tree(G, terminal_nodes)
+
+        assert_edges_equal(list(T.edges(keys=True, data=True)), expected_edges)

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -4,7 +4,6 @@ from networkx.algorithms.approximation.steinertree import metric_closure
 from networkx.algorithms.approximation.steinertree import steiner_tree
 from networkx.testing.utils import assert_edges_equal
 
-
 class TestSteinerTree:
     def setUp(self):
         G = nx.Graph()
@@ -15,7 +14,27 @@ class TestSteinerTree:
         G.add_edge(5, 6, weight=10)
         G.add_edge(2, 7, weight=1)
         G.add_edge(7, 5, weight=1)
+
+        M = nx.MultiGraph()
+
+        M.add_edges_from([
+            ('A', 'B', 'k1', {'weight': 2}),
+            ('A', 'B', 'k2', {'weight': 999}),
+            ('B', 'C', 'k3', {'weight': 999}),
+            ('B', 'C', 'k4', {'weight': 2}),
+            ('B', 'C', 'k5', {'weight': 2}),
+            ('C', 'D', 'k6', {'weight': 2}),
+            ('C', 'E', 'k7', {'weight': 2}),
+            ('D', 'F', 'k8', {'weight': 2}),
+            ('D', 'F', 'k9', {'weight': 999}),
+            ('F', 'H', 'k10', {'weight': 2}),
+            ('E', 'H', 'k12', {'weight': 5}),
+            # ('Q', 'W', 'k8', {'weight': 1}),
+        ])
+
         self.G = G
+        self.M = M
+
         self.term_nodes = [1, 2, 3, 4, 5]
 
     def test_connected_metric_closure(self):
@@ -47,8 +66,64 @@ class TestSteinerTree:
               (5, 7, {'distance': 1, 'path': [5, 7], 'keys': None, }),
               (6, 7, {'distance': 11, 'path': [6, 5, 7], 'keys': None, })]
 
-        import pprint
-        pprint.pprint([M.edges(data=True)])
+        assert_edges_equal(list(M.edges(data=True)), mc)
+
+    def test_metric_closure_multigraph(self):
+        M = metric_closure(self.M)
+
+        mc = [
+            ('A', 'C', {'distance': 4, 'keys': ['k1', 'k4'], 'path': ['A', 'B', 'C']}),
+            ('A', 'D', {'distance': 6, 'keys': ['k1', 'k4', 'k6'], 'path': ['A', 'B', 'C', 'D']}),
+            ('A', 'B', {'distance': 2, 'keys': ['k1'], 'path': ['A', 'B']}),
+            ('A', 'F', {'distance': 8, 'keys': ['k1', 'k4', 'k6', 'k8'], 'path': ['A', 'B', 'C', 'D', 'F']}),
+            ('A', 'H', {'distance': 10, 'keys': ['k1', 'k4', 'k6', 'k8', 'k10'], 'path': ['A', 'B', 'C', 'D', 'F', 'H']}),
+            ('A', 'E', {'distance': 6, 'keys': ['k1', 'k4', 'k7'], 'path': ['A', 'B', 'C', 'E']}),
+            ('C', 'B', {'distance': 2, 'keys': ['k4'], 'path': ['B', 'C']}),
+            ('C', 'D', {'distance': 2, 'keys': ['k6'], 'path': ['C', 'D']}),
+            ('C', 'F', {'distance': 4, 'keys': ['k6', 'k8'], 'path': ['C', 'D', 'F']}),
+            ('C', 'H', {'distance': 6, 'keys': ['k6', 'k8', 'k10'], 'path': ['C', 'D', 'F', 'H']}),
+            ('C', 'E', {'distance': 2, 'keys': ['k7'], 'path': ['C', 'E']}),
+            ('D', 'B', {'distance': 4, 'keys': ['k4', 'k6'], 'path': ['B', 'C', 'D']}),
+            ('D', 'F', {'distance': 2, 'keys': ['k8'], 'path': ['D', 'F']}),
+            ('D', 'H', {'distance': 4, 'keys': ['k8', 'k10'], 'path': ['D', 'F', 'H']}),
+            ('D', 'E', {'distance': 4, 'keys': ['k6', 'k7'], 'path': ['D', 'C', 'E']}),
+            ('B', 'F', {'distance': 6, 'keys': ['k4', 'k6', 'k8'], 'path': ['B', 'C', 'D', 'F']}),
+            ('B', 'H', {'distance': 8, 'keys': ['k4', 'k6', 'k8', 'k10'], 'path': ['B', 'C', 'D', 'F', 'H']}),
+            ('B', 'E', {'distance': 4, 'keys': ['k4', 'k7'], 'path': ['B', 'C', 'E']}),
+            ('F', 'E', {'distance': 6, 'keys': ['k7', 'k6', 'k8'], 'path': ['E', 'C', 'D', 'F']}),
+            ('F', 'H', {'distance': 2, 'keys': ['k10'], 'path': ['F', 'H']}),
+            ('H', 'E', {'distance': 5, 'keys': ['k12'], 'path': ['E', 'H']})
+        ]
+
+        assert_edges_equal(list(M.edges(data=True)), mc)
+
+    def test_metric_closure_no_weight(self):
+        M = metric_closure(self.M, weight=None)
+
+        mc = [
+            ('A', 'C', {'distance': 2, 'keys': ['k1', 'k3'], 'path': ['A', 'B', 'C']}),
+            ('A', 'E', {'distance': 3, 'keys': ['k1', 'k3', 'k7'], 'path': ['A', 'B', 'C', 'E']}),
+            ('A', 'F', {'distance': 4, 'keys': ['k1', 'k3', 'k6', 'k8'], 'path': ['A', 'B', 'C', 'D', 'F']}),
+            ('A', 'B', {'distance': 1, 'keys': ['k1'], 'path': ['A', 'B']}),
+            ('A', 'H', {'distance': 4, 'keys': ['k1', 'k3', 'k7', 'k12'], 'path': ['A', 'B', 'C', 'E', 'H']}),
+            ('A', 'D', {'distance': 3, 'keys': ['k1', 'k3', 'k6'], 'path': ['A', 'B', 'C', 'D']}),
+            ('C', 'B', {'distance': 1, 'keys': ['k3'], 'path': ['B', 'C']}),
+            ('C', 'E', {'distance': 1, 'keys': ['k7'], 'path': ['C', 'E']}),
+            ('C', 'F', {'distance': 2, 'keys': ['k6', 'k8'], 'path': ['C', 'D', 'F']}),
+            ('C', 'H', {'distance': 2, 'keys': ['k7', 'k12'], 'path': ['C', 'E', 'H']}),
+            ('C', 'D', {'distance': 1, 'keys': ['k6'], 'path': ['C', 'D']}),
+            ('E', 'B', {'distance': 2, 'keys': ['k3', 'k7'], 'path': ['B', 'C', 'E']}),
+            ('E', 'D', {'distance': 2, 'keys': ['k6', 'k7'], 'path': ['D', 'C', 'E']}),
+            ('E', 'F', {'distance': 2, 'keys': ['k12', 'k10'], 'path': ['E', 'H', 'F']}),
+            ('E', 'H', {'distance': 1, 'keys': ['k12'], 'path': ['E', 'H']}),
+            ('F', 'B', {'distance': 3, 'keys': ['k3', 'k6', 'k8'], 'path': ['B', 'C', 'D', 'F']}),
+            ('F', 'D', {'distance': 1, 'keys': ['k8'], 'path': ['D', 'F']}),
+            ('F', 'H', {'distance': 1, 'keys': ['k10'], 'path': ['F', 'H']}),
+            ('B', 'H', {'distance': 3, 'keys': ['k3', 'k7', 'k12'], 'path': ['B', 'C', 'E', 'H']}),
+            ('B', 'D', {'distance': 2, 'keys': ['k3', 'k6'], 'path': ['B', 'C', 'D']}),
+            ('H', 'D', {'distance': 2, 'keys': ['k8', 'k10'], 'path': ['D', 'F', 'H']})
+        ]
+
         assert_edges_equal(list(M.edges(data=True)), mc)
 
     def test_steiner_tree(self):
@@ -60,26 +135,48 @@ class TestSteinerTree:
                                  (5, 7, {'weight': 1})]
         assert_edges_equal(list(S.edges(data=True)), expected_steiner_tree)
 
-    # @raises(nx.NetworkXNotImplemented)
     def test_multigraph_steiner_tree(self):
-        G = nx.MultiGraph()
-
-        G.add_edges_from([
-            ('A', 'B', 'k1', {'weight': 1}),
-            ('A', 'B', 'k2', {'weight': 999}),
-            ('B', 'C', 'k3', {'weight': 999}),
-            ('B', 'C', 'k4', {'weight': 1}),
-            ('B', 'C', 'k5', {'weight': 1}),
-            ('C', 'D', 'k6', {'weight': 1}),
-            ('C', 'E', 'k7', {'weight': 1}),
-            # ('Q', 'W', 'k8', {'weight': 1}),
-        ])
         terminal_nodes = ['A', 'D']
         expected_edges = [
-            ('A', 'B', 'k1', {'weight': 1}),  # edge with key 1 has lower weight
-            ('B', 'C', 'k4', {'weight': 1}),
-            ('C', 'D', 'k6', {'weight': 1})
+            ('A', 'B', 'k1', {'weight': 2}),
+            ('B', 'C', 'k4', {'weight': 2}),
+            ('C', 'D', 'k6', {'weight': 2})
         ]
-        T = steiner_tree(G, terminal_nodes)
+        T = steiner_tree(self.M, terminal_nodes)
+
+        assert_edges_equal(list(T.edges(keys=True, data=True)), expected_edges)
+
+    def test_multigraph_steiner_tree_adjacent(self):
+        terminal_nodes = ['A', 'B']
+        expected_edges = [
+            ('A', 'B', 'k1', {'weight': 2}),
+        ]
+        T = steiner_tree(self.M, terminal_nodes)
+
+        assert_edges_equal(list(T.edges(keys=True, data=True)), expected_edges)
+
+    def test_multigraph_steiner_tree_multiple_terminals(self):
+        terminal_nodes = ['A', 'C', 'H']
+        expected_edges = [
+            ('A', 'B', 'k1', {'weight': 2}),
+            ('B', 'C', 'k4', {'weight': 2}),
+            ('C', 'D', 'k6', {'weight': 2}),
+            ('D', 'F', 'k8', {'weight': 2}),
+            ('F', 'H', 'k10', {'weight': 2})
+        ]
+
+        T = steiner_tree(self.M, terminal_nodes)
+
+        assert_edges_equal(list(T.edges(keys=True, data=True)), expected_edges)
+
+    def test_multigraph_steiner_tree_no_weight(self):
+        terminal_nodes = ['A', 'D']
+        expected_edges = [
+            ('A', 'B', 'k1', {'weight': 2}),
+            ('B', 'C', 'k4', {'weight': 2}),
+            ('C', 'D', 'k6', {'weight': 2})
+        ]
+        T = steiner_tree(self.M, terminal_nodes)
+
 
         assert_edges_equal(list(T.edges(keys=True, data=True)), expected_edges)

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -178,7 +178,7 @@ def local_bridges(G, with_span=True, weight=None):
             if not (set(G[u]) & set(G[v])):
                 enodes = {u, v}
 
-                def hide_edge(n, nbr, d):
+                def hide_edge(n, nbr, d, k):
                     if n not in enodes or nbr not in enodes:
                         return wt(n, nbr, d)
                     return None

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -109,7 +109,7 @@ def global_reaching_centrality(G, weight=None, normalized=True):
     # If weight is None, we leave it as-is so that the shortest path
     # algorithm can use a faster, unweighted algorithm.
     if weight is not None:
-        def as_distance(u, v, d): return total_weight / d.get(weight, 1)
+        def as_distance(u, v, d, k): return total_weight / d.get(weight, 1)
         shortest_paths = nx.shortest_path(G, weight=as_distance)
     else:
         shortest_paths = nx.shortest_path(G)
@@ -191,7 +191,7 @@ def local_reaching_centrality(G, v, paths=None, weight=None, normalized=True):
             raise nx.NetworkXError('Size of G must be positive')
         if weight is not None:
             # Interpret weights as lengths.
-            def as_distance(u, v, d): return total_weight / d.get(weight, 1)
+            def as_distance(u, v, d, k): return total_weight / d.get(weight, 1)
             paths = nx.shortest_path(G, source=v, weight=as_distance)
         else:
             paths = nx.shortest_path(G, source=v)

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -77,7 +77,9 @@ class WeightedTestBase(object):
 class TestWeightedPath(WeightedTestBase):
 
     def test_dijkstra(self):
-        (D, P) = nx.single_source_dijkstra(self.XG, 's')
+        from pprint import pprint 
+        pprint(nx.single_source_dijkstra(self.XG, 's'))
+        (D, P, K) = nx.single_source_dijkstra(self.XG, 's')
         validate_path(self.XG, 's', 'v', 9, P['v'])
         assert_equal(D['v'], 9)
 
@@ -95,7 +97,7 @@ class TestWeightedPath(WeightedTestBase):
         # make sure we get lower weight
         # to_undirected might choose either edge with weight 2 or weight 3
         GG['u']['x']['weight'] = 2
-        (D, P) = nx.single_source_dijkstra(GG, 's')
+        (D, P, K) = nx.single_source_dijkstra(GG, 's')
         validate_path(GG, 's', 'v', 8, P['v'])
         assert_equal(D['v'], 8)     # uses lower weight of 2 on u<->x edge
         validate_path(GG, 's', 'v', 8, nx.dijkstra_path(GG, 's', 'v'))
@@ -246,15 +248,15 @@ class TestWeightedPath(WeightedTestBase):
         # the weights on the edges. This way, weights that were large
         # before now become small and vice versa.
 
-        def weight(u, v, d): return 1 / d['weight']
+        def weight(u, v, d, k): return 1 / d['weight']
         # The shortest path from 0 to 2 using the actual weights on the
         # edges should be [0, 1, 2].
-        distance, path = nx.single_source_dijkstra(G, 0, 2)
+        distance, path, keys = nx.single_source_dijkstra(G, 0, 2)
         assert_equal(distance, 2)
         assert_equal(path, [0, 1, 2])
         # However, with the above weight function, the shortest path
         # should be [0, 2], since that has a very small weight.
-        distance, path = nx.single_source_dijkstra(G, 0, 2, weight=weight)
+        distance, path, keys = nx.single_source_dijkstra(G, 0, 2, weight=weight)
         assert_equal(distance, 1 / 10)
         assert_equal(path, [0, 2])
 
@@ -309,7 +311,7 @@ class TestDijkstraPathLength(object):
         # the weights on the edges. This way, weights that were large
         # before now become small and vice versa.
 
-        def weight(u, v, d): return 1 / d['weight']
+        def weight(u, v, d, k): return 1 / d['weight']
         # The shortest path from 0 to 2 using the actual weights on the
         # edges should be [0, 1, 2]. However, with the above weight
         # function, the shortest path should be [0, 2], since that has a
@@ -348,7 +350,7 @@ class TestMultiSourceDijkstra(object):
         G = nx.Graph()
         G.add_weighted_edges_from(edges)
         sources = {0, 4}
-        distances, paths = nx.multi_source_dijkstra(G, sources)
+        distances, paths, keys = nx.multi_source_dijkstra(G, sources)
         expected_distances = {0: 0, 1: 1, 2: 2, 3: 1, 4: 0}
         expected_paths = {0: [0], 1: [0, 1], 2: [0, 1, 2], 3: [4, 3], 4: [4]}
         assert_equal(distances, expected_distances)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -746,7 +746,8 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     if target is None:
         return (dist, paths, keys)
     try:
-        return (dist[target], paths[target], keys[target])
+        return_keys = keys[target] if keys else None
+        return (dist[target], paths[target], return_keys)
     except KeyError:
         raise nx.NetworkXNoPath("No path to {}.".format(target))
 
@@ -2177,8 +2178,8 @@ def johnson(G, weight='weight'):
 
     # Update the weight function to take into account the Bellman--Ford
     # relaxation distances.
-    def new_weight(u, v, d):
-        return weight(u, v, d) + dist_bellman[u] - dist_bellman[v]
+    def new_weight(u, v, d, k):
+        return weight(u, v, d, k) + dist_bellman[u] - dist_bellman[v]
 
     def dist_path(v):
         paths = {v: [v]}

--- a/networkx/generators/ego.py
+++ b/networkx/generators/ego.py
@@ -51,7 +51,7 @@ def ego_graph(G, n, radius=1, center=True, undirected=False, distance=None):
     """
     if undirected:
         if distance is not None:
-            sp, _ = nx.single_source_dijkstra(G.to_undirected(),
+            sp, _, k = nx.single_source_dijkstra(G.to_undirected(),
                                               n, cutoff=radius,
                                               weight=distance)
         else:
@@ -59,7 +59,7 @@ def ego_graph(G, n, radius=1, center=True, undirected=False, distance=None):
                                                             n, cutoff=radius))
     else:
         if distance is not None:
-            sp, _ = nx.single_source_dijkstra(G,
+            sp, _, k = nx.single_source_dijkstra(G,
                                               n, cutoff=radius,
                                               weight=distance)
         else:


### PR DESCRIPTION
I am proposing a change in `networkx.algorithms.approximation.steinertree` to make it work with multigraphs. This affects Dijkstra algorithms results too. The change is not complete yet, but I would be happy to get some feedback from the core maintainers on the current progress as I think the main task is done, what's left are some fixes here and there.

- [ ] update documentation of the updated functions
- [ ] update tests of the updated functions
- [x] add more tests for Steiner algorithm
- [x] fix for unweighted multigraph

However, there is a breaking change, as Dijkstra algorithm funtions no longer returns 2 items in a tuple, but 3 (the new one for the tuples, if any, see for example `nx.single_source_dijkstra`). I am planning to use it for my project, so I need to finish it for sure.


