### PR TITLE
DOC: Update docstrings in cytoscape module

### DIFF
--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -16,7 +16,7 @@ def cytoscape_data(G, attrs=None):
         A dictionary containing the keys 'name' and 'ident' which are mapped to
         the 'name' and 'id' node elements in cyjs format. All other keys are
         ignored. Default is `None` which results in the default mapping
-        ``{name="name", ident="id"}``.
+        ``dict(name="name", ident="id")``.
 
     Returns
     -------
@@ -101,7 +101,7 @@ def cytoscape_graph(data, attrs=None):
         A dictionary containing the keys 'name' and 'ident' which are mapped to
         the 'name' and 'id' node elements in cyjs format. All other keys are
         ignored. Default is `None` which results in the default mapping
-        ``{name="name", ident="id"}``.
+        ``dict(name="name", ident="id")``.
 
     Returns
     -------

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -14,7 +14,7 @@ def cytoscape_data(G, attrs=None):
         The graph to convert to cytoscape format
     attrs : dict or None (default=None)
         A dictionary containing the keys 'name' and 'ident' which are mapped to
-        the 'name' and 'id' node elements in cyjs format.All other keys are
+        the 'name' and 'id' node elements in cyjs format. All other keys are
         ignored. Default is `None` which results in the default mapping
         ``{name="name", ident="id"}``.
 
@@ -26,7 +26,7 @@ def cytoscape_data(G, attrs=None):
     Raises
     ------
     NetworkXError
-        If values in attrs are not unique.
+        If values in `attrs` are not unique.
 
     See Also
     --------
@@ -34,7 +34,7 @@ def cytoscape_data(G, attrs=None):
 
     References
     ----------
-    .. [1] Cytoscape user's manual: 
+    .. [1] Cytoscape user's manual:
        http://manual.cytoscape.org/en/stable/index.html
 
     Examples
@@ -90,6 +90,59 @@ def cytoscape_data(G, attrs=None):
 
 
 def cytoscape_graph(data, attrs=None):
+    """
+    Create a NetworkX graph from a dictionary in cytoscape JSON format.
+
+    Parameters
+    ----------
+    data : dict
+        A dictionary of data conforming to cytoscape JSON format.
+    attrs : dict or None (default=None)
+        A dictionary containing the keys 'name' and 'ident' which are mapped to
+        the 'name' and 'id' node elements in cyjs format. All other keys are
+        ignored. Default is `None` which results in the default mapping
+        ``{name="name", ident="id"}``.
+
+    Returns
+    -------
+    graph : a NetworkX graph instance
+        The `graph` can be an instance of `Graph`, `DiGraph`, `MultiGraph`, or
+        `MultiDiGraph` depending on the input data.
+
+    Raises
+    ------
+    NetworkXError
+        If values in `attrs` are not unique.
+
+    See Also
+    --------
+    cytoscape_data - convert a NetworkX graph to a dict in cyjs format
+
+    References
+    ----------
+    .. [1] Cytoscape user's manual:
+       http://manual.cytoscape.org/en/stable/index.html
+
+    Examples
+    --------
+    >>> data_dict = {
+    ...     'data': [],
+    ...     'directed': False,
+    ...     'multigraph': False,
+    ...     'elements': {'nodes': [{'data': {'id': '0', 'value': 0, 'name': '0'}},
+    ...       {'data': {'id': '1', 'value': 1, 'name': '1'}}],
+    ...      'edges': [{'data': {'source': 0, 'target': 1}}]}
+    ... }
+    >>> G = nx.cytoscape_graph(data_dict)
+    >>> G.name
+    ''
+    >>> G.nodes()
+    NodeView((0, 1))
+    >>> G.nodes(data=True)[0]
+    {'id': '0', 'value': 0, 'name': '0'}
+    >>> G.edges(data=True)
+    EdgeDataView([(0, 1, {'source': 0, 'target': 1})])
+    """
     if not attrs:
         attrs = _attrs
     else:

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -11,16 +11,42 @@ def cytoscape_data(G, attrs=None):
     Parameters
     ----------
     G : NetworkX Graph
-
+        The graph to convert to cytoscape format
+    attrs : dict or None (default=None)
+        A dictionary containing the keys 'name' and 'ident' which are mapped to
+        the 'name' and 'id' node elements in cyjs format.All other keys are
+        ignored. Default is `None` which results in the default mapping
+        ``{name="name", ident="id"}``.
 
     Returns
     -------
     data: dict
         A dictionary with cyjs formatted data.
+
     Raises
     ------
     NetworkXError
         If values in attrs are not unique.
+
+    See Also
+    --------
+    cytoscape_graph - convert a dictionary in cyjs format to a graph
+
+    References
+    ----------
+    .. [1] Cytoscape user's manual: 
+       http://manual.cytoscape.org/en/stable/index.html
+
+    Examples
+    --------
+    >>> G = nx.path_graph(2)
+    >>> nx.cytoscape_data(G)  # doctest: +SKIP
+    {'data': [],
+     'directed': False,
+     'multigraph': False,
+     'elements': {'nodes': [{'data': {'id': '0', 'value': 0, 'name': '0'}},
+       {'data': {'id': '1', 'value': 1, 'name': '1'}}],
+      'edges': [{'data': {'source': 0, 'target': 1}}]}}
     """
     if not attrs:
         attrs = _attrs


### PR DESCRIPTION
Add missing parameter and additional sections to `cytoscape_data` docstring, and add a docstring to the `cytoscape_graph` function.

Related to discussion in #4173 