### PR TITLE
Update sphinx

### DIFF
--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,4 +1,4 @@
-sphinx==3.1.1
+sphinx==3.1.2
 sphinx_rtd_theme==0.5.0
 sphinx-gallery==0.7.0
 pillow>=7.2.0


### PR DESCRIPTION
The previous version had an error that was preventing bridges
from being autodocumented.