### PR TITLE
Fix default solver of approximate_current_flow_betweenness_centrality, edge_current_flow_betweenness_centrality and current_flow_betweenness_centrality

### DIFF
--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -46,7 +46,7 @@ def approximate_current_flow_betweenness_centrality(G, normalized=True,
       Default data type for internal matrices.
       Set to np.float32 for lower memory consumption.
 
-    solver : string (default='lu')
+    solver : string (default='full')
        Type of linear solver to use for computing the flow matrix.
        Options are "full" (uses most memory), "lu" (recommended), and
        "cg" (uses least memory).
@@ -168,7 +168,7 @@ def current_flow_betweenness_centrality(G, normalized=True, weight=None,
       Default data type for internal matrices.
       Set to np.float32 for lower memory consumption.
 
-    solver : string (default='lu')
+    solver : string (default='full')
        Type of linear solver to use for computing the flow matrix.
        Options are "full" (uses most memory), "lu" (recommended), and
        "cg" (uses least memory).
@@ -273,7 +273,7 @@ def edge_current_flow_betweenness_centrality(G, normalized=True,
       Default data type for internal matrices.
       Set to np.float32 for lower memory consumption.
 
-    solver : string (default='lu')
+    solver : string (default='full')
        Type of linear solver to use for computing the flow matrix.
        Options are "full" (uses most memory), "lu" (recommended), and
        "cg" (uses least memory).


### PR DESCRIPTION
Fixes the mismatching defaults as described in https://github.com/networkx/networkx/issues/3980