### PR TITLE
Fixes #3573:GEXF output problem

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -25,10 +25,12 @@ import time
 import networkx as nx
 from networkx.utils import open_file, make_str
 try:
-    from xml.etree.cElementTree import Element, ElementTree, SubElement, tostring
+    from xml.etree.cElementTree import (Element, ElementTree, SubElement,
+                                        tostring)
 except ImportError:
     try:
-        from xml.etree.ElementTree import Element, ElementTree, SubElement, tostring
+        from xml.etree.ElementTree import (Element, ElementTree, SubElement,
+                                           tostring)
     except ImportError:
         pass
 
@@ -36,7 +38,8 @@ __all__ = ['write_gexf', 'read_gexf', 'relabel_gexf_graph', 'generate_gexf']
 
 
 @open_file(1, mode='wb')
-def write_gexf(G, path, encoding='utf-8', prettyprint=True, version='1.2draft'):
+def write_gexf(G, path, encoding='utf-8', prettyprint=True,
+               version='1.2draft'):
     """Write G in GEXF format to path.
 
     "GEXF (Graph Exchange XML Format) is a language for describing
@@ -98,14 +101,14 @@ def generate_gexf(G, encoding='utf-8', prettyprint=True, version='1.2draft'):
     Parameters
     ----------
     G : graph
-       A NetworkX graph
+    A NetworkX graph
     encoding : string (optional, default: 'utf-8')
-       Encoding for text data.
+    Encoding for text data.
     prettyprint : bool (optional, default: True)
-       If True use line breaks and indenting in output XML.
+    If True use line breaks and indenting in output XML.
     version : string (default: 1.2draft)
-       Version of GEFX File Format (see https://gephi.org/gexf/format/schema.html).
-       Supported values: "1.1draft", "1.2draft"
+    Version of GEFX File Format (see https://gephi.org/gexf/format/schema.html)
+    Supported values: "1.1draft", "1.2draft"
 
 
     Examples
@@ -154,7 +157,7 @@ def read_gexf(path, node_type=None, relabel=False, version='1.2draft'):
        If True relabel the nodes to use the GEXF node "label" attribute
        instead of the node "id" attribute as the NetworkX node label.
     version : string (default: 1.2draft)
-       Version of GEFX File Format (see https://gephi.org/gexf/format/schema.html).
+    Version of GEFX File Format (see https://gephi.org/gexf/format/schema.html)
        Supported values: "1.1draft", "1.2draft"
 
     Returns
@@ -223,7 +226,7 @@ class GEXF(object):
                  (np.uint16, "int"), (np.uint32, "int"),
                  (np.uint64, "int"), (np.int_, "int"),
                  (np.intc, "int"), (np.intp, "int"),
-                ] + types
+                 ] + types
 
     xml_type = dict(types)
     python_type = dict(reversed(a) for a in types)
@@ -266,13 +269,15 @@ class GEXFWriter(GEXF):
                             'xmlns:xsi': self.NS_XSI,
                             'xsi:schemaLocation': self.SCHEMALOCATION,
                             'version': self.VERSION})
-        
-        #Make meta element a non-graph element, and add lastmodifieddate as attribute not tag
+
+        # Make meta element a non-graph element
+        # Also add lastmodifieddate as attribute, not tag
         meta_element = Element('meta')
-        SubElement(meta_element, 'creator').text = 'NetworkX {}'.format(nx.__version__)
-        meta_element.set('lastmodifieddate' , time.strftime('%Y-%m-%d'))
+        subelement_text = 'NetworkX {}'.format(nx.__version__)
+        SubElement(meta_element, 'creator').text = subelement_text
+        meta_element.set('lastmodifieddate', time.strftime('%Y-%m-%d'))
         self.xml.append(meta_element)
-        
+
         ET.register_namespace('viz', self.NS_VIZ)
 
         # counters for edge and attribute identifiers
@@ -320,7 +325,6 @@ class GEXFWriter(GEXF):
         self.add_nodes(G, graph_element)
         self.add_edges(G, graph_element)
         self.xml.append(graph_element)
-
 
     def add_nodes(self, G, graph_element):
         nodes_element = Element('nodes')
@@ -438,7 +442,8 @@ class GEXFWriter(GEXF):
                 k = 'networkx_key'
             val_type = type(v)
             if val_type not in self.xml_type:
-                raise TypeError('attribute value type is not allowed: %s' % val_type)
+                raise TypeError('attribute value type is not allowed: %s'
+                                % val_type)
             if isinstance(v, list):
                 # dynamic data
                 for val, start, end in v:
@@ -448,13 +453,14 @@ class GEXFWriter(GEXF):
                         self.alter_graph_mode_timeformat(start)
                         self.alter_graph_mode_timeformat(end)
                         break
-                attr_id = self.get_attr_id(make_str(k), self.xml_type[val_type],
+                attr_id = self.get_attr_id(make_str(k),
+                                           self.xml_type[val_type],
                                            node_or_edge, default, mode)
                 for val, start, end in v:
                     e = Element('attvalue')
                     e.attrib['for'] = attr_id
                     e.attrib['value'] = make_str(val)
-                    #Handle nan, inf, -inf differently
+                    # Handle nan, inf, -inf differently
                     if e.attrib['value'] == 'inf':
                         e.attrib['value'] = 'INF'
                     elif e.attrib['value'] == 'nan':
@@ -469,7 +475,8 @@ class GEXFWriter(GEXF):
             else:
                 # static data
                 mode = 'static'
-                attr_id = self.get_attr_id(make_str(k), self.xml_type[val_type],
+                attr_id = self.get_attr_id(make_str(k),
+                                           self.xml_type[val_type],
                                            node_or_edge, default, mode)
                 e = Element('attvalue')
                 e.attrib['for'] = attr_id
@@ -477,7 +484,7 @@ class GEXFWriter(GEXF):
                     e.attrib['value'] = make_str(v).lower()
                 else:
                     e.attrib['value'] = make_str(v)
-                    #Handle nan, inf, -inf differently
+                    # Handle nan, inf, -inf differently
                     if e.attrib['value'] == 'inf':
                         e.attrib['value'] = 'INF'
                     elif e.attrib['value'] == 'nan':
@@ -545,7 +552,8 @@ class GEXFWriter(GEXF):
 
             thickness = viz.get('thickness')
             if thickness is not None:
-                e = Element('{%s}thickness' % self.NS_VIZ, value=str(thickness))
+                e = Element('{%s}thickness' % self.NS_VIZ,
+                            value=str(thickness))
                 element.append(e)
 
             shape = viz.get('shape')
@@ -604,7 +612,8 @@ class GEXFWriter(GEXF):
         return node_or_edge_data
 
     def alter_graph_mode_timeformat(self, start_or_end):
-        # if 'start' or 'end' appears, alter Graph mode to dynamic and set timeformat
+        # If 'start' or 'end' appears, alter Graph mode to dynamic and
+        # set timeformat
         if self.graph_element.get('mode') == 'static':
             if start_or_end is not None:
                 if isinstance(start_or_end, str):
@@ -700,7 +709,8 @@ class GEXFReader(GEXF):
             self.timeformat = 'string'
 
         # node and edge attributes
-        attributes_elements = graph_xml.findall('{%s}attributes' % self.NS_GEXF)
+        attributes_elements = graph_xml.findall('{%s}attributes' %
+                                                self.NS_GEXF)
         # dictionaries to hold attributes and attribute defaults
         node_attr = {}
         node_default = {}
@@ -723,7 +733,8 @@ class GEXFReader(GEXF):
 
         # Hack to handle Gephi0.7beta bug
         # add weight attribute
-        ea = {'weight': {'type': 'double', 'mode': 'static', 'title': 'weight'}}
+        ea = {'weight': {'type': 'double', 'mode': 'static',
+                                 'title': 'weight'}}
         ed = {}
         edge_attr.update(ea)
         edge_default.update(ed)
@@ -781,9 +792,9 @@ class GEXFReader(GEXF):
         if subnodes is not None:
             for node_xml in subnodes.findall('{%s}node' % self.NS_GEXF):
                 self.add_node(G, node_xml, node_attr, node_pid=node_id)
-        
-        #Handle nan, inf, -inf differently
-        for k,v in data.items():
+
+        # Handle nan, inf, -inf differently
+        for k, v in data.items():
             if make_str(v) == 'inf':
                 data[k] = 'INF'
             elif make_str(v) == 'nan':
@@ -938,7 +949,8 @@ class GEXFReader(GEXF):
                 try:  # should be in our gexf_keys dictionary
                     title = gexf_keys[key]['title']
                 except KeyError:
-                    raise nx.NetworkXError('No attribute defined for=%s.' % key)
+                    raise nx.NetworkXError('No attribute defined for=%s.'
+                                           % key)
                 atype = gexf_keys[key]['type']
                 value = a.get('value')
                 if atype == 'boolean':
@@ -1036,7 +1048,7 @@ def setup_module(module):
     from nose import SkipTest
     try:
         import xml.etree.cElementTree
-    except:
+    except Exception as e:
         raise SkipTest('xml.etree.cElementTree not available.')
 
 
@@ -1045,5 +1057,5 @@ def teardown_module(module):
     import os
     try:
         os.unlink('test.gexf')
-    except:
+    except Exception as e:
         pass

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -304,13 +304,13 @@ class TestGEXF(object):
             G.nodes[i]['start'] = i
             G.nodes[i]['end'] = i + 1
 
+
         if sys.version_info < (3,8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance">
+            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
+  <meta lastmodifieddate="{}">
+    <creator>NetworkX {}</creator>
+  </meta>
   <graph defaultedgetype="undirected" mode="dynamic" name="" timeformat="long">
-    <meta>
-      <creator>NetworkX {}</creator>
-      <lastmodified>{}</lastmodified>
-    </meta>
     <nodes>
       <node end="1" id="0" label="0" pid="0" start="0" />
       <node end="2" id="1" label="1" pid="1" start="1" />
@@ -323,14 +323,13 @@ class TestGEXF(object):
       <edge id="2" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(nx.__version__, time.strftime('%d/%m/%Y'))
+</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance" version="1.2">
+            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="{}">
+    <creator>NetworkX {}</creator>
+  </meta>
   <graph defaultedgetype="undirected" mode="dynamic" name="" timeformat="long">
-    <meta>
-      <creator>NetworkX {}</creator>
-      <lastmodified>{}</lastmodified>
-    </meta>
     <nodes>
       <node id="0" label="0" pid="0" start="0" end="1" />
       <node id="1" label="1" pid="1" start="1" end="2" />
@@ -343,21 +342,20 @@ class TestGEXF(object):
       <edge source="2" target="3" id="2" />
     </edges>
   </graph>
-</gexf>""".format(nx.__version__, time.strftime('%d/%m/%Y'))
-
+</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
         obtained = '\n'.join(nx.generate_gexf(G))
         assert_equal(expected, obtained)
 
     def test_edge_id_construct(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1, {'id': 0}), (1, 2, {'id': 2}), (2, 3)])
+        
         if sys.version_info < (3,8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance">
+            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
+  <meta lastmodifieddate="{}">
+    <creator>NetworkX {}</creator>
+  </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
-    <meta>
-      <creator>NetworkX {}</creator>
-      <lastmodified>{}</lastmodified>
-    </meta>
     <nodes>
       <node id="0" label="0" />
       <node id="1" label="1" />
@@ -370,14 +368,13 @@ class TestGEXF(object):
       <edge id="1" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(nx.__version__, time.strftime('%d/%m/%Y'))
+</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance" version="1.2">
+            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="{}">
+    <creator>NetworkX {}</creator>
+  </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
-    <meta>
-      <creator>NetworkX {}</creator>
-      <lastmodified>{}</lastmodified>
-    </meta>
     <nodes>
       <node id="0" label="0" />
       <node id="1" label="1" />
@@ -390,7 +387,7 @@ class TestGEXF(object):
       <edge source="2" target="3" id="1" />
     </edges>
   </graph>
-</gexf>""".format(nx.__version__, time.strftime('%d/%m/%Y'))
+</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
 
         obtained = '\n'.join(nx.generate_gexf(G))
         assert_equal(expected, obtained)
@@ -404,7 +401,10 @@ class TestGEXF(object):
         nx.set_node_attributes(G, {n:n for n in numpy.arange(4)}, 'number')
         G[0][1]['edge-number'] = numpy.float64(1.1)
 
-        expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema-instance">
+        expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
+  <meta lastmodifieddate="{}">
+    <creator>NetworkX {}</creator>
+  </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
     <attributes class="edge" mode="static">
       <attribute id="1" title="edge-number" type="float" />
@@ -412,10 +412,6 @@ class TestGEXF(object):
     <attributes class="node" mode="static">
       <attribute id="0" title="number" type="int" />
     </attributes>
-    <meta>
-      <creator>NetworkX {}</creator>
-      <lastmodified>{}</lastmodified>
-    </meta>
     <nodes>
       <node id="0" label="0">
         <attvalues>
@@ -448,7 +444,7 @@ class TestGEXF(object):
       <edge id="2" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(nx.__version__, time.strftime('%d/%m/%Y'))
+</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
         obtained = '\n'.join(nx.generate_gexf(G))
         assert_equal(expected, obtained)
 
@@ -460,3 +456,17 @@ class TestGEXF(object):
         fh.seek(0)
         H = nx.read_gexf(fh, node_type=int)
         assert_equal(H.nodes[1]['testattr'], True)
+        
+    #Test for NaN, INF and -INF
+    def test_specials(self):
+        G = nx.Graph()
+        G.add_node(1, testattr=float('inf'))
+        G.add_node(2, testattr=float('nan'))
+        G.add_node(3, testattr=float('-inf'))
+        fh = io.BytesIO()
+        nx.write_gexf(G, fh)
+        fh.seek(0)
+        H = nx.read_gexf(fh, node_type=float)#float as inf,-inf and nan are all floats internally
+        assert_equal(H.nodes[1]['testattr'], "INF")
+        assert_equal(H.nodes[2]['testattr'], "NaN")
+        assert_equal(H.nodes[3]['testattr'], "-INF")

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -38,8 +38,10 @@ class TestGEXF(object):
         self.simple_directed_fh = \
             io.BytesIO(self.simple_directed_data.encode('UTF-8'))
 
-        self.attribute_data = """<?xml version="1.0" encoding="UTF-8"?>
-<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+        self.attribute_data = """<?xml version="1.0" encoding="UTF-8"?>\
+<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.\
+org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/\
+1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
   <meta lastmodifieddate="2009-03-20">
     <creator>Gephi.org</creator>
     <description>A Web network</description>
@@ -135,7 +137,8 @@ class TestGEXF(object):
         self.simple_undirected_graph.add_node('1', label='World')
         self.simple_undirected_graph.add_edge('0', '1', id='0')
 
-        self.simple_undirected_fh = io.BytesIO(self.simple_undirected_data.encode('UTF-8'))
+        self.simple_undirected_fh = io.BytesIO(self.simple_undirected_data
+                                                   .encode('UTF-8'))
 
     def test_read_simple_directed_graphml(self):
         G = self.simple_directed_graph
@@ -304,9 +307,11 @@ class TestGEXF(object):
             G.nodes[i]['start'] = i
             G.nodes[i]['end'] = i + 1
 
-
-        if sys.version_info < (3,8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
+        if sys.version_info < (3, 8):
+            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2\
+draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:\
+schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/\
+gexf.xsd">
   <meta lastmodifieddate="{}">
     <creator>NetworkX {}</creator>
   </meta>
@@ -323,9 +328,12 @@ class TestGEXF(object):
       <edge id="2" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
+</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi\
+="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=\
+"http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/\
+gexf.xsd" version="1.2">
   <meta lastmodifieddate="{}">
     <creator>NetworkX {}</creator>
   </meta>
@@ -342,16 +350,19 @@ class TestGEXF(object):
       <edge source="2" target="3" id="2" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
+</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
         obtained = '\n'.join(nx.generate_gexf(G))
         assert_equal(expected, obtained)
 
     def test_edge_id_construct(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1, {'id': 0}), (1, 2, {'id': 2}), (2, 3)])
-        
-        if sys.version_info < (3,8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
+
+        if sys.version_info < (3, 8):
+            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/\
+1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:\
+schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/\
+gexf.xsd">
   <meta lastmodifieddate="{}">
     <creator>NetworkX {}</creator>
   </meta>
@@ -368,9 +379,11 @@ class TestGEXF(object):
       <edge id="1" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
+</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi\
+="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.\
+gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
   <meta lastmodifieddate="{}">
     <creator>NetworkX {}</creator>
   </meta>
@@ -387,7 +400,7 @@ class TestGEXF(object):
       <edge source="2" target="3" id="1" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
+</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
 
         obtained = '\n'.join(nx.generate_gexf(G))
         assert_equal(expected, obtained)
@@ -398,10 +411,12 @@ class TestGEXF(object):
             import numpy
         except ImportError:
             return
-        nx.set_node_attributes(G, {n:n for n in numpy.arange(4)}, 'number')
+        nx.set_node_attributes(G, {n: n for n in numpy.arange(4)}, 'number')
         G[0][1]['edge-number'] = numpy.float64(1.1)
 
-        expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
+        expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft"\
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation\
+="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
   <meta lastmodifieddate="{}">
     <creator>NetworkX {}</creator>
   </meta>
@@ -444,7 +459,7 @@ class TestGEXF(object):
       <edge id="2" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d') , nx.__version__)
+</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
         obtained = '\n'.join(nx.generate_gexf(G))
         assert_equal(expected, obtained)
 
@@ -456,8 +471,8 @@ class TestGEXF(object):
         fh.seek(0)
         H = nx.read_gexf(fh, node_type=int)
         assert_equal(H.nodes[1]['testattr'], True)
-        
-    #Test for NaN, INF and -INF
+
+    # Test for NaN, INF and -INF
     def test_specials(self):
         G = nx.Graph()
         G.add_node(1, testattr=float('inf'))
@@ -466,7 +481,8 @@ class TestGEXF(object):
         fh = io.BytesIO()
         nx.write_gexf(G, fh)
         fh.seek(0)
-        H = nx.read_gexf(fh, node_type=float)#float as inf,-inf and nan are all floats internally
+        # float as inf,-inf and nan are all floats internally
+        H = nx.read_gexf(fh, node_type=float)
         assert_equal(H.nodes[1]['testattr'], "INF")
         assert_equal(H.nodes[2]['testattr'], "NaN")
         assert_equal(H.nodes[3]['testattr'], "-INF")

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -478,6 +478,8 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
         G.add_node(1, testattr=float('inf'))
         G.add_node(2, testattr=float('nan'))
         G.add_node(3, testattr=float('-inf'))
+        list_value = [(1, 2, 3), (2, 1, 2)]
+        G.add_node(4, key=list_value)
         fh = io.BytesIO()
         nx.write_gexf(G, fh)
         fh.seek(0)
@@ -486,3 +488,4 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
         assert_equal(H.nodes[1]['testattr'], "INF")
         assert_equal(H.nodes[2]['testattr'], "NaN")
         assert_equal(H.nodes[3]['testattr'], "-INF")
+        assert_equals(H.nodes[4]['networkx_key'], list_value)


### PR DESCRIPTION
This fixes issue #3573 . As discussed in PR #3595, this is a PR that conforms to the best practices and passes the test for python 3.8. Please review and comment as necessary.

**Note**: A test for INF, -INF and NaN called test_specials() has been added in tests/test_gexf.py