### PR TITLE
Raise NetworkXError when k < 2

### DIFF
--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -94,7 +94,7 @@ def connected_caveman_graph(l, k):
     l : int
       number of cliques
     k : int
-      size of cliques
+      size of cliques (k at least 2 or NetworkXError is raised)
 
     Returns
     -------

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -101,6 +101,11 @@ def connected_caveman_graph(l, k):
     G : NetworkX Graph
       connected caveman graph
 
+    Raises
+    ------
+    NetworkXError
+        If the size of cliques `k` is smaller than 2.
+
     Notes
     -----
     This returns an undirected graph, it can be converted to a directed
@@ -118,6 +123,10 @@ def connected_caveman_graph(l, k):
     .. [1] Watts, D. J. 'Networks, Dynamics, and the Small-World Phenomenon.'
        Amer. J. Soc. 105, 493-527, 1999.
     """
+    if k < 2:
+        raise nx.NetworkXError('The size of cliques in a connected caveman graph '
+                               'must be at least 2.')
+
     G = nx.caveman_graph(l, k)
     for start in range(0, l * k, k):
         G.remove_edge(start, start + 1)

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -102,6 +102,9 @@ def test_connected_caveman_graph():
     K5.remove_edge(3, 4)
     assert nx.is_isomorphic(G, K5)
 
+    # need at least 2 nodes in each clique
+    pytest.raises(nx.NetworkXError, nx.connected_caveman_graph, 4, 1)
+
 
 def test_caveman_graph():
     G = nx.caveman_graph(4, 3)


### PR DESCRIPTION
As far as I understand, the connected caveman graph isn't defined when the size of cliques is < 2. However, there are no constraints on the parameters of the function `nx.generators.community.connected_caveman_graph()`: https://github.com/networkx/networkx/blob/eb75efa80831a08d58f17e54db20e1bfc11b67cc/networkx/generators/community.py#L85, and when called with `l=1`, the function raises the following somewhat unclear error:

```python
>>> nx.connected_caveman_graph(3, 1)

NetworkXError: The edge 0-1 is not in the graph
```

The PR ensures a slightly more informative error is raised when the function is called with `l=1`. 