### PR TITLE
Adding onion decomposition

### DIFF
--- a/doc/reference/algorithms/core.rst
+++ b/doc/reference/algorithms/core.rst
@@ -12,3 +12,4 @@ Cores
    k_crust
    k_corona
    k_truss
+   onion_layers

--- a/doc/reference/algorithms/core.rst
+++ b/doc/reference/algorithms/core.rst
@@ -11,3 +11,4 @@ Cores
    k_shell
    k_crust
    k_corona
+   k_truss

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -433,7 +433,8 @@ def onion_layers(G):
     """Returns the layer of each vertex in the onion decomposition of the graph.
 
     The onion decomposition refines the k-core decomposition by providing
-    information on the internal organization of each k-shell.
+    information on the internal organization of each k-shell. It is usually
+    used alongside the `core numbers`.
 
     Parameters
     ----------
@@ -443,7 +444,8 @@ def onion_layers(G):
     Returns
     -------
     od_layers : dictionary
-       A dictionary keyed by vertex to the onion layer.
+       A dictionary keyed by vertex to the onion layer. The layers are
+       contiguous integers starting at 1.
 
     Raises
     ------

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -490,7 +490,7 @@ def onion_layers(G):
     current_core = 1
     current_layer = 1
     # Sets vertices of degree 0 to layer 1, if any.
-    isolated_nodes = nx.isolates(G)
+    isolated_nodes = [v for v in nx.isolates(G)]
     if len(isolated_nodes) > 0:
         for v in isolated_nodes:
             od_layers[v] = current_layer

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -429,6 +429,7 @@ def k_truss(G, k):
 
 @not_implemented_for('directed')
 @not_implemented_for('multigraph')
+@not_implemented_for('directed')
 def onion_layers(G):
     """Returns the layer of each vertex in the onion decomposition of the graph.
 
@@ -470,53 +471,53 @@ def onion_layers(G):
        L. Hébert-Dufresne, J. A. Grochow, and A. Allard
        Scientific Reports 6, 31708 (2016)
        http://doi.org/10.1038/srep31708
+    .. [2] Percolation and the effective structure of complex networks
+       A. Allard and L. Hébert-Dufresne
+       Physical Review X 9, 011023 (2019)
+       http://doi.org/10.1103/PhysRevX.9.011023
     """
     if nx.number_of_selfloops(G) > 0:
-        msg = ('Input graph has self loops which is not permitted; '
+        msg = ('Input graph contains self loops which is not permitted; '
                'Consider using G.remove_edges_from(nx.selfloop_edges(G)).')
         raise NetworkXError(msg)
-    if nx.is_directed(G):
-        msg = ('Input graph is directed which is not permitted; '
-               'Consider using G.to_undirected().')
-        raise NetworkXError(msg)
     # Dictionaries to register the k-core/onion decompositions.
-    # _coreness_map = {}
     od_layers = {}
     # Adjacency list
     neighbors = {v: list(nx.all_neighbors(G, v)) for v in G}
     # Effective degree of nodes.
     degrees = dict(G.degree())
     # Performs the onion decomposition.
-    _current_core = 1
-    _current_layer = 1
-    # Sets vertices of degree 0 to layer 1.
-    for v in nx.isolates(G):
-        od_layers[v] = _current_layer
-        degrees.pop(v)
-    if len(degrees) < G.number_of_nodes():
-        _current_layer = 2
+    current_core = 1
+    current_layer = 1
+    # Sets vertices of degree 0 to layer 1, if any.
+    isolated_nodes = nx.isolates(G)
+    if len(isolated_nodes) > 0:
+        for v in isolated_nodes:
+            od_layers[v] = current_layer
+            degrees.pop(v)
+        current_layer = 2
+    # Finds the layer for the remaining nodes.
     while len(degrees) > 0:
         # Sets the order for looking at nodes.
         nodes = sorted(degrees, key=degrees.get)
         # Sets properly the current core.
-        _min_degree = degrees[nodes[0]]
-        if _min_degree > _current_core:
-            _current_core = _min_degree
+        min_degree = degrees[nodes[0]]
+        if min_degree > current_core:
+            current_core = min_degree
         # Identifies vertices in the current layer.
-        _this_layer_ = []
+        this_layer = []
         for n in nodes:
-            if degrees[n] > _current_core:
+            if degrees[n] > current_core:
                 break
-            _this_layer_.append(n)
+            this_layer.append(n)
         # Identifies the core/layer of the vertices in the current layer.
-        for v in _this_layer_:
-            # _coreness_map[v] = _current_core
-            od_layers[v] = _current_layer
+        for v in this_layer:
+            od_layers[v] = current_layer
             for n in neighbors[v]:
                 neighbors[n].remove(v)
                 degrees[n] = degrees[n] - 1
             degrees.pop(v)
         # Updates the layer count.
-        _current_layer = _current_layer + 1
+        current_layer = current_layer + 1
     # Returns the dictionaries containing the onion layer of each vertices.
     return od_layers

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -2,12 +2,14 @@
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
+#    Antoine Allard <antoine.allard@phy.ulaval.ca>
 #    All rights reserved.
 #    BSD license.
 #
 # Authors: Dan Schult (dschult@colgate.edu)
 #          Jason Grout (jason-sage@creativetrax.com)
 #          Aric Hagberg (hagberg@lanl.gov)
+#          Antoine Allard (antoine.allard@phy.ulaval.ca)
 """
 Find the k-cores of a graph.
 
@@ -30,13 +32,20 @@ is the k-core.
 D-cores: Measuring Collaboration of Directed Graphs Based on Degeneracy
 Christos Giatsidis, Dimitrios M. Thilikos, Michalis Vazirgiannis, ICDM 2011.
 http://www.graphdegeneracy.org/dcores_ICDM_2011.pdf
+
+Multi-scale structure and topological anomaly detection via a new network \
+statistic: The onion decomposition
+L. Hébert-Dufresne, J. A. Grochow, and A. Allard
+Scientific Reports 6, 31708 (2016)
+http://doi.org/10.1038/srep31708
+
 """
 import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils import not_implemented_for
 
-__all__ = ['core_number', 'find_cores', 'k_core',
-           'k_shell', 'k_crust', 'k_corona', 'k_truss']
+__all__ = ['core_number', 'find_cores', 'k_core', 'k_shell',
+           'k_crust', 'k_corona', 'k_truss', 'onion_layers']
 
 
 @not_implemented_for('multigraph')
@@ -378,6 +387,7 @@ def k_truss(G, k):
     Raises
     ------
     NetworkXError
+
       The k-truss is not defined for graphs with self loops or parallel edges
       or directed graphs.
 
@@ -415,3 +425,90 @@ def k_truss(G, k):
         H.remove_nodes_from(list(nx.isolates(H)))
 
     return H
+
+
+@not_implemented_for('directed')
+@not_implemented_for('multigraph')
+def onion_layers(G):
+    """Returns the layer of each vertex in the onion decomposition of the graph.
+
+    The onion decomposition refines the k-core decomposition by providing
+    information on the internal organization of each k-shell.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+       A simple graph without self loops or parallel edges
+
+    Returns
+    -------
+    od_layers : dictionary
+       A dictionary keyed by vertex to the onion layer.
+
+    Raises
+    ------
+    NetworkXError
+        The onion decomposition is not implemented for graphs with self loops
+        or parallel edges or for directed graphs.
+
+    Notes
+    -----
+    Not implemented for graphs with parallel edges or self loops.
+
+    Not implemented for directed graphs.
+
+    See Also
+    --------
+    core_number
+
+    References
+    ----------
+    .. [1] Multi-scale structure and topological anomaly detection via a new
+       network statistic: The onion decomposition
+       L. Hébert-Dufresne, J. A. Grochow, and A. Allard
+       Scientific Reports 6, 31708 (2016)
+       http://doi.org/10.1038/srep31708
+    """
+    if nx.number_of_selfloops(G) > 0:
+        msg = ('Input graph has self loops which is not permitted; '
+               'Consider using G.remove_edges_from(nx.selfloop_edges(G)).')
+        raise NetworkXError(msg)
+    if nx.is_directed(G):
+        msg = ('Input graph is directed which is not permitted; '
+               'Consider using G.to_undirected().')
+        raise NetworkXError(msg)
+    # Dictionaries to register the k-core/onion decompositions.
+    # _coreness_map = {}
+    od_layers = {}
+    # Adjacency list
+    neighbors = {v: list(nx.all_neighbors(G, v)) for v in G}
+    # Effective degree of nodes.
+    degrees = dict(G.degree())
+    # Performs the onion decomposition.
+    _current_core = 1
+    _current_layer = 1
+    while len(degrees) > 0:
+        # Sets the order for looking at nodes.
+        nodes = sorted(degrees, key=degrees.get)
+        # Sets properly the current core.
+        _min_degree = degrees[nodes[0]]
+        if _min_degree > _current_core:
+            _current_core = _min_degree
+        # Identifies vertices in the current layer.
+        _this_layer_ = []
+        for n in nodes:
+            if degrees[n] > _current_core:
+                break
+            _this_layer_.append(n)
+        # Identifies the core/layer of the vertices in the current layer.
+        for v in _this_layer_:
+            # _coreness_map[v] = _current_core
+            od_layers[v] = _current_layer
+            for n in neighbors[v]:
+                neighbors[n].remove(v)
+                degrees[n] = degrees[n] - 1
+            degrees.pop(v)
+        # Updates the layer count.
+        _current_layer = _current_layer + 1
+    # Returns the dictionaries containing the onion layer of each vertices.
+    return od_layers

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -440,13 +440,13 @@ def onion_layers(G):
     Parameters
     ----------
     G : NetworkX graph
-       A simple graph without self loops or parallel edges
+        A simple graph without self loops or parallel edges
 
     Returns
     -------
     od_layers : dictionary
-       A dictionary keyed by vertex to the onion layer. The layers are
-       contiguous integers starting at 1.
+        A dictionary keyed by vertex to the onion layer. The layers are
+        contiguous integers starting at 1.
 
     Raises
     ------

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -489,6 +489,12 @@ def onion_layers(G):
     # Performs the onion decomposition.
     _current_core = 1
     _current_layer = 1
+    # Sets vertices of degree 0 to layer 1.
+    for v in nx.isolates(G):
+        od_layers[v] = _current_layer
+        degrees.pop(v)
+    if len(degrees) < G.number_of_nodes():
+        _current_layer = 2
     while len(degrees) > 0:
         # Sets the order for looking at nodes.
         nodes = sorted(degrees, key=degrees.get)

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -124,3 +124,20 @@ class TestCore:
         # k=2
         k_corona_subgraph = nx.k_corona(self.H, k=0)
         assert_equal(sorted(k_corona_subgraph.nodes()), [0])
+
+    def test_k_truss(self):
+        # k=-1
+        k_truss_subgraph = nx.k_truss(self.G, -1)
+        assert_equal(sorted(k_truss_subgraph.nodes()), list(range(1,21)))
+        # k=0
+        k_truss_subgraph = nx.k_truss(self.G, 0)
+        assert_equal(sorted(k_truss_subgraph.nodes()), list(range(1,21)))
+        # k=1
+        k_truss_subgraph = nx.k_truss(self.G, 1)
+        assert_equal(sorted(k_truss_subgraph.nodes()), list(range(1,13)))
+        # k=2
+        k_truss_subgraph = nx.k_truss(self.G, 2)
+        assert_equal(sorted(k_truss_subgraph.nodes()), list(range(1,9)))
+        # k=3
+        k_truss_subgraph = nx.k_truss(self.G, 3)
+        assert_equal(sorted(k_truss_subgraph.nodes()), [])

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -141,3 +141,14 @@ class TestCore:
         # k=3
         k_truss_subgraph = nx.k_truss(self.G, 3)
         assert_equal(sorted(k_truss_subgraph.nodes()), [])
+
+    def test_onion_layers(self):
+        layers = nx.onion_layers(self.G)
+        nodes_by_layer = [sorted([n for n in layers if layers[n] == val])
+                          for val in range(1, 7)]
+        assert_nodes_equal(nodes_by_layer[0], [21])
+        assert_nodes_equal(nodes_by_layer[1], [17, 18, 19, 20])
+        assert_nodes_equal(nodes_by_layer[2], [10, 12, 13, 14, 15, 16])
+        assert_nodes_equal(nodes_by_layer[3], [9, 11])
+        assert_nodes_equal(nodes_by_layer[4], [1, 2, 4, 5, 6, 8])
+        assert_nodes_equal(nodes_by_layer[5], [3, 7])

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -414,7 +414,7 @@ def draw_networkx_nodes(G, pos,
                                  linewidths=linewidths,
                                  edgecolors=edgecolors,
                                  label=label)
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,
@@ -689,7 +689,7 @@ def draw_networkx_edges(G, pos,
     ax.update_datalim(corners)
     ax.autoscale_view()
 
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,
@@ -803,7 +803,7 @@ def draw_networkx_labels(G, pos,
                     )
         text_items[n] = t
 
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,
@@ -956,7 +956,7 @@ def draw_networkx_edge_labels(G, pos,
                     )
         text_items[(n1, n2)] = t
 
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -550,7 +550,6 @@ def draw_networkx_edges(G, pos,
     try:
         import matplotlib
         import matplotlib.pyplot as plt
-        import matplotlib.cbook as cb
         from matplotlib.colors import colorConverter, Colormap, Normalize
         from matplotlib.collections import LineCollection
         from matplotlib.patches import FancyArrowPatch
@@ -582,7 +581,7 @@ def draw_networkx_edges(G, pos,
 
     # Check if edge_color is an array of floats and map to edge_cmap.
     # This is the only case handled differently from matplotlib
-    if cb.iterable(edge_color) and (len(edge_color) == len(edge_pos)) \
+    if np.iterable(edge_color) and (len(edge_color) == len(edge_pos)) \
         and np.alltrue([isinstance(c,Number) for c in edge_color]):
             if edge_cmap is not None:
                 assert(isinstance(edge_cmap, Colormap))
@@ -635,7 +634,7 @@ def draw_networkx_edges(G, pos,
             x2, y2 = dst
             shrink_source = 0  # space from source to tail
             shrink_target = 0  # space from  head to target
-            if cb.iterable(node_size):  # many node sizes
+            if np.iterable(node_size):  # many node sizes
                 src_node, dst_node = edgelist[i][:2]
                 index_node = nodelist.index(dst_node)
                 marker_size = node_size[index_node]
@@ -643,7 +642,7 @@ def draw_networkx_edges(G, pos,
             else:
                 shrink_target = to_marker_edge(node_size, node_shape)
 
-            if cb.iterable(arrow_colors):
+            if np.iterable(arrow_colors):
                 if len(arrow_colors) == len(edge_pos):
                     arrow_color = arrow_colors[i]
                 elif len(arrow_colors)==1:
@@ -653,7 +652,7 @@ def draw_networkx_edges(G, pos,
             else:
                 arrow_color = edge_color
 
-            if cb.iterable(width):
+            if np.iterable(width):
                 if len(width) == len(edge_pos):
                     line_width = width[i]
                 else:
@@ -768,7 +767,6 @@ def draw_networkx_labels(G, pos,
     """
     try:
         import matplotlib.pyplot as plt
-        import matplotlib.cbook as cb
     except ImportError:
         raise ImportError("Matplotlib required for draw()")
     except RuntimeError:

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -10,7 +10,7 @@
 """
 Read graphs in GML format.
 
-"GML, the G>raph Modelling Language, is our proposal for a portable
+"GML, the Graph Modelling Language, is our proposal for a portable
 file format for graphs. GML's key features are portability, simple
 syntax, extensibility and flexibility. A GML file consists of a
 hierarchical key-value lists. Graphs can be annotated with arbitrary


### PR DESCRIPTION
The onion decomposition refines the k-core decomposition by providing information on the internal organization of each shell. This is a relatively new tool from network science, but I'm being increasingly more asked for the code and I thought the community might appreciate having it well integrated in networkx.

The extraction code takes the form of a single function which has been added to the `core` submodule (`algorithms/core.py`); its natural home in my opinion.

I added a test function to `algorithms/tests/test_core.py` which is similar to the one for the function `core_number`.

This is my first contribution to networkx; any feedback will be greatly appreciated.