### PR TITLE
add paley graph

### DIFF
--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -4,7 +4,7 @@
 import itertools
 import networkx as nx
 
-__all__ = ['margulis_gabber_galil_graph', 'chordal_cycle_graph']
+__all__ = ['margulis_gabber_galil_graph', 'chordal_cycle_graph', 'paley_graph']
 
 
 # Other discrete torus expanders can be constructed by using the following edge
@@ -137,4 +137,62 @@ def chordal_cycle_graph(p, create_using=None):
         for y in (left, right, chord):
             G.add_edge(x, y)
     G.graph['name'] = f"chordal_cycle_graph({p})"
+    return G
+
+
+def paley_graph(p, create_using=None):
+    """Returns the Paley (p-1)/2-regular graph on p nodes.
+
+    The returned graph is a graph on Z/pZ with edges between x and y
+    if and only if x-y is a nonzero square in Z/pZ.
+
+    If p = 1 mod 4, -1 is a square in Z/pZ and therefore x-y is a square if and
+    only if y-x is also a square, i.e the edges in the Paley graph are symmetric.
+
+    If p = 3 mod 4, -1 is not a square in Z/pZ and therefore either x-y or y-x
+    is a square in Z/pZ but not both.
+
+    Note that a more general definition of Paley graphs extends this construction
+    to graphs over q=p^n vertices, by using the finite field F_q instead of Z/pZ.
+    This construction requires to compute squares in general finite fields and is
+    not what is implemented here (i.e paley_graph(25) does not return the true
+    Paley graph associated with 5^2).
+
+    Parameters
+    ----------
+    p : int, an odd prime number.
+
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : graph
+        The constructed directed graph.
+
+    Raises
+    ------
+    NetworkXError
+        If the graph is a multigraph.
+
+    References
+    ----------
+    Chapter 13 in B. Bollobas, Random Graphs. Second edition.
+    Cambridge Studies in Advanced Mathematics, 73.
+    Cambridge University Press, Cambridge (2001).
+    """
+    G = nx.empty_graph(0, create_using, default=nx.DiGraph)
+    if G.is_multigraph():
+        msg = "`create_using` cannot be a multigraph."
+        raise nx.NetworkXError(msg)
+
+    # Compute the squares in Z/pZ.
+    # Make it a set to uniquify (there are exactly (p-1)/2 squares in Z/pZ
+    # when is prime).
+    square_set = set([(x ** 2) % p for x in range(1, p) if (x ** 2) % p != 0])
+
+    for x in range(p):
+        for x2 in square_set:
+           G.add_edge(x, (x + x2) % p)
+    G.graph['name'] =f"paley({p})"
     return G

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -193,6 +193,6 @@ def paley_graph(p, create_using=None):
 
     for x in range(p):
         for x2 in square_set:
-           G.add_edge(x, (x + x2) % p)
-    G.graph['name'] =f"paley({p})"
+            G.add_edge(x, (x + x2) % p)
+    G.graph['name'] = f"paley({p})"
     return G

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -7,6 +7,7 @@ from networkx import adjacency_matrix
 from networkx import number_of_nodes
 from networkx.generators.expanders import chordal_cycle_graph
 from networkx.generators.expanders import margulis_gabber_galil_graph
+from networkx.generators.expanders import paley_graph
 
 import pytest
 
@@ -43,6 +44,25 @@ def test_chordal_cycle_graph():
         #     eigs = sorted(scipy.linalg.eigvalsh(adjacency_matrix(G).A))
         #     assert_less(eigs[-2], ...)
         #
+
+def test_paley_graph():
+    """Test for the :func:`networkx.paley_graph` function."""
+    primes = [3, 5, 7, 11, 13]
+    for p in primes:
+        G = paley_graph(p)
+        # G has p nodes
+        assert len(G) == p
+        # G is (p-1)/2-regular
+        in_degrees = set([G.in_degree(node) for node in G.nodes])
+        out_degrees = set([G.out_degree(node) for node in G.nodes])
+        assert len(in_degrees) == 1 and in_degrees.pop() == (p - 1) // 2
+        assert len(out_degrees) == 1 and out_degrees.pop() == (p - 1) // 2
+
+        # If p = 1 mod 4, -1 is a square mod 4 and therefore the
+        # edge in the Paley graph are symmetric.
+        if p % 4 == 1:
+            for (u, v) in G.edges:
+                assert (v, u) in G.edges
 
 
 def test_margulis_gabber_galil_graph_badinput():

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -45,6 +45,7 @@ def test_chordal_cycle_graph():
         #     assert_less(eigs[-2], ...)
         #
 
+
 def test_paley_graph():
     """Test for the :func:`networkx.paley_graph` function."""
     primes = [3, 5, 7, 11, 13]


### PR DESCRIPTION
Hi,

I'm a young researcher in math with a keen interest in graphs. I've been using networkx a lot recently so I'd like to start contributing.

I've been doing some work around expanders, a class of regular graphs for which there are only two generators currently available in networkx. This is a proposal to add the class of Paley graphs, a family of graphs on p nodes obtained by matching x and y iif y-x is a square mod p. 

Said graphs are indeed regular when p is a prime number (there are (p-1)/2 distinct squares in this case).

I tried to match the style of existing functions in expanders.py and the associated test, but any feedback would be greatly appreciated.

Thanks,

Patrick

P.S : below is a visualization of Paley graphs for a few increasing values of p:
![paley](https://user-images.githubusercontent.com/46052865/78700059-26255680-7905-11ea-9269-d27197ca6fc0.gif)