### PR TITLE
Document `subgraph_view` function with support for filter functions

### DIFF
--- a/doc/reference/functions.rst
+++ b/doc/reference/functions.rst
@@ -22,6 +22,7 @@ Graph
    add_path
    add_cycle
    subgraph
+   subgraph_view
    induced_subgraph
    restricted_view
    reverse_view

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -21,11 +21,14 @@ except ImportError:
 import networkx as nx
 from networkx.utils import pairwise, not_implemented_for
 
+from networkx.classes.graphviews import subgraph_view, reverse_view
+
 __all__ = ['nodes', 'edges', 'degree', 'degree_histogram', 'neighbors',
            'number_of_nodes', 'number_of_edges', 'density',
-           'is_directed', 'info', 'freeze', 'is_frozen', 'subgraph',
-           'induced_subgraph', 'edge_subgraph', 'restricted_view',
-           'reverse_view', 'to_directed', 'to_undirected',
+           'is_directed', 'info', 'freeze', 'is_frozen',
+           'subgraph', 'subgraph_view', 'induced_subgraph', 'reverse_view',
+           'edge_subgraph', 'restricted_view',
+           'to_directed', 'to_undirected',
            'add_star', 'add_path', 'add_cycle',
            'create_empty_copy', 'set_node_attributes',
            'get_node_attributes', 'set_edge_attributes',
@@ -490,15 +493,6 @@ def restricted_view(G, nodes, edges):
         else:
             hide_edges = nxf.hide_edges(edges)
     return nx.graphviews.subgraph_view(G, hide_nodes, hide_edges)
-
-
-@not_implemented_for('undirected')
-def reverse_view(digraph):
-    """Provide a reverse view of the digraph with edges reversed.
-
-    Identical to digraph.reverse(copy=False)
-    """
-    return nx.graphviews.reverse_view(digraph)
 
 
 def to_directed(graph):


### PR DESCRIPTION
This is functionality I've developed external to networkx and thought it might be a welcome feature.

An example of how I've used it is in an energy distribution circuit, where I want to stop iterating a series of conducting elements when I encounter an open switch. For example, in the following circuit i have several conductors (a,b), (b, c), (b, d) and (c, e) -- one of which is a switch. Depending on the status of the switch, i would want to stop traversing the graph so that I don't build a model of the circuit where there is a demand for power that can't be satisfied, which would probably cause my model to fail to solve.

```
    a---------b---------c./ .e->L
               \
                \
                 d->L
```

I'm open to suggestions about how this could work , but my vision for it is that traversal functions can accept a callable which takes a standard set of arguments -- for example, a depth-first-search edge traversal interrupt would be parametrized by the graph and the parent/child, so that within the interrupt i can perform any analysis on the graph and/or edge data that I want before deciding if the branch should be interrupted, which I can do by raising a `StopIteration` error.

I've created an issue, https://github.com/networkx/networkx/issues/3625, related to this PR, which may be a better place to discuss this at a high-level. 

I'll probably work on adding this interface to the `edge_dfs` function and the bfs functions as well, which is why this PR is marked WIP for now.
