### PR TITLE
MAINT: Remove dependency version info from INSTALL

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -85,19 +85,21 @@ Optional packages
    with `pip`, please review the instructions for installing
    the full `scientific Python stack <https://scipy.org/install.html>`_.
 
-The following optional packages provide additional functionality.
+The following optional packages provide additional functionality. See the
+`requirements files <https://github.com/networkx/networkx/tree/master/requirements>`_
+for information about specific version requirements.
 
-- `NumPy <http://www.numpy.org/>`_ (>= 1.15.4) provides matrix representation of
+- `NumPy <http://www.numpy.org/>`_ provides matrix representation of
   graphs and is used in some graph algorithms for high-performance matrix
   computations.
-- `SciPy <http://scipy.org/>`_ (>= 1.1.0) provides sparse matrix representation
+- `SciPy <http://scipy.org/>`_ provides sparse matrix representation
   of graphs and many numerical scientific tools.
-- `pandas <http://pandas.pydata.org/>`_ (>= 0.23.3) provides a DataFrame, which
+- `pandas <http://pandas.pydata.org/>`_ provides a DataFrame, which
   is a tabular data structure with labeled axes.
-- `Matplotlib <http://matplotlib.org/>`_ (>= 3.0.2) provides flexible drawing of
+- `Matplotlib <http://matplotlib.org/>`_ provides flexible drawing of
   graphs.
-- `PyGraphviz <http://pygraphviz.github.io/>`_ (>= 1.5) and
-  `pydot <https://github.com/erocarrera/pydot>`_ (>= 1.2.4) provide graph drawing
+- `PyGraphviz <http://pygraphviz.github.io/>`_ and
+  `pydot <https://github.com/erocarrera/pydot>`_ provide graph drawing
   and graph layout algorithms via `GraphViz <http://graphviz.org/>`_.
 - `PyYAML <http://pyyaml.org/>`_ provides YAML format reading and writing.
 - `gdal <http://www.gdal.org/>`_ provides shapefile format reading and writing.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -80,7 +80,7 @@ Optional packages
 -----------------
 
 .. note::
-   Some optional packages (e.g., `scipy`, `gdal`) may require compiling
+   Some optional packages (e.g., `gdal`) may require compiling
    C or C++ code.  If you have difficulty installing these packages
    with `pip`, please review the instructions for installing
    the full `scientific Python stack <https://scipy.org/install.html>`_.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -86,8 +86,8 @@ Optional packages
    the full `scientific Python stack <https://scipy.org/install.html>`_.
 
 The following optional packages provide additional functionality. See the
-`requirements files <https://github.com/networkx/networkx/tree/master/requirements>`_
-for information about specific version requirements.
+files in the ``requirements/`` directory for information about specific
+version requirements.
 
 - `NumPy <http://www.numpy.org/>`_ provides matrix representation of
   graphs and is used in some graph algorithms for high-performance matrix


### PR DESCRIPTION
The info on required versions of dependencies in INSTALL.rst had gotten out-of-sync with the actual requirements files. Rather than update them, I removed the version info from INSTALL and replaced it instead with a link to the requirements folder so that version info doesn't need to be maintained in multiple documents.

Currently, the link is external as the `requirements/` folder is not included in the docs build, though I could include it and use an internal link if that is preferred.

Also removed a note about needing to compile C/C++ for SciPy as this is generally not the case anymore.