### PR TITLE
Fix test_gexf to handle XML default serialisation order 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,6 @@ matrix:
       dist: xenial
       sudo: true
 
-  fast_finish: true
-  allow_failures:
-    - python: 3.8-dev
-
 before_install:
   # prepare the system to install prerequisites or dependencies
   - source tools/travis/before_install.sh


### PR DESCRIPTION
This fixes the following errors:

```
======================================================================

FAIL: test_gexf.TestGEXF.test_edge_id_construct

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/home/travis/venv/lib/python3.8/site-packages/nose/case.py", line 198, in runTest

    self.test(*self.arg)

  File "/home/travis/venv/lib/python3.8/site-packages/networkx/readwrite/tests/test_gexf.py", line 339, in test_edge_id_construct

    assert_equal(expected, obtained)

AssertionError: '<gexf version="1.2" xmlns="http://www.gexf.net/[660 chars]exf>' != '<gexf xmlns="http://www.gexf.net/1.2draft" xmln[660 chars]exf>'

Diff is 1440 characters long. Set self.maxDiff to None to see it.

    """Fail immediately, with the given message."""

>>  raise self.failureException('\'<gexf version="1.2" xmlns="http://www.gexf.net/[660 chars]exf>\' != \'<gexf xmlns="http://www.gexf.net/1.2draft" xmln[660 chars]exf>\'\nDiff is 1440 characters long. Set self.maxDiff to None to see it.')

    


======================================================================

FAIL: test_gexf.TestGEXF.test_write_with_node_attributes

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/home/travis/venv/lib/python3.8/site-packages/nose/case.py", line 198, in runTest

    self.test(*self.arg)

  File "/home/travis/venv/lib/python3.8/site-packages/networkx/readwrite/tests/test_gexf.py", line 314, in test_write_with_node_attributes

    assert_equal(expected, obtained)

AssertionError: '<gexf version="1.2" xmlns="http://www.gexf.net/[783 chars]exf>' != '<gexf xmlns="http://www.gexf.net/1.2draft" xmln[783 chars]exf>'

Diff is 2123 characters long. Set self.maxDiff to None to see it.

    """Fail immediately, with the given message."""

>>  raise self.failureException('\'<gexf version="1.2" xmlns="http://www.gexf.net/[783 chars]exf>\' != \'<gexf xmlns="http://www.gexf.net/1.2draft" xmln[783 chars]exf>\'\nDiff is 2123 characters long. Set self.maxDiff to None to see it.')
```

The issue is that

> Prior to Python 3.8, the serialisation order of the XML attributes of elements was artificially made predictable by sorting the attributes by their name. Based on the now guaranteed ordering of dicts, this arbitrary reordering was removed in Python 3.8 to preserve the order in which attributes were originally parsed or created by user code.

https://docs.python.org/3.8/library/xml.etree.elementtree.html
https://bugs.python.org/issue34160
    