### PR TITLE
remove cyclical references from OutEdgeDataView

### DIFF
--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -641,12 +641,12 @@ class OutEdgeDataView(object):
 
     def __init__(self, viewer, nbunch=None, data=False, default=None):
         self._viewer = viewer
-        self._adjdict = viewer._adjdict
+        adjdict = self._adjdict = viewer._adjdict
         if nbunch is None:
-            self._nodes_nbrs = self._adjdict.items
+            self._nodes_nbrs = adjdict.items
         else:
             nbunch = list(viewer._graph.nbunch_iter(nbunch))
-            self._nodes_nbrs = lambda: [(n, self._adjdict[n]) for n in nbunch]
+            self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
         self._default = default
@@ -769,13 +769,13 @@ class OutMultiEdgeDataView(OutEdgeDataView):
     def __init__(self, viewer, nbunch=None,
                  data=False, keys=False, default=None):
         self._viewer = viewer
-        self._adjdict = viewer._adjdict
+        adjdict = self._adjdict = viewer._adjdict
         self.keys = keys
         if nbunch is None:
-            self._nodes_nbrs = self._adjdict.items
+            self._nodes_nbrs = adjdict.items
         else:
             nbunch = list(viewer._graph.nbunch_iter(nbunch))
-            self._nodes_nbrs = lambda: [(n, self._adjdict[n]) for n in nbunch]
+            self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
         self._default = default


### PR DESCRIPTION
We noticed that our garbage collection runs were frequently sweeping OutEdgeDataView objects. Turns out this was because `self._nodes_nbrs`, being stored on `self`, was also referring to `self` inside of its lambda, creating a cycle that required garbage collection to clear.

Fix this by instead holding onto the relevant dictionary object inside the lambda.