### PR TITLE
Handle k==n within the Watts-Strogatz graph generator

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -334,8 +334,13 @@ def newman_watts_strogatz_graph(n, k, p, seed=None):
        Physics Letters A, 263, 341, 1999.
        https://doi.org/10.1016/S0375-9601(99)00757-4
     """
-    if k >= n:
+    if k > n:
         raise nx.NetworkXError("k>=n, choose smaller k or larger n")
+    
+    #If k == n the graph return is a complete graph
+    if k == n:
+        return nx.complete_graph(n)
+
     G = empty_graph(n)
     nlist = list(G.nodes())
     fromv = nlist

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -402,8 +402,12 @@ def watts_strogatz_graph(n, k, p, seed=None):
        Collective dynamics of small-world networks,
        Nature, 393, pp. 440--442, 1998.
     """
-    if k >= n:
-        raise nx.NetworkXError("k>=n, choose smaller k or larger n")
+    if k > n:
+        raise nx.NetworkXError("k>n, choose smaller k or larger n")
+    
+    #If k == n, the graph is complete not Watts-Strogatz
+    if k == n:
+        return nx.complete_graph(n)
 
     G = nx.Graph()
     nodes = list(range(n))  # nodes are labeled 0 to n-1

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -253,16 +253,18 @@ class TestGeneratorsRandom(object):
         assert_equal(sum(1 for _ in G.edges()), 0)
 
     def test_watts_strogatz_big_k(self):
-        #Test to make sure than n<= k
+        #Test to make sure than n <= k
         assert_raises(NetworkXError, watts_strogatz_graph, 10, 11, 0.25)
         assert_raises(NetworkXError, newman_watts_strogatz_graph, 10, 11, 0.25)
+        
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
         watts_strogatz_graph(10, 9, 0.25, seed=0)
         newman_watts_strogatz_graph(10, 9, 0.5, seed=0)
 
-        #test k==n scenario
+        #Test k==n scenario
         watts_strogatz_graph(10, 10, 0.25, seed=0)
+        newman_watts_strogatz_graph(10, 10, 0.25, seed=0)
 
     def test_random_kernel_graph(self):
         def integral(u, w, z):

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -253,12 +253,16 @@ class TestGeneratorsRandom(object):
         assert_equal(sum(1 for _ in G.edges()), 0)
 
     def test_watts_strogatz_big_k(self):
-        assert_raises(NetworkXError, watts_strogatz_graph, 10, 10, 0.25)
-        assert_raises(NetworkXError, newman_watts_strogatz_graph, 10, 10, 0.25)
+        #Test to make sure than n<= k
+        assert_raises(NetworkXError, watts_strogatz_graph, 10, 11, 0.25)
+        assert_raises(NetworkXError, newman_watts_strogatz_graph, 10, 11, 0.25)
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
         watts_strogatz_graph(10, 9, 0.25, seed=0)
         newman_watts_strogatz_graph(10, 9, 0.5, seed=0)
+
+        #test k==n scenario
+        watts_strogatz_graph(10, 10, 0.25, seed=0)
 
     def test_random_kernel_graph(self):
         def integral(u, w, z):


### PR DESCRIPTION
It is now compatible with k==n scenario
additionally changed the unit tests for the same effect

This is my first pull request, relating to issue #3522

Please let me know if I need to make any changes!