### PR TITLE
Update Knuth miles example.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,11 @@ jobs:
             sudo apt-get install texlive texlive-latex-extra latexmk
 
       - run:
+          name: Install cartopy dependencies
+          command: |
+            sudo apt-get install libgeos-dev libproj-dev
+
+      - run:
           name: Install Python dependencies
           command: |
             python3 -m venv venv
@@ -33,7 +38,8 @@ jobs:
             pip install --upgrade pip wheel setuptools
             pip install -r requirements.txt
             pip install -r requirements/doc.txt
-            pip install pydot pygraphviz
+            pip install -r requirements/extra.txt
+            pip install -r requirements/example.txt
 
       - run:
           name: Install

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
           - texlive
           - texlive-latex-extra
           - latexmk
+          - libgeos-dev
+          - libproj-dev
     - os: linux
       python: 3.7
       env:
@@ -59,6 +61,9 @@ install:
   - pip install --retries 3 ${PIP_FLAGS} -r requirements.txt
   - if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
       pip install --retries 3 ${PIP_FLAGS} -r requirements/extra.txt;
+    fi
+  - if [[ "${BUILD_DOCS}" == 1 ]]; then
+      pip install --retries 3 ${PIP_FLAGS} -r requirements/example.txt;
     fi
   # install networkx
   - printenv PWD

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -3,7 +3,7 @@
 Knuth Miles
 ===========
 
-`miles_graph()` returns an undirected graph over the 128 US cities from.  The
+`miles_graph()` returns an undirected graph over 128 US cities. The
 cities each have location and population data.  The edges are labeled with the
 distance between the two cities.
 
@@ -67,7 +67,7 @@ def miles_graph():
 G = miles_graph()
 
 print("Loaded miles_dat.txt containing 128 cities.")
-print(f"digraph has {nx.number_of_nodes(G)} nodes with {nx.number_of_edges(G)} edges")
+print(G)
 
 # make new graph of cites, edge if less then 300 miles between them
 H = nx.Graph()
@@ -76,6 +76,7 @@ for v in G:
 for (u, v, d) in G.edges(data=True):
     if d["weight"] < 300:
         H.add_edge(u, v)
+
 
 # draw with matplotlib/pylab
 plt.figure(figsize=(8, 8))

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -118,6 +118,7 @@ try:
             edge_coords[:, 0],
             edge_coords[:, 1],
             transform=ccrs.PlateCarree(),
+            linewidth=0.75,
             color="k",
         )
 

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -89,19 +89,19 @@ try:
     import cartopy.crs as ccrs
     import cartopy.io.shapereader as shpreader
 
-    # Add map of US as a backdrop
     ax = fig.add_axes([0, 0, 1, 1], projection=ccrs.LambertConformal(), frameon=False)
     ax.set_extent([-125, -66.5, 20, 50], ccrs.Geodetic())
-    shapename = "admin_1_states_provinces_lakes_shp"
-    states_shp = shpreader.natural_earth(
-        resolution="110m", category="cultural", name=shapename
-    )
-    ax.add_geometries(
-        shpreader.Reader(states_shp).geometries(),
-        ccrs.PlateCarree(),
-        facecolor="none",
-        edgecolor="k",
-    )
+    # Add map of countries & US states as a backdrop
+    for shapename in ("admin_1_states_provinces_lakes_shp", "admin_0_countries"):
+        shp = shpreader.natural_earth(
+            resolution="110m", category="cultural", name=shapename
+        )
+        ax.add_geometries(
+            shpreader.Reader(shp).geometries(),
+            ccrs.PlateCarree(),
+            facecolor="none",
+            edgecolor="k",
+        )
     # NOTE: When using cartopy, use matplotlib directly rather than nx.draw
     # to take advantage of the cartopy transforms
     ax.scatter(

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -79,7 +79,7 @@ for (u, v, d) in G.edges(data=True):
         H.add_edge(u, v)
 
 # draw with matplotlib/pylab
-fig = plt.figure(figsize=(8, 8))
+fig = plt.figure(figsize=(8, 6))
 
 # nodes colored by degree sized by population
 node_color = [float(H.degree(v)) for v in H]

--- a/examples/drawing/plot_knuth_miles.py
+++ b/examples/drawing/plot_knuth_miles.py
@@ -21,6 +21,11 @@ The data file can be found at:
 import gzip
 import re
 
+# Ignore any warnings related to downloading shpfiles with cartopy
+import warnings
+
+warnings.simplefilter("ignore")
+
 import numpy as np
 import matplotlib.pyplot as plt
 import networkx as nx

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -6,6 +6,8 @@
   Default requirements
 - [`extra.txt`](extra.txt)
   Optional requirements that may require extra steps to install
+- [`example.txt`](example.txt)
+  Requirements for gallery examples
 - [`test.txt`](test.txt)
   Requirements for running test suite
 - [`doc.txt`](doc.txt)

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -1,0 +1,6 @@
+Cython>=0.29
+pyshp>=2.1
+six>=1.15
+--no-binary shapely
+shapely>=1.5.17
+Cartopy>=0.18.0


### PR DESCRIPTION
Uses `cartopy` to add a map of the US as a backdrop to the `plot_knuth_miles.py` example.

As of now, the example is organized so that it will run whether or not cartopy is available.

CI configuration for the `cartopy` dependency cherry-picked from #4250 