### PR TITLE
DOC: Update docstrings for public functions in threshold module

### DIFF
--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -385,7 +385,7 @@ def find_threshold_graph(G, create_using=None):
 
     Examples
     --------
-    >>> G = nx.barbell_graph(3, 3)    
+    >>> G = nx.barbell_graph(3, 3)
     >>> T = find_threshold_graph(G)
     >>> T.nodes # may vary
     NodeView((7, 8, 5, 6))

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -10,7 +10,27 @@ __all__ = ["is_threshold_graph", "find_threshold_graph"]
 
 def is_threshold_graph(G):
     """
-    Returns True if G is a threshold graph.
+    Returns `True` if `G` is a threshold graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph instance
+        An instance of `Graph`, `DiGraph`, `MultiGraph` or `MultiDiGraph`
+
+    Returns
+    -------
+    bool
+        `True` if `G` is a threshold graph, `False` otherwise.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(3)
+    >>> is_threshold_graph(G)
+    True
+
+    References
+    ----------
+    .. [1] Threshold graphs: https://en.wikipedia.org/wiki/Threshold_graph
     """
     return is_threshold_sequence(list(d for n, d in G.degree()))
 

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -366,9 +366,33 @@ def find_alternating_4_cycle(G):
 
 def find_threshold_graph(G, create_using=None):
     """
-    Return a threshold subgraph that is close to largest in G.
+    Returns a threshold subgraph that is close to largest in `G`.
+
     The threshold graph will contain the largest degree node in G.
 
+    Parameters
+    ----------
+    G : NetworkX graph instance
+        An instance of `Graph`, or `MultiDiGraph`
+    create_using : NetworkX graph class or `None` (default), optional
+        Type of graph to use when constructing the threshold graph.
+        If `None`, infer the appropriate graph type from the input.
+
+    Returns
+    -------
+    graph :
+        A graph instance representing the threshold graph
+
+    Examples
+    --------
+    >>> G = nx.barbell_graph(3, 3)    
+    >>> T = find_threshold_graph(G)
+    >>> T.nodes # may vary
+    NodeView((7, 8, 5, 6))
+
+    References
+    ----------
+    .. [1] Threshold graphs: https://en.wikipedia.org/wiki/Threshold_graph
     """
     return threshold_graph(find_creation_sequence(G), create_using)
 

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -24,6 +24,7 @@ def is_threshold_graph(G):
 
     Examples
     --------
+    >>> from networkx.algorithms.threshold import is_threshold_graph
     >>> G = nx.path_graph(3)
     >>> is_threshold_graph(G)
     True
@@ -385,6 +386,7 @@ def find_threshold_graph(G, create_using=None):
 
     Examples
     --------
+    >>> from networkx.algorithms.threshold import find_threshold_graph
     >>> G = nx.barbell_graph(3, 3)
     >>> T = find_threshold_graph(G)
     >>> T.nodes # may vary

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -27,6 +27,9 @@ def is_threshold_graph(G):
     >>> G = nx.path_graph(3)
     >>> is_threshold_graph(G)
     True
+    >>> G = nx.barbell_graph(3, 3)
+    >>> is_threshold_graph(G)
+    False
 
     References
     ----------


### PR DESCRIPTION
Adds properly-formatted docstrings for `is_threshold_graph` and `find_threshold_graph` which were recently added to the reference documentation in #4161 .