### PR TITLE
Added optional center_spring feature to spring_layout for unconnected graphs

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -501,6 +501,9 @@ def _fruchterman_reingold(A, k=None, pos=None, fixed=None, iterations=50,
         msg = "fruchterman_reingold() takes an adjacency matrix as input"
         raise nx.NetworkXError(msg)
 
+    # Normalize A so only k controls equilibrium distance
+    A = A / np.median(A[A!=0])
+
     if pos is None:
         # random initial positions
         pos = np.asarray(seed.rand(nnodes, dim), dtype=A.dtype)
@@ -572,6 +575,10 @@ def _sparse_fruchterman_reingold(A, k=None, pos=None, fixed=None,
     except ImportError:
         msg = "_sparse_fruchterman_reingold() scipy numpy: http://scipy.org/ "
         raise ImportError(msg)
+
+    # Normalize A so only k controls equilibrium distance
+    A = A / np.median(A[A!=0])
+
     # make sure we have a LIst of Lists representation
     try:
         A = A.tolil()

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -346,7 +346,7 @@ def bipartite_layout(G, nodes, align='vertical',
     raise ValueError(msg)
 
 
-@random_state(10)
+@random_state(11)
 def fruchterman_reingold_layout(G,
                                 k=None,
                                 pos=None,
@@ -488,7 +488,7 @@ def fruchterman_reingold_layout(G,
 spring_layout = fruchterman_reingold_layout
 
 
-@random_state(7)
+@random_state(8)
 def _fruchterman_reingold(A, k=None, pos=None, fixed=None, iterations=50,
                           threshold=1e-4, center_spring=False, dim=2, seed=None):
     # Position nodes in adjacency matrix A using Fruchterman-Reingold
@@ -553,7 +553,7 @@ def _fruchterman_reingold(A, k=None, pos=None, fixed=None, iterations=50,
     return pos
 
 
-@random_state(7)
+@random_state(8)
 def _sparse_fruchterman_reingold(A, k=None, pos=None, fixed=None,
                                  iterations=50, threshold=1e-4, center_spring=False,
                                  dim=2, seed=None):

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -619,7 +619,7 @@ def _sparse_fruchterman_reingold(A, k=None, pos=None, fixed=None,
                 (delta * (k * k / distance**2 - Ai * distance / k)).sum(axis=1)
             # prevent nodes from flying off into infinity if not connected
             if center_spring: 
-                displacement[:,i] = displacement[:,i] - pos[i].T / ( 
+                displacement[:,i] = displacement[:,i] - pos[i] / ( 
                            k * np.sqrt(nnodes))
         # update positions
         length = np.sqrt((displacement**2).sum(axis=0))

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -502,7 +502,7 @@ def _fruchterman_reingold(A, k=None, pos=None, fixed=None, iterations=50,
         raise nx.NetworkXError(msg)
 
     # Normalize A so only k controls equilibrium distance
-    A = A / np.median(A[A!=0])
+    A = A / np.mean(A[A!=0])
 
     if pos is None:
         # random initial positions
@@ -577,7 +577,7 @@ def _sparse_fruchterman_reingold(A, k=None, pos=None, fixed=None,
         raise ImportError(msg)
 
     # Normalize A so only k controls equilibrium distance
-    A = A / np.median(A[A!=0])
+    A = A / np.mean(A[A!=0])
 
     # make sure we have a LIst of Lists representation
     try:


### PR DESCRIPTION
This addresses https://github.com/networkx/networkx/issues/3325

Previously, spring_layout would not converge for unconnected graphs since each connected piece (component) would fly away to infinity. This optional feature (default = False, i.e. not used) fixes this.

With center_spring=True:
![Figure_1](https://user-images.githubusercontent.com/18585219/59970561-2ee7a000-951e-11e9-9463-cece244e3daa.png)

With center_spring=False (current behavior):
![Figure_2](https://user-images.githubusercontent.com/18585219/59970566-46268d80-951e-11e9-8361-4d79ba4b6a82.png)

This also enables "petri dish" plots (a name I just invented..?) like the following:
![montecarlo_orange_vs_historical_corr_blue_with_SIC_labels_and_colors](https://user-images.githubusercontent.com/18585219/60050784-522d5f00-9686-11e9-9b99-836f4f64e399.png)

