### PR TITLE
Implemented subgraph monomorphism

### DIFF
--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -317,11 +317,11 @@ class GraphMatcher(object):
             yield self.mapping
         else:
             for G1_node, G2_node in self.candidate_pairs_iter():
-                if self.syntactic_feasibility(G1_node, G2_node, mono=mono):
+                if self.syntactic_feasibility(G1_node, G2_node):
                     if self.semantic_feasibility(G1_node, G2_node):
                         # Recursive call, adding the feasible state.
                         newstate = self.state.__class__(self, G1_node, G2_node)
-                        for mapping in self.match(mono=mono):
+                        for mapping in self.match():
                             yield mapping
 
                         # restore data structures

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -215,7 +215,7 @@ def test_selfloop_mono():
                 gm = iso.GraphMatcher(g2, g1)
             else:
                 gm = iso.DiGraphMatcher(g2, g1)
-            assert_true(!gm.subgraph_is_monomorphic())
+            assert_true(not gm.subgraph_is_monomorphic())
 
 
 def test_isomorphism_iter1():
@@ -258,7 +258,7 @@ def test_monomorphism_iter1():
     for ii in range(3):
         gm12.subgraph_is_monomorphic()
     #Check if StopIteration exception returns False
-    assert_true(!(gm12.subgraph_is_monomorphic()))
+    assert_true(not gm12.subgraph_is_monomorphic())
 
 
 def test_isomorphism_iter2():

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -35,6 +35,8 @@ class TestWikipediaExample(object):
         g2.add_edges_from(self.g2edges)
         gm = iso.GraphMatcher(g1, g2)
         assert_true(gm.is_isomorphic())
+        #Just testing some cases
+        assert_true(gm.subgraph_is_monomorphic())
 
         mapping = sorted(gm.mapping.items())
 # this mapping is only one of the possibilies
@@ -51,6 +53,7 @@ class TestWikipediaExample(object):
         g3 = g2.subgraph([1, 2, 3, 4])
         gm = iso.GraphMatcher(g1, g3)
         assert_true(gm.subgraph_is_isomorphic())
+
 
     def test_subgraph_mono(self):
         g1 = nx.Graph()
@@ -110,6 +113,9 @@ class TestVF2GraphDB(object):
         graph = self.create_graph(os.path.join(head, 'si2_b06_m200.B99'))
         gm = iso.GraphMatcher(graph, subgraph)
         assert_true(gm.subgraph_is_isomorphic())
+        #Just testing some cases
+        assert_true(gm.subgraph_is_monomorphic())
+
         
     # There isn't a similar test implemented for subgraph monomorphism,
     # feel free to create one.
@@ -282,9 +288,13 @@ def test_noncomparable_nodes():
     G = nx.path_graph([node1, node2, node3])
     gm = iso.GraphMatcher(G, G)
     assert_true(gm.is_isomorphic())
+    #Just testing some cases
+    assert_true(gm.subgraph_is_monomorphic())
 
     # DiGraph
     G = nx.path_graph([node1, node2, node3], create_using=nx.DiGraph)
     H = nx.path_graph([node3, node2, node1], create_using=nx.DiGraph)
     dgm = iso.DiGraphMatcher(G, H)
     assert_true(dgm.is_isomorphic())
+    #Just testing some cases
+    assert_true(gm.subgraph_is_monomorphic())

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -256,7 +256,7 @@ def test_monomorphism_iter1():
     assert_equal(len(x), 3)
     gm21 = iso.DiGraphMatcher(g2, g1)
     #Check if StopIteration exception returns False
-    assert_true(not gm12.subgraph_is_monomorphic())
+    assert_true(not gm21.subgraph_is_monomorphic())
 
 
 def test_isomorphism_iter2():

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -59,14 +59,6 @@ class TestWikipediaExample(object):
         g2.add_edges_from([[1, 2], [2, 3], [3, 4]])
         gm = iso.GraphMatcher(g1, g2)
         assert_true(gm.subgraph_is_monomorphic())
-        
-    def test_subgraph_mono2(self):
-        g1 = nx.Graph()
-        g2 = nx.Graph()
-        g1.add_edges_from(self.g1edges)
-        g2.add_edges_from([[1, 2], [2, 3], [3, 4], [4, 5]])
-        gm = iso.GraphMatcher(g1, g2)
-        assert_false(gm.subgraph_is_monomorphic())
 
 
 class TestVF2GraphDB(object):

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -254,9 +254,7 @@ def test_monomorphism_iter1():
     assert_true({'A': 'Y', 'B': 'Z', 'C': 'X'} in x)
     assert_true({'A': 'Z', 'B': 'X', 'C': 'Y'} in x)
     assert_equal(len(x), 3)
-    tmp = True
-    for ii in range(3):
-        gm12.subgraph_is_monomorphic()
+    gm21 = iso.DiGraphMatcher(g2, g1)
     #Check if StopIteration exception returns False
     assert_true(not gm12.subgraph_is_monomorphic())
 

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -208,8 +208,6 @@ def test_isomorphism_iter1():
 
 
 def test_monomorphism_iter1():
-    # As described in:
-    # http://groups.google.com/group/networkx-discuss/browse_thread/thread/2ff65c67f5e3b99f/d674544ebea359bb?fwc=1
     g1 = nx.DiGraph()
     g2 = nx.DiGraph()
     g1.add_edge('A', 'B')

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -59,6 +59,14 @@ class TestWikipediaExample(object):
         g2.add_edges_from([[1, 2], [2, 3], [3, 4]])
         gm = iso.GraphMatcher(g1, g2)
         assert_true(gm.subgraph_is_monomorphic())
+        
+    def test_subgraph_mono2(self):
+        g1 = nx.Graph()
+        g2 = nx.Graph()
+        g1.add_edges_from(self.g1edges)
+        g2.add_edges_from([[1, 2], [2, 3], [3, 4], [4, 5]])
+        gm = iso.GraphMatcher(g1, g2)
+        assert_false(gm.subgraph_is_monomorphic())
 
 
 class TestVF2GraphDB(object):
@@ -110,6 +118,9 @@ class TestVF2GraphDB(object):
         graph = self.create_graph(os.path.join(head, 'si2_b06_m200.B99'))
         gm = iso.GraphMatcher(graph, subgraph)
         assert_true(gm.subgraph_is_isomorphic())
+        
+    # There isn't a similar test implemented for subgraph monomorphism,
+    # feel free to create one.
 
 
 class TestAtlas(object):
@@ -163,6 +174,8 @@ def test_multiedge():
             else:
                 gm = iso.DiGraphMatcher(g1, g2)
             assert_true(gm.is_isomorphic())
+            #Testing if monomorphism works in multigraphs
+            assert_true(gm.subgraph_is_monomorphic())
 
 
 def test_selfloop():
@@ -183,6 +196,8 @@ def test_selfloop():
             else:
                 gm = iso.DiGraphMatcher(g1, g2)
             assert_true(gm.is_isomorphic())
+            #Testing if monomorphism works in multigraphs
+            assert_true(gm.subgraph_is_monomorphic())
 
 
 def test_isomorphism_iter1():
@@ -259,6 +274,8 @@ def test_multiple():
             gmA = iso.DiGraphMatcher(g1, g2)
         assert_true(gmA.subgraph_is_isomorphic())
         assert_true(gmB.subgraph_is_isomorphic())
+        assert_true(gmA.subgraph_is_monomorphic())
+        assert_true(gmB.subgraph_is_monomorphic())
 #        for m in [gmB.mapping, gmB.mapping]:
 #            assert_true(m['A'] == 'A')
 #            assert_true(m['B'] == 'B')

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -52,6 +52,16 @@ class TestWikipediaExample(object):
         gm = iso.GraphMatcher(g1, g3)
         assert_true(gm.subgraph_is_isomorphic())
 
+    def test_subgraph_mono(self):
+        g1 = nx.Graph()
+        g2 = nx.Graph()
+        g1.add_edges_from(self.g1edges)
+        g2.add_edges_from(self.g2edges)
+        g3 = g2.subgraph([1, 2, 3, 4])
+        g3.remove_edge(1,4)
+        gm = iso.GraphMatcher(g1, g3)
+        assert_true(gm.subgraph_is_monomorphic())
+
 
 class TestVF2GraphDB(object):
     # http://amalfi.dis.unina.it/graph/db/
@@ -197,6 +207,24 @@ def test_isomorphism_iter1():
     assert_true({'B': 'Z', 'C': 'Y'} in y)
     assert_equal(len(x), len(y))
     assert_equal(len(x), 2)
+
+
+def test_monomorphism_iter1():
+    # As described in:
+    # http://groups.google.com/group/networkx-discuss/browse_thread/thread/2ff65c67f5e3b99f/d674544ebea359bb?fwc=1
+    g1 = nx.DiGraph()
+    g2 = nx.DiGraph()
+    g1.add_edge('A', 'B')
+    g1.add_edge('B', 'C')
+    g1.add_edge('C', 'A')
+    g2.add_edge('X', 'Y')
+    g2.add_edge('Y', 'Z')
+    gm12 = iso.DiGraphMatcher(g1, g2)
+    x = list(gm12.subgraph_monomorphisms_iter())
+    assert_true({'A': 'X', 'B': 'Y', 'C': 'Z'} in x)
+    assert_true({'A': 'Y', 'B': 'Z', 'C': 'X'} in x)
+    assert_true({'A': 'Z', 'B': 'X', 'C': 'Y'} in x)
+    assert_equal(len(x), 3)
 
 
 def test_isomorphism_iter2():

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -194,8 +194,28 @@ def test_selfloop():
             else:
                 gm = iso.DiGraphMatcher(g1, g2)
             assert_true(gm.is_isomorphic())
-            #Testing if monomorphism works in multigraphs
-            assert_true(gm.subgraph_is_monomorphic())
+            
+
+def test_selfloop_mono():
+    # Simple test for graphs with selfloops
+    edges0 = [(0, 1), (0, 2), (1, 2), (1, 3),
+             (2, 4), (3, 1), (3, 2), (4, 2), (4, 5), (5, 4)]
+    edges = edges0 + [(2, 2)]
+    nodes = list(range(6))
+
+    for g1 in [nx.Graph(), nx.DiGraph()]:
+        g1.add_edges_from(edges)
+        for _ in range(100):
+            new_nodes = list(nodes)
+            random.shuffle(new_nodes)
+            d = dict(zip(nodes, new_nodes))
+            g2 = nx.relabel_nodes(g1, d)
+            g2.remove_edges_from(g2.selfloop_edges())
+            if not g1.is_directed():
+                gm = iso.GraphMatcher(g2, g1)
+            else:
+                gm = iso.DiGraphMatcher(g2, g1)
+            assert_true(!gm.subgraph_is_monomorphic())
 
 
 def test_isomorphism_iter1():
@@ -234,6 +254,11 @@ def test_monomorphism_iter1():
     assert_true({'A': 'Y', 'B': 'Z', 'C': 'X'} in x)
     assert_true({'A': 'Z', 'B': 'X', 'C': 'Y'} in x)
     assert_equal(len(x), 3)
+    tmp = True
+    for ii in range(3):
+        gm12.subgraph_is_monomorphic()
+    #Check if StopIteration exception returns False
+    assert_true(!(gm12.subgraph_is_monomorphic()))
 
 
 def test_isomorphism_iter2():

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -56,10 +56,8 @@ class TestWikipediaExample(object):
         g1 = nx.Graph()
         g2 = nx.Graph()
         g1.add_edges_from(self.g1edges)
-        g2.add_edges_from(self.g2edges)
-        g3 = g2.subgraph([1, 2, 3, 4])
-        g3.remove_edge(1,4)
-        gm = iso.GraphMatcher(g1, g3)
+        g2.add_edges_from([[1, 2], [2, 3], [3, 4]])
+        gm = iso.GraphMatcher(g1, g2)
         assert_true(gm.subgraph_is_monomorphic())
 
 


### PR DESCRIPTION
It is now possible to search for subgraph monomorphisms by using `subgraph_is_monomorphic()` and `subgraph_monomorphisms_iter()` in the same way that `subgraph_is_isomorphic()` and `subgraph_isomorphisms_iter()` is used, respectively.