### PR TITLE
Fixed error message for single_target_shortest_path_length

### DIFF
--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -132,7 +132,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     single_source_shortest_path_length, shortest_path_length
     """
     if target not in G:
-        raise nx.NodeNotFound('Target {} is not in G'.format(source))
+        raise nx.NodeNotFound('Target {} is not in G'.format(target))
 
     if cutoff is None:
         cutoff = float('inf')


### PR DESCRIPTION
Discovered a small copy-paste error in the error message for `single_target_shortest_path_length`.

Currently, if the node passed into `single_target_shortest_path_length` is not defined, it will throw an error that `source` is not defined. Replaced `source` with `target` since that is the variable defined for this function.