### PR TITLE
Fix return values when drawing empty nodes and edges  #3833

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -368,6 +368,7 @@ def draw_networkx_nodes(G, pos,
     from collections.abc import Iterable
     try:
         import matplotlib.pyplot as plt
+        from matplotlib.collections import PathCollection
         import numpy as np
     except ImportError:
         raise ImportError("Matplotlib required for draw()")
@@ -382,7 +383,7 @@ def draw_networkx_nodes(G, pos,
         nodelist = list(G)
 
     if len(nodelist) == 0:  # empty nodelist, no drawing
-        return
+        return PathCollection(None)
 
     try:
         xy = np.asarray([pos[v] for v in nodelist])
@@ -567,7 +568,10 @@ def draw_networkx_edges(G, pos,
         edgelist = list(G.edges())
 
     if not edgelist or len(edgelist) == 0:  # no edges!
-        return None
+        if not G.is_directed() or not arrows:
+            return LineCollection(None)
+        else:
+            return []
 
     if nodelist is None:
         nodelist = list(G.nodes())

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -168,6 +168,24 @@ class TestPylab:
         G = nx.Graph()
         nx.draw(G)
 
+    def test_draw_empty_nodes_return_values(self):
+        # See Issue #3833
+        from matplotlib.collections import PathCollection, LineCollection
+        G = nx.Graph([(1, 2), (2, 3)])
+        DG = nx.DiGraph([(1, 2), (2, 3)])
+        pos = nx.circular_layout(G)
+        assert isinstance(nx.draw_networkx_nodes(G, pos, nodelist=[]), PathCollection)
+        assert isinstance(nx.draw_networkx_nodes(DG, pos, nodelist=[]), PathCollection)
+
+        # drawing empty edges either return an empty LineCollection or empty list.
+        assert isinstance(nx.draw_networkx_edges(G, pos, edgelist=[], arrows=True),
+                          LineCollection)
+        assert isinstance(nx.draw_networkx_edges(G, pos, edgelist=[], arrows=False),
+                          LineCollection)
+        assert isinstance(nx.draw_networkx_edges(DG, pos, edgelist=[], arrows=False),
+                          LineCollection)
+        assert nx.draw_networkx_edges(DG, pos, edgelist=[], arrows=True) == []
+
     def test_multigraph_edgelist_tuples(self):
         # See Issue #3295
         G = nx.path_graph(3, create_using=nx.MultiDiGraph)


### PR DESCRIPTION
drawing an empty collection of nodes returns an empty PathCollection.
drawing an empty collection of edges returns (i) an empty LineCollection if neither a given graph is a directed graph nor `arrows` is enabled, (ii) an empty list, otherwise.