### PR TITLE
Fix issue 3431: Return error in case of bad input to make_small_graph

### DIFF
--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -83,6 +83,10 @@ def make_small_graph(graph_description, create_using=None):
 
     Use the create_using argument to choose the graph class/type.
     """
+
+    if graph_description[0] not in ("adjacencylist", "edgelist"):
+        raise NetworkXError("ltype must be either adjacencylist or edgelist")
+
     ltype = graph_description[0]
     name = graph_description[1]
     n = graph_description[2]

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -16,9 +16,15 @@ null = nx.null_graph()
 
 class TestGeneratorsSmall():
     def test_make_small_graph(self):
-        d = ["adjacencylist", "Bull Graph", 5, [[2, 3], [1, 3, 4], [1, 2, 5], [2], [3]]]
+        d = ["adjacencylist", "Bull Graph", 5, [[2, 3], [1, 3, 4], [1, 2, 5],
+                                                [2], [3]]]
         G = nx.make_small_graph(d)
         assert is_isomorphic(G, nx.bull_graph())
+
+        # Test small graph creation error with wrong ltype
+        d[0] = "erroneouslist"
+        pytest.raises(nx.NetworkXError, nx.make_small_graph,
+                      graph_description=d)
 
     def test__LCF_graph(self):
         # If n<=0, then return the null_graph


### PR DESCRIPTION
Fixes #3431 

Checked that `ltype` was either **adjacencylist/edgelist**, else raised an error. Also added a tiny test for the same. Also refractored a single line in the test file as it was too long as per *pycodestyle*.

Please let me know if something else needs to be modified.