### PR TITLE
Consistent dijkstra api

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -151,9 +151,7 @@ def dijkstra_path(G, source, target, weight='weight'):
     bidirectional_dijkstra(), bellman_ford_path()
     single_source_dijkstra()
     """
-    (length, path) = single_source_dijkstra(G, source, target=target,
-                                            weight=weight)
-    return path
+    return single_source_dijkstra_path(G, source, target=target, weight=weight)
 
 
 def dijkstra_path_length(G, source, target, weight='weight'):
@@ -222,14 +220,7 @@ def dijkstra_path_length(G, source, target, weight='weight'):
     single_source_dijkstra()
 
     """
-    if source == target:
-        return 0
-    weight = _weight_function(G, weight)
-    length = _dijkstra(G, source, weight, target=target)
-    try:
-        return length[target]
-    except KeyError:
-        raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
+    return single_source_dijkstra_path_length(G, source, target=target, weight=weight)
 
 
 def single_source_dijkstra_path(G, source, target=None, cutoff=None, weight='weight'):
@@ -544,7 +535,7 @@ def multi_source_dijkstra_path(G, sources, target=None, cutoff=None, weight='wei
     multi_source_dijkstra(), multi_source_bellman_ford()
 
     """
-    length, path = multi_source_dijkstra(G, sources, target=target, cutoff=cutoff,
+    _, path = multi_source_dijkstra(G, sources, target=target, cutoff=cutoff,
                                          weight=weight)
     return path
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -5,9 +5,9 @@ Shortest path algorithms for weighed graphs.
 from collections import deque
 from heapq import heappush, heappop
 from itertools import count
+
 import networkx as nx
 from networkx.utils import generate_unique_node
-
 
 __all__ = ['dijkstra_path',
            'dijkstra_path_length',
@@ -536,7 +536,7 @@ def multi_source_dijkstra_path(G, sources, target=None, cutoff=None, weight='wei
 
     """
     _, path = multi_source_dijkstra(G, sources, target=target, cutoff=cutoff,
-                                         weight=weight)
+                                    weight=weight)
     return path
 
 
@@ -616,7 +616,7 @@ def multi_source_dijkstra_path_length(G, sources, target=None, cutoff=None,
 
     """
     length, _ = multi_source_dijkstra(G, sources, target=target, cutoff=cutoff,
-                                         weight=weight, capture_paths=False)
+                                      weight=weight, capture_paths=False)
     return length
 
 
@@ -2014,7 +2014,7 @@ def bidirectional_dijkstra(G, source, target, weight='weight'):
     push = heappush
     pop = heappop
     # Init:  [Forward, Backward]
-    dists = [{}, {}]   # dictionary of final distances
+    dists = [{}, {}]  # dictionary of final distances
     paths = [{source: [source]}, {target: [target]}]  # dictionary of paths
     fringe = [[], []]  # heap of (distance, node) for choosing node to expand
     seen = [{source: 0}, {target: 0}]  # dict of distances to seen nodes
@@ -2048,7 +2048,7 @@ def bidirectional_dijkstra(G, source, target, weight='weight'):
             return (finaldist, finalpath)
 
         for w, d in neighs[dir][v].items():
-            if(dir == 0):  # forward
+            if (dir == 0):  # forward
                 vwLength = dists[dir][v] + weight(v, w, d)
             else:  # back, must remember to change v,w->w,v
                 vwLength = dists[dir][v] + weight(w, v, d)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -232,7 +232,7 @@ def dijkstra_path_length(G, source, target, weight='weight'):
         raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
 
 
-def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
+def single_source_dijkstra_path(G, source, target=None, cutoff=None, weight='weight'):
     """Find shortest weighted paths in G from a source node.
 
     Compute shortest path between source and all other reachable
@@ -244,6 +244,9 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
 
     source : node
        Starting node for path.
+
+    target : node label, optional
+       Ending node for path
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
@@ -293,10 +296,10 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight='weight'):
 
     """
     return multi_source_dijkstra_path(G, {source}, cutoff=cutoff,
-                                      weight=weight)
+                                      weight=weight, target=target)
 
 
-def single_source_dijkstra_path_length(G, source, cutoff=None,
+def single_source_dijkstra_path_length(G, source, target=None, cutoff=None,
                                        weight='weight'):
     """Find shortest weighted path lengths in G from a source node.
 
@@ -309,6 +312,9 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
 
     source : node label
        Starting node for path
+
+    target : node label, optional
+       Ending node for path
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
@@ -365,7 +371,7 @@ def single_source_dijkstra_path_length(G, source, cutoff=None,
 
     """
     return multi_source_dijkstra_path_length(G, {source}, cutoff=cutoff,
-                                             weight=weight)
+                                             weight=weight, target=target)
 
 
 def single_source_dijkstra(G, source, target=None, cutoff=None,
@@ -467,7 +473,7 @@ def single_source_dijkstra(G, source, target=None, cutoff=None,
                                  weight=weight)
 
 
-def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
+def multi_source_dijkstra_path(G, sources, target=None, cutoff=None, weight='weight'):
     """Find shortest weighted paths in G from a given set of source
     nodes.
 
@@ -483,6 +489,9 @@ def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
         single node, then all paths computed by this function will start
         from that node. If there are two or more nodes in the set, the
         computed paths may begin from any one of the start nodes.
+
+    target : node label, optional
+       Ending node for path
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
@@ -535,12 +544,12 @@ def multi_source_dijkstra_path(G, sources, cutoff=None, weight='weight'):
     multi_source_dijkstra(), multi_source_bellman_ford()
 
     """
-    length, path = multi_source_dijkstra(G, sources, cutoff=cutoff,
+    length, path = multi_source_dijkstra(G, sources, target=target, cutoff=cutoff,
                                          weight=weight)
     return path
 
 
-def multi_source_dijkstra_path_length(G, sources, cutoff=None,
+def multi_source_dijkstra_path_length(G, sources, target=None, cutoff=None,
                                       weight='weight'):
     """Find shortest weighted path lengths in G from a given set of
     source nodes.
@@ -557,6 +566,9 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
         single node, then all paths computed by this function will start
         from that node. If there are two or more nodes in the set, the
         computed paths may begin from any one of the start nodes.
+
+    target : node label, optional
+       Ending node for path
 
     cutoff : integer or float, optional
        Depth to stop the search. Only return paths with length <= cutoff.
@@ -614,8 +626,17 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None,
     """
     if not sources:
         raise ValueError('sources must not be empty')
+    if target in sources:
+        return 0
     weight = _weight_function(G, weight)
-    return _dijkstra_multisource(G, sources, weight, cutoff=cutoff)
+    dist = _dijkstra_multisource(G, sources, weight, cutoff=cutoff, target=target)
+
+    if target is None:
+        return dist
+    try:
+        return dist[target]
+    except KeyError:
+        raise nx.NetworkXNoPath(f"No path to {target}.")
 
 
 def multi_source_dijkstra(G, sources, target=None, cutoff=None,


### PR DESCRIPTION
The [API for weighted shortest paths](https://networkx.github.io/documentation/latest/reference/algorithms/shortest_paths.html) has two triples of functions of the form `*_source_dijkstra`, `*_source_dijkstra_path`, `*_source_dijkstra_path_length`, where the first returns both lengths *and* paths, the second only the path, and the third only the length.
While intuitively all three should function roughly the same, only the first version allows to specify a `target` parameter.

In short, this PR
* Adds a `target` parameter to the `*_source_dijkstra_path` and `*_source_dijkstra_path_length` variants
* Uses the new parameter to remove some duplicate code
* Makes `multi_source_dijkstra` the effective "backend" of all versions, with a new `capture_paths` flag to prevent full path computation when they are not needed.