### PR TITLE
Added k==n support for Watts-Strogatz generator

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -402,8 +402,12 @@ def watts_strogatz_graph(n, k, p, seed=None):
        Collective dynamics of small-world networks,
        Nature, 393, pp. 440--442, 1998.
     """
-    if k >= n:
-        raise nx.NetworkXError("k>=n, choose smaller k or larger n")
+    if k > n:
+        raise nx.NetworkXError("k>n, choose smaller k or larger n")
+    
+    #If k == n, the graph is complete not Watts-Strogatz
+    if k == n:
+        return nx.complete_graph(n)
 
     G = nx.Graph()
     nodes = list(range(n))  # nodes are labeled 0 to n-1

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -253,12 +253,17 @@ class TestGeneratorsRandom(object):
         assert_equal(sum(1 for _ in G.edges()), 0)
 
     def test_watts_strogatz_big_k(self):
-        assert_raises(NetworkXError, watts_strogatz_graph, 10, 10, 0.25)
-        assert_raises(NetworkXError, newman_watts_strogatz_graph, 10, 10, 0.25)
+        #Test to make sure than n<= k
+        assert_raises(NetworkXError, watts_strogatz_graph, 10, 11, 0.25)
+        assert_raises(NetworkXError, newman_watts_strogatz_graph, 10, 11, 0.25)
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
         watts_strogatz_graph(10, 9, 0.25, seed=0)
         newman_watts_strogatz_graph(10, 9, 0.5, seed=0)
+
+        #test k==n scenario
+        watts_strogatz_graph(10, 10, 0.25, seed=0.25)
+        newman_watts_strogatz_graph(10, 10, 0.5, seed=0.25)
 
     def test_random_kernel_graph(self):
         def integral(u, w, z):


### PR DESCRIPTION
I added support for k==n arguments within the Watts-Strogatz Generator: `watts_strogatz_graph`

As stated in #3522 the function explicitly checks for `k==n` and then calls the `nx.complete_graph()` function instead of throwing an error.

This is my first PR, so if I need to change anything let me know!