### PR TITLE
Correct VoteRank Algorithm to align with reference paper and avoid negative voting ability

### DIFF
--- a/networkx/algorithms/centrality/voterank_alg.py
+++ b/networkx/algorithms/centrality/voterank_alg.py
@@ -73,4 +73,5 @@ def voterank(G, number_of_nodes=None, max_iter=10000):
         # step 4 - update voterank properties
         for nbr in G.neighbors(n):
             G.nodes[nbr]['voterank'][1] -= 1 / avgDegree
+            G.nodes[nbr]['voterank'][1] = max(G.nodes[nbr]['voterank'][1], 0)
     return voterank


### PR DESCRIPTION
As mentioned in Issue #3826, in the current implementation of VoteRank, the voting ability of a few nodes could become negative.
This was because step 4 of the reference paper was wrongly implemented. Step 4 states that the voting ability is updated only if the new value doesn't become negative. This is fixed in the pull request.