### PR TITLE
Improve readibility of chess_example in gallery

### DIFF
--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -111,20 +111,20 @@ nodesize = [wins[v] * 50 for v in H]
 # Generate layout for visualization
 pos = nx.kamada_kawai_layout(H)
 
-plt.rcParams["text.usetex"] = False
 fig, ax = plt.subplots(figsize=(12, 12))
+# Visualize graph components
 nx.draw_networkx_edges(H, pos, alpha=0.3, width=edgewidth, edge_color="m")
 nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="w", alpha=0.4)
 nx.draw_networkx_edges(H, pos, alpha=0.4, node_size=0, width=1, edge_color="k")
 nx.draw_networkx_labels(H, pos, font_size=14)
-ax.set_xlim(-0.8, 0.8)
-font = {"fontname": "Helvetica", "color": "k", "fontweight": "bold", "fontsize": 14}
-plt.title("World Chess Championship Games: 1886 - 1985", font)
 
+# Title/legend
+font = {"fontname": "Helvetica", "color": "k", "fontweight": "bold", "fontsize": 14}
+ax.set_title("World Chess Championship Games: 1886 - 1985", font)
 # Change font color for legend
 font["color"] = "r"
 
-plt.text(
+ax.text(
     0.80,
     0.10,
     "edge width = # games played",
@@ -132,7 +132,7 @@ plt.text(
     transform=plt.gca().transAxes,
     fontdict=font,
 )
-plt.text(
+ax.text(
     0.80,
     0.06,
     "node size = # games won",
@@ -141,6 +141,8 @@ plt.text(
     fontdict=font,
 )
 
+# Resize figure for label readibility
+ax.set_xlim(-0.8, 0.8)
 fig.tight_layout()
 plt.axis("off")
 plt.show()

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -93,9 +93,7 @@ for (white, black, game_info) in G.edges(data=True):
 H = nx.Graph(G)
 
 # edge width is proportional number of games played
-edgewidth = []
-for (u, v, d) in H.edges(data=True):
-    edgewidth.append(len(G.get_edge_data(u, v)))
+edgewidth = [len(G.get_edge_data(u, v)) for u, v in H.edges()]
 
 # node size is proportional to number of games won
 wins = dict.fromkeys(G.nodes(), 0.0)
@@ -108,16 +106,14 @@ for (u, v, d) in G.edges(data=True):
         wins[v] += 0.5
     else:
         wins[v] += 1.0
-# try:
-#    pos = nx.nx_agraph.graphviz_layout(H)
-# except ImportError:
-#    pos = nx.spring_layout(H, iterations=20)
+nodesize = [wins[v] * 50 for v in H]
+
+# Generate layout for visualization
 pos = nx.kamada_kawai_layout(H)
 
 plt.rcParams["text.usetex"] = False
 fig, ax = plt.subplots(figsize=(12, 12))
 nx.draw_networkx_edges(H, pos, alpha=0.3, width=edgewidth, edge_color="m")
-nodesize = [wins[v] * 50 for v in H]
 nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="w", alpha=0.4)
 nx.draw_networkx_edges(H, pos, alpha=0.4, node_size=0, width=1, edge_color="k")
 nx.draw_networkx_labels(H, pos, font_size=14)

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -129,7 +129,7 @@ ax.text(
     0.10,
     "edge width = # games played",
     horizontalalignment="center",
-    transform=plt.gca().transAxes,
+    transform=ax.transAxes,
     fontdict=font,
 )
 ax.text(
@@ -137,7 +137,7 @@ ax.text(
     0.06,
     "node size = # games won",
     horizontalalignment="center",
-    transform=plt.gca().transAxes,
+    transform=ax.transAxes,
     fontdict=font,
 )
 

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -46,8 +46,8 @@ def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
 
     G = nx.MultiDiGraph()
     game = {}
-    datafile = bz2.BZ2File(pgn_file)
-    lines = (line.decode().rstrip("\r\n") for line in datafile)
+    with bz2.BZ2File(pgn_file) as datafile:
+        lines = [line.decode().rstrip("\r\n") for line in datafile]
     for line in lines:
         if line.startswith("["):
             tag, value = line[1:-1].split(" ", 1)

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -145,7 +145,7 @@ ax.text(
 )
 
 # Resize figure for label readibility
-ax.set_xlim(-0.8, 0.8)
+ax.margins(0.1, 0.05)
 fig.tight_layout()
 plt.axis("off")
 plt.show()

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -115,7 +115,6 @@ fig, ax = plt.subplots(figsize=(12, 12))
 # Visualize graph components
 nx.draw_networkx_edges(H, pos, alpha=0.3, width=edgewidth, edge_color="m")
 nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="w", alpha=0.4)
-nx.draw_networkx_edges(H, pos, alpha=0.4, node_size=0, width=1, edge_color="k")
 nx.draw_networkx_labels(H, pos, font_size=14)
 
 # Title/legend

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -3,10 +3,10 @@
 Chess Masters
 =============
 
-An example of the MultiDiGraph class
+An example of the MultiDiGraph class.
 
-The function chess_pgn_graph reads a collection of chess matches stored in the
-specified PGN file (PGN ="Portable Game Notation").  Here the (compressed)
+The function `chess_pgn_graph` reads a collection of chess matches stored in
+the specified PGN file (PGN ="Portable Game Notation").  Here the (compressed)
 default file::
 
     chess_masters_WCC.pgn.bz2
@@ -36,7 +36,7 @@ game_details = ["Event", "Date", "Result", "ECO", "Site"]
 def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
     """Read chess games in pgn format in pgn_file.
 
-    Filenames ending in .gz or .bz2 will be uncompressed.
+    Filenames ending in .bz2 will be uncompressed.
 
     Return the MultiDiGraph of players connected by a chess game.
     Edges contain game data in a dict.

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -118,8 +118,9 @@ pos["Smyslov, Vassily V"] += (0.05, -0.03)
 fig, ax = plt.subplots(figsize=(12, 12))
 # Visualize graph components
 nx.draw_networkx_edges(H, pos, alpha=0.3, width=edgewidth, edge_color="m")
-nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="#210070", alpha=0.3)
-nx.draw_networkx_labels(H, pos, font_size=14)
+nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="#210070", alpha=0.9)
+label_options = {"ec": "k", "fc": "white", "alpha": 0.7}
+nx.draw_networkx_labels(H, pos, font_size=14, bbox=label_options)
 
 # Title/legend
 font = {"fontname": "Helvetica", "color": "k", "fontweight": "bold", "fontsize": 14}

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -114,7 +114,7 @@ pos = nx.kamada_kawai_layout(H)
 fig, ax = plt.subplots(figsize=(12, 12))
 # Visualize graph components
 nx.draw_networkx_edges(H, pos, alpha=0.3, width=edgewidth, edge_color="m")
-nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="w", alpha=0.4)
+nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="#210070", alpha=0.3)
 nx.draw_networkx_labels(H, pos, font_size=14)
 
 # Title/legend

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -65,18 +65,15 @@ def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
 
 G = chess_pgn_graph()
 
-ngames = G.number_of_edges()
-nplayers = G.number_of_nodes()
+print(
+    f"Loaded {G.number_of_edges()} chess games between {G.number_of_nodes()} players\n"
+)
 
-print(f"Loaded {ngames} chess games between {nplayers} players\n")
-
-# identify connected components
-# of the undirected version
+# identify connected components of the undirected version
 H = G.to_undirected()
 Gcc = [H.subgraph(c) for c in nx.connected_components(H)]
 if len(Gcc) > 1:
-    print("Note the disconnected component consisting of:")
-    print(Gcc[1].nodes())
+    print(f"Note the disconnected component consisting of:\n{Gcc[1].nodes()}")
 
 # find all games with B97 opening (as described in ECO)
 openings = {game_info["ECO"] for (white, black, game_info) in G.edges(data=True)}
@@ -86,10 +83,11 @@ print('with the Najdorff 7...Qb6 "Poisoned Pawn" variation.\n')
 
 for (white, black, game_info) in G.edges(data=True):
     if game_info["ECO"] == "B97":
-        print(white, "vs", black)
+        summary = f"{white} vs {black}\n"
         for k, v in game_info.items():
-            print("   ", k, ": ", v)
-        print("\n")
+            summary += f"   {k}: {v}\n"
+        summary += "\n"
+        print(summary)
 
 # make new undirected graph H without multi-edges
 H = nx.Graph(G)

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -3,7 +3,7 @@
 Chess Masters
 =============
 
-An example of the MultiDiGraph clas
+An example of the MultiDiGraph class
 
 The function chess_pgn_graph reads a collection of chess matches stored in the
 specified PGN file (PGN ="Portable Game Notation").  Here the (compressed)
@@ -110,38 +110,43 @@ for (u, v, d) in G.edges(data=True):
         wins[v] += 0.5
     else:
         wins[v] += 1.0
-try:
-    pos = nx.nx_agraph.graphviz_layout(H)
-except ImportError:
-    pos = nx.spring_layout(H, iterations=20)
+# try:
+#    pos = nx.nx_agraph.graphviz_layout(H)
+# except ImportError:
+#    pos = nx.spring_layout(H, iterations=20)
+pos = nx.kamada_kawai_layout(H)
 
 plt.rcParams["text.usetex"] = False
-plt.figure(figsize=(8, 8))
+fig, ax = plt.subplots(figsize=(12, 12))
 nx.draw_networkx_edges(H, pos, alpha=0.3, width=edgewidth, edge_color="m")
 nodesize = [wins[v] * 50 for v in H]
 nx.draw_networkx_nodes(H, pos, node_size=nodesize, node_color="w", alpha=0.4)
 nx.draw_networkx_edges(H, pos, alpha=0.4, node_size=0, width=1, edge_color="k")
 nx.draw_networkx_labels(H, pos, font_size=14)
+ax.set_xlim(-0.8, 0.8)
 font = {"fontname": "Helvetica", "color": "k", "fontweight": "bold", "fontsize": 14}
 plt.title("World Chess Championship Games: 1886 - 1985", font)
 
-# change font and write text (using data coordinates)
-font = {"fontname": "Helvetica", "color": "r", "fontweight": "bold", "fontsize": 14}
+# Change font color for legend
+font["color"] = "r"
 
 plt.text(
-    0.5,
-    0.97,
+    0.80,
+    0.10,
     "edge width = # games played",
     horizontalalignment="center",
     transform=plt.gca().transAxes,
+    fontdict=font,
 )
 plt.text(
-    0.5,
-    0.94,
+    0.80,
+    0.06,
     "node size = # games won",
     horizontalalignment="center",
     transform=plt.gca().transAxes,
+    fontdict=font,
 )
 
+fig.tight_layout()
 plt.axis("off")
 plt.show()

--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -110,6 +110,10 @@ nodesize = [wins[v] * 50 for v in H]
 
 # Generate layout for visualization
 pos = nx.kamada_kawai_layout(H)
+# Manual tweaking to limit node label overlap in the visualization
+pos["Reshevsky, Samuel H"] += (0.05, -0.10)
+pos["Botvinnik, Mikhail M"] += (0.03, -0.06)
+pos["Smyslov, Vassily V"] += (0.05, -0.03)
 
 fig, ax = plt.subplots(figsize=(12, 12))
 # Visualize graph components


### PR DESCRIPTION
The current visualization produced by `plot_chess_masters.py` results labels that are not very readible.

This PR contains some minor tweaks to improve the visualization without changing the overall aesthetic (colors etc., though the layout has changed), as well as some minor improvements to the code in the example.