### PR TITLE
MAINT: Switch to abc-based isinstance checks in to_networkx_graph

### DIFF
--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -51,7 +51,9 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
          any NetworkX graph
          dict-of-dicts
          dict-of-lists
-         container (ie set, list, tuple, iterator) of edges
+         container (e.g. set, list, tuple) of edges
+         iterator (e.g. itertools.chain) that produces edges
+         generator of edges
          Pandas DataFrame (row per edge)
          numpy matrix
          numpy ndarray


### PR DESCRIPTION
Refactors `to_networkx_graph` to use ABCs from `collections.abc` for the `isinstance` checks which map the input data to the corresponding sub-function that does the conversion. The main improvement is that this replaces a hand-curated list of types (list, set, tuple, etc.) with the more general ABCs. A couple points that need special attention:
 - I removed the `hasattr` checks for `_adjdict` and `next` though I'm not sure which kinds of objects they were designed to check. The test suite didn't complain about this, but if there are objects/types that depended on these (that perhaps aren't tested) please LMK.
 - The execution order has to be modified for this check to work. Since the ABC-based check is the most general, I moved it to the last `if` (right before the final `raise` when the input type isn't recognized). 

Closes #3945 

