### PR TITLE
Fix A* returning wrong solution

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -109,14 +109,13 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
             path.reverse()
             return path
 
-        if curnode in explored:
+        # Do not override the parent of starting node
+        if curnode in explored and explored[curnode] is None:
             continue
 
         explored[curnode] = parent
 
         for neighbor, w in G[curnode].items():
-            if neighbor in explored:
-                continue
             ncost = dist + w.get(weight, 1)
             if neighbor in enqueued:
                 qcost, h = enqueued[neighbor]

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -109,9 +109,15 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
             path.reverse()
             return path
 
-        # Do not override the parent of starting node
-        if curnode in explored and explored[curnode] is None:
-            continue
+        if curnode in explored:
+            # Do not override the parent of starting node
+            if explored[curnode] is None:
+                continue
+
+            # Skip bad paths that were enqueued before finding a better one
+            qcost, h = enqueued[curnode]
+            if qcost < dist:
+                continue
 
         explored[curnode] = parent
 

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -87,6 +87,20 @@ class TestAStar:
         assert_equal(nx.astar_path(XG4, 0, 2), [0, 1, 2])
         assert_equal(nx.astar_path_length(XG4, 0, 2), 4)
 
+    """ Tests that A* finds correct path when there are multiple paths through a node
+        and the best one is not expanded first (GH issue #3464)
+    """
+    def test_astar_directed3(self):
+        heuristic_values = {"n5": 36, "n2": 4, "n1": 0, "n0": 0}
+
+        def h(u, v):
+            return heuristic_values[u]
+
+        edges = [("n5", "n1", 11), ("n5", "n2", 9), ("n2", "n1", 1), ("n1", "n0", 32)]
+        graph = nx.DiGraph()
+        graph.add_weighted_edges_from(edges)
+        assert_equal(nx.astar_path(graph, "n5", "n0", h), ["n5", "n2", "n1", "n0"])
+
 # >>> MXG4=NX.MultiGraph(XG4)
 # >>> MXG4.add_edge(0,1,3)
 # >>> NX.dijkstra_path(MXG4,0,2)

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -23,8 +23,7 @@ class TestAStar:
         self.XG.add_weighted_edges_from(edges)
 
     def test_multiple_optimal_paths(self):
-        """Tests that A* algorithm finds any of the optimal paths when there are multiple optimal
-        paths. """
+        """Tests that A* algorithm finds any of multiple optimal paths"""
         heuristic_values = {"a": 1.35, "b": 1.18, "c": 0.67, "d": 0}
 
         def h(u, v):
@@ -32,7 +31,8 @@ class TestAStar:
 
         graph = nx.Graph()
         points = ["a", "b", "c", "d"]
-        edges = [("a", "b", 0.18), ("a", "c", 0.68), ("b", "c", 0.50), ("c", "d", 0.67)]
+        edges = [("a", "b", 0.18), ("a", "c", 0.68),
+                 ("b", "c", 0.50), ("c", "d", 0.67)]
 
         graph.add_nodes_from(points)
         graph.add_weighted_edges_from(edges)
@@ -83,7 +83,7 @@ class TestAStar:
         assert_equal(nx.astar_path(XG4, 0, 2), [0, 1, 2])
         assert_equal(nx.astar_path_length(XG4, 0, 2), 4)
 
-    """ Tests that A* finds correct path when there are multiple paths through a node
+    """ Tests that A* finds correct path when multiple paths exist
         and the best one is not expanded first (GH issue #3464)
     """
     def test_astar_directed3(self):
@@ -92,16 +92,19 @@ class TestAStar:
         def h(u, v):
             return heuristic_values[u]
 
-        edges = [("n5", "n1", 11), ("n5", "n2", 9), ("n2", "n1", 1), ("n1", "n0", 32)]
+        edges = [("n5", "n1", 11), ("n5", "n2", 9),
+                 ("n2", "n1", 1), ("n1", "n0", 32)]
         graph = nx.DiGraph()
         graph.add_weighted_edges_from(edges)
-        assert_equal(nx.astar_path(graph, "n5", "n0", h), ["n5", "n2", "n1", "n0"])
+        answer = ["n5", "n2", "n1", "n0"]
+        assert_equal(nx.astar_path(graph, "n5", "n0", h), answer)
 
-    """ Tests that that parent is not wrongly overridden when a node is re-explored multiple
-        times.
+    """ Tests that that parent is not wrongly overridden when a
+        node is re-explored multiple times.
     """
     def test_astar_directed4(self):
-        edges = [("a", "b", 1), ("a", "c", 1), ("b", "d", 2), ("c", "d", 1), ("d", "e", 1)]
+        edges = [("a", "b", 1), ("a", "c", 1), ("b", "d", 2),
+                 ("c", "d", 1), ("d", "e", 1)]
         graph = nx.DiGraph()
         graph.add_weighted_edges_from(edges)
         assert_equal(nx.astar_path(graph, "a", "e"), ["a", "c", "d", "e"])

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -101,6 +101,15 @@ class TestAStar:
         graph.add_weighted_edges_from(edges)
         assert_equal(nx.astar_path(graph, "n5", "n0", h), ["n5", "n2", "n1", "n0"])
 
+    """ Tests that that parent is not wrongly overridden when a node is re-explored multiple
+        times.
+    """
+    def test_astar_directed4(self):
+        edges = [("a", "b", 1), ("a", "c", 1), ("b", "d", 2), ("c", "d", 1), ("d", "e", 1)]
+        graph = nx.DiGraph()
+        graph.add_weighted_edges_from(edges)
+        assert_equal(nx.astar_path(graph, "a", "e"), ["a", "c", "d", "e"])
+
 # >>> MXG4=NX.MultiGraph(XG4)
 # >>> MXG4.add_edge(0,1,3)
 # >>> NX.dijkstra_path(MXG4,0,2)

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -1,9 +1,8 @@
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in
 from nose.tools import assert_raises
 from nose.tools import raises
 
 from math import sqrt
-from random import random, choice
 
 import networkx as nx
 from networkx.utils import pairwise
@@ -23,27 +22,24 @@ class TestAStar:
         self.XG = nx.DiGraph()
         self.XG.add_weighted_edges_from(edges)
 
-    def test_random_graph(self):
-        """Tests that the A* shortest path agrees with Dijkstra's
-        shortest path for a random graph.
+    def test_multiple_optimal_paths(self):
+        """Tests that A* algorithm finds any of the optimal paths when there are multiple optimal
+        paths. """
+        heuristic_values = {"a": 1.35, "b": 1.18, "c": 0.67, "d": 0}
 
-        """
+        def h(u, v):
+            return heuristic_values[u]
 
-        G = nx.Graph()
+        graph = nx.Graph()
+        points = ["a", "b", "c", "d"]
+        edges = [("a", "b", 0.18), ("a", "c", 0.68), ("b", "c", 0.50), ("c", "d", 0.67)]
 
-        points = [(random(), random()) for _ in range(100)]
+        graph.add_nodes_from(points)
+        graph.add_weighted_edges_from(edges)
 
-        # Build a path from points[0] to points[-1] to be sure it exists
-        for p1, p2 in pairwise(points):
-            G.add_edge(p1, p2, weight=dist(p1, p2))
-
-        # Add other random edges
-        for _ in range(100):
-            p1, p2 = choice(points), choice(points)
-            G.add_edge(p1, p2, weight=dist(p1, p2))
-
-        path = nx.astar_path(G, points[0], points[-1], dist)
-        assert_equal(path, nx.dijkstra_path(G, points[0], points[-1]))
+        path1 = ["a", "c", "d"]
+        path2 = ["a", "b", "c", "d"]
+        assert_in(nx.astar_path(graph, "a", "d", h), (path1, path2))
 
     def test_astar_directed(self):
         assert_equal(nx.astar_path(self.XG, 's', 'v'), ['s', 'x', 'u', 'v'])


### PR DESCRIPTION
Fixes #3464.

The problem was that each node was allowed to be explored at most once, but sometimes, there are multiple paths through the same node, where the first one is not necessarily the best.  
I fixed it by removing the checks for whether a node was already explored and adding logic to prevent the overriding of starting node's parent. The latter is required because when returning a path, that is done by backtracking until the node's parent is `None`. Without the check, the parent of starting node could be overridden and the backtracking would never end.

The added test contains a smaller version of the graph, mentioned in issue #3464. 