### PR TITLE
Allow custom keys for multiedges in from_pandas_edgelist

### DIFF
--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -94,7 +94,7 @@ class MultiGraph(Graph):
 
     >>> keys = G.add_edges_from([(4,5,{'route':28}), (4,5,{'route':37})])
     >>> G[4]
-    AdjacencyView({3: {0: {}}, 5: {0: {}, 1: {'route': 28}, 2: {'route': 37}}})
+    AdjacencyView({5: {0: {}, 1: {'route': 28}, 2: {'route': 37}}})
 
     **Attributes:**
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -94,7 +94,7 @@ class MultiGraph(Graph):
 
     >>> keys = G.add_edges_from([(4,5,{'route':28}), (4,5,{'route':37})])
     >>> G[4]
-    AdjacencyView({5: {0: {}, 1: {'route': 28}, 2: {'route': 37}}})
+    AdjacencyView({3: {0: {}}, 5: {0: {}, 1: {'route': 28}, 2: {'route': 37}}})
 
     **Attributes:**
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -363,6 +363,7 @@ def from_pandas_edgelist(
     >>> G[0][2]
     AtlasView({'A': {'weight': 3, 'color': 'red'}})
 
+
     """
     g = nx.empty_graph(0, create_using)
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -361,7 +361,7 @@ def from_pandas_edgelist(
                                     edge_attr=['weight', 'color'], \
                                     create_using=nx.MultiGraph())
     >>> G[0][2]
-    {'A': {'weight': 3, 'color': 'red'}}
+    AtlasView({'A': {'weight': 3, 'color': 'red'}})
 
     """
     g = nx.empty_graph(0, create_using)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -353,7 +353,7 @@ def from_pandas_edgelist(
 
     >>> edges = pd.DataFrame({'source': [0, 1, 2],
     ...                       'target': [2, 2, 3],
-                              'key': ['A', 'B', 'C'],
+    ...                       'key': ['A', 'B', 'C'],
     ...                       'weight': [3, 4, 5],
     ...                       'color': ['red', 'blue', 'blue']})
     >>> G = nx.from_pandas_edgelist(edges, 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -383,8 +383,8 @@ def from_pandas_edgelist(
     else:
         attr_col_headings = [edge_attr]
     if len(attr_col_headings) == 0:
-        msg = f"""Invalid edge_attr argument. 
-                No columns found with name: {attr_col_headings}"""
+        msg = ("Invalid edge_attr argument:"
+               f"No columns found with name: {attr_col_headings}")
         raise nx.NetworkXError(msg)
 
     try:
@@ -404,7 +404,6 @@ def from_pandas_edgelist(
                 raise nx.NetworkXError(msg) from e
 
         for s, t, attrs in zip(df[source], df[target], attribute_data):
-            key = -1
             if edge_key is not None:
                 attrs, multigraph_edge_key = attrs
                 key = g.add_edge(s, t, key=multigraph_edge_key)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -386,8 +386,12 @@ def handle_multigraph_pandas_conversion(g,attribute_data,df,source,target,edge_k
 
     # => append the edge keys from the df to the bundled data
     if edge_key is not None:
-        multigraph_edge_keys = df[edge_key]
-        attributes_by_row = zip(attributes_by_row,multigraph_edge_keys)
+        try:
+            multigraph_edge_keys = df[edge_key]
+            attributes_by_row = zip(attributes_by_row,multigraph_edge_keys)
+        except (KeyError, TypeError) as e:
+            msg = f"Invalid edge_key argument: {edge_key}"
+            raise nx.NetworkXError(msg) from e
     
     for s, t, attrs in zip(df[source], df[target], attributes_by_row):
         key = -1

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -272,7 +272,12 @@ def to_pandas_edgelist(
 
 
 def from_pandas_edgelist(
-    df, source="source", target="target", edge_attr=None, create_using=None,edge_key=None
+    df,
+    source="source",
+    target="target",
+    edge_attr=None,
+    create_using=None,
+    edge_key=None,
 ):
     """Returns a graph from Pandas DataFrame containing an edge list.
 
@@ -350,19 +355,22 @@ def from_pandas_edgelist(
     if edge_attr is None:
         g.add_edges_from(zip(df[source], df[target]))
         return g
-    
-    reserved_columns = [source,target]
-    attribute_data = extract_attributes(df,reserved_columns,edge_attr)
+
+    reserved_columns = [source, target]
+    attribute_data = extract_attributes(df, reserved_columns, edge_attr)
 
     if g.is_multigraph():
-        handle_multigraph_pandas_conversion(g,attribute_data,df,source,target,edge_key)
+        handle_multigraph_pandas_conversion(
+            g, attribute_data, df, source, target, edge_key
+        )
     else:
-        handle_base_pandas_conversion(g,attribute_data,df,source,target)
-    
+        handle_base_pandas_conversion(g, attribute_data, df, source, target)
+
     return g
 
+
 def extract_attributes(df, reserved_columns, edge_attr):
-        # Additional columns requested
+    # Additional columns requested
     if edge_attr is True:
         attr_col_headings = [c for c in df.columns if c not in reserved_columns]
     elif isinstance(edge_attr, (list, tuple)):
@@ -378,21 +386,24 @@ def extract_attributes(df, reserved_columns, edge_attr):
     except (KeyError, TypeError) as e:
         msg = f"Invalid edge_attr argument: {edge_attr}"
         raise nx.NetworkXError(msg) from e
-    
+
     return attr_col_headings, attribute_data
 
-def handle_multigraph_pandas_conversion(g,attribute_data,df,source,target,edge_key):
+
+def handle_multigraph_pandas_conversion(
+    g, attribute_data, df, source, target, edge_key
+):
     attribute_headers, attributes_by_row = attribute_data
 
     # => append the edge keys from the df to the bundled data
     if edge_key is not None:
         try:
             multigraph_edge_keys = df[edge_key]
-            attributes_by_row = zip(attributes_by_row,multigraph_edge_keys)
+            attributes_by_row = zip(attributes_by_row, multigraph_edge_keys)
         except (KeyError, TypeError) as e:
             msg = f"Invalid edge_key argument: {edge_key}"
             raise nx.NetworkXError(msg) from e
-    
+
     for s, t, attrs in zip(df[source], df[target], attributes_by_row):
         key = -1
         if edge_key is not None:
@@ -404,11 +415,13 @@ def handle_multigraph_pandas_conversion(g,attribute_data,df,source,target,edge_k
 
         g[s][t][key].update(zip(attribute_headers, attrs))
 
-def handle_base_pandas_conversion(g,attribute_data,df,source,target):
+
+def handle_base_pandas_conversion(g, attribute_data, df, source, target):
     attribute_headers, attributes_by_row = attribute_data
     for s, t, attrs in zip(df[source], df[target], attributes_by_row):
         g.add_edge(s, t)
         g[s][t].update(zip(attribute_headers, attrs))
+
 
 def to_numpy_matrix(
     G,

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -383,9 +383,9 @@ def from_pandas_edgelist(
     else:
         attr_col_headings = [edge_attr]
     if len(attr_col_headings) == 0:
-        msg = ("Invalid edge_attr argument:"
-               f"No columns found with name: {attr_col_headings}")
-        raise nx.NetworkXError(msg)
+        raise nx.NetworkXError(
+            f"Invalid edge_attr argument: No columns found with name: {attr_col_headings}"
+        )
 
     try:
         attribute_data = zip(*[df[col] for col in attr_col_headings])

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -356,9 +356,9 @@ def from_pandas_edgelist(
     ...                       'key': ['A', 'B', 'C'],
     ...                       'weight': [3, 4, 5],
     ...                       'color': ['red', 'blue', 'blue']})
-    >>> G = nx.from_pandas_edgelist(edges, 
-                                    edge_key='key', 
-                                    edge_attr=['weight', 'color'], 
+    >>> G = nx.from_pandas_edgelist(edges, \
+                                    edge_key='key', \
+                                    edge_attr=['weight', 'color'], \
                                     create_using=nx.MultiGraph())
     >>> G[0][2]
     {'A': {'weight': 3, 'color': 'red'}}

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -378,7 +378,8 @@ def extract_attributes(df, reserved_columns, edge_attr):
     else:
         attr_col_headings = [edge_attr]
     if len(attr_col_headings) == 0:
-        msg = f"Invalid edge_attr argument. No columns found with name: {attr_col_headings}"
+        msg = f"""Invalid edge_attr argument. 
+                No columns found with name: {attr_col_headings}"""
         raise nx.NetworkXError(msg)
 
     try:
@@ -411,7 +412,6 @@ def handle_multigraph_pandas_conversion(
             key = g.add_edge(s, t, key=multigraph_edge_key)
         else:
             key = g.add_edge(s, t)
-            basic_attributes = attrs
 
         g[s][t][key].update(zip(attribute_headers, attrs))
 

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -262,35 +262,7 @@ class TestConvertPandas:
             create_using=nx.MultiGraph(),
         )
         assert_graphs_equal(G, Gtrue)
-
-    def test_edgekey_with_multigraph(self):
-        df = pd.DataFrame(
-            {
-                "attr1": {"A": "F1", "B": "F2", "C": "F3"},
-                "attr2": {"A": 1, "B": 0, "C": 0},
-                "attr3": {"A": 0, "B": 1, "C": 0},
-                "source": {"A": "N1", "B": "N2", "C": "N1"},
-                "target": {"A": "N2", "B": "N3", "C": "N1"},
-            }
-        )
-        Gtrue = nx.Graph(
-            [
-                ("N1", "N2", {"F1": {"attr2": 1, "attr3": 0}}),
-                ("N2", "N3", {"F2": {"attr2": 0, "attr3": 1}}),
-                ("N1", "N1", {"F3": {"attr2": 0, "attr3": 0}}),
-            ]
-        )
-        # example from issue #4065
-        G = nx.from_pandas_edgelist(
-            df,
-            source="source",
-            target="target",
-            edge_attr=["attr2", "attr3"],
-            edge_key="attr1",
-            create_using=nx.MultiGraph(),
-        )
-        assert_graphs_equal(G, Gtrue)
-
+        
     def test_edgekey_with_normal_graph_no_action(self):
         Gtrue = nx.Graph(
             [
@@ -303,7 +275,7 @@ class TestConvertPandas:
         assert_graphs_equal(G, Gtrue)
 
     def test_nonexisting_edgekey_raises(self):
-        with pytest.raises(nx.exception.NetworkXError) as excinfo:
+        with pytest.raises(nx.exception.NetworkXError):
             nx.from_pandas_edgelist(
                 self.df,
                 source="source",

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -234,49 +234,63 @@ class TestConvertPandas:
         G = nx.from_pandas_adjacency(df, create_using=nx.DiGraph())
         df = nx.to_pandas_adjacency(G, dtype=np.intp)
         pd.testing.assert_frame_equal(df, dftrue)
-    
+
     def test_edgekey_with_multigraph(self):
-        df = pd.DataFrame({
-            "attr1": {"A": "F1", "B": "F2", "C": "F3"},
-            "attr2": {"A": 1, "B": 0, "C": 0},
-            "attr3": {"A": 0, "B": 1, "C": 0},
-            "source":{"A": "N1", "B": "N2", "C": "N1"},
-            "target":{"A": "N2", "B": "N3", "C": "N1"}
-        })
+        df = pd.DataFrame(
+            {
+                "attr1": {"A": "F1", "B": "F2", "C": "F3"},
+                "attr2": {"A": 1, "B": 0, "C": 0},
+                "attr3": {"A": 0, "B": 1, "C": 0},
+                "source": {"A": "N1", "B": "N2", "C": "N1"},
+                "target": {"A": "N2", "B": "N3", "C": "N1"},
+            }
+        )
         Gtrue = nx.Graph(
             [
-                ("N1", "N2", {'F1': {'attr2': 1, 'attr3': 0}}),
-                ("N2", "N3", {'F2': {'attr2': 0, 'attr3': 1}}),
-                ("N1", "N1", {'F3': {'attr2': 0, 'attr3': 0}}),
+                ("N1", "N2", {"F1": {"attr2": 1, "attr3": 0}}),
+                ("N2", "N3", {"F2": {"attr2": 0, "attr3": 1}}),
+                ("N1", "N1", {"F3": {"attr2": 0, "attr3": 0}}),
             ]
         )
         # example from issue #4065
-        G = nx.from_pandas_edgelist(df, source="source", target="target", \
-                                        edge_attr=["attr2", "attr3"], \
-                                        edge_key="attr1", create_using=nx.MultiGraph())
+        G = nx.from_pandas_edgelist(
+            df,
+            source="source",
+            target="target",
+            edge_attr=["attr2", "attr3"],
+            edge_key="attr1",
+            create_using=nx.MultiGraph(),
+        )
         assert_graphs_equal(G, Gtrue)
-    
+
     def test_edgekey_with_multigraph(self):
-        df = pd.DataFrame({
-            "attr1": {"A": "F1", "B": "F2", "C": "F3"},
-            "attr2": {"A": 1, "B": 0, "C": 0},
-            "attr3": {"A": 0, "B": 1, "C": 0},
-            "source":{"A": "N1", "B": "N2", "C": "N1"},
-            "target":{"A": "N2", "B": "N3", "C": "N1"}
-        })
+        df = pd.DataFrame(
+            {
+                "attr1": {"A": "F1", "B": "F2", "C": "F3"},
+                "attr2": {"A": 1, "B": 0, "C": 0},
+                "attr3": {"A": 0, "B": 1, "C": 0},
+                "source": {"A": "N1", "B": "N2", "C": "N1"},
+                "target": {"A": "N2", "B": "N3", "C": "N1"},
+            }
+        )
         Gtrue = nx.Graph(
             [
-                ("N1", "N2", {'F1': {'attr2': 1, 'attr3': 0}}),
-                ("N2", "N3", {'F2': {'attr2': 0, 'attr3': 1}}),
-                ("N1", "N1", {'F3': {'attr2': 0, 'attr3': 0}}),
+                ("N1", "N2", {"F1": {"attr2": 1, "attr3": 0}}),
+                ("N2", "N3", {"F2": {"attr2": 0, "attr3": 1}}),
+                ("N1", "N1", {"F3": {"attr2": 0, "attr3": 0}}),
             ]
         )
         # example from issue #4065
-        G = nx.from_pandas_edgelist(df, source="source", target="target", \
-                                        edge_attr=["attr2", "attr3"], \
-                                        edge_key="attr1", create_using=nx.MultiGraph())
+        G = nx.from_pandas_edgelist(
+            df,
+            source="source",
+            target="target",
+            edge_attr=["attr2", "attr3"],
+            edge_key="attr1",
+            create_using=nx.MultiGraph(),
+        )
         assert_graphs_equal(G, Gtrue)
-    
+
     def test_edgekey_with_normal_graph_no_action(self):
         Gtrue = nx.Graph(
             [
@@ -285,11 +299,16 @@ class TestConvertPandas:
                 ("A", "D", {"cost": 7, "weight": 4}),
             ]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", True,edge_key="weight")
+        G = nx.from_pandas_edgelist(self.df, 0, "b", True, edge_key="weight")
         assert_graphs_equal(G, Gtrue)
 
     def test_nonexisting_edgekey_raises(self):
         with pytest.raises(nx.exception.NetworkXError) as excinfo:
-            nx.from_pandas_edgelist(self.df, source='source', target='target', \
-                                    edge_key="Not_real",edge_attr=True, \
-                                    create_using=nx.MultiGraph())
+            nx.from_pandas_edgelist(
+                self.df,
+                source="source",
+                target="target",
+                edge_key="Not_real",
+                edge_attr=True,
+                create_using=nx.MultiGraph(),
+            )

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -234,3 +234,62 @@ class TestConvertPandas:
         G = nx.from_pandas_adjacency(df, create_using=nx.DiGraph())
         df = nx.to_pandas_adjacency(G, dtype=np.intp)
         pd.testing.assert_frame_equal(df, dftrue)
+    
+    def test_edgekey_with_multigraph(self):
+        df = pd.DataFrame({
+            "attr1": {"A": "F1", "B": "F2", "C": "F3"},
+            "attr2": {"A": 1, "B": 0, "C": 0},
+            "attr3": {"A": 0, "B": 1, "C": 0},
+            "source":{"A": "N1", "B": "N2", "C": "N1"},
+            "target":{"A": "N2", "B": "N3", "C": "N1"}
+        })
+        Gtrue = nx.Graph(
+            [
+                ("N1", "N2", {'F1': {'attr2': 1, 'attr3': 0}}),
+                ("N2", "N3", {'F2': {'attr2': 0, 'attr3': 1}}),
+                ("N1", "N1", {'F3': {'attr2': 0, 'attr3': 0}}),
+            ]
+        )
+        # example from issue #4065
+        G = nx.from_pandas_edgelist(df, source="source", target="target", \
+                                        edge_attr=["attr2", "attr3"], \
+                                        edge_key="attr1", create_using=nx.MultiGraph())
+        assert_graphs_equal(G, Gtrue)
+    
+    def test_edgekey_with_multigraph(self):
+        df = pd.DataFrame({
+            "attr1": {"A": "F1", "B": "F2", "C": "F3"},
+            "attr2": {"A": 1, "B": 0, "C": 0},
+            "attr3": {"A": 0, "B": 1, "C": 0},
+            "source":{"A": "N1", "B": "N2", "C": "N1"},
+            "target":{"A": "N2", "B": "N3", "C": "N1"}
+        })
+        Gtrue = nx.Graph(
+            [
+                ("N1", "N2", {'F1': {'attr2': 1, 'attr3': 0}}),
+                ("N2", "N3", {'F2': {'attr2': 0, 'attr3': 1}}),
+                ("N1", "N1", {'F3': {'attr2': 0, 'attr3': 0}}),
+            ]
+        )
+        # example from issue #4065
+        G = nx.from_pandas_edgelist(df, source="source", target="target", \
+                                        edge_attr=["attr2", "attr3"], \
+                                        edge_key="attr1", create_using=nx.MultiGraph())
+        assert_graphs_equal(G, Gtrue)
+    
+    def test_edgekey_with_normal_graph_no_action(self):
+        Gtrue = nx.Graph(
+            [
+                ("E", "C", {"cost": 9, "weight": 10}),
+                ("B", "A", {"cost": 1, "weight": 7}),
+                ("A", "D", {"cost": 7, "weight": 4}),
+            ]
+        )
+        G = nx.from_pandas_edgelist(self.df, 0, "b", True,edge_key="weight")
+        assert_graphs_equal(G, Gtrue)
+
+    def test_nonexisting_edgekey_raises(self):
+        with pytest.raises(nx.exception.NetworkXError) as excinfo:
+            nx.from_pandas_edgelist(self.df, source='source', target='target', \
+                                    edge_key="Not_real",edge_attr=True, \
+                                    create_using=nx.MultiGraph())


### PR DESCRIPTION
Adding PR for feature stated in issue #4065, regarding the ability to provide a custom key for multigraphs in the from_pandas_edgelist function. Code currently (as stated in issue) deals with duplicate keys by overwriting them, and I will look into better mechanisms in future PRs. Tests have been added and code was run through black.

