### PR TITLE
Fix typo + factorize `if` statement

### DIFF
--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -293,7 +293,7 @@ def greedy_color(G, strategy='largest_first', interchange=False):
        Will use the color interchange algorithm described by [3]_ if set
        to ``True``.
 
-       Note that ``strategy_saturation_largest_first`` and
+       Note that ``saturation_largest_first`` and
        ``strategy_independent_set`` do not work with
        interchange. Furthermore, if you use interchange with your own
        strategy function, you cannot rely on the values in the
@@ -314,8 +314,8 @@ def greedy_color(G, strategy='largest_first', interchange=False):
     Raises
     ------
     NetworkXPointlessConcept
-        If ``strategy`` is ``strategy_saturation_largest_first`` or
-        ``strategy_independent_set`` and ``interchange`` is ``True``.
+        If ``strategy`` is ``saturation_largest_first`` or
+        ``independent_set`` and ``interchange`` is ``True``.
 
     References
     ----------
@@ -340,12 +340,8 @@ def greedy_color(G, strategy='largest_first', interchange=False):
     # Perform some validation on the arguments before executing any
     # strategy functions.
     if interchange:
-        if strategy is strategy_independent_set:
-            msg = 'interchange cannot be used with strategy_independent_set'
-            raise nx.NetworkXPointlessConcept(msg)
-        if strategy is strategy_saturation_largest_first:
-            msg = ('interchange cannot be used with'
-                   ' strategy_saturation_largest_first')
+        if strategy is strategy_independent_set or strategy is strategy_saturation_largest_first:
+            msg = 'interchange cannot be used with ' + strategy
             raise nx.NetworkXPointlessConcept(msg)
     colors = {}
     nodes = strategy(G, colors)

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -341,7 +341,7 @@ def greedy_color(G, strategy='largest_first', interchange=False):
     # strategy functions.
     if interchange:
         if strategy is strategy_independent_set or strategy is strategy_saturation_largest_first:
-            msg = 'interchange cannot be used with ' + strategy
+            msg = 'interchange cannot be used with ' + strategy[0]
             raise nx.NetworkXPointlessConcept(msg)
     colors = {}
     nodes = strategy(G, colors)


### PR DESCRIPTION
* replace `strategy_saturation_largest_first` and `strategy_independent_set` by respectively `saturation_largest_first` and `independent_set` (similar to issue  #3621).

* replace
```python
if strategy is strategy_independent_set:
    msg = 'interchange cannot be used with strategy_independent_set'
    raise nx.NetworkXPointlessConcept(msg)
if strategy is strategy_saturation_largest_first:
    msg = ('interchange cannot be used with'
           ' strategy_saturation_largest_first')
    raise nx.NetworkXPointlessConcept(msg)
```
by
```python
if strategy is strategy_independent_set or strategy is strategy_saturation_largest_first:
    msg = 'interchange cannot be used with ' + strategy
    raise nx.NetworkXPointlessConcept(msg)
```