### PR TITLE
include analytics to hits and pagerank #4178

### DIFF
--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -38,19 +38,23 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=Fa
 
     normalized : bool (default=True)
        Normalize results by the sum of all of the values.
+    
+    analytics : bool (default=False)
+        Store the authority and hub scores and error delta of each Iteration.
+        Iteration values are not normalized.
 
     Returns
     -------
     (hubs,authorities) : two-tuple of dictionaries
        Two dictionaries keyed by node containing the hub and authority
-       values.
+       values. With further analytics information if specified.
 
     Raises
     ------
     PowerIterationFailedConvergence
         If the algorithm fails to converge to the specified tolerance
         within the specified number of iterations of the power iteration
-        method.
+        method and analytics is disabled.
 
     Examples
     --------

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -4,16 +4,18 @@ import networkx as nx
 
 __all__ = ["hits", "hits_numpy", "hits_scipy", "authority_matrix", "hub_matrix"]
 
+
 class HitsResult(tuple):
-    def __new__ (cls, hub_score, authority_score, analytics_info) -> tuple:
+    def __new__(cls, hub_score, authority_score, analytics_info) -> tuple:
         return super().__new__(cls, (hub_score, authority_score))
-    
+
     def __init__(self, hub_score, authority_score, analytics_info) -> None:
-        self.hub_iterations=analytics_info['h']
-        self.authority_iterations=analytics_info['a']
-        self.convergence = analytics_info['err']
-        self.iterations = analytics_info['iterations']
-        self.return_message=analytics_info['return_message']
+        self.hub_iterations = analytics_info["h"]
+        self.authority_iterations = analytics_info["a"]
+        self.convergence = analytics_info["err"]
+        self.iterations = analytics_info["iterations"]
+        self.return_message = analytics_info["return_message"]
+
 
 def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=False):
     """Returns HITS hubs and authorities values for nodes.
@@ -38,7 +40,7 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=Fa
 
     normalized : bool (default=True)
        Normalize results by the sum of all of the values.
-    
+
     analytics : bool (default=False)
         Store the authority and hub scores and error delta of each Iteration.
         Iteration values are not normalized.
@@ -96,12 +98,7 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=Fa
         s = 1.0 / sum(h.values())
         for k in h:
             h[k] *= s
-    analytics_info=dict(
-        h=[],
-        a=[],
-        err=[],
-        iterations=0
-    )
+    analytics_info = dict(h=[], a=[], err=[], iterations=0)
     for _ in range(max_iter):  # power iteration: make up to max_iter iterations
         hlast = h
         h = dict.fromkeys(hlast.keys(), 0)
@@ -122,22 +119,26 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=Fa
         # normalize vector
         s = 1.0 / max(a.values())
         for n in a:
-            a[n] *= s        
+            a[n] *= s
         # check convergence, l1 norm
         err = sum([abs(h[n] - hlast[n]) for n in h])
         if analytics:
-            analytics_info['a'].append(a)
-            analytics_info['h'].append(h)
-            analytics_info['err'].append(err)
-        analytics_info['iterations']+=1
+            analytics_info["a"].append(a)
+            analytics_info["h"].append(h)
+            analytics_info["err"].append(err)
+        analytics_info["iterations"] += 1
         if err < tol:
-            analytics_info['return_message']=f"iteration converged within {analytics_info['iterations']} iterations"
+            analytics_info[
+                "return_message"
+            ] = f"iteration converged within {analytics_info['iterations']} iterations"
             break
     else:
         if not analytics:
             raise nx.PowerIterationFailedConvergence(max_iter)
-        analytics_info['return_message']=f"power iteration failed to converge within {max_iter} iterations"
-        return HitsResult(dict(),dict(),analytics_info)
+        analytics_info[
+            "return_message"
+        ] = f"power iteration failed to converge within {max_iter} iterations"
+        return HitsResult(dict(), dict(), analytics_info)
     if normalized:
         s = 1.0 / sum(a.values())
         for n in a:
@@ -145,7 +146,7 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=Fa
         s = 1.0 / sum(h.values())
         for n in h:
             h[n] *= s
-    return HitsResult(h,a,analytics_info)
+    return HitsResult(h, a, analytics_info)
 
 
 def authority_matrix(G, nodelist=None):

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -5,7 +5,7 @@ import networkx as nx
 __all__ = ["hits", "hits_numpy", "hits_scipy", "authority_matrix", "hub_matrix"]
 
 class HitsResult(tuple):
-    def __new__ (cls, hub_score, authority_score, analytics) -> tuple:
+    def __new__ (cls, hub_score, authority_score, analytics_info) -> tuple:
         return super().__new__(cls, (hub_score, authority_score))
     
     def __init__(self, hub_score, authority_score, analytics_info) -> None:

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -133,6 +133,7 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True, analytics=Fa
         if not analytics:
             raise nx.PowerIterationFailedConvergence(max_iter)
         analytics_info['return_message']=f"power iteration failed to converge within {max_iter} iterations"
+        return HitsResult(dict(),dict(),analytics_info)
     if normalized:
         s = 1.0 / sum(a.values())
         for n in a:

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -4,13 +4,14 @@ from networkx.utils import not_implemented_for
 
 __all__ = ["pagerank", "pagerank_numpy", "pagerank_scipy", "google_matrix"]
 
+
 class PageRankResult(dict):
-  def __init__(self, pagerank_score, analytics_info) -> None:
-    super().__init__(pagerank_score)
-    self.pagerank_iterations = analytics_info['x']
-    self.convergence = analytics_info['err']
-    self.iterations = analytics_info['iterations']
-    self.return_message=analytics_info['return_message']
+    def __init__(self, pagerank_score, analytics_info) -> None:
+        super().__init__(pagerank_score)
+        self.pagerank_iterations = analytics_info["x"]
+        self.convergence = analytics_info["err"]
+        self.iterations = analytics_info["iterations"]
+        self.return_message = analytics_info["return_message"]
 
 
 @not_implemented_for("multigraph")
@@ -23,7 +24,7 @@ def pagerank(
     nstart=None,
     weight="weight",
     dangling=None,
-    analytics=False
+    analytics=False,
 ):
     """Returns the PageRank of the nodes in the graph.
 
@@ -153,11 +154,7 @@ def pagerank(
     dangling_nodes = [n for n in W if W.out_degree(n, weight=weight) == 0.0]
 
     # power iteration: make up to max_iter iterations
-    analytics_info=dict(
-        x=[],
-        err=[],
-        iterations=0
-    )
+    analytics_info = dict(x=[], err=[], iterations=0)
     for _ in range(max_iter):
         xlast = x
         x = dict.fromkeys(xlast.keys(), 0)
@@ -171,16 +168,21 @@ def pagerank(
         # check convergence, l1 norm
         err = sum([abs(x[n] - xlast[n]) for n in x])
         if analytics:
-            analytics_info['x'].append(x)
-            analytics_info['err'].append(err)
-        analytics_info['iterations']+=1
+            analytics_info["x"].append(x)
+            analytics_info["err"].append(err)
+        analytics_info["iterations"] += 1
         if err < N * tol:
-            analytics_info['return_message'] = f"iteration converged within {analytics_info['iterations']} iterations"
+            analytics_info[
+                "return_message"
+            ] = f"iteration converged within {analytics_info['iterations']} iterations"
             return PageRankResult(x, analytics_info)
     if not analytics:
         raise nx.PowerIterationFailedConvergence(max_iter)
-    analytics_info['return_message']=f"power iteration failed to converge within {max_iter} iterations"
+    analytics_info[
+        "return_message"
+    ] = f"power iteration failed to converge within {max_iter} iterations"
     return PageRankResult(dict(), analytics_info)
+
 
 def google_matrix(
     G, alpha=0.85, personalization=None, nodelist=None, weight="weight", dangling=None

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -68,10 +68,14 @@ def pagerank(
       matrix (see notes under google_matrix). It may be common to have the
       dangling dict to be the same as the personalization dict.
 
+    analytics : bool (default=False)
+        Store the pagerank scores and error deltas of each Iteration.
+
     Returns
     -------
     pagerank : dictionary
        Dictionary of nodes with PageRank as value
+       with further analytics information if specified.
 
     Examples
     --------
@@ -101,7 +105,7 @@ def pagerank(
     PowerIterationFailedConvergence
         If the algorithm fails to converge to the specified tolerance
         within the specified number of iterations of the power iteration
-        method.
+        method and analytics is disabled.
 
     References
     ----------

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -176,7 +176,7 @@ def pagerank(
     if not analytics:
         raise nx.PowerIterationFailedConvergence(max_iter)
     analytics_info['return_message']=f"power iteration failed to converge within {max_iter} iterations"
-    return PageRankResult(x, analytics_info)
+    return PageRankResult(dict(), analytics_info)
 
 def google_matrix(
     G, alpha=0.85, personalization=None, nodelist=None, weight="weight", dangling=None

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -4,16 +4,16 @@ from networkx.utils import not_implemented_for
 
 __all__ = ["pagerank", "pagerank_numpy", "pagerank_scipy", "google_matrix"]
 
-class PageRankResult():
-  def __init__(self):
-    self.result = None
+class PageRankResult(dict):
+  def __init__(self) -> None:
+    super().__init__()
     self.iteration_values = []
     self.convergence = []
     self.return_message = ""
     self.iterations = None
   
-  def __getitem__(self, index):
-    return self.result[index]
+  def set_result(self, res: dict) -> None:
+    super().__init__(res)
 
 @not_implemented_for("multigraph")
 def pagerank(
@@ -166,7 +166,7 @@ def pagerank(
         err = sum([abs(x[n] - xlast[n]) for n in x])
         res.convergence.append(err)
         if err < N * tol:
-            res.result=x
+            res.set_result(x)
             res.return_message = f"iteration converged within {i} iterations"
             res.iterations = i+1
             return res

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -74,8 +74,7 @@ class TestHITS:
         with pytest.raises(networkx.PowerIterationFailedConvergence):
             G = self.G
             networkx.hits(G, max_iter=0)
-    
-    
+
     def test_hits_not_convergent_analytics(self):
-        h=networkx.hits(self.G, max_iter=0, analytics=True)
-        assert 'power iteration failed to converge' in h.return_message
+        h = networkx.hits(self.G, max_iter=0, analytics=True)
+        assert "power iteration failed to converge" in h.return_message

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -28,7 +28,7 @@ class TestHITS:
 
     def test_hits(self):
         G = self.G
-        h, a = networkx.hits(G, tol=1.0e-08)
+        h, a = networkx.hits(G, tol=1.0e-08, analytics=True)
         for n in G:
             assert almost_equal(h[n], G.h[n], places=4)
         for n in G:
@@ -74,3 +74,8 @@ class TestHITS:
         with pytest.raises(networkx.PowerIterationFailedConvergence):
             G = self.G
             networkx.hits(G, max_iter=0)
+    
+    
+    def test_hits_not_convergent_analytics(self):
+        h=networkx.hits(self.G, max_iter=0, analytics=True)
+        assert 'power iteration failed to converge' in h.return_message

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -68,10 +68,10 @@ class TestPageRank:
     def test_pagerank_max_iter(self):
         with pytest.raises(networkx.PowerIterationFailedConvergence):
             networkx.pagerank(self.G, max_iter=0)
-    
+
     def test_pagerank_max_iter_analytics(self):
-        pr=networkx.pagerank(self.G, max_iter=0, analytics=True)
-        assert 'power iteration failed to converge' in pr.return_message
+        pr = networkx.pagerank(self.G, max_iter=0, analytics=True)
+        assert "power iteration failed to converge" in pr.return_message
 
     def test_numpy_pagerank(self):
         G = self.G

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -56,7 +56,7 @@ class TestPageRank:
 
     def test_pagerank(self):
         G = self.G
-        p = networkx.pagerank(G, alpha=0.9, tol=1.0e-08)
+        p = networkx.pagerank(G, alpha=0.9, tol=1.0e-08, analytics=True)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
 
@@ -68,6 +68,10 @@ class TestPageRank:
     def test_pagerank_max_iter(self):
         with pytest.raises(networkx.PowerIterationFailedConvergence):
             networkx.pagerank(self.G, max_iter=0)
+    
+    def test_pagerank_max_iter_analytics(self):
+        pr=networkx.pagerank(self.G, max_iter=0, analytics=True)
+        assert 'power iteration failed to converge' in pr.return_message
 
     def test_numpy_pagerank(self):
         G = self.G


### PR DESCRIPTION
#4178

In some cases it is useful for me to analyze the development of the pagerank and hits algorithm. Thats why I created the `HitsResult()` and the `PageRankResult()` to return analytics information of the algorithm. By deriving theses return objects from `tuple` respectivly `dict` the implementation should be compatible to the current version.

The tests and docstrings are also adapted.
