### PR TITLE
fix: gaussian_random_partition_graph kwargs fix [#3871];

### DIFF
--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -377,7 +377,7 @@ def gaussian_random_partition_graph(n, s, v, p_in, p_out, directed=False,
             break
         assigned += size
         sizes.append(size)
-    return random_partition_graph(sizes, p_in, p_out, directed, seed)
+    return random_partition_graph(sizes, p_in, p_out, directed=directed, seed=seed)
 
 
 def ring_of_cliques(num_cliques, clique_size):


### PR DESCRIPTION
Description: Previously, there was a mismatch where `directed` was being sent to `seed` and vice versa on this line.  This makes it explicit which arg is passed where.

Tested locally and passes.