### PR TITLE
Fix documentation issues for exceptions in a few places

### DIFF
--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -307,7 +307,7 @@ def _bidirectional_shortest_path(G, source, target, exclude):
 
     Raises
     ------
-    NetworkXNoPath: exception
+    NetworkXNoPath
         If there is no path or if nodes are adjacent and have only one path
         between them
 

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -34,11 +34,12 @@ def color(G):
     Returns
     -------
     color : dictionary
-       A dictionary keyed by node with a 1 or 0 as data for each node color.
+        A dictionary keyed by node with a 1 or 0 as data for each node color.
 
     Raises
     ------
-    exc:`NetworkXError` if the graph is not two-colorable.
+    NetworkXError
+        If the graph is not two-colorable.
 
     Examples
     --------

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -85,8 +85,7 @@ def hopcroft_karp_matching(G, top_nodes=None):
 
     Raises
     ------
-    AmbiguousSolution : Exception
-
+    AmbiguousSolution
       Raised if the input bipartite graph is disconnected and no container
       with all nodes in one bipartite set is provided. When determining
       the nodes in each bipartite set more than one valid solution is
@@ -202,8 +201,7 @@ def eppstein_matching(G, top_nodes=None):
 
     Raises
     ------
-    AmbiguousSolution : Exception
-
+    AmbiguousSolution
       Raised if the input bipartite graph is disconnected and no container
       with all nodes in one bipartite set is provided. When determining
       the nodes in each bipartite set more than one valid solution is
@@ -436,8 +434,7 @@ def to_vertex_cover(G, matching, top_nodes=None):
 
     Raises
     ------
-    AmbiguousSolution : Exception
-
+    AmbiguousSolution
       Raised if the input bipartite graph is disconnected and no container
       with all nodes in one bipartite set is provided. When determining
       the nodes in each bipartite set more than one valid solution is
@@ -531,12 +528,10 @@ def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
 
     Raises
     ------
-    ValueError : Exception
-
+    ValueError
       Raised if the input bipartite graph is not complete.
 
-    ImportError : Exception
-
+    ImportError
       Raised if SciPy is not available.
 
     Notes

--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -72,7 +72,7 @@ def in_degree_centrality(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     See Also
@@ -115,7 +115,7 @@ def out_degree_centrality(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     See Also

--- a/networkx/algorithms/centrality/voterank_alg.py
+++ b/networkx/algorithms/centrality/voterank_alg.py
@@ -38,7 +38,7 @@ def voterank(G, number_of_nodes=None, max_iter=10000):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is digraph.
 
     References

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -44,7 +44,7 @@ def attracting_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is undirected.
 
     See Also
@@ -76,7 +76,7 @@ def number_attracting_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is undirected.
 
     See Also
@@ -104,7 +104,7 @@ def is_attracting_component(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is undirected.
 
     See Also

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -43,7 +43,7 @@ def is_biconnected(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is not undirected.
 
     Examples
@@ -119,7 +119,7 @@ def biconnected_component_edges(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is not undirected.
 
     Examples
@@ -193,7 +193,7 @@ def biconnected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is not undirected.
 
     See Also
@@ -287,7 +287,7 @@ def articulation_points(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is not undirected.
 
     Examples

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -38,7 +38,7 @@ def connected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is directed.
 
     Examples
@@ -119,7 +119,7 @@ def is_connected(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is directed.
 
     Examples
@@ -166,7 +166,7 @@ def node_connected_component(G, n):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is directed.
 
     See Also

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -36,10 +36,10 @@ def is_semiconnected(G, topo_order=None):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If the input graph is undirected.
 
-    NetworkXPointlessConcept :
+    NetworkXPointlessConcept
         If the graph is empty.
 
     Examples

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -39,7 +39,7 @@ def strongly_connected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If G is undirected.
 
     Examples
@@ -134,7 +134,7 @@ def kosaraju_strongly_connected_components(G, source=None):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     Examples
@@ -194,7 +194,7 @@ def strongly_connected_components_recursive(G):
 
     Raises
     ------
-    NetworkXNotImplemented :
+    NetworkXNotImplemented
         If G is undirected.
 
     Examples
@@ -281,7 +281,7 @@ def number_strongly_connected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     See Also
@@ -316,7 +316,7 @@ def is_strongly_connected(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     See Also
@@ -368,7 +368,7 @@ def condensation(G, scc=None):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     Notes

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -36,7 +36,7 @@ def weakly_connected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     Examples
@@ -88,7 +88,7 @@ def number_weakly_connected_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     See Also
@@ -128,7 +128,7 @@ def is_weakly_connected(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If G is undirected.
 
     See Also

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -82,10 +82,10 @@ def edge_disjoint_paths(G, s, t, flow_func=None, cutoff=None, auxiliary=None,
 
     Raises
     ------
-    NetworkXNoPath : exception
+    NetworkXNoPath
         If there is no path between source and target.
 
-    NetworkXError : exception
+    NetworkXError
         If source or target are not in the graph G.
 
     See also
@@ -284,10 +284,10 @@ def node_disjoint_paths(G, s, t, flow_func=None, cutoff=None, auxiliary=None,
 
     Raises
     ------
-    NetworkXNoPath : exception
+    NetworkXNoPath
         If there is no path between source and target.
 
-    NetworkXError : exception
+    NetworkXError
         If source or target are not in the graph G.
 
     Examples

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -197,10 +197,10 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
 
     Raises
     ------
-    NetworkXUnfeasible:
+    NetworkXUnfeasible
         If partial is False and no k-edge-augmentation exists.
 
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If the input graph is directed or a multigraph.
 
     ValueError:
@@ -424,7 +424,7 @@ def one_edge_augmentation(G, avail=None, weight=None, partial=False):
 
     Raises
     ------
-    NetworkXUnfeasible:
+    NetworkXUnfeasible
         If partial is False and no one-edge-augmentation exists.
 
     Notes
@@ -474,7 +474,7 @@ def bridge_augmentation(G, avail=None, weight=None):
 
     Raises
     ------
-    NetworkXUnfeasible:
+    NetworkXUnfeasible
         If no bridge-augmentation exists.
 
     Notes

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -58,7 +58,7 @@ def k_edge_components(G, k):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If the input graph is a multigraph.
 
     ValueError:
@@ -141,7 +141,7 @@ def k_edge_subgraphs(G, k):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If the input graph is a multigraph.
 
     ValueError:
@@ -225,7 +225,7 @@ def bridge_components(G):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If the input graph is directed or a multigraph.
 
     Notes

--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -47,7 +47,7 @@ def k_components(G, flow_func=None):
 
     Raises
     ------
-    NetworkXNotImplemented:
+    NetworkXNotImplemented
         If the input graph is directed.
 
     Examples

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -402,16 +402,16 @@ def barycenter(G, weight=None, attr=None, sp=None):
 
     Returns
     -------
-    :class:`list`
+    list
         Nodes of `G` that induce the barycenter of `G`.
 
     Raises
     ------
-    :exc:`networkx.NetworkXNoPath`
+    NetworkXNoPath
         If `G` is disconnected. `G` may appear disconnected to
         :func:`barycenter` if `sp` is given but is missing shortest path
         lengths for any pairs.
-    :exc:`ValueError`
+    ValueError
         If `sp` and `weight` are both given.
 
     See Also

--- a/networkx/algorithms/flow/gomory_hu.py
+++ b/networkx/algorithms/flow/gomory_hu.py
@@ -70,10 +70,10 @@ def gomory_hu_tree(G, capacity='capacity', flow_func=None):
 
     Raises
     ------
-    NetworkXNotImplemented : Exception
+    NetworkXNotImplemented
         Raised if the input graph is directed.
 
-    NetworkXError: Exception
+    NetworkXError
         Raised if the input graph is an empty Graph.
 
     Examples

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -34,14 +34,15 @@ def harmonic_function(G, max_iter=30, label_name='label'):
     label_name : string
         name of target labels to predict
 
-    Raises
-    ----------
-    `NetworkXError` if no nodes on `G` has `label_name`.
-
     Returns
     ----------
     predicted : array, shape = [n_samples]
         Array of predicted labels
+
+    Raises
+    ----------
+    NetworkXError
+        If no nodes on `G` has `label_name`.
 
     Examples
     --------

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -38,14 +38,15 @@ def local_and_global_consistency(G, alpha=0.99,
     label_name : string
         Name of target labels to predict
 
-    Raises
-    ----------
-    `NetworkXError` if no nodes on `G` has `label_name`.
-
     Returns
     ----------
     predicted : array, shape = [n_samples]
         Array of predicted labels
+
+    Raises
+    ------
+    NetworkXError
+        If no nodes on `G` has `label_name`.
 
     Examples
     --------

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -849,7 +849,7 @@ class PlanarEmbedding(nx.DiGraph):
 
         Raises
         ------
-        nx.NetworkXException
+        NetworkXException
             This exception is raised with a short explanation if the
             PlanarEmbedding is invalid.
         """
@@ -912,7 +912,7 @@ class PlanarEmbedding(nx.DiGraph):
 
         Raises
         ------
-        nx.NetworkXException
+        NetworkXException
             If the reference_neighbor does not exist.
 
         See Also
@@ -954,7 +954,7 @@ class PlanarEmbedding(nx.DiGraph):
 
         Raises
         ------
-        nx.NetworkXException
+        NetworkXException
             If the reference_neighbor does not exist.
 
         See Also

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -921,7 +921,7 @@ def planar_layout(G, scale=1, center=None, dim=2):
 
     Raises
     ------
-    nx.NetworkXException
+    NetworkXException
         If G is not planar
 
     Examples
@@ -981,6 +981,7 @@ def spiral_layout(G, scale=1, center=None, dim=2,
     -------
     ValueError
         If dim != 2
+
     Examples
     --------
     >>> G = nx.path_graph(4)

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -162,7 +162,7 @@ def relaxed_caveman_graph(l, k, p, seed=None):
 
     Raises
     ------
-    NetworkXError:
+    NetworkXError
      If p is not in [0,1]
 
     Examples
@@ -291,7 +291,7 @@ def planted_partition_graph(l, k, p_in, p_out, seed=None, directed=False):
 
     Raises
     ------
-    NetworkXError:
+    NetworkXError
       If p_in,p_out are not in [0,1] or
 
     Examples

--- a/networkx/generators/triads.py
+++ b/networkx/generators/triads.py
@@ -62,7 +62,7 @@ def triad_graph(triad_name):
 
     Raises
     ------
-    :exc:`ValueError`
+    ValueError
         If `triad_name` is not the name of a triad.
 
     See also


### PR DESCRIPTION
This takes care of a couple of function in which the documentation of raised exceptions had gone bad. For instance, in [`flow.gomory_hu_tree`](https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.flow.gomory_hu_tree.html#networkx.algorithms.flow.gomory_hu_tree), the documentation currently looks as follows:

![Screenshot from 2019-11-09 20-10-49](https://user-images.githubusercontent.com/6169306/68533763-0f1a1280-032d-11ea-8669-82847feee4e6.png)

We take care of all cases where this particular issue showed up; that is,

```
grep -r --include \*.py ": Exception"
```

outputs nothing after the fix.