### PR TITLE
Update giant component example

### DIFF
--- a/examples/drawing/plot_giant_component.py
+++ b/examples/drawing/plot_giant_component.py
@@ -13,13 +13,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 
 # This example needs Graphviz and either PyGraphviz or pydot.
-# from networkx.drawing.nx_pydot import graphviz_layout as layout
-# If you don't have pygraphviz or pydot, the script will fall back to
-# a built-in layout
-try:
-    from networkx.drawing.nx_agraph import graphviz_layout as layout
-except ImportError:
-    layout = nx.spring_layout
+from networkx.drawing.nx_agraph import graphviz_layout as layout
 
 
 n = 150  # 150 nodes
@@ -32,9 +26,9 @@ p_conn = math.log(n) / n
 pvals = [0.003, 0.006, 0.008, 0.015]
 
 fig, axes = plt.subplots(2, 2)
-for p, ax in zip(pvals, axes.ravel()):
+for p, ax, seed in zip(pvals, axes.ravel(), range(len(pvals))):
     #### generate graph ####
-    G = nx.binomial_graph(n, p)
+    G = nx.binomial_graph(n, p, seed=seed)
     # identify connected/disconnected nodes
     connected = [n for n, d in G.degree() if d > 0]
     disconnected = list(set(G.nodes()) - set(connected))

--- a/examples/drawing/plot_giant_component.py
+++ b/examples/drawing/plot_giant_component.py
@@ -14,10 +14,12 @@ import networkx as nx
 
 # This example needs Graphviz and either PyGraphviz or pydot.
 # from networkx.drawing.nx_pydot import graphviz_layout as layout
-from networkx.drawing.nx_agraph import graphviz_layout as layout
-
-# If you don't have pygraphviz or pydot, you can do this
-# layout = nx.spring_layout
+# If you don't have pygraphviz or pydot, the script will fall back to
+# a built-in layout
+try:
+    from networkx.drawing.nx_agraph import graphviz_layout as layout
+except ImportError:
+    layout = nx.spring_layout
 
 
 n = 150  # 150 nodes

--- a/examples/drawing/plot_giant_component.py
+++ b/examples/drawing/plot_giant_component.py
@@ -36,7 +36,11 @@ for p, ax in zip(pvals, axes.ravel()):
     G = nx.binomial_graph(n, p)
     pos = layout(G)
     ax.set_title(f"p = {p:.3f}")
-    nx.draw(G, pos, ax=ax, with_labels=False, node_size=10)
+    # Draw connected/disconnected nodes with different alpha values
+    connected = [n for n, d in G.degree() if d > 0]
+    disconnected = list(set(G.nodes()) - set(connected))
+    nx.draw(G, pos, ax=ax, nodelist=connected, with_labels=False, node_size=10)
+    nx.draw(G, pos, ax=ax, nodelist=disconnected, node_size=10, alpha=0.25)
     # identify largest connected component
     Gcc = sorted(nx.connected_components(G), key=len, reverse=True)
     G0 = G.subgraph(Gcc[0])

--- a/examples/drawing/plot_giant_component.py
+++ b/examples/drawing/plot_giant_component.py
@@ -26,32 +26,31 @@ n = 150  # 150 nodes
 # p value at which giant component (of size log(n) nodes) is expected
 p_giant = 1.0 / (n - 1)
 # p value at which graph is expected to become completely connected
-p_conn = math.log(n) / float(n)
+p_conn = math.log(n) / n
 
 # the following range of p values should be close to the threshold
 pvals = [0.003, 0.006, 0.008, 0.015]
 
-region = 220  # for pylab 2x2 subplot layout
-plt.subplots_adjust(left=0, right=1, bottom=0, top=0.95, wspace=0.01, hspace=0.01)
-for p in pvals:
+fig, axes = plt.subplots(2, 2)
+for p, ax in zip(pvals, axes.ravel()):
     G = nx.binomial_graph(n, p)
     pos = layout(G)
-    region += 1
-    plt.subplot(region)
-    plt.title(f"p = {p:.3f}")
-    nx.draw(G, pos, with_labels=False, node_size=10)
+    ax.set_title(f"p = {p:.3f}")
+    nx.draw(G, pos, ax=ax, with_labels=False, node_size=10)
     # identify largest connected component
     Gcc = sorted(nx.connected_components(G), key=len, reverse=True)
     G0 = G.subgraph(Gcc[0])
-    nx.draw_networkx_edges(G0, pos, edge_color="r", width=6.0)
+    nx.draw_networkx_edges(G0, pos, ax=ax, edge_color="r", width=6.0)
     # show other connected components
     for Gi in Gcc[1:]:
         if len(Gi) > 1:
             nx.draw_networkx_edges(
                 G.subgraph(Gi),
                 pos,
+                ax=ax,
                 edge_color="r",
                 alpha=0.3,
                 width=5.0,
             )
+fig.tight_layout()
 plt.show()


### PR DESCRIPTION
As a first attempt, I tried reducing the alpha value for nodes that are not part of connected components to de-emphasize their contribution to the visualization overall. Making the non-connected nodes have consistent position between the axes is trickier than I expected as the layout is re-computed for each graph to take into account the new edges. It should be possible with a little set intersection code, but I went with the simplest solution first.

LMK what you think - whether the alpha reduction is an improvement or a different approach is needed.