### PR TITLE
MAINT: Refactor nx.info

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -575,24 +575,20 @@ def info(G, n=None):
         If n is not in the graph G
 
     """
-    info = ""  # append this all to a string
     if n is None:
-        info += f"Name: {G.name}\n"
-        type_name = [type(G).__name__]
-        info += f"Type: {','.join(type_name)}\n"
         n_nodes = G.number_of_nodes()
         n_edges = G.number_of_edges()
-        info += f"Number of nodes: {n_nodes}\n"
-        info += f"Number of edges: {n_edges}\n"
-        if n_nodes:
-            if G.is_directed():
-                deg = n_edges / n_nodes
-                info += f"Average in/out degree: {deg:8.4f}"
-            else:
-                info += f"Average degree: {(2 * n_edges / n_nodes):8.4f}"
+        return "".join(
+            [
+                type(G).__name__,
+                f" named '{G.name}'" if G.name else "",
+                f" with {n_nodes} nodes and {n_edges} edges",
+            ]
+        )
     else:
         if n not in G:
             raise nx.NetworkXError(f"node {n} not in graph")
+        info = ""  # append this all to a string
         info += f"Node {n} has the following properties:\n"
         info += f"Degree: {G.degree(n)}\n"
         info += "Neighbors: "

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -580,18 +580,17 @@ def info(G, n=None):
         info += f"Name: {G.name}\n"
         type_name = [type(G).__name__]
         info += f"Type: {','.join(type_name)}\n"
-        info += f"Number of nodes: {G.number_of_nodes()}\n"
-        info += f"Number of edges: {G.number_of_edges()}\n"
-        nnodes = G.number_of_nodes()
+        n_nodes = G.number_of_nodes()
+        n_edges = G.number_of_edges()
+        info += f"Number of nodes: {n_nodes}\n"
+        info += f"Number of edges: {n_edges}\n"
         if len(G) > 0:
             if G.is_directed():
-                deg = sum(d for n, d in G.in_degree()) / float(nnodes)
+                deg = n_edges / n_nodes
                 info += f"Average in degree: {deg:8.4f}\n"
-                deg = sum(d for n, d in G.out_degree()) / float(nnodes)
                 info += f"Average out degree: {deg:8.4f}"
             else:
-                s = sum(dict(G.degree()).values())
-                info += f"Average degree: {(float(s) / float(nnodes)):8.4f}"
+                info += f"Average degree: {(2 * n_edges / n_nodes):8.4f}"
     else:
         if n not in G:
             raise nx.NetworkXError(f"node {n} not in graph")

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -584,11 +584,10 @@ def info(G, n=None):
         n_edges = G.number_of_edges()
         info += f"Number of nodes: {n_nodes}\n"
         info += f"Number of edges: {n_edges}\n"
-        if len(G) > 0:
+        if n_nodes:
             if G.is_directed():
                 deg = n_edges / n_nodes
-                info += f"Average in degree: {deg:8.4f}\n"
-                info += f"Average out degree: {deg:8.4f}"
+                info += f"Average in/out degree: {deg:8.4f}"
             else:
                 info += f"Average degree: {(2 * n_edges / n_nodes):8.4f}"
     else:

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -554,8 +554,8 @@ def create_empty_copy(G, with_data=True):
 def info(G, n=None):
     """Return a summary of information for the graph G or a single node n.
 
-    The summary includes the number of nodes and edges (or neighbours for a single
-    node), and their average degree.
+    The summary includes the number of nodes and edges, or neighbours for a single
+    node.
 
     Parameters
     ----------

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -298,8 +298,7 @@ class TestFunction:
                 "Type: DiGraph",
                 "Number of nodes: 5",
                 "Number of edges: 4",
-                "Average in degree:   0.8000",
-                "Average out degree:   0.8000",
+                "Average in/out degree:   0.8000",
             ]
         )
         assert info == expected_graph_info

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -267,15 +267,7 @@ class TestFunction:
         G = nx.path_graph(5)
         G.name = "path_graph(5)"
         info = nx.info(G)
-        expected_graph_info = "\n".join(
-            [
-                "Name: path_graph(5)",
-                "Type: Graph",
-                "Number of nodes: 5",
-                "Number of edges: 4",
-                "Average degree:   1.6000",
-            ]
-        )
+        expected_graph_info = "Graph named 'path_graph(5)' with 5 nodes and 4 edges"
         assert info == expected_graph_info
 
         info = nx.info(G, n=1)
@@ -292,15 +284,7 @@ class TestFunction:
         G = nx.DiGraph(name="path_graph(5)")
         nx.add_path(G, [0, 1, 2, 3, 4])
         info = nx.info(G)
-        expected_graph_info = "\n".join(
-            [
-                "Name: path_graph(5)",
-                "Type: DiGraph",
-                "Number of nodes: 5",
-                "Number of edges: 4",
-                "Average in/out degree:   0.8000",
-            ]
-        )
+        expected_graph_info = "DiGraph named 'path_graph(5)' with 5 nodes and 4 edges"
         assert info == expected_graph_info
 
         info = nx.info(G, n=1)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -190,12 +190,7 @@ def from_pandas_adjacency(df, create_using=None):
     >>> G = nx.from_pandas_adjacency(df)
     >>> G.name = "Graph from pandas adjacency matrix"
     >>> print(nx.info(G))
-    Name: Graph from pandas adjacency matrix
-    Type: Graph
-    Number of nodes: 2
-    Number of edges: 3
-    Average degree:   3.0000
-
+    Graph named 'Graph from pandas adjacency matrix' with 2 nodes and 3 edges
     """
 
     try:


### PR DESCRIPTION
I was reading the discussion into #4139 and it led me to some questionable code in `nx.info`. For example, in a digraph we compute the average in-degree and out-degree by iterating over the nodes (twice), even though both `G.number_of_edges` and `G.number_of_nodes` are called earlier in the function. Unless I'm missing something (certainly possible), these are both equal to #nodes/#edges by definition. Similarly, the average degree in an undirected graph should just be double the ratio of edges to nodes.

This is a small refactor to eliminate redundant computation. In theory, it should make `nx.info` faster on large graphs, but using @rossbar's example of `nx.path_graph(int(1e7))` I got similar results before and after the changes. So maybe it's unnecessary, but I figured I'd leave that up to the maintainers since it's already done.