### PR TITLE
Improves docs regarding aliases of erdos-reyni graph generators

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -117,9 +117,6 @@ def gnp_random_graph(n, p, seed=None, directed=False):
 
     The $G_{n,p}$ model chooses each of the possible edges with probability $p$.
 
-    The functions :func:`gnp_random_graph`, :func:`binomial_graph` and :func:`erdos_renyi_graph` are
-    aliases of each other.
-
     Parameters
     ----------
     n : int
@@ -164,9 +161,20 @@ def gnp_random_graph(n, p, seed=None, directed=False):
     return G
 
 
-# add some aliases to common names
-binomial_graph = gnp_random_graph
-erdos_renyi_graph = gnp_random_graph
+def binomial_graph(n, p, seed=None, directed=False):
+    """Returns a binomial graph.
+    This is an alias for ``gnp_random_graph``.  See the ``gnp_random_graph``
+    docstring for more details.
+    """
+    return gnp_random_graph(n, p, seed, directed)
+
+
+def erdos_renyi_graph(n, p, seed=None, directed=False):
+    """Returns an Erdos-Renyi $G_{n,p}$ random graph.
+    This is an alias for ``gnp_random_graph``.  See the ``gnp_random_graph``
+    docstring for more details.
+    """
+    return gnp_random_graph(n, p, seed, directed)
 
 
 @py_random_state(2)

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -117,8 +117,8 @@ def gnp_random_graph(n, p, seed=None, directed=False):
 
     The $G_{n,p}$ model chooses each of the possible edges with probability $p$.
 
-    The functions :func:`binomial_graph` and :func:`erdos_renyi_graph` are
-    aliases of this function.
+    The functions :func:`gnp_random_graph`, :func:`binomial_graph` and :func:`erdos_renyi_graph` are
+    aliases of each other.
 
     Parameters
     ----------

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -138,6 +138,14 @@ def gnp_random_graph(n, p, seed=None, directed=False):
     This algorithm [2]_ runs in $O(n^2)$ time.  For sparse graphs (that is, for
     small values of $p$), :func:`fast_gnp_random_graph` is a faster algorithm.
 
+    :func:`binomial_graph` and :func:`erdos_renyi_graph` are
+    aliases for :func:`gnp_random_graph`.
+
+    >>> nx.binomial_graph is nx.gnp_random_graph
+    True
+    >>> nx.erdos_renyi_graph is nx.gnp_random_graph
+    True
+
     References
     ----------
     .. [1] P. Erdős and A. Rényi, On Random Graphs, Publ. Math. 6, 290 (1959).
@@ -161,20 +169,9 @@ def gnp_random_graph(n, p, seed=None, directed=False):
     return G
 
 
-def binomial_graph(n, p, seed=None, directed=False):
-    """Returns a binomial graph.
-    This is an alias for ``gnp_random_graph``.  See the ``gnp_random_graph``
-    docstring for more details.
-    """
-    return gnp_random_graph(n, p, seed, directed)
-
-
-def erdos_renyi_graph(n, p, seed=None, directed=False):
-    """Returns an Erdos-Renyi $G_{n,p}$ random graph.
-    This is an alias for ``gnp_random_graph``.  See the ``gnp_random_graph``
-    docstring for more details.
-    """
-    return gnp_random_graph(n, p, seed, directed)
+# add some aliases to common names
+binomial_graph = gnp_random_graph
+erdos_renyi_graph = gnp_random_graph
 
 
 @py_random_state(2)


### PR DESCRIPTION
The functions `gnp_random_graph`, `binomial_graph` and `erdos_renyi_graph` are all aliases of each other. 
However current documentation reads like this, "_The functions `binomial_graph` and `erdos_renyi_graph` are aliases of this function._". 
This is a bit unclear. To improve clarity, this PR changes the wording of the documentation to "_The functions `gnp_random_graph`, `binomial_graph` and `erdos_renyi_graph` are aliases of each other._"