### PR TITLE
Adjust function "is_list_of_ints". (fix #3322)

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -18,13 +18,13 @@ True
 #    Pieter Swart <swart@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-from collections import defaultdict
-from collections import deque
+from collections import defaultdict, deque
+from typing import Iterable
+from numbers import Integral
 import warnings
 import sys
 import uuid
 from itertools import tee, chain
-import networkx as nx
 
 # itertools.accumulate is only available on Python 3.2 or later.
 #
@@ -93,10 +93,10 @@ def flatten(obj, result=None):
 
 def is_list_of_ints(intlist):
     """ Return True if list is a list of ints. """
-    if not isinstance(intlist, list):
+    if not isinstance(intlist, Iterable):
         return False
     for i in intlist:
-        if not isinstance(i, int):
+        if not isinstance(i, Integral):
             return False
     return True
 

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -19,7 +19,7 @@ True
 #    All rights reserved.
 #    BSD license.
 from collections import defaultdict, deque
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, ItemsView
 from numbers import Integral
 import warnings
 import sys
@@ -93,7 +93,7 @@ def flatten(obj, result=None):
 
 def is_list_of_ints(intlist):
     """ Return True if list is a list of ints. """
-    if isinstance(intlist, Iterator) or not isinstance(intlist, Iterable):
+    if isinstance(intlist, (Iterator, ItemsView)) or not isinstance(intlist, Iterable):
         return False
     for i in intlist:
         if not isinstance(i, Integral):

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -19,7 +19,7 @@ True
 #    All rights reserved.
 #    BSD license.
 from collections import defaultdict, deque
-from typing import Iterable
+from typing import Iterable, Iterator
 from numbers import Integral
 import warnings
 import sys
@@ -93,7 +93,7 @@ def flatten(obj, result=None):
 
 def is_list_of_ints(intlist):
     """ Return True if list is a list of ints. """
-    if not isinstance(intlist, Iterable):
+    if isinstance(intlist, Iterator) or not isinstance(intlist, Iterable):
         return False
     for i in intlist:
         if not isinstance(i, Integral):


### PR DESCRIPTION
Following script allows numpy array or any iterable object with integers to pass the test:

```python
>> from numbers import Integral
>> import numpy as np
>> isinstance(np.int32(0), Integral)
True
>> from typing import Iterable, Iterator, ItemsView
>> isinstance(np.array([0, 1, 2]), Iterable)
True
>> isinstance(np.array([0, 1, 2]), (Iterator, ItemsView))
False
```

Allowed types:

+ List[int], Tuple[int, ...]
+ range
+ Dict[int, Any]
+ ndarray[dtype=int]