### PR TITLE
Improve modularity calculation

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -256,8 +256,9 @@ def modularity(G, communities, weight="weight"):
 
     According to [2]_ (and verified by some algebra) this can be reduced to
 
-    .. math:: Q = \sum_{c=1}^{n}  
-    \left[ \frac{L_c}{m} - \left( \frac{k_c}{2m} \right) ^2 \right]
+    .. math:: 
+       Q = \sum_{c=1}^{n}  
+       \left[ \frac{L_c}{m} - \left( \frac{k_c}{2m} \right) ^2 \right]
 
     where the sum iterates over all communities $c$, $m$ is the number of edges,
     $L_c$ is the number of intra-community links for community $c$,
@@ -301,8 +302,8 @@ def modularity(G, communities, weight="weight"):
     .. [1] M. E. J. Newman *Networks: An Introduction*, page 224.
        Oxford University Press, 2011.
     .. [2] Clauset, Aaron, Mark EJ Newman, and Cristopher Moore.
-    "Finding community structure in very large networks."
-    Physical review E 70.6 (2004). <https://arxiv.org/abs/cond-mat/0408187>
+       "Finding community structure in very large networks."
+       Physical review E 70.6 (2004). <https://arxiv.org/abs/cond-mat/0408187>
     """
     if not isinstance(communities, list):
         communities = list(communities)

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -254,9 +254,9 @@ def modularity(G, communities, weight="weight"):
     `G`, $k_i$ is the degree of $i$ and $\delta(c_i, c_j)$
     is 1 if $i$ and $j$ are in the same community and 0 otherwise.
 
-    According to [2]_ this can be reduced to
+    According to [2]_ (and verified by some algebra) this can be reduced to
 
-    .. math:: Q = \sum_{c=1}^{n} =
+    .. math:: Q = \sum_{c=1}^{n}  
     \left[ \frac{L_c}{m} - \left( \frac{k_c}{2m} \right) ^2 \right]
 
     where the sum iterates over all communities $c$, $m$ is the number of edges,

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -272,6 +272,11 @@ def modularity(G, communities, weight="weight"):
     communities : list or iterable of set of nodes
         These node sets must represent a partition of G's nodes.
 
+    weight : string or None, optional (default="weight")
+            The edge attribute that holds the numerical value used
+            as a weight. If None or an edge does not have that attribute,
+            then that edge has weight 1.
+
     Returns
     -------
     Q : float

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -256,8 +256,8 @@ def modularity(G, communities, weight="weight"):
 
     According to [2]_ (and verified by some algebra) this can be reduced to
 
-    .. math:: 
-       Q = \sum_{c=1}^{n}  
+    .. math::
+       Q = \sum_{c=1}^{n}
        \left[ \frac{L_c}{m} - \left( \frac{k_c}{2m} \right) ^2 \right]
 
     where the sum iterates over all communities $c$, $m$ is the number of edges,
@@ -318,8 +318,9 @@ def modularity(G, communities, weight="weight"):
         norm = 1 / m ** 2
     else:
         out_degree = in_degree = dict(G.degree(weight=weight))
-        m = sum(out_degree.values()) / 2
-        norm = 1 / (2 * m) ** 2
+        deg_sum = sum(out_degree.values())
+        m = deg_sum / 2
+        norm = 1 / deg_sum ** 2
 
     def community_contribution(community):
         comm = set(community)

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -53,6 +53,22 @@ def test_modularity():
     C = [{0, 1, 2}, {3, 4, 5}]
     assert almost_equal((35 * 2) / (14 ** 2), modularity(G, C))
 
+    n = 1000
+    G = nx.erdos_renyi_graph(n, 0.09, seed=42, directed=True)
+    C = [set(range(n // 2)), set(range(n // 2, n))]
+    assert almost_equal(0.00017154251389292754, modularity(G, C))
+
+    G = nx.margulis_gabber_galil_graph(10)
+    mid_value = G.number_of_nodes() // 2
+    nodes = list(G.nodes)
+    C = [set(nodes[:mid_value]), set(nodes[mid_value:])]
+    assert almost_equal(0.13, modularity(G, C))
+
+    G = nx.DiGraph()
+    G.add_edges_from([(2, 1), (2, 3), (3, 4)])
+    C = [{1, 2}, {3, 4}]
+    assert almost_equal(2 / 9, modularity(G, C))
+
 
 def test_inter_community_edges_with_digraphs():
     G = nx.complete_graph(2, create_using=nx.DiGraph())


### PR DESCRIPTION
I've improved the runtime of the modularity calculation for a partition of a graph and simplified the function.

As mentioned in #4095 the modularity function not appearing in the documentation prompted me to implement it myself. Based on ["Finding community structure in very large networks"](https://arxiv.org/abs/cond-mat/0408187) and the lecture I was hearing at university, there is a more simplified approach to calculating the modularity of a partition of a graph. The simplification can be found in equation (7) in the [pdf of the paper](https://arxiv.org/pdf/cond-mat/0408187.pdf).

The simplified calculation seems to run 3 times as fast as the original function on some graphs, at least judging based on one test on [this commit](https://github.com/bernwaldl/networkx/commit/a7f5a5247392f47f03918c36be92c361f6cc23b2) in [this branch](https://github.com/bernwaldl/networkx/tree/time_measurement).

![image](https://user-images.githubusercontent.com/4204375/88311227-e9913580-cd10-11ea-82a3-a80063a34946.png)

As far as I can tell the calculation should also work for multi graphs and directed graphs. I've added multi and directed graphs in the tests and the new function returns, besides some very small rounding errors, the same as the old function. I am, however, not 100% positive, whether it yields the same result for all multi and directed graphs.

As this is my first pull request in the networkx repository, feedback is greatly appreciated 😃 


