### PR TITLE
Improve legibility of labels in plot_labels_and_colors example

### DIFF
--- a/examples/drawing/plot_labels_and_colors.py
+++ b/examples/drawing/plot_labels_and_colors.py
@@ -12,9 +12,9 @@ G = nx.cubical_graph()
 pos = nx.spring_layout(G, seed=3113794652)  # positions for all nodes
 
 # nodes
-options = {"node_size": 600, "alpha": 0.9}
-nx.draw_networkx_nodes(G, pos, nodelist=[0, 1, 2, 3], node_color="r", **options)
-nx.draw_networkx_nodes(G, pos, nodelist=[4, 5, 6, 7], node_color="b", **options)
+options = {"edgecolors": "tab:gray", "node_size": 800, "alpha": 0.9}
+nx.draw_networkx_nodes(G, pos, nodelist=[0, 1, 2, 3], node_color="tab:red", **options)
+nx.draw_networkx_nodes(G, pos, nodelist=[4, 5, 6, 7], node_color="tab:blue", **options)
 
 # edges
 nx.draw_networkx_edges(G, pos, width=1.0, alpha=0.5)
@@ -24,7 +24,7 @@ nx.draw_networkx_edges(
     edgelist=[(0, 1), (1, 2), (2, 3), (3, 0)],
     width=8,
     alpha=0.5,
-    edge_color="r",
+    edge_color="tab:red",
 )
 nx.draw_networkx_edges(
     G,
@@ -32,7 +32,7 @@ nx.draw_networkx_edges(
     edgelist=[(4, 5), (5, 6), (6, 7), (7, 4)],
     width=8,
     alpha=0.5,
-    edge_color="b",
+    edge_color="tab:blue",
 )
 
 

--- a/examples/drawing/plot_labels_and_colors.py
+++ b/examples/drawing/plot_labels_and_colors.py
@@ -12,7 +12,7 @@ G = nx.cubical_graph()
 pos = nx.spring_layout(G)  # positions for all nodes
 
 # nodes
-options = {"node_size": 500, "alpha": 0.8}
+options = {"node_size": 600, "alpha": 0.9}
 nx.draw_networkx_nodes(G, pos, nodelist=[0, 1, 2, 3], node_color="r", **options)
 nx.draw_networkx_nodes(G, pos, nodelist=[4, 5, 6, 7], node_color="b", **options)
 
@@ -46,7 +46,8 @@ labels[4] = r"$\alpha$"
 labels[5] = r"$\beta$"
 labels[6] = r"$\gamma$"
 labels[7] = r"$\delta$"
-nx.draw_networkx_labels(G, pos, labels, font_size=16)
+nx.draw_networkx_labels(G, pos, labels, font_size=22, font_color="whitesmoke")
 
+plt.tight_layout()
 plt.axis("off")
 plt.show()

--- a/examples/drawing/plot_labels_and_colors.py
+++ b/examples/drawing/plot_labels_and_colors.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 
 G = nx.cubical_graph()
-pos = nx.spring_layout(G)  # positions for all nodes
+pos = nx.spring_layout(G, seed=3113794652)  # positions for all nodes
 
 # nodes
 options = {"node_size": 600, "alpha": 0.9}

--- a/examples/drawing/plot_labels_and_colors.py
+++ b/examples/drawing/plot_labels_and_colors.py
@@ -3,7 +3,8 @@
 Labels And Colors
 =================
 
-Draw a graph with matplotlib, color by degree.
+Use `nodelist` and `edgelist` to apply custom coloring and labels to various
+components of a graph.
 """
 import matplotlib.pyplot as plt
 import networkx as nx


### PR DESCRIPTION
Attempt to improve legibility of labels by:
 * Increasing background alpha and background node size
 * Increasing font size
 * Changing to a light font color to contrast with the red/blue bgnds