### PR TITLE
Add links to data files

### DIFF
--- a/examples/basic/plot_read_write.py
+++ b/examples/basic/plot_read_write.py
@@ -6,8 +6,6 @@ Read and write graphs.
 Read and write graphs.
 """
 
-import sys
-
 import matplotlib.pyplot as plt
 import networkx as nx
 

--- a/examples/drawing/plot_atlas.py
+++ b/examples/drawing/plot_atlas.py
@@ -4,20 +4,13 @@ Atlas
 =====
 
 Atlas of all graphs of 6 nodes or less.
-
 """
 
 import random
 
-try:
-    import pygraphviz
-    from networkx.drawing.nx_agraph import graphviz_layout
-except ImportError:
-    try:
-        import pydot
-        from networkx.drawing.nx_pydot import graphviz_layout
-    except ImportError:
-        raise ImportError("This example needs Graphviz and either PyGraphviz or pydot.")
+# This example needs Graphviz and either PyGraphviz or pydot.
+# from networkx.drawing.nx_pydot import graphviz_layout
+from networkx.drawing.nx_agraph import graphviz_layout
 
 import matplotlib.pyplot as plt
 

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -112,7 +112,7 @@ for (u, v, d) in G.edges(data=True):
         wins[v] += 1.0
 try:
     pos = nx.nx_agraph.graphviz_layout(H)
-except:
+except ImportError:
     pos = nx.spring_layout(H, iterations=20)
 
 plt.rcParams["text.usetex"] = False

--- a/examples/drawing/plot_circular_tree.py
+++ b/examples/drawing/plot_circular_tree.py
@@ -2,21 +2,15 @@
 =============
 Circular Tree
 =============
-
-This
 """
+
 import matplotlib.pyplot as plt
 import networkx as nx
 
-try:
-    import pygraphviz
-    from networkx.drawing.nx_agraph import graphviz_layout
-except ImportError:
-    try:
-        import pydot
-        from networkx.drawing.nx_pydot import graphviz_layout
-    except ImportError:
-        raise ImportError("This example needs Graphviz and either PyGraphviz or pydot")
+# This example needs Graphviz and either PyGraphviz or pydot
+# from networkx.drawing.nx_pydot import graphviz_layout
+from networkx.drawing.nx_agraph import graphviz_layout
+
 
 G = nx.balanced_tree(3, 5)
 pos = graphviz_layout(G, prog="twopi", args="")

--- a/examples/drawing/plot_giant_component.py
+++ b/examples/drawing/plot_giant_component.py
@@ -12,23 +12,12 @@ import math
 import matplotlib.pyplot as plt
 import networkx as nx
 
-try:
-    import pygraphviz
-    from networkx.drawing.nx_agraph import graphviz_layout
+# This example needs Graphviz and either PyGraphviz or pydot.
+# from networkx.drawing.nx_pydot import graphviz_layout as layout
+from networkx.drawing.nx_agraph import graphviz_layout as layout
 
-    layout = graphviz_layout
-except ImportError:
-    try:
-        import pydot
-        from networkx.drawing.nx_pydot import graphviz_layout
-
-        layout = graphviz_layout
-    except ImportError:
-        print(
-            "PyGraphviz and pydot not found;\n"
-            "drawing with spring layout will be slow."
-        )
-        layout = nx.spring_layout
+# If you don't have pygraphviz or pydot, you can do this
+# layout = nx.spring_layout
 
 
 n = 150  # 150 nodes

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -3,27 +3,23 @@
 Knuth Miles
 ===========
 
-`miles_graph()` returns an undirected graph over the 128 US cities from
-the datafile `miles_dat.txt`. The cities each have location and population
-data.  The edges are labeled with the distance between the two cities.
+`miles_graph()` returns an undirected graph over the 128 US cities from.  The
+cities each have location and population data.  The edges are labeled with the
+distance between the two cities.
 
-This example is described in Section 1.1 in Knuth's book (see [1]_ and [2]_).
+This example is described in Section 1.1 of
+
+    Donald E. Knuth, "The Stanford GraphBase: A Platform for Combinatorial
+    Computing", ACM Press, New York, 1993.
+    http://www-cs-faculty.stanford.edu/~knuth/sgb.html
 
 The data file can be found at:
-https://github.com/networkx/networkx/blob/master/examples/drawing/knuth_miles.txt.gz
 
-References.
------------
-
-.. [1] Donald E. Knuth,
-   "The Stanford GraphBase: A Platform for Combinatorial Computing",
-   ACM Press, New York, 1993.
-.. [2] http://www-cs-faculty.stanford.edu/~knuth/sgb.html
-
+- https://github.com/networkx/networkx/blob/master/examples/drawing/knuth_miles.txt.gz
 """
 
+import gzip
 import re
-import sys
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -34,7 +30,6 @@ def miles_graph():
         from the Stanford GraphBase.
     """
     # open file miles_dat.txt.gz (or miles_dat.txt)
-    import gzip
 
     fh = gzip.open("knuth_miles.txt.gz", "r")
 

--- a/examples/drawing/plot_lanl_routes.py
+++ b/examples/drawing/plot_lanl_routes.py
@@ -4,20 +4,18 @@ Lanl Routes
 ===========
 
 Routes to LANL from 186 sites on the Internet.
+
+The data file can be found at:
+
+- https://github.com/networkx/networkx/blob/master/examples/drawing/lanl_routes.edgelist
 """
 
 import matplotlib.pyplot as plt
 import networkx as nx
 
-try:
-    import pygraphviz
-    from networkx.drawing.nx_agraph import graphviz_layout
-except ImportError:
-    try:
-        import pydot
-        from networkx.drawing.nx_pydot import graphviz_layout
-    except ImportError:
-        raise ImportError("This example needs Graphviz and either PyGraphviz or pydot")
+# This example needs Graphviz and either PyGraphviz or pydot
+# from networkx.drawing.nx_pydot import graphviz_layout
+from networkx.drawing.nx_agraph import graphviz_layout
 
 
 def lanl_graph():
@@ -50,7 +48,7 @@ def lanl_graph():
 
 G = lanl_graph()
 
-print("graph has {nx.number_of_nodes(G)} nodes with {nx.number_of_edges(G)} edges")
+print(f"graph has {nx.number_of_nodes(G)} nodes with {nx.number_of_edges(G)} edges")
 print(nx.number_connected_components(G), "connected components")
 
 plt.figure(figsize=(8, 8))
@@ -58,7 +56,7 @@ plt.figure(figsize=(8, 8))
 pos = graphviz_layout(G, prog="twopi", root=0)
 # draw nodes, coloring by rtt ping time
 options = {"with_labels": False, "alpha": 0.5, "node_size": 15}
-nx.draw( G, pos, node_color=[G.rtt[v] for v in G], **options)
+nx.draw(G, pos, node_color=[G.rtt[v] for v in G], **options)
 # adjust the plot limits
 xmax = 1.02 * max(xx for xx, yy in pos.values())
 ymax = 1.02 * max(yy for xx, yy in pos.values())

--- a/examples/drawing/plot_sampson.py
+++ b/examples/drawing/plot_sampson.py
@@ -7,6 +7,9 @@ Sampson's monastery data.
 
 Shows how to read data from a zip file and plot multiple frames.
 
+The data file can be found at:
+
+- https://github.com/networkx/networkx/blob/master/examples/drawing/sampson_data.zip
 """
 
 import zipfile
@@ -15,10 +18,11 @@ from io import BytesIO as StringIO
 import matplotlib.pyplot as plt
 import networkx as nx
 
-zf = zipfile.ZipFile("sampson_data.zip")  # zipfile object
-e1 = StringIO(zf.read("samplike1.txt"))  # read info file
-e2 = StringIO(zf.read("samplike2.txt"))  # read info file
-e3 = StringIO(zf.read("samplike3.txt"))  # read info file
+with zipfile.ZipFile("sampson_data.zip") as zf:
+    e1 = StringIO(zf.read("samplike1.txt"))
+    e2 = StringIO(zf.read("samplike2.txt"))
+    e3 = StringIO(zf.read("samplike3.txt"))
+
 G1 = nx.read_edgelist(e1, delimiter="\t")
 G2 = nx.read_edgelist(e2, delimiter="\t")
 G3 = nx.read_edgelist(e3, delimiter="\t")

--- a/examples/drawing/plot_spectral_grid.py
+++ b/examples/drawing/plot_spectral_grid.py
@@ -25,10 +25,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 
 
-options = {
-    "node_color": "C0",
-    "node_size": 100,
-}
+options = {"node_color": "C0", "node_size": 100}
 
 G = nx.grid_2d_graph(6, 6)
 plt.subplot(332)

--- a/examples/drawing/plot_unix_email.py
+++ b/examples/drawing/plot_unix_email.py
@@ -3,23 +3,22 @@
 Unix Email
 ==========
 
-Create a directed graph, allowing multiple edges and self loops, from
-a unix mailbox.  The nodes are email addresses with links
-that point from the sender to the receivers.  The edge data
-is a Python email.Message object which contains all of
-the email message data.
+Create a directed graph, allowing multiple edges and self loops, from a unix
+mailbox.  The nodes are email addresses with links that point from the sender
+to the receivers.  The edge data is a Python email.Message object which
+contains all of the email message data.
 
-This example shows the power of `DiGraph` to hold edge data
-of arbitrary Python objects (in this case a list of email messages).
+This example shows the power of `DiGraph` to hold edge data of arbitrary Python
+objects (in this case a list of email messages).
+
 
 The sample unix email mailbox called "unix_email.mbox" may be found here:
-https://raw.githubusercontent.com/networkx/networkx/master/examples/drawing/unix_email.mbox
 
+- https://github.com/networkx/networkx/blob/master/examples/drawing/unix_email.mbox
 """
 
 from email.utils import getaddresses, parseaddr
 import mailbox
-import sys
 
 import matplotlib.pyplot as plt
 import networkx as nx

--- a/examples/graph/plot_karate_club.py
+++ b/examples/graph/plot_karate_club.py
@@ -8,7 +8,6 @@ Zachary's Karate Club graph
 Data file from:
 http://vlado.fmf.uni-lj.si/pub/networks/data/Ucinet/UciData.htm
 
-Reference:
 Zachary W. (1977).
 An information flow model for conflict and fission in small groups.
 Journal of Anthropological Research, 33, 452-473.

--- a/examples/graph/plot_roget.py
+++ b/examples/graph/plot_roget.py
@@ -3,23 +3,21 @@
 Roget
 =====
 
-Build a directed graph of 1022 categories and
-5075 cross-references as defined in the 1879 version of Roget's Thesaurus
-contained in the datafile roget_dat.txt. This example is described in
-Section 1.2 in Knuth's book (see [1]_ and [2]_).
+Build a directed graph of 1022 categories and 5075 cross-references as defined
+in the 1879 version of Roget's Thesaurus. This example is described in Section
+1.2 of
 
-Note that one of the 5075 cross references is a self loop yet
-it is included in the graph built here because
-the standard networkx `DiGraph` class allows self loops.
-(cf. 400pungency:400 401 403 405).
+    Donald E. Knuth, "The Stanford GraphBase: A Platform for Combinatorial
+    Computing", ACM Press, New York, 1993.
+    http://www-cs-faculty.stanford.edu/~knuth/sgb.html
 
-References
-----------
+Note that one of the 5075 cross references is a self loop yet it is included in
+the graph built here because the standard networkx `DiGraph` class allows self
+loops.  (cf. 400pungency:400 401 403 405).
 
-.. [1] Donald E. Knuth,
-   "The Stanford GraphBase: A Platform for Combinatorial Computing",
-   ACM Press, New York, 1993.
-.. [2] http://www-cs-faculty.stanford.edu/~knuth/sgb.html
+The data file can be found at:
+
+- https://github.com/networkx/networkx/blob/master/examples/graph/roget_dat.txt.gz
 """
 
 import gzip
@@ -34,7 +32,7 @@ def roget_graph():
     """ Return the thesaurus graph from the roget.dat example in
     the Stanford Graph Base.
     """
-    # open file roget_dat.txt.gz (or roget_dat.txt)
+    # open file roget_dat.txt.gz
     fh = gzip.open("roget_dat.txt.gz", "r")
 
     G = nx.DiGraph()

--- a/examples/graph/plot_words.py
+++ b/examples/graph/plot_words.py
@@ -1,31 +1,25 @@
 """
-=====
-Words
-=====
-
+==================
 Words/Ladder Graph
-------------------
-Generate  an undirected graph over the 5757 5-letter words in the
-datafile `words_dat.txt.gz`.  Two words are connected by an edge
-if they differ in one letter, resulting in 14,135 edges. This example
-is described in Section 1.1 in Knuth's book (see [1]_ and [2]_).
+==================
 
-References
-----------
-.. [1] Donald E. Knuth,
-   "The Stanford GraphBase: A Platform for Combinatorial Computing",
-   ACM Press, New York, 1993.
-.. [2] http://www-cs-faculty.stanford.edu/~knuth/sgb.html
+Generate  an undirected graph over the 5757 5-letter words in the datafile
+`words_dat.txt.gz`.  Two words are connected by an edge if they differ in one
+letter, resulting in 14,135 edges. This example is described in Section 1.1 of
+
+    Donald E. Knuth, "The Stanford GraphBase: A Platform for Combinatorial
+    Computing", ACM Press, New York, 1993.
+    http://www-cs-faculty.stanford.edu/~knuth/sgb.html
+
+The data file can be found at:
+
+- https://github.com/networkx/networkx/blob/master/examples/graph/words_dat.txt.gz
 """
 
 import gzip
 from string import ascii_lowercase as lowercase
 
 import networkx as nx
-
-# -------------------------------------------------------------------
-#   The Words/Ladder graph of Section 1.1
-# -------------------------------------------------------------------
 
 
 def generate_graph(words):

--- a/examples/javascript/force.py
+++ b/examples/javascript/force.py
@@ -16,21 +16,21 @@ G = nx.barbell_graph(6, 3)
 # this d3 example uses the name attribute for the mouse-hover value,
 # so add a name to each node
 for n in G:
-    G.nodes[n]['name'] = n
+    G.nodes[n]["name"] = n
 # write json formatted data
 d = json_graph.node_link_data(G)  # node-link format to serialize
 # write json
-json.dump(d, open('force/force.json', 'w'))
-print('Wrote node-link JSON data to force/force.json')
+json.dump(d, open("force/force.json", "w"))
+print("Wrote node-link JSON data to force/force.json")
 
 # Serve the file over http to allow for cross origin requests
 app = flask.Flask(__name__, static_folder="force")
 
 
-@app.route('/')
+@app.route("/")
 def static_proxy():
-    return app.send_static_file('force.html')
+    return app.send_static_file("force.html")
 
 
-print('\nGo to http://localhost:8000 to see the example\n')
+print("\nGo to http://localhost:8000 to see the example\n")
 app.run(port=8000)

--- a/examples/pygraphviz/plot_write_dotfile.py
+++ b/examples/pygraphviz/plot_write_dotfile.py
@@ -9,34 +9,14 @@ Write a dot file from a networkx graph for further processing with graphviz.
 You need to have either pygraphviz or pydot for this example.
 
 See https://networkx.github.io/documentation/latest/reference/drawing.html
-for more info.
-
 """
 
 import networkx as nx
 
-# and the following code block is not needed
-# but we want to see which module is used and
-# if and why it fails
-try:
-    import pygraphviz
-    from networkx.drawing.nx_agraph import write_dot
+# This example needs Graphviz and either PyGraphviz or pydot.
+# from networkx.drawing.nx_pydot import write_dot
+from networkx.drawing.nx_agraph import write_dot
 
-    print("using package pygraphviz")
-except ImportError:
-    try:
-        import pydot
-        from networkx.drawing.nx_pydot import write_dot
-
-        print("using package pydot")
-    except ImportError:
-        print()
-        print("Both pygraphviz and pydot were not found ")
-        print(
-            "see https://networkx.github.io/documentation/latest/reference/drawing.html"
-        )
-        print()
-        raise
 
 G = nx.grid_2d_graph(5, 5)  # 5x5 grid
 write_dot(G, "grid.dot")

--- a/examples/subclass/plot_printgraph.py
+++ b/examples/subclass/plot_printgraph.py
@@ -5,7 +5,6 @@ Print Graph
 
 Example subclass of the Graph class.
 """
-from copy import deepcopy
 
 import matplotlib.pyplot as plt
 import networkx as nx


### PR DESCRIPTION
Fix #3692.

I started by, for example, adding a line like
```
The data file can be found at:

- https://github.com/networkx/networkx/blob/master/examples/drawing/sampson_data.zip
```
to `plot_sampson.py`.


I also removed several `try` and `except` import blocks.  For example, I replaced things like
```
try:
    import pygraphviz
    from networkx.drawing.nx_agraph import graphviz_layout
except ImportError:
    try:
        import pydot
        from networkx.drawing.nx_pydot import graphviz_layout
    except ImportError:
        raise ImportError("This example needs Graphviz and either PyGraphviz or pydot")
```
with
```
# This example needs Graphviz and either PyGraphviz or pydot
# from networkx.drawing.nx_pydot import graphviz_layout
from networkx.drawing.nx_agraph import graphviz_layout
```

There are also a few other miscellaneous changes.