### PR TITLE
Breadth traversal fix

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -81,8 +81,9 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
         parent, depth_now, children = queue[0]
         try:
             child = next(children)
+            yield parent, child
+
             if child not in visited:
-                yield parent, child
                 visited.add(child)
                 if depth_now > 1:
                     queue.append((child, depth_now - 1, neighbors(child)))


### PR DESCRIPTION
# Possible bug in the graph traversal

Used graph class - `OrderedDiGraph`.

Result of the `list(networkx.edges(graph))`:

```
[('hdf_reader', 'buffer1'), ('buffer1', 'filter1'), ('buffer1', 'filter2'), ('filter1', 'extractor_dest'), ('filter2', 'extractor_dest')]
```

Incorrect result of the `list(bfs_successors(graph, 'buffer1'))`:

```
[('buffer1', ['filter1', 'filter2']), ('filter1', ['extractor_dest'])]
```

Correct result of the `list(bfs_successors(graph, 'buffer1'))`:

```
[('buffer1', ['filter1', 'filter2']), ('filter1', ['extractor_dest']), ('filter2', ['extractor_dest'])]
```