### PR TITLE
Fix for #3930 (source & target columns not overwritten when converting to pd.DataFrame)

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -259,9 +259,9 @@ def to_pandas_edgelist(
     target_nodes = [t for s, t, d in edgelist]
     all_keys = set().union(*(d.keys() for s, t, d in edgelist))
     if source in all_keys:
-        raise NetworkXError("Specified source column '{}' already exists as an attribute in some edges.".format(source))
+        raise NetworkXError(f"Source name '{source}' is an edge attribute name")
     if target in all_keys:
-        raise NetworkXError("Specified target column '{}' already exists as an attribute in some edges.".format(target))
+        raise NetworkXError(f"Target name '{target}' is an edge attribute name")
     edge_attr = {k: [d.get(k, float("nan")) for s, t, d in edgelist] for k in all_keys}
     edgelistdict = {source: source_nodes, target: target_nodes}
     edgelistdict.update(edge_attr)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -602,7 +602,7 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n))
     # Get a list of all the entries in the matrix with nonzero entries. These
-    # coordinates will become the edges in the graph. (convert to int)
+    # coordinates become edges in the graph. (convert to int from np.int64)
     edges = ((int(e[0]), int(e[1])) for e in zip(*np.asarray(A).nonzero()))
     # handle numpy constructed data type
     if python_type == "void":

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -24,6 +24,7 @@ nx_agraph, nx_pydot
 import itertools
 import networkx as nx
 from networkx.utils import not_implemented_for
+from networkx.exception import NetworkXError
 
 __all__ = [
     "from_numpy_matrix",
@@ -257,6 +258,10 @@ def to_pandas_edgelist(
     source_nodes = [s for s, t, d in edgelist]
     target_nodes = [t for s, t, d in edgelist]
     all_keys = set().union(*(d.keys() for s, t, d in edgelist))
+    if source in all_keys:
+        raise NetworkXError("Specified source column '{}' already exists as an attribute in some edges.".format(source))
+    if target in all_keys:
+        raise NetworkXError("Specified target column '{}' already exists as an attribute in some edges.".format(target))
     edge_attr = {k: [d.get(k, float("nan")) for s, t, d in edgelist] for k in all_keys}
     edgelistdict = {source: source_nodes, target: target_nodes}
     edgelistdict.update(edge_attr)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -24,7 +24,6 @@ nx_agraph, nx_pydot
 import itertools
 import networkx as nx
 from networkx.utils import not_implemented_for
-from networkx.exception import NetworkXError
 
 __all__ = [
     "from_numpy_matrix",
@@ -212,9 +211,8 @@ def from_pandas_adjacency(df, create_using=None):
     return G
 
 
-def to_pandas_edgelist(
-    G, source="source", target="target", nodelist=None, dtype=None, order=None
-):
+def to_pandas_edgelist(G, source="source", target="target", nodelist=None,
+                       dtype=None, order=None):
     """Returns the graph edge list as a Pandas DataFrame.
 
     Parameters
@@ -257,20 +255,23 @@ def to_pandas_edgelist(
         edgelist = G.edges(nodelist, data=True)
     source_nodes = [s for s, t, d in edgelist]
     target_nodes = [t for s, t, d in edgelist]
+
     all_keys = set().union(*(d.keys() for s, t, d in edgelist))
     if source in all_keys:
-        raise NetworkXError(f"Source name '{source}' is an edge attribute name")
+        raise nx.NetworkXError(f"Source name '{source}' is an edge attr name")
     if target in all_keys:
-        raise NetworkXError(f"Target name '{target}' is an edge attribute name")
-    edge_attr = {k: [d.get(k, float("nan")) for s, t, d in edgelist] for k in all_keys}
+        raise nx.NetworkXError(f"Target name '{target}' is an edge attr name")
+
+    nan = float("nan")
+    edge_attr = {k: [d.get(k, nan) for s, t, d in edgelist] for k in all_keys}
+
     edgelistdict = {source: source_nodes, target: target_nodes}
     edgelistdict.update(edge_attr)
     return pd.DataFrame(edgelistdict)
 
 
-def from_pandas_edgelist(
-    df, source="source", target="target", edge_attr=None, create_using=None
-):
+def from_pandas_edgelist(df, source="source", target="target", edge_attr=None,
+                         create_using=None):
     """Returns a graph from Pandas DataFrame containing an edge list.
 
     The Pandas DataFrame should contain at least two columns of node names and
@@ -361,7 +362,7 @@ def from_pandas_edgelist(
 
     try:
         eattrs = zip(*[df[col] for col in cols])
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError):
         msg = f"Invalid edge_attr argument: {edge_attr}"
         raise nx.NetworkXError(msg)
     for s, t, attrs in zip(df[source], df[target], eattrs):
@@ -591,7 +592,7 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
     G = nx.empty_graph(0, create_using)
     n, m = A.shape
     if n != m:
-        raise nx.NetworkXError("Adjacency matrix is not square.", f"nx,ny={A.shape}")
+        raise nx.NetworkXError(f"Adjacency matrix not square: nx,ny={A.shape}")
     dt = A.dtype
     try:
         python_type = kind_to_python_type[dt.kind]
@@ -601,25 +602,16 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n))
     # Get a list of all the entries in the matrix with nonzero entries. These
-    # coordinates will become the edges in the graph.
-    edges = map(lambda e: (int(e[0]), int(e[1])), zip(*(np.asarray(A).nonzero())))
+    # coordinates will become the edges in the graph. (convert to int)
+    edges = ((int(e[0]), int(e[1])) for e in zip(*np.asarray(A).nonzero()))
     # handle numpy constructed data type
     if python_type == "void":
         # Sort the fields by their offset, then by dtype, then by name.
-        fields = sorted(
-            (offset, dtype, name) for name, (dtype, offset) in A.dtype.fields.items()
-        )
-        triples = (
-            (
-                u,
-                v,
-                {
-                    name: kind_to_python_type[dtype.kind](val)
-                    for (_, dtype, name), val in zip(fields, A[u, v])
-                },
-            )
-            for u, v in edges
-        )
+        fields = sorted((offset, dtype, name)
+                        for name, (dtype, offset) in A.dtype.fields.items())
+        triples = ((u, v, {name: kind_to_python_type[dtype.kind](val)
+                           for (_, dtype, name), val in zip(fields, A[u, v])})
+                   for u, v in edges)
     # If the entries in the adjacency matrix are integers, the graph is a
     # multigraph, and parallel_edges is True, then create parallel edges, each
     # with weight 1, for each entry in the adjacency matrix. Otherwise, create
@@ -633,9 +625,8 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
         #         for d in range(A[u, v]):
         #             G.add_edge(u, v, weight=1)
         #
-        triples = chain(
-            ((u, v, dict(weight=1)) for d in range(A[u, v])) for (u, v) in edges
-        )
+        triples = chain(((u, v, {"weight": 1}) for d in range(A[u, v]))
+                        for (u, v) in edges)
     else:  # basic data type
         triples = ((u, v, dict(weight=python_type(A[u, v]))) for u, v in edges)
     # If we are creating an undirected multigraph, only add the edges from the
@@ -725,7 +716,8 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
     return M.view(np.recarray)
 
 
-def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format="csr"):
+def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
+                           weight="weight", format="csr"):
     """Returns the graph adjacency matrix as a SciPy sparse matrix.
 
     Parameters
@@ -835,7 +827,8 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
         row, col, data = [], [], []
 
     if G.is_directed():
-        M = sparse.coo_matrix((data, (row, col)), shape=(nlen, nlen), dtype=dtype)
+        M = sparse.coo_matrix((data, (row, col)),
+                              shape=(nlen, nlen), dtype=dtype)
     else:
         # symmetrize matrix
         d = data + data
@@ -923,9 +916,8 @@ def _generate_weighted_edges(A):
     return _coo_gen_triples(A.tocoo())
 
 
-def from_scipy_sparse_matrix(
-    A, parallel_edges=False, create_using=None, edge_attribute="weight"
-):
+def from_scipy_sparse_matrix(A, parallel_edges=False, create_using=None,
+                             edge_attribute="weight"):
     """Creates a new graph from an adjacency matrix given as a SciPy sparse
     matrix.
 
@@ -992,7 +984,7 @@ def from_scipy_sparse_matrix(
     G = nx.empty_graph(0, create_using)
     n, m = A.shape
     if n != m:
-        raise nx.NetworkXError(f"Adjacency matrix is not square. nx,ny={A.shape}")
+        raise nx.NetworkXError(f"Adjacency matrix not square: nx,ny={A.shape}")
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n))
     # Create an iterable over (u, v, w) triples and for each triple, add an

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,9 +1,10 @@
 import pytest
+import networkx as nx
+from networkx.testing import assert_nodes_equal
+from networkx.testing import assert_edges_equal
+from networkx.testing import assert_graphs_equal
 
 pd = pytest.importorskip("pandas")
-
-import networkx as nx
-from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
 
 
 class TestConvertPandas:
@@ -17,7 +18,8 @@ class TestConvertPandas:
         df["b"] = b  # Column label 'b' (str)
         self.df = df
 
-        mdf = pd.DataFrame([[4, 16, "A", "D"]], columns=["weight", "cost", 0, "b"])
+        mdf = pd.DataFrame([[4, 16, "A", "D"]],
+                           columns=["weight", "cost", 0, "b"])
         self.mdf = df.append(mdf)
 
     def test_exceptions(self):
@@ -25,7 +27,8 @@ class TestConvertPandas:
         pytest.raises(nx.NetworkXError, nx.to_networkx_graph, G)
         G = pd.DataFrame(["a", 0.0])  # elist
         pytest.raises(nx.NetworkXError, nx.to_networkx_graph, G)
-        df = pd.DataFrame([[1, 1], [1, 0]], dtype=int, index=[1, 2], columns=["a", "b"])
+        df = pd.DataFrame([[1, 1], [1, 0]],
+                          dtype=int, index=[1, 2], columns=["a", "b"])
         pytest.raises(nx.NetworkXError, nx.from_pandas_adjacency, df)
 
     def test_from_edgelist_all_attr(self):
@@ -81,25 +84,20 @@ class TestConvertPandas:
             ("Z1", "Z3", {"Co": "zD", "Mi": 14, "St": "X3"}),
         ]
         Gtrue = nx.MultiDiGraph(edges)
-        df = pd.DataFrame.from_dict(
-            {
-                "O": ["X1", "X1", "X1", "X1", "Y1", "Y1", "Y1", "Y1", "Z1", "Z1"],
-                "D": ["X4", "X4", "X4", "X4", "Y3", "Y3", "Y3", "Y3", "Z3", "Z3"],
-                "St": ["X1", "X2", "X3", "X4", "Y1", "Y2", "X2", "Y3", "Z1", "X3"],
-                "Co": ["zA", "zB", "zB", "zB", "zC", "zC", "zC", "zC", "zD", "zD"],
-                "Mi": [0, 54, 49, 44, 0, 34, 29, 24, 0, 14],
+        data = {
+            "O": ["X1", "X1", "X1", "X1", "Y1", "Y1", "Y1", "Y1", "Z1", "Z1"],
+            "D": ["X4", "X4", "X4", "X4", "Y3", "Y3", "Y3", "Y3", "Z3", "Z3"],
+            "St": ["X1", "X2", "X3", "X4", "Y1", "Y2", "X2", "Y3", "Z1", "X3"],
+            "Co": ["zA", "zB", "zB", "zB", "zC", "zC", "zC", "zC", "zD", "zD"],
+            "Mi": [0, 54, 49, 44, 0, 34, 29, 24, 0, 14],
             }
-        )
-        G1 = nx.from_pandas_edgelist(
-            df, source="O", target="D", edge_attr=True, create_using=nx.MultiDiGraph
-        )
-        G2 = nx.from_pandas_edgelist(
-            df,
-            source="O",
-            target="D",
-            edge_attr=["St", "Co", "Mi"],
-            create_using=nx.MultiDiGraph,
-        )
+        df = pd.DataFrame.from_dict(data)
+        G1 = nx.from_pandas_edgelist(df, source="O", target="D",
+                                     edge_attr=True,
+                                     create_using=nx.MultiDiGraph)
+        G2 = nx.from_pandas_edgelist(df, source="O", target="D",
+                                     edge_attr=["St", "Co", "Mi"],
+                                     create_using=nx.MultiDiGraph)
         assert_graphs_equal(G1, Gtrue)
         assert_graphs_equal(G2, Gtrue)
 
@@ -123,26 +121,18 @@ class TestConvertPandas:
         assert_graphs_equal(G, Gtrue)
 
     def test_from_edgelist_invalid_attr(self):
-        pytest.raises(
-            nx.NetworkXError, nx.from_pandas_edgelist, self.df, 0, "b", "misspell"
-        )
-        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist, self.df, 0, "b", 1)
+        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist,
+                      self.df, 0, "b", "misspell")
+        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist,
+                      self.df, 0, "b", 1)
         # see Issue #3562
         edgeframe = pd.DataFrame([[0, 1], [1, 2], [2, 0]], columns=["s", "t"])
-        pytest.raises(
-            nx.NetworkXError, nx.from_pandas_edgelist, edgeframe, "s", "t", True
-        )
-        pytest.raises(
-            nx.NetworkXError, nx.from_pandas_edgelist, edgeframe, "s", "t", "weight"
-        )
-        pytest.raises(
-            nx.NetworkXError,
-            nx.from_pandas_edgelist,
-            edgeframe,
-            "s",
-            "t",
-            ["weight", "size"],
-        )
+        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist,
+                      edgeframe, "s", "t", True)
+        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist,
+                      edgeframe, "s", "t", "weight")
+        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist,
+                      edgeframe, "s", "t", ["weight", "size"])
 
     def test_from_edgelist_no_attr(self):
         Gtrue = nx.Graph([("E", "C", {}), ("B", "A", {}), ("A", "D", {})])
@@ -151,15 +141,16 @@ class TestConvertPandas:
 
     def test_from_edgelist(self):
         # Pandas DataFrame
-        g = nx.cycle_graph(10)
-        G = nx.Graph()
-        G.add_nodes_from(g)
-        G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
+        G = nx.cycle_graph(10)
+        G.add_weighted_edges_from((u, v, u) for u, v in list(G.edges))
+
         edgelist = nx.to_edgelist(G)
         source = [s for s, t, d in edgelist]
         target = [t for s, t, d in edgelist]
         weight = [d["weight"] for s, t, d in edgelist]
-        edges = pd.DataFrame({"source": source, "target": target, "weight": weight})
+        edges = pd.DataFrame({"source": source, "target": target,
+                              "weight": weight})
+
         GG = nx.from_pandas_edgelist(edges, edge_attr="weight")
         assert_nodes_equal(G.nodes(), GG.nodes())
         assert_edges_equal(G.edges(), GG.edges())
@@ -174,7 +165,7 @@ class TestConvertPandas:
         nx.set_edge_attributes(G, 0, name="source")
         pytest.raises(nx.NetworkXError, nx.to_pandas_edgelist, G)
 
-        # drop the source column to make sure an exception is also raised for the target column
+        # drop source column to test an exception raised for the target column
         for u, v, d in G.edges(data=True):
             d.pop("source", None)
 
@@ -186,14 +177,16 @@ class TestConvertPandas:
         G = nx.path_graph(10)
         G.add_weighted_edges_from((u, v, u) for u, v in list(G.edges))
         nx.set_edge_attributes(G, 0, name="source_col_name")
-        pytest.raises(nx.NetworkXError, nx.to_pandas_edgelist, G, source="source_col_name")
+        pytest.raises(nx.NetworkXError,
+                      nx.to_pandas_edgelist, G, source="source_col_name")
 
-        # drop the source column to make sure an exception is also raised for the target column
+        # drop source column to test an exception raised for the target column
         for u, v, d in G.edges(data=True):
             d.pop("source_col_name", None)
 
         nx.set_edge_attributes(G, 0, name="target_col_name")
-        pytest.raises(nx.NetworkXError, nx.to_pandas_edgelist, G, target="target_col_name")
+        pytest.raises(nx.NetworkXError,
+                      nx.to_pandas_edgelist, G, target="target_col_name")
 
     def test_from_adjacency(self):
         nodelist = [1, 2]

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -173,24 +173,26 @@ class TestConvertPandas:
         G = nx.Graph()
         G.add_nodes_from(g)
         G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
-        nx.set_edge_attributes(G, 0, name="source_co")
+        nx.set_edge_attributes(G, 0, name="source_col")
+        failed = False
         try:
             nx.to_pandas_edgelist(G, source="source_col")
         except NetworkXError:
-            assert True
-        assert False
+            failed = True
+        assert failed
 
     def test_to_edgelist_target_col_exists(self):
         g = nx.cycle_graph(10)
         G = nx.Graph()
         G.add_nodes_from(g)
         G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
-        nx.set_edge_attributes(G, 0, name="target_co")
+        nx.set_edge_attributes(G, 0, name="target_col")
+        failed = False
         try:
             nx.to_pandas_edgelist(G, source="target_col")
         except NetworkXError:
-            assert True
-        assert False
+            failed = True
+        assert failed
 
     def test_from_adjacency(self):
         nodelist = [1, 2]

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -173,22 +173,24 @@ class TestConvertPandas:
         G = nx.Graph()
         G.add_nodes_from(g)
         G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
-        nx.set_edge_attributes(G, 0, name="source_col")
+        nx.set_edge_attributes(G, 0, name="source_co")
         try:
             nx.to_pandas_edgelist(G, source="source_col")
         except NetworkXError:
             assert True
+        assert False
 
     def test_to_edgelist_target_col_exists(self):
         g = nx.cycle_graph(10)
         G = nx.Graph()
         G.add_nodes_from(g)
         G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
-        nx.set_edge_attributes(G, 0, name="target_col")
+        nx.set_edge_attributes(G, 0, name="target_co")
         try:
             nx.to_pandas_edgelist(G, source="target_col")
         except NetworkXError:
             assert True
+        assert False
 
     def test_from_adjacency(self):
         nodelist = [1, 2]

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -4,6 +4,7 @@ pd = pytest.importorskip("pandas")
 
 import networkx as nx
 from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
+from networkx.exception import NetworkXError
 
 
 class TestConvertPandas:
@@ -166,6 +167,28 @@ class TestConvertPandas:
         GW = nx.to_networkx_graph(edges, create_using=nx.Graph)
         assert_nodes_equal(G.nodes(), GW.nodes())
         assert_edges_equal(G.edges(), GW.edges())
+
+    def test_to_edgelist_source_col_exists(self):
+        g = nx.cycle_graph(10)
+        G = nx.Graph()
+        G.add_nodes_from(g)
+        G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
+        nx.set_edge_attributes(G, 0, name="source_col")
+        try:
+            nx.to_pandas_edgelist(G, source="source_col")
+        except NetworkXError:
+            assert True
+
+    def test_to_edgelist_target_col_exists(self):
+        g = nx.cycle_graph(10)
+        G = nx.Graph()
+        G.add_nodes_from(g)
+        G.add_weighted_edges_from((u, v, u) for u, v in g.edges())
+        nx.set_edge_attributes(G, 0, name="target_col")
+        try:
+            nx.to_pandas_edgelist(G, source="target_col")
+        except NetworkXError:
+            assert True
 
     def test_from_adjacency(self):
         nodelist = [1, 2]


### PR DESCRIPTION
`nx.to_pandas_edgelist()` will now check the source and target column names individually and raise a `NetworkXError` if there is a detected conflict.

Two tests also added to verify this. They try to convert a graph with source and target column names that already exist as attributes. They will only assert True if a `NetworkXError` is raised, otherwise they will assert False.