### PR TITLE
Enable ThinGraph tests

### DIFF
--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -40,15 +40,6 @@ class BaseDiGraphTester(BaseGraphTester):
         with pytest.raises(nx.NetworkXError):
             G.edges(-1)
 
-    def test_edges_data(self):
-        G = self.K3
-        all_edges = [(0, 1, {}), (0, 2, {}), (1, 0, {}), (1, 2, {}), (2, 0, {}), (2, 1, {})]
-        assert sorted(G.edges(data=True)) == all_edges
-        assert sorted(G.edges(0, data=True)) == all_edges[:2]
-        assert sorted(G.edges([0, 1], data=True)) == all_edges[:4]
-        with pytest.raises(nx.NetworkXError):
-            G.edges(-1, True)
-
     def test_out_edges(self):
         G = self.K3
         assert sorted(G.out_edges()) == [(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
@@ -97,28 +88,6 @@ class BaseDiGraphTester(BaseGraphTester):
         assert G.in_degree(0) == 2
         assert list(G.in_degree(iter([0]))) == [(0, 2)]  # run through iterator
 
-    def test_in_degree_weighted(self):
-        G = self.K3
-        G.add_edge(0, 1, weight=0.3, other=1.2)
-        assert sorted(G.in_degree(weight='weight')) == [(0, 2), (1, 1.3), (2, 2)]
-        assert dict(G.in_degree(weight='weight')) == {0: 2, 1: 1.3, 2: 2}
-        assert G.in_degree(1, weight='weight') == 1.3
-        assert sorted(G.in_degree(weight='other')) == [(0, 2), (1, 2.2), (2, 2)]
-        assert dict(G.in_degree(weight='other')) == {0: 2, 1: 2.2, 2: 2}
-        assert G.in_degree(1, weight='other') == 2.2
-        assert list(G.in_degree(iter([1]), weight='other')) == [(1, 2.2)]
-
-    def test_out_degree_weighted(self):
-        G = self.K3
-        G.add_edge(0, 1, weight=0.3, other=1.2)
-        assert sorted(G.out_degree(weight='weight')) == [(0, 1.3), (1, 2), (2, 2)]
-        assert dict(G.out_degree(weight='weight')) == {0: 1.3, 1: 2, 2: 2}
-        assert G.out_degree(0, weight='weight') == 1.3
-        assert sorted(G.out_degree(weight='other')) == [(0, 2.2), (1, 2), (2, 2)]
-        assert dict(G.out_degree(weight='other')) == {0: 2.2, 1: 2, 2: 2}
-        assert G.out_degree(0, weight='other') == 2.2
-        assert list(G.out_degree(iter([0]), weight='other')) == [(0, 2.2)]
-
     def test_out_degree(self):
         G = self.K3
         assert sorted(G.out_degree()) == [(0, 2), (1, 2), (2, 2)]
@@ -166,7 +135,37 @@ class BaseDiGraphTester(BaseGraphTester):
 
 
 class BaseAttrDiGraphTester(BaseDiGraphTester, BaseAttrGraphTester):
-    pass
+    def test_edges_data(self):
+        G = self.K3
+        all_edges = [(0, 1, {}), (0, 2, {}), (1, 0, {}), (1, 2, {}), (2, 0, {}), (2, 1, {})]
+        assert sorted(G.edges(data=True)) == all_edges
+        assert sorted(G.edges(0, data=True)) == all_edges[:2]
+        assert sorted(G.edges([0, 1], data=True)) == all_edges[:4]
+        with pytest.raises(nx.NetworkXError):
+            G.edges(-1, True)
+
+    def test_in_degree_weighted(self):
+        G = self.K3.copy()
+        G.add_edge(0, 1, weight=0.3, other=1.2)
+        assert sorted(G.in_degree(weight='weight')) == [(0, 2), (1, 1.3), (2, 2)]
+        assert dict(G.in_degree(weight='weight')) == {0: 2, 1: 1.3, 2: 2}
+        assert G.in_degree(1, weight='weight') == 1.3
+        assert sorted(G.in_degree(weight='other')) == [(0, 2), (1, 2.2), (2, 2)]
+        assert dict(G.in_degree(weight='other')) == {0: 2, 1: 2.2, 2: 2}
+        assert G.in_degree(1, weight='other') == 2.2
+        assert list(G.in_degree(iter([1]), weight='other')) == [(1, 2.2)]
+
+    def test_out_degree_weighted(self):
+        G = self.K3.copy()
+        G.add_edge(0, 1, weight=0.3, other=1.2)
+        assert sorted(G.out_degree(weight='weight')) == [(0, 1.3), (1, 2), (2, 2)]
+        assert dict(G.out_degree(weight='weight')) == {0: 1.3, 1: 2, 2: 2}
+        assert G.out_degree(0, weight='weight') == 1.3
+        assert sorted(G.out_degree(weight='other')) == [(0, 2.2), (1, 2), (2, 2)]
+        assert dict(G.out_degree(weight='other')) == {0: 2.2, 1: 2, 2: 2}
+        assert G.out_degree(0, weight='other') == 2.2
+        assert list(G.out_degree(iter([0]), weight='other')) == [(0, 2.2)]
+
 
 
 class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
@@ -231,7 +230,7 @@ class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
             G.add_edges_from([0])  # not a tuple
 
     def test_remove_edge(self):
-        G = self.K3
+        G = self.K3.copy()
         G.remove_edge(0, 1)
         assert G.succ == {0: {2: {}}, 1: {0: {}, 2: {}}, 2: {0: {}, 1: {}}}
         assert G.pred == {0: {1: {}, 2: {}}, 1: {2: {}}, 2: {0: {}, 1: {}}}
@@ -239,7 +238,7 @@ class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
             G.remove_edge(-1, 0)
 
     def test_remove_edges_from(self):
-        G = self.K3
+        G = self.K3.copy()
         G.remove_edges_from([(0, 1)])
         assert G.succ == {0: {2: {}}, 1: {0: {}, 2: {}}, 2: {0: {}, 1: {}}}
         assert G.pred == {0: {1: {}, 2: {}}, 1: {2: {}}, 2: {0: {}, 1: {}}}

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -137,7 +137,8 @@ class BaseDiGraphTester(BaseGraphTester):
 class BaseAttrDiGraphTester(BaseDiGraphTester, BaseAttrGraphTester):
     def test_edges_data(self):
         G = self.K3
-        all_edges = [(0, 1, {}), (0, 2, {}), (1, 0, {}), (1, 2, {}), (2, 0, {}), (2, 1, {})]
+        all_edges = [(0, 1, {}), (0, 2, {}), (1, 0, {}),
+                     (1, 2, {}), (2, 0, {}), (2, 1, {})]
         assert sorted(G.edges(data=True)) == all_edges
         assert sorted(G.edges(0, data=True)) == all_edges[:2]
         assert sorted(G.edges([0, 1], data=True)) == all_edges[:4]

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -60,6 +60,7 @@ class BaseGraphTester(object):
         gc.collect()
         before = count_objects_of_type(self.Graph)
         G.copy()
+        gc.collect()
         after = count_objects_of_type(self.Graph)
         assert before == after
 
@@ -71,6 +72,7 @@ class BaseGraphTester(object):
         G = MyGraph()
         before = count_objects_of_type(MyGraph)
         G.copy()
+        gc.collect()
         after = count_objects_of_type(MyGraph)
         assert before == after
 
@@ -81,16 +83,6 @@ class BaseGraphTester(object):
         assert_edges_equal(G.edges([0, 1]), [(0, 1), (0, 2), (1, 2)])
         with pytest.raises(nx.NetworkXError):
             G.edges(-1)
-
-    def test_weighted_degree(self):
-        G = self.Graph()
-        G.add_edge(1, 2, weight=2)
-        G.add_edge(2, 3, weight=3)
-        assert (sorted(d for n, d in G.degree(weight='weight')) ==
-                [2, 3, 5])
-        assert dict(G.degree(weight='weight')) == {1: 2, 2: 5, 3: 3}
-        assert G.degree(1, weight='weight') == 2
-        assert G.degree([1], weight='weight') == [(1, 2)]
 
     def test_degree(self):
         G = self.K3
@@ -337,7 +329,7 @@ class BaseAttrGraphTester(BaseGraphTester):
             assert G._succ[1][2] is G._pred[2][1]
 
     def test_graph_attr(self):
-        G = self.K3
+        G = self.K3.copy()
         G.graph['foo'] = 'bar'
         assert G.graph['foo'] == 'bar'
         del G.graph['foo']
@@ -346,7 +338,7 @@ class BaseAttrGraphTester(BaseGraphTester):
         assert H.graph['foo'] == 'bar'
 
     def test_node_attr(self):
-        G = self.K3
+        G = self.K3.copy()
         G.add_node(1, foo='bar')
         assert_nodes_equal(G.nodes(), [0, 1, 2])
         assert_nodes_equal(G.nodes(data=True),
@@ -360,7 +352,7 @@ class BaseAttrGraphTester(BaseGraphTester):
                            [(0, 'bar'), (1, 'baz'), (2, 'bar')])
 
     def test_node_attr2(self):
-        G = self.K3
+        G = self.K3.copy()
         a = {'foo': 'bar'}
         G.add_node(3, **a)
         assert_nodes_equal(G.nodes(), [0, 1, 2, 3])
@@ -557,7 +549,7 @@ class TestGraph(BaseAttrGraphTester):
         assert H.nodes[3]['c'] == 'cyan'
 
     def test_remove_node(self):
-        G = self.K3
+        G = self.K3.copy()
         G.remove_node(0)
         assert G.adj == {1: {2: {}}, 2: {1: {}}}
         with pytest.raises(nx.NetworkXError):
@@ -565,7 +557,7 @@ class TestGraph(BaseAttrGraphTester):
 
         # generator here to implement list,set,string...
     def test_remove_nodes_from(self):
-        G = self.K3
+        G = self.K3.copy()
         G.remove_nodes_from([0, 1])
         assert G.adj == {2: {}}
         G.remove_nodes_from([-1])  # silent fail
@@ -600,20 +592,20 @@ class TestGraph(BaseAttrGraphTester):
             G.add_edges_from([0])  # not a tuple
 
     def test_remove_edge(self):
-        G = self.K3
+        G = self.K3.copy()
         G.remove_edge(0, 1)
         assert G.adj == {0: {2: {}}, 1: {2: {}}, 2: {0: {}, 1: {}}}
         with pytest.raises(nx.NetworkXError):
             G.remove_edge(-1, 0)
 
     def test_remove_edges_from(self):
-        G = self.K3
+        G = self.K3.copy()
         G.remove_edges_from([(0, 1)])
         assert G.adj == {0: {2: {}}, 1: {2: {}}, 2: {0: {}, 1: {}}}
         G.remove_edges_from([(0, 0)])  # silent fail
 
     def test_clear(self):
-        G = self.K3
+        G = self.K3.copy()
         G.clear()
         assert G.adj == {}
 
@@ -627,7 +619,7 @@ class TestGraph(BaseAttrGraphTester):
             G.edges(-1, True)
 
     def test_get_edge_data(self):
-        G = self.K3
+        G = self.K3.copy()
         assert G.get_edge_data(0, 1) == {}
         assert G[0][1] == {}
         assert G.get_edge_data(10, 20) is None

--- a/networkx/classes/tests/test_special.py
+++ b/networkx/classes/tests/test_special.py
@@ -2,7 +2,9 @@
 from collections import OrderedDict
 import networkx as nx
 from .test_graph import TestGraph
+from .test_graph import BaseGraphTester
 from .test_digraph import TestDiGraph
+from .test_digraph import BaseDiGraphTester
 from .test_multigraph import TestMultiGraph
 from .test_multidigraph import TestMultiDiGraph
 
@@ -66,7 +68,7 @@ class TestOrderedGraph(TestGraph):
         self.Graph = MyGraph
 
 
-class TestThinGraph(TestGraph):
+class TestThinGraph(BaseGraphTester):
     def setup_method(self):
         all_edge_dict = {'weight': 1}
 
@@ -106,7 +108,7 @@ class TestOrderedDiGraph(TestDiGraph):
         self.Graph = MyGraph
 
 
-class TestThinDiGraph(TestDiGraph):
+class TestThinDiGraph(BaseDiGraphTester):
     def setup_method(self):
         all_edge_dict = {'weight': 1}
 
@@ -115,17 +117,27 @@ class TestThinDiGraph(TestDiGraph):
         self.Graph = MyGraph
         # build dict-of-dict-of-dict K3
         ed1, ed2, ed3 = (all_edge_dict, all_edge_dict, all_edge_dict)
-        self.k3adj = {0: {1: ed1, 2: ed2},
-                      1: {0: ed1, 2: ed3},
-                      2: {0: ed2, 1: ed3}}
+        ed4, ed5, ed6 = (all_edge_dict, all_edge_dict, all_edge_dict)
+        self.k3adj = {0: {1: ed1, 2: ed2}, 1: {0: ed3, 2: ed4}, 2: {0: ed5, 1: ed6}}
         self.k3edges = [(0, 1), (0, 2), (1, 2)]
         self.k3nodes = [0, 1, 2]
         self.K3 = self.Graph()
-        self.K3._adj = self.k3adj
+        self.K3._adj = self.K3._succ = self.k3adj
+        self.K3._pred = {0: {1: ed3, 2: ed5}, 1: {0: ed1, 2: ed6}, 2: {0: ed2, 1: ed4}}
         self.K3._node = {}
         self.K3._node[0] = {}
         self.K3._node[1] = {}
         self.K3._node[2] = {}
+
+        ed1, ed2 = (all_edge_dict, all_edge_dict)
+        self.P3 = self.Graph()
+        self.P3._adj = {0: {1: ed1}, 1: {2: ed2}, 2: {}}
+        self.P3._succ = self.P3._adj
+        self.P3._pred = {0: {}, 1: {0: ed1}, 2: {1: ed2}}
+        self.P3._node = {}
+        self.P3._node[0] = {}
+        self.P3._node[1] = {}
+        self.P3._node[2] = {}
 
 
 class TestSpecialMultiGraph(TestMultiGraph):

--- a/networkx/classes/tests/test_special.py
+++ b/networkx/classes/tests/test_special.py
@@ -66,8 +66,8 @@ class TestOrderedGraph(TestGraph):
         self.Graph = MyGraph
 
 
-class ThinGraphTester(TestGraph):
-    def setUp(self):
+class TestThinGraph(TestGraph):
+    def setup_method(self):
         all_edge_dict = {'weight': 1}
 
         class MyGraph(nx.Graph):
@@ -106,8 +106,8 @@ class TestOrderedDiGraph(TestDiGraph):
         self.Graph = MyGraph
 
 
-class ThinDiGraphTester(TestDiGraph):
-    def setUp(self):
+class TestThinDiGraph(TestDiGraph):
+    def setup_method(self):
         all_edge_dict = {'weight': 1}
 
         class MyGraph(nx.DiGraph):


### PR DESCRIPTION
@dschult I mentioned this problem in a previous PR.  I decided to repackage the issue in this PR and merge all the other changes in the previous PR.

I made the class names start with Test so pytest collects it to run.  I also changed from nose style `setUp` to pytest style `setup_method`.

Any idea how to fix this?