### PR TITLE
Correctly infer numpy float types

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -382,9 +382,10 @@ class GraphMLWriter(GraphML):
             types = self.attribute_types[(name, scope)]
 
             if len(types) > 1:
-                if str in types:
+                types = set(self.xml_type[t] for t in types)
+                if "string" in types:
                     return str
-                elif float in types:
+                elif "float" in types or "double" in types:
                     return float
                 else:
                     return int

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -988,6 +988,17 @@ class TestWriteGraphML(BaseGraphML):
         os.close(fd)
         os.unlink(fname)
 
+    def test_numpy_float64_inference(self):
+        np = pytest.importorskip('numpy')
+        G = self.attribute_numeric_type_graph
+        G.edges[('n1', 'n1')]['weight'] = np.float64(1.1)
+        fd, fname = tempfile.mkstemp()
+        self.writer(G, fname, infer_numeric_types=True)
+        H = nx.read_graphml(fname)
+        assert G._adj == H._adj
+        os.close(fd)
+        os.unlink(fname)
+
     def test_unicode_attributes(self):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)


### PR DESCRIPTION
This fixes a bug where np.float64 values are given an integer type in the GraphML file, which leads to parsing errors.