### PR TITLE
Fix typo within incode documentation

### DIFF
--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -286,7 +286,7 @@ def greedy_color(G, strategy='largest_first', interchange=False):
        * ``'connected_sequential_bfs'``
        * ``'connected_sequential_dfs'``
        * ``'connected_sequential'`` (alias for the previous strategy)
-       * ``'strategy_saturation_largest_first'``
+       * ``'saturation_largest_first'``
        * ``'DSATUR'`` (alias for the previous strategy)
 
     interchange: bool


### PR DESCRIPTION
Modify *'strategy_saturation_largest_first'* into *'saturation_largest_first'*