### PR TITLE
Don't remove ticks of other pyplot axes

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -414,7 +414,7 @@ def draw_networkx_nodes(G, pos,
                                  linewidths=linewidths,
                                  edgecolors=edgecolors,
                                  label=label)
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,
@@ -689,7 +689,7 @@ def draw_networkx_edges(G, pos,
     ax.update_datalim(corners)
     ax.autoscale_view()
 
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,
@@ -803,7 +803,7 @@ def draw_networkx_labels(G, pos,
                     )
         text_items[n] = t
 
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,
@@ -956,7 +956,7 @@ def draw_networkx_edge_labels(G, pos,
                     )
         text_items[(n1, n2)] = t
 
-    plt.tick_params(
+    ax.tick_params(
         axis='both',
         which='both',
         bottom=False,


### PR DESCRIPTION
Fix for issue raised in https://stackoverflow.com/questions/56496486/axes-disappear-after-drawing-networkx-graph-on-another-subplot

`plt.tick_params` operates on the currently active pyplot axes, which is not necessarily the one where the networkx graph resides in. 

This PR makes sure the axes `ax` is operated on. (`ax.tick_params`)