### PR TITLE
Add bethe hessian matrix

### DIFF
--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -25,6 +25,14 @@ Laplacian Matrix
    normalized_laplacian_matrix
    directed_laplacian_matrix
 
+Bethe Hessian Matrix
+--------------------
+.. automodule:: networkx.linalg.bethehessianmatrix
+.. autosummary::
+   :toctree: generated/
+
+   bethe_hessian_matrix
+
 Spectrum
 ---------
 .. automodule:: networkx.linalg.spectrum
@@ -32,6 +40,7 @@ Spectrum
    :toctree: generated/
 
    laplacian_spectrum
+   bethe_hessian_spectrum
    adjacency_spectrum
    modularity_spectrum
 

--- a/networkx/linalg/__init__.py
+++ b/networkx/linalg/__init__.py
@@ -9,3 +9,5 @@ import networkx.linalg.laplacianmatrix
 from networkx.linalg.algebraicconnectivity import *
 from networkx.linalg.modularitymatrix import *
 import networkx.linalg.modularitymatrix
+from networkx.linalg.bethehessianmatrix import *
+import networkx.linalg.bethehessianmatrix

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -1,18 +1,18 @@
-"""Bethe Hessian matrix of graphs.
-"""
+# -*- coding: utf-8 -*-
 #    Copyright (C) 2004-2019 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
+#    Jean-Gabriel Young <jeangabriel.young@gmail.com>
 #    All rights reserved.
 #    BSD license.
+#
+# Authors: Jean-Gabriel Young (jeangabriel.young@gmail.com)
+"""Bethe Hessian or deformed Laplacian matrix of graphs."""
 import networkx as nx
 from networkx.utils import not_implemented_for
-__author__ = "\n".join(['Aric Hagberg <aric.hagberg@gmail.com>',
-                        'Pieter Swart (swart@lanl.gov)',
-                        'Dan Schult (dschult@colgate.edu)',
-                        'Jean-Gabriel Young (Jean.gabriel.young@gmail.com)'])
-__all__ = ['bethe_hessian_matrix',]
+
+__all__ = ['bethe_hessian_matrix']
 
 
 @not_implemented_for('directed')

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -1,0 +1,94 @@
+"""Bethe Hessian matrix of graphs.
+"""
+#    Copyright (C) 2004-2019 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+import networkx as nx
+from networkx.utils import not_implemented_for
+__author__ = "\n".join(['Aric Hagberg <aric.hagberg@gmail.com>',
+                        'Pieter Swart (swart@lanl.gov)',
+                        'Dan Schult (dschult@colgate.edu)',
+                        'Jean-Gabriel Young (Jean.gabriel.young@gmail.com)'])
+__all__ = ['bethe_hessian_matrix',]
+
+
+@not_implemented_for('directed')
+@not_implemented_for('multigraph')
+def bethe_hessian_matrix(G, r=None, nodelist=None):
+    r"""Returns the Bethe Hessian matrix of G.
+
+    The Bethe Hessian is a family of matrices parametrized by r, defined as
+    H(r) = (r^2 - 1) I - r A + D where A is the adjacency matrix, D is the
+    diagonal matrix of node degrees, and I is the identify matrix. It is equal
+    to the graph laplacian when the regularizer r = 1.
+
+    The default choice of regularizer should be the ratio [2]
+
+    .. math::
+      r_m = \left(\sum k_i \right)^{-1}\left(\sum k_i^2 \right) - 1
+
+    Parameters
+    ----------
+    G : Graph
+       A NetworkX graph
+
+    r : float
+       Regularizer parameter
+
+    nodelist : list, optional
+       The rows and columns are ordered according to the nodes in nodelist.
+       If nodelist is None, then the ordering is produced by G.nodes().
+
+
+    Returns
+    -------
+    H : Numpy matrix
+      The Bethe Hessian matrix of G, with paramter r.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> k =[3, 2, 2, 1, 0]
+    >>> G = nx.havel_hakimi_graph(k)
+    >>> H = nx.modularity_matrix(G)
+
+
+    See Also
+    --------
+    bethe_hessian_spectrum
+    to_numpy_matrix
+    adjacency_matrix
+    laplacian_matrix
+
+    References
+    ----------
+    .. [1] A. Saade, F. Krzakala and L. Zdeborová
+      "Spectral clustering of graphs with the bethe hessian",
+       Advances in Neural Information Processing Systems. 2014.
+    .. [2] C. M. Lee, E. Levina
+      "Estimating the number of communities in networks by spectral methods"
+      arXiv:1507.00827, 2015.
+    """
+    import scipy.sparse
+    if nodelist is None:
+        nodelist = list(G)
+    if r is None:
+        r = sum([d ** 2 for v, d in nx.degree(G)]) /\
+            sum([d for v, d in nx.degree(G)]) - 1
+    A = nx.to_scipy_sparse_matrix(G, nodelist=nodelist, format='csr')
+    n, m = A.shape
+    diags = A.sum(axis=1)
+    D = scipy.sparse.spdiags(diags.flatten(), [0], m, n, format='csr')
+    I = scipy.sparse.eye(m, n, format='csr')
+    return (r ** 2 - 1) * I - r * A + D
+
+# fixture for nose tests
+def setup_module(module):
+    from nose import SkipTest
+    try:
+        import numpy
+    except:
+        raise SkipTest("NumPy not available")

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -14,7 +14,7 @@ __author__ = "\n".join(['Aric Hagberg <aric.hagberg@gmail.com>',
                         'Jean-Gabriel Young (jean.gabriel.young@gmail.com)'])
 
 __all__ = ['laplacian_spectrum', 'adjacency_spectrum', 'modularity_spectrum', 
-   'normalized_laplacian_spectrum']
+   'normalized_laplacian_spectrum', 'bethe_hessian_spectrum']
 
 
 def laplacian_spectrum(G, weight='weight'):

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -135,6 +135,36 @@ def modularity_spectrum(G):
     else:
         return eigvals(nx.modularity_matrix(G))
 
+
+def bethe_hessian_spectrum(G, r=None):
+    """Returns eigenvalues of the Bethe Hessian matrix of G.
+
+    Parameters
+    ----------
+    G : Graph
+       A NetworkX Graph or DiGraph
+
+    r : float
+       Regularizer parameter
+
+    Returns
+    -------
+    evals : NumPy array
+      Eigenvalues
+
+    See Also
+    --------
+    bethe_hessian_matrix
+
+    References
+    ----------
+    .. [1] A. Saade, F. Krzakala and L. Zdeborová
+      "Spectral clustering of graphs with the bethe hessian",
+       Advances in Neural Information Processing Systems. 2014.
+    """
+    from scipy.linalg import eigvalsh
+    return eigvalsh(nx.bethe_hessian_matrix(G, r).todense())
+ 
 # fixture for nose tests
 
 

--- a/networkx/linalg/tests/test_bethehessian.py
+++ b/networkx/linalg/tests/test_bethehessian.py
@@ -31,11 +31,15 @@ class TestBetheHessian(object):
         H = numpy.array([[ 4, -2,  0],
                           [-2,  5, -2],
                           [ 0, -2,  4]])
-
         permutation = [2, 0, 1]
-        print(nx.bethe_hessian_matrix(self.P, r=2).todense())
+        # Bethe Hessian gives expected form
         assert_equal(nx.bethe_hessian_matrix(self.P, r=2).todense(), H)
+        # nodelist is correctly implemented
         assert_equal(nx.bethe_hessian_matrix(self.P, r=2, nodelist=permutation).todense(),
                      H[numpy.ix_(permutation, permutation)])
+        # Equal to Laplacian matrix when r=1
         assert_equal(nx.bethe_hessian_matrix(self.G, r=1).todense(),
                      nx.laplacian_matrix(self.G).todense())
+        # Correct default for the regularizer r
+        assert_equal(nx.bethe_hessian_matrix(self.G).todense(),
+                     nx.bethe_hessian_matrix(self.G, r=1.25).todense())

--- a/networkx/linalg/tests/test_bethehessian.py
+++ b/networkx/linalg/tests/test_bethehessian.py
@@ -1,0 +1,39 @@
+from nose import SkipTest
+
+import networkx as nx
+from networkx.generators.degree_seq import havel_hakimi_graph
+
+
+class TestModularity(object):
+    numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
+
+    @classmethod
+    def setupClass(cls):
+        global numpy
+        global scipy
+        global assert_equal
+        global assert_almost_equal
+        try:
+            import numpy
+            import scipy
+            from numpy.testing import assert_equal, assert_almost_equal
+        except ImportError:
+            raise SkipTest('SciPy not available.')
+
+    def setUp(self):
+        deg = [3, 2, 2, 1, 0]
+        self.G = havel_hakimi_graph(deg)
+        self.P = nx.path_graph(3)
+
+    def test_bethe_hessian(self):
+        "Bethe matrix"
+        H = numpy.matrix([[ 4, -2,  0],
+                          [-2,  5, -2],
+                          [ 0, -2,  4]])
+
+        permutation = [2, 0, 1]
+        assert_equal(nx.bethe_hessian_matrix(self.P, r=2), H)
+        assert_equal(nx.bethe_hessian_matrix(self.P, r=2, nodelist=permutation),
+                     H[numpy.ix_(permutation, permutation)])
+        assert_equal(nx.bethe_hessian_matrix(self.G, r=1),
+                     nx.laplacian_matrix(self.G))

--- a/networkx/linalg/tests/test_bethehessian.py
+++ b/networkx/linalg/tests/test_bethehessian.py
@@ -1,10 +1,11 @@
+
 from nose import SkipTest
 
 import networkx as nx
 from networkx.generators.degree_seq import havel_hakimi_graph
 
 
-class TestModularity(object):
+class TestBetheHessian(object):
     numpy = 1  # nosetests attribute, use nosetests -a 'not numpy' to skip test
 
     @classmethod
@@ -26,14 +27,15 @@ class TestModularity(object):
         self.P = nx.path_graph(3)
 
     def test_bethe_hessian(self):
-        "Bethe matrix"
-        H = numpy.matrix([[ 4, -2,  0],
+        "Bethe Hessian matrix"
+        H = numpy.array([[ 4, -2,  0],
                           [-2,  5, -2],
                           [ 0, -2,  4]])
 
         permutation = [2, 0, 1]
-        assert_equal(nx.bethe_hessian_matrix(self.P, r=2), H)
-        assert_equal(nx.bethe_hessian_matrix(self.P, r=2, nodelist=permutation),
+        print(nx.bethe_hessian_matrix(self.P, r=2).todense())
+        assert_equal(nx.bethe_hessian_matrix(self.P, r=2).todense(), H)
+        assert_equal(nx.bethe_hessian_matrix(self.P, r=2, nodelist=permutation).todense(),
                      H[numpy.ix_(permutation, permutation)])
-        assert_equal(nx.bethe_hessian_matrix(self.G, r=1),
-                     nx.laplacian_matrix(self.G))
+        assert_equal(nx.bethe_hessian_matrix(self.G, r=1).todense(),
+                     nx.laplacian_matrix(self.G).todense())

--- a/networkx/linalg/tests/test_spectrum.py
+++ b/networkx/linalg/tests/test_spectrum.py
@@ -69,3 +69,14 @@ class TestSpectrum(object):
         evals = numpy.array([-0.5, 0., 0.])
         e = sorted(nx.modularity_spectrum(self.DG))
         assert_almost_equal(e, evals)
+
+    def test_bethe_hessian_spectrum(self):
+        "Bethe Hessian eigenvalues"
+        evals = numpy.array([0.5 * (9 - numpy.sqrt(33)), 4,
+                             0.5 * (9 + numpy.sqrt(33))])
+        e = sorted(nx.bethe_hessian_spectrum(self.P, r=2))
+        assert_almost_equal(e, evals)
+        # Collapses back to Laplacian:
+        e1 = sorted(nx.bethe_hessian_spectrum(self.P, r=1))
+        e2 = sorted(nx.laplacian_spectrum(self.P))
+        assert_almost_equal(e1, e2)


### PR DESCRIPTION
The Bethe Hessian matrix or deformed Laplacian matrix generalizes the graph Laplacian.
 It is great for clustering, and also for counting the number of communities in dense networks, see:

[Saade, Alaa, Florent Krzakala, and Lenka Zdeborová. "Spectral clustering of graphs with the bethe hessian." Advances in Neural Information Processing Systems. 2014.](https://arxiv.org/abs/1406.1880)

and
[Le, Can M., and Elizaveta Levina. "Estimating the number of communities in networks by spectral methods." arXiv preprint arXiv:1507.00827 (2015).](https://arxiv.org/abs/1507.00827).

This PR implements this family of matrices and its spectrum, for undirected networks, with tests and documentation.