### PR TITLE
Set seed in random_degree_sequence_graph docstring test

### DIFF
--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -745,7 +745,7 @@ def random_degree_sequence_graph(sequence, seed=None, tries=10):
     Examples
     --------
     >>> sequence = [1, 2, 2, 3]
-    >>> G = nx.random_degree_sequence_graph(sequence)
+    >>> G = nx.random_degree_sequence_graph(sequence, seed=42)
     >>> sorted(d for n, d in G.degree())
     [1, 2, 2, 3]
     """


### PR DESCRIPTION
Aims to fix issue #3450 by setting random seed value in the docstring test.

The seed has been sent to an `int` value of 42. Let me know if it should be changed to a random state or if any other change is required.