### PR TITLE
Deprecate context_manager reversed in favor of reversed_view

### DIFF
--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -65,11 +65,3 @@ Cuthill-Mckee Ordering
 
    cuthill_mckee_ordering
    reverse_cuthill_mckee_ordering
-
-Context Managers
-----------------
-.. automodule:: networkx.utils.contextmanagers
-.. autosummary::
-   :toctree: generated/
-
-   reversed

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -149,8 +149,7 @@ def kosaraju_strongly_connected_components(G, source=None):
     Uses Kosaraju's algorithm.
 
     """
-    with nx.utils.reversed(G):
-        post = list(nx.dfs_postorder_nodes(G, source=source))
+    post = list(nx.dfs_postorder_nodes(G.reverse(copy=False), source=source))
 
     seen = set()
     while post:

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -131,18 +131,19 @@ def shortest_path(G, source=None, target=None, weight=None, method='dijkstra'):
                 paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
         else:
             # Find paths from all nodes co-accessible to the target.
-            with nx.utils.reversed(G):
-                if method == 'unweighted':
-                    paths = nx.single_source_shortest_path(G, target)
-                elif method == 'dijkstra':
-                    paths = nx.single_source_dijkstra_path(G, target,
+            if G.is_directed():
+                G = G.reverse(copy=False)
+            if method == 'unweighted':
+                paths = nx.single_source_shortest_path(G, target)
+            elif method == 'dijkstra':
+                paths = nx.single_source_dijkstra_path(G, target,
+                                                       weight=weight)
+            else:  # method == 'bellman-ford':
+                paths = nx.single_source_bellman_ford_path(G, target,
                                                            weight=weight)
-                else:  # method == 'bellman-ford':
-                    paths = nx.single_source_bellman_ford_path(G, target,
-                                                               weight=weight)
-                # Now flip the paths so they go from a source to the target.
-                for target in paths:
-                    paths[target] = list(reversed(paths[target]))
+            # Now flip the paths so they go from a source to the target.
+            for target in paths:
+                paths[target] = list(reversed(paths[target]))
     else:
         if target is None:
             # Find paths to all nodes accessible from the source.
@@ -273,18 +274,17 @@ def shortest_path_length(G,
                 paths = nx.all_pairs_bellman_ford_path_length(G, weight=weight)
         else:
             # Find paths from all nodes co-accessible to the target.
-            with nx.utils.reversed(G):
-                if method == 'unweighted':
-                    # We need to exhaust the iterator as Graph needs
-                    # to be reversed.
-                    path_length = nx.single_source_shortest_path_length
-                    paths = path_length(G, target)
-                elif method == 'dijkstra':
-                    path_length = nx.single_source_dijkstra_path_length
-                    paths = path_length(G, target, weight=weight)
-                else:  # method == 'bellman-ford':
-                    path_length = nx.single_source_bellman_ford_path_length
-                    paths = path_length(G, target, weight=weight)
+            if G.is_directed():
+                G = G.reverse(copy=False)
+            if method == 'unweighted':
+                path_length = nx.single_source_shortest_path_length
+                paths = path_length(G, target)
+            elif method == 'dijkstra':
+                path_length = nx.single_source_dijkstra_path_length
+                paths = path_length(G, target, weight=weight)
+            else:  # method == 'bellman-ford':
+                path_length = nx.single_source_bellman_ford_path_length
+                paths = path_length(G, target, weight=weight)
     else:
         if target is None:
             # Find paths to all nodes accessible from the source.

--- a/networkx/algorithms/tests/test_dominance.py
+++ b/networkx/algorithms/tests/test_dominance.py
@@ -57,18 +57,18 @@ class TestImmediateDominators:
         edges = [(1, 2), (2, 1), (2, 3), (3, 2), (4, 2), (4, 3), (5, 1),
                  (6, 4), (6, 5)]
         G = nx.DiGraph(edges)
-        assert (nx.immediate_dominators(G, 6) ==
-                {i: 6 for i in range(1, 7)})
+        result = nx.immediate_dominators(G, 6)
+        assert (result == {i: 6 for i in range(1, 7)})
 
     def test_domrel_png(self):
         # Graph taken from https://commons.wikipedia.org/wiki/File:Domrel.png
         edges = [(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)]
         G = nx.DiGraph(edges)
-        assert (nx.immediate_dominators(G, 1) ==
-                {1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 2})
+        result = nx.immediate_dominators(G, 1)
+        assert (result == {1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 2})
         # Test postdominance.
-        assert (nx.immediate_dominators(G.reverse(copy=False), 6) ==
-                {1: 2, 2: 6, 3: 5, 4: 5, 5: 2, 6: 6})
+        result = nx.immediate_dominators(G.reverse(copy=False), 6)
+        assert (result == {1: 2, 2: 6, 3: 5, 4: 5, 5: 2, 6: 6})
 
     def test_boost_example(self):
         # Graph taken from Figure 1 of
@@ -76,11 +76,11 @@ class TestImmediateDominators:
         edges = [(0, 1), (1, 2), (1, 3), (2, 7), (3, 4), (4, 5), (4, 6),
                  (5, 7), (6, 4)]
         G = nx.DiGraph(edges)
-        assert (nx.immediate_dominators(G, 0) ==
-                {0: 0, 1: 0, 2: 1, 3: 1, 4: 3, 5: 4, 6: 4, 7: 1})
+        result = nx.immediate_dominators(G, 0)
+        assert (result == {0: 0, 1: 0, 2: 1, 3: 1, 4: 3, 5: 4, 6: 4, 7: 1})
         # Test postdominance.
-        assert (nx.immediate_dominators(G.reverse(copy=False), 7) ==
-                {0: 1, 1: 7, 2: 7, 3: 4, 4: 5, 5: 7, 6: 4, 7: 7})
+        result = nx.immediate_dominators(G.reverse(copy=False), 7)
+        assert (result == {0: 1, 1: 7, 2: 7, 3: 4, 4: 5, 5: 7, 6: 4, 7: 7})
 
 
 class TestDominanceFrontiers:
@@ -148,11 +148,10 @@ class TestDominanceFrontiers:
         edges = [(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)]
         G = nx.DiGraph(edges)
         assert (nx.dominance_frontiers(G, 1) ==
-                {1: set(), 2: {2}, 3: {5}, 4: {5},
-                 5: {2}, 6: set()})
+                {1: set(), 2: {2}, 3: {5}, 4: {5}, 5: {2}, 6: set()})
         # Test postdominance.
-        assert (nx.dominance_frontiers(G.reverse(copy=False), 6) ==
-                {1: set(), 2: {2}, 3: {2}, 4: {2}, 5: {2}, 6: set()})
+        result = nx.dominance_frontiers(G.reverse(copy=False), 6)
+        assert (result == {1: set(), 2: {2}, 3: {2}, 4: {2}, 5: {2}, 6: set()})
 
     def test_boost_example(self):
         # Graph taken from Figure 1 of
@@ -164,9 +163,10 @@ class TestDominanceFrontiers:
                 {0: set(), 1: set(), 2: {7}, 3: {7},
                  4: {4, 7}, 5: {7}, 6: {4}, 7: set()})
         # Test postdominance.
-        assert (nx.dominance_frontiers(G.reverse(copy=False), 7) ==
-                {0: set(), 1: set(), 2: {1}, 3: {1},
-                     4: {1, 4}, 5: {1}, 6: {4}, 7: set()})
+        result = nx.dominance_frontiers(G.reverse(copy=False), 7)
+        expected = {0: set(), 1: set(), 2: {1}, 3: {1},
+                    4: {1, 4}, 5: {1}, 6: {4}, 7: set()}
+        assert result == expected
 
     def test_discard_issue(self):
         # https://github.com/networkx/networkx/issues/2071

--- a/networkx/algorithms/tests/test_dominance.py
+++ b/networkx/algorithms/tests/test_dominance.py
@@ -67,9 +67,8 @@ class TestImmediateDominators:
         assert (nx.immediate_dominators(G, 1) ==
                 {1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 2})
         # Test postdominance.
-        with nx.utils.reversed(G):
-            assert (nx.immediate_dominators(G, 6) ==
-                    {1: 2, 2: 6, 3: 5, 4: 5, 5: 2, 6: 6})
+        assert (nx.immediate_dominators(G.reverse(copy=False), 6) ==
+                {1: 2, 2: 6, 3: 5, 4: 5, 5: 2, 6: 6})
 
     def test_boost_example(self):
         # Graph taken from Figure 1 of
@@ -80,9 +79,8 @@ class TestImmediateDominators:
         assert (nx.immediate_dominators(G, 0) ==
                 {0: 0, 1: 0, 2: 1, 3: 1, 4: 3, 5: 4, 6: 4, 7: 1})
         # Test postdominance.
-        with nx.utils.reversed(G):
-            assert (nx.immediate_dominators(G, 7) ==
-                    {0: 1, 1: 7, 2: 7, 3: 4, 4: 5, 5: 7, 6: 4, 7: 7})
+        assert (nx.immediate_dominators(G.reverse(copy=False), 7) ==
+                {0: 1, 1: 7, 2: 7, 3: 4, 4: 5, 5: 7, 6: 4, 7: 7})
 
 
 class TestDominanceFrontiers:
@@ -153,10 +151,8 @@ class TestDominanceFrontiers:
                 {1: set(), 2: {2}, 3: {5}, 4: {5},
                  5: {2}, 6: set()})
         # Test postdominance.
-        with nx.utils.reversed(G):
-            assert (nx.dominance_frontiers(G, 6) ==
-                    {1: set(), 2: {2}, 3: {2}, 4: {2},
-                     5: {2}, 6: set()})
+        assert (nx.dominance_frontiers(G.reverse(copy=False), 6) ==
+                {1: set(), 2: {2}, 3: {2}, 4: {2}, 5: {2}, 6: set()})
 
     def test_boost_example(self):
         # Graph taken from Figure 1 of
@@ -168,9 +164,8 @@ class TestDominanceFrontiers:
                 {0: set(), 1: set(), 2: {7}, 3: {7},
                  4: {4, 7}, 5: {7}, 6: {4}, 7: set()})
         # Test postdominance.
-        with nx.utils.reversed(G):
-            assert (nx.dominance_frontiers(G, 7) ==
-                    {0: set(), 1: set(), 2: {1}, 3: {1},
+        assert (nx.dominance_frontiers(G.reverse(copy=False), 7) ==
+                {0: set(), 1: set(), 2: {1}, 3: {1},
                      4: {1, 4}, 5: {1}, 6: {4}, 7: set()})
 
     def test_discard_issue(self):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -28,24 +28,27 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(autouse=True)
 def set_warnings():
     warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
+        "ignore", category=DeprecationWarning,
         message="literal_stringizer is deprecated*",
     )
     warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
+        "ignore", category=DeprecationWarning,
         message="literal_destringizer is deprecated*",
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="is_string_like is deprecated*"
+        "ignore", category=DeprecationWarning,
+        message="is_string_like is deprecated*"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="make_str is deprecated*"
+        "ignore", category=DeprecationWarning,
+        message="make_str is deprecated*"
     )
     warnings.filterwarnings(
-        "ignore",
-        category=PendingDeprecationWarning,
+        "ignore", category=DeprecationWarning,
+        message="context_manager reversed is deprecated*"
+    )
+    warnings.filterwarnings(
+        "ignore", category=PendingDeprecationWarning,
         message="the matrix subclass is not the recommended way*",
     )
 

--- a/networkx/utils/contextmanagers.py
+++ b/networkx/utils/contextmanagers.py
@@ -20,7 +20,7 @@ def reversed(G):
     Warning
     -------
     The reversed context manager is deprecated in favor
-    of G.reverse(copy=False). The view allows multiple threads to use the 
+    of G.reverse(copy=False). The view allows multiple threads to use the
     same graph without confusion while the context manager does not.
     This context manager is scheduled to be removed in version 2.7.
     """

--- a/networkx/utils/contextmanagers.py
+++ b/networkx/utils/contextmanagers.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import warnings
 
 __all__ = [
     'reversed',
@@ -15,7 +16,18 @@ def reversed(G):
     ----------
     G : graph
         A NetworkX graph.
+
+    Warning
+    -------
+    The reversed context manager is deprecated in favor
+    of G.reverse(copy=False). The view allows multiple threads to use the 
+    same graph without confusion while the context manager does not.
+    This context manager is scheduled to be removed in version 2.7.
     """
+    msg = "context manager reversed is deprecated and to be removed in 2.7." \
+          "Use G.reverse(copy=False) if G.is_directed() else G instead."
+    warnings.warn(msg, DeprecationWarning)
+
     directed = G.is_directed()
     if directed:
         G._pred, G._succ = G._succ, G._pred


### PR DESCRIPTION
The context manager reverses a DiGraph in-place which doesn't work well in multithread environments. (see #3936 ) The ```reversed_view``` a.k.a. ```G.reverse(copy=False)``` feature does the same as reversed, but you have to check if G is undirected.
This set of changes replaces code that uses the context_manager with the view. It also marks the context manager as deprecated and removes it from the documentation. Scheduled for removal in v2.7

Fixes #3936