### PR TITLE
Py36+ updates

### DIFF
--- a/doc/release/contribs.py
+++ b/doc/release/contribs.py
@@ -1,5 +1,5 @@
 # https://github.com/scikit-image/scikit-image/blob/master/doc/release/contribs.py
-import subprocess
+from subprocess import check_output
 import sys
 import string
 import shlex
@@ -10,45 +10,50 @@ if len(sys.argv) != 2:
 
 tag = sys.argv[1]
 
+
 def call(cmd):
-    return subprocess.check_output(shlex.split(cmd), universal_newlines=True).split('\n')
+    return check_output(shlex.split(cmd), universal_newlines=True).split("\n")
 
-tag_date = call("git log -n1 --format='%%ci' %s" % tag)[0]
-print("Release %s was on %s\n" % (tag, tag_date))
 
-merges = call("git log --since='%s' --merges --format='>>>%%B' --reverse" % tag_date)
+tag_date = call(f"git log -n1 --format='%ci' {tag}")[0]
+print(f"Release {tag} was on {tag_date}\n")
+
+merges = call(f"git log --since='{tag_date}' --merges --format='>>>%B' --reverse")
 merges = [m for m in merges if m.strip()]
-merges = '\n'.join(merges).split('>>>')
-merges = [m.split('\n')[:2] for m in merges]
+merges = "\n".join(merges).split(">>>")
+merges = [m.split("\n")[:2] for m in merges]
 merges = [m for m in merges if len(m) == 2 and m[1].strip()]
 
-num_commits = call("git rev-list %s..HEAD --count" % tag)[0]
-print("A total of %s changes have been committed.\n" % num_commits)
+num_commits = call(f"git rev-list {tag}..HEAD --count")[0]
+print(f"A total of {num_commits} changes have been committed.\n")
 
-commits = call("git log --since='%s' --pretty=%%s --reverse" % tag_date)
+# Use filter to remove empty strings
+commits = filter(None, call(f"git log --since='{tag_date}' --pretty=%s --reverse"))
 for c in commits:
-    print('- ' + c)
+    print("- " + c)
 
-print("It contained the following %d merges:\n" % len(merges))
+print(f"\nIt contained the following {len(merges)} merges:\n")
 for (merge, message) in merges:
-    if merge.startswith('Merge pull request #'):
-        PR = ' (%s)' % merge.split()[3]
+    if merge.startswith("Merge pull request #"):
+        PR = f" ({merge.split()[3]})"
     else:
-        PR = ''
+        PR = ""
 
-    print('- ' + message + PR)
+    print("- " + message + PR)
 
 print("\nMade by the following committers [alphabetical by last name]:\n")
 
-authors = call("git log --since='%s' --format=%%aN" % tag_date)
+authors = call(f"git log --since='{tag_date}' --format=%aN")
 authors = [a.strip() for a in authors if a.strip()]
+
 
 def key(author):
     author = [v for v in author.split() if v[0] in string.ascii_letters]
     if len(author) > 0:
         return author[-1]
 
+
 authors = sorted(set(authors), key=key)
 
 for a in authors:
-    print('- ' + a)
+    print("- " + a)

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -235,7 +235,7 @@ Note that for undirected graphs, adjacency iteration sees each edge twice.
     >>> for n, nbrs in FG.adj.items():
     ...    for nbr, eattr in nbrs.items():
     ...        wt = eattr['weight']
-    ...        if wt < 0.5: print('(%d, %d, %.3f)' % (n, nbr, wt))
+    ...        if wt < 0.5: print(f"({n}, {nbr}, {wt:.3})")
     (1, 2, 0.125)
     (2, 1, 0.125)
     (3, 4, 0.375)
@@ -246,7 +246,7 @@ Convenient access to all edges is achieved with the edges property.
 .. nbplot::
 
     >>> for (u, v, wt) in FG.edges.data('weight'):
-    ...     if wt < 0.5: print('(%d, %d, %.3f)' % (u, v, wt))
+    ...     if wt < 0.5: print(f"({u}, {v}, {wt:.3})")
     (1, 2, 0.125)
     (3, 4, 0.375)
 

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -79,7 +79,7 @@ if len(Gcc) > 1:
     print(Gcc[1].nodes())
 
 # find all games with B97 opening (as described in ECO)
-openings = set([game_info["ECO"] for (white, black, game_info) in G.edges(data=True)])
+openings = {game_info["ECO"] for (white, black, game_info) in G.edges(data=True)}
 print(f"\nFrom a total of {len(openings)} different openings,")
 print("the following games used the Sicilian opening")
 print('with the Najdorff 7...Qb6 "Poisoned Pawn" variation.\n')

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -43,7 +43,7 @@ def miles_graph():
         if line.startswith("*"):  # skip comments
             continue
 
-        numfind = re.compile("^\d+")
+        numfind = re.compile(r"^\d+")
 
         if numfind.match(line):  # this line is distances
             dist = line.split()

--- a/examples/drawing/plot_lanl_routes.py
+++ b/examples/drawing/plot_lanl_routes.py
@@ -23,7 +23,7 @@ def lanl_graph():
     """
     try:
         fh = open("lanl_routes.edgelist", "r")
-    except IOError:
+    except OSError:
         print("lanl.edges not found")
         raise
 

--- a/examples/graph/plot_roget.py
+++ b/examples/graph/plot_roget.py
@@ -50,7 +50,7 @@ def roget_graph():
         (headname, tails) = line.split(":")
 
         # head
-        numfind = re.compile("^\d+")  # re to find the number of this word
+        numfind = re.compile(r"^\d+")  # re to find the number of this word
         head = numfind.findall(headname)[0]  # get the number
 
         G.add_node(head)

--- a/examples/graph/plot_words.py
+++ b/examples/graph/plot_words.py
@@ -24,7 +24,7 @@ import networkx as nx
 
 def generate_graph(words):
     G = nx.Graph(name="words")
-    lookup = dict((c, lowercase.index(c)) for c in lowercase)
+    lookup = {c: lowercase.index(c) for c in lowercase}
 
     def edit_distance_one(word):
         for i in range(len(word)):

--- a/examples/subclass/plot_antigraph.py
+++ b/examples/subclass/plot_antigraph.py
@@ -54,10 +54,9 @@ class AntiGraph(nx.Graph):
            The adjacency dictionary for nodes connected to n.
 
         """
-        return dict(
-            (node, self.all_edge_dict)
-            for node in set(self.adj) - set(self.adj[n]) - set([n])
-        )
+        return {
+            node: self.all_edge_dict for node in set(self.adj) - set(self.adj[n]) - {n}
+        }
 
     def neighbors(self, n):
         """Return an iterator over all neighbors of node n in the
@@ -65,7 +64,7 @@ class AntiGraph(nx.Graph):
 
         """
         try:
-            return iter(set(self.adj) - set(self.adj[n]) - set([n]))
+            return iter(set(self.adj) - set(self.adj[n]) - {n})
         except KeyError:
             raise NetworkXError(f"The node {n} is not in the graph.")
 
@@ -109,7 +108,7 @@ class AntiGraph(nx.Graph):
                     n,
                     {
                         v: self.all_edge_dict
-                        for v in set(self.adj) - set(self.adj[n]) - set([n])
+                        for v in set(self.adj) - set(self.adj[n]) - {n}
                     },
                 )
                 for n in self.nodes()
@@ -123,7 +122,7 @@ class AntiGraph(nx.Graph):
                     n,
                     {
                         v: self.all_edge_dict
-                        for v in set(self.nodes()) - set(self.adj[n]) - set([n])
+                        for v in set(self.nodes()) - set(self.adj[n]) - {n}
                     },
                 )
                 for n in self.nbunch_iter(nbunch)
@@ -153,7 +152,7 @@ class AntiGraph(nx.Graph):
 
         """
         for n in self.adj:
-            yield (n, set(self.adj) - set(self.adj[n]) - set([n]))
+            yield (n, set(self.adj) - set(self.adj[n]) - {n})
 
 
 # Build several pairs of graphs, a regular graph

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -17,9 +17,12 @@ del sys
 # Release data
 from networkx import release
 
-__author__ = '%s <%s>\n%s <%s>\n%s <%s>' % \
-    (release.authors['Hagberg'] + release.authors['Schult'] +
-        release.authors['Swart'])
+
+__author__ = (
+    f"{release.authors['Hagberg'][0]} <{release.authors['Hagberg'][1]}>\n"
+    f"{release.authors['Schult'][0]} <{release.authors['Schult'][1]}>\n"
+    f"{release.authors['Swart'][0]} <{release.authors['Swart'][1]}>"
+)
 
 __date__ = release.date
 __version__ = release.version

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -202,7 +202,7 @@ def node_connectivity(G, s=None, t=None):
     K = minimum_degree
     # compute local node connectivity with all non-neighbors nodes
     # and store the minimum
-    for w in set(G) - set(neighbors(v)) - set([v]):
+    for w in set(G) - set(neighbors(v)) - {v}:
         K = min(K, local_node_connectivity(G, v, w, cutoff=K))
     # Same for non adjacent pairs of neighbors of v
     for x, y in iter_func(neighbors(v), 2):

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -176,9 +176,9 @@ def node_connectivity(G, s=None, t=None):
     # Local node connectivity
     if s is not None and t is not None:
         if s not in G:
-            raise nx.NetworkXError('node %s not in graph' % s)
+            raise nx.NetworkXError(f"node {s} not in graph")
         if t not in G:
-            raise nx.NetworkXError('node %s not in graph' % t)
+            raise nx.NetworkXError(f"node {t} not in graph")
         return local_node_connectivity(G, s, t)
 
     # Global node connectivity
@@ -396,4 +396,4 @@ def _bidirectional_pred_succ(G, source, target, exclude):
                     if w in pred:
                         return pred, succ, w  # found path
 
-    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+    raise nx.NetworkXNoPath(f"No path between {source} and {target}.")

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -238,7 +238,7 @@ class _AntiGraph(nx.Graph):
         try:
             return iter(set(self._adj) - set(self._adj[n]) - set([n]))
         except KeyError:
-            raise NetworkXError("The node %s is not in the graph." % (n,))
+            raise NetworkXError(f"The node {n} is not in the graph.")
 
     class AntiAtlasView(Mapping):
         """An adjacency inner dict for AntiGraph"""

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -158,13 +158,13 @@ def k_components(G, min_density=0.95):
 def _cliques_heuristic(G, H, k, min_density):
     h_cnumber = nx.core_number(H)
     for i, c_value in enumerate(sorted(set(h_cnumber.values()), reverse=True)):
-        cands = set(n for n, c in h_cnumber.items() if c == c_value)
+        cands = {n for n, c in h_cnumber.items() if c == c_value}
         # Skip checking for overlap for the highest core value
         if i == 0:
             overlap = False
         else:
             overlap = set.intersection(*[
-                set(x for x in H[n] if x not in cands)
+                {x for x in H[n] if x not in cands}
                 for n in cands])
         if overlap and len(overlap) < k:
             SH = H.subgraph(cands | overlap)
@@ -229,14 +229,14 @@ class _AntiGraph(nx.Graph):
         """
         all_edge_dict = self.all_edge_dict
         return {node: all_edge_dict for node in
-                set(self._adj) - set(self._adj[n]) - set([n])}
+                set(self._adj) - set(self._adj[n]) - {n}}
 
     def neighbors(self, n):
         """Returns an iterator over all neighbors of node n in the
            dense graph.
         """
         try:
-            return iter(set(self._adj) - set(self._adj[n]) - set([n]))
+            return iter(set(self._adj) - set(self._adj[n]) - {n})
         except KeyError:
             raise NetworkXError(f"The node {n} is not in the graph.")
 
@@ -255,7 +255,7 @@ class _AntiGraph(nx.Graph):
             return (n for n in self._graph if n not in self._atlas and n != self._node)
 
         def __getitem__(self, nbr):
-            nbrs = set(self._graph._adj) - set(self._atlas) - set([self._node])
+            nbrs = set(self._graph._adj) - set(self._atlas) - {self._node}
             if nbr in nbrs:
                 return self._graph.all_edge_dict
             raise KeyError(nbr)
@@ -301,11 +301,11 @@ class _AntiGraph(nx.Graph):
         def __iter__(self):
             all_nodes = set(self._succ)
             for n in self._nodes:
-                nbrs = all_nodes - set(self._succ[n]) - set([n])
+                nbrs = all_nodes - set(self._succ[n]) - {n}
                 yield (n, len(nbrs))
 
         def __getitem__(self, n):
-            nbrs = set(self._succ) - set(self._succ[n]) - set([n])
+            nbrs = set(self._succ) - set(self._succ[n]) - {n}
             # AntiGraph is a ThinGraph so all edges have weight 1
             return len(nbrs) + (n in nbrs)
 
@@ -363,4 +363,4 @@ class _AntiGraph(nx.Graph):
 
         """
         for n in self._adj:
-            yield (n, set(self._adj) - set(self._adj[n]) - set([n]))
+            yield (n, set(self._adj) - set(self._adj[n]) - {n})

--- a/networkx/algorithms/approximation/tests/test_clique.py
+++ b/networkx/algorithms/approximation/tests/test_clique.py
@@ -33,7 +33,7 @@ def is_clique(G, nodes):
     return H.number_of_edges() == n * (n - 1) // 2
 
 
-class TestCliqueRemoval(object):
+class TestCliqueRemoval:
     """Unit tests for the
     :func:`~networkx.algorithms.approximation.clique_removal` function.
 
@@ -60,7 +60,7 @@ class TestCliqueRemoval(object):
         assert all(is_clique(G, clique) for clique in cliques)
 
 
-class TestMaxClique(object):
+class TestMaxClique:
     """Unit tests for the :func:`networkx.algorithms.approximation.max_clique`
     function.
 

--- a/networkx/algorithms/approximation/tests/test_dominating_set.py
+++ b/networkx/algorithms/approximation/tests/test_dominating_set.py
@@ -15,7 +15,7 @@ class TestMinWeightDominatingSet:
         graph.add_edge(3, 6)
         graph.add_edge(5, 6)
 
-        vertices = set([1, 2, 3, 4, 5, 6])
+        vertices = {1, 2, 3, 4, 5, 6}
         # due to ties, this might be hard to test tight bounds
         dom_set = min_weighted_dominating_set(graph)
         for vertex in vertices - dom_set:

--- a/networkx/algorithms/approximation/tests/test_treewidth.py
+++ b/networkx/algorithms/approximation/tests/test_treewidth.py
@@ -35,7 +35,7 @@ def is_tree_decomp(graph, decomp):
         assert nx.is_connected(sub_graph)
 
 
-class TestTreewidthMinDegree(object):
+class TestTreewidthMinDegree:
     """Unit tests for the min_degree function"""
     @classmethod
     def setup_class(cls):
@@ -135,15 +135,15 @@ class TestTreewidthMinDegree(object):
 
     def test_heuristic_first_steps(self):
         """Test first steps of min_degree heuristic"""
-        graph = {n: set(self.deterministic_graph[n]) - set([n])
+        graph = {n: set(self.deterministic_graph[n]) - {n}
                  for n in self.deterministic_graph}
         deg_heuristic = MinDegreeHeuristic(graph)
         elim_node = deg_heuristic.best_node(graph)
-        print("Graph {}:".format(graph))
+        print(f"Graph {graph}:")
         steps = []
 
         while elim_node is not None:
-            print("Removing {}:".format(elim_node))
+            print(f"Removing {elim_node}:")
             steps.append(elim_node)
             nbrs = graph[elim_node]
 
@@ -156,14 +156,14 @@ class TestTreewidthMinDegree(object):
                     graph[u].remove(elim_node)
 
             del graph[elim_node]
-            print("Graph {}:".format(graph))
+            print(f"Graph {graph}:")
             elim_node = deg_heuristic.best_node(graph)
 
         # check only the first 5 elements for equality
         assert steps[:5] == [0, 1, 2, 3, 4]
 
 
-class TestTreewidthMinFillIn(object):
+class TestTreewidthMinFillIn:
     """Unit tests for the treewidth_min_fill_in function."""
     @classmethod
     def setup_class(cls):
@@ -238,14 +238,14 @@ class TestTreewidthMinFillIn(object):
 
     def test_heuristic_first_steps(self):
         """Test first steps of min_fill_in heuristic"""
-        graph = {n: set(self.deterministic_graph[n]) - set([n])
+        graph = {n: set(self.deterministic_graph[n]) - {n}
                  for n in self.deterministic_graph}
-        print("Graph {}:".format(graph))
+        print(f"Graph {graph}:")
         elim_node = min_fill_in_heuristic(graph)
         steps = []
 
         while elim_node is not None:
-            print("Removing {}:".format(elim_node))
+            print(f"Removing {elim_node}:")
             steps.append(elim_node)
             nbrs = graph[elim_node]
 
@@ -258,7 +258,7 @@ class TestTreewidthMinFillIn(object):
                     graph[u].remove(elim_node)
 
             del graph[elim_node]
-            print("Graph {}:".format(graph))
+            print(f"Graph {graph}:")
             elim_node = min_fill_in_heuristic(graph)
 
         # check only the first 2 elements for equality

--- a/networkx/algorithms/approximation/tests/test_vertex_cover.py
+++ b/networkx/algorithms/approximation/tests/test_vertex_cover.py
@@ -6,7 +6,7 @@ def is_cover(G, node_cover):
     return all({u, v} & node_cover for u, v in G.edges())
 
 
-class TestMWVC(object):
+class TestMWVC:
     """Unit tests for the approximate minimum weighted vertex cover
     function,
     :func:`~networkx.algorithms.approximation.vertex_cover.min_weighted_vertex_cover`.

--- a/networkx/algorithms/approximation/treewidth.py
+++ b/networkx/algorithms/approximation/treewidth.py
@@ -189,7 +189,7 @@ def treewidth_decomp(G, heuristic=min_fill_in_heuristic):
     """
 
     # make dict-of-sets structure
-    graph = {n: set(G[n]) - set([n]) for n in G}
+    graph = {n: set(G[n]) - {n} for n in G}
 
     # stack containing nodes and neighbors in the order from the heuristic
     node_stack = []

--- a/networkx/algorithms/assortativity/tests/base_test.py
+++ b/networkx/algorithms/assortativity/tests/base_test.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 
-class BaseTestAttributeMixing(object):
+class BaseTestAttributeMixing:
 
     @classmethod
     def setup_class(cls):
@@ -39,7 +39,7 @@ class BaseTestAttributeMixing(object):
         cls.S = S
 
 
-class BaseTestDegreeMixing(object):
+class BaseTestDegreeMixing:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/assortativity/tests/test_connectivity.py
+++ b/networkx/algorithms/assortativity/tests/test_connectivity.py
@@ -6,7 +6,7 @@ import networkx as nx
 from networkx.testing import almost_equal
 
 
-class TestNeighborConnectivity(object):
+class TestNeighborConnectivity:
 
     def test_degree_p4(self):
         G = nx.path_graph(4)

--- a/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
+++ b/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
@@ -2,7 +2,7 @@ import networkx as nx
 from networkx.testing import almost_equal
 
 
-class TestAverageNeighbor(object):
+class TestAverageNeighbor:
 
     def test_degree_p4(self):
         G = nx.path_graph(4)

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -150,7 +150,7 @@ def create_component_structure(G):
     component_structure = {}
     for v in V:
         label = 0
-        closed_neighborhood = set(G[v]).union(set([v]))
+        closed_neighborhood = set(G[v]).union({v})
         row_dict = {}
         for u in closed_neighborhood:
             row_dict[u] = 0

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -66,9 +66,9 @@ def degree_centrality(G, nodes):
     top = set(nodes)
     bottom = set(G) - top
     s = 1.0 / len(bottom)
-    centrality = dict((n, d * s) for n, d in G.degree(top))
+    centrality = {n: d * s for n, d in G.degree(top)}
     s = 1.0 / len(top)
-    centrality.update(dict((n, d * s) for n, d in G.degree(bottom)))
+    centrality.update({n: d * s for n, d in G.degree(bottom)})
     return centrality
 
 

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -120,7 +120,7 @@ def latapy_clustering(G, nodes=None, mode='dot'):
     ccs = {}
     for v in nodes:
         cc = 0.0
-        nbrs2 = set([u for nbr in G[v] for u in G[nbr]]) - set([v])
+        nbrs2 = {u for nbr in G[v] for u in G[nbr]} - {v}
         for u in nbrs2:
             cc += cc_func(set(G[u]), set(G[v]))
         if cc > 0.0:  # len(nbrs2)>0
@@ -261,7 +261,7 @@ def _four_cycles(G):
     cycles = 0
     for v in G:
         for u, w in itertools.combinations(G[v], 2):
-            cycles += len((set(G[u]) & set(G[w])) - set([v]))
+            cycles += len((set(G[u]) & set(G[w])) - {v})
     return cycles / 4
 
 
@@ -269,8 +269,8 @@ def _threepaths(G):
     paths = 0
     for v in G:
         for u in G[v]:
-            for w in set(G[u]) - set([v]):
-                paths += len(set(G[w]) - set([v, u]))
+            for w in set(G[u]) - {v}:
+                paths += len(set(G[w]) - {v, u})
     # Divide by two because we count each three path twice
     # one for each possible starting point
     return paths / 2

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -237,8 +237,7 @@ def parse_edgelist(lines, comments='#', delimiter=None,
                 u = nodetype(u)
                 v = nodetype(v)
             except:
-                raise TypeError("Failed to convert nodes %s,%s to type %s."
-                                % (u, v, nodetype))
+                raise TypeError(f"Failed to convert nodes {u},{v} to type {nodetype}.")
 
         if len(d) == 0 or data is False:
             # no data or data type specified
@@ -248,22 +247,17 @@ def parse_edgelist(lines, comments='#', delimiter=None,
             try:  # try to evaluate as dictionary
                 edgedata = dict(literal_eval(' '.join(d)))
             except:
-                raise TypeError(
-                    "Failed to convert edge data (%s) to dictionary." % (d))
+                raise TypeError(f"Failed to convert edge data ({d}) to dictionary.")
         else:
             # convert edge data to dictionary with specified keys and type
             if len(d) != len(data):
-                raise IndexError(
-                    "Edge data %s and data_keys %s are not the same length" %
-                    (d, data))
+                raise IndexError(f"Edge data {d} and data_keys {data} are not the same length")
             edgedata = {}
             for (edge_key, edge_type), edge_value in zip(data, d):
                 try:
                     edge_value = edge_type(edge_value)
                 except:
-                    raise TypeError(
-                        "Failed to convert %s data %s to type %s."
-                        % (edge_key, edge_value, edge_type))
+                    raise TypeError(f"Failed to convert {edge_key} data {edge_value} to type {edge_type}.")
                 edgedata.update({edge_key: edge_value})
         G.add_node(u, bipartite=0)
         G.add_node(v, bipartite=1)

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -56,7 +56,7 @@ def complete_bipartite_graph(n1, n2, create_using=None):
     G.add_nodes_from(top, bipartite=0)
     G.add_nodes_from(bottom, bipartite=1)
     G.add_edges_from((u, v) for u in top for v in bottom)
-    G.graph['name'] = "complete_bipartite_graph(%s,%s)" % (n1, n2)
+    G.graph['name'] = f"complete_bipartite_graph({n1},{n2})"
     return G
 
 
@@ -105,9 +105,7 @@ def configuration_model(aseq, bseq, create_using=None, seed=None):
     sumb = sum(bseq)
 
     if not suma == sumb:
-        raise nx.NetworkXError(
-            'invalid degree sequences, sum(aseq)!=sum(bseq),%s,%s'
-            % (suma, sumb))
+        raise nx.NetworkXError(f"invalid degree sequences, sum(aseq)!=sum(bseq),{suma},{sumb}")
 
     G = _add_nodes_with_bipartite_label(G, lena, lenb)
 
@@ -179,9 +177,7 @@ def havel_hakimi_graph(aseq, bseq, create_using=None):
     sumb = sum(bseq)
 
     if not suma == sumb:
-        raise nx.NetworkXError(
-            'invalid degree sequences, sum(aseq)!=sum(bseq),%s,%s'
-            % (suma, sumb))
+        raise nx.NetworkXError(f"invalid degree sequences, sum(aseq)!=sum(bseq),{suma},{sumb}")
 
     G = _add_nodes_with_bipartite_label(G, naseq, nbseq)
 
@@ -252,9 +248,7 @@ def reverse_havel_hakimi_graph(aseq, bseq, create_using=None):
     sumb = sum(bseq)
 
     if not suma == sumb:
-        raise nx.NetworkXError(
-            'invalid degree sequences, sum(aseq)!=sum(bseq),%s,%s'
-            % (suma, sumb))
+        raise nx.NetworkXError(f"invalid degree sequences, sum(aseq)!=sum(bseq),{suma},{sumb}")
 
     G = _add_nodes_with_bipartite_label(G, lena, lenb)
 
@@ -326,9 +320,7 @@ def alternating_havel_hakimi_graph(aseq, bseq, create_using=None):
     sumb = sum(bseq)
 
     if not suma == sumb:
-        raise nx.NetworkXError(
-            'invalid degree sequences, sum(aseq)!=sum(bseq),%s,%s'
-            % (suma, sumb))
+        raise nx.NetworkXError(f"invalid degree sequences, sum(aseq)!=sum(bseq),{suma},{sumb}")
 
     G = _add_nodes_with_bipartite_label(G, naseq, nbseq)
 
@@ -404,7 +396,7 @@ def preferential_attachment_graph(aseq, p, create_using=None, seed=None):
         raise nx.NetworkXError("Directed Graph not supported")
 
     if p > 1:
-        raise nx.NetworkXError("probability %s > 1" % (p))
+        raise nx.NetworkXError(f"probability {p} > 1")
 
     naseq = len(aseq)
     G = _add_nodes_with_bipartite_label(G, naseq, 0)
@@ -479,7 +471,7 @@ def random_graph(n, m, p, seed=None, directed=False):
     G = _add_nodes_with_bipartite_label(G, n, m)
     if directed:
         G = nx.DiGraph(G)
-    G.name = "fast_gnp_random_graph(%s,%s,%s)" % (n, m, p)
+    G.name = f"fast_gnp_random_graph({n},{m},{p})"
 
     if p <= 0:
         return G
@@ -564,7 +556,7 @@ def gnmk_random_graph(n, m, k, seed=None, directed=False):
     G = _add_nodes_with_bipartite_label(G, n, m)
     if directed:
         G = nx.DiGraph(G)
-    G.name = "bipartite_gnm_random_graph(%s,%s,%s)" % (n, m, k)
+    G.name = f"bipartite_gnm_random_graph({n},{m},{k})"
     if n == 1 or m == 1:
         return G
     max_edges = n * m  # max_edges for bipartite networks

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -102,7 +102,7 @@ def biadjacency_matrix(G, row_order, column_order=None,
     # From Scipy 1.1.0, asformat will throw a ValueError instead of an
     # AttributeError if the format if not recognized.
     except (AttributeError, ValueError):
-        raise nx.NetworkXError("Unknown sparse matrix format: %s" % format)
+        raise nx.NetworkXError(f"Unknown sparse matrix format: {format}")
 
 
 def from_biadjacency_matrix(A, create_using=None, edge_attribute='weight'):

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -98,7 +98,7 @@ def projected_graph(B, nodes, multigraph=False):
     G.graph.update(B.graph)
     G.add_nodes_from((n, B.nodes[n]) for n in nodes)
     for u in nodes:
-        nbrs2 = set(v for nbr in B[u] for v in B[nbr] if v != u)
+        nbrs2 = {v for nbr in B[u] for v in B[nbr] if v != u}
         if multigraph:
             for n in nbrs2:
                 if directed:
@@ -190,7 +190,7 @@ def weighted_projected_graph(B, nodes, ratio=False):
     n_top = float(len(B) - len(nodes))
     for u in nodes:
         unbrs = set(B[u])
-        nbrs2 = set((n for nbr in unbrs for n in B[nbr])) - set([u])
+        nbrs2 = {n for nbr in unbrs for n in B[nbr]} - {u}
         for v in nbrs2:
             vnbrs = set(pred[v])
             common = unbrs & vnbrs
@@ -286,7 +286,7 @@ def collaboration_weighted_projected_graph(B, nodes):
     G.add_nodes_from((n, B.nodes[n]) for n in nodes)
     for u in nodes:
         unbrs = set(B[u])
-        nbrs2 = set(n for nbr in unbrs for n in B[nbr] if n != u)
+        nbrs2 = {n for nbr in unbrs for n in B[nbr] if n != u}
         for v in nbrs2:
             vnbrs = set(pred[v])
             common_degree = (len(B[n]) for n in unbrs & vnbrs)
@@ -383,7 +383,7 @@ def overlap_weighted_projected_graph(B, nodes, jaccard=True):
     G.add_nodes_from((n, B.nodes[n]) for n in nodes)
     for u in nodes:
         unbrs = set(B[u])
-        nbrs2 = set((n for nbr in unbrs for n in B[nbr])) - set([u])
+        nbrs2 = {n for nbr in unbrs for n in B[nbr]} - {u}
         for v in nbrs2:
             vnbrs = set(pred[v])
             if jaccard:
@@ -496,7 +496,7 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     G.graph.update(B.graph)
     G.add_nodes_from((n, B.nodes[n]) for n in nodes)
     for u in nodes:
-        nbrs2 = set((n for nbr in set(B[u]) for n in B[nbr])) - set([u])
+        nbrs2 = {n for nbr in set(B[u]) for n in B[nbr]} - {u}
         for v in nbrs2:
             weight = weight_function(B, u, v)
             G.add_edge(u, v, weight=weight)

--- a/networkx/algorithms/bipartite/tests/test_basic.py
+++ b/networkx/algorithms/bipartite/tests/test_basic.py
@@ -72,8 +72,8 @@ class TestBipartiteBasic:
 
     def test_bipartite_degrees(self):
         G = nx.path_graph(5)
-        X = set([1, 3])
-        Y = set([0, 2, 4])
+        X = {1, 3}
+        Y = {0, 2, 4}
         u, d = bipartite.degrees(G, Y)
         assert dict(u) == {1: 2, 3: 2}
         assert dict(d) == {0: 1, 2: 2, 4: 1}
@@ -81,8 +81,8 @@ class TestBipartiteBasic:
     def test_bipartite_weighted_degrees(self):
         G = nx.path_graph(5)
         G.add_edge(0, 1, weight=0.1, other=0.2)
-        X = set([1, 3])
-        Y = set([0, 2, 4])
+        X = {1, 3}
+        Y = {0, 2, 4}
         u, d = bipartite.degrees(G, Y, weight='weight')
         assert dict(u) == {1: 1.1, 3: 2}
         assert dict(d) == {0: 0.1, 2: 2, 4: 1}

--- a/networkx/algorithms/bipartite/tests/test_centrality.py
+++ b/networkx/algorithms/bipartite/tests/test_centrality.py
@@ -3,7 +3,7 @@ from networkx.algorithms import bipartite
 from networkx.testing import almost_equal
 
 
-class TestBipartiteCentrality(object):
+class TestBipartiteCentrality:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -1,4 +1,3 @@
-
 import pytest
 import networkx as nx
 from ..generators import (

--- a/networkx/algorithms/bipartite/tests/test_matching.py
+++ b/networkx/algorithms/bipartite/tests/test_matching.py
@@ -191,7 +191,7 @@ def test_eppstein_matching():
     assert all(x in set(matching.keys()) for x in set(matching.values()))
 
 
-class TestMinimumWeightFullMatching(object):
+class TestMinimumWeightFullMatching:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/bipartite/tests/test_spectral_bipartivity.py
+++ b/networkx/algorithms/bipartite/tests/test_spectral_bipartivity.py
@@ -9,7 +9,7 @@ from networkx.testing import almost_equal
 # bipartivity in complex networks", PhysRev E 72, 046105 (2005)
 
 
-class TestSpectralBipartivity(object):
+class TestSpectralBipartivity:
     @classmethod
     def setup_class(cls):
         global scipy

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -136,7 +136,7 @@ def approximate_current_flow_betweenness_centrality(G, normalized=True,
     else:
         factor = nb / 2.0
     # remap to original node names and "unnormalize" if required
-    return dict((ordering[k], float(v * factor)) for k, v in betweenness.items())
+    return {ordering[k]: float(v * factor) for k, v in betweenness.items()}
 
 
 @not_implemented_for('directed')
@@ -240,7 +240,7 @@ def current_flow_betweenness_centrality(G, normalized=True, weight=None,
         nb = 2.0
     for v in H:
         betweenness[v] = float((betweenness[v] - v) * 2.0 / nb)
-    return dict((ordering[k], v) for k, v in betweenness.items())
+    return {ordering[k]: v for k, v in betweenness.items()}
 
 
 @not_implemented_for('directed')
@@ -352,5 +352,5 @@ def edge_current_flow_betweenness_centrality(G, normalized=True,
             betweenness[e] += (i + 1 - pos[i]) * row[i]
             betweenness[e] += (n - i - pos[i]) * row[i]
         betweenness[e] /= nb
-    return dict(((ordering[s], ordering[t]), float(v))
-                for (s, t), v in betweenness.items())
+    return {(ordering[s], ordering[t]): float(v)
+                for (s, t), v in betweenness.items()}

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -116,7 +116,7 @@ def approximate_current_flow_betweenness_centrality(G, normalized=True,
     l = 1  # parameter in approximation, adjustable
     k = l * int(np.ceil((cstar / epsilon)**2 * np.log(n)))
     if k > kmax:
-        msg = 'Number random pairs k>kmax (%d>%d) ' % (k, kmax)
+        msg = f"Number random pairs k>kmax ({k}>{kmax}) "
         raise nx.NetworkXError(msg, 'Increase kmax or epsilon')
     cstar2k = cstar / (2 * k)
     for i in range(k):

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -120,7 +120,7 @@ def current_flow_betweenness_centrality_subset(G, sources, targets,
         nb = 2.0
     for v in H:
         betweenness[v] = betweenness[v] / nb + 1.0 / (2 - n)
-    return dict((ordering[k], v) for k, v in betweenness.items())
+    return {ordering[k]: v for k, v in betweenness.items()}
 
 
 @not_implemented_for('directed')
@@ -234,5 +234,5 @@ def edge_current_flow_betweenness_centrality_subset(G, sources, targets,
                 j = mapping[tt]
                 betweenness[e] += 0.5 * np.abs(row[i] - row[j])
         betweenness[e] /= nb
-    return dict(((ordering[s], ordering[t]), v)
-                for (s, t), v in betweenness.items())
+    return {(ordering[s], ordering[t]): v
+                for (s, t), v in betweenness.items()}

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -91,7 +91,7 @@ def current_flow_closeness_centrality(G, weight=None,
             betweenness[w] += col[v]
     for v in H:
         betweenness[v] = 1.0 / (betweenness[v])
-    return dict((ordering[k], float(v)) for k, v in betweenness.items())
+    return {ordering[k]: float(v) for k, v in betweenness.items()}
 
 
 information_centrality = current_flow_closeness_centrality

--- a/networkx/algorithms/centrality/dispersion.py
+++ b/networkx/algorithms/centrality/dispersion.py
@@ -47,8 +47,8 @@ def dispersion(G, u=None, v=None, normalized=True, alpha=1.0, b=0.0, c=0.0):
     def _dispersion(G_u, u, v):
         """dispersion for all nodes 'v' in a ego network G_u of node 'u'"""
         u_nbrs = set(G_u[u])
-        ST = set(n for n in G_u[v] if n in u_nbrs)
-        set_uv = set([u, v])
+        ST = {n for n in G_u[v] if n in u_nbrs}
+        set_uv = {u, v}
         # all possible ties of connections that u and b share
         possib = combinations(ST, 2)
         total = 0
@@ -79,7 +79,7 @@ def dispersion(G, u=None, v=None, normalized=True, alpha=1.0, b=0.0, c=0.0):
     if u is None:
         # v and u are not specified
         if v is None:
-            results = dict((n, {}) for n in G)
+            results = {n: {} for n in G}
             for u in G:
                 for v in G[u]:
                     results[u][v] = _dispersion(G, u, v)

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -53,7 +53,7 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None,
     --------
     >>> G = nx.path_graph(4)
     >>> centrality = nx.eigenvector_centrality(G)
-    >>> sorted((v, '{:0.2f}'.format(c)) for v, c in centrality.items())
+    >>> sorted((v, f"{c:0.2f}") for v, c in centrality.items())
     [(0, '0.37'), (1, '0.60'), (2, '0.60'), (3, '0.37')]
 
     Raises
@@ -177,7 +177,7 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     --------
     >>> G = nx.path_graph(4)
     >>> centrality = nx.eigenvector_centrality_numpy(G)
-    >>> print(['{} {:0.2f}'.format(node, centrality[node]) for node in centrality])
+    >>> print([f"{node} {centrality[node]:0.2f}" for node in centrality]) 
     ['0 0.37', '1 0.60', '2 0.60', '3 0.37']
 
     See Also

--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -31,7 +31,7 @@ def flow_matrix_row(G, weight=None, dtype=float, solver='lu'):
 # Class to compute the inverse laplacian only for specified rows
 # Allows computation of the current-flow matrix without storing entire
 # inverse laplacian matrix
-class InverseLaplacian(object):
+class InverseLaplacian:
     def __init__(self, L, width=None, dtype=None):
         global np
         import numpy as np

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -91,7 +91,7 @@ def katz_centrality(G, alpha=0.1, beta=1.0, max_iter=1000, tol=1.0e-6,
     >>> phi = (1 + math.sqrt(5)) / 2.0  # largest eigenvalue of adj matrix
     >>> centrality = nx.katz_centrality(G, 1/phi - 0.01)
     >>> for n, c in sorted(centrality.items()):
-    ...    print("%d %0.2f" % (n, c))
+    ...    print(f"{n} {c:.2f}")
     0 0.37
     1 0.60
     2 0.60
@@ -253,7 +253,7 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,
     >>> phi = (1 + math.sqrt(5)) / 2.0  # largest eigenvalue of adj matrix
     >>> centrality = nx.katz_centrality_numpy(G, 1/phi)
     >>> for n, c in sorted(centrality.items()):
-    ...    print("%d %0.2f" % (n, c))
+    ...    print(f"{n} {c:.2f}")
     0 0.37
     1 0.60
     2 0.60

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -142,7 +142,7 @@ def katz_centrality(G, alpha=0.1, beta=1.0, max_iter=1000, tol=1.0e-6,
 
     if nstart is None:
         # choose starting vector with entries of 0
-        x = dict([(n, 0) for n in G])
+        x = {n: 0 for n in G}
     else:
         x = nstart
 

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -133,5 +133,5 @@ def second_order_centrality(G):
                                   np.ones([n, 1])[:, 0])  # eq 3
 
     return dict(zip(G.nodes,
-                    [np.sqrt((2*np.sum(M[:, i])-n*(n+1))) for i in range(n)]
+                    [np.sqrt(2*np.sum(M[:, i])-n*(n+1)) for i in range(n)]
                     ))  # eq 6

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -17,7 +17,7 @@ def weighted_G():
     return G
 
 
-class TestBetweennessCentrality(object):
+class TestBetweennessCentrality:
     def test_K5(self):
         """Betweenness centrality: K5"""
         G = nx.complete_graph(5)
@@ -315,7 +315,7 @@ class TestBetweennessCentrality(object):
             assert almost_equal(b[n], b_answer[n])
 
 
-class TestWeightedBetweennessCentrality(object):
+class TestWeightedBetweennessCentrality:
     def test_K5(self):
         """Weighted betweenness centrality: K5"""
         G = nx.complete_graph(5)
@@ -533,7 +533,7 @@ class TestWeightedBetweennessCentrality(object):
             assert almost_equal(b[n], b_answer[n])
 
 
-class TestEdgeBetweennessCentrality(object):
+class TestEdgeBetweennessCentrality:
     def test_K5(self):
         """Edge betweenness centrality: K5"""
         G = nx.complete_graph(5)
@@ -584,7 +584,7 @@ class TestEdgeBetweennessCentrality(object):
             assert almost_equal(b[n], b_answer[n])
 
 
-class TestWeightedEdgeBetweennessCentrality(object):
+class TestWeightedEdgeBetweennessCentrality:
     def test_K5(self):
         """Edge betweenness centrality: K5"""
         G = nx.complete_graph(5)

--- a/networkx/algorithms/centrality/tests/test_closeness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_closeness_centrality.py
@@ -278,7 +278,7 @@ class TestClosenessCentrality:
             test_cc = nx.incremental_closeness_centrality(
                 G, edge, prev_cc, insert)
             # inc_elapsed = (timeit.default_timer() - start)
-            # print("incremental time: {}".format(inc_elapsed))
+            # print(f"incremental time: {inc_elapsed}")
 
             if insert:
                 G.add_edges_from([edge])
@@ -288,7 +288,7 @@ class TestClosenessCentrality:
             # start = timeit.default_timer()
             real_cc = nx.closeness_centrality(G)
             # reg_elapsed = (timeit.default_timer() - start)
-            # print("regular time: {}".format(reg_elapsed))
+            # print(f"regular time: {reg_elapsed}")
             # Example output:
             # incremental time: 0.208
             # regular time: 0.276

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
@@ -13,7 +13,7 @@ npt = pytest.importorskip('numpy.testing')
 scipy = pytest.importorskip('scipy')
 
 
-class TestFlowBetweennessCentrality(object):
+class TestFlowBetweennessCentrality:
     def test_K4_normalized(self):
         """Betweenness centrality: K4"""
         G = nx.complete_graph(4)
@@ -80,7 +80,7 @@ class TestFlowBetweennessCentrality(object):
                 assert almost_equal(b[n], b_answer[n])
 
 
-class TestApproximateFlowBetweennessCentrality(object):
+class TestApproximateFlowBetweennessCentrality:
 
     def test_K4_normalized(self):
         "Approximate current-flow betweenness centrality: K4 normalized"
@@ -138,11 +138,11 @@ class TestApproximateFlowBetweennessCentrality(object):
                 npt.assert_allclose(b[n], b_answer[n], atol=epsilon)
 
 
-class TestWeightedFlowBetweennessCentrality(object):
+class TestWeightedFlowBetweennessCentrality:
     pass
 
 
-class TestEdgeFlowBetweennessCentrality(object):
+class TestEdgeFlowBetweennessCentrality:
 
     def test_K4(self):
         """Edge flow betweenness centrality: K4"""

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
@@ -12,7 +12,7 @@ from networkx import edge_current_flow_betweenness_centrality_subset \
     as edge_current_flow_subset
 
 
-class TestFlowBetweennessCentrality(object):
+class TestFlowBetweennessCentrality:
 
     def test_K4_normalized(self):
         """Betweenness centrality: K4"""
@@ -99,7 +99,7 @@ class TestFlowBetweennessCentrality(object):
 #     pass
 
 
-class TestEdgeFlowBetweennessCentrality(object):
+class TestEdgeFlowBetweennessCentrality:
 
     def test_K4_normalized(self):
         """Betweenness centrality: K4"""

--- a/networkx/algorithms/centrality/tests/test_current_flow_closeness.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_closeness.py
@@ -6,7 +6,7 @@ import networkx as nx
 from networkx.testing import almost_equal
 
 
-class TestFlowClosenessCentrality(object):
+class TestFlowClosenessCentrality:
 
     def test_K4(self):
         """Closeness centrality: K4"""
@@ -34,5 +34,5 @@ class TestFlowClosenessCentrality(object):
             assert almost_equal(b[n], b_answer[n])
 
 
-class TestWeightedFlowClosenessCentrality(object):
+class TestWeightedFlowClosenessCentrality:
     pass

--- a/networkx/algorithms/centrality/tests/test_degree_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_degree_centrality.py
@@ -65,7 +65,7 @@ class TestDegreeCentrality:
         exact = {0: .444, 1: .444, 2: .333, 3: .667, 4: .333,
                  5: .556, 6: .556, 7: .333, 8: .222, 9: .111}
         for n, dc in d.items():
-            assert almost_equal(exact[n], float("%5.3f" % dc))
+            assert almost_equal(exact[n], float(f"{dc:.3f}"))
 
     def test_degree_centrality_4(self):
         d = nx.degree_centrality(self.F)
@@ -74,7 +74,7 @@ class TestDegreeCentrality:
                0.071, 0.429, 0.071, 0.214, 0.214, 0.143, 0.286, 0.214]
         exact = dict(zip(names, dcs))
         for n, dc in d.items():
-            assert almost_equal(exact[n], float("%5.3f" % dc))
+            assert almost_equal(exact[n], float(f"{dc:.3f}"))
 
     def test_indegree_centrality(self):
         d = nx.in_degree_centrality(self.G)

--- a/networkx/algorithms/centrality/tests/test_dispersion.py
+++ b/networkx/algorithms/centrality/tests/test_dispersion.py
@@ -14,7 +14,7 @@ def small_ego_G():
     return G
 
 
-class TestDispersion(object):
+class TestDispersion:
 
     def test_article(self):
         """our algorithm matches article's"""

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -8,7 +8,7 @@ import networkx as nx
 from networkx.testing import almost_equal
 
 
-class TestEigenvectorCentrality(object):
+class TestEigenvectorCentrality:
 
     def test_K5(self):
         """Eigenvector centrality: K5"""
@@ -18,7 +18,7 @@ class TestEigenvectorCentrality(object):
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n])
-        nstart = dict([(n, 1) for n in G])
+        nstart = {n: 1 for n in G}
         b = nx.eigenvector_centrality(G, nstart=nstart)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n])
@@ -52,7 +52,7 @@ class TestEigenvectorCentrality(object):
             b = nx.eigenvector_centrality(G, max_iter=0)
 
 
-class TestEigenvectorCentralityDirected(object):
+class TestEigenvectorCentralityDirected:
 
     @classmethod
     def setup_class(cls):
@@ -103,7 +103,7 @@ class TestEigenvectorCentralityDirected(object):
             assert almost_equal(a, b)
 
 
-class TestEigenvectorCentralityExceptions(object):
+class TestEigenvectorCentralityExceptions:
 
     def test_multigraph(self):
         with pytest.raises(nx.NetworkXException):

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -5,7 +5,7 @@ from networkx.testing import almost_equal
 import pytest
 
 
-class TestKatzCentrality(object):
+class TestKatzCentrality:
 
     def test_K5(self):
         """Katz centrality: K5"""
@@ -16,7 +16,7 @@ class TestKatzCentrality(object):
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n])
-        nstart = dict([(n, 1) for n in G])
+        nstart = {n: 1 for n in G}
         b = nx.katz_centrality(G, alpha, nstart=nstart)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n])
@@ -102,7 +102,7 @@ class TestKatzCentrality(object):
             e = nx.katz_centrality(G, 0.1, beta='foo')
 
 
-class TestKatzCentralityNumpy(object):
+class TestKatzCentralityNumpy:
 
     @classmethod
     def setup_class(cls):
@@ -119,7 +119,7 @@ class TestKatzCentralityNumpy(object):
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n])
-        nstart = dict([(n, 1) for n in G])
+        nstart = {n: 1 for n in G}
         b = nx.eigenvector_centrality_numpy(G)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n], places=3)
@@ -202,7 +202,7 @@ class TestKatzCentralityNumpy(object):
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n])
-        nstart = dict([(n, 1) for n in G])
+        nstart = {n: 1 for n in G}
         b = nx.eigenvector_centrality_numpy(G, weight=None)
         for n in sorted(G):
             assert almost_equal(b[n], b_answer[n], places=3)
@@ -218,7 +218,7 @@ class TestKatzCentralityNumpy(object):
             assert almost_equal(b[n], b_answer[n], places=4)
 
 
-class TestKatzCentralityDirected(object):
+class TestKatzCentralityDirected:
     @classmethod
     def setup_class(cls):
         G = nx.DiGraph()
@@ -291,7 +291,7 @@ class TestKatzCentralityDirectedNumpy(TestKatzCentralityDirected):
             assert almost_equal(a, b)
 
 
-class TestKatzEigenvectorVKatz(object):
+class TestKatzEigenvectorVKatz:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/centrality/tests/test_percolation_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_percolation_centrality.py
@@ -30,7 +30,7 @@ def example1b_G():
     return G
 
 
-class TestPercolationCentrality(object):
+class TestPercolationCentrality:
     def test_percolation_example1a(self):
         """percolation centrality: example 1a"""
         G = example1a_G()

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -10,7 +10,7 @@ import networkx as nx
 from networkx.testing import almost_equal
 
 
-class TestSecondOrderCentrality(object):
+class TestSecondOrderCentrality:
 
     def test_empty(self):
         with pytest.raises(nx.NetworkXException):

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -302,8 +302,7 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
             # The graph seems to be chordal by now. We update the treewidth
             current_treewidth = max(current_treewidth, len(clique_wanna_be))
             if current_treewidth > treewidth_bound:
-                raise nx.NetworkXTreewidthBoundExceeded(
-                    "treewidth_bound exceeded: %s" % current_treewidth)
+                raise nx.NetworkXTreewidthBoundExceeded(f"treewidth_bound exceeded: {current_treewidth}")
         else:
             # sg is not a clique,
             # look for an edge that is not included in sg

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -290,7 +290,7 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
     if s is None:
         s = arbitrary_element(G)
     unnumbered.remove(s)
-    numbered = set([s])
+    numbered = {s}
     current_treewidth = -1
     while unnumbered:  # and current_treewidth <= treewidth_bound:
         v = _max_cardinality_node(G, unnumbered, numbered)
@@ -315,14 +315,14 @@ def _connected_chordal_graph_cliques(G):
     """Returns the set of maximal cliques of a connected chordal graph."""
     if G.number_of_nodes() == 1:
         x = frozenset(G.nodes())
-        return set([x])
+        return {x}
     else:
         cliques = set()
         unnumbered = set(G.nodes())
         v = arbitrary_element(G)
         unnumbered.remove(v)
-        numbered = set([v])
-        clique_wanna_be = set([v])
+        numbered = {v}
+        clique_wanna_be = {v}
         while unnumbered:
             v = _max_cardinality_node(G, unnumbered, numbered)
             unnumbered.remove(v)
@@ -386,7 +386,7 @@ def complete_to_chordal_graph(G):
     alpha = {node: 0 for node in H}
     if nx.is_chordal(H):
         return H, alpha
-    chords = set([])
+    chords = set()
     weight = {node: 0 for node in H.nodes()}
     unnumbered_nodes = list(H.nodes())
     for i in range(len(H.nodes()), 0, -1):

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -280,8 +280,7 @@ def find_cliques_recursive(G):
             else:
                 cand_q = cand & adj_q
                 if cand_q:
-                    for clique in expand(subg_q, cand_q):
-                        yield clique
+                    yield from expand(subg_q, cand_q)
             Q.pop()
 
     return expand(set(G), set(G))
@@ -460,10 +459,10 @@ def node_clique_number(G, nodes=None, cliques=None):
                 d = {}
                 for n in nodes:
                     H = nx.ego_graph(G, n)
-                    d[n] = max((len(c) for c in find_cliques(H)))
+                    d[n] = max(len(c) for c in find_cliques(H))
             else:
                 H = nx.ego_graph(G, nodes)
-                d = max((len(c) for c in find_cliques(H)))
+                d = max(len(c) for c in find_cliques(H))
             return d
         # nodes is None--find all cliques
         cliques = list(find_cliques(G))

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -127,11 +127,11 @@ def _directed_triangles_and_degree_iter(G, nodes=None):
         for j in chain(ipreds, isuccs):
             jpreds = set(G._pred[j]) - {j}
             jsuccs = set(G._succ[j]) - {j}
-            directed_triangles += sum((1 for k in
+            directed_triangles += sum(1 for k in
                                        chain((ipreds & jpreds),
                                              (ipreds & jsuccs),
                                              (isuccs & jpreds),
-                                             (isuccs & jsuccs))))
+                                             (isuccs & jsuccs)))
         dtotal = len(ipreds) + len(isuccs)
         dbidirectional = len(ipreds & isuccs)
         yield (i, dtotal, dbidirectional, directed_triangles)
@@ -447,7 +447,7 @@ def square_clustering(G, nodes=None):
         clustering[v] = 0
         potential = 0
         for u, w in combinations(G[v], 2):
-            squares = len((set(G[u]) & set(G[w])) - set([v]))
+            squares = len((set(G[u]) & set(G[w])) - {v})
             clustering[v] += squares
             degm = squares + 1
             if w in G[u]:

--- a/networkx/algorithms/coloring/equitable_coloring.py
+++ b/networkx/algorithms/coloring/equitable_coloring.py
@@ -408,8 +408,8 @@ def equitable_color(G, num_colors):
 
     if r_ >= num_colors:
         raise nx.NetworkXAlgorithmError(
-            'Graph has maximum degree {}, needs {} (> {}) colors for guaranteed coloring.'
-            .format(r_, r_ + 1, num_colors)
+            f"Graph has maximum degree {r_}, needs "
+            f"{r_ + 1} (> {num_colors}) colors for guaranteed coloring."
         )
 
     # Ensure that the number of nodes in G is a multiple of (r + 1)

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -135,8 +135,7 @@ def strategy_independent_set(G, colors):
     while len(remaining_nodes) > 0:
         nodes = _maximal_independent_set(G.subgraph(remaining_nodes))
         remaining_nodes -= nodes
-        for v in nodes:
-            yield v
+        yield from nodes
 
 
 def strategy_connected_sequential_bfs(G, colors):
@@ -327,7 +326,7 @@ def greedy_color(G, strategy='largest_first', interchange=False):
     strategy = STRATEGIES.get(strategy, strategy)
     if not callable(strategy):
         raise nx.NetworkXError('strategy must be callable or a valid string. '
-                               '{0} not valid.'.format(strategy))
+                               '{} not valid.'.format(strategy))
     # Perform some validation on the arguments before executing any
     # strategy functions.
     if interchange:

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -326,7 +326,7 @@ def greedy_color(G, strategy='largest_first', interchange=False):
     strategy = STRATEGIES.get(strategy, strategy)
     if not callable(strategy):
         raise nx.NetworkXError('strategy must be callable or a valid string. '
-                               '{} not valid.'.format(strategy))
+                               f'{strategy} not valid.')
     # Perform some validation on the arguments before executing any
     # strategy functions.
     if interchange:

--- a/networkx/algorithms/coloring/greedy_coloring_with_interchange.py
+++ b/networkx/algorithms/coloring/greedy_coloring_with_interchange.py
@@ -14,9 +14,10 @@ class Node:
         self.adj_color = [None for _ in range(n)]
 
     def __repr__(self):
-        return "Node_id: {}, Color: {}, Adj_list: ({}), \
-            adj_color: ({})".format(
-            self.node_id, self.color, self.adj_list, self.adj_color)
+        return (
+            f"Node_id: {self.node_id}, Color: {self.color}, "
+            f"Adj_list: ({self.adj_list}), adj_color: ({self.adj_color})"
+        )
 
     def assign_color(self, adj_entry, color):
         adj_entry.col_prev = None
@@ -58,13 +59,12 @@ class AdjEntry:
         self.col_prev = None
 
     def __repr__(self):
-        return "Node_id: {}, Next: ({}), Mate: ({}), \
-            col_next: ({}), col_prev: ({})".format(
-            self.node_id,
-            self.next,
-            self.mate.node_id,
-            None if self.col_next is None else self.col_next.node_id,
-            None if self.col_prev is None else self.col_prev.node_id
+        col_next = None if self.col_next is None else self.col_next.node_id
+        col_prev = None if self.col_prev is None else self.col_prev.node_id
+        return (
+            f"Node_id: {self.node_id}, Next: ({self.next}), "
+            f"Mate: ({self.mate.node_id}), "
+            f"col_next: ({col_next}), col_prev: ({col_prev})"
         )
 
 

--- a/networkx/algorithms/coloring/greedy_coloring_with_interchange.py
+++ b/networkx/algorithms/coloring/greedy_coloring_with_interchange.py
@@ -3,7 +3,7 @@ import itertools
 __all__ = ['greedy_coloring_with_interchange']
 
 
-class Node(object):
+class Node:
 
     __slots__ = ['node_id', 'color', 'adj_list', 'adj_color']
 
@@ -14,8 +14,8 @@ class Node(object):
         self.adj_color = [None for _ in range(n)]
 
     def __repr__(self):
-        return "Node_id: {0}, Color: {1}, Adj_list: ({2}), \
-            adj_color: ({3})".format(
+        return "Node_id: {}, Color: {}, Adj_list: ({}), \
+            adj_color: ({})".format(
             self.node_id, self.color, self.adj_list, self.adj_color)
 
     def assign_color(self, adj_entry, color):
@@ -46,7 +46,7 @@ class Node(object):
             adj_color_node = adj_color_node.col_next
 
 
-class AdjEntry(object):
+class AdjEntry:
 
     __slots__ = ['node_id', 'next', 'mate', 'col_next', 'col_prev']
 
@@ -58,8 +58,8 @@ class AdjEntry(object):
         self.col_prev = None
 
     def __repr__(self):
-        return "Node_id: {0}, Next: ({1}), Mate: ({2}), \
-            col_next: ({3}), col_prev: ({4})".format(
+        return "Node_id: {}, Next: ({}), Mate: ({}), \
+            col_next: ({}), col_prev: ({})".format(
             self.node_id,
             self.next,
             self.mate.node_id,

--- a/networkx/algorithms/community/community_utils.py
+++ b/networkx/algorithms/community/community_utils.py
@@ -22,6 +22,6 @@ def is_partition(G, communities):
     # return all(sum(1 if v in c else 0 for c in communities) == 1 for v in G)
     if not isinstance(communities, list):
         communities = list(communities)
-    nodes = set(n for c in communities for n in c if n in G)
+    nodes = {n for c in communities for n in c if n in G}
 
     return len(G) == len(nodes) == sum(len(c) for c in communities)

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -44,7 +44,7 @@ def k_clique_communities(G, k, cliques=None):
        doi:10.1038/nature03607
     """
     if k < 2:
-        raise nx.NetworkXError("k=%d, k must be greater than 1." % k)
+        raise nx.NetworkXError(f"k={k}, k must be greater than 1.")
     if cliques is None:
         cliques = nx.find_cliques(G)
     cliques = [frozenset(c) for c in cliques if len(c) >= k]

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -134,7 +134,7 @@ def label_propagation_communities(G):
                 _update_label(n, labeling, G)
 
     for label in set(labeling.values()):
-        yield set((x for x in labeling if labeling[x] == label))
+        yield {x for x in labeling if labeling[x] == label}
 
 
 def _color_network(G):
@@ -148,7 +148,7 @@ def _color_network(G):
         if color in coloring:
             coloring[color].add(node)
         else:
-            coloring[color] = set([node])
+            coloring[color] = {node}
     return coloring
 
 

--- a/networkx/algorithms/community/lukes.py
+++ b/networkx/algorithms/community/lukes.py
@@ -109,8 +109,7 @@ def lukes_partitioning(G,
     for x in all_n_attr:
         if not isinstance(x, int):
             raise TypeError('lukes_partitioning needs integer '
-                            'values for node_weight ({})'
-                            .format(node_weight))
+                            f'values for node_weight ({node_weight})')
 
     # SUBROUTINES -----------------------
     # these functions are defined here for two reasons:

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -53,15 +53,15 @@ def greedy_modularity_communities(G, weight=None):
     q0 = 1.0 / (2.0*m)
 
     # Map node labels to contiguous integers
-    label_for_node = dict((i, v) for i, v in enumerate(G.nodes()))
-    node_for_label = dict((label_for_node[i], i) for i in range(N))
+    label_for_node = {i: v for i, v in enumerate(G.nodes())}
+    node_for_label = {label_for_node[i]: i for i in range(N)}
 
     # Calculate degrees
     k_for_label = G.degree(G.nodes(), weight=weight)
     k = [k_for_label[label_for_node[i]] for i in range(N)]
 
     # Initialize community and merge lists
-    communities = dict((i, frozenset([i])) for i in range(N))
+    communities = {i: frozenset([i]) for i in range(N)}
     merges = []
 
     # Initial modularity
@@ -75,14 +75,14 @@ def greedy_modularity_communities(G, weight=None):
     # dq_heap[i][n] : (-dq, i, j) for communitiy i nth largest dQ
     # H[n]: (-dq, i, j) for community with nth largest max_j(dQ_ij)
     a = [k[i]*q0 for i in range(N)]
-    dq_dict = dict(
-        (i, dict(
-            (j, 2*q0 - 2*k[i]*k[j]*q0*q0)
+    dq_dict = {
+        i: {
+            j: 2*q0 - 2*k[i]*k[j]*q0*q0
             for j in [
                 node_for_label[u]
                 for u in G.neighbors(label_for_node[i])]
-            if j != i))
-        for i in range(N))
+            if j != i}
+        for i in range(N)}
     dq_heap = [
         MappedQueue([
             (-dq, i, j)
@@ -133,7 +133,7 @@ def greedy_modularity_communities(G, weight=None):
         # Get list of communities connected to merged communities
         i_set = set(dq_dict[i].keys())
         j_set = set(dq_dict[j].keys())
-        all_set = (i_set | j_set) - set([i, j])
+        all_set = (i_set | j_set) - {i, j}
         both_set = i_set & j_set
         # Merge i into j and update dQ
         for k in all_set:
@@ -264,5 +264,4 @@ def _naive_greedy_modularity_communities(G):
             communities[i] = frozenset([])
     # Remove empty communities and sort
     communities = [c for c in communities if len(c) > 0]
-    for com in sorted(communities, key=lambda x: len(x), reverse=True):
-        yield com
+    yield from sorted(communities, key=lambda x: len(x), reverse=True)

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -21,7 +21,7 @@ class NotAPartition(NetworkXError):
     def __init__(self, G, collection):
         msg = '{} is not a valid partition of the graph {}'
         msg = msg.format(G, collection)
-        super(NotAPartition, self).__init__(msg)
+        super().__init__(msg)
 
 
 def require_partition(func):

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -19,8 +19,7 @@ class NotAPartition(NetworkXError):
 
     """
     def __init__(self, G, collection):
-        msg = '{} is not a valid partition of the graph {}'
-        msg = msg.format(G, collection)
+        msg = f"{G} is not a valid partition of the graph {collection}"
         super().__init__(msg)
 
 

--- a/networkx/algorithms/community/tests/test_asyn_fluid.py
+++ b/networkx/algorithms/community/tests/test_asyn_fluid.py
@@ -19,7 +19,7 @@ def test_single_node():
     test.add_node('a')
 
     # ground truth
-    ground_truth = set([frozenset(['a'])])
+    ground_truth = {frozenset(['a'])}
 
     communities = asyn_fluidc(test, 1)
     result = {frozenset(c) for c in communities}
@@ -32,7 +32,7 @@ def test_two_nodes():
     test.add_edge('a', 'b')
 
     # ground truth
-    ground_truth = set([frozenset(['a']), frozenset(['b'])])
+    ground_truth = {frozenset(['a']), frozenset(['b'])}
 
     communities = asyn_fluidc(test, 2)
     result = {frozenset(c) for c in communities}
@@ -56,8 +56,8 @@ def test_two_clique_communities():
     test.add_edge('f', 'e')
 
     # ground truth
-    ground_truth = set([frozenset(['a', 'c', 'b']),
-                        frozenset(['e', 'd', 'f'])])
+    ground_truth = {frozenset(['a', 'c', 'b']),
+                        frozenset(['e', 'd', 'f'])}
 
     communities = asyn_fluidc(test, 2, seed=7)
     result = {frozenset(c) for c in communities}
@@ -115,11 +115,11 @@ def test_five_clique_ring():
     test.add_edge('5a', '1c')
 
     # ground truth
-    ground_truth = set([frozenset(['1a', '1b', '1c', '1d']),
+    ground_truth = {frozenset(['1a', '1b', '1c', '1d']),
                         frozenset(['2a', '2b', '2c', '2d']),
                         frozenset(['3a', '3b', '3c', '3d']),
                         frozenset(['4a', '4b', '4c', '4d']),
-                        frozenset(['5a', '5b', '5c', '5d'])])
+                        frozenset(['5a', '5b', '5c', '5d'])}
 
     communities = asyn_fluidc(test, 5, seed=9)
     result = {frozenset(c) for c in communities}

--- a/networkx/algorithms/community/tests/test_centrality.py
+++ b/networkx/algorithms/community/tests/test_centrality.py
@@ -21,7 +21,7 @@ def validate_possible_communities(result, *expected):
     assert any(set_of_sets(result) == set_of_sets(p) for p in expected)
 
 
-class TestGirvanNewman(object):
+class TestGirvanNewman:
     """Unit tests for the
     :func:`networkx.algorithms.community.centrality.girvan_newman`
     function.

--- a/networkx/algorithms/community/tests/test_kclique.py
+++ b/networkx/algorithms/community/tests/test_kclique.py
@@ -24,7 +24,7 @@ def test_isolated_K5():
     assert c == {frozenset(range(5)), frozenset(range(5, 10))}
 
 
-class TestZacharyKarateClub(object):
+class TestZacharyKarateClub:
 
     def setup(self):
         self.G = nx.karate_club_graph()

--- a/networkx/algorithms/community/tests/test_label_propagation.py
+++ b/networkx/algorithms/community/tests/test_label_propagation.py
@@ -23,7 +23,7 @@ def test_one_node():
     test.add_node('a')
 
     # The expected communities are:
-    ground_truth = set([frozenset(['a'])])
+    ground_truth = {frozenset(['a'])}
 
     communities = label_propagation_communities(test)
     result = {frozenset(c) for c in communities}
@@ -42,8 +42,8 @@ def test_unconnected_communities():
     test.add_edge('f', 'b')
 
     # The expected communities are:
-    ground_truth = set([frozenset(['a', 'c', 'd']),
-                        frozenset(['b', 'e', 'f'])])
+    ground_truth = {frozenset(['a', 'c', 'd']),
+                        frozenset(['b', 'e', 'f'])}
 
     communities = label_propagation_communities(test)
     result = {frozenset(c) for c in communities}
@@ -82,14 +82,14 @@ def test_connected_communities():
     test.add_node('z')
 
     # The expected communities are:
-    ground_truth1 = set([frozenset(['a', 'b', 'c', 'd', 'e']),
+    ground_truth1 = {frozenset(['a', 'b', 'c', 'd', 'e']),
                          frozenset(['1', '2', '3', '4', '5']),
                          frozenset(['x', 'y']),
-                         frozenset(['z'])])
-    ground_truth2 = set([frozenset(['a', 'b', 'c', 'd', 'e',
+                         frozenset(['z'])}
+    ground_truth2 = {frozenset(['a', 'b', 'c', 'd', 'e',
                                     '1', '2', '3', '4', '5']),
                          frozenset(['x', 'y']),
-                         frozenset(['z'])])
+                         frozenset(['z'])}
     ground_truth = (ground_truth1, ground_truth2)
 
     communities = label_propagation_communities(test)
@@ -107,7 +107,7 @@ def test_termination():
     asyn_lpa_communities(test2)
 
 
-class TestAsynLpaCommunities(object):
+class TestAsynLpaCommunities:
     def _check_communities(self, G, expected):
         """Checks that the communities computed from the given graph ``G``
         using the :func:`~networkx.asyn_lpa_communities` function match

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -1,12 +1,10 @@
-
-
 import networkx as nx
 from networkx.algorithms.community import (
     greedy_modularity_communities,
     _naive_greedy_modularity_communities)
 
 
-class TestCNM(object):
+class TestCNM:
 
     def setup(self):
         self.G = nx.karate_club_graph()
@@ -23,7 +21,7 @@ class TestCNM(object):
         self._check_communities({john_a, overlap, mr_hi})
 
 
-class TestNaive(object):
+class TestNaive:
 
     def setup(self):
         self.G = nx.karate_club_graph()

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -12,7 +12,7 @@ from networkx.algorithms.community.quality import inter_community_edges
 from networkx.testing import almost_equal
 
 
-class TestPerformance(object):
+class TestPerformance:
     """Unit tests for the :func:`performance` function."""
 
     def test_bad_partition(self):
@@ -30,7 +30,7 @@ class TestPerformance(object):
         assert almost_equal(14 / 15, performance(G, partition))
 
 
-class TestCoverage(object):
+class TestCoverage:
     """Unit tests for the :func:`coverage` function."""
 
     def test_bad_partition(self):

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -152,8 +152,7 @@ def biconnected_component_edges(G):
            Communications of the ACM 16: 372–378. doi:10.1145/362248.362272
 
     """
-    for comp in _biconnected_dfs(G, components=True):
-        yield comp
+    yield from _biconnected_dfs(G, components=True)
 
 
 @not_implemented_for('directed')

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -228,8 +228,7 @@ def strongly_connected_components_recursive(G):
         stack.append(v)
         for w in G[v]:
             if w not in visited:
-                for c in visit(w, cnt):
-                    yield c
+                yield from visit(w, cnt)
             if w not in component:
                 root[v] = min(root[v], root[w])
         if root[v] == visited[v]:
@@ -249,8 +248,7 @@ def strongly_connected_components_recursive(G):
     stack = []
     for source in G:
         if source not in visited:
-            for c in visit(source, cnt):
-                yield c
+            yield from visit(source, cnt)
 
 
 @not_implemented_for('undirected')

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -3,7 +3,7 @@ import networkx as nx
 from networkx import NetworkXNotImplemented
 
 
-class TestAttractingComponents(object):
+class TestAttractingComponents:
     @classmethod
     def setup_class(cls):
         cls.G1 = nx.DiGraph()

--- a/networkx/algorithms/components/tests/test_semiconnected.py
+++ b/networkx/algorithms/components/tests/test_semiconnected.py
@@ -3,7 +3,7 @@ import networkx as nx
 import pytest
 
 
-class TestIsSemiconnected(object):
+class TestIsSemiconnected:
 
     def test_undirected(self):
         pytest.raises(nx.NetworkXNotImplemented, nx.is_semiconnected,

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -6,6 +6,7 @@ import itertools
 from operator import itemgetter
 
 import networkx as nx
+
 # Define the default maximum flow function to use in all flow based
 # connectivity algorithms.
 from networkx.algorithms.flow import boykov_kolmogorov
@@ -13,21 +14,22 @@ from networkx.algorithms.flow import dinitz
 from networkx.algorithms.flow import edmonds_karp
 from networkx.algorithms.flow import shortest_augmenting_path
 from networkx.algorithms.flow import build_residual_network
+
 default_flow_func = edmonds_karp
 
-from .utils import (build_auxiliary_node_connectivity,
-                    build_auxiliary_edge_connectivity)
+from .utils import build_auxiliary_node_connectivity, build_auxiliary_edge_connectivity
 
-__all__ = ['average_node_connectivity',
-           'local_node_connectivity',
-           'node_connectivity',
-           'local_edge_connectivity',
-           'edge_connectivity',
-           'all_pairs_node_connectivity']
+__all__ = [
+    "average_node_connectivity",
+    "local_node_connectivity",
+    "node_connectivity",
+    "local_edge_connectivity",
+    "edge_connectivity",
+    "all_pairs_node_connectivity",
+]
 
 
-def local_node_connectivity(G, s, t, flow_func=None, auxiliary=None,
-                            residual=None, cutoff=None):
+def local_node_connectivity(G, s, t, flow_func=None, auxiliary=None, residual=None, cutoff=None):
     r"""Computes local node connectivity for nodes s and t.
 
     Local node connectivity for two non adjacent nodes s and t is the
@@ -188,22 +190,22 @@ def local_node_connectivity(G, s, t, flow_func=None, auxiliary=None,
     else:
         H = auxiliary
 
-    mapping = H.graph.get('mapping', None)
+    mapping = H.graph.get("mapping", None)
     if mapping is None:
-        raise nx.NetworkXError('Invalid auxiliary digraph.')
+        raise nx.NetworkXError("Invalid auxiliary digraph.")
 
     kwargs = dict(flow_func=flow_func, residual=residual)
     if flow_func is shortest_augmenting_path:
-        kwargs['cutoff'] = cutoff
-        kwargs['two_phase'] = True
+        kwargs["cutoff"] = cutoff
+        kwargs["two_phase"] = True
     elif flow_func is edmonds_karp:
-        kwargs['cutoff'] = cutoff
+        kwargs["cutoff"] = cutoff
     elif flow_func is dinitz:
-        kwargs['cutoff'] = cutoff
+        kwargs["cutoff"] = cutoff
     elif flow_func is boykov_kolmogorov:
-        kwargs['cutoff'] = cutoff
+        kwargs["cutoff"] = cutoff
 
-    return nx.maximum_flow_value(H, '%sB' % mapping[s], '%sA' % mapping[t], **kwargs)
+    return nx.maximum_flow_value(H, f"{mapping[s]}B", f"{mapping[t]}A", **kwargs)
 
 
 def node_connectivity(G, s=None, t=None, flow_func=None):
@@ -297,7 +299,7 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
-        raise nx.NetworkXError('Both source and target must be specified.')
+        raise nx.NetworkXError("Both source and target must be specified.")
 
     # Local node connectivity
     if s is not None and t is not None:
@@ -316,8 +318,8 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
         # and successors for directed graphs
 
         def neighbors(v):
-            return itertools.chain.from_iterable([G.predecessors(v),
-                                                  G.successors(v)])
+            return itertools.chain.from_iterable([G.predecessors(v), G.successors(v)])
+
     else:
         if not nx.is_connected(G):
             return 0
@@ -326,7 +328,7 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
 
     # Reuse the auxiliary digraph and the residual network
     H = build_auxiliary_node_connectivity(G)
-    R = build_residual_network(H, 'capacity')
+    R = build_residual_network(H, "capacity")
     kwargs = dict(flow_func=flow_func, auxiliary=H, residual=R)
 
     # Pick a node with minimum degree
@@ -334,13 +336,13 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     v, K = min(G.degree(), key=itemgetter(1))
     # compute local node connectivity with all its non-neighbors nodes
     for w in set(G) - set(neighbors(v)) - {v}:
-        kwargs['cutoff'] = K
+        kwargs["cutoff"] = K
         K = min(K, local_node_connectivity(G, v, w, **kwargs))
     # Also for non adjacent pairs of neighbors of v
     for x, y in iter_func(neighbors(v), 2):
         if y in G[x]:
             continue
-        kwargs['cutoff'] = K
+        kwargs["cutoff"] = K
         K = min(K, local_node_connectivity(G, x, y, **kwargs))
 
     return K
@@ -401,7 +403,7 @@ def average_node_connectivity(G, flow_func=None):
 
     # Reuse the auxiliary digraph and the residual network
     H = build_auxiliary_node_connectivity(G)
-    R = build_residual_network(H, 'capacity')
+    R = build_residual_network(H, "capacity")
     kwargs = dict(flow_func=flow_func, auxiliary=H, residual=R)
 
     num, den = 0, 0
@@ -468,8 +470,8 @@ def all_pairs_node_connectivity(G, nbunch=None, flow_func=None):
 
     # Reuse auxiliary digraph and residual network
     H = build_auxiliary_node_connectivity(G)
-    mapping = H.graph['mapping']
-    R = build_residual_network(H, 'capacity')
+    mapping = H.graph["mapping"]
+    R = build_residual_network(H, "capacity")
     kwargs = dict(flow_func=flow_func, auxiliary=H, residual=R)
 
     for u, v in iter_func(nbunch, 2):
@@ -481,8 +483,7 @@ def all_pairs_node_connectivity(G, nbunch=None, flow_func=None):
     return all_pairs
 
 
-def local_edge_connectivity(G, s, t, flow_func=None, auxiliary=None,
-                            residual=None, cutoff=None):
+def local_edge_connectivity(G, s, t, flow_func=None, auxiliary=None, residual=None, cutoff=None):
     r"""Returns local edge connectivity for nodes s and t in G.
 
     Local edge connectivity for two nodes s and t is the minimum number
@@ -632,14 +633,14 @@ def local_edge_connectivity(G, s, t, flow_func=None, auxiliary=None,
 
     kwargs = dict(flow_func=flow_func, residual=residual)
     if flow_func is shortest_augmenting_path:
-        kwargs['cutoff'] = cutoff
-        kwargs['two_phase'] = True
+        kwargs["cutoff"] = cutoff
+        kwargs["two_phase"] = True
     elif flow_func is edmonds_karp:
-        kwargs['cutoff'] = cutoff
+        kwargs["cutoff"] = cutoff
     elif flow_func is dinitz:
-        kwargs['cutoff'] = cutoff
+        kwargs["cutoff"] = cutoff
     elif flow_func is boykov_kolmogorov:
-        kwargs['cutoff'] = cutoff
+        kwargs["cutoff"] = cutoff
 
     return nx.maximum_flow_value(H, s, t, **kwargs)
 
@@ -747,7 +748,7 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
-        raise nx.NetworkXError('Both source and target must be specified.')
+        raise nx.NetworkXError("Both source and target must be specified.")
 
     # Local edge connectivity
     if s is not None and t is not None:
@@ -755,13 +756,12 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
             raise nx.NetworkXError(f"node {s} not in graph")
         if t not in G:
             raise nx.NetworkXError(f"node {t} not in graph")
-        return local_edge_connectivity(G, s, t, flow_func=flow_func,
-                                       cutoff=cutoff)
+        return local_edge_connectivity(G, s, t, flow_func=flow_func, cutoff=cutoff)
 
     # Global edge connectivity
     # reuse auxiliary digraph and residual network
     H = build_auxiliary_edge_connectivity(G)
-    R = build_residual_network(H, 'capacity')
+    R = build_residual_network(H, "capacity")
     kwargs = dict(flow_func=flow_func, auxiliary=H, residual=R)
 
     if G.is_directed():
@@ -778,13 +778,11 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
             L = min(cutoff, L)
 
         for i in range(n):
-            kwargs['cutoff'] = L
+            kwargs["cutoff"] = L
             try:
-                L = min(L, local_edge_connectivity(G, nodes[i], nodes[i + 1],
-                                                   **kwargs))
+                L = min(L, local_edge_connectivity(G, nodes[i], nodes[i + 1], **kwargs))
             except IndexError:  # last node!
-                L = min(L, local_edge_connectivity(G, nodes[i], nodes[0],
-                                                   **kwargs))
+                L = min(L, local_edge_connectivity(G, nodes[i], nodes[0], **kwargs))
         return L
     else:  # undirected
         # Algorithm 6 in [1]
@@ -810,7 +808,7 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
             return L
 
         for w in D:
-            kwargs['cutoff'] = L
+            kwargs["cutoff"] = L
             L = min(L, local_edge_connectivity(G, v, w, **kwargs))
 
         return L

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -302,9 +302,9 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     # Local node connectivity
     if s is not None and t is not None:
         if s not in G:
-            raise nx.NetworkXError('node %s not in graph' % s)
+            raise nx.NetworkXError(f"node {s} not in graph")
         if t not in G:
-            raise nx.NetworkXError('node %s not in graph' % t)
+            raise nx.NetworkXError(f"node {t} not in graph")
         return local_node_connectivity(G, s, t, flow_func=flow_func)
 
     # Global node connectivity
@@ -752,9 +752,9 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
     # Local edge connectivity
     if s is not None and t is not None:
         if s not in G:
-            raise nx.NetworkXError('node %s not in graph' % s)
+            raise nx.NetworkXError(f"node {s} not in graph")
         if t not in G:
-            raise nx.NetworkXError('node %s not in graph' % t)
+            raise nx.NetworkXError(f"node {t} not in graph")
         return local_edge_connectivity(G, s, t, flow_func=flow_func,
                                        cutoff=cutoff)
 

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -333,7 +333,7 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     # Node connectivity is bounded by degree.
     v, K = min(G.degree(), key=itemgetter(1))
     # compute local node connectivity with all its non-neighbors nodes
-    for w in set(G) - set(neighbors(v)) - set([v]):
+    for w in set(G) - set(neighbors(v)) - {v}:
         kwargs['cutoff'] = K
         K = min(K, local_node_connectivity(G, v, w, **kwargs))
     # Also for non adjacent pairs of neighbors of v

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -286,7 +286,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
 
     # The edge cut in the auxiliary digraph corresponds to the node cut in the
     # original graph.
-    edge_cut = minimum_st_edge_cut(H, '%sB' % mapping[s], '%sA' % mapping[t],
+    edge_cut = minimum_st_edge_cut(H, f'{mapping[s]}B', f'{mapping[t]}A',
                                    **kwargs)
     # Each node in the original graph maps to two nodes of the auxiliary graph
     node_cut = set(H.nodes[node]['id'] for edge in edge_cut for node in edge)
@@ -392,9 +392,9 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     # Local minimum node cut.
     if s is not None and t is not None:
         if s not in G:
-            raise nx.NetworkXError('node %s not in graph' % s)
+            raise nx.NetworkXError(f"node {s} not in graph")
         if t not in G:
-            raise nx.NetworkXError('node %s not in graph' % t)
+            raise nx.NetworkXError(f"node {t} not in graph")
         return minimum_st_node_cut(G, s, t, flow_func=flow_func)
 
     # Global minimum node cut.
@@ -544,9 +544,9 @@ def minimum_edge_cut(G, s=None, t=None, flow_func=None):
     # Local minimum edge cut if s and t are not None
     if s is not None and t is not None:
         if s not in G:
-            raise nx.NetworkXError('node %s not in graph' % s)
+            raise nx.NetworkXError(f"node {s} not in graph")
         if t not in G:
-            raise nx.NetworkXError('node %s not in graph' % t)
+            raise nx.NetworkXError(f"node {t} not in graph")
         return minimum_st_edge_cut(H, s, t, **kwargs)
 
     # Global minimum edge cut

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -289,8 +289,8 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     edge_cut = minimum_st_edge_cut(H, f'{mapping[s]}B', f'{mapping[t]}A',
                                    **kwargs)
     # Each node in the original graph maps to two nodes of the auxiliary graph
-    node_cut = set(H.nodes[node]['id'] for edge in edge_cut for node in edge)
-    return node_cut - set([s, t])
+    node_cut = {H.nodes[node]['id'] for edge in edge_cut for node in edge}
+    return node_cut - {s, t}
 
 
 def minimum_node_cut(G, s=None, t=None, flow_func=None):
@@ -423,7 +423,7 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     # Initial node cutset is all neighbors of the node with minimum degree.
     min_cut = set(G[v])
     # Compute st node cuts between v and all its non-neighbors nodes in G.
-    for w in set(G) - set(neighbors(v)) - set([v]):
+    for w in set(G) - set(neighbors(v)) - {v}:
         this_cut = minimum_st_node_cut(G, v, w, **kwargs)
         if len(min_cut) >= len(this_cut):
             min_cut = this_cut

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -151,9 +151,9 @@ def edge_disjoint_paths(G, s, t, flow_func=None, cutoff=None, auxiliary=None,
 
     """
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % s)
+        raise nx.NetworkXError(f"node {s} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % t)
+        raise nx.NetworkXError(f"node {t} not in graph")
 
     if flow_func is None:
         flow_func = default_flow_func
@@ -346,9 +346,9 @@ def node_disjoint_paths(G, s, t, flow_func=None, cutoff=None, auxiliary=None,
 
     """
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % s)
+        raise nx.NetworkXError(f"node {s} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % t)
+        raise nx.NetworkXError(f"node {t} not in graph")
 
     if auxiliary is None:
         H = build_auxiliary_node_connectivity(G)
@@ -360,8 +360,8 @@ def node_disjoint_paths(G, s, t, flow_func=None, cutoff=None, auxiliary=None,
         raise nx.NetworkXError('Invalid auxiliary digraph.')
 
     # Maximum possible edge disjoint paths
-    possible = min(H.out_degree('%sB' % mapping[s]),
-                   H.in_degree('%sA' % mapping[t]))
+    possible = min(H.out_degree(f'{mapping[s]}B'),
+                   H.in_degree(f'{mapping[t]}A'))
     if not possible:
         raise NetworkXNoPath
 
@@ -375,7 +375,7 @@ def node_disjoint_paths(G, s, t, flow_func=None, cutoff=None, auxiliary=None,
 
     # The edge disjoint paths in the auxiliary digraph correspond to the node
     # disjoint paths in the original graph.
-    paths_edges = edge_disjoint_paths(H, '%sB' % mapping[s], '%sA' % mapping[t],
+    paths_edges = edge_disjoint_paths(H, f'{mapping[s]}B', f'{mapping[t]}A',
                                       **kwargs)
     for path in paths_edges:
         # Each node in the original graph maps to two nodes in auxiliary graph

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -250,8 +250,8 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
         if k <= 0:
             raise ValueError(f'k must be a positive integer, not {k}')
         elif G.number_of_nodes() < k + 1:
-            msg = 'impossible to {} connect in graph with less than {} nodes'
-            raise nx.NetworkXUnfeasible(msg.format(k, k + 1))
+            msg = f"impossible to {k} connect in graph with less than {k + 1} nodes"
+            raise nx.NetworkXUnfeasible(msg)
         elif avail is not None and len(avail) == 0:
             if not nx.is_k_edge_connected(G, k):
                 raise nx.NetworkXUnfeasible('no available edges')
@@ -262,8 +262,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
         elif k == 2:
             aug_edges = bridge_augmentation(G, avail=avail, weight=weight)
         else:
-            # raise NotImplementedError(
-            #    'not implemented for k>2. k={}'.format(k))
+            # raise NotImplementedError(f'not implemented for k>2. k={k}')
             aug_edges = greedy_k_edge_augmentation(
                 G, k=k, avail=avail, weight=weight, seed=0)
         # Do eager evaulation so we can catch any exceptions

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -59,7 +59,7 @@ def is_k_edge_connected(G, k):
     False
     """
     if k < 1:
-        raise ValueError('k must be positive, not {}'.format(k))
+        raise ValueError(f'k must be positive, not {k}')
     # First try to quickly determine if G is not k-edge-connected
     if G.number_of_nodes() < k + 1:
         return False
@@ -118,7 +118,7 @@ def is_locally_k_edge_connected(G, s, t, k):
     True
     """
     if k < 1:
-        raise ValueError('k must be positive, not {}'.format(k))
+        raise ValueError(f'k must be positive, not {k}')
 
     # First try to quickly determine s, t is not k-locally-edge-connected in G
     if G.degree(s) < k or G.degree(t) < k:
@@ -248,7 +248,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
     """
     try:
         if k <= 0:
-            raise ValueError('k must be a positive integer, not {}'.format(k))
+            raise ValueError(f'k must be a positive integer, not {k}')
         elif G.number_of_nodes() < k + 1:
             msg = 'impossible to {} connect in graph with less than {} nodes'
             raise nx.NetworkXUnfeasible(msg.format(k, k + 1))
@@ -268,8 +268,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
                 G, k=k, avail=avail, weight=weight, seed=0)
         # Do eager evaulation so we can catch any exceptions
         # Before executing partial code.
-        for edge in list(aug_edges):
-            yield edge
+        yield from list(aug_edges)
     except nx.NetworkXUnfeasible:
         if partial:
             # Return all available edges
@@ -280,8 +279,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
                 # k-edge-connect as much as possible
                 aug_edges = partial_k_edge_augmentation(G, k=k, avail=avail,
                                                         weight=weight)
-            for edge in aug_edges:
-                yield edge
+            yield from aug_edges
         else:
             raise
 
@@ -371,8 +369,7 @@ def partial_k_edge_augmentation(G, k, avail, weight=None):
             C.remove_edges_from(sub_avail.keys())
             # Find a subset of these edges that makes the compoment
             # k-edge-connected and ignore the rest
-            for edge in nx.k_edge_augmentation(C, k=k, avail=sub_avail):
-                yield edge
+            yield from nx.k_edge_augmentation(C, k=k, avail=sub_avail)
 
     # Generate all edges between CCs that could not be k-edge-connected
     for cc1, cc2 in it.combinations(k_edge_subgraphs, 2):
@@ -909,8 +906,7 @@ def weighted_bridge_augmentation(G, avail, weight=None):
         connectors = list(one_edge_augmentation(H, avail=avail, weight=weight))
         H.add_edges_from(connectors)
 
-        for edge in connectors:
-            yield edge
+        yield from connectors
     else:
         connectors = []
         H = G
@@ -1002,8 +998,7 @@ def weighted_bridge_augmentation(G, avail, weight=None):
             edge = data['generator']
             bridge_connectors.add(edge)
 
-    for edge in bridge_connectors:
-        yield edge
+    yield from bridge_connectors
 
 
 def _minimum_rooted_branching(D, root):
@@ -1085,7 +1080,7 @@ def collapse(G, grouped_nodes):
         mapping.update((n, i) for n in group)
     # remaining nodes are in their own group
     for i, node in enumerate(remaining, start=i + 1):
-        group = set([node])
+        group = {node}
         members[i] = group
         mapping.update((n, i) for n in group)
     number_of_groups = i + 1
@@ -1251,5 +1246,4 @@ def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
             aug_edges.append((u, v))
 
     # Generate results
-    for edge in aug_edges:
-        yield edge
+    yield from aug_edges

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -233,11 +233,10 @@ def bridge_components(G):
     """
     H = G.copy()
     H.remove_edges_from(bridges(G))
-    for cc in nx.connected_components(H):
-        yield cc
+    yield from nx.connected_components(H)
 
 
-class EdgeComponentAuxGraph(object):
+class EdgeComponentAuxGraph:
     r"""A simple algorithm to find all k-edge-connected components in a graph.
 
     Constructing the AuxillaryGraph (which may take some time) allows for the
@@ -410,8 +409,7 @@ class EdgeComponentAuxGraph(object):
         R.add_edges_from(e for e, w in aux_weights.items() if w >= k)
 
         # Return the nodes that are k-edge-connected in the original graph
-        for cc in nx.connected_components(R):
-            yield cc
+        yield from nx.connected_components(R)
 
     def k_edge_subgraphs(self, k):
         """Queries the auxiliary graph for k-edge-connected subgraphs.
@@ -455,8 +453,7 @@ class EdgeComponentAuxGraph(object):
             else:
                 # Call subgraph solution to refine the results
                 C = H.subgraph(cc)
-                for sub_cc in k_edge_subgraphs(C, k):
-                    yield sub_cc
+                yield from k_edge_subgraphs(C, k)
 
 
 def _low_degree_nodes(G, k, nbunch=None):
@@ -500,11 +497,9 @@ def _high_degree_components(G, k):
 
     # Note: remaining connected components may not be k-edge-connected
     if G.is_directed():
-        for cc in nx.strongly_connected_components(H):
-            yield cc
+        yield from nx.strongly_connected_components(H)
     else:
-        for cc in nx.connected_components(H):
-            yield cc
+        yield from nx.connected_components(H)
 
 
 def general_k_edge_subgraphs(G, k):

--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -191,8 +191,7 @@ def _generate_partition(G, cuts, k):
                     component.add(node)
         if len(component) < G.order():
             components.append(component)
-    for component in _consolidate(components, k + 1):
-        yield component
+    yield from _consolidate(components, k + 1)
 
 
 def _reconstruct_k_components(k_comps):

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -130,7 +130,7 @@ def all_node_cuts(G, k=None, flow_func=None):
         for v in non_adjacent:
             # step 4: compute maximum flow in an Even-Tarjan reduction H of G
             # and step 5: build the associated residual network R
-            R = flow_func(H, '%sB' % mapping[x], '%sA' % mapping[v], **kwargs)
+            R = flow_func(H, f'{mapping[x]}B', f'{mapping[v]}A', **kwargs)
             flow_value = R.graph['flow_value']
 
             if flow_value == k:
@@ -177,7 +177,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                     for n in S:
                         S_ancestors.update(R_closure._pred[n])
                     S.update(S_ancestors)
-                    if '%sB' % mapping[x] not in S or '%sA' % mapping[v] in S:
+                    if f'{mapping[x]}B' not in S or f'{mapping[v]}A' in S:
                         continue
                     # Find the cutset that links the node partition (S,~S) in H
                     cutset = set()
@@ -207,18 +207,18 @@ def all_node_cuts(G, k=None, flow_func=None):
                 # Add edges to the auxiliary digraph.
                 # See build_residual_network for convention we used
                 # in residual graphs.
-                H.add_edge('%sB' % mapping[x], '%sA' % mapping[v],
+                H.add_edge(f'{mapping[x]}B', f'{mapping[v]}A',
                            capacity=1)
-                H.add_edge('%sB' % mapping[v], '%sA' % mapping[x],
+                H.add_edge(f'{mapping[v]}B', f'{mapping[x]}A',
                            capacity=1)
                 # Add edges to the residual network.
-                R.add_edge('%sB' % mapping[x], '%sA' % mapping[v],
+                R.add_edge(f'{mapping[x]}B', f'{mapping[v]}A',
                            capacity=1)
-                R.add_edge('%sA' % mapping[v], '%sB' % mapping[x],
+                R.add_edge(f'{mapping[v]}A', f'{mapping[x]}B',
                            capacity=0)
-                R.add_edge('%sB' % mapping[v], '%sA' % mapping[x],
+                R.add_edge(f'{mapping[v]}B', f'{mapping[x]}A',
                            capacity=1)
-                R.add_edge('%sA' % mapping[x], '%sB' % mapping[v],
+                R.add_edge(f'{mapping[x]}A', f'{mapping[v]}B',
                            capacity=0)
 
                 # Add again the saturated edges to reuse the residual network

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -138,7 +138,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                 E1 = flowed_edges = [(u, w) for (u, w, d) in
                                      R.edges(data=True)
                                      if d['flow'] != 0]
-                VE1 = incident_nodes = set([n for edge in E1 for n in edge])
+                VE1 = incident_nodes = {n for edge in E1 for n in edge}
                 # Remove saturated edges form the residual network.
                 # Note that reversed edges are introduced with capacity 0
                 # in the residual graph and they need to be removed too.
@@ -156,7 +156,7 @@ def all_node_cuts(G, k=None, flow_func=None):
                 for n, scc in cmap.items():
                     inv_cmap[scc].append(n)
                 # Find the incident nodes in the condensed graph.
-                VE1 = set([cmap[n] for n in VE1])
+                VE1 = {cmap[n] for n in VE1}
                 # step 7: Compute all antichains of L;
                 # they map to closed sets in H.
                 # Any edge in H that links a closed set is part of a cutset.

--- a/networkx/algorithms/connectivity/stoerwagner.py
+++ b/networkx/algorithms/connectivity/stoerwagner.py
@@ -106,7 +106,7 @@ def stoer_wagner(G, weight='weight', heap=BinaryHeap):
     for i in range(n - 1):
         # Pick an arbitrary node u and create a set A = {u}.
         u = arbitrary_element(G)
-        A = set([u])
+        A = {u}
         # Repeatedly pick the node "most tightly connected" to A and add it to
         # A. The tightness of connectivity of a node not in A is defined by the
         # of edges connecting it to nodes in A.

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -253,7 +253,7 @@ def test_cutoff():
                 continue
             for cutoff in [3, 2, 1]:
                 result = local_func(G, 0, 4, flow_func=flow_func, cutoff=cutoff)
-                assert cutoff == result, "cutoff error in {0}".format(flow_func.__name__)
+                assert cutoff == result, f"cutoff error in {flow_func.__name__}"
 
 
 def test_invalid_auxiliary():

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -14,8 +14,6 @@ flow_funcs = [
     flow.shortest_augmenting_path,
 ]
 
-msg = "Assertion failed in function: {0}"
-
 # Tests for node and edge cutsets
 
 
@@ -29,7 +27,7 @@ def _generate_no_biconnected(max_attempts=50):
         else:
             if attempts >= max_attempts:
                 msg = f"Tried {attempts} times: no suitable Graph."
-                raise Exception(msg % max_attempts)
+                raise Exception(msg)
             else:
                 attempts += 1
 
@@ -37,11 +35,12 @@ def _generate_no_biconnected(max_attempts=50):
 def test_articulation_points():
     Ggen = _generate_no_biconnected()
     for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         for i in range(1):  # change 1 to 3 or more for more realizations.
             G = next(Ggen)
             cut = nx.minimum_node_cut(G, flow_func=flow_func)
-            assert len(cut) == 1, msg.format(flow_func.__name__)
-            assert cut.pop() in set(nx.articulation_points(G)), msg.format(flow_func.__name__)
+            assert len(cut) == 1, errmsg
+            assert cut.pop() in set(nx.articulation_points(G)), errmsg
 
 
 def test_brandes_erlebach_book():
@@ -53,22 +52,23 @@ def test_brandes_erlebach_book():
                       (7, 10), (8, 11), (9, 10), (9, 11), (10, 11)])
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge cutsets
-        assert 3 == len(nx.minimum_edge_cut(G, 1, 11, **kwargs)), msg.format(flow_func.__name__)
+        assert 3 == len(nx.minimum_edge_cut(G, 1, 11, **kwargs)), errmsg
         edge_cut = nx.minimum_edge_cut(G, **kwargs)
         # Node 5 has only two edges
-        assert 2 == len(edge_cut), msg.format(flow_func.__name__)
+        assert 2 == len(edge_cut), errmsg
         H = G.copy()
         H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
         # node cuts
-        assert {6, 7} == minimum_st_node_cut(G, 1, 11, **kwargs), msg.format(flow_func.__name__)
-        assert {6, 7} == nx.minimum_node_cut(G, 1, 11, **kwargs), msg.format(flow_func.__name__)
+        assert {6, 7} == minimum_st_node_cut(G, 1, 11, **kwargs), errmsg
+        assert {6, 7} == nx.minimum_node_cut(G, 1, 11, **kwargs), errmsg
         node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 2 == len(node_cut), msg.format(flow_func.__name__)
+        assert 2 == len(node_cut), errmsg
         H = G.copy()
         H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
 
 
 def test_white_harary_paper():
@@ -86,72 +86,76 @@ def test_white_harary_paper():
         G.add_edge(0, i)
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge cuts
         edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 3 == len(edge_cut), msg.format(flow_func.__name__)
+        assert 3 == len(edge_cut), errmsg
         H = G.copy()
         H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
         # node cuts
         node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert {0} == node_cut, msg.format(flow_func.__name__)
+        assert {0} == node_cut, errmsg
         H = G.copy()
         H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
 
 
 def test_petersen_cutset():
     G = nx.petersen_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge cuts
         edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 3 == len(edge_cut), msg.format(flow_func.__name__)
+        assert 3 == len(edge_cut), errmsg
         H = G.copy()
         H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
         # node cuts
         node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 3 == len(node_cut), msg.format(flow_func.__name__)
+        assert 3 == len(node_cut), errmsg
         H = G.copy()
         H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
 
 
 def test_octahedral_cutset():
     G = nx.octahedral_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge cuts
         edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 4 == len(edge_cut), msg.format(flow_func.__name__)
+        assert 4 == len(edge_cut), errmsg
         H = G.copy()
         H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
         # node cuts
         node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 4 == len(node_cut), msg.format(flow_func.__name__)
+        assert 4 == len(node_cut), errmsg
         H = G.copy()
         H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
 
 
 def test_icosahedral_cutset():
     G = nx.icosahedral_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge cuts
         edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 5 == len(edge_cut), msg.format(flow_func.__name__)
+        assert 5 == len(edge_cut), errmsg
         H = G.copy()
         H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
         # node cuts
         node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 5 == len(node_cut), msg.format(flow_func.__name__)
+        assert 5 == len(node_cut), errmsg
         H = G.copy()
         H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), msg.format(flow_func.__name__)
+        assert not nx.is_connected(H), errmsg
 
 
 def test_node_cutset_exception():
@@ -163,6 +167,7 @@ def test_node_cutset_exception():
 
 def test_node_cutset_random_graphs():
     for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         for i in range(3):
             G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
             if not nx.is_connected(G):
@@ -170,13 +175,14 @@ def test_node_cutset_random_graphs():
                 start = arbitrary_element(next(ccs))
                 G.add_edges_from((start, arbitrary_element(c)) for c in ccs)
             cutset = nx.minimum_node_cut(G, flow_func=flow_func)
-            assert nx.node_connectivity(G) == len(cutset), msg.format(flow_func.__name__)
+            assert nx.node_connectivity(G) == len(cutset), errmsg
             G.remove_nodes_from(cutset)
-            assert not nx.is_connected(G), msg.format(flow_func.__name__)
+            assert not nx.is_connected(G), errmsg
 
 
 def test_edge_cutset_random_graphs():
     for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         for i in range(3):
             G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
             if not nx.is_connected(G):
@@ -184,9 +190,9 @@ def test_edge_cutset_random_graphs():
                 start = arbitrary_element(next(ccs))
                 G.add_edges_from((start, arbitrary_element(c)) for c in ccs)
             cutset = nx.minimum_edge_cut(G, flow_func=flow_func)
-            assert nx.edge_connectivity(G) == len(cutset), msg.format(flow_func.__name__)
+            assert nx.edge_connectivity(G) == len(cutset), errmsg
             G.remove_edges_from(cutset)
-            assert not nx.is_connected(G), msg.format(flow_func.__name__)
+            assert not nx.is_connected(G), errmsg
 
 
 def test_empty_graphs():

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -62,8 +62,8 @@ def test_brandes_erlebach_book():
         H.remove_edges_from(edge_cut)
         assert not nx.is_connected(H), msg.format(flow_func.__name__)
         # node cuts
-        assert set([6, 7]) == minimum_st_node_cut(G, 1, 11, **kwargs), msg.format(flow_func.__name__)
-        assert set([6, 7]) == nx.minimum_node_cut(G, 1, 11, **kwargs), msg.format(flow_func.__name__)
+        assert {6, 7} == minimum_st_node_cut(G, 1, 11, **kwargs), msg.format(flow_func.__name__)
+        assert {6, 7} == nx.minimum_node_cut(G, 1, 11, **kwargs), msg.format(flow_func.__name__)
         node_cut = nx.minimum_node_cut(G, **kwargs)
         assert 2 == len(node_cut), msg.format(flow_func.__name__)
         H = G.copy()
@@ -94,7 +94,7 @@ def test_white_harary_paper():
         assert not nx.is_connected(H), msg.format(flow_func.__name__)
         # node cuts
         node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert set([0]) == node_cut, msg.format(flow_func.__name__)
+        assert {0} == node_cut, msg.format(flow_func.__name__)
         H = G.copy()
         H.remove_nodes_from(node_cut)
         assert not nx.is_connected(H), msg.format(flow_func.__name__)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -28,7 +28,7 @@ def _generate_no_biconnected(max_attempts=50):
             yield G
         else:
             if attempts >= max_attempts:
-                msg = "Tried %d times: no suitable Graph." % attempts
+                msg = f"Tried {attempts} times: no suitable Graph."
                 raise Exception(msg % max_attempts)
             else:
                 attempts += 1

--- a/networkx/algorithms/connectivity/tests/test_disjoint_paths.py
+++ b/networkx/algorithms/connectivity/tests/test_disjoint_paths.py
@@ -12,8 +12,6 @@ flow_funcs = [
     flow.shortest_augmenting_path,
 ]
 
-msg = "Assertion failed in function: {0}"
-
 
 def is_path(G, path):
     return all(v in G[u] for u, v in pairwise(path))
@@ -55,100 +53,107 @@ def test_graph_from_pr_2053():
         ('E', 'F'), ('E', 'Z'), ('F', 'Z'), ('G', 'Z')])
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge disjoint paths
         edge_paths = list(nx.edge_disjoint_paths(G, 'A', 'Z', **kwargs))
-        assert are_edge_disjoint_paths(G, edge_paths), msg.format(flow_func.__name__)
-        assert nx.edge_connectivity(G, 'A', 'Z') == len(edge_paths), msg.format(flow_func.__name__)
+        assert are_edge_disjoint_paths(G, edge_paths), errmsg
+        assert nx.edge_connectivity(G, 'A', 'Z') == len(edge_paths), errmsg
         # node disjoint paths
         node_paths = list(nx.node_disjoint_paths(G, 'A', 'Z', **kwargs))
-        assert are_node_disjoint_paths(G, node_paths), msg.format(flow_func.__name__)
-        assert nx.node_connectivity(G, 'A', 'Z') == len(node_paths), msg.format(flow_func.__name__)
+        assert are_node_disjoint_paths(G, node_paths), errmsg
+        assert nx.node_connectivity(G, 'A', 'Z') == len(node_paths), errmsg
 
 
 def test_florentine_families():
     G = nx.florentine_families_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge disjoint paths
         edge_dpaths = list(nx.edge_disjoint_paths(G, 'Medici', 'Strozzi', **kwargs))
-        assert are_edge_disjoint_paths(G, edge_dpaths), msg.format(flow_func.__name__)
-        assert nx.edge_connectivity(G, 'Medici', 'Strozzi') == len(edge_dpaths), msg.format(flow_func.__name__)
+        assert are_edge_disjoint_paths(G, edge_dpaths), errmsg
+        assert nx.edge_connectivity(G, 'Medici', 'Strozzi') == len(edge_dpaths), errmsg
         # node disjoint paths
         node_dpaths = list(nx.node_disjoint_paths(G, 'Medici', 'Strozzi', **kwargs))
-        assert are_node_disjoint_paths(G, node_dpaths), msg.format(flow_func.__name__)
-        assert nx.node_connectivity(G, 'Medici', 'Strozzi') == len(node_dpaths), msg.format(flow_func.__name__)
+        assert are_node_disjoint_paths(G, node_dpaths), errmsg
+        assert nx.node_connectivity(G, 'Medici', 'Strozzi') == len(node_dpaths), errmsg
 
 
 def test_karate():
     G = nx.karate_club_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge disjoint paths
         edge_dpaths = list(nx.edge_disjoint_paths(G, 0, 33, **kwargs))
-        assert are_edge_disjoint_paths(G, edge_dpaths), msg.format(flow_func.__name__)
-        assert nx.edge_connectivity(G, 0, 33) == len(edge_dpaths), msg.format(flow_func.__name__)
+        assert are_edge_disjoint_paths(G, edge_dpaths), errmsg
+        assert nx.edge_connectivity(G, 0, 33) == len(edge_dpaths), errmsg
         # node disjoint paths
         node_dpaths = list(nx.node_disjoint_paths(G, 0, 33, **kwargs))
-        assert are_node_disjoint_paths(G, node_dpaths), msg.format(flow_func.__name__)
-        assert nx.node_connectivity(G, 0, 33) == len(node_dpaths), msg.format(flow_func.__name__)
+        assert are_node_disjoint_paths(G, node_dpaths), errmsg
+        assert nx.node_connectivity(G, 0, 33) == len(node_dpaths), errmsg
 
 
 def test_petersen_disjoint_paths():
     G = nx.petersen_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge disjoint paths
         edge_dpaths = list(nx.edge_disjoint_paths(G, 0, 6, **kwargs))
-        assert are_edge_disjoint_paths(G, edge_dpaths), msg.format(flow_func.__name__)
-        assert 3 == len(edge_dpaths), msg.format(flow_func.__name__)
+        assert are_edge_disjoint_paths(G, edge_dpaths), errmsg
+        assert 3 == len(edge_dpaths), errmsg
         # node disjoint paths
         node_dpaths = list(nx.node_disjoint_paths(G, 0, 6, **kwargs))
-        assert are_node_disjoint_paths(G, node_dpaths), msg.format(flow_func.__name__)
-        assert 3 == len(node_dpaths), msg.format(flow_func.__name__)
+        assert are_node_disjoint_paths(G, node_dpaths), errmsg
+        assert 3 == len(node_dpaths), errmsg
 
 
 def test_octahedral_disjoint_paths():
     G = nx.octahedral_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge disjoint paths
         edge_dpaths = list(nx.edge_disjoint_paths(G, 0, 5, **kwargs))
-        assert are_edge_disjoint_paths(G, edge_dpaths), msg.format(flow_func.__name__)
-        assert 4 == len(edge_dpaths), msg.format(flow_func.__name__)
+        assert are_edge_disjoint_paths(G, edge_dpaths), errmsg
+        assert 4 == len(edge_dpaths), errmsg
         # node disjoint paths
         node_dpaths = list(nx.node_disjoint_paths(G, 0, 5, **kwargs))
-        assert are_node_disjoint_paths(G, node_dpaths), msg.format(flow_func.__name__)
-        assert 4 == len(node_dpaths), msg.format(flow_func.__name__)
+        assert are_node_disjoint_paths(G, node_dpaths), errmsg
+        assert 4 == len(node_dpaths), errmsg
 
 
 def test_icosahedral_disjoint_paths():
     G = nx.icosahedral_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         # edge disjoint paths
         edge_dpaths = list(nx.edge_disjoint_paths(G, 0, 6, **kwargs))
-        assert are_edge_disjoint_paths(G, edge_dpaths), msg.format(flow_func.__name__)
-        assert 5 == len(edge_dpaths), msg.format(flow_func.__name__)
+        assert are_edge_disjoint_paths(G, edge_dpaths), errmsg
+        assert 5 == len(edge_dpaths), errmsg
         # node disjoint paths
         node_dpaths = list(nx.node_disjoint_paths(G, 0, 6, **kwargs))
-        assert are_node_disjoint_paths(G, node_dpaths), msg.format(flow_func.__name__)
-        assert 5 == len(node_dpaths), msg.format(flow_func.__name__)
+        assert are_node_disjoint_paths(G, node_dpaths), errmsg
+        assert 5 == len(node_dpaths), errmsg
 
 
 def test_cutoff_disjoint_paths():
     G = nx.icosahedral_graph()
     for flow_func in flow_funcs:
         kwargs = dict(flow_func=flow_func)
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
         for cutoff in [2, 4]:
             kwargs['cutoff'] = cutoff
             # edge disjoint paths
             edge_dpaths = list(nx.edge_disjoint_paths(G, 0, 6, **kwargs))
-            assert are_edge_disjoint_paths(G, edge_dpaths), msg.format(flow_func.__name__)
-            assert cutoff == len(edge_dpaths), msg.format(flow_func.__name__)
+            assert are_edge_disjoint_paths(G, edge_dpaths), errmsg
+            assert cutoff == len(edge_dpaths), errmsg
             # node disjoint paths
             node_dpaths = list(nx.node_disjoint_paths(G, 0, 6, **kwargs))
-            assert are_node_disjoint_paths(G, node_dpaths), msg.format(flow_func.__name__)
-            assert cutoff == len(node_dpaths), msg.format(flow_func.__name__)
+            assert are_node_disjoint_paths(G, node_dpaths), errmsg
+            assert cutoff == len(node_dpaths), errmsg
 
 
 def test_missing_source_edge_paths():

--- a/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
@@ -288,7 +288,7 @@ def _augment_and_check(G, k, avail=None, weight=None, verbose=False,
                 n_nodes = G.number_of_nodes()
                 assert n_nodes <= k, (
                     'unconstrained cases are only unfeasible if |V| <= k. '
-                    'Got |V|={} and k={}'.format(n_nodes, k)
+                    f'Got |V|={n_nodes} and k={k}'
                 )
             else:
                 if max_aug_k is None:
@@ -362,10 +362,10 @@ def _augment_and_check(G, k, avail=None, weight=None, verbose=False,
 
     except Exception:
         info['failed'] = True
-        print('edges = {}'.format(list(G.edges())))
-        print('nodes = {}'.format(list(G.nodes())))
-        print('aug_edges = {}'.format(list(aug_edges)))
-        print(f'info  = {info}')
+        print(f"edges = {list(G.edges())}")
+        print(f"nodes = {list(G.nodes())}")
+        print(f"aug_edges = {list(aug_edges)}")
+        print(f"info  = {info}")
         raise
     else:
         if verbose:
@@ -403,11 +403,11 @@ def _check_augmentations(G, avail=None, max_k=None, weight=None,
 
     if verbose:
         print('\n=== CHECK_AUGMENTATION ===')
-        print('G.number_of_nodes = {!r}'.format(G.number_of_nodes()))
-        print('G.number_of_edges = {!r}'.format(G.number_of_edges()))
-        print(f'max_k = {max_k!r}')
-        print(f'max_aug_k = {max_aug_k!r}')
-        print(f'orig_k = {orig_k!r}')
+        print(f"G.number_of_nodes = {G.number_of_nodes()!r}")
+        print(f"G.number_of_edges = {G.number_of_edges()!r}")
+        print(f"max_k = {max_k!r}")
+        print(f"max_aug_k = {max_aug_k!r}")
+        print(f"orig_k = {orig_k!r}")
 
     # check augmentation for multiple values of k
     for k in range(1, max_k + 1):

--- a/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
@@ -159,7 +159,7 @@ def test_tarjan():
     G = tarjan_bridge_graph()
 
     aug_edges = set(_augment_and_check(G, k=2)[0])
-    print('aug_edges = {!r}'.format(aug_edges))
+    print(f'aug_edges = {aug_edges!r}')
     # can't assert edge exactly equality due to non-determinant edge order
     # but we do know the size of the solution must be 3
     assert len(aug_edges) == 3
@@ -353,7 +353,7 @@ def _augment_and_check(G, k, avail=None, weight=None, verbose=False,
         # Do checks
         if not infeasible and orig_k < k:
             assert info['aug_k'] >= k, (
-                'connectivity should increase to k={} or more'.format(k))
+                f'connectivity should increase to k={k} or more')
 
         assert info['aug_k'] >= orig_k, (
             'augmenting should never reduce connectivity')
@@ -365,11 +365,11 @@ def _augment_and_check(G, k, avail=None, weight=None, verbose=False,
         print('edges = {}'.format(list(G.edges())))
         print('nodes = {}'.format(list(G.nodes())))
         print('aug_edges = {}'.format(list(aug_edges)))
-        print('info  = {}'.format(info))
+        print(f'info  = {info}')
         raise
     else:
         if verbose:
-            print('info  = {}'.format(info))
+            print(f'info  = {info}')
 
     if infeasible:
         aug_edges = None
@@ -405,15 +405,15 @@ def _check_augmentations(G, avail=None, max_k=None, weight=None,
         print('\n=== CHECK_AUGMENTATION ===')
         print('G.number_of_nodes = {!r}'.format(G.number_of_nodes()))
         print('G.number_of_edges = {!r}'.format(G.number_of_edges()))
-        print('max_k = {!r}'.format(max_k))
-        print('max_aug_k = {!r}'.format(max_aug_k))
-        print('orig_k = {!r}'.format(orig_k))
+        print(f'max_k = {max_k!r}')
+        print(f'max_aug_k = {max_aug_k!r}')
+        print(f'orig_k = {orig_k!r}')
 
     # check augmentation for multiple values of k
     for k in range(1, max_k + 1):
         if verbose:
             print('---------------')
-            print('Checking k = {}'.format(k))
+            print(f'Checking k = {k}')
 
         # Check the unweighted version
         if verbose:

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -175,7 +175,7 @@ def _generate_no_biconnected(max_attempts=50):
             yield G
         else:
             if attempts >= max_attempts:
-                msg = "Tried %d times: no suitable Graph." % attempts
+                msg = f"Tried {attempts} times: no suitable Graph."
                 raise Exception(msg % max_attempts)
             else:
                 attempts += 1

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -176,7 +176,7 @@ def _generate_no_biconnected(max_attempts=50):
         else:
             if attempts >= max_attempts:
                 msg = f"Tried {attempts} times: no suitable Graph."
-                raise Exception(msg % max_attempts)
+                raise Exception(msg)
             else:
                 attempts += 1
 

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -196,10 +196,10 @@ def test_grid_2d_graph():
     # neighbors of the four corner nodes.
     G = nx.grid_2d_graph(5, 5)
     solution = [
-        set([(0, 1), (1, 0)]),
-        set([(3, 0), (4, 1)]),
-        set([(3, 4), (4, 3)]),
-        set([(0, 3), (1, 4)]),
+        {(0, 1), (1, 0)},
+        {(3, 0), (4, 1)},
+        {(3, 4), (4, 3)},
+        {(0, 3), (1, 4)},
     ]
     for cut in nx.all_node_cuts(G):
         assert cut in solution
@@ -246,8 +246,8 @@ def test_non_repeated_cuts():
     cuts = list(nx.all_node_cuts(G))
     if len(solution) != len(cuts):
         print(nx.info(G))
-        print("Solution: {}".format(solution))
-        print("Result: {}".format(cuts))
+        print(f"Solution: {solution}")
+        print(f"Result: {cuts}")
     assert len(solution) == len(cuts)
     for cut in cuts:
         assert cut in solution

--- a/networkx/algorithms/connectivity/utils.py
+++ b/networkx/algorithms/connectivity/utils.py
@@ -3,8 +3,7 @@ Utilities for connectivity package
 """
 import networkx as nx
 
-__all__ = ['build_auxiliary_node_connectivity',
-           'build_auxiliary_edge_connectivity']
+__all__ = ["build_auxiliary_node_connectivity", "build_auxiliary_edge_connectivity"]
 
 
 def build_auxiliary_node_connectivity(G):
@@ -45,17 +44,17 @@ def build_auxiliary_node_connectivity(G):
         mapping[node] = i
         H.add_node(f"{i}A", id=node)
         H.add_node(f"{i}B", id=node)
-        H.add_edge(f"{i}A", f'{i}B', capacity=1)
+        H.add_edge(f"{i}A", f"{i}B", capacity=1)
 
     edges = []
     for (source, target) in G.edges():
-        edges.append(('%sB' % mapping[source], '%sA' % mapping[target]))
+        edges.append((f"{mapping[source]}B", f"{mapping[target]}A"))
         if not directed:
-            edges.append(('%sB' % mapping[target], '%sA' % mapping[source]))
+            edges.append((f"{mapping[target]}B", f"{mapping[source]}A"))
     H.add_edges_from(edges, capacity=1)
 
     # Store mapping as graph attribute
-    H.graph['mapping'] = mapping
+    H.graph["mapping"] = mapping
     return H
 
 

--- a/networkx/algorithms/connectivity/utils.py
+++ b/networkx/algorithms/connectivity/utils.py
@@ -43,9 +43,9 @@ def build_auxiliary_node_connectivity(G):
 
     for i, node in enumerate(G):
         mapping[node] = i
-        H.add_node('%dA' % i, id=node)
-        H.add_node('%dB' % i, id=node)
-        H.add_edge('%dA' % i, '%dB' % i, capacity=1)
+        H.add_node(f"{i}A", id=node)
+        H.add_node(f"{i}B", id=node)
+        H.add_edge(f"{i}A", f'{i}B', capacity=1)
 
     edges = []
     for (source, target) in G.edges():

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -75,7 +75,7 @@ def cycle_basis(G, root=None):
                 if nbr not in used:   # new node
                     pred[nbr] = z
                     stack.append(nbr)
-                    used[nbr] = set([z])
+                    used[nbr] = {z}
                 elif nbr == z:          # self loops
                     cycles.append([z])
                 elif nbr not in zused:  # found a cycle
@@ -155,7 +155,7 @@ def simple_cycles(G):
     cycle_basis
     """
     def _unblock(thisnode, blocked, B):
-        stack = set([thisnode])
+        stack = {thisnode}
         while stack:
             node = stack.pop()
             if node in blocked:
@@ -545,7 +545,7 @@ def _min_cycle_basis(comp, weight):
     N = len(edges_excl)
 
     # We maintain a set of vectors orthogonal to sofar found cycles
-    set_orth = [set([edge]) for edge in edges_excl]
+    set_orth = [{edge} for edge in edges_excl]
     for k in range(N):
         # kth cycle is "parallel" to kth vector in set_orth
         new_cycle = _min_cycle(comp, set_orth[k], weight=weight)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -55,7 +55,7 @@ def descendants(G, source):
         The descendants of `source` in `G`
     """
     if not G.has_node(source):
-        raise nx.NetworkXError("The node %s is not in the graph." % source)
+        raise nx.NetworkXError(f"The node {source} is not in the graph.")
     des = set(n for n, d in nx.shortest_path_length(G, source=source).items())
     return des - {source}
 
@@ -75,7 +75,7 @@ def ancestors(G, source):
         The ancestors of source in G
     """
     if not G.has_node(source):
-        raise nx.NetworkXError("The node %s is not in the graph." % source)
+        raise nx.NetworkXError(f"The node {source} is not in the graph.")
     anc = set(n for n, d in nx.shortest_path_length(G, target=source).items())
     return anc - {source}
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -56,7 +56,7 @@ def descendants(G, source):
     """
     if not G.has_node(source):
         raise nx.NetworkXError(f"The node {source} is not in the graph.")
-    des = set(n for n, d in nx.shortest_path_length(G, source=source).items())
+    des = {n for n, d in nx.shortest_path_length(G, source=source).items()}
     return des - {source}
 
 
@@ -76,7 +76,7 @@ def ancestors(G, source):
     """
     if not G.has_node(source):
         raise nx.NetworkXError(f"The node {source} is not in the graph.")
-    anc = set(n for n, d in nx.shortest_path_length(G, target=source).items())
+    anc = {n for n, d in nx.shortest_path_length(G, target=source).items()}
     return anc - {source}
 
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -417,8 +417,9 @@ def barycenter(G, weight=None, attr=None, sp=None):
     for v, dists in sp:
         if len(dists) < n:
             raise nx.NetworkXNoPath(
-                ("Input graph %r is disconnected, so every induced subgraph "
-                 "has infinite barycentricity.") % G)
+                f"Input graph {G} is disconnected, so every induced subgraph "
+                "has infinite barycentricity."
+        )
         barycentricity = sum(dists.values())
         if attr is not None:
             G.nodes[v][attr] = barycentricity

--- a/networkx/algorithms/dominating.py
+++ b/networkx/algorithms/dominating.py
@@ -47,7 +47,7 @@ def dominating_set(G, start_with=None):
     if start_with is None:
         start_with = arbitrary_element(all_nodes)
     if start_with not in G:
-        raise nx.NetworkXError('node {} is not in G'.format(start_with))
+        raise nx.NetworkXError(f'node {start_with} is not in G')
     dominating_set = {start_with}
     dominated_nodes = set(G[start_with])
     remaining_nodes = all_nodes - dominated_nodes - dominating_set
@@ -87,6 +87,6 @@ def is_dominating_set(G, nbunch):
     .. [1] https://en.wikipedia.org/wiki/Dominating_set
 
     """
-    testset = set(n for n in nbunch if n in G)
+    testset = {n for n in nbunch if n in G}
     nbrs = set(chain.from_iterable(G[n] for n in testset))
     return len(set(G) - testset - nbrs) == 0

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -204,8 +204,7 @@ def eulerian_circuit(G, source=None, keys=False):
             else:
                 yield u, v
     else:
-        for u, v in _simplegraph_eulerian_circuit(G, source):
-            yield u, v
+        yield from _simplegraph_eulerian_circuit(G, source)
 
 
 def has_eulerian_path(G):
@@ -290,8 +289,7 @@ def eulerian_path(G, source=None, keys=False):
             else:
                 yield u, v
     else:
-        for u, v in _simplegraph_eulerian_circuit(G, source):
-            yield u, v
+        yield from _simplegraph_eulerian_circuit(G, source)
 
 
 @not_implemented_for('directed')

--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -160,9 +160,9 @@ def boykov_kolmogorov(G, s, t, capacity='capacity', residual=None,
 
 def boykov_kolmogorov_impl(G, s, t, capacity, residual, cutoff):
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(s))
+        raise nx.NetworkXError(f"node {str(s)} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(t))
+        raise nx.NetworkXError(f"node {str(t)} not in graph")
     if s == t:
         raise nx.NetworkXError('source and sink are the same node')
 

--- a/networkx/algorithms/flow/capacityscaling.py
+++ b/networkx/algorithms/flow/capacityscaling.py
@@ -101,11 +101,11 @@ def _build_flow_dict(G, R, capacity, weight):
         for u in G:
             flow_dict[u] = {}
             for v, es in G[u].items():
-                flow_dict[u][v] = dict(
+                flow_dict[u][v] = {
                     # Always saturate negative selfloops.
-                    (k, (0 if (u != v or e.get(capacity, inf) <= 0 or
-                               e.get(weight, 0) >= 0) else e[capacity]))
-                    for k, e in es.items())
+                    k: (0 if (u != v or e.get(capacity, inf) <= 0 or
+                               e.get(weight, 0) >= 0) else e[capacity])
+                    for k, e in es.items()}
             for v, es in R[u].items():
                 if v in flow_dict[u]:
                     flow_dict[u][v].update((k[0], e['flow'])
@@ -113,11 +113,11 @@ def _build_flow_dict(G, R, capacity, weight):
                                            if e['flow'] > 0)
     else:
         for u in G:
-            flow_dict[u] = dict(
+            flow_dict[u] = {
                 # Always saturate negative selfloops.
-                (v, (0 if (u != v or e.get(capacity, inf) <= 0 or
-                           e.get(weight, 0) >= 0) else e[capacity]))
-                for v, e in G[u].items())
+                v: (0 if (u != v or e.get(capacity, inf) <= 0 or
+                           e.get(weight, 0) >= 0) else e[capacity])
+                for v, e in G[u].items()}
             flow_dict[u].update((v, e['flow']) for v, es in R[u].items()
                                 for e in es.values() if e['flow'] > 0)
     return flow_dict

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -140,9 +140,9 @@ def dinitz(G, s, t, capacity='capacity', residual=None, value_only=False, cutoff
 
 def dinitz_impl(G, s, t, capacity, residual, cutoff):
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(s))
+        raise nx.NetworkXError(f"node {str(s)} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(t))
+        raise nx.NetworkXError(f"node {str(t)} not in graph")
     if s == t:
         raise nx.NetworkXError('source and sink are the same node')
 

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -99,9 +99,9 @@ def edmonds_karp_impl(G, s, t, capacity, residual, cutoff):
     """Implementation of the Edmonds-Karp algorithm.
     """
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(s))
+        raise nx.NetworkXError(f"node {str(s)} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(t))
+        raise nx.NetworkXError(f"node {str(t)} not in graph")
     if s == t:
         raise nx.NetworkXError('source and sink are the same node')
 

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -182,7 +182,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
     inf = float('inf')
     for p, b in zip(N, D):
         if abs(b) == inf:
-            raise nx.NetworkXError('node %r has infinite demand' % (p,))
+            raise nx.NetworkXError(f'node {p!r} has infinite demand')
 
     multigraph = G.is_multigraph()
     S = []  # edge sources
@@ -210,14 +210,14 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
 
     for e, c in zip(E, C):
         if abs(c) == inf:
-            raise nx.NetworkXError('edge %r has infinite weight' % (e,))
+            raise nx.NetworkXError(f'edge {e!r} has infinite weight')
     if not multigraph:
         edges = nx.selfloop_edges(G, data=True)
     else:
         edges = nx.selfloop_edges(G, data=True, keys=True)
     for e in edges:
         if abs(e[-1].get(weight, 0)) == inf:
-            raise nx.NetworkXError('edge %r has infinite weight' % (e[:-1],))
+            raise nx.NetworkXError('edge {!r} has infinite weight'.format(e[:-1]))
 
     ###########################################################################
     # Quick infeasibility detection
@@ -227,7 +227,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
         raise nx.NetworkXUnfeasible('total node demand is not zero')
     for e, u in zip(E, U):
         if u < 0:
-            raise nx.NetworkXUnfeasible('edge %r has negative capacity' % (e,))
+            raise nx.NetworkXUnfeasible(f'edge {e!r} has negative capacity')
     if not multigraph:
         edges = nx.selfloop_edges(G, data=True)
     else:
@@ -235,7 +235,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
     for e in edges:
         if e[-1].get(capacity, inf) < 0:
             raise nx.NetworkXUnfeasible(
-                'edge %r has negative capacity' % (e[:-1],))
+                'edge {!r} has negative capacity'.format(e[:-1]))
 
     ###########################################################################
     # Initialization

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -217,7 +217,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
         edges = nx.selfloop_edges(G, data=True, keys=True)
     for e in edges:
         if abs(e[-1].get(weight, 0)) == inf:
-            raise nx.NetworkXError('edge {!r} has infinite weight'.format(e[:-1]))
+            raise nx.NetworkXError(f'edge {e[:-1]!r} has infinite weight')
 
     ###########################################################################
     # Quick infeasibility detection
@@ -234,8 +234,7 @@ def network_simplex(G, demand='demand', capacity='capacity', weight='weight'):
         edges = nx.selfloop_edges(G, data=True, keys=True)
     for e in edges:
         if e[-1].get(capacity, inf) < 0:
-            raise nx.NetworkXUnfeasible(
-                'edge {!r} has negative capacity'.format(e[:-1]))
+            raise nx.NetworkXUnfeasible(f'edge {e[:-1]!r} has negative capacity')
 
     ###########################################################################
     # Initialization

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -20,9 +20,9 @@ def preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq,
     """Implementation of the highest-label preflow-push algorithm.
     """
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(s))
+        raise nx.NetworkXError(f"node {str(s)} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(t))
+        raise nx.NetworkXError(f"node {str(t)} not in graph")
     if s == t:
         raise nx.NetworkXError('source and sink are the same node')
 

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -15,9 +15,9 @@ def shortest_augmenting_path_impl(G, s, t, capacity, residual, two_phase,
     """Implementation of the shortest augmenting path algorithm.
     """
     if s not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(s))
+        raise nx.NetworkXError(f"node {str(s)} not in graph")
     if t not in G:
-        raise nx.NetworkXError('node %s not in graph' % str(t))
+        raise nx.NetworkXError(f"node {str(t)} not in graph")
     if s == t:
         raise nx.NetworkXError('source and sink are the same node')
 

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -375,7 +375,7 @@ class TestMaxFlowMinCutInterface:
         self.H = H
 
     def test_flow_func_not_callable(self):
-        elements = ['this_should_be_callable', 10, set([1, 2, 3])]
+        elements = ['this_should_be_callable', 10, {1, 2, 3}]
         G = nx.Graph()
         G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1)], weight='capacity')
         for flow_func in interface_funcs:
@@ -499,4 +499,4 @@ class TestCutoff:
             for cutoff in [3, 2, 1]:
                 result = nx.maximum_flow_value(G, 0, 4, flow_func=flow_func,
                                                cutoff=cutoff)
-                assert cutoff == result, "cutoff error in {0}".format(flow_func.__name__)
+                assert cutoff == result, f"cutoff error in {flow_func.__name__}"

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -21,8 +21,6 @@ flow_funcs = [
     shortest_augmenting_path,
 ]
 
-msg = "Assertion failed in function: {0}"
-
 
 def gen_pyramid(N):
     # This graph admits a flow of value 1 for which every arc is at
@@ -53,26 +51,25 @@ def read_graph(name):
 def validate_flows(G, s, t, soln_value, R, flow_func):
     flow_value = R.graph["flow_value"]
     flow_dict = build_flow_dict(G, R)
-    assert soln_value == flow_value, msg.format(flow_func.__name__)
-    assert set(G) == set(flow_dict), msg.format(flow_func.__name__)
+    errmsg = f"Assertion failed in function: {flow_func.__name__}"
+    assert soln_value == flow_value, errmsg
+    assert set(G) == set(flow_dict), errmsg
     for u in G:
-        assert set(G[u]) == set(flow_dict[u]), msg.format(flow_func.__name__)
+        assert set(G[u]) == set(flow_dict[u]), errmsg
     excess = {u: 0 for u in flow_dict}
     for u in flow_dict:
         for v, flow in flow_dict[u].items():
-            assert flow <= G[u][v].get("capacity", float("inf")), msg.format(
-                flow_func.__name__
-            )
-            assert flow >= 0, msg.format(flow_func.__name__)
+            assert flow <= G[u][v].get("capacity", float("inf")), errmsg 
+            assert flow >= 0, errmsg
             excess[u] -= flow
             excess[v] += flow
     for u, exc in excess.items():
         if u == s:
-            assert exc == -soln_value, msg.format(flow_func.__name__)
+            assert exc == -soln_value, errmsg
         elif u == t:
-            assert exc == soln_value, msg.format(flow_func.__name__)
+            assert exc == soln_value, errmsg
         else:
-            assert exc == 0, msg.format(flow_func.__name__)
+            assert exc == 0, errmsg
 
 
 class TestMaxflowLargeGraph:
@@ -85,8 +82,9 @@ class TestMaxflowLargeGraph:
 
         for flow_func in flow_funcs:
             kwargs["flow_func"] = flow_func
+            errmsg = f"Assertion failed in function: {flow_func.__name__}"
             flow_value = nx.maximum_flow_value(G, 1, 2, **kwargs)
-            assert flow_value == 5 * (N - 1), msg.format(flow_func.__name__)
+            assert flow_value == 5 * (N - 1), errmsg
 
     def test_pyramid(self):
         N = 10
@@ -97,8 +95,9 @@ class TestMaxflowLargeGraph:
 
         for flow_func in flow_funcs:
             kwargs["flow_func"] = flow_func
+            errmsg = f"Assertion failed in function: {flow_func.__name__}"
             flow_value = nx.maximum_flow_value(G, (0, 0), "t", **kwargs)
-            assert almost_equal(flow_value, 1.0), msg.format(flow_func.__name__)
+            assert almost_equal(flow_value, 1.0), errmsg
 
     def test_gl1(self):
         G = read_graph("gl1")

--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -1,4 +1,3 @@
-
 import networkx as nx
 import pytest
 import os

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -9,7 +9,7 @@ __all__ = ['CurrentEdge', 'Level', 'GlobalRelabelThreshold',
            'build_residual_network', 'detect_unboundedness', 'build_flow_dict']
 
 
-class CurrentEdge(object):
+class CurrentEdge:
     """Mechanism for iterating over out-edges incident to a node in a circular
     manner. StopIteration exception is raised when wraparound occurs.
     """
@@ -35,7 +35,7 @@ class CurrentEdge(object):
         self._curr = next(self._it)
 
 
-class Level(object):
+class Level:
     """Active and inactive nodes in a level.
     """
     __slots__ = ('active', 'inactive')
@@ -45,7 +45,7 @@ class Level(object):
         self.inactive = set()
 
 
-class GlobalRelabelThreshold(object):
+class GlobalRelabelThreshold:
     """Measurement of work before the global relabeling heuristic should be
     applied.
     """
@@ -140,7 +140,7 @@ def detect_unboundedness(R, s, t):
     """Detect an infinite-capacity s-t path in R.
     """
     q = deque([s])
-    seen = set([s])
+    seen = {s}
     inf = R.graph['inf']
     while q:
         u = q.popleft()

--- a/networkx/algorithms/hybrid.py
+++ b/networkx/algorithms/hybrid.py
@@ -73,7 +73,7 @@ def kl_connected_subgraph(G, k, l, low_memory=False, same_as_graph=False):
             (u, v) = edge
             # Get copy of graph needed for this search
             if low_memory:
-                verts = set([u, v])
+                verts = {u, v}
                 for i in range(k):
                     for w in verts.copy():
                         verts.update(G[w])
@@ -158,7 +158,7 @@ def is_kl_connected(G, k, l, low_memory=False):
         (u, v) = edge
         # Get copy of graph needed for this search
         if low_memory:
-            verts = set([u, v])
+            verts = {u, v}
             for i in range(k):
                 [verts.update(G.neighbors(w)) for w in verts.copy()]
             G2 = G.subgraph(verts)

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -182,7 +182,7 @@ def make_partitions(items, test):
                 partition.add(item)
                 break
         else:  # No break
-            partitions.append(set((item,)))
+            partitions.append({item})
     return partitions
 
 

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -948,8 +948,7 @@ class ISMAGS:
             # top and bot have only one element
             if len(top) != 1 or len(bot) != 1:
                 raise IndexError("Not all nodes are coupled. This is"
-                                 " impossible: {}, {}".format(top_partitions,
-                                                              bottom_partitions))
+                                 f" impossible: {top_partitions}, {bottom_partitions}")
             if top != bot:
                 permutations.add(frozenset((next(iter(top)), next(iter(bot)))))
         return permutations

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -516,7 +516,6 @@ class DiGraphMatcher(GraphMatcher):
 
     Suitable for DiGraph and MultiDiGraph instances.
     """
-#    __doc__ += "Notes\n%s-----" % (indent,) + sources.replace('\n','\n'+indent)
 
     def __init__(self, G1, G2):
         """Initialize DiGraphMatcher.

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -145,7 +145,7 @@ __all__ = ['GraphMatcher',
            'DiGraphMatcher']
 
 
-class GraphMatcher(object):
+class GraphMatcher:
     """Implementation of VF2 algorithm for matching undirected graphs.
 
     Suitable for Graph and MultiGraph instances.
@@ -292,8 +292,7 @@ class GraphMatcher(object):
         # Declare that we are looking for a graph-graph isomorphism.
         self.test = 'graph'
         self.initialize()
-        for mapping in self.match():
-            yield mapping
+        yield from self.match()
 
     def match(self):
         """Extends the isomorphism mapping.
@@ -315,8 +314,7 @@ class GraphMatcher(object):
                     if self.semantic_feasibility(G1_node, G2_node):
                         # Recursive call, adding the feasible state.
                         newstate = self.state.__class__(self, G1_node, G2_node)
-                        for mapping in self.match():
-                            yield mapping
+                        yield from self.match()
 
                         # restore data structures
                         newstate.restore()
@@ -384,16 +382,14 @@ class GraphMatcher(object):
         # Declare that we are looking for graph-subgraph isomorphism.
         self.test = 'subgraph'
         self.initialize()
-        for mapping in self.match():
-            yield mapping
+        yield from self.match()
 
     def subgraph_monomorphisms_iter(self):
         """Generator over monomorphisms between a subgraph of G1 and G2."""
         # Declare that we are looking for graph-subgraph monomorphism.
         self.test = 'mono'
         self.initialize()
-        for mapping in self.match():
-            yield mapping
+        yield from self.match()
 
 #    subgraph_isomorphisms_iter.__doc__ += "\n" + subgraph.replace('\n','\n'+indent)
 
@@ -531,7 +527,7 @@ class DiGraphMatcher(GraphMatcher):
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
         >>> DiGM = isomorphism.DiGraphMatcher(G1,G2)
         """
-        super(DiGraphMatcher, self).__init__(G1, G2)
+        super().__init__(G1, G2)
 
     def candidate_pairs_iter(self):
         """Iterator over candidate pairs of nodes in G1 and G2."""
@@ -822,7 +818,7 @@ class DiGraphMatcher(GraphMatcher):
         return True
 
 
-class GMState(object):
+class GMState:
     """Internal representation of state for the GraphMatcher class.
 
     This class is used internally by the GraphMatcher class.  It is used
@@ -875,7 +871,7 @@ class GMState(object):
             # Now we add every other node...
 
             # Updates for T_1^{inout}
-            new_nodes = set([])
+            new_nodes = set()
             for node in GM.core_1:
                 new_nodes.update([neighbor for neighbor in GM.G1[node] if neighbor not in GM.core_1])
             for node in new_nodes:
@@ -883,7 +879,7 @@ class GMState(object):
                     GM.inout_1[node] = self.depth
 
             # Updates for T_2^{inout}
-            new_nodes = set([])
+            new_nodes = set()
             for node in GM.core_2:
                 new_nodes.update([neighbor for neighbor in GM.G2[node] if neighbor not in GM.core_2])
             for node in new_nodes:
@@ -906,7 +902,7 @@ class GMState(object):
                     del vector[node]
 
 
-class DiGMState(object):
+class DiGMState:
     """Internal representation of state for the DiGraphMatcher class.
 
     This class is used internally by the DiGraphMatcher class.  It is used
@@ -964,7 +960,7 @@ class DiGMState(object):
             # Now we add every other node...
 
             # Updates for T_1^{in}
-            new_nodes = set([])
+            new_nodes = set()
             for node in GM.core_1:
                 new_nodes.update([predecessor for predecessor in GM.G1.predecessors(node)
                                   if predecessor not in GM.core_1])
@@ -973,7 +969,7 @@ class DiGMState(object):
                     GM.in_1[node] = self.depth
 
             # Updates for T_2^{in}
-            new_nodes = set([])
+            new_nodes = set()
             for node in GM.core_2:
                 new_nodes.update([predecessor for predecessor in GM.G2.predecessors(node)
                                   if predecessor not in GM.core_2])
@@ -982,7 +978,7 @@ class DiGMState(object):
                     GM.in_2[node] = self.depth
 
             # Updates for T_1^{out}
-            new_nodes = set([])
+            new_nodes = set()
             for node in GM.core_1:
                 new_nodes.update([successor for successor in GM.G1.successors(node) if successor not in GM.core_1])
             for node in new_nodes:
@@ -990,7 +986,7 @@ class DiGMState(object):
                     GM.out_1[node] = self.depth
 
             # Updates for T_2^{out}
-            new_nodes = set([])
+            new_nodes = set()
             for node in GM.core_2:
                 new_nodes.update([successor for successor in GM.G2.successors(node) if successor not in GM.core_2])
             for node in new_nodes:

--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -111,18 +111,18 @@ except NotImplementedError:
 def categorical_multiedge_match(attr, default):
     if isinstance(attr, str):
         def match(datasets1, datasets2):
-            values1 = set([data.get(attr, default) for data in datasets1.values()])
-            values2 = set([data.get(attr, default) for data in datasets2.values()])
+            values1 = {data.get(attr, default) for data in datasets1.values()}
+            values2 = {data.get(attr, default) for data in datasets2.values()}
             return values1 == values2
     else:
         attrs = list(zip(attr, default))  # Python 3
 
         def match(datasets1, datasets2):
-            values1 = set([])
+            values1 = set()
             for data1 in datasets1.values():
                 x = tuple(data1.get(attr, d) for attr, d in attrs)
                 values1.add(x)
-            values2 = set([])
+            values2 = set()
             for data2 in datasets2.values():
                 x = tuple(data2.get(attr, d) for attr, d in attrs)
                 values2.add(x)

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -94,7 +94,7 @@ class TimeRespectingGraphMatcher(GraphMatcher):
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
-        super(TimeRespectingGraphMatcher, self).__init__(G1, G2)
+        super().__init__(G1, G2)
 
     def one_hop(self, Gx, Gx_node, neighbors):
         """
@@ -157,7 +157,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
-        super(TimeRespectingDiGraphMatcher, self).__init__(G1, G2)
+        super().__init__(G1, G2)
 
     def get_pred_dates(self, Gx, Gx_node, core_x, pred):
         """

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -15,7 +15,7 @@ def _matches_to_sets(matches):
     return set(map(lambda m: frozenset(m.items()), matches))
 
 
-class TestSelfIsomorphism(object):
+class TestSelfIsomorphism:
     data = [
         (
             [(0, dict(name='a')),
@@ -94,7 +94,7 @@ class TestSelfIsomorphism(object):
                     [{n: n for n in graph.nodes}])
 
 
-class TestSubgraphIsomorphism(object):
+class TestSubgraphIsomorphism:
     def test_isomorphism(self):
         g1 = nx.Graph()
         nx.add_cycle(g1, range(4))
@@ -165,7 +165,7 @@ class TestSubgraphIsomorphism(object):
                 _matches_to_sets(expected_symmetric + expected_asymmetric))
 
 
-class TestWikipediaExample(object):
+class TestWikipediaExample:
     # Nodes 'a', 'b', 'c' and 'd' form a column.
     # Nodes 'g', 'h', 'i' and 'j' form a column.
     g1edges = [['a', 'g'], ['a', 'h'], ['a', 'i'],
@@ -188,7 +188,7 @@ class TestWikipediaExample(object):
         assert gm.is_isomorphic()
 
 
-class TestLargestCommonSubgraph(object):
+class TestLargestCommonSubgraph:
     def test_mcis(self):
         # Example graphs from DOI: 10.1002/spe.588
         graph1 = nx.Graph()

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -11,7 +11,7 @@ import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
 
-class TestWikipediaExample(object):
+class TestWikipediaExample:
     # Source: https://en.wikipedia.org/wiki/Graph_isomorphism
 
     # Nodes 'a', 'b', 'c' and 'd' form a column.
@@ -62,7 +62,7 @@ class TestWikipediaExample(object):
         assert gm.subgraph_is_monomorphic()
 
 
-class TestVF2GraphDB(object):
+class TestVF2GraphDB:
     # http://amalfi.dis.unina.it/graph/db/
 
     @staticmethod
@@ -118,7 +118,7 @@ class TestVF2GraphDB(object):
     # feel free to create one.
 
 
-class TestAtlas(object):
+class TestAtlas:
     @classmethod
     def setup_class(cls):
         global atlas

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -63,7 +63,7 @@ def put_time_config_2(G, att_name):
     return G
 
 
-class TestTimeRespectingGraphMatcher(object):
+class TestTimeRespectingGraphMatcher:
     """
         A test class for the undirected temporal graph matcher.
     """
@@ -146,7 +146,7 @@ class TestTimeRespectingGraphMatcher(object):
         assert count_match == 10
 
 
-class TestDiTimeRespectingGraphMatcher(object):
+class TestDiTimeRespectingGraphMatcher:
     """
         A test class for the directed time-respecting graph matcher.
     """

--- a/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py
@@ -76,7 +76,7 @@ def test_weightkey():
     assert nx.is_isomorphic(g1, g2, edge_match=em)
 
 
-class TestNodeMatch_Graph(object):
+class TestNodeMatch_Graph:
     def setup_method(self):
         self.g1 = nx.Graph()
         self.g2 = nx.Graph()
@@ -127,7 +127,7 @@ class TestNodeMatch_Graph(object):
                                     node_match=self.nm, edge_match=self.em)
 
 
-class TestEdgeMatch_MultiGraph(object):
+class TestEdgeMatch_MultiGraph:
     def setup_method(self):
         self.g1 = nx.MultiGraph()
         self.g2 = nx.MultiGraph()

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -115,21 +115,21 @@ def pagerank(G, alpha=0.85, personalization=None,
     else:
         # Normalized nstart vector
         s = float(sum(nstart.values()))
-        x = dict((k, v / s) for k, v in nstart.items())
+        x = {k: v / s for k, v in nstart.items()}
 
     if personalization is None:
         # Assign uniform personalization vector if not given
         p = dict.fromkeys(W, 1.0 / N)
     else:
         s = float(sum(personalization.values()))
-        p = dict((k, v / s) for k, v in personalization.items())
+        p = {k: v / s for k, v in personalization.items()}
 
     if dangling is None:
         # Use personalization vector if dangling vector not specified
         dangling_weights = p
     else:
         s = float(sum(dangling.values()))
-        dangling_weights = dict((k, v / s) for k, v in dangling.items())
+        dangling_weights = {k: v / s for k, v in dangling.items()}
     dangling_nodes = [n for n in W if W.out_degree(n, weight=weight) == 0.0]
 
     # power iteration: make up to max_iter iterations

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -39,7 +39,7 @@ class TestHITS:
 
     def test_hits_nstart(self):
         G = self.G
-        nstart = dict([(i, 1. / 2) for i in G])
+        nstart = {i: 1. / 2 for i in G}
         h, a = networkx.hits(G, nstart=nstart)
 
     def test_hits_numpy(self):

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -12,7 +12,7 @@ from networkx.testing import almost_equal
 # information retrieval."  http://citeseer.ist.psu.edu/713792.html
 
 
-class TestPageRank(object):
+class TestPageRank:
 
     @classmethod
     def setup_class(cls):
@@ -41,7 +41,7 @@ class TestPageRank(object):
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
 
-        nstart = dict((n, random.random()) for n in G)
+        nstart = {n: random.random() for n in G}
         p = networkx.pagerank(G, alpha=0.9, tol=1.e-08, nstart=nstart)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
@@ -55,7 +55,7 @@ class TestPageRank(object):
         p = networkx.pagerank_numpy(G, alpha=0.9)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
-        personalize = dict((n, random.random()) for n in G)
+        personalize = {n: random.random() for n in G}
         p = networkx.pagerank_numpy(G, alpha=0.9, personalization=personalize)
 
     def test_google_matrix(self):
@@ -140,11 +140,11 @@ class TestPageRankScipy(TestPageRank):
         p = networkx.pagerank_scipy(G, alpha=0.9, tol=1.e-08)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
-        personalize = dict((n, random.random()) for n in G)
+        personalize = {n: random.random() for n in G}
         p = networkx.pagerank_scipy(G, alpha=0.9, tol=1.e-08,
                                     personalization=personalize)
 
-        nstart = dict((n, random.random()) for n in G)
+        nstart = {n: random.random() for n in G}
         p = networkx.pagerank_scipy(G, alpha=0.9, tol=1.e-08, nstart=nstart)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -475,8 +475,8 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community='community'):
         if Cu != Cv:
             return 0
         cnbors = set(nx.common_neighbors(G, u, v))
-        within = set(w for w in cnbors
-                     if _community(G, w, community) == Cu)
+        within = {w for w in cnbors
+                     if _community(G, w, community) == Cu}
         inter = cnbors - within
         return len(within) / (len(inter) + delta)
 

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -74,10 +74,9 @@ def resource_allocation_index(G, ebunch=None):
     >>> G = nx.complete_graph(5)
     >>> preds = nx.resource_allocation_index(G, [(0, 1), (2, 3)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %.8f' % (u, v, p)
-    ...
-    '(0, 1) -> 0.75000000'
-    '(2, 3) -> 0.75000000'
+    ...     print(f'({u}, {v}) -> {p:.8f}')
+    (0, 1) -> 0.75000000
+    (2, 3) -> 0.75000000
 
     References
     ----------
@@ -128,10 +127,9 @@ def jaccard_coefficient(G, ebunch=None):
     >>> G = nx.complete_graph(5)
     >>> preds = nx.jaccard_coefficient(G, [(0, 1), (2, 3)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %.8f' % (u, v, p)
-    ...
-    '(0, 1) -> 0.60000000'
-    '(2, 3) -> 0.60000000'
+    ...     print(f'({u}, {v}) -> {p:.8f}')
+    (0, 1) -> 0.60000000
+    (2, 3) -> 0.60000000
 
     References
     ----------
@@ -186,10 +184,9 @@ def adamic_adar_index(G, ebunch=None):
     >>> G = nx.complete_graph(5)
     >>> preds = nx.adamic_adar_index(G, [(0, 1), (2, 3)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %.8f' % (u, v, p)
-    ...
-    '(0, 1) -> 2.16404256'
-    '(2, 3) -> 2.16404256'
+    ...     print(f'({u}, {v}) -> {p:.8f}')
+    (0, 1) -> 2.16404256
+    (2, 3) -> 2.16404256
 
     References
     ----------
@@ -239,10 +236,9 @@ def preferential_attachment(G, ebunch=None):
     >>> G = nx.complete_graph(5)
     >>> preds = nx.preferential_attachment(G, [(0, 1), (2, 3)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %d' % (u, v, p)
-    ...
-    '(0, 1) -> 16'
-    '(2, 3) -> 16'
+    ...     print(f'({u}, {v}) -> {p}')
+    (0, 1) -> 16
+    (2, 3) -> 16
 
     References
     ----------
@@ -305,8 +301,8 @@ def cn_soundarajan_hopcroft(G, ebunch=None, community='community'):
     >>> G.nodes[2]['community'] = 0
     >>> preds = nx.cn_soundarajan_hopcroft(G, [(0, 2)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %d' % (u, v, p)
-    '(0, 2) -> 2'
+    ...     print(f'({u}, {v}) -> {p}')
+    (0, 2) -> 2
 
     References
     ----------
@@ -379,8 +375,8 @@ def ra_index_soundarajan_hopcroft(G, ebunch=None, community='community'):
     >>> G.nodes[3]['community'] = 0
     >>> preds = nx.ra_index_soundarajan_hopcroft(G, [(0, 3)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %.8f' % (u, v, p)
-    '(0, 3) -> 0.50000000'
+    ...     print(f'({u}, {v}) -> {p:.8f}')
+    (0, 3) -> 0.50000000
 
     References
     ----------
@@ -455,14 +451,12 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community='community'):
     >>> G.nodes[4]['community'] = 0
     >>> preds = nx.within_inter_cluster(G, [(0, 4)])
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %.8f' % (u, v, p)
-    ...
-    '(0, 4) -> 1.99800200'
+    ...     print(f'({u}, {v}) -> {p:.8f}')
+    (0, 4) -> 1.99800200
     >>> preds = nx.within_inter_cluster(G, [(0, 4)], delta=0.5)
     >>> for u, v, p in preds:
-    ...     '(%d, %d) -> %.8f' % (u, v, p)
-    ...
-    '(0, 4) -> 1.33333333'
+    ...     print(f'({u}, {v}) -> {p:.8f}')
+    (0, 4) -> 1.33333333
 
     References
     ----------

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -64,7 +64,7 @@ def tree_all_pairs_lowest_common_ancestor(G, root=None, pairs=None):
         for u, v in pairs:
             for n in (u, v):
                 if n not in G:
-                    msg = "The node %s is not in the digraph." % str(n)
+                    msg = f"The node {str(n)} is not in the digraph."
                     raise nx.NodeNotFound(msg)
             pair_dict[u].add(v)
             pair_dict[v].add(u)
@@ -251,7 +251,7 @@ def all_pairs_lowest_common_ancestor(G, pairs=None):
 
     for n in pairset:
         if n not in G:
-            msg = "The node %s is not in the digraph." % str(n)
+            msg = f"The node {str(n)} is not in the digraph."
             raise nx.NodeNotFound(msg)
 
     # Generate the transitive closure over the dag (not G) of all nodes, and

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -57,7 +57,7 @@ def matching_dict_to_set(matching):
     # only the (frozen)set `{u, v}` appears as an element in the
     # returned set.
 
-    return set((u, v) for (u, v) in set(map(frozenset, matching.items())))
+    return {(u, v) for (u, v) in set(map(frozenset, matching.items()))}
 
 
 def is_matching(G, matching):
@@ -262,8 +262,7 @@ def max_weight_matching(G, maxcardinality=False, weight='weight'):
         def leaves(self):
             for t in self.childs:
                 if isinstance(t, Blossom):
-                    for v in t.leaves():
-                        yield v
+                    yield from t.leaves()
                 else:
                     yield t
 

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -458,6 +458,5 @@ def contracted_edge(G, edge, self_loops=True):
 
     """
     if not G.has_edge(*edge):
-        raise ValueError('Edge {} does not exist in graph G; cannot contract'
-                         ' it'.format(edge))
+        raise ValueError(f'Edge {edge} does not exist in graph G; cannot contract it')
     return contracted_nodes(G, *edge, self_loops=self_loops)

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -458,6 +458,6 @@ def contracted_edge(G, edge, self_loops=True):
 
     """
     if not G.has_edge(*edge):
-        raise ValueError('Edge {0} does not exist in graph G; cannot contract'
+        raise ValueError('Edge {} does not exist in graph G; cannot contract'
                          ' it'.format(edge))
     return contracted_nodes(G, *edge, self_loops=self_loops)

--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -60,7 +60,7 @@ def maximal_independent_set(G, nodes=None, seed=None):
 
     """
     if not nodes:
-        nodes = set([seed.choice(list(G))])
+        nodes = {seed.choice(list(G))}
     else:
         nodes = set(nodes)
     if not nodes.issubset(G):

--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -64,12 +64,10 @@ def maximal_independent_set(G, nodes=None, seed=None):
     else:
         nodes = set(nodes)
     if not nodes.issubset(G):
-        raise nx.NetworkXUnfeasible(
-            "%s is not a subset of the nodes of G" % nodes)
+        raise nx.NetworkXUnfeasible(f"{nodes} is not a subset of the nodes of G")
     neighbors = set.union(*[set(G.adj[v]) for v in nodes])
     if set.intersection(neighbors, nodes):
-        raise nx.NetworkXUnfeasible(
-            "%s is not an independent set of G" % nodes)
+        raise nx.NetworkXUnfeasible(f"{nodes} is not an independent set of G")
     indep_nodes = list(nodes)
     available_nodes = set(G.nodes()).difference(neighbors.union(nodes))
     while available_nodes:

--- a/networkx/algorithms/node_classification/tests/test_harmonic_function.py
+++ b/networkx/algorithms/node_classification/tests/test_harmonic_function.py
@@ -70,7 +70,7 @@ class TestHarmonicFunction:
     def test_labeled_nodes_are_not_changed(self):
         G = nx.karate_club_graph()
         label_name = 'club'
-        label_removed = set([0, 1, 2, 3, 4, 5, 6, 7])
+        label_removed = {0, 1, 2, 3, 4, 5, 6, 7}
         for i in label_removed:
             del G.nodes[i][label_name]
         predicted = node_classification.harmonic_function(

--- a/networkx/algorithms/node_classification/utils.py
+++ b/networkx/algorithms/node_classification/utils.py
@@ -1,5 +1,3 @@
-
-
 def _propagate(P, F, B):
     """Propagate labels by one step
 

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -12,7 +12,7 @@ __all__ = ['tensor_product', 'cartesian_product',
 
 
 def _dict_product(d1, d2):
-    return dict((k, (d1.get(k), d2.get(k))) for k in set(d1) | set(d2))
+    return {k: (d1.get(k), d2.get(k)) for k in set(d1) | set(d2)}
 
 
 # Generators for producting graph products

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -21,7 +21,7 @@ def test_union_all_attributes():
     j.nodes[0]['x'] = 7
 
     ghj = nx.union_all([g, h, j], rename=('g', 'h', 'j'))
-    assert set(ghj.nodes()) == set(['h0', 'h1', 'g0', 'g1', 'j0', 'j1'])
+    assert set(ghj.nodes()) == {'h0', 'h1', 'g0', 'g1', 'j0', 'j1'}
     for n in ghj:
         graph, node = n
         assert ghj.nodes[n] == eval(graph).nodes[int(node)]
@@ -44,7 +44,7 @@ def test_intersection_all():
     R.add_edge(2, 3)
     R.add_edge(4, 1)
     I = nx.intersection_all([G, H, R])
-    assert set(I.nodes()) == set([1, 2, 3, 4])
+    assert set(I.nodes()) == {1, 2, 3, 4}
     assert sorted(I.edges()) == [(2, 3)]
 
 

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -16,7 +16,7 @@ def test_union_attributes():
     h.nodes[0]['x'] = 7
 
     gh = nx.union(g, h, rename=('g', 'h'))
-    assert set(gh.nodes()) == set(['h0', 'h1', 'g0', 'g1'])
+    assert set(gh.nodes()) == {'h0', 'h1', 'g0', 'g1'}
     for n in gh:
         graph, node = n
         assert gh.nodes[n] == eval(graph).nodes[int(node)]
@@ -35,7 +35,7 @@ def test_intersection():
     H.add_edge(2, 3)
     H.add_edge(3, 4)
     I = nx.intersection(G, H)
-    assert set(I.nodes()) == set([1, 2, 3, 4])
+    assert set(I.nodes()) == {1, 2, 3, 4}
     assert sorted(I.edges()) == [(2, 3)]
 
 
@@ -85,13 +85,13 @@ def test_difference():
     H.add_edge(2, 3)
     H.add_edge(3, 4)
     D = nx.difference(G, H)
-    assert set(D.nodes()) == set([1, 2, 3, 4])
+    assert set(D.nodes()) == {1, 2, 3, 4}
     assert sorted(D.edges()) == [(1, 2)]
     D = nx.difference(H, G)
-    assert set(D.nodes()) == set([1, 2, 3, 4])
+    assert set(D.nodes()) == {1, 2, 3, 4}
     assert sorted(D.edges()) == [(3, 4)]
     D = nx.symmetric_difference(G, H)
-    assert set(D.nodes()) == set([1, 2, 3, 4])
+    assert set(D.nodes()) == {1, 2, 3, 4}
     assert sorted(D.edges()) == [(1, 2), (3, 4)]
 
 
@@ -104,14 +104,14 @@ def test_difference2():
     H.add_edge(1, 2)
     G.add_edge(2, 3)
     D = nx.difference(G, H)
-    assert set(D.nodes()) == set([1, 2, 3, 4])
+    assert set(D.nodes()) == {1, 2, 3, 4}
     assert sorted(D.edges()) == [(2, 3)]
     D = nx.difference(H, G)
-    assert set(D.nodes()) == set([1, 2, 3, 4])
+    assert set(D.nodes()) == {1, 2, 3, 4}
     assert sorted(D.edges()) == []
     H.add_edge(3, 4)
     D = nx.difference(H, G)
-    assert set(D.nodes()) == set([1, 2, 3, 4])
+    assert set(D.nodes()) == {1, 2, 3, 4}
     assert sorted(D.edges()) == [(3, 4)]
 
 
@@ -291,7 +291,7 @@ def test_full_join_graph():
 
     # Rename
     U = nx.full_join(G, H, rename=('g', 'h'))
-    assert set(U) == set(['g0', 'g1', 'g2', 'h3', 'h4'])
+    assert set(U) == {'g0', 'g1', 'g2', 'h3', 'h4'}
     assert len(U) == len(G) + len(H)
     assert (len(U.edges()) ==
             len(G.edges()) + len(H.edges()) + len(G) * len(H))
@@ -304,7 +304,7 @@ def test_full_join_graph():
     H.add_edge("d", "e")
 
     U = nx.full_join(G, H, rename=('g', 'h'))
-    assert set(U) == set(['ga', 'gb', 'gc', 'hd', 'he'])
+    assert set(U) == {'ga', 'gb', 'gc', 'hd', 'he'}
     assert len(U) == len(G) + len(H)
     assert (len(U.edges()) ==
             len(G.edges()) + len(H.edges()) + len(G) * len(H))
@@ -324,7 +324,7 @@ def test_full_join_graph():
 
     # DiGraphs Rename
     U = nx.full_join(G, H, rename=('g', 'h'))
-    assert set(U) == set(['g0', 'g1', 'g2', 'h3', 'h4'])
+    assert set(U) == {'g0', 'g1', 'g2', 'h3', 'h4'}
     assert len(U) == len(G) + len(H)
     assert (len(U.edges()) ==
             len(G.edges()) + len(H.edges()) + len(G) * len(H) * 2)
@@ -346,7 +346,7 @@ def test_full_join_multigraph():
 
     # MultiGraphs rename
     U = nx.full_join(G, H, rename=('g', 'h'))
-    assert set(U) == set(['g0', 'g1', 'g2', 'h3', 'h4'])
+    assert set(U) == {'g0', 'g1', 'g2', 'h3', 'h4'}
     assert len(U) == len(G) + len(H)
     assert (len(U.edges()) ==
             len(G.edges()) + len(H.edges()) + len(G) * len(H))
@@ -366,7 +366,7 @@ def test_full_join_multigraph():
 
     # MultiDiGraphs rename
     U = nx.full_join(G, H, rename=('g', 'h'))
-    assert set(U) == set(['g0', 'g1', 'g2', 'h3', 'h4'])
+    assert set(U) == {'g0', 'g1', 'g2', 'h3', 'h4'}
     assert len(U) == len(G) + len(H)
     assert (len(U.edges()) ==
             len(G.edges()) + len(H.edges()) + len(G) * len(H) * 2)

--- a/networkx/algorithms/planar_drawing.py
+++ b/networkx/algorithms/planar_drawing.py
@@ -89,7 +89,7 @@ def combinatorial_embedding_to_pos(embedding, fully_triangulate=False):
         delta_x[wp1] += 1
         delta_x[wq] += 1
 
-        delta_x_wp_wq = sum((delta_x[x] for x in contour_neighbors[1:]))
+        delta_x_wp_wq = sum(delta_x[x] for x in contour_neighbors[1:])
 
         # Adjust offsets
         delta_x[vk] = (-y_coordinate[wp] + delta_x_wp_wq + y_coordinate[wq])//2

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -858,8 +858,7 @@ class PlanarEmbedding(nx.DiGraph):
             try:
                 sorted_nbrs = set(self.neighbors_cw_order(v))
             except KeyError:
-                msg = "Bad embedding. " \
-                      "Missing orientation for a neighbor of {}".format(v)
+                msg = f"Bad embedding. Missing orientation for a neighbor of {v}"
                 raise nx.NetworkXException(msg)
 
             unsorted_nbrs = set(self[v])

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -138,7 +138,7 @@ def get_counterexample_recursive(G):
     return subgraph
 
 
-class Interval(object):
+class Interval:
     """Represents a set of return edges.
 
     All return edges in an interval induce a same constraint on the contained
@@ -164,7 +164,7 @@ class Interval(object):
                 planarity_state.lowpt[self.high] > planarity_state.lowpt[b])
 
 
-class ConflictPair(object):
+class ConflictPair:
     """Represents a different constraint between two intervals.
 
     The edges in the left interval must have a different orientation than
@@ -198,7 +198,7 @@ def top_of_stack(l):
     return l[-1]
 
 
-class LRPlanarity(object):
+class LRPlanarity:
     """A class to maintain the state during planarity check."""
     __slots__ = [
         'G', 'roots', 'height', 'lowpt', 'lowpt2', 'nesting_depth',

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -60,8 +60,8 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
 
     """
     if source not in G or target not in G:
-        msg = 'Either source {} or target {} is not in G'
-        raise nx.NodeNotFound(msg.format(source, target))
+        msg = f"Either source {source} or target {target} is not in G"
+        raise nx.NodeNotFound(msg)
 
     if heuristic is None:
         # The default heuristic is h=0 - same as Dijkstra's algorithm
@@ -159,8 +159,8 @@ def astar_path_length(G, source, target, heuristic=None, weight='weight'):
 
     """
     if source not in G or target not in G:
-        msg = 'Either source {} or target {} is not in G'
-        raise nx.NodeNotFound(msg.format(source, target))
+        msg = f"Either source {source} or target {target} is not in G"
+        raise nx.NodeNotFound(msg)
 
     path = astar_path(G, source, target, heuristic, weight)
     return sum(G[u][v].get(weight, 1) for u, v in zip(path[:-1], path[1:]))

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -126,7 +126,7 @@ def astar_path(G, source, target, heuristic=None, weight='weight'):
             enqueued[neighbor] = ncost, h
             push(queue, (ncost + h, next(c), neighbor, ncost, curnode))
 
-    raise nx.NetworkXNoPath("Node %s not reachable from %s" % (target, source))
+    raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
 
 
 def astar_path_length(G, source, target, heuristic=None, weight='weight'):

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -118,7 +118,7 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
     """
     if method not in ('dijkstra', 'bellman-ford'):
         # so we don't need to check in each branch later
-        raise ValueError('method not supported: {}'.format(method))
+        raise ValueError(f'method not supported: {method}')
     method = 'unweighted' if weight is None else method
     if source is None:
         if target is None:
@@ -260,7 +260,7 @@ def shortest_path_length(G,
     """
     if method not in ('dijkstra', 'bellman-ford'):
         # so we don't need to check in each branch later
-        raise ValueError('method not supported: {}'.format(method))
+        raise ValueError(f'method not supported: {method}')
     method = 'unweighted' if weight is None else method
     if source is None:
         if target is None:
@@ -376,7 +376,7 @@ def average_shortest_path_length(G, weight=None, method=None):
     if method is None:
         method = 'unweighted' if weight is None else 'dijkstra'
     if method not in supported_methods:
-        raise ValueError('method not supported: {}'.format(method))
+        raise ValueError(f'method not supported: {method}')
 
     n = len(G)
     # For the special case of the null graph, raise an exception, since
@@ -482,7 +482,7 @@ def all_shortest_paths(G, source, target, weight=None, method='dijkstra'):
         pred, dist = nx.bellman_ford_predecessor_and_distance(G, source,
                                                               weight=weight)
     else:
-        raise ValueError('method not supported: {}'.format(method))
+        raise ValueError(f'method not supported: {method}')
 
     if target not in pred:
         raise nx.NetworkXNoPath('Target {} cannot be reached'

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -485,8 +485,8 @@ def all_shortest_paths(G, source, target, weight=None, method='dijkstra'):
         raise ValueError(f'method not supported: {method}')
 
     if target not in pred:
-        raise nx.NetworkXNoPath('Target {} cannot be reached'
-                                'from Source {}'.format(target, source))
+        raise nx.NetworkXNoPath(f'Target {target} cannot be reached'
+                                f'from Source {source}')
 
     stack = [[target, 0]]
     top = 0

--- a/networkx/algorithms/shortest_paths/tests/test_dense_numpy.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense_numpy.py
@@ -6,7 +6,7 @@ npt = pytest.importorskip('numpy.testing')
 import networkx as nx
 
 
-class TestFloydNumpy(object):
+class TestFloydNumpy:
 
     def test_cycle_numpy(self):
         dist = nx.floyd_warshall_numpy(nx.cycle_graph(7))

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -264,7 +264,7 @@ class TestGenericPath:
             list(nx.all_shortest_paths(G, 0, 1, weight='weight', method='SPAM'))
 
 
-class TestAverageShortestPathLength(object):
+class TestAverageShortestPathLength:
 
     def test_cycle_graph(self):
         ans = nx.average_shortest_path_length(nx.cycle_graph(7))
@@ -344,7 +344,7 @@ class TestAverageShortestPathLength(object):
             nx.average_shortest_path_length(G, weight='weight', method='SPAM')
 
 
-class TestAverageShortestPathLengthNumpy(object):
+class TestAverageShortestPathLengthNumpy:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import networkx as nx
@@ -22,7 +21,7 @@ def validate_length_path(G, s, t, soln_len, length, path):
     validate_path(G, s, t, length, path)
 
 
-class WeightedTestBase(object):
+class WeightedTestBase:
     """Base class for test classes that test functions for computing
     shortest paths in weighted graphs.
 
@@ -283,7 +282,7 @@ class TestWeightedPath(WeightedTestBase):
         assert out[0][1][3] == [0, 6, 5, 4, 3]
 
 
-class TestDijkstraPathLength(object):
+class TestDijkstraPathLength:
     """Unit tests for the :func:`networkx.dijkstra_path_length`
     function.
 
@@ -313,7 +312,7 @@ class TestDijkstraPathLength(object):
         assert length == 1 / 10
 
 
-class TestMultiSourceDijkstra(object):
+class TestMultiSourceDijkstra:
     """Unit tests for the multi-source dialect of Dijkstra's shortest
     path algorithms.
 

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -287,7 +287,7 @@ def _bidirectional_pred_succ(G, source, target):
                     if w in pred:  # found path
                         return pred, succ, w
 
-    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+    raise nx.NetworkXNoPath(f"No path between {source} and {target}.")
 
 
 def single_source_shortest_path(G, source, cutoff=None):

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -50,7 +50,7 @@ def single_source_shortest_path_length(G, source, cutoff=None):
     shortest_path_length
     """
     if source not in G:
-        raise nx.NodeNotFound('Source {} is not in G'.format(source))
+        raise nx.NodeNotFound(f'Source {source} is not in G')
     if cutoff is None:
         cutoff = float('inf')
     nextlevel = {source: 1}
@@ -76,7 +76,7 @@ def _single_shortest_path_length(adj, firstlevel, cutoff):
     n = len(adj)
     while nextlevel and cutoff >= level:
         thislevel = nextlevel  # advance to next level
-        nextlevel = set([])  # and start a new set (fringe)
+        nextlevel = set()  # and start a new set (fringe)
         found = []
         for v in thislevel:
             if v not in seen:
@@ -128,7 +128,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     single_source_shortest_path_length, shortest_path_length
     """
     if target not in G:
-        raise nx.NodeNotFound('Target {} is not in G'.format(target))
+        raise nx.NodeNotFound(f'Target {target} is not in G')
 
     if cutoff is None:
         cutoff = float('inf')
@@ -328,7 +328,7 @@ def single_source_shortest_path(G, source, cutoff=None):
     shortest_path
     """
     if source not in G:
-        raise nx.NodeNotFound("Source {} not in G".format(source))
+        raise nx.NodeNotFound(f"Source {source} not in G")
 
     def join(p1, p2):
         return p1 + p2
@@ -409,7 +409,7 @@ def single_target_shortest_path(G, target, cutoff=None):
     shortest_path, single_source_shortest_path
     """
     if target not in G:
-        raise nx.NodeNotFound("Target {} not in G".format(target))
+        raise nx.NodeNotFound(f"Target {target} not in G")
 
     def join(p1, p2):
         return p2 + p1
@@ -489,7 +489,7 @@ def predecessor(G, source, target=None, cutoff=None, return_seen=None):
 
     """
     if source not in G:
-        raise nx.NodeNotFound("Source {} not in G".format(source))
+        raise nx.NodeNotFound(f"Source {source} not in G")
 
     level = 0                  # the current level
     nextlevel = [source]       # list of nodes to check at next level

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -38,7 +38,7 @@ def single_source_shortest_path_length(G, source, cutoff=None):
     >>> length[4]
     4
     >>> for node in length:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -116,7 +116,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     >>> length[0]
     4
     >>> for node in range(5):
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 4
     1: 3
     2: 2
@@ -164,7 +164,7 @@ def all_pairs_shortest_path_length(G, cutoff=None):
     >>> G = nx.path_graph(5)
     >>> length = dict(nx.all_pairs_shortest_path_length(G))
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('1 - {}: {}'.format(node, length[1][node]))
+    ...     print(f"1 - {node}: {length[1][node]}")
     1 - 0: 1
     1 - 1: 0
     1 - 2: 1
@@ -215,8 +215,8 @@ def bidirectional_shortest_path(G, source, target):
     """
 
     if source not in G or target not in G:
-        msg = 'Either source {} or target {} is not in G'
-        raise nx.NodeNotFound(msg.format(source, target))
+        msg = f"Either source {source} or target {target} is not in G"
+        raise nx.NodeNotFound(msg)
 
     # call helper to do the real work
     results = _bidirectional_pred_succ(G, source, target)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -343,7 +343,7 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
     >>> length[4]
     4
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -427,7 +427,7 @@ def single_source_dijkstra(G, source, target=None, cutoff=None,
     >>> print(length[4])
     4
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -584,7 +584,7 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
     >>> G = nx.path_graph(5)
     >>> length = nx.multi_source_dijkstra_path_length(G, {0, 4})
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -671,7 +671,7 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     >>> G = nx.path_graph(5)
     >>> length, path = nx.multi_source_dijkstra(G, {0, 4})
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -959,7 +959,7 @@ def all_pairs_dijkstra(G, cutoff=None, weight='weight'):
     >>> print(len_path[3][0][1])
     2
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('3 - {}: {}'.format(node, len_path[3][0][node]))
+    ...     print(f"3 - {node}: {len_path[3][0][node]}")
     3 - 0: 3
     3 - 1: 2
     3 - 2: 1
@@ -1021,7 +1021,7 @@ def all_pairs_dijkstra_path_length(G, cutoff=None, weight='weight'):
     >>> G = nx.path_graph(5)
     >>> length = dict(nx.all_pairs_dijkstra_path_length(G))
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('1 - {}: {}'.format(node, length[1][node]))
+    ...     print(f"1 - {node}: {length[1][node]}")
     1 - 0: 1
     1 - 1: 0
     1 - 2: 1
@@ -1497,7 +1497,7 @@ def single_source_bellman_ford_path_length(G, source, weight='weight'):
     >>> length[4]
     4
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -1555,7 +1555,7 @@ def single_source_bellman_ford(G, source, target=None, weight='weight'):
     >>> print(length[4])
     4
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('{}: {}'.format(node, length[node]))
+    ...     print(f"{node}: {length[node]}")
     0: 0
     1: 1
     2: 2
@@ -1617,7 +1617,7 @@ def all_pairs_bellman_ford_path_length(G, weight='weight'):
     >>> G = nx.path_graph(5)
     >>> length = dict(nx.all_pairs_bellman_ford_path_length(G))
     >>> for node in [0, 1, 2, 3, 4]:
-    ...     print('1 - {}: {}'.format(node, length[1][node]))
+    ...     print(f"1 - {node}: {length[1][node]}")
     1 - 0: 1
     1 - 1: 0
     1 - 2: 1
@@ -1992,8 +1992,8 @@ def bidirectional_dijkstra(G, source, target, weight='weight'):
     shortest_path_length
     """
     if source not in G or target not in G:
-        msg = 'Either source {} or target {} is not in G'
-        raise nx.NodeNotFound(msg.format(source, target))
+        msg = f"Either source {source} or target {target} is not in G"
+        raise nx.NodeNotFound(msg)
 
     if source == target:
         return (0, [source])

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -730,7 +730,7 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     try:
         return (dist[target], paths[target])
     except KeyError:
-        raise nx.NetworkXNoPath("No path to {}.".format(target))
+        raise nx.NetworkXNoPath(f"No path to {target}.")
 
 
 def _dijkstra(G, source, weight, pred=None, paths=None, cutoff=None,
@@ -809,7 +809,7 @@ def _dijkstra_multisource(G, sources, weight, pred=None, paths=None,
     fringe = []
     for source in sources:
         if source not in G:
-            raise nx.NodeNotFound("Source {} not in G".format(source))
+            raise nx.NodeNotFound(f"Source {source} not in G")
         seen[source] = 0
         push(fringe, (0, next(c), source))
     while fringe:
@@ -1256,7 +1256,7 @@ def _bellman_ford(G, source, weight, pred=None, paths=None, dist=None,
     """
     for s in source:
         if s not in G:
-            raise nx.NodeNotFound("Source {} not in G".format(s))
+            raise nx.NodeNotFound(f"Source {s} not in G")
 
     if pred is None:
         pred = {v: [] for v in source}
@@ -1801,7 +1801,7 @@ def goldberg_radzik(G, source, weight='weight'):
             # nonpositive reduced costs into to_scan in (reverse) topological
             # order.
             stack = [(u, iter(G_succ[u].items()))]
-            in_stack = set([u])
+            in_stack = {u}
             neg_count[u] = 0
             while stack:
                 u, it = stack[-1]
@@ -1851,7 +1851,7 @@ def goldberg_radzik(G, source, weight='weight'):
 
     # Set of nodes relabled in the last round of scan operations. Denoted by B
     # in Goldberg and Radzik's paper.
-    relabeled = set([source])
+    relabeled = {source}
 
     while relabeled:
         to_scan = topo_sort(relabeled)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -229,8 +229,7 @@ def dijkstra_path_length(G, source, target, weight='weight'):
     try:
         return length[target]
     except KeyError:
-        raise nx.NetworkXNoPath(
-            "Node %s not reachable from %s" % (target, source))
+        raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
 
 
 def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
@@ -1183,7 +1182,7 @@ def bellman_ford_predecessor_and_distance(G, source, target=None,
     In NetworkX v2.2 this changed to the source node having predecessor `[]`
     """
     if source not in G:
-        raise nx.NodeNotFound("Node %s is not found in the graph" % source)
+        raise nx.NodeNotFound(f"Node {source} is not found in the graph")
     weight = _weight_function(G, weight)
     if any(weight(u, v, d) < 0 for u, v, d in nx.selfloop_edges(G, data=True)):
         raise nx.NetworkXUnbounded("Negative cost cycle detected.")
@@ -1418,8 +1417,7 @@ def bellman_ford_path_length(G, source, target, weight='weight'):
     try:
         return length[target]
     except KeyError:
-        raise nx.NetworkXNoPath(
-            "node %s not reachable from %s" % (target, source))
+        raise nx.NetworkXNoPath(f"node {target} not reachable from {source}")
 
 
 def single_source_bellman_ford_path(G, source, weight='weight'):
@@ -1594,7 +1592,7 @@ def single_source_bellman_ford(G, source, target=None, weight='weight'):
     try:
         return (dist[target], paths[target])
     except KeyError:
-        msg = "Node %s not reachable from %s" % (target, source)
+        msg = f"Node {target} not reachable from {source}"
         raise nx.NetworkXNoPath(msg)
 
 
@@ -1758,7 +1756,7 @@ def goldberg_radzik(G, source, weight='weight'):
 
     """
     if source not in G:
-        raise nx.NodeNotFound("Node %s is not found in the graph" % source)
+        raise nx.NodeNotFound(f"Node {source} is not found in the graph")
     weight = _weight_function(G, weight)
     if any(weight(u, v, d) < 0 for u, v, d in nx.selfloop_edges(G, data=True)):
         raise nx.NetworkXUnbounded("Negative cost cycle detected.")
@@ -2069,7 +2067,7 @@ def bidirectional_dijkstra(G, source, target, weight='weight'):
                         revpath = paths[1][w][:]
                         revpath.reverse()
                         finalpath = paths[0][w] + revpath[1:]
-    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+    raise nx.NetworkXNoPath(f"No path between {source} and {target}.")
 
 
 def johnson(G, weight='weight'):

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1047,7 +1047,7 @@ def optimize_edit_paths(
         [ins_costs[i] if i == j else inf for i in range(n) for j in range(n)]
     ).reshape(n, n)
     Cv = make_CostMatrix(C, m, n)
-    # debug_print('Cv: {} x {}'.format(m, n))
+    # debug_print(f"Cv: {m} x {n}")
     # debug_print(Cv.C)
 
     pending_g = list(G1.edges)
@@ -1095,7 +1095,7 @@ def optimize_edit_paths(
         [ins_costs[i] if i == j else inf for i in range(n) for j in range(n)]
     ).reshape(n, n)
     Ce = make_CostMatrix(C, m, n)
-    # debug_print('Ce: {} x {}'.format(m, n))
+    # debug_print(f'Ce: {m} x {n}')
     # debug_print(Ce.C)
     # debug_print()
 

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -420,7 +420,7 @@ def shortest_simple_paths(G, source, target, weight=None):
             break
 
 
-class PathBuffer(object):
+class PathBuffer:
 
     def __init__(self):
         self.paths = set()

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -218,14 +218,14 @@ def all_simple_paths(G, source, target, cutoff=None):
 
     """
     if source not in G:
-        raise nx.NodeNotFound('source node %s not in graph' % source)
+        raise nx.NodeNotFound(f"source node {source} not in graph")
     if target in G:
         targets = {target}
     else:
         try:
             targets = set(target)
         except TypeError:
-            raise nx.NodeNotFound('target node %s not in graph' % target)
+            raise nx.NodeNotFound(f"target node {target} not in graph")
     if source in targets:
         return []
     if cutoff is None:
@@ -371,10 +371,10 @@ def shortest_simple_paths(G, source, target, weight=None):
 
     """
     if source not in G:
-        raise nx.NodeNotFound('source node %s not in graph' % source)
+        raise nx.NodeNotFound(f"source node {source} not in graph")
 
     if target not in G:
-        raise nx.NodeNotFound('target node %s not in graph' % target)
+        raise nx.NodeNotFound(f"target node {target} not in graph")
 
     if weight is None:
         length_func = len
@@ -515,7 +515,7 @@ def _bidirectional_pred_succ(G, source, target, ignore_nodes=None, ignore_edges=
     """
     # does BFS from both source and target and meets in the middle
     if ignore_nodes and (source in ignore_nodes or target in ignore_nodes):
-        raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+        raise nx.NetworkXNoPath(f"No path between {source} and {target}.")
     if target == source:
         return ({target: None}, {source: None}, source)
 
@@ -603,7 +603,7 @@ def _bidirectional_pred_succ(G, source, target, ignore_nodes=None, ignore_edges=
                         # found path
                         return pred, succ, w
 
-    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+    raise nx.NetworkXNoPath(f"No path between {source} and {target}.")
 
 
 def _bidirectional_dijkstra(G, source, target, weight='weight',
@@ -675,7 +675,7 @@ def _bidirectional_dijkstra(G, source, target, weight='weight',
     shortest_path_length
     """
     if ignore_nodes and (source in ignore_nodes or target in ignore_nodes):
-        raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+        raise nx.NetworkXNoPath(f"No path between {source} and {target}.")
     if source == target:
         return (0, [source])
 
@@ -800,4 +800,4 @@ def _bidirectional_dijkstra(G, source, target, weight='weight',
                         revpath = paths[1][w][:]
                         revpath.reverse()
                         finalpath = paths[0][w] + revpath[1:]
-    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+    raise nx.NetworkXNoPath(f"No path between {source} and {target}.")

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -86,8 +86,8 @@ def double_edge_swap(G, nswap=1, max_tries=100, seed=None):
             G.remove_edge(x, y)
             swapcount += 1
         if n >= max_tries:
-            e = ('Maximum number of swap attempts (%s) exceeded ' % n +
-                 'before desired swaps achieved (%s).' % nswap)
+            e = (f'Maximum number of swap attempts ({n}) exceeded '
+                 f'before desired swaps achieved ({nswap}).')
             raise nx.NetworkXAlgorithmError(e)
         n += 1
     return G

--- a/networkx/algorithms/tests/test_boundary.py
+++ b/networkx/algorithms/tests/test_boundary.py
@@ -7,7 +7,7 @@ from networkx.testing import almost_equal, assert_edges_equal
 from networkx import convert_node_labels_to_integers as cnlti
 
 
-class TestNodeBoundary(object):
+class TestNodeBoundary:
     """Unit tests for the :func:`~networkx.node_boundary` function."""
 
     def test_null_graph(self):
@@ -84,7 +84,7 @@ class TestNodeBoundary(object):
         assert boundary == expected
 
 
-class TestEdgeBoundary(object):
+class TestEdgeBoundary:
     """Unit tests for the :func:`~networkx.edge_boundary` function."""
 
     def test_null_graph(self):

--- a/networkx/algorithms/tests/test_chordal.py
+++ b/networkx/algorithms/tests/test_chordal.py
@@ -36,17 +36,17 @@ class TestMCS:
     def test_induced_nodes(self):
         G = nx.generators.classic.path_graph(10)
         Induced_nodes = nx.find_induced_nodes(G, 1, 9, 2)
-        assert Induced_nodes == set([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        assert Induced_nodes == {1, 2, 3, 4, 5, 6, 7, 8, 9}
         pytest.raises(nx.NetworkXTreewidthBoundExceeded,
                       nx.find_induced_nodes, G, 1, 9, 1)
         Induced_nodes = nx.find_induced_nodes(self.chordal_G, 1, 6)
-        assert Induced_nodes == set([1, 2, 4, 6])
+        assert Induced_nodes == {1, 2, 4, 6}
         pytest.raises(nx.NetworkXError,
                       nx.find_induced_nodes, self.non_chordal_G, 1, 5)
 
     def test_chordal_find_cliques(self):
-        cliques = set([frozenset([9]), frozenset([7, 8]), frozenset([1, 2, 3]),
-                       frozenset([2, 3, 4]), frozenset([3, 4, 5, 6])])
+        cliques = {frozenset([9]), frozenset([7, 8]), frozenset([1, 2, 3]),
+                       frozenset([2, 3, 4]), frozenset([3, 4, 5, 6])}
         assert nx.chordal_graph_cliques(self.chordal_G) == cliques
 
     def test_chordal_find_cliques_path(self):
@@ -57,8 +57,8 @@ class TestMCS:
                     or frozenset([v, u]) in cliqueset)
 
     def test_chordal_find_cliquesCC(self):
-        cliques = set([frozenset([1, 2, 3]), frozenset([2, 3, 4]),
-                       frozenset([3, 4, 5, 6])])
+        cliques = {frozenset([1, 2, 3]), frozenset([2, 3, 4]),
+                       frozenset([3, 4, 5, 6])}
         cgc = nx.chordal_graph_cliques
         assert cgc(self.connected_chordal_G) == cliques
 

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -10,7 +10,7 @@ class TestCliques:
         self.G = cnlti(nx.generators.havel_hakimi_graph(z), first_label=1)
         self.cl = list(nx.find_cliques(self.G))
         H = nx.complete_graph(6)
-        H = nx.relabel_nodes(H, dict([(i, i + 1) for i in range(6)]))
+        H = nx.relabel_nodes(H, {i: i + 1 for i in range(6)})
         H.remove_edges_from([(2, 6), (2, 5), (2, 4), (1, 3), (5, 3)])
         self.H = H
 

--- a/networkx/algorithms/tests/test_cuts.py
+++ b/networkx/algorithms/tests/test_cuts.py
@@ -4,7 +4,7 @@
 import networkx as nx
 
 
-class TestCutSize(object):
+class TestCutSize:
     """Unit tests for the :func:`~networkx.cut_size` function."""
 
     def test_symmetric(self):
@@ -45,7 +45,7 @@ class TestCutSize(object):
         assert nx.cut_size(G, {'a'}, {'b'}) == 2
 
 
-class TestVolume(object):
+class TestVolume:
     """Unit tests for the :func:`~networkx.volume` function."""
 
     def test_graph(self):
@@ -67,7 +67,7 @@ class TestVolume(object):
         assert nx.volume(G, {0, 1}) == 4
 
 
-class TestNormalizedCutSize(object):
+class TestNormalizedCutSize:
     """Unit tests for the :func:`~networkx.normalized_cut_size`
     function.
 
@@ -92,7 +92,7 @@ class TestNormalizedCutSize(object):
         assert expected == size
 
 
-class TestConductance(object):
+class TestConductance:
     """Unit tests for the :func:`~networkx.conductance` function."""
 
     def test_graph(self):
@@ -106,7 +106,7 @@ class TestConductance(object):
         assert expected == conductance
 
 
-class TestEdgeExpansion(object):
+class TestEdgeExpansion:
     """Unit tests for the :func:`~networkx.edge_expansion` function."""
 
     def test_graph(self):
@@ -118,7 +118,7 @@ class TestEdgeExpansion(object):
         assert expected == expansion
 
 
-class TestNodeExpansion(object):
+class TestNodeExpansion:
     """Unit tests for the :func:`~networkx.node_expansion` function.
 
     """
@@ -133,7 +133,7 @@ class TestNodeExpansion(object):
         assert expected == expansion
 
 
-class TestBoundaryExpansion(object):
+class TestBoundaryExpansion:
     """Unit tests for the :func:`~networkx.boundary_expansion` function.
 
     """
@@ -148,7 +148,7 @@ class TestBoundaryExpansion(object):
         assert expected == expansion
 
 
-class TestMixingExpansion(object):
+class TestMixingExpansion:
     """Unit tests for the :func:`~networkx.mixing_expansion` function.
 
     """

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -154,7 +154,7 @@ class TestCycles:
 #    networkx/algorithms/traversal/tests/test_edgedfs.py
 
 
-class TestFindCycle(object):
+class TestFindCycle:
     @classmethod
     def setup_class(cls):
         cls.nodes = [0, 1, 2, 3]
@@ -292,7 +292,7 @@ def assert_basis_equal(a, b):
     assert sorted(a) == sorted(b)
 
 
-class TestMinimumCycles(object):
+class TestMinimumCycles:
     @classmethod
     def setup_class(cls):
         T = nx.Graph()

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -8,7 +8,7 @@ from networkx.utils import consume
 from networkx.utils import pairwise
 
 
-class TestDagLongestPath(object):
+class TestDagLongestPath:
     """Unit tests computing the longest path in a directed acyclic graph."""
 
     def test_empty(self):
@@ -56,7 +56,7 @@ class TestDagLongestPath(object):
         nx.dag_longest_path(G)
 
 
-class TestDagLongestPathLength(object):
+class TestDagLongestPathLength:
     """Unit tests for computing the length of a longest path in a
     directed acyclic graph.
 
@@ -255,8 +255,8 @@ class TestDAG:
         ancestors = nx.algorithms.dag.ancestors
         G.add_edges_from([
             (1, 2), (1, 3), (4, 2), (4, 3), (4, 5), (2, 6), (5, 6)])
-        assert ancestors(G, 6) == set([1, 2, 4, 5])
-        assert ancestors(G, 3) == set([1, 4])
+        assert ancestors(G, 6) == {1, 2, 4, 5}
+        assert ancestors(G, 3) == {1, 4}
         assert ancestors(G, 1) == set()
         pytest.raises(nx.NetworkXError, ancestors, G, 8)
 
@@ -265,8 +265,8 @@ class TestDAG:
         descendants = nx.algorithms.dag.descendants
         G.add_edges_from([
             (1, 2), (1, 3), (4, 2), (4, 3), (4, 5), (2, 6), (5, 6)])
-        assert descendants(G, 1) == set([2, 3, 6])
-        assert descendants(G, 4) == set([2, 3, 5, 6])
+        assert descendants(G, 1) == {2, 3, 6}
+        assert descendants(G, 4) == {2, 3, 5, 6}
         assert descendants(G, 3) == set()
         pytest.raises(nx.NetworkXError, descendants, G, 8)
 
@@ -413,7 +413,7 @@ class TestDAG:
                 self.priority = 1
 
             def __repr__(self):
-                return 'Node({})'.format(self.label)
+                return f'Node({self.label})'
 
         def sorting_key(node):
             return node.priority
@@ -497,7 +497,7 @@ def test_is_aperiodic_disconnected2():
     assert not nx.is_aperiodic(G)
 
 
-class TestDagToBranching(object):
+class TestDagToBranching:
     """Unit tests for the :func:`networkx.dag_to_branching` function."""
 
     def test_single_root(self):

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -50,10 +50,10 @@ class TestDistance:
         assert nx.radius(self.G) == 4
 
     def test_periphery(self):
-        assert set(nx.periphery(self.G)) == set([1, 4, 13, 16])
+        assert set(nx.periphery(self.G)) == {1, 4, 13, 16}
 
     def test_center(self):
-        assert set(nx.center(self.G)) == set([6, 7, 10, 11])
+        assert set(nx.center(self.G)) == {6, 7, 10, 11}
 
     def test_bound_diameter(self):
         assert nx.diameter(self.G, usebounds=True) == 6
@@ -62,11 +62,11 @@ class TestDistance:
         assert nx.radius(self.G, usebounds=True) == 4
 
     def test_bound_periphery(self):
-        result = set([1, 4, 13, 16])
+        result = {1, 4, 13, 16}
         assert set(nx.periphery(self.G, usebounds=True)) == result
 
     def test_bound_center(self):
-        result = set([6, 7, 10, 11])
+        result = {6, 7, 10, 11}
         assert set(nx.center(self.G, usebounds=True)) == result
 
     def test_radius_exception(self):
@@ -187,7 +187,7 @@ class TestResistanceDistance:
             nx.resistance_distance(self.G, 1, 9)
 
 
-class TestBarycenter(object):
+class TestBarycenter:
     """Test :func:`networkx.algorithms.distance_measures.barycenter`."""
     def barycenter_as_subgraph(self, g, **kwargs):
         """Return the subgraph induced on the barycenter of g"""

--- a/networkx/algorithms/tests/test_distance_regular.py
+++ b/networkx/algorithms/tests/test_distance_regular.py
@@ -1,9 +1,8 @@
-
 import networkx as nx
 from networkx import is_strongly_regular
 
 
-class TestDistanceRegular(object):
+class TestDistanceRegular:
 
     def test_is_distance_regular(self):
         assert nx.is_distance_regular(nx.icosahedral_graph())
@@ -43,7 +42,7 @@ class TestDistanceRegular(object):
         assert c == [1, 2, 5]
 
 
-class TestStronglyRegular(object):
+class TestStronglyRegular:
     """Unit tests for the :func:`~networkx.is_strongly_regular`
     function.
 

--- a/networkx/algorithms/tests/test_dominance.py
+++ b/networkx/algorithms/tests/test_dominance.py
@@ -2,7 +2,7 @@ import networkx as nx
 import pytest
 
 
-class TestImmediateDominators(object):
+class TestImmediateDominators:
 
     def test_exceptions(self):
         G = nx.Graph()
@@ -85,7 +85,7 @@ class TestImmediateDominators(object):
                     {0: 1, 1: 7, 2: 7, 3: 4, 4: 5, 5: 7, 6: 4, 7: 7})
 
 
-class TestDominanceFrontiers(object):
+class TestDominanceFrontiers:
 
     def test_exceptions(self):
         G = nx.Graph()
@@ -131,8 +131,8 @@ class TestDominanceFrontiers(object):
         G = nx.DiGraph(edges)
         assert ({u: df
                  for u, df in nx.dominance_frontiers(G, 5).items()} ==
-                {1: set([2]), 2: set([1]), 3: set([2]),
-                 4: set([1]), 5: set()})
+                {1: {2}, 2: {1}, 3: {2},
+                 4: {1}, 5: set()})
 
     def test_irreducible2(self):
         # Graph taken from Figure 4 of
@@ -143,20 +143,20 @@ class TestDominanceFrontiers(object):
                  (6, 4), (6, 5)]
         G = nx.DiGraph(edges)
         assert (nx.dominance_frontiers(G, 6) ==
-                {1: set([2]), 2: set([1, 3]), 3: set([2]), 4: set([2, 3]), 5: set([1]), 6: set([])})
+                {1: {2}, 2: {1, 3}, 3: {2}, 4: {2, 3}, 5: {1}, 6: set()})
 
     def test_domrel_png(self):
         # Graph taken from https://commons.wikipedia.org/wiki/File:Domrel.png
         edges = [(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)]
         G = nx.DiGraph(edges)
         assert (nx.dominance_frontiers(G, 1) ==
-                {1: set([]), 2: set([2]), 3: set([5]), 4: set([5]),
-                 5: set([2]), 6: set()})
+                {1: set(), 2: {2}, 3: {5}, 4: {5},
+                 5: {2}, 6: set()})
         # Test postdominance.
         with nx.utils.reversed(G):
             assert (nx.dominance_frontiers(G, 6) ==
-                    {1: set(), 2: set([2]), 3: set([2]), 4: set([2]),
-                     5: set([2]), 6: set()})
+                    {1: set(), 2: {2}, 3: {2}, 4: {2},
+                     5: {2}, 6: set()})
 
     def test_boost_example(self):
         # Graph taken from Figure 1 of
@@ -165,13 +165,13 @@ class TestDominanceFrontiers(object):
                  (5, 7), (6, 4)]
         G = nx.DiGraph(edges)
         assert (nx.dominance_frontiers(G, 0) ==
-                {0: set(), 1: set(), 2: set([7]), 3: set([7]),
-                 4: set([4, 7]), 5: set([7]), 6: set([4]), 7: set()})
+                {0: set(), 1: set(), 2: {7}, 3: {7},
+                 4: {4, 7}, 5: {7}, 6: {4}, 7: set()})
         # Test postdominance.
         with nx.utils.reversed(G):
             assert (nx.dominance_frontiers(G, 7) ==
-                    {0: set(), 1: set(), 2: set([1]), 3: set([1]),
-                     4: set([1, 4]), 5: set([1]), 6: set([4]), 7: set()})
+                    {0: set(), 1: set(), 2: {1}, 3: {1},
+                     4: {1, 4}, 5: {1}, 6: {4}, 7: set()})
 
     def test_discard_issue(self):
         # https://github.com/networkx/networkx/issues/2071
@@ -191,10 +191,10 @@ class TestDominanceFrontiers(object):
         ]
         )
         df = nx.dominance_frontiers(g, 'b0')
-        assert df == {'b4': set(), 'b5': set(['b3']), 'b6': set(['b7']),
-                      'b7': set(['b3']),
-                      'b0': set(), 'b1': set(['b1']), 'b2': set(['b3']),
-                      'b3': set(['b1']), 'b8': set(['b7'])}
+        assert df == {'b4': set(), 'b5': {'b3'}, 'b6': {'b7'},
+                      'b7': {'b3'},
+                      'b0': set(), 'b1': {'b1'}, 'b2': {'b3'},
+                      'b3': {'b1'}, 'b8': {'b7'}}
 
     def test_loop(self):
         g = nx.DiGraph()
@@ -249,12 +249,12 @@ class TestDominanceFrontiers(object):
         g.add_edges_from(edges)
         df = nx.dominance_frontiers(g, 'entry')
         answer = {'entry': set(),
-                  '1': set(['exit']),
-                  '2': set(['exit', '2']),
-                  '3': set(['exit', '3', '2']),
-                  '4': set(['exit', '4', '3', '2']),
-                  '5': set(['exit', '3', '2']),
-                  '6': set(['exit', '2']),
+                  '1': {'exit'},
+                  '2': {'exit', '2'},
+                  '3': {'exit', '3', '2'},
+                  '4': {'exit', '4', '3', '2'},
+                  '5': {'exit', '3', '2'},
+                  '6': {'exit', '2'},
                   'exit': set()}
         for n in df:
             assert set(df[n]) == set(answer[n])

--- a/networkx/algorithms/tests/test_dominating.py
+++ b/networkx/algorithms/tests/test_dominating.py
@@ -28,11 +28,11 @@ def test_raise_dominating_set():
 
 def test_is_dominating_set():
     G = nx.path_graph(4)
-    d = set([1, 3])
+    d = {1, 3}
     assert nx.is_dominating_set(G, d)
-    d = set([0, 2])
+    d = {0, 2}
     assert nx.is_dominating_set(G, d)
-    d = set([1])
+    d = {1}
     assert not nx.is_dominating_set(G, d)
 
 
@@ -41,6 +41,6 @@ def test_wikipedia_is_dominating_set():
     """
     G = nx.cycle_graph(4)
     G.add_edges_from([(0, 4), (1, 4), (2, 5)])
-    assert nx.is_dominating_set(G, set([4, 3, 5]))
-    assert nx.is_dominating_set(G, set([0, 2]))
-    assert nx.is_dominating_set(G, set([1, 2]))
+    assert nx.is_dominating_set(G, {4, 3, 5})
+    assert nx.is_dominating_set(G, {0, 2})
+    assert nx.is_dominating_set(G, {1, 2})

--- a/networkx/algorithms/tests/test_graphical.py
+++ b/networkx/algorithms/tests/test_graphical.py
@@ -37,7 +37,7 @@ def test_negative_input():
     assert not nx.is_graphical([-1], 'eg')
 
 
-class TestAtlas(object):
+class TestAtlas:
     @classmethod
     def setup_class(cls):
         global atlas

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -8,8 +8,8 @@ import networkx as nx
 
 def _test_func(G, ebunch, expected, predict_func, **kwargs):
     result = predict_func(G, ebunch, **kwargs)
-    exp_dict = dict((tuple(sorted([u, v])), score) for u, v, score in expected)
-    res_dict = dict((tuple(sorted([u, v])), score) for u, v, score in result)
+    exp_dict = {tuple(sorted([u, v])): score for u, v, score in expected}
+    res_dict = {tuple(sorted([u, v])): score for u, v, score in result}
 
     assert len(exp_dict) == len(res_dict)
     for p in exp_dict:

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -14,15 +14,15 @@ def get_pair(dictionary, n1, n2):
         return dictionary[n2, n1]
 
 
-class TestTreeLCA(object):
+class TestTreeLCA:
     @classmethod
     def setup_class(cls):
         cls.DG = nx.DiGraph()
         edges = [(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)]
         cls.DG.add_edges_from(edges)
         cls.ans = dict(tree_all_pairs_lca(cls.DG, 0))
-        gold = dict([((n, n), n) for n in cls.DG])
-        gold.update(dict(((0, i), 0) for i in range(1, 7)))
+        gold = {(n, n): n for n in cls.DG}
+        gold.update({(0, i): 0 for i in range(1, 7)})
         gold.update({(1, 2): 0,
                      (1, 3): 1,
                      (1, 4): 1,
@@ -81,8 +81,8 @@ class TestTreeLCA(object):
     def test_tree_all_pairs_lowest_common_ancestor6(self):
         """Works on subtrees."""
         ans = dict(tree_all_pairs_lca(self.DG, 1))
-        gold = dict((pair, lca) for (pair, lca) in self.gold.items()
-                    if all(n in (1, 3, 4) for n in pair))
+        gold = {pair: lca for (pair, lca) in self.gold.items()
+                    if all(n in (1, 3, 4) for n in pair)}
         self.assert_has_same_pairs(gold, ans)
 
     def test_tree_all_pairs_lowest_common_ancestor7(self):

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -6,7 +6,7 @@ from networkx.algorithms.matching import matching_dict_to_set
 from networkx.testing import assert_edges_equal
 
 
-class TestMaxWeightMatching(object):
+class TestMaxWeightMatching:
     """Unit tests for the
     :func:`~networkx.algorithms.matching.max_weight_matching` function.
 
@@ -220,7 +220,7 @@ class TestMaxWeightMatching(object):
                                                  6: 7, 7: 6, 8: 10, 9: 4, 10: 8}))
 
 
-class TestIsMatching(object):
+class TestIsMatching:
     """Unit tests for the
     :func:`~networkx.algorithms.matching.is_matching` function.
 
@@ -254,7 +254,7 @@ class TestIsMatching(object):
         assert not nx.is_matching(G, {(0, 1), (1, 2), (2, 3)})
 
 
-class TestIsMaximalMatching(object):
+class TestIsMaximalMatching:
     """Unit tests for the
     :func:`~networkx.algorithms.matching.is_maximal_matching` function.
 
@@ -277,7 +277,7 @@ class TestIsMaximalMatching(object):
         assert not nx.is_maximal_matching(G, {(0, 1)})
 
 
-class TestIsPerfectMatching(object):
+class TestIsPerfectMatching:
     """Unit tests for the
     :func:`~networkx.algorithms.matching.is_perfect_matching` function.
 
@@ -311,7 +311,7 @@ class TestIsPerfectMatching(object):
         assert not nx.is_perfect_matching(G, {(1, 4), (0, 3)})
 
 
-class TestMaximalMatching(object):
+class TestMaximalMatching:
     """Unit tests for the
     :func:`~networkx.algorithms.matching.maximal_matching`.
 

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -6,7 +6,7 @@ from networkx.testing.utils import assert_edges_equal, assert_nodes_equal
 from networkx.utils import arbitrary_element
 
 
-class TestQuotient(object):
+class TestQuotient:
     """Unit tests for computing quotient graphs."""
 
     def test_quotient_graph_complete_multipartite(self):
@@ -216,7 +216,7 @@ class TestQuotient(object):
         assert_edges_equal(H.edges(), [(0, 1)])
 
 
-class TestContraction(object):
+class TestContraction:
     """Unit tests for node and edge contraction functions."""
 
     def test_undirected_node_contraction(self):

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -8,7 +8,7 @@ import networkx as nx
 import random
 
 
-class TestMaximalIndependantSet(object):
+class TestMaximalIndependantSet:
     def setup(self):
         self.florentine = nx.Graph()
         self.florentine.add_edge('Acciaiuoli', 'Medici')

--- a/networkx/algorithms/tests/test_planar_drawing.py
+++ b/networkx/algorithms/tests/test_planar_drawing.py
@@ -174,7 +174,7 @@ def check_edge_intersections(G, pos):
     # No edge intersection found
 
 
-class Vector(object):
+class Vector:
     """Compare vectors by their angle without loss of precision
 
     All vectors in direction [0, 1] are the smallest.

--- a/networkx/algorithms/tests/test_planar_drawing.py
+++ b/networkx/algorithms/tests/test_planar_drawing.py
@@ -160,8 +160,7 @@ def check_edge_intersections(G, pos):
                     # Check if intersection lies between the points
                     if (point_in_between(pos[a], pos[b], (px, py)) and
                             point_in_between(pos[c], pos[d], (px, py))):
-                        msg = "There is an intersection at {},{}".format(px,
-                                                                         py)
+                        msg = f"There is an intersection at {px},{py}"
                         raise nx.NetworkXException(msg)
 
                 #  Check overlap

--- a/networkx/algorithms/tests/test_reciprocity.py
+++ b/networkx/algorithms/tests/test_reciprocity.py
@@ -2,7 +2,7 @@ import pytest
 import networkx as nx
 
 
-class TestReciprocity(object):
+class TestReciprocity:
 
     # test overall reicprocity by passing whole graph
     def test_reciprocity_digraph(self):

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -174,8 +174,8 @@ class TestSimilarity:
                           ([(0, 1), (1, 2), (2, 0)], [((0, 1), (1, 2)), ((1, 2), (0, 2)), (None, (0, 1))]),
                           ([(0, 2), (1, 0), (2, 1)], [((0, 1), (0, 2)), ((1, 2), (0, 1)), (None, (1, 2))]),
                           ([(0, 2), (1, 1), (2, 0)], [((0, 1), (1, 2)), ((1, 2), (0, 1)), (None, (0, 2))])]
-        assert (set(canonical(*p) for p in paths) ==
-                set(canonical(*p) for p in expected_paths))
+        assert ({canonical(*p) for p in paths} ==
+                {canonical(*p) for p in expected_paths})
 
     def test_optimize_graph_edit_distance(self):
         G1 = circular_ladder_graph(2)

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -9,7 +9,7 @@ from networkx.algorithms.simple_paths import _bidirectional_shortest_path
 from networkx.utils import arbitrary_element
 
 
-class TestIsSimplePath(object):
+class TestIsSimplePath:
     """Unit tests for the
     :func:`networkx.algorithms.simple_paths.is_simple_path` function.
 
@@ -81,55 +81,55 @@ class TestIsSimplePath(object):
 def test_all_simple_paths():
     G = nx.path_graph(4)
     paths = nx.all_simple_paths(G, 0, 3)
-    assert set(tuple(p) for p in paths) == {(0, 1, 2, 3)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2, 3)}
 
 
 def test_all_simple_paths_with_two_targets_emits_two_paths():
     G = nx.path_graph(4)
     G.add_edge(2, 4)
     paths = nx.all_simple_paths(G, 0, [3, 4])
-    assert set(tuple(p) for p in paths) == {(0, 1, 2, 3), (0, 1, 2, 4)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2, 3), (0, 1, 2, 4)}
 
 
 def test_digraph_all_simple_paths_with_two_targets_emits_two_paths():
     G = nx.path_graph(4, create_using=nx.DiGraph())
     G.add_edge(2, 4)
     paths = nx.all_simple_paths(G, 0, [3, 4])
-    assert set(tuple(p) for p in paths) == {(0, 1, 2, 3), (0, 1, 2, 4)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2, 3), (0, 1, 2, 4)}
 
 
 def test_all_simple_paths_with_two_targets_cutoff():
     G = nx.path_graph(4)
     G.add_edge(2, 4)
     paths = nx.all_simple_paths(G, 0, [3, 4], cutoff=3)
-    assert set(tuple(p) for p in paths) == {(0, 1, 2, 3), (0, 1, 2, 4)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2, 3), (0, 1, 2, 4)}
 
 
 def test_digraph_all_simple_paths_with_two_targets_cutoff():
     G = nx.path_graph(4, create_using=nx.DiGraph())
     G.add_edge(2, 4)
     paths = nx.all_simple_paths(G, 0, [3, 4], cutoff=3)
-    assert set(tuple(p) for p in paths) == {(0, 1, 2, 3), (0, 1, 2, 4)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2, 3), (0, 1, 2, 4)}
 
 
 def test_all_simple_paths_with_two_targets_in_line_emits_two_paths():
     G = nx.path_graph(4)
     paths = nx.all_simple_paths(G, 0, [2, 3])
-    assert set(tuple(p) for p in paths) == {(0, 1, 2), (0, 1, 2, 3)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2), (0, 1, 2, 3)}
 
 
 def test_all_simple_paths_ignores_cycle():
     G = nx.cycle_graph(3, create_using=nx.DiGraph())
     G.add_edge(1, 3)
     paths = nx.all_simple_paths(G, 0, 3)
-    assert set(tuple(p) for p in paths) == {(0, 1, 3)}
+    assert {tuple(p) for p in paths} == {(0, 1, 3)}
 
 
 def test_all_simple_paths_with_two_targets_inside_cycle_emits_two_paths():
     G = nx.cycle_graph(3, create_using=nx.DiGraph())
     G.add_edge(1, 3)
     paths = nx.all_simple_paths(G, 0, [2, 3])
-    assert set(tuple(p) for p in paths) == {(0, 1, 2), (0, 1, 3)}
+    assert {tuple(p) for p in paths} == {(0, 1, 2), (0, 1, 3)}
 
 
 def test_all_simple_paths_source_target():
@@ -141,9 +141,9 @@ def test_all_simple_paths_source_target():
 def test_all_simple_paths_cutoff():
     G = nx.complete_graph(4)
     paths = nx.all_simple_paths(G, 0, 1, cutoff=1)
-    assert set(tuple(p) for p in paths) == {(0, 1)}
+    assert {tuple(p) for p in paths} == {(0, 1)}
     paths = nx.all_simple_paths(G, 0, 1, cutoff=2)
-    assert set(tuple(p) for p in paths) == {(0, 1), (0, 2, 1), (0, 3, 1)}
+    assert {tuple(p) for p in paths} == {(0, 1), (0, 2, 1), (0, 3, 1)}
 
 
 def test_all_simple_paths_on_non_trivial_graph():
@@ -151,14 +151,14 @@ def test_all_simple_paths_on_non_trivial_graph():
     G = nx.path_graph(5, create_using=nx.DiGraph())
     G.add_edges_from([(0, 5), (1, 5), (1, 3), (5, 4), (4, 2), (4, 3)])
     paths = nx.all_simple_paths(G, 1, [2, 3])
-    assert set(tuple(p) for p in paths) == {
+    assert {tuple(p) for p in paths} == {
         (1, 2), (1, 3, 4, 2), (1, 5, 4, 2), (1, 3), (1, 2, 3), (1, 5, 4, 3),
         (1, 5, 4, 2, 3)}
     paths = nx.all_simple_paths(G, 1, [2, 3], cutoff=3)
-    assert set(tuple(p) for p in paths) == {
+    assert {tuple(p) for p in paths} == {
         (1, 2), (1, 3, 4, 2), (1, 5, 4, 2), (1, 3), (1, 2, 3), (1, 5, 4, 3)}
     paths = nx.all_simple_paths(G, 1, [2, 3], cutoff=2)
-    assert set(tuple(p) for p in paths) == {(1, 2), (1, 3), (1, 2, 3)}
+    assert {tuple(p) for p in paths} == {(1, 2), (1, 3), (1, 2, 3)}
 
 
 def test_all_simple_paths_multigraph():
@@ -168,14 +168,14 @@ def test_all_simple_paths_multigraph():
     nx.add_path(G, [3, 1, 10, 2])
     paths = list(nx.all_simple_paths(G, 1, 2))
     assert len(paths) == 3
-    assert set(tuple(p) for p in paths) == {(1, 2), (1, 2), (1, 10, 2)}
+    assert {tuple(p) for p in paths} == {(1, 2), (1, 2), (1, 10, 2)}
 
 
 def test_all_simple_paths_multigraph_with_cutoff():
     G = nx.MultiGraph([(1, 2), (1, 2), (1, 10), (10, 2)])
     paths = list(nx.all_simple_paths(G, 1, 2, cutoff=1))
     assert len(paths) == 2
-    assert set(tuple(p) for p in paths) == {(1, 2), (1, 2)}
+    assert {tuple(p) for p in paths} == {(1, 2), (1, 2)}
 
 
 def test_all_simple_paths_directed():
@@ -183,7 +183,7 @@ def test_all_simple_paths_directed():
     nx.add_path(G, [1, 2, 3])
     nx.add_path(G, [3, 2, 1])
     paths = nx.all_simple_paths(G, 1, 3)
-    assert set(tuple(p) for p in paths) == {(1, 2, 3)}
+    assert {tuple(p) for p in paths} == {(1, 2, 3)}
 
 
 def test_all_simple_paths_empty():
@@ -200,7 +200,7 @@ def test_all_simple_paths_corner_cases():
 
 def hamiltonian_path(G, source):
     source = arbitrary_element(G)
-    neighbors = set(G[source]) - set([source])
+    neighbors = set(G[source]) - {source}
     n = len(G)
     for target in neighbors:
         for path in nx.all_simple_paths(G, source, target):

--- a/networkx/algorithms/tests/test_structuralholes.py
+++ b/networkx/algorithms/tests/test_structuralholes.py
@@ -4,7 +4,7 @@ import networkx as nx
 from networkx.testing import almost_equal
 
 
-class TestStructuralHoles(object):
+class TestStructuralHoles:
     """Unit tests for computing measures of structural holes.
 
     The expected values for these functions were originally computed using the

--- a/networkx/algorithms/tests/test_tournament.py
+++ b/networkx/algorithms/tests/test_tournament.py
@@ -10,7 +10,7 @@ from networkx.algorithms.tournament import random_tournament
 from networkx.algorithms.tournament import hamiltonian_path
 
 
-class TestIsTournament(object):
+class TestIsTournament:
     """Unit tests for the :func:`networkx.tournament.is_tournament`
     function.
 
@@ -48,7 +48,7 @@ class TestIsTournament(object):
         assert not is_tournament(G)
 
 
-class TestRandomTournament(object):
+class TestRandomTournament:
     """Unit tests for the :func:`networkx.tournament.random_tournament`
     function.
 
@@ -64,7 +64,7 @@ class TestRandomTournament(object):
             assert is_tournament(G)
 
 
-class TestHamiltonianPath(object):
+class TestHamiltonianPath:
     """Unit tests for the :func:`networkx.tournament.hamiltonian_path`
     function.
 
@@ -91,7 +91,7 @@ class TestHamiltonianPath(object):
         assert path[0] in G[path[-1]]
 
 
-class TestReachability(object):
+class TestReachability:
     """Unit tests for the :func:`networkx.tournament.is_reachable`
     function.
 
@@ -114,7 +114,7 @@ class TestReachability(object):
         assert not is_reachable(G, 1, 0)
 
 
-class TestStronglyConnected(object):
+class TestStronglyConnected:
     """Unit tests for the
     :func:`networkx.tournament.is_strongly_connected` function.
 

--- a/networkx/algorithms/tests/test_vitality.py
+++ b/networkx/algorithms/tests/test_vitality.py
@@ -1,8 +1,7 @@
-
 import networkx as nx
 
 
-class TestClosenessVitality(object):
+class TestClosenessVitality:
 
     def test_unweighted(self):
         G = nx.cycle_graph(3)

--- a/networkx/algorithms/tests/test_voronoi.py
+++ b/networkx/algorithms/tests/test_voronoi.py
@@ -2,7 +2,7 @@ import networkx as nx
 from networkx.utils import pairwise
 
 
-class TestVoronoiCells(object):
+class TestVoronoiCells:
     """Unit tests for the Voronoi cells function."""
 
     def test_isolates(self):

--- a/networkx/algorithms/tests/test_wiener.py
+++ b/networkx/algorithms/tests/test_wiener.py
@@ -8,7 +8,7 @@ from networkx import path_graph
 from networkx import wiener_index
 
 
-class TestWienerIndex(object):
+class TestWienerIndex:
     """Unit tests for computing the Wiener index of a graph."""
 
     def test_disconnected_graph(self):

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -504,7 +504,7 @@ def degree_correlation(creation_sequence):
     if denom == 0:
         if numer == 0:
             return 1
-        raise ValueError("Zero Denominator but Numerator is %s" % numer)
+        raise ValueError(f"Zero Denominator but Numerator is {numer}")
     return numer / float(denom)
 
 
@@ -539,9 +539,9 @@ def shortest_path(creation_sequence, u, v):
 
     verts = [s[0] for s in cs]
     if v not in verts:
-        raise ValueError("Vertex %s not in graph from creation_sequence" % v)
+        raise ValueError(f"Vertex {v} not in graph from creation_sequence")
     if u not in verts:
-        raise ValueError("Vertex %s not in graph from creation_sequence" % u)
+        raise ValueError(f"Vertex {u} not in graph from creation_sequence")
     # Done checking
     if u == v:
         return [u]

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -337,7 +337,7 @@ def descendants_at_distance(G, source, distance):
         The descendants of `source` in `G` at the given `distance` from `source`
     """
     if not G.has_node(source):
-        raise nx.NetworkXError("The node %s is not in the graph." % source)
+        raise nx.NetworkXError(f"The node {source} is not in the graph.")
     current_distance = 0
     queue = {source}
     visited = {source}

--- a/networkx/algorithms/traversal/tests/test_edgebfs.py
+++ b/networkx/algorithms/traversal/tests/test_edgebfs.py
@@ -8,7 +8,7 @@ FORWARD = nx.algorithms.edgedfs.FORWARD
 REVERSE = nx.algorithms.edgedfs.REVERSE
 
 
-class TestEdgeBFS(object):
+class TestEdgeBFS:
     @classmethod
     def setup_class(cls):
         cls.nodes = [0, 1, 2, 3]

--- a/networkx/algorithms/traversal/tests/test_edgedfs.py
+++ b/networkx/algorithms/traversal/tests/test_edgedfs.py
@@ -18,7 +18,7 @@ REVERSE = nx.algorithms.edgedfs.REVERSE
 # this can fail, see TestEdgeDFS.test_multigraph.
 
 
-class TestEdgeDFS(object):
+class TestEdgeDFS:
     @classmethod
     def setup_class(cls):
         cls.nodes = [0, 1, 2, 3]

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -44,7 +44,7 @@ __all__ = [
     'Edmonds'
 ]
 
-KINDS = set(['max', 'min'])
+KINDS = {'max', 'min'}
 
 STYLES = {
     'branching': 'branching',
@@ -175,14 +175,14 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
     """
 
     def __init__(self, incoming_graph_data=None, **attr):
-        cls = super(MultiDiGraph_EdgeKey, self)
+        cls = super()
         cls.__init__(incoming_graph_data=incoming_graph_data, **attr)
 
         self._cls = cls
         self.edge_index = {}
 
     def remove_node(self, n):
-        keys = set([])
+        keys = set()
         for keydict in self.pred[n].values():
             keys.update(keydict)
         for keydict in self.succ[n].values():
@@ -206,7 +206,7 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
         if key in self.edge_index:
             uu, vv, _ = self.edge_index[key]
             if (u != uu) or (v != vv):
-                raise Exception("Key {0!r} is already in use.".format(key))
+                raise Exception(f"Key {key!r} is already in use.")
 
         self._cls.add_edge(u, v, key, **attr)
         self.edge_index[key] = (u, v, self.succ[u][v][key])
@@ -219,7 +219,7 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
         try:
             u, v, _ = self.edge_index[key]
         except KeyError:
-            raise KeyError('Invalid edge key {0!r}'.format(key))
+            raise KeyError(f'Invalid edge key {key!r}')
         else:
             del self.edge_index[key]
             self._cls.remove_edge(u, v, key)
@@ -251,7 +251,7 @@ def get_path(G, u, v):
     return nodes, edges
 
 
-class Edmonds(object):
+class Edmonds:
     """
     Edmonds algorithm for finding optimal branchings and spanning arborescences.
 
@@ -374,7 +374,7 @@ class Edmonds(object):
         # This enormous while loop could use some refactoring...
 
         G, B = self.G, self.B
-        D = set([])
+        D = set()
         nodes = iter(list(G.nodes()))
         attr = self._attr
         G_pred = G.pred
@@ -548,7 +548,7 @@ class Edmonds(object):
             """
             if u not in G:
                 # print(G.nodes(), u)
-                raise Exception('{0!r} not in G'.format(u))
+                raise Exception(f'{u!r} not in G')
             for v in G.pred[u]:
                 for edgekey in G.pred[u][v]:
                     if edgekey in edgekeys:

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -423,12 +423,12 @@ class Edmonds:
                     continue
 
             # Put v into bucket D^i.
-            # print("Adding node {0}".format(v))
+            # print(f"Adding node {v}")
             D.add(v)
             B.add_node(v)
 
             edge, weight = desired_edge(v)
-            # print("Max edge is {0!r}".format(edge))
+            # print(f"Max edge is {edge!r}")
             if edge is None:
                 # If there is no edge, continue with a new node at (I1).
                 continue
@@ -456,7 +456,7 @@ class Edmonds:
                 else:
                     acceptable = True
 
-                # print("Edge is acceptable: {0}".format(acceptable))
+                # print(f"Edge is acceptable: {acceptable}")
                 if acceptable:
                     dd = {attr: weight}
                     B.add_edge(u, v, edge[2], **dd)
@@ -606,7 +606,7 @@ class Edmonds:
                         break
                 else:
                     raise Exception("Couldn't find edge incoming to merged node.")
-                # print("not a root. removing {0}".format(edgekey))
+                # print(f"not a root. removing {edgekey}")
 
                 edges.remove(edgekey)
 

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -117,7 +117,7 @@ def to_nested_tuple(T, root, canonical_form=False):
     if not nx.is_tree(T):
         raise nx.NotATree('provided graph is not a tree')
     if root not in T:
-        raise nx.NodeNotFound('Graph {} contains no node {}'.format(T, root))
+        raise nx.NodeNotFound(f'Graph {T} contains no node {root}')
 
     return _make_tuple(T, root, None)
 

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -293,7 +293,7 @@ def prim_mst_edges(G, minimum, weight='weight',
 
 ALGORITHMS = {
     'boruvka': boruvka_mst_edges,
-    u'borůvka': boruvka_mst_edges,
+    'borůvka': boruvka_mst_edges,
     'kruskal': kruskal_mst_edges,
     'prim': prim_mst_edges
 }
@@ -384,7 +384,7 @@ def minimum_spanning_edges(G, algorithm='kruskal', weight='weight',
     try:
         algo = ALGORITHMS[algorithm]
     except KeyError:
-        msg = '{} is not a valid choice for an algorithm.'.format(algorithm)
+        msg = f'{algorithm} is not a valid choice for an algorithm.'
         raise ValueError(msg)
 
     return algo(G, minimum=True, weight=weight, keys=keys, data=data,
@@ -475,7 +475,7 @@ def maximum_spanning_edges(G, algorithm='kruskal', weight='weight',
     try:
         algo = ALGORITHMS[algorithm]
     except KeyError:
-        msg = '{} is not a valid choice for an algorithm.'.format(algorithm)
+        msg = f'{algorithm} is not a valid choice for an algorithm.'
         raise ValueError(msg)
 
     return algo(G, minimum=False, weight=weight, keys=keys, data=data,

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -67,8 +67,8 @@ def boruvka_mst_edges(G, minimum=True, weight='weight',
             if isnan(wt):
                 if ignore_nan:
                     continue
-                msg = "NaN found as an edge weight. Edge %s"
-                raise ValueError(msg % (e,))
+                msg = f"NaN found as an edge weight. Edge {e}"
+                raise ValueError(msg)
             if wt < minwt:
                 minwt = wt
                 boundary = e
@@ -152,8 +152,8 @@ def kruskal_mst_edges(G, minimum, weight='weight',
                 if isnan(wt):
                     if ignore_nan:
                         continue
-                    msg = "NaN found as an edge weight. Edge %s"
-                    raise ValueError(msg % ((u, v, k, d),))
+                    msg = f"NaN found as an edge weight. Edge {(u, v, k, d)}"
+                    raise ValueError(msg)
                 yield wt, u, v, k, d
     else:
         edges = G.edges(data=True)
@@ -165,8 +165,8 @@ def kruskal_mst_edges(G, minimum, weight='weight',
                 if isnan(wt):
                     if ignore_nan:
                         continue
-                    msg = "NaN found as an edge weight. Edge %s"
-                    raise ValueError(msg % ((u, v, d),))
+                    msg = f"NaN found as an edge weight. Edge {(u, v, d)}"
+                    raise ValueError(msg)
                 yield wt, u, v, d
     edges = sorted(filter_nan_edges(), key=itemgetter(0))
     # Multigraphs need to handle edge keys in addition to edge data.
@@ -243,8 +243,8 @@ def prim_mst_edges(G, minimum, weight='weight',
                     if isnan(wt):
                         if ignore_nan:
                             continue
-                        msg = "NaN found as an edge weight. Edge %s"
-                        raise ValueError(msg % ((u, v, k, d),))
+                        msg = f"NaN found as an edge weight. Edge {(u, v, k, d)}"
+                        raise ValueError(msg)
                     push(frontier, (wt, next(c), u, v, k, d))
         else:
             for v, d in G.adj[u].items():
@@ -252,8 +252,8 @@ def prim_mst_edges(G, minimum, weight='weight',
                 if isnan(wt):
                     if ignore_nan:
                         continue
-                    msg = "NaN found as an edge weight. Edge %s"
-                    raise ValueError(msg % ((u, v, d),))
+                    msg = f"NaN found as an edge weight. Edge {(u, v, d)}"
+                    raise ValueError(msg)
                 push(frontier, (wt, next(c), u, v, d))
         while frontier:
             if is_multigraph:
@@ -384,7 +384,7 @@ def minimum_spanning_edges(G, algorithm='kruskal', weight='weight',
     try:
         algo = ALGORITHMS[algorithm]
     except KeyError:
-        msg = f'{algorithm} is not a valid choice for an algorithm.'
+        msg = f"{algorithm} is not a valid choice for an algorithm."
         raise ValueError(msg)
 
     return algo(G, minimum=True, weight=weight, keys=keys, data=data,
@@ -475,7 +475,7 @@ def maximum_spanning_edges(G, algorithm='kruskal', weight='weight',
     try:
         algo = ALGORITHMS[algorithm]
     except KeyError:
-        msg = f'{algorithm} is not a valid choice for an algorithm.'
+        msg = f"{algorithm} is not a valid choice for an algorithm."
         raise ValueError(msg)
 
     return algo(G, minimum=False, weight=weight, keys=keys, data=data,

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -294,12 +294,12 @@ def test_mst():
     G = G.to_directed()
     x = branchings.minimum_spanning_arborescence(G)
 
-    edges = [(set([0, 1]), 7), (set([0, 3]), 5), (set([3, 5]), 6),
-             (set([1, 4]), 7), (set([4, 2]), 5), (set([4, 6]), 9)]
+    edges = [({0, 1}, 7), ({0, 3}, 5), ({3, 5}, 6),
+             ({1, 4}, 7), ({4, 2}, 5), ({4, 6}, 9)]
 
     assert x.number_of_edges() == len(edges)
     for u, v, d in x.edges(data=True):
-        assert (set([u, v]), d['weight']) in edges
+        assert ({u, v}, d['weight']) in edges
 
 
 def test_mixed_nodetypes():

--- a/networkx/algorithms/tree/tests/test_coding.py
+++ b/networkx/algorithms/tree/tests/test_coding.py
@@ -7,7 +7,7 @@ from networkx.testing import assert_nodes_equal
 from networkx.testing import assert_edges_equal
 
 
-class TestPruferSequence(object):
+class TestPruferSequence:
     """Unit tests for the Prüfer sequence encoding and decoding
     functions.
 
@@ -72,7 +72,7 @@ class TestPruferSequence(object):
             assert list(seq) == seq2
 
 
-class TestNestedTuple(object):
+class TestNestedTuple:
     """Unit tests for the nested tuple encoding and decoding functions.
 
     """

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -11,7 +11,7 @@ def test_unknown_algorithm():
         nx.minimum_spanning_tree(nx.Graph(), algorithm='random')
 
 
-class MinimumSpanningTreeTestBase(object):
+class MinimumSpanningTreeTestBase:
     """Base class for test classes for minimum spanning tree algorithms.
 
     This class contains some common tests that will be inherited by
@@ -180,7 +180,7 @@ class TestBoruvka(MinimumSpanningTreeTestBase):
         Borůvka's algorithm.
 
         """
-        edges = nx.minimum_spanning_edges(self.G, algorithm=u'borůvka')
+        edges = nx.minimum_spanning_edges(self.G, algorithm='borůvka')
         # Edges from the spanning edges functions don't come in sorted
         # orientation, so we need to sort each edge individually.
         actual = sorted((min(u, v), max(u, v), d) for u, v, d in edges)

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -7,7 +7,7 @@ from networkx.testing import assert_nodes_equal
 from networkx.testing import assert_edges_equal
 
 
-class TestJoin(object):
+class TestJoin:
     """Unit tests for the :func:`networkx.tree.join` function."""
 
     def test_empty_sequence(self):

--- a/networkx/algorithms/tree/tests/test_recognition.py
+++ b/networkx/algorithms/tree/tests/test_recognition.py
@@ -2,7 +2,7 @@ import pytest
 import networkx as nx
 
 
-class TestTreeRecognition(object):
+class TestTreeRecognition:
 
     graph = nx.Graph
     multigraph = nx.MultiGraph

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -49,7 +49,7 @@ class AtlasView(Mapping):
         return str(self._atlas)  # {nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self._atlas)
+        return f'{self.__class__.__name__}({self._atlas!r})'
 
 
 class AdjacencyView(AtlasView):
@@ -145,7 +145,7 @@ class UnionAtlas(Mapping):
         return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self._succ, self._pred)
+        return f'{self.__class__.__name__}({self._succ!r}, {self._pred!r})'
 
 
 class UnionAdjacency(Mapping):
@@ -196,7 +196,7 @@ class UnionAdjacency(Mapping):
         return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self._succ, self._pred)
+        return f'{self.__class__.__name__}({self._succ!r}, {self._pred!r})'
 
 
 class UnionMultiInner(UnionAtlas):
@@ -267,7 +267,7 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     def __getitem__(self, key):
         if key in self._atlas and self.NODE_OK(key):
             return self._atlas[key]
-        raise KeyError("Key {} not found".format(key))
+        raise KeyError(f"Key {key} not found")
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -284,7 +284,7 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self._atlas,
+        return '{}({!r}, {!r})'.format(self.__class__.__name__, self._atlas,
                                self.NODE_OK)
 
 
@@ -311,7 +311,7 @@ class FilterAdjacency(Mapping):   # edgedict
             def new_node_ok(nbr):
                 return self.NODE_OK(nbr) and self.EDGE_OK(node, nbr)
             return FilterAtlas(self._atlas[node], new_node_ok)
-        raise KeyError("Key {} not found".format(node))
+        raise KeyError(f"Key {node} not found")
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -331,7 +331,7 @@ class FilterAdjacency(Mapping):   # edgedict
         return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '%s(%r, %r, %r)' % (self.__class__.__name__, self._atlas,
+        return '{}({!r}, {!r}, {!r})'.format(self.__class__.__name__, self._atlas,
                                    self.NODE_OK, self.EDGE_OK)
 
 
@@ -359,7 +359,7 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
             def new_node_ok(key):
                 return self.EDGE_OK(nbr, key)
             return FilterAtlas(self._atlas[nbr], new_node_ok)
-        raise KeyError("Key {} not found".format(nbr))
+        raise KeyError(f"Key {nbr} not found")
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -380,7 +380,7 @@ class FilterMultiAdjacency(FilterAdjacency):  # multiedgedict
             def edge_ok(nbr, key):
                 return self.NODE_OK(nbr) and self.EDGE_OK(node, nbr, key)
             return FilterMultiInner(self._atlas[node], self.NODE_OK, edge_ok)
-        raise KeyError("Key {} not found".format(node))
+        raise KeyError(f"Key {node} not found")
 
     def copy(self):
         try:  # check that NODE_OK has attr 'nodes'

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -284,8 +284,7 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '{}({!r}, {!r})'.format(self.__class__.__name__, self._atlas,
-                               self.NODE_OK)
+        return f"{self.__class__.__name__}({self._atlas!r}, {self.NODE_OK!r})"
 
 
 class FilterAdjacency(Mapping):   # edgedict
@@ -331,8 +330,8 @@ class FilterAdjacency(Mapping):   # edgedict
         return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
-        return '{}({!r}, {!r}, {!r})'.format(self.__class__.__name__, self._atlas,
-                                   self.NODE_OK, self.EDGE_OK)
+        name = self.__class__.__name__
+        return f"{name}({self._atlas!r}, {self.NODE_OK!r}, {self.EDGE_OK!r})"
 
 
 class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -519,7 +519,7 @@ class DiGraph(Graph):
             nbrs = self._succ[n]
             del self._node[n]
         except KeyError:  # NetworkXError if n not in self
-            raise NetworkXError("The node %s is not in the digraph." % (n,))
+            raise NetworkXError(f"The node {n} is not in the digraph.")
         for u in nbrs:
             del self._pred[u][n]   # remove all edges n-u in digraph
         del self._succ[n]          # remove node from succ
@@ -676,8 +676,7 @@ class DiGraph(Graph):
                 u, v = e
                 dd = {}
             else:
-                raise NetworkXError(
-                    "Edge tuple %s must be a 2-tuple or 3-tuple." % (e,))
+                raise NetworkXError(f"Edge tuple {e} must be a 2-tuple or 3-tuple.")
             if u not in self._succ:
                 self._succ[u] = self.adjlist_inner_dict_factory()
                 self._pred[u] = self.adjlist_inner_dict_factory()
@@ -723,7 +722,7 @@ class DiGraph(Graph):
             del self._succ[u][v]
             del self._pred[v][u]
         except KeyError:
-            raise NetworkXError("The edge %s-%s not in graph." % (u, v))
+            raise NetworkXError(f"The edge {u}-{v} not in graph.")
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -798,7 +797,7 @@ class DiGraph(Graph):
         try:
             return iter(self._succ[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the digraph." % (n,))
+            raise NetworkXError(f"The node {n} is not in the digraph.")
 
     # digraph definitions
     neighbors = successors
@@ -826,7 +825,7 @@ class DiGraph(Graph):
         try:
             return iter(self._pred[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the digraph." % (n,))
+            raise NetworkXError(f"The node {n} is not in the digraph.")
 
     @property
     def edges(self):

--- a/networkx/classes/filters.py
+++ b/networkx/classes/filters.py
@@ -41,7 +41,7 @@ def hide_multiedges(edges):
 
 
 # write show_nodes as a class to make SubGraph pickleable
-class show_nodes(object):
+class show_nodes:
     def __init__(self, nodes):
         self.nodes = set(nodes)
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -958,7 +958,7 @@ def is_weighted(G, edge=None, weight='weight'):
     if edge is not None:
         data = G.get_edge_data(*edge)
         if data is None:
-            msg = 'Edge {!r} does not exist.'.format(edge)
+            msg = f'Edge {edge!r} does not exist.'
             raise nx.NetworkXError(msg)
         return weight in data
 
@@ -1015,7 +1015,7 @@ def is_negatively_weighted(G, edge=None, weight='weight'):
     if edge is not None:
         data = G.get_edge_data(*edge)
         if data is None:
-            msg = 'Edge {!r} does not exist.'.format(edge)
+            msg = f'Edge {edge!r} does not exist.'
             raise nx.NetworkXError(msg)
         return weight in data and data[weight] < 0
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -536,27 +536,26 @@ def info(G, n=None):
     """
     info = ''  # append this all to a string
     if n is None:
-        info += "Name: %s\n" % G.name
+        info += f"Name: {G.name}\n"
         type_name = [type(G).__name__]
-        info += "Type: %s\n" % ",".join(type_name)
-        info += "Number of nodes: %d\n" % G.number_of_nodes()
-        info += "Number of edges: %d\n" % G.number_of_edges()
+        info += f"Type: {','.join(type_name)}\n"
+        info += f"Number of nodes: {G.number_of_nodes()}\n"
+        info += f"Number of edges: {G.number_of_edges()}\n"
         nnodes = G.number_of_nodes()
         if len(G) > 0:
             if G.is_directed():
                 deg = sum(d for n, d in G.in_degree()) / float(nnodes)
-                info += "Average in degree: %8.4f\n" % deg
+                info += f"Average in degree: {deg:8.4f}\n"
                 deg = sum(d for n, d in G.out_degree()) / float(nnodes)
-                info += "Average out degree: %8.4f" % deg
+                info += f"Average out degree: {deg:8.4f}"
             else:
                 s = sum(dict(G.degree()).values())
-                info += "Average degree: %8.4f" % (float(s) / float(nnodes))
-
+                info += f"Average degree: {(float(s) / float(nnodes)):8.4f}"
     else:
         if n not in G:
-            raise nx.NetworkXError("node %s not in graph" % (n,))
-        info += "Node % s has the following properties:\n" % n
-        info += "Degree: %d\n" % G.degree(n)
+            raise nx.NetworkXError(f"node {n} not in graph")
+        info += f"Node {n} has the following properties:\n"
+        info += f"Degree: {G.degree(n)}\n"
         info += "Neighbors: "
         info += ' '.join(str(nbr) for nbr in G.neighbors(n))
     return info

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -610,7 +610,7 @@ class Graph(object):
             nbrs = list(adj[n])  # list handles self-loops (allows mutation)
             del self._node[n]
         except KeyError:  # NetworkXError if n not in self
-            raise NetworkXError("The node %s is not in the graph." % (n,))
+            raise NetworkXError(f"The node {n} is not in the graph.")
         for u in nbrs:
             del adj[u][n]   # remove all edges n-u in graph
         del adj[n]          # now remove node
@@ -924,8 +924,7 @@ class Graph(object):
                 u, v = e
                 dd = {}  # doesn't need edge_attr_dict_factory
             else:
-                raise NetworkXError(
-                    "Edge tuple %s must be a 2-tuple or 3-tuple." % (e,))
+                raise NetworkXError(f"Edge tuple {e} must be a 2-tuple or 3-tuple.")
             if u not in self._node:
                 self._adj[u] = self.adjlist_inner_dict_factory()
                 self._node[u] = self.node_attr_dict_factory()
@@ -1002,7 +1001,7 @@ class Graph(object):
             if u != v:  # self-loop needs only one entry removed
                 del self._adj[v][u]
         except KeyError:
-            raise NetworkXError("The edge %s-%s is not in the graph" % (u, v))
+            raise NetworkXError(f"The edge {u}-{v} is not in the graph")
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1223,7 +1222,7 @@ class Graph(object):
         try:
             return iter(self._adj[n])
         except KeyError:
-            raise NetworkXError("The node %s is not in the graph." % (n,))
+            raise NetworkXError(f"The node {n} is not in the graph.")
 
     @property
     def edges(self):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1867,8 +1867,8 @@ class Graph:
                         raise NetworkXError(msg)
                     # capture error for unhashable node.
                     elif 'hashable' in message:
-                        msg = "Node {} in sequence nbunch is not a valid node."
-                        raise NetworkXError(msg.format(n))
+                        msg = f"Node {n} in sequence nbunch is not a valid node."
+                        raise NetworkXError(msg)
                     else:
                         raise
             bunch = bunch_iter(nbunch, self._adj)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -16,7 +16,7 @@ from networkx.exception import NetworkXError
 import networkx.convert as convert
 
 
-class Graph(object):
+class Graph:
     """
     Base class for undirected graphs.
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -501,8 +501,8 @@ class MultiDiGraph(MultiGraph, DiGraph):
             try:
                 del d[key]
             except KeyError:
-                msg = "The edge %s-%s with key %s is not in the graph."
-                raise NetworkXError(msg % (u, v, key))
+                msg = f"The edge {u}-{v} with key {key} is not in the graph."
+                raise NetworkXError(msg)
         if len(d) == 0:
             # remove the key entries if last edge
             del self._succ[u][v]

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -493,8 +493,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         try:
             d = self._adj[u][v]
         except KeyError:
-            raise NetworkXError(
-                "The edge %s-%s is not in the graph." % (u, v))
+            raise NetworkXError(f"The edge {u}-{v} is not in the graph.")
         # remove the edge with specified data
         if key is None:
             d.popitem()

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -577,8 +577,7 @@ class MultiGraph(Graph):
         try:
             d = self._adj[u][v]
         except KeyError:
-            raise NetworkXError(
-                "The edge %s-%s is not in the graph." % (u, v))
+            raise NetworkXError(f"The edge {u}-{v} is not in the graph.")
         # remove the edge with specified data
         if key is None:
             d.popitem()

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -513,8 +513,8 @@ class MultiGraph(Graph):
                 dd = {}
                 key = None
             else:
-                msg = "Edge tuple {} must be a 2-tuple, 3-tuple or 4-tuple."
-                raise NetworkXError(msg.format(e))
+                msg = f"Edge tuple {e} must be a 2-tuple, 3-tuple or 4-tuple."
+                raise NetworkXError(msg)
             ddd = {}
             ddd.update(attr)
             try:
@@ -585,8 +585,8 @@ class MultiGraph(Graph):
             try:
                 del d[key]
             except KeyError:
-                msg = "The edge %s-%s with key %s is not in the graph."
-                raise NetworkXError(msg % (u, v, key))
+                msg = f"The edge {u}-{v} with key {key} is not in the graph."
+                raise NetworkXError(msg)
         if len(d) == 0:
             # remove the key entries if last edge
             del self._adj[u][v]

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -189,7 +189,7 @@ class NodeView(Mapping, Set):
         return str(list(self))
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, tuple(self))
+        return '{}({!r})'.format(self.__class__.__name__, tuple(self))
 
 
 class NodeDataView(Set):
@@ -274,15 +274,15 @@ class NodeDataView(Set):
 
     def __repr__(self):
         if self._data is False:
-            return '%s(%r)' % (self.__class__.__name__, tuple(self))
+            return '{}({!r})'.format(self.__class__.__name__, tuple(self))
         if self._data is True:
-            return '%s(%r)' % (self.__class__.__name__, dict(self))
+            return '{}({!r})'.format(self.__class__.__name__, dict(self))
         return '%s(%r, data=%r)' % \
                (self.__class__.__name__, dict(self), self._data)
 
 
 # DegreeViews
-class DiDegreeView(object):
+class DiDegreeView:
     """A View class for degree of nodes in a NetworkX Graph
 
     The functionality is like dict.items() with (node, degree) pairs.
@@ -373,7 +373,7 @@ class DiDegreeView(object):
         return str(list(self))
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, dict(self))
+        return '{}({!r})'.format(self.__class__.__name__, dict(self))
 
 
 class DegreeView(DiDegreeView):
@@ -614,7 +614,7 @@ class OutMultiDegreeView(DiDegreeView):
 
 
 # EdgeDataViews
-class OutEdgeDataView(object):
+class OutEdgeDataView:
     """EdgeDataView for outward edges of DiGraph; See EdgeDataView"""
     __slots__ = ('_viewer', '_nbunch', '_data', '_default',
                  '_adjdict', '_nodes_nbrs', '_report')
@@ -667,7 +667,7 @@ class OutEdgeDataView(object):
         return str(list(self))
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, list(self))
+        return '{}({!r})'.format(self.__class__.__name__, list(self))
 
 
 class EdgeDataView(OutEdgeDataView):

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -189,7 +189,7 @@ class NodeView(Mapping, Set):
         return str(list(self))
 
     def __repr__(self):
-        return '{}({!r})'.format(self.__class__.__name__, tuple(self))
+        return f"{self.__class__.__name__}({tuple(self)})"
 
 
 class NodeDataView(Set):
@@ -273,12 +273,12 @@ class NodeDataView(Set):
         return str(list(self))
 
     def __repr__(self):
+        name = self.__class__.__name__
         if self._data is False:
-            return '{}({!r})'.format(self.__class__.__name__, tuple(self))
+            return f"{name}({tuple(self)})"
         if self._data is True:
-            return '{}({!r})'.format(self.__class__.__name__, dict(self))
-        return '%s(%r, data=%r)' % \
-               (self.__class__.__name__, dict(self), self._data)
+            return f"{name}({dict(self)})"
+        return f"{name}({dict(self)}, data={self._data!r})"
 
 
 # DegreeViews
@@ -373,7 +373,7 @@ class DiDegreeView:
         return str(list(self))
 
     def __repr__(self):
-        return '{}({!r})'.format(self.__class__.__name__, dict(self))
+        return f"{self.__class__.__name__}({dict(self)})"
 
 
 class DegreeView(DiDegreeView):
@@ -667,7 +667,7 @@ class OutEdgeDataView:
         return str(list(self))
 
     def __repr__(self):
-        return '{}({!r})'.format(self.__class__.__name__, list(self))
+        return f"{self.__class__.__name__}({list(self)})"
 
 
 class EdgeDataView(OutEdgeDataView):
@@ -934,7 +934,7 @@ class OutEdgeView(Set, Mapping):
         return str(list(self))
 
     def __repr__(self):
-        return "{0.__class__.__name__}({1!r})".format(self, list(self))
+        return f"{self.__class__.__name__}({list(self)})"
 
 
 class EdgeView(OutEdgeView):
@@ -980,7 +980,7 @@ class EdgeView(OutEdgeView):
     >>> EVdata = G.edges(data='color', default='aqua')
     >>> G.add_edge(2, 3, color='blue')
     >>> assert((2, 3, 'blue') in EVdata)
-    >>> for u, v, c in EVdata: print("({}, {}) has color: {}".format(u, v, c))
+    >>> for u, v, c in EVdata: print(f"({u}, {v}) has color: {c}")
     (0, 1) has color: aqua
     (1, 2) has color: aqua
     (2, 3) has color: blue

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -5,7 +5,7 @@ from networkx import convert_node_labels_to_integers as cnlti
 from networkx.testing import assert_edges_equal, assert_nodes_equal
 
 
-class HistoricalTests(object):
+class HistoricalTests:
 
     @classmethod
     def setup_class(cls):
@@ -234,7 +234,7 @@ class HistoricalTests(object):
         # nbunch can be a list
         assert_edges_equal(list(G.edges(['A', 'B'])), elist)
         # nbunch can be a set
-        assert_edges_equal(G.edges(set(['A', 'B'])), elist)
+        assert_edges_equal(G.edges({'A', 'B'}), elist)
         # nbunch can be a graph
         G1 = self.G()
         G1.add_nodes_from('AB')
@@ -414,7 +414,7 @@ class HistoricalTests(object):
         H = K5.subgraph(1)
         assert nx.is_isomorphic(H, K1)
         # Test G.subgraph(nbunch), where nbunch is a set
-        H = K5.subgraph(set([1]))
+        H = K5.subgraph({1})
         assert nx.is_isomorphic(H, K1)
         # Test G.subgraph(nbunch), where nbunch is an iterator
         H = K5.subgraph(iter(K3))

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -4,7 +4,7 @@ import pickle
 import networkx as nx
 
 
-class TestAtlasView(object):
+class TestAtlasView:
     # node->data
     def setup(self):
         self.d = {0: {'color': 'blue', 'weight': 1.2}, 1: {}, 2: {'color': 1}}
@@ -59,7 +59,7 @@ class TestAtlasView(object):
         assert repr(self.av) == out
 
 
-class TestAdjacencyView(object):
+class TestAdjacencyView:
     # node->nbr->data
     def setup(self):
         dd = {'color': 'blue', 'weight': 1.2}
@@ -140,7 +140,7 @@ class TestMultiAdjacencyView(TestAdjacencyView):
         assert not hasattr(self.adjview, '__setitem__')
 
 
-class TestUnionAtlas(object):
+class TestUnionAtlas:
     # node->data
     def setup(self):
         self.s = {0: {'color': 'blue', 'weight': 1.2}, 1: {}, 2: {'color': 1}}
@@ -192,11 +192,11 @@ class TestUnionAtlas(object):
         assert str(self.av) == out
 
     def test_repr(self):
-        out = "{}({}, {})".format(self.av.__class__.__name__, self.s, self.p)
+        out = f"{self.av.__class__.__name__}({self.s}, {self.p})"
         assert repr(self.av) == out
 
 
-class TestUnionAdjacency(object):
+class TestUnionAdjacency:
     # node->nbr->data
     def setup(self):
         dd = {'color': 'blue', 'weight': 1.2}
@@ -242,7 +242,7 @@ class TestUnionAdjacency(object):
 
     def test_repr(self):
         clsname = self.adjview.__class__.__name__
-        out = "{}({}, {})".format(clsname, self.s, self.p)
+        out = f"{clsname}({self.s}, {self.p})"
         assert repr(self.adjview) == out
 
 
@@ -312,7 +312,7 @@ class TestUnionMultiAdjacency(TestUnionAdjacency):
         assert hasattr(avcopy, '__setitem__')
 
 
-class TestFilteredGraphs(object):
+class TestFilteredGraphs:
     def setup(self):
         self.Graphs = [nx.Graph,
                        nx.DiGraph,

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -122,7 +122,7 @@ class BaseDiGraphTester(BaseGraphTester):
             R.remove_edge(1, 0)
 
     def test_reverse_hashable(self):
-        class Foo(object):
+        class Foo:
             pass
         x = Foo()
         y = Foo()
@@ -251,7 +251,7 @@ class TestEdgeSubgraph(_TestGraphEdgeSubgraph):
         G = nx.DiGraph(nx.path_graph(5))
         # Add some node, edge, and graph attributes.
         for i in range(5):
-            G.nodes[i]['name'] = 'node{}'.format(i)
+            G.nodes[i]['name'] = f'node{i}'
         G.edges[0, 1]['name'] = 'edge01'
         G.edges[3, 4]['name'] = 'edge34'
         G.graph['name'] = 'graph'

--- a/networkx/classes/tests/test_filters.py
+++ b/networkx/classes/tests/test_filters.py
@@ -2,7 +2,7 @@ import pytest
 import networkx as nx
 
 
-class TestFilterFactory(object):
+class TestFilterFactory:
     def test_no_filter(self):
         nf = nx.filters.no_filter
         assert nf()

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -4,7 +4,7 @@ import networkx as nx
 from networkx.testing.utils import assert_edges_equal, assert_nodes_equal
 
 
-class TestFunction(object):
+class TestFunction:
     def setup_method(self):
         self.G = nx.Graph({0: [1, 2, 3], 1: [1, 2, 0], 4: []}, name='Test')
         self.Gdegree = {0: 3, 1: 2, 2: 2, 3: 1, 4: 0}

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -11,7 +11,7 @@ from networkx.testing.utils import (
 import pytest
 
 
-class BaseGraphTester(object):
+class BaseGraphTester:
     """ Tests for data-structure independent graph class features."""
 
     def test_contains(self):
@@ -666,7 +666,7 @@ class TestGraph(BaseAttrGraphTester):
         # update nodes only
         H = self.Graph()
         H.update(nodes=[3, 4])
-        assert H.nodes ^ {3, 4} == set([])
+        assert H.nodes ^ {3, 4} == set()
         assert H.size() == 0
 
         # update edges only
@@ -680,7 +680,7 @@ class TestGraph(BaseAttrGraphTester):
             nx.Graph().update()
 
 
-class TestEdgeSubgraph(object):
+class TestEdgeSubgraph:
     """Unit tests for the :meth:`Graph.edge_subgraph` method."""
 
     def setup_method(self):
@@ -688,7 +688,7 @@ class TestEdgeSubgraph(object):
         G = nx.path_graph(5)
         # Add some node, edge, and graph attributes.
         for i in range(5):
-            G.nodes[i]['name'] = 'node{}'.format(i)
+            G.nodes[i]['name'] = f'node{i}'
         G.edges[0, 1]['name'] = 'edge01'
         G.edges[3, 4]['name'] = 'edge34'
         G.graph['name'] = 'graph'

--- a/networkx/classes/tests/test_graphviews.py
+++ b/networkx/classes/tests/test_graphviews.py
@@ -6,7 +6,7 @@ from networkx.testing import assert_edges_equal, assert_nodes_equal
 # Note: SubGraph views are not tested here. They have their own testing file
 
 
-class TestReverseView(object):
+class TestReverseView:
     def setup(self):
         self.G = nx.path_graph(9, create_using=nx.DiGraph())
         self.rv = nx.reverse_view(self.G)
@@ -53,7 +53,7 @@ class TestReverseView(object):
         assert RMC.my_method() == "me"
 
 
-class TestMultiReverseView(object):
+class TestMultiReverseView:
     def setup(self):
         self.G = nx.path_graph(9, create_using=nx.MultiDiGraph())
         self.G.add_edge(4, 5)
@@ -85,7 +85,7 @@ class TestMultiReverseView(object):
         pytest.raises(nx.NetworkXNotImplemented, nxg.reverse_view, MG)
 
 
-class TestToDirected(object):
+class TestToDirected:
     def setup(self):
         self.G = nx.path_graph(9)
         self.dv = nx.to_directed(self.G)
@@ -123,7 +123,7 @@ class TestToDirected(object):
         assert sorted(self.dv.edges) == expected
 
 
-class TestToUndirected(object):
+class TestToUndirected:
     def setup(self):
         self.DG = nx.path_graph(9, create_using=nx.DiGraph())
         self.uv = nx.to_undirected(self.DG)
@@ -160,7 +160,7 @@ class TestToUndirected(object):
         assert sorted(self.uv.edges) == expected
 
 
-class TestChainsOfViews(object):
+class TestChainsOfViews:
     @classmethod
     def setup_class(cls):
         cls.G = nx.path_graph(9)

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -347,7 +347,7 @@ class TestEdgeSubgraph(_TestMultiGraphEdgeSubgraph):
         nx.add_path(G, reversed(range(5)))
         # Add some node, edge, and graph attributes.
         for i in range(5):
-            G.nodes[i]['name'] = 'node{}'.format(i)
+            G.nodes[i]['name'] = f'node{i}'
         G.adj[0][1][0]['name'] = 'edge010'
         G.adj[0][1][1]['name'] = 'edge011'
         G.adj[3][4][0]['name'] = 'edge340'

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import networkx as nx
@@ -274,7 +273,7 @@ class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
             G.remove_edge(-1, 0)
 
 
-class TestEdgeSubgraph(object):
+class TestEdgeSubgraph:
     """Unit tests for the :meth:`MultiGraph.edge_subgraph` method."""
 
     def setup_method(self):
@@ -284,7 +283,7 @@ class TestEdgeSubgraph(object):
         nx.add_path(G, range(5))
         # Add some node, edge, and graph attributes.
         for i in range(5):
-            G.nodes[i]['name'] = 'node{}'.format(i)
+            G.nodes[i]['name'] = f'node{i}'
         G.adj[0][1][0]['name'] = 'edge010'
         G.adj[0][1][1]['name'] = 'edge011'
         G.adj[3][4][0]['name'] = 'edge340'

--- a/networkx/classes/tests/test_ordered.py
+++ b/networkx/classes/tests/test_ordered.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 
-class TestOrdered(object):
+class TestOrdered:
     # Just test instantiation.
     def test_graph(self):
         G = nx.OrderedGraph()
@@ -16,7 +16,7 @@ class TestOrdered(object):
         G = nx.OrderedMultiDiGraph()
 
 
-class TestOrderedFeatures(object):
+class TestOrderedFeatures:
     @classmethod
     def setup_class(cls):
         cls.G = nx.OrderedDiGraph()

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -5,7 +5,7 @@ from networkx.classes.reportviews import NodeDataView
 
 
 # Nodes
-class TestNodeView(object):
+class TestNodeView:
     @classmethod
     def setup_class(cls):
         cls.G = nx.path_graph(9)
@@ -65,7 +65,7 @@ class TestNodeView(object):
         assert nodes is not nodes(data="weight")
 
 
-class TestNodeDataView(object):
+class TestNodeDataView:
     @classmethod
     def setup_class(cls):
         cls.G = nx.path_graph(9)
@@ -187,7 +187,7 @@ def test_nodedataview_unhashable():
     Gn | Gn
 
 
-class TestNodeViewSetOps(object):
+class TestNodeViewSetOps:
     @classmethod
     def setup_class(cls):
         cls.G = nx.path_graph(9)
@@ -259,7 +259,7 @@ class TestNodeDataViewDefaultSetOps(TestNodeDataViewSetOps):
 
 
 # Edges Data View
-class TestEdgeDataView(object):
+class TestEdgeDataView:
     @classmethod
     def setup_class(cls):
         cls.G = nx.path_graph(9)
@@ -472,7 +472,7 @@ class TestInMultiEdgeDataView(TestOutMultiEdgeDataView):
 
 
 # Edge Views
-class TestEdgeView(object):
+class TestEdgeView:
     @classmethod
     def setup_class(cls):
         cls.G = nx.path_graph(9)
@@ -833,7 +833,7 @@ class TestInMultiEdgeView(TestMultiEdgeView):
 
 
 # Degrees
-class TestDegreeView(object):
+class TestDegreeView:
     GRAPH = nx.Graph
     dview = nx.reportviews.DegreeView
 

--- a/networkx/classes/tests/test_subgraphviews.py
+++ b/networkx/classes/tests/test_subgraphviews.py
@@ -3,7 +3,7 @@ import pytest
 import networkx as nx
 
 
-class TestSubGraphView(object):
+class TestSubGraphView:
     gview = staticmethod(nx.graphviews.subgraph_view)
     graph = nx.Graph
     hide_edges_filter = staticmethod(nx.filters.hide_edges)
@@ -209,7 +209,7 @@ class TestMultiDiGraphView(TestMultiGraphView, TestSubDiGraphView):
 
 
 # induced_subgraph
-class TestInducedSubGraph(object):
+class TestInducedSubGraph:
     @classmethod
     def setup_class(cls):
         cls.K3 = G = nx.complete_graph(3)
@@ -270,14 +270,14 @@ class TestInducedSubGraph(object):
 
 
 # edge_subgraph
-class TestEdgeSubGraph(object):
+class TestEdgeSubGraph:
     @classmethod
     def setup_class(cls):
         # Create a path graph on five nodes.
         cls.G = G = nx.path_graph(5)
         # Add some node, edge, and graph attributes.
         for i in range(5):
-            G.nodes[i]['name'] = 'node{}'.format(i)
+            G.nodes[i]['name'] = f'node{i}'
         G.edges[0, 1]['name'] = 'edge01'
         G.edges[3, 4]['name'] = 'edge34'
         G.graph['name'] = 'graph'

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -179,9 +179,9 @@ def from_pandas_adjacency(df, create_using=None):
     try:
         df = df[df.index]
     except Exception:
-        msg = "%s not in columns"
         missing = list(set(df.index).difference(set(df.columns)))
-        raise nx.NetworkXError("Columns must match Indices.", msg % missing)
+        msg = f"{missing} not in columns"
+        raise nx.NetworkXError("Columns must match Indices.", msg)
 
     A = df.values
     G = from_numpy_matrix(A, create_using=create_using)
@@ -328,8 +328,8 @@ def from_pandas_edgelist(df, source='source', target='target', edge_attr=None,
     else:
         cols = [edge_attr]
     if len(cols) == 0:
-        msg = "Invalid edge_attr argument. No columns found with name: %s"
-        raise nx.NetworkXError(msg % cols)
+        msg = f"Invalid edge_attr argument. No columns found with name: {cols}"
+        raise nx.NetworkXError(msg)
 
     try:
         eattrs = zip(*[df[col] for col in cols])

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -334,7 +334,7 @@ def from_pandas_edgelist(df, source='source', target='target', edge_attr=None,
     try:
         eattrs = zip(*[df[col] for col in cols])
     except (KeyError, TypeError) as e:
-        msg = "Invalid edge_attr argument: %s" % edge_attr
+        msg = f"Invalid edge_attr argument: {edge_attr}"
         raise nx.NetworkXError(msg)
     for s, t, attrs in zip(df[source], df[target], eattrs):
         if g.is_multigraph():
@@ -547,13 +547,12 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
     G = nx.empty_graph(0, create_using)
     n, m = A.shape
     if n != m:
-        raise nx.NetworkXError("Adjacency matrix is not square.",
-                               "nx,ny=%s" % (A.shape,))
+        raise nx.NetworkXError('Adjacency matrix is not square.', f"nx,ny={A.shape}")
     dt = A.dtype
     try:
         python_type = kind_to_python_type[dt.kind]
     except Exception:
-        raise TypeError("Unknown numpy data type: %s" % dt)
+        raise TypeError(f"Unknown numpy data type: {dt}")
 
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n))
@@ -802,7 +801,7 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
     # From Scipy 1.1.0, asformat will throw a ValueError instead of an
     # AttributeError if the format if not recognized.
     except (AttributeError, ValueError):
-        raise nx.NetworkXError("Unknown sparse matrix format: %s" % format)
+        raise nx.NetworkXError(f"Unknown sparse matrix format: {format}")
 
 
 def _csr_gen_triples(A):
@@ -932,8 +931,7 @@ def from_scipy_sparse_matrix(A, parallel_edges=False, create_using=None,
     G = nx.empty_graph(0, create_using)
     n, m = A.shape
     if n != m:
-        raise nx.NetworkXError(
-            "Adjacency matrix is not square. nx,ny=%s" % (A.shape,))
+        raise nx.NetworkXError(f"Adjacency matrix is not square. nx,ny={A.shape}")
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n))
     # Create an iterable over (u, v, w) triples and for each triple, add an

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -277,7 +277,7 @@ def pygraphviz_layout(G, prog='neato', root=None, args=''):
         raise ImportError('requires pygraphviz ',
                           'http://pygraphviz.github.io/')
     if root is not None:
-        args += "-Groot=%s" % root
+        args += f"-Groot={root}"
     A = to_agraph(G)
     A.layout(prog=prog, args=args)
     node_pos = {}
@@ -408,9 +408,9 @@ def view_pygraphviz(G, edgelabel=None, prog='dot', args='',
     if path is None:
         ext = 'png'
         if suffix:
-            suffix = '_%s.%s' % (suffix, ext)
+            suffix = f"_{suffix}.{ext}"
         else:
-            suffix = '.%s' % (ext,)
+            suffix = f".{ext}"
         path = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
     else:
         # Assume the decorator worked and it is a file-object.

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -198,21 +198,21 @@ def to_pydot(N):
         pass
 
     for n, nodedata in N.nodes(data=True):
-        str_nodedata = dict((k, str(v)) for k, v in nodedata.items())
+        str_nodedata = {k: str(v) for k, v in nodedata.items()}
         p = pydot.Node(str(n), **str_nodedata)
         P.add_node(p)
 
     if N.is_multigraph():
         for u, v, key, edgedata in N.edges(data=True, keys=True):
-            str_edgedata = dict((k, str(v)) for k, v in edgedata.items()
-                                if k != 'key')
+            str_edgedata = {k: str(v) for k, v in edgedata.items()
+                                if k != 'key'}
             edge = pydot.Edge(str(u), str(v),
                               key=str(key), **str_edgedata)
             P.add_edge(edge)
 
     else:
         for u, v, edgedata in N.edges(data=True):
-            str_edgedata = dict((k, str(v)) for k, v in edgedata.items())
+            str_edgedata = {k: str(v) for k, v in edgedata.items()}
             edge = pydot.Edge(str(u), str(v), **str_edgedata)
             P.add_edge(edge)
     return P

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -187,8 +187,7 @@ def to_pydot(N):
         P = pydot.Dot('', graph_type=graph_type, strict=strict,
                       **graph_defaults)
     else:
-        P = pydot.Dot('"%s"' % name, graph_type=graph_type, strict=strict,
-                      **graph_defaults)
+        P = pydot.Dot(f'"{name}"', graph_type=graph_type, strict=strict, **graph_defaults)
     try:
         P.set_node_defaults(**N.graph['node'])
     except KeyError:
@@ -303,12 +302,12 @@ def pydot_layout(G, prog='neato', root=None):
     D = str(D_bytes, encoding=getpreferredencoding())
 
     if D == "":  # no data returned
-        print("Graphviz layout with %s failed" % (prog))
+        print(f"Graphviz layout with {prog} failed")
         print()
         print("To debug what happened try:")
         print("P = nx.nx_pydot.to_pydot(G)")
         print("P.write_dot(\"file.dot\")")
-        print("And then run %s on file.dot" % (prog))
+        print(f"And then run {prog} on file.dot")
         return
 
     # List of one or more "pydot.Dot" instances deserialized from this string.

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -387,7 +387,7 @@ def draw_networkx_nodes(G, pos,
     try:
         xy = np.asarray([pos[v] for v in nodelist])
     except KeyError as e:
-        raise nx.NetworkXError('Node %s has no position.' % e)
+        raise nx.NetworkXError(f"Node {e} has no position.")
     except ValueError:
         raise nx.NetworkXError('Bad value in node positions.')
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -784,7 +784,7 @@ def draw_networkx_labels(G, pos,
         ax = plt.gca()
 
     if labels is None:
-        labels = dict((n, n) for n in G.nodes())
+        labels = {n: n for n in G.nodes()}
 
     # set optional alignment
     horizontalalignment = kwds.get('horizontalalignment', 'center')

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -11,7 +11,7 @@ from networkx.testing import assert_edges_equal, assert_nodes_equal, \
 import networkx as nx
 
 
-class TestAGraph(object):
+class TestAGraph:
 
     def build_graph(self, G):
         edges = [('A', 'B'), ('A', 'C'), ('A', 'C'), ('B', 'C'), ('A', 'D')]

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -7,7 +7,7 @@ numpy = pytest.importorskip('numpy')
 test_smoke_empty_graphscipy = pytest.importorskip('scipy')
 
 
-class TestLayout(object):
+class TestLayout:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -8,7 +8,7 @@ import pytest
 pydot = pytest.importorskip('pydot')
 
 
-class TestPydot(object):
+class TestPydot:
     def pydot_checks(self, G, prog):
         '''
         Validate :mod:`pydot`-based usage of the passed NetworkX graph with the

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -11,7 +11,7 @@ plt.rcParams['text.usetex'] = False
 import networkx as nx
 
 
-class TestPylab(object):
+class TestPylab:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/exception.py
+++ b/networkx/exception.py
@@ -121,5 +121,5 @@ class PowerIterationFailedConvergence(ExceededMaxIterations):
     def __init__(self, num_iterations, *args, **kw):
         msg = 'power iteration failed to converge within {} iterations'
         exception_message = msg.format(num_iterations)
-        superinit = super(PowerIterationFailedConvergence, self).__init__
+        superinit = super().__init__
         superinit(self, exception_message, *args, **kw)

--- a/networkx/exception.py
+++ b/networkx/exception.py
@@ -119,7 +119,7 @@ class PowerIterationFailedConvergence(ExceededMaxIterations):
     """
 
     def __init__(self, num_iterations, *args, **kw):
-        msg = 'power iteration failed to converge within {} iterations'
-        exception_message = msg.format(num_iterations)
+        msg = f"power iteration failed to converge within {num_iterations} iterations"
+        exception_message = msg
         superinit = super().__init__
         superinit(self, exception_message, *args, **kw)

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -47,8 +47,8 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 #:
 #:     with gzip.open('atlas.dat.gz', 'wb') as f:
 #:         for i, G in enumerate(graph_atlas_g()):
-#:             f.write(bytes('GRAPH {}\n'.format(i), encoding='utf-8'))
-#:             f.write(bytes('NODES {}\n'.format(len(G)), encoding='utf-8'))
+#:             f.write(bytes(f'GRAPH {i}\n', encoding='utf-8'))
+#:             f.write(bytes(f'NODES {len(G)}\n', encoding='utf-8'))
 #:             write_edgelist(G, f, data=False)
 #:
 ATLAS_FILE = os.path.join(THIS_DIR, 'atlas.dat.gz')

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -82,7 +82,7 @@ def _generate_graphs():
                 edgelist.append(line.rstrip())
                 line = f.readline()
             G = nx.Graph()
-            G.name = 'G{}'.format(graph_index)
+            G.name = f'G{graph_index}'
             G.add_nodes_from(range(num_nodes))
             G.add_edges_from(tuple(map(int, e.split())) for e in edgelist)
             yield G
@@ -122,7 +122,7 @@ def graph_atlas(i):
 
     """
     if not (0 <= i < NUM_GRAPHS):
-        raise ValueError('index must be between 0 and {}'.format(NUM_GRAPHS))
+        raise ValueError(f'index must be between 0 and {NUM_GRAPHS}')
     return next(islice(_generate_graphs(), i, None))
 
 

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -736,7 +736,7 @@ def random_degree_sequence_graph(sequence, seed=None, tries=10):
             return DSRG.generate()
         except nx.NetworkXUnfeasible:
             pass
-    raise nx.NetworkXError('failed to generate graph in %d tries' % tries)
+    raise nx.NetworkXError(f"failed to generate graph in {tries} tries")
 
 
 class DegreeSequenceRandomGraph(object):

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -739,7 +739,7 @@ def random_degree_sequence_graph(sequence, seed=None, tries=10):
     raise nx.NetworkXError(f"failed to generate graph in {tries} tries")
 
 
-class DegreeSequenceRandomGraph(object):
+class DegreeSequenceRandomGraph:
     # class to generate random graphs with a given degree sequence
     # use random_degree_sequence_graph()
     def __init__(self, degree, rng):

--- a/networkx/generators/duplication.py
+++ b/networkx/generators/duplication.py
@@ -129,7 +129,7 @@ def duplication_divergence_graph(n, p, seed=None):
 
     """
     if p > 1 or p < 0:
-        msg = "NetworkXError p={0} is not in [0,1].".format(p)
+        msg = f"NetworkXError p={p} is not in [0,1]."
         raise nx.NetworkXError(msg)
     if n < 2:
         msg = 'n must be greater than or equal to 2'

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -73,7 +73,7 @@ def margulis_gabber_galil_graph(n, create_using=None):
         for (u, v) in (((x + 2 * y) % n, y), ((x + (2 * y + 1)) % n, y),
                        (x, (y + 2 * x) % n), (x, (y + (2 * x + 1)) % n)):
             G.add_edge((x, y), (u, v))
-    G.graph['name'] = "margulis_gabber_galil_graph({0})".format(n)
+    G.graph['name'] = f"margulis_gabber_galil_graph({n})"
     return G
 
 
@@ -136,5 +136,5 @@ def chordal_cycle_graph(p, create_using=None):
         chord = pow(x, p - 2, p) if x > 0 else 0
         for y in (left, right, chord):
             G.add_edge(x, y)
-    G.graph['name'] = "chordal_cycle_graph({0})".format(p)
+    G.graph['name'] = f"chordal_cycle_graph({p})"
     return G

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -263,7 +263,7 @@ def soft_random_geometric_graph(n, radius, dim=2, pos=None, p=2, p_dist=None,
     """
     n_name, nodes = n
     G = nx.Graph()
-    G.name = 'soft_random_geometric_graph({}, {}, {})'.format(n, radius, dim)
+    G.name = f'soft_random_geometric_graph({n}, {radius}, {dim})'
     G.add_nodes_from(nodes)
     # If no positions are provided, choose uniformly random vectors in
     # Euclidean space of the specified dimension.

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -743,8 +743,7 @@ def thresholded_random_geometric_graph(n, radius, theta, dim=2,
 
     n_name, nodes = n
     G = nx.Graph()
-    namestr = 'thresholded_random_geometric_graph({}, {}, {}, {})'
-    G.name = namestr.format(n, radius, theta, dim)
+    G.name = f"thresholded_random_geometric_graph({n}, {radius}, {theta}, {dim})"
     G.add_nodes_from(nodes)
     # If no weights are provided, choose them from an exponential
     # distribution.

--- a/networkx/generators/internet_as_graphs.py
+++ b/networkx/generators/internet_as_graphs.py
@@ -67,7 +67,7 @@ def choose_pref_attach(degs, seed):
     return nodes[i]
 
 
-class AS_graph_generator(object):
+class AS_graph_generator:
     """ Generates random internet AS graphs.
     """
 
@@ -128,8 +128,8 @@ class AS_graph_generator(object):
             for j in self.G.nodes():
                 if i != j:
                     self.add_edge(i, j, 'peer')
-            self.customers[i] = set([])
-            self.providers[i] = set([])
+            self.customers[i] = set()
+            self.providers[i] = set()
         return self.G
 
     def add_edge(self, i, j, kind):
@@ -374,7 +374,7 @@ class AS_graph_generator(object):
         self.graph_regions(5)
         self.customers = {}
         self.providers = {}
-        self.nodes = {'T': set([]), 'M': set([]), 'CP': set([]), 'C': set([])}
+        self.nodes = {'T': set(), 'M': set(), 'CP': set(), 'C': set()}
 
         self.t_graph()
         self.nodes['T'] = set(list(self.G.nodes()))

--- a/networkx/generators/joint_degree_seq.py
+++ b/networkx/generators/joint_degree_seq.py
@@ -244,10 +244,10 @@ def joint_degree_graph(joint_degrees, seed=None):
 
                 # k_unsat and l_unsat consist of nodes of degree k and l that
                 # are unsaturated (nodes that have at least 1 available stub)
-                k_unsat = set(v for v in k_nodes if h_node_residual[v] > 0)
+                k_unsat = {v for v in k_nodes if h_node_residual[v] > 0}
 
                 if k != l:
-                    l_unsat = set(w for w in l_nodes if h_node_residual[w] > 0)
+                    l_unsat = {w for w in l_nodes if h_node_residual[w] > 0}
                 else:
                     l_unsat = k_unsat
                     n_edges_add = joint_degrees[k][l] // 2

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -235,7 +235,7 @@ def triangular_lattice_graph(m, n, periodic=False, with_positions=True,
             H = contracted_nodes(H, (0, j), (N, j))
     elif n % 2:
         # remove extra nodes
-        H.remove_nodes_from(((N, j) for j in rows[1::2]))
+        H.remove_nodes_from((N, j) for j in rows[1::2])
 
     # Add position node attributes
     if with_positions:

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -213,8 +213,8 @@ def triangular_lattice_graph(m, n, periodic=False, with_positions=True,
         return H
     if periodic:
         if n < 5 or m < 3:
-            msg = "m > 2 and n > 4 required for periodic. m={}, n={}"
-            raise NetworkXError(msg.format(m, n))
+            msg = f"m > 2 and n > 4 required for periodic. m={m}, n={n}"
+            raise NetworkXError(msg)
 
     N = (n + 1) // 2  # number of nodes in row
     rows = range(m + 1)

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -326,9 +326,9 @@ def _triangles(G, e):
     """ Return list of all triangles containing edge e"""
     u, v = e
     if u not in G:
-        raise nx.NetworkXError("Vertex %s not in graph" % u)
+        raise nx.NetworkXError(f"Vertex {u} not in graph")
     if v not in G[u]:
-        raise nx.NetworkXError("Edge (%s, %s) not in graph" % (u, v))
+        raise nx.NetworkXError(f"Edge ({u}, {v}) not in graph")
     triangle_list = []
     for x in G[u]:
         if x in G[v]:
@@ -363,10 +363,10 @@ def _odd_triangle(G, T):
     """
     for u in T:
         if u not in G.nodes():
-            raise nx.NetworkXError("Vertex %s not in graph" % u)
+            raise nx.NetworkXError(f"Vertex {u} not in graph")
     for e in list(combinations(T, 2)):
         if e[0] not in G[e[1]]:
-            raise nx.NetworkXError("Edge (%s, %s) not in graph" % (e[0], e[1]))
+            raise nx.NetworkXError(f"Edge ({e[0]}, {e[1]}) not in graph")
 
     T_neighbors = defaultdict(int)
     for t in T:

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -212,7 +212,7 @@ def _lg_undirected(G, selfloops=False, create_using=None):
     # Determine if we include self-loops or not.
     shift = 0 if selfloops else 1
 
-    edges = set([])
+    edges = set()
     for u in G:
         # Label nodes as a sorted tuple of nodes in original graph.
         nodes = [sorted_node(*x) for x in get_edges(u)]
@@ -492,7 +492,7 @@ def _select_starting_cell(G, starting_edge=None):
             # check if odd triangles containing e form complete subgraph
             # there must be exactly s+2 of them
             # and they must all be connected
-            triangle_nodes = set([])
+            triangle_nodes = set()
             for T in odd_triangles:
                 for x in T:
                     triangle_nodes.add(x)

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -455,8 +455,8 @@ def _select_starting_cell(G, starting_edge=None):
     else:
         e = starting_edge
         if e[0] not in G[e[1]]:
-            msg = 'starting_edge (%s, %s) is not in the Graph'
-            raise nx.NetworkXError(msg % e)
+            msg = f"starting_edge ({e[0]}, {e[1]}) is not in the Graph"
+            raise nx.NetworkXError(msg)
     e_triangles = _triangles(G, e)
     r = len(e_triangles)
     if r == 0:

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -794,11 +794,11 @@ def extended_barabasi_albert_graph(n, m, p, q, seed=None):
        Physical review letters, 85(24), 5234.
     """
     if m < 1 or m >= n:
-        msg = "Extended Barabasi-Albert network needs m>=1 and m<n, m=%d, n=%d"
-        raise nx.NetworkXError(msg % (m, n))
+        msg = f"Extended Barabasi-Albert network needs m>=1 and m<n, m={m}, n={n}"
+        raise nx.NetworkXError(msg)
     if p + q >= 1:
-        msg = "Extended Barabasi-Albert network needs p + q <= 1, p=%d, q=%d"
-        raise nx.NetworkXError(msg % (p, q))
+        msg = f"Extended Barabasi-Albert network needs p + q <= 1, p={p}, q={q}"
+        raise nx.NetworkXError(msg)
 
     # Add m initial nodes (m0 in barabasi-speak)
     G = empty_graph(m)

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -638,8 +638,7 @@ def barabasi_albert_graph(n, m, seed=None):
     """
 
     if m < 1 or m >= n:
-        raise nx.NetworkXError("Barabási–Albert network must have m >= 1"
-                               " and m < n, m = %d, n = %d" % (m, n))
+        raise nx.NetworkXError(f"Barabási–Albert network must have m >= 1 and m < n, m = {m}, n = {n}")
 
     # Add m initial nodes (m0 in barabasi-speak)
     G = empty_graph(m)
@@ -701,14 +700,11 @@ def dual_barabasi_albert_graph(n, m1, m2, p, seed=None):
     """
 
     if m1 < 1 or m1 >= n:
-        raise nx.NetworkXError("Dual Barabási–Albert network must have m1 >= 1"
-                               " and m1 < n, m1 = %d, n = %d" % (m1, n))
+        raise nx.NetworkXError(f"Dual Barabási–Albert network must have m1 >= 1 and m1 < n, m1 = {m1}, n = {n}")
     if m2 < 1 or m2 >= n:
-        raise nx.NetworkXError("Dual Barabási–Albert network must have m2 >= 1"
-                               " and m2 < n, m2 = %d, n = %d" % (m2, n))
+        raise nx.NetworkXError(f"Dual Barabási–Albert network must have m2 >= 1 and m2 < n, m2 = {m2}, n = {n}")
     if p < 0 or p > 1:
-        raise nx.NetworkXError("Dual Barabási–Albert network must have 0 <= p <= 1,"
-                               "p = %f" % p)
+        raise nx.NetworkXError(f"Dual Barabási–Albert network must have 0 <= p <= 1, p = {p}")
 
     # For simplicity, if p == 0 or 1, just return BA
     if p == 1:
@@ -958,12 +954,10 @@ def powerlaw_cluster_graph(n, m, p, seed=None):
     """
 
     if m < 1 or n < m:
-        raise nx.NetworkXError(
-            "NetworkXError must have m>1 and m<n, m=%d,n=%d" % (m, n))
+        raise nx.NetworkXError(f"NetworkXError must have m>1 and m<n, m={m},n={n}")
 
     if p > 1 or p < 0:
-        raise nx.NetworkXError(
-            "NetworkXError p must be in [0,1], p=%f" % (p))
+        raise nx.NetworkXError(f"NetworkXError p must be in [0,1], p={p}")
 
     G = empty_graph(m)  # add m initial nodes (m0 in barabasi-speak)
     repeated_nodes = list(G.nodes())  # list of existing nodes to sample from
@@ -1177,8 +1171,7 @@ def random_powerlaw_tree_sequence(n, gamma=3, seed=None, tries=100):
         index = seed.randint(0, n - 1)
         zseq[index] = swap.pop()
 
-    raise nx.NetworkXError('Exceeded max (%d) attempts for a valid tree'
-                           ' sequence.' % tries)
+    raise nx.NetworkXError(f"Exceeded max ({tries}) attempts for a valid tree sequence.")
 
 
 @py_random_state(3)

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -164,8 +164,8 @@ def spectral_graph_forge(G, alpha, transformation='identity', seed=None):
     level = int(round(n*alpha))
 
     if transformation not in available_transformations:
-        msg = '\'{0}\' is not a valid transformation. '.format(transformation)
-        msg += 'Transformations: {0}'.format(available_transformations)
+        msg = f'\'{transformation}\' is not a valid transformation. '
+        msg += f'Transformations: {available_transformations}'
         raise nx.NetworkXError(msg)
 
     K = np.ones((1, n)) * A

--- a/networkx/generators/tests/test_atlas.py
+++ b/networkx/generators/tests/test_atlas.py
@@ -10,7 +10,7 @@ from networkx.generators.atlas import NUM_GRAPHS
 from networkx.utils import pairwise
 
 
-class TestAtlasGraph(object):
+class TestAtlasGraph:
     """Unit tests for the :func:`~networkx.graph_atlas` function."""
 
     def test_index_too_small(self):
@@ -27,7 +27,7 @@ class TestAtlasGraph(object):
         assert_edges_equal(G.edges(), [(0, 1), (0, 2)])
 
 
-class TestAtlasGraphG(object):
+class TestAtlasGraphG:
     """Unit tests for the :func:`~networkx.graph_atlas_g` function."""
 
     @classmethod

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -5,32 +5,32 @@ import pytest
 def test_random_partition_graph():
     G = nx.random_partition_graph([3, 3, 3], 1, 0, seed=42)
     C = G.graph['partition']
-    assert C == [set([0, 1, 2]), set([3, 4, 5]), set([6, 7, 8])]
+    assert C == [{0, 1, 2}, {3, 4, 5}, {6, 7, 8}]
     assert len(G) == 9
     assert len(list(G.edges())) == 9
 
     G = nx.random_partition_graph([3, 3, 3], 0, 1)
     C = G.graph['partition']
-    assert C == [set([0, 1, 2]), set([3, 4, 5]), set([6, 7, 8])]
+    assert C == [{0, 1, 2}, {3, 4, 5}, {6, 7, 8}]
     assert len(G) == 9
     assert len(list(G.edges())) == 27
 
     G = nx.random_partition_graph([3, 3, 3], 1, 0, directed=True)
     C = G.graph['partition']
-    assert C == [set([0, 1, 2]), set([3, 4, 5]), set([6, 7, 8])]
+    assert C == [{0, 1, 2}, {3, 4, 5}, {6, 7, 8}]
     assert len(G) == 9
     assert len(list(G.edges())) == 18
 
     G = nx.random_partition_graph([3, 3, 3], 0, 1, directed=True)
     C = G.graph['partition']
-    assert C == [set([0, 1, 2]), set([3, 4, 5]), set([6, 7, 8])]
+    assert C == [{0, 1, 2}, {3, 4, 5}, {6, 7, 8}]
     assert len(G) == 9
     assert len(list(G.edges())) == 54
 
     G = nx.random_partition_graph([1, 2, 3, 4, 5], 0.5, 0.1)
     C = G.graph['partition']
-    assert C == [set([0]), set([1, 2]), set([3, 4, 5]),
-                 set([6, 7, 8, 9]), set([10, 11, 12, 13, 14])]
+    assert C == [{0}, {1, 2}, {3, 4, 5},
+                 {6, 7, 8, 9}, {10, 11, 12, 13, 14}]
     assert len(G) == 15
 
     rpg = nx.random_partition_graph

--- a/networkx/generators/tests/test_degree_seq.py
+++ b/networkx/generators/tests/test_degree_seq.py
@@ -3,7 +3,7 @@ import pytest
 import networkx as nx
 
 
-class TestConfigurationModel(object):
+class TestConfigurationModel:
     """Unit tests for the :func:`~networkx.configuration_model`
     function.
 

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -14,7 +14,7 @@ from networkx.generators.directed import random_uniform_k_out_graph
 from networkx.generators.directed import scale_free_graph
 
 
-class TestGeneratorsDirected(object):
+class TestGeneratorsDirected:
     def test_smoke_test_random_graphs(self):
         gn_graph(100)
         gnr_graph(100, 0.5)
@@ -54,7 +54,7 @@ class TestGeneratorsDirected(object):
         pytest.raises(ValueError, scale_free_graph, 100, gamma=-0.3)
 
 
-class TestRandomKOutGraph(object):
+class TestRandomKOutGraph:
     """Unit tests for the
     :func:`~networkx.generators.directed.random_k_out_graph` function.
 
@@ -79,7 +79,7 @@ class TestRandomKOutGraph(object):
         assert nx.number_of_selfloops(G) == 0
 
 
-class TestUniformRandomKOutGraph(object):
+class TestUniformRandomKOutGraph:
     """Unit tests for the
     :func:`~networkx.generators.directed.random_uniform_k_out_graph`
     function.

--- a/networkx/generators/tests/test_duplication.py
+++ b/networkx/generators/tests/test_duplication.py
@@ -8,7 +8,7 @@ from networkx.generators.duplication import duplication_divergence_graph
 from networkx.generators.duplication import partial_duplication_graph
 
 
-class TestDuplicationDivergenceGraph(object):
+class TestDuplicationDivergenceGraph:
     """Unit tests for the
     :func:`networkx.generators.duplication.duplication_divergence_graph`
     function.
@@ -30,7 +30,7 @@ class TestDuplicationDivergenceGraph(object):
             duplication_divergence_graph(3, -1)
 
 
-class TestPartialDuplicationGraph(object):
+class TestPartialDuplicationGraph:
     """Unit tests for the
     :func:`networkx.generators.duplication.partial_duplication_graph`
     function.

--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -11,7 +11,7 @@ def l1dist(x, y):
     return sum(abs(a - b) for a, b in zip(x, y))
 
 
-class TestRandomGeometricGraph(object):
+class TestRandomGeometricGraph:
     """Unit tests for the :func:`~networkx.random_geometric_graph`
     function.
 
@@ -75,7 +75,7 @@ class TestRandomGeometricGraph(object):
                 assert not dist(G.nodes[u]['pos'], G.nodes[v]['pos']) <= 0.25
 
 
-class TestSoftRandomGeometricGraph(object):
+class TestSoftRandomGeometricGraph:
     """Unit tests for the :func:`~networkx.soft_random_geometric_graph`
     function.
 
@@ -170,7 +170,7 @@ def join(G, u, v, theta, alpha, metric):
     return (u_weight + v_weight) * metric(u_pos, v_pos) ** alpha >= theta
 
 
-class TestGeographicalThresholdGraph(object):
+class TestGeographicalThresholdGraph:
     """Unit tests for the :func:`~networkx.geographical_threshold_graph`
     function.
 
@@ -226,7 +226,7 @@ class TestGeographicalThresholdGraph(object):
         assert len(G.edges) == 0
 
 
-class TestWaxmanGraph(object):
+class TestWaxmanGraph:
     """Unit tests for the :func:`~networkx.waxman_graph` function."""
 
     def test_number_of_nodes_1(self):
@@ -252,7 +252,7 @@ class TestWaxmanGraph(object):
         assert len(G) == 50
 
 
-class TestNavigableSmallWorldGraph(object):
+class TestNavigableSmallWorldGraph:
 
     def test_navigable_small_world(self):
         G = nx.navigable_small_world_graph(5, p=1, q=0, seed=42)
@@ -268,7 +268,7 @@ class TestNavigableSmallWorldGraph(object):
         assert nx.is_isomorphic(G, gg)
 
 
-class TestThresholdedRandomGeometricGraph(object):
+class TestThresholdedRandomGeometricGraph:
     """Unit tests for the :func:`~networkx.thresholded_random_geometric_graph`
     function.
 

--- a/networkx/generators/tests/test_mycielski.py
+++ b/networkx/generators/tests/test_mycielski.py
@@ -3,7 +3,7 @@
 import networkx as nx
 
 
-class TestMycielski(object):
+class TestMycielski:
 
     def test_construction(self):
         G = nx.path_graph(2)

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -25,7 +25,7 @@ from networkx.generators.random_graphs import random_shell_graph
 from networkx.generators.random_graphs import watts_strogatz_graph
 
 
-class TestGeneratorsRandom(object):
+class TestGeneratorsRandom:
 
     def test_random_graph(self):
         seed = 42

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -1,4 +1,3 @@
-
 import pytest
 import networkx as nx
 from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic

--- a/networkx/generators/tests/test_stochastic.py
+++ b/networkx/generators/tests/test_stochastic.py
@@ -3,7 +3,7 @@ import pytest
 import networkx as nx
 
 
-class TestStochasticGraph(object):
+class TestStochasticGraph:
     """Unit tests for the :func:`~networkx.stochastic_graph` function.
 
     """

--- a/networkx/generators/tests/test_trees.py
+++ b/networkx/generators/tests/test_trees.py
@@ -1,10 +1,9 @@
-
 import networkx as nx
 from networkx.generators.trees import NIL
 from networkx.utils import arbitrary_element
 
 
-class TestPrefixTree(object):
+class TestPrefixTree:
     """Unit tests for the prefix tree generator function."""
 
     def test_basic(self):

--- a/networkx/generators/triads.py
+++ b/networkx/generators/triads.py
@@ -64,8 +64,8 @@ def triad_graph(triad_name):
 
     """
     if triad_name not in TRIAD_EDGES:
-        raise ValueError('unknown triad name "{}"; use one of the triad names'
-                         ' in the TRIAD_NAMES constant'.format(triad_name))
+        raise ValueError(f'unknown triad name "{triad_name}"; use one of the triad names'
+                         ' in the TRIAD_NAMES constant')
     G = DiGraph()
     G.add_nodes_from('abc')
     G.add_edges_from(TRIAD_EDGES[triad_name])

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -31,7 +31,7 @@ except ImportError:
             return y
 
 
-class _PCGSolver(object):
+class _PCGSolver:
     """Preconditioned conjugate gradient method.
 
     To solve Ax = b:
@@ -82,7 +82,7 @@ class _PCGSolver(object):
             p = daxpy(p, z, a=beta)
 
 
-class _CholeskySolver(object):
+class _CholeskySolver:
     """Cholesky factorization.
 
     To solve Ax = b:
@@ -108,7 +108,7 @@ class _CholeskySolver(object):
         _cholesky = None
 
 
-class _LUSolver(object):
+class _LUSolver:
     """LU factorization.
 
     To solve Ax = b:

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -316,7 +316,7 @@ def _get_fiedler_func(method):
                                   maxiter=n, largest=False)
                 return sigma[0], X[:, 0]
     else:
-        raise nx.NetworkXError("unknown method '%s'." % method)
+        raise nx.NetworkXError(f"unknown method '{method}'.")
 
     return find_fiedler
 

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -249,7 +249,7 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
     node_value = _node_value(G, node_attr)
 
     if rc_order is None:
-        ordering = list(set([node_value(n) for n in G]))
+        ordering = list({node_value(n) for n in G})
     else:
         ordering = rc_order
 
@@ -258,7 +258,7 @@ def attr_matrix(G, edge_attr=None, node_attr=None, normalized=False,
     index = dict(zip(ordering, range(N)))
     M = np.zeros((N, N), dtype=dtype, order=order)
 
-    seen = set([])
+    seen = set()
     for u, nbrdict in G.adjacency():
         for v in nbrdict:
             # Obtain the node attribute values.
@@ -413,7 +413,7 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
     node_value = _node_value(G, node_attr)
 
     if rc_order is None:
-        ordering = list(set([node_value(n) for n in G]))
+        ordering = list({node_value(n) for n in G})
     else:
         ordering = rc_order
 
@@ -422,7 +422,7 @@ def attr_sparse_matrix(G, edge_attr=None, node_attr=None,
     index = dict(zip(ordering, range(N)))
     M = sparse.lil_matrix((N, N), dtype=dtype)
 
-    seen = set([])
+    seen = set()
     for u, nbrdict in G.adjacency():
         for v in nbrdict:
             # Obtain the node attribute values.

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -68,7 +68,7 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
         else:
             edgelist = list(G.edges())
     A = scipy.sparse.lil_matrix((len(nodelist), len(edgelist)))
-    node_index = dict((node, i) for i, node in enumerate(nodelist))
+    node_index = {node: i for i, node in enumerate(nodelist)}
     for ei, e in enumerate(edgelist):
         (u, v) = e[:2]
         if u == v:

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -77,8 +77,7 @@ def incidence_matrix(G, nodelist=None, edgelist=None,
             ui = node_index[u]
             vi = node_index[v]
         except KeyError:
-            raise nx.NetworkXError('node %s or %s in edgelist '
-                                   'but not in nodelist' % (u, v))
+            raise nx.NetworkXError(f"node {u} or {v} in edgelist but not in nodelist")
         if weight is None:
             wt = 1
         else:

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -34,7 +34,7 @@ def check_eigenvector(A, l, x):
     assert almost_equal(ny, l * nx)
 
 
-class TestAlgebraicConnectivity(object):
+class TestAlgebraicConnectivity:
 
     def test_directed(self):
         G = nx.DiGraph()
@@ -187,7 +187,7 @@ class TestAlgebraicConnectivity(object):
     _methods = methods
 
 
-class TestSpectralOrdering(object):
+class TestSpectralOrdering:
 
     def test_nullgraph(self):
         for graph in (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph):
@@ -215,13 +215,13 @@ class TestSpectralOrdering(object):
         for method in self._methods:
             order = nx.spectral_ordering(G, weight='spam', method=method)
             assert set(order) == set(G)
-            assert set([1, 3]) in (set(order[:-1]), set(order[1:]))
+            assert {1, 3} in (set(order[:-1]), set(order[1:]))
         G = nx.MultiDiGraph()
         G.add_weighted_edges_from([(1, 2, 1), (1, 3, 2), (2, 3, 1), (2, 3, 2)])
         for method in self._methods:
             order = nx.spectral_ordering(G, method=method)
             assert set(order) == set(G)
-            assert set([2, 3]) in (set(order[:-1]), set(order[1:]))
+            assert {2, 3} in (set(order[:-1]), set(order[1:]))
 
     def test_path(self):
         # based on setup_class numpy is installed if we get here

--- a/networkx/linalg/tests/test_bethehessian.py
+++ b/networkx/linalg/tests/test_bethehessian.py
@@ -7,7 +7,7 @@ import networkx as nx
 from networkx.generators.degree_seq import havel_hakimi_graph
 
 
-class TestBetheHessian(object):
+class TestBetheHessian:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -42,7 +42,7 @@ def test_incidence_matrix_simple():
         nx.incidence_matrix(G, nodelist=[0, 1])
 
 
-class TestGraphMatrix(object):
+class TestGraphMatrix:
     @classmethod
     def setup_class(cls):
         deg = [3, 2, 2, 1, 0]

--- a/networkx/linalg/tests/test_laplacian.py
+++ b/networkx/linalg/tests/test_laplacian.py
@@ -9,7 +9,7 @@ from networkx.generators.degree_seq import havel_hakimi_graph
 from networkx.generators.expanders import margulis_gabber_galil_graph
 
 
-class TestLaplacian(object):
+class TestLaplacian:
 
     @classmethod
     def setup_class(cls):
@@ -94,7 +94,7 @@ class TestLaplacian(object):
         npt.assert_almost_equal(L, GL, decimal=3)
 
         # Make the graph strongly connected, so we can use a random and lazy walk
-        G.add_edges_from((((2, 5), (6, 1))))
+        G.add_edges_from(((2, 5), (6, 1)))
         GL = np.array([[1., -0.3062, -0.4714,  0.,  0., -0.3227],
                        [-0.3062,  1., -0.1443,  0., -0.3162,  0.],
                        [-0.4714, -0.1443,  1.,  0., -0.0913,  0.],
@@ -145,7 +145,7 @@ class TestLaplacian(object):
         npt.assert_almost_equal(L, GL, decimal=3)
 
         # Make the graph strongly connected, so we can use a random and lazy walk
-        G.add_edges_from((((2, 5), (6, 1))))
+        G.add_edges_from(((2, 5), (6, 1)))
 
         GL = np.array([[0.1395, -0.0349, -0.0465, 0, 0, -0.0581],
                        [-0.0349, 0.0930, -0.0116, 0, -0.0465, 0],

--- a/networkx/linalg/tests/test_modularity.py
+++ b/networkx/linalg/tests/test_modularity.py
@@ -7,7 +7,7 @@ import networkx as nx
 from networkx.generators.degree_seq import havel_hakimi_graph
 
 
-class TestModularity(object):
+class TestModularity:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/linalg/tests/test_spectrum.py
+++ b/networkx/linalg/tests/test_spectrum.py
@@ -7,7 +7,7 @@ import networkx as nx
 from networkx.generators.degree_seq import havel_hakimi_graph
 
 
-class TestSpectrum(object):
+class TestSpectrum:
 
     @classmethod
     def setup_class(cls):

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -127,7 +127,7 @@ def write_adjlist(G, path, comments="#", delimiter=' ', encoding='utf-8'):
     pargs = comments + " ".join(sys.argv) + '\n'
     header = (pargs
               + comments + " GMT {}\n".format(time.asctime(time.gmtime()))
-              + comments + " {}\n".format(G.name))
+              + comments + f" {G.name}\n")
     path.write(header.encode(encoding))
 
     for line in generate_adjlist(G, delimiter):

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -105,13 +105,13 @@ def write_adjlist(G, path, comments="#", delimiter=' ', encoding='utf-8'):
 
     Examples
     --------
-    >>> G=nx.path_graph(4)
+    >>> G = nx.path_graph(4)
     >>> nx.write_adjlist(G,"test.adjlist")
 
     The path can be a filehandle or a string with the name of the file. If a
     filehandle is provided, it has to be opened in 'wb' mode.
 
-    >>> fh=open("test.adjlist",'wb')
+    >>> fh = open("test.adjlist",'wb')
     >>> nx.write_adjlist(G, fh)
 
     Notes
@@ -126,7 +126,7 @@ def write_adjlist(G, path, comments="#", delimiter=' ', encoding='utf-8'):
     import time
     pargs = comments + " ".join(sys.argv) + '\n'
     header = (pargs
-              + comments + " GMT {}\n".format(time.asctime(time.gmtime()))
+              + comments + f" GMT {time.asctime(time.gmtime())}\n"
               + comments + f" {G.name}\n")
     path.write(header.encode(encoding))
 
@@ -195,15 +195,13 @@ def parse_adjlist(lines, comments='#', delimiter=None,
             try:
                 u = nodetype(u)
             except:
-                raise TypeError("Failed to convert node ({}) to type {}"
-                                .format(u, nodetype))
+                raise TypeError(f"Failed to convert node ({u}) to type {nodetype}")
         G.add_node(u)
         if nodetype is not None:
             try:
                 vlist = list(map(nodetype, vlist))
             except:
-                raise TypeError("Failed to convert nodes ({}) to type {}"
-                                .format(','.join(vlist), nodetype))
+                raise TypeError(f"Failed to convert nodes ({','.join(vlist)}) to type {nodetype}")
         G.add_edges_from([(u, v) for v in vlist])
     return G
 
@@ -238,26 +236,26 @@ def read_adjlist(path, comments="#", delimiter=None, create_using=None,
 
     Examples
     --------
-    >>> G=nx.path_graph(4)
+    >>> G = nx.path_graph(4)
     >>> nx.write_adjlist(G, "test.adjlist")
-    >>> G=nx.read_adjlist("test.adjlist")
+    >>> G = nx.read_adjlist("test.adjlist")
 
     The path can be a filehandle or a string with the name of the file. If a
     filehandle is provided, it has to be opened in 'rb' mode.
 
-    >>> fh=open("test.adjlist", 'rb')
-    >>> G=nx.read_adjlist(fh)
+    >>> fh = open("test.adjlist", 'rb')
+    >>> G = nx.read_adjlist(fh)
 
     Filenames ending in .gz or .bz2 will be compressed.
 
     >>> nx.write_adjlist(G,"test.adjlist.gz")
-    >>> G=nx.read_adjlist("test.adjlist.gz")
+    >>> G = nx.read_adjlist("test.adjlist.gz")
 
     The optional nodetype is a function to convert node strings to nodetype.
 
     For example
 
-    >>> G=nx.read_adjlist("test.adjlist", nodetype=int)
+    >>> G = nx.read_adjlist("test.adjlist", nodetype=int)
 
     will attempt to convert all nodes to integer type.
 
@@ -268,7 +266,7 @@ def read_adjlist(path, comments="#", delimiter=None, create_using=None,
     created.  The default is `nx.Graph`, an undirected graph.
     To read the data as a directed graph use
 
-    >>> G=nx.read_adjlist("test.adjlist", create_using=nx.DiGraph)
+    >>> G = nx.read_adjlist("test.adjlist", create_using=nx.DiGraph)
 
     Notes
     -----

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -257,8 +257,7 @@ def parse_edgelist(lines, comments='#', delimiter=None,
                 u = nodetype(u)
                 v = nodetype(v)
             except:
-                raise TypeError("Failed to convert nodes %s,%s to type %s."
-                                % (u, v, nodetype))
+                raise TypeError(f"Failed to convert nodes {u},{v} to type {nodetype}.")
 
         if len(d) == 0 or data is False:
             # no data or data type specified
@@ -268,22 +267,17 @@ def parse_edgelist(lines, comments='#', delimiter=None,
             try:  # try to evaluate as dictionary
                 edgedata = dict(literal_eval(' '.join(d)))
             except:
-                raise TypeError(
-                    "Failed to convert edge data (%s) to dictionary." % (d))
+                raise TypeError(f"Failed to convert edge data ({d}) to dictionary.")
         else:
             # convert edge data to dictionary with specified keys and type
             if len(d) != len(data):
-                raise IndexError(
-                    "Edge data %s and data_keys %s are not the same length" %
-                    (d, data))
+                raise IndexError(f"Edge data {d} and data_keys {data} are not the same length")
             edgedata = {}
             for (edge_key, edge_type), edge_value in zip(data, d):
                 try:
                     edge_value = edge_type(edge_value)
                 except:
-                    raise TypeError(
-                        "Failed to convert %s data %s to type %s."
-                        % (edge_key, edge_value, edge_type))
+                    raise TypeError(f"Failed to convert {edge_key} data {edge_value} to type {edge_type}.")
                 edgedata.update({edge_key: edge_value})
         G.add_edge(u, v, **edgedata)
     return G

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -123,8 +123,7 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
     """
     writer = GEXFWriter(encoding=encoding, prettyprint=prettyprint, version=version)
     writer.add_graph(G)
-    for line in str(writer).splitlines():
-        yield line
+    yield from str(writer).splitlines()
 
 
 @open_file(0, mode="rb")
@@ -171,7 +170,7 @@ def read_gexf(path, node_type=None, relabel=False, version="1.2draft"):
     return G
 
 
-class GEXF(object):
+class GEXF:
     versions = {}
     d = {
         "NS_GEXF": "http://www.gexf.net/1.1draft",
@@ -282,7 +281,7 @@ class GEXFWriter(GEXF):
         # Make meta element a non-graph element
         # Also add lastmodifieddate as attribute, not tag
         meta_element = Element("meta")
-        subelement_text = "NetworkX {}".format(nx.__version__)
+        subelement_text = f"NetworkX {nx.__version__}"
         SubElement(meta_element, "creator").text = subelement_text
         meta_element.set("lastmodifieddate", time.strftime("%Y-%m-%d"))
         self.xml.append(meta_element)

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -251,7 +251,7 @@ class GEXF(object):
     def set_version(self, version):
         d = self.versions.get(version)
         if d is None:
-            raise nx.NetworkXError("Unknown GEXF version %s." % version)
+            raise nx.NetworkXError(f"Unknown GEXF version {version}.")
         self.NS_GEXF = d["NS_GEXF"]
         self.NS_VIZ = d["NS_VIZ"]
         self.NS_XSI = d["NS_XSI"]
@@ -448,7 +448,7 @@ class GEXFWriter(GEXF):
                 k = "networkx_key"
             val_type = type(v)
             if val_type not in self.xml_type:
-                raise TypeError("attribute value type is not allowed: %s" % val_type)
+                raise TypeError(f"attribute value type is not allowed: {val_type}")
             if isinstance(v, list):
                 # dynamic data
                 for val, start, end in v:
@@ -541,14 +541,14 @@ class GEXFWriter(GEXF):
             if color is not None:
                 if self.VERSION == "1.1":
                     e = Element(
-                        "{%s}color" % self.NS_VIZ,
+                        f"{{{self.NS_VIZ}}}color",
                         r=str(color.get("r")),
                         g=str(color.get("g")),
                         b=str(color.get("b")),
                     )
                 else:
                     e = Element(
-                        "{%s}color" % self.NS_VIZ,
+                        f"{{{self.NS_VIZ}}}color",
                         r=str(color.get("r")),
                         g=str(color.get("g")),
                         b=str(color.get("b")),
@@ -558,28 +558,28 @@ class GEXFWriter(GEXF):
 
             size = viz.get("size")
             if size is not None:
-                e = Element("{%s}size" % self.NS_VIZ, value=str(size))
+                e = Element(f"{{{self.NS_VIZ}}}size", value=str(size))
                 element.append(e)
 
             thickness = viz.get("thickness")
             if thickness is not None:
-                e = Element("{%s}thickness" % self.NS_VIZ, value=str(thickness))
+                e = Element(f"{{{self.NS_VIZ}}}thickness", value=str(thickness))
                 element.append(e)
 
             shape = viz.get("shape")
             if shape is not None:
                 if shape.startswith("http"):
                     e = Element(
-                        "{%s}shape" % self.NS_VIZ, value="image", uri=str(shape)
+                        f"{{{self.NS_VIZ}}}shape", value="image", uri=str(shape)
                     )
                 else:
-                    e = Element("{%s}shape" % self.NS_VIZ, value=str(shape))
+                    e = Element(f"{{{self.NS_VIZ}}}shape", value=str(shape))
                 element.append(e)
 
             position = viz.get("position")
             if position is not None:
                 e = Element(
-                    "{%s}position" % self.NS_VIZ,
+                    f"{{{self.NS_VIZ}}}position",
                     x=str(position.get("x")),
                     y=str(position.get("y")),
                     z=str(position.get("z")),
@@ -677,13 +677,13 @@ class GEXFReader(GEXF):
 
     def __call__(self, stream):
         self.xml = ElementTree(file=stream)
-        g = self.xml.find("{%s}graph" % self.NS_GEXF)
+        g = self.xml.find(f"{{{self.NS_GEXF}}}graph")
         if g is not None:
             return self.make_graph(g)
         # try all the versions
         for version in self.versions:
             self.set_version(version)
-            g = self.xml.find("{%s}graph" % self.NS_GEXF)
+            g = self.xml.find(f"{{{self.NS_GEXF}}}graph")
             if g is not None:
                 return self.make_graph(g)
         raise nx.NetworkXError("No <graph> element in GEXF file.")
@@ -718,7 +718,7 @@ class GEXFReader(GEXF):
             self.timeformat = "string"
 
         # node and edge attributes
-        attributes_elements = graph_xml.findall("{%s}attributes" % self.NS_GEXF)
+        attributes_elements = graph_xml.findall(f"{{{self.NS_GEXF}}}attributes")
         # dictionaries to hold attributes and attribute defaults
         node_attr = {}
         node_default = {}
@@ -748,15 +748,15 @@ class GEXFReader(GEXF):
         G.graph["edge_default"] = edge_default
 
         # add nodes
-        nodes_element = graph_xml.find("{%s}nodes" % self.NS_GEXF)
+        nodes_element = graph_xml.find(f"{{{self.NS_GEXF}}}nodes")
         if nodes_element is not None:
-            for node_xml in nodes_element.findall("{%s}node" % self.NS_GEXF):
+            for node_xml in nodes_element.findall(f"{{{self.NS_GEXF}}}node"):
                 self.add_node(G, node_xml, node_attr)
 
         # add edges
-        edges_element = graph_xml.find("{%s}edges" % self.NS_GEXF)
+        edges_element = graph_xml.find(f"{{{self.NS_GEXF}}}edges")
         if edges_element is not None:
-            for edge_xml in edges_element.findall("{%s}edge" % self.NS_GEXF):
+            for edge_xml in edges_element.findall(f"{{{self.NS_GEXF}}}edge"):
                 self.add_edge(G, edge_xml, edge_attr)
 
         # switch to Graph or DiGraph if no parallel edges were found.
@@ -795,9 +795,9 @@ class GEXFReader(GEXF):
             data["pid"] = node_pid
 
         # check for subnodes, recursive
-        subnodes = node_xml.find("{%s}nodes" % self.NS_GEXF)
+        subnodes = node_xml.find(f"{{{self.NS_GEXF}}}nodes")
         if subnodes is not None:
-            for node_xml in subnodes.findall("{%s}node" % self.NS_GEXF):
+            for node_xml in subnodes.findall(f"{{{self.NS_GEXF}}}node"):
                 self.add_node(G, node_xml, node_attr, node_pid=node_id)
 
         G.add_node(node_id, **data)
@@ -816,7 +816,7 @@ class GEXFReader(GEXF):
     def add_viz(self, data, node_xml):
         # add viz element for node
         viz = {}
-        color = node_xml.find("{%s}color" % self.NS_VIZ)
+        color = node_xml.find(f"{{{self.NS_VIZ}}}color")
         if color is not None:
             if self.VERSION == "1.1":
                 viz["color"] = {
@@ -832,21 +832,21 @@ class GEXFReader(GEXF):
                     "a": float(color.get("a", 1)),
                 }
 
-        size = node_xml.find("{%s}size" % self.NS_VIZ)
+        size = node_xml.find(f"{{{self.NS_VIZ}}}size")
         if size is not None:
             viz["size"] = float(size.get("value"))
 
-        thickness = node_xml.find("{%s}thickness" % self.NS_VIZ)
+        thickness = node_xml.find(f"{{{self.NS_VIZ}}}thickness")
         if thickness is not None:
             viz["thickness"] = float(thickness.get("value"))
 
-        shape = node_xml.find("{%s}shape" % self.NS_VIZ)
+        shape = node_xml.find(f"{{{self.NS_VIZ}}}shape")
         if shape is not None:
             viz["shape"] = shape.get("shape")
             if viz["shape"] == "image":
                 viz["shape"] = shape.get("uri")
 
-        position = node_xml.find("{%s}position" % self.NS_VIZ)
+        position = node_xml.find(f"{{{self.NS_VIZ}}}position")
         if position is not None:
             viz["position"] = {
                 "x": float(position.get("x", 0)),
@@ -859,30 +859,30 @@ class GEXFReader(GEXF):
         return data
 
     def add_parents(self, data, node_xml):
-        parents_element = node_xml.find("{%s}parents" % self.NS_GEXF)
+        parents_element = node_xml.find(f"{{{self.NS_GEXF}}}parents")
         if parents_element is not None:
             data["parents"] = []
-            for p in parents_element.findall("{%s}parent" % self.NS_GEXF):
+            for p in parents_element.findall(f"{{{self.NS_GEXF}}}parent"):
                 parent = p.get("for")
                 data["parents"].append(parent)
         return data
 
     def add_slices(self, data, node_or_edge_xml):
-        slices_element = node_or_edge_xml.find("{%s}slices" % self.NS_GEXF)
+        slices_element = node_or_edge_xml.find(f"{{{self.NS_GEXF}}}slices")
         if slices_element is not None:
             data["slices"] = []
-            for s in slices_element.findall("{%s}slice" % self.NS_GEXF):
+            for s in slices_element.findall(f"{{{self.NS_GEXF}}}slice"):
                 start = s.get("start")
                 end = s.get("end")
                 data["slices"].append((start, end))
         return data
 
     def add_spells(self, data, node_or_edge_xml):
-        spells_element = node_or_edge_xml.find("{%s}spells" % self.NS_GEXF)
+        spells_element = node_or_edge_xml.find(f"{{{self.NS_GEXF}}}spells")
         if spells_element is not None:
             data["spells"] = []
             ttype = self.timeformat
-            for s in spells_element.findall("{%s}spell" % self.NS_GEXF):
+            for s in spells_element.findall(f"{{{self.NS_GEXF}}}spell"):
                 start = self.python_type[ttype](s.get("start"))
                 end = self.python_type[ttype](s.get("end"))
                 data["spells"].append((start, end))
@@ -944,15 +944,15 @@ class GEXFReader(GEXF):
         # Use the key information to decode the attr XML
         attr = {}
         # look for outer '<attvalues>' element
-        attr_element = obj_xml.find("{%s}attvalues" % self.NS_GEXF)
+        attr_element = obj_xml.find(f"{{{self.NS_GEXF}}}attvalues")
         if attr_element is not None:
             # loop over <attvalue> elements
-            for a in attr_element.findall("{%s}attvalue" % self.NS_GEXF):
+            for a in attr_element.findall(f"{{{self.NS_GEXF}}}attvalue"):
                 key = a.get("for")  # for is required
                 try:  # should be in our gexf_keys dictionary
                     title = gexf_keys[key]["title"]
                 except KeyError:
-                    raise nx.NetworkXError("No attribute defined for=%s." % key)
+                    raise nx.NetworkXError(f"No attribute defined for={key}.")
                 atype = gexf_keys[key]["type"]
                 value = a.get("value")
                 if atype == "boolean":
@@ -979,13 +979,13 @@ class GEXFReader(GEXF):
         attrs = {}
         defaults = {}
         mode = attributes_element.get("mode")
-        for k in attributes_element.findall("{%s}attribute" % self.NS_GEXF):
+        for k in attributes_element.findall(f"{{{self.NS_GEXF}}}attribute"):
             attr_id = k.get("id")
             title = k.get("title")
             atype = k.get("type")
             attrs[attr_id] = {"title": title, "type": atype, "mode": mode}
             # check for the 'default' subelement of key element and add
-            default = k.find("{%s}default" % self.NS_GEXF)
+            default = k.find(f"{{{self.NS_GEXF}}}default")
             if default is not None:
                 if atype == "boolean":
                     value = self.convert_bool[default.text]

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -302,8 +302,8 @@ def parse_gml_lines(lines, label, destringizer):
             while pos < length:
                 match = tokens.match(line, pos)
                 if match is None:
-                    m = "cannot tokenize %r at (%d, %d)"
-                    raise NetworkXError(m % (line[pos:], lineno + 1, pos + 1))
+                    m = f"cannot tokenize {line[pos:]} at ({lineno + 1}, {pos + 1})"
+                    raise NetworkXError(m)
                 for i in range(len(patterns)):
                     group = match.group(i + 1)
                     if group is not None:

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -326,8 +326,7 @@ def parse_gml_lines(lines, label, destringizer):
     def unexpected(curr_token, expected):
         category, value, lineno, pos = curr_token
         value = repr(value) if value is not None else "EOF"
-        msg = "expected %s, found %s at (%d, %d)"
-        raise NetworkXError(msg % (expected, value, lineno, pos))
+        raise NetworkXError(f"expected {expected}, found {value} at ({lineno}, {pos})")
 
     def consume(curr_token, category, expected):
         if curr_token.category == category:
@@ -423,8 +422,7 @@ def parse_gml_lines(lines, label, destringizer):
         try:
             return dct.pop(attr)
         except KeyError:
-            outputs = (category, i, attr)
-            raise NetworkXError("%s #%d has no '%s' attribute" % outputs)
+            raise NetworkXError(f"{category} #{i} has no '{attr}' attribute")
 
     nodes = graph.get("node", [])
     mapping = {}

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -115,7 +115,7 @@ def from_graph6_bytes(string):
     nd = (n * (n - 1) // 2 + 5) // 6
     if len(data) != nd:
         raise NetworkXError(
-            'Expected %d bits but got %d in graph6' % (n * (n - 1) // 2, len(data) * 6))
+            f'Expected {n * (n - 1) // 2} bits but got {len(data) * 6} in graph6')
 
     G = nx.Graph()
     G.add_nodes_from(range(n))

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -421,8 +421,8 @@ class GraphMLWriter(GraphML):
         type in the keys table.
         """
         if element_type not in self.xml_type:
-            msg = 'GraphML writer does not support %s as data values.'
-            raise nx.NetworkXError(msg % element_type)
+            msg = f"GraphML writer does not support {element_type} as data values."
+            raise nx.NetworkXError(msg)
         keyid = self.get_key(name, self.xml_type[element_type], scope, default)
         data_element = self.myElement("data", key=keyid)
         data_element.text = str(value)

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -163,8 +163,7 @@ def generate_graphml(G, encoding='utf-8', prettyprint=True):
     """
     writer = GraphMLWriter(encoding=encoding, prettyprint=prettyprint)
     writer.add_graph_element(G)
-    for line in str(writer).splitlines():
-        yield line
+    yield from str(writer).splitlines()
 
 
 @open_file(0, mode='rb')
@@ -297,7 +296,7 @@ def parse_graphml(graphml_string, node_type=str):
     return glist[0]
 
 
-class GraphML(object):
+class GraphML:
     NS_GRAPHML = "http://graphml.graphdrawing.org/xmlns"
     NS_XSI = "http://www.w3.org/2001/XMLSchema-instance"
     # xmlns:y="http://www.yworks.com/xml/graphml"
@@ -524,7 +523,7 @@ class GraphMLWriter(GraphML):
                 elem.tail = i
 
 
-class IncrementalElement(object):
+class IncrementalElement:
     """Wrapper for _IncrementalWriter providing an Element like interface.
 
     This wrapper does not intend to be a complete implementation but rather to

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -30,7 +30,7 @@ def cytoscape_data(G, attrs=None):
     name = attrs["name"]
     ident = attrs["ident"]
 
-    if len(set([name, ident])) < 2:
+    if len({name, ident}) < 2:
         raise nx.NetworkXError('Attribute names are not unique.')
 
     jsondata = {"data": list(G.graph.items())}
@@ -72,7 +72,7 @@ def cytoscape_graph(data, attrs=None):
     name = attrs["name"]
     ident = attrs["ident"]
 
-    if len(set([ident, name])) < 2:
+    if len({ident, name}) < 2:
         raise nx.NetworkXError('Attribute names are not unique.')
 
     multigraph = data.get('multigraph')

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -157,18 +157,18 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
     c = count()
     for d in data['nodes']:
         node = to_tuple(d.get(name, next(c)))
-        nodedata = dict((str(k), v) for k, v in d.items() if k != name)
+        nodedata = {str(k): v for k, v in d.items() if k != name}
         graph.add_node(node, **nodedata)
     for d in data[links]:
         src = tuple(d[source]) if isinstance(d[source], list) else d[source]
         tgt = tuple(d[target]) if isinstance(d[target], list) else d[target]
         if not multigraph:
-            edgedata = dict((str(k), v) for k, v in d.items()
-                            if k != source and k != target)
+            edgedata = {str(k): v for k, v in d.items()
+                            if k != source and k != target}
             graph.add_edge(src, tgt, **edgedata)
         else:
             ky = d.get(key, None)
-            edgedata = dict((str(k), v) for k, v in d.items()
-                            if k != source and k != target and k != key)
+            edgedata = {str(k): v for k, v in d.items()
+                            if k != source and k != target and k != key}
             graph.add_edge(src, tgt, ky, **edgedata)
     return graph

--- a/networkx/readwrite/json_graph/tests/test_jit.py
+++ b/networkx/readwrite/json_graph/tests/test_jit.py
@@ -4,7 +4,7 @@ import networkx as nx
 from networkx.readwrite.json_graph import jit_data, jit_graph
 
 
-class TestJIT(object):
+class TestJIT:
     def test_jit(self):
         G = nx.Graph()
         G.add_node('Node1', node_data='foobar')

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -133,14 +133,14 @@ def tree_graph(data, attrs=_attrs):
             grandchildren = data.get(children, [])
             if grandchildren:
                 add_children(child, grandchildren)
-            nodedata = dict((str(k), v) for k, v in data.items()
-                            if k != id_ and k != children)
+            nodedata = {str(k): v for k, v in data.items()
+                            if k != id_ and k != children}
             graph.add_node(child, **nodedata)
 
     root = data[id_]
     children_ = data.get(children, [])
-    nodedata = dict((str(k), v) for k, v in data.items()
-                    if k != id_ and k != children)
+    nodedata = {str(k): v for k, v in data.items()
+                    if k != id_ and k != children}
     graph.add_node(root, **nodedata)
     add_children(root, children_)
     return graph

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -95,7 +95,7 @@ def parse_leda(lines):
         try:
             s, t, reversal, label = next(lines).split()
         except:
-            raise NetworkXError('Too few fields in LEDA.GRAPH edge %d' % (i + 1))
+            raise NetworkXError(f'Too few fields in LEDA.GRAPH edge {i+1}')
         # BEWARE: no handling of reversal edges
         G.add_edge(node[int(s)], node[int(t)], label=label[2:-2])
     return G

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -168,9 +168,9 @@ def write_multiline_adjlist(G, path, delimiter=' ',
     import time
 
     pargs = comments + " ".join(sys.argv)
-    header = ("{}\n".format(pargs)
+    header = (f"{pargs}\n"
               + comments + " GMT {}\n".format(time.asctime(time.gmtime()))
-              + comments + " {}\n".format(G.name))
+              + comments + f" {G.name}\n")
     path.write(header.encode(encoding))
 
     for multiline in generate_multiline_adjlist(G, delimiter):
@@ -229,7 +229,7 @@ def parse_multiline_adjlist(lines, comments='#', delimiter=None,
             (u, deg) = line.strip().split(delimiter)
             deg = int(deg)
         except:
-            raise TypeError("Failed to read node and degree on line ({})".format(line))
+            raise TypeError(f"Failed to read node and degree on line ({line})")
         if nodetype is not None:
             try:
                 u = nodetype(u)
@@ -242,7 +242,7 @@ def parse_multiline_adjlist(lines, comments='#', delimiter=None,
                 try:
                     line = next(lines)
                 except StopIteration:
-                    msg = "Failed to find neighbor for node ({})".format(u)
+                    msg = f"Failed to find neighbor for node ({u})"
                     raise TypeError(msg)
                 p = line.find(comments)
                 if p >= 0:

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -169,7 +169,7 @@ def write_multiline_adjlist(G, path, delimiter=' ',
 
     pargs = comments + " ".join(sys.argv)
     header = (f"{pargs}\n"
-              + comments + " GMT {}\n".format(time.asctime(time.gmtime()))
+              + comments + f" GMT {time.asctime(time.gmtime())}\n"
               + comments + f" {G.name}\n")
     path.write(header.encode(encoding))
 
@@ -234,8 +234,7 @@ def parse_multiline_adjlist(lines, comments='#', delimiter=None,
             try:
                 u = nodetype(u)
             except:
-                raise TypeError("Failed to convert node ({}) to type {}"
-                                .format(u, nodetype))
+                raise TypeError(f"Failed to convert node ({u}) to type {nodetype}")
         G.add_node(u)
         for i in range(deg):
             while True:
@@ -259,16 +258,12 @@ def parse_multiline_adjlist(lines, comments='#', delimiter=None,
                 try:
                     v = nodetype(v)
                 except:
-                    raise TypeError(
-                        "Failed to convert node ({}) to type {}"
-                        .format(v, nodetype))
+                    raise TypeError("Failed to convert node ({v}) to type {nodetype}")
             if edgetype is not None:
                 try:
                     edgedata = {'weight': edgetype(data)}
                 except:
-                    raise TypeError(
-                        "Failed to convert edge data ({}) to type {}"
-                        .format(data, edgetype))
+                    raise TypeError("Failed to convert edge data ({data}) to type {edgetype}")
             else:
                 try:  # try to evaluate
                     edgedata = literal_eval(data)

--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -86,7 +86,7 @@ def read_shp(path, simplify=True, geom_attrs=True, strict=True):
     net = nx.DiGraph()
     shp = ogr.Open(path)
     if shp is None:
-        raise RuntimeError("Unable to open {}".format(path))
+        raise RuntimeError(f"Unable to open {path}")
     for lyr in shp:
         fields = [x.GetName() for x in lyr.schema]
         for f in lyr:
@@ -177,8 +177,7 @@ def edges_from_line(geom, attrs, simplify=True, geom_attrs=True):
     elif geom.GetGeometryType() == ogr.wkbMultiLineString:
         for i in range(geom.GetGeometryCount()):
             geom_i = geom.GetGeometryRef(i)
-            for edge in edges_from_line(geom_i, attrs, simplify, geom_attrs):
-                yield edge
+            yield from edges_from_line(geom_i, attrs, simplify, geom_attrs)
 
 
 def write_shp(G, outdir):

--- a/networkx/readwrite/p2g.py
+++ b/networkx/readwrite/p2g.py
@@ -44,15 +44,15 @@ def write_p2g(G, path, encoding='utf-8'):
     This format is meant to be used with directed graphs with
     possible self loops.
     """
-    path.write(("%s\n" % G.name).encode(encoding))
-    path.write(("%s %s\n" % (G.order(), G.size())).encode(encoding))
+    path.write((f"{G.name}\n").encode(encoding))
+    path.write((f"{G.order()} {G.size()}\n").encode(encoding))
     nodes = list(G)
     # make dictionary mapping nodes to integers
     nodenumber = dict(zip(nodes, range(len(nodes))))
     for n in nodes:
-        path.write(("%s\n" % n).encode(encoding))
+        path.write((f"{n}\n").encode(encoding))
         for nbr in G.neighbors(n):
-            path.write(("%s " % nodenumber[nbr]).encode(encoding))
+            path.write((f"{nodenumber[nbr]} ").encode(encoding))
         path.write("\n".encode(encoding))
 
 

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -44,7 +44,7 @@ def generate_pajek(G):
     # yield '*network %s'%name
 
     # write nodes with attributes
-    yield '*vertices %s' % (G.order())
+    yield f"*vertices {G.order()}"
     nodes = list(G)
     # make dictionary mapping nodes to integers
     nodenumber = dict(zip(nodes, range(1, len(nodes) + 1)))
@@ -61,12 +61,9 @@ def generate_pajek(G):
         # only optional attributes are left in na.
         for k, v in na.items():
             if isinstance(v, str) and v.strip() != '':
-                s += ' %s %s' % (make_qstr(k), make_qstr(v))
+                s += f" {make_qstr(k)} {make_qstr(v)}"
             else:
-                warnings.warn('Node attribute %s is not processed. %s.' %
-                              (k,
-                               'Empty attribute' if isinstance(v, str) else
-                               'Non-string attribute'))
+                warnings.warn(f"Node attribute {k} is not processed. {('Empty attribute' if isinstance(v, str) else 'Non-string attribute')}.")
         yield s
 
     # write edges with attributes
@@ -80,12 +77,9 @@ def generate_pajek(G):
         s = ' '.join(map(make_qstr, (nodenumber[u], nodenumber[v], value)))
         for k, v in d.items():
             if isinstance(v, str) and v.strip() != '':
-                s += ' %s %s' % (make_qstr(k), make_qstr(v))
+                s += f" {make_qstr(k)} {make_qstr(v)}"
             else:
-                warnings.warn('Edge attribute %s is not processed. %s.' %
-                              (k,
-                               'Empty attribute' if isinstance(v, str) else
-                               'Non-string attribute'))
+                warnings.warn(f"Edge attribute {k} is not processed. {('Empty attribute' if isinstance(v, str) else 'Non-string attribute')}.")
         yield s
 
 
@@ -268,5 +262,5 @@ def make_qstr(t):
     if not isinstance(t, str):
         t = str(t)
     if " " in t:
-        t = r'"%s"' % t
+        t = f'"{t}"'
     return t

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -298,12 +298,12 @@ org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/\
             G.nodes[i]['end'] = i + 1
 
         if sys.version_info < (3, 8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2\
+            expected = f"""<gexf version="1.2" xmlns="http://www.gexf.net/1.2\
 draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:\
 schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/\
 gexf.xsd">
-  <meta lastmodifieddate="{}">
-    <creator>NetworkX {}</creator>
+  <meta lastmodifieddate="{time.strftime('%Y-%m-%d')}">
+    <creator>NetworkX {nx.__version__}</creator>
   </meta>
   <graph defaultedgetype="undirected" mode="dynamic" name="" timeformat="long">
     <nodes>
@@ -318,14 +318,14 @@ gexf.xsd">
       <edge id="2" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+</gexf>"""
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi\
+            expected = f"""<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi\
 ="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=\
 "http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/\
 gexf.xsd" version="1.2">
-  <meta lastmodifieddate="{}">
-    <creator>NetworkX {}</creator>
+  <meta lastmodifieddate="{time.strftime('%Y-%m-%d')}">
+    <creator>NetworkX {nx.__version__}</creator>
   </meta>
   <graph defaultedgetype="undirected" mode="dynamic" name="" timeformat="long">
     <nodes>
@@ -340,7 +340,7 @@ gexf.xsd" version="1.2">
       <edge source="2" target="3" id="2" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+</gexf>"""
         obtained = '\n'.join(nx.generate_gexf(G))
         assert expected == obtained
 
@@ -349,12 +349,12 @@ gexf.xsd" version="1.2">
         G.add_edges_from([(0, 1, {'id': 0}), (1, 2, {'id': 2}), (2, 3)])
 
         if sys.version_info < (3, 8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/\
+            expected = f"""<gexf version="1.2" xmlns="http://www.gexf.net/\
 1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:\
 schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/\
 gexf.xsd">
-  <meta lastmodifieddate="{}">
-    <creator>NetworkX {}</creator>
+  <meta lastmodifieddate="{time.strftime('%Y-%m-%d')}">
+    <creator>NetworkX {nx.__version__}</creator>
   </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
     <nodes>
@@ -369,13 +369,13 @@ gexf.xsd">
       <edge id="1" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+</gexf>"""
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi\
+            expected = f"""<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi\
 ="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.\
 gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
-  <meta lastmodifieddate="{}">
-    <creator>NetworkX {}</creator>
+  <meta lastmodifieddate="{time.strftime('%Y-%m-%d')}">
+    <creator>NetworkX {nx.__version__}</creator>
   </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
     <nodes>
@@ -390,7 +390,7 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
       <edge source="2" target="3" id="1" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+</gexf>"""
 
         obtained = '\n'.join(nx.generate_gexf(G))
         assert expected == obtained
@@ -405,11 +405,11 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
         G[0][1]['edge-number'] = numpy.float64(1.1)
 
         if sys.version_info < (3, 8):
-            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft"\
+            expected = f"""<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft"\
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation\
 ="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
-  <meta lastmodifieddate="{}">
-    <creator>NetworkX {}</creator>
+  <meta lastmodifieddate="{time.strftime('%Y-%m-%d')}">
+    <creator>NetworkX {nx.__version__}</creator>
   </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
     <attributes class="edge" mode="static">
@@ -450,14 +450,14 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
       <edge id="2" source="2" target="3" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+</gexf>"""
         else:
-            expected = """<gexf xmlns="http://www.gexf.net/1.2draft"\
+            expected = f"""<gexf xmlns="http://www.gexf.net/1.2draft"\
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation\
 ="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd"\
  version="1.2">
-  <meta lastmodifieddate="{}">
-    <creator>NetworkX {}</creator>
+  <meta lastmodifieddate="{time.strftime('%Y-%m-%d')}">
+    <creator>NetworkX {nx.__version__}</creator>
   </meta>
   <graph defaultedgetype="undirected" mode="static" name="">
     <attributes mode="static" class="edge">
@@ -498,7 +498,7 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
       <edge source="2" target="3" id="2" />
     </edges>
   </graph>
-</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+</gexf>"""
         obtained = '\n'.join(nx.generate_gexf(G))
         assert expected == obtained
 

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -6,7 +6,7 @@ import pytest
 import networkx as nx
 
 
-class TestGEXF(object):
+class TestGEXF:
     @classmethod
     def setup_class(cls):
         _ = pytest.importorskip("xml.etree.ElementTree")

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -10,7 +10,7 @@ import tempfile
 from textwrap import dedent
 
 
-class TestGraph(object):
+class TestGraph:
     @classmethod
     def setup_class(cls):
         cls.simple_data = """Creator "me"
@@ -347,7 +347,7 @@ graph
         gml = "\n".join(nx.generate_gml(G, stringizer=literal_stringizer))
         G = nx.parse_gml(gml, destringizer=literal_destringizer)
         assert data == G.name
-        assert {"name": data, str("data"): data} == G.graph
+        assert {"name": data, "data": data} == G.graph
         assert list(G.nodes(data=True)) == [(0, dict(int=-1, data=dict(data=data)))]
         assert list(G.edges(data=True)) == [(0, 0, dict(float=-2.5, data=data))]
         G = nx.Graph()
@@ -382,14 +382,14 @@ graph
         pytest.raises(ValueError, literal_stringizer, frozenset([1, 2, 3]))
         pytest.raises(ValueError, literal_stringizer, literal_stringizer)
         with tempfile.TemporaryFile() as f:
-            f.write(codecs.BOM_UTF8 + "graph[]".encode("ascii"))
+            f.write(codecs.BOM_UTF8 + b"graph[]")
             f.seek(0)
             pytest.raises(nx.NetworkXError, nx.read_gml, f)
 
         def assert_parse_error(gml):
             pytest.raises(nx.NetworkXError, nx.parse_gml, gml)
 
-        assert_parse_error(["graph [\n\n", str("]")])
+        assert_parse_error(["graph [\n\n", "]"])
         assert_parse_error("")
         assert_parse_error('Creator ""')
         assert_parse_error("0")
@@ -522,7 +522,7 @@ def byte_file():
     _file_handle.seek(0)
 
 
-class TestPropertyLists(object):
+class TestPropertyLists:
     def test_writing_graph_with_multi_element_property_list(self):
         g = nx.Graph()
         g.add_node("n1", properties=["element", 0, 1, 2.5, True, False])

--- a/networkx/readwrite/tests/test_gpickle.py
+++ b/networkx/readwrite/tests/test_gpickle.py
@@ -9,7 +9,7 @@ from networkx.testing.utils import (
 )
 
 
-class TestGpickle(object):
+class TestGpickle:
     @classmethod
     def setup_class(cls):
         G = nx.Graph(name="test")

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -1,4 +1,3 @@
-
 from io import BytesIO
 import tempfile
 import pytest
@@ -9,7 +8,7 @@ from networkx.testing.utils import assert_edges_equal
 from networkx.testing.utils import assert_nodes_equal
 
 
-class TestGraph6Utils(object):
+class TestGraph6Utils:
 
     def test_n_data_n_conversion(self):
         for i in [0, 1, 42, 62, 63, 64, 258047, 258048, 7744773, 68719476735]:

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -7,7 +7,7 @@ import os
 from networkx.testing import almost_equal
 
 
-class BaseGraphML(object):
+class BaseGraphML:
     @classmethod
     def setup_class(cls):
         cls.simple_directed_data = """<?xml version="1.0" encoding="UTF-8"?>

--- a/networkx/readwrite/tests/test_leda.py
+++ b/networkx/readwrite/tests/test_leda.py
@@ -2,7 +2,7 @@ import networkx as nx
 import io
 
 
-class TestLEDA(object):
+class TestLEDA:
 
     def test_parse_leda(self):
         data = """#header section         \nLEDA.GRAPH \nstring\nint\n-1\n#nodes section\n5 \n|{v1}| \n|{v2}| \n|{v3}| \n|{v4}| \n|{v5}| \n\n#edges section\n7 \n1 2 0 |{4}| \n1 3 0 |{3}| \n2 3 0 |{2}| \n3 4 0 |{3}| \n3 5 0 |{7}| \n4 5 0 |{6}| \n5 1 0 |{foo}|"""

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -7,7 +7,7 @@ import tempfile
 from networkx.testing import assert_edges_equal, assert_nodes_equal
 
 
-class TestPajek(object):
+class TestPajek:
     @classmethod
     def setup_class(cls):
         cls.data = """*network Tralala\n*vertices 4\n   1 "A1"         0.0938 0.0896   ellipse x_fact 1 y_fact 1\n   2 "Bb"         0.8188 0.2458   ellipse x_fact 1 y_fact 1\n   3 "C"          0.3688 0.7792   ellipse x_fact 1\n   4 "D2"         0.9583 0.8563   ellipse x_fact 1\n*arcs\n1 1 1  h2 0 w 3 c Blue s 3 a1 -130 k1 0.6 a2 -130 k2 0.6 ap 0.5 l "Bezier loop" lc BlueViolet fos 20 lr 58 lp 0.3 la 360\n2 1 1  h2 0 a1 120 k1 1.3 a2 -120 k2 0.3 ap 25 l "Bezier arc" lphi 270 la 180 lr 19 lp 0.5\n1 2 1  h2 0 a1 40 k1 2.8 a2 30 k2 0.8 ap 25 l "Bezier arc" lphi 90 la 0 lp 0.65\n4 2 -1  h2 0 w 1 k1 -2 k2 250 ap 25 l "Circular arc" c Red lc OrangeRed\n3 4 1  p Dashed h2 0 w 2 c OliveGreen ap 25 l "Straight arc" lc PineGreen\n1 3 1  p Dashed h2 0 w 5 k1 -1 k2 -20 ap 25 l "Oval arc" c Brown lc Black\n3 3 -1  h1 6 w 1 h2 12 k1 -2 k2 -15 ap 0.5 l "Circular loop" c Red lc OrangeRed lphi 270 la 180"""

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -9,7 +9,7 @@ ogr = pytest.importorskip('osgeo.ogr')
 import networkx as nx
 
 
-class TestShp(object):
+class TestShp:
     def setup_method(self):
 
         def createlayer(driver, layerType=ogr.wkbLineString):
@@ -225,7 +225,7 @@ def test_read_shp_nofile():
         G = nx.read_shp("hopefully_this_file_will_not_be_available")
 
 
-class TestMissingGeometry(object):
+class TestMissingGeometry:
     def setup_method(self):
         self.setup_path()
         self.delete_shapedir()
@@ -256,7 +256,7 @@ class TestMissingGeometry(object):
             G = nx.read_shp(self.path)
 
 
-class TestMissingAttrWrite(object):
+class TestMissingAttrWrite:
     def setup_method(self):
         self.setup_path()
         self.delete_shapedir()

--- a/networkx/readwrite/tests/test_yaml.py
+++ b/networkx/readwrite/tests/test_yaml.py
@@ -11,7 +11,7 @@ import networkx as nx
 from networkx.testing import assert_edges_equal, assert_nodes_equal
 
 
-class TestYaml(object):
+class TestYaml:
     @classmethod
     def setup_class(cls):
         cls.build_graphs()

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -124,7 +124,7 @@ def _relabel_inplace(G, mapping):
         try:
             G.add_node(new, **G.nodes[old])
         except KeyError:
-            raise KeyError("Node %s is not in the graph" % old)
+            raise KeyError(f"Node {old} is not in the graph")
         if multigraph:
             new_edges = [(new, new if old == target else target, key, data)
                          for (_, target, key, data)
@@ -210,7 +210,7 @@ def convert_node_labels_to_integers(G, first_label=0, ordering="default",
         dv_pairs.reverse()
         mapping = dict(zip([n for d, n in dv_pairs], range(first_label, N)))
     else:
-        raise nx.NetworkXError('Unknown node ordering: %s' % ordering)
+        raise nx.NetworkXError(f"Unknown node ordering: {ordering}")
     H = relabel_nodes(G, mapping)
     # create node attribute with the old label
     if label_attribute is not None:

--- a/networkx/testing/tests/test_utils.py
+++ b/networkx/testing/tests/test_utils.py
@@ -8,7 +8,7 @@ from networkx.testing import (
 # thanks to numpy for this GenericTest class (numpy/testing/test_utils.py)
 
 
-class _GenericTest(object):
+class _GenericTest:
     @classmethod
     def _test_equal(cls, a, b):
         cls._assert_func(a, b)

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -40,13 +40,13 @@ class TestConvert():
 
     def test_exceptions(self):
         # NX graph
-        class G(object):
+        class G:
             adj = None
 
         pytest.raises(nx.NetworkXError, to_networkx_graph, G)
 
         # pygraphviz  agraph
-        class G(object):
+        class G:
             is_strict = None
 
         pytest.raises(nx.NetworkXError, to_networkx_graph, G)
@@ -56,7 +56,7 @@ class TestConvert():
         pytest.raises(TypeError, to_networkx_graph, G)
 
         # list or generator of edges
-        class G(object):
+        class G:
             next = None
 
         pytest.raises(nx.NetworkXError, to_networkx_graph, G)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -7,7 +7,7 @@ from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 from networkx.testing.utils import assert_graphs_equal
 
 
-class TestConvertNumpy(object):
+class TestConvertNumpy:
     def setup_method(self):
         self.G1 = barbell_graph(10, 3)
         self.G2 = cycle_graph(10, create_using=nx.DiGraph)
@@ -238,7 +238,7 @@ class TestConvertNumpy(object):
         assert A.dtype == int
 
 
-class TestConvertNumpyArray(object):
+class TestConvertNumpyArray:
     def setup_method(self):
         self.G1 = barbell_graph(10, 3)
         self.G2 = cycle_graph(10, create_using=nx.DiGraph)

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -6,7 +6,7 @@ import networkx as nx
 from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
 
 
-class TestConvertPandas(object):
+class TestConvertPandas:
     def setup_method(self):
         self.rng = pd.np.random.RandomState(seed=5)
         ints = self.rng.randint(1, 11, size=(3, 2))

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -5,7 +5,7 @@ from networkx.testing import assert_graphs_equal
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 
 
-class TestConvertNumpy(object):
+class TestConvertNumpy:
     @classmethod
     def setup_class(cls):
         global np, sp, sparse, np_assert_equal
@@ -22,7 +22,7 @@ class TestConvertNumpy(object):
         self.G4 = self.create_weighted(nx.DiGraph())
 
     def test_exceptions(self):
-        class G(object):
+        class G:
             format = None
 
         pytest.raises(nx.NetworkXError, nx.to_networkx_graph, G)

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -164,10 +164,10 @@ class TestRelabel():
     def test_relabel_toposort(self):
         K5 = nx.complete_graph(4)
         G = nx.complete_graph(4)
-        G = nx.relabel_nodes(G, dict([(i, i + 1) for i in range(4)]), copy=False)
+        G = nx.relabel_nodes(G, {i: i + 1 for i in range(4)}, copy=False)
         nx.is_isomorphic(K5, G)
         G = nx.complete_graph(4)
-        G = nx.relabel_nodes(G, dict([(i, i - 1) for i in range(4)]), copy=False)
+        G = nx.relabel_nodes(G, {i: i - 1 for i in range(4)}, copy=False)
         nx.is_isomorphic(K5, G)
 
     def test_relabel_selfloop(self):

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -68,7 +68,7 @@ def not_implemented_for(*graph_types):
             raise KeyError('use one or more of ',
                            'directed, undirected, multigraph, graph')
         if match:
-            msg = 'not implemented for %s type' % ' '.join(graph_types)
+            msg = f"not implemented for {' '.join(graph_types)} type"
             raise nx.NetworkXNotImplemented(msg)
         else:
             return not_implement_for_func(*args, **kwargs)
@@ -289,7 +289,7 @@ def nodes_or_number(which_args):
                 nodes = tuple(n)
             else:
                 if n < 0:
-                    msg = "Negative number of nodes not valid: %i" % n
+                    msg = "Negative number of nodes not valid: {n}"
                     raise nx.NetworkXError(msg)
             new_args[i] = (n, nodes)
         return func_to_be_decorated(*new_args, **kw)

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -185,8 +185,8 @@ def open_file(path_arg, mode='r'):
             except KeyError:
                 # Could not find the keyword. Thus, no default was specified
                 # in the function signature and the user did not provide it.
-                msg = 'Missing required keyword argument: {0}'
-                raise nx.NetworkXError(msg.format(path_arg))
+                msg = f"Missing required keyword argument: {path_arg}"
+                raise nx.NetworkXError(msg)
             else:
                 is_kwarg = True
         except IndexError:

--- a/networkx/utils/heaps.py
+++ b/networkx/utils/heaps.py
@@ -9,7 +9,7 @@ import networkx as nx
 __all__ = ['MinHeap', 'PairingHeap', 'BinaryHeap']
 
 
-class MinHeap(object):
+class MinHeap:
     """Base class for min-heaps.
 
     A MinHeap stores a collection of key-value pairs ordered by their values.
@@ -17,7 +17,7 @@ class MinHeap(object):
     value in an existing pair and deleting the minimum pair.
     """
 
-    class _Item(object):
+    class _Item:
         """Used by subclassess to represent a key-value pair.
         """
         __slots__ = ('key', 'value')
@@ -167,7 +167,7 @@ class PairingHeap(MinHeap):
     def __init__(self):
         """Initialize a pairing heap.
         """
-        super(PairingHeap, self).__init__()
+        super().__init__()
         self._root = None
 
     @_inherit_doc(MinHeap)
@@ -303,7 +303,7 @@ class BinaryHeap(MinHeap):
     def __init__(self):
         """Initialize a binary heap.
         """
-        super(BinaryHeap, self).__init__()
+        super().__init__()
         self._heap = []
         self._count = count()
 

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -6,7 +6,7 @@ import heapq
 __all__ = ['MappedQueue']
 
 
-class MappedQueue(object):
+class MappedQueue:
     """The MappedQueue class implements an efficient minimum heap. The
     smallest element can be popped in O(1) time, new elements can be pushed
     in O(log n) time, and any element can be removed or updated in O(log n)
@@ -61,7 +61,7 @@ class MappedQueue(object):
     def _heapify(self):
         """Restore heap invariant and recalculate map."""
         heapq.heapify(self.h)
-        self.d = dict([(elt, pos) for pos, elt in enumerate(self.h)])
+        self.d = {elt: pos for pos, elt in enumerate(self.h)}
         if len(self.h) != len(self.d):
             raise AssertionError("Heap contains duplicate elements")
 

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -67,28 +67,29 @@ def make_list_of_ints(sequence):
     If sequence is a list, the non-int values are replaced with ints.
     So, no new list is created
     """
-    msg = 'sequence is not all integers: %s'
     if not isinstance(sequence, list):
         result = []
         for i in sequence:
+            errmsg = f"sequence is not all integers: {i}"
             try:
                 ii = int(i)
             except ValueError:
-                raise nx.NetworkXError(msg % i) from None
+                raise nx.NetworkXError(errmsg) from None
             if ii != i:
-                raise nx.NetworkXError(msg % i)
+                raise nx.NetworkXError(errmsg)
             result.append(ii)
         return result
     # original sequence is a list... in-place conversion to ints
     for indx, i in enumerate(sequence):
+        errmsg = f"sequence is not all integers: {i}"
         if isinstance(i, int):
             continue
         try:
             ii = int(i)
         except ValueError:
-            raise nx.NetworkXError(msg % i) from None
+            raise nx.NetworkXError(errmsg) from None
         if ii != i:
-            raise nx.NetworkXError(msg % i)
+            raise nx.NetworkXError(errmsg)
         sequence[indx] = ii
     return sequence
 
@@ -296,8 +297,8 @@ def create_random_state(random_state=None):
         return random_state
     if isinstance(random_state, int):
         return np.random.RandomState(random_state)
-    msg = '%r cannot be used to generate a numpy.random.RandomState instance'
-    raise ValueError(msg % random_state)
+    msg = f"{random_state} cannot be used to generate a numpy.random.RandomState instance"
+    raise ValueError(msg)
 
 
 class PythonRandomInterface:
@@ -392,5 +393,5 @@ def create_py_random_state(random_state=None):
         return random_state
     if isinstance(random_state, int):
         return random.Random(random_state)
-    msg = '%r cannot be used to generate a random.Random instance'
-    raise ValueError(msg % random_state)
+    msg = f"{random_state} cannot be used to generate a random.Random instance"
+    raise ValueError(msg)

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -300,7 +300,7 @@ def create_random_state(random_state=None):
     raise ValueError(msg % random_state)
 
 
-class PythonRandomInterface(object):
+class PythonRandomInterface:
     try:
         def __init__(self, rng=None):
             import numpy

--- a/networkx/utils/rcm.py
+++ b/networkx/utils/rcm.py
@@ -65,8 +65,7 @@ def cuthill_mckee_ordering(G, heuristic=None):
        Springer-Verlag New York, Inc., New York, NY, USA.
     """
     for c in nx.connected_components(G):
-        for n in connected_cuthill_mckee_ordering(G.subgraph(c), heuristic):
-            yield n
+        yield from connected_cuthill_mckee_ordering(G.subgraph(c), heuristic)
 
 
 def reverse_cuthill_mckee_ordering(G, heuristic=None):

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -39,7 +39,7 @@ def test_not_implemented_decorator_raise():
         test1(nx.Graph())
 
 
-class TestOpenFileDecorator(object):
+class TestOpenFileDecorator:
     def setup_method(self):
         self.text = ['Blah... ', 'BLAH ', 'BLAH!!!!']
         self.fobj = tempfile.NamedTemporaryFile('wb+', delete=False)
@@ -60,7 +60,7 @@ class TestOpenFileDecorator(object):
     @staticmethod
     @open_file(0, 'wb')
     def writer_arg0(path):
-        path.write('demo'.encode('ascii'))
+        path.write(b'demo')
 
     @open_file(1, 'wb+')
     def writer_arg1(self, path):
@@ -152,7 +152,7 @@ def test_preserve_random_state():
     assert(abs(r - 0.61879477158568) < 1e-16)
 
 
-class TestRandomState(object):
+class TestRandomState:
     @classmethod
     def setup_class(cls):
         global np

--- a/networkx/utils/tests/test_heaps.py
+++ b/networkx/utils/tests/test_heaps.py
@@ -3,7 +3,7 @@ import networkx as nx
 from networkx.utils import BinaryHeap, PairingHeap
 
 
-class X(object):
+class X:
 
     def __eq__(self, other):
         raise self is other

--- a/networkx/utils/tests/test_mapped_queue.py
+++ b/networkx/utils/tests/test_mapped_queue.py
@@ -1,20 +1,19 @@
-
 from networkx.utils.mapped_queue import MappedQueue
 
 
-class TestMappedQueue(object):
+class TestMappedQueue:
 
     def setup(self):
         pass
 
     def _check_map(self, q):
-        d = dict((elt, pos) for pos, elt in enumerate(q.h))
+        d = {elt: pos for pos, elt in enumerate(q.h)}
         assert d == q.d
 
     def _make_mapped_queue(self, h):
         q = MappedQueue()
         q.h = h
-        q.d = dict((elt, pos) for pos, elt in enumerate(h))
+        q.d = {elt: pos for pos, elt in enumerate(h)}
         return q
 
     def test_heapify(self):

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -71,7 +71,7 @@ def test_make_str_with_unicode():
     assert len(y) == 7
 
 
-class TestNumpyArray(object):
+class TestNumpyArray:
     @classmethod
     def setup_class(cls):
         global numpy
@@ -184,7 +184,7 @@ def test_create_random_state():
     assert isinstance(create_random_state(rs(1)), rs)
     pytest.raises(ValueError, create_random_state, 'a')
 
-    assert np.all((rs(1).rand(10) == create_random_state(1).rand(10)))
+    assert np.all(rs(1).rand(10) == create_random_state(1).rand(10))
 
 
 def test_create_py_random_state():

--- a/networkx/utils/tests/test_unionfind.py
+++ b/networkx/utils/tests/test_unionfind.py
@@ -21,4 +21,4 @@ def test_subtree_union():
     uf.union(3, 4)
     uf.union(4, 5)
     uf.union(1, 5)
-    assert list(uf.to_sets()) == [set([1, 2, 3, 4, 5])]
+    assert list(uf.to_sets()) == [{1, 2, 3, 4, 5}]


### PR DESCRIPTION
This upgrades the syntax to Python 3.6 using two automated tools: [fstringify](https://github.com/jacktasia/fstringify) and [pyupgrade](https://github.com/asottile/pyupgrade).

@dschult We have a bunch of code that uses older syntax.  This upgrades the code to use new syntax.  I know we normally don't do this type of thing, but moving from Python 2 to 3.6 is a bit unusual.  I am fairly confident that this doesn't break anything.  It also makes the code shorter, more readable, and more modern.  It should also make the code slightly faster.

It doesn't get everything, since the automated tools are a bit conservative.  But it greatly reduces the number of things that we will need to fix by hand.  If this seems reasonable to you, I will also try to take care of most of the remaining updates (mostly fstring updates) by hand.

