### PR TITLE
CI: hypothetical fix for CI latex installation issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/python:3.8.2
+      - image: circleci/python:3.8.3-buster
 
     steps:
       - checkout


### PR DESCRIPTION
The CircleCI build intermittently fails to install the necessary dependencies for building the latex doc via the container's package manager (`apt-get`). This PR switches to a more modern version of Debian with the hope that the base-OS package management will be more reliable. 