### PR TITLE
Install Python after updating brew

### DIFF
--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -3,16 +3,16 @@ set -ex
 
 section "OSX install section"
 
-# set up Python and virtualenv on OSX
-git clone https://github.com/matthew-brett/multibuild
-source multibuild/osx_utils.sh
-get_macpython_environment $TRAVIS_PYTHON_VERSION venv
-
 if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
     brew install graphviz
     dot -V
     sed -i "" 's/^gdal.*/gdal==3.1.2/' requirements/extras.txt
 fi
+
+# set up Python and virtualenv on OSX
+git clone https://github.com/matthew-brett/multibuild
+source multibuild/osx_utils.sh
+get_macpython_environment $TRAVIS_PYTHON_VERSION venv
 
 section_end "OSX install section"
 


### PR DESCRIPTION
> Formulae that declare an unconditional dependency on the "python" formula are bottled against Homebrew’s Python 3.x and require it to be installed.

``graphviz``  declares an unconditional dependency on the "python", which is now 3.8 by default.  And

> WARNING: When you brew install formulae that provide Python bindings, you should not be in an active virtual environment.

So I moved the brew install before we create the venv.

NOTE:  Quotes are from https://docs.brew.sh/Homebrew-and-Python