### PR TITLE
Restore checking PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-    - python: pypy3-7.0
+    - python: pypy3.5-7.0
       dist: xenial
       sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,9 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
+    - python: pypy3-7.0
+      dist: xenial
+      sudo: true
 
 before_install:
   # prepare the system to install prerequisites or dependencies

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -144,7 +144,7 @@ def weighted_projected_graph(B, nodes, ratio=False):
 
     ratio: Bool (default=False)
         If True, edge weight is the ratio between actual shared neighbors
-        and maximum possible shared neighbors (i.e., the size of the other 
+        and maximum possible shared neighbors (i.e., the size of the other
         node set). If False, edges weight is the number of shared neighbors.
 
     Returns
@@ -255,7 +255,7 @@ def collaboration_weighted_projected_graph(B, nodes):
     >>> G = bipartite.collaboration_weighted_projected_graph(B, [0, 2, 4, 5])
     >>> list(G)
     [0, 2, 4, 5]
-    >>> for edge in G.edges(data=True): print(edge)
+    >>> for edge in sorted(G.edges(data=True)): print(edge)
     ...
     (0, 2, {'weight': 0.5})
     (0, 5, {'weight': 0.5})
@@ -454,7 +454,7 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     >>> # Add some arbitrary weight to the edges
     >>> for i,(u,v) in enumerate(B.edges()):
     ...     B.edges[u, v]['weight'] = i + 1
-    ... 
+    ...
     >>> for edge in B.edges(data=True):
     ...     print(edge)
     ...

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -117,7 +117,7 @@ def find_induced_nodes(G, s, t, treewidth_bound=sys.maxsize):
     >>> G=nx.Graph()
     >>> G = nx.generators.classic.path_graph(10)
     >>> I = nx.find_induced_nodes(G,1,9,2)
-    >>> list(I)
+    >>> sorted(list(I))
     [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     Notes

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -24,7 +24,7 @@ def k_clique_communities(G, k, cliques=None):
     k : int
        Size of smallest clique
 
-    cliques: list or generator       
+    cliques: list or generator
        Precomputed cliques (use networkx.find_cliques(G))
 
     Returns
@@ -38,7 +38,7 @@ def k_clique_communities(G, k, cliques=None):
     >>> K5 = nx.convert_node_labels_to_integers(G,first_label=2)
     >>> G.add_edges_from(K5.edges())
     >>> c = list(k_clique_communities(G, 4))
-    >>> list(c[0])
+    >>> sorted(list(c[0]))
     [0, 1, 2, 3, 4, 5, 6]
     >>> list(k_clique_communities(G, 6))
     []
@@ -46,7 +46,7 @@ def k_clique_communities(G, k, cliques=None):
     References
     ----------
     .. [1] Gergely Palla, Imre Derényi, Illés Farkas1, and Tamás Vicsek,
-       Uncovering the overlapping community structure of complex networks 
+       Uncovering the overlapping community structure of complex networks
        in nature and society Nature 435, 814-818, 2005,
        doi:10.1038/nature03607
     """

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -526,7 +526,7 @@ def minimum_cycle_basis(G, weight=None):
     >>> G=nx.Graph()
     >>> G.add_cycle([0,1,2,3])
     >>> G.add_cycle([0,3,4,5])
-    >>> print(nx.minimum_cycle_basis(G))
+    >>> print([sorted(c) for c in nx.minimum_cycle_basis(G)])
     [[0, 1, 2, 3], [0, 3, 4, 5]]
 
     References:

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -93,16 +93,19 @@ class TestCliques:
                      [[2, 6, 1, 3]])
         assert_equal(list(nx.cliques_containing_node(G, [1]).values()),
                      [[[2, 6, 1, 3]]])
-        assert_equal(list(nx.cliques_containing_node(G, [1, 2]).values()),
+        assert_equal([sorted(c) for c in list(nx.cliques_containing_node(G, [1, 2]).values())],
                      [[[2, 6, 1, 3]], [[2, 6, 1, 3], [2, 6, 4]]])
-        assert_equal(nx.cliques_containing_node(G, [1, 2]),
+        result = nx.cliques_containing_node(G, [1, 2])
+        for k, v in result.items():
+            result[k] = sorted(v)
+        assert_equal(result,
                      {1: [[2, 6, 1, 3]], 2: [[2, 6, 1, 3], [2, 6, 4]]})
         assert_equal(nx.cliques_containing_node(G, 1),
                      [[2, 6, 1, 3]])
-        assert_equal(nx.cliques_containing_node(G, 2),
-                     [[2, 6, 1, 3], [2, 6, 4]])
-        assert_equal(nx.cliques_containing_node(G, 2, cliques=self.cl),
-                     [[2, 6, 1, 3], [2, 6, 4]])
+        assert_equal([sorted(c) for c in nx.cliques_containing_node(G, 2)],
+                     [[2, 4, 6], [1, 2, 3, 6]])
+        assert_equal([sorted(c) for c in nx.cliques_containing_node(G, 2, cliques=self.cl)],
+                     [[2, 4, 6], [1, 2, 3, 6]])
         assert_equal(len(nx.cliques_containing_node(G)), 11)
 
     def test_make_clique_bipartite(self):

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -25,10 +25,11 @@ class TestCliques:
     def test_selfloops(self):
         self.G.add_edge(1, 1)
         cl = list(nx.find_cliques(self.G))
-        rcl = nx.find_cliques_recursive(self.G)
-        assert_equal(sorted(map(sorted, cl)), sorted(map(sorted, rcl)))
-        assert_equal(cl,
-                     [[2, 6, 1, 3], [2, 6, 4], [5, 4, 7], [8, 9], [10, 11]])
+        rcl = list(nx.find_cliques_recursive(self.G))
+        assert_equal(set(map(frozenset, cl)), set(map(frozenset, rcl)))
+        answer = [{2, 6, 1, 3}, {2, 6, 4}, {5, 4, 7}, {8, 9}, {10, 11}]
+        assert_equal(len(answer), len(cl))
+        assert_true(all(set(c) in answer for c in cl))
 
     def test_find_cliques2(self):
         hcl = list(nx.find_cliques(self.H))
@@ -102,10 +103,12 @@ class TestCliques:
                      {1: [[2, 6, 1, 3]], 2: [[2, 6, 1, 3], [2, 6, 4]]})
         assert_equal(nx.cliques_containing_node(G, 1),
                      [[2, 6, 1, 3]])
-        assert_equal([sorted(c) for c in nx.cliques_containing_node(G, 2)],
-                     [[2, 4, 6], [1, 2, 3, 6]])
-        assert_equal([sorted(c) for c in nx.cliques_containing_node(G, 2, cliques=self.cl)],
-                     [[2, 4, 6], [1, 2, 3, 6]])
+        expected = [{2, 6, 1, 3}, {2, 6, 4}]
+        answer = [set(c) for c in nx.cliques_containing_node(G, 2)]
+        assert_in(answer, (expected, list(reversed(expected))))
+
+        answer = [set(c) for c in nx.cliques_containing_node(G, 2, cliques=self.cl)]
+        assert_in(answer, (expected, list(reversed(expected))))
         assert_equal(len(nx.cliques_containing_node(G)), 11)
 
     def test_make_clique_bipartite(self):

--- a/networkx/algorithms/tests/test_covering.py
+++ b/networkx/algorithms/tests/test_covering.py
@@ -4,7 +4,7 @@
 #    All rights reserved.
 #    BSD license.
 
-from nose.tools import assert_equal, assert_true, assert_false
+from nose.tools import assert_equal, assert_true, assert_false, assert_in
 import networkx as nx
 
 
@@ -23,8 +23,7 @@ class TestMinEdgeCover:
     def test_graph_single_edge(self):
         G = nx.Graph()
         G.add_edge(0, 1)
-        assert_equal(nx.min_edge_cover(G),
-                     {(0, 1)})
+        assert_in(nx.min_edge_cover(G), ({(0, 1)}, {(1, 0)}))
 
     def test_bipartite_explicit(self):
         G = nx.Graph()

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -300,11 +300,11 @@ class TestMinimumCycles(object):
 
     def test_unweighted_diamond(self):
         mcb = minimum_cycle_basis(self.diamond_graph)
-        assert_basis_equal(mcb, [[1, 2, 4], [2, 3, 4]])
+        assert_basis_equal([sorted(c) for c in mcb], [[1, 2, 4], [2, 3, 4]])
 
     def test_weighted_diamond(self):
         mcb = minimum_cycle_basis(self.diamond_graph, weight='weight')
-        assert_basis_equal(mcb, [[1, 2, 4], [1, 2, 3, 4]])
+        assert_basis_equal([sorted(c) for c in mcb], [[1, 2, 4], [1, 2, 3, 4]])
 
     def test_dimensionality(self):
         # checks |MCB|=|E|-|V|+|NC|

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -118,8 +118,10 @@ class TestMaxWeightMatching(object):
         G.add_weighted_edges_from([(1, 2, 9), (1, 3, 9), (2, 3, 10),
                                    (2, 4, 8), (3, 5, 8), (4, 5, 10),
                                    (5, 6, 6)])
-        assert_equal(nx.max_weight_matching(G),
-                     matching_dict_to_set({1: 3, 2: 4, 3: 1, 4: 2, 5: 6, 6: 5}))
+        dict_format = {1: 3, 2: 4, 3: 1, 4: 2, 5: 6, 6: 5}
+        expected = {frozenset(e) for e in matching_dict_to_set(dict_format)}
+        answer = {frozenset(e) for e in nx.max_weight_matching(G)}
+        assert_equal(answer, expected)
 
     def test_nested_s_blossom_relabel(self):
         """Create S-blossom, relabel as S, include in nested S-blossom:"""

--- a/networkx/algorithms/tests/test_planar_drawing.py
+++ b/networkx/algorithms/tests/test_planar_drawing.py
@@ -67,7 +67,7 @@ def test_multiple_component_graph2():
 
 @raises(nx.NetworkXException)
 def test_invalid_half_edge():
-    embedding_data = {1: [2, 3], 2: [1, 3], 3: [1, 2], 4: [1, 2, 3]}
+    embedding_data = {1: [2, 3, 4], 2: [1, 3, 4], 3: [1, 2, 4], 4: [1, 2, 3]}
     embedding = nx.PlanarEmbedding()
     embedding.set_data(embedding_data)
     nx.combinatorial_embedding_to_pos(embedding)


### PR DESCRIPTION
I don't know why it was removed but PyPy3 now supports Python 3.5 and hopefully the next major PyPy version will support PyPy 3.6.

It's really important for me to know that this library is portable since I'm going to use it quite a bit.