### PR TITLE
Partitions for quotient graphs

### DIFF
--- a/doc/reference/algorithms/minors.rst
+++ b/doc/reference/algorithms/minors.rst
@@ -9,5 +9,5 @@ Minors
    contracted_edge
    contracted_nodes
    identified_nodes
-   equivalence_relation
+   equivalence_classes
    quotient_graph

--- a/doc/reference/algorithms/minors.rst
+++ b/doc/reference/algorithms/minors.rst
@@ -9,4 +9,5 @@ Minors
    contracted_edge
    contracted_nodes
    identified_nodes
+   equivalence_relation
    quotient_graph

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -21,7 +21,7 @@ chaini = chain.from_iterable
 
 
 def equivalence_classes(iterable, relation):
-    """Returns equivalence classes of `iterable` given by `relation`.
+    """Returns equivalence classes of `relation` when applied to `iterable`.
 
     The equivalence classes, or blocks, consist of objects from `iterable`
     which are all equivalent. They are defined to be equivalent if the

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -9,7 +9,13 @@ from networkx import density
 from networkx.exception import NetworkXException
 from networkx.utils import arbitrary_element
 
-__all__ = ["contracted_edge", "contracted_nodes", "identified_nodes", "quotient_graph"]
+__all__ = [
+    "contracted_edge",
+    "contracted_nodes",
+    "equivalence_classes",
+    "identified_nodes",
+    "quotient_graph"
+]
 
 chaini = chain.from_iterable
 

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -265,6 +265,19 @@ def quotient_graph(
         >>> list(M.edges())
         [(0, 1), (1, 2)]
 
+    Partitions can be represented in various ways:
+    ::
+
+        (0) a list/tuple/set of block lists/tuples/sets
+        (1) a dict with block labels as keys and blocks lists/tuples/sets as values
+        (2) a dict with block lists/tuples/sets as keys and block labels as values
+        (3) a function from nodes in the original iterable to block labels
+        (4) an equivalence relation function on the target iterable
+
+    As `quotient_graph` is designed to accept partitions represented as (0), (1) or
+    (4) only, the `equivalence_classes` function can be used to get the partitions
+    in the right form, in order to call `quotient_graph`.
+
     .. _Strongly connected component: https://en.wikipedia.org/wiki/Strongly_connected_component
 
     References
@@ -285,8 +298,7 @@ def quotient_graph(
         )
 
     # If the partition is a dict, it is assumed to be one where the keys are
-    # user-defined block labels, and values are block lists, i.e. lists of
-    # graph nodes related under the graph equivalence relation
+    # user-defined block labels, and values are block lists, tuples or sets.
     if isinstance(partition, dict):
         partition = [block for block in partition.values()]
 

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -21,17 +21,60 @@ chaini = chain.from_iterable
 
 
 def equivalence_classes(iterable, relation):
-    """Returns the set of equivalence classes of the given `iterable` under
-    the specified equivalence relation.
+    """Returns the set of equivalence classes, or blocks, of the equivalence
+    relation `relation` when applied to the elements of `iterable`.
 
-    `relation` must be a Boolean-valued function that takes two argument. It
-    must represent an equivalence relation (that is, the relation induced by
-    the function must be reflexive, symmetric, and transitive).
+    Parameters
+    ----------
+    iterable : list, tuple, or set
+        An iterable of elements/nodes.
 
-    The return value is a set of sets. It is a partition of the elements of
-    `iterable`; duplicate elements will be ignored so it makes the most sense
-    for `iterable` to be a :class:`set`.
+    relation : function
+        A Boolean-valued function that implements an equivalence relation
+        (reflexive, symmetric, transitive binary relation) on the elements
+        of `iterable` - it must take two elements and return `True` if
+        they are related, or `False` if not.
 
+    Returns
+    -------
+    set of frozensets
+        A set of frozensets representing the partition induced by the equivalence
+        relation function `relation` on the elements of `iterable`. Each
+        member set in the return set represents an equivalence class, or
+        block, of the partition.
+
+        Duplicate elements will be ignored so it makes the most sense for
+        `iterable` to be a :class:`set`.
+
+    Examples
+    --------
+    Let `X` be the ring of integers from `0` to `9`, modulo 3, and consider
+    an equivalence relation `R` on `X` of congruence modulo 3: this means that
+    two integers `x` and `y` in `X` are equivalent under `R` if they leave the
+    same remainder when divided by `3`, i.e.::
+
+        (x - y) mod 3 = 0
+
+    The equivalence classes of this relation are `{0, 3, 6, 9}`, `{1, 4, 7}`,
+    `{2, 5, 8}`: `0`, `3`, `6`, `9` are all divisible by `3` so leave a zero
+    remainder; `1`, `4`, `7` all leave a remainder of `1`; while `2`, `5`
+    and `8` all leave the remainder `2`. We can see this by calling
+    `equivalence_classes` with `iterable` as X and `relation` as a function
+    implementation of `R`.
+
+        >>> def mod3(x, y): return (x - y) % 3 == 0
+        >>> X = set(range(10))
+        >>> equivalence_classes(X, mod3)
+        >>> {frozenset({1, 4, 7}), frozenset({2, 5, 8}), frozenset({0, 3, 6, 9})
+
+    In this example, the only possible remainders of division modulo `3` are
+    `0`, `1`, `2`, and therefore the blocks of the relation can actually be
+    identified with certain elements in the blocks: namely, `{0, 3, 6, 9}` can
+    be identified with `0`, as all these integers are congruent to `0` modulo
+    `3`; `{1, 4, 7}` can be identified with `1`, as all these integers are
+    congruent to `1` modulo `3`; `{2, 5, 8}` can be identified with `2`, as
+    all these integers are congruent to `2` modulo `3`. The set of block
+    labels `{0, 1, 2}` is also a finite ring modulo `3`.
     """
     # For simplicity of implementation, we initialize the return value as a
     # list of lists, then convert it to a set of sets at the end of the

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -116,12 +116,18 @@ def quotient_graph(
         The graph for which to return the quotient graph with the
         specified node relation.
 
-    partition : function or list of sets
+    partition : function, or dict or list of lists, tuples or sets
         If a function, this function must represent an equivalence
         relation on the nodes of `G`. It must take two arguments *u*
         and *v* and return True exactly when *u* and *v* are in the
         same equivalence class. The equivalence classes form the nodes
         in the returned graph.
+
+        If a dict of lists/tuples/sets, the keys can be any meaningful
+        block labels, but the values must be the block lists/tuples/sets
+        (one list/tuple/set per block), and the blocks must form a valid
+        partition of the nodes of the graph. That is, each node must be
+        in exactly one block of the partition.
 
         If a list of sets, the list must form a valid partition of
         the nodes of the graph. That is, each node must be in exactly
@@ -261,6 +267,14 @@ def quotient_graph(
         >>> list(M.edges())
         [(0, 1), (1, 2)]
 
+    Here is the sample example but using partition as a dict of block sets.
+
+        >>> G = nx.path_graph(6)
+        >>> partition = {0: {0, 1}, 2: {2, 3}, 4: {4, 5}}
+        >>> M = nx.quotient_graph(G, partition, relabel=True)
+        >>> list(M.edges())
+        [(0, 1), (1, 2)]
+
     .. _Strongly connected component: https://en.wikipedia.org/wiki/Strongly_connected_component
 
     References
@@ -270,7 +284,7 @@ def quotient_graph(
            Cambridge University Press, 2004.
 
     """
-    # If the user provided an equivalence relation as a function compute
+    # If the user provided an equivalence relation as a function to compute
     # the blocks of the partition on the nodes of G induced by the
     # equivalence relation.
     if callable(partition):
@@ -279,6 +293,12 @@ def quotient_graph(
         return _quotient_graph(
             G, partition, edge_relation, node_data, edge_data, relabel, create_using
         )
+
+    # If the partition is a dict, it is assumed to be one where the keys are
+    # user-defined block labels, and values are block lists, i.e. lists of
+    # graph nodes related under the graph equivalence relation
+    if isinstance(partition, dict):
+        partition = [block for block in partition.values()]
 
     # If the user provided partition as a collection of sets. Then we
     # need to check if partition covers all of G nodes. If the answer

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -21,8 +21,13 @@ chaini = chain.from_iterable
 
 
 def equivalence_classes(iterable, relation):
-    """Returns the set of equivalence classes, or blocks, of the equivalence
-    relation `relation` when applied to the elements of `iterable`.
+    """Returns equivalence classes of `iterable` given by `relation`.
+
+    The equivalence classes, or blocks, consist of objects from `iterable`
+    which are all equivalent. They are defined to be equivalent if the
+    `relation` function returns `True` when passed any two objects from that
+    class, and `False` otherwise. To define an equivalence relation the
+    function must be reflexive, symmetric and transitive.
 
     Parameters
     ----------
@@ -62,7 +67,7 @@ def equivalence_classes(iterable, relation):
         >>> X = set(range(10))
         >>> def mod3(x, y): return (x - y) % 3 == 0
         >>> equivalence_classes(X, mod3)    # doctest: +SKIP
-        {frozenset({1, 4, 7}), frozenset({2, 5, 8}), frozenset({0, 3, 6, 9})} # doctest: +SKIP
+        {frozenset({1, 4, 7}), frozenset({8, 2, 5}), frozenset({0, 9, 3, 6})} # doctest: +SKIP
 
     """
     # For simplicity of implementation, we initialize the return value as a

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -48,33 +48,22 @@ def equivalence_classes(iterable, relation):
 
     Examples
     --------
-    Let `X` be the ring of integers from `0` to `9`, modulo 3, and consider
-    an equivalence relation `R` on `X` of congruence modulo 3: this means that
-    two integers `x` and `y` in `X` are equivalent under `R` if they leave the
-    same remainder when divided by `3`, i.e.::
-
-        (x - y) mod 3 = 0
+    Let `X` be the set of integers from `0` to `9`, and consider an equivalence
+    relation `R` on `X` of congruence modulo `3`: this means that two integers
+    `x` and `y` in `X` are equivalent under `R` if they leave the same
+    remainder when divided by `3`, i.e. `(x - y) mod 3 = 0`.
 
     The equivalence classes of this relation are `{0, 3, 6, 9}`, `{1, 4, 7}`,
-    `{2, 5, 8}`: `0`, `3`, `6`, `9` are all divisible by `3` so leave a zero
-    remainder; `1`, `4`, `7` all leave a remainder of `1`; while `2`, `5`
-    and `8` all leave the remainder `2`. We can see this by calling
-    `equivalence_classes` with `iterable` as X and `relation` as a function
-    implementation of `R`.
+    `{2, 5, 8}`: `0`, `3`, `6`, `9` are all divisible by `3` and leave zero
+    remainder; `1`, `4`, `7` leave remainder `1`; while `2`, `5` and `8` leave
+    remainder `2`. We can see this by calling `equivalence_classes` with
+    with `X` and a function implementation of `R`.::
 
-        >>> def mod3(x, y): return (x - y) % 3 == 0
         >>> X = set(range(10))
-        >>> equivalence_classes(X, mod3)
-        >>> {frozenset({1, 4, 7}), frozenset({2, 5, 8}), frozenset({0, 3, 6, 9})
+        >>> def mod3(x, y): return (x - y) % 3 == 0
+        >>> equivalence_classes(X, mod3)    # doctest: +SKIP
+        {frozenset({1, 4, 7}), frozenset({2, 5, 8}), frozenset({0, 3, 6, 9})} # doctest: +SKIP
 
-    In this example, the only possible remainders of division modulo `3` are
-    `0`, `1`, `2`, and therefore the blocks of the relation can actually be
-    identified with certain elements in the blocks: namely, `{0, 3, 6, 9}` can
-    be identified with `0`, as all these integers are congruent to `0` modulo
-    `3`; `{1, 4, 7}` can be identified with `1`, as all these integers are
-    congruent to `1` modulo `3`; `{2, 5, 8}` can be identified with `2`, as
-    all these integers are congruent to `2` modulo `3`. The set of block
-    labels `{0, 1, 2}` is also a finite ring modulo `3`.
     """
     # For simplicity of implementation, we initialize the return value as a
     # list of lists, then convert it to a set of sets at the end of the
@@ -268,6 +257,7 @@ def quotient_graph(
         [(0, 1), (1, 2)]
 
     Here is the sample example but using partition as a dict of block sets.
+    ::
 
         >>> G = nx.path_graph(6)
         >>> partition = {0: {0, 1}, 2: {2, 3}, 4: {4, 5}}

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -120,6 +120,51 @@ class TestQuotient:
             assert M.nodes[n]["nnodes"] == 2
             assert M.nodes[n]["density"] == 1
 
+    def test_path__partition_provided_as_dict_of_lists(self):
+        G = nx.path_graph(6)
+        partition = {
+            0: [0, 1],
+            2: [2, 3],
+            4: [4, 5]
+        }
+        M = nx.quotient_graph(G, partition, relabel=True)
+        assert_nodes_equal(M, [0, 1, 2])
+        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        for n in M:
+            assert M.nodes[n]["nedges"] == 1
+            assert M.nodes[n]["nnodes"] == 2
+            assert M.nodes[n]["density"] == 1
+
+    def test_path__partition_provided_as_dict_of_tuples(self):
+        G = nx.path_graph(6)
+        partition = {
+            0: (0, 1),
+            2: (2, 3),
+            4: (4, 5)
+        }
+        M = nx.quotient_graph(G, partition, relabel=True)
+        assert_nodes_equal(M, [0, 1, 2])
+        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        for n in M:
+            assert M.nodes[n]["nedges"] == 1
+            assert M.nodes[n]["nnodes"] == 2
+            assert M.nodes[n]["density"] == 1
+
+    def test_path__partition_provided_as_dict_of_sets(self):
+        G = nx.path_graph(6)
+        partition = {
+            0: {0, 1},
+            2: {2, 3},
+            4: {4, 5}
+        }
+        M = nx.quotient_graph(G, partition, relabel=True)
+        assert_nodes_equal(M, [0, 1, 2])
+        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        for n in M:
+            assert M.nodes[n]["nedges"] == 1
+            assert M.nodes[n]["nnodes"] == 2
+            assert M.nodes[n]["density"] == 1
+
     def test_multigraph_path(self):
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]


### PR DESCRIPTION
Various updates in `algorithms/minors.py`:

* make `equivalence_classes` a public method
* tweak `quotient_graph` to accept partitions as dicts (of block labels as keys and block lists/tuples/sets as values)
* update `quotient_graph` docstring to provide examples to the user of how to use `equivalence_classes` to represent different representations of partitions in a form acceptable to `quotient_graph` (see discussion in https://github.com/networkx/networkx/pull/3839#issuecomment-675217619)