### PR TITLE
MAINT: Update from_graph6_bytes arg/docs.

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -60,12 +60,12 @@ def _generate_graph6_bytes(G, nodes, header):
     yield b'\n'
 
 
-def from_graph6_bytes(string):
-    """Read a simple undirected graph in graph6 format from string.
+def from_graph6_bytes(bytes_in):
+    """Read a simple undirected graph in graph6 format from bytes.
 
     Parameters
     ----------
-    string : string
+    bytes_in : bytes
        Data in graph6 format, without a trailing newline.
 
     Returns
@@ -75,10 +75,10 @@ def from_graph6_bytes(string):
     Raises
     ------
     NetworkXError
-        If the string is unable to be parsed in graph6 format
+        If bytes_in is unable to be parsed in graph6 format
 
     ValueError
-        If any character ``c`` in the input string does not satisfy
+        If any character ``c`` in bytes_in does not satisfy
         ``63 <= ord(c) < 127``.
 
     Examples
@@ -104,10 +104,10 @@ def from_graph6_bytes(string):
             for i in [5, 4, 3, 2, 1, 0]:
                 yield (d >> i) & 1
 
-    if string.startswith(b'>>graph6<<'):
-        string = string[10:]
+    if bytes_in.startswith(b'>>graph6<<'):
+        bytes_in = bytes_in[10:]
 
-    data = [c - 63 for c in string]
+    data = [c - 63 for c in bytes_in]
     if any(c > 63 for c in data):
         raise ValueError('each input character must be in range(63, 127)')
 


### PR DESCRIPTION
Closes #4032

The argument for `from_graph6_bytes` was originally named "string" but
the function expected a bytes object. Fixes the mismatch between
implementation and naming convention by updating argument name from
"string" to "bytes_in". Updates associated docstring accordingly.

More extensive changes are possible (e.g. adding an `isinstance` check),
but IMO updating the variable name/docstring signature is sufficient to
resolve the ambiguity in this case.