### PR TITLE
Make is_graphical raise error for invalid input

### DIFF
--- a/networkx/algorithms/graphical.py
+++ b/networkx/algorithms/graphical.py
@@ -35,7 +35,7 @@ def is_graphical(sequence, method='eg'):
     sequence : list or iterable container
         A sequence of integer node degrees
 
-    method : "eg" | "hh"
+    method : "eg" | "hh"  (default: 'eg')
         The method used to validate the degree sequence.
         "eg" corresponds to the Erdős-Gallai algorithm, and
         "hh" to the Havel-Hakimi algorithm.
@@ -73,7 +73,17 @@ def is_graphical(sequence, method='eg'):
 def _basic_graphical_tests(deg_sequence):
     # Sort and perform some simple tests on the sequence
     if not nx.utils.is_list_of_ints(deg_sequence):
-        raise nx.NetworkXUnfeasible
+        # check for a type that can be converted to int. Like numpy.int64
+        ds = []
+        for d in deg_sequence:
+            try:
+                intd = int(d)
+            except ValueError:
+                raise nx.NetworkXError("Invalid type in deg_sequence: not an integer")
+            if intd != d:
+                raise nx.NetworkXError("Invalid type in deg_sequence: not an integer")
+            ds.append(intd)
+        deg_sequence = ds
     p = len(deg_sequence)
     num_degs = [0] * p
     dmax, dmin, dsum, n = 0, p, 0, 0

--- a/networkx/algorithms/tests/test_graphical.py
+++ b/networkx/algorithms/tests/test_graphical.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from nose.tools import *
+from nose.tools import assert_true, assert_false, raises
 from nose import SkipTest
 import networkx as nx
 
@@ -31,7 +31,14 @@ def test_string_input():
 def test_negative_input():
     assert_false(nx.is_graphical([-1], 'hh'))
     assert_false(nx.is_graphical([-1], 'eg'))
-    assert_false(nx.is_graphical([72.5], 'eg'))
+
+@raises(nx.NetworkXException)
+def test_non_integer_input():
+    a = nx.is_graphical([72.5], 'eg')
+
+@raises(nx.NetworkXException)
+def test_non_integer_input():
+    a = nx.is_graphical([72.5], 'hh')
 
 
 class TestAtlas(object):
@@ -133,3 +140,24 @@ def test_pseudo_sequence():
     # Test for negative integer in sequence
     seq = [1000, 3, 3, 3, 3, 2, 2, -2, 1, 1]
     assert_false(nx.is_pseudographical(seq))
+
+def test_numpy_degree_sequence():
+    try:
+        import numpy
+    except ImportError:
+        return
+    ds = numpy.array([1, 2, 2, 2, 1], dtype=numpy.int64)
+    assert_true(nx.is_graphical(ds, 'eg'))
+    assert_true(nx.is_graphical(ds, 'hh'))
+    ds = numpy.array([1, 2, 2, 2, 1], dtype=numpy.float64)
+    assert_true(nx.is_graphical(ds, 'eg'))
+    assert_true(nx.is_graphical(ds, 'hh'))
+
+@raises(nx.NetworkXError, AssertionError)
+def test_numpy_noninteger_degree_sequence():
+    try:
+        import numpy
+    except ImportError:
+        raise nx.NetworkXError('make test pass by raising exception')
+    ds = numpy.array([1.1, 2, 2, 2, 1], dtype=numpy.float64)
+    a = nx.is_graphical(ds, 'eg')


### PR DESCRIPTION
Allow is_graphcial to work with numpy arrays and lists of floats that
have integer values

Fixes #3322