### PR TITLE
CI: Setup circle CI for documentation builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@0.2.1
+
+jobs:
+  build-and-test:
+    executor: python/default
+    steps:
+      - checkout
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
+      - run:
+          command: ./manage.py test
+          name: Test
+
+workflows:
+  main:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ jobs:
             pip install pydot pygraphviz
 
       - run:
+          name: install
+          command: |
+            source venv/bin/activate
+            pip install -e .
+
+      - run:
           name: build_docs
           command: |
             source venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,35 @@
-version: 2.1
+# See: https://circleci.com/docs/2.0/language-python/
 
-orbs:
-  python: circleci/python@0.2.1
-
+version: 2
 jobs:
-  build-and-test:
-    executor: python/default
+  build:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/python:3.8.2
+
     steps:
       - checkout
-      - python/load-cache
-      - python/install-deps
-      - python/save-cache
-      - run:
-          command: ./manage.py test
-          name: Test
 
-workflows:
-  main:
-    jobs:
-      - build-and-test
+      - run:
+          name: install_graphviz
+          command: |
+            sudo apt-get install graphviz
+
+      - run:
+          name: install_dependencies
+          command: |
+            python3 -m venv venv
+            source venv/bin/activate
+            pip install -r requirements.txt
+            pip install -r requirements/doc.txt
+            pip install -r requirements/optional.txt
+            pip install pydot pygraphviz
+
+      - run:
+          name: build_docs
+          command: |
+            source venv/bin/activate
+            make -C doc/ html
+
+      - store_artifacts:
+          path: _build/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: install_graphviz
           command: |
-            sudo apt-get install graphviz
+            sudo apt-get install graphviz libgraphviz-dev
 
       - run:
           name: install_dependencies

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifact redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/_build/html/index.html
+          circleci-jobs: build

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -8,5 +8,5 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/_build/html/index.html
+          artifact-path: 0/doc/build/html/index.html
           circleci-jobs: build


### PR DESCRIPTION
First part of addressing #4118 - this PR adds a circleCI config defining a workflow for building the documentation. Note that this workflow is *only* for documentation building - testing remains on travis.

Note: I set this up within the NetworkX organization so that all members of the organization *should* have full access on CircleCI to modify settings etc. This will likely require some additional tweaking but if there are access problems please let me know.