### PR TITLE
CI: Configure circleCI to deploy docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,51 @@ jobs:
 
       - store_artifacts:
           path: doc/build/html
+
+      - persist_to_workspace:
+          root: doc/build
+          paths:
+            - html
+
+  deploy:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/python:3.8.3-buster
+    steps:
+
+      - attach_workspace:
+        at: /tmp/build
+
+      - add_ssh_keys:
+          fingerprints:
+            - "e5:04:e6:c4:d6:c3:34:b9:02:e6:9f:25:1c:01:9e:e9"
+
+      - run:
+        name: install_dependencies
+        command: |
+          pip install --user ghp-import
+
+      - run:
+        name: upload_devdocs
+        command: |
+          set -e
+          git clone git@github.com:networkx/documentation.git
+          cd documentation/latest
+          cp -R /tmp/build/html/. .
+          git config --global user.email "networkx-circleci-bot@nomail"
+          git config --global user.name "networkx-circleci-bot"
+          git config --global push.default simple;
+          git commit -am "Docs built from $CIRCLE_SHA1"
+          ghp-import -n -f -p --remote=origin --branch=gh-pages .
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,22 +67,19 @@ jobs:
             - "e5:04:e6:c4:d6:c3:34:b9:02:e6:9f:25:1c:01:9e:e9"
 
       - run:
-          name: install_dependencies
-          command: |
-            pip install --user ghp-import
-
-      - run:
           name: upload_devdocs
           command: |
             set -e
             git clone git@github.com:networkx/documentation.git
-            cd documentation/latest
-            cp -R /tmp/build/html/. .
+            cd documentation
+            rm -rf latest
+            cp -R /tmp/build/html latest
+            touch latest/.nojekyll
             git config --global user.email "networkx-circleci-bot@nomail"
             git config --global user.name "networkx-circleci-bot"
             git config --global push.default simple;
             git commit -am "Docs built from $CIRCLE_SHA1"
-            ghp-import -n -f -p --remote=origin --branch=gh-pages .
+            git push origin gh-pages
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
             cd documentation
             rm -rf latest
             cp -R /tmp/build/html latest
-            touch latest/.nojekyll
             git config --global user.email "networkx-circleci-bot@nomail"
             git config --global user.name "networkx-circleci-bot"
             git config --global push.default simple;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,32 +57,32 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: circleci/python:3.8.3-buster
-    steps:
 
+    steps:
       - attach_workspace:
-        at: /tmp/build
+          at: /tmp/build
 
       - add_ssh_keys:
           fingerprints:
             - "e5:04:e6:c4:d6:c3:34:b9:02:e6:9f:25:1c:01:9e:e9"
 
       - run:
-        name: install_dependencies
-        command: |
-          pip install --user ghp-import
+          name: install_dependencies
+          command: |
+            pip install --user ghp-import
 
       - run:
-        name: upload_devdocs
-        command: |
-          set -e
-          git clone git@github.com:networkx/documentation.git
-          cd documentation/latest
-          cp -R /tmp/build/html/. .
-          git config --global user.email "networkx-circleci-bot@nomail"
-          git config --global user.name "networkx-circleci-bot"
-          git config --global push.default simple;
-          git commit -am "Docs built from $CIRCLE_SHA1"
-          ghp-import -n -f -p --remote=origin --branch=gh-pages .
+          name: upload_devdocs
+          command: |
+            set -e
+            git clone git@github.com:networkx/documentation.git
+            cd documentation/latest
+            cp -R /tmp/build/html/. .
+            git config --global user.email "networkx-circleci-bot@nomail"
+            git config --global user.name "networkx-circleci-bot"
+            git config --global push.default simple;
+            git commit -am "Docs built from $CIRCLE_SHA1"
+            ghp-import -n -f -p --remote=origin --branch=gh-pages .
 
 workflows:
   version: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,6 @@ matrix:
       python: 3.7
       env:
       - OPTIONAL_DEPS=1
-      - BUILD_DOCS=1
-      - DEPLOY_DOCS=1
-      addons:
-        apt:
-          packages:
-          - libgdal-dev
-          - graphviz
-          - texlive
-          - texlive-latex-extra
-          - latexmk
-    - os: linux
-      python: 3.7
-      env:
-      - OPTIONAL_DEPS=1
       - PIP_FLAGS="--pre"
       addons:
         apt:


### PR DESCRIPTION
Closes #4118 - configure CircleCI to deploy the development documentation. Largely drawn from the doc deployment configuration for [scipy](https://github.com/scipy/scipy/blob/master/.circleci/config.yml).

Other tasks (beyond reviewing the proposed configuration) to be done before removing draft status:
 - [x] remove doc deployment from travis CI