### PR TITLE
Fix TypeError: 'int' object is not iterable

### DIFF
--- a/examples/drawing/plot_degree_histogram.py
+++ b/examples/drawing/plot_degree_histogram.py
@@ -12,7 +12,7 @@ import networkx as nx
 
 G = nx.gnp_random_graph(100, 0.02)
 
-degree_sequence = sorted([d for n, d in G.degree()], reverse=True)  # degree sequence
+degree_sequence = sorted([d for d in G.degree().values()], reverse=True)  # degree sequence
 degreeCount = collections.Counter(degree_sequence)
 deg, cnt = zip(*degreeCount.items())
 


### PR DESCRIPTION
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-40-2cdbcd665332> in draw_hist(G)
      2     import collections
      3     import matplotlib.pyplot as plt
----> 4     degree_sequence = sorted([d for n,d in G.degree()], reverse=True)  # degree sequence
      5     # print "Degree sequence", degree_sequence
      6     degreeCount = collections.Counter(degree_sequence)

<ipython-input-40-2cdbcd665332> in <listcomp>(.0)
      2     import collections
      3     import matplotlib.pyplot as plt
----> 4     degree_sequence = sorted([d for n,d in G.degree()], reverse=True)  # degree sequence
      5     # print "Degree sequence", degree_sequence
      6     degreeCount = collections.Counter(degree_sequence)

TypeError: 'int' object is not iterable