### PR TITLE
Run doctest without optional dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ test_script:
   # Change to a non-source folder to make sure we run the tests on the
   # installed library.
   - "pushd %TEMP%"
-  - "pytest --pyargs networkx"
+  - "pytest --doctest-modules --pyargs networkx"
 
 cache:
   # Avoid re-downloading large packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ matrix:
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.8
     - python: 3.6
+      env:
+      - DOCTEST=1
     - python: 3.8
     - python: pypy3.6-7.1.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
       python: 3.7
       env:
       - OPTIONAL_DEPS=1
-      - DOCTEST=1
       - PIP_FLAGS="--pre"
       addons:
         apt:
@@ -64,8 +63,6 @@ matrix:
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.8
     - python: 3.6
-      env:
-      - DOCTEST=1
     - python: 3.8
     - python: pypy3.6-7.1.1
 

--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -12,8 +12,6 @@
 
 from collections import defaultdict
 
-import networkx as nx
-
 __all__ = ['average_degree_connectivity',
            'k_nearest_neighbors']
 

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -285,10 +285,3 @@ def numeric_ac(M):
     xy = numpy.outer(x, y)
     ab = numpy.outer(a, b)
     return (xy * (M - ab)).sum() / numpy.sqrt(vara * varb)
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Node assortativity coefficients and correlation measures.
 """
-import networkx as nx
 from networkx.algorithms.assortativity.mixing import degree_mixing_matrix, \
     attribute_mixing_matrix, numeric_mixing_matrix
 from networkx.algorithms.assortativity.pairs import node_degree_xy
@@ -46,8 +45,8 @@ def degree_assortativity_coefficient(G, x='out', y='in', weight=None,
 
     Examples
     --------
-    >>> G=nx.path_graph(4)
-    >>> r=nx.degree_assortativity_coefficient(G)
+    >>> G = nx.path_graph(4)
+    >>> r = nx.degree_assortativity_coefficient(G)
     >>> print("%3.1f"%r)
     -0.5
 
@@ -113,8 +112,8 @@ def degree_pearson_correlation_coefficient(G, x='out', y='in',
 
     Examples
     --------
-    >>> G=nx.path_graph(4)
-    >>> r=nx.degree_pearson_correlation_coefficient(G)
+    >>> G = nx.path_graph(4)
+    >>> r = nx.degree_pearson_correlation_coefficient(G)
     >>> print("%3.1f"%r)
     -0.5
 
@@ -163,7 +162,7 @@ def attribute_assortativity_coefficient(G, attribute, nodes=None):
 
     Examples
     --------
-    >>> G=nx.Graph()
+    >>> G = nx.Graph()
     >>> G.add_nodes_from([0,1],color='red')
     >>> G.add_nodes_from([2,3],color='blue')
     >>> G.add_edges_from([(0,1),(2,3)])
@@ -211,7 +210,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
 
     Examples
     --------
-    >>> G=nx.Graph()
+    >>> G = nx.Graph()
     >>> G.add_nodes_from([0,1],size=2)
     >>> G.add_nodes_from([2,3],size=3)
     >>> G.add_edges_from([(0,1),(2,3)])

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -235,10 +235,3 @@ def mixing_dict(xy, normalized=False):
             for j in jdict:
                 jdict[j] /= psum
     return d
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -2,7 +2,6 @@
 """
 Mixing matrices for node attributes and degree.
 """
-import networkx as nx
 from networkx.utils import dict_to_numpy_array
 from networkx.algorithms.assortativity.pairs import node_degree_xy, \
     node_attribute_xy

--- a/networkx/algorithms/assortativity/neighbor_degree.py
+++ b/networkx/algorithms/assortativity/neighbor_degree.py
@@ -4,7 +4,6 @@
 #    Aric Hagberg <hagberg@lanl.gov>
 #    All rights reserved.
 #    BSD license.
-import networkx as nx
 __author__ = """\n""".join(['Jordi Torrents <jtorrents@milnou.net>',
                             'Aric Hagberg (hagberg@lanl.gov)'])
 __all__ = ["average_neighbor_degree"]

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -119,10 +119,3 @@ def node_degree_xy(G, x='out', y='in', weight=None, nodes=None):
         neighbors = (nbr for _, nbr in G.edges(u) if nbr in nodes)
         for v, degv in ydeg(neighbors, weight=weight):
             yield degu, degv
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Generators of  x-y pairs of node data."""
-import networkx as nx
 __author__ = ' '.join(['Aric Hagberg <aric.hagberg@gmail.com>'])
 __all__ = ['node_attribute_xy',
            'node_degree_xy']

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -167,9 +167,3 @@ def from_biadjacency_matrix(A, create_using=None, edge_attribute='weight'):
         triples = chain(((u, v, 1) for d in range(w)) for (u, v, w) in triples)
     G.add_weighted_edges_from(triples, weight=edge_attribute)
     return G
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -75,10 +75,3 @@ def spectral_bipartivity(G, nodes=None, weight='weight'):
             i = index[n]
             sb[n] = coshA[i, i] / expA[i, i]
         return sb
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -362,10 +362,3 @@ def edge_current_flow_betweenness_centrality(G, normalized=True,
         betweenness[e] /= nb
     return dict(((ordering[s], ordering[t]), float(v))
                 for (s, t), v in betweenness.items())
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -244,10 +244,3 @@ def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
         betweenness[e] /= nb
     return dict(((ordering[s], ordering[t]), v)
                 for (s, t), v in betweenness.items())
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -103,9 +103,3 @@ def current_flow_closeness_centrality(G, weight=None,
 
 
 information_centrality = current_flow_closeness_centrality
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -236,9 +236,3 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     largest = eigenvector.flatten().real
     norm = sp.sign(largest.sum()) * sp.linalg.norm(largest)
     return dict(zip(G, largest / norm))
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -334,10 +334,3 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,
         norm = 1.0
     centrality = dict(zip(nodelist, map(float, centrality / norm)))
     return centrality
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -136,10 +136,3 @@ def second_order_centrality(G):
     return dict(zip(G.nodes,
                     [np.sqrt((2*np.sum(M[:, i])-n*(n+1))) for i in range(n)]
                     ))  # eq 6
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -315,10 +315,3 @@ def estrada_index(G):
     >>> ei=nx.estrada_index(G)
     """
     return sum(subgraph_centrality(G).values())
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -12,7 +12,6 @@ from itertools import chain
 from itertools import combinations
 from collections import Counter
 
-import networkx as nx
 from networkx.utils import not_implemented_for
 
 __author__ = """\n""".join(['Aric Hagberg <aric.hagberg@gmail.com>',

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -168,10 +168,3 @@ def communicability_exp(G):
         for v in G:
             c[u][v] = float(expA[mapping[u], mapping[v]])
     return c
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -16,7 +16,6 @@
 """Functions for detecting communities based on modularity.
 """
 
-import networkx as nx
 from networkx.algorithms.community.quality import modularity
 
 from networkx.utils.mapped_queue import MappedQueue

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -11,7 +11,6 @@
 #          Aric Hagberg (aric.hagberg@gmail.com)
 """Biconnected components and articulation points."""
 from itertools import chain
-import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
 __all__ = [

--- a/networkx/algorithms/isolate.py
+++ b/networkx/algorithms/isolate.py
@@ -9,7 +9,6 @@
 """
 Functions for identifying isolate (degree zero) nodes.
 """
-import networkx as nx
 
 __author__ = """\n""".join(['Drew Conway <drew.conway@nyu.edu>',
                             'Aric Hagberg <hagberg@lanl.gov>'])

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -145,7 +145,6 @@ polynomial-time algorithm is known to exist).
 #    Complexity Sciences Center and Physics Department, UC Davis.
 
 import sys
-import networkx as nx
 
 __all__ = ['GraphMatcher',
            'DiGraphMatcher']

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -310,10 +310,3 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, normalized=True):
     hubs = dict(zip(G, map(float, h)))
     authorities = dict(zip(G, map(float, a)))
     return hubs, authorities
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -468,10 +468,3 @@ def pagerank_scipy(G, alpha=0.85, personalization=None,
         if err < N * tol:
             return dict(zip(nodelist, map(float, x)))
     raise nx.PowerIterationFailedConvergence(max_iter)
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -142,10 +142,3 @@ def harmonic_function(G, max_iter=30, label_name='label'):
     predicted = _predict(F, label_dict)
 
     return predicted
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -152,10 +152,3 @@ def local_and_global_consistency(G, alpha=0.99,
     predicted = _predict(F, label_dict)
 
     return predicted
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -90,9 +90,3 @@ def non_randomness(G, k=None):
     nr_rd = (nr - ((n - 2 * k) * p + k)) / math.sqrt(2 * k * p * (1 - p))
 
     return nr, nr_rd
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -209,9 +209,3 @@ def floyd_warshall(G, weight='weight'):
     """
     # could make this its own function to reduce memory costs
     return floyd_warshall_predecessor_and_distance(G, weight=weight)[1]
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1240,10 +1240,3 @@ def simrank_similarity_numpy(G, source=None, target=None, importance_factor=0.9,
     if source is not None:
         return newsim[source]
     return newsim
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/algorithms/traversal/beamsearch.py
+++ b/networkx/algorithms/traversal/beamsearch.py
@@ -8,7 +8,6 @@
 # information.
 """Basic algorithms for breadth-first searching the nodes of a graph."""
 
-import networkx as nx
 from .breadth_first_search import generic_bfs_edges
 
 __all__ = ['bfs_beam_edges']

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -20,7 +20,7 @@ For directed graphs see DiGraph and MultiDiGraph.
 from copy import deepcopy
 
 import networkx as nx
-from networkx.classes.coreviews import AtlasView, AdjacencyView
+from networkx.classes.coreviews import AdjacencyView
 from networkx.classes.reportviews import NodeView, EdgeView, DegreeView
 from networkx.exception import NetworkXError
 import networkx.convert as convert

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -93,7 +93,6 @@ EdgeDataView
     The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 """
 from collections.abc import Mapping, Set
-import networkx as nx
 
 __all__ = ['NodeView', 'NodeDataView',
            'EdgeView', 'OutEdgeView', 'InEdgeView',

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -1,0 +1,133 @@
+import pytest
+import networkx
+
+
+@pytest.fixture(autouse=True)
+def add_np(doctest_namespace):
+    doctest_namespace["nx"] = networkx
+
+
+# What dependencies are installed?
+
+try:
+    import numpy
+
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
+try:
+    import scipy
+
+    has_scipy = True
+except ImportError:
+    has_scipy = False
+
+try:
+    import matplotlib
+
+    has_matplotlib = True
+except ImportError:
+    has_matplotlib = False
+
+try:
+    import pandas
+
+    has_pandas = True
+except ImportError:
+    has_pandas = False
+
+try:
+    import pygraphviz
+
+    has_pygraphviz = True
+except ImportError:
+    has_pygraphviz = False
+
+try:
+    import yaml
+
+    has_yaml = True
+except ImportError:
+    has_yaml = False
+
+try:
+    import pydot
+
+    has_pydot = True
+except ImportError:
+    has_pydot = False
+
+try:
+    import ogr
+
+    has_ogr = True
+except ImportError:
+    has_ogr = False
+
+
+# List of files that pytest should ignore
+
+collect_ignore = []
+
+needs_numpy = [
+    "algorithms/centrality/current_flow_closeness.py",
+    "algorithms/node_classification/__init__.py",
+    "algorithms/non_randomness.py",
+    "algorithms/shortest_paths/dense.py",
+    "linalg/bethehessianmatrix.py",
+    "linalg/laplacianmatrix.py",
+    "utils/misc.py",
+]
+needs_scipy = [
+    "algorithms/assortativity/correlation.py",
+    "algorithms/assortativity/mixing.py",
+    "algorithms/assortativity/pairs.py",
+    "algorithms/bipartite/matrix.py",
+    "algorithms/bipartite/spectral.py",
+    "algorithms/centrality/current_flow_betweenness.py",
+    "algorithms/centrality/current_flow_betweenness_subset.py",
+    "algorithms/centrality/eigenvector.py",
+    "algorithms/centrality/katz.py",
+    "algorithms/centrality/second_order.py",
+    "algorithms/centrality/subgraph_alg.py",
+    "algorithms/communicability_alg.py",
+    "algorithms/link_analysis/hits_alg.py",
+    "algorithms/link_analysis/pagerank_alg.py",
+    "algorithms/node_classification/hmn.py",
+    "algorithms/node_classification/lgc.py",
+    "algorithms/similarity.py",
+    "convert_matrix.py",
+    "drawing/layout.py",
+    "generators/spectral_graph_forge.py",
+    "linalg/algebraicconnectivity.py",
+    "linalg/attrmatrix.py",
+    "linalg/graphmatrix.py",
+    "linalg/modularitymatrix.py",
+    "linalg/spectrum.py",
+    "utils/rcm.py",
+]
+needs_matplotlib = ["drawing/nx_pylab.py"]
+needs_pandas = ["convert_matrix.py"]
+needs_yaml = ["readwrite/nx_yaml.py"]
+# needs_xml?
+needs_pygraphviz = ["drawing/nx_agraph.py"]
+needs_pydot = ["drawing/nx_pydot.py"]
+needs_ogr = ["readwrite/nx_shp.py"]
+
+if not has_numpy:
+    collect_ignore += needs_numpy
+if not has_scipy:
+    collect_ignore += needs_scipy
+if not has_matplotlib:
+    collect_ignore += needs_matplotlib
+if not has_pandas:
+    collect_ignore += needs_pandas
+if not has_yaml:
+    collect_ignore += needs_yaml
+if not has_pygraphviz:
+    collect_ignore += needs_pygraphviz
+if not has_pydot:
+    collect_ignore += needs_pydot
+if not has_ogr:
+    collect_ignore += needs_ogr

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 import networkx
+import sys
 
 
 @pytest.fixture(autouse=True)
-def add_np(doctest_namespace):
+def add_nx(doctest_namespace):
     doctest_namespace["nx"] = networkx
 
 
@@ -110,7 +111,6 @@ needs_scipy = [
 needs_matplotlib = ["drawing/nx_pylab.py"]
 needs_pandas = ["convert_matrix.py"]
 needs_yaml = ["readwrite/nx_yaml.py"]
-# needs_xml?
 needs_pygraphviz = ["drawing/nx_agraph.py"]
 needs_pydot = ["drawing/nx_pydot.py"]
 needs_ogr = ["readwrite/nx_shp.py"]
@@ -131,3 +131,7 @@ if not has_pydot:
     collect_ignore += needs_pydot
 if not has_ogr:
     collect_ignore += needs_ogr
+
+# FIXME:  This is to avoid errors on AppVeyor
+if sys.platform.startswith("win"):
+    collect_ignore += ["readwrite/graph6.py", "readwrite/sparse6.py"]

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1235,11 +1235,3 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
     """
     return from_numpy_matrix(A, parallel_edges=parallel_edges,
                              create_using=create_using)
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')
-    pandas = pytest.importorskip('pandas')

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1069,10 +1069,3 @@ def rescale_layout(pos, scale=1):
         for i in range(pos.shape[1]):
             pos[:, i] *= scale / lim
     return pos
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -465,9 +465,3 @@ def display_pygraphviz(graph, path, format=None, prog=None, args=''):
     graph.draw(path, format, prog, args)
     path.close()
     nx.utils.default_opener(filename)
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    pygraphviz = pytest.importorskip('pygraphviz')

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -339,9 +339,3 @@ def pydot_layout(G, prog='neato', root=None):
             xx, yy = pos.split(",")
             node_pos[n] = (float(xx), float(yy))
     return node_pos
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    pydot = pytest.importorskip('pydot')

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1176,11 +1176,3 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
     except TypeError:
         rgba_colors[:, -1] = alpha
     return rgba_colors
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    mpl = pytest.importorskip('matplotlib')
-    mpl.use('PS', warn=False)
-    plt = pytest.importorskip('matplotlib.pyplot')

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -194,10 +194,3 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     H = nx.from_numpy_matrix(B)
 
     return H
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -582,10 +582,3 @@ def spectral_ordering(G, weight='weight', normalized=False, tol=1e-8,
             order.extend(component)
 
     return order
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy.sparse = pytest.importorskip('scipy.sparse')

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -4,7 +4,6 @@
 
 __all__ = ['attr_matrix', 'attr_sparse_matrix']
 
-import networkx as nx
 
 
 def _node_value(G, node_attr):

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -446,10 +446,3 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
         return M, ordering
     else:
         return M
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -84,9 +84,3 @@ def bethe_hessian_matrix(G, r=None, nodelist=None):
     D = scipy.sparse.spdiags(diags.flatten(), [0], m, n, format='csr')
     I = scipy.sparse.eye(m, n, format='csr')
     return (r ** 2 - 1) * I - r * A + D
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -164,9 +164,3 @@ def adjacency_matrix(G, nodelist=None, weight='weight'):
 
 
 adj_matrix = adjacency_matrix
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    scipy = pytest.importorskip('scipy')

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -367,9 +367,3 @@ def _transition_matrix(G, nodelist=None, weight='weight',
         raise nx.NetworkXError("walk_type must be random, lazy, or pagerank")
 
     return P
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')

--- a/networkx/linalg/modularitymatrix.py
+++ b/networkx/linalg/modularitymatrix.py
@@ -157,10 +157,3 @@ def directed_modularity_matrix(G, nodelist=None, weight=None):
     # Expected adjacency matrix
     X = k_out * k_in / m
     return A - X
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')
-    scipy = pytest.importorskip('scipy')

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -164,9 +164,3 @@ def bethe_hessian_spectrum(G, r=None):
     """
     from scipy.linalg import eigvalsh
     return eigvalsh(nx.bethe_hessian_matrix(G, r).todense())
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    scipy.linalg = pytest.importorskip('scipy.linalg')

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -294,11 +294,3 @@ def read_adjlist(path, comments="#", delimiter=None, create_using=None,
                          delimiter=delimiter,
                          create_using=create_using,
                          nodetype=nodetype)
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    for fname in ['test.adjlist', 'test.adjlist.gz']:
-        if os.path.isfile(fname):
-            os.unlink(fname)

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -458,12 +458,3 @@ def read_weighted_edgelist(path, comments="#", delimiter=None,
                          data=(('weight', float),),
                          encoding=encoding
                          )
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    for fname in ['test.edgelist', 'test.edgelist.gz',
-                  'test.weighted.edgelist']:
-        if os.path.isfile(fname):
-            os.unlink(fname)

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -24,15 +24,8 @@ import time
 
 import networkx as nx
 from networkx.utils import open_file, make_str
-try:
-    from xml.etree.cElementTree import (Element, ElementTree, SubElement,
-                                        tostring)
-except ImportError:
-    try:
-        from xml.etree.ElementTree import (Element, ElementTree, SubElement,
-                                           tostring)
-    except ImportError:
-        pass
+
+from xml.etree.ElementTree import Element, ElementTree, SubElement, tostring
 
 __all__ = ['write_gexf', 'read_gexf', 'relabel_gexf_graph', 'generate_gexf']
 

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -1035,18 +1035,3 @@ def relabel_gexf_graph(G):
         if 'parents' in H.nodes[m]:
             H.nodes[m]['parents'] = [mapping[p] for p in G.nodes[n]['parents']]
     return H
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    xml.etree.cElementTree = pytest.importorskip('xml.etree.cElementTree')
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    try:
-        os.unlink('test.gexf')
-    except Exception as e:
-        pass

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -832,11 +832,3 @@ def write_gml(G, path, stringizer=None):
     """
     for line in generate_gml(G, stringizer):
         path.write((line + '\n').encode('ascii'))
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    for fname in ['test.gml', 'test.gml.gz']:
-        if os.path.isfile(fname):
-            os.unlink(fname)

--- a/networkx/readwrite/gpickle.py
+++ b/networkx/readwrite/gpickle.py
@@ -99,9 +99,3 @@ def read_gpickle(path):
     .. [1] https://docs.python.org/2/library/pickle.html
     """
     return pickle.load(path)
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    os.unlink('test.gpickle')

--- a/networkx/readwrite/gpickle.py
+++ b/networkx/readwrite/gpickle.py
@@ -30,7 +30,6 @@ __author__ = """Aric Hagberg (hagberg@lanl.gov)\nDan Schult (dschult@colgate.edu
 
 __all__ = ['read_gpickle', 'write_gpickle']
 
-import networkx as nx
 from networkx.utils import open_file
 
 try:

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -46,15 +46,8 @@ for examples.
 import warnings
 from collections import defaultdict
 
-try:
-    from xml.etree.cElementTree import Element, ElementTree
-    from xml.etree.cElementTree import tostring, fromstring
-except ImportError:
-    try:
-        from xml.etree.ElementTree import Element, ElementTree
-        from xml.etree.ElementTree import tostring, fromstring
-    except ImportError:
-        pass
+from xml.etree.ElementTree import Element, ElementTree
+from xml.etree.ElementTree import tostring, fromstring
 
 try:
     import lxml.etree as lxmletree

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -901,18 +901,3 @@ class GraphMLReader(GraphML):
             if default is not None:
                 graphml_key_defaults[attr_id] = default.text
         return graphml_keys, graphml_key_defaults
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    xml.etree.ElementTree = pytest.importorskip('xml.etree.ElementTree')
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    try:
-        os.unlink('test.graphml')
-    except:
-        pass

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -372,11 +372,3 @@ def read_multiline_adjlist(path, comments="#", delimiter=None,
                                    create_using=create_using,
                                    nodetype=nodetype,
                                    edgetype=edgetype)
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    for fname in ['test.adjlist', 'test.adjlist.gz']:
-        if os.path.isfile(fname):
-            os.unlink(fname)

--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -322,9 +322,3 @@ def write_shp(G, outdir):
         create_feature(g, edges, attributes)
 
     nodes, edges = None, None
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    ogr = pytest.importorskip('ogr')

--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -98,14 +98,3 @@ def read_yaml(path):
 
     G = yaml.load(path, Loader=yaml.FullLoader)
     return G
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    yaml = pytest.importorskip('yaml')
-
-
-def teardown_module(module):
-    import os
-    os.unlink('test.yaml')

--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -23,7 +23,6 @@ __author__ = """Aric Hagberg (hagberg@lanl.gov)"""
 
 __all__ = ['read_yaml', 'write_yaml']
 
-import networkx as nx
 from networkx.utils import open_file
 
 

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -278,9 +278,3 @@ def make_qstr(t):
     if " " in t:
         t = r'"%s"' % t
     return t
-
-
-# fixture for pytest
-def teardown_module(module):
-    import os
-    os.unlink('test.net')

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -879,7 +879,7 @@ class TestWriteGraphML(BaseGraphML):
 
         xml = parse(fh)
         # Children are the key elements, and the graph element
-        children = xml.getroot().getchildren()
+        children = list(xml.getroot())
         assert len(children) == 3
 
         keys = [child.items() for child in children[:2]]
@@ -1022,4 +1022,4 @@ class TestXMLGraphML(TestWriteGraphML):
     @classmethod
     def setup_class(cls):
         TestWriteGraphML.setup_class()
-        _ = pytest.importorskip("xml.etree.ElementTree")
+        pytest.importorskip("xml.etree.ElementTree")

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -397,9 +397,3 @@ def create_py_random_state(random_state=None):
         return random.Random(random_state)
     msg = '%r cannot be used to generate a random.Random instance'
     raise ValueError(msg % random_state)
-
-
-# fixture for pytest
-def setup_module(module):
-    import pytest
-    numpy = pytest.importorskip('numpy')

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -28,7 +28,7 @@ if [[ "${REPORT_COVERAGE}" == 1 ]]; then
 elif [[ "${DOCTEST}" == 1 ]]; then
   pytest --doctest-modules --pyargs networkx
 else
-  pytest --pyargs networkx
+  pytest --doctest-modules --pyargs networkx
 fi
 
 cd $NX_SOURCE


### PR DESCRIPTION
Pytest isn't running fixtures like
```
# fixture for pytest
def setup_module(module):
    import pytest
    numpy = pytest.importorskip('numpy')
    scipy = pytest.importorskip('scipy')
    pandas = pytest.importorskip('pandas')
```
in `networkx/convert_matrix.py` or
```
# fixture for pytest
def setup_module(module):
    import pytest
    yaml = pytest.importorskip('yaml')


def teardown_module(module):
    import os
    os.unlink('test.yaml')
```
in `networkx/readwrite/nx_yaml.py`.
