### PR TITLE
Fix typo in all_pairs_node_connectivity method's doctring in connectivity.py

### DIFF
--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -252,7 +252,7 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
     See Also
     --------
     local_node_connectivity
-    all_pairs_node_connectivity
+    node_connectivity
 
     References
     ----------


### PR DESCRIPTION
Self references instead of referencing node_connectivity method.