### PR TITLE
Adding module for group centrality measures

### DIFF
--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -67,6 +67,13 @@ Communicability Betweenness
 
    communicability_betweenness_centrality
 
+Group Centrality
+----------------
+.. autosummary::
+   :toctree: generated/
+
+   group_betweenness_centrality
+
 Load
 ----
 .. autosummary::

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -8,6 +8,7 @@ from .current_flow_betweenness_subset import *
 from .degree_alg import *
 from .dispersion import *
 from .eigenvector import *
+from .group import *
 from .harmonic import *
 from .katz import *
 from .load import *

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -99,13 +99,14 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None):
     # accumulation
     for pair in combinations(V_C, 2):  # (s, t) pairs of V_C
         try:
-            paths = list(nx.all_shortest_paths(G, source=pair[0],
-                                               target=pair[1], weight=weight))
+            paths = 0
             paths_through_C = 0
-            for path in paths:
+            for path in nx.all_shortest_paths(G, source=pair[0],
+                                              target=pair[1], weight=weight):
                 if set(path) & C:
                     paths_through_C += 1
-            betweenness += paths_through_C / len(paths)
+                paths += 1
+            betweenness += paths_through_C / paths
         except nx.exception.NetworkXNoPath:
             betweenness += 0
     # rescaling

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -123,7 +123,7 @@ def _group_rescale(betweenness, v, c,
              normalized, directed=False):
     if normalized:
         scale = 1 / ((v - c) * (v - c - 1))
-        if directed:
+        if not directed:
             scale *= 2
     else:
         scale = None

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -1,0 +1,123 @@
+"""Group centrality measures."""
+from __future__ import division
+from itertools import combinations
+
+
+import networkx as nx
+
+
+__all__ = ['betweenness_centrality']
+
+
+def betweenness_centrality(G, C, normalized=True, weight=None):
+    r"""Compute the group betweenness centrality for a group of nodes.
+
+    Group betweenness centrality of a group of nodes $C$ is the sum of the
+    fraction of all-pairs shortest paths that pass through any vertex in $C$
+
+    .. math::
+
+    c_B(C) =\sum_{s,t \in V-C; s<t} \frac{\sigma(s, t|C)}{\sigma(s, t)}
+    
+    where $V$ is the set of nodes, $\sigma(s, t)$ is the number of
+    shortest $(s, t)$-paths, and $\sigma(s, t|C)$ is the number of
+    those paths passing through some node in group $C$. Note that
+    $(s, t)$ are not members of the group ($V-C$ is the set of nodes
+    in $V$ that are not in $C$).
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX graph.
+
+    C : list or set
+      C is a group of nodes which belong to G, for which group betweenness
+      centrality is to be calculated.
+
+    normalized : bool, optional
+      If True the betweenness values are normalized by `2/((|V|-|C|)(|V|-|C|-1))`
+      for graphs, and `1/((|V|-|C|)(|V|-|C|-1))` for directed graphs where `|V|`
+      is the number of nodes in G and `|C|` is the number of nodes in the group C.
+      
+    weight : None or string, optional (default=None)
+      If None, all edge weights are considered equal.
+      Otherwise holds the name of the edge attribute used as weight.
+      
+    Returns
+    -------
+    betweenness : float
+       Group betweenness centrality of the group C.
+
+    See Also
+    --------
+    betweenness_centrality
+
+    Notes
+    -----
+    The measure is described in [1]_.
+    The algorithm is an extension of the one proposed by Ulrik Brandes for
+    betweenness centrality of nodes. Group betweenness is also mentioned in
+    his paper [2]_ along with the algorithm. The importance of the measure is
+    discussed in [3]_.
+    
+    The number of nodes in the group must be a maximum of n - 2 where `n`
+    is the total number of nodes in the graph.
+
+    For weighted graphs the edge weights must be greater than zero.
+    Zero edge weights can produce an infinite number of equal length
+    paths between pairs of nodes.
+
+    References
+    ----------
+    .. [1] M G Everett and S P Borgatti:
+       The Centrality of Groups and Classes.
+       Journal of Mathematical Sociology. 23(3): 181-201. 1999.
+       http://www.analytictech.com/borgatti/group_centrality.htm
+    .. [2] Ulrik Brandes:
+       On Variants of Shortest-Path Betweenness
+       Centrality and their Generic Computation.
+       Social Networks 30(2):136-145, 2008.
+       http://www.inf.uni-konstanz.de/algo/publications/b-vspbc-08.pdf
+    .. [3] Sourav Medya et. al.:
+       Group Centrality Maximization via Network Design.
+       SIAM International Conference on Data Mining, SDM 2018, 126–134.
+       https://sites.cs.ucsb.edu/~arlei/pubs/sdm18.pdf
+       
+    """
+    betweenness = 0  # initialize betweenness to 0
+    V = set(G.nodes()) # set of nodes in G
+    C = set(C) # set of nodes in C (group)
+    V_C = set(V - C) # set of nodes in V but not in C
+    pairs = [_ for _ in combinations(V_C, 2)] # (s, t) pairs of V_C
+    # accumulation
+    for pair in pairs:
+        try:
+            paths = [_ for _ in nx.all_shortest_paths(G, source=pair[0],
+                                        target=pair[1], weight=weight)]
+        except (nx.exception.NetworkXNoPath, nx.exception.NodeNotFound):
+            paths = []
+        paths_through_C = []
+        for _ in paths:
+            if set(_) & C:
+                paths_through_C.append(_)
+        try:
+            betweenness += len(paths_through_C) / len(paths)
+        except ZeroDivisionError:
+            pass
+    # rescaling
+    betweenness = _rescale(betweenness, len(G), len(C),
+                           normalized=normalized, directed=G.is_directed())
+    return betweenness
+
+
+def _rescale(betweenness, v, c,
+             normalized, directed=False):
+    if normalized:
+        scale = 1 / ((v - c) * (v - c - 1))
+        if directed:
+            scale *= 2
+    else:
+        scale = None
+    if scale is not None:
+        betweenness *= scale
+    return betweenness

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -101,15 +101,12 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None):
         try:
             paths = list(nx.all_shortest_paths(G, source=pair[0],
                                                target=pair[1], weight=weight))
-        except (nx.exception.NetworkXNoPath, nx.exception.NodeNotFound):
-            paths = []
-        paths_through_C = 0
-        for path in paths:
-            if set(path) & C:
-                paths_through_C += 1
-        try:
+            paths_through_C = 0
+            for path in paths:
+                if set(path) & C:
+                    paths_through_C += 1
             betweenness += paths_through_C / len(paths)
-        except ZeroDivisionError:
+        except nx.exception.NetworkXNoPath:
             betweenness += 0
     # rescaling
     v, c = len(G), len(C)

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-#    Copyright (C) 2017-2019 by
+#    Copyright (C) 2004-2019 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
+#    Nanda H Krishna <nanda.harishankar@gmail.com>
 #    All rights reserved.
 #    BSD license.
-#
-# Author: Nanda H Krishna <nanda.harishankar@gmail.com>
 #
 """Group centrality measures."""
 from __future__ import division

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8 -*-
+#    Copyright (C) 2017-2019 by
+#    Aric Hagberg <hagberg@lanl.gov>
+#    Dan Schult <dschult@colgate.edu>
+#    Pieter Swart <swart@lanl.gov>
+#    All rights reserved.
+#    BSD license.
+#
+# Author: Nanda H Krishna <nanda.harishankar@gmail.com>
+#
 """Group centrality measures."""
 from __future__ import division
 from itertools import combinations
@@ -6,10 +16,10 @@ from itertools import combinations
 import networkx as nx
 
 
-__all__ = ['betweenness_centrality']
+__all__ = ['group_betweenness_centrality']
 
 
-def betweenness_centrality(G, C, normalized=True, weight=None):
+def group_betweenness_centrality(G, C, normalized=True, weight=None):
     r"""Compute the group betweenness centrality for a group of nodes.
 
     Group betweenness centrality of a group of nodes $C$ is the sum of the
@@ -105,12 +115,12 @@ def betweenness_centrality(G, C, normalized=True, weight=None):
         except ZeroDivisionError:
             pass
     # rescaling
-    betweenness = _rescale(betweenness, len(G), len(C),
+    betweenness = _group_rescale(betweenness, len(G), len(C),
                            normalized=normalized, directed=G.is_directed())
     return betweenness
 
 
-def _rescale(betweenness, v, c,
+def _group_rescale(betweenness, v, c,
              normalized, directed=False):
     if normalized:
         scale = 1 / ((v - c) * (v - c - 1))

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -9,9 +9,9 @@ import networkx as nx
 
 class TestGroupBetweennessCentrality:
 
-    def test_group_betweenness_centrality_1(self):
+    def test_group_betweenness_single_node(self):
         """
-            Group betweenness centrality in P5 for single node group
+            Group betweenness centrality for single node group
         """
         G = nx.path_graph(5)
         C = [1]
@@ -20,9 +20,9 @@ class TestGroupBetweennessCentrality:
         b_answer = 3.0
         assert_equal(b, b_answer)
 
-    def test_group_betweenness_centrality_2(self):
+    def test_group_betweenness_normalized(self):
         """
-            Group betweenness centrality in P5 for group with more than
+            Group betweenness centrality for group with more than
             1 node and normalized
         """
         G = nx.path_graph(5)
@@ -32,7 +32,7 @@ class TestGroupBetweennessCentrality:
         b_answer = 1.0
         assert_equal(b, b_answer)
 
-    def test_group_betweenness_centrality_3(self):
+    def test_group_betweenness_value_zero(self):
         """
             Group betweenness centrality value of 0
         """
@@ -42,7 +42,7 @@ class TestGroupBetweennessCentrality:
         b_answer = 0.0
         assert_equal(b, b_answer)
 
-    def test_group_betweenness_centrality_4(self):
+    def test_group_betweenness_disconnected_graph(self):
         """
             Group betweenness centrality in a disconnected graph
         """

--- a/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
@@ -12,13 +12,13 @@ class TestGroupBetweennessCentrality:
         """Group betweenness centrality in P5 for single node group"""
         G = nx.path_graph(5)
         C = [1]
-        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, weight=None, normalized=False)
+        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, C, weight=None, normalized=False)
         b_answer = 3.0
         assert_equal(b, b_answer)
     def test_group_betweenness_centrality_2(self):
-        """Group etweenness centrality in P5 for group with more than 1 node and normalized"""
+        """Group betweenness centrality in P5 for group with more than 1 node and normalized"""
         G = nx.path_graph(5)
         C = [1, 3]
-        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, weight=None, normalized=True)
+        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, C, weight=None, normalized=True)
         b_answer = 0.25
         assert_equal(b, b_answer)

--- a/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
@@ -38,8 +38,7 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
-        b = nx.group_betweenness_centrality(G, C,
-                                            weight=None, normalized=False)
+        b = nx.group_betweenness_centrality(G, C, weight=None)
         b_answer = 0.0
         assert_equal(b, b_answer)
 
@@ -49,8 +48,7 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.path_graph(5)
         G.remove_edge(0, 1)
-        C = [0, 1, 2]
-        b = nx.group_betweenness_centrality(G, C,
-                                            weight=None, normalized=False)
+        C = [1]
+        b = nx.group_betweenness_centrality(G, C, weight=None)
         b_answer = 0.0
         assert_equal(b, b_answer)

--- a/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
@@ -2,23 +2,32 @@
     Tests for Group Betweenness Centrality
 """
 
-from __future__ import division
+
 from nose.tools import *
 import networkx as nx
 
 
 class TestGroupBetweennessCentrality:
+
     def test_group_betweenness_centrality_1(self):
-        """Group betweenness centrality in P5 for single node group"""
+        """
+            Group betweenness centrality in P5 for single node group
+        """
         G = nx.path_graph(5)
         C = [1]
-        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, C, weight=None, normalized=False)
+        b = nx.group_betweenness_centrality(G, C,
+                                            weight=None, normalized=False)
         b_answer = 3.0
         assert_equal(b, b_answer)
+
     def test_group_betweenness_centrality_2(self):
-        """Group betweenness centrality in P5 for group with more than 1 node and normalized"""
+        """
+            Group betweenness centrality in P5 for group with more than
+            1 node and normalized
+        """
         G = nx.path_graph(5)
         C = [1, 3]
-        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, C, weight=None, normalized=True)
+        b = nx.group_betweenness_centrality(G, C,
+                                            weight=None, normalized=True)
         b_answer = 1.0
         assert_equal(b, b_answer)

--- a/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
@@ -1,0 +1,24 @@
+"""
+    Tests for Group Betweenness Centrality
+"""
+
+from __future__ import division
+from nose.tools import *
+import networkx as nx
+
+
+class TestGroupBetweennessCentrality:
+    def test_group_betweenness_centrality_1(self):
+        """Group betweenness centrality in P5 for single node group"""
+        G = nx.path_graph(5)
+        C = [1]
+        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, weight=None, normalized=False)
+        b_answer = 3.0
+        assert_equal(b, b_answer)
+    def test_group_betweenness_centrality_2(self):
+        """Group etweenness centrality in P5 for group with more than 1 node and normalized"""
+        G = nx.path_graph(5)
+        C = [1, 3]
+        b = nx.algorithms.centrality.group.group_betweenness_centrality(G, weight=None, normalized=True)
+        b_answer = 0.25
+        assert_equal(b, b_answer)

--- a/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
@@ -20,5 +20,5 @@ class TestGroupBetweennessCentrality:
         G = nx.path_graph(5)
         C = [1, 3]
         b = nx.algorithms.centrality.group.group_betweenness_centrality(G, C, weight=None, normalized=True)
-        b_answer = 0.25
+        b_answer = 1.0
         assert_equal(b, b_answer)

--- a/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_group_betweenness_centrality.py
@@ -31,3 +31,26 @@ class TestGroupBetweennessCentrality:
                                             weight=None, normalized=True)
         b_answer = 1.0
         assert_equal(b, b_answer)
+
+    def test_group_betweenness_centrality_3(self):
+        """
+            Group betweenness centrality value of 0
+        """
+        G = nx.cycle_graph(6)
+        C = [0, 1, 5]
+        b = nx.group_betweenness_centrality(G, C,
+                                            weight=None, normalized=False)
+        b_answer = 0.0
+        assert_equal(b, b_answer)
+
+    def test_group_betweenness_centrality_4(self):
+        """
+            Group betweenness centrality in a disconnected graph
+        """
+        G = nx.path_graph(5)
+        G.remove_edge(0, 1)
+        C = [0, 1, 2]
+        b = nx.group_betweenness_centrality(G, C,
+                                            weight=None, normalized=False)
+        b_answer = 0.0
+        assert_equal(b, b_answer)


### PR DESCRIPTION
Added group.py, a new module, to networkx.algorithms.centrality for group centrality computation functions. Added function for group betweenness centrality. Please do review the code and suggest any changes/improvements. Thanks.
(Future work: Adding functions for group closeness and group degree centralities)
Issue: #3388 