### PR TITLE
Wheels are python 3 only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,3 @@ with-doctest=0
 #
 match=(?:^|[\b_\./-])[Tt]est(?!ing)
 
-
-[wheel]
-universal = 1


### PR DESCRIPTION
version 2.3 dropped python2 support until py2 is actually deprecated we
shouldn't mark these wheels as universal