### PR TITLE
Bugfix: Added flexibility in reading values for label and id

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -193,7 +193,7 @@ def read_gml(path, label='label', destringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML website <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
 
@@ -263,7 +263,7 @@ def parse_gml(lines, label='label', destringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML website <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
     """
@@ -302,7 +302,8 @@ def parse_gml_lines(lines, label, destringizer):
     def tokenize():
         patterns = [
             r'[A-Za-z][0-9A-Za-z_]*\b',  # keys
-            r'[+-]?(?:[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)(?:[Ee][+-]?[0-9]+)?',  # reals
+            # reals
+            r'[+-]?(?:[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)(?:[Ee][+-]?[0-9]+)?',
             r'[+-]?[0-9]+',   # ints
             r'".*?"',         # strings
             r'\[',            # dict start
@@ -371,19 +372,23 @@ def parse_gml_lines(lines, label, destringizer):
             elif category == 4:  # dict start
                 curr_token, value = parse_dict(curr_token)
             else:
-                if key in ("id", "label", "source", "target"): #Allow for string convertible id and label values
-                    try:       
-                        value = unescape(str(curr_token[1])) #String convert the token value
+                # Allow for string convertible id and label values
+                if key in ("id", "label", "source", "target"):
+                    try:
+                        # String convert the token value
+                        value = unescape(str(curr_token[1]))
                         if destringizer:
                             try:
                                 value = destringizer(value)
                             except ValueError:
                                 pass
                         curr_token = next(tokens)
-                    except:
-                        unexpected(curr_token, "an int, float, string, '[' or string convertable ASCII value for node id or label")
-                else: #Otherwise error out
-                    unexpected(curr_token, "an int, float, string or '['") 
+                    except Exception:
+                        msg = "an int, float, string, '[' or string" + \
+                              " convertable ASCII value for node id or label"
+                        unexpected(curr_token, msg)
+                else:  # Otherwise error out
+                    unexpected(curr_token, "an int, float, string or '['")
             dct[key].append(value)
         dct = {key: (value if not isinstance(value, list) or len(value) != 1
                      else value[0]) for key, value in dct.items()}
@@ -455,11 +460,10 @@ def parse_gml_lines(lines, label, destringizer):
             if not G.has_edge(source, target):
                 G.add_edge(source, target, **edge)
             else:
-                raise nx.NetworkXError(
-                    """edge #%d (%r%s%r) is duplicated
-
-Hint:  If this is a multigraph, add "multigraph 1" to the header of the file.""" %
-                    (i, source, '->' if directed else '--', target))
+                msg = "edge #%d (%r%s%r) is duplicated.\n"
+                msg2 = 'Hint: If multigraph add "multigraph 1" to file header.'
+                info = (i, source, '->' if directed else '--', target)
+                raise nx.NetworkXError((msg % info) + msg2)
         else:
             key = edge.pop('key', None)
             if key is not None and G.has_edge(source, target, key):
@@ -622,7 +626,7 @@ def generate_gml(G, stringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML website <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
 
@@ -813,7 +817,7 @@ def write_gml(G, path, stringizer=None):
     sure to write GML format. In particular, underscores are not allowed in
     attribute names.
     For additional documentation on the GML file format, please see the
-    `GML website <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -370,7 +370,7 @@ def parse_gml_lines(lines, label, destringizer):
                 curr_token = next(tokens)
             elif category == 4:  # dict start
                 curr_token, value = parse_dict(curr_token)
-            else: 
+            else:
                 if key in ("id", "label", "source", "target"): #Allow for string convertible id and label values
                     try:       
                         value = unescape(str(curr_token[1])) #String convert the token value
@@ -381,7 +381,7 @@ def parse_gml_lines(lines, label, destringizer):
                                 pass
                         curr_token = next(tokens)
                     except:
-                        unexpected(curr_token, "an int, float, string, '[' or string convertable value for node id or label")
+                        unexpected(curr_token, "an int, float, string, '[' or string convertable ASCII value for node id or label")
                 else: #Otherwise error out
                     unexpected(curr_token, "an int, float, string or '['") 
             dct[key].append(value)

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -370,8 +370,20 @@ def parse_gml_lines(lines, label, destringizer):
                 curr_token = next(tokens)
             elif category == 4:  # dict start
                 curr_token, value = parse_dict(curr_token)
-            else:
-                unexpected(curr_token, "an int, float, string or '['")
+            else: 
+                if key in ("id", "label", "source", "target"): #Allow for string convertible id and label values
+                    try:       
+                        value = unescape(str(curr_token[1])) #String convert the token value
+                        if destringizer:
+                            try:
+                                value = destringizer(value)
+                            except ValueError:
+                                pass
+                        curr_token = next(tokens)
+                    except:
+                        unexpected(curr_token, "an int, float, string, '[' or string convertable value for node id or label")
+                else: #Otherwise error out
+                    unexpected(curr_token, "an int, float, string or '['") 
             dct[key].append(value)
         dct = {key: (value if not isinstance(value, list) or len(value) != 1
                      else value[0]) for key, value in dct.items()}

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -446,6 +446,8 @@ graph
             'graph [ node [ id n42 label 0 ] node [ id x43 label 1 ] '
             'edge [ source n42 target x43 key 0 ] edge [ source x43 target n42 key 0 ]'
             'directed 1 multigraph 1 ]')
+        assert_parse_error(
+            "graph [edge [ source u'u\4200' target u'u\4200' ] node [ id u'u\4200' label b ] ]")
 
         def assert_generate_error(*args, **kwargs):
             assert_raises(nx.NetworkXError,

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -439,6 +439,14 @@ graph
             'edge [ source 0 target 1 key 0 ] edge [ source 1 target 0 key 0 ]'
             'directed 1 multigraph 1 ]')
 
+       #Tests for string convertable alphanumeric id and label values 
+        nx.parse_gml(
+            'graph [edge [ source a target a ] node [ id a label b ] ]')
+        nx.parse_gml(
+            'graph [ node [ id n42 label 0 ] node [ id x43 label 1 ] '
+            'edge [ source n42 target x43 key 0 ] edge [ source x43 target n42 key 0 ]'
+            'directed 1 multigraph 1 ]')
+
         def assert_generate_error(*args, **kwargs):
             assert_raises(nx.NetworkXError,
                           lambda: list(nx.generate_gml(*args, **kwargs)))

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -337,12 +337,12 @@ graph
     def test_data_types(self):
         data = [True, False, 10 ** 20, -2e33, "'", '"&&amp;&&#34;"',
                 [{(b'\xfd',): '\x7f', unichr(0x4444): (1, 2)}, (2, "3")]]
-        try:
-            data.append(unichr(0x14444))  # fails under IronPython
+        try:  # fails under IronPython
+            data.append(unichr(0x14444))
         except ValueError:
             data.append(unichr(0x1444))
-        try:
-            data.append(literal_eval('{2.3j, 1 - 2.3j, ()}'))  # fails under Python 2.7
+        try:  # fails under Python 2.7
+            data.append(literal_eval('{2.3j, 1 - 2.3j, ()}'))
         except ValueError:
             data.append([2.3j, 1 - 2.3j, ()])
         G = nx.Graph()
@@ -356,7 +356,8 @@ graph
         assert_equal({'name': data, unicode('data'): data}, G.graph)
         assert_equal(list(G.nodes(data=True)),
                      [(0, dict(int=-1, data=dict(data=data)))])
-        assert_equal(list(G.edges(data=True)), [(0, 0, dict(float=-2.5, data=data))])
+        assert_equal(list(G.edges(data=True)),
+                     [(0, 0, dict(float=-2.5, data=data))])
         G = nx.Graph()
         G.graph['data'] = 'frozenset([1, 2, 3])'
         G = nx.parse_gml(nx.generate_gml(G), destringizer=literal_eval)
@@ -368,12 +369,15 @@ graph
 ]"""
         G = nx.parse_gml(gml)
         assert_equal(
-            '&"\x0f' + unichr(0x4444) + '&#1234567890;&#x1234567890abcdef;&unknown;',
+            '&"\x0f' + unichr(0x4444) +
+            '&#1234567890;&#x1234567890abcdef;&unknown;',
             G.name)
         gml = '\n'.join(nx.generate_gml(G))
-        assert_equal("""graph [
-  name "&#38;&#34;&#15;&#17476;&#38;#1234567890;&#38;#x1234567890abcdef;&#38;unknown;"
-]""", gml)
+        alnu = "#1234567890;&#38;#x1234567890abcdef"
+        answer = """graph [
+  name "&#38;&#34;&#15;&#17476;&#38;""" + alnu + """;&#38;unknown;"
+]"""
+        assert_equal(answer, gml)
 
     def test_exceptions(self):
         assert_raises(ValueError, literal_destringizer, '(')
@@ -439,15 +443,17 @@ graph
             'edge [ source 0 target 1 key 0 ] edge [ source 1 target 0 key 0 ]'
             'directed 1 multigraph 1 ]')
 
-       #Tests for string convertable alphanumeric id and label values 
+        # Tests for string convertable alphanumeric id and label values
         nx.parse_gml(
             'graph [edge [ source a target a ] node [ id a label b ] ]')
         nx.parse_gml(
-            'graph [ node [ id n42 label 0 ] node [ id x43 label 1 ] '
-            'edge [ source n42 target x43 key 0 ] edge [ source x43 target n42 key 0 ]'
+            'graph [ node [ id n42 label 0 ] node [ id x43 label 1 ]'
+            'edge [ source n42 target x43 key 0 ]'
+            'edge [ source x43 target n42 key 0 ]'
             'directed 1 multigraph 1 ]')
         assert_parse_error(
-            "graph [edge [ source u'u\4200' target u'u\4200' ] node [ id u'u\4200' label b ] ]")
+            "graph [edge [ source u'u\4200' target u'u\4200' ] " +
+            "node [ id u'u\4200' label b ] ]")
 
         def assert_generate_error(*args, **kwargs):
             assert_raises(nx.NetworkXError,
@@ -479,22 +485,24 @@ graph
         assert_equals(labels, ['Node 1', 'Node 2', 'Node 3'])
 
     def test_outofrange_integers(self):
-        # GML restricts integers to 32 signed bits. Check that we honor this restriction on export
+        # GML restricts integers to 32 signed bits.
+        # Check that we honor this restriction on export
         G = nx.Graph()
-        # Test export for numbers that barely fit or don't fit into 32 bits, and 3 numbers in the middle
-        numbers = { 'toosmall': (-2**31)-1,
-                    'small': -2**31,
-                    'med1': -4,
-                    'med2': 0,
-                    'med3': 17,
-                    'big': (2**31)-1,
-                    'toobig': 2**31 }
+        # Test export for numbers that barely fit or don't fit into 32 bits,
+        # and 3 numbers in the middle
+        numbers = {'toosmall': (-2**31)-1,
+                   'small': -2**31,
+                   'med1': -4,
+                   'med2': 0,
+                   'med3': 17,
+                   'big': (2**31)-1,
+                   'toobig': 2**31}
         G.add_node('Node', **numbers)
 
         fd, fname = tempfile.mkstemp()
         try:
             nx.write_gml(G, fname)
-            # Check that the export wrote the numbers that didn't fit as strings
+            # Check that the export wrote the nonfitting numbers as strings
             G2 = nx.read_gml(fname)
             for attr, value in G2.nodes['Node'].items():
                 if attr == 'toosmall' or attr == 'toobig':


### PR DESCRIPTION
As per issue #3157 

Added in support for string convertible objects to be used as ID's and labels, as well as source and targets for the GML reader. This adds increased flexibility in reading, even if the file is technically out of spec.