### PR TITLE
MAINT: Deprecate numpy matrix conversion functions

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -55,3 +55,4 @@ Version 3.0
 * In ``algorithms/centrality/betweenness.py`` remove ``edge_betweeness``.
 * In ``algorithms/community_modularity_max.py`` remove old name ``_naive_greedy_modularity_communities``.
 * In ``linalg/algebraicconnectivity.py`` remove ``_CholeskySolver`` and related code.
+* In ``convert_matrix.py`` remove ``to_numpy_matrix`` and ``from_numpy_matrix``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -36,6 +36,9 @@ API Changes
 Deprecations
 ------------
 
+- [`#4238 <https://github.com/networkx/networkx/pull/4238>`_]
+  Deprecate `to_numpy_matrix` and `from_numpy_matrix`.
+
 Contributors to this release
 ----------------------------
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -54,14 +54,10 @@ def set_warnings():
         message="This will return a generator in 3.0*",
     )
     warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
-        message="betweenness_centrality_source*",
+        "ignore", category=DeprecationWarning, message="betweenness_centrality_source*"
     )
     warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
-        message="edge_betweeness*",
+        "ignore", category=DeprecationWarning, message="edge_betweeness*"
     )
     warnings.filterwarnings(
         "ignore",

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -54,15 +54,25 @@ def set_warnings():
         message="This will return a generator in 3.0*",
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="betweenness_centrality_source*"
+        "ignore",
+        category=DeprecationWarning,
+        message="betweenness_centrality_source*",
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="edge_betweeness*"
+        "ignore",
+        category=DeprecationWarning,
+        message="edge_betweeness*",
     )
     warnings.filterwarnings(
         "ignore",
         category=PendingDeprecationWarning,
         message="the matrix subclass is not the recommended way*",
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="to_numpy_matrix"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="from_numpy_matrix"
     )
 
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1270,8 +1270,7 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
     >>> A = np.array([[1, 1], [2, 1]])
     >>> G = nx.from_numpy_array(A)
     >>> G.edges(data=True)
-    EdgeDataView([(0, 0, {'weight': 1}), (0, 1, {'weight': 2}), \
-(1, 1, {'weight': 1})])
+    EdgeDataView([(0, 0, {'weight': 1}), (0, 1, {'weight': 2}), (1, 1, {'weight': 1})])
 
     If `create_using` indicates a multigraph and the array has only integer
     entries and `parallel_edges` is False, then the entries will be treated
@@ -1305,9 +1304,6 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
     1.0
 
     """
-    # This should never fail if you have created a numpy array with numpy...
-    import numpy as np
-
     kind_to_python_type = {
         "f": float,
         "i": int,
@@ -1315,9 +1311,9 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
         "b": bool,
         "c": complex,
         "S": str,
+        "U": str,
         "V": "void",
     }
-    kind_to_python_type["U"] = str
     G = nx.empty_graph(0, create_using)
     if A.ndim != 2:
         raise nx.NetworkXError(f"Input array must be 2D, not {A.ndim}")

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -23,6 +23,7 @@ nx_agraph, nx_pydot
 """
 
 import itertools
+import warnings
 import networkx as nx
 from networkx.utils import not_implemented_for
 
@@ -487,7 +488,7 @@ def to_numpy_matrix(
 
     See Also
     --------
-    to_numpy_recarray, from_numpy_matrix
+    to_numpy_recarray
 
     Notes
     -----
@@ -534,6 +535,14 @@ def to_numpy_matrix(
             [0., 0., 4.]])
 
     """
+    warnings.warn(
+        (
+            "to_numpy_matrix is deprecated and will be removed in NetworkX 3.0.\n"
+            "Use to_numpy_array instead, e.g. np.asmatrix(to_numpy_array(G, **kwargs))"
+        ),
+        DeprecationWarning,
+    )
+
     import numpy as np
 
     A = to_numpy_array(
@@ -592,7 +601,7 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
 
     See Also
     --------
-    to_numpy_matrix, to_numpy_recarray
+    to_numpy_recarray
 
     Examples
     --------
@@ -634,81 +643,14 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
     1.0
 
     """
-    # This should never fail if you have created a numpy matrix with numpy...
-    import numpy as np
-
-    kind_to_python_type = {
-        "f": float,
-        "i": int,
-        "u": int,
-        "b": bool,
-        "c": complex,
-        "S": str,
-        "V": "void",
-    }
-    kind_to_python_type["U"] = str
-    G = nx.empty_graph(0, create_using)
-    n, m = A.shape
-    if n != m:
-        raise nx.NetworkXError(f"Adjacency matrix not square: nx,ny={A.shape}")
-    dt = A.dtype
-    try:
-        python_type = kind_to_python_type[dt.kind]
-    except Exception as e:
-        raise TypeError(f"Unknown numpy data type: {dt}") from e
-
-    # Make sure we get even the isolated nodes of the graph.
-    G.add_nodes_from(range(n))
-    # Get a list of all the entries in the matrix with nonzero entries. These
-    # coordinates become edges in the graph. (convert to int from np.int64)
-    edges = ((int(e[0]), int(e[1])) for e in zip(*np.asarray(A).nonzero()))
-    # handle numpy constructed data type
-    if python_type == "void":
-        # Sort the fields by their offset, then by dtype, then by name.
-        fields = sorted(
-            (offset, dtype, name) for name, (dtype, offset) in A.dtype.fields.items()
-        )
-        triples = (
-            (
-                u,
-                v,
-                {
-                    name: kind_to_python_type[dtype.kind](val)
-                    for (_, dtype, name), val in zip(fields, A[u, v])
-                },
-            )
-            for u, v in edges
-        )
-    # If the entries in the adjacency matrix are integers, the graph is a
-    # multigraph, and parallel_edges is True, then create parallel edges, each
-    # with weight 1, for each entry in the adjacency matrix. Otherwise, create
-    # one edge for each positive entry in the adjacency matrix and set the
-    # weight of that edge to be the entry in the matrix.
-    elif python_type is int and G.is_multigraph() and parallel_edges:
-        chain = itertools.chain.from_iterable
-        # The following line is equivalent to:
-        #
-        #     for (u, v) in edges:
-        #         for d in range(A[u, v]):
-        #             G.add_edge(u, v, weight=1)
-        #
-        triples = chain(
-            ((u, v, {"weight": 1}) for d in range(A[u, v])) for (u, v) in edges
-        )
-    else:  # basic data type
-        triples = ((u, v, dict(weight=python_type(A[u, v]))) for u, v in edges)
-    # If we are creating an undirected multigraph, only add the edges from the
-    # upper triangle of the matrix. Otherwise, add all the edges. This relies
-    # on the fact that the vertices created in the
-    # `_generated_weighted_edges()` function are actually the row/column
-    # indices for the matrix `A`.
-    #
-    # Without this check, we run into a problem where each edge is added twice
-    # when `G.add_edges_from()` is invoked below.
-    if G.is_multigraph() and not G.is_directed():
-        triples = ((u, v, d) for u, v, d in triples if u <= v)
-    G.add_edges_from(triples)
-    return G
+    warnings.warn(
+        (
+            "from_numpy_matrix is deprecated and will be removed in NetworkX 3.0.\n"
+            "Use from_numpy_array instead, e.g. from_numpy_array(A, **kwargs)"
+        ),
+        DeprecationWarning,
+    )
+    return from_numpy_array(A, parallel_edges=parallel_edges, create_using=create_using)
 
 
 @not_implemented_for("multigraph")
@@ -1276,13 +1218,13 @@ def to_numpy_array(
 
 
 def from_numpy_array(A, parallel_edges=False, create_using=None):
-    """Returns a graph from NumPy array.
+    """Returns a graph from a 2D NumPy array.
 
-    The NumPy array is interpreted as an adjacency matrix for the graph.
+    The 2D NumPy array is interpreted as an adjacency matrix for the graph.
 
     Parameters
     ----------
-    A : NumPy ndarray
+    A : a 2D numpy.ndarray
         An adjacency matrix representation of a graph
 
     parallel_edges : Boolean
@@ -1363,6 +1305,80 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
     1.0
 
     """
-    return from_numpy_matrix(
-        A, parallel_edges=parallel_edges, create_using=create_using
-    )
+    # This should never fail if you have created a numpy array with numpy...
+    import numpy as np
+
+    kind_to_python_type = {
+        "f": float,
+        "i": int,
+        "u": int,
+        "b": bool,
+        "c": complex,
+        "S": str,
+        "V": "void",
+    }
+    kind_to_python_type["U"] = str
+    G = nx.empty_graph(0, create_using)
+    if A.ndim != 2:
+        raise nx.NetworkXError(f"Input array must be 2D, not {A.ndim}")
+    n, m = A.shape
+    if n != m:
+        raise nx.NetworkXError(f"Adjacency matrix not square: nx,ny={A.shape}")
+    dt = A.dtype
+    try:
+        python_type = kind_to_python_type[dt.kind]
+    except Exception as e:
+        raise TypeError(f"Unknown numpy data type: {dt}") from e
+
+    # Make sure we get even the isolated nodes of the graph.
+    G.add_nodes_from(range(n))
+    # Get a list of all the entries in the array with nonzero entries. These
+    # coordinates become edges in the graph. (convert to int from np.int64)
+    edges = ((int(e[0]), int(e[1])) for e in zip(*A.nonzero()))
+    # handle numpy constructed data type
+    if python_type == "void":
+        # Sort the fields by their offset, then by dtype, then by name.
+        fields = sorted(
+            (offset, dtype, name) for name, (dtype, offset) in A.dtype.fields.items()
+        )
+        triples = (
+            (
+                u,
+                v,
+                {
+                    name: kind_to_python_type[dtype.kind](val)
+                    for (_, dtype, name), val in zip(fields, A[u, v])
+                },
+            )
+            for u, v in edges
+        )
+    # If the entries in the adjacency matrix are integers, the graph is a
+    # multigraph, and parallel_edges is True, then create parallel edges, each
+    # with weight 1, for each entry in the adjacency matrix. Otherwise, create
+    # one edge for each positive entry in the adjacency matrix and set the
+    # weight of that edge to be the entry in the matrix.
+    elif python_type is int and G.is_multigraph() and parallel_edges:
+        chain = itertools.chain.from_iterable
+        # The following line is equivalent to:
+        #
+        #     for (u, v) in edges:
+        #         for d in range(A[u, v]):
+        #             G.add_edge(u, v, weight=1)
+        #
+        triples = chain(
+            ((u, v, {"weight": 1}) for d in range(A[u, v])) for (u, v) in edges
+        )
+    else:  # basic data type
+        triples = ((u, v, dict(weight=python_type(A[u, v]))) for u, v in edges)
+    # If we are creating an undirected multigraph, only add the edges from the
+    # upper triangle of the matrix. Otherwise, add all the edges. This relies
+    # on the fact that the vertices created in the
+    # `_generated_weighted_edges()` function are actually the row/column
+    # indices for the matrix `A`.
+    #
+    # Without this check, we run into a problem where each edge is added twice
+    # when `G.add_edges_from()` is invoked below.
+    if G.is_multigraph() and not G.is_directed():
+        triples = ((u, v, d) for u, v, d in triples if u <= v)
+    G.add_edges_from(triples)
+    return G

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -8,7 +8,17 @@ from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 from networkx.testing.utils import assert_graphs_equal
 
 
-class TestConvertNumpy:
+def test_to_numpy_matrix_deprecation():
+    pytest.deprecated_call(nx.to_numpy_matrix, nx.Graph())
+
+
+def test_from_numpy_matrix_deprecation():
+    pytest.deprecated_call(nx.from_numpy_matrix, np.eye(2))
+
+
+class TestConvertNumpyMatrix:
+    # TODO: This entire class can be removed when to/from_numpy_matrix
+    # deprecation expires
     def setup_method(self):
         self.G1 = barbell_graph(10, 3)
         self.G2 = cycle_graph(10, create_using=nx.DiGraph)


### PR DESCRIPTION
Adds deprecation warnings + associated tests to `to_numpy_matrix` and `from_numpy_matrix`. 

Originally, `from_numpy_array` as simply a pass-through function calling `from_numpy_matrix`. Re-organized so that `from_numpy_matrix` is now the pass-through, and the implementation is in `from_numpy_array` to make the removal easier down the road.

Added tests to ensure the deprecation warnings are raised, and warnings filters to suppress warnings related to `to/from_numpy_matrix` in the remainder of the test suite.