### PR TITLE
shortest paths: use internal nodes

### DIFF
--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -215,8 +215,8 @@ def bidirectional_shortest_path(G, source, target):
     """
 
     # make sure both source and target are contained in G
-    source = G.get_node(source, what='Source')    
-    target = G.get_node(target, what='Target')    
+    source = G.get_node(source, what='Source')
+    target = G.get_node(target, what='Target')
 
     # call helper to do the real work
     results = _bidirectional_pred_succ(G, source, target)

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -214,9 +214,9 @@ def bidirectional_shortest_path(G, source, target):
     This algorithm is used by shortest_path(G, source, target).
     """
 
-    if source not in G or target not in G:
-        msg = 'Either source {} or target {} is not in G'
-        raise nx.NodeNotFound(msg.format(source, target))
+    # make sure both source and target are contained in G
+    source = G.get_node(source, what='Source')    
+    target = G.get_node(target, what='Target')    
 
     # call helper to do the real work
     results = _bidirectional_pred_succ(G, source, target)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -720,7 +720,7 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     """
     if not sources:
         raise ValueError('sources must not be empty')
-    target = G.get_node(target, what='Target') # make sure target is in G
+    target = G.get_node(target, what='Target')  # make sure target is in G
     if target in sources:
         return (0, [target])
     weight = _weight_function(G, weight)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -720,10 +720,14 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None,
     """
     if not sources:
         raise ValueError('sources must not be empty')
+    target = G.get_node(target, what='Target') # make sure target is in G
     if target in sources:
         return (0, [target])
     weight = _weight_function(G, weight)
-    paths = {source: [source] for source in sources}  # dictionary of paths
+
+    # dictionary of paths
+    paths = {source: [G.get_node(source, what='Source')] for source in sources}
+
     dist = _dijkstra_multisource(G, sources, weight, paths=paths,
                                  cutoff=cutoff, target=target)
     if target is None:
@@ -1582,8 +1586,11 @@ def single_source_bellman_ford(G, source, target=None, weight='weight'):
     single_source_bellman_ford_path()
     single_source_bellman_ford_path_length()
     """
+    target = G.get_node(target, what='Target')  # make sure target is in G
     if source == target:
         return (0, [source])
+
+    source = G.get_node(source, what='Source')  # make sure source is in G
 
     weight = _weight_function(G, weight)
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1335,7 +1335,7 @@ class Graph(object):
         ----------
         node : node
         what : string
-            The string used in the exception's message in case the node is not 
+            The string used in the exception's message in case the node is not
             found.
         """
         _node = {node} & self._node.keys()

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1328,6 +1328,21 @@ class Graph(object):
         except KeyError:
             return default
 
+    def get_node(self, node, what='Node'):
+        """Returns the internal node of G or raises a NodeNotFound exception.
+
+        Parameters
+        ----------
+        node : node
+        what : string
+            The string used in the exception's message in case the node is not 
+            found.
+        """
+        _node = {node} & self._node.keys()
+        if not _node:
+            raise nx.NodeNotFound(f'{what} {node} is not in G')
+        return _node.pop()
+
     def adjacency(self):
         """Returns an iterator over (node, adjacency dict) tuples for all nodes.
 


### PR DESCRIPTION
This implements the changes proposed in #3765 and also adds some more sanity checks.

Regarding the newly introduced function `.get_node` on graphs, you guys probably must decide how to name it and whether you want to make it publicly documented or a dunder method, rename it etc.