### PR TITLE
When exporting to GML, write non 32-bit numbers as strings.

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -667,6 +667,9 @@ def generate_gml(G, stringizer=None):
                     yield indent + key + ' 1'
                 elif value is False:
                     yield indent + key + ' 0'
+                # GML only supports signed 32-bit integers
+                elif value < -2**31 or value >= 2**31:
+                    yield indent + key + ' "' + str(value) + '"'
                 else:
                     yield indent + key + ' ' + str(value)
             elif isinstance(value, float):


### PR DESCRIPTION
According to the GML technical report, integers in GML must fit into a
signed 32-bit integer. Values outside this range have to be written as
strings instead.