### PR TITLE
Improve formatting of None in tutorial

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -144,7 +144,7 @@ better in other contexts.
     2
 
 One can specify to report the edges and degree from a subset of all nodes
-using an *nbunch*. An *nbunch* is any of: None (meaning all nodes), a node,
+using an *nbunch*. An *nbunch* is any of: ``None`` (meaning all nodes), a node,
 or an iterable container of nodes that is not itself a node in the graph.
 
 .. nbplot::


### PR DESCRIPTION
Set `None` to monospace in tutorial.