### PR TITLE
User-defined labelling of block nodes when creating quotient graphs

### DIFF
--- a/examples/algorithms/plot_blockmodel.py
+++ b/examples/algorithms/plot_blockmodel.py
@@ -58,7 +58,8 @@ H = nx.convert_node_labels_to_integers(H)
 # Create parititions with hierarchical clustering
 partitions = create_hc(H)
 # Build blockmodel graph
-BM = nx.quotient_graph(H, partitions, relabel=True)
+labels = {frozenset(b): i for i, b in enumerate(partitions)}
+BM = nx.quotient_graph(H, partitions, labels=labels)
 
 # Draw original graph
 pos = nx.spring_layout(H, iterations=100)

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -310,10 +310,10 @@ def _quotient_graph(G, partition, edge_relation=None, node_data=None,
     if isinstance(labels, dict):
         H = nx.relabel_nodes(H, labels)
     elif isinstance(labels, Callable):
-        b_iters = tuple(tee(b, 1)[0] for b in partition)
+        block_iters = tuple(tee(block, 1)[0] for block in partition)
         _labels = {
-            b: labels(next(b_iters[i]))
-            for i, b in enumerate(partition)
+            block: labels(next(block_iters[i]))
+            for i, block in enumerate(partition)
         }
         H = nx.relabel_nodes(H, _labels)
 

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -11,7 +11,13 @@ from networkx import density
 from networkx.exception import NetworkXException
 from networkx.utils import arbitrary_element
 
-__all__ = ["contracted_edge", "contracted_nodes", "identified_nodes", "quotient_graph"]
+__all__ = [
+    "contracted_edge",
+    "contracted_nodes",
+    "equivalence_classes",  
+    "identified_nodes",
+    "quotient_graph"
+]
 
 chaini = chain.from_iterable
 

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -112,7 +112,8 @@ class TestQuotient:
     def test_path(self):
         G = nx.path_graph(6)
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
@@ -123,7 +124,8 @@ class TestQuotient:
     def test_multigraph_path(self):
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
@@ -135,7 +137,8 @@ class TestQuotient:
         G = nx.DiGraph()
         nx.add_path(G, range(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
@@ -147,7 +150,8 @@ class TestQuotient:
         G = nx.MultiDiGraph()
         nx.add_path(G, range(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
@@ -166,7 +170,8 @@ class TestQuotient:
         for i in range(5):
             G[i][i + 1]["weight"] = i + 1
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         assert M[0][1]["weight"] == 2
@@ -179,7 +184,8 @@ class TestQuotient:
     def test_barbell(self):
         G = nx.barbell_graph(3, 0)
         partition = [{0, 1, 2}, {3, 4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1,2}): 0, frozenset({3,4,5}): 1}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1])
         assert_edges_equal(M.edges(), [(0, 1)])
         for n in M:
@@ -192,7 +198,8 @@ class TestQuotient:
         # Add an extra edge joining the bells.
         G.add_edge(0, 5)
         partition = [{0, 1, 2}, {3, 4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1,2}): 0, frozenset({3,4,5}): 1}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1])
         assert_edges_equal(M.edges(), [(0, 1)])
         assert M[0][1]["weight"] == 2
@@ -204,7 +211,8 @@ class TestQuotient:
     def test_blockmodel(self):
         G = nx.path_graph(6)
         partition = [[0, 1], [2, 3], [4, 5]]
-        M = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M.nodes(), [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M.nodes():
@@ -215,7 +223,9 @@ class TestQuotient:
     def test_multigraph_blockmodel(self):
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [[0, 1], [2, 3], [4, 5]]
-        M = nx.quotient_graph(G, partition, create_using=nx.MultiGraph(), relabel=True)
+        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        M = nx.quotient_graph(G, partition,
+                              create_using=nx.MultiGraph(), labels=labels)
         assert_nodes_equal(M.nodes(), [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M.nodes():
@@ -226,12 +236,13 @@ class TestQuotient:
     def test_quotient_graph_incomplete_partition(self):
         G = nx.path_graph(6)
         partition = []
-        H = nx.quotient_graph(G, partition, relabel=True)
+        H = nx.quotient_graph(G, partition, labels=None)
         assert_nodes_equal(H.nodes(), [])
         assert_edges_equal(H.edges(), [])
 
         partition = [[0, 1], [2, 3], [5]]
-        H = nx.quotient_graph(G, partition, relabel=True)
+        labels = {frozenset([0,1]): 0, frozenset([2,3]): 1, frozenset([5]): 2}
+        H = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(H.nodes(), [0, 1, 2])
         assert_edges_equal(H.edges(), [(0, 1)])
 

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -112,7 +112,11 @@ class TestQuotient:
     def test_path(self):
         G = nx.path_graph(6)
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
@@ -124,7 +128,11 @@ class TestQuotient:
     def test_multigraph_path(self):
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
@@ -137,7 +145,11 @@ class TestQuotient:
         G = nx.DiGraph()
         nx.add_path(G, range(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
@@ -150,7 +162,11 @@ class TestQuotient:
         G = nx.MultiDiGraph()
         nx.add_path(G, range(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
@@ -170,7 +186,11 @@ class TestQuotient:
         for i in range(5):
             G[i][i + 1]["weight"] = i + 1
         partition = [{0, 1}, {2, 3}, {4, 5}]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
@@ -184,7 +204,7 @@ class TestQuotient:
     def test_barbell(self):
         G = nx.barbell_graph(3, 0)
         partition = [{0, 1, 2}, {3, 4, 5}]
-        labels = {frozenset({0,1,2}): 0, frozenset({3,4,5}): 1}
+        labels = {frozenset({0, 1, 2}): 0, frozenset({3, 4, 5}): 1}
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1])
         assert_edges_equal(M.edges(), [(0, 1)])
@@ -198,7 +218,7 @@ class TestQuotient:
         # Add an extra edge joining the bells.
         G.add_edge(0, 5)
         partition = [{0, 1, 2}, {3, 4, 5}]
-        labels = {frozenset({0,1,2}): 0, frozenset({3,4,5}): 1}
+        labels = {frozenset({0, 1, 2}): 0, frozenset({3, 4, 5}): 1}
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M, [0, 1])
         assert_edges_equal(M.edges(), [(0, 1)])
@@ -211,7 +231,11 @@ class TestQuotient:
     def test_blockmodel(self):
         G = nx.path_graph(6)
         partition = [[0, 1], [2, 3], [4, 5]]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(M.nodes(), [0, 1, 2])
         assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
@@ -223,7 +247,11 @@ class TestQuotient:
     def test_multigraph_blockmodel(self):
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [[0, 1], [2, 3], [4, 5]]
-        labels = {frozenset({0,1}): 0, frozenset({2,3}): 1, frozenset({4,5}): 2}
+        labels = {
+            frozenset({0, 1}): 0,
+            frozenset({2, 3}): 1,
+            frozenset({4, 5}): 2
+        }
         M = nx.quotient_graph(G, partition,
                               create_using=nx.MultiGraph(), labels=labels)
         assert_nodes_equal(M.nodes(), [0, 1, 2])
@@ -241,7 +269,11 @@ class TestQuotient:
         assert_edges_equal(H.edges(), [])
 
         partition = [[0, 1], [2, 3], [5]]
-        labels = {frozenset([0,1]): 0, frozenset([2,3]): 1, frozenset([5]): 2}
+        labels = {
+            frozenset([0, 1]): 0,
+            frozenset([2, 3]): 1,
+            frozenset([5]): 2
+        }
         H = nx.quotient_graph(G, partition, labels=labels)
         assert_nodes_equal(H.nodes(), [0, 1, 2])
         assert_edges_equal(H.edges(), [(0, 1)])

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -569,7 +569,8 @@ def stochastic_block_model(
     >>> g = nx.stochastic_block_model(sizes, probs, seed=0)
     >>> len(g)
     450
-    >>> H = nx.quotient_graph(g, g.graph['partition'], relabel=True)
+    >>> labels = {frozenset(c): i for i, c in enumerate(g.graph['partition'])}
+    >>> H = nx.quotient_graph(g, g.graph['partition'], labels=labels)
     >>> for v in H.nodes(data=True):
     ...     print(round(v[1]['density'], 3))
     ...


### PR DESCRIPTION
* Tweak quotient graph method (`networkx.algorithms.minors.quotient_graph` - allow user-defined mapping of blocks (`frozenset` objects) to labels via dicts and functions via an optional argument with default of `None`; no labels dict or function will cause blocks to be labelled/represented by themselves as `frozenset` objects
* update all tests for quotient graphs involving block relabelling (`networkx.algorithms.tests.test_minors`).