### PR TITLE
MAINT: Remove instances of np.matrix used in internal code.

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -234,8 +234,8 @@ def attribute_ac(M):
 
     Parameters
     ----------
-    M : numpy array or matrix
-        Attribute mixing matrix.
+    M : numpy.ndarray
+        2D ndarray representing the attribute mixing matrix.
 
     Notes
     -----
@@ -254,12 +254,11 @@ def attribute_ac(M):
         raise ImportError('attribute_assortativity requires '
                           'NumPy: http://scipy.org/') from e
     if M.sum() != 1.0:
-        M = M / float(M.sum())
-    M = numpy.asmatrix(M)
-    s = (M * M).sum()
+        M = M / M.sum()
+    s = (M @ M).sum()
     t = M.trace()
     r = (t - s) / (1 - s)
-    return float(r)
+    return r
 
 
 def numeric_ac(M):

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -8,7 +8,9 @@ from networkx.utils import reverse_cuthill_mckee_ordering
 from networkx.utils import random_state
 
 try:
-    from numpy import array, asmatrix, asarray, dot, ndarray, ones, sqrt, zeros
+    from numpy import (
+        array, asarray, dot, ndarray, ones, sqrt, zeros, atleast_2d
+    )
     from numpy.linalg import norm, qr
     from scipy.linalg import eigh, inv
     from scipy.sparse import csc_matrix, spdiags
@@ -271,26 +273,26 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
     # Initialize.
     Lnorm = abs(L).sum(axis=1).flatten().max()
     project(X)
-    W = asmatrix(ndarray(X.shape, order="F"))
+    W = ndarray(X.shape, order="F")
 
     while True:
         # Orthonormalize X.
         X = qr(X)[0]
         # Compute iteration matrix H.
-        W[:, :] = L * X
-        H = X.T * W
+        W[:, :] = L @ X
+        H = X.T @ W
         sigma, Y = eigh(H, overwrite_a=True)
         # Compute the Ritz vectors.
-        X *= Y
+        X = X @ Y
         # Test for convergence exploiting the fact that L * X == W * Y.
-        res = dasum(W * asmatrix(Y)[:, 0] - sigma[0] * X[:, 0]) / Lnorm
+        res = dasum(W @ Y[:, 0] - sigma[0] * X[:, 0]) / Lnorm
         if res < tol:
             break
         # Compute X = L \ X / (X' * (L \ X)).
         # L \ X can have an arbitrary projection on the nullspace of L,
         # which will be eliminated.
         W[:, :] = solver.solve(X, tol)
-        X = (inv(W.T * X) * W.T).T  # Preserves Fortran storage order.
+        X = (inv(W.T @ X) @ W.T).T  # Preserves Fortran storage order.
         project(X)
 
     return sigma, asarray(X)
@@ -305,7 +307,7 @@ def _get_fiedler_func(method):
 
         def find_fiedler(L, x, normalized, tol, seed):
             q = 1 if method == "tracemin_pcg" else min(4, L.shape[0] - 1)
-            X = asmatrix(seed.normal(size=(q, L.shape[0]))).T
+            X = asarray(seed.normal(size=(q, L.shape[0]))).T
             sigma, X = _tracemin_fiedler(L, X, normalized, tol, method)
             return sigma[0], X[:, 0]
 
@@ -324,13 +326,13 @@ def _get_fiedler_func(method):
                 sigma, X = eigsh(L, 2, which="SM", tol=tol, return_eigenvectors=True)
                 return sigma[1], X[:, 1]
             else:
-                X = asarray(asmatrix(x).T)
+                X = asarray(atleast_2d(x).T)
                 M = spdiags(1.0 / L.diagonal(), [0], n, n)
                 Y = ones(n)
                 if normalized:
                     Y /= D.diagonal()
                 sigma, X = lobpcg(
-                    L, X, M=M, Y=asmatrix(Y).T, tol=tol, maxiter=n, largest=False
+                    L, X, M=M, Y=atleast_2d(Y).T, tol=tol, maxiter=n, largest=False
                 )
                 return sigma[0], X[:, 0]
 


### PR DESCRIPTION
Partially addresses #3107.

Removes the use of numpy `matrix` objects from the implementation of two functions, one private and one public.

 * 26e1e60 re-implements `_tracemin_fiedler` using `@` and `np.atleast_2d` in place of the corresponding functionality provided by the `matrx` class. 
 * ac7678d does the same for the public `attribute_ac` function

This PR does introduce subtle differences in un-tested behavior. For example, the `asmatrix` function is not strictly equivalent to `atleast_2d` w.r.t. shape checking: the former will raise an exception if the input array has ndim > 2. In the case of `_tracemin_fiedler`, it is only intended for internal use and I didn't notice any codepaths that could generate input arrays with `ndim > 2`. For `attribute_ac`, there is a reduction in the amount of input checking, though the necessary input is clearly documented. I'd be happy to add additional input checking (and corresponding tests) to more closely mimic the exact behavior of `asmatrix` for the inputs to these functions, but since the behavior (i.e. behavior with non-2D input arrays) was untested, I wasn't sure that it was necessarily desired. LMK what you think!