### PR TITLE
MAINT,TST: Replace hash function for test of weighted astar #4236 

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -198,7 +198,7 @@ class TestWeightedPath(WeightedTestBase):
 
     def test_weight_functions(self):
         def heuristic(*z):
-            return hash(z)
+            return sum(val ** 2 for val in z)
 
         def getpath(pred, v, s):
             return [v] if v == s else getpath(pred, pred[v], s) + [v]


### PR DESCRIPTION
Closes #4203 

The `heuristic` function for the weighted astar search test formerly computed the hash of the input. The hypothesis is that the hashing function can vary between platforms, which means that this test was not deterministic and could fail on some untested platforms.

Replaced `hash` with a sum-of-squares function which should be platform independent and give the minimum path result on all platforms.