### PR TITLE
Updated has_eulerian_path 

### DIFF
--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -224,7 +224,7 @@ def has_eulerian_path(G):
         - at most one vertex has in_degree - out_degree = 1,
         - every other vertex has equal in_degree and out_degree,
         - and all of its vertices with nonzero degree belong to a
-        - single connected component of the underlying undirected graph.
+          single connected component of the underlying undirected graph.
 
     An undirected graph has an Eulerian path iff:
         - exactly zero or two vertices have odd degree,

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -246,10 +246,12 @@ def has_eulerian_path(G):
     eulerian_path
     """
     if G.is_directed():
+        # Remove isolated nodes (if any) without altering the input graph
         nodes_remove = [v for v in G if G.in_degree[v] == 0 and G.out_degree[v] == 0]
         if nodes_remove:
             G = G.copy()
             G.remove_nodes_from(nodes_remove)
+
         ins = G.in_degree
         outs = G.out_degree
         unbalanced_ins = 0

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -247,8 +247,9 @@ def has_eulerian_path(G):
     """
     if G.is_directed():
         H = G.copy()
-        H.remove_nodes_from(v for v in H
-                            if H.in_degree(v) == 0 and H.out_degree(v) == 0)
+        H.remove_nodes_from(
+            v for v in H if H.in_degree(v) == 0 and H.out_degree(v) == 0
+        )
         ins = H.in_degree
         outs = H.out_degree
         unbalanced_ins = 0
@@ -262,9 +263,7 @@ def has_eulerian_path(G):
                 return False
 
         return(
-            unbalanced_ins <= 1
-            and unbalanced_outs <= 1
-            and nx.is_weakly_connected(H)
+            unbalanced_ins <= 1 and unbalanced_outs <= 1 and nx.is_weakly_connected(H)
         )
 
     else:

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -262,7 +262,7 @@ def has_eulerian_path(G):
             elif ins(v) != outs(v):
                 return False
 
-        return(
+        return (
             unbalanced_ins <= 1 and unbalanced_outs <= 1 and nx.is_weakly_connected(H)
         )
 

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -246,16 +246,27 @@ def has_eulerian_path(G):
     eulerian_path
     """
     if G.is_directed():
-        ins = G.in_degree
-        outs = G.out_degree
-        semibalanced_ins = sum(ins(v) - outs(v) == 1 for v in G)
-        semibalanced_outs = sum(outs(v) - ins(v) == 1 for v in G)
-        return (
-            semibalanced_ins <= 1
-            and semibalanced_outs <= 1
-            and sum(G.in_degree(v) != G.out_degree(v) for v in G) <= 2
-            and nx.is_weakly_connected(G)
+        H = G.copy()
+        H.remove_nodes_from(v for v in H
+                            if H.in_degree(v) == 0 and H.out_degree(v) == 0)
+        ins = H.in_degree
+        outs = H.out_degree
+        unbalanced_ins = 0
+        unbalanced_outs = 0
+        for v in H:
+            if ins(v) - outs(v) == 1:
+                unbalanced_ins += 1
+            elif outs(v) - ins(v) == 1:
+                unbalanced_outs += 1
+            elif ins(v) != outs(v):
+                return False
+
+        return(
+            unbalanced_ins <= 1
+            and unbalanced_outs <= 1
+            and nx.is_weakly_connected(H)
         )
+
     else:
         return sum(d % 2 == 1 for v, d in G.degree()) in (0, 2) and nx.is_connected(G)
 

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -246,23 +246,24 @@ def has_eulerian_path(G):
     eulerian_path
     """
     if G.is_directed():
-        H = G.copy()
-        nodes_remove = [v for v in H if H.in_degree(v) == 0 and H.out_degree(v) == 0]
-        H.remove_nodes_from(nodes_remove)
-        ins = H.in_degree
-        outs = H.out_degree
+        nodes_remove = [v for v in G if G.in_degree[v] == 0 and G.out_degree[v] == 0]
+        if nodes_remove:
+            G = G.copy()
+            G.remove_nodes_from(nodes_remove)
+        ins = G.in_degree
+        outs = G.out_degree
         unbalanced_ins = 0
         unbalanced_outs = 0
-        for v in H:
-            if ins(v) - outs(v) == 1:
+        for v in G:
+            if ins[v] - outs[v] == 1:
                 unbalanced_ins += 1
-            elif outs(v) - ins(v) == 1:
+            elif outs[v] - ins[v] == 1:
                 unbalanced_outs += 1
-            elif ins(v) != outs(v):
+            elif ins[v] != outs[v]:
                 return False
 
         return (
-            unbalanced_ins <= 1 and unbalanced_outs <= 1 and nx.is_weakly_connected(H)
+            unbalanced_ins <= 1 and unbalanced_outs <= 1 and nx.is_weakly_connected(G)
         )
 
     else:

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -247,9 +247,8 @@ def has_eulerian_path(G):
     """
     if G.is_directed():
         H = G.copy()
-        H.remove_nodes_from(
-            v for v in H if H.in_degree(v) == 0 and H.out_degree(v) == 0
-        )
+        nodes_remove = [v for v in H if H.in_degree(v) == 0 and H.out_degree(v) == 0]
+        H.remove_nodes_from(nodes_remove)
         ins = H.in_degree
         outs = H.out_degree
         unbalanced_ins = 0

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -135,18 +135,18 @@ class TestHasEulerianPath:
         assert nx.has_eulerian_path(G)
 
     def test_has_eulerian_path_directed_graph(self):
-        #Test directed graphs and returns False
+        # Test directed graphs and returns False
         G = nx.DiGraph()
-        G.add_edges_from([(0, 1), (1,2), (0,2)])
+        G.add_edges_from([(0, 1), (1, 2), (0, 2)])
         assert not nx.has_eulerian_path(G)
 
     def test_has_eulerian_path_isolated_point(self):
-        #Test directed graphs without isolated points returns True
+        # Test directed graphs without isolated points returns True
         G = nx.DiGraph()
-        G.add_edges_from([(0, 1), (1,2), (2,0)])
+        G.add_edges_from([(0, 1), (1, 2), (2, 0)])
         assert nx.has_eulerian_path(G)
 
-        #Test directed graphs with isolated points returns True
+        # Test directed graphs with isolated points returns True
         G.add_node(3)
         assert nx.has_eulerian_path(G)
 

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -134,6 +134,22 @@ class TestHasEulerianPath:
         G = nx.path_graph(6, create_using=nx.DiGraph)
         assert nx.has_eulerian_path(G)
 
+    def test_has_eulerian_path_directed_graph(self):
+        #Test directed graphs and returns False
+        G = nx.DiGraph()
+        G.add_edges_from([(0, 1), (1,2), (0,2)])
+        assert not nx.has_eulerian_path(G)
+
+    def test_has_eulerian_path_isolated_point(self):
+        #Test directed graphs without isolated points returns True
+        G = nx.DiGraph()
+        G.add_edges_from([(0, 1), (1,2), (2,0)])
+        assert nx.has_eulerian_path(G)
+
+        #Test directed graphs with isolated points returns True
+        G.add_node(3)
+        assert nx.has_eulerian_path(G)
+
 
 class TestFindPathStart:
     def testfind_path_start(self):

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -140,13 +140,13 @@ class TestHasEulerianPath:
         G.add_edges_from([(0, 1), (1, 2), (0, 2)])
         assert not nx.has_eulerian_path(G)
 
-    def test_has_eulerian_path_isolated_point(self):
-        # Test directed graphs without isolated points returns True
+    def test_has_eulerian_path_isolated_node(self):
+        # Test directed graphs without isolated node returns True
         G = nx.DiGraph()
         G.add_edges_from([(0, 1), (1, 2), (2, 0)])
         assert nx.has_eulerian_path(G)
 
-        # Test directed graphs with isolated points returns True
+        # Test directed graphs with isolated node returns True
         G.add_node(3)
         assert nx.has_eulerian_path(G)
 


### PR DESCRIPTION
Fixes #4244

As @rossbar said, the description does not match the implementation for a directed graph. This pull request fixes this issue.
The new implementation adequately checks if  
> "every other vertex has equal in_degree and out_degree".
It also addresses another issue about isolated points. The definition states
> "and all of its vertices with nonzero degree belong to a single connected component of the underlying undirected graph."

The previous implementation ignored vertices that had "nonzero degree". In this one, I created a copy of the graph and removed the isolated points before checking if it was weakly connected.

The code works on the test case that @tlarock brought up. However, this test case has not yet been added to test_euler.py

