### PR TITLE
Faster transitive closure computation for DAGs

### DIFF
--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -33,17 +33,6 @@ Bethe Hessian Matrix
 
    bethe_hessian_matrix
 
-Spectrum
----------
-.. automodule:: networkx.linalg.spectrum
-.. autosummary::
-   :toctree: generated/
-
-   laplacian_spectrum
-   bethe_hessian_spectrum
-   adjacency_spectrum
-   modularity_spectrum
-
 Algebraic Connectivity
 ----------------------
 .. automodule:: networkx.linalg.algebraicconnectivity
@@ -73,3 +62,15 @@ Modularity Matrices
 
    modularity_matrix
    directed_modularity_matrix
+
+Spectrum
+---------
+.. automodule:: networkx.linalg.spectrum
+.. autosummary::
+   :toctree: generated/
+
+   adjacency_spectrum
+   laplacian_spectrum
+   bethe_hessian_spectrum
+   normalized_laplacian_spectrum
+   modularity_spectrum

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -693,7 +693,7 @@ def antichains(G):
     .. [1] Free Lattices, by R. Freese, J. Jezek and J. B. Nation,
        AMS, Vol 42, 1995, p. 226.
     """
-    TC = nx.transitive_closure(G)
+    TC = nx.transitive_closure_dag(G)
     antichains_stacks = [([], list(reversed(list(nx.topological_sort(G)))))]
     while antichains_stacks:
         (antichain, stack) = antichains_stacks.pop()

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -564,7 +564,7 @@ def transitive_closure(G):
 
 
 @not_implemented_for('undirected')
-def transitive_closure_dag(G):
+def transitive_closure_dag(G, topo_order=None):
     """ Returns the transitive closure of a directed acyclic graph. This
     function is faster than the function `transitive_closure`, but will fail
     if the graph has a cycle.
@@ -577,6 +577,9 @@ def transitive_closure_dag(G):
     ----------
     G : NetworkX DiGraph
         A directed acyclic graph (DAG)
+
+    topo_order: list or tuple, optional
+        A topological order for G (if None, the function will compute one)
 
     Returns
     -------
@@ -595,11 +598,14 @@ def transitive_closure_dag(G):
     This algorithm is probably simple enough to be well-known but I didn't find
     a mention in the literature.
     """
+    if topo_order is None:
+        topo_order = list(topological_sort(G))
+
     TC = G.copy()
 
     # idea: traverse vertices following a reverse topological order, connecting
     # each vertex to its descendants at distance 2 as we go
-    for v in list(topological_sort(G))[-1::-1]:
+    for v in topo_order[-1::-1]:
         TC.add_edges_from((v, u) for u in descendants_at_distance(TC, v, 2))
 
     return TC
@@ -693,8 +699,9 @@ def antichains(G):
     .. [1] Free Lattices, by R. Freese, J. Jezek and J. B. Nation,
        AMS, Vol 42, 1995, p. 226.
     """
-    TC = nx.transitive_closure_dag(G)
-    antichains_stacks = [([], list(reversed(list(nx.topological_sort(G)))))]
+    topo_order = list(nx.topological_sort(G))
+    TC = nx.transitive_closure_dag(G, topo_order)
+    antichains_stacks = [([], list(reversed(topo_order)))]
     while antichains_stacks:
         (antichain, stack) = antichains_stacks.pop()
         # Invariant:

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -36,6 +36,7 @@ from networkx.utils import generate_unique_node
 from networkx.utils import not_implemented_for
 
 __all__ = ['descendants',
+           'descendants_at_distance',
            'ancestors',
            'topological_sort',
            'lexicographical_topological_sort',
@@ -43,6 +44,7 @@ __all__ = ['descendants',
            'is_directed_acyclic_graph',
            'is_aperiodic',
            'transitive_closure',
+           'transitive_closure_dag',
            'transitive_reduction',
            'antichains',
            'dag_longest_path',

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -28,7 +28,8 @@ from itertools import starmap
 import heapq
 
 import networkx as nx
-from networkx.algorithms.traversal.breadth_first_search import descendants_at_distance
+from networkx.algorithms.traversal.breadth_first_search import \
+    descendants_at_distance
 from networkx.generators.trees import NIL
 from networkx.utils import arbitrary_element
 from networkx.utils import consume

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -566,7 +566,7 @@ def transitive_closure(G):
 @not_implemented_for('undirected')
 def transitive_closure_dag(G):
     """ Returns the transitive closure of a directed acyclic graph. This
-    function is faster than the function `transitive_closure`, but will faill
+    function is faster than the function `transitive_closure`, but will fail
     if the graph has a cycle.
 
     The transitive closure of G = (V,E) is a graph G+ = (V,E+) such that

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -311,6 +311,29 @@ class TestDAG:
         for u, v in G.edges():
             assert_equal(G.get_edge_data(u, v), H.get_edge_data(u, v))
 
+    def test_transitive_closure_dag(self):
+        G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
+        transitive_closure = nx.algorithms.dag.transitive_closure_dag
+        solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
+        assert_edges_equal(transitive_closure(G).edges(), solution)
+        G = nx.DiGraph([(1, 2), (2, 3), (2, 4)])
+        solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)]
+        assert_edges_equal(transitive_closure(G).edges(), solution)
+        G = nx.Graph([(1, 2), (2, 3), (3, 4)])
+        assert_raises(nx.NetworkXNotImplemented, transitive_closure, G)
+
+        # test if edge data is copied
+        G = nx.DiGraph([(1, 2, {"a": 3}), (2, 3, {"b": 0}), (3, 4)])
+        H = transitive_closure(G)
+        for u, v in G.edges():
+            assert_equal(G.get_edge_data(u, v), H.get_edge_data(u, v))
+
+        k = 10
+        G = nx.DiGraph((i, i + 1, {"foo": "bar", "weight": i}) for i in range(k))
+        H = transitive_closure(G)
+        for u, v in G.edges():
+            assert_equal(G.get_edge_data(u, v), H.get_edge_data(u, v))
+
     def test_transitive_reduction(self):
         G = nx.DiGraph([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)])
         transitive_reduction = nx.algorithms.dag.transitive_reduction

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -17,7 +17,10 @@
 import networkx as nx
 from collections import deque
 
-__all__ = ['bfs_edges', 'bfs_tree', 'bfs_predecessors', 'bfs_successors']
+__all__ = [
+    'bfs_edges', 'bfs_tree', 'bfs_predecessors', 'bfs_successors',
+    'descendants_at_distance'
+]
 
 
 def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
@@ -301,3 +304,44 @@ def bfs_successors(G, source, depth_limit=None):
         children = [c]
         parent = p
     yield (parent, children)
+
+
+def descendants_at_distance(G, source, distance):
+    """Returns all nodes at a fixed `distance` from `source` in `G`.
+
+    Parameters
+    ----------
+    G : NetworkX DiGraph
+        A directed graph
+    source : node in `G`
+    distance : the distance of the wanted nodes from `source`
+
+    Returns
+    -------
+    set()
+        The descendants of `source` in `G` at the given `distance` from `source`
+    """
+    if not G.has_node(source):
+        raise nx.NetworkXError("The node %s is not in the graph." % source)
+    current_distance = 0
+    queue = {source}
+    visited = {source}
+
+    # this is basically BFS, except that the queue only stores the nodes at
+    # current_distance from source at each iteration
+    while queue:
+        if current_distance == distance:
+            return queue
+
+        current_distance += 1
+
+        next_vertices = set()
+        for vertex in queue:
+            for child in G[vertex]:
+                if child not in visited:
+                    visited.add(child)
+                    next_vertices.add(child)
+
+        queue = next_vertices
+
+    return set()


### PR DESCRIPTION
This is an improved algorithm for computing the transitive closure of a DAG using topological_sort (so an exception will be raised if the input graph is not a DAG): traverse vertices following a reverse topological order, and connect each vertex to its descendants at distance 2 as we go. The topological order guarantees that each successor v of a node u is connected to all descendants of u in the transitive closure, and therefore it is enough to connect u to nodes at distance 2 from u rather than attempting to explore all descendants.

The algorithm is probably folklore but I didn't find a reference in my books, feel free to add one if you can.

I also added a function to compute the descendants of a node at a fixed distance. `bfs_successors` worked just as well in my tests but resulted in code that was harder to read. Moreover, the new function can be of general interest and is less memory-hungry since each iteration only stores nodes at a fixed distance, whereas `bfs_successors` will keep previous nodes as well.

A taste of the kind of results one can expect using the time function (I used assert to check that both computed closures have the same vertex and edge sets): 

    $ python3 better_transitive_closure_dag.py 
    Testing transitive closure on a random DAG with 800 nodes and 239532 edges
    Running time for NetworkX's TC:             17.484230041503906
    Running time for TC dag-optimized:           3.222315549850464

I'd gladly add my benchmarks but I'm at loss as to where to include them. I shamelessly copied the tests for `transitive_closure` in the meantime.