### PR TITLE
Remove old Python 2 code

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -17,10 +17,6 @@ from collections import deque
 from itertools import chain
 from itertools import combinations
 from itertools import islice
-try:
-    from itertools import ifilter as filter
-except ImportError:
-    pass
 import networkx as nx
 from networkx.utils import not_implemented_for
 __author__ = """Dan Schult (dschult@colgate.edu)"""

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -15,15 +15,6 @@ from math import ceil, sqrt
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-try:
-    from itertools import izip as zip
-except ImportError:
-    pass
-try:
-    range = xrange
-except NameError:
-    pass
-
 
 @not_implemented_for('undirected')
 def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,11 +1,5 @@
 """Unit tests for pydot drawing functions."""
-try:
-    try:
-        from cStringIO import StringIO
-    except ImportError:
-        from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import tempfile
 import networkx as nx
 from networkx.testing import assert_graphs_equal

--- a/networkx/readwrite/gpickle.py
+++ b/networkx/readwrite/gpickle.py
@@ -32,10 +32,7 @@ __all__ = ['read_gpickle', 'write_gpickle']
 
 from networkx.utils import open_file
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 @open_file(1, mode='wb')

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -96,10 +96,6 @@ def write_graphml_xml(G, path, encoding='utf-8', prettyprint=True,
 
     Notes
     -----
-    It may be a good idea in Python2 to convert strings to unicode
-    before giving the graph to write_gml. At least the strings with
-    either many characters to escape.
-
     This implementation does not support mixed graphs (directed
     and unidirected edges together) hyperedges, nested graphs, or ports.
     """
@@ -319,17 +315,9 @@ class GraphML(object):
         ' '.join(['http://graphml.graphdrawing.org/xmlns',
                   'http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd'])
 
-    try:
-        chr(12345)     # Fails on Py!=3.
-        unicode = str  # Py3k's str is our unicode type
-        long = int     # Py3K's int is our long type
-    except ValueError:
-        # Python 2.x
-        pass
-
     types = [(int, "integer"),  # for Gephi GraphML bug
-             (str, "yfiles"), (str, "string"), (unicode, "string"),
-             (int, "int"), (long, "long"),
+             (str, "yfiles"), (str, "string"),
+             (int, "int"),
              (float, "float"), (float, "double"),
              (bool, "boolean")]
 
@@ -403,24 +391,11 @@ class GraphMLWriter(GraphML):
         if self.infer_numeric_types:
             types = self.attribute_types[(name, scope)]
 
-            try:
-                chr(12345)     # Fails on Py<3.
-                local_long = int     # Py3's int is Py2's long type
-                local_unicode = str  # Py3's str is Py2's unicode type
-            except ValueError:
-                # Python 2.x
-                local_long = long
-                local_unicode = unicode
-
             if len(types) > 1:
                 if str in types:
                     return str
-                elif local_unicode in types:
-                    return local_unicode
                 elif float in types:
                     return float
-                elif local_long in types:
-                    return local_long
                 else:
                     return int
             else:

--- a/networkx/readwrite/json_graph/jit.py
+++ b/networkx/readwrite/json_graph/jit.py
@@ -60,7 +60,7 @@ def jit_graph(data, create_using=None):
         G = create_using
         G.clear()
 
-    if nx.utils.is_string_like(data):
+    if isinstance(data, str):
         data = json.loads(data)
 
     for node in data:


### PR DESCRIPTION
This removes some of the last remaining bits of Python 2 support.

@dschult Should we deprecate `literal_stringizer` and `literal_destringizer` in `networkx/readwrite/gml.py` (and remove it in nx 2.6)?  According to the documentation,
```
For better interoperability of data generated by Python 2 and Python 3,
we've provided `literal_stringizer` and `literal_destringizer`.
```