### PR TITLE
Update apt-get on circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,23 +5,28 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/python:3.8.3-buster
+      - image: circleci/python:3.8.5-buster
 
     steps:
       - checkout
 
       - run:
-          name: install_graphviz
+          name: Update apt-get
+          command: |
+            sudo apt-get update
+
+      - run:
+          name: Install Graphviz
           command: |
             sudo apt-get install graphviz libgraphviz-dev
 
       - run:
-          name: install_tex
+          name: Install TeX
           command: |
             sudo apt-get install texlive texlive-latex-extra latexmk
 
       - run:
-          name: install_dependencies
+          name: Install Python dependencies
           command: |
             python3 -m venv venv
             source venv/bin/activate
@@ -32,13 +37,13 @@ jobs:
             pip install pydot pygraphviz
 
       - run:
-          name: install
+          name: Install
           command: |
             source venv/bin/activate
             pip install -e .
 
       - run:
-          name: build_docs
+          name: Build docs
           command: |
             source venv/bin/activate
             make -C doc/ html


### PR DESCRIPTION
We were still getting errors on circleci.  The errors end with
```
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

I don't use Debian, so I am just guessing:  I suspect the image has an out-of-date apt cache and it is trying to install things with old/incorrect names.  Running ``sudo apt-get update`` updates the list of available packages and their versions.  So I suspect it will fix issues like this [one](https://app.circleci.com/pipelines/github/networkx/networkx/74/workflows/8494bd33-b0ab-48e0-83e3-e3f57961ec30/jobs/82) where it states:
```
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/r/ruby2.5/libruby2.5_2.5.5-3+deb10u1_amd64.deb  404  Not Found [IP: 199.232.64.204 80]
```
When I went to the website, it had ``libruby2.5_2.5.5-3+deb10u2_amd64.deb `` but not ``libruby2.5_2.5.5-3+deb10u1_amd64.deb``.  