### PR TITLE
Prevent KeyError on subgraph_is_monomorphic

### DIFF
--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -318,3 +318,20 @@ def test_noncomparable_nodes():
     assert dgm.is_isomorphic()
     # Just testing some cases
     assert gm.subgraph_is_monomorphic()
+
+def test_monomorphism_edge_match():
+    G = nx.DiGraph()
+    G.add_node(1)
+    G.add_node(2)
+    G.add_edge(1,2, label="A")
+    G.add_edge(2,1, label="B")
+    G.add_edge(2,2, label="C")
+
+    SG = nx.DiGraph()
+
+    SG.add_node(5)
+    SG.add_node(6)
+    SG.add_edge(5,6, label="A")
+
+    gm = iso.DiGraphMatcher(G, SG, edge_match=iso.categorical_edge_match('label', None))
+    assert gm.subgraph_is_monomorphic()

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -319,19 +319,19 @@ def test_noncomparable_nodes():
     # Just testing some cases
     assert gm.subgraph_is_monomorphic()
 
+
 def test_monomorphism_edge_match():
     G = nx.DiGraph()
     G.add_node(1)
     G.add_node(2)
-    G.add_edge(1,2, label="A")
-    G.add_edge(2,1, label="B")
-    G.add_edge(2,2, label="C")
+    G.add_edge(1, 2, label="A")
+    G.add_edge(2, 1, label="B")
+    G.add_edge(2, 2, label="C")
 
     SG = nx.DiGraph()
-
     SG.add_node(5)
     SG.add_node(6)
-    SG.add_edge(5,6, label="A")
+    SG.add_edge(5, 6, label="A")
 
     gm = iso.DiGraphMatcher(G, SG, edge_match=iso.categorical_edge_match('label', None))
     assert gm.subgraph_is_monomorphic()

--- a/networkx/algorithms/isomorphism/vf2userfunc.py
+++ b/networkx/algorithms/isomorphism/vf2userfunc.py
@@ -53,22 +53,21 @@ def _semantic_feasibility(self, G1_node, G2_node):
     if self.edge_match is not None:
 
         # Cached lookups
-        G1_adj = self.G1_adj
-        G2_adj = self.G2_adj
+        G1nbrs = self.G1_adj[G1_node]
+        G2nbrs = self.G2_adj[G2_node]
         core_1 = self.core_1
         edge_match = self.edge_match
 
-        for neighbor in G1_adj[G1_node]:
+        for neighbor in G1nbrs:
             # G1_node is not in core_1, so we must handle R_self separately
             if neighbor == G1_node:
-                if G2_node in G2_adj[G2_node] and \
-                        not edge_match(G1_adj[G1_node][G1_node],
-                                       G2_adj[G2_node][G2_node]):
+                if G2_node in G2nbrs and \
+                        not edge_match(G1nbrs[G1_node], G2nbrs[G2_node]):
                     return False
             elif neighbor in core_1:
-                if core_1[neighbor] in G2_adj[G2_node] and \
-                        not edge_match(G1_adj[G1_node][neighbor],
-                                       G2_adj[G2_node][core_1[neighbor]]):
+                G2_nbr = core_1[neighbor]
+                if G2_nbr in G2nbrs and \
+                        not edge_match(G1nbrs[neighbor], G2nbrs[G2_nbr]):
                     return False
         # syntactic check has already verified that neighbors are symmetric
 

--- a/networkx/algorithms/isomorphism/vf2userfunc.py
+++ b/networkx/algorithms/isomorphism/vf2userfunc.py
@@ -61,12 +61,14 @@ def _semantic_feasibility(self, G1_node, G2_node):
         for neighbor in G1_adj[G1_node]:
             # G1_node is not in core_1, so we must handle R_self separately
             if neighbor == G1_node:
-                if not edge_match(G1_adj[G1_node][G1_node],
-                                  G2_adj[G2_node][G2_node]):
+                if G2_node in G2_adj[G2_node] and \
+                        not edge_match(G1_adj[G1_node][G1_node],
+                                       G2_adj[G2_node][G2_node]):
                     return False
             elif neighbor in core_1:
-                if not edge_match(G1_adj[G1_node][neighbor],
-                                  G2_adj[G2_node][core_1[neighbor]]):
+                if core_1[neighbor] in G2_adj[G2_node] and \
+                        not edge_match(G1_adj[G1_node][neighbor],
+                                       G2_adj[G2_node][core_1[neighbor]]):
                     return False
         # syntactic check has already verified that neighbors are symmetric
 


### PR DESCRIPTION
For #3775, checks that core_1[neighbor] is in G2's adj before checking edge_match for semantic feasibility.

Checking for monomorphism for MultiDiGraph seems like it may be more subtle than I thought, so this just handles DiGraphs.

