### PR TITLE
fix "see also" links in json_graph.tree

### DIFF
--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -59,7 +59,7 @@ def tree_data(G, root, attrs=_attrs):
 
     See Also
     --------
-    tree_graph, node_link_data, node_link_data
+    tree_graph, node_link_data, adjacency_data
     """
     if G.number_of_nodes() != G.number_of_edges() + 1:
         raise TypeError("G is not a tree.")
@@ -120,7 +120,7 @@ def tree_graph(data, attrs=_attrs):
 
     See Also
     --------
-    tree_graph, node_link_data, adjacency_data
+    tree_data, node_link_data, adjacency_data
     """
     graph = nx.DiGraph()
     id_ = attrs["id"]


### PR DESCRIPTION
one was duplicate and one was self-referential.  https://networkx.github.io/documentation/stable/reference/readwrite/generated/networkx.readwrite.json_graph.tree_data.html