### PR TITLE
Made CONTRIBUTING.rst more clearer

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ Developer overview
 
       git clone git@github.com:your-username/networkx.git
 
-   * Add the upstream repository::
+   * Navigate to the folder networkx and add the upstream repository::
 
       git remote add upstream git@github.com:networkx/networkx.git
 


### PR DESCRIPTION
I saw that in CONTRIBUTING.rst that is wasn't clear that you had to navigate to the folder before adding the upstream repo. So I added that to make sure that that was clearer for newbies like me.