### PR TITLE
Fix indexing in kernighan_lin_bisection

### DIFF
--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -104,7 +104,7 @@ def kernighan_lin_bisection(G, partition=None, max_iter=10, weight="weight", see
             raise nx.NetworkXError("partition invalid")
         side = [0] * n
         for a in A:
-            side[a] = 1
+            side[index[a]] = 1
 
     if G.is_multigraph():
         edges = [

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -3,6 +3,7 @@ module.
 
 """
 import pytest
+from random import shuffle
 
 import networkx as nx
 from networkx.algorithms.community import kernighan_lin_bisection
@@ -57,3 +58,25 @@ def test_multigraph():
         assert_partition_equal(
             [A, B], [{mapping[0], mapping[1]}, {mapping[2], mapping[3]}]
         )
+
+
+def test_defined_partition_str_nodes():
+    G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
+    labels = list(G)
+    shuffle(labels)
+
+    with pytest.raises(KeyError):
+        for i in range(1, len(labels)):
+            k_partition = (set(labels[0:i]), set(labels[i : len(labels)]))
+            kernighan_lin_bisection(G, partition=k_partition)
+
+
+def test_defined_partition_int_nodes():
+    G = nx.Graph([(1, 2), (1, 3), (2, 3), (3, 4)])
+    labels = list(G)
+    shuffle(labels)
+
+    with pytest.raises(KeyError):
+        for i in range(1, len(labels)):
+            k_partition = (set(labels[0:i]), set(labels[i : len(labels)]))
+            kernighan_lin_bisection(G, partition=k_partition)

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -24,6 +24,13 @@ def test_partition_argument():
     assert_partition_equal(C, partition)
 
 
+def test_partition_argument_non_integer_nodes():
+    G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
+    partition = ({"A", "B"}, {"C", "D"})
+    C = kernighan_lin_bisection(G, partition)
+    assert_partition_equal(C, partition)
+
+
 def test_seed_argument():
     G = nx.barbell_graph(3, 0)
     C = kernighan_lin_bisection(G, seed=1)
@@ -55,15 +62,3 @@ def test_multigraph():
         assert_partition_equal(
             [A, B], [{mapping[0], mapping[1]}, {mapping[2], mapping[3]}]
         )
-
-
-def test_defined_partition_str_nodes():
-    G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
-    partition = ({"A", "B"}, {"C", "D"})
-    kernighan_lin_bisection(G, partition)
-
-
-def test_defined_partition_int_nodes():
-    G = nx.Graph([(1, 2), (1, 3), (2, 3), (3, 4)])
-    partition = ({1, 2}, {3, 4})
-    kernighan_lin_bisection(G, partition)

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -1,10 +1,7 @@
 """Unit tests for the :mod:`networkx.algorithms.community.kernighan_lin`
 module.
-
 """
 import pytest
-from random import shuffle
-
 import networkx as nx
 from networkx.algorithms.community import kernighan_lin_bisection
 from itertools import permutations
@@ -62,21 +59,11 @@ def test_multigraph():
 
 def test_defined_partition_str_nodes():
     G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
-    labels = list(G)
-    shuffle(labels)
-
-    with pytest.raises(KeyError):
-        for i in range(1, len(labels)):
-            k_partition = (set(labels[0:i]), set(labels[i : len(labels)]))
-            kernighan_lin_bisection(G, partition=k_partition)
+    partition = ({"A", "B"}, {"C", "D"})
+    kernighan_lin_bisection(G, partition)
 
 
 def test_defined_partition_int_nodes():
     G = nx.Graph([(1, 2), (1, 3), (2, 3), (3, 4)])
-    labels = list(G)
-    shuffle(labels)
-
-    with pytest.raises(KeyError):
-        for i in range(1, len(labels)):
-            k_partition = (set(labels[0:i]), set(labels[i : len(labels)]))
-            kernighan_lin_bisection(G, partition=k_partition)
+    partition = ({1, 2}, {3, 4})
+    kernighan_lin_bisection(G, partition)


### PR DESCRIPTION
initialize side list from input partition, must set index of members of A, not the element itself