### PR TITLE
add a check before del operation

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -521,7 +521,8 @@ class DiGraph(Graph):
         except KeyError:  # NetworkXError if n not in self
             raise NetworkXError(f"The node {n} is not in the digraph.")
         for u in nbrs:
-            del self._pred[u][n]   # remove all edges n-u in digraph
+            if n in self._pred[u]:
+                del self._pred[u][n]   # remove all edges n-u in digraph
         del self._succ[n]          # remove node from succ
         for u in self._pred[n]:
             del self._succ[u][n]   # remove all edges n-u in digraph


### PR DESCRIPTION
Hi, I'm using angr-management, a cross-platform binary analysis platform which uses networkx and found sometimes the `DiGraph.remove_node()` runs into errors. I added a check before `del self._pred[u][n]` to fix this.