### PR TITLE
Faster transitive_closure using BFS on TC

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -505,7 +505,7 @@ def transitive_closure(G):
     """
     TC = G.copy()
     for v in G:
-        TC.add_edges_from((v, u) for u in nx.algorithms.dag.descendants(TC, v))
+        TC.add_edges_from((v, u) for u in descendants(TC, v))
     return TC
 
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -505,8 +505,7 @@ def transitive_closure(G):
     """
     TC = G.copy()
     for v in G:
-        TC.add_edges_from((v, u) for u in nx.dfs_preorder_nodes(G, source=v)
-                          if v != u)
+        TC.add_edges_from((v, u) for u in nx.algorithms.dag.descendants(TC, v))
     return TC
 
 


### PR DESCRIPTION
This is a simple modification of the naive approach currently implemented in networkx: for each vertex in the graph, add all edges from that vertex to its descendants. My two changes are pretty minor and linked:

    1) I use BFS instead of DFS (through the descendants function);
    2) I traverse the transitive closure instead of the original graph.

The rationale is that as we keep adding shortcuts to the transitive closure, we'll eventually reach all accessible vertices quicker with a BFS than with a DFS.

Surprisingly, change 2) does not seem to have any impact. Change 1) on the other hand resulted in more than a 10x-speedup in my tests (random digraphs on >= 400 vertices generated by fast_gnp_random_graph (p >= .5)).