### PR TITLE
avoid duplicate tests due to imports

### DIFF
--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -5,8 +5,9 @@ import pytest
 
 import networkx as nx
 from networkx.testing import assert_nodes_equal
-from .test_graph import BaseGraphTester, BaseAttrGraphTester, TestGraph
-from .test_graph import TestEdgeSubgraph as TestGraphEdgeSubgraph
+from .test_graph import BaseGraphTester, BaseAttrGraphTester
+from .test_graph import TestGraph as ttttGraph
+from .test_graph import TestEdgeSubgraph as ttttGraphEdgeSubgraph
 
 
 class BaseDiGraphTester(BaseGraphTester):
@@ -169,7 +170,7 @@ class BaseAttrDiGraphTester(BaseDiGraphTester, BaseAttrGraphTester):
     pass
 
 
-class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
+class TestDiGraph(BaseAttrDiGraphTester, ttttGraph):
     """Tests specific to dict-of-dict-of-dict digraph data structure"""
 
     def setup_method(self):
@@ -246,7 +247,7 @@ class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
         G.remove_edges_from([(0, 0)])  # silent fail
 
 
-class TestEdgeSubgraph(TestGraphEdgeSubgraph):
+class TestEdgeSubgraph(ttttGraphEdgeSubgraph):
     """Unit tests for the :meth:`DiGraph.edge_subgraph` method."""
 
     def setup_method(self):

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -2,8 +2,9 @@
 import pytest
 from networkx.testing import assert_edges_equal
 import networkx as nx
-from .test_multigraph import BaseMultiGraphTester, TestMultiGraph
-from .test_multigraph import TestEdgeSubgraph as TestMultiGraphEdgeSubgraph
+from .test_multigraph import BaseMultiGraphTester
+from .test_multigraph import TestMultiGraph as ttttMultiGraph
+from .test_multigraph import TestEdgeSubgraph as ttttMultiGraphEdgeSubgraph
 
 
 class BaseMultiDiGraphTester(BaseMultiGraphTester):
@@ -220,7 +221,7 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         pytest.raises(nx.NetworkXError, R.remove_edge, 1, 0)
 
 
-class TestMultiDiGraph(BaseMultiDiGraphTester, TestMultiGraph):
+class TestMultiDiGraph(BaseMultiDiGraphTester, ttttMultiGraph):
     def setup_method(self):
         self.Graph = nx.MultiDiGraph
         # build K3
@@ -335,7 +336,7 @@ class TestMultiDiGraph(BaseMultiDiGraphTester, TestMultiGraph):
         G.remove_edges_from([(0, 0)])  # silent fail
 
 
-class TestEdgeSubgraph(TestMultiGraphEdgeSubgraph):
+class TestEdgeSubgraph(ttttMultiGraphEdgeSubgraph):
     """Unit tests for the :meth:`MultiDiGraph.edge_subgraph` method."""
 
     def setup_method(self):

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -5,7 +5,8 @@ import pytest
 import networkx as nx
 from networkx.testing.utils import assert_edges_equal
 
-from .test_graph import BaseAttrGraphTester, TestGraph
+from .test_graph import BaseAttrGraphTester
+from .test_graph import TestGraph as ttttGraph
 
 
 class BaseMultiGraphTester(BaseAttrGraphTester):
@@ -144,7 +145,7 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
                                     'listdata': [20, 200], 'weight':20})])
 
 
-class TestMultiGraph(BaseMultiGraphTester, TestGraph):
+class TestMultiGraph(BaseMultiGraphTester, ttttGraph):
     def setup_method(self):
         self.Graph = nx.MultiGraph
         # build K3

--- a/networkx/classes/tests/test_special.py
+++ b/networkx/classes/tests/test_special.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 from collections import OrderedDict
 import networkx as nx
-from .test_graph import TestGraph
-from .test_digraph import TestDiGraph
-from .test_multigraph import TestMultiGraph
-from .test_multidigraph import TestMultiDiGraph
+from .test_graph import TestGraph as ttttGraph
+from .test_graph import BaseGraphTester
+from .test_digraph import TestDiGraph as ttttDiGraph
+from .test_digraph import BaseDiGraphTester
+from .test_multigraph import TestMultiGraph as ttttMultiGraph
+from .test_multidigraph import TestMultiDiGraph as ttttMultiDiGraph
 
 
 def test_factories():
@@ -48,15 +50,15 @@ def test_factories():
             assert isinstance(G._adj[1][2], mydict5)
 
 
-class TestSpecialGraph(TestGraph):
+class TestSpecialGraph(ttttGraph):
     def setup_method(self):
-        TestGraph.setup_method(self)
+        ttttGraph.setup_method(self)
         self.Graph = nx.Graph
 
 
-class TestOrderedGraph(TestGraph):
+class TestOrderedGraph(ttttGraph):
     def setup_method(self):
-        TestGraph.setup_method(self)
+        ttttGraph.setup_method(self)
 
         class MyGraph(nx.Graph):
             node_dict_factory = OrderedDict
@@ -66,7 +68,7 @@ class TestOrderedGraph(TestGraph):
         self.Graph = MyGraph
 
 
-class ThinGraphTester(TestGraph):
+class ThinGraphTester(BaseGraphTester):
     def setUp(self):
         all_edge_dict = {'weight': 1}
 
@@ -88,15 +90,15 @@ class ThinGraphTester(TestGraph):
         self.K3._node[2] = {}
 
 
-class TestSpecialDiGraph(TestDiGraph):
+class TestSpecialDiGraph(ttttDiGraph):
     def setup_method(self):
-        TestDiGraph.setup_method(self)
+        ttttDiGraph.setup_method(self)
         self.Graph = nx.DiGraph
 
 
-class TestOrderedDiGraph(TestDiGraph):
+class TestOrderedDiGraph(ttttDiGraph):
     def setup_method(self):
-        TestDiGraph.setup_method(self)
+        ttttDiGraph.setup_method(self)
 
         class MyGraph(nx.DiGraph):
             node_dict_factory = OrderedDict
@@ -106,7 +108,7 @@ class TestOrderedDiGraph(TestDiGraph):
         self.Graph = MyGraph
 
 
-class ThinDiGraphTester(TestDiGraph):
+class ThinDiGraphTester(BaseDiGraphTester):
     def setUp(self):
         all_edge_dict = {'weight': 1}
 
@@ -128,15 +130,15 @@ class ThinDiGraphTester(TestDiGraph):
         self.K3._node[2] = {}
 
 
-class TestSpecialMultiGraph(TestMultiGraph):
+class TestSpecialMultiGraph(ttttMultiGraph):
     def setup_method(self):
-        TestMultiGraph.setup_method(self)
+        ttttMultiGraph.setup_method(self)
         self.Graph = nx.MultiGraph
 
 
-class TestOrderedMultiGraph(TestMultiGraph):
+class TestOrderedMultiGraph(ttttMultiGraph):
     def setup_method(self):
-        TestMultiGraph.setup_method(self)
+        ttttMultiGraph.setup_method(self)
 
         class MyGraph(nx.MultiGraph):
             node_dict_factory = OrderedDict
@@ -147,15 +149,15 @@ class TestOrderedMultiGraph(TestMultiGraph):
         self.Graph = MyGraph
 
 
-class TestSpecialMultiDiGraph(TestMultiDiGraph):
+class TestSpecialMultiDiGraph(ttttMultiDiGraph):
     def setup_method(self):
-        TestMultiDiGraph.setup_method(self)
+        ttttMultiDiGraph.setup_method(self)
         self.Graph = nx.MultiDiGraph
 
 
-class TestOrderedMultiDiGraph(TestMultiDiGraph):
+class TestOrderedMultiDiGraph(ttttMultiDiGraph):
     def setup_method(self):
-        TestMultiDiGraph.setup_method(self)
+        ttttMultiDiGraph.setup_method(self)
 
         class MyGraph(nx.MultiDiGraph):
             node_dict_factory = OrderedDict


### PR DESCRIPTION
Changing the name of ```TestGraph``` when importing it avoids having the tests run in the importing module.  This should speed up CI testing

I rename TestGraph as ttttGraph.  There must be a better name...?