### PR TITLE
Fix UnionFind.union to actually select the heaviest root as the new root

### DIFF
--- a/networkx/utils/tests/test_unionfind.py
+++ b/networkx/utils/tests/test_unionfind.py
@@ -34,6 +34,19 @@ def test_unionfind_weights():
     assert uf.weights[uf[1]] == 9
 
 
+def test_unbalanced_merge_weights():
+    # Tests if the largest set's root is used as the new root when merging
+    uf = nx.utils.UnionFind()
+    uf.union(1, 2, 3)
+    uf.union(4, 5, 6, 7, 8, 9)
+    assert uf.weights[uf[1]] == 3
+    assert uf.weights[uf[4]] == 6
+    largest_root = uf[4]
+    uf.union(1, 4)
+    assert uf[1] == largest_root
+    assert uf.weights[largest_root] == 9
+
+
 def test_empty_union():
     # Tests if a null-union does nothing.
     uf = nx.utils.UnionFind((0, 1))

--- a/networkx/utils/union_find.py
+++ b/networkx/utils/union_find.py
@@ -92,7 +92,11 @@ class UnionFind:
     def union(self, *objects):
         """Find the sets containing the objects and merge them all."""
         # Find the heaviest root according to its weight.
-        roots = iter(sorted({self[x] for x in objects}, key=lambda r: self.weights[r]))
+        roots = iter(
+            sorted(
+                {self[x] for x in objects}, key=lambda r: self.weights[r], reverse=True
+            )
+        )
         try:
             root = next(roots)
         except StopIteration:


### PR DESCRIPTION
Previous versions in this area of code used `max()` to select the root of the heaviest set, but a fix for a different issue changed this to pull the first element from the sorted set of roots, i.e. the _lightest_ root, not the heaviest.