### PR TITLE
add slice to __getitem__ for Node(Data)View

### DIFF
--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -181,6 +181,8 @@ class NodeView(Mapping, Set):
         return iter(self._nodes)
 
     def __getitem__(self, n):
+        if isinstance(n, slice):
+            return list(self._nodes).__getitem__(n)
         return self._nodes[n]
 
     # Set methods
@@ -281,10 +283,15 @@ class NodeDataView(Set):
         return n in self._nodes and self[n] == d
 
     def __getitem__(self, n):
-        ddict = self._nodes[n]
         data = self._data
         if data is False or data is True:
-            return ddict
+            if isinstance(n, slice):
+                return list(self._nodes.items()).__getitem__(n)
+            return self._nodes[n]
+        if isinstance(n, slice):
+            return [(n, dd.get(data, self._default)) for n, dd in
+                    list(self._nodes.items()).__getitem__(n)]
+        ddict = self._nodes[n]
         return ddict[data] if data in ddict else self._default
 
     def __str__(self):


### PR DESCRIPTION
@dschult I started playing around with returning slice lists when the user explicitly asks for it. I have done this for `Node(Data)View` right now, would love to get some feedback and thoughts about this design before going further with this.

The following code will be valid if we have slices in `Node(Data)View`.
``` python
In [13]: G.nodes[0:5]                                                                                                             
Out[13]: [8433035090, 6272075181, 1180114949, 3701032566, 4290388111]

In [14]: G.nodes(data=True)[0:5]                                                                                                  
Out[14]: 
[(8433035090, {'w': 2716738093, 't': '6076217445'}),
 (6272075181, {'w': 7046427529, 't': '891215421'}),
 (1180114949, {'w': 9901849457, 't': '4451045765'}),
 (3701032566, {'w': 2467916768, 't': '3668632860'}),
 (4290388111, {'w': 505061655, 't': '5801405547'})]

In [15]: G.nodes(data='w')[0:5]                                                                                                   
Out[15]: 
[(8433035090, 2716738093),
 (6272075181, 7046427529),
 (1180114949, 9901849457),
 (3701032566, 2467916768),
 (4290388111, 505061655)]
```