### PR TITLE
Fixed raise error in `algorithms/centrality/flow_matrix.py`

### DIFF
--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -50,10 +50,10 @@ class InverseLaplacian(object):
         pass
 
     def solve(self, r):
-        raise("Implement solver")
+        raise nx.NetworkXError("Implement solver")
 
     def solve_inverse(self, r):
-        raise("Implement solver")
+        raise nx.NetworkXError("Implement solver")
 
     def get_rows(self, r1, r2):
         for r in range(r1, r2 + 1):


### PR DESCRIPTION
There were two erroneous raise statements `raise("Implement solver")` in `algorithms/centrality/flow_matrix.py`. I've fixed these errors by raising the `nx.NetworkXError` exception but I'm not sure if this is the desirable behavior, perhaps raising a `Warning` would be more appropriate.

I work for Semmle and I noticed these issues with out LGTM code analyzer
https://lgtm.com/projects/g/networkx/networkx/alerts/?mode=tree&ruleFocus=3980085