### PR TITLE
Fix test_numpy_type to pass under Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,6 @@ matrix:
           - libgdal-dev
           - graphviz
     - python: pypy3.6-7.1.1
-  allow_failures:
-    - python: 3.8
 
 before_install:
   # prepare the system to install prerequisites or dependencies

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -404,7 +404,8 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
         nx.set_node_attributes(G, {n: n for n in numpy.arange(4)}, 'number')
         G[0][1]['edge-number'] = numpy.float64(1.1)
 
-        expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft"\
+        if sys.version_info < (3, 8):
+            expected = """<gexf version="1.2" xmlns="http://www.gexf.net/1.2draft"\
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation\
 ="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
   <meta lastmodifieddate="{}">
@@ -447,6 +448,54 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
       </edge>
       <edge id="1" source="1" target="2" />
       <edge id="2" source="2" target="3" />
+    </edges>
+  </graph>
+</gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)
+        else:
+            expected = """<gexf xmlns="http://www.gexf.net/1.2draft"\
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation\
+="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd"\
+ version="1.2">
+  <meta lastmodifieddate="{}">
+    <creator>NetworkX {}</creator>
+  </meta>
+  <graph defaultedgetype="undirected" mode="static" name="">
+    <attributes mode="static" class="edge">
+      <attribute id="1" title="edge-number" type="float" />
+    </attributes>
+    <attributes mode="static" class="node">
+      <attribute id="0" title="number" type="int" />
+    </attributes>
+    <nodes>
+      <node id="0" label="0">
+        <attvalues>
+          <attvalue for="0" value="0" />
+        </attvalues>
+      </node>
+      <node id="1" label="1">
+        <attvalues>
+          <attvalue for="0" value="1" />
+        </attvalues>
+      </node>
+      <node id="2" label="2">
+        <attvalues>
+          <attvalue for="0" value="2" />
+        </attvalues>
+      </node>
+      <node id="3" label="3">
+        <attvalues>
+          <attvalue for="0" value="3" />
+        </attvalues>
+      </node>
+    </nodes>
+    <edges>
+      <edge source="0" target="1" id="0">
+        <attvalues>
+          <attvalue for="1" value="1.1" />
+        </attvalues>
+      </edge>
+      <edge source="1" target="2" id="1" />
+      <edge source="2" target="3" id="2" />
     </edges>
   </graph>
 </gexf>""".format(time.strftime('%Y-%m-%d'), nx.__version__)


### PR DESCRIPTION
readwrite.tests.test_gexf.TestGEXF.test_numpy_type failed under Python
3.8 due to ordering of XML attributes, handle it as per f75dbe8. Also
change travis to no longer allow failures under 3.8.

Fixes #3720