### PR TITLE
fix bug for to_scipy_sparse_matrix function

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -836,7 +836,7 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None,
         c = col + row
         # selfloop entries get double counted when symmetrizing
         # so we subtract the data on the diagonal
-        selfloops = list(nx.selfloop_edges(G, data=True))
+        selfloops = list(nx.selfloop_edges(G.subgraph(nodelist), data=True))
         if selfloops:
             diag_index, diag_data = zip(
                 *(

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -192,10 +192,18 @@ class TestConvertNumpy:
         M = nx.to_scipy_sparse_matrix(G)
         np_assert_equal(M.todense(), np.matrix([[1]]))
 
+        G.add_edges_from([(2, 3), (3, 4)])
+        M = nx.to_scipy_sparse_matrix(G, nodelist=[2, 3, 4])
+        np_assert_equal(M.todense(), np.matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]]))
+
     def test_selfloop_digraph(self):
         G = nx.DiGraph([(1, 1)])
         M = nx.to_scipy_sparse_matrix(G)
         np_assert_equal(M.todense(), np.matrix([[1]]))
+
+        G.add_edges_from([(2, 3), (3, 4)])
+        M = nx.to_scipy_sparse_matrix(G, nodelist=[2, 3, 4])
+        np_assert_equal(M.todense(), np.matrix([[0, 1, 0], [0, 0, 1], [0, 0, 0]]))
 
     def test_from_scipy_sparse_matrix_parallel_edges(self):
         """Tests that the :func:`networkx.from_scipy_sparse_matrix` function


### PR DESCRIPTION
The nx.to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight='weight', format='csr') function will raise a ValueError if the the input graph G contains selfloops, but the subgraph induced on the input nodelist does not contains any selfloop. For example:

>>> g = nx.Graph()
>>> g.add_edges_from([[0,0],[1,2],[1,3]])
>>> nx.to_scipy_sparse_matrix(g, [1,2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "XXX/networkx/convert_matrix.py", line 845, in to_scipy_sparse_matrix
    for u, v, d in selfloops
ValueError: not enough values to unpack (expected 2, got 0)

So when we subtract the data on the diagonal to avoid selfloop entries get double counted when symmetrizing, we only judge if the subgraph induced on the input nodelist contains selfloops, otherwise, we do not have to do the subtraction.