### PR TITLE
Deprecate `utils.is_iterator`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -48,6 +48,7 @@ Version 3.0
 * In ``readwrite/gml.py`` remove ``literal_destringizer`` and related tests.
 * In ``utils/misc.py`` remove ``is_string_like`` and related tests.
 * In ``utils/misc.py`` remove ``make_str`` and related tests.
+* In ``utils/misc.py`` remove ``is_iterator``.
 * Remove ``utils/contextmanagers.py`` and related tests.
 * In ``drawing/nx_agraph.py`` remove ``display_pygraphviz`` and related tests.
 * In ``algorithms/chordal.py`` replace ``chordal_graph_cliques`` with ``_chordal_graph_cliques``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -38,6 +38,9 @@ Deprecations
 
 - [`#4238 <https://github.com/networkx/networkx/pull/4238>`_]
   Deprecate `to_numpy_matrix` and `from_numpy_matrix`.
+- [`#4279 <https://github.com/networkx/networkx/pull/4279>`_]
+  Deprecate ``networkx.utils.misc.is_iterator``.
+  Use ``isinstance(obj, collections.abc.Iterator)`` instead.
 
 Contributors to this release
 ----------------------------

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -11,8 +11,8 @@ True
 False
 """
 
-from collections import defaultdict
-from collections import deque
+from collections import defaultdict, deque
+from collections.abc import Iterator
 import warnings
 import sys
 import uuid
@@ -200,7 +200,16 @@ def is_iterator(obj):
     """Returns True if and only if the given object is an iterator
     object.
 
+    .. deprecated:: 2.6.0
+
+       Deprecated in favor of ``isinstance(obj, collections.abc.Iterator)``
+
     """
+    msg = (
+        "is_iterator is deprecated and will be removed in version 3.0. "
+        "Use ``isinstance(obj, collections.abc.Iterator)`` instead."
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     has_next_attr = hasattr(obj, "__next__") or hasattr(obj, "next")
     return iter(obj) is obj and has_next_attr
 
@@ -227,7 +236,7 @@ def arbitrary_element(iterable):
         ValueError: cannot return an arbitrary item from an iterator
 
     """
-    if is_iterator(iterable):
+    if isinstance(iterable, Iterator):
         raise ValueError("cannot return an arbitrary item from an iterator")
     # Another possible implementation is ``for x in iterable: return x``.
     return next(iter(iterable))


### PR DESCRIPTION
The function `is_iterator` from the utils module is only used in one other place in NetworkX and is not currently tested. I think it can be safely replaced with an `isinstance` check against the `Iterator` abc.