### PR TITLE
Fix Topological Sort

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -178,7 +178,7 @@ def topological_sort(G):
     zero_indegree = [v for v, d in G.in_degree() if d == 0]
 
     while zero_indegree:
-        node = zero_indegree.pop()
+        node = zero_indegree.pop(0)
         if node not in G:
             raise RuntimeError("Graph changed during iteration")
         for _, child in G.edges(node):

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -201,6 +201,11 @@ class TestDAG:
             pytest.raises(RuntimeError, runtime_error2)
             pytest.raises(nx.NetworkXUnfeasible, unfeasible_error)
 
+    def test_topological_sort7(self):
+        G = nx.DiGraph([(1, 3), (2, 4), (3, 5), (4, 5)])
+        sort_result = list(nx.topological_sort(G))
+        assert sort_result[0] + sort_result[1] == 3
+
     def test_all_topological_sorts_1(self):
         DG = nx.DiGraph([(1, 2), (2, 3), (3, 4), (4, 5)])
         assert list(nx.all_topological_sorts(DG)) == [[1, 2, 3, 4, 5]]


### PR DESCRIPTION
This PR tries to fix https://github.com/networkx/networkx/issues/4194 .

The root cause: `zero_indegree.pop()` pops out the last element, while `zero_indegree.append(child)` appends the next layer `child` to the last. These two operation together makes `zero_indegree` a stack instead of a queue. 

The fix: simply use `zero_indegree.pop(0)` to pop out the first element, and then it becomes a queue. 
