### PR TITLE
WIP: Change EdgeView contains feature

### DIFF
--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -766,6 +766,7 @@ class OutMultiEdgeDataView(OutEdgeDataView):
         else:
             nbunch = list(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
+            self._adjdict = {u: self._adjdict[u] for u in self._adjdict if u in nbunch}
         self._nbunch = nbunch
         self._data = data
         self._default = default

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -636,6 +636,7 @@ class OutEdgeDataView:
         else:
             nbunch = list(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
+            self._adjdict = {u: self._adjdict[u] for u in self._adjdict if u in nbunch}
         self._nbunch = nbunch
         self._data = data
         self._default = default

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -608,10 +608,15 @@ class TestEdgeView:
         for edge in graph.edges:
             inclusion[edge] = edge in end_edges
 
-        for edge_tuple in [(0, 1), (7, 8)]:
-            assert inclusion[edge_tuple]
-        for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]:
-            assert not inclusion[edge_tuple]
+        if self.G.is_directed():
+            assert inclusion[(0, 1)]
+            for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7), (7, 8)]:
+                assert not inclusion[edge_tuple]
+        else:
+            assert inclusion[(0, 1)]
+            assert inclusion[(7, 8)]
+            for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]:
+                assert not inclusion[edge_tuple]
 
 
 class TestOutEdgeView(TestEdgeView):
@@ -627,21 +632,6 @@ class TestOutEdgeView(TestEdgeView):
             + "(4, 5), (5, 6), (6, 7), (7, 8)])"
         )
         assert repr(ev) == rep
-
-    def test_contains_edge_tuples_digraph(self):
-
-        graph = self.G
-        end_nodes = [n for n in graph.nodes if nx.degree(graph, n) == 1]
-        end_edges = graph.edges(end_nodes)
-
-        inclusion = {}
-        for edge in graph.edges:
-            inclusion[edge] = edge in end_edges
-
-        for edge_tuple in [(0, 1)]:
-            assert inclusion[edge_tuple]
-        for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7), (7, 8)]:
-            assert not inclusion[edge_tuple]
 
 
 class TestInEdgeView(TestEdgeView):

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -608,15 +608,27 @@ class TestEdgeView:
         for edge in graph.edges:
             inclusion[edge] = edge in end_edges
 
-        if self.G.is_directed():
-            assert inclusion[(0, 1)]
-            for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7), (7, 8)]:
-                assert not inclusion[edge_tuple]
+        if type(self.G) in {nx.Graph, nx.DiGraph}:
+            if self.G.is_directed():
+                assert inclusion[(0, 1)]
+                for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7), (7, 8)]:
+                    assert not inclusion[edge_tuple]
+            else:
+                assert inclusion[(0, 1)]
+                assert inclusion[(7, 8)]
+                for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]:
+                    assert not inclusion[edge_tuple]
+
         else:
-            assert inclusion[(0, 1)]
-            assert inclusion[(7, 8)]
-            for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]:
-                assert not inclusion[edge_tuple]
+            if self.G.is_directed():
+                assert inclusion[(0, 1)]
+                for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7), (7, 8)]:
+                    assert not inclusion[edge_tuple]
+            else:
+                assert inclusion[(0, 1)]
+                assert inclusion[(7, 8)]
+                for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]:
+                    assert not inclusion[edge_tuple]
 
 
 class TestOutEdgeView(TestEdgeView):

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -598,6 +598,21 @@ class TestEdgeView:
         result.remove((0, 1))
         assert ev - some_edges, result
 
+    def test_contains_edge_tuples_graph(self):
+
+        graph = self.G
+        end_nodes = [n for n in graph.nodes if nx.degree(graph, n) == 1]
+        end_edges = graph.edges(end_nodes)
+
+        inclusion = {}
+        for edge in graph.edges:
+            inclusion[edge] = edge in end_edges
+
+        for edge_tuple in [(0, 1), (7, 8)]:
+            assert inclusion[edge_tuple]
+        for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]:
+            assert not inclusion[edge_tuple]
+
 
 class TestOutEdgeView(TestEdgeView):
     @classmethod
@@ -612,6 +627,21 @@ class TestOutEdgeView(TestEdgeView):
             + "(4, 5), (5, 6), (6, 7), (7, 8)])"
         )
         assert repr(ev) == rep
+
+    def test_contains_edge_tuples_digraph(self):
+
+        graph = self.G
+        end_nodes = [n for n in graph.nodes if nx.degree(graph, n) == 1]
+        end_edges = graph.edges(end_nodes)
+
+        inclusion = {}
+        for edge in graph.edges:
+            inclusion[edge] = edge in end_edges
+
+        for edge_tuple in [(0, 1)]:
+            assert inclusion[edge_tuple]
+        for edge_tuple in [(1, 2), (2, 3), (3, 4), (4, 5), (6, 7), (7, 8)]:
+            assert not inclusion[edge_tuple]
 
 
 class TestInEdgeView(TestEdgeView):


### PR DESCRIPTION
This PR is a WIP to get feedback

It is addressing issue 3819: https://github.com/networkx/networkx/issues/3819

After mucking around in the `EdgeView` classes, it seems to me that the simplest way to fix the `__contains__` bug is actually to just constrain the `self._adjdict` variable in the `__init__` function by comparing it to the `nbunch` param (if there is one).

I put a big test in `TestEdgeView` because I noticed it gets executed for all the other test classes due to inheritance. I'm not sure if this is the best way to do this and while I have some experience in pytest, I am not really an expert in all its inner workings so I am open to feedback on how to better structure it.

This seems to work for `Graph` and `DiGraph` objects, but fails for `MultiGraph` and `DiMultiGraph` objects, where I am now stuck. I constrain `self._adjdict` just as before, but for some reason, `__contains__` is now always returning False. You can see this by looking at the `inclusion` dict in the new test in the debugger, it marks the edge `(0, 1, 0)` as being False even though it should be included in both the directed and the undirected graph.

Can I get some feedback on this? Am I going in the right direction or does it need a different approach?