### PR TITLE
relabel_nodes now preserves edges in multigraphs

### DIFF
--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -13,7 +13,7 @@ def relabel_nodes(G, mapping, copy=True):
 
     mapping : dictionary
        A dictionary with the old labels as keys and new labels as values.
-       A partial mapping is allowed.
+       A partial mapping is allowed. Mapping 2 nodes to a single node is allowed.
 
     copy : bool (optional, default=True)
        If True return a copy, or if False relabel the nodes in place.
@@ -64,9 +64,8 @@ def relabel_nodes(G, mapping, copy=True):
     >>> list(H)
     [0, 1, 4]
 
-    In a multigraph, relabeling two or more nodes that share predecessors
-    into the same new label will preserve all edges, but will change the
-    edge keys in the process:
+    In a multigraph, relabeling two or more nodes to the same new node
+    will retain all edges, but may change the edge keys in the process:
 
     >>> G = nx.MultiGraph()
     >>> G.add_edge(0, 1, value="a")  # returns the key for this edge
@@ -100,12 +99,11 @@ def relabel_nodes(G, mapping, copy=True):
     In that case, use copy=True.
 
     If a relabel operation on a multigraph would cause two or more
-    edges to have the same head, tail and key, relabel_nodes will
-    resolve this by finding the lowest non-negative integer values
-    for all the other edges such that they all have different keys.
-    This way, edges will not be lost when two nodes are merged into
-    one, but the edge keys may be changed. In particular, non-numeric
-    keys may be replaced by numeric ones.
+    edges to have the same source, target and key, the second edge must
+    be assigned a new key to retain all edges. The new key is set
+    to the lowest non-negative integer not already used as a key
+    for edges between these two nodes. Note that this means non-numeric
+    keys may be replaced by numeric keys.
 
     See Also
     --------
@@ -167,13 +165,14 @@ def _relabel_inplace(G, mapping):
                     for (source, _, key, data) in G.in_edges(old, data=True, keys=True)
                 ]
             # Ensure new edges won't overwrite existing ones
-            for i, (tail, head, key, data) in enumerate(new_edges):
-                if head in G[tail] and key in G[tail][head]:
-                    new_key = 0
-                    current_keys = G[tail][head]
-                    while new_key in current_keys:
+            seen = set()
+            for i, (source, target, key, data) in enumerate(new_edges):
+                if (target in G[source] and key in G[source][target]):
+                    new_key = 0 if not isinstance(key, (int, float)) else key
+                    while (new_key in G[source][target] or (target, new_key) in seen):
                         new_key += 1
-                    new_edges[i] = (tail, head, new_key, data)
+                    new_edges[i] = (source, target, new_key, data)
+                    seen.add((target, new_key))
         else:
             new_edges = [
                 (new, new if old == target else target, data)
@@ -200,14 +199,17 @@ def _relabel_copy(G, mapping):
         ]
 
         # check for conflicting edge-keys
+        undirected = not G.is_directed()
         seen_edges = set()
-        for i, (tail, head, key, data) in enumerate(new_edges):
-            while (tail, head, key) in seen_edges:
+        for i, (source, target, key, data) in enumerate(new_edges):
+            while (source, target, key) in seen_edges:
                 if not isinstance(key, (int, float)):
                     key = 0
                 key += 1
-            seen_edges.add((tail, head, key))
-            new_edges[i] = (tail, head, key, data)
+            seen_edges.add((source, target, key))
+            if undirected:
+                seen_edges.add((target, source, key))
+            new_edges[i] = (source, target, key, data)
 
         H.add_edges_from(new_edges)
     else:

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -67,11 +67,14 @@ def relabel_nodes(G, mapping, copy=True):
     In a multigraph, relabeling two or more nodes that share predecessors
     into the same new label will preserve all edges, but will change the
     edge keys in the process:
-    
+
     >>> G = nx.MultiGraph()
-    >>> G.add_edge(0, 1, value="a")
+    >>> G.add_edge(0, 1, value="a")  # returns the key for this edge
+    0
     >>> G.add_edge(0, 2, value="b")
+    0
     >>> G.add_edge(0, 3, value="c")
+    0
     >>> mapping = {1: 4, 2: 4, 3: 4}
     >>> H = nx.relabel_nodes(G, mapping, copy=True)
     >>> print(H[0])
@@ -79,7 +82,7 @@ def relabel_nodes(G, mapping, copy=True):
 
     This works for in-place relabeling too:
 
-    >>> nx.relabel_nodes(G, mapping, copy=False)
+    >>> G = nx.relabel_nodes(G, mapping, copy=False)
     >>> print(G[0])
     {4: {0: {'value': 'a'}, 1: {'value': 'b'}, 2: {'value': 'c'}}}
 
@@ -100,7 +103,7 @@ def relabel_nodes(G, mapping, copy=True):
     edges to have the same head, tail and key, relabel_nodes will
     resolve this by finding the lowest non-negative integer values
     for all the other edges such that they all have different keys.
-    This way, edges will not be lost when two nodes are merged into 
+    This way, edges will not be lost when two nodes are merged into
     one, but the edge keys may be changed. In particular, non-numeric
     keys may be replaced by numeric ones.
 

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -85,8 +85,7 @@ class TestRelabel:
     def test_convert_to_integers_raise(self):
         with pytest.raises(nx.NetworkXError):
             G = nx.Graph()
-            H = nx.convert_node_labels_to_integers(
-                G, ordering="increasing age")
+            H = nx.convert_node_labels_to_integers(G, ordering="increasing age")
 
     def test_relabel_nodes_copy(self):
         G = nx.empty_graph()
@@ -131,16 +130,14 @@ class TestRelabel:
         mapping = {"a": "aardvark", "b": "bear"}
         G = nx.relabel_nodes(G, mapping, copy=False)
         assert_nodes_equal(G.nodes(), ["aardvark", "bear"])
-        assert_edges_equal(
-            G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
+        assert_edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
 
     def test_relabel_nodes_multidigraph(self):
         G = nx.MultiDiGraph([("a", "b"), ("a", "b")])
         mapping = {"a": "aardvark", "b": "bear"}
         G = nx.relabel_nodes(G, mapping, copy=False)
         assert_nodes_equal(G.nodes(), ["aardvark", "bear"])
-        assert_edges_equal(
-            G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
+        assert_edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
 
     def test_relabel_isolated_nodes_to_same(self):
         G = nx.Graph()
@@ -187,8 +184,32 @@ class TestRelabel:
         G = nx.relabel_nodes(G, {1: 0}, copy=False)
         assert_nodes_equal(G.nodes(), [0])
 
+#    def test_relabel_multidigraph_inout_inplace(self):
+#        pass
+    def test_relabel_multidigraph_inout_merge_nodes(self):
+        for MG in (nx.MultiGraph, nx.MultiDiGraph):
+            for cc in (True, False):
+                G = MG([(0, 4), (1, 4), (4, 2), (4, 3)])
+                G[0][4][0]["value"] = "a"
+                G[1][4][0]["value"] = "b"
+                G[4][2][0]["value"] = "c"
+                G[4][3][0]["value"] = "d"
+                G.add_edge(0, 4, key="x", value="e")
+                G.add_edge(4, 3, key="x", value="f")
+                mapping = {0: 9, 1: 9, 2: 9, 3: 9}
+                H = nx.relabel_nodes(G, mapping, copy=cc)
+                # No ordering on keys enforced
+                assert {"value": "a"} in H[9][4].values()
+                assert {"value": "b"} in H[9][4].values()
+                assert {"value": "c"} in H[4][9].values()
+                assert len(H[4][9]) == 3 if G.is_directed() else 6
+                assert {"value": "d"} in H[4][9].values()
+                assert {"value": "e"} in H[9][4].values()
+                assert {"value": "f"} in H[4][9].values()
+                assert len(H[9][4]) == 3 if G.is_directed() else 6
+
     def test_relabel_multigraph_merge_inplace(self):
-        G = nx.MultiGraph([(0, 1), (0, 2), (0, 3)])
+        G = nx.MultiGraph([(0, 1), (0, 2), (0, 3), (0, 1), (0, 2), (0, 3)])
         G[0][1][0]["value"] = "a"
         G[0][2][0]["value"] = "b"
         G[0][3][0]["value"] = "c"
@@ -210,6 +231,26 @@ class TestRelabel:
         assert {"value": "a"} in G[0][4].values()
         assert {"value": "b"} in G[0][4].values()
         assert {"value": "c"} in G[0][4].values()
+
+    def test_relabel_multidigraph_inout_copy(self):
+        G = nx.MultiDiGraph([(0, 4), (1, 4), (4, 2), (4, 3)])
+        G[0][4][0]["value"] = "a"
+        G[1][4][0]["value"] = "b"
+        G[4][2][0]["value"] = "c"
+        G[4][3][0]["value"] = "d"
+        G.add_edge(0, 4, key="x", value="e")
+        G.add_edge(4, 3, key="x", value="f")
+        mapping = {0: 9, 1: 9, 2: 9, 3: 9}
+        H = nx.relabel_nodes(G, mapping, copy=True)
+        # No ordering on keys enforced
+        assert {"value": "a"} in H[9][4].values()
+        assert {"value": "b"} in H[9][4].values()
+        assert {"value": "c"} in H[4][9].values()
+        assert len(H[4][9]) == 3
+        assert {"value": "d"} in H[4][9].values()
+        assert {"value": "e"} in H[9][4].values()
+        assert {"value": "f"} in H[4][9].values()
+        assert len(H[9][4]) == 3
 
     def test_relabel_multigraph_merge_copy(self):
         G = nx.MultiGraph([(0, 1), (0, 2), (0, 3)])
@@ -233,24 +274,18 @@ class TestRelabel:
         assert {"value": "b"} in H[0][4].values()
         assert {"value": "c"} in H[0][4].values()
 
-    def test_relabel_multigraph_nonnumeric_key_inplace(self):
-        G = nx.MultiGraph()
-        G.add_edge(0, 1, key="I", value="a")
-        G.add_edge(0, 2, key="II", value="b")
-        G.add_edge(0, 3, key="II", value="c")
-        mapping = {1: 4, 2: 4, 3: 4}
-        nx.relabel_nodes(G, mapping, copy=False)
-        assert {"value": "a"} in G[0][4].values()
-        assert {"value": "b"} in G[0][4].values()
-        assert {"value": "c"} in G[0][4].values()
-
-    def test_relabel_multigraph_nonnumeric_key_copy(self):
-        G = nx.MultiGraph()
-        G.add_edge(0, 1, key="I", value="a")
-        G.add_edge(0, 2, key="II", value="b")
-        G.add_edge(0, 3, key="II", value="c")
-        mapping = {1: 4, 2: 4, 3: 4}
-        H = nx.relabel_nodes(G, mapping, copy=True)
-        assert {"value": "a"} in H[0][4].values()
-        assert {"value": "b"} in H[0][4].values()
-        assert {"value": "c"} in H[0][4].values()
+    def test_relabel_multigraph_nonnumeric_key(self):
+        for MG in (nx.MultiGraph, nx.MultiDiGraph):
+            for cc in (True, False):
+                G = nx.MultiGraph()
+                G.add_edge(0, 1, key="I", value="a")
+                G.add_edge(0, 2, key="II", value="b")
+                G.add_edge(0, 3, key="II", value="c")
+                mapping = {1: 4, 2: 4, 3: 4}
+                nx.relabel_nodes(G, mapping, copy=False)
+                assert {"value": "a"} in G[0][4].values()
+                assert {"value": "b"} in G[0][4].values()
+                assert {"value": "c"} in G[0][4].values()
+                assert 0 in G[0][4]
+                assert "I" in G[0][4]
+                assert "II" in G[0][4]

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -85,7 +85,8 @@ class TestRelabel:
     def test_convert_to_integers_raise(self):
         with pytest.raises(nx.NetworkXError):
             G = nx.Graph()
-            H = nx.convert_node_labels_to_integers(G, ordering="increasing age")
+            H = nx.convert_node_labels_to_integers(
+                G, ordering="increasing age")
 
     def test_relabel_nodes_copy(self):
         G = nx.empty_graph()
@@ -130,14 +131,16 @@ class TestRelabel:
         mapping = {"a": "aardvark", "b": "bear"}
         G = nx.relabel_nodes(G, mapping, copy=False)
         assert_nodes_equal(G.nodes(), ["aardvark", "bear"])
-        assert_edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
+        assert_edges_equal(
+            G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
 
     def test_relabel_nodes_multidigraph(self):
         G = nx.MultiDiGraph([("a", "b"), ("a", "b")])
         mapping = {"a": "aardvark", "b": "bear"}
         G = nx.relabel_nodes(G, mapping, copy=False)
         assert_nodes_equal(G.nodes(), ["aardvark", "bear"])
-        assert_edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
+        assert_edges_equal(
+            G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
 
     def test_relabel_isolated_nodes_to_same(self):
         G = nx.Graph()
@@ -183,3 +186,71 @@ class TestRelabel:
         G = nx.MultiDiGraph([(1, 1)])
         G = nx.relabel_nodes(G, {1: 0}, copy=False)
         assert_nodes_equal(G.nodes(), [0])
+
+    def test_relabel_multigraph_merge_inplace(self):
+        G = nx.MultiGraph([(0, 1), (0, 2), (0, 3)])
+        G[0][1][0]["value"] = "a"
+        G[0][2][0]["value"] = "b"
+        G[0][3][0]["value"] = "c"
+        mapping = {1: 4, 2: 4, 3: 4}
+        nx.relabel_nodes(G, mapping, copy=False)
+        # No ordering on keys enforced
+        assert {"value": "a"} in G[0][4].values()
+        assert {"value": "b"} in G[0][4].values()
+        assert {"value": "c"} in G[0][4].values()
+
+    def test_relabel_multidigraph_merge_inplace(self):
+        G = nx.MultiDiGraph([(0, 1), (0, 2), (0, 3)])
+        G[0][1][0]["value"] = "a"
+        G[0][2][0]["value"] = "b"
+        G[0][3][0]["value"] = "c"
+        mapping = {1: 4, 2: 4, 3: 4}
+        nx.relabel_nodes(G, mapping, copy=False)
+        # No ordering on keys enforced
+        assert {"value": "a"} in G[0][4].values()
+        assert {"value": "b"} in G[0][4].values()
+        assert {"value": "c"} in G[0][4].values()
+
+    def test_relabel_multigraph_merge_copy(self):
+        G = nx.MultiGraph([(0, 1), (0, 2), (0, 3)])
+        G[0][1][0]["value"] = "a"
+        G[0][2][0]["value"] = "b"
+        G[0][3][0]["value"] = "c"
+        mapping = {1: 4, 2: 4, 3: 4}
+        H = nx.relabel_nodes(G, mapping, copy=True)
+        assert {"value": "a"} in H[0][4].values()
+        assert {"value": "b"} in H[0][4].values()
+        assert {"value": "c"} in H[0][4].values()
+
+    def test_relabel_multidigraph_merge_copy(self):
+        G = nx.MultiDiGraph([(0, 1), (0, 2), (0, 3)])
+        G[0][1][0]["value"] = "a"
+        G[0][2][0]["value"] = "b"
+        G[0][3][0]["value"] = "c"
+        mapping = {1: 4, 2: 4, 3: 4}
+        H = nx.relabel_nodes(G, mapping, copy=True)
+        assert {"value": "a"} in H[0][4].values()
+        assert {"value": "b"} in H[0][4].values()
+        assert {"value": "c"} in H[0][4].values()
+
+    def test_relabel_multigraph_nonnumeric_key_inplace(self):
+        G = nx.MultiGraph()
+        G.add_edge(0, 1, key="I", value="a")
+        G.add_edge(0, 2, key="II", value="b")
+        G.add_edge(0, 3, key="II", value="c")
+        mapping = {1: 4, 2: 4, 3: 4}
+        nx.relabel_nodes(G, mapping, copy=False)
+        assert {"value": "a"} in G[0][4].values()
+        assert {"value": "b"} in G[0][4].values()
+        assert {"value": "c"} in G[0][4].values()
+
+    def test_relabel_multigraph_nonnumeric_key_copy(self):
+        G = nx.MultiGraph()
+        G.add_edge(0, 1, key="I", value="a")
+        G.add_edge(0, 2, key="II", value="b")
+        G.add_edge(0, 3, key="II", value="c")
+        mapping = {1: 4, 2: 4, 3: 4}
+        H = nx.relabel_nodes(G, mapping, copy=True)
+        assert {"value": "a"} in H[0][4].values()
+        assert {"value": "b"} in H[0][4].values()
+        assert {"value": "c"} in H[0][4].values()


### PR DESCRIPTION
Fixes #4058.

In a multigraph, relabeling two or more nodes that share predecessors into the same new label will preserve all edges, but will change the edge keys in the process. Previously, edge keys were not changed, but if edges ended up having the same (tail, head, key) tuple after the relabel, only one of those edges would be inserted into the relabeled graph.
