### PR TITLE
make return value of minimum_st_node_cut consistently a set

### DIFF
--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -281,7 +281,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     if mapping is None:
         raise nx.NetworkXError('Invalid auxiliary digraph.')
     if G.has_edge(s, t) or G.has_edge(t, s):
-        return []
+        return {}
     kwargs = dict(flow_func=flow_func, residual=residual, auxiliary=H)
 
     # The edge cut in the auxiliary digraph corresponds to the node cut in the

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -268,7 +268,7 @@ def tests_minimum_st_node_cut():
     G.add_nodes_from([0, 1, 2, 3, 7, 8, 11, 12])
     G.add_edges_from([(7, 11), (1, 11), (1, 12), (12, 8), (0, 1)])
     nodelist = minimum_st_node_cut(G, 7, 11)
-    assert(nodelist == [])
+    assert(nodelist == {})
 
 
 def test_invalid_auxiliary():


### PR DESCRIPTION
Fixes #3846 

As given in the issue description, replaced the list with set and changed the test that was expecting a list to make it expect a set. Please review and tell if anything else is to be done.