### PR TITLE
add the option of sorting node's neighbors during bfs traversal 

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -62,6 +62,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
     .. _PADS: http://www.ics.uci.edu/~eppstein/PADS/BFS.py
     .. _Depth-limited-search: https://en.wikipedia.org/wiki/Depth-limited_search
     """
+
     def get_neighbors(node):
         neighbors_list = neighbors(node)
         if callable(sort_neighbors):
@@ -218,7 +219,8 @@ def bfs_tree(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
     """
     T = nx.DiGraph()
     T.add_node(source)
-    edges_gen = bfs_edges(G, source, reverse=reverse, depth_limit=depth_limit, sort_neighbors=sort_neighbors)
+    edges_gen = bfs_edges(G, source, reverse=reverse, depth_limit=depth_limit,
+                          sort_neighbors=sort_neighbors)
     T.add_edges_from(edges_gen)
     return T
 
@@ -277,7 +279,8 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
     bfs_edges
     edge_bfs
     """
-    for s, t in bfs_edges(G, source, depth_limit=depth_limit, sort_neighbors=sort_neighbors):
+    for s, t in bfs_edges(G, source, depth_limit=depth_limit,
+                          sort_neighbors=sort_neighbors):
         yield (t, s)
 
 
@@ -337,7 +340,8 @@ def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
     """
     parent = source
     children = []
-    for p, c in bfs_edges(G, source, depth_limit=depth_limit, sort_neighbors=sort_neighbors):
+    for p, c in bfs_edges(G, source, depth_limit=depth_limit,
+                          sort_neighbors=sort_neighbors):
         if p == parent:
             children.append(c)
             continue

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 
-def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
+def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbors=None):
     """Iterate over edges in a breadth-first search.
 
     The breadth-first search begins at `source` and enqueues the
@@ -35,6 +35,10 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
     depth_limit : int, optional(default=len(G))
         Specify the maximum search depth
 
+    sort_neighbors : function
+        A function that takes the list of neighbors of given node as input, and
+        returns an *iterator* over these neighbors but with custom ordering.
+
     Yields
     ------
     edge
@@ -58,10 +62,16 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
     .. _PADS: http://www.ics.uci.edu/~eppstein/PADS/BFS.py
     .. _Depth-limited-search: https://en.wikipedia.org/wiki/Depth-limited_search
     """
+    def get_neighbors(node):
+        neighbors_list = neighbors(node)
+        if callable(sort_neighbors):
+            neighbors_list = sort_neighbors(neighbors_list)
+        return iter(neighbors_list)
+
     visited = {source}
     if depth_limit is None:
         depth_limit = len(G)
-    queue = deque([(source, depth_limit, neighbors(source))])
+    queue = deque([(source, depth_limit, get_neighbors(source))])
     while queue:
         parent, depth_now, children = queue[0]
         try:
@@ -70,12 +80,12 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
                 yield parent, child
                 visited.add(child)
                 if depth_now > 1:
-                    queue.append((child, depth_now - 1, neighbors(child)))
+                    queue.append((child, depth_now - 1, get_neighbors(child)))
         except StopIteration:
             queue.popleft()
 
 
-def bfs_edges(G, source, reverse=False, depth_limit=None):
+def bfs_edges(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
     """Iterate over edges in a breadth-first-search starting at source.
 
     Parameters
@@ -92,6 +102,10 @@ def bfs_edges(G, source, reverse=False, depth_limit=None):
 
     depth_limit : int, optional(default=len(G))
         Specify the maximum search depth
+
+    sort_neighbors : function
+        A function that takes the list of neighbors of given node as input, and
+        returns an *iterator* over these neighbors but with custom ordering.
 
     Returns
     -------
@@ -146,10 +160,10 @@ def bfs_edges(G, source, reverse=False, depth_limit=None):
         successors = G.predecessors
     else:
         successors = G.neighbors
-    yield from generic_bfs_edges(G, source, successors, depth_limit)
+    yield from generic_bfs_edges(G, source, successors, depth_limit, sort_neighbors)
 
 
-def bfs_tree(G, source, reverse=False, depth_limit=None):
+def bfs_tree(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
     """Returns an oriented tree constructed from of a breadth-first-search
     starting at source.
 
@@ -165,6 +179,10 @@ def bfs_tree(G, source, reverse=False, depth_limit=None):
 
     depth_limit : int, optional(default=len(G))
         Specify the maximum search depth
+
+    sort_neighbors : function
+        A function that takes the list of neighbors of given node as input, and
+        returns an *iterator* over these neighbors but with custom ordering.
 
     Returns
     -------
@@ -200,12 +218,12 @@ def bfs_tree(G, source, reverse=False, depth_limit=None):
     """
     T = nx.DiGraph()
     T.add_node(source)
-    edges_gen = bfs_edges(G, source, reverse=reverse, depth_limit=depth_limit)
+    edges_gen = bfs_edges(G, source, reverse=reverse, depth_limit=depth_limit, sort_neighbors=sort_neighbors)
     T.add_edges_from(edges_gen)
     return T
 
 
-def bfs_predecessors(G, source, depth_limit=None):
+def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
     """Returns an iterator of predecessors in breadth-first-search from source.
 
     Parameters
@@ -217,6 +235,10 @@ def bfs_predecessors(G, source, depth_limit=None):
 
     depth_limit : int, optional(default=len(G))
         Specify the maximum search depth
+
+    sort_neighbors : function
+        A function that takes the list of neighbors of given node as input, and
+        returns an *iterator* over these neighbors but with custom ordering.
 
     Returns
     -------
@@ -255,11 +277,11 @@ def bfs_predecessors(G, source, depth_limit=None):
     bfs_edges
     edge_bfs
     """
-    for s, t in bfs_edges(G, source, depth_limit=depth_limit):
+    for s, t in bfs_edges(G, source, depth_limit=depth_limit, sort_neighbors=sort_neighbors):
         yield (t, s)
 
 
-def bfs_successors(G, source, depth_limit=None):
+def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
     """Returns an iterator of successors in breadth-first-search from source.
 
     Parameters
@@ -271,6 +293,10 @@ def bfs_successors(G, source, depth_limit=None):
 
     depth_limit : int, optional(default=len(G))
         Specify the maximum search depth
+
+    sort_neighbors : function
+        A function that takes the list of neighbors of given node as input, and
+        returns an *iterator* over these neighbors but with custom ordering.
 
     Returns
     -------
@@ -311,7 +337,7 @@ def bfs_successors(G, source, depth_limit=None):
     """
     parent = source
     children = []
-    for p, c in bfs_edges(G, source, depth_limit=depth_limit):
+    for p, c in bfs_edges(G, source, depth_limit=depth_limit, sort_neighbors=sort_neighbors):
         if p == parent:
             children.append(c)
             continue

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -62,17 +62,14 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
     .. _PADS: http://www.ics.uci.edu/~eppstein/PADS/BFS.py
     .. _Depth-limited-search: https://en.wikipedia.org/wiki/Depth-limited_search
     """
-
-    def get_neighbors(node):
-        neighbors_list = neighbors(node)
-        if callable(sort_neighbors):
-            neighbors_list = sort_neighbors(neighbors_list)
-        return iter(neighbors_list)
+    if callable(sort_neighbors):
+        _neighbors = neighbors
+        neighbors = lambda node: iter(sort_neighbors(_neighbors(node)))
 
     visited = {source}
     if depth_limit is None:
         depth_limit = len(G)
-    queue = deque([(source, depth_limit, get_neighbors(source))])
+    queue = deque([(source, depth_limit, neighbors(source))])
     while queue:
         parent, depth_now, children = queue[0]
         try:
@@ -81,7 +78,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
                 yield parent, child
                 visited.add(child)
                 if depth_now > 1:
-                    queue.append((child, depth_now - 1, get_neighbors(child)))
+                    queue.append((child, depth_now - 1, neighbors(child)))
         except StopIteration:
             queue.popleft()
 

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -1,3 +1,4 @@
+from functools import partial
 import networkx as nx
 
 
@@ -32,6 +33,15 @@ class TestBFS:
         D.add_edges_from([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4)])
         edges = nx.bfs_edges(D, source=4, reverse=True)
         assert list(edges) == [(4, 2), (4, 3), (2, 1), (1, 0)]
+
+    def test_bfs_edges_sorting(self):
+        D = nx.DiGraph()
+        D.add_edges_from([(0, 1), (0, 2), (1, 4), (1, 3), (2, 5)])
+        sort_desc = partial(sorted, reverse=True)
+        edges_asc = nx.bfs_edges(D, source=0, sort_neighbors=sorted)
+        edges_desc = nx.bfs_edges(D, source=0, sort_neighbors=sort_desc)
+        assert list(edges_asc) == [(0, 1), (0, 2), (1, 3), (1, 4), (2, 5)]
+        assert list(edges_desc) == [(0, 2), (0, 1), (2, 5), (1, 4), (1, 3)]
 
     def test_bfs_tree_isolates(self):
         G = nx.Graph()
@@ -80,3 +90,4 @@ class TestBreadthLimitedSearch:
         edges = nx.bfs_edges(self.G, source=9, depth_limit=4)
         assert list(edges) == [(9, 8), (9, 10), (8, 7),
                                (7, 2), (2, 1), (2, 3)]
+


### PR DESCRIPTION
Allow client to pass a function that customize the order in which neighboring nodes are queued.