### PR TITLE
K-truss is defined for edges being in (k-2) triangles and not for k triangles

### DIFF
--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -370,7 +370,7 @@ def k_truss(G, k):
     """Returns the k-truss of `G`.
 
     The k-truss is the maximal subgraph of `G` which contains at least three
-    vertices where every edge is incident to at least `k` triangles.
+    vertices where every edge is incident to at least `k-2` triangles.
 
     Parameters
     ----------

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -369,7 +369,7 @@ def k_corona(G, k, core_number=None):
 def k_truss(G, k):
     """Returns the k-truss of `G`.
 
-    The k-truss is the maximal subgraph of `G` which contains at least three
+    The k-truss is the maximal induced subgraph of `G` which contains at least three
     vertices where every edge is incident to at least `k-2` triangles.
 
     Parameters
@@ -398,6 +398,13 @@ def k_truss(G, k):
     Not implemented for digraphs or graphs with parallel edges or self loops.
 
     Graph, node, and edge attributes are copied to the subgraph.
+    
+    K-trusses were originally defined in [2] which states that the k-truss is the
+    maximal induced subgraph where each edge belongs to at least `k-2` triangles.
+    A more recent paper, [1], uses a slightly different notation and requires that
+    each edge belong to `k` triangles. This implementation uses the more standard 
+    of the two notations for `k-2` triangles.
+    
 
     References
     ----------

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -418,7 +418,7 @@ def k_truss(G, k):
             seen.add(u)
             new_nbrs = [v for v in nbrs_u if v not in seen]
             for v in new_nbrs:
-                if len(nbrs_u & set(H[v])) < k:
+                if len(nbrs_u & set(H[v])) < (k-2):
                     to_drop.append((u, v))
         H.remove_edges_from(to_drop)
         n_dropped = len(to_drop)

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -418,7 +418,7 @@ def k_truss(G, k):
             seen.add(u)
             new_nbrs = [v for v in nbrs_u if v not in seen]
             for v in new_nbrs:
-                if len(nbrs_u & set(H[v])) < (k-2):
+                if (len(nbrs_u & set(H[v])) < (k-2) ) :
                     to_drop.append((u, v))
         H.remove_edges_from(to_drop)
         n_dropped = len(to_drop)

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -418,7 +418,7 @@ def k_truss(G, k):
             seen.add(u)
             new_nbrs = [v for v in nbrs_u if v not in seen]
             for v in new_nbrs:
-                if (len(nbrs_u & set(H[v])) < (k-2) ) :
+                if (len(nbrs_u & set(H[v])) < (k - 2)):
                     to_drop.append((u, v))
         H.remove_edges_from(to_drop)
         n_dropped = len(to_drop)

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -369,8 +369,8 @@ def k_corona(G, k, core_number=None):
 def k_truss(G, k):
     """Returns the k-truss of `G`.
 
-    The k-truss is the maximal induced subgraph of `G` which contains at least three
-    vertices where every edge is incident to at least `k-2` triangles.
+    The k-truss is the maximal induced subgraph of `G` which contains at least
+    three vertices where every edge is incident to at least `k-2` triangles.
 
     Parameters
     ----------
@@ -398,13 +398,12 @@ def k_truss(G, k):
     Not implemented for digraphs or graphs with parallel edges or self loops.
 
     Graph, node, and edge attributes are copied to the subgraph.
-    
-    K-trusses were originally defined in [2] which states that the k-truss is the
-    maximal induced subgraph where each edge belongs to at least `k-2` triangles.
-    A more recent paper, [1], uses a slightly different notation and requires that
-    each edge belong to `k` triangles. This implementation uses the more standard 
-    of the two notations for `k-2` triangles.
-    
+
+    K-trusses were originally defined in [2] which states that the k-truss
+    is the maximal induced subgraph where each edge belongs to at least
+    `k-2` triangles. A more recent paper, [1], uses a slightly different
+    definition requiring that each edge belong to at least `k` triangles.
+    This implementation uses the original definition of `k-2` triangles.
 
     References
     ----------
@@ -437,7 +436,7 @@ def k_truss(G, k):
 @not_implemented_for('multigraph')
 @not_implemented_for('directed')
 def onion_layers(G):
-    """Returns the layer of each vertex in the onion decomposition of the graph.
+    """Returns the layer of each vertex in an onion decomposition of the graph.
 
     The onion decomposition refines the k-core decomposition by providing
     information on the internal organization of each k-shell. It is usually

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -145,7 +145,6 @@ class TestCore:
         k_truss_subgraph = nx.k_truss(self.G, 4)
         assert sorted(k_truss_subgraph.nodes()) == list(range(1, 9))
 
-
         k_truss_subgraph = nx.k_truss(self.G, 5)
         assert sorted(k_truss_subgraph.nodes()) == []
 

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -134,13 +134,21 @@ class TestCore:
         assert sorted(k_truss_subgraph.nodes()) == list(range(1, 21))
         # k=1
         k_truss_subgraph = nx.k_truss(self.G, 1)
-        assert sorted(k_truss_subgraph.nodes()) == list(range(1, 13))
+        assert sorted(k_truss_subgraph.nodes()) == list(range(1, 21))
         # k=2
         k_truss_subgraph = nx.k_truss(self.G, 2)
-        assert sorted(k_truss_subgraph.nodes()) == list(range(1, 9))
+        assert sorted(k_truss_subgraph.nodes()) == list(range(1, 21))
         # k=3
         k_truss_subgraph = nx.k_truss(self.G, 3)
+        assert sorted(k_truss_subgraph.nodes()) == list(range(1, 13))
+
+        k_truss_subgraph = nx.k_truss(self.G, 4)
+        assert sorted(k_truss_subgraph.nodes()) == list(range(1, 9))
+
+
+        k_truss_subgraph = nx.k_truss(self.G, 5)
         assert sorted(k_truss_subgraph.nodes()) == []
+
 
     def test_onion_layers(self):
         layers = nx.onion_layers(self.G)

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -148,7 +148,6 @@ class TestCore:
         k_truss_subgraph = nx.k_truss(self.G, 5)
         assert sorted(k_truss_subgraph.nodes()) == []
 
-
     def test_onion_layers(self):
         layers = nx.onion_layers(self.G)
         nodes_by_layer = [sorted([n for n in layers if layers[n] == val])


### PR DESCRIPTION
NX is pruning edges incorrectly for k-truss. Specifically, NX is pruning edges that belong to fewer than k triangles. The correct definition is to remove edges that belong to fewer than (k-2) triangles. As such. NX is pruning edges in an aggressive manner.
The following links point to several verified sources that have the definition of k-truss (including the original paper by J. Cohen).
- https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.505.7006&rep=rep1&type=pdf  (page 6)
- https://graphchallenge.mit.edu/sites/default/files/documents/SubGraphChallenge-2017-02-09.pdf
- https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.505.7006&rep=rep1&type=pdf (page 2 on the bottom right)

This PR also fixes the problem.