### PR TITLE
adds dedensification function

### DIFF
--- a/doc/reference/algorithms/index.rst
+++ b/doc/reference/algorithms/index.rst
@@ -66,6 +66,7 @@ Algorithms
    smetric
    sparsifiers
    structuralholes
+   summarization
    swap
    threshold
    tournament

--- a/doc/reference/algorithms/summarization.rst
+++ b/doc/reference/algorithms/summarization.rst
@@ -1,0 +1,9 @@
+*************
+Summarization
+*************
+
+.. automodule:: networkx.algorithms.summarization
+.. autosummary::
+   :toctree: generated/
+
+   dedensify

--- a/examples/algorithms/plot_dedensification.py
+++ b/examples/algorithms/plot_dedensification.py
@@ -1,0 +1,93 @@
+"""
+=============
+Dedensification
+=============
+
+Examples of dedensification of a graph.  Dedensification retains the structural
+pattern of the original graph and will only add compressor nodes when doing so
+would result in fewer edges in the compressed graph.
+"""
+import networkx as nx
+from networkx.algorithms import summarization
+import matplotlib.pyplot as plt
+
+plt.suptitle("Dedensification")
+
+original_graph = nx.DiGraph()
+white_nodes = ["1", "2", "3", "4", "5", "6"]
+red_nodes = ["A", "B", "C"]
+node_sizes = [250 for node in white_nodes + red_nodes]
+node_colors = ["white" for n in white_nodes] + ["red" for n in red_nodes]
+
+original_graph.add_nodes_from(white_nodes + red_nodes)
+original_graph.add_edges_from(
+    [
+        ("1", "C"),
+        ("1", "B"),
+        ("2", "C"),
+        ("2", "B"),
+        ("2", "A"),
+        ("3", "B"),
+        ("3", "A"),
+        ("3", "6"),
+        ("4", "C"),
+        ("4", "B"),
+        ("4", "A"),
+        ("5", "B"),
+        ("5", "A"),
+        ("6", "5"),
+        ("A", "6"),
+    ]
+)
+base_options = dict(with_labels=True, edgecolors="black")
+pos = {
+    "3": (0, 1),
+    "2": (0, 2),
+    "1": (0, 3),
+    "6": (1, 0),
+    "A": (1, 1),
+    "B": (1, 2),
+    "C": (1, 3),
+    "4": (2, 3),
+    "5": (2, 1),
+}
+ax1 = plt.subplot(1, 2, 1)
+plt.title("Original (%s edges)" % original_graph.number_of_edges())
+nx.draw_networkx(original_graph, pos=pos, node_color=node_colors, **base_options)
+
+nonexp_graph, compression_nodes = summarization.dedensify(
+    original_graph, threshold=2, copy=False
+)
+nonexp_node_colors = list(node_colors)
+nonexp_node_sizes = list(node_sizes)
+for node in compression_nodes:
+    nonexp_node_colors.append("yellow")
+    nonexp_node_sizes.append(600)
+plt.subplot(1, 2, 2)
+
+plt.title("Dedensified (%s edges)" % nonexp_graph.number_of_edges())
+nonexp_pos = {
+    "5": (0, 0),
+    "B": (0, 2),
+    "1": (0, 3),
+    "6": (1, 0.75),
+    "3": (1.5, 1.5),
+    "A": (2, 0),
+    "C": (2, 3),
+    "4": (3, 1.5),
+    "2": (3, 2.5),
+}
+c_nodes = list(compression_nodes)
+c_nodes.sort()
+for spot, node in enumerate(c_nodes):
+    nonexp_pos[node] = (2, spot + 2)
+nx.draw_networkx(
+    nonexp_graph,
+    pos=nonexp_pos,
+    node_color=nonexp_node_colors,
+    node_size=nonexp_node_sizes,
+    **base_options
+)
+
+plt.tight_layout()
+plt.show()

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -48,6 +48,7 @@ from networkx.algorithms.smallworld import *
 from networkx.algorithms.smetric import *
 from networkx.algorithms.structuralholes import *
 from networkx.algorithms.sparsifiers import *
+from networkx.algorithms.summarization import *
 from networkx.algorithms.swap import *
 from networkx.algorithms.traversal import *
 from networkx.algorithms.triads import *

--- a/networkx/algorithms/summarization.py
+++ b/networkx/algorithms/summarization.py
@@ -1,0 +1,215 @@
+"""
+Graph summarization finds smaller representations of graphs resulting in faster
+runtime of algorithms, reduced storage needs, and noise reduction.
+Summarization has applications in areas such as visualization, pattern mining,
+clustering and community detection, and more.  Core graph summarization
+techniques are grouping/aggregation, bit-compression,
+simplification/sparsification, and influence based. Graph summarization
+algorithms often produce either summary graphs in the form of supergraphs or
+sparsified graphs, or a list of independent structures. Supergraphs are the
+most common product, which consist of supernodes and original nodes and are
+connected by edges and superedges, which represent aggregate edges between
+nodes and supernodes.
+
+Grouping/aggregation based techniques compress graphs by representing
+close/connected nodes and edges in a graph by a single node/edge in a
+supergraph. Nodes can be grouped together into supernodes based on their
+structural similarities or proximity within a graph to reduce the total number
+of nodes in a graph. Edge-grouping techniques group edges into lossy/lossless
+nodes called compressor or virtual nodes to reduce the total number of edges in
+a graph. Edge-grouping techniques can be lossless, meaning that they can be
+used to re-create the original graph, or techniques can be lossy, requiring
+less space to store the summary graph, but at the expense of lower
+recontruction accuracy of the original graph.
+
+Bit-compression techniques minimize the amount of information needed to
+describe the original graph, while revealing structural patterns in the
+original graph.  The two-part minimum description length (MDL) is often used to
+represent the model and the original graph in terms of the model.  A key
+difference between graph compression and graph summarization is that graph
+summarization focuses on finding structural patterns within the original graph,
+whereas graph compression focuses on compressions the original graph to be as
+small as possible.  **NOTE**: Some bit-compression methods exist solely to
+compress a graph without creating a summary graph or finding comprehensible
+structural patterns.
+
+Simplification/Sparsification techniques attempt to create a sparse
+representation of a graph by removing unimportant nodes and edges from the
+graph.  Sparsified graphs differ from supergraphs created by
+grouping/aggregation by only containing a subset of the original nodes and
+edges of the original graph.
+
+Influence based techniques aim to find a high-level description of influence
+propagation in a large graph.  These methods are scarce and have been mostly
+applied to social graphs.
+
+*dedensification* is a grouping/aggregation based technique to compress the
+neighborhoods around high-degree nodes in unweighted graphs by adding
+compressor nodes that summarize multiple edges of the same type to
+high-degree nodes (nodes with a degree greater than a given threshold).
+Dedensification was developed for the purpose of increasing performance of
+query processing around high-degree nodes in graph databases and enables direct
+operations on the compressed graph.  The structural patterns surrounding
+high-degree nodes in the original is preserved while using fewer edges and
+adding a small number of compressor nodes.  The degree of nodes present in the
+original graph is also preserved. The current implementation of dedensification
+supports graphs with one edge type.
+
+For more information on graph summarization, see `Graph Summarization Methods
+and Applications: A Survey <https://dl.acm.org/doi/abs/10.1145/3186727>`_
+"""
+import networkx as nx
+
+__all__ = [
+    "dedensify",
+]
+
+
+def dedensify(G, threshold, prefix=None, copy=True):
+    """Compresses neighborhoods around high-degree nodes
+
+    Reduces the number of edges to high-degree nodes by adding compressor nodes
+    that summarize multiple edges of the same type to high-degree nodes (nodes
+    with a degree greater than a given threshold).  Dedensification also has
+    the added benefit of reducing the number of edges around high-degree nodes.
+    The implementation currently supports graphs with a single edge type.
+
+    Parameters
+    ----------
+    G: graph
+       A networkx graph
+    threshold: int
+       Minimum degree threshold of a node to be considered a high degree node.
+       The threshold must be greater than or equal to 2.
+    prefix: str or None, optional (default: None)
+       An optional prefix for denoting compressor nodes
+    copy: bool, optional (default: True)
+       Indicates if dedensification should be done inplace
+
+    Returns
+    -------
+    dedensified networkx graph : (graph, set)
+        2-tuple of the dedensified graph and set of compressor nodes
+
+    Notes
+    -----
+    According to the algorithm in [1]_, removes edges in a graph by
+    compressing/decompressing the neighborhoods around high degree nodes by
+    adding compressor nodes that summarize multiple edges of the same type
+    to high-degree nodes.  Dedensification will only add a compressor node when
+    doing so will reduce the total number of edges in the given graph. This
+    implementation currently supports graphs with a single edge type.
+
+    Examples
+    --------
+    Dedensification will only add compressor nodes when doing so would result
+    in fewer edges::
+
+        >>> original_graph = nx.DiGraph()
+        >>> original_graph.add_nodes_from(
+        ...     ["1", "2", "3", "4", "5", "6", "A", "B", "C"]
+        ... )
+        >>> original_graph.add_edges_from(
+        ...     [
+        ...         ("1", "C"), ("1", "B"),
+        ...         ("2", "C"), ("2", "B"), ("2", "A"),
+        ...         ("3", "B"), ("3", "A"), ("3", "6"),
+        ...         ("4", "C"), ("4", "B"), ("4", "A"),
+        ...         ("5", "B"), ("5", "A"),
+        ...         ("6", "5"),
+        ...         ("A", "6")
+        ...     ]
+        ... )
+        >>> c_graph, c_nodes = nx.dedensify(original_graph, threshold=2)
+        >>> original_graph.number_of_edges()
+        15
+        >>> c_graph.number_of_edges()
+        14
+
+    A dedensified, directed graph can be "densified" to reconstruct the
+    original graph::
+
+        >>> original_graph = nx.DiGraph()
+        >>> original_graph.add_nodes_from(
+        ...     ["1", "2", "3", "4", "5", "6", "A", "B", "C"]
+        ... )
+        >>> original_graph.add_edges_from(
+        ...     [
+        ...         ("1", "C"), ("1", "B"),
+        ...         ("2", "C"), ("2", "B"), ("2", "A"),
+        ...         ("3", "B"), ("3", "A"), ("3", "6"),
+        ...         ("4", "C"), ("4", "B"), ("4", "A"),
+        ...         ("5", "B"), ("5", "A"),
+        ...         ("6", "5"),
+        ...         ("A", "6")
+        ...     ]
+        ... )
+        >>> c_graph, c_nodes = nx.dedensify(original_graph, threshold=2)
+        >>> # re-densifies the compressed graph into the original graph
+        >>> for c_node in c_nodes:
+        ...     all_neighbors = set(nx.all_neighbors(c_graph, c_node))
+        ...     out_neighbors = set(c_graph.neighbors(c_node))
+        ...     for out_neighbor in out_neighbors:
+        ...         c_graph.remove_edge(c_node, out_neighbor)
+        ...     in_neighbors = all_neighbors - out_neighbors
+        ...     for in_neighbor in in_neighbors:
+        ...         c_graph.remove_edge(in_neighbor, c_node)
+        ...         for out_neighbor in out_neighbors:
+        ...             c_graph.add_edge(in_neighbor, out_neighbor)
+        ...     c_graph.remove_node(c_node)
+        ...
+        >>> nx.is_isomorphic(original_graph, c_graph)
+        True
+
+    References
+    ----------
+    .. [1] Maccioni, A., & Abadi, D. J. (2016, August).
+       Scalable pattern matching over compressed graphs via dedensification.
+       In Proceedings of the 22nd ACM SIGKDD International Conference on
+       Knowledge Discovery and Data Mining (pp. 1755-1764).
+       http://www.cs.umd.edu/~abadi/papers/graph-dedense.pdf
+    """
+    if threshold < 2:
+        raise nx.NetworkXError("The degree threshold must be >= 2")
+
+    high_degree_nodes = set()
+    low_degree_nodes = set()
+
+    degrees = G.in_degree if G.is_directed() else G.degree
+    # Group nodes based on degree threshold
+    high_degree_nodes = set([n for n, d in degrees if d > threshold])
+    low_degree_nodes = G.nodes() - high_degree_nodes
+
+    auxillary = {}
+    for node in G:
+        high_degree_neighbors = frozenset(high_degree_nodes & set(G[node]))
+        if high_degree_neighbors:
+            if high_degree_neighbors in auxillary:
+                auxillary[high_degree_neighbors].add(node)
+            else:
+                auxillary[high_degree_neighbors] = {node}
+
+    if copy:
+        G = G.copy()
+
+    compressor_nodes = set()
+    for index, (high_degree_nodes, low_degree_nodes) in enumerate(auxillary.items()):
+        low_degree_node_count = len(low_degree_nodes)
+        high_degree_node_count = len(high_degree_nodes)
+        old_edges = high_degree_node_count * low_degree_node_count
+        new_edges = high_degree_node_count + low_degree_node_count
+        if old_edges <= new_edges:
+            continue
+        compression_node = "".join(str(node) for node in high_degree_nodes)
+        if prefix:
+            compression_node = str(prefix) + compression_node
+        for node in low_degree_nodes:
+            for high_node in high_degree_nodes:
+                if G.has_edge(node, high_node):
+                    G.remove_edge(node, high_node)
+
+            G.add_edge(node, compression_node)
+        for node in high_degree_nodes:
+            G.add_edge(compression_node, node)
+        compressor_nodes.add(compression_node)
+    return G, compressor_nodes

--- a/networkx/algorithms/summarization.py
+++ b/networkx/algorithms/summarization.py
@@ -172,9 +172,6 @@ def dedensify(G, threshold, prefix=None, copy=True):
     if threshold < 2:
         raise nx.NetworkXError("The degree threshold must be >= 2")
 
-    high_degree_nodes = set()
-    low_degree_nodes = set()
-
     degrees = G.in_degree if G.is_directed() else G.degree
     # Group nodes based on degree threshold
     high_degree_nodes = set([n for n, d in degrees if d > threshold])

--- a/networkx/algorithms/tests/test_summarization.py
+++ b/networkx/algorithms/tests/test_summarization.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for dedensification/densification
+"""
+
+import networkx as nx
+from networkx.algorithms.summarization import dedensify
+
+
+class TestDirectedDedensification:
+    def build_original_graph(self):
+        original_matrix = [
+            ("1", "BC"),
+            ("2", "ABC"),
+            ("3", ["A", "B", "6"]),
+            ("4", "ABC"),
+            ("5", "AB"),
+            ("6", ["5"]),
+            ("A", ["6"]),
+        ]
+        graph = nx.DiGraph()
+        for source, targets in original_matrix:
+            for target in targets:
+                graph.add_edge(source, target)
+        return graph
+
+    def build_compressed_graph(self):
+        compressed_matrix = [
+            ("1", "BC"),
+            ("2", ["ABC"]),
+            ("3", ["A", "B", "6"]),
+            ("4", ["ABC"]),
+            ("5", "AB"),
+            ("6", ["5"]),
+            ("A", ["6"]),
+            ("ABC", "ABC"),
+        ]
+        compressed_graph = nx.DiGraph()
+        for source, targets in compressed_matrix:
+            for target in targets:
+                compressed_graph.add_edge(source, target)
+        return compressed_graph
+
+    def test_empty(self):
+        """
+        Verify that an empty directed graph results in no compressor nodes
+        """
+        G = nx.DiGraph()
+        compressed_graph, c_nodes = dedensify(G, threshold=2)
+        assert c_nodes == set()
+
+    @staticmethod
+    def densify(G, compressor_nodes, copy=True):
+        """
+        Reconstructs the original graph from a dedensified, directed graph
+
+        Parameters
+        ----------
+        G: dedensified graph
+           A networkx graph
+        compressor_nodes: iterable
+           Iterable of compressor nodes in the dedensified graph
+        inplace: bool, optional (default: False)
+           Indicates if densification should be done inplace
+
+        Returns
+        -------
+        G: graph
+           A densified networkx graph
+        """
+        if copy:
+            G = G.copy()
+        for compressor_node in compressor_nodes:
+            all_neighbors = set(nx.all_neighbors(G, compressor_node))
+            out_neighbors = set(G.neighbors(compressor_node))
+            for out_neighbor in out_neighbors:
+                G.remove_edge(compressor_node, out_neighbor)
+            in_neighbors = all_neighbors - out_neighbors
+            for in_neighbor in in_neighbors:
+                G.remove_edge(in_neighbor, compressor_node)
+                for out_neighbor in out_neighbors:
+                    G.add_edge(in_neighbor, out_neighbor)
+            G.remove_node(compressor_node)
+        return G
+
+    def setup_method(self):
+        self.c_nodes = ("ABC",)
+
+    def test_dedensify_edges(self):
+        """
+        Verifies that dedensify produced the correct edges to/from compressor
+        nodes in a directed graph
+        """
+        G = self.build_original_graph()
+        compressed_G = self.build_compressed_graph()
+        compressed_graph, c_nodes = dedensify(G, threshold=2)
+        for s, t in compressed_graph.edges():
+            o_s = "".join(sorted(s))
+            o_t = "".join(sorted(t))
+            compressed_graph_exists = compressed_graph.has_edge(s, t)
+            verified_compressed_exists = compressed_G.has_edge(o_s, o_t)
+            assert compressed_graph_exists == verified_compressed_exists
+        assert len(c_nodes) == len(self.c_nodes)
+
+    def test_dedensify_edge_count(self):
+        """
+        Verifies that dedensify produced the correct number of comrpessor nodes
+        in a directed graph
+        """
+        G = self.build_original_graph()
+        original_edge_count = len(G.edges())
+        c_G, c_nodes = dedensify(G, threshold=2)
+        compressed_edge_count = len(c_G.edges())
+        assert compressed_edge_count <= original_edge_count
+        compressed_G = self.build_compressed_graph()
+        assert compressed_edge_count == len(compressed_G.edges())
+
+    def test_densify_edges(self):
+        """
+        Verifies that densification produces the correct edges from the
+        original directed graph
+        """
+        compressed_G = self.build_compressed_graph()
+        original_graph = self.densify(compressed_G, self.c_nodes, copy=True)
+        G = self.build_original_graph()
+        for s, t in G.edges():
+            assert G.has_edge(s, t) == original_graph.has_edge(s, t)
+
+    def test_densify_edge_count(self):
+        """
+        Verifies that densification produces the correct number of edges in the
+        original directed graph
+        """
+        compressed_G = self.build_compressed_graph()
+        compressed_edge_count = len(compressed_G.edges())
+        original_graph = self.densify(compressed_G, self.c_nodes)
+        original_edge_count = len(original_graph.edges())
+        assert compressed_edge_count <= original_edge_count
+        G = self.build_original_graph()
+        assert original_edge_count == len(G.edges())
+
+
+class TestUnDirectedDedensification:
+    def build_original_graph(self):
+        """
+        Builds graph shown in the original research paper
+        """
+        original_matrix = [
+            ("1", "CB"),
+            ("2", "ABC"),
+            ("3", ["A", "B", "6"]),
+            ("4", "ABC"),
+            ("5", "AB"),
+            ("6", ["5"]),
+            ("A", ["6"]),
+        ]
+        graph = nx.Graph()
+        for source, targets in original_matrix:
+            for target in targets:
+                graph.add_edge(source, target)
+        return graph
+
+    def test_empty(self):
+        """
+        Verify that an empty undirected graph results in no compressor nodes
+        """
+        G = nx.Graph()
+        compressed_G, c_nodes = dedensify(G, threshold=2)
+        assert c_nodes == set()
+
+    def setup_method(self):
+        self.c_nodes = (
+            "6AB",
+            "ABC",
+        )
+
+    def build_compressed_graph(self):
+        compressed_matrix = [
+            ("1", ["B", "C"]),
+            ("2", ["ABC"]),
+            ("3", ["6AB"]),
+            ("4", ["ABC"]),
+            ("5", ["6AB"]),
+            ("6", ["6AB", "A"]),
+            ("A", ["6AB", "ABC"]),
+            ("B", ["ABC", "6AB"]),
+            ("C", ["ABC"]),
+        ]
+        compressed_graph = nx.Graph()
+        for source, targets in compressed_matrix:
+            for target in targets:
+                compressed_graph.add_edge(source, target)
+        return compressed_graph
+
+    def test_dedensify_edges(self):
+        """
+        Verifies that dedensify produced correct compressor nodes and the
+        correct edges to/from the compressor nodes in an undirected graph
+        """
+        G = self.build_original_graph()
+        c_G, c_nodes = dedensify(G, threshold=2)
+        v_compressed_G = self.build_compressed_graph()
+        for s, t in c_G.edges():
+            o_s = "".join(sorted(s))
+            o_t = "".join(sorted(t))
+            has_compressed_edge = c_G.has_edge(s, t)
+            verified_has_compressed_edge = v_compressed_G.has_edge(o_s, o_t)
+            assert has_compressed_edge == verified_has_compressed_edge
+        assert len(c_nodes) == len(self.c_nodes)
+
+    def test_dedensify_edge_count(self):
+        """
+        Verifies that dedensify produced the correct number of edges in an
+        undirected graph
+        """
+        G = self.build_original_graph()
+        c_G, c_nodes = dedensify(G, threshold=2, copy=True)
+        compressed_edge_count = len(c_G.edges())
+        verified_original_edge_count = len(G.edges())
+        assert compressed_edge_count <= verified_original_edge_count
+        verified_compressed_G = self.build_compressed_graph()
+        verified_compressed_edge_count = len(verified_compressed_G.edges())
+        assert compressed_edge_count == verified_compressed_edge_count


### PR DESCRIPTION
**NOTE**:  This change was originally found in pull request #3856, but Github Actions wouldn't work anymore due to changes to the `.github/workflow` files since my initial fork, so I re-forked and re-implemented the changes.

Original content:

Adds dedensification (`networkx.algorithms.dedensification.dedensify`) and densification (`networkx.algorithms.dedensification.densify`) functions as defined in [Scalable Pattern Matching over Compressed Graphs via Dedensification](http://www.cs.umd.edu/~abadi/papers/graph-dedense.pdf) with option for `expansive` or `nonexpansive` results, and option for `inplace` dedensification or densification.

Examples of how functions can be called:
```python
import networkx as nx

graph = nx.DiGraph()
# build structure of graph by adding nodes and edges

dedensified_graph, compression_nodes = nx.algorithms.dedensification.dedensify(graph, threshold=10, prefix='compression-')

# perform business operations on dedensified graph

# convert dedensified graph back into original graph
densified_graph = nx.algorithms.dedensification.densify(dedensified_graph, compression_nodes)
```