### PR TITLE
Add option for named key ids to GraphML writing.

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -409,7 +409,7 @@ class GraphMLWriter(GraphML):
         try:
             return self.keys[keys_key]
         except KeyError:
-            if self.named_key_ids is True:
+            if self.named_key_ids:
                 new_id = name
             else:
                 new_id = f"d{len(list(self.keys))}"

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -61,7 +61,7 @@ __all__ = [
 
 @open_file(1, mode='wb')
 def write_graphml_xml(G, path, encoding='utf-8', prettyprint=True,
-                      infer_numeric_types=False):
+                      infer_numeric_types=False, named_key_ids=False):
     """Write G in GraphML XML format to path
 
     Parameters
@@ -79,6 +79,8 @@ def write_graphml_xml(G, path, encoding='utf-8', prettyprint=True,
        Determine if numeric types should be generalized.
        For example, if edges have both int and float 'weight' attributes,
        we infer in GraphML that both are floats.
+    named_key_ids : bool (optional)
+       If True use attr.name as value for key elements' id attribute.
 
     Examples
     --------
@@ -91,14 +93,15 @@ def write_graphml_xml(G, path, encoding='utf-8', prettyprint=True,
     and unidirected edges together) hyperedges, nested graphs, or ports.
     """
     writer = GraphMLWriter(encoding=encoding, prettyprint=prettyprint,
-                           infer_numeric_types=infer_numeric_types)
+                           infer_numeric_types=infer_numeric_types,
+                           named_key_ids=named_key_ids)
     writer.add_graph_element(G)
     writer.dump(path)
 
 
 @open_file(1, mode='wb')
 def write_graphml_lxml(G, path, encoding='utf-8', prettyprint=True,
-                       infer_numeric_types=False):
+                       infer_numeric_types=False, named_key_ids=False):
     """Write G in GraphML XML format to path
 
     This function uses the LXML framework and should be faster than
@@ -119,6 +122,8 @@ def write_graphml_lxml(G, path, encoding='utf-8', prettyprint=True,
        Determine if numeric types should be generalized.
        For example, if edges have both int and float 'weight' attributes,
        we infer in GraphML that both are floats.
+    named_key_ids : bool (optional)
+       If True use attr.name as value for key elements' id attribute.
 
     Examples
     --------
@@ -132,11 +137,13 @@ def write_graphml_lxml(G, path, encoding='utf-8', prettyprint=True,
     """
     writer = GraphMLWriterLxml(path, graph=G, encoding=encoding,
                                prettyprint=prettyprint,
-                               infer_numeric_types=infer_numeric_types)
+                               infer_numeric_types=infer_numeric_types,
+                               named_key_ids=named_key_ids)
     writer.dump()
 
 
-def generate_graphml(G, encoding='utf-8', prettyprint=True):
+def generate_graphml(G, encoding='utf-8', prettyprint=True,
+                     named_key_ids=False):
     """Generate GraphML lines for G
 
     Parameters
@@ -147,6 +154,8 @@ def generate_graphml(G, encoding='utf-8', prettyprint=True):
        Encoding for text data.
     prettyprint : bool (optional)
        If True use line breaks and indenting in output XML.
+    named_key_ids : bool (optional)
+       If True use attr.name as value for key elements' id attribute.
 
     Examples
     --------
@@ -161,7 +170,8 @@ def generate_graphml(G, encoding='utf-8', prettyprint=True):
     This implementation does not support mixed graphs (directed and unidirected
     edges together) hyperedges, nested graphs, or ports.
     """
-    writer = GraphMLWriter(encoding=encoding, prettyprint=prettyprint)
+    writer = GraphMLWriter(encoding=encoding, prettyprint=prettyprint,
+                           named_key_ids=named_key_ids)
     writer.add_graph_element(G)
     yield from str(writer).splitlines()
 
@@ -346,11 +356,12 @@ class GraphML:
 
 class GraphMLWriter(GraphML):
     def __init__(self, graph=None, encoding="utf-8", prettyprint=True,
-                 infer_numeric_types=False):
+                 infer_numeric_types=False, named_key_ids=False):
         self.myElement = Element
 
         self.infer_numeric_types = infer_numeric_types
         self.prettyprint = prettyprint
+        self.named_key_ids = named_key_ids
         self.encoding = encoding
         self.xml = self.myElement("graphml",
                                   {'xmlns': self.NS_GRAPHML,
@@ -398,7 +409,11 @@ class GraphMLWriter(GraphML):
         try:
             return self.keys[keys_key]
         except KeyError:
-            new_id = f"d{len(list(self.keys))}"
+            if self.named_key_ids is True:
+                new_id = name
+            else:
+                new_id = f"d{len(list(self.keys))}"
+
             self.keys[keys_key] = new_id
             key_kwargs = {"id": new_id,
                           "for": scope,
@@ -540,11 +555,12 @@ class IncrementalElement:
 
 class GraphMLWriterLxml(GraphMLWriter):
     def __init__(self, path, graph=None, encoding='utf-8', prettyprint=True,
-                 infer_numeric_types=False):
+                 infer_numeric_types=False, named_key_ids=False):
         self.myElement = lxmletree.Element
 
         self._encoding = encoding
         self._prettyprint = prettyprint
+        self.named_key_ids = named_key_ids
         self.infer_numeric_types = infer_numeric_types
 
         self._xml_base = lxmletree.xmlfile(path, encoding=encoding)

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -921,6 +921,21 @@ class TestWriteGraphML(BaseGraphML):
         assert ('id', 'prop1') in keys[2]
         assert ('attr.name', 'prop1') in keys[2]
 
+        # Confirm the read graph nodes/edge are identical when compared to
+        # default writing behavior.
+        default_behavior_fh = io.BytesIO()
+        nx.write_graphml(G, default_behavior_fh)
+        default_behavior_fh.seek(0)
+        H = nx.read_graphml(default_behavior_fh)
+
+        named_key_ids_behavior_fh = io.BytesIO()
+        nx.write_graphml(G, named_key_ids_behavior_fh, named_key_ids=True)
+        named_key_ids_behavior_fh.seek(0)
+        J = nx.read_graphml(named_key_ids_behavior_fh)
+
+        assert(all(n1 == n2 for (n1, n2) in zip(H.nodes, J.nodes)))
+        assert(all(e1 == e2 for (e1, e2) in zip(H.edges, J.edges)))
+
     def test_write_read_attribute_numeric_type_graphml(self):
         from xml.etree.ElementTree import parse
 

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -116,6 +116,36 @@ class BaseGraphML:
         cls.attribute_graph.add_edge('n5', 'n4', id='e6', weight=1.1)
         cls.attribute_fh = io.BytesIO(cls.attribute_data.encode('UTF-8'))
 
+        cls.attribute_named_key_ids_data = """<?xml version='1.0' encoding='utf-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <key id="edge_prop" for="edge" attr.name="edge_prop" attr.type="string"/>
+  <key id="prop2" for="node" attr.name="prop2" attr.type="string"/>
+  <key id="prop1" for="node" attr.name="prop1" attr.type="string"/>
+  <graph edgedefault="directed">
+    <node id="0">
+      <data key="prop1">val1</data>
+      <data key="prop2">val2</data>
+    </node>
+    <node id="1">
+      <data key="prop1">val_one</data>
+      <data key="prop2">val2</data>
+    </node>
+    <edge source="0" target="1">
+      <data key="edge_prop">edge_value</data>
+    </edge>
+  </graph>
+</graphml>
+"""
+        cls.attribute_named_key_ids_graph = nx.DiGraph()
+        cls.attribute_named_key_ids_graph.add_node("0", prop1="val1", prop2="val2")
+        cls.attribute_named_key_ids_graph.add_node("1", prop1="val_one", prop2="val2")
+        cls.attribute_named_key_ids_graph.add_edge("0", "1", edge_prop="edge_value")
+        fh = io.BytesIO(cls.attribute_named_key_ids_data.encode('UTF-8'))
+        cls.attribute_named_key_ids_fh = fh
+
         cls.attribute_numeric_type_data = """<?xml version='1.0' encoding='utf-8'?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -860,6 +890,36 @@ class TestWriteGraphML(BaseGraphML):
         assert sorted(G.edges()) == sorted(H.edges())
         assert sorted(G.edges(data=True)) == sorted(H.edges(data=True))
         self.simple_directed_fh.seek(0)
+
+    def test_write_read_attribute_named_key_ids_graphml(self):
+        from xml.etree.ElementTree import parse
+
+        G = self.attribute_named_key_ids_graph
+        fh = io.BytesIO()
+        self.writer(G, fh, named_key_ids=True)
+        fh.seek(0)
+        H = nx.read_graphml(fh)
+        fh.seek(0)
+
+        assert_nodes_equal(G.nodes(), H.nodes())
+        assert_edges_equal(G.edges(), H.edges())
+        assert_edges_equal(G.edges(data=True), H.edges(data=True))
+        self.attribute_named_key_ids_fh.seek(0)
+
+        xml = parse(fh)
+        # Children are the key elements, and the graph element
+        children = list(xml.getroot())
+        assert len(children) == 4
+
+        keys = [child.items() for child in children[:3]]
+
+        assert len(keys) == 3
+        assert ('id', 'edge_prop') in keys[0]
+        assert ('attr.name', 'edge_prop') in keys[0]
+        assert ('id', 'prop2') in keys[1]
+        assert ('attr.name', 'prop2') in keys[1]
+        assert ('id', 'prop1') in keys[2]
+        assert ('attr.name', 'prop1') in keys[2]
 
     def test_write_read_attribute_numeric_type_graphml(self):
         from xml.etree.ElementTree import parse


### PR DESCRIPTION
Provide the option to give the `<key>` elements' `id` attribute the same value as the `attr.name`'s attribute value.

```
<?xml version='1.0' encoding='utf-8'?>					<?xml version='1.0' encoding='utf-8'?>
<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:	  |	<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:
<key id="d1" for="node" attr.name="prop2" attr.type="string"/	  |	<key id="prop2" for="node" attr.name="prop2" attr.type="strin
<key id="d0" for="node" attr.name="prop1" attr.type="string"/	  |	<key id="prop1" for="node" attr.name="prop1" attr.type="strin
<graph edgedefault="directed"><node id="0">				<graph edgedefault="directed"><node id="0">
  <data key="d0">val1</data>					  |	  <data key="prop1">val1</data>
  <data key="d1">val2</data>					  |	  <data key="prop2">val2</data>
</node>									</node>
<node id="1">								<node id="1">
  <data key="d0">val_one</data>					  |	  <data key="prop1">val_one</data>
  <data key="d1">val2</data>					  |	  <data key="prop2">val2</data>
</node>									</node>
<edge source="0" target="1">						<edge source="0" target="1">
  <data key="d2">edge_value</data>				  |	  <data key="edge_prop">edge_value</data>
</edge>									</edge>
</graph></graphml>							</graph></graphml>
```