### PR TITLE
Fixed issue where edge attributes were being silently overwritten during node contraction

### DIFF
--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -508,7 +508,7 @@ def contracted_nodes(G, u, v, self_loops=True, copy=True):
             continue
 
         if not H.has_edge(w, x) or G.is_multigraph():
-            H.add_edge(w, x, *d)
+            H.add_edge(w, x, **d)
         else:
             if "contraction" in H.edges[(w, x)]:
                 H.edges[(w, x)]["contraction"][(prev_w, prev_x)] = d

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -445,6 +445,10 @@ def contracted_nodes(G, u, v, self_loops=True, copy=True):
     not be the same as the edge keys for the old edges. This is
     natural because edge keys are unique only within each pair of nodes.
 
+    For non-multigraphs where `u` and `v` are adjacent to a third node
+    `w`, the edge (`v`, `w`) will be contracted into the edge (`u`,
+    `w`) with its attributes stored into a "contraction" attribute.
+
     This function is also available as `identified_nodes`.
 
     Examples
@@ -484,32 +488,32 @@ def contracted_nodes(G, u, v, self_loops=True, copy=True):
 
     # edge code uses G.edges(v) instead of G.adj[v] to handle multiedges
     if H.is_directed():
-        in_edges = (
-            (w if w != v else u, u, d)
-            for w, x, d in G.in_edges(v, data=True)
-            if self_loops or w != u
-        )
-        out_edges = (
-            (u, w if w != v else u, d)
-            for x, w, d in G.out_edges(v, data=True)
-            if self_loops or w != u
-        )
-        new_edges = chain(in_edges, out_edges)
+        edges_to_remap = chain(G.in_edges(v, data=True), G.out_edges(v, data=True))
     else:
-        new_edges = (
-            (u, w if w != v else u, d)
-            for x, w, d in G.edges(v, data=True)
-            if self_loops or w != u
-        )
+        edges_to_remap = G.edges(v, data=True)
 
     # If the H=G, the generators change as H changes
-    # This makes the new_edges independent of H
+    # This makes the edges_to_remap independent of H
     if not copy:
-        new_edges = list(new_edges)
+        edges_to_remap = list(edges_to_remap)
 
     v_data = H.nodes[v]
     H.remove_node(v)
-    H.add_edges_from(new_edges)
+
+    for (prev_w, prev_x, d) in edges_to_remap:
+        w = prev_w if prev_w != v else u
+        x = prev_x if prev_x != v else u
+
+        if w is x and not self_loops:
+            continue
+
+        if not H.has_edge(w, x) or G.is_multigraph():
+            H.add_edge(w, x, *d)
+        else:
+            if "contraction" in H.edges[(w, x)]:
+                H.edges[(w, x)]["contraction"][(prev_w, prev_x)] = d
+            else:
+                H.edges[(w, x)]["contraction"] = {(prev_w, prev_x): d}
 
     if "contraction" in H.nodes[u]:
         H.nodes[u]["contraction"][v] = v_data

--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -504,7 +504,7 @@ def contracted_nodes(G, u, v, self_loops=True, copy=True):
         w = prev_w if prev_w != v else u
         x = prev_x if prev_x != v else u
 
-        if w is x and not self_loops:
+        if ({prev_w, prev_x} == {u, v}) and not self_loops:
             continue
 
         if not H.has_edge(w, x) or G.is_multigraph():

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -357,6 +357,24 @@ class TestContraction:
         assert nx.is_isomorphic(actual, expected)
         assert actual.nodes == expected.nodes
 
+    def test_edge_attributes(self):
+        """Tests that node contraction preserves edge attributes."""
+        # Shape: src1 --> dest <-- src2
+        G = nx.DiGraph([("src1", "dest"), ("src2", "dest")])
+        G["src1"]["dest"]["value"] = "src1-->dest"
+        G["src2"]["dest"]["value"] = "src2-->dest"
+        H = nx.MultiDiGraph(G)
+
+        G = nx.contracted_nodes(G, "src1", "src2")  # New Shape: src1 --> dest
+        assert G.edges[("src1", "dest")]["value"] == "src1-->dest"
+        assert (
+            G.edges[("src1", "dest")]["contraction"][("src2", "dest")]["value"]
+            == "src2-->dest"
+        )
+
+        H = nx.contracted_nodes(H, "src1", "src2")  # New Shape: src1 -(x2)-> dest
+        assert len(H.edges(("src1", "dest"))) == 2
+
     def test_without_self_loops(self):
         """Tests for node contraction without preserving self-loops."""
         G = nx.cycle_graph(4)


### PR DESCRIPTION
This PR fixes issue #4150 where remapped edges during node contraction were silently overwriting existing edges. Take the example from the original reported issue:

Given a Graph or DiGraph with the shape `(src1) --> (dest) <-- (src2)`; the node `src2` is contracted into the node `src1` to give the resulting graph `(src1) --> (dest)`. Currently, the "disappearing" edge `(src2, dest)` _overwrites_ the existing edge `(src1, dest)` including all of the edge's attributes.

This PR adds a check for existing edges while remapping edges from the "disappearing" node to the existing one. If we would be overwriting an edge, we instead append the attributes of the "disappearing" edge into a `"contraction"` attribute on the existing edge - this mirrors how the contracting node attributes are handled. In the case outlined in the original issue, we now end up with the following attributes:

```
{
  "value": "src1-value",
  "contraction": {
    ("src2", "dest"): {
      "value": "src2-value"
    }
  }
}
```

Note that this is a break from the existing API (even if it's pretty esoteric) - does this warrant an entry in the release notes?