### PR TITLE
adds dedensification and densification functions

### DIFF
--- a/doc/reference/algorithms/dedensification.rst
+++ b/doc/reference/algorithms/dedensification.rst
@@ -1,0 +1,10 @@
+*********
+Dominance
+*********
+
+.. automodule:: networkx.algorithms.dedensification
+.. autosummary::
+   :toctree: generated/
+
+   dedensify
+   densify

--- a/doc/reference/algorithms/index.rst
+++ b/doc/reference/algorithms/index.rst
@@ -30,6 +30,7 @@ Algorithms
    cycles
    cuts
    dag
+   dedensification
    distance_measures
    distance_regular
    dominance

--- a/networkx/algorithms/dedensification.py
+++ b/networkx/algorithms/dedensification.py
@@ -1,0 +1,163 @@
+"""
+Algorithms for reducing the number of edges in a graph
+"""
+import networkx as nx
+from networkx.utils import not_implemented_for
+
+__all__ = ['dedensify', 'densify']
+
+
+def dedensify(G, **kwargs):
+    """
+    Reduce the number of edges in a graph by adding compressor nodes
+
+    Reduces the number of edges in a graph by removing edges around high-degree
+    nodes by adding compressor nodes
+
+    Parameters
+    ----------
+    G: graph
+       A networkx graph
+
+    Keyword Parameters
+    ------------------
+    threshold: int, optional (default=2)
+       Number of edges a node must have to be considered a high degree node
+    expansive: bool, (default=False)
+       Indicates if densification should occur in cases where the number of
+       edges are not reduced
+    prefix: str or None, optional (default: None)
+       An optional prefix for denoting compressor nodes
+    inplace: bool, optional (default: False)
+       Indicates if dedensification should be done inplace
+
+    Returns
+    -------
+    G: NetworkX graph
+       The dedensified graph
+
+    Notes
+    -----
+    According to the algorithm in [1]_, dedensification identifies low degree
+    nodes connecting to the same set of high degree nodes, and re-routes the
+    edges between the two sets of nodes through a compressor node.
+
+    When expansiveness is used, dedensification is performend on all sets of
+    low/high degree nodes, even when it will not reduce the number of edges.
+
+    When expansiveness is not used, dedensification will only be applied when
+    it would result in fewer edges.
+
+    References
+    ----------
+    .. [1] Maccioni, A., & Abadi, D. J. (2016, August).
+       Scalable pattern matching over compressed graphs via dedensification.
+       In Proceedings of the 22nd ACM SIGKDD International Conference on
+       Knowledge Discovery and Data Mining (pp. 1755-1764).
+       http://www.cs.umd.edu/~abadi/papers/graph-dedense.pdf
+
+    See Also
+    --------
+    densify
+    """
+    high_degree_nodes = set()
+    low_degree_nodes = set()
+    for node in G.nodes():
+        if isinstance(G, nx.DiGraph):
+            node_degrees = G.in_degree(node)
+        else:
+            node_degrees = G.degree(node)
+        if node_degrees > kwargs.get('threshold', 2):
+            high_degree_nodes.add(node)
+        else:
+            low_degree_nodes.add(node)
+
+    auxillary = dict()
+    for node in high_degree_nodes | low_degree_nodes:
+        node_neighbors = set(G.neighbors(node))
+        high_degree_neighbors = frozenset(node_neighbors & high_degree_nodes)
+        if high_degree_neighbors:
+            low_degree_neighbors = auxillary.get(high_degree_neighbors)
+            if not low_degree_neighbors:
+                auxillary[high_degree_neighbors] = set([node])
+            else:
+                low_degree_neighbors.add(node)
+
+    if kwargs.get('inplace', False):
+        G = G.copy()
+
+    prefix = kwargs.get('prefix')
+    compressor_nodes = set()
+    for index, (high_degree_nodes, low_degree_nodes) in enumerate(auxillary.items()):
+        if not kwargs.get('expansive', False):
+            low_degree_node_count = len(low_degree_nodes)
+            high_degree_node_count = len(high_degree_nodes)
+            old_edges = high_degree_node_count * low_degree_node_count
+            new_edges = high_degree_node_count + low_degree_node_count
+            if old_edges <= new_edges:
+                continue
+        compression_node = ''.join(str(node) for node in high_degree_nodes)
+        if prefix:
+            compression_node = str(prefix) + compression_node
+        for node in low_degree_nodes:
+            for high_node in high_degree_nodes:
+                if G.has_edge(node, high_node):
+                    G.remove_edge(node, high_node)
+
+            G.add_edge(node, compression_node)
+        for node in high_degree_nodes:
+            G.add_edge(compression_node, node)
+        compressor_nodes.add(compression_node)
+    return G, compressor_nodes
+
+
+@not_implemented_for('undirected')
+def densify(G, compressor_nodes, **kwargs):
+    """
+    Densifies a compressed graph
+
+    Parameters
+    ----------
+    G: dedensified graph
+       A networkx graph
+    compressor_nodes: list
+       Iterable of compressor nodes in the dedensified graph
+
+    Keyword Parameters
+    ------------------
+    inplace: bool, optional (default: False)
+       Indicates if densification should be done inplace
+
+    Returns
+    -------
+    G: graph
+       A densified networkx graph
+
+    Notes
+    -----
+    Removes compressor nodes and adds the original edges between nodes
+
+    References
+    ----------
+    .. [1] Maccioni, A., & Abadi, D. J. (2016, August).
+       Scalable pattern matching over compressed graphs via dedensification.
+       In Proceedings of the 22nd ACM SIGKDD International Conference on
+       Knowledge Discovery and Data Mining (pp. 1755-1764).
+       http://www.cs.umd.edu/~abadi/papers/graph-dedense.pdf
+
+
+    """
+    if kwargs.get('inplace', False):
+        G = G.copy()
+    for compressor_node in compressor_nodes:
+        all_neighbors = set(nx.all_neighbors(G, compressor_node))
+        out_neighbors = set(G.neighbors(compressor_node))
+        for out_neighbor in out_neighbors:
+            G.remove_edge(compressor_node, out_neighbor)
+        in_neighbors = all_neighbors - out_neighbors
+        for in_neighbor in in_neighbors:
+            G.remove_edge(in_neighbor, compressor_node)
+            for out_neighbor in out_neighbors:
+                G.add_edge(in_neighbor, out_neighbor)
+        G.remove_node(compressor_node)
+    return G

--- a/networkx/algorithms/dedensification.py
+++ b/networkx/algorithms/dedensification.py
@@ -4,10 +4,10 @@ Algorithms for reducing the number of edges in a graph
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-__all__ = ['dedensify', 'densify']
+__all__ = ["dedensify", "densify"]
 
 
-def dedensify(G, **kwargs):
+def dedensify(G, threshold=2, expansive=False, prefix=None, inplace=False):
     """
     Reduce the number of edges in a graph by adding compressor nodes
 
@@ -18,9 +18,6 @@ def dedensify(G, **kwargs):
     ----------
     G: graph
        A networkx graph
-
-    Keyword Parameters
-    ------------------
     threshold: int, optional (default=2)
        Number of edges a node must have to be considered a high degree node
     expansive: bool, (default=False)
@@ -33,8 +30,8 @@ def dedensify(G, **kwargs):
 
     Returns
     -------
-    G: NetworkX graph
-       The dedensified graph
+    dedensified networkx graph : (graph, set)
+        2-tuple of the dedensified graph and list of compressor nodes
 
     Notes
     -----
@@ -42,7 +39,7 @@ def dedensify(G, **kwargs):
     nodes connecting to the same set of high degree nodes, and re-routes the
     edges between the two sets of nodes through a compressor node.
 
-    When expansiveness is used, dedensification is performend on all sets of
+    When expansiveness is used, dedensification is performed on all sets of
     low/high degree nodes, even when it will not reduce the number of edges.
 
     When expansiveness is not used, dedensification will only be applied when
@@ -67,7 +64,7 @@ def dedensify(G, **kwargs):
             node_degrees = G.in_degree(node)
         else:
             node_degrees = G.degree(node)
-        if node_degrees > kwargs.get('threshold', 2):
+        if node_degrees > threshold:
             high_degree_nodes.add(node)
         else:
             low_degree_nodes.add(node)
@@ -83,20 +80,19 @@ def dedensify(G, **kwargs):
             else:
                 low_degree_neighbors.add(node)
 
-    if kwargs.get('inplace', False):
+    if not inplace:
         G = G.copy()
 
-    prefix = kwargs.get('prefix')
     compressor_nodes = set()
     for index, (high_degree_nodes, low_degree_nodes) in enumerate(auxillary.items()):
-        if not kwargs.get('expansive', False):
+        if not expansive:
             low_degree_node_count = len(low_degree_nodes)
             high_degree_node_count = len(high_degree_nodes)
             old_edges = high_degree_node_count * low_degree_node_count
             new_edges = high_degree_node_count + low_degree_node_count
             if old_edges <= new_edges:
                 continue
-        compression_node = ''.join(str(node) for node in high_degree_nodes)
+        compression_node = "".join(str(node) for node in high_degree_nodes)
         if prefix:
             compression_node = str(prefix) + compression_node
         for node in low_degree_nodes:
@@ -111,8 +107,8 @@ def dedensify(G, **kwargs):
     return G, compressor_nodes
 
 
-@not_implemented_for('undirected')
-def densify(G, compressor_nodes, **kwargs):
+@not_implemented_for("undirected")
+def densify(G, compressor_nodes, inplace=False):
     """
     Densifies a compressed graph
 
@@ -120,11 +116,8 @@ def densify(G, compressor_nodes, **kwargs):
     ----------
     G: dedensified graph
        A networkx graph
-    compressor_nodes: list
+    compressor_nodes: iterable
        Iterable of compressor nodes in the dedensified graph
-
-    Keyword Parameters
-    ------------------
     inplace: bool, optional (default: False)
        Indicates if densification should be done inplace
 
@@ -147,7 +140,7 @@ def densify(G, compressor_nodes, **kwargs):
 
 
     """
-    if kwargs.get('inplace', False):
+    if not inplace:
         G = G.copy()
     for compressor_node in compressor_nodes:
         all_neighbors = set(nx.all_neighbors(G, compressor_node))

--- a/networkx/algorithms/tests/test_dedensification.py
+++ b/networkx/algorithms/tests/test_dedensification.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for dedensification/densification
+"""
+
+import networkx as nx
+from networkx.algorithms.dedensification import dedensify, densify
+
+
+class TestDirectedDedensification:
+
+    def build_original_graph(self):
+        original_matrix = [
+            ('1', 'BC'),
+            ('2', 'ABC'),
+            ('3', ['A', 'B', '6']),
+            ('4', 'ABC'),
+            ('5', 'AB'),
+            ('6', ['5']),
+            ('A', ['6']),
+        ]
+        graph = nx.DiGraph()
+        for source, targets in original_matrix:
+            for target in targets:
+                graph.add_edge(source, target)
+        return graph
+
+    def build_compressed_graph(self):
+        compressed_matrix = [
+            ('1', ['BC']),
+            ('2', ['ABC']),
+            ('3', ['AB', '6']),
+            ('4', ['ABC']),
+            ('5', ['AB']),
+            ('6', ['5']),
+            ('A', ['6']),
+            ('ABC', 'ABC'),
+            ('AB', 'AB'),
+            ('BC', 'BC')
+        ]
+        compressed_graph = nx.DiGraph()
+        for source, targets in compressed_matrix:
+            for target in targets:
+                compressed_graph.add_edge(source, target)
+        return compressed_graph
+
+    def test_empty(self):
+        G = nx.Graph()
+        compressed_graph, c_nodes = dedensify(G, expansive=True, prefix='C-')
+        assert c_nodes == set()
+
+
+class TestDirectedExpansiveDedensification(TestDirectedDedensification):
+
+    def setup_method(self):
+        self.c_nodes = ('AB', 'BC', 'ABC')
+
+    def test_dedensify_edges(self):
+        G = self.build_original_graph()
+        compressed_G = self.build_compressed_graph()
+        compressed_graph, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=True,
+            inplace=True
+        )
+        for s, t in compressed_graph.edges():
+            o_s = ''.join(sorted(s))
+            o_t = ''.join(sorted(t))
+            compressed_graph_edge_exists = compressed_graph.has_edge(s, t)
+            verified_compressed_edge_exists = compressed_G.has_edge(o_s, o_t)
+            assert compressed_graph_edge_exists == verified_compressed_edge_exists
+        assert len(c_nodes) == len(self.c_nodes)
+
+    def test_densify_edges(self):
+        original_graph = self.build_original_graph()
+        compressed_G = self.build_compressed_graph()
+        G = densify(compressed_G, self.c_nodes, inplace=True)
+        for s, t in original_graph.edges():
+            assert original_graph.has_edge(s, t) == G.has_edge(s, t)
+
+
+class TestDirectedNonExpansiveDedensification(TestDirectedDedensification):
+
+    def setup_method(self):
+        print('setup_method TestDirectedNonExpansiveDedensification')
+        self.c_nodes = ('ABC', )
+
+    def build_compressed_graph(self):
+        compressed_matrix = [
+            ('1', 'BC'),
+            ('2', ['ABC']),
+            ('3', ['A', 'B', '6']),
+            ('4', ['ABC']),
+            ('5', 'AB'),
+            ('6', ['5']),
+            ('A', ['6']),
+            ('ABC', 'ABC')
+        ]
+        compressed_graph = nx.DiGraph()
+        for source, targets in compressed_matrix:
+            for target in targets:
+                compressed_graph.add_edge(source, target)
+        return compressed_graph
+
+    def test_dedensify_edges(self):
+        G = self.build_original_graph()
+        compressed_G = self.build_compressed_graph()
+        compressed_graph, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=False,
+        )
+        for s, t in compressed_graph.edges():
+            o_s = ''.join(sorted(s))
+            o_t = ''.join(sorted(t))
+            compressed_graph_edge_exists = compressed_graph.has_edge(s, t)
+            print(o_s, o_t)
+            verified_compressed_edge_exists = compressed_G.has_edge(o_s, o_t)
+            assert compressed_graph_edge_exists == verified_compressed_edge_exists
+        assert len(c_nodes) == len(self.c_nodes)
+
+    def test_dedensify_edge_count(self):
+        G = self.build_original_graph()
+        original_edge_count = len(G.edges())
+        compressed_G, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=False,
+            inplace=True
+        )
+        compressed_edge_count = len(compressed_G.edges())
+        assert compressed_edge_count <= original_edge_count
+        compressed_G = self.build_compressed_graph()
+        assert compressed_edge_count == len(compressed_G.edges())
+
+    def test_densify_edges(self):
+        compressed_G = self.build_compressed_graph()
+        original_graph = densify(compressed_G, self.c_nodes, inplace=True)
+        G = self.build_original_graph()
+        for s, t in G.edges():
+            assert G.has_edge(s, t) == original_graph.has_edge(s, t)
+
+    def test_densify_edge_count(self):
+        compressed_G = self.build_compressed_graph()
+        compressed_edge_count = len(compressed_G.edges())
+        original_graph = densify(compressed_G, self.c_nodes, inplace=True)
+        original_edge_count = len(original_graph.edges())
+        assert compressed_edge_count <= original_edge_count
+        G = self.build_original_graph()
+        assert original_edge_count == len(G.edges())
+
+
+class TestUnDirectedDedensification:
+
+    def build_original_graph(self):
+        """
+        Builds graph shown in the original research paper
+        """
+        original_matrix = [
+            ('1', 'CB'),
+            ('2', 'ABC'),
+            ('3', ['A', 'B', '6']),
+            ('4', 'ABC'),
+            ('5', 'AB'),
+            ('6', ['5']),
+            ('A', ['6']),
+        ]
+        graph = nx.Graph()
+        for source, targets in original_matrix:
+            for target in targets:
+                graph.add_edge(source, target)
+        return graph
+
+    def test_empty(self):
+        G = nx.Graph()
+        compressed_G, c_nodes = dedensify(G, expansive=True, prefix='C-')
+        assert c_nodes == set()
+
+
+class TestUnDirectedExpansiveDedensification(TestUnDirectedDedensification):
+
+    def setup_method(self):
+        self.c_nodes = ('BC', 'ABC', '35A', '24', '23456', '2345', '6AB')
+
+    def build_compressed_graph(self):
+        compressed_matrix = [
+            ('1', ['BC']),
+            ('2', ['24', '2345', '23456', 'ABC']),
+            ('3', ['35A', '2345', '23456', '6AB']),
+            ('4', ['24', '2345', '23456', 'ABC']),
+            ('5', ['2345', '23456', '35A', '6AB']),
+            ('6', ['35A', '6AB', '23456']),
+            ('A', ['23456', '35A', 'ABC', '6AB']),
+            ('B', ['BC', '2345', '6AB', 'ABC']),
+            ('C', ['24', 'BC', 'ABC']),
+        ]
+        compressed_graph = nx.Graph()
+        for source, targets in compressed_matrix:
+            for target in targets:
+                compressed_graph.add_edge(source, target)
+        return compressed_graph
+
+    def test_dedensify_edges(self):
+        G = self.build_original_graph()
+        v_compressed_G = self.build_compressed_graph()
+        compressed_G, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=True,
+            inplace=True
+        )
+        for s, t in compressed_G.edges():
+            o_s = ''.join(sorted(s))
+            o_t = ''.join(sorted(t))
+            assert compressed_G.has_edge(s, t) == v_compressed_G.has_edge(o_s, o_t)
+        assert len(c_nodes) == len(self.c_nodes)
+
+    def test_dedensify_edge_count(self):
+        G = self.build_original_graph()
+        verified_compressed_G = self.build_compressed_graph()
+        compressed_G, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=True,
+            inplace=True
+        )
+        compressed_edge_count = len(compressed_G.edges())
+        verified_compressed_edge_count = len(verified_compressed_G.edges())
+        assert compressed_edge_count == verified_compressed_edge_count
+
+
+class TestUnDirectedNonExpansiveDedensification(TestUnDirectedDedensification):
+
+    def setup_method(self):
+        self.c_nodes = ('6AB', 'ABC', )
+
+    def build_compressed_graph(self):
+        compressed_matrix = [
+            ('1', ['B', 'C']),
+            ('2', ['ABC']),
+            ('3', ['6AB']),
+            ('4', ['ABC']),
+            ('5', ['6AB']),
+            ('6', ['6AB', 'A']),
+            ('A', ['6AB', 'ABC']),
+            ('B', ['ABC', '6AB']),
+            ('C', ['ABC'])
+        ]
+        compressed_graph = nx.Graph()
+        for source, targets in compressed_matrix:
+            for target in targets:
+                compressed_graph.add_edge(source, target)
+        return compressed_graph
+
+    def test_dedensify_edges(self):
+        G = self.build_original_graph()
+        compressed_G, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=False,
+            inplace=True
+        )
+        v_compressed_G = self.build_compressed_graph()
+        for s, t in compressed_G.edges():
+            o_s = ''.join(sorted(s))
+            o_t = ''.join(sorted(t))
+            assert compressed_G.has_edge(s, t) == v_compressed_G.has_edge(o_s, o_t)
+        assert len(c_nodes) == len(self.c_nodes)
+
+    def test_dedensify_edge_count(self):
+        G = self.build_original_graph()
+        compressed_G, c_nodes = dedensify(
+            G,
+            threshold=2,
+            expansive=False,
+            inplace=True
+        )
+        compressed_edge_count = len(compressed_G.edges())
+        verified_original_edge_count = len(G.edges())
+        assert compressed_edge_count <= verified_original_edge_count
+        verified_compressed_G = self.build_compressed_graph()
+        verified_compressed_edge_count = len(verified_compressed_G.edges())
+        assert compressed_edge_count == verified_compressed_edge_count

--- a/networkx/algorithms/tests/test_dedensification.py
+++ b/networkx/algorithms/tests/test_dedensification.py
@@ -7,16 +7,15 @@ from networkx.algorithms.dedensification import dedensify, densify
 
 
 class TestDirectedDedensification:
-
     def build_original_graph(self):
         original_matrix = [
-            ('1', 'BC'),
-            ('2', 'ABC'),
-            ('3', ['A', 'B', '6']),
-            ('4', 'ABC'),
-            ('5', 'AB'),
-            ('6', ['5']),
-            ('A', ['6']),
+            ("1", "BC"),
+            ("2", "ABC"),
+            ("3", ["A", "B", "6"]),
+            ("4", "ABC"),
+            ("5", "AB"),
+            ("6", ["5"]),
+            ("A", ["6"]),
         ]
         graph = nx.DiGraph()
         for source, targets in original_matrix:
@@ -26,16 +25,16 @@ class TestDirectedDedensification:
 
     def build_compressed_graph(self):
         compressed_matrix = [
-            ('1', ['BC']),
-            ('2', ['ABC']),
-            ('3', ['AB', '6']),
-            ('4', ['ABC']),
-            ('5', ['AB']),
-            ('6', ['5']),
-            ('A', ['6']),
-            ('ABC', 'ABC'),
-            ('AB', 'AB'),
-            ('BC', 'BC')
+            ("1", ["BC"]),
+            ("2", ["ABC"]),
+            ("3", ["AB", "6"]),
+            ("4", ["ABC"]),
+            ("5", ["AB"]),
+            ("6", ["5"]),
+            ("A", ["6"]),
+            ("ABC", "ABC"),
+            ("AB", "AB"),
+            ("BC", "BC"),
         ]
         compressed_graph = nx.DiGraph()
         for source, targets in compressed_matrix:
@@ -45,27 +44,23 @@ class TestDirectedDedensification:
 
     def test_empty(self):
         G = nx.Graph()
-        compressed_graph, c_nodes = dedensify(G, expansive=True, prefix='C-')
+        compressed_graph, c_nodes = dedensify(G, expansive=True, prefix="C-")
         assert c_nodes == set()
 
 
 class TestDirectedExpansiveDedensification(TestDirectedDedensification):
-
     def setup_method(self):
-        self.c_nodes = ('AB', 'BC', 'ABC')
+        self.c_nodes = ("AB", "BC", "ABC")
 
     def test_dedensify_edges(self):
         G = self.build_original_graph()
         compressed_G = self.build_compressed_graph()
         compressed_graph, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=True,
-            inplace=True
+            G, threshold=2, expansive=True, inplace=True
         )
         for s, t in compressed_graph.edges():
-            o_s = ''.join(sorted(s))
-            o_t = ''.join(sorted(t))
+            o_s = "".join(sorted(s))
+            o_t = "".join(sorted(t))
             compressed_graph_edge_exists = compressed_graph.has_edge(s, t)
             verified_compressed_edge_exists = compressed_G.has_edge(o_s, o_t)
             assert compressed_graph_edge_exists == verified_compressed_edge_exists
@@ -80,21 +75,19 @@ class TestDirectedExpansiveDedensification(TestDirectedDedensification):
 
 
 class TestDirectedNonExpansiveDedensification(TestDirectedDedensification):
-
     def setup_method(self):
-        print('setup_method TestDirectedNonExpansiveDedensification')
-        self.c_nodes = ('ABC', )
+        self.c_nodes = ("ABC",)
 
     def build_compressed_graph(self):
         compressed_matrix = [
-            ('1', 'BC'),
-            ('2', ['ABC']),
-            ('3', ['A', 'B', '6']),
-            ('4', ['ABC']),
-            ('5', 'AB'),
-            ('6', ['5']),
-            ('A', ['6']),
-            ('ABC', 'ABC')
+            ("1", "BC"),
+            ("2", ["ABC"]),
+            ("3", ["A", "B", "6"]),
+            ("4", ["ABC"]),
+            ("5", "AB"),
+            ("6", ["5"]),
+            ("A", ["6"]),
+            ("ABC", "ABC"),
         ]
         compressed_graph = nx.DiGraph()
         for source, targets in compressed_matrix:
@@ -105,16 +98,11 @@ class TestDirectedNonExpansiveDedensification(TestDirectedDedensification):
     def test_dedensify_edges(self):
         G = self.build_original_graph()
         compressed_G = self.build_compressed_graph()
-        compressed_graph, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=False,
-        )
+        compressed_graph, c_nodes = dedensify(G, threshold=2, expansive=False)
         for s, t in compressed_graph.edges():
-            o_s = ''.join(sorted(s))
-            o_t = ''.join(sorted(t))
+            o_s = "".join(sorted(s))
+            o_t = "".join(sorted(t))
             compressed_graph_edge_exists = compressed_graph.has_edge(s, t)
-            print(o_s, o_t)
             verified_compressed_edge_exists = compressed_G.has_edge(o_s, o_t)
             assert compressed_graph_edge_exists == verified_compressed_edge_exists
         assert len(c_nodes) == len(self.c_nodes)
@@ -122,12 +110,7 @@ class TestDirectedNonExpansiveDedensification(TestDirectedDedensification):
     def test_dedensify_edge_count(self):
         G = self.build_original_graph()
         original_edge_count = len(G.edges())
-        compressed_G, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=False,
-            inplace=True
-        )
+        compressed_G, c_nodes = dedensify(G, threshold=2, expansive=False, inplace=True)
         compressed_edge_count = len(compressed_G.edges())
         assert compressed_edge_count <= original_edge_count
         compressed_G = self.build_compressed_graph()
@@ -151,19 +134,18 @@ class TestDirectedNonExpansiveDedensification(TestDirectedDedensification):
 
 
 class TestUnDirectedDedensification:
-
     def build_original_graph(self):
         """
         Builds graph shown in the original research paper
         """
         original_matrix = [
-            ('1', 'CB'),
-            ('2', 'ABC'),
-            ('3', ['A', 'B', '6']),
-            ('4', 'ABC'),
-            ('5', 'AB'),
-            ('6', ['5']),
-            ('A', ['6']),
+            ("1", "CB"),
+            ("2", "ABC"),
+            ("3", ["A", "B", "6"]),
+            ("4", "ABC"),
+            ("5", "AB"),
+            ("6", ["5"]),
+            ("A", ["6"]),
         ]
         graph = nx.Graph()
         for source, targets in original_matrix:
@@ -173,26 +155,25 @@ class TestUnDirectedDedensification:
 
     def test_empty(self):
         G = nx.Graph()
-        compressed_G, c_nodes = dedensify(G, expansive=True, prefix='C-')
+        compressed_G, c_nodes = dedensify(G, expansive=True, prefix="C-")
         assert c_nodes == set()
 
 
 class TestUnDirectedExpansiveDedensification(TestUnDirectedDedensification):
-
     def setup_method(self):
-        self.c_nodes = ('BC', 'ABC', '35A', '24', '23456', '2345', '6AB')
+        self.c_nodes = ("BC", "ABC", "35A", "24", "23456", "2345", "6AB")
 
     def build_compressed_graph(self):
         compressed_matrix = [
-            ('1', ['BC']),
-            ('2', ['24', '2345', '23456', 'ABC']),
-            ('3', ['35A', '2345', '23456', '6AB']),
-            ('4', ['24', '2345', '23456', 'ABC']),
-            ('5', ['2345', '23456', '35A', '6AB']),
-            ('6', ['35A', '6AB', '23456']),
-            ('A', ['23456', '35A', 'ABC', '6AB']),
-            ('B', ['BC', '2345', '6AB', 'ABC']),
-            ('C', ['24', 'BC', 'ABC']),
+            ("1", ["BC"]),
+            ("2", ["24", "2345", "23456", "ABC"]),
+            ("3", ["35A", "2345", "23456", "6AB"]),
+            ("4", ["24", "2345", "23456", "ABC"]),
+            ("5", ["2345", "23456", "35A", "6AB"]),
+            ("6", ["35A", "6AB", "23456"]),
+            ("A", ["23456", "35A", "ABC", "6AB"]),
+            ("B", ["BC", "2345", "6AB", "ABC"]),
+            ("C", ["24", "BC", "ABC"]),
         ]
         compressed_graph = nx.Graph()
         for source, targets in compressed_matrix:
@@ -203,48 +184,40 @@ class TestUnDirectedExpansiveDedensification(TestUnDirectedDedensification):
     def test_dedensify_edges(self):
         G = self.build_original_graph()
         v_compressed_G = self.build_compressed_graph()
-        compressed_G, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=True,
-            inplace=True
-        )
+        compressed_G, c_nodes = dedensify(G, threshold=2, expansive=True, inplace=True)
         for s, t in compressed_G.edges():
-            o_s = ''.join(sorted(s))
-            o_t = ''.join(sorted(t))
+            o_s = "".join(sorted(s))
+            o_t = "".join(sorted(t))
             assert compressed_G.has_edge(s, t) == v_compressed_G.has_edge(o_s, o_t)
         assert len(c_nodes) == len(self.c_nodes)
 
     def test_dedensify_edge_count(self):
         G = self.build_original_graph()
         verified_compressed_G = self.build_compressed_graph()
-        compressed_G, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=True,
-            inplace=True
-        )
+        compressed_G, c_nodes = dedensify(G, threshold=2, expansive=True, inplace=True)
         compressed_edge_count = len(compressed_G.edges())
         verified_compressed_edge_count = len(verified_compressed_G.edges())
         assert compressed_edge_count == verified_compressed_edge_count
 
 
 class TestUnDirectedNonExpansiveDedensification(TestUnDirectedDedensification):
-
     def setup_method(self):
-        self.c_nodes = ('6AB', 'ABC', )
+        self.c_nodes = (
+            "6AB",
+            "ABC",
+        )
 
     def build_compressed_graph(self):
         compressed_matrix = [
-            ('1', ['B', 'C']),
-            ('2', ['ABC']),
-            ('3', ['6AB']),
-            ('4', ['ABC']),
-            ('5', ['6AB']),
-            ('6', ['6AB', 'A']),
-            ('A', ['6AB', 'ABC']),
-            ('B', ['ABC', '6AB']),
-            ('C', ['ABC'])
+            ("1", ["B", "C"]),
+            ("2", ["ABC"]),
+            ("3", ["6AB"]),
+            ("4", ["ABC"]),
+            ("5", ["6AB"]),
+            ("6", ["6AB", "A"]),
+            ("A", ["6AB", "ABC"]),
+            ("B", ["ABC", "6AB"]),
+            ("C", ["ABC"]),
         ]
         compressed_graph = nx.Graph()
         for source, targets in compressed_matrix:
@@ -254,27 +227,17 @@ class TestUnDirectedNonExpansiveDedensification(TestUnDirectedDedensification):
 
     def test_dedensify_edges(self):
         G = self.build_original_graph()
-        compressed_G, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=False,
-            inplace=True
-        )
+        compressed_G, c_nodes = dedensify(G, threshold=2, expansive=False, inplace=True)
         v_compressed_G = self.build_compressed_graph()
         for s, t in compressed_G.edges():
-            o_s = ''.join(sorted(s))
-            o_t = ''.join(sorted(t))
+            o_s = "".join(sorted(s))
+            o_t = "".join(sorted(t))
             assert compressed_G.has_edge(s, t) == v_compressed_G.has_edge(o_s, o_t)
         assert len(c_nodes) == len(self.c_nodes)
 
     def test_dedensify_edge_count(self):
         G = self.build_original_graph()
-        compressed_G, c_nodes = dedensify(
-            G,
-            threshold=2,
-            expansive=False,
-            inplace=True
-        )
+        compressed_G, c_nodes = dedensify(G, threshold=2, expansive=False, inplace=True)
         compressed_edge_count = len(compressed_G.edges())
         verified_original_edge_count = len(G.edges())
         assert compressed_edge_count <= verified_original_edge_count


### PR DESCRIPTION
Adds dedensification (`networkx.algorithms.dedensification.dedensify`) and densification (`networkx.algorithms.dedensification.densify`) functions as defined in [Scalable Pattern Matching over Compressed Graphs via Dedensification](http://www.cs.umd.edu/~abadi/papers/graph-dedense.pdf) with option for `expansive` or `nonexpansive` results, and option for `inplace` dedensification or densification.

Examples of how functions can be called:
```python
import networkx as nx

graph = nx.DiGraph()
# build structure of graph by adding nodes and edges

dedensified_graph, compression_nodes = nx.algorithms.dedensification.dedensify(graph, threshold=10, prefix='compression-')

# perform business operations on dedensified graph

# convert dedensified graph back into original graph
densified_graph = nx.algorithms.dedensification.densify(dedensified_graph, compression_nodes)
```