### PR TITLE
WIP: Change EdgeDataView __contains__ feature (2nd attempt)

### DIFF
--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -634,7 +634,8 @@ class OutEdgeDataView:
         if nbunch is None:
             self._nodes_nbrs = adjdict.items
         else:
-            nbunch = set(viewer._graph.nbunch_iter(nbunch))
+            # dict retains order of nodes but acts like a set
+            nbunch = dict.fromkeys(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
@@ -656,7 +657,6 @@ class OutEdgeDataView:
                 for nbr, dd in nbrs.items())
 
     def __contains__(self, e):
-
         u, v = e[:2]
         if self._nbunch is not None and u not in self._nbunch:
             return False  # this edge doesn't start in nbunch
@@ -716,7 +716,6 @@ class EdgeDataView(OutEdgeDataView):
         del seen
 
     def __contains__(self, e):
-
         u, v = e[:2]
         if self._nbunch is not None and u not in self._nbunch and v not in self._nbunch:
             return False  # this edge doesn't start and it doesn't end in nbunch
@@ -736,9 +735,8 @@ class InEdgeDataView(OutEdgeDataView):
                 for nbr, dd in nbrs.items())
 
     def __contains__(self, e):
-
         u, v = e[:2]
-        if v not in self._nbunch:
+        if self._nbunch is not None and v not in self._nbunch:
             return False  # this edge doesn't end in nbunch
         try:
             ddict = self._adjdict[v][u]
@@ -770,7 +768,8 @@ class OutMultiEdgeDataView(OutEdgeDataView):
         if nbunch is None:
             self._nodes_nbrs = adjdict.items
         else:
-            nbunch = set(viewer._graph.nbunch_iter(nbunch))
+            # dict retains order of nodes but acts like a set
+            nbunch = dict.fromkeys(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
@@ -802,7 +801,6 @@ class OutMultiEdgeDataView(OutEdgeDataView):
                 for nbr, kd in nbrs.items() for k, dd in kd.items())
 
     def __contains__(self, e):
-
         u, v = e[:2]
         if self._nbunch is not None and u not in self._nbunch:
             return False  # this edge doesn't start in nbunch
@@ -838,7 +836,6 @@ class MultiEdgeDataView(OutMultiEdgeDataView):
         del seen
 
     def __contains__(self, e):
-
         u, v = e[:2]
         if self._nbunch is not None and u not in self._nbunch and v not in self._nbunch:
             return False  # this edge doesn't start and doesn't end in nbunch
@@ -871,7 +868,6 @@ class InMultiEdgeDataView(OutMultiEdgeDataView):
                 for nbr, kd in nbrs.items() for k, dd in kd.items())
 
     def __contains__(self, e):
-
         u, v = e[:2]
         if self._nbunch is not None and v not in self._nbunch:
             return False  # this edge doesn't end in nbunch

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -634,7 +634,6 @@ class OutEdgeDataView:
         if nbunch is None:
             self._nodes_nbrs = adjdict.items
         else:
-            # nbunch = list(viewer._graph.nbunch_iter(nbunch))
             nbunch = set(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
@@ -658,15 +657,8 @@ class OutEdgeDataView:
 
     def __contains__(self, e):
 
-        # try:
-        #     u, v = e[:2]
-        #     ddict = self._adjdict[u][v]
-        # except KeyError:
-        #     return False
-        # return e == self._report(u, v, ddict)
-
         u, v = e[:2]
-        if u not in self._nbunch:
+        if self._nbunch is not None and u not in self._nbunch:
             return False  # this edge doesn't start in nbunch
         try:
             ddict = self._adjdict[u][v]
@@ -725,18 +717,8 @@ class EdgeDataView(OutEdgeDataView):
 
     def __contains__(self, e):
 
-        # try:
-        #     u, v = e[:2]
-        #     ddict = self._adjdict[u][v]
-        # except KeyError:
-        #     try:
-        #         ddict = self._adjdict[v][u]
-        #     except KeyError:
-        #         return False
-        # return e == self._report(u, v, ddict)
-
         u, v = e[:2]
-        if u not in self._nbunch and v not in self._nbunch:
+        if self._nbunch is not None and u not in self._nbunch and v not in self._nbunch:
             return False  # this edge doesn't start and it doesn't end in nbunch
         try:
             ddict = self._adjdict[u][v]
@@ -754,14 +736,6 @@ class InEdgeDataView(OutEdgeDataView):
                 for nbr, dd in nbrs.items())
 
     def __contains__(self, e):
-
-
-        # try:
-        #     u, v = e[:2]
-        #     ddict = self._adjdict[v][u]
-        # except KeyError:
-        #     return False
-        # return e == self._report(u, v, ddict)
 
         u, v = e[:2]
         if v not in self._nbunch:
@@ -796,7 +770,6 @@ class OutMultiEdgeDataView(OutEdgeDataView):
         if nbunch is None:
             self._nodes_nbrs = adjdict.items
         else:
-            # nbunch = list(viewer._graph.nbunch_iter(nbunch))
             nbunch = set(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
@@ -829,25 +802,9 @@ class OutMultiEdgeDataView(OutEdgeDataView):
                 for nbr, kd in nbrs.items() for k, dd in kd.items())
 
     def __contains__(self, e):
-        # u, v = e[:2]
-        # try:
-        #     kdict = self._adjdict[u][v]
-        # except KeyError:
-        #     return False
-        # if self.keys is True:
-        #     k = e[2]
-        #     try:
-        #         dd = kdict[k]
-        #     except KeyError:
-        #         return False
-        #     return e == self._report(u, v, k, dd)
-        # for k, dd in kdict.items():
-        #     if e == self._report(u, v, k, dd):
-        #         return True
-        # return False
 
         u, v = e[:2]
-        if u not in self._nbunch:
+        if self._nbunch is not None and u not in self._nbunch:
             return False  # this edge doesn't start in nbunch
         try:
             kdict = self._adjdict[u][v]
@@ -881,28 +838,9 @@ class MultiEdgeDataView(OutMultiEdgeDataView):
         del seen
 
     def __contains__(self, e):
-        # u, v = e[:2]
-        # try:
-        #     kdict = self._adjdict[u][v]
-        # except KeyError:
-        #     try:
-        #         kdict = self._adjdict[v][u]
-        #     except KeyError:
-        #         return False
-        # if self.keys is True:
-        #     k = e[2]
-        #     try:
-        #         dd = kdict[k]
-        #     except KeyError:
-        #         return False
-        #     return e == self._report(u, v, k, dd)
-        # for k, dd in kdict.items():
-        #     if e == self._report(u, v, k, dd):
-        #         return True
-        # return False
 
         u, v = e[:2]
-        if u not in self._nbunch and v not in self._nbunch:
+        if self._nbunch is not None and u not in self._nbunch and v not in self._nbunch:
             return False  # this edge doesn't start and doesn't end in nbunch
         try:
             kdict = self._adjdict[u][v]
@@ -933,22 +871,9 @@ class InMultiEdgeDataView(OutMultiEdgeDataView):
                 for nbr, kd in nbrs.items() for k, dd in kd.items())
 
     def __contains__(self, e):
-        # u, v = e[:2]
-        # try:
-        #     kdict = self._adjdict[v][u]
-        # except KeyError:
-        #     return False
-        # if self.keys is True:
-        #     k = e[2]
-        #     dd = kdict[k]
-        #     return e == self._report(u, v, k, dd)
-        # for k, dd in kdict.items():
-        #     if e == self._report(u, v, k, dd):
-        #         return True
-        # return False
 
         u, v = e[:2]
-        if v not in self._nbunch:
+        if self._nbunch is not None and v not in self._nbunch:
             return False  # this edge doesn't end in nbunch
         try:
             kdict = self._adjdict[v][u]

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -634,7 +634,8 @@ class OutEdgeDataView:
         if nbunch is None:
             self._nodes_nbrs = adjdict.items
         else:
-            nbunch = list(viewer._graph.nbunch_iter(nbunch))
+            # nbunch = list(viewer._graph.nbunch_iter(nbunch))
+            nbunch = set(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
@@ -656,8 +657,18 @@ class OutEdgeDataView:
                 for nbr, dd in nbrs.items())
 
     def __contains__(self, e):
+
+        # try:
+        #     u, v = e[:2]
+        #     ddict = self._adjdict[u][v]
+        # except KeyError:
+        #     return False
+        # return e == self._report(u, v, ddict)
+
+        u, v = e[:2]
+        if u not in self._nbunch:
+            return False  # this edge doesn't start in nbunch
         try:
-            u, v = e[:2]
             ddict = self._adjdict[u][v]
         except KeyError:
             return False
@@ -713,14 +724,24 @@ class EdgeDataView(OutEdgeDataView):
         del seen
 
     def __contains__(self, e):
+
+        # try:
+        #     u, v = e[:2]
+        #     ddict = self._adjdict[u][v]
+        # except KeyError:
+        #     try:
+        #         ddict = self._adjdict[v][u]
+        #     except KeyError:
+        #         return False
+        # return e == self._report(u, v, ddict)
+
+        u, v = e[:2]
+        if u not in self._nbunch and v not in self._nbunch:
+            return False  # this edge doesn't start and it doesn't end in nbunch
         try:
-            u, v = e[:2]
             ddict = self._adjdict[u][v]
         except KeyError:
-            try:
-                ddict = self._adjdict[v][u]
-            except KeyError:
-                return False
+            return False
         return e == self._report(u, v, ddict)
 
 
@@ -733,12 +754,24 @@ class InEdgeDataView(OutEdgeDataView):
                 for nbr, dd in nbrs.items())
 
     def __contains__(self, e):
+
+
+        # try:
+        #     u, v = e[:2]
+        #     ddict = self._adjdict[v][u]
+        # except KeyError:
+        #     return False
+        # return e == self._report(u, v, ddict)
+
+        u, v = e[:2]
+        if v not in self._nbunch:
+            return False  # this edge doesn't end in nbunch
         try:
-            u, v = e[:2]
             ddict = self._adjdict[v][u]
         except KeyError:
             return False
         return e == self._report(u, v, ddict)
+
 
 
 class OutMultiEdgeDataView(OutEdgeDataView):
@@ -763,7 +796,8 @@ class OutMultiEdgeDataView(OutEdgeDataView):
         if nbunch is None:
             self._nodes_nbrs = adjdict.items
         else:
-            nbunch = list(viewer._graph.nbunch_iter(nbunch))
+            # nbunch = list(viewer._graph.nbunch_iter(nbunch))
+            nbunch = set(viewer._graph.nbunch_iter(nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
@@ -795,7 +829,26 @@ class OutMultiEdgeDataView(OutEdgeDataView):
                 for nbr, kd in nbrs.items() for k, dd in kd.items())
 
     def __contains__(self, e):
+        # u, v = e[:2]
+        # try:
+        #     kdict = self._adjdict[u][v]
+        # except KeyError:
+        #     return False
+        # if self.keys is True:
+        #     k = e[2]
+        #     try:
+        #         dd = kdict[k]
+        #     except KeyError:
+        #         return False
+        #     return e == self._report(u, v, k, dd)
+        # for k, dd in kdict.items():
+        #     if e == self._report(u, v, k, dd):
+        #         return True
+        # return False
+
         u, v = e[:2]
+        if u not in self._nbunch:
+            return False  # this edge doesn't start in nbunch
         try:
             kdict = self._adjdict[u][v]
         except KeyError:
@@ -828,7 +881,29 @@ class MultiEdgeDataView(OutMultiEdgeDataView):
         del seen
 
     def __contains__(self, e):
+        # u, v = e[:2]
+        # try:
+        #     kdict = self._adjdict[u][v]
+        # except KeyError:
+        #     try:
+        #         kdict = self._adjdict[v][u]
+        #     except KeyError:
+        #         return False
+        # if self.keys is True:
+        #     k = e[2]
+        #     try:
+        #         dd = kdict[k]
+        #     except KeyError:
+        #         return False
+        #     return e == self._report(u, v, k, dd)
+        # for k, dd in kdict.items():
+        #     if e == self._report(u, v, k, dd):
+        #         return True
+        # return False
+
         u, v = e[:2]
+        if u not in self._nbunch and v not in self._nbunch:
+            return False  # this edge doesn't start and doesn't end in nbunch
         try:
             kdict = self._adjdict[u][v]
         except KeyError:
@@ -858,7 +933,23 @@ class InMultiEdgeDataView(OutMultiEdgeDataView):
                 for nbr, kd in nbrs.items() for k, dd in kd.items())
 
     def __contains__(self, e):
+        # u, v = e[:2]
+        # try:
+        #     kdict = self._adjdict[v][u]
+        # except KeyError:
+        #     return False
+        # if self.keys is True:
+        #     k = e[2]
+        #     dd = kdict[k]
+        #     return e == self._report(u, v, k, dd)
+        # for k, dd in kdict.items():
+        #     if e == self._report(u, v, k, dd):
+        #         return True
+        # return False
+
         u, v = e[:2]
+        if v not in self._nbunch:
+            return False  # this edge doesn't end in nbunch
         try:
             kdict = self._adjdict[v][u]
         except KeyError:

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1003,7 +1003,7 @@ class EdgeView(OutEdgeView):
 
     >>> EVnbunch = G.edges(nbunch=2)
     >>> assert((2, 3) in EVnbunch)
-    >>> assert((0, 1) in EVnbunch)   #  nbunch is ignored in __contains__
+    >>> assert((0, 1) not in EVnbunch)
     >>> for u, v in EVnbunch: assert(u == 2 or v == 2)
 
     >>> MG = nx.path_graph(4, create_using=nx.MultiGraph)

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -345,6 +345,23 @@ class TestEdgeDataView:
         assert not (1, 90) in ev
         assert not (90, 1) in ev
 
+    def test_contains_with_nbunch(self):
+        evr = self.eview(self.G)
+        ev = evr(nbunch=[0, 2])
+        if self.G.is_directed():
+            assert (0, 1) in ev
+            assert not (1, 2) in ev
+            assert (2, 3) in ev
+        else:
+            assert (0, 1) in ev
+            assert (1, 2) in ev
+            assert (2, 3) in ev
+        assert not (3, 4) in ev
+        assert not (4, 5) in ev
+        assert not (5, 6) in ev
+        assert not (7, 8) in ev
+        assert not (8, 9) in ev
+
     def test_len(self):
         evr = self.eview(self.G)
         ev = evr(data="foo")
@@ -396,6 +413,18 @@ class TestOutEdgeDataView(TestEdgeDataView):
         assert len(H.edges()) == 9
         assert len(H.edges) == 9
 
+    def test_contains_with_nbunch(self):
+        evr = self.eview(self.G)
+        ev = evr(nbunch=[0, 2])
+        assert (0, 1) in ev
+        assert not (1, 2) in ev
+        assert (2, 3) in ev
+        assert not (3, 4) in ev
+        assert not (4, 5) in ev
+        assert not (5, 6) in ev
+        assert not (7, 8) in ev
+        assert not (8, 9) in ev
+
 
 class TestInEdgeDataView(TestOutEdgeDataView):
     @classmethod
@@ -412,6 +441,18 @@ class TestInEdgeDataView(TestOutEdgeDataView):
             + "(6, 7, {}), (7, 8, {})])"
         )
         assert repr(ev) == rep
+
+    def test_contains_with_nbunch(self):
+        evr = self.eview(self.G)
+        ev = evr(nbunch=[0, 2])
+        assert not (0, 1) in ev
+        assert (1, 2) in ev
+        assert not (2, 3) in ev
+        assert not (3, 4) in ev
+        assert not (4, 5) in ev
+        assert not (5, 6) in ev
+        assert not (7, 8) in ev
+        assert not (8, 9) in ev
 
 
 class TestMultiEdgeDataView(TestEdgeDataView):
@@ -433,6 +474,18 @@ class TestMultiEdgeDataView(TestEdgeDataView):
         )
         assert repr(ev) == rep
 
+    def test_contains_with_nbunch(self):
+        evr = self.eview(self.G)
+        ev = evr(nbunch=[0, 2])
+        assert (0, 1) in ev
+        assert (1, 2) in ev
+        assert (2, 3) in ev
+        assert not (3, 4) in ev
+        assert not (4, 5) in ev
+        assert not (5, 6) in ev
+        assert not (7, 8) in ev
+        assert not (8, 9) in ev
+
 
 class TestOutMultiEdgeDataView(TestOutEdgeDataView):
     @classmethod
@@ -453,6 +506,18 @@ class TestOutMultiEdgeDataView(TestOutEdgeDataView):
         )
         assert repr(ev) == rep
 
+    def test_contains_with_nbunch(self):
+        evr = self.eview(self.G)
+        ev = evr(nbunch=[0, 2])
+        assert (0, 1) in ev
+        assert not (1, 2) in ev
+        assert (2, 3) in ev
+        assert not (3, 4) in ev
+        assert not (4, 5) in ev
+        assert not (5, 6) in ev
+        assert not (7, 8) in ev
+        assert not (8, 9) in ev
+
 
 class TestInMultiEdgeDataView(TestOutMultiEdgeDataView):
     @classmethod
@@ -469,6 +534,18 @@ class TestInMultiEdgeDataView(TestOutMultiEdgeDataView):
             + "(6, 7, {}), (7, 8, {})])"
         )
         assert repr(ev) == rep
+
+    def test_contains_with_nbunch(self):
+        evr = self.eview(self.G)
+        ev = evr(nbunch=[0, 2])
+        assert not (0, 1) in ev
+        assert (1, 2) in ev
+        assert not (2, 3) in ev
+        assert not (3, 4) in ev
+        assert not (4, 5) in ev
+        assert not (5, 6) in ev
+        assert not (7, 8) in ev
+        assert not (8, 9) in ev
 
 
 # Edge Views
@@ -542,6 +619,18 @@ class TestEdgeView:
         assert not (1, 90) in edv
         assert not (90, 1) in edv
 
+    def test_contains_with_nbunch(self):
+        ev = self.eview(self.G)
+        evn = ev(nbunch=[0, 2])
+        assert (0, 1) in evn
+        assert (1, 2) in evn
+        assert (2, 3) in evn
+        assert not (3, 4) in evn
+        assert not (4, 5) in evn
+        assert not (5, 6) in evn
+        assert not (7, 8) in evn
+        assert not (8, 9) in evn
+
     def test_len(self):
         ev = self.eview(self.G)
         num_ed = 9 if self.G.is_multigraph() else 8
@@ -613,6 +702,18 @@ class TestOutEdgeView(TestEdgeView):
         )
         assert repr(ev) == rep
 
+    def test_contains_with_nbunch(self):
+        ev = self.eview(self.G)
+        evn = ev(nbunch=[0, 2])
+        assert (0, 1) in evn
+        assert not (1, 2) in evn
+        assert (2, 3) in evn
+        assert not (3, 4) in evn
+        assert not (4, 5) in evn
+        assert not (5, 6) in evn
+        assert not (7, 8) in evn
+        assert not (8, 9) in evn
+
 
 class TestInEdgeView(TestEdgeView):
     @classmethod
@@ -627,6 +728,18 @@ class TestInEdgeView(TestEdgeView):
             + "(4, 5), (5, 6), (6, 7), (7, 8)])"
         )
         assert repr(ev) == rep
+
+    def test_contains_with_nbunch(self):
+        ev = self.eview(self.G)
+        evn = ev(nbunch=[0, 2])
+        assert not (0, 1) in evn
+        assert (1, 2) in evn
+        assert not (2, 3) in evn
+        assert not (3, 4) in evn
+        assert not (4, 5) in evn
+        assert not (5, 6) in evn
+        assert not (7, 8) in evn
+        assert not (8, 9) in evn
 
 
 class TestMultiEdgeView(TestEdgeView):
@@ -789,6 +902,18 @@ class TestMultiEdgeView(TestEdgeView):
             assert ev & some_edges == {(0, 1, 0), (1, 0, 0)}
             assert some_edges & ev == {(0, 1, 0), (1, 0, 0)}
 
+    def test_contains_with_nbunch(self):
+        ev = self.eview(self.G)
+        evn = ev(nbunch=[0, 2])
+        assert (0, 1) in evn
+        assert (1, 2) in evn
+        assert (2, 3) in evn
+        assert not (3, 4) in evn
+        assert not (4, 5) in evn
+        assert not (5, 6) in evn
+        assert not (7, 8) in evn
+        assert not (8, 9) in evn
+
 
 class TestOutMultiEdgeView(TestMultiEdgeView):
     @classmethod
@@ -810,6 +935,18 @@ class TestOutMultiEdgeView(TestMultiEdgeView):
         )
         assert repr(ev) == rep
 
+    def test_contains_with_nbunch(self):
+        ev = self.eview(self.G)
+        evn = ev(nbunch=[0, 2])
+        assert (0, 1) in evn
+        assert not (1, 2) in evn
+        assert (2, 3) in evn
+        assert not (3, 4) in evn
+        assert not (4, 5) in evn
+        assert not (5, 6) in evn
+        assert not (7, 8) in evn
+        assert not (8, 9) in evn
+
 
 class TestInMultiEdgeView(TestMultiEdgeView):
     @classmethod
@@ -830,6 +967,18 @@ class TestInMultiEdgeView(TestMultiEdgeView):
             + "(3, 4, 0), (4, 5, 0), (5, 6, 0), (6, 7, 0), (7, 8, 0)])"
         )
         assert repr(ev) == rep
+
+    def test_contains_with_nbunch(self):
+        ev = self.eview(self.G)
+        evn = ev(nbunch=[0, 2])
+        assert not (0, 1) in evn
+        assert (1, 2) in evn
+        assert not (2, 3) in evn
+        assert not (3, 4) in evn
+        assert not (4, 5) in evn
+        assert not (5, 6) in evn
+        assert not (7, 8) in evn
+        assert not (8, 9) in evn
 
 
 # Degrees


### PR DESCRIPTION
I took the advice of last time and this time I think I am close, but I am still having trouble with the MultiEdge class family tests.

From what I can tell, it seems that as soon as you pass an `nbunch` parameter to the `EdgeView` cosntructor (and those of its family), it automatically redirects to an (associated) `EdgeDataView`. For this reason I didn't implement any nbunch check logic because it seems to already be handled in the associated EdgeDataViews.

However now it seems to be failing whenever it runs the `test_contains` function in the context of any `MultiEdge` class. It seems to me that this function is just run in all of its subclasses and can no longer handle the new restriction of edges via the `nbunch`. Could it be that this test was only passing due to the presence of the bug, and its fix now causes the test to fail? As I said before I am no big expert on pytest so I don't want to presume anything so someone else should look at this. But if my guess is correct then I think this test has to be split down into the respective subclasses to take into account the changes to the various `__contains__` methods