### PR TITLE
MAINT: Replace internal usage of to_numpy_matrix and from_numpy_matrix

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,9 +89,9 @@ The following optional packages provide additional functionality. See the
 files in the ``requirements/`` directory for information about specific
 version requirements.
 
-- `NumPy <http://www.numpy.org/>`_ provides matrix representation of
-  graphs and is used in some graph algorithms for high-performance matrix
-  computations.
+- `NumPy <http://www.numpy.org/>`_ provides array-based dense 
+  matrix representations of graphs and high-performance array math and linear
+  algebra which is used in some graph algorithms.
 - `SciPy <http://scipy.org/>`_ provides sparse matrix representation
   of graphs and many numerical scientific tools.
 - `pandas <http://pandas.pydata.org/>`_ provides a DataFrame, which

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -140,7 +140,7 @@ def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight"):
     See Also
     --------
     biadjacency_matrix
-    from_numpy_matrix
+    from_numpy_array
 
     References
     ----------

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -54,7 +54,7 @@ def spectral_bipartivity(G, nodes=None, weight="weight"):
             "spectral_bipartivity() requires SciPy: ", "http://scipy.org/"
         ) from e
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_matrix(G, nodelist, weight=weight)
+    A = nx.to_numpy_array(G, nodelist, weight=weight)
     expA = scipy.linalg.expm(A)
     expmA = scipy.linalg.expm(-A)
     coshA = 0.5 * (expA + expmA)

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -118,8 +118,8 @@ def second_order_centrality(G):
         if deg < d_max:
             G.add_edge(i, i, weight=d_max - deg)
 
-    P = nx.to_numpy_matrix(G)
-    P = P / P.sum(axis=1)  # to transition probability matrix
+    P = nx.to_numpy_array(G)
+    P /= P.sum(axis=1)[:, np.newaxis]  # to transition probability matrix
 
     def _Qj(P, j):
         P = P.copy()

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -174,10 +174,10 @@ def subgraph_centrality(G):
     import numpy.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_matrix(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist)
     # convert to 0-1 matrix
-    A[A != 0.0] = 1
-    w, v = numpy.linalg.eigh(A.A)
+    A[np.nonzero(A)] = 1
+    w, v = numpy.linalg.eigh(A)
     vsquare = np.array(v) ** 2
     expw = np.exp(w)
     xg = np.dot(vsquare, expw)
@@ -269,10 +269,10 @@ def communicability_betweenness_centrality(G, normalized=True):
 
     nodelist = list(G)  # ordering of nodes in matrix
     n = len(nodelist)
-    A = nx.to_numpy_matrix(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist)
     # convert to 0-1 matrix
-    A[A != 0.0] = 1
-    expA = scipy.linalg.expm(A.A)
+    A[np.nonzero(A)] = 1
+    expA = scipy.linalg.expm(A)
     mapping = dict(zip(nodelist, range(n)))
     cbc = {}
     for v in G:
@@ -282,7 +282,7 @@ def communicability_betweenness_centrality(G, normalized=True):
         col = A[:, i].copy()
         A[i, :] = 0
         A[:, i] = 0
-        B = (expA - scipy.linalg.expm(A.A)) / expA
+        B = (expA - scipy.linalg.expm(A)) / expA
         # sum with row/col of node v and diag set to zero
         B[i, :] = 0
         B[:, i] = 0

--- a/networkx/algorithms/centrality/tests/test_trophic.py
+++ b/networkx/algorithms/centrality/tests/test_trophic.py
@@ -79,7 +79,7 @@ def test_trophic_levels_levine():
 
 def test_trophic_levels_simple():
     matrix_a = np.array([[0, 0], [1, 0]])
-    G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_a, create_using=nx.DiGraph)
     d = nx.trophic_levels(G)
     assert almost_equal(d[0], 2)
     assert almost_equal(d[1], 1)
@@ -94,7 +94,7 @@ def test_trophic_levels_more_complex():
         [0, 0, 0, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix, create_using=nx.DiGraph)
     d = nx.trophic_levels(G)
     expected_result = [1, 2, 3, 4]
     for ind in range(4):
@@ -108,7 +108,7 @@ def test_trophic_levels_more_complex():
         [0, 0, 0, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix, create_using=nx.DiGraph)
     d = nx.trophic_levels(G)
 
     expected_result = [1, 2, 2.5, 3.25]
@@ -139,7 +139,7 @@ def test_trophic_levels_even_more_complex():
     ])
     # fmt: on
     result_1 = np.ravel(np.matmul(np.linalg.inv(K), np.ones(5)))
-    G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix, create_using=nx.DiGraph)
     result_2 = nx.trophic_levels(G)
 
     for ind in range(5):
@@ -150,7 +150,7 @@ def test_trophic_levels_singular_matrix():
     """Should raise an error with graphs with only non-basal nodes
     """
     matrix = np.identity(4)
-    G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix, create_using=nx.DiGraph)
     with pytest.raises(nx.NetworkXError) as e:
         nx.trophic_levels(G)
     msg = (
@@ -203,7 +203,7 @@ def test_trophic_levels_singular_with_basal():
 
 def test_trophic_differences():
     matrix_a = np.array([[0, 1], [0, 0]])
-    G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_a, create_using=nx.DiGraph)
     diffs = nx.trophic_differences(G)
     assert almost_equal(diffs[(0, 1)], 1)
 
@@ -215,7 +215,7 @@ def test_trophic_differences():
         [0, 0, 0, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix_b, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_b, create_using=nx.DiGraph)
     diffs = nx.trophic_differences(G)
 
     assert almost_equal(diffs[(0, 1)], 1)
@@ -227,7 +227,7 @@ def test_trophic_differences():
 
 def test_trophic_incoherence_parameter_no_cannibalism():
     matrix_a = np.array([[0, 1], [0, 0]])
-    G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_a, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=False)
     assert almost_equal(q, 0)
 
@@ -239,7 +239,7 @@ def test_trophic_incoherence_parameter_no_cannibalism():
         [0, 0, 0, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix_b, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_b, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=False)
     assert almost_equal(q, np.std([1, 1.5, 0.5, 0.75, 1.25]))
 
@@ -251,7 +251,7 @@ def test_trophic_incoherence_parameter_no_cannibalism():
         [0, 0, 0, 1]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix_c, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_c, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=False)
     # Ignore the -link
     assert almost_equal(q, np.std([1, 1.5, 0.5, 0.75, 1.25]))
@@ -265,7 +265,7 @@ def test_trophic_incoherence_parameter_no_cannibalism():
         [0, 0, 0, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix_d, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_d, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=False)
     # Ignore the -link
     assert almost_equal(q, np.std([1, 1.5, 0.5, 0.75, 1.25]))
@@ -273,7 +273,7 @@ def test_trophic_incoherence_parameter_no_cannibalism():
 
 def test_trophic_incoherence_parameter_cannibalism():
     matrix_a = np.array([[0, 1], [0, 0]])
-    G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_a, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=True)
     assert almost_equal(q, 0)
 
@@ -286,7 +286,7 @@ def test_trophic_incoherence_parameter_cannibalism():
         [0, 0, 0, 1, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix_b, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_b, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=True)
     assert almost_equal(q, 2)
 
@@ -298,7 +298,7 @@ def test_trophic_incoherence_parameter_cannibalism():
         [0, 0, 0, 0]
     ])
     # fmt: on
-    G = nx.from_numpy_matrix(matrix_c, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_c, create_using=nx.DiGraph)
     q = nx.trophic_incoherence_parameter(G, cannibalism=True)
     # Ignore the -link
     assert almost_equal(q, np.std([1, 1.5, 0.5, 0.75, 1.25]))

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -121,14 +121,14 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
 
 def authority_matrix(G, nodelist=None):
     """Returns the HITS authority matrix."""
-    M = nx.to_numpy_matrix(G, nodelist=nodelist)
-    return M.T * M
+    M = nx.to_numpy_array(G, nodelist=nodelist)
+    return M.T @ M
 
 
 def hub_matrix(G, nodelist=None):
     """Returns the HITS hub matrix."""
-    M = nx.to_numpy_matrix(G, nodelist=nodelist)
-    return M * M.T
+    M = nx.to_numpy_array(G, nodelist=nodelist)
+    return M @ M.T
 
 
 def hits_numpy(G, normalized=True):

--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -70,7 +70,7 @@ def non_randomness(G, k=None):
         raise ImportError(msg) from e
 
     # eq. 4.4
-    nr = np.real(np.sum(np.linalg.eigvals(nx.to_numpy_matrix(G))[:k]))
+    nr = np.real(np.sum(np.linalg.eigvals(nx.to_numpy_array(G))[:k]))
 
     n = G.number_of_nodes()
     m = G.number_of_edges()

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -41,17 +41,18 @@ def floyd_warshall_numpy(G, nodelist=None, weight="weight"):
     try:
         import numpy as np
     except ImportError as e:
-        raise ImportError("to_numpy_matrix() requires numpy: http://numpy.org/ ") from e
+        raise ImportError("to_numpy_array() requires numpy: http://numpy.org/ ") from e
 
     # To handle cases when an edge has weight=0, we must make sure that
     # nonedges are not given the value 0 as well.
-    A = nx.to_numpy_matrix(
+    A = nx.to_numpy_array(
         G, nodelist=nodelist, multigraph_weight=min, weight=weight, nonedge=np.inf
     )
     n, m = A.shape
-    A[np.identity(n) == 1] = 0  # diagonal elements should be zero
+    np.fill_diagonal(A, 0)  # diagonal elements should be zero
     for i in range(n):
-        A = np.minimum(A, A[i, :] + A[:, i])
+        # The second term has the same shape as A due to broadcasting
+        A = np.minimum(A, A[i, :][np.newaxis, :] + A[:, i][:, np.newaxis])
     return A
 
 

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -29,25 +29,18 @@ G_array = np.array([
 ], dtype=int)
 # fmt: on
 
-# We convert to MultiDiGraph after using from_numpy_matrix
-# https://github.com/networkx/networkx/pull/1305
-
 
 def G1():
-    G = nx.DiGraph()
-    G = nx.from_numpy_matrix(G_array, create_using=G)
-    G = nx.MultiDiGraph(G)
+    G = nx.from_numpy_array(G_array, create_using=nx.MultiDiGraph)
     return G
 
 
 def G2():
     # Now we shift all the weights by -10.
     # Should not affect optimal arborescence, but does affect optimal branching.
-    G = nx.DiGraph()
     Garr = G_array.copy()
     Garr[np.nonzero(Garr)] -= 10
-    G = nx.from_numpy_matrix(Garr, create_using=G)
-    G = nx.MultiDiGraph(G)
+    G = nx.from_numpy_array(Garr, create_using=nx.MultiDiGraph)
     return G
 
 
@@ -387,8 +380,7 @@ def test_edmonds1_minbranch():
     # but with all edges negative.
     edges = [(u, v, -w) for (u, v, w) in optimal_arborescence_1]
 
-    G = nx.DiGraph()
-    G = nx.from_numpy_matrix(-G_array, create_using=G)
+    G = nx.from_numpy_array(-G_array, create_using=nx.DiGraph)
 
     # Quickly make sure max branching is empty.
     x = branchings.maximum_branching(G)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -206,7 +206,7 @@ def from_pandas_adjacency(df, create_using=None):
         raise nx.NetworkXError("Columns must match Indices.", msg) from e
 
     A = df.values
-    G = from_numpy_matrix(A, create_using=create_using)
+    G = from_numpy_array(A, create_using=create_using)
 
     nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=False)
     return G

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1,4 +1,5 @@
-"""Functions to convert NetworkX graphs to and from numpy/scipy matrices.
+"""Functions to convert NetworkX graphs to and from common data containers
+like numpy arrays, scipy sparse matrices, and pandas DataFrames.
 
 The preferred way of converting data to a NetworkX graph is through the
 graph constructor.  The constructor calls the to_networkx_graph() function
@@ -6,7 +7,7 @@ which attempts to guess the input type and convert it automatically.
 
 Examples
 --------
-Create a 10 node random graph from a numpy matrix
+Create a 10 node random graph from a numpy array
 
 >>> import numpy as np
 >>> a = np.random.randint(0, 2, size=(10, 10))
@@ -164,10 +165,10 @@ def from_pandas_adjacency(df, create_using=None):
     For directed graphs, explicitly mention create_using=nx.DiGraph,
     and entry i,j of df corresponds to an edge from i to j.
 
-    If the numpy matrix has a single data type for each matrix entry it
-    will be converted to an appropriate Python data type.
+    If `df` has a single data type for each entry it will be converted to an
+    appropriate Python data type.
 
-    If the numpy matrix has a user-specified compound data type the names
+    If `df` has a user-specified compound data type the names
     of the data fields will be used as attribute keys in the resulting
     NetworkX graph.
 
@@ -703,7 +704,7 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
     Parameters
     ----------
     G : graph
-        The NetworkX graph used to construct the NumPy matrix.
+        The NetworkX graph used to construct the NumPy recarray.
 
     nodelist : list, optional
        The rows and columns are ordered according to the nodes in `nodelist`.
@@ -726,8 +727,9 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
 
     Notes
     -----
-    When `nodelist` does not contain every node in `G`, the matrix is built
-    from the subgraph of `G` that is induced by the nodes in `nodelist`.
+    When `nodelist` does not contain every node in `G`, the adjacency
+    matrix is built from the subgraph of `G` that is induced by the nodes in
+    `nodelist`.
 
     Examples
     --------
@@ -775,7 +777,7 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
     Parameters
     ----------
     G : graph
-        The NetworkX graph used to construct the NumPy matrix.
+        The NetworkX graph used to construct the sparse matrix.
 
     nodelist : list, optional
        The rows and columns are ordered according to the nodes in `nodelist`.
@@ -809,11 +811,9 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
 
     For multiple edges the matrix values are the sums of the edge weights.
 
-    When `nodelist` does not contain every node in `G`, the matrix is built
-    from the subgraph of `G` that is induced by the nodes in `nodelist`.
-
-    Uses coo_matrix format. To convert to other formats specify the
-    format= keyword.
+    When `nodelist` does not contain every node in `G`, the adjacency matrix
+    is built from the subgraph of `G` that is induced by the nodes in
+    `nodelist`.
 
     The convention used for self-loop edges in graphs is to assign the
     diagonal matrix entry value to the weight attribute of the edge

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -49,7 +49,7 @@ def bethe_hessian_matrix(G, r=None, nodelist=None):
     See Also
     --------
     bethe_hessian_spectrum
-    to_numpy_matrix
+    to_numpy_array
     adjacency_matrix
     laplacian_matrix
 

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -126,7 +126,7 @@ def adjacency_matrix(G, nodelist=None, weight="weight"):
     sparse matrix.
 
     For MultiGraph/MultiDiGraph with parallel edges the weights are summed.
-    See to_numpy_matrix for other options.
+    See `to_numpy_array` for other options.
 
     The convention used for self-loop edges in graphs is to assign the
     diagonal matrix entry value to the edge weight attribute
@@ -145,7 +145,7 @@ def adjacency_matrix(G, nodelist=None, weight="weight"):
 
     See Also
     --------
-    to_numpy_matrix
+    to_numpy_array
     to_scipy_sparse_matrix
     to_dict_of_dicts
     adjacency_spectrum

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -42,7 +42,7 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
 
     See Also
     --------
-    to_numpy_matrix
+    to_numpy_array
     normalized_laplacian_matrix
     laplacian_spectrum
     """
@@ -91,7 +91,7 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
     Notes
     -----
     For MultiGraph/MultiDiGraph, the edges weights are summed.
-    See to_numpy_matrix for other options.
+    See to_numpy_array for other options.
 
     If the Graph contains selfloops, D is defined as diag(sum(A,1)), where A is
     the adjacency matrix [2]_.

--- a/networkx/linalg/modularitymatrix.py
+++ b/networkx/linalg/modularitymatrix.py
@@ -52,7 +52,7 @@ def modularity_matrix(G, nodelist=None, weight=None):
 
     See Also
     --------
-    to_numpy_matrix
+    to_numpy_array
     modularity_spectrum
     adjacency_matrix
     directed_modularity_matrix
@@ -126,7 +126,7 @@ def directed_modularity_matrix(G, nodelist=None, weight=None):
 
     See Also
     --------
-    to_numpy_matrix
+    to_numpy_array
     modularity_spectrum
     adjacency_matrix
     modularity_matrix

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -32,7 +32,7 @@ def laplacian_spectrum(G, weight="weight"):
     Notes
     -----
     For MultiGraph/MultiDiGraph, the edges weights are summed.
-    See to_numpy_matrix for other options.
+    See to_numpy_array for other options.
 
     See Also
     --------
@@ -63,7 +63,7 @@ def normalized_laplacian_spectrum(G, weight="weight"):
     Notes
     -----
     For MultiGraph/MultiDiGraph, the edges weights are summed.
-    See to_numpy_matrix for other options.
+    See to_numpy_array for other options.
 
     See Also
     --------
@@ -94,7 +94,7 @@ def adjacency_spectrum(G, weight="weight"):
     Notes
     -----
     For MultiGraph/MultiDiGraph, the edges weights are summed.
-    See to_numpy_matrix for other options.
+    See to_numpy_array for other options.
 
     See Also
     --------


### PR DESCRIPTION
Related to the cleanup in #3107 

Replaces all internal instances (i.e. when used in the implementation of the function, but not affecting the output - see #3107 for details) of `to_numpy_matrix` and `from_numpy_matrix` with `to_numpy_array` and `from_numpy_array`. In preparation for the deprecation of the `*_numpy_matrix` functions.

If the changes are approved, I would propose that I squash this down to 2 commits, one for doc-only changes and one for code changes.