### PR TITLE
Remove duplicate license parameter

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -74,7 +74,6 @@ from networkx import release
 __author__ = '%s <%s>\n%s <%s>\n%s <%s>' % \
     (release.authors['Hagberg'] + release.authors['Schult'] +
         release.authors['Swart'])
-__license__ = release.license
 
 __date__ = release.date
 __version__ = release.version

--- a/networkx/release.py
+++ b/networkx/release.py
@@ -184,7 +184,6 @@ dev = True
 
 
 description = "Python package for creating and manipulating graphs and networks"
-license = 'BSD'
 authors = {'Hagberg': ('Aric Hagberg', 'hagberg@lanl.gov'),
            'Schult': ('Dan Schult', 'dschult@colgate.edu'),
            'Swart': ('Pieter Swart', 'swart@lanl.gov')}

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,6 @@ if __name__ == "__main__":
         description=release.description,
         keywords=release.keywords,
         long_description=long_description,
-        license=release.license,
         platforms=release.platforms,
         url=release.url,
         project_urls=release.project_urls,


### PR DESCRIPTION
The [Python packaging specifications](https://packaging.python.org/specifications/core-metadata) indicate that the [`license` parameter](https://packaging.python.org/specifications/core-metadata/#license) to `setup()` should be used in one of the following cases:

* the license is not a selection from the “License” Trove classifiers
* to specify a particular version of a license which is named via the `Classifier` field
* to indicate a variation or exception to such a license

This PR removes the explicit `license` parameter since the usage for this project does not fit any of those cases and it makes it more difficult to use tools like [pip-licenses](https://pypi.org/project/pip-licenses) since it is not consistent with other projects that just have `License :: OSI Approved :: BSD License` as one of their trove classifiers.

Please note that this does _not_ change the license of the project in any way, and since this project already has a `License :: OSI Approved :: BSD License` trove classifier the `license` parameter is redundant.