### PR TITLE
Add spiral layout for graph drawing

### DIFF
--- a/doc/reference/drawing.rst
+++ b/doc/reference/drawing.rst
@@ -87,4 +87,5 @@ Graph Layout
    shell_layout
    spring_layout
    spectral_layout
+   spiral_layout
 

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -38,7 +38,8 @@ __all__ = ['bipartite_layout',
            'spring_layout',
            'spectral_layout',
            'planar_layout',
-           'fruchterman_reingold_layout']
+           'fruchterman_reingold_layout',
+           'spiral_layout']
 
 
 def _process_params(G, center, dim):

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -3,6 +3,8 @@
 #    Dan Schult <dschult@colgate.edu>
 #    Pieter Swart <swart@lanl.gov>
 #    Richard Penney <rwpenney@users.sourceforge.net>
+#    Michael Fedell <mfedell@jpl.nasa.gov>
+#    Valentino Constantinou <vconstan@jpl.nasa.gov>
 #    All rights reserved.
 #    BSD license.
 #
@@ -966,6 +968,7 @@ def spiral_layout(G, scale=1, center=None, dim=2,
     --------
     >>> G = nx.path_graph(4)
     >>> pos = nx.spiral_layout(G)
+
     Notes
     -----
     This algorithm currently only works in two dimensions.

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -971,6 +971,8 @@ def spiral_layout(G, scale=1, center=None, dim=2,
     This algorithm currently only works in two dimensions.
 
     """
+    import numpy as np
+
     if dim != 2:
         raise ValueError('can only handle 2 dimensions')
 


### PR DESCRIPTION
New method in layout will arrange nodes of a graph in a spiral layout
with variable compactness. Nodes may be positioned with equal angles
(increasing separation further from center), or equidistant (decreasing
angle further from center)