### PR TITLE
Remove unused variable so grid_graph() supports dim=tuple

### DIFF
--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -107,14 +107,13 @@ def grid_graph(dim, periodic=False):
     To produce a 2 by 3 by 4 grid graph, a graph on 24 nodes:
 
     >>> from networkx import grid_graph
-    >>> G = grid_graph(dim=[2, 3, 4])
+    >>> G = grid_graph(dim=(2, 3, 4))
     >>> len(G)
     24
-    >>> G = grid_graph(dim=[range(7, 9), range(3, 6)])
+    >>> G = grid_graph(dim=(range(7, 9), range(3, 6)))
     >>> len(G)
     6
     """
-    dlabel = "%s" % dim
     if not dim:
         return empty_graph(0)
 


### PR DESCRIPTION
Trying to give a tuple of dimensions to networkx.grid_graph results in an exception:

    from networkx import grid_graph
    G = grid_graph(dim=(2, 3, 4))

      File "[..]\Python38-32\lib\site-packages\networkx\generators\lattice.py", line 130, in grid_graph        
        dlabel = "%s" % dim
    TypeError: not all arguments converted during string formatting

That's despite the documentation saying "dim : list **or tuple** of numbers or iterables of nodes"

Well, since that variable is a leftover from some previous refactoring and is unused, we can just remove it.

I also changed the syntax to tuples in the documentation examples (because it's slightly more efficient and so a better style) and manually verified with doctest. This can also help with detecting regressions, though I'm not sure if your pytest configuration runs doctests.