### PR TITLE
Add see also links to linalg.spectrum

### DIFF
--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -158,6 +158,7 @@ def adjacency_matrix(G, nodelist=None, weight='weight'):
     to_numpy_matrix
     to_scipy_sparse_matrix
     to_dict_of_dicts
+    adjacency_spectrum
     """
     return nx.to_scipy_sparse_matrix(G, nodelist=nodelist, weight=weight)
 

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -51,6 +51,7 @@ def laplacian_matrix(G, nodelist=None, weight='weight'):
     --------
     to_numpy_matrix
     normalized_laplacian_matrix
+    laplacian_spectrum
     """
     import scipy.sparse
     if nodelist is None:
@@ -105,6 +106,7 @@ def normalized_laplacian_matrix(G, nodelist=None, weight='weight'):
     See Also
     --------
     laplacian_matrix
+    normalized_laplacian_spectrum
 
     References
     ----------

--- a/networkx/linalg/modularitymatrix.py
+++ b/networkx/linalg/modularitymatrix.py
@@ -63,8 +63,8 @@ def modularity_matrix(G, nodelist=None, weight=None):
     See Also
     --------
     to_numpy_matrix
+    modularity_spectrum
     adjacency_matrix
-    laplacian_matrix
     directed_modularity_matrix
 
     References
@@ -138,8 +138,8 @@ def directed_modularity_matrix(G, nodelist=None, weight=None):
     See Also
     --------
     to_numpy_matrix
+    modularity_spectrum
     adjacency_matrix
-    laplacian_matrix
     modularity_matrix
 
     References


### PR DESCRIPTION
Very simple doc PR.
While prepping PR #3401 I noticed that the doc was missing see also links from the matrices definition to their equivalent in linalg.spectrum.
This fixes it.

On a side note:
There's a lot of doc inconsistencies in the linealg module BTW.
algebraicconnectivity.py and attrmatrix.py don't follow the standard at all.