### PR TITLE
to_numpy/scipy array functions should not allow non-nodes in nodelist

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -29,6 +29,10 @@ API Changes
 - [`#4190 <https://github.com/networkx/networkx/pull/4190>`_]
   Removed ``tracemin_chol``.  Use ``tracemin_lu`` instead.
 
+- [`#4216 <https://github.com/networkx/networkx/pull/4216>`_]
+  In `to_*_array/matrix`, nodes in nodelist but not in G now raise an exception.
+  Use G.add_nodes_from(nodelist) to add them to G before converting.
+
 Deprecations
 ------------
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -768,9 +768,6 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
     if dtype is None:
         dtype = [("weight", float)]
 
-    if len(G) == 0:
-        raise nx.NetworkXError("Graph has no nodes or edges")
-
     if nodelist is None:
         nodelist = list(G)
         nodeset = G
@@ -1205,9 +1202,6 @@ def to_numpy_array(
     """
     import numpy as np
 
-    if len(G) == 0:
-        raise nx.NetworkXError("Graph has no nodes or edges")
-
     if nodelist is None:
         nodelist = list(G)
         nodeset = G
@@ -1215,8 +1209,6 @@ def to_numpy_array(
     else:
         nlen = len(nodelist)
         nodeset = set(nodelist)
-        if nlen == 0:
-            raise nx.NetworkXError("nodelist has no nodes")
         if nlen != len(nodeset):
             raise nx.NetworkXError("nodelist contains duplicates.")
         for n in nodelist:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -763,17 +763,29 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
      [5 0]]
 
     """
+    import numpy as np
+
     if dtype is None:
         dtype = [("weight", float)]
-    import numpy as np
+
+    if len(G) == 0:
+        raise nx.NetworkXError("Graph has no nodes or edges")
 
     if nodelist is None:
         nodelist = list(G)
-    nodeset = set(nodelist)
-    if len(nodelist) != len(nodeset):
-        msg = "Ambiguous ordering: `nodelist` contained duplicates."
-        raise nx.NetworkXError(msg)
-    nlen = len(nodelist)
+        nodeset = G
+        nlen = len(G)
+    else:
+        nlen = len(nodelist)
+        nodeset = set(nodelist)
+        if nlen == 0:
+            raise nx.NetworkXError("nodelist has no nodes")
+        if nlen != len(set(nodelist)):
+            raise nx.NetworkXError("nodelist contains duplicates.")
+        for n in nodelist:
+            if n not in G:
+                raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
+
     undirected = not G.is_directed()
     index = dict(zip(nodelist, range(nlen)))
     M = np.zeros((nlen, nlen), dtype=dtype, order=order)
@@ -873,22 +885,29 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
     """
     from scipy import sparse
 
-    if nodelist is None:
-        nodelist = list(G)
-    nlen = len(nodelist)
-    if nlen == 0:
+    if len(G) == 0:
         raise nx.NetworkXError("Graph has no nodes or edges")
 
-    if len(nodelist) != len(set(nodelist)):
-        msg = "Ambiguous ordering: `nodelist` contained duplicates."
-        raise nx.NetworkXError(msg)
+    if nodelist is None:
+        nodelist = list(G)
+        nlen = len(G)
+    else:
+        nlen = len(nodelist)
+        if nlen == 0:
+            raise nx.NetworkXError("nodelist has no nodes")
+        if nlen != len(set(nodelist)):
+            raise nx.NetworkXError("nodelist contains duplicates.")
+        for n in nodelist:
+            if n not in G:
+                raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
+        if nlen < len(G):
+            G = G.subgraph(nodelist)
 
     index = dict(zip(nodelist, range(nlen)))
     coefficients = zip(
         *(
             (index[u], index[v], d.get(weight, 1))
             for u, v, d in G.edges(nodelist, data=True)
-            if u in index and v in index
         )
     )
     try:
@@ -906,15 +925,9 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
         c = col + row
         # selfloop entries get double counted when symmetrizing
         # so we subtract the data on the diagonal
-        selfloops = list(nx.selfloop_edges(G.subgraph(nodelist), data=True))
+        selfloops = list(nx.selfloop_edges(G, data=weight, default=1))
         if selfloops:
-            diag_index, diag_data = zip(
-                *(
-                    (index[u], -d.get(weight, 1))
-                    for u, v, d in selfloops
-                    if u in index and v in index
-                )
-            )
+            diag_index, diag_data = zip(*((index[u], -wt) for u, v, wt in selfloops))
             d += diag_data
             r += diag_index
             c += diag_index
@@ -1192,14 +1205,24 @@ def to_numpy_array(
     """
     import numpy as np
 
+    if len(G) == 0:
+        raise nx.NetworkXError("Graph has no nodes or edges")
+
     if nodelist is None:
         nodelist = list(G)
-    nodeset = set(nodelist)
-    if len(nodelist) != len(nodeset):
-        msg = "Ambiguous ordering: `nodelist` contained duplicates."
-        raise nx.NetworkXError(msg)
+        nodeset = G
+        nlen = len(G)
+    else:
+        nlen = len(nodelist)
+        nodeset = set(nodelist)
+        if nlen == 0:
+            raise nx.NetworkXError("nodelist has no nodes")
+        if nlen != len(nodeset):
+            raise nx.NetworkXError("nodelist contains duplicates.")
+        for n in nodelist:
+            if n not in G:
+                raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
 
-    nlen = len(nodelist)
     undirected = not G.is_directed()
     index = dict(zip(nodelist, range(nlen)))
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -774,14 +774,12 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
         nlen = len(G)
     else:
         nlen = len(nodelist)
-        nodeset = set(nodelist)
-        if nlen == 0:
-            raise nx.NetworkXError("nodelist has no nodes")
-        if nlen != len(set(nodelist)):
+        nodeset = set(G.nbunch_iter(nodelist))
+        if nlen != len(nodeset):
+            for n in nodelist:
+                if n not in G:
+                    raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
             raise nx.NetworkXError("nodelist contains duplicates.")
-        for n in nodelist:
-            if n not in G:
-                raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
 
     undirected = not G.is_directed()
     index = dict(zip(nodelist, range(nlen)))
@@ -892,19 +890,20 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
         nlen = len(nodelist)
         if nlen == 0:
             raise nx.NetworkXError("nodelist has no nodes")
-        if nlen != len(set(nodelist)):
+        nodeset = set(G.nbunch_iter(nodelist))
+        if nlen != len(nodeset):
+            for n in nodelist:
+                if n not in G:
+                    raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
             raise nx.NetworkXError("nodelist contains duplicates.")
-        for n in nodelist:
-            if n not in G:
-                raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
         if nlen < len(G):
             G = G.subgraph(nodelist)
 
     index = dict(zip(nodelist, range(nlen)))
     coefficients = zip(
         *(
-            (index[u], index[v], d.get(weight, 1))
-            for u, v, d in G.edges(nodelist, data=True)
+            (index[u], index[v], wt)
+            for u, v, wt in G.edges(data=weight, default=1)
         )
     )
     try:
@@ -1208,12 +1207,12 @@ def to_numpy_array(
         nlen = len(G)
     else:
         nlen = len(nodelist)
-        nodeset = set(nodelist)
+        nodeset = set(G.nbunch_iter(nodelist))
         if nlen != len(nodeset):
+            for n in nodelist:
+                if n not in G:
+                    raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
             raise nx.NetworkXError("nodelist contains duplicates.")
-        for n in nodelist:
-            if n not in G:
-                raise nx.NetworkXError(f"Node {n} in nodelist is not in G")
 
     undirected = not G.is_directed()
     index = dict(zip(nodelist, range(nlen)))

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -97,9 +97,15 @@ class TestConvertNumpy:
         GA = nx.Graph(A)
         self.assert_equal(GA, P3)
 
-        # Make nodelist ambiguous by containing duplicates.
-        nodelist += [nodelist[0]]
-        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=nodelist)
+        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, nx.Graph())
+        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=[])
+        # Test nodelist duplicates.
+        long_nodelist = nodelist + [0]
+        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=long_nodelist)
+
+        # Test nodelist contains non-nodes
+        nonnodelist = [-1, 0, 1, 2]
+        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=nonnodelist)
 
     def test_weight_keyword(self):
         WP4 = nx.Graph()

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -97,8 +97,7 @@ class TestConvertNumpy:
         GA = nx.Graph(A)
         self.assert_equal(GA, P3)
 
-        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, nx.Graph())
-        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=[])
+        assert nx.to_numpy_matrix(P3, nodelist=[]).shape == (0, 0)
         # Test nodelist duplicates.
         long_nodelist = nodelist + [0]
         pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=long_nodelist)

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -104,9 +104,15 @@ class TestConvertNumpy:
         GA = nx.Graph(A)
         self.assert_isomorphic(GA, P3)
 
-        # Make nodelist ambiguous by containing duplicates.
-        nodelist += [nodelist[0]]
-        pytest.raises(nx.NetworkXError, nx.to_numpy_matrix, P3, nodelist=nodelist)
+        pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, nx.Graph())
+        pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, P3, nodelist=[])
+        # Test nodelist duplicates.
+        long_nl = nodelist + [0]
+        pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, P3, nodelist=long_nl)
+
+        # Test nodelist contains non-nodes
+        non_nl = [-1, 0, 1, 2]
+        pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, P3, nodelist=non_nl)
 
     def test_weight_keyword(self):
         WP4 = nx.Graph()

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -104,7 +104,6 @@ class TestConvertNumpy:
         GA = nx.Graph(A)
         self.assert_isomorphic(GA, P3)
 
-        pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, nx.Graph())
         pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, P3, nodelist=[])
         # Test nodelist duplicates.
         long_nl = nodelist + [0]


### PR DESCRIPTION
Currently, adding non-nodes to nodelist makes the created matrices have empty rows/columns showing an isolated node. But this (silently) means typos in nodelist create isolated nodes instead of raising an exception.

I don't think users should create isolated nodes when converting a graph to matrix form.
It seems better to raise an exception to "avoid surprises" at the cost of making people add the isolated nodes to G.
I'm proposing changing this to raise an error if nodelist contains nodes not in G. 

Strictly speaking this is not backward compatible because someone might have written code that depends on the matrix conversion adding the extra nodes. But if we raise an exception with a good message, it should be obvious what the trouble is and easy to fix. 
