### PR TITLE
TST: add dtype to pandas test

### DIFF
--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -229,7 +229,7 @@ class TestConvertPandas:
             "B": {"A": 1, "B": 0, "C": 0},
             "C": {"A": 0, "B": 1, "C": 0},
         }
-        dftrue = pd.DataFrame(data)
+        dftrue = pd.DataFrame(data, dtype=np.intp)
         df = dftrue[["A", "C", "B"]]
         G = nx.from_pandas_adjacency(df, create_using=nx.DiGraph())
         df = nx.to_pandas_adjacency(G, dtype=np.intp)


### PR DESCRIPTION
Closes #4054 - hopefully for good this time. Applies the same explicit dtype to a df created in the test suite via the `DataFrame` constructor to prevent incorrect integer sizes being used on 32-bit platforms.