### PR TITLE
Fixes Issue #3493 - Bug in lexicographical_topological_sort()

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -277,7 +277,7 @@ def lexicographical_topological_sort(G, key=None):
     heapq.heapify(zero_indegree)
 
     while zero_indegree:
-        _, node = heapq.heappop(zero_indegree)
+        _, _, node = heapq.heappop(zero_indegree)
 
         if node not in G:
             raise RuntimeError("Graph changed during iteration")

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -260,11 +260,12 @@ def lexicographical_topological_sort(G, key=None):
        *Introduction to Algorithms - A Creative Approach.* Addison-Wesley.
     """
     if not G.is_directed():
-        raise nx.NetworkXError(
-            "Topological sort not defined on undirected graphs.")
+        msg = "Topological sort not defined on undirected graphs."
+        raise nx.NetworkXError(msg)
 
     if key is None:
-        def key(x): return x
+        def key(node):
+            return node
 
     nodeid_map = {n: i for i, n in enumerate(G)}
 
@@ -293,8 +294,8 @@ def lexicographical_topological_sort(G, key=None):
         yield node
 
     if indegree_map:
-        raise nx.NetworkXUnfeasible("Graph contains a cycle or graph changed "
-                                    "during iteration")
+        msg = "Graph contains a cycle or graph changed during iteration"
+        raise nx.NetworkXUnfeasible(msg)
 
 
 @not_implemented_for('undirected')
@@ -459,7 +460,7 @@ def is_aperiodic(G):
     levels = {s: 0}
     this_level = [s]
     g = 0
-    l = 1
+    lev = 1
     while this_level:
         next_level = []
         for u in this_level:
@@ -468,9 +469,9 @@ def is_aperiodic(G):
                     g = gcd(g, levels[u] - levels[v] + 1)
                 else:  # Tree Edge
                     next_level.append(v)
-                    levels[v] = l
+                    levels[v] = lev
         this_level = next_level
-        l += 1
+        lev += 1
     if len(levels) == len(G):  # All nodes in tree
         return g == 1
     else:

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -266,8 +266,10 @@ def lexicographical_topological_sort(G, key=None):
     if key is None:
         def key(x): return x
 
+    nodeid_map = {n: i for i, n in enumerate(G)}
+
     def create_tuple(node):
-        return key(node), node
+        return key(node), nodeid_map[node], node
 
     indegree_map = {v: d for v, d in G.in_degree() if d > 0}
     # These nodes have zero indegree and ready to be returned.

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -368,6 +368,28 @@ class TestDAG:
             G, key=lambda x: -x)),
             [1, 5, 4, 2, 6, 3])
 
+    def test_lexicographical_topological_sort2(self):
+        '''
+        This test checks for a case where two or more nodes have same key value.
+        See Issue #3493
+        '''
+        class Test_Node:
+            def __init__(self, n):
+                self.label = n
+                self.priority = 1
+
+            def __repr__(self):
+                return 'Node({})'.format(self.label)
+
+        def sorting_key(node):
+            return node.priority
+
+        test_nodes = [Test_Node(n) for n in range(4)]
+        G = nx.DiGraph()
+        G.add_edges_from([(test_nodes[a], test_nodes[b]) for a,b in [(0,1), (0,2), (0,3), (2,3)]])
+
+        assert_equal(list(nx.lexicographical_topological_sort(G, key=sorting_key)),
+                     test_nodes)
 
 def test_is_aperiodic_cycle():
     G = nx.DiGraph()

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -371,6 +371,7 @@ class TestDAG:
     def test_lexicographical_topological_sort2(self):
         '''
         Check the case of two or more nodes with same key value.
+        Want to avoid exception raised due to comparing nodes directly.
         See Issue #3493
         '''
         class Test_Node:
@@ -390,7 +391,11 @@ class TestDAG:
         G.add_edges_from((test_nodes[a], test_nodes[b]) for a, b in edges)
 
         sorting = list(nx.lexicographical_topological_sort(G, key=sorting_key))
-        assert_equal(sorting, test_nodes)
+        # order reported does depend on order of list(G) in python 3.5
+        # and that is not deterministic due to dicts not being ordered until v3.6
+        # after dropping NX support for 3.5 this can become:
+        # assert_equal(sorting, test_nodes)
+        assert_equal(set(sorting), set(test_nodes))
 
 
 def test_is_aperiodic_cycle():

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -58,9 +58,9 @@ class TestDagLongestPath(object):
         # by replacing `Unorderable()` by `object()`.
         class Unorderable(object):
             def __lt__(self, other):
-                error_msg = "< not supported between instances of " \
-                    "{} and {}".format(type(self).__name__, type(other).__name__)
-                raise TypeError(error_msg)
+                error_msg = "< not supported between instances of {} and {}"
+                types = (type(self).__name__, type(other).__name__)
+                raise TypeError(error_msg.format(types))
 
         # Create the directed path graph on four nodes in a diamond shape,
         # with nodes represented as (unorderable) Python objects.
@@ -306,7 +306,7 @@ class TestDAG:
             assert_equal(G.get_edge_data(u, v), H.get_edge_data(u, v))
 
         k = 10
-        G = nx.DiGraph((i, i + 1, {"foo": "bar", "weight": i}) for i in range(k))
+        G = nx.DiGraph((i, i + 1, {"f": "b", "weight": i}) for i in range(k))
         H = transitive_closure(G)
         for u, v in G.edges():
             assert_equal(G.get_edge_data(u, v), H.get_edge_data(u, v))
@@ -370,7 +370,7 @@ class TestDAG:
 
     def test_lexicographical_topological_sort2(self):
         '''
-        This test checks for a case where two or more nodes have same key value.
+        Check the case of two or more nodes with same key value.
         See Issue #3493
         '''
         class Test_Node:
@@ -386,10 +386,12 @@ class TestDAG:
 
         test_nodes = [Test_Node(n) for n in range(4)]
         G = nx.DiGraph()
-        G.add_edges_from([(test_nodes[a], test_nodes[b]) for a,b in [(0,1), (0,2), (0,3), (2,3)]])
+        edges = [(0, 1), (0, 2), (0, 3), (2, 3)]
+        G.add_edges_from((test_nodes[a], test_nodes[b]) for a, b in edges)
 
-        assert_equal(list(nx.lexicographical_topological_sort(G, key=sorting_key)),
-                     test_nodes)
+        sorting = list(nx.lexicographical_topological_sort(G, key=sorting_key))
+        assert_equal(sorting, test_nodes)
+
 
 def test_is_aperiodic_cycle():
     G = nx.DiGraph()


### PR DESCRIPTION
Add `NodeId` filed to the tuple for cases where two or more nodes have the same key. It causes a problem with the `heapq` object in `lexicographical_topological_sort` function. 