### PR TITLE
add d-separation algorithm

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -171,6 +171,7 @@ is partially historical, and now, mostly arbitrary.
 - Alessandro Luongo
 - Huston Hedinger
 - Oleguer Sagarra
+- Arun Nampally, GitHub `<https://github.com/arunwise>`_, LinkedIn `<https://www.linkedin.com/in/arun-nampally-b57845b7/>`_
 
 Support
 -------

--- a/doc/reference/algorithms/d_separation.rst
+++ b/doc/reference/algorithms/d_separation.rst
@@ -1,0 +1,9 @@
+============
+D-Separation
+============
+
+.. automodule:: networkx.algorithms.d_separation
+.. autosummary::
+   :toctree: generated/
+
+   d_separated

--- a/doc/reference/algorithms/index.rst
+++ b/doc/reference/algorithms/index.rst
@@ -29,6 +29,7 @@ Algorithms
    covering
    cycles
    cuts
+   d_separation
    dag
    distance_measures
    distance_regular

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -14,6 +14,7 @@ from networkx.algorithms.core import *
 from networkx.algorithms.covering import *
 from networkx.algorithms.cycles import *
 from networkx.algorithms.cuts import *
+from networkx.algorithms.d_separation import *
 from networkx.algorithms.dag import *
 from networkx.algorithms.distance_measures import *
 from networkx.algorithms.distance_regular import *
@@ -51,7 +52,6 @@ from networkx.algorithms.triads import *
 from networkx.algorithms.vitality import *
 from networkx.algorithms.voronoi import *
 from networkx.algorithms.wiener import *
-from networkx.algorithms.d_separation import *
 
 # Make certain subpackages available to the user as direct imports from
 # the `networkx` namespace.

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -51,6 +51,7 @@ from networkx.algorithms.triads import *
 from networkx.algorithms.vitality import *
 from networkx.algorithms.voronoi import *
 from networkx.algorithms.wiener import *
+from networkx.algorithms.d_separation import *
 
 # Make certain subpackages available to the user as direct imports from
 # the `networkx` namespace.

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -4,12 +4,45 @@ Algorithm for testing d-separation in DAGs.
 *d-separation* is a test for conditional independence in probability
 distributions that can be factorized using DAGs.  It is a purely
 graphical test that uses the underlying graph and makes no reference
-to the actual distribution parameters.  For a detailed treatment see
-[1]_, [2]_.
+to the actual distribution parameters.  See [1]_ for a formal
+definition.
+
+The implementation is based on the conceptually simple linear time
+algorithm presented in [2]_.  Refer to [3]_, [4]_ for a couple of
+alternative algorithms.
+
+
+Examples
+--------
+
+>>> import networkx as nx
+>>> 
+>>> # HMM graph with five states and observation nodes
+... g= nx.DiGraph()
+>>> g.add_edges_from([('S1', 'S2'), ('S2', 'S3'), ('S3', 'S4'), ('S4', 'S5'),
+...                   ('S1', 'O1'), ('S2', 'O2'), ('S3', 'O3'), ('S4', 'O4'),
+...                   ('S5', 'O5')])
+>>> 
+>>> # states/obs before 'S3' are d-separated from states/obs after 'S3'
+... nx.d_separated(g, {'S1', 'S2', 'O1', 'O2'}, {'S4', 'S5', 'O4', 'O5'}, {'S3'})
+True
+
+
+References
+----------
+
+..  [1] Pearl, J.  (2009).  Causality.  Cambridge: Cambridge University Press.
+
+..  [2] Darwiche, A.  (2009).  Modeling and reasoning with Bayesian networks.  Cambridge: Cambridge University Press.
+
+..  [3] Shachter, R.  D.  (1998).  Bayes-ball: rational pastime (for determining irrelevance and requisite information in belief networks and influence diagrams).  In , Proceedings of the Fourteenth Conference on Uncertainty in Artificial Intelligence (pp.  480–487).  San Francisco, CA, USA: Morgan Kaufmann Publishers Inc.
+
+..  [4] Koller, D., & Friedman, N. (2009). Probabilistic graphical models: principles and techniques. The MIT Press.
+
 """
 
 from collections import deque
-from typing import Hashable, AbstractSet
+from typing import AbstractSet
 
 import networkx as nx
 from networkx.utils import not_implemented_for, UnionFind
@@ -18,10 +51,10 @@ __all__ = ["d_separated"]
 
 
 @not_implemented_for("undirected")
-def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
-                y: AbstractSet[Hashable], z: AbstractSet[Hashable]) -> bool:
+def d_separated(G: nx.DiGraph, x: AbstractSet, y: AbstractSet,
+                z: AbstractSet) -> bool:
     """
-    Return whether node sets ``x`` and ``y` are separated by ``z``.
+    Return whether node sets ``x`` and ``y`` are d-separated by ``z``.
 
     Parameters
     ----------
@@ -39,7 +72,8 @@ def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
 
     Returns
     -------
-    bool : True if ``x`` is d-separated from ``y`` given ``z`` in ``G``.
+    b : bool
+        A boolean that is true if ``x`` is d-separated from ``y`` given ``z`` in ``G``.
 
     Raises
     ------
@@ -51,32 +85,6 @@ def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
     NodeNotFound
         If any of the input nodes are not found in the graph,
         a :exc:`NodeNotFound` exception is raised.
-
-    Examples
-    --------
-    >>> import networkx as nx
-    >>> g = nx.path_graph(10, nx.DiGraph)
-    >>> assert nx.d_separated(g, {0,1,2,3}, {5,6,7,8,9}, {4})
-
-    Notes
-    -----
-    While there are other algorithms for testing *d-separation* (for
-    e.g. [3]_), the algorithm presented in [1]_ is perhaps the simplest
-    linear time algorithm and is therefore used in this implementation.
-
-
-    References
-    ----------
-    ..  [1] Darwiche, A.  (2009).  Modeling and reasoning with
-        Bayesian networks.  Cambridge: Cambridge University Press.
-
-    ..  [2] Pearl, J. (2009). Causality. Cambridge: Cambridge University Press.
-
-    ..  [2] Shachter, R. D. (1998). Bayes-ball: rational pastime (for
-        determining irrelevance and requisite information in belief networks
-        and influence diagrams). In , Proceedings of the Fourteenth Conference
-        on Uncertainty in Artificial Intelligence (pp. 480–487). San
-        Francisco, CA, USA: Morgan Kaufmann Publishers Inc.
 
     """
 

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -35,7 +35,7 @@ def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
         Second set of nodes in ``G``.
 
     z : set
-        Set of conditioning nodes in `G`.
+        Set of conditioning nodes in ``G``. Can be empty set.
 
     Returns
     -------

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -1,0 +1,122 @@
+"""
+Algorithm for testing d-separation in DAGs.
+
+*d-separation* is a test for conditional independence in probability
+distributions that can be factorized using DAGs.  It is a purely
+graphical test that uses the underlying graph and makes no reference
+to the actual distribution parameters.  For a detailed treatment see
+[1]_, [2]_.
+"""
+
+from collections import deque
+from typing import Hashable, AbstractSet
+
+import networkx as nx
+from networkx.utils import not_implemented_for, UnionFind
+
+__all__ = ["d_separated"]
+
+
+@not_implemented_for("undirected")
+def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
+                y: AbstractSet[Hashable], z: AbstractSet[Hashable]) -> bool:
+    """
+    Test whether two sets of nodes are d-separated in a DAG by a third
+    set of conditioning nodes.
+
+    Parameters
+    ----------
+    G : graph
+        A NetworkX DAG.
+
+    x : set
+        First set of nodes in `G`.
+
+    y : set
+        Second set of nodes in `G`.
+
+    z : set
+        Set of conditioning nodes in `G`.
+
+    Returns
+    -------
+    bool : True if `x` is d-separated from `y` given `z` in `G`.
+
+    Raises
+    ------
+    NetworkXError
+        The *d-separation* test is commonly used with directed
+        graphical models which are acyclic.  Accordingly, the algorithm
+        raises a :exc:`NetworkXError` if the input graph is not a DAG.
+
+    NodeNotFound
+        If any of the input nodes are not found in the graph,
+        a :exc:`NodeNotFound` exception is raised.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> g = nx.path_graph(10, nx.DiGraph)
+    >>> assert nx.d_separated(g, {0,1,2,3}, {5,6,7,8,9}, {4})
+
+    Notes
+    -----
+    While there are other algorithms for testing *d-separation* (for
+    e.g. [3]_), the algorithm presented in [1]_ is perhaps the simplest
+    linear time algorithm and is therefore used in this implementation.
+
+
+    References
+    ----------
+    ..  [1] Darwiche, A.  (2009).  Modeling and reasoning with
+        Bayesian networks.  Cambridge: Cambridge University Press.
+
+    ..  [2] Pearl, J. (2009). Causality. Cambridge: Cambridge University Press.
+
+    ..  [2] Shachter, R. D. (1998). Bayes-ball: rational pastime (for
+        determining irrelevance and requisite information in belief networks
+        and influence diagrams). In , Proceedings of the Fourteenth Conference
+        on Uncertainty in Artificial Intelligence (pp. 480–487). San
+        Francisco, CA, USA: Morgan Kaufmann Publishers Inc.
+
+    """
+
+    if not nx.is_directed_acyclic_graph(G):
+        raise nx.NetworkXError("graph should be directed acyclic")
+
+    union_xyz = x.union(y).union(z)
+
+    if any((n not in G.nodes for n in union_xyz)):
+        raise nx.NodeNotFound(
+            "one or more specified nodes not found in the graph")
+
+    G_copy = G.copy()
+
+    # transform the graph by removing leaves that are not in x | y | z
+    # until no more leaves can be removed.
+    leaves = deque([n for n in G_copy.nodes if G_copy.out_degree[n] == 0])
+    while len(leaves) > 0:
+        leaf = leaves.popleft()
+        if leaf not in union_xyz:
+            for p in G_copy.predecessors(leaf):
+                if G_copy.out_degree[p] == 1:
+                    leaves.append(p)
+            G_copy.remove_node(leaf)
+
+    # transform the graph by removing outgoing edges from the
+    # conditioning set.
+    edges_to_remove = list(G_copy.out_edges(z))
+    G_copy.remove_edges_from(edges_to_remove)
+
+    # use disjoint-set data structure to check if any node in `x`
+    # occurs in the same weakly connected component as a node in `y`.
+    disjoint_set = UnionFind(G_copy.nodes())
+    for component in nx.weakly_connected_components(G_copy):
+        disjoint_set.union(*component)
+    disjoint_set.union(*x)
+    disjoint_set.union(*y)
+
+    if x and y and disjoint_set[next(iter(x))] == disjoint_set[next(iter(y))]:
+        return False
+    else:
+        return True

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -21,8 +21,7 @@ __all__ = ["d_separated"]
 def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
                 y: AbstractSet[Hashable], z: AbstractSet[Hashable]) -> bool:
     """
-    Test whether two sets of nodes are d-separated in a DAG by a third
-    set of conditioning nodes.
+    Return whether node sets ``x`` and ``y` are separated by ``z``.
 
     Parameters
     ----------
@@ -30,17 +29,17 @@ def d_separated(G: nx.DiGraph, x: AbstractSet[Hashable],
         A NetworkX DAG.
 
     x : set
-        First set of nodes in `G`.
+        First set of nodes in ``G``.
 
     y : set
-        Second set of nodes in `G`.
+        Second set of nodes in ``G``.
 
     z : set
         Set of conditioning nodes in `G`.
 
     Returns
     -------
-    bool : True if `x` is d-separated from `y` given `z` in `G`.
+    bool : True if ``x`` is d-separated from ``y`` given ``z`` in ``G``.
 
     Raises
     ------

--- a/networkx/algorithms/tests/test_d_separation.py
+++ b/networkx/algorithms/tests/test_d_separation.py
@@ -123,7 +123,7 @@ def test_asia_graph_dsep(asia_graph):
 def test_undirected_graphs_are_not_supported():
     """
     Test that undirected graphs are not supported.
-    
+
     d-separation does not apply in the case of undirected graphs.
     """
     with pytest.raises(nx.NetworkXNotImplemented):
@@ -134,7 +134,7 @@ def test_undirected_graphs_are_not_supported():
 def test_cyclic_graphs_raise_error():
     """
     Test that cycle graphs should cause erroring.
-    
+
     This is because PGMs assume a directed acyclic graph.
     """
     with pytest.raises(nx.NetworkXError):

--- a/networkx/algorithms/tests/test_d_separation.py
+++ b/networkx/algorithms/tests/test_d_separation.py
@@ -1,0 +1,79 @@
+from itertools import combinations
+import pytest
+import networkx as nx
+
+
+class TestDSeparation:
+    @classmethod
+    def setup_class(cls):
+        cls.path_G = nx.path_graph(3, create_using=nx.DiGraph)
+        cls.path_G.graph["name"] = "path"
+        nx.freeze(cls.path_G)
+
+        cls.fork_G = nx.DiGraph(name="fork")
+        cls.fork_G.add_edges_from([(0, 1), (0, 2)])
+        nx.freeze(cls.fork_G)
+
+        cls.collider_G = nx.DiGraph(name="collider")
+        cls.collider_G.add_edges_from([(0, 2), (1, 2)])
+        nx.freeze(cls.collider_G)
+
+        cls.naive_bayes_G = nx.DiGraph(name="naive_bayes")
+        cls.naive_bayes_G.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
+        nx.freeze(cls.naive_bayes_G)
+
+        cls.asia_G = nx.DiGraph(name="asia")
+        cls.asia_G.add_edges_from([('asia', 'tuberculosis'),
+                                   ('smoking', 'cancer'),
+                                   ('smoking', 'bronchitis'),
+                                   ('tuberculosis', 'either'),
+                                   ('cancer', 'either'), ('either', 'xray'),
+                                   ('either', 'dyspnea'),
+                                   ('bronchitis', 'dyspnea')])
+        nx.freeze(cls.asia_G)
+
+        cls.graphs = [
+            cls.path_G, cls.fork_G, cls.collider_G, cls.naive_bayes_G,
+            cls.asia_G
+        ]
+
+    def test_markov_condition(self):
+        for graph in self.graphs:
+            for node in graph.nodes:
+                parents = set(graph.predecessors(node))
+                non_descendants = graph.nodes - nx.descendants(
+                    graph, node) - {node} - parents
+                assert nx.d_separated(graph, {node}, non_descendants, parents)
+
+    def test_d_separation_examples(self):
+        assert nx.d_separated(self.path_G, {0}, {2}, {1})
+        assert not nx.d_separated(self.path_G, {0}, {2}, {})
+
+        assert nx.d_separated(self.fork_G, {1}, {2}, {0})
+        assert not nx.d_separated(self.fork_G, {1}, {2}, {})
+
+        assert nx.d_separated(self.collider_G, {0}, {1}, {})
+        assert not nx.d_separated(self.collider_G, {0}, {1}, {2})
+
+        for u, v in combinations(range(1, 5), 2):
+            assert nx.d_separated(self.naive_bayes_G, {u}, {v}, {0})
+            assert not nx.d_separated(self.naive_bayes_G, {u}, {v}, {})
+
+        assert nx.d_separated(self.asia_G, {'asia', 'smoking'},
+                              {'dyspnea', 'xray'}, {'bronchitis', 'either'})
+        assert nx.d_separated(self.asia_G, {'tuberculosis', 'cancer'},
+                              {'bronchitis'}, {'smoking', 'xray'})
+
+    def test_undirected_graphs_are_not_supported(self):
+        with pytest.raises(nx.NetworkXNotImplemented):
+            g = nx.path_graph(3, nx.Graph)
+            nx.d_separated(g, {0}, {1}, {2})
+
+    def test_cyclic_graphs_raise_error(self):
+        with pytest.raises(nx.NetworkXError):
+            g = nx.cycle_graph(3, nx.DiGraph)
+            nx.d_separated(g, {0}, {1}, {2})
+
+    def test_invalid_nodes_raise_error(self):
+        with pytest.raises(nx.NodeNotFound):
+            nx.d_separated(self.asia_G, {0}, {1}, {2})

--- a/networkx/algorithms/tests/test_d_separation.py
+++ b/networkx/algorithms/tests/test_d_separation.py
@@ -3,77 +3,148 @@ import pytest
 import networkx as nx
 
 
-class TestDSeparation:
-    @classmethod
-    def setup_class(cls):
-        cls.path_G = nx.path_graph(3, create_using=nx.DiGraph)
-        cls.path_G.graph["name"] = "path"
-        nx.freeze(cls.path_G)
+def path_graph():
+    """Return a path graph of length three."""
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    G.graph["name"] = "path"
+    nx.freeze(G)
+    return G
 
-        cls.fork_G = nx.DiGraph(name="fork")
-        cls.fork_G.add_edges_from([(0, 1), (0, 2)])
-        nx.freeze(cls.fork_G)
 
-        cls.collider_G = nx.DiGraph(name="collider")
-        cls.collider_G.add_edges_from([(0, 2), (1, 2)])
-        nx.freeze(cls.collider_G)
+def fork_graph():
+    """Return a three node fork graph."""
+    G = nx.DiGraph(name="fork")
+    G.add_edges_from([(0, 1), (0, 2)])
+    nx.freeze(G)
+    return G
 
-        cls.naive_bayes_G = nx.DiGraph(name="naive_bayes")
-        cls.naive_bayes_G.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
-        nx.freeze(cls.naive_bayes_G)
 
-        cls.asia_G = nx.DiGraph(name="asia")
-        cls.asia_G.add_edges_from([('asia', 'tuberculosis'),
-                                   ('smoking', 'cancer'),
-                                   ('smoking', 'bronchitis'),
-                                   ('tuberculosis', 'either'),
-                                   ('cancer', 'either'), ('either', 'xray'),
-                                   ('either', 'dyspnea'),
-                                   ('bronchitis', 'dyspnea')])
-        nx.freeze(cls.asia_G)
+def collider_graph():
+    """Return a collider/v-structure graph with three nodes."""
+    G = nx.DiGraph(name="collider")
+    G.add_edges_from([(0, 2), (1, 2)])
+    nx.freeze(G)
+    return G
 
-        cls.graphs = [
-            cls.path_G, cls.fork_G, cls.collider_G, cls.naive_bayes_G,
-            cls.asia_G
-        ]
 
-    def test_markov_condition(self):
-        for graph in self.graphs:
-            for node in graph.nodes:
-                parents = set(graph.predecessors(node))
-                non_descendants = graph.nodes - nx.descendants(
-                    graph, node) - {node} - parents
-                assert nx.d_separated(graph, {node}, non_descendants, parents)
+def naive_bayes_graph():
+    """Return a simply Naive Bayes PGM graph."""
+    G = nx.DiGraph(name="naive_bayes")
+    G.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
+    nx.freeze(G)
+    return G
 
-    def test_d_separation_examples(self):
-        assert nx.d_separated(self.path_G, {0}, {2}, {1})
-        assert not nx.d_separated(self.path_G, {0}, {2}, {})
 
-        assert nx.d_separated(self.fork_G, {1}, {2}, {0})
-        assert not nx.d_separated(self.fork_G, {1}, {2}, {})
+def asia_graph():
+    """Return the 'Asia' PGM graph."""
+    G = nx.DiGraph(name="asia")
+    G.add_edges_from([('asia', 'tuberculosis'), ('smoking', 'cancer'),
+                      ('smoking', 'bronchitis'), ('tuberculosis', 'either'),
+                      ('cancer', 'either'), ('either', 'xray'),
+                      ('either', 'dyspnea'), ('bronchitis', 'dyspnea')])
+    nx.freeze(G)
+    return G
 
-        assert nx.d_separated(self.collider_G, {0}, {1}, {})
-        assert not nx.d_separated(self.collider_G, {0}, {1}, {2})
 
-        for u, v in combinations(range(1, 5), 2):
-            assert nx.d_separated(self.naive_bayes_G, {u}, {v}, {0})
-            assert not nx.d_separated(self.naive_bayes_G, {u}, {v}, {})
+@pytest.fixture(name='path_graph')
+def path_graph_fixture():
+    return path_graph()
 
-        assert nx.d_separated(self.asia_G, {'asia', 'smoking'},
-                              {'dyspnea', 'xray'}, {'bronchitis', 'either'})
-        assert nx.d_separated(self.asia_G, {'tuberculosis', 'cancer'},
-                              {'bronchitis'}, {'smoking', 'xray'})
 
-    def test_undirected_graphs_are_not_supported(self):
-        with pytest.raises(nx.NetworkXNotImplemented):
-            g = nx.path_graph(3, nx.Graph)
-            nx.d_separated(g, {0}, {1}, {2})
+@pytest.fixture(name='fork_graph')
+def fork_graph_fixture():
+    return fork_graph()
 
-    def test_cyclic_graphs_raise_error(self):
-        with pytest.raises(nx.NetworkXError):
-            g = nx.cycle_graph(3, nx.DiGraph)
-            nx.d_separated(g, {0}, {1}, {2})
 
-    def test_invalid_nodes_raise_error(self):
-        with pytest.raises(nx.NodeNotFound):
-            nx.d_separated(self.asia_G, {0}, {1}, {2})
+@pytest.fixture(name='collider_graph')
+def collider_graph_fixture():
+    return collider_graph()
+
+
+@pytest.fixture(name='naive_bayes_graph')
+def naive_bayes_graph_fixture():
+    return naive_bayes_graph()
+
+
+@pytest.fixture(name='asia_graph')
+def asia_graph_fixture():
+    return asia_graph()
+
+
+@pytest.mark.parametrize("graph", [
+    path_graph(),
+    fork_graph(),
+    collider_graph(),
+    naive_bayes_graph(),
+    asia_graph(),
+])
+def test_markov_condition(graph):
+    """Test that the Markov condition holds for each PGM graph."""
+    for node in graph.nodes:
+        parents = set(graph.predecessors(node))
+        non_descendants = graph.nodes - nx.descendants(graph,
+                                                       node) - {node} - parents
+        assert nx.d_separated(graph, {node}, non_descendants, parents)
+
+
+def test_path_graph_dsep(path_graph):
+    """Example-based test of d-separation for path_graph."""
+    assert nx.d_separated(path_graph, {0}, {2}, {1})
+    assert not nx.d_separated(path_graph, {0}, {2}, {})
+
+
+def test_fork_graph_dsep(fork_graph):
+    """Example-based test of d-separation for fork_graph."""
+    assert nx.d_separated(fork_graph, {1}, {2}, {0})
+    assert not nx.d_separated(fork_graph, {1}, {2}, {})
+
+
+def test_collider_graph_dsep(collider_graph):
+    """Example-based test of d-separation for collider_graph."""
+    assert nx.d_separated(collider_graph, {0}, {1}, {})
+    assert not nx.d_separated(collider_graph, {0}, {1}, {2})
+
+
+def test_naive_bayes_dsep(naive_bayes_graph):
+    """Example-based test of d-separation for naive_bayes_graph."""
+    for u, v in combinations(range(1, 5), 2):
+        assert nx.d_separated(naive_bayes_graph, {u}, {v}, {0})
+        assert not nx.d_separated(naive_bayes_graph, {u}, {v}, {})
+
+
+def test_asia_graph_dsep(asia_graph):
+    """Example-based test of d-separation for asia_graph."""
+    assert nx.d_separated(asia_graph, {'asia', 'smoking'}, {'dyspnea', 'xray'},
+                          {'bronchitis', 'either'})
+    assert nx.d_separated(asia_graph, {'tuberculosis', 'cancer'},
+                          {'bronchitis'}, {'smoking', 'xray'})
+
+
+def test_undirected_graphs_are_not_supported():
+    """
+    Test that undirected graphs are not supported.
+    
+    d-separation does not apply in the case of undirected graphs.
+    """
+    with pytest.raises(nx.NetworkXNotImplemented):
+        g = nx.path_graph(3, nx.Graph)
+        nx.d_separated(g, {0}, {1}, {2})
+
+
+def test_cyclic_graphs_raise_error():
+    """
+    Test that cycle graphs should cause erroring.
+    
+    This is because PGMs assume a directed acyclic graph.
+    """
+    with pytest.raises(nx.NetworkXError):
+        g = nx.cycle_graph(3, nx.DiGraph)
+        nx.d_separated(g, {0}, {1}, {2})
+
+
+def test_invalid_nodes_raise_error(asia_graph):
+    """
+    Test that graphs that have invalid nodes passed in raise errors.
+    """
+    with pytest.raises(nx.NodeNotFound):
+        nx.d_separated(asia_graph, {0}, {1}, {2})


### PR DESCRIPTION
This PR implements an algorithm for testing _d-separation_ in DAGs. _d_separation_ is a central concept in probabilistic graphical models and it is used for testing conditional independence between random variables. 

Given that many libraries for probabilistic graphical models (like Pomegranate, Pyro etc) use NetworkX, it is somewhat surprising that this hasn't made its way into NetworkX so far. While the application is for probabilistic graphical models, the concept is purely graph theoretical. So, I hope that it gets added to the NetworkX library.

