### PR TITLE
add modularity to the docs

### DIFF
--- a/doc/reference/algorithms/community.rst
+++ b/doc/reference/algorithms/community.rst
@@ -62,6 +62,7 @@ Measuring partitions
    :toctree: generated/
 
    coverage
+   modularity
    performance
 
 Partitions via centrality measures


### PR DESCRIPTION
Fixes #4095 
modularity function was never added to docs when added to quality.py