### PR TITLE
MAINT,TST: Improve coverage of nx_agraph module

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -146,26 +146,26 @@ def to_agraph(N):
     # add nodes
     for n, nodedata in N.nodes(data=True):
         A.add_node(n)
-        if nodedata is not None:
-            a = A.get_node(n)
-            a.attr.update({k: str(v) for k, v in nodedata.items()})
+        # Add node data
+        a = A.get_node(n)
+        a.attr.update({k: str(v) for k, v in nodedata.items()})
 
     # loop over edges
     if N.is_multigraph():
         for u, v, key, edgedata in N.edges(data=True, keys=True):
             str_edgedata = {k: str(v) for k, v in edgedata.items() if k != "key"}
             A.add_edge(u, v, key=str(key))
-            if edgedata is not None:
-                a = A.get_edge(u, v)
-                a.attr.update(str_edgedata)
+            # Add edge data
+            a = A.get_edge(u, v)
+            a.attr.update(str_edgedata)
 
     else:
         for u, v, edgedata in N.edges(data=True):
             str_edgedata = {k: str(v) for k, v in edgedata.items()}
             A.add_edge(u, v)
-            if edgedata is not None:
-                a = A.get_edge(u, v)
-                a.attr.update(str_edgedata)
+            # Add edge data
+            a = A.get_edge(u, v)
+            a.attr.update(str_edgedata)
 
     return A
 

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -251,7 +251,9 @@ def pygraphviz_layout(G, prog="neato", root=None, args=""):
     args : string, optional
       Extra arguments to Graphviz layout program
 
-    Returns : dictionary
+    Returns
+    -------
+    node_pos : dict
       Dictionary of x, y, positions keyed by node.
 
     Examples
@@ -266,11 +268,11 @@ def pygraphviz_layout(G, prog="neato", root=None, args=""):
     representation and GraphViz could treat them as the same node.
     The layout may assign both nodes a single location. See Issue #1568
     If this occurs in your case, consider relabeling the nodes just
-    for the layout computation using something similar to:
+    for the layout computation using something similar to::
 
-        H = nx.convert_node_labels_to_integers(G, label_attribute='node_label')
-        H_layout = nx.nx_agraph.pygraphviz_layout(G, prog='dot')
-        G_layout = {H.nodes[n]['node_label']: p for n, p in H_layout.items()}
+        >>> H = nx.convert_node_labels_to_integers(G, label_attribute='node_label')
+        >>> H_layout = nx.nx_agraph.pygraphviz_layout(G, prog='dot')
+        >>> G_layout = {H.nodes[n]['node_label']: p for n, p in H_layout.items()}
 
     """
     try:

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -38,8 +38,9 @@ def from_agraph(A, create_using=None):
     A : PyGraphviz AGraph
       A graph created with PyGraphviz
 
-    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+    create_using : NetworkX graph constructor, optional (default=None)
        Graph type to create. If graph instance, then cleared before populated.
+       If `None`, then the appropriate Graph type is inferred from `A`.
 
     Examples
     --------

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -141,6 +141,12 @@ class TestAGraph:
         H = nx.nx_agraph.from_agraph(A)
         assert_graphs_equal(G, H)
 
+    def test_graphviz_alias(self):
+        G = self.build_graph(nx.Graph())
+        pos_graphviz = nx.nx_agraph.graphviz_layout(G)
+        pos_pygraphviz = nx.nx_agraph.pygraphviz_layout(G)
+        assert pos_graphviz == pos_pygraphviz
+
     def test_2d_layout(self):
         G = nx.Graph()
         G = self.build_graph(G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -58,7 +58,19 @@ class TestAGraph:
         G = nx.path_graph(3)
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A, create_using=graph_class)
-        assert type(H) == graph_class
+        assert isinstance(H, graph_class)
+
+    def test_from_agraph_named_edges(self):
+        # Create an AGraph from an existing (non-multi) Graph
+        G = nx.Graph()
+        G.add_nodes_from([0, 1])
+        A = nx.nx_agraph.to_agraph(G)
+        # Add edge (+ name, given by key) to the AGraph
+        A.add_edge(0, 1, key="foo")
+        # Verify a.name roundtrips out to 'key' in from_agraph
+        H = nx.nx_agraph.from_agraph(A)
+        assert isinstance(H, nx.Graph)
+        assert ("0", "1", {"key": "foo"}) in H.edges(data=True)
 
     def test_undirected(self):
         self.agraph_checks(nx.Graph())

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -147,6 +147,19 @@ class TestAGraph:
         pos_pygraphviz = nx.nx_agraph.pygraphviz_layout(G)
         assert pos_graphviz == pos_pygraphviz
 
+    @pytest.mark.parametrize("root", range(5))
+    def test_pygraphviz_layout_root(self, root):
+        # NOTE: test depends on layout prog being deterministic
+        G = nx.complete_graph(5)
+        A = nx.nx_agraph.to_agraph(G)
+        # Get layout with root arg is not None
+        pygv_layout = nx.nx_agraph.pygraphviz_layout(G, prog="circo", root=root)
+        # Equivalent layout directly on AGraph
+        A.layout(args=f"-Groot={root}", prog="circo")
+        # Parse AGraph layout
+        a1_pos = tuple(float(v) for v in dict(A.get_node("1").attr)["pos"].split(","))
+        assert pygv_layout[1] == a1_pos
+
     def test_2d_layout(self):
         G = nx.Graph()
         G = self.build_graph(G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -78,7 +78,7 @@ class TestAGraph:
         G = nx.barbell_graph(4, 6)
         nx.nx_agraph.view_pygraphviz(G)
 
-    def test_view_pygraphviz_edgelable(self):
+    def test_view_pygraphviz_edgelabel(self):
         G = nx.Graph()
         G.add_edge(1, 2, weight=7)
         G.add_edge(2, 3, weight=8)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -110,6 +110,16 @@ class TestAGraph:
         G.add_edge(2, 3, weight=8)
         nx.nx_agraph.view_pygraphviz(G, edgelabel="weight")
 
+    def test_view_pygraphviz_callable_edgelabel(self):
+        G = nx.complete_graph(3)
+
+        def foo_label(data):
+            return "foo"
+
+        path, A = nx.nx_agraph.view_pygraphviz(G, edgelabel=foo_label)
+        for edge in A.edges():
+            assert edge.attr["label"] == "foo"
+
     def test_graph_with_reserved_keywords(self):
         # test attribute/keyword clash case for #1582
         # node: n

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -122,6 +122,16 @@ class TestAGraph:
         for edge in A.edges():
             assert edge.attr["label"] == "foo"
 
+    def test_view_pygraphviz_multigraph_edgelabels(self):
+        G = nx.MultiGraph()
+        G.add_edge(0, 1, key=0, name="left_fork")
+        G.add_edge(0, 1, key=1, name="right_fork")
+        path, A = nx.nx_agraph.view_pygraphviz(G, edgelabel="name")
+        edges = A.edges()
+        assert len(edges) == 2
+        for edge in edges:
+            assert edge.attr["label"].strip() in ("left_fork", "right_fork")
+
     def test_graph_with_reserved_keywords(self):
         # test attribute/keyword clash case for #1582
         # node: n

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -95,7 +95,7 @@ class TestAGraph:
         G.edges[("A", "B")]["v"] = "keyword"
         A = nx.nx_agraph.to_agraph(G)
 
-    def test_round_trip(self):
+    def test_round_trip_empty_graph(self):
         G = nx.Graph()
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A)
@@ -107,6 +107,13 @@ class TestAGraph:
         G.graph["node"] = {}
         G.graph["edge"] = {}
         assert_graphs_equal(G, HH)
+
+    @pytest.mark.xfail(reason="integer->string node conversion in round trip")
+    def test_round_trip_integer_nodes(self):
+        G = nx.complete_graph(3)
+        A = nx.nx_agraph.to_agraph(G)
+        H = nx.nx_agraph.from_agraph(A)
+        assert_graphs_equal(G, H)
 
     def test_2d_layout(self):
         G = nx.Graph()

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -121,6 +121,20 @@ class TestAGraph:
         G.edges[("A", "B")]["v"] = "keyword"
         A = nx.nx_agraph.to_agraph(G)
 
+    def test_view_pygraphviz_no_added_attrs_to_input(self):
+        G = nx.complete_graph(2)
+        path, A = nx.nx_agraph.view_pygraphviz(G)
+        assert G.graph == {}
+
+    @pytest.mark.xfail(reason="known bug in clean_attrs")
+    def test_view_pygraphviz_leaves_input_graph_unmodified(self):
+        G = nx.complete_graph(2)
+        # Add entries to graph dict that to_agraph handles specially
+        G.graph["node"] = {"width": "0.80"}
+        G.graph["edge"] = {"fontsize": "14"}
+        path, A = nx.nx_agraph.view_pygraphviz(G)
+        assert G.graph == {"node": {"width": "0.80"}, "edge": {"fontsize": "14"}}
+
     def test_graph_with_AGraph_attrs(self):
         G = nx.complete_graph(2)
         # Add entries to graph dict that to_agraph handles specially

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -98,6 +98,16 @@ class TestAGraph:
         A = nx.nx_agraph.to_agraph(G)
         assert dict(A.edges()[0].attr) == {"color": "yellow"}
 
+    def test_view_pygraphviz_path(self, tmp_path):
+        G = nx.complete_graph(3)
+        input_path = str(tmp_path / "graph.png")
+        out_path, A = nx.nx_agraph.view_pygraphviz(G, path=input_path)
+        assert out_path == input_path
+        # Ensure file is not empty
+        with open(input_path, "rb") as fh:
+            data = fh.read()
+        assert len(data) > 0
+
     def test_view_pygraphviz(self):
         G = nx.Graph()  # "An empty graph cannot be drawn."
         pytest.raises(nx.NetworkXException, nx.nx_agraph.view_pygraphviz, G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -108,7 +108,9 @@ class TestAGraph:
         G = nx.Graph()
         G.add_edge(1, 2, weight=7)
         G.add_edge(2, 3, weight=8)
-        nx.nx_agraph.view_pygraphviz(G, edgelabel="weight")
+        path, A = nx.nx_agraph.view_pygraphviz(G, edgelabel="weight")
+        for edge in A.edges():
+            assert edge.attr["weight"] in ("7", "8")
 
     def test_view_pygraphviz_callable_edgelabel(self):
         G = nx.complete_graph(3)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -72,6 +72,19 @@ class TestAGraph:
     def test_multi_directed(self):
         self.agraph_checks(nx.MultiDiGraph())
 
+    def test_to_agraph_with_nodedata(self):
+        G = nx.Graph()
+        G.add_node(1, color="red")
+        A = nx.nx_agraph.to_agraph(G)
+        assert dict(A.nodes()[0].attr) == {"color": "red"}
+
+    def test_to_agraph_with_edgedata(self):
+        G = nx.Graph()
+        G.add_nodes_from([0, 1])
+        G.add_edge(0, 1, color="yellow")
+        A = nx.nx_agraph.to_agraph(G)
+        assert dict(A.edges()[0].attr) == {"color": "yellow"}
+
     def test_view_pygraphviz(self):
         G = nx.Graph()  # "An empty graph cannot be drawn."
         pytest.raises(nx.NetworkXException, nx.nx_agraph.view_pygraphviz, G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -108,6 +108,11 @@ class TestAGraph:
             data = fh.read()
         assert len(data) > 0
 
+    def test_view_pygraphviz_file_suffix(self, tmp_path):
+        G = nx.complete_graph(3)
+        path, A = nx.nx_agraph.view_pygraphviz(G, suffix=1)
+        assert path[-6:] == "_1.png"
+
     def test_view_pygraphviz(self):
         G = nx.Graph()  # "An empty graph cannot be drawn."
         pytest.raises(nx.NetworkXException, nx.nx_agraph.view_pygraphviz, G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -78,8 +78,9 @@ class TestAGraph:
         A = nx.nx_agraph.to_agraph(G)
         assert dict(A.nodes()[0].attr) == {"color": "red"}
 
-    def test_to_agraph_with_edgedata(self):
-        G = nx.Graph()
+    @pytest.mark.parametrize("graph_class", (nx.Graph, nx.MultiGraph))
+    def test_to_agraph_with_edgedata(self, graph_class):
+        G = graph_class()
         G.add_nodes_from([0, 1])
         G.add_edge(0, 1, color="yellow")
         A = nx.nx_agraph.to_agraph(G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -51,6 +51,15 @@ class TestAGraph:
         H = nx.nx_agraph.from_agraph(A)
         assert G.name == "test"
 
+    @pytest.mark.parametrize(
+        "graph_class", (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph,)
+    )
+    def test_from_agraph_create_using(self, graph_class):
+        G = nx.path_graph(3)
+        A = nx.nx_agraph.to_agraph(G)
+        H = nx.nx_agraph.from_agraph(A, create_using=graph_class)
+        assert type(H) == graph_class
+
     def test_undirected(self):
         self.agraph_checks(nx.Graph())
 

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -121,6 +121,16 @@ class TestAGraph:
         G.edges[("A", "B")]["v"] = "keyword"
         A = nx.nx_agraph.to_agraph(G)
 
+    def test_graph_with_AGraph_attrs(self):
+        G = nx.complete_graph(2)
+        # Add entries to graph dict that to_agraph handles specially
+        G.graph["node"] = {"width": "0.80"}
+        G.graph["edge"] = {"fontsize": "14"}
+        path, A = nx.nx_agraph.view_pygraphviz(G)
+        # Ensure user-specified values are not lost
+        assert dict(A.node_attr)["width"] == "0.80"
+        assert dict(A.edge_attr)["fontsize"] == "14"
+
     def test_round_trip_empty_graph(self):
         G = nx.Graph()
         A = nx.nx_agraph.to_agraph(G)


### PR DESCRIPTION
Improves the test coverage of `networkx/drawing/nx_agraph` module from ~85% -> 94%. Most of the improved coverage is related to keyword arguments whose non-default values were uncovered. This PR also includes a few ancillary fixes including things like fixing docstring formatting issues, fixing typos, etc. I'm happy to pull these out into a separate PR if it will make this easier to review. 

A couple notable points:
 - Currently, there is no way to suppress the opening of the rendered graphs from `view_pygraphviz` (assuming an appropriate graph viewer is installed on the system). This means that running the test suite will open 2 new windows. With the additional tests in this PR, many more (>10 new windows) are opened. I've proposed a new kwarg in #4155 that allows users to toggle the opening of these windows, which would allow for suppressing the opening of windows in the test suite.
 - Roundtripping with `to_agraph/from_agraph` fails due to implicit conversion of all nodes types to strings. This is documented e.g. in the Notes section of `view_pygraphviz`. I've added an xfailed test to indicate that roundtripping is *not* expected to be successful.
 - There is a function called `graphviz_layout` which simply calls `pygraphviz_layout` (with no remapping of argument names or any modification to inputs at all). Perhaps the former could be considered for deprecation as it is purely duplicate?
 - There was a failure in previously un-tested behavior in `view_pygraphviz`. I've added an xfailed test for this and the bug will be addressed in a follow-up PR.
 - The remaining lack of coverage is mostly related to `except` branches when `import pygraphviz` fails.