### PR TITLE
NX 3.0: changed return type of directed_combinatorial_laplacian to SciPy Sparse Matrix

### DIFF
--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -272,8 +272,9 @@ def directed_combinatorial_laplacian_matrix(
     """
     from scipy.sparse import spdiags, linalg
 
-    P = _transition_matrix(G, nodelist=nodelist, weight=weight,
-                           walk_type=walk_type, alpha=alpha)
+    P = _transition_matrix(
+        G, nodelist=nodelist, weight=weight, walk_type=walk_type, alpha=alpha
+    )
 
     n, m = P.shape
 
@@ -348,7 +349,7 @@ def _transition_matrix(G, nodelist=None, weight="weight", walk_type=None, alpha=
 
     elif walk_type == "pagerank":
         if not (0 < alpha < 1):
-            raise nx.NetworkXError('alpha must be between 0 and 1')
+            raise nx.NetworkXError("alpha must be between 0 and 1")
         # add constant to dangling nodes' row
         dangling = sp.where(M.sum(axis=1) == 0)
         for d in dangling[0]:

--- a/networkx/linalg/tests/test_laplacian.py
+++ b/networkx/linalg/tests/test_laplacian.py
@@ -177,7 +177,9 @@ class TestLaplacian:
                        [-0.0027, -0.0069, -0.0027, -0.2187, -0.0505, 0.2815]])
         # fmt: on
 
-        L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G)).toarray()
+        L = nx.directed_combinatorial_laplacian_matrix(
+            G, alpha=0.9, nodelist=sorted(G)
+        ).toarray()
         npt.assert_almost_equal(L, GL, decimal=3)
 
         # Make the graph strongly connected, so we can use a random and lazy walk

--- a/networkx/linalg/tests/test_laplacian.py
+++ b/networkx/linalg/tests/test_laplacian.py
@@ -177,7 +177,7 @@ class TestLaplacian:
                        [-0.0027, -0.0069, -0.0027, -0.2187, -0.0505, 0.2815]])
         # fmt: on
 
-        L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
+        L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G)).toarray()
         npt.assert_almost_equal(L, GL, decimal=3)
 
         # Make the graph strongly connected, so we can use a random and lazy walk
@@ -194,7 +194,7 @@ class TestLaplacian:
 
         L = nx.directed_combinatorial_laplacian_matrix(
             G, alpha=0.9, nodelist=sorted(G), walk_type="random"
-        )
+        ).toarray()
         npt.assert_almost_equal(L, GL, decimal=3)
 
         # fmt: off
@@ -208,11 +208,11 @@ class TestLaplacian:
 
         L = nx.directed_combinatorial_laplacian_matrix(
             G, alpha=0.9, nodelist=sorted(G), walk_type="lazy"
-        )
+        ).toarray()
         npt.assert_almost_equal(L, GL, decimal=3)
 
         E = nx.DiGraph(margulis_gabber_galil_graph(2))
-        L = nx.directed_combinatorial_laplacian_matrix(E)
+        L = nx.directed_combinatorial_laplacian_matrix(E).toarray()
         # fmt: off
         expected = np.array(
             [[ 0.16666667, -0.08333333, -0.08333333,  0.        ],


### PR DESCRIPTION
This is a change for nx 3.0.