### PR TITLE
Fix spring_layout bug with fixed nodes

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -377,6 +377,7 @@ def fruchterman_reingold_layout(G,
 
     fixed : list or None  optional (default=None)
         Nodes to keep fixed at initial position.
+        ValueError raised if `fixed` specified and `pos` not.
 
     iterations : int  optional (default=50)
         Maximum number of iterations taken
@@ -425,7 +426,9 @@ def fruchterman_reingold_layout(G,
     G, center = _process_params(G, center, dim)
 
     if fixed is not None:
-        nfixed = dict(zip(G, range(len(G))))
+        if pos is None:
+            raise ValueError('nodes are fixed without positions given')
+        nfixed = {v: i for i, v in enumerate(G)}
         fixed = np.asarray([nfixed[v] for v in fixed])
 
     if pos is not None:
@@ -440,6 +443,7 @@ def fruchterman_reingold_layout(G,
                 pos_arr[i] = np.asarray(pos[n])
     else:
         pos_arr = None
+        dom_size = 1
 
     if len(G) == 0:
         return {}

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -428,8 +428,11 @@ def fruchterman_reingold_layout(G,
     if fixed is not None:
         if pos is None:
             raise ValueError('nodes are fixed without positions given')
-        nfixed = {v: i for i, v in enumerate(G)}
-        fixed = np.asarray([nfixed[v] for v in fixed])
+        for node in fixed:
+            if node not in pos:
+                raise ValueError('nodes are fixed without positions given')
+        nfixed = {node: i for i, node in enumerate(G)}
+        fixed = np.asarray([nfixed[node] for node in fixed])
 
     if pos is not None:
         # Determine size of existing domain to adjust initial positions

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -27,6 +27,10 @@ class TestLayout(object):
         nx.add_path(self.Gs, 'abcdef')
         self.bigG = nx.grid_2d_graph(25, 25)  # bigger than 500 nodes for sparse
 
+    def test_spring_fixed_without_pos(self):
+        G = nx.path_graph(4)
+        assert_raises(ValueError, nx.fruchterman_reingold_layout, G, fixed=[0])
+
     def test_spring_init_pos(self):
         # Tests GH #2448
         import math

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -29,7 +29,10 @@ class TestLayout(object):
 
     def test_spring_fixed_without_pos(self):
         G = nx.path_graph(4)
-        assert_raises(ValueError, nx.fruchterman_reingold_layout, G, fixed=[0])
+        assert_raises(ValueError, nx.spring_layout, G, fixed=[0])
+        pos = {0: (1, 1), 2: (0, 0)}
+        assert_raises(ValueError, nx.spring_layout, G, fixed=[0, 1], pos=pos)
+        nx.spring_layout(G, fixed=[0, 2], pos=pos)  # No ValueError
 
     def test_spring_init_pos(self):
         # Tests GH #2448


### PR DESCRIPTION
When fixed nodes are used in spring_layout() but positions are not assigned, the domain size variable ```dom_size``` is not given a value so Python raises an exception. 

This PR sets ```dom_size``` in all cases, and also changes the code to check that all fixed nodes are assigned positions in the input ```pos```.