### PR TITLE
Fix parse_edgelist behavior with multiple attributes

### DIFF
--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -270,7 +270,11 @@ def parse_edgelist(
         elif data is True:
             # no edge types specified
             try:  # try to evaluate as dictionary
-                edgedata = dict(literal_eval(" ".join(d)))
+                if delimiter == ",":
+                    edgedata_str = ",".join(d)
+                else:
+                    edgedata_str = " ".join(d)
+                edgedata = dict(literal_eval(edgedata_str.strip()))
             except BaseException as e:
                 raise TypeError(
                     f"Failed to convert edge data ({d}) " f"to dictionary."

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -114,11 +114,14 @@ class TestEdgelist:
         bytesIO = io.BytesIO(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
         assert_edges_equal(
-                G.edges(data=True), [(1, 2, {"weight": 2.0, "color":"green"}),
-                    (2, 3, {"weight": 3.0, "color":"red"})]
+            G.edges(data=True),
+            [
+                (1, 2, {"weight": 2.0, "color": "green"}),
+                (2, 3, {"weight": 3.0, "color": "red"}),
+            ],
         )
 
-    def test_read_edgelist_5(self):
+    def test_read_edgelist_6(self):
         s = b"""\
 # comment line
 1, 2, {'weight':2.0, 'color':'green'}
@@ -132,8 +135,11 @@ class TestEdgelist:
         bytesIO = io.BytesIO(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=True, delimiter=",")
         assert_edges_equal(
-                G.edges(data=True), [(1, 2, {"weight": 2.0, "color":"green"}),
-                    (2, 3, {"weight": 3.0, "color":"red"})]
+            G.edges(data=True),
+            [
+                (1, 2, {"weight": 2.0, "color": "green"}),
+                (2, 3, {"weight": 3.0, "color": "red"}),
+            ],
         )
 
     def test_write_edgelist_1(self):

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -100,6 +100,42 @@ class TestEdgelist:
             G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
         )
 
+    def test_read_edgelist_5(self):
+        s = b"""\
+# comment line
+1 2 {'weight':2.0, 'color':'green'}
+# comment line
+2 3 {'weight':3.0, 'color':'red'}
+"""
+        bytesIO = io.BytesIO(s)
+        G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
+        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
+
+        bytesIO = io.BytesIO(s)
+        G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
+        assert_edges_equal(
+                G.edges(data=True), [(1, 2, {"weight": 2.0, "color":"green"}),
+                    (2, 3, {"weight": 3.0, "color":"red"})]
+        )
+
+    def test_read_edgelist_5(self):
+        s = b"""\
+# comment line
+1, 2, {'weight':2.0, 'color':'green'}
+# comment line
+2, 3, {'weight':3.0, 'color':'red'}
+"""
+        bytesIO = io.BytesIO(s)
+        G = nx.read_edgelist(bytesIO, nodetype=int, data=False, delimiter=",")
+        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
+
+        bytesIO = io.BytesIO(s)
+        G = nx.read_edgelist(bytesIO, nodetype=int, data=True, delimiter=",")
+        assert_edges_equal(
+                G.edges(data=True), [(1, 2, {"weight": 2.0, "color":"green"}),
+                    (2, 3, {"weight": 3.0, "color":"red"})]
+        )
+
     def test_write_edgelist_1(self):
         fh = io.BytesIO()
         G = nx.OrderedGraph()


### PR DESCRIPTION
Fixes #4116 

Multiple edge attributes are now parsed correctly. Additional test cases have been added.