### PR TITLE
Silence known warnings

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import networkx
 import sys
+import warnings
 
 
 def pytest_addoption(parser):
@@ -21,6 +22,32 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+# TODO: The warnings below need to be dealt with, but for now we silence them.
+@pytest.fixture(autouse=True)
+def set_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="literal_stringizer is deprecated*",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="literal_destringizer is deprecated*",
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="is_string_like is deprecated*"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="make_str is deprecated*"
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=PendingDeprecationWarning,
+        message="the matrix subclass is not the recommended way*",
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
@dschult This PR silences a ton of warnings in the test reports.   We need to fix them eventually, but they make it hard to see new warnings.  Please feel free to merge this once you've looked over the change.