### PR TITLE
Add max common induced subgraph

### DIFF
--- a/doc/reference/algorithms/index.rst
+++ b/doc/reference/algorithms/index.rst
@@ -48,6 +48,7 @@ Algorithms
    link_prediction
    lowest_common_ancestors
    matching
+   maximum_common_subgraph
    minors
    mis
    non_randomness

--- a/doc/reference/algorithms/maximum_common_subgraph.rst
+++ b/doc/reference/algorithms/maximum_common_subgraph.rst
@@ -1,0 +1,16 @@
+***********************
+Maximum Common Subgraph
+***********************
+
+.. automodule:: networkx.algorithms.maximum_common_subgraph
+
+Maximum Common Induced Subgraph
+-------------------------------
+.. automodule:: networkx.algorithms.maximum_common_subgraph.maximum_common_induced_subgraph
+.. autosummary::
+   :toctree: generated/
+
+   max_common_induced_subgraph
+   weak_modular_product_mcis
+   ismags_mcis
+   common_induced_subgraph

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -30,6 +30,7 @@ from networkx.algorithms.link_prediction import *
 from networkx.algorithms.lowest_common_ancestors import *
 from networkx.algorithms.isolate import *
 from networkx.algorithms.matching import *
+from networkx.algorithms.maximum_common_subgraph import *
 from networkx.algorithms.minors import *
 from networkx.algorithms.mis import *
 from networkx.algorithms.moral import *
@@ -72,6 +73,7 @@ import networkx.algorithms.flow
 import networkx.algorithms.isomorphism
 import networkx.algorithms.link_analysis
 import networkx.algorithms.lowest_common_ancestors
+import networkx.algorithms.maximum_common_subgraph
 import networkx.algorithms.operators
 import networkx.algorithms.shortest_paths
 import networkx.algorithms.tournament

--- a/networkx/algorithms/maximum_common_subgraph/__init__.py
+++ b/networkx/algorithms/maximum_common_subgraph/__init__.py
@@ -1,0 +1,5 @@
+"""Maximum common subgraph algorithms
+"""
+from .maximum_common_induced_subgraph import *
+
+__all__ = maximum_common_induced_subgraph.__all__

--- a/networkx/algorithms/maximum_common_subgraph/maximum_common_induced_subgraph.py
+++ b/networkx/algorithms/maximum_common_subgraph/maximum_common_induced_subgraph.py
@@ -204,7 +204,7 @@ def check_valid_labels(G, H, node_label, edge_label):
     for graph in G, H:
         for edge in graph.edges():
             if edge_label(graph.edges[edge]) is None:
-                raise ValueError(f'Edge {edge} has label None')
+                raise ValueError(f"Edge {edge} has label None")
         for node in graph.nodes():
             # Make sure that accessing the node does not raise an exception
             node_label(graph.nodes[node])
@@ -629,14 +629,22 @@ def ismags_mcis(G, H, node_label=None, edge_label=None):
     if node_label is None:
         node_match = None
     else:
-        node_match = lambda node1_attrs, node2_attrs: node_label_fun(node1_attrs) == node_label_fun(node2_attrs)
+        node_match = lambda node1_attrs, node2_attrs: node_label_fun(
+            node1_attrs
+        ) == node_label_fun(node2_attrs)
 
     if edge_label is None:
         edge_match = None
     else:
-        edge_match = lambda edge1_attrs, edge2_attrs: edge_label_fun(edge1_attrs) == edge_label_fun(edge2_attrs)
+        edge_match = lambda edge1_attrs, edge2_attrs: edge_label_fun(
+            edge1_attrs
+        ) == edge_label_fun(edge2_attrs)
 
     try:
-        return next(nx.isomorphism.ISMAGS(G, H, node_match=node_match, edge_match=edge_match).largest_common_subgraph(False))
+        return next(
+            nx.isomorphism.ISMAGS(
+                G, H, node_match=node_match, edge_match=edge_match
+            ).largest_common_subgraph(False)
+        )
     except StopIteration:
         return {}

--- a/networkx/algorithms/maximum_common_subgraph/maximum_common_induced_subgraph.py
+++ b/networkx/algorithms/maximum_common_subgraph/maximum_common_induced_subgraph.py
@@ -1,0 +1,642 @@
+"""Maximum common induced subgraph algorithms
+
+A common induced subgraph of graphs $G$ and $H$ is an induced subgraph of $G$
+that is isomorphic to an induced subgraph of $H$.  A `maximum common induced
+subgraph`_ is a common induced subgraph with as many nodes as possible.
+
+The function :func:`max_common_induced_subgraph` finds the maximum common
+induced subgraph of two graphs using a variant of the McSplit algorithm. [1]_
+The function :func:`common_induced_subgraph` solves the decision problem: for a
+given `target`, it finds a common induced subgraph with at least `target` nodes,
+if one exists.  Both of these functions can optionally be called with the
+restriction that the common subgraph be connected.
+
+The function :func:`weak_modular_product_mcis` provides an alternative approach to
+solving the optimisation problem: it finds a maximum clique in the weak modular
+product graph. [2]_
+
+The function :func:`ismags_mcis` is a wrapper for convienience around
+:func:`networkx.algorithms.isomorphism.ISMAGS.largest_common_subgraph`; this
+provides another alternative approach to solving the optimisation problem.
+
+.. _`maximum common induced subgraph`: https://en.wikipedia.org/wiki/Maximum_common_induced_subgraph 
+.. [1] McCreesh, C., Prosser, P., & Trimble, J. (2017). A partitioning
+   algorithm for maximum common subgraph problems. In Proceedings of the 26th
+   International Joint Conference on Artificial Intelligence (pp. 712-719).
+   https://www.ijcai.org/Proceedings/2017/0099.pdf
+.. [2] Levi, G. (1973), "A note on the derivation of maximal common subgraphs
+   of two directed or undirected graphs", Calcolo, 9 (4): 341–352,
+   doi:10.1007/BF02575586.
+"""
+
+import itertools
+import networkx as nx
+from networkx.utils import not_implemented_for
+
+
+__all__ = [
+    "max_common_induced_subgraph",
+    "weak_modular_product_mcis",
+    "ismags_mcis",
+    "common_induced_subgraph",
+]
+
+
+def _label_function(label):
+    """Returns a function that returns the label of a node or edge.
+
+    In general, maximum common induced subgraph functions should call this
+    function twice: once to create a node label function and once to create
+    an edge label function.
+
+    Parameters
+    ----------
+    G : NetworkX graph.
+
+    label : string, function or None
+        If it is callable, `label` itself is returned. If it is None, a
+        function that simply returns the value 1 is returned.  If `label` is a
+        string, it is assumed to be the name of the node or edge attribute that
+        represents the label of a node or edge. In that case, a function is
+        returned that gets the node or edge label according to the specified
+        node or edge attribute.
+
+    Returns
+    -------
+    function
+        This function returns a callable that accepts exactly one input:
+        a node or edge.  That function returns the label of the given node
+        or edge.  Each label must be hashable, and edge labels must not be
+        None.
+    """
+    if label is None:
+        return lambda data: 1
+    if callable(label):
+        return label
+    return lambda data: data[label]
+
+
+def get_edge_label(G, edge_label_fun, node_a, node_b):
+    """Return the label of an edge, or None if the two nodes are not adjacent"""
+    if G.has_edge(node_a, node_b):
+        return edge_label_fun(G.edges[node_a, node_b])
+    else:
+        return None
+
+
+class LabelClass(object):
+    """A label class, used by the McSplit algorithm.
+
+    A label class contains a list of nodes from graph G and a list of nodes
+    from graph H to which these may be mapped.  The `is_adjacent` member is
+    a boolean which is true if and only if the nodes in the label class are
+    adjacent to at least one node of the current subgraph.
+    """
+
+    __slots__ = ["G_nodes", "H_nodes", "is_adjacent"]
+
+    def __init__(self, is_adjacent):
+        self.G_nodes = []
+        self.H_nodes = []
+        self.is_adjacent = is_adjacent
+
+
+class PartitioningMCISFinder(object):
+    """A class implementing a variant of the McSplit algorithm"""
+
+    __slots__ = ["G", "H", "connected", "node_label_fun", "edge_label_fun"]
+
+    def __init__(self, G, H, connected, node_label_fun, edge_label_fun):
+        self.G = G
+        self.H = H
+        self.connected = connected
+        self.node_label_fun = node_label_fun
+        self.edge_label_fun = edge_label_fun
+
+    def refine_label_classes(self, label_classes, v, w):
+        new_label_classes = []
+        for lc in label_classes:
+            label_to_new_lc = {}
+            for u in lc.G_nodes:
+                edge_label = get_edge_label(self.G, self.edge_label_fun, v, u)
+                if edge_label not in label_to_new_lc:
+                    is_adjacent = lc.is_adjacent or self.G.has_edge(v, u)
+                    label_to_new_lc[edge_label] = LabelClass(is_adjacent)
+                label_to_new_lc[edge_label].G_nodes.append(u)
+            for u in lc.H_nodes:
+                edge_label = get_edge_label(self.H, self.edge_label_fun, w, u)
+                if edge_label in label_to_new_lc:
+                    label_to_new_lc[edge_label].H_nodes.append(u)
+            for new_lc in label_to_new_lc.values():
+                if new_lc.H_nodes:
+                    new_label_classes.append(new_lc)
+        return new_label_classes
+
+    def select_label_class(self, label_classes, assignment_count):
+        if self.connected and assignment_count > 0:
+            candidates = [lc for lc in label_classes if lc.is_adjacent]
+        else:
+            candidates = label_classes
+        if not candidates:
+            return None
+        return min(candidates, key=lambda lc: max(len(lc.G_nodes), len(lc.H_nodes)))
+
+    def calculate_bound(self, label_classes):
+        return sum(min(len(lc.G_nodes), len(lc.H_nodes)) for lc in label_classes)
+
+    def search(self, label_classes, assignments, target):
+        if len(assignments) == target:
+            return assignments
+        if len(assignments) + self.calculate_bound(label_classes) < target:
+            return None
+        label_class = self.select_label_class(label_classes, len(assignments))
+        if label_class is None:
+            return None
+        v = label_class.G_nodes.pop()
+        H_nodes = label_class.H_nodes[:]
+        for w in H_nodes:
+            label_class.H_nodes[:] = [u for u in H_nodes if u != w]
+            assignments[v] = w
+            new_label_classes = self.refine_label_classes(label_classes, v, w)
+            search_result = self.search(new_label_classes, assignments, target)
+            if search_result is not None:
+                return search_result
+            del assignments[v]
+        label_class.H_nodes[:] = H_nodes
+        new_label_classes = [lc for lc in label_classes if lc.G_nodes]
+        return self.search(new_label_classes, assignments, target)
+
+    def get_node_labels(self, G):
+        return (self.node_label_fun(G.nodes[node]) for node in G.nodes())
+
+    def find_common_subgraph(self, target):
+        """Find a common subgraph with at least `target` nodes using a variant
+        of McSplit
+        """
+        G_labels = set(self.get_node_labels(self.G))
+        H_labels = set(self.get_node_labels(self.H))
+        label_classes = {label: LabelClass(False) for label in G_labels & H_labels}
+        for v in self.G.nodes():
+            label = self.node_label_fun(self.G.nodes[v])
+            if label in label_classes:
+                label_classes[label].G_nodes.append(v)
+        for v in self.H.nodes():
+            label = self.node_label_fun(self.H.nodes[v])
+            if label in label_classes:
+                label_classes[label].H_nodes.append(v)
+        return self.search(label_classes.values(), {}, target)
+
+
+def check_valid_graph_types(G, H):
+    if G.is_directed() or H.is_directed():
+        msg = f"not implemented for directed graphs"
+        raise nx.NetworkXNotImplemented(msg)
+    if G.is_multigraph() or H.is_multigraph():
+        msg = f"not implemented for multigraphs"
+        raise nx.NetworkXNotImplemented(msg)
+    if nx.number_of_selfloops(G) or nx.number_of_selfloops(H):
+        msg = f"not implemented for graphs with self-loops"
+        raise nx.NetworkXNotImplemented(msg)
+
+
+def check_valid_labels(G, H, node_label, edge_label):
+    """Raise an exception if any edge label is None or if accessing any label raises an exception"""
+    for graph in G, H:
+        for edge in graph.edges():
+            if edge_label(graph.edges[edge]) is None:
+                raise ValueError(f'Edge {edge} has label None')
+        for node in graph.nodes():
+            # Make sure that accessing the node does not raise an exception
+            node_label(graph.nodes[node])
+
+
+def common_induced_subgraph(
+    G, H, target, connected=False, node_label=None, edge_label=None
+):
+    """
+    Find a common induced subgraph with at least a given number of nodes
+
+
+    This is the decision version of the :func:`max_common_induced_subgraph`
+    function.
+
+    Optionally, nodes and/or edges can be labelled using the `node_label` and
+    `edge_label` parameters.  If these are used, the algorithm will search for
+    subgraphs of G and H that have identical labels.
+
+    If the `connected` parameter is set to True, the function finds a maximum
+    common connected induced subgraph.
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+    H : NetworkX graph
+        An undirected graph.
+    target : int
+        The found subgraph must have at least `target` nodes
+    node_label : None, string or function, optional (default=None)
+        If this is None, nodes are unlabelled.
+
+        If this is a string, then node labels will be accessed via the node
+        attribute with this key (that is, the label of node `v` will be
+        `G.nodes[v][node_label]`).
+
+        If this is a function, the label of a node is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of node attributes for that node. The
+        label returned by the function must be hashable.
+
+    edge_label : None, string or function, optional (default=None)
+        If this is None, edges are unlabelled.
+
+        If this is a string, then edge labels will be accessed via the edge
+        attribute with this key (that is, the label of the edge joining `u`
+        to `v` will be `G.edges[u, v][edge_label]`).
+
+        If this is a function, the label of an edge is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of edge attributes for that edge. The
+        label returned by the function must be hashable and must not be None.
+
+    connected : boolean, optional (default=False)
+        If this is True, the algorithm will search for a maximum common
+        *connected* induced subgraph.
+
+
+    Returns
+    -------
+    map : dict or None
+        A dictionary whose keys are a subset of the node set of G, and whose
+        values are a subset of the node set of H.  The subgraph of G induced by
+        the keys is a maximum common subgraph of G and H.  This is isomorphic
+        to the subgraph of H induced by the dictionary's values.  The mapping
+        given by the dictionary is an isomorphism from the first of these
+        subgraphs to the second.
+
+        If no common subgraph with at least `target` nodes is found, None is
+        returned.
+
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G or H is directed or a multigraph
+
+    NetworkXNotImplemented
+        If G or H has self-loops
+
+
+    Notes
+    -----
+    The algorithm used is a simplified variant of McSplit. [1]_  The McSplit
+    algorithm builds up a partial map from the node set of G to the node
+    set of H, and keeps track of possible additional node-node assignments
+    using a partitioning procedure.  For simplicity, the NetworkX version
+    creates new lists when partitioning, rather than modifying lists
+    in-place as in the original McSplit implementation.
+
+    The implementation currently does not support directed graphs, multigraphs,
+    or graphs with self-loops.
+
+
+    See also
+    --------
+    max_common_induced_subgraph()
+
+
+    References
+    ----------
+    .. [1] McCreesh, C., Prosser, P., & Trimble, J. (2017). A partitioning
+       algorithm for maximum common subgraph problems. In Proceedings of the 26th
+       International Joint Conference on Artificial Intelligence (pp. 712-719).
+       https://www.ijcai.org/Proceedings/2017/0099.pdf
+    """
+    check_valid_graph_types(G, H)
+    node_label = _label_function(node_label)
+    edge_label = _label_function(edge_label)
+    check_valid_labels(G, H, node_label, edge_label)
+    return PartitioningMCISFinder(
+        G, H, connected, node_label, edge_label
+    ).find_common_subgraph(target)
+
+
+def max_common_induced_subgraph(
+    G, H, node_label=None, edge_label=None, connected=False
+):
+    """
+    Find a maximum common induced subgraph
+
+
+    Optionally, nodes and/or edges can be labelled using the `node_label` and
+    `edge_label` parameters.  If these are used, the algorithm will search for
+    isomorphic subgraphs of G and H that have identical labels.
+
+    If the `connected` parameter is set to True, the function finds a maximum
+    common connected induced subgraph.
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+    H : NetworkX graph
+        An undirected graph.
+    node_label : None, string or function, optional (default=None)
+        If this is None, nodes are unlabelled.
+
+        If this is a string, then node labels will be accessed via the node
+        attribute with this key (that is, the label of node `v` will be
+        `G.nodes[v][node_label]`).
+
+        If this is a function, the label of a node is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of node attributes for that node. The
+        label returned by the function must be hashable.
+
+    edge_label : None, string or function, optional (default=None)
+        If this is None, edges are unlabelled.
+
+        If this is a string, then edge labels will be accessed via the edge
+        attribute with this key (that is, the label of the edge joining `u`
+        to `v` will be `G.edges[u, v][edge_label]`).
+
+        If this is a function, the label of an edge is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of edge attributes for that edge. The
+        label returned by the function must be hashable and must not be None.
+
+    connected : boolean, optional (default=False)
+        If this is True, the algorithm will search for a maximum common
+        *connected* induced subgraph.
+
+
+    Returns
+    -------
+    map : dict
+        A dictionary whose keys are a subset of the node set of G, and whose
+        values are a subset of the node set of H.  The subgraph of G induced by
+        the keys is a maximum common subgraph of G and H.  This is isomorphic
+        to the subgraph of H induced by the dictionary's values.  The mapping
+        given by the dictionary is an isomorphism from the first of these
+        subgraphs to the second.
+
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G or H is directed or a multigraph
+
+    NetworkXNotImplemented
+        If G or H has self-loops
+
+
+    Notes
+    -----
+    The algorithm used is a simplified variant of McSplit. [1]_  The McSplit
+    algorithm builds up a partial map from the node set of G to the node
+    set of H, and keeps track of possible additional node-node assignments
+    using a partitioning procedure.  For simplicity, the NetworkX version
+    creates new lists when partitioning, rather than modifying lists
+    in-place as in the original McSplit implementation.
+
+    The implementation currently does not support directed graphs, multigraphs,
+    or graphs with self-loops.
+
+
+    See also
+    --------
+    weak_modular_product_mcis()
+    ismags_mcis()
+    common_induced_subgraph()
+
+
+    References
+    ----------
+    .. [1] McCreesh, C., Prosser, P., & Trimble, J. (2017). A partitioning
+       algorithm for maximum common subgraph problems. In Proceedings of the 26th
+       International Joint Conference on Artificial Intelligence (pp. 712-719).
+       https://www.ijcai.org/Proceedings/2017/0099.pdf
+    """
+    check_valid_graph_types(G, H)
+    min_n = min(G.number_of_nodes(), H.number_of_nodes())
+    for target in range(min_n, -1, -1):
+        search_result = common_induced_subgraph(
+            G, H, target, connected, node_label, edge_label
+        )
+        if search_result is not None:
+            return search_result
+
+
+def weak_modular_product_graph(G, H, node_label=None, edge_label=None):
+    check_valid_graph_types(G, H)
+    node_label = _label_function(node_label)
+    edge_label = _label_function(edge_label)
+    check_valid_labels(G, H, node_label, edge_label)
+    mp_graph = nx.Graph()
+    for v in G.nodes():
+        for w in H.nodes():
+            if node_label(G.nodes[v]) == node_label(H.nodes[w]):
+                mp_graph.add_node((v, w))
+    for (v, w), (v_, w_) in itertools.combinations(mp_graph.nodes(), 2):
+        if v != v_ and w != w_:
+            G_label = get_edge_label(G, edge_label, v, v_)
+            H_label = get_edge_label(H, edge_label, w, w_)
+            if G_label == H_label:
+                mp_graph.add_edge((v, w), (v_, w_))
+    return mp_graph
+
+
+def weak_modular_product_mcis(G, H, node_label=None, edge_label=None):
+    """
+    Find a maximum common induced subgraph using a maximum clique algorithm
+
+
+    Optionally, nodes and/or edges can be labelled using the `node_label` and
+    `edge_label` parameters.  If these are used, the algorithm will search for
+    subgraphs of G and H that have identical labels.
+
+    The current implementation does not support finding a maximum common
+    *connected* induced subgraph.
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+    H : NetworkX graph
+        An undirected graph.
+    node_label : None, string or function, optional (default=None)
+        If this is None, nodes are unlabelled.
+
+        If this is a string, then node labels will be accessed via the node
+        attribute with this key (that is, the label of node `v` will be
+        `G.nodes[v][node_label]`).
+
+        If this is a function, the label of a node is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of node attributes for that node. The
+        label returned by the function must be hashable.
+
+    edge_label : None, string or function, optional (default=None)
+        If this is None, edges are unlabelled.
+
+        If this is a string, then edge labels will be accessed via the edge
+        attribute with this key (that is, the label of the edge joining `u`
+        to `v` will be `G.edges[u, v][edge_label]`).
+
+        If this is a function, the label of an edge is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of edge attributes for that edge. The
+        label returned by the function must be hashable and must not be None.
+
+
+    Returns
+    -------
+    map : dict
+        A dictionary whose keys are a subset of the node set of G, and whose
+        values are a subset of the node set of H.  The subgraph of G induced by
+        the keys is a maximum common subgraph of G and H.  This is isomorphic
+        to the subgraph of H induced by the dictionary's values.  The mapping
+        given by the dictionary is an isomorphism from the first of these
+        subgraphs to the second.
+
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G or H is directed or a multigraph
+
+    NetworkXNotImplemented
+        If G or H has self-loops
+
+
+    Notes
+    -----
+    The algorithm creates the weak modular product graph, and uses a maximum
+    clique algorithm on this to find a maximum common induced subgraph.  This
+    approach was first applied to the *maximal* common subgraph problem by
+    Levi. [1]_  McCreesh et al. [2]_ conduct extensive experiments using a modern
+    maximum clique solver to solve the *maximum* common subgraph problem; they
+    find that this approach is very effective for labelled graphs.
+
+    The implementation currently does not support directed graphs, multigraphs,
+    or graphs with self-loops.
+
+
+    See also
+    --------
+    max_common_induced_subgraph()
+    ismags_mcis()
+    common_induced_subgraph()
+
+
+    References
+    ----------
+    .. [1] Levi, G. (1973), "A note on the derivation of maximal common subgraphs
+       of two directed or undirected graphs", Calcolo, 9 (4): 341–352,
+       doi:10.1007/BF02575586.
+    .. [2] McCreesh C., Ndiaye S.N., Prosser P., Solnon C. (2016) Clique and
+       Constraint Models for Maximum Common (Connected) Subgraph Problems. In:
+       Rueher M. (eds) Principles and Practice of Constraint Programming. CP
+       2016.  Lecture Notes in Computer Science, vol 9892. Springer, Cham.
+       https://doi.org/10.1007/978-3-319-44953-1_23
+    """
+    mp_graph = weak_modular_product_graph(G, H, node_label, edge_label)
+    return dict(nx.max_weight_clique(mp_graph, None)[0])
+
+
+def ismags_mcis(G, H, node_label=None, edge_label=None):
+    """
+    Find a maximum common induced subgraph using the ISMAGS algorithm
+
+
+    Optionally, nodes and/or edges can be labelled using the `node_label` and
+    `edge_label` parameters.  If these are used, the algorithm will search for
+    subgraphs of G and H that have identical labels.
+
+    This is a small wrapper for convenience around
+    :func:`networkx.algorithms.isomorphism.ISMAGS.largest_common_subgraph`.
+
+    This function does not support finding a maximum common *connected* induced
+    subgraph.
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+    H : NetworkX graph
+        An undirected graph.
+    node_label : None, string or function, optional (default=None)
+        If this is None, nodes are unlabelled.
+
+        If this is a string, then node labels will be accessed via the node
+        attribute with this key (that is, the label of node `v` will be
+        `G.nodes[v][node_label]`).
+
+        If this is a function, the label of a node is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of node attributes for that node. The
+        label returned by the function must be hashable.
+
+    edge_label : None, string or function, optional (default=None)
+        If this is None, edges are unlabelled.
+
+        If this is a string, then edge labels will be accessed via the edge
+        attribute with this key (that is, the label of the edge joining `u`
+        to `v` will be `G.edges[u, v][edge_label]`).
+
+        If this is a function, the label of an edge is the value returned by
+        the function. The function must accept exactly one positional
+        argument: the dictionary of edge attributes for that edge. The
+        label returned by the function must be hashable and must not be None.
+
+
+    Returns
+    -------
+    map : dict
+        A dictionary whose keys are a subset of the node set of G, and whose
+        values are a subset of the node set of H.  The subgraph of G induced by
+        the keys is a maximum common subgraph of G and H.  This is isomorphic
+        to the subgraph of H induced by the dictionary's values.  The mapping
+        given by the dictionary is an isomorphism from the first of these
+        subgraphs to the second.
+
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G or H is directed or a multigraph
+
+    NetworkXNotImplemented
+        If G or H has self-loops
+
+
+    See also
+    --------
+    networkx.algorithms.isomorphism.ISMAGS.largest_common_subgraph()
+    max_common_induced_subgraph()
+    weak_modular_product_mcis()
+    common_induced_subgraph()
+    """
+    check_valid_graph_types(G, H)
+    node_label_fun = _label_function(node_label)
+    edge_label_fun = _label_function(edge_label)
+    check_valid_labels(G, H, node_label_fun, edge_label_fun)
+
+    if node_label is None:
+        node_match = None
+    else:
+        node_match = lambda node1_attrs, node2_attrs: node_label_fun(node1_attrs) == node_label_fun(node2_attrs)
+
+    if edge_label is None:
+        edge_match = None
+    else:
+        edge_match = lambda edge1_attrs, edge2_attrs: edge_label_fun(edge1_attrs) == edge_label_fun(edge2_attrs)
+
+    try:
+        return next(nx.isomorphism.ISMAGS(G, H, node_match=node_match, edge_match=edge_match).largest_common_subgraph(False))
+    except StopIteration:
+        return {}

--- a/networkx/algorithms/maximum_common_subgraph/tests/test_max_common_induced_subgraph.py
+++ b/networkx/algorithms/maximum_common_subgraph/tests/test_max_common_induced_subgraph.py
@@ -14,7 +14,11 @@ class TestMaxCommonSubgraph:
         G0 = nx.Graph()
         G0.add_edge(1, 1)
         G1 = nx.Graph()
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
             with pytest.raises(nx.exception.NetworkXNotImplemented):
                 algorithm(G0, G1)
             with pytest.raises(nx.exception.NetworkXNotImplemented):
@@ -27,7 +31,11 @@ class TestMaxCommonSubgraph:
     def test_digraph_exception(self):
         G0 = nx.Graph()
         G1 = nx.DiGraph()
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
             with pytest.raises(nx.exception.NetworkXNotImplemented):
                 algorithm(G0, G1)
             with pytest.raises(nx.exception.NetworkXNotImplemented):
@@ -40,7 +48,11 @@ class TestMaxCommonSubgraph:
     def test_multigraph_exception(self):
         G0 = nx.Graph()
         G1 = nx.MultiGraph()
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
             with pytest.raises(nx.exception.NetworkXNotImplemented):
                 algorithm(G0, G1)
             with pytest.raises(nx.exception.NetworkXNotImplemented):
@@ -55,8 +67,12 @@ class TestMaxCommonSubgraph:
         G1 = nx.Graph()
         G0.add_edge(0, 1, label=1)
         G1.add_edge(0, 1, label=2)
-        edge_label = lambda d: None if d['label']==1 else 1
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+        edge_label = lambda d: None if d["label"] == 1 else 1
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
             with pytest.raises(ValueError):
                 algorithm(G0, G1, edge_label=edge_label)
             with pytest.raises(ValueError):
@@ -70,29 +86,37 @@ class TestMaxCommonSubgraph:
         G0 = nx.Graph()
         G1 = nx.Graph()
         G0.add_node(1)
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
             with pytest.raises(KeyError):
-                algorithm(G0, G1, node_label='missing_key')
+                algorithm(G0, G1, node_label="missing_key")
             with pytest.raises(KeyError):
-                algorithm(G1, G0, node_label='missing_key')
+                algorithm(G1, G0, node_label="missing_key")
         with pytest.raises(KeyError):
-            nx.common_induced_subgraph(G0, G1, 1, node_label='missing_key')
+            nx.common_induced_subgraph(G0, G1, 1, node_label="missing_key")
         with pytest.raises(KeyError):
-            nx.common_induced_subgraph(G1, G0, 1, node_label='missing_key')
+            nx.common_induced_subgraph(G1, G0, 1, node_label="missing_key")
 
     def test_missing_edge_label_exception(self):
         G0 = nx.Graph()
         G1 = nx.Graph()
         G0.add_edge(0, 1, label=1)
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
             with pytest.raises(KeyError):
-                algorithm(G0, G1, edge_label='missing_key')
+                algorithm(G0, G1, edge_label="missing_key")
             with pytest.raises(KeyError):
-                algorithm(G1, G0, edge_label='missing_key')
+                algorithm(G1, G0, edge_label="missing_key")
         with pytest.raises(KeyError):
-            nx.common_induced_subgraph(G0, G1, 1, edge_label='missing_key')
+            nx.common_induced_subgraph(G0, G1, 1, edge_label="missing_key")
         with pytest.raises(KeyError):
-            nx.common_induced_subgraph(G1, G0, 1, edge_label='missing_key')
+            nx.common_induced_subgraph(G1, G0, 1, edge_label="missing_key")
 
     def test_unsupported_connected_exception(self):
         G0 = nx.Graph()
@@ -148,17 +172,17 @@ class TestMaxCommonSubgraph:
         G1.add_node(0, label="x")
         G1.add_node(1, label="y")
         generate_and_check_mcis(G0, G1, 2)
-        fun = lambda node_data: node_data['label']
+        fun = lambda node_data: node_data["label"]
         generate_and_check_mcis(G0, G0, 2, node_label=fun)
-        generate_and_check_mcis(G0, G0, 2, node_label='label')
+        generate_and_check_mcis(G0, G0, 2, node_label="label")
         generate_and_check_mcis(G0, G1, 0, node_label=fun)
-        generate_and_check_mcis(G0, G1, 0, node_label='label')
+        generate_and_check_mcis(G0, G1, 0, node_label="label")
         G1.add_node(2, label="a")
         generate_and_check_mcis(G0, G1, 1, node_label=fun)
-        generate_and_check_mcis(G0, G1, 1, node_label='label')
+        generate_and_check_mcis(G0, G1, 1, node_label="label")
         G1.add_node(3, label="b")
         generate_and_check_mcis(G0, G1, 2, node_label=fun)
-        generate_and_check_mcis(G0, G1, 2, node_label='label')
+        generate_and_check_mcis(G0, G1, 2, node_label="label")
 
     def test_edge_labelled_mcis(self):
         G0 = nx.empty_graph(3)
@@ -167,14 +191,14 @@ class TestMaxCommonSubgraph:
         G0.add_edge(0, 2, label="b")
         G1.add_edge(0, 1, label="x")
         G1.add_edge(0, 2, label="y")
-        fun = lambda edge_data: edge_data['label']
+        fun = lambda edge_data: edge_data["label"]
         generate_and_check_mcis(G0, G1, 2, edge_label=fun)
-        generate_and_check_mcis(G0, G1, 2, edge_label='label')
+        generate_and_check_mcis(G0, G1, 2, edge_label="label")
         G0.add_edge(1, 2, label="c")
         generate_and_check_mcis(G0, G1, 1, edge_label=fun)
-        generate_and_check_mcis(G0, G1, 1, edge_label='label')
+        generate_and_check_mcis(G0, G1, 1, edge_label="label")
         generate_and_check_mcis(G0, G0, 3, edge_label=fun)
-        generate_and_check_mcis(G0, G0, 3, edge_label='label')
+        generate_and_check_mcis(G0, G0, 3, edge_label="label")
 
     def test_weak_modular_product_graph(self):
         G0 = nx.Graph()
@@ -187,17 +211,28 @@ class TestMaxCommonSubgraph:
         G1.add_node(2, label="a")
         G0.add_edge(0, 2, label="x")
         G1.add_edge(0, 1, label="x")
-        node_fun = lambda node_data: node_data['label']
-        edge_fun = lambda edge_data: edge_data['label']
-        G = nx.algorithms.maximum_common_subgraph.maximum_common_induced_subgraph.weak_modular_product_graph(G0, G1, node_fun, edge_fun)
+        node_fun = lambda node_data: node_data["label"]
+        edge_fun = lambda edge_data: edge_data["label"]
+        G = nx.algorithms.maximum_common_subgraph.maximum_common_induced_subgraph.weak_modular_product_graph(
+            G0, G1, node_fun, edge_fun
+        )
         assert len(G.nodes()) == 4
         assert len(G.edges()) == 2
-        
+
+
 def generate_and_check_mcis(G0, G1, expected_size, **kwargs):
     sizes = set()
     for G, H in [(G0, G1), (G1, G0)]:
-        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
-            if algorithm in [nx.weak_modular_product_mcis, nx.ismags_mcis] and 'connected' in kwargs and kwargs['connected']:
+        for algorithm in (
+            nx.max_common_induced_subgraph,
+            nx.weak_modular_product_mcis,
+            nx.ismags_mcis,
+        ):
+            if (
+                algorithm in [nx.weak_modular_product_mcis, nx.ismags_mcis]
+                and "connected" in kwargs
+                and kwargs["connected"]
+            ):
                 continue
             mcis = algorithm(G, H, **kwargs)
             check_common_induced_subgraph(mcis, G, H, expected_size, **kwargs)
@@ -211,7 +246,10 @@ def generate_and_check_mcis(G0, G1, expected_size, **kwargs):
             assert nx.common_induced_subgraph(H, G, expected_size + 1, **kwargs) is None
     assert len(sizes) == 1
 
-def check_common_induced_subgraph(mcis, G0, G1, expected_size=None, connected=False, node_label=None, edge_label=None):
+
+def check_common_induced_subgraph(
+    mcis, G0, G1, expected_size=None, connected=False, node_label=None, edge_label=None
+):
     # Vertices should be in G0 and G1
     for v in mcis.keys():
         assert v in G0.nodes()

--- a/networkx/algorithms/maximum_common_subgraph/tests/test_max_common_induced_subgraph.py
+++ b/networkx/algorithms/maximum_common_subgraph/tests/test_max_common_induced_subgraph.py
@@ -1,0 +1,249 @@
+"""Maximum common subgraph test suite.
+
+"""
+
+import itertools
+import networkx as nx
+import pytest
+from networkx.utils import not_implemented_for
+
+
+class TestMaxCommonSubgraph:
+    def test_selfloop_exception(self):
+        # Self-loops are not yet supported
+        G0 = nx.Graph()
+        G0.add_edge(1, 1)
+        G1 = nx.Graph()
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            with pytest.raises(nx.exception.NetworkXNotImplemented):
+                algorithm(G0, G1)
+            with pytest.raises(nx.exception.NetworkXNotImplemented):
+                algorithm(G1, G0)
+        with pytest.raises(nx.exception.NetworkXNotImplemented):
+            nx.common_induced_subgraph(G0, G1, 0)
+        with pytest.raises(nx.exception.NetworkXNotImplemented):
+            nx.common_induced_subgraph(G1, G0, 0)
+
+    def test_digraph_exception(self):
+        G0 = nx.Graph()
+        G1 = nx.DiGraph()
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            with pytest.raises(nx.exception.NetworkXNotImplemented):
+                algorithm(G0, G1)
+            with pytest.raises(nx.exception.NetworkXNotImplemented):
+                algorithm(G1, G0)
+        with pytest.raises(nx.exception.NetworkXNotImplemented):
+            nx.common_induced_subgraph(G0, G1, 0)
+        with pytest.raises(nx.exception.NetworkXNotImplemented):
+            nx.common_induced_subgraph(G1, G0, 0)
+
+    def test_multigraph_exception(self):
+        G0 = nx.Graph()
+        G1 = nx.MultiGraph()
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            with pytest.raises(nx.exception.NetworkXNotImplemented):
+                algorithm(G0, G1)
+            with pytest.raises(nx.exception.NetworkXNotImplemented):
+                algorithm(G1, G0)
+        with pytest.raises(nx.exception.NetworkXNotImplemented):
+            nx.common_induced_subgraph(G0, G1, 0)
+        with pytest.raises(nx.exception.NetworkXNotImplemented):
+            nx.common_induced_subgraph(G1, G0, 0)
+
+    def test_None_edge_label_exception(self):
+        G0 = nx.Graph()
+        G1 = nx.Graph()
+        G0.add_edge(0, 1, label=1)
+        G1.add_edge(0, 1, label=2)
+        edge_label = lambda d: None if d['label']==1 else 1
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            with pytest.raises(ValueError):
+                algorithm(G0, G1, edge_label=edge_label)
+            with pytest.raises(ValueError):
+                algorithm(G1, G0, edge_label=edge_label)
+        with pytest.raises(ValueError):
+            nx.common_induced_subgraph(G0, G1, 1, edge_label=edge_label)
+        with pytest.raises(ValueError):
+            nx.common_induced_subgraph(G1, G0, 1, edge_label=edge_label)
+
+    def test_missing_node_label_exception(self):
+        G0 = nx.Graph()
+        G1 = nx.Graph()
+        G0.add_node(1)
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            with pytest.raises(KeyError):
+                algorithm(G0, G1, node_label='missing_key')
+            with pytest.raises(KeyError):
+                algorithm(G1, G0, node_label='missing_key')
+        with pytest.raises(KeyError):
+            nx.common_induced_subgraph(G0, G1, 1, node_label='missing_key')
+        with pytest.raises(KeyError):
+            nx.common_induced_subgraph(G1, G0, 1, node_label='missing_key')
+
+    def test_missing_edge_label_exception(self):
+        G0 = nx.Graph()
+        G1 = nx.Graph()
+        G0.add_edge(0, 1, label=1)
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            with pytest.raises(KeyError):
+                algorithm(G0, G1, edge_label='missing_key')
+            with pytest.raises(KeyError):
+                algorithm(G1, G0, edge_label='missing_key')
+        with pytest.raises(KeyError):
+            nx.common_induced_subgraph(G0, G1, 1, edge_label='missing_key')
+        with pytest.raises(KeyError):
+            nx.common_induced_subgraph(G1, G0, 1, edge_label='missing_key')
+
+    def test_unsupported_connected_exception(self):
+        G0 = nx.Graph()
+        G1 = nx.Graph()
+        with pytest.raises(TypeError):
+            # Check that connected keyword is unsupported
+            nx.weak_modular_product_mcis(G0, G1, connected=True)
+        with pytest.raises(TypeError):
+            # Check that connected keyword is unsupported
+            nx.ismags_mcis(G0, G1, connected=True)
+
+    def test_mcis(self):
+        G0 = nx.path_graph(4)
+        G1 = nx.complete_graph(4)
+        generate_and_check_mcis(G0, G1, 2)
+        generate_and_check_mcis(G0, G1, 2)
+
+    def test_mcis_with_letters_for_nodes(self):
+        G0 = nx.path_graph(4)
+        mapping0 = {0: "a", 1: "b", 2: "c", 3: "d"}
+        nx.relabel_nodes(G0, mapping0, copy=False)
+        G1 = nx.complete_graph(4)
+        mapping1 = {0: "Z", 1: "Y", 2: "X", 3: "W"}
+        nx.relabel_nodes(G1, mapping1, copy=False)
+        generate_and_check_mcis(G0, G1, 2)
+
+    def test_mcis_empty_graph(self):
+        for i in range(6):
+            G0 = nx.empty_graph(i)
+            G1 = nx.complete_graph(4)
+            generate_and_check_mcis(G0, G1, 1 if i else 0)
+
+    def test_connected_mcis(self):
+        G0 = nx.path_graph(5)
+        G1 = nx.empty_graph(5)
+        G1.add_edge(0, 1)
+        G1.add_edge(3, 4)
+        generate_and_check_mcis(G0, G1, 2, connected=True)
+
+    def test_decision_problem(self):
+        G0 = nx.path_graph(3)
+        G1 = nx.complete_graph(3)
+        assert nx.common_induced_subgraph(G0, G1, 3) is None
+        assert nx.common_induced_subgraph(G1, G0, 3) is None
+        assert len(nx.common_induced_subgraph(G0, G1, 2)) == 2
+        assert len(nx.common_induced_subgraph(G1, G0, 2)) == 2
+
+    def test_node_labelled_mcis(self):
+        G0 = nx.Graph()
+        G1 = nx.Graph()
+        G0.add_node(0, label="a")
+        G0.add_node(1, label="b")
+        G1.add_node(0, label="x")
+        G1.add_node(1, label="y")
+        generate_and_check_mcis(G0, G1, 2)
+        fun = lambda node_data: node_data['label']
+        generate_and_check_mcis(G0, G0, 2, node_label=fun)
+        generate_and_check_mcis(G0, G0, 2, node_label='label')
+        generate_and_check_mcis(G0, G1, 0, node_label=fun)
+        generate_and_check_mcis(G0, G1, 0, node_label='label')
+        G1.add_node(2, label="a")
+        generate_and_check_mcis(G0, G1, 1, node_label=fun)
+        generate_and_check_mcis(G0, G1, 1, node_label='label')
+        G1.add_node(3, label="b")
+        generate_and_check_mcis(G0, G1, 2, node_label=fun)
+        generate_and_check_mcis(G0, G1, 2, node_label='label')
+
+    def test_edge_labelled_mcis(self):
+        G0 = nx.empty_graph(3)
+        G1 = nx.empty_graph(3)
+        G0.add_edge(0, 1, label="a")
+        G0.add_edge(0, 2, label="b")
+        G1.add_edge(0, 1, label="x")
+        G1.add_edge(0, 2, label="y")
+        fun = lambda edge_data: edge_data['label']
+        generate_and_check_mcis(G0, G1, 2, edge_label=fun)
+        generate_and_check_mcis(G0, G1, 2, edge_label='label')
+        G0.add_edge(1, 2, label="c")
+        generate_and_check_mcis(G0, G1, 1, edge_label=fun)
+        generate_and_check_mcis(G0, G1, 1, edge_label='label')
+        generate_and_check_mcis(G0, G0, 3, edge_label=fun)
+        generate_and_check_mcis(G0, G0, 3, edge_label='label')
+
+    def test_weak_modular_product_graph(self):
+        G0 = nx.Graph()
+        G1 = nx.Graph()
+        G0.add_node(0, label="a")
+        G0.add_node(1, label="b")
+        G0.add_node(2, label="b")
+        G1.add_node(0, label="b")
+        G1.add_node(1, label="a")
+        G1.add_node(2, label="a")
+        G0.add_edge(0, 2, label="x")
+        G1.add_edge(0, 1, label="x")
+        node_fun = lambda node_data: node_data['label']
+        edge_fun = lambda edge_data: edge_data['label']
+        G = nx.algorithms.maximum_common_subgraph.maximum_common_induced_subgraph.weak_modular_product_graph(G0, G1, node_fun, edge_fun)
+        assert len(G.nodes()) == 4
+        assert len(G.edges()) == 2
+        
+def generate_and_check_mcis(G0, G1, expected_size, **kwargs):
+    sizes = set()
+    for G, H in [(G0, G1), (G1, G0)]:
+        for algorithm in nx.max_common_induced_subgraph, nx.weak_modular_product_mcis, nx.ismags_mcis:
+            if algorithm in [nx.weak_modular_product_mcis, nx.ismags_mcis] and 'connected' in kwargs and kwargs['connected']:
+                continue
+            mcis = algorithm(G, H, **kwargs)
+            check_common_induced_subgraph(mcis, G, H, expected_size, **kwargs)
+            sizes.add(len(mcis))
+        if expected_size is not None:
+            cis = nx.common_induced_subgraph(G, H, expected_size, **kwargs)
+            check_common_induced_subgraph(cis, G, H, expected_size, **kwargs)
+            cis = nx.common_induced_subgraph(H, G, expected_size, **kwargs)
+            check_common_induced_subgraph(cis, H, G, expected_size, **kwargs)
+            assert nx.common_induced_subgraph(G, H, expected_size + 1, **kwargs) is None
+            assert nx.common_induced_subgraph(H, G, expected_size + 1, **kwargs) is None
+    assert len(sizes) == 1
+
+def check_common_induced_subgraph(mcis, G0, G1, expected_size=None, connected=False, node_label=None, edge_label=None):
+    # Vertices should be in G0 and G1
+    for v in mcis.keys():
+        assert v in G0.nodes()
+    for v in mcis.values():
+        assert v in G1.nodes()
+
+    # At most one vertex of G0 should map to any vertex of G1
+    assert len(set(mcis.values())) == len(mcis.values())
+
+    # Node labels should match
+    if node_label is not None:
+        for v, w in mcis.items():
+            if callable(node_label):
+                assert node_label(G0.nodes[v]) == node_label(G1.nodes[w])
+            else:
+                assert G0.nodes[v][node_label] == G1.nodes[w][node_label]
+
+    # The isomorphism should preserve edges and non-edges
+    for (v, w), (v_, w_) in itertools.combinations(mcis.items(), 2):
+        assert G0.has_edge(v, v_) == G1.has_edge(w, w_)
+
+    # The isomorphism should preserve edge labels
+    if edge_label is not None:
+        for (v, w), (v_, w_) in itertools.combinations(mcis.items(), 2):
+            if G0.has_edge(v, v_):
+                if callable(edge_label):
+                    assert edge_label(G0.edges[v, v_]) == edge_label(G1.edges[w, w_])
+                else:
+                    assert G0.edges[v, v_][edge_label] == G1.edges[w, w_][edge_label]
+
+    if connected:
+        assert nx.is_connected(nx.subgraph(G0, mcis.keys()))
+
+    if expected_size is not None:
+        assert len(mcis) == expected_size


### PR DESCRIPTION
This PR adds functions for the max common (connected) induced subgraph problem.

I created a new module for these within `nx.algorithms`. Was this the right thing to do? There already exists one max common induced subgraph implementation in `networkx.algorithms.isomorphism.ISMAGS.largest_common_subgraph`. I added a small function wrapping this to the new module.