### PR TITLE
Write mixed-type attributes correctly in write_graphml_lxml

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -644,36 +644,30 @@ class GraphMLWriterLxml(GraphMLWriter):
             element_type = self.xml_type[self.attr_type(k, "graph", v)]
             self.get_key(make_str(k), element_type, "graph", None)
         # Nodes and data
-        attributes = {}
         for node, d in G.nodes(data=True):
             for k, v in d.items():
                 self.attribute_types[(make_str(k), "node")].add(type(v))
-                if k not in attributes:
-                    attributes[k] = v
-        for k, v in attributes.items():
-            T = self.xml_type[self.attr_type(k, "node", v)]
-            self.get_key(make_str(k), T, "node", node_default.get(k))
+        for node, d in G.nodes(data=True):
+            for k, v in d.items():
+                T = self.xml_type[self.attr_type(k, "node", v)]
+                self.get_key(make_str(k), T, "node", node_default.get(k))
         # Edges and data
         if G.is_multigraph():
-            attributes = {}
             for u, v, ekey, d in G.edges(keys=True, data=True):
                 for k, v in d.items():
                     self.attribute_types[(make_str(k), "edge")].add(type(v))
-                    if k not in attributes:
-                        attributes[k] = v
-            for k, v in attributes.items():
-                T = self.xml_type[self.attr_type(k, "edge", v)]
-                self.get_key(make_str(k), T, "edge", edge_default.get(k))
+            for u, v, ekey, d in G.edges(keys=True, data=True):
+                for k, v in d.items():
+                    T = self.xml_type[self.attr_type(k, "edge", v)]
+                    self.get_key(make_str(k), T, "edge", edge_default.get(k))
         else:
-            attributes = {}
             for u, v, d in G.edges(data=True):
                 for k, v in d.items():
                     self.attribute_types[(make_str(k), "edge")].add(type(v))
-                    if k not in attributes:
-                        attributes[k] = v
-            for k, v in attributes.items():
-                T = self.xml_type[self.attr_type(k, "edge", v)]
-                self.get_key(make_str(k), T, "edge", edge_default.get(k))
+            for u, v, d in G.edges(data=True):
+                for k, v in d.items():
+                    T = self.xml_type[self.attr_type(k, "edge", v)]
+                    self.get_key(make_str(k), T, "edge", edge_default.get(k))
 
         # Now add attribute keys to the xml file
         for key in self.xml:

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -921,6 +921,21 @@ class TestWriteGraphML(BaseGraphML):
         assert_edges_equal(G.edges(), H.edges())
         assert_equal(G.graph, H.graph)
 
+    def test_mixed_type_attributes(self):
+        G = nx.MultiGraph()
+        G.add_node('n0', special=False)
+        G.add_node('n1', special=0)
+        G.add_edge('n0', 'n1', special=False)
+        G.add_edge('n0', 'n1', special=0)
+        fh = io.BytesIO()
+        self.writer(G, fh)
+        fh.seek(0)
+        H = nx.read_graphml(fh)
+        assert_true(H.nodes['n0']['special'] is False)
+        assert_true(H.nodes['n1']['special'] is 0)
+        assert_true(H.edges['n0','n1',0]['special'] is False)
+        assert_true(H.edges['n0','n1',1]['special'] is 0)
+
     def test_multigraph_to_graph(self):
         # test converting multigraph to graph if no parallel edges found
         G = nx.MultiGraph()


### PR DESCRIPTION
If an attribute has different types on different nodes, it needs a separate key for each type. This has always worked fine when calling `write_graphml_xml`, but `write_graphml_lxml` wouldn't write all of the necessary `<key>` elements, which resulted in an invalid GraphML file. (I have added a test case that you can try out to see what I mean.) This patch fixes it so that the two functions produce the same output.