### PR TITLE
Add team gallery

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -8,16 +8,16 @@
 }
 
 .team-member-photo {
+    display: block;
 }
 
 .team-member-photo img {
     width: 60px;
     border-radius: 50%;
+    margin-bottom: 0.5rem;
 }
 
 .team-member-name {
-    display: block;
-    margin-top: 0.5rem;
     font-weight: bold;
 }
 

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,0 +1,26 @@
+.team-member {
+    display: inline-block;
+    padding: 1rem;
+    margin: 0.25rem;
+    width: 7rem;
+    text-align: center;
+    vertical-align: top;
+}
+
+.team-member-photo {
+}
+
+.team-member-photo img {
+    width: 60px;
+    border-radius: 50%;
+}
+
+.team-member-name {
+    display: block;
+    margin-top: 0.5rem;
+    font-weight: bold;
+}
+
+.team-member-handle {
+    display: none;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -203,6 +203,6 @@ default_role = "obj"
 numpydoc_show_class_members = False
 
 
-# Add the 'copybutton' javascript, to hide/show the prompt in code examples
 def setup(app):
+    app.add_css_file("custom.css")
     app.add_js_file("copybutton.js")

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -6,6 +6,8 @@ and has been developed with the help of many others. Thanks to everyone who has
 improved NetworkX by contributing code, bug reports (and fixes), documentation,
 and input on design, features, and the future of NetworkX.
 
+.. include:: team.rst 
+
 Contributions
 -------------
 

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -1,5 +1,5 @@
-Credits
-=======
+About Us
+========
 
 NetworkX was originally written by Aric Hagberg, Dan Schult, and Pieter Swart,
 and has been developed with the help of many others. Thanks to everyone who has
@@ -8,53 +8,13 @@ and input on design, features, and the future of NetworkX.
 
 .. include:: team.rst 
 
-Contributions
--------------
-
-This section aims to provide a list of people and projects that have
-contributed to ``networkx``. It is intended to be an *inclusive* list, and
-anyone who has contributed and wishes to make that contribution known is
-welcome to add an entry into this file.  Generally, no name should be added to
-this list without the approval of the person associated with that name.
-
-Creating a comprehensive list of contributors can be difficult, and the list
-within this file is almost certainly incomplete.  Contributors include
-testers, bug reporters, contributors who wish to remain anonymous, funding
-sources, academic advisors, end users, and even build/integration systems (such
-as `TravisCI <https://travis-ci.org>`_).
-
-Do you want to make your contribution known? If you have commit access, edit
-this file and add your name. If you do not have commit access, feel free to
-open an `issue <https://github.com/networkx/networkx/issues/new>`_, submit a
-`pull request <https://github.com/networkx/networkx/compare/>`_, or get in
-contact with one of the official team
-`members <https://github.com/networkx?tab=members>`_.
-
-A supplementary (but still incomplete) list of contributors is given by the
-list of names that have commits in ``networkx``'s
-`git <http://git-scm.com>`_ repository. This can be obtained via::
-
-    git log --raw | grep "^Author: " | sort | uniq
-
-A historical, partial listing of contributors and their contributions to some
-of the earlier versions of NetworkX can be found
-`here <https://github.com/networkx/networkx/blob/886e790437bcf30e9f58368829d483efef7a2acc/doc/source/reference/credits_old.rst>`_.
-
-
-Original Authors
-^^^^^^^^^^^^^^^^
-
-| Aric Hagberg
-| Dan Schult
-| Pieter Swart
-|
-
-
 Contributors
-^^^^^^^^^^^^
+------------
 
-Optionally, add your desired name and include a few relevant links. The order
-is partially historical, and now, mostly arbitrary.
+If you are a NetworkX contributor, please feel free to
+open an `issue <https://github.com/networkx/networkx/issues/new>`_ or
+submit a `pull request <https://github.com/networkx/networkx/compare/>`_
+to add your name to the bottom of the list.
 
 - Aric Hagberg, GitHub: `hagberg <https://github.com/hagberg>`_
 - Dan Schult, GitHub: `dschult <https://github.com/dschult>`_
@@ -182,19 +142,21 @@ is partially historical, and now, mostly arbitrary.
 - Danny Niquette
 - James Trimble, Github: `jamestrimble <https://github.com/jamestrimble>`_
 
+A supplementary (but still incomplete) list of contributors is given by the
+list of names that have commits in ``networkx``'s
+`git <http://git-scm.com>`_ repository. This can be obtained via::
+
+    git log --raw | grep "^Author: " | sort | uniq
+
+A historical, partial listing of contributors and their contributions to some
+of the earlier versions of NetworkX can be found
+`here <https://github.com/networkx/networkx/blob/886e790437bcf30e9f58368829d483efef7a2acc/doc/source/reference/credits_old.rst>`_.
+
+
 Support
 -------
 
-``networkx`` and those who have contributed to ``networkx`` have received
-support throughout the years from a variety of sources.  We list them below.
-If you have provided support to ``networkx`` and a support acknowledgment does
-not appear below, please help us remedy the situation, and similarly, please
-let us know if you'd like something modified or corrected.
-
-Research Groups
-^^^^^^^^^^^^^^^
-
-``networkx`` acknowledges support from the following:
+NetworkX acknowledges support from the following research groups:
 
 - `Center for Nonlinear Studies <http://cnls.lanl.gov>`_, Los Alamos National
   Laboratory, PI: Aric Hagberg
@@ -209,10 +171,7 @@ Research Groups
   Wisconsin Institute for Discovery, University of Wisconsin-Madison,
   PIs: Jessica C. Flack and David C. Krakauer
 
-Funding
-^^^^^^^
-
-``networkx`` acknowledges support from the following:
+NetworkX acknowledges the following financial support:
 
 - Google Summer of Code via Python Software Foundation
 

--- a/doc/team.rst
+++ b/doc/team.rst
@@ -1,0 +1,181 @@
+
+Our Team
+--------
+
+Along with a large community of contributors, NetworkX development
+is guided by the following core team:
+
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/569654?u=c29b79275293c22fa3c56a06ed04e004465ef331&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/boothby" class="team-member-name">Kelly Boothby</a>
+     <div class="team-member-handle">@boothby</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/2896301?u=bd57c546510c131f4f7f41e3999fb8e6e33a2298&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/camillescott" class="team-member-name">Camille Scott</a>
+     <div class="team-member-handle">@camillescott</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/915037?u=6a27f396c666c5c2172a1cfc7b0d4bbcd0069eed&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/dschult" class="team-member-name">Dan Schult</a>
+     <div class="team-member-handle">@dschult</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars0.githubusercontent.com/u/2631566?u=c5d73d769c251a862d7d4bbf1119297d8085c34c&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/ericmjl" class="team-member-name">Eric Ma</a>
+     <div class="team-member-handle">@ericmjl</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/187875?v=4&s=40"/>
+     </div>
+     <a href="https://github.com/hagberg" class="team-member-name">Aric Hagberg</a>
+     <div class="team-member-handle">@hagberg</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars1.githubusercontent.com/u/123428?v=4&s=40"/>
+     </div>
+     <a href="https://github.com/jarrodmillman" class="team-member-name">Jarrod Millman</a>
+     <div class="team-member-handle">@jarrodmillman</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars1.githubusercontent.com/u/5363860?u=ce5c6e9388d2fd153ebf8b0bb521c928b0813608&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/MridulS" class="team-member-name">Mridul Seth</a>
+     <div class="team-member-handle">@MridulS</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/1268991?u=974707b96081a9705f3a239c0773320f353ee02f&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/rossbar" class="team-member-name">Ross Barnowski</a>
+     <div class="team-member-handle">@rossbar</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/stefanv" class="team-member-name">Stefan van der Walt</a>
+     <div class="team-member-handle">@stefanv</div>
+   </div>
+
+
+
+Emeritus Developers
+-------------------
+
+We thank these previously-active core developers for their contributions to NetworkX.
+
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars0.githubusercontent.com/u/726274?u=e493f38cb65425f6de7a9568ee3802a183deaa8e&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/bjedwards" class="team-member-name">Benjamin Edwards</a>
+     <div class="team-member-handle">@bjedwards</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/326005?u=a5a33cadf55b2fbdd8b033517f97f763563aa72a&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/chebee7i" class="team-member-name">None</a>
+     <div class="team-member-handle">@chebee7i</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars0.githubusercontent.com/u/121755?v=4&s=40"/>
+     </div>
+     <a href="https://github.com/jfinkels" class="team-member-name">None</a>
+     <div class="team-member-handle">@jfinkels</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/1184374?v=4&s=40"/>
+     </div>
+     <a href="https://github.com/jtorrents" class="team-member-name">Jordi Torrents</a>
+     <div class="team-member-handle">@jtorrents</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/812562?v=4&s=40"/>
+     </div>
+     <a href="https://github.com/loicseguin" class="team-member-name">Loïc Séguin-Charbonneau</a>
+     <div class="team-member-handle">@loicseguin</div>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/7018196?v=4&s=40"/>
+     </div>
+     <a href="https://github.com/ysitu" class="team-member-name">None</a>
+     <div class="team-member-handle">@ysitu</div>
+   </div>
+

--- a/doc/team.rst
+++ b/doc/team.rst
@@ -1,19 +1,24 @@
 
-Our Team
---------
+Core Developers
+---------------
 
-Along with a large community of contributors, NetworkX development
-is guided by the following core team:
+NetworkX development is guided by the following core team:
 
 
 
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/569654?u=c29b79275293c22fa3c56a06ed04e004465ef331&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/boothby" class="team-member-name">Kelly Boothby</a>
+     <a href="https://github.com/boothby" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/569654?u=c29b79275293c22fa3c56a06ed04e004465ef331&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @boothby"
+           />
+        </div>
+        Kelly Boothby
+     </a>
      <div class="team-member-handle">@boothby</div>
    </div>
 
@@ -21,10 +26,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/2896301?u=bd57c546510c131f4f7f41e3999fb8e6e33a2298&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/camillescott" class="team-member-name">Camille Scott</a>
+     <a href="https://github.com/camillescott" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/2896301?u=bd57c546510c131f4f7f41e3999fb8e6e33a2298&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @camillescott"
+           />
+        </div>
+        Camille Scott
+     </a>
      <div class="team-member-handle">@camillescott</div>
    </div>
 
@@ -32,10 +43,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/915037?u=6a27f396c666c5c2172a1cfc7b0d4bbcd0069eed&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/dschult" class="team-member-name">Dan Schult</a>
+     <a href="https://github.com/dschult" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/915037?u=6a27f396c666c5c2172a1cfc7b0d4bbcd0069eed&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @dschult"
+           />
+        </div>
+        Dan Schult
+     </a>
      <div class="team-member-handle">@dschult</div>
    </div>
 
@@ -43,10 +60,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars0.githubusercontent.com/u/2631566?u=c5d73d769c251a862d7d4bbf1119297d8085c34c&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/ericmjl" class="team-member-name">Eric Ma</a>
+     <a href="https://github.com/ericmjl" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/2631566?u=c5d73d769c251a862d7d4bbf1119297d8085c34c&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @ericmjl"
+           />
+        </div>
+        Eric Ma
+     </a>
      <div class="team-member-handle">@ericmjl</div>
    </div>
 
@@ -54,10 +77,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/187875?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/hagberg" class="team-member-name">Aric Hagberg</a>
+     <a href="https://github.com/hagberg" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/187875?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @hagberg"
+           />
+        </div>
+        Aric Hagberg
+     </a>
      <div class="team-member-handle">@hagberg</div>
    </div>
 
@@ -65,10 +94,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars1.githubusercontent.com/u/123428?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/jarrodmillman" class="team-member-name">Jarrod Millman</a>
+     <a href="https://github.com/jarrodmillman" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars1.githubusercontent.com/u/123428?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @jarrodmillman"
+           />
+        </div>
+        Jarrod Millman
+     </a>
      <div class="team-member-handle">@jarrodmillman</div>
    </div>
 
@@ -76,10 +111,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars1.githubusercontent.com/u/5363860?u=ce5c6e9388d2fd153ebf8b0bb521c928b0813608&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/MridulS" class="team-member-name">Mridul Seth</a>
+     <a href="https://github.com/MridulS" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars1.githubusercontent.com/u/5363860?u=ce5c6e9388d2fd153ebf8b0bb521c928b0813608&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @MridulS"
+           />
+        </div>
+        Mridul Seth
+     </a>
      <div class="team-member-handle">@MridulS</div>
    </div>
 
@@ -87,10 +128,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/1268991?u=974707b96081a9705f3a239c0773320f353ee02f&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/rossbar" class="team-member-name">Ross Barnowski</a>
+     <a href="https://github.com/rossbar" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/1268991?u=974707b96081a9705f3a239c0773320f353ee02f&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @rossbar"
+           />
+        </div>
+        Ross Barnowski
+     </a>
      <div class="team-member-handle">@rossbar</div>
    </div>
 
@@ -98,10 +145,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/stefanv" class="team-member-name">Stefan van der Walt</a>
+     <a href="https://github.com/stefanv" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @stefanv"
+           />
+        </div>
+        Stefan van der Walt
+     </a>
      <div class="team-member-handle">@stefanv</div>
    </div>
 
@@ -117,10 +170,16 @@ We thank these previously-active core developers for their contributions to Netw
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars0.githubusercontent.com/u/726274?u=e493f38cb65425f6de7a9568ee3802a183deaa8e&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/bjedwards" class="team-member-name">Benjamin Edwards</a>
+     <a href="https://github.com/bjedwards" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/726274?u=e493f38cb65425f6de7a9568ee3802a183deaa8e&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @bjedwards"
+           />
+        </div>
+        Benjamin Edwards
+     </a>
      <div class="team-member-handle">@bjedwards</div>
    </div>
 
@@ -128,10 +187,16 @@ We thank these previously-active core developers for their contributions to Netw
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/326005?u=a5a33cadf55b2fbdd8b033517f97f763563aa72a&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/chebee7i" class="team-member-name">None</a>
+     <a href="https://github.com/chebee7i" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/326005?u=a5a33cadf55b2fbdd8b033517f97f763563aa72a&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @chebee7i"
+           />
+        </div>
+        @chebee7i
+     </a>
      <div class="team-member-handle">@chebee7i</div>
    </div>
 
@@ -139,10 +204,16 @@ We thank these previously-active core developers for their contributions to Netw
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars0.githubusercontent.com/u/121755?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/jfinkels" class="team-member-name">None</a>
+     <a href="https://github.com/jfinkels" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/121755?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @jfinkels"
+           />
+        </div>
+        @jfinkels
+     </a>
      <div class="team-member-handle">@jfinkels</div>
    </div>
 
@@ -150,10 +221,16 @@ We thank these previously-active core developers for their contributions to Netw
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/1184374?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/jtorrents" class="team-member-name">Jordi Torrents</a>
+     <a href="https://github.com/jtorrents" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/1184374?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @jtorrents"
+           />
+        </div>
+        Jordi Torrents
+     </a>
      <div class="team-member-handle">@jtorrents</div>
    </div>
 
@@ -161,10 +238,16 @@ We thank these previously-active core developers for their contributions to Netw
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/812562?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/loicseguin" class="team-member-name">Loïc Séguin-Charbonneau</a>
+     <a href="https://github.com/loicseguin" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/812562?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @loicseguin"
+           />
+        </div>
+        Loïc Séguin-Charbonneau
+     </a>
      <div class="team-member-handle">@loicseguin</div>
    </div>
 
@@ -172,10 +255,16 @@ We thank these previously-active core developers for their contributions to Netw
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/7018196?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/ysitu" class="team-member-name">None</a>
+     <a href="https://github.com/ysitu" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/7018196?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @ysitu"
+           />
+        </div>
+        @ysitu
+     </a>
      <div class="team-member-handle">@ysitu</div>
    </div>
 

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -20,7 +20,11 @@ if token is None:
 
 
 def api(url):
-    return requests.get(url=url, headers={"Authorization": f"token {token}"}).json()
+    json = requests.get(url=url, headers={"Authorization": f"token {token}"}).json()
+    if "message" in json and json["message"] == "Bad credentials":
+        raise RuntimeError("Invalid token provided")
+    else:
+        return json
 
 
 resp = api(core_url)

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -39,10 +39,16 @@ def render_team(team):
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="{member['avatar_url']}&s=40"/>
-     </div>
-     <a href="https://github.com/{member['login']}" class="team-member-name">{profile['name']}</a>
+     <a href="https://github.com/{member['login']}" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="{member['avatar_url']}&s=40"
+             loading="lazy"
+             alt="Avatar picture of @{profile['login']}"
+           />
+        </div>
+        {profile['name'] if profile['name'] else '@' + profile['login']}
+     </a>
      <div class="team-member-handle">@{member['login']}</div>
    </div>
 """
@@ -51,11 +57,10 @@ def render_team(team):
 
 print(
     """
-Our Team
---------
+Core Developers
+---------------
 
-Along with a large community of contributors, NetworkX development
-is guided by the following core team:
+NetworkX development is guided by the following core team:
 
 """
 )

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import requests
+
+
+project = "networkx"
+core = "core-developers"
+emeritus = "emeritus-developers"
+core_url = f"https://api.github.com/orgs/{project}/teams/{core}/members"
+emeritus_url = f"https://api.github.com/orgs/{project}/teams/{emeritus}/members"
+
+
+token = os.environ.get("GH_TOKEN", None)
+if token is None:
+    print(
+        "No token found.  Please export a GH_TOKEN with permissions "
+        "to read team members."
+    )
+    sys.exit(-1)
+
+
+def api(url):
+    return requests.get(url=url, headers={"Authorization": f"token {token}"}).json()
+
+
+resp = api(core_url)
+core = sorted(resp, key=lambda user: user["login"].lower())
+
+resp = api(emeritus_url)
+emeritus = sorted(resp, key=lambda user: user["login"].lower())
+
+
+def render_team(team):
+    for member in team:
+        profile = api(member["url"])
+
+        print(
+            f"""
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="{member['avatar_url']}&s=40"/>
+     </div>
+     <a href="https://github.com/{member['login']}" class="team-member-name">{profile['name']}</a>
+     <div class="team-member-handle">@{member['login']}</div>
+   </div>
+"""
+        )
+
+
+print(
+    """
+Our Team
+--------
+
+Along with a large community of contributors, NetworkX development
+is guided by the following core team:
+
+"""
+)
+
+render_team(core)
+
+print(
+    """
+
+Emeritus Developers
+-------------------
+
+We thank these previously-active core developers for their contributions to NetworkX.
+
+"""
+)
+
+render_team(emeritus)


### PR DESCRIPTION
The ``team.rst`` page is generate from the NetworkX GitHub teams via:
```
python tools/team_list.py > doc/team.rst
```

Eventually I will add it to Travis-CI.   It needs some minor fixes and we may want to put it somewhere else.  This is based on:
https://github.com/scikit-image/scikit-image-web/pull/69