### PR TITLE
Make optional dependencies default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,7 @@ install:
 
   # Install the build and runtime dependencies of the project.
   - "python -m pip install --upgrade pip wheel setuptools"
+  - "pip install -r requirements.txt"
   - "pip install ."
 
 # Not a .NET project, we build networkx in the install step instead

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,15 +12,15 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.8"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.5"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python38-x64"
-      PYTHON_VERSION: "3.8.0"
+      PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       PIP_FLAGS: "--pre"
 
@@ -34,12 +34,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # install required packages
-  - "pip install --cache-dir=%CACHE_DIR% %PIP_FLAGS% -r requirements.txt"
-  - "pip install --cache-dir=%CACHE_DIR% %PIP_FLAGS% -r requirements/optional.txt"
-
   # Install the build and runtime dependencies of the project.
-  # - "%CMD_IN_ENV% pip install --timeout=60 -r requirements.txt"
+  - "python -m pip install --upgrade pip wheel setuptools"
   - "pip install ."
 
 # Not a .NET project, we build networkx in the install step instead

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,9 @@ jobs:
           command: |
             python3 -m venv venv
             source venv/bin/activate
-            pip install --upgrade pip
+            pip install --upgrade pip wheel setuptools
             pip install -r requirements.txt
             pip install -r requirements/doc.txt
-            pip install -r requirements/optional.txt
             pip install pydot pygraphviz
 
       - run:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,3 +1,5 @@
+name: macOS tests
+
 on:
   push:
     branches: [ master ]
@@ -6,7 +8,6 @@ on:
 
 jobs:
   test_macos:
-    name: macOS tests
     runs-on: macos-latest
     strategy:
       max-parallel: 3
@@ -28,7 +29,6 @@ jobs:
       run: |
         pip install --upgrade pip wheel setuptools
         pip install -r requirements.txt
-        pip install -r requirements/optional.txt
         pip install pydot pygraphviz
         pip install .
         pip list

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: pip
 matrix:
   include:
     - os: linux
-      python: 3.7
+      python: 3.6
       env:
       - OPTIONAL_DEPS=1
       - MINIMUM_REQUIREMENTS=1
@@ -42,15 +42,9 @@ matrix:
           packages:
           - libgdal-dev
           - graphviz
-    - python: 3.6
-    - python: 3.7
     - python: 3.8
     - python: 3.9-dev
-      env:
-      - MIN_DEPS=1
-    - python: pypy3.6-7.1.1
-      env:
-      - MIN_DEPS=1
+    - python: pypy3
 
 before_install:
   # prepare the system to install prerequisites or dependencies
@@ -61,13 +55,10 @@ before_install:
 
 install:
   # install required packages
-  - pip install --upgrade pip
+  - pip install --upgrade pip wheel setuptools
   - pip install --retries 3 ${PIP_FLAGS} -r requirements.txt
   - if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
-      pip install --retries 3 ${PIP_FLAGS} -r requirements/optional.txt;
-      pip install --retries 3 ${PIP_FLAGS} -r requirements/extras.txt;
-    elif [[ "${MIN_DEPS}" != 1 ]]; then
-      pip install --retries 3 ${PIP_FLAGS} -r requirements/optional.txt;
+      pip install --retries 3 ${PIP_FLAGS} -r requirements/extra.txt;
     fi
   # install networkx
   - printenv PWD

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -43,7 +43,7 @@ Development Workflow
          # (Optional) Install pygraphviz, pydot, and gdal packages
          # These packages require that you have your system properly configured
          # and what that involves differs on various systems.
-         # pip install -r requirements/extras.txt
+         # pip install -r requirements/extra.txt
          #
          # Build and install networkx from source
          pip install -e .
@@ -64,7 +64,7 @@ Development Workflow
          # (Optional) Install pygraphviz, pydot, and gdal packages
          # These packages require that you have your system properly configured
          # and what that involves differs on various systems.
-         # pip install -r requirements/extras.txt
+         # pip install -r requirements/extra.txt
          #
          # Install networkx from source
          pip install -e . --no-deps
@@ -228,12 +228,22 @@ Guidelines
 * All changes are reviewed.  Ask on the
   `mailing list <http://groups.google.com/group/networkx-discuss>`_ if
   you get no response to your pull request.
+* Default dependencies are listed in ``requirements/default.txt`` and extra
+  (i.e., optional) dependencies are listed in ``requirements/extra.txt``.
+  We don't often add new default and extra dependencies.  If you are considering
+  adding code that has a dependency, you should first consider adding a gallery
+  example.  Typically, new proposed dependencies would first be added as extra
+  dependencies.  Extra dependencies should be easy to install on all platforms
+  and widely-used.  New default dependencies should be easy to install on all
+  platforms, widely-used in the community, and have demonstrated potential for
+  wide-spread use in NetworkX.
 * Use the following import conventions::
 
    import numpy as np
    import scipy as sp
    import matplotlib as mpl
    import matplotlib.pyplot as plt
+   import pandas as pd 
    import networkx as nx
 
 * Use the decorator ``not_implemented_for`` in ``networkx/utils/decorators.py``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -65,28 +65,18 @@ Then, if you want to update ``networkx`` at any time, in the same directory do::
 
     $ git pull
 
-Optional packages
------------------
+Extra packages
+--------------
 
 .. note::
    Some optional packages (e.g., `gdal`) may require compiling
    C or C++ code.  If you have difficulty installing these packages
-   with `pip`, please review the instructions for installing
-   the full `scientific Python stack <https://scipy.org/install.html>`_.
+   with `pip`, please consult the homepages of those packages.
 
-The following optional packages provide additional functionality. See the
+The following extra packages provide additional functionality. See the
 files in the ``requirements/`` directory for information about specific
 version requirements.
 
-- `NumPy <http://www.numpy.org/>`_ provides array-based dense 
-  matrix representations of graphs and high-performance array math and linear
-  algebra which is used in some graph algorithms.
-- `SciPy <http://scipy.org/>`_ provides sparse matrix representation
-  of graphs and many numerical scientific tools.
-- `pandas <http://pandas.pydata.org/>`_ provides a DataFrame, which
-  is a tabular data structure with labeled axes.
-- `Matplotlib <http://matplotlib.org/>`_ provides flexible drawing of
-  graphs.
 - `PyGraphviz <http://pygraphviz.github.io/>`_ and
   `pydot <https://github.com/erocarrera/pydot>`_ provide graph drawing
   and graph layout algorithms via `GraphViz <http://graphviz.org/>`_.
@@ -94,17 +84,17 @@ version requirements.
 - `gdal <http://www.gdal.org/>`_ provides shapefile format reading and writing.
 - `lxml <http://lxml.de/>`_ used for GraphML XML format.
 
-To install ``networkx`` and all optional packages, do::
+To install ``networkx`` and extra packages, do::
 
-    $ pip install networkx[all]
+    $ pip install networkx[extra]
 
 To explicitly install all optional packages, do::
 
-    $ pip install numpy scipy pandas matplotlib pygraphviz pydot pyyaml gdal
+    $ pip install pygraphviz pydot pyyaml gdal lxml
 
-Or, install any optional package (e.g., ``numpy``) individually::
+Or, install any optional package (e.g., ``pygraphviz``) individually::
 
-    $ pip install numpy
+    $ pip install pygraphviz
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,9 @@ NetworkX
 .. image:: https://travis-ci.org/networkx/networkx.svg?branch=master
    :target: https://travis-ci.org/networkx/networkx
 
+.. image:: https://github.com/networkx/networkx/workflows/macOS%20tests/badge.svg?branch=master
+  :target: https://github.com/networkx/networkx/actions?query=workflow%3A%22macOS+tests%22
+
 .. image:: https://ci.appveyor.com/api/projects/status/github/networkx/networkx?branch=master&svg=true
    :target: https://ci.appveyor.com/project/dschult/networkx-pqott
 

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -54,3 +54,4 @@ Version 3.0
 * In ``algorithms/centrality/betweenness_centrality_subset.py`` remove ``betweenness_centrality_source``.
 * In ``algorithms/centrality/betweenness.py`` remove ``edge_betweeness``.
 * In ``algorithms/community_modularity_max.py`` remove old name ``_naive_greedy_modularity_communities``.
+* In ``linalg/algebraicconnectivity.py`` remove ``_CholeskySolver`` and related code.

--- a/doc/developer/release.rst
+++ b/doc/developer/release.rst
@@ -57,6 +57,7 @@ Release Process
 - Publish on PyPi::
 
    git clean -fxd
+   pip install -r requirements/release.txt
    python setup.py sdist bdist_wheel
    twine upload -s dist/*
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -26,10 +26,11 @@ Improvements
 API Changes
 -----------
 
+- [`#4190 <https://github.com/networkx/networkx/pull/4190>`_]
+  Removed ``tracemin_chol``.  Use ``tracemin_lu`` instead.
 
 Deprecations
 ------------
-
 
 Contributors to this release
 ----------------------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -17,6 +17,7 @@ Highlights
 This release is the result of X of work with over X pull requests by
 X contributors. Highlights include:
 
+- NumPy, SciPy, Matplotlib, and pandas are now default requirements.
 
 Improvements
 ------------

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -129,10 +129,8 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
-    try:
-        import scipy.stats as stats
-    except ImportError as e:
-        raise ImportError("Assortativity requires SciPy:" "http://scipy.org/ ") from e
+    import scipy.stats as stats
+
     xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
     x, y = zip(*xy)
     return stats.pearsonr(x, y)[0]
@@ -250,12 +248,6 @@ def attribute_ac(M):
     .. [1] M. E. J. Newman, Mixing patterns in networks,
        Physical Review E, 67 026126, 2003
     """
-    try:
-        import numpy
-    except ImportError as e:
-        raise ImportError(
-            "attribute_assortativity requires " "NumPy: http://scipy.org/"
-        ) from e
     if M.sum() != 1.0:
         M = M / M.sum()
     s = (M @ M).sum()
@@ -267,21 +259,17 @@ def attribute_ac(M):
 def numeric_ac(M):
     # M is a numpy matrix or array
     # numeric assortativity coefficient, pearsonr
-    try:
-        import numpy
-    except ImportError as e:
-        raise ImportError(
-            "numeric_assortativity requires " "NumPy: http://scipy.org/"
-        ) from e
+    import numpy as np
+
     if M.sum() != 1.0:
         M = M / float(M.sum())
     nx, ny = M.shape  # nx=ny
-    x = numpy.arange(nx)
-    y = numpy.arange(ny)
+    x = np.arange(nx)
+    y = np.arange(ny)
     a = M.sum(axis=0)
     b = M.sum(axis=1)
     vara = (a * x ** 2).sum() - ((a * x).sum()) ** 2
     varb = (b * x ** 2).sum() - ((b * x).sum()) ** 2
-    xy = numpy.outer(x, y)
-    ab = numpy.outer(a, b)
-    return (xy * (M - ab)).sum() / numpy.sqrt(vara * varb)
+    xy = np.outer(x, y)
+    ab = np.outer(a, b)
+    return (xy * (M - ab)).sum() / np.sqrt(vara * varb)

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -57,13 +57,13 @@ INFINITY = float("inf")
 def hopcroft_karp_matching(G, top_nodes=None):
     """Returns the maximum cardinality matching of the bipartite graph `G`.
 
-    A matching is a set of edges that do not share any nodes. A maximum 
+    A matching is a set of edges that do not share any nodes. A maximum
     cardinality matching is a matching with the most edges possible. It
     is not always unique. Finding a matching in a bipartite graph can be
     treated as a networkx flow problem.
-    
+
     The functions ``hopcroft_karp_matching`` and ``maximum_matching``
-    are aliases of the same function. 
+    are aliases of the same function.
 
     Parameters
     ----------
@@ -556,13 +556,9 @@ def minimum_weight_full_matching(G, top_nodes=None, weight="weight"):
        Networks, 10(2):143–152, 1980.
 
     """
-    try:
-        import numpy as np
-        import scipy.optimize
-    except ImportError as e:
-        raise ImportError(
-            "minimum_weight_full_matching requires SciPy: " + "https://scipy.org/"
-        ) from e
+    import numpy as np
+    import scipy.optimize
+
     left, right = nx.bipartite.sets(G, top_nodes)
     U = list(left)
     V = list(right)

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -47,12 +47,8 @@ def spectral_bipartivity(G, nodes=None, weight="weight"):
     .. [1] E. Estrada and J. A. Rodríguez-Velázquez, "Spectral measures of
        bipartivity in complex networks", PhysRev E 72, 046105 (2005)
     """
-    try:
-        import scipy.linalg
-    except ImportError as e:
-        raise ImportError(
-            "spectral_bipartivity() requires SciPy: ", "http://scipy.org/"
-        ) from e
+    import scipy.linalg
+
     nodelist = list(G)  # ordering of nodes in matrix
     A = nx.to_numpy_array(G, nodelist, weight=weight)
     expA = scipy.linalg.expm(A)

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -95,12 +95,8 @@ def approximate_current_flow_betweenness_centrality(
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
        http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "current_flow_betweenness_centrality requires NumPy " "http://numpy.org/"
-        ) from e
+    import numpy as np
+
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
     solvername = {

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -88,13 +88,8 @@ def current_flow_betweenness_centrality_subset(
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
     from networkx.utils import reverse_cuthill_mckee_ordering
+    import numpy as np
 
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "current_flow_betweenness_centrality requires NumPy ", "http://numpy.org/"
-        ) from e
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
     n = G.number_of_nodes()
@@ -198,12 +193,8 @@ def edge_current_flow_betweenness_centrality_subset(
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "current_flow_betweenness_centrality requires NumPy " "http://numpy.org/"
-        ) from e
+    import numpy as np
+
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
     n = G.number_of_nodes()

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -302,10 +302,8 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
        Psychometrika 18(1):39–43, 1953
        http://phya.snu.ac.kr/~dkim/PRL87278701.pdf
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("Requires NumPy: http://numpy.org/") from e
+    import numpy as np
+
     if len(G) == 0:
         return {}
     try:

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -95,11 +95,7 @@ def second_order_centrality(G):
        "Second order centrality: Distributed assessment of nodes criticity in
        complex networks", Elsevier Computer Communications 34(5):619-628, 2011.
     """
-
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("Requires NumPy: http://numpy.org/") from e
+    import numpy as np
 
     n = len(G)
 

--- a/networkx/algorithms/centrality/trophic.py
+++ b/networkx/algorithms/centrality/trophic.py
@@ -40,10 +40,7 @@ def trophic_levels(G, weight="weight"):
     ----------
     .. [1] Stephen Levine (1980) J. theor. Biol. 83, 195-207
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("trophic_levels() requires NumPy: http://numpy.org/") from e
+    import numpy as np
 
     # find adjacency matrix
     a = nx.adjacency_matrix(G, weight=weight).T.toarray()
@@ -145,12 +142,7 @@ def trophic_incoherence_parameter(G, weight="weight", cannibalism=False):
     .. [1] Samuel Johnson, Virginia Dominguez-Garcia, Luca Donetti, Miguel A.
         Munoz (2014) PNAS "Trophic coherence determines food-web stability"
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "trophic_incoherence_parameter() requires NumPy: " "http://scipy.org/"
-        ) from e
+    import numpy as np
 
     if cannibalism:
         diffs = trophic_differences(G, weight=weight)

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -176,10 +176,8 @@ def hits_numpy(G, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("hits_numpy() requires NumPy: " "http://numpy.org/") from e
+    import numpy as np
+
     if len(G) == 0:
         return {}, {}
     H = nx.hub_matrix(G, list(G))
@@ -267,13 +265,8 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "hits_scipy() requires SciPy and NumPy:"
-            "http://scipy.org/ http://numpy.org/"
-        ) from e
+    import numpy as np
+
     if len(G) == 0:
         return {}, {}
     M = nx.to_scipy_sparse_matrix(G, nodelist=list(G))

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -61,18 +61,8 @@ def harmonic_function(G, max_iter=30, label_name="label"):
     Semi-supervised learning using gaussian fields and harmonic functions.
     In ICML (Vol. 3, pp. 912-919).
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "harmonic_function() requires numpy: http://numpy.org/ "
-        ) from e
-    try:
-        from scipy import sparse
-    except ImportError as e:
-        raise ImportError(
-            "harmonic_function() requires scipy: http://scipy.org/ "
-        ) from e
+    import numpy as np
+    from scipy import sparse
 
     def _build_propagation_matrix(X, labels):
         """Build propagation matrix of Harmonic function

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -64,18 +64,8 @@ def local_and_global_consistency(G, alpha=0.99, max_iter=30, label_name="label")
     Learning with local and global consistency.
     Advances in neural information processing systems, 16(16), 321-328.
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError(
-            "local_and_global_consistency() requires numpy: ", "http://numpy.org/ "
-        ) from e
-    try:
-        from scipy import sparse
-    except ImportError as e:
-        raise ImportError(
-            "local_and_global_consistensy() requires scipy: ", "http://scipy.org/ "
-        ) from e
+    import numpy as np
+    from scipy import sparse
 
     def _build_propagation_matrix(X, labels, alpha):
         """Build propagation matrix of Local and global consistency

--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -54,6 +54,7 @@ def non_randomness(G, k=None):
             On Randomness Measures for Social Networks,
             SIAM International Conference on Data Mining. 2009
     """
+    import numpy as np
 
     if not nx.is_connected(G):
         raise nx.NetworkXException("Non connected graph.")
@@ -62,12 +63,6 @@ def non_randomness(G, k=None):
 
     if k is None:
         k = len(tuple(nx.community.label_propagation_communities(G)))
-
-    try:
-        import numpy as np
-    except ImportError as e:
-        msg = "non_randomness requires NumPy: http://numpy.org/"
-        raise ImportError(msg) from e
 
     # eq. 4.4
     nr = np.real(np.sum(np.linalg.eigvals(nx.to_numpy_array(G))[:k]))

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -38,10 +38,7 @@ def floyd_warshall_numpy(G, nodelist=None, weight="weight"):
     algorithm fails. This algorithm can still fail if there are negative
     cycles.  It has running time $O(n^3)$ with running space of $O(n^2)$.
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("to_numpy_array() requires numpy: http://numpy.org/ ") from e
+    import numpy as np
 
     # To handle cases when an edge has weight=0, we must make sure that
     # nonedges are not given the value 0 as well.

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -129,8 +129,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                     msg = "Input is not a correct Pandas DataFrame edge-list."
                     raise nx.NetworkXError(msg) from e
     except ImportError:
-        msg = "pandas not found, skipping conversion test."
-        warnings.warn(msg, ImportWarning)
+        warnings.warn("pandas not found, skipping conversion test.", ImportWarning)
 
     # numpy matrix or ndarray
     try:

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -580,17 +580,13 @@ def _sparse_fruchterman_reingold(
     # Entry point for NetworkX graph is fruchterman_reingold_layout()
     # Sparse version
     import numpy as np
+    from scipy.sparse import coo_matrix
 
     try:
         nnodes, _ = A.shape
     except AttributeError as e:
         msg = "fruchterman_reingold() takes an adjacency matrix as input"
         raise nx.NetworkXError(msg) from e
-    try:
-        from scipy.sparse import coo_matrix
-    except ImportError as e:
-        msg = "_sparse_fruchterman_reingold() scipy numpy: http://scipy.org/ "
-        raise ImportError(msg) from e
     # make sure we have a LIst of Lists representation
     try:
         A = A.tolil()

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -13,6 +13,7 @@ matplotlib:     http://matplotlib.org/
 pygraphviz:     http://pygraphviz.github.io/
 
 """
+
 from numbers import Number
 import networkx as nx
 from networkx.drawing.layout import (
@@ -98,13 +99,7 @@ def draw(G, pos=None, ax=None, **kwds):
     Also see the NetworkX drawing examples at
     https://networkx.github.io/documentation/latest/auto_examples/index.html
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
-    except RuntimeError:
-        print("Matplotlib unable to open display")
-        raise
+    import matplotlib.pyplot as plt
 
     if ax is None:
         cf = plt.gcf()
@@ -262,13 +257,7 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
     draw_networkx_labels()
     draw_networkx_edge_labels()
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
-    except RuntimeError:
-        print("Matplotlib unable to open display")
-        raise
+    import matplotlib.pyplot as plt
 
     valid_node_kwds = (
         "nodelist",
@@ -432,16 +421,9 @@ def draw_networkx_nodes(
     draw_networkx_edge_labels()
     """
     from collections.abc import Iterable
-
-    try:
-        import matplotlib.pyplot as plt
-        from matplotlib.collections import PathCollection
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
-    except RuntimeError:
-        print("Matplotlib unable to open display")
-        raise
+    import matplotlib.pyplot as plt
+    from matplotlib.collections import PathCollection
+    import numpy as np
 
     if ax is None:
         ax = plt.gca()
@@ -621,17 +603,11 @@ def draw_networkx_edges(
     draw_networkx_labels()
     draw_networkx_edge_labels()
     """
-    try:
-        import matplotlib.pyplot as plt
-        from matplotlib.colors import colorConverter, Colormap, Normalize
-        from matplotlib.collections import LineCollection
-        from matplotlib.patches import FancyArrowPatch
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
-    except RuntimeError:
-        print("Matplotlib unable to open display")
-        raise
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import colorConverter, Colormap, Normalize
+    from matplotlib.collections import LineCollection
+    from matplotlib.patches import FancyArrowPatch
+    import numpy as np
 
     if ax is None:
         ax = plt.gca()
@@ -875,13 +851,7 @@ def draw_networkx_labels(
     draw_networkx_edges()
     draw_networkx_edge_labels()
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
-    except RuntimeError:
-        print("Matplotlib unable to open display")
-        raise
+    import matplotlib.pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -1015,14 +985,8 @@ def draw_networkx_edge_labels(
     draw_networkx_edges()
     draw_networkx_labels()
     """
-    try:
-        import matplotlib.pyplot as plt
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
-    except RuntimeError:
-        print("Matplotlib unable to open display")
-        raise
+    import matplotlib.pyplot as plt
+    import numpy as np
 
     if ax is None:
         ax = plt.gca()
@@ -1250,13 +1214,9 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
 
     """
     from itertools import islice, cycle
-
-    try:
-        import numpy as np
-        from matplotlib.colors import colorConverter
-        import matplotlib.cm as cm
-    except ImportError as e:
-        raise ImportError("Matplotlib required for draw()") from e
+    import numpy as np
+    from matplotlib.colors import colorConverter
+    import matplotlib.cm as cm
 
     # If we have been provided with a list of numbers as long as elem_list,
     # apply the color mapping.

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -83,19 +83,7 @@ class _CholeskySolver:
     """
 
     def __init__(self, A):
-        if not self._cholesky:
-            raise nx.NetworkXError("Cholesky solver unavailable.")
-        self._chol = self._cholesky(A)
-
-    def solve(self, B, tol=None):
-        return self._chol(B)
-
-    try:
-        from scikits.sparse.cholmod import cholesky
-
-        _cholesky = cholesky
-    except ImportError:
-        _cholesky = None
+        raise nx.NetworkXError("Cholesky solver removed.  Use LU solver instead.")
 
 
 class _LUSolver:
@@ -194,7 +182,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         Warning: There is no limit on number of iterations.
 
     method : string
-        Should be 'tracemin_pcg', 'tracemin_chol' or 'tracemin_lu'.
+        Should be 'tracemin_pcg' or 'tracemin_lu'.
         Otherwise exception is raised.
 
     Returns
@@ -358,7 +346,6 @@ def algebraic_connectivity(
         Value           Solver
         =============== ========================================
         'tracemin_pcg'  Preconditioned conjugate gradient method
-        'tracemin_chol' Cholesky factorization
         'tracemin_lu'   LU factorization
         =============== ========================================
 
@@ -445,7 +432,6 @@ def fiedler_vector(
         Value           Solver
         =============== ========================================
         'tracemin_pcg'  Preconditioned conjugate gradient method
-        'tracemin_chol' Cholesky factorization
         'tracemin_lu'   LU factorization
         =============== ========================================
 
@@ -531,7 +517,6 @@ def spectral_ordering(
         Value           Solver
         =============== ========================================
         'tracemin_pcg'  Preconditioned conjugate gradient method
-        'tracemin_chol' Cholesky factorization
         'tracemin_lu'   LU factorization
         =============== ========================================
 

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -267,10 +267,7 @@ def attr_matrix(
         (blue, blue) is 0   # there are no edges with blue endpoints
 
     """
-    try:
-        import numpy as np
-    except ImportError as e:
-        raise ImportError("attr_matrix() requires numpy: http://scipy.org/ ") from e
+    import numpy as np
 
     edge_value = _edge_value(G, edge_attr)
     node_value = _node_value(G, node_attr)
@@ -428,13 +425,8 @@ def attr_sparse_matrix(
         (blue, blue) is 0   # there are no edges with blue endpoints
 
     """
-    try:
-        import numpy as np
-        from scipy import sparse
-    except ImportError as e:
-        raise ImportError(
-            "attr_sparse_matrix() requires scipy: " "http://scipy.org/ "
-        ) from e
+    import numpy as np
+    from scipy import sparse
 
     edge_value = _edge_value(G, edge_attr)
     node_value = _node_value(G, node_attr)

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -11,17 +11,28 @@ scipy.sparse = pytest.importorskip("scipy.sparse")
 import networkx as nx
 from networkx.testing import almost_equal
 
-try:
-    from scikits.sparse.cholmod import cholesky
+methods = ("tracemin_pcg", "tracemin_lu", "lanczos", "lobpcg")
 
-    _cholesky = cholesky
-except ImportError:
-    _cholesky = None
 
-if _cholesky is None:
-    methods = ("tracemin_pcg", "tracemin_lu", "lanczos", "lobpcg")
-else:
-    methods = ("tracemin_pcg", "tracemin_chol", "tracemin_lu", "lanczos", "lobpcg")
+def test_algebraic_connectivity_tracemin_chol():
+    """Test that "tracemin_chol" raises an exception."""
+    G = nx.barbell_graph(5, 4)
+    with pytest.raises(nx.NetworkXError):
+        nx.algebraic_connectivity(G, method="tracemin_chol")
+
+
+def test_fiedler_vector_tracemin_chol():
+    """Test that "tracemin_chol" raises an exception."""
+    G = nx.barbell_graph(5, 4)
+    with pytest.raises(nx.NetworkXError):
+        nx.fiedler_vector(G, method="tracemin_chol")
+
+
+def test_spectral_ordering_tracemin_chol():
+    """Test that "tracemin_chol" raises an exception."""
+    G = nx.barbell_graph(5, 4)
+    with pytest.raises(nx.NetworkXError):
+        nx.spectral_ordering(G, method="tracemin_chol")
 
 
 def check_eigenvector(A, l, x):

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -4,9 +4,7 @@
 
 - [`default.txt`](default.txt)
   Default requirements
-- [`optional.txt`](optional.txt)
-  Optional requirements that are easy to install
-- [`extras.txt`](extras.txt)
+- [`extra.txt`](extra.txt)
   Optional requirements that may require extra steps to install
 - [`test.txt`](test.txt)
   Requirements for running test suite

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,5 @@
 decorator>=4.3.0
+numpy>=1.19
+scipy>=1.4
+matplotlib>=3.2
+pandas>=1.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
-decorator>=4.3.0
-numpy>=1.19
-scipy>=1.4
-matplotlib>=3.2
-pandas>=1.0
+decorator>=4.4
+numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.9'
+scipy>=1.5; platform_python_implementation!='PyPy' and python_version<'3.9'
+matplotlib>=3.3; platform_python_implementation!='PyPy' and python_version<'3.9'
+pandas>=1.1; platform_python_implementation!='PyPy' and python_version<'3.9'

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,2 +1,4 @@
+lxml>=4.5
 pygraphviz>=1.5, <2.0
 pydot>=1.4.1
+pyyaml>=5.3

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,6 +1,0 @@
-numpy>=1.19
-scipy>=1.4
-pandas>=1.0
-matplotlib>=3.2
-pyyaml>=5.3
-lxml>=4.5

--- a/setup.py
+++ b/setup.py
@@ -124,29 +124,23 @@ package_data = {
     "networkx.utils": ["tests/*.py"],
 }
 
-install_requires = ["decorator>=4.3.0"]
+install_requires = [
+    "decorator>=4.3.0",
+    "numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.9'",
+    "scipy>=1.4; platform_python_implementation!='PyPy' and python_version<'3.9'",
+    "matplotlib>=3.2; platform_python_implementation!='PyPy' and python_version<'3.9'",
+    "pandas>=1.0; platform_python_implementation!='PyPy' and python_version<'3.9'",
+]
 extras_require = {
-    "all": [
-        "numpy",
-        "scipy",
-        "pandas",
-        "matplotlib",
-        "pygraphviz",
-        "pydot",
-        "pyyaml",
-        "lxml",
-        "pytest",
+    "extra": [
+        "lxml>=4.5",
+        "pygraphviz>=1.5, <2.0",
+        "pydot>=1.4.1",
+        "pyyaml>=5.3",
     ],
     "gdal": ["gdal"],
-    "lxml": ["lxml"],
-    "matplotlib": ["matplotlib"],
-    "pytest": ["pytest"],
-    "numpy": ["numpy"],
-    "pandas": ["pandas"],
     "pydot": ["pydot"],
     "pygraphviz": ["pygraphviz"],
-    "pyyaml": ["pyyaml"],
-    "scipy": ["scipy"],
 }
 
 with open("README.rst", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -124,23 +124,18 @@ package_data = {
     "networkx.utils": ["tests/*.py"],
 }
 
-install_requires = [
-    "decorator>=4.3.0",
-    "numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.9'",
-    "scipy>=1.4; platform_python_implementation!='PyPy' and python_version<'3.9'",
-    "matplotlib>=3.2; platform_python_implementation!='PyPy' and python_version<'3.9'",
-    "pandas>=1.0; platform_python_implementation!='PyPy' and python_version<'3.9'",
-]
+
+def parse_requirements_file(filename):
+    with open(filename, encoding="utf-8") as fid:
+        requires = [l.strip() for l in fid.readlines() if l]
+
+    return requires
+
+
+install_requires = parse_requirements_file("requirements/default.txt")
 extras_require = {
-    "extra": [
-        "lxml>=4.5",
-        "pygraphviz>=1.5, <2.0",
-        "pydot>=1.4.1",
-        "pyyaml>=5.3",
-    ],
-    "gdal": ["gdal"],
-    "pydot": ["pydot"],
-    "pygraphviz": ["pygraphviz"],
+    dep: parse_requirements_file("requirements/" + dep + ".txt")
+    for dep in ["developer", "doc", "extra", "test"]
 }
 
 with open("README.rst", "r") as fh:

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -14,7 +14,7 @@ export -f section_end
 
 if [[ "${MINIMUM_REQUIREMENTS}" == 1 ]]; then
     sed -i 's/>=/==/g' requirements/default.txt
-    sed -i 's/>=/==/g' requirements/extras.txt
+    sed -i 's/>=/==/g' requirements/extra.txt
     sed -i 's/>=/==/g' requirements/test.txt
     sed -i 's/>=/==/g' requirements/doc.txt
 fi


### PR DESCRIPTION
Given their central position in the scientific Python ecosystem and the fact that they provide self-contained, easy to install wheels, NumPy, SciPy, Matplotlib, and Pandas are now default dependencies.  They don't have pre-built wheels for pypy or 3.9-dev, so they aren't installed by default on those instances via the environment marker:
```
platform_python_implementation!='PyPy' and python_version<'3.9'
```
Before we officially add support for Python 3.9, we will change ``python_version<'3.9'`` to ``python_version<'3.10'``.  If and when the core projects (ie., NumPy, SciPy, Matplotlib, and Pandas) provide self-contained wheels for PyPy, we will remove ``platform_python_implementation!='PyPy'``.

This also makes pyyaml a default dependency.  According to https://pypistats.org/top, pyyaml is among the top 15 packages downloaded from pypi and has more conda downloads than networkx.  It also easy to install and works on pypy.

It is unlikely that we will add additional new default dependencies.  We will also be unlikely to add new extra dependencies.  More detail can be found in the new dependency bullet to the ``Guidelines`` section of the ``Contributor Guide`` (see c9395c8ce1).

This removes code (mostly boiler plate stuff), simplifies our CI system, and should help reduce the number of user installation issues.

@dschult , @rossbar , @stefanv, @MridulS  I think this is ready to go.  Let me know if you have any questions or suggestions.
