### PR TITLE
Fixed issue where edge contraction was unpacking edges incorrectly

### DIFF
--- a/networkx/algorithms/minors.py
+++ b/networkx/algorithms/minors.py
@@ -580,6 +580,7 @@ def contracted_edge(G, edge, self_loops=True):
     quotient_graph
 
     """
-    if not G.has_edge(*edge):
+    u, v = edge[:2]
+    if not G.has_edge(u, v):
         raise ValueError(f"Edge {edge} does not exist in graph G; cannot contract it")
-    return contracted_nodes(G, *edge, self_loops=self_loops)
+    return contracted_nodes(G, u, v, self_loops=self_loops)

--- a/networkx/algorithms/tests/test_minors.py
+++ b/networkx/algorithms/tests/test_minors.py
@@ -387,6 +387,14 @@ class TestContraction:
         expected.add_edge(0, 0)
         assert nx.is_isomorphic(actual, expected)
 
+    def test_multigraph_edge_contraction(self):
+        """Tests for edge contraction in a multigraph"""
+        G = nx.cycle_graph(4)
+        actual = nx.contracted_edge(G, (0, 1, 0))
+        expected = nx.complete_graph(3)
+        expected.add_edge(0, 0)
+        assert nx.is_isomorphic(actual, expected)
+
     def test_nonexistent_edge(self):
         """Tests that attempting to contract a non-existent edge raises an
         exception.


### PR DESCRIPTION
Fixes issue #3139 where edge contraction had the incorrect assumption that edges were always a 2-tuple such as `('u', 'v')`. This was causing failures when contracting multigraph edges which can be referenced explicitly with their index such as `('u', 'v', 0)`.

Updated the edge contraction logic to use at most the first two elements in the tuple