### PR TITLE
Limit nx.all_simple_paths by weight

### DIFF
--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -5,7 +5,7 @@
 #    BSD license.
 import collections
 from heapq import heappush, heappop
-from itertools import count
+from itertools import count, tee
 
 import networkx as nx
 from networkx.utils import not_implemented_for
@@ -91,7 +91,7 @@ def is_simple_path(G, nodes):
             all(v in G[u] for u, v in pairwise(nodes)))
 
 
-def all_simple_paths(G, source, target, cutoff=None):
+def all_simple_paths(G, source, target, cutoff_len=None, weight=None, cutoff_weight=None):
     """Generate all simple paths in the graph G from source to target.
 
     A simple path is a path with no repeated nodes.
@@ -106,14 +106,21 @@ def all_simple_paths(G, source, target, cutoff=None):
     target : nodes
        Single node or iterable of nodes at which to end path
 
-    cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+    cutoff_len : integer, optional
+        Depth to stop the search. Only paths of length <= cutoff_len are returned.
+
+    weight : string, optional
+        Name of the edge attribute to be used as a weight. If None all
+        edges are considered to have unit weight. Default value None.
+
+    cutoff_weight : integer, optional
+        Weighted path length to stop the search. Only paths of weight_length <= cutoff_weight are returned.
 
     Returns
     -------
     path_generator: generator
        A generator that produces lists of simple paths.  If there are no paths
-       between the source and target within the given cutoff the generator
+       between the source and target within the given cutoff_len the generator
        produces no output.
 
     Examples
@@ -131,9 +138,9 @@ def all_simple_paths(G, source, target, cutoff=None):
         [0, 3]
 
     You can generate only those paths that are shorter than a certain
-    length by using the `cutoff` keyword argument::
+    length by using the `cutoff_len` keyword argument::
 
-        >>> paths = nx.all_simple_paths(G, source=0, target=3, cutoff=2)
+        >>> paths = nx.all_simple_paths(G, source=0, target=3, cutoff_len=2)
         >>> print(list(paths))
         [[0, 1, 3], [0, 2, 3], [0, 3]]
 
@@ -238,14 +245,25 @@ def all_simple_paths(G, source, target, cutoff=None):
             raise nx.NodeNotFound('target node %s not in graph' % target)
     if source in targets:
         return []
-    if cutoff is None:
-        cutoff = len(G) - 1
-    if cutoff < 1:
+    if cutoff_len is None:
+        cutoff_len = len(G) - 1
+    if cutoff_len < 1:
         return []
+
+    if weight is not None:
+        weights = nx.get_edge_attributes(G, weight)
+        if None in weights.values():
+            raise ValueError('Weight: {} cannot include None'.format(weight))
+    if cutoff_weight is None:
+        cutoff_weight = float('inf')
+
     if G.is_multigraph():
-        return _all_simple_paths_multigraph(G, source, targets, cutoff)
+        return _all_simple_paths_multigraph(G, source, targets, cutoff_len)
     else:
-        return _all_simple_paths_graph(G, source, targets, cutoff)
+        if weight is False:
+            return _all_simple_paths_graph(G, source, targets, cutoff_len)
+        else:
+            return _all_simple_paths_weighted_graph(G, source, targets, cutoff_len, weight, cutoff_weight)
 
 
 def _all_simple_paths_graph(G, source, targets, cutoff):
@@ -271,6 +289,52 @@ def _all_simple_paths_graph(G, source, targets, cutoff):
             for target in (targets & (set(children) | {child})) - set(visited.keys()):
                 yield list(visited) + [target]
             stack.pop()
+            visited.popitem()
+
+
+def _all_simple_paths_weighted_graph(G, source, targets, cutoff, weight, maxdist):
+
+    def _get_last_pair_dist(nodes):
+        if len(nodes) > 1:
+            return G[nodes[-2]][nodes[-1]][weight]
+        else:
+            return 0
+
+    visited = collections.OrderedDict.fromkeys([source])
+    path_dist = 0
+    stack = [iter(G[source])]
+    while stack:
+        children = stack[-1]
+        child = next(children, None)
+        if child is None:
+            stack.pop()
+            visited.popitem()
+            if len(visited) > 1:
+                path_dist -= _get_last_pair_dist(list(visited))
+            else:
+                path_dist = 0
+        elif ((len(visited) < cutoff) and
+                (path_dist + _get_last_pair_dist(list(visited)) < maxdist)):
+            if child in visited:
+                continue
+            if child in targets:
+                yield list(visited) + [child]
+
+            visited[child] = None
+            path_dist += _get_last_pair_dist(list(visited))
+
+            if targets - set(visited.keys()):  # expand stack until find all targets
+                stack.append(iter(G[child]))
+            else:
+                path_dist -= _get_last_pair_dist(list(visited))
+                visited.popitem()# maybe other ways to child
+        else:  # len(visited) == cutoff:
+            for target in (targets & (set(children) | {child})) - set(visited.keys()):
+                # check if length requirement is met
+                if (path_dist + _get_last_pair_dist(list(visited)+[target])) <= maxdist:
+                    yield list(visited) + [target]
+            stack.pop()
+            path_dist -= _get_last_pair_dist(list(visited))
             visited.popitem()
 
 

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -105,14 +105,14 @@ def test_digraph_all_simple_paths_with_two_targets_emits_two_paths():
 def test_all_simple_paths_with_two_targets_cutoff():
     G = nx.path_graph(4)
     G.add_edge(2, 4)
-    paths = nx.all_simple_paths(G, 0, [3, 4], cutoff=3)
+    paths = nx.all_simple_paths(G, 0, [3, 4], cutoff_len=3)
     assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
 
 
 def test_digraph_all_simple_paths_with_two_targets_cutoff():
     G = nx.path_graph(4, create_using=nx.DiGraph())
     G.add_edge(2, 4)
-    paths = nx.all_simple_paths(G, 0, [3, 4], cutoff=3)
+    paths = nx.all_simple_paths(G, 0, [3, 4], cutoff_len=3)
     assert_equal(set(tuple(p) for p in paths), {(0, 1, 2, 3), (0, 1, 2, 4)})
 
 
@@ -144,9 +144,9 @@ def test_all_simple_paths_source_target():
 
 def test_all_simple_paths_cutoff():
     G = nx.complete_graph(4)
-    paths = nx.all_simple_paths(G, 0, 1, cutoff=1)
+    paths = nx.all_simple_paths(G, 0, 1, cutoff_len=1)
     assert_equal(set(tuple(p) for p in paths), {(0, 1)})
-    paths = nx.all_simple_paths(G, 0, 1, cutoff=2)
+    paths = nx.all_simple_paths(G, 0, 1, cutoff_len=2)
     assert_equal(set(tuple(p) for p in paths), {(0, 1), (0, 2, 1), (0, 3, 1)})
 
 
@@ -158,10 +158,10 @@ def test_all_simple_paths_on_non_trivial_graph():
     assert_equal(set(tuple(p) for p in paths), {
         (1, 2), (1, 3, 4, 2), (1, 5, 4, 2), (1, 3), (1, 2, 3), (1, 5, 4, 3),
         (1, 5, 4, 2, 3)})
-    paths = nx.all_simple_paths(G, 1, [2, 3], cutoff=3)
+    paths = nx.all_simple_paths(G, 1, [2, 3], cutoff_len=3)
     assert_equal(set(tuple(p) for p in paths), {
         (1, 2), (1, 3, 4, 2), (1, 5, 4, 2), (1, 3), (1, 2, 3), (1, 5, 4, 3)})
-    paths = nx.all_simple_paths(G, 1, [2, 3], cutoff=2)
+    paths = nx.all_simple_paths(G, 1, [2, 3], cutoff_len=2)
     assert_equal(set(tuple(p) for p in paths), {(1, 2), (1, 3), (1, 2, 3)})
 
 
@@ -177,9 +177,34 @@ def test_all_simple_paths_multigraph():
 
 def test_all_simple_paths_multigraph_with_cutoff():
     G = nx.MultiGraph([(1, 2), (1, 2), (1, 10), (10, 2)])
-    paths = list(nx.all_simple_paths(G, 1, 2, cutoff=1))
+    paths = list(nx.all_simple_paths(G, 1, 2, cutoff_len=1))
     assert_equal(len(paths), 2)
     assert_equal(set(tuple(p) for p in paths), {(1, 2), (1, 2)})
+
+
+def test_all_simple_paths_weighted_graph_with_maxdist():
+    edges = [(1, 2), (2, 10), (1, 5), (5, 4), (4, 3), (3, 10)]
+    distances = [5, 6, 1, 3, 2, 2]
+    d = {e: {'Distance': dist} for e, dist in zip(edges, distances)}
+
+    G = nx.Graph(edges)
+    nx.set_edge_attributes(G, d)
+
+    paths = list(nx.all_simple_paths(G, 1, 10, weight='Distance', cutoff_weight=10))
+    assert_equal(len(paths), 1)
+    assert_equal(paths[0], [1, 5, 4, 3, 10])
+
+
+def test_all_simple_paths_weighted_graph_with_cutoff_and_maxdist():
+    edges = [(1, 2), (2, 10), (1, 5), (5, 4), (4, 3), (3, 10)]
+    distances = [5, 6, 1, 3, 2, 2]
+    d = {e: {'Distance': dist} for e, dist in zip(edges, distances)}
+
+    G = nx.Graph(edges)
+    nx.set_edge_attributes(G, d)
+
+    paths = list(nx.all_simple_paths(G, 1, 10, cutoff_len=2, weight='Distance', cutoff_weight=10))
+    assert_equal(len(paths), 0)
 
 
 def test_all_simple_paths_directed():
@@ -192,9 +217,8 @@ def test_all_simple_paths_directed():
 
 def test_all_simple_paths_empty():
     G = nx.path_graph(4)
-    paths = nx.all_simple_paths(G, 0, 3, cutoff=2)
+    paths = nx.all_simple_paths(G, 0, 3, cutoff_len=2)
     assert_equal(list(paths), [])
-
 
 def test_all_simple_paths_corner_cases():
     assert_equal(list(nx.all_simple_paths(nx.empty_graph(2), 0, 0)), [])
@@ -222,9 +246,9 @@ def test_hamiltonian_path():
 
 def test_cutoff_zero():
     G = nx.complete_graph(4)
-    paths = nx.all_simple_paths(G, 0, 3, cutoff=0)
+    paths = nx.all_simple_paths(G, 0, 3, cutoff_len=0)
     assert_equal(list(list(p) for p in paths), [])
-    paths = nx.all_simple_paths(nx.MultiGraph(G), 0, 3, cutoff=0)
+    paths = nx.all_simple_paths(nx.MultiGraph(G), 0, 3, cutoff_len=0)
     assert_equal(list(list(p) for p in paths), [])
 
 

--- a/networkx/release.py
+++ b/networkx/release.py
@@ -177,7 +177,7 @@ def get_info(dynamic=True):
 # Version information
 name = 'networkx'
 major = "2"
-minor = "3rc3"
+minor = "3rc4"
 
 
 # Declare current release as a development release.
@@ -200,7 +200,11 @@ authors = {'Hagberg': ('Aric Hagberg', 'hagberg@lanl.gov'),
 maintainer = "NetworkX Developers"
 maintainer_email = "networkx-discuss@googlegroups.com"
 url = 'http://networkx.github.io/'
-download_url = 'https://pypi.python.org/pypi/networkx/'
+project_urls={
+    "Bug Tracker": "https://github.com/networkx/networkx/issues",
+    "Documentation": "https://networkx.github.io/documentation/stable/",
+    "Source Code": "https://github.com/networkx/networkx",
+}
 platforms = ['Linux', 'Mac OSX', 'Windows', 'Unix']
 keywords = ['Networks', 'Graph Theory', 'Mathematics',
             'network', 'graph', 'discrete mathematics', 'math']

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
         license=release.license,
         platforms=release.platforms,
         url=release.url,
-        download_url=release.download_url,
+        project_urls=release.project_urls,
         classifiers=release.classifiers,
         packages=packages,
         data_files=data,


### PR DESCRIPTION
This a first effort to allow limiting the results of `nx.all_simple_paths` not only by the length of the path but as well as by the distance covered as specified by the `weight` attribute.
The suggested is most likely inefficient but it could work as a basis for further improvement.  