### PR TITLE
Fix edge_color inconsistency with node_color and description.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -181,11 +181,11 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
        Size of nodes.  If an array is specified it must be the
        same length as nodelist.
 
-    node_color : color string, or array of floats, (default='#1f78b4')
-       Node color. Can be a single color format string,
-       or a  sequence of colors with the same length as nodelist.
-       If numeric values are specified they will be mapped to
-       colors using the cmap and vmin,vmax parameters.  See
+    node_color : color or array of colors (default='#1f78b4')
+       Node color. Can be a single color or a sequence of colors with the same
+       length as nodelist. Color can be string, or (rgb) or (rgba) tuple of
+       three floats from 0-1. If numeric values are specified they will be
+       mapped to colors using the cmap and vmin,vmax parameters. See
        matplotlib.scatter for more details.
 
     node_shape :  string, optional (default='o')
@@ -207,11 +207,11 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
     width : float, optional (default=1.0)
        Line width of edges
 
-    edge_color : color string, or array of floats (default='r')
-       Edge color. Can be a single color format string,
-       or a sequence of colors with the same length as edgelist.
-       If numeric values are specified they will be mapped to
-       colors using the edge_cmap and edge_vmin,edge_vmax parameters.
+    edge_color : color or array of colors (default='k')
+       Edge color. Can be a single color or a sequence of colors with the same
+       length as edgelist. Color can be string, or (rgb) or (rgba) tuple of
+       three floats from 0-1. If numeric values are specified they will be
+       mapped to colors using the edge_cmap and edge_vmin,edge_vmax parameters.
 
     edge_cmap : Matplotlib colormap, optional (default=None)
        Colormap for mapping intensities of edges
@@ -320,11 +320,11 @@ def draw_networkx_nodes(G, pos,
        Size of nodes (default=300).  If an array is specified it must be the
        same length as nodelist.
 
-    node_color : color string, or array of floats
-       Node color. Can be a single color format string (default='#1f78b4'),
-       or a  sequence of colors with the same length as nodelist.
-       If numeric values are specified they will be mapped to
-       colors using the cmap and vmin,vmax parameters.  See
+    node_color : color or array of colors (default='#1f78b4')
+       Node color. Can be a single color or a sequence of colors with the same
+       length as nodelist. Color can be string, or (rgb) or (rgba) tuple of
+       three floats from 0-1. If numeric values are specified they will be
+       mapped to colors using the cmap and vmin,vmax parameters. See
        matplotlib.scatter for more details.
 
     node_shape :  string
@@ -464,11 +464,11 @@ def draw_networkx_edges(G, pos,
     width : float, or array of floats
        Line width of edges (default=1.0)
 
-    edge_color : color string, or array of floats
-       Edge color. Can be a single color format string (default='r'),
-       or a sequence of colors with the same length as edgelist.
-       If numeric values are specified they will be mapped to
-       colors using the edge_cmap and edge_vmin,edge_vmax parameters.
+    edge_color : color or array of colors (default='k')
+       Edge color. Can be a single color or a sequence of colors with the same
+       length as edgelist. Color can be string, or (rgb) or (rgba) tuple of
+       three floats from 0-1. If numeric values are specified they will be
+       mapped to colors using the edge_cmap and edge_vmin,edge_vmax parameters.
 
     style : string
        Edge line style (default='solid') (solid|dashed|dotted,dashdot)
@@ -600,7 +600,7 @@ def draw_networkx_edges(G, pos,
         else:
             raise ValueError('edge_color must contain color names or numbers')
     else:
-        if is_string_like(edge_color) or len(edge_color) == 1:
+        if is_string_like(edge_color) or len(edge_color) in (3, 4):
             edge_colors = (colorConverter.to_rgba(edge_color, alpha), )
         else:
             msg = 'edge_color must be a color or list of one color per edge'
@@ -833,7 +833,7 @@ def draw_networkx_labels(G, pos,
                     clip_on=True,
                     )
         text_items[n] = t
-        
+
     plt.tick_params(
         axis='both',
         which='both',

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -192,7 +192,7 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
        The shape of the node.  Specification is as matplotlib.scatter
        marker, one of 'so^>v<dph8'.
 
-    alpha : float, optional (default=1.0)
+    alpha : float, optional (default=None)
        The node and edge transparency
 
     cmap : Matplotlib colormap, optional (default=None)
@@ -288,7 +288,7 @@ def draw_networkx_nodes(G, pos,
                         node_size=300,
                         node_color='#1f78b4',
                         node_shape='o',
-                        alpha=1.0,
+                        alpha=None,
                         cmap=None,
                         vmin=None,
                         vmax=None,
@@ -332,7 +332,7 @@ def draw_networkx_nodes(G, pos,
        marker, one of 'so^>v<dph8' (default='o').
 
     alpha : float or array of floats
-       The node transparency.  This can be a single alpha value (default=1.0),
+       The node transparency.  This can be a single alpha value (default=None),
        in which case it will be applied to all the nodes of color. Otherwise,
        if it is an array, the elements of alpha will be applied to the colors
        in order (cycling through alpha multiple times if necessary).
@@ -431,7 +431,7 @@ def draw_networkx_edges(G, pos,
                         width=1.0,
                         edge_color='k',
                         style='solid',
-                        alpha=1.0,
+                        alpha=None,
                         arrowstyle='-|>',
                         arrowsize=10,
                         edge_cmap=None,
@@ -474,7 +474,7 @@ def draw_networkx_edges(G, pos,
        Edge line style (default='solid') (solid|dashed|dotted,dashdot)
 
     alpha : float
-       The edge transparency (default=1.0)
+       The edge transparency (default=None)
 
     edge_ cmap : Matplotlib colormap
        Colormap for mapping intensities of edges (default=None)
@@ -602,19 +602,12 @@ def draw_networkx_edges(G, pos,
                                          antialiaseds=(1,),
                                          linestyle=style,
                                          transOffset=ax.transData,
+                                         alpha=alpha
                                          )
 
         edge_collection.set_zorder(1)  # edges go behind nodes
         edge_collection.set_label(label)
         ax.add_collection(edge_collection)
-
-        # Note: there was a bug in mpl regarding the handling of alpha values
-        # for each line in a LineCollection. It was fixed in matplotlib by
-        # r7184 and r7189 (June 6 2009). We should then not set the alpha
-        # value globally, since the user can instead provide per-edge alphas
-        # now.  Only set it globally if provided as a scalar.
-        if isinstance(alpha, Number):
-            edge_collection.set_alpha(alpha)
 
         return edge_collection
 
@@ -714,7 +707,7 @@ def draw_networkx_labels(G, pos,
                          font_color='k',
                          font_family='sans-serif',
                          font_weight='normal',
-                         alpha=1.0,
+                         alpha=None,
                          bbox=None,
                          ax=None,
                          **kwds):
@@ -746,8 +739,8 @@ def draw_networkx_labels(G, pos,
     font_weight : string
        Font weight (default='normal')
 
-    alpha : float
-       The text transparency (default=1.0)
+    alpha : float or None
+       The text transparency (default=None)
 
     ax : Matplotlib Axes object, optional
        Draw the graph in the specified Matplotlib axes.
@@ -830,7 +823,7 @@ def draw_networkx_edge_labels(G, pos,
                               font_color='k',
                               font_family='sans-serif',
                               font_weight='normal',
-                              alpha=1.0,
+                              alpha=None,
                               bbox=None,
                               ax=None,
                               rotate=True,
@@ -849,8 +842,8 @@ def draw_networkx_edge_labels(G, pos,
     ax : Matplotlib Axes object, optional
        Draw the graph in the specified Matplotlib axes.
 
-    alpha : float
-       The text transparency (default=1.0)
+    alpha : float or None
+       The text transparency (default=None)
 
     edge_labels : dictionary
        Edge labels in a dictionary keyed by edge two-tuple of text

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -56,8 +56,46 @@ class TestPylab(object):
         nx.draw_spring(self.G.to_directed())
         plt.show()
 
+    def test_arrows_colors_and_widths(self):
+        D = self.G.to_directed()
+        pos = nx.circular_layout(D)
+        # test node edgecolors, which refers to the node object line color
+        nx.draw_networkx_nodes(D, pos, edgecolors='cyan')
+        # edges with default color
+        nx.draw_networkx_edges(D, pos, edgelist=[(0, 1), (0, 2)],
+                               width=[1, 3],
+                               edge_color=None)
+        # edges with color strings for each edge
+        nx.draw_networkx_edges(D, pos, edgelist=[(0, 3), (1, 2)],
+                               width=[1, 3],
+                               edge_color=['r', 'b'])
+        # edges with fewer color strings and widths than edges
+        nx.draw_networkx_edges(D, pos,
+                               edgelist=[(1, 3), (2, 3), (3, 4), (4, 5)],
+                               width=[1, 3],
+                               edge_color=['g', 'm'])
+        # edges with more color strings and widths than edges
+        nx.draw_networkx_edges(D, pos, edgelist=[(5, 6), (6, 7)],
+                               width=[1, 2, 3, 4],
+                               edge_color=['r', 'b', 'g', 'k'])
+        # with rgb tuple
+        nx.draw_networkx_edges(D, pos, edgelist=[(7, 8), (8, 9)],
+                               edge_color=[(1.0, 1.0, 0.0)])
+        # with rgba tuple
+        nx.draw_networkx_edges(D, pos,
+                               edgelist=[(9, 10), (10, 11), (10, 12), (10, 13)],
+                               edge_color=[(0.0, 1.0, 1.0, 0.2)])
+        # with color string and global alpha
+        nx.draw_networkx_edges(D, pos, edgelist=[(11, 12), (11, 13)],
+                               edge_color='purple', alpha=0.2)
+        # with single edge and color
+        nx.draw_networkx_edges(D, pos, edgelist=[(12, 13)],
+                               edge_color='#1f78b4')
+
     def test_edge_colors_and_widths(self):
-        nx.draw_random(self.G, edgelist=[(0, 1), (0, 2)], width=[1, 2], edge_colors=['r', 'b'])
+        nx.draw_random(self.G, edgelist=[(0, 1), (0, 2)],
+                               width=[1, 2],
+                               edge_colors=['r', 'b'])
 
     def test_labels_and_colors(self):
         G = nx.cubical_graph()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -93,7 +93,7 @@ class TestPylab(object):
                                    edge_color='purple', alpha=0.2)
             # with single edge and hex color string
             nx.draw_networkx_edges(G, pos, edgelist=[(12, 13)],
-                                   edge_color='#1f78b4')
+                                   edge_color='#1f78b4f0')
             plt.show()
 
     def test_labels_and_colors(self):

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -56,46 +56,45 @@ class TestPylab(object):
         nx.draw_spring(self.G.to_directed())
         plt.show()
 
-    def test_arrows_colors_and_widths(self):
-        D = self.G.to_directed()
-        pos = nx.circular_layout(D)
-        # test node edgecolors, which refers to the node object line color
-        nx.draw_networkx_nodes(D, pos, edgecolors='cyan')
-        # edges with default color
-        nx.draw_networkx_edges(D, pos, edgelist=[(0, 1), (0, 2)],
-                               width=[1, 3],
-                               edge_color=None)
-        # edges with color strings for each edge
-        nx.draw_networkx_edges(D, pos, edgelist=[(0, 3), (1, 2)],
-                               width=[1, 3],
-                               edge_color=['r', 'b'])
-        # edges with fewer color strings and widths than edges
-        nx.draw_networkx_edges(D, pos,
-                               edgelist=[(1, 3), (2, 3), (3, 4), (4, 5)],
-                               width=[1, 3],
-                               edge_color=['g', 'm'])
-        # edges with more color strings and widths than edges
-        nx.draw_networkx_edges(D, pos, edgelist=[(5, 6), (6, 7)],
-                               width=[1, 2, 3, 4],
-                               edge_color=['r', 'b', 'g', 'k'])
-        # with rgb tuple
-        nx.draw_networkx_edges(D, pos, edgelist=[(7, 8), (8, 9)],
-                               edge_color=[(1.0, 1.0, 0.0)])
-        # with rgba tuple
-        nx.draw_networkx_edges(D, pos,
-                               edgelist=[(9, 10), (10, 11), (10, 12), (10, 13)],
-                               edge_color=[(0.0, 1.0, 1.0, 0.2)])
-        # with color string and global alpha
-        nx.draw_networkx_edges(D, pos, edgelist=[(11, 12), (11, 13)],
-                               edge_color='purple', alpha=0.2)
-        # with single edge and color
-        nx.draw_networkx_edges(D, pos, edgelist=[(12, 13)],
-                               edge_color='#1f78b4')
-
     def test_edge_colors_and_widths(self):
-        nx.draw_random(self.G, edgelist=[(0, 1), (0, 2)],
-                               width=[1, 2],
-                               edge_colors=['r', 'b'])
+        pos = nx.circular_layout(self.G)
+        for G in (self.G, self.G.to_directed()):
+            nx.draw_networkx_nodes(G, pos, node_color=[(1.0,1.0,0.2,0.5)])
+            nx.draw_networkx_labels(G, pos)
+            # edge with default color and width
+            nx.draw_networkx_edges(G, pos, edgelist=[(0, 1)],
+                                   width=None,
+                                   edge_color=None)
+            # edges with color strings and widths for each edge
+            nx.draw_networkx_edges(G, pos, edgelist=[(0, 2), (0, 3)],
+                                   width=[1, 3],
+                                   edge_color=['r', 'b'])
+            # edges with fewer color strings and widths than edges
+            nx.draw_networkx_edges(G, pos,
+                                   edgelist=[(1, 2), (1, 3), (2, 3)],
+                                   width=[1, 3],
+                                   edge_color=['g', 'm'])
+            # edges with more color strings and widths than edges
+            nx.draw_networkx_edges(G, pos, edgelist=[(3, 4)],
+                                   width=[1, 2, 3, 4],
+                                   edge_color=['r', 'b', 'g', 'k'])
+            # with rgb tuple and 3 edges - is interpreted with cmap
+            nx.draw_networkx_edges(G, pos, edgelist=[(4, 5), (5, 6), (6, 7)],
+                                    edge_color=(1.0, 0.4, 0.3))
+            # with rgb tuple in list
+            nx.draw_networkx_edges(G, pos, edgelist=[(7, 8), (8, 9)],
+                                   edge_color=[(0.4, 1.0, 0.0)])
+            # with rgba tuple in list
+            nx.draw_networkx_edges(G, pos, edgelist=[(9, 10), (10, 11),
+                                   (10, 12), (10, 13)],
+                                   edge_color=[(0.0, 1.0, 1.0, 0.5)])
+            # with color string and global alpha
+            nx.draw_networkx_edges(G, pos, edgelist=[(11, 12), (11, 13)],
+                                   edge_color='purple', alpha=0.2)
+            # with single edge and hex color string
+            nx.draw_networkx_edges(G, pos, edgelist=[(12, 13)],
+                                   edge_color='#1f78b4')
+            plt.show()
 
     def test_labels_and_colors(self):
         G = nx.cubical_graph()
@@ -105,12 +104,12 @@ class TestPylab(object):
                                nodelist=[0, 1, 2, 3],
                                node_color='r',
                                node_size=500,
-                               alpha=0.8)
+                               alpha=0.75)
         nx.draw_networkx_nodes(G, pos,
                                nodelist=[4, 5, 6, 7],
                                node_color='b',
                                node_size=500,
-                               alpha=0.8)
+                               alpha=[0.25,0.5,0.75,1.0])
         # edges
         nx.draw_networkx_edges(G, pos, width=1.0, alpha=0.5)
         nx.draw_networkx_edges(G, pos,

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -59,31 +59,39 @@ class TestPylab(object):
     def test_edge_colors_and_widths(self):
         pos = nx.circular_layout(self.G)
         for G in (self.G, self.G.to_directed()):
-            nx.draw_networkx_nodes(G, pos, node_color=[(1.0,1.0,0.2,0.5)])
+            nx.draw_networkx_nodes(G, pos, node_color=[(1.0, 1.0, 0.2, 0.5)])
             nx.draw_networkx_labels(G, pos)
             # edge with default color and width
             nx.draw_networkx_edges(G, pos, edgelist=[(0, 1)],
                                    width=None,
                                    edge_color=None)
+            # edges with global color strings and widths in lists
+            nx.draw_networkx_edges(G, pos, edgelist=[(0, 2), (0, 3)],
+                                   width=[3],
+                                   edge_color=['r'])
             # edges with color strings and widths for each edge
             nx.draw_networkx_edges(G, pos, edgelist=[(0, 2), (0, 3)],
                                    width=[1, 3],
                                    edge_color=['r', 'b'])
             # edges with fewer color strings and widths than edges
             nx.draw_networkx_edges(G, pos,
-                                   edgelist=[(1, 2), (1, 3), (2, 3)],
+                                   edgelist=[(1, 2), (1, 3), (2, 3), (3, 4)],
                                    width=[1, 3],
-                                   edge_color=['g', 'm'])
+                                   edge_color=['g', 'm', 'c'])
             # edges with more color strings and widths than edges
             nx.draw_networkx_edges(G, pos, edgelist=[(3, 4)],
                                    width=[1, 2, 3, 4],
                                    edge_color=['r', 'b', 'g', 'k'])
             # with rgb tuple and 3 edges - is interpreted with cmap
             nx.draw_networkx_edges(G, pos, edgelist=[(4, 5), (5, 6), (6, 7)],
-                                    edge_color=(1.0, 0.4, 0.3))
+                                   edge_color=(1.0, 0.4, 0.3))
             # with rgb tuple in list
             nx.draw_networkx_edges(G, pos, edgelist=[(7, 8), (8, 9)],
                                    edge_color=[(0.4, 1.0, 0.0)])
+            # with rgba tuple and 4 edges - is interpretted with cmap
+            nx.draw_networkx_edges(G, pos, edgelist=[(9, 10), (10, 11),
+                                   (10, 12), (10, 13)],
+                                   edge_color=(0.0, 1.0, 1.0, 0.5))
             # with rgba tuple in list
             nx.draw_networkx_edges(G, pos, edgelist=[(9, 10), (10, 11),
                                    (10, 12), (10, 13)],
@@ -91,9 +99,13 @@ class TestPylab(object):
             # with color string and global alpha
             nx.draw_networkx_edges(G, pos, edgelist=[(11, 12), (11, 13)],
                                    edge_color='purple', alpha=0.2)
+            # with color string in a list
+            nx.draw_networkx_edges(G, pos, edgelist=[(11, 12), (11, 13)],
+                                   edge_color=['purple'])
             # with single edge and hex color string
             nx.draw_networkx_edges(G, pos, edgelist=[(12, 13)],
                                    edge_color='#1f78b4f0')
+
             plt.show()
 
     def test_labels_and_colors(self):
@@ -109,7 +121,7 @@ class TestPylab(object):
                                nodelist=[4, 5, 6, 7],
                                node_color='b',
                                node_size=500,
-                               alpha=[0.25,0.5,0.75,1.0])
+                               alpha=[0.25, 0.5, 0.75, 1.0])
         # edges
         nx.draw_networkx_edges(G, pos, width=1.0, alpha=0.5)
         nx.draw_networkx_edges(G, pos,


### PR DESCRIPTION
Both draw_networkx_nodes and draw_networkx_edges support RGB or RGBA tuples.
Fixes #3394 