### PR TITLE
Update "four_grids" gallery example

### DIFF
--- a/examples/drawing/plot_four_grids.py
+++ b/examples/drawing/plot_four_grids.py
@@ -3,7 +3,10 @@
 Four Grids
 ==========
 
-Draw a graph with matplotlib.
+Draw a 4x4 graph with matplotlib.
+
+This example illustrates the use of keyword arguments to `networkx.draw` to
+customize the visualization of a simple Graph comprising a 4x4 grid.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/drawing/plot_four_grids.py
+++ b/examples/drawing/plot_four_grids.py
@@ -27,13 +27,23 @@ nx.draw(
     pos,
     ax=ax[2],
     node_color="tab:green",
-    edge_color="tab:gray",
+    edgecolors="tab:gray",  # Node surface color
+    edge_color="tab:gray",  # Color of graph edges
     node_size=250,
     with_labels=False,
     width=6,
 )
 H = G.to_directed()
-nx.draw(H, pos, ax=ax[3], node_color="tab:orange", node_size=20, with_labels=False)
+nx.draw(
+    H,
+    pos,
+    ax=ax[3],
+    node_color="tab:orange",
+    node_size=20,
+    with_labels=False,
+    arrowsize=10,
+    width=2,
+)
 
 # Set margins for the axes so that nodes aren't clipped
 for a in ax:

--- a/examples/drawing/plot_four_grids.py
+++ b/examples/drawing/plot_four_grids.py
@@ -26,4 +26,8 @@ nx.draw(G, pos, ax=ax[2], node_color="g", node_size=250, with_labels=False, widt
 H = G.to_directed()
 nx.draw(H, pos, ax=ax[3], node_color="b", node_size=20, with_labels=False)
 
+# Set margins for the axes so that nodes aren't clipped
+for a in ax:
+    a.margins(0.10)
+fig.tight_layout()
 plt.show()

--- a/examples/drawing/plot_four_grids.py
+++ b/examples/drawing/plot_four_grids.py
@@ -21,10 +21,19 @@ fig, all_axes = plt.subplots(2, 2)
 ax = all_axes.flat
 
 nx.draw(G, pos, ax=ax[0], font_size=8)
-nx.draw(G, pos, ax=ax[1], node_color="k", node_size=0, with_labels=False)
-nx.draw(G, pos, ax=ax[2], node_color="g", node_size=250, with_labels=False, width=6)
+nx.draw(G, pos, ax=ax[1], node_size=0, with_labels=False)
+nx.draw(
+    G,
+    pos,
+    ax=ax[2],
+    node_color="tab:green",
+    edge_color="tab:gray",
+    node_size=250,
+    with_labels=False,
+    width=6,
+)
 H = G.to_directed()
-nx.draw(H, pos, ax=ax[3], node_color="b", node_size=20, with_labels=False)
+nx.draw(H, pos, ax=ax[3], node_color="tab:orange", node_size=20, with_labels=False)
 
 # Set margins for the axes so that nodes aren't clipped
 for a in ax:

--- a/examples/drawing/plot_four_grids.py
+++ b/examples/drawing/plot_four_grids.py
@@ -14,7 +14,7 @@ import networkx as nx
 
 G = nx.grid_2d_graph(4, 4)  # 4x4 grid
 
-pos = nx.spring_layout(G, iterations=100)
+pos = nx.spring_layout(G, iterations=100, seed=39775)
 
 # Create a 2x2 subplot
 fig, all_axes = plt.subplots(2, 2)

--- a/examples/drawing/plot_four_grids.py
+++ b/examples/drawing/plot_four_grids.py
@@ -16,17 +16,14 @@ G = nx.grid_2d_graph(4, 4)  # 4x4 grid
 
 pos = nx.spring_layout(G, iterations=100)
 
-plt.subplot(221)
-nx.draw(G, pos, font_size=8)
+# Create a 2x2 subplot
+fig, all_axes = plt.subplots(2, 2)
+ax = all_axes.flat
 
-plt.subplot(222)
-nx.draw(G, pos, node_color="k", node_size=0, with_labels=False)
-
-plt.subplot(223)
-nx.draw(G, pos, node_color="g", node_size=250, with_labels=False, width=6)
-
-plt.subplot(224)
+nx.draw(G, pos, ax=ax[0], font_size=8)
+nx.draw(G, pos, ax=ax[1], node_color="k", node_size=0, with_labels=False)
+nx.draw(G, pos, ax=ax[2], node_color="g", node_size=250, with_labels=False, width=6)
 H = G.to_directed()
-nx.draw(H, pos, node_color="b", node_size=20, with_labels=False)
+nx.draw(H, pos, ax=ax[3], node_color="b", node_size=20, with_labels=False)
 
 plt.show()


### PR DESCRIPTION
 * Prevent node clipping.
 * Add slightly more descriptive intro to the example.
 * Switch from `plt.subplot` mechanism to using the `ax=` kwarg of nx.draw to show how to populate existing axes instances