### PR TITLE
added linestyle as argument

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -674,6 +674,7 @@ def draw_networkx_edges(G, pos,
                                     color=arrow_color,
                                     linewidth=line_width,
                                     connectionstyle=connectionstyle,
+                                    linestyle=style,
                                     zorder=1)  # arrows go behind nodes
 
             # There seems to be a bug in matplotlib to make collections of


### PR DESCRIPTION
When plotting a directed graph, linestyle is not set

    import networkx as nx
    from matplotlib import pyplot as plt

    G = nx.DiGraph()
    G.add_nodes_from([0,1])
    G.add_edge(0,1)

    pos = {0 : (0,0), 1 : (1,0)}

    plt.figure()
    nx.draw_networkx_nodes(G,pos=pos)
    nx.draw_networkx_edges(G,pos=pos,style='dashed',arrows=True)

    plt.show()
    
This results in a solid line between two nodes, instead of a dashed one. If arrows is set to False, the line is dashed, but of course there is no arrow anymore.