### PR TITLE
MAINT: Refactor test_edgelist.py, add tests for parse_edgelist

### DIFF
--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -7,7 +7,6 @@ import itertools
 import tempfile
 import os
 from textwrap import dedent
-from typing import Callable, List, Tuple
 
 import networkx as nx
 from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
@@ -26,19 +25,19 @@ class TestEdgelist:
         cls.XDG = nx.MultiDiGraph(cls.XG)
 
     @staticmethod
-    def bytes_io(s: str, encoding="utf8") -> io.BytesIO:
+    def bytes_io(s, encoding="utf8"):
         return io.BytesIO(bytes(dedent(s), encoding=encoding))
 
     @staticmethod
-    def string_io(s: str) -> io.StringIO:
+    def string_io(s):
         return io.StringIO(dedent(s))
 
     @pytest.fixture(params=["BytesIO", "StringIO"])
-    def stream(self, request) -> Callable[[str], io.IOBase]:
+    def stream(self, request):
         return self.bytes_io if request.param == "BytesIO" else self.string_io
 
     @pytest.fixture(params=["", ","])
-    def delimiter(self, request) -> str:
+    def delimiter(self, request):
         return request.param
 
     @pytest.fixture
@@ -53,7 +52,7 @@ class TestEdgelist:
         return s, expected, delimiter if delimiter != "" else None
 
     @pytest.fixture(params=itertools.product([True, False], repeat=2))
-    def edgelist_data_dict(self, request, delimiter) -> (str, List[Tuple]):
+    def edgelist_data_dict(self, request, delimiter):
         weights, colors = request.param
         data1, data2 = {}, {}
         if weights:

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -5,9 +5,14 @@ import pytest
 import io
 import tempfile
 import os
+from textwrap import dedent
 
 import networkx as nx
 from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
+
+
+def multiline_str_to_bytes_io(s: str, encoding="utf8") -> io.BytesIO:
+    return io.BytesIO(bytes(dedent(s), encoding=encoding))
 
 
 class TestEdgelist:
@@ -23,95 +28,89 @@ class TestEdgelist:
         cls.XDG = nx.MultiDiGraph(cls.XG)
 
     def test_read_edgelist_1(self):
-        s = b"""\
-# comment line
-1 2
-# comment line
-2 3
-"""
-        bytesIO = io.BytesIO(s)
+        s = """\
+            # comment line
+            1 2
+            # comment line
+            2 3
+            """
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
     def test_read_edgelist_2(self):
-        s = b"""\
-# comment line
-1 2 2.0
-# comment line
-2 3 3.0
-"""
-        bytesIO = io.BytesIO(s)
+        s = """\
+            # comment line
+            1 2 2.0
+            # comment line
+            2 3 3.0
+            """
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
-        bytesIO = io.BytesIO(s)
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_weighted_edgelist(bytesIO, nodetype=int)
         assert_edges_equal(
             G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
         )
 
     def test_read_edgelist_3(self):
-        s = b"""\
-# comment line
-1 2 {'weight':2.0}
-# comment line
-2 3 {'weight':3.0}
-"""
-        bytesIO = io.BytesIO(s)
+        s = """\
+            # comment line
+            1 2 {'weight':2.0}
+            # comment line
+            2 3 {'weight':3.0}
+            """
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
-        bytesIO = io.BytesIO(s)
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
         assert_edges_equal(
             G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
         )
 
     def test_read_edgelist_4(self):
-        s = b"""\
-# comment line
-1 2 {'weight':2.0}
-# comment line
-2 3 {'weight':3.0}
-"""
-        bytesIO = io.BytesIO(s)
+        s = """\
+            # comment line
+            1 2 {'weight':2.0}
+            # comment line
+            2 3 {'weight':3.0}
+            """
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
-        bytesIO = io.BytesIO(s)
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
         assert_edges_equal(
             G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
         )
 
-        s = """\
-# comment line
-1 2 {'weight':2.0}
-# comment line
-2 3 {'weight':3.0}
-"""
-        StringIO = io.StringIO(s)
+        StringIO = io.StringIO(dedent(s))
         G = nx.read_edgelist(StringIO, nodetype=int, data=False)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
-        StringIO = io.StringIO(s)
+        StringIO = io.StringIO(dedent(s))
         G = nx.read_edgelist(StringIO, nodetype=int, data=True)
         assert_edges_equal(
             G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
         )
 
     def test_read_edgelist_5(self):
-        s = b"""\
-# comment line
-1 2 {'weight':2.0, 'color':'green'}
-# comment line
-2 3 {'weight':3.0, 'color':'red'}
-"""
-        bytesIO = io.BytesIO(s)
+        s = """\
+            # comment line
+            1 2 {'weight':2.0, 'color':'green'}
+            # comment line
+            2 3 {'weight':3.0, 'color':'red'}
+            """
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
-        bytesIO = io.BytesIO(s)
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
         assert_edges_equal(
             G.edges(data=True),
@@ -122,17 +121,17 @@ class TestEdgelist:
         )
 
     def test_read_edgelist_6(self):
-        s = b"""\
-# comment line
-1, 2, {'weight':2.0, 'color':'green'}
-# comment line
-2, 3, {'weight':3.0, 'color':'red'}
-"""
-        bytesIO = io.BytesIO(s)
+        s = """\
+            # comment line
+            1, 2, {'weight':2.0, 'color':'green'}
+            # comment line
+            2, 3, {'weight':3.0, 'color':'red'}
+            """
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=False, delimiter=",")
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
 
-        bytesIO = io.BytesIO(s)
+        bytesIO = multiline_str_to_bytes_io(s)
         G = nx.read_edgelist(bytesIO, nodetype=int, data=True, delimiter=",")
         assert_edges_equal(
             G.edges(data=True),

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -79,16 +79,6 @@ class TestEdgelist:
             # comment line
             2 3 {'weight':3.0}
             """
-        bytesIO = multiline_str_to_bytes_io(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        bytesIO = multiline_str_to_bytes_io(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
-        assert_edges_equal(
-            G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
-        )
-
         StringIO = io.StringIO(dedent(s))
         G = nx.read_edgelist(StringIO, nodetype=int, data=False)
         assert_edges_equal(G.edges(), [(1, 2), (2, 3)])


### PR DESCRIPTION
The scope of this PR consists of several improvements to `networkx/readwrite/tests/test_edgelist.py`:
- Adds static methods to generate data used repeatedly throughout tests for `read_edgelist`.
- Uses the `textwrap.dedent` utility to avoid ugly (byte)string formatting, and adds static methods to generate StringIO and BytesIO objects from indented multiline strings.
- Gives `read_edgelist` tests more informative names, e.g. `test_read_edgelist_no_data` rather than `test_read_edgelist_1`.
- Removes some code which was duplicated across tests.
- Adds three test cases for `parse_edgelist` to match the [documentation](https://networkx.github.io/documentation/stable/reference/readwrite/generated/networkx.readwrite.edgelist.parse_edgelist.html?highlight=parse_edgelist).

Fixes #4127 