### PR TITLE
Fixes bug in networkx.algorithms.community.label_propagation.asyn_lpa_communities

### DIFF
--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -91,11 +91,13 @@ def asyn_lpa_communities(G, weight=None, seed=None):
             max_freq = max(label_freq.values())
             best_labels = [label for label, freq in label_freq.items()
                            if freq == max_freq]
-            new_label = seed.choice(best_labels)
-            labels[node] = new_label
-            # Continue until all nodes have a label that is better than other
-            # neighbour labels (only one label has max_freq for each node).
-            cont = cont or len(best_labels) > 1
+            
+            # Continue until all nodes have a majority label
+            if labels[node] in best_labels:
+                cont = cont or False
+            else:
+                labels[node] = seed.choice(best_labels)
+                cont = cont or True
 
     # TODO In Python 3.3 or later, this should be `yield from ...`.
     return iter(groups(labels).values())

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -93,11 +93,9 @@ def asyn_lpa_communities(G, weight=None, seed=None):
                            if freq == max_freq]
             
             # Continue until all nodes have a majority label
-            if labels[node] in best_labels:
-                cont = cont or False
-            else:
+            if labels[node] not in best_labels:
                 labels[node] = seed.choice(best_labels)
-                cont = cont or True
+                cont = True
 
     # TODO In Python 3.3 or later, this should be `yield from ...`.
     return iter(groups(labels).values())

--- a/networkx/algorithms/community/tests/test_label_propagation.py
+++ b/networkx/algorithms/community/tests/test_label_propagation.py
@@ -98,6 +98,16 @@ def test_connected_communities():
     assert_in(result, ground_truth)
 
 
+def test_termination():
+    # ensure termination of asyn_lpa_communities in two cases  
+    # that led to an endless loop in a previous version
+    test1 = nx.karate_club_graph()
+    test2 = nx.caveman_graph(2, 10)
+    test2.add_edges_from([(0, 20), (20, 10)])
+    asyn_lpa_communities(test1)
+    asyn_lpa_communities(test2)
+
+
 class TestAsynLpaCommunities(object):
     def _check_communities(self, G, expected):
         """Checks that the communities computed from the given graph ``G``


### PR DESCRIPTION
The old convergence test was inconsistent with the reference paper. It would stop only if each node has a single majority label among its neighbors. In a network like below, the bridge node will always have `best_labels` = 2 and the stopping condition will never be met.

![ex](https://user-images.githubusercontent.com/10651090/63064936-d86d6100-bed1-11e9-88d4-2040024a4829.jpg)

This prevented convergence in many cases, including the karate_club_graph. 

Instead, according to the cited reference, a node should be satisfied if it has a majority label (either blue or red in the above example), even if there are multiple tied majority labels (two in the case above).

The algorithm is now consistent with the cited reference and is guaranteed to converge.