### PR TITLE
WIP: Fix matplotlib deprecation

### DIFF
--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -172,7 +172,7 @@ class TestPylab(object):
         # See Issue #3295
         G = nx.path_graph(3, create_using=nx.MultiDiGraph)
         nx.draw_networkx(G, edgelist=[(0, 1, 0)])
-        nx.draw_networkx(G, edgelist=[(0, 1, 0)], node_size=[10, 20])
+        nx.draw_networkx(G, edgelist=[(0, 1, 0)], node_size=[10, 20, 0])
 
     def test_alpha_iter(self):
         pos = nx.random_layout(self.G)

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 numpy>=1.15.4
 scipy>=1.1.0
 pandas>=0.23.3
-matplotlib>=3.0.2
+matplotlib>=3.1
 pygraphviz>=1.5
 pydot>=1.2.4
 pyyaml>=5.1


### PR DESCRIPTION
Fix #3694.

The test was added b/c of #3295.

The graph
```
G = nx.path_graph(3, create_using=nx.MultiDiGraph)
```
I made the third node have size 0.  Does that seem reasonable?