### PR TITLE
AT-free graph recognition

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -126,6 +126,7 @@ is partially historical, and now, mostly arbitrary.
 - Brian Kiefer, Github: `bkief <https://github.com/bkief>`_
 - Julien Klaus
 - Weisheng Si, Github: `ws4u <https://github.com/ws4u>`_
+- Haakon H. Rød, Gitlab: `haakonhr <https://gitlab.com/haakonhr>`_, `<https://haakonhr.gitlab.io>`_ 
 
 Support
 -------

--- a/doc/reference/algorithms/asteroidal.rst
+++ b/doc/reference/algorithms/asteroidal.rst
@@ -6,4 +6,5 @@ Asteroidal
 .. autosummary::
    :toctree: generated/
 
-   is_at_free 
+   is_at_free
+   find_asteroidal_triple

--- a/doc/reference/algorithms/asteroidal.rst
+++ b/doc/reference/algorithms/asteroidal.rst
@@ -1,0 +1,9 @@
+**********
+Asteroidal
+**********
+
+.. automodule:: networkx.algorithms.asteroidal
+.. autosummary::
+   :toctree: generated/
+
+   is_at_free 

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -1,4 +1,5 @@
 from networkx.algorithms.assortativity import *
+from networkx.algorithms.asteroidal import *
 from networkx.algorithms.boundary import *
 from networkx.algorithms.bridges import *
 from networkx.algorithms.chains import *

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -125,10 +125,7 @@ def is_at_free(G):
     >>> nx.is_at_free(G)
     False
     """
-    asteroidal_triple = find_asteroidal_triple(G)
-    if asteroidal_triple:
-        return False
-    return True
+    return find_asteroidal_triple(G) is None
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -14,9 +14,9 @@ An asteroidal triple in a graph G is a set of three non-adjacent vertices
 u, v and w such that there exist a path between any two of them avoiding the
 neighborhood of the third. More formally, v_j, v_k belongs to the same
 connected component of G - N[v_i]. A graph which contains no asteroidal
-triples is called an AT-free graph. AT-free graphs is a graph class
-for which many NP-complete problems are solvable in polynomial time.
-Amongst them, independent set and coloring.
+triples is called an AT-free graph. The class of AT-free graphs
+is a graph class for which many NP-complete problems are solvable
+in polynomial time. Amongst them, independent set and coloring.
 """
 import networkx as nx
 from networkx.utils import not_implemented_for
@@ -27,13 +27,14 @@ __all__ = ["is_at_free"]
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 def find_asteroidal_triple(G):
+    r"""Find an asteroidal triple in the given graph.
 
     An asteroidal triple is a triple of non-adjacent vertices such that
     there exists a path between any two of them which avoids the closed
     neighborhood of the third. It checks all independent triples of vertices
     and whether they are an asteroidal triple or not. This is done with the
     help of a data structure called a component structure.
-    The component structure encodes information about which vertices belongs to
+    A component structure encodes information about which vertices belongs to
     the same connected component when the closed neighborhood of a given vertex
     is removed from the graph. The algorithm used to check is the trivial
     one, outlined in [1]_, which has a runtime of
@@ -45,33 +46,15 @@ def find_asteroidal_triple(G):
     G : NetworkX Graph
         The graph to check whether is AT-free or not
 
-    certificate : bool (default: False)
-        If the first detected asteroidal triple should be output, if one
-        exists, or None, in the case where a graph is AT-free.
-
     Returns
     -------
-    bool (default)
+    list or None
+        An asteroidal triple is returned as a list of nodes. If no asteroidal
+        triple exists, i.e. the graph is AT-free, then None is returned.
         The returned value depends on the certificate parameter. The default
         option is a bool which is True if the graph is AT-free, i.e. the
         given graph contains no asteroidal triples, and False otherwise, i.e.
         if the graph contains at least one asteroidal triple.
-
-    tuple
-        If the optional parameter `certificate` is set to True then a
-        tuple containing False and an asteroidal triple, represented as a tuple
-        of vertices, is returend if the graph is not AT-free. If the graph
-        is AT-free a tuple with True and None is returned.
-
-    Examples
-    --------
-    >>> G = nx.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (1, 4), (4, 5)])
-    >>> nx.is_at_free(G)
-    True
-
-    >>> G = nx.cycle_graph(6)
-    >>> nx.is_at_free(G)
-    False
 
     Notes
     -----

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+#    Copyright (C) 2004-2019 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Authors: Haakon H. Rød (haakonhr@gmail.com)
+"""
+Algorithms for asteroidal triples and asteroidal numbers in graphs.
+
+An asteroidal triple in a graph G is a set of three non-adjacent vertices
+u, v and w such that there exist a path between any two of them avoiding the
+neighborhood of the third. More formally, v_j, v_k belongs to the same
+connected component of G - N[v_i]. A graph which contains no asteroidal
+triples is called an AT-free graph. AT-free graphs is a graph class
+for which many NP-complete problems are solvable in polynomial time.
+Amongst them, independent set and coloring.
+"""
+import networkx as nx
+from networkx.utils import not_implemented_for
+
+__all__ = ["is_at_free"]
+
+
+@not_implemented_for("directed", "multigraph")
+def is_at_free(G, certificate=False):
+    """Check if graph contains asteroidal triples.
+
+    An asteroidal triple is a triple of non-adjacent vertices such that
+    there exists a path between any two of them which avoids the closed
+    neighborhood of the third. The algorithm used to check is the trivial
+    one, outlined in [1]_, which has a runtime of `O(|V||E|^2)`.
+    It checks all independent triples of vertices and whether they are an
+    asteroidal triple or not. This is done with the help of a data structure
+    called a component structure. The component structure encodes information
+    about which vertices belongs to the same connected component
+    when the closed neighborhood of a given vertex is removed from the graph.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        The graph to check whether is AT-free or not
+
+    certificate : boolean
+        If the first detected asteroidal triple should be output, if one
+        exists, or None, in the case where a graph is AT-free.
+
+    Returns
+    -------
+    boolean
+        True if the given graph is AT-free and False otherwise.
+
+    Examples
+    --------
+    >>> G = nx.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (1, 4), (4, 5)])
+    >>> nx.is_at_free(G)
+    True
+
+    >>> G = nx.cycle_graph(6)
+    >>> nx.is_at_free(G)
+    False
+
+    Notes
+    -----
+    The component structure and the algorithm is described in [1]_. The current
+    implementation implements the trivial algorithm for simple graphs.
+
+    References
+    ----------
+    .. [1] Ekkehard Köhler,
+       "Recognizing Graphs without asteroidal triples",
+       Journal of Discrete Algorithms 2, pages 439-452, 2004.
+       https://www.sciencedirect.com/science/article/pii/S157086670400019X
+    """
+    def _is_asteroidal_triple(u, v, w, component_structure):
+        """Check whether a triple of vertices is an asteroidal triple."""
+        first_cond = component_structure[u][v] == component_structure[u][w]
+        second_cond = component_structure[v][u] == component_structure[v][w]
+        third_cond = component_structure[w][u] == component_structure[w][v]
+        if first_cond and second_cond and third_cond:
+            return True
+        else:
+            return False
+
+    V = set(G.nodes)
+
+    if len(V) < 6:
+        # An asteroidal triple cannot exist in a graph with 5 or less vertices.
+        return True
+
+    component_structure = create_component_structure(G)
+    E_complement = set(nx.complement(G).edges)
+
+    for e in E_complement:
+        u = e[0]
+        v = e[1]
+        u_neighborhood = set(G[u]).union([u])
+        v_neighborhood = set(G[v]).union([v])
+        union_of_neighborhoods = u_neighborhood.union(v_neighborhood)
+        for w in V - union_of_neighborhoods:
+            if _is_asteroidal_triple(u, v, w, component_structure):
+                if certificate:
+                    return (u, v, w)
+                else:
+                    return False
+
+    if certificate:
+        return None
+    else:
+        return True
+
+
+@not_implemented_for("directed", "multigraph")
+def create_component_structure(G):
+    """Create component structure for G.
+
+    A *component structure* is an `nxn` array, denoted `c`, where `n` is
+    the number of vertices,  where each row and column corresponds to a vertex.
+
+    .. math::
+        c_{uv} = \begin{cases} 0, if v \in N[u] \\
+            k, if v \in component k of G \setminus N[u] \end{cases}
+
+    Where `k` is an arbitrary label for each component. The structure is used
+    to simplify the detection of asteroidal triples.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        Undirected, simple graph.
+
+    Returns
+    -------
+    component_structure : dictionary
+        A dictionary of dictionaries, keyed by pairs of vertices.
+
+    """
+    V = set(G.nodes)
+    component_structure = {}
+    for v in V:
+        label = 0
+        closed_neighborhood = set(G[v]).union(set([v]))
+        row_dict = {}
+        for u in closed_neighborhood:
+            row_dict[u] = 0
+
+        G_reduced = G.subgraph(set(G.nodes) - closed_neighborhood)
+        connected_components = (G_reduced.subgraph(cc) for cc in
+                                nx.connected_components(G_reduced))
+        for cc in connected_components:
+            label += 1
+            for u in cc.nodes:
+                row_dict[u] = label
+
+        component_structure[v] = row_dict
+
+    return component_structure

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -31,7 +31,7 @@ def is_at_free(G, certificate=False):
     An asteroidal triple is a triple of non-adjacent vertices such that
     there exists a path between any two of them which avoids the closed
     neighborhood of the third. The algorithm used to check is the trivial
-    one, outlined in [1]_, which has a runtime of `O(|V||E|^2)`.
+    one, outlined in [1]_, which has a runtime of `O(|V|^3)`.
     It checks all independent triples of vertices and whether they are an
     asteroidal triple or not. This is done with the help of a data structure
     called a component structure. The component structure encodes information

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -114,7 +114,7 @@ def is_at_free(G, certificate=False):
 
 @not_implemented_for("directed", "multigraph")
 def create_component_structure(G):
-    """Create component structure for G.
+    r"""Create component structure for G.
 
     A *component structure* is an `nxn` array, denoted `c`, where `n` is
     the number of vertices,  where each row and column corresponds to a vertex.

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -116,6 +116,39 @@ def is_at_free(G, certificate=False):
 
     if certificate:
         return (True, None)
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
+def is_at_free(G):
+    """Check if a graph is AT-free.
+
+    The method uses the `find_asteroidal_triple` method to recognize
+    an AT-free graph. If no asteroidal triple is found the graph is
+    AT-free and True is returned. If at least one asteroidal triple is
+    found the graph is not AT-free and False is returned.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        The graph to check whether is AT-free or not.
+
+    Returns
+    -------
+    bool
+        True if G is AT-free and False otherwise.
+
+    Examples
+    --------
+    >>> G = nx.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (1, 4), (4, 5)])
+    >>> nx.is_at_free(G)
+    True
+
+    >>> G = nx.cycle_graph(6)
+    >>> nx.is_at_free(G)
+    False
+    """
+    asteroidal_triple = find_asteroidal_triple(G)
+    if asteroidal_triple:
+        return False
     else:
         return True
 

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -27,31 +27,40 @@ __all__ = ["is_at_free"]
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 def is_at_free(G, certificate=False):
-    """Check if graph contains asteroidal triples.
+    r"""Check if graph contains no asteroidal triples.
 
     An asteroidal triple is a triple of non-adjacent vertices such that
     there exists a path between any two of them which avoids the closed
-    neighborhood of the third. The algorithm used to check is the trivial
-    one, outlined in [1]_, which has a runtime of `O(|V|^3)`.
-    It checks all independent triples of vertices and whether they are an
-    asteroidal triple or not. This is done with the help of a data structure
-    called a component structure. The component structure encodes information
-    about which vertices belongs to the same connected component
-    when the closed neighborhood of a given vertex is removed from the graph.
+    neighborhood of the third. It checks all independent triples of vertices
+    and whether they are an asteroidal triple or not. This is done with the
+    help of a data structure called a component structure.
+    The component structure encodes information about which vertices belongs to
+    the same connected component when the closed neighborhood of a given vertex
+    is removed from the graph. The algorithm used to check is the trivial
+    one, outlined in [1]_, which has a runtime of
+    :math:`O(|V||\overline{E} + |V||E|)`, where the second factor is the
+    creation of the component structure.
 
     Parameters
     ----------
     G : NetworkX Graph
         The graph to check whether is AT-free or not
 
-    certificate : boolean
+    certificate : boolean (default: False)
         If the first detected asteroidal triple should be output, if one
         exists, or None, in the case where a graph is AT-free.
 
     Returns
     -------
-    boolean
-        True if the given graph is AT-free and False otherwise.
+    bool or tuple (default: bool)
+        The returned value depends on the certificate parameter. The default
+        option is a bool which is True if the graph is AT-free, i.e. the
+        given graph contains no asteroidal triples, and False otherwise, i.e.
+        if the graph contains at least one asteroidal triple. If the optional
+        parameter `certificate` is set to True then the function returns a
+        tuple containing False and an asteroidal triple, represented as a tuple
+        of vertices, if the graph is not AT-free, and a tuple with True and
+        None if the graph is AT-free.
 
     Examples
     --------

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -24,7 +24,8 @@ from networkx.utils import not_implemented_for
 __all__ = ["is_at_free"]
 
 
-@not_implemented_for("directed", "multigraph")
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
 def is_at_free(G, certificate=False):
     """Check if graph contains asteroidal triples.
 
@@ -112,7 +113,8 @@ def is_at_free(G, certificate=False):
         return True
 
 
-@not_implemented_for("directed", "multigraph")
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
 def create_component_structure(G):
     r"""Create component structure for G.
 

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -38,7 +38,7 @@ def is_at_free(G, certificate=False):
     the same connected component when the closed neighborhood of a given vertex
     is removed from the graph. The algorithm used to check is the trivial
     one, outlined in [1]_, which has a runtime of
-    :math:`O(|V||\overline{E} + |V||E|)`, where the second factor is the
+    :math:`O(|V||\overline{E} + |V||E|)`, where the second term is the
     creation of the component structure.
 
     Parameters
@@ -46,21 +46,23 @@ def is_at_free(G, certificate=False):
     G : NetworkX Graph
         The graph to check whether is AT-free or not
 
-    certificate : boolean (default: False)
+    certificate : bool (default: False)
         If the first detected asteroidal triple should be output, if one
         exists, or None, in the case where a graph is AT-free.
 
     Returns
     -------
-    bool or tuple (default: bool)
+    bool (default)
         The returned value depends on the certificate parameter. The default
         option is a bool which is True if the graph is AT-free, i.e. the
         given graph contains no asteroidal triples, and False otherwise, i.e.
-        if the graph contains at least one asteroidal triple. If the optional
-        parameter `certificate` is set to True then the function returns a
+        if the graph contains at least one asteroidal triple.
+
+    tuple
+        If the optional parameter `certificate` is set to True then a
         tuple containing False and an asteroidal triple, represented as a tuple
-        of vertices, if the graph is not AT-free, and a tuple with True and
-        None if the graph is AT-free.
+        of vertices, is returend if the graph is not AT-free. If the graph
+        is AT-free a tuple with True and None is returned.
 
     Examples
     --------

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -68,12 +68,6 @@ def find_asteroidal_triple(G):
        Journal of Discrete Algorithms 2, pages 439-452, 2004.
        https://www.sciencedirect.com/science/article/pii/S157086670400019X
     """
-    def _is_asteroidal_triple(u, v, w, component_structure):
-        """Check whether a triple of vertices is an asteroidal triple."""
-        return (component_structure[u][v] == component_structure[u][w] and
-                component_structure[v][u] == component_structure[v][w] and
-                component_structure[w][u] == component_structure[w][v])
-
     V = set(G.nodes)
 
     if len(V) < 6:
@@ -90,14 +84,12 @@ def find_asteroidal_triple(G):
         v_neighborhood = set(G[v]).union([v])
         union_of_neighborhoods = u_neighborhood.union(v_neighborhood)
         for w in V - union_of_neighborhoods:
-            if _is_asteroidal_triple(u, v, w, component_structure):
-                if certificate:
-                    return (False,  (u, v, w))
-                else:
-                    return False
-
-    if certificate:
-        return (True, None)
+            """Check for each pair of vertices whether they belong to the
+            same connected component when the closed neighborhood of the
+            third is removed."""
+            if (component_structure[u][v] == component_structure[u][w] and
+                component_structure[v][u] == component_structure[v][w] and
+                    component_structure[w][u] == component_structure[w][v]):
                 return [u, v, w]
 
     return None

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -128,8 +128,7 @@ def is_at_free(G):
     asteroidal_triple = find_asteroidal_triple(G)
     if asteroidal_triple:
         return False
-    else:
-        return True
+    return True
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -11,12 +11,13 @@
 Algorithms for asteroidal triples and asteroidal numbers in graphs.
 
 An asteroidal triple in a graph G is a set of three non-adjacent vertices
-u, v and w such that there exist a path between any two of them avoiding the
-neighborhood of the third. More formally, v_j, v_k belongs to the same
-connected component of G - N[v_i]. A graph which contains no asteroidal
-triples is called an AT-free graph. The class of AT-free graphs
-is a graph class for which many NP-complete problems are solvable
-in polynomial time. Amongst them, independent set and coloring.
+u, v and w such that there exist a path between any two of them that avoids
+closed neighborhood of the third. More formally, v_j, v_k belongs to the same
+connected component of G - N[v_i], where N[v_i] denotes the closed neighborhood
+of v_i. A graph which does not contain any asteroidal triples is called
+an AT-free graph. The class of AT-free graphs is a graph class for which
+many NP-complete problems are solvable in polynomial time. Amongst them,
+independent set and coloring.
 """
 import networkx as nx
 from networkx.utils import not_implemented_for

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -26,8 +26,7 @@ __all__ = ["is_at_free"]
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-def is_at_free(G, certificate=False):
-    r"""Check if graph contains no asteroidal triples.
+def find_asteroidal_triple(G):
 
     An asteroidal triple is a triple of non-adjacent vertices such that
     there exists a path between any two of them which avoids the closed
@@ -96,7 +95,7 @@ def is_at_free(G, certificate=False):
 
     if len(V) < 6:
         # An asteroidal triple cannot exist in a graph with 5 or less vertices.
-        return True
+        return None
 
     component_structure = create_component_structure(G)
     E_complement = set(nx.complement(G).edges)
@@ -116,6 +115,11 @@ def is_at_free(G, certificate=False):
 
     if certificate:
         return (True, None)
+                return [u, v, w]
+
+    return None
+
+
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 def is_at_free(G):

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -108,12 +108,12 @@ def is_at_free(G, certificate=False):
         for w in V - union_of_neighborhoods:
             if _is_asteroidal_triple(u, v, w, component_structure):
                 if certificate:
-                    return (u, v, w)
+                    return (False,  (u, v, w))
                 else:
                     return False
 
     if certificate:
-        return None
+        return (True, None)
     else:
         return True
 

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -77,13 +77,9 @@ def is_at_free(G, certificate=False):
     """
     def _is_asteroidal_triple(u, v, w, component_structure):
         """Check whether a triple of vertices is an asteroidal triple."""
-        first_cond = component_structure[u][v] == component_structure[u][w]
-        second_cond = component_structure[v][u] == component_structure[v][w]
-        third_cond = component_structure[w][u] == component_structure[w][v]
-        if first_cond and second_cond and third_cond:
-            return True
-        else:
-            return False
+        return (component_structure[u][v] == component_structure[u][w] and
+                component_structure[v][u] == component_structure[v][w] and
+                component_structure[w][u] == component_structure[w][v])
 
     V = set(G.nodes)
 
@@ -149,11 +145,9 @@ def create_component_structure(G):
             row_dict[u] = 0
 
         G_reduced = G.subgraph(set(G.nodes) - closed_neighborhood)
-        connected_components = (G_reduced.subgraph(cc) for cc in
-                                nx.connected_components(G_reduced))
-        for cc in connected_components:
+        for cc in nx.connected_components(G_reduced):
             label += 1
-            for u in cc.nodes:
+            for u in cc:
                 row_dict[u] = label
 
         component_structure[v] = row_dict

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -21,7 +21,7 @@ in polynomial time. Amongst them, independent set and coloring.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-__all__ = ["is_at_free"]
+__all__ = ["is_at_free", "find_asteroidal_triple"]
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/tests/test_asteroidal.py
+++ b/networkx/algorithms/tests/test_asteroidal.py
@@ -1,0 +1,25 @@
+import networkx as nx
+from nose.tools import *
+
+
+def test_is_at_free():
+    cycle = nx.cycle_graph(6)
+    path = nx.path_graph(6)
+    small_graph = nx.complete_graph(2)
+    petersen = nx.petersen_graph()
+    clique = nx.complete_graph(6)
+    line_clique = nx.line_graph(clique)
+
+    cycle_at_free = nx.asteroidal.is_at_free(cycle)
+    path_at_free = nx.asteroidal.is_at_free(path)
+    small_graph_at_free = nx.asteroidal.is_at_free(small_graph)
+    petersen_at_free = nx.asteroidal.is_at_free(petersen)
+    clique_at_free = nx.asteroidal.is_at_free(clique)
+    line_clique_at_free = nx.asteroidal.is_at_free(line_clique)
+
+    assert_equal(cycle_at_free, False)
+    assert_equal(path_at_free, True)
+    assert_equal(small_graph_at_free, True)
+    assert_equal(petersen_at_free, False)
+    assert_equal(clique_at_free, True)
+    assert_equal(line_clique_at_free, False)

--- a/networkx/algorithms/tests/test_asteroidal.py
+++ b/networkx/algorithms/tests/test_asteroidal.py
@@ -1,6 +1,7 @@
 import networkx as nx
 from nose.tools import assert_true
 from nose.tools import assert_false
+from nose.tools import assert_equal
 
 
 def test_is_at_free():
@@ -9,9 +10,11 @@ def test_is_at_free():
 
     cycle = nx.cycle_graph(6)
     assert_false(is_at_free(cycle))
+    assert_equals(is_at_free(cycle, True), (False, (1, 3, 5)))
 
     path = nx.path_graph(6)
     assert_true(is_at_free(path))
+    assert_equal(is_at_free(path, True), (True, None))
 
     small_graph = nx.complete_graph(2)
     assert_true(is_at_free(small_graph))

--- a/networkx/algorithms/tests/test_asteroidal.py
+++ b/networkx/algorithms/tests/test_asteroidal.py
@@ -1,25 +1,26 @@
 import networkx as nx
-from nose.tools import *
+from nose.tools import assert_true
+from nose.tools import assert_false
 
 
 def test_is_at_free():
+
+    is_at_free = nx.asteroidal.is_at_free
+
     cycle = nx.cycle_graph(6)
+    assert_false(is_at_free(cycle))
+
     path = nx.path_graph(6)
+    assert_true(is_at_free(path))
+
     small_graph = nx.complete_graph(2)
+    assert_true(is_at_free(small_graph))
+
     petersen = nx.petersen_graph()
+    assert_false(is_at_free(petersen))
+
     clique = nx.complete_graph(6)
+    assert_true(is_at_free(clique))
+
     line_clique = nx.line_graph(clique)
-
-    cycle_at_free = nx.asteroidal.is_at_free(cycle)
-    path_at_free = nx.asteroidal.is_at_free(path)
-    small_graph_at_free = nx.asteroidal.is_at_free(small_graph)
-    petersen_at_free = nx.asteroidal.is_at_free(petersen)
-    clique_at_free = nx.asteroidal.is_at_free(clique)
-    line_clique_at_free = nx.asteroidal.is_at_free(line_clique)
-
-    assert_equal(cycle_at_free, False)
-    assert_equal(path_at_free, True)
-    assert_equal(small_graph_at_free, True)
-    assert_equal(petersen_at_free, False)
-    assert_equal(clique_at_free, True)
-    assert_equal(line_clique_at_free, False)
+    assert_false(is_at_free(line_clique))

--- a/networkx/algorithms/tests/test_asteroidal.py
+++ b/networkx/algorithms/tests/test_asteroidal.py
@@ -10,7 +10,7 @@ def test_is_at_free():
 
     cycle = nx.cycle_graph(6)
     assert_false(is_at_free(cycle))
-    assert_equals(is_at_free(cycle, True), (False, (1, 3, 5)))
+    assert_equal(is_at_free(cycle, True), (False, (1, 3, 5)))
 
     path = nx.path_graph(6)
     assert_true(is_at_free(path))

--- a/networkx/algorithms/tests/test_asteroidal.py
+++ b/networkx/algorithms/tests/test_asteroidal.py
@@ -10,11 +10,9 @@ def test_is_at_free():
 
     cycle = nx.cycle_graph(6)
     assert_false(is_at_free(cycle))
-    assert_equal(is_at_free(cycle, True), (False, (1, 3, 5)))
 
     path = nx.path_graph(6)
     assert_true(is_at_free(path))
-    assert_equal(is_at_free(path, True), (True, None))
 
     small_graph = nx.complete_graph(2)
     assert_true(is_at_free(small_graph))


### PR DESCRIPTION
Dear all,

This is my first contribution to networkx and to any open-source project so bear with me. I have created a module called `asteroidal.py`which contains a method for recognition of AT-free graphs. I plan to implement more functionality for asteroidal recognition and some other graph recognitions which I have developed, but I try to keep my first pull request small.

### What does the PR contain
`asteroidal.py` implements the method `is_at_free` which takes a graph and checks whether it contains any asteroidal triples or not, i.e. if it is AT-free or not. AT-free graphs is a graph class for which several classical NP-complete problems are solvable polynomial time, independent set and coloring (even list coloring) amongst them.

### Documentation
I have tried to set up sphinx locally to check what my docstrings would look like, but have not been able yet. I'm particularly curious about the math codes.