### PR TITLE
No multigraphs for betweenness

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -14,12 +14,14 @@ from itertools import count
 
 import networkx as nx
 from networkx.utils import py_random_state
+from networkx.utils.decorators import not_implemented_for
 
 __all__ = ['betweenness_centrality', 'edge_betweenness_centrality',
            'edge_betweenness']
 
 
 @py_random_state(5)
+@not_implemented_for('multigraph')
 def betweenness_centrality(G, k=None, normalized=True, weight=None,
                            endpoints=False, seed=None):
     r"""Compute the shortest-path betweenness centrality for nodes.


### PR DESCRIPTION
Aims to fix issue #3432 by adding `@not_implemented_for('multigraph')` in `betweenness_centrality`. If the generalised shortest path functions should be used, or if the custom Dijkstra code should be modified rather than not implementing `betweenness_centrality` for multigraph, let me know. Thanks!