### PR TITLE
reconsider the lobster generator

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -1011,19 +1011,29 @@ def random_lobster(n, p1, p2, seed=None):
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
+
+    Raises
+    ------
+    NetworkXError
+        If `p1` or `p2` parameters are >= 1 the while loops will never finish.
     """
+    p1, p2 = abs(p1), abs(p2)
+    if any([p >= 1 for p in [p1, p2]]):
+        raise nx.NetworkXError(f"Probability value of `p1` and `p2` must be < 1.")
+
     # a necessary ingredient in any self-respecting graph library
     llen = int(2 * seed.random() * n + 0.5)
     L = path_graph(llen)
     # build caterpillar: add edges to path graph with probability p1
     current_node = llen - 1
     for n in range(llen):
-        if seed.random() < p1:  # add fuzzy caterpillar parts
+        while seed.random() < p1:  # add fuzzy caterpillar parts
             current_node += 1
             L.add_edge(n, current_node)
-            if seed.random() < p2:  # add crunchy lobster bits
+            cat_node = current_node
+            while seed.random() < p2:  # add crunchy lobster bits
                 current_node += 1
-                L.add_edge(current_node - 1, current_node)
+                L.add_edge(cat_node, current_node)
     return L  # voila, un lobster!
 
 

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -1000,6 +1000,11 @@ def random_lobster(n, p1, p2, seed=None):
     leaf nodes. A caterpillar is a tree that reduces to a path graph
     when pruning all leaf nodes; setting `p2` to zero produces a caterpillar.
 
+    This implementation iterates on the probabilities `p1` and `p2` to add
+    edges at levels 1 and 2, respectively. Graphs are therefore constructed
+    iteratively with uniform randomness at each level rather than being selected
+    uniformly at random from the set of all possible lobsters.
+
     Parameters
     ----------
     n : int
@@ -1015,11 +1020,11 @@ def random_lobster(n, p1, p2, seed=None):
     Raises
     ------
     NetworkXError
-        If `p1` or `p2` parameters are >= 1 the while loops will never finish.
+        If `p1` or `p2` parameters are >= 1 because the while loops would never finish.
     """
     p1, p2 = abs(p1), abs(p2)
     if any([p >= 1 for p in [p1, p2]]):
-        raise nx.NetworkXError(f"Probability value of `p1` and `p2` must be < 1.")
+        raise nx.NetworkXError("Probability values for `p1` and `p2` must both be < 1.")
 
     # a necessary ingredient in any self-respecting graph library
     llen = int(2 * seed.random() * n + 0.5)

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -91,7 +91,38 @@ class TestGeneratorsRandom:
         constructor = [(10, 20, 0.8), (20, 40, 0.8)]
         G = random_shell_graph(constructor, seed)
 
+        def is_caterpillar(g):
+            """
+            A tree is a caterpillar iff all nodes of degree >=3 are surrounded
+            by at most two nodes of degree two or greater.
+            ref: http://mathworld.wolfram.com/CaterpillarGraph.html
+            """
+            deg_over_3 = [n for n in g if g.degree(n) >= 3]
+            for n in deg_over_3:
+                nbh_deg_over_2 = [nbh for nbh in g.neighbors(n) if g.degree(nbh) >= 2]
+                if not len(nbh_deg_over_2) <= 2:
+                    return False
+            return True
+
+        def is_lobster(g):
+            """
+            A tree is a lobster if it has the property that the removal of leaf
+            nodes leaves a caterpillar graph (Gallian 2007)
+            ref: http://mathworld.wolfram.com/LobsterGraph.html
+            """
+            non_leafs = [n for n in g if g.degree(n) > 1]
+            return is_caterpillar(g.subgraph(non_leafs))
+
         G = random_lobster(10, 0.1, 0.5, seed)
+        assert max([G.degree(n) for n in G.nodes()]) > 3
+        assert is_lobster(G)
+        pytest.raises(NetworkXError, random_lobster, 10, 0.1, 1, seed)
+        pytest.raises(NetworkXError, random_lobster, 10, 1, 1, seed)
+        pytest.raises(NetworkXError, random_lobster, 10, 1, 0.5, seed)
+
+        # docstring says this should be a caterpillar
+        G = random_lobster(10, 0.1, 0.0, seed)
+        assert is_caterpillar(G)
 
         # difficult to find seed that requires few tries
         seq = random_powerlaw_tree_sequence(10, 3, seed=14, tries=1)


### PR DESCRIPTION
## The Issue
In it's present form, the `random_lobster` generator function produces valid lobsters with multiple leaves, but it's only capable of producing an extremely small subset of the allowable lobsters which fit the general definition of "a tree having the property that the removal of leaf nodes leaves a caterpillar graph" and where a caterpillar graph is on in which all leafs are only one edge from a continuous path graph.

To illustrate the present limitation I've created a 15 node lobster graph with the original implementation:
``` python
g = nx.random_lobster(15, 0.6, 0.5, seed=42)
pos = nx.nx_pydot.pydot_layout(g)
nx.draw(g, pos=pos)
```
![old_lobster](https://user-images.githubusercontent.com/8422403/74614519-57d02d00-50cd-11ea-8486-98fdd29dab30.png)

This graph is clearly a valid lobster, and clearly has multiple leaves. However, none of the branches from the main path will ever fork even though it's allowed by the definition. 

This limitation means that lobsters built with the current implementation will never have a node with degree > 3 even though both the 'backbone' nodes and the 'caterpillar' nodes of the lobster are allowed to have multiple connections as long as the additional connections don't violate the definition.

## Proposed solution requirements
An acceptable solution should:
* not change the current api, or the meaning of any of the existing parameters
* pass all existing tests

## Proposed changes to codebase
This PR closes #3701 by allowing multiple edges to be added at each depth traversed during graph construction. Note that the change converts `if` statements to `while` and adds some safety checks at the top of the function to catch risky user inputs before they start an infinite loop. 

This means we can return valid lobsters that have nodes with degree > 3. The following plot was made with the code submitted in this PR:

```python
g = nx.random_lobster(10, 0.6, 0.5, seed=42)
pos = nx.nx_pydot.pydot_layout(g)
nx.draw(g, pos=pos)
```
![new_lobster](https://user-images.githubusercontent.com/8422403/74614968-49841000-50d1-11ea-9569-42aabb8ced83.png)

## Proposed additional tests
Previous tests for the lobster function checked only that the function ran without throwing an exception. This PR adds a couple of checks to assert that the graph is a lobster according to the definition, and that the subgraph formed by dropping its leaves is a caterpillar graph. I've also added test to assert that if `p2=0` then the graph is a caterpillar. 

To be clear, the existing implementation will pass those tests since it's a valid, if narrow, implementation for lobster creation. I've therefore also added an assertion to check that the max degree is larger than 3 for the test graph. This assertion would fail in the existing implementation but passes in the proposed one.

## Additional discussion
It'd be nice to see if this PR addresses the concerns voiced by @silent567 and @dschult. I think in this case it turns out to be pretty straight-forward to patch the algorithm to generate nearly any graph in the set of valid lobsters.

In fact, I don't think the original implementation meant to limit the breadth of available lobsters so severely, and I'd suggest this PR be considered as a lowly 'bug fix' rather than as a feature change. 
