### PR TITLE
Add max_weight_clique to doc

### DIFF
--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -178,6 +178,7 @@ is partially historical, and now, mostly arbitrary.
 - Ryan Duve
 - Shashi Prakash Tripathi, Github `<https://github.com/itsshavar>`_,LinkedIn `<https://www.linkedin.com/in/itsshashitripathi/>`_
 - Danny Niquette
+- James Trimble, Github: `jamestrimble <https://github.com/jamestrimble>`_
 
 Support
 -------

--- a/doc/reference/algorithms/clique.rst
+++ b/doc/reference/algorithms/clique.rst
@@ -15,3 +15,4 @@ Clique
    node_clique_number
    number_of_cliques
    cliques_containing_node
+   max_weight_clique

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -662,9 +662,9 @@ class MaxWeightClique(object):
 def max_weight_clique(G, weight='weight'):
     """Find a maximum weight clique in G.
 
-    A _clique_ in a graph is a set of nodes such that every two distinct nodes
-    are adjacent.  The _weight_ of a clique is the sum of the weights of its
-    nodes.  A _maximum weight clique_ of graph G is a clique C in G such that
+    A *clique* in a graph is a set of nodes such that every two distinct nodes
+    are adjacent.  The *weight* of a clique is the sum of the weights of its
+    nodes.  A *maximum weight clique* of graph G is a clique C in G such that
     no clique in G has weight greater than the weight of C.
 
     Parameters
@@ -693,19 +693,19 @@ def max_weight_clique(G, weight='weight'):
     nodes on which to branch.  The algorithm is very similar to the algorithm
     of Tavares et al. [1]_, other than the fact that the NetworkX version does
     not use bitsets.  This style of algorithm for maximum weight clique (and
-    maximum independent set, which is the same problem but on the complement
-    graph) has a decades-long history.  See Algorithm B of Warren and Hicks
-    [2]_ and the references in that paper.
+    maximum weight independent set, which is the same problem but on the
+    complement graph) has a decades-long history.  See Algorithm B of Warren
+    and Hicks [2]_ and the references in that paper.
 
     References
     ----------
-    [1] Tavares, W.A., Neto, M.B.C., Rodrigues, C.D., Michelon, P.: Um
-    algoritmo de branch and bound para o problema da clique máxima ponderada.
-    Proceedings of XLVII SBPO 1 (2015).
+    .. [1] Tavares, W.A., Neto, M.B.C., Rodrigues, C.D., Michelon, P.: Um
+           algoritmo de branch and bound para o problema da clique máxima
+           ponderada.  Proceedings of XLVII SBPO 1 (2015).
 
-    [2] Warrent, Jeffrey S, Hicks, Illya V.: Combinatorial Branch-and-Bound for
-    the Maximum Weight Independent Set Problem.  Technical Report, Texas A&M
-    University (2016).
+    .. [2] Warrent, Jeffrey S, Hicks, Illya V.: Combinatorial Branch-and-Bound
+           for the Maximum Weight Independent Set Problem.  Technical Report,
+           Texas A&M University (2016).
     """
 
     mwc = MaxWeightClique(G, weight)


### PR DESCRIPTION
I forgot to add the max_weight_clique function (#4016) to the documentation, so I have added it in this pull request. I have made a few minor changes to the function's docstring, such as correcting the syntax for italics and references. I have also also added my name to the list of contributors.

I'd also like to say a quick "thank you" to @dschult and @jarrodmillman for reviewing and merging my code in #4016. This was my first contribution to a large piece of software, and it has been an enjoyable experience.