### PR TITLE
Fix a few documentation issues for the bipartite algorithm reference

### DIFF
--- a/doc/reference/algorithms/bipartite.rst
+++ b/doc/reference/algorithms/bipartite.rst
@@ -27,6 +27,7 @@ Matching
    eppstein_matching
    hopcroft_karp_matching
    to_vertex_cover
+   minimum_weight_full_matching
 
 
 Matrix

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -488,7 +488,7 @@ maximum_matching = hopcroft_karp_matching
 
 
 def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
-    """Returns the minimum weight full matching of the bipartite graph `G`.
+    r"""Returns the minimum weight full matching of the bipartite graph `G`.
 
     Let :math:`G = ((U, V), E)` be a complete weighted bipartite graph with
     real weights :math:`w : E \to \mathbb{R}`. This function then produces
@@ -504,7 +504,7 @@ def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
     When :math:`\lvert U \rvert = \lvert V \rvert`, this is commonly
     referred to as a perfect matching; here, since we allow
     :math:`\lvert U \rvert` and :math:`\lvert V \rvert` to differ, we
-    follow Karp[1]_ and refer to the matching as *full*.
+    follow Karp [1]_ and refer to the matching as *full*.
 
     Parameters
     ----------


### PR DESCRIPTION
In https://github.com/networkx/networkx/pull/3527 we added `nx.algorithms.bipartite.minimum_weight_full_matching`; this introduced a few issues in the reference documentation which we fix here:

 - The function was missing from the general overview.
 - The documentation itself had some rendering issues due to backslashes
   not being properly escaped.
 - The reference to Karp was not formatted properly.