### PR TITLE
Add colormap and color limits to LineCollection

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -611,7 +611,7 @@ def draw_networkx_edges(G, pos,
                                          transOffset=ax.transData,
                                          alpha=alpha
                                          )
-        
+
         edge_collection.set_cmap(edge_cmap)
         edge_collection.set_clim(edge_vmin, edge_vmax)
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -611,6 +611,9 @@ def draw_networkx_edges(G, pos,
                                          transOffset=ax.transData,
                                          alpha=alpha
                                          )
+        
+        edge_collection.set_cmap(edge_cmap)
+        edge_collection.set_clim(edge_vmin, edge_vmax)
 
         edge_collection.set_zorder(1)  # edges go behind nodes
         edge_collection.set_label(label)


### PR DESCRIPTION
This PR adds the colomap and colomap limits to the LineCollection returned by draw_networkx_edges.  This allows the correct edge colormap to be added to the figure after it's created.  Since graphics are hard to test, here is the code I used to test this out.

```
import networkx as nx
import numpy as np
import matplotlib.pylab as plt

G = nx.grid_2d_graph(4, 4)  # 4x4 grid
H = G.to_directed()
pos = nx.spring_layout(G, iterations=100)

node_values = np.random.rand(H.number_of_nodes())+1 # values between 1 and 2
edge_values = np.random.rand(H.number_of_edges())+2 # values between 2 and 3

plt.figure()
ax = plt.gca()

nodes = nx.draw_networkx_nodes(H, pos, nodelist=list(H.nodes()), 
                               node_color=node_values,
                               vmin=1, vmax=2,
                               cmap=plt.cm.winter, ax=ax)

edges = nx.draw_networkx_edges(H, pos, edgelist=list(H.edges()), 
                               edge_color=edge_values,
                               edge_vmin=2, edge_vmax=3,
                               edge_cmap=plt.cm.spring, ax=ax, arrows=False)

plt.colorbar(nodes, pad=0, ax=ax)
plt.colorbar(edges, pad=0.05, ax=ax)
```
![networkx_colorbar_example](https://user-images.githubusercontent.com/17935331/67815696-45be7600-fa6d-11e9-8470-309d72ebcfe8.png)

Fixes #3696.  

Thanks for creating this great software package!