### PR TITLE
Clear pygraphviz object after creating networkx object

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -200,7 +200,9 @@ def read_dot(path):
             "read_dot() requires pygraphviz " "http://pygraphviz.github.io/"
         ) from e
     A = pygraphviz.AGraph(file=path)
-    return from_agraph(A)
+    gr = from_agraph(A)
+    A.clear()
+    return gr
 
 
 def graphviz_layout(G, prog="neato", root=None, args=""):


### PR DESCRIPTION
I noticed a memory leak in a downstream application that reads a ton of dot files and converts them to networkx objects using `read_dot` function. My application crashed after reading about 500 dot files (each has around 500 nodes). Upon inspecting the `nx_agraph.py` file, I noticed that the pygraphviz object created during `read_dot` is not cleared. This PR fixes the memory leak issue by first creating networkx object (the one we want to return) and then clearing the intermediate pygraphviz object.

P.S : The reverse function `write_dot` does indeed clear the intermediate object.