### PR TITLE
Fix centrality betweeness subset

### DIFF
--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -192,15 +192,16 @@ def betweenness_centrality_source(G, normalized=True, weight=None,
 
 
 def _accumulate_subset(betweenness, S, P, sigma, s, targets):
-    delta = dict.fromkeys(S, 0)
-    target_set = set(targets)
+    delta = dict.fromkeys(S, 0.0)
+    target_set = set(targets) - {s}
     while S:
         w = S.pop()
+        if w in target_set:
+            coeff = (delta[w] + 1.0)/ sigma[w]
+        else:
+            coeff = delta[w] / sigma[w]
         for v in P[w]:
-            if w in target_set:
-                delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w])
-            else:
-                delta[v] += delta[w] / len(P[w])
+            delta[v] += sigma[v] * coeff
         if w != s:
             betweenness[w] += delta[w]
     return betweenness

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
@@ -77,7 +77,23 @@ class TestSubsetBetweennessCentrality:
     def test_diamond_multi_path(self):
         """Betweenness Centrality Subset: Diamond Multi Path"""
         G = nx.Graph()
-        G.add_edges_from([(1,2), (1,3), (1,4), (1,5), (1,10), (10,11), (11,12), (12,9), (2,6), (3,6), (4,6), (5,7), (7,8), (6,8), (8,9)])
+        G.add_edges_from([
+            (1,2), 
+            (1,3), 
+            (1,4), 
+            (1,5), 
+            (1,10), 
+            (10,11), 
+            (11,12), 
+            (12,9), 
+            (2,6), 
+            (3,6), 
+            (4,6), 
+            (5,7), 
+            (7,8), 
+            (6,8), 
+            (8,9)
+        ])
         b = nx.betweenness_centrality_subset(
             G,
             sources=[1],

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
@@ -6,7 +6,7 @@ import networkx as nx
 class TestSubsetBetweennessCentrality:
 
     def test_K5(self):
-        """Betweenness centrality: K5"""
+        """Betweenness Centrality Subset: K5"""
         G = nx.complete_graph(5)
         b = nx.betweenness_centrality_subset(G, sources=[0], targets=[1, 3],
                                              weight=None)
@@ -15,7 +15,7 @@ class TestSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P5_directed(self):
-        """Betweenness centrality: P5 directed"""
+        """Betweenness Centrality Subset: P5 directed"""
         G = nx.DiGraph()
         nx.add_path(G, range(5))
         b_answer = {0: 0, 1: 1, 2: 1, 3: 0, 4: 0, 5: 0}
@@ -25,7 +25,7 @@ class TestSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P5(self):
-        """Betweenness centrality: P5"""
+        """Betweenness Centrality Subset: P5"""
         G = nx.Graph()
         nx.add_path(G, range(5))
         b_answer = {0: 0, 1: 0.5, 2: 0.5, 3: 0, 4: 0, 5: 0}
@@ -35,7 +35,7 @@ class TestSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P5_multiple_target(self):
-        """Betweenness centrality: P5 multiple target"""
+        """Betweenness Centrality Subset: P5 multiple target"""
         G = nx.Graph()
         nx.add_path(G, range(5))
         b_answer = {0: 0, 1: 1, 2: 1, 3: 0.5, 4: 0, 5: 0}
@@ -45,7 +45,7 @@ class TestSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_box(self):
-        """Betweenness centrality: box"""
+        """Betweenness Centrality Subset: box"""
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 3), (2, 3)])
         b_answer = {0: 0, 1: 0.25, 2: 0.25, 3: 0}
@@ -55,7 +55,7 @@ class TestSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_box_and_path(self):
-        """Betweenness centrality: box and path"""
+        """Betweenness Centrality Subset: box and path"""
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (4, 5)])
         b_answer = {0: 0, 1: 0.5, 2: 0.5, 3: 0.5, 4: 0, 5: 0}
@@ -65,7 +65,7 @@ class TestSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_box_and_path2(self):
-        """Betweenness centrality: box and path multiple target"""
+        """Betweenness Centrality Subset: box and path multiple target"""
         G = nx.Graph()
         G.add_edges_from([(0, 1), (1, 2), (2, 3), (1, 20), (20, 3), (3, 4)])
         b_answer = {0: 0, 1: 1.0, 2: 0.5, 20: 0.5, 3: 0.5, 4: 0}
@@ -74,11 +74,40 @@ class TestSubsetBetweennessCentrality:
         for n in sorted(G):
             assert_almost_equal(b[n], b_answer[n])
 
+    def test_diamond_multi_path(self):
+        """Betweenness Centrality Subset: Diamond Multi Path"""
+        G = nx.Graph()
+        G.add_edges_from([(1,2), (1,3), (1,4), (1,5), (1,10), (10,11), (11,12), (12,9), (2,6), (3,6), (4,6), (5,7), (7,8), (6,8), (8,9)])
+        b = nx.betweenness_centrality_subset(
+            G,
+            sources=[1],
+            targets=[9],
+            weight=None
+        )
+
+        expected_b = {
+        1: 0,
+        2: 1./10,
+        3: 1./10,
+        4: 1./10,
+        5: 1./10,
+        6: 3./10,
+        7:1./10,
+        8:4./10,
+        9:0,
+        10:1./10,
+        11:1./10,
+        12:1./10,
+        }
+
+        for n in sorted(G):
+            assert_almost_equal(b[n], expected_b[n])
+
 
 class TestBetweennessCentralitySources:
 
     def test_K5(self):
-        """Betweenness centrality: K5"""
+        """Betweenness Centrality Sources: K5"""
         G = nx.complete_graph(5)
         b = nx.betweenness_centrality_source(G, weight=None, normalized=False)
         b_answer = {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}
@@ -86,7 +115,7 @@ class TestBetweennessCentralitySources:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P3(self):
-        """Betweenness centrality: P3"""
+        """Betweenness Centrality Sources: P3"""
         G = nx.path_graph(3)
         b_answer = {0: 0.0, 1: 1.0, 2: 0.0}
         b = nx.betweenness_centrality_source(G, weight=None, normalized=True)
@@ -97,7 +126,7 @@ class TestBetweennessCentralitySources:
 class TestEdgeSubsetBetweennessCentrality:
 
     def test_K5(self):
-        """Edge betweenness centrality: K5"""
+        """Edge betweenness subset centrality: K5"""
         G = nx.complete_graph(5)
         b = nx.edge_betweenness_centrality_subset(G, sources=[0],
                                                   targets=[1, 3], weight=None)
@@ -107,7 +136,7 @@ class TestEdgeSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P5_directed(self):
-        """Edge betweenness centrality: P5 directed"""
+        """Edge betweenness subset centrality: P5 directed"""
         G = nx.DiGraph()
         nx.add_path(G, range(5))
         b_answer = dict.fromkeys(G.edges(), 0)
@@ -118,7 +147,7 @@ class TestEdgeSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P5(self):
-        """Edge betweenness centrality: P5"""
+        """Edge betweenness subset centrality: P5"""
         G = nx.Graph()
         nx.add_path(G, range(5))
         b_answer = dict.fromkeys(G.edges(), 0)
@@ -129,7 +158,7 @@ class TestEdgeSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_P5_multiple_target(self):
-        """Edge betweenness centrality: P5 multiple target"""
+        """Edge betweenness subset centrality: P5 multiple target"""
         G = nx.Graph()
         nx.add_path(G, range(5))
         b_answer = dict.fromkeys(G.edges(), 0)
@@ -141,7 +170,7 @@ class TestEdgeSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_box(self):
-        """Edge etweenness centrality: box"""
+        """Edge etweenness subset centrality: box"""
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 3), (2, 3)])
         b_answer = dict.fromkeys(G.edges(), 0)
@@ -153,7 +182,7 @@ class TestEdgeSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_box_and_path(self):
-        """Edge etweenness centrality: box and path"""
+        """Edge etweenness subset centrality: box and path"""
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (4, 5)])
         b_answer = dict.fromkeys(G.edges(), 0)
@@ -166,7 +195,7 @@ class TestEdgeSubsetBetweennessCentrality:
             assert_almost_equal(b[n], b_answer[n])
 
     def test_box_and_path2(self):
-        """Edge betweenness centrality: box and path multiple target"""
+        """Edge betweenness subset centrality: box and path multiple target"""
         G = nx.Graph()
         G.add_edges_from([(0, 1), (1, 2), (2, 3), (1, 20), (20, 3), (3, 4)])
         b_answer = dict.fromkeys(G.edges(), 0)


### PR DESCRIPTION
This proposed changeset fixes a bug in the implementation of the `subset centrality betweeness`.

I believe that the existing implementation fails to take into account the case where a node lies on multiple shortest paths, and only accounts for the number of predecessors of those nodes.
This changeset adds a test case that illustrates the problem, along with a proposed fix. I also took the liberty of fixing what apperas to be a mistake in some tests fixtures names.