### PR TITLE
DOC,BLD: Fix doc build warning from markup error.

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -219,7 +219,7 @@ def read_graphml(path, node_type=str, edge_key_type=int, force_multigraph=False)
     Returns
     -------
     graph: NetworkX graph
-        If parallel edges are present or `force_multigraph == True```then
+        If parallel edges are present or `force_multigraph=True` then
         a MultiGraph or MultiDiGraph is returned. Otherwise a Graph/DiGraph.
         The returned graph is directed if the file indicates it should be.
 


### PR DESCRIPTION
I just noticed there are two new warnings when building the docs on 99fc1bb6. This fixes one of them. The other is in `doc/release/release_dev.rst` (line 276). I didn't change the latter as it seems the list is auto-generated from PR titles.