### PR TITLE
Implement minimum weight full matching of bipartite graphs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -128,6 +128,7 @@ is partially historical, and now, mostly arbitrary.
 - Weisheng Si, Github: `ws4u <https://github.com/ws4u>`_
 - Haakon H. Rød, Gitlab: `haakonhr <https://gitlab.com/haakonhr>`_, `<https://haakonhr.gitlab.io>`_ 
 - Efraim Rodrigues, `GitHub <https://github.com/efraimrodrigues>`_, `LinkedIn <https://linkedin.com/in/efraim-rodrigues/>`_
+- Søren Fuglede Jørgensen, GitHub: `fuglede <https://github.com/fuglede>`_
 
 Support
 -------

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -1,6 +1,7 @@
 # matching.py - bipartite graph maximum matching algorithms
 #
-# Copyright 2015 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>.
+# Copyright 2015 Jeffrey Finkelstein <jeffrey.finkelstein@gmail.com>,
+# Copyright 2019 Søren Fuglede Jørgensen
 #
 # This file is part of NetworkX.
 #
@@ -17,8 +18,8 @@
 # Portions of this module use code from David Eppstein's Python Algorithms and
 # Data Structures (PADS) library, which is dedicated to the public domain (for
 # proof, see <http://www.ics.uci.edu/~eppstein/PADS/ABOUT-PADS.txt>).
-"""Provides functions for computing a maximum cardinality matching in a
-bipartite graph.
+"""Provides functions for computing maximum cardinality matchings and minimum
+weight full matchings in a bipartite graph.
 
 If you don't care about the particular implementation of the maximum matching
 algorithm, simply use the :func:`maximum_matching`. If you do care, you can
@@ -40,15 +41,35 @@ two vertices on the left and three vertices on the right:
 The dictionary returned by :func:`maximum_matching` includes a mapping for
 vertices in both the left and right vertex sets.
 
+Similarly, :func:`minimum_weight_full_matching` produces, for a complete
+weighted bipartite graph, a matching whose cardinality is the cardinality of
+the smaller of the two partitions, and for which the sum of the weights of the
+edges included in the matching is minimal.
+
+>>> G = nx.Graph()
+>>> U = [1, 2, 3]
+>>> V = ['a', 'b']
+>>> G.add_nodes_from(U, bipartite=0)
+>>> G.add_nodes_from(V, bipartite=1)
+>>> G.add_edge(1, 'a', weight=-2)
+>>> G.add_edge(1, 'b', weight=0.2)
+>>> G.add_edge(2, 'a', weight=0)
+>>> G.add_edge(2, 'b', weight=0.7)
+>>> G.add_edge(3, 'a', weight=-2)
+>>> G.add_edge(3, 'b', weight=1)
+>>> nx.bipartite.minimum_weight_full_matching(G, top_nodes=U)
+{1: 'b', 3: 'a', 'b': 1, 'a': 3}
+
 """
 import collections
 import itertools
 
+from networkx.algorithms.bipartite.matrix import biadjacency_matrix
 from networkx.algorithms.bipartite import sets as bipartite_sets
 import networkx as nx
 
 __all__ = ['maximum_matching', 'hopcroft_karp_matching', 'eppstein_matching',
-           'to_vertex_cover']
+           'to_vertex_cover', 'minimum_weight_full_matching']
 
 INFINITY = float('inf')
 
@@ -483,3 +504,77 @@ def to_vertex_cover(G, matching, top_nodes=None):
 #:
 #: This function is simply an alias for :func:`hopcroft_karp_matching`.
 maximum_matching = hopcroft_karp_matching
+
+
+def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
+    """Returns the minimum weight full matching of the bipartite graph `G`.
+
+    A full matching is a subset of edges whose cardinality is the smaller of
+    the cardinalities of the two partitions, and in which no node occurs more
+    than once. The weight of a matching is the sum of the weights of the edges.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+      Undirected bipartite graph
+
+    top_nodes : container
+
+      Container with all nodes in one bipartite node set. If not supplied
+      it will be computed.
+
+    weight : string, optional (default='weight')
+       The edge data key used to provide each value in the matrix.
+
+    Returns
+    -------
+    matches : dictionary
+
+      The matching is returned as a dictionary, `matches`, such that
+      ``matches[v] == w`` if node `v` is matched to node `w`. Unmatched
+      nodes do not occur as a key in matches.
+
+    Raises
+    ------
+    ValueError : Exception
+
+      Raised if the input bipartite graph is not complete.
+
+    ImportError : Exception
+
+      Raised if SciPy is not available.
+
+    Notes
+    -----
+
+    The problem of determining a minimum weight full matching is also known as
+    the rectangular linear assignment problem. This implementation defers the
+    calculation of the assignment to SciPy.
+
+    """
+    try:
+        import scipy.optimize
+    except ImportError:
+        raise ImportError('minimum_weight_full_matching requires SciPy: ' +
+                          'https://scipy.org/')
+    left, right = nx.bipartite.sets(G, top_nodes)
+    # Ensure that the graph is complete. This is currently a requirement in
+    # the underlying  optimization algorithm from SciPy, but the constraint
+    # will be removed in SciPy 1.4.0, at which point it can also be removed
+    # here.
+    for (u, v) in itertools.product(left, right):
+        # As the graph is undirected, make sure to check for edges in
+        # both directions
+        if (u, v) not in G.edges() and (v, u) not in G.edges():
+            raise ValueError('The bipartite graph must be complete.')
+    U = list(left)
+    V = list(right)
+    weights = biadjacency_matrix(G, row_order=U,
+                                 column_order=V, weight=weight).toarray()
+    left_matches = scipy.optimize.linear_sum_assignment(weights)
+    d = {U[u]: V[v] for u, v in zip(*left_matches)}
+    # d will contain the matching from edges in left to right; we need to
+    # add the ones from right to left as well.
+    d.update({v: u for u, v in d.items()})
+    return d

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -94,7 +94,6 @@ def hopcroft_karp_matching(G, top_nodes=None):
 
     Notes
     -----
-
     This function is implemented with the `Hopcroft--Karp matching algorithm
     <https://en.wikipedia.org/wiki/Hopcroft%E2%80%93Karp_algorithm>`_ for
     bipartite graphs.
@@ -212,7 +211,6 @@ def eppstein_matching(G, top_nodes=None):
 
     Notes
     -----
-
     This function is implemented with David Eppstein's version of the algorithm
     Hopcroft--Karp algorithm (see :func:`hopcroft_karp_matching`), which
     originally appeared in the `Python Algorithms and Data Structures library
@@ -413,7 +411,6 @@ def to_vertex_cover(G, matching, top_nodes=None):
 
     Parameters
     ----------
-
     G : NetworkX graph
 
       Undirected bipartite graph
@@ -433,7 +430,6 @@ def to_vertex_cover(G, matching, top_nodes=None):
 
     Returns
     -------
-
     vertex_cover : :class:`set`
 
       The minimum vertex cover in `G`.
@@ -449,7 +445,6 @@ def to_vertex_cover(G, matching, top_nodes=None):
 
     Notes
     -----
-
     This function is implemented using the procedure guaranteed by `Konig's
     theorem
     <https://en.wikipedia.org/wiki/K%C3%B6nig%27s_theorem_%28graph_theory%29>`_,
@@ -533,7 +528,6 @@ def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
 
     Notes
     -----
-
     The problem of determining a minimum weight full matching is also known as
     the rectangular linear assignment problem. This implementation defers the
     calculation of the assignment to SciPy.

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -490,9 +490,21 @@ maximum_matching = hopcroft_karp_matching
 def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
     """Returns the minimum weight full matching of the bipartite graph `G`.
 
-    A full matching is a subset of edges whose cardinality is the smaller of
-    the cardinalities of the two partitions, and in which no node occurs more
-    than once. The weight of a matching is the sum of the weights of the edges.
+    Let :math:`G = ((U, V), E)` be a complete weighted bipartite graph with
+    real weights :math:`w : E \to \mathbb{R}`. This function then produces
+    a maximum matching :math:`M \subseteq E` which, since the graph is
+    assumed to be complete, has cardinality
+   
+    .. math::
+       \lvert M \rvert = \min(\lvert U \rvert, \lvert V \rvert),
+
+    and which minimizes the sum of the weights of the edges included in the
+    matching, :math:`\sum_{e \in M} w(e)`.
+    
+    When :math:`\lvert U \rvert = \lvert V \rvert`, this is commonly
+    referred to as a perfect matching; here, since we allow
+    :math:`\lvert U \rvert` and :math:`\lvert V \rvert` to differ, we
+    follow Karp[1]_ and refer to the matching as *full*.
 
     Parameters
     ----------
@@ -506,6 +518,7 @@ def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
       it will be computed.
 
     weight : string, optional (default='weight')
+
        The edge data key used to provide each value in the matrix.
 
     Returns
@@ -531,6 +544,13 @@ def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
     The problem of determining a minimum weight full matching is also known as
     the rectangular linear assignment problem. This implementation defers the
     calculation of the assignment to SciPy.
+
+    References
+    ----------
+    .. [1] Richard Manning Karp:
+       An algorithm to Solve the m x n Assignment Problem in Expected Time
+       O(mn log n).
+       Networks, 10(2):143–152, 1980.
 
     """
     try:

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -46,20 +46,6 @@ weighted bipartite graph, a matching whose cardinality is the cardinality of
 the smaller of the two partitions, and for which the sum of the weights of the
 edges included in the matching is minimal.
 
->>> G = nx.Graph()
->>> U = [1, 2, 3]
->>> V = ['a', 'b']
->>> G.add_nodes_from(U, bipartite=0)
->>> G.add_nodes_from(V, bipartite=1)
->>> G.add_edge(1, 'a', weight=-2)
->>> G.add_edge(1, 'b', weight=0.2)
->>> G.add_edge(2, 'a', weight=0)
->>> G.add_edge(2, 'b', weight=0.7)
->>> G.add_edge(3, 'a', weight=-2)
->>> G.add_edge(3, 'b', weight=1)
->>> nx.bipartite.minimum_weight_full_matching(G, top_nodes=U)
-{1: 'b', 3: 'a', 'b': 1, 'a': 3}
-
 """
 import collections
 import itertools


### PR DESCRIPTION
This provides an implementation of the minimum weight full matching problem, also known as the linear assignment problem, for complete bipartite graphs by deferring the calculation of the assignment to `scipy.optimize.linear_sum_assignment`.

This closes #3520; note that there, I referred to the matchings as "perfect"; since we also support bipartite graphs in which the two partitions have different cardinalities, "perfect" becomes a bit of a misnomer, so here we use term "full" instead; this follows the terminology used in Karp's *An algorithm to Solve the m x n Assignment Problem in Expected Time O(mn log n)* (doi:10.1002/net.3230100205).

I've marked the PR as "WIP" mainly because this is my first contribution, so I'm sure it has some rough edges. All suggestions for improvements are taken positively. One thing I can see myself:

* As mentioned in the code comments, there's an improvement coming to SciPy 1.4.0 that simplifies the solution here. NetworkX currently requires only 1.1.0; is there a way to ensure that the constraint is removed once 1.4.0 becomes an extra requirement? One could add a check on the SciPy version number but that seems hacky and unrobust.
* I added myself as a contributor. I don't know what sort of precedence exists in terms of the size of contribution, but I'll remove it again if this is too awkward.