### PR TITLE
DOC: Fix return types in laplacianmatrix.

### DIFF
--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -85,7 +85,7 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
 
     Returns
     -------
-    N : NumPy matrix
+    N : Scipy sparse matrix
       The normalized Laplacian matrix of G.
 
     Notes
@@ -175,7 +175,7 @@ def directed_laplacian_matrix(
 
     Returns
     -------
-    L : NumPy array
+    L : NumPy matrix
       Normalized Laplacian of G.
 
     Notes
@@ -253,7 +253,7 @@ def directed_combinatorial_laplacian_matrix(
 
     Returns
     -------
-    L : NumPy array
+    L : NumPy matrix
       Combinatorial Laplacian of G.
 
     Notes
@@ -318,7 +318,7 @@ def _transition_matrix(G, nodelist=None, weight="weight", walk_type=None, alpha=
 
     Returns
     -------
-    P : NumPy array
+    P : NumPy matrix
       transition matrix of G.
 
     Raises


### PR DESCRIPTION
The docstrings for most of the functions in the
`laplacianmatrix` module listed incorrect types for the objects
returned by the functions.

This PR fixes the return types so they match the current implementations. The implementations themselves will likely be modified as part of the #3107 cleanup.