### PR TITLE
Fix a few typos in documentation of implementations of maximum matching

### DIFF
--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -71,7 +71,7 @@ def hopcroft_karp_matching(G, top_nodes=None):
 
       The matching is returned as a dictionary, `matches`, such that
       ``matches[v] == w`` if node `v` is matched to node `w`. Unmatched
-      nodes do not occur as a key in mate.
+      nodes do not occur as a key in `matches`.
 
     Raises
     ------
@@ -187,7 +187,7 @@ def eppstein_matching(G, top_nodes=None):
 
       The matching is returned as a dictionary, `matching`, such that
       ``matching[v] == w`` if node `v` is matched to node `w`. Unmatched
-      nodes do not occur as a key in mate.
+      nodes do not occur as a key in `matching`.
 
     Raises
     ------
@@ -514,7 +514,7 @@ def minimum_weight_full_matching(G, top_nodes=None, weight='weight'):
 
       The matching is returned as a dictionary, `matches`, such that
       ``matches[v] == w`` if node `v` is matched to node `w`. Unmatched
-      nodes do not occur as a key in matches.
+      nodes do not occur as a key in `matches`.
 
     Raises
     ------


### PR DESCRIPTION
The documentation currently refers to "mate", which is not defined anywhere. It
could seem like that's simply an earlier name for the output directory, and we
update the documentation accordingly.