### PR TITLE
Deprecate utils.is_list_of_ints

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -49,6 +49,7 @@ Version 3.0
 * In ``utils/misc.py`` remove ``is_string_like`` and related tests.
 * In ``utils/misc.py`` remove ``make_str`` and related tests.
 * In ``utils/misc.py`` remove ``is_iterator``.
+* In ``utils/misc.py`` remove ``is_list_of_ints``.
 * Remove ``utils/contextmanagers.py`` and related tests.
 * In ``drawing/nx_agraph.py`` remove ``display_pygraphviz`` and related tests.
 * In ``algorithms/chordal.py`` replace ``chordal_graph_cliques`` with ``_chordal_graph_cliques``.

--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -14,7 +14,6 @@ Helper Functions
    is_string_like
    flatten
    iterable
-   is_list_of_ints
    make_list_of_ints
    make_str
    generate_unique_node

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -41,6 +41,9 @@ Deprecations
 - [`#4279 <https://github.com/networkx/networkx/pull/4279>`_]
   Deprecate ``networkx.utils.misc.is_iterator``.
   Use ``isinstance(obj, collections.abc.Iterator)`` instead.
+- [`#4280 <https://github.com/networkx/networkx/pull/4280>`_]
+  Deprecate ``networkx.utils.misc.is_list_of_ints`` as it is no longer used.
+  See ``networkx.utils.misc.make_list_of_ints`` for related functionality.
 
 Contributors to this release
 ----------------------------

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -102,7 +102,16 @@ def make_list_of_ints(sequence):
 
 
 def is_list_of_ints(intlist):
-    """ Return True if list is a list of ints. """
+    """
+    Return True if list is a list of ints.
+
+    .. deprecated:: 2.6
+    """
+    msg = (
+        "is_list_of_ints is deprecated and will be removed in 3.0."
+        "See also: ``networkx.utils.make_list_of_ints.``"
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     if not isinstance(intlist, list):
         return False
     for i in intlist:

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -5,10 +5,10 @@ These are not imported into the base networkx namespace but
 can be accessed, for example, as
 
 >>> import networkx
->>> networkx.utils.is_list_of_ints([1, 2, 3])
-True
->>> networkx.utils.is_list_of_ints([1, 2, "spam"])
-False
+>>> networkx.utils.make_list_of_ints({1, 2, 3})
+[1, 2, 3]
+>>> networkx.utils.arbitrary_element({5, 1, 7})  # doctest: +SKIP
+1
 """
 
 from collections import defaultdict, deque


### PR DESCRIPTION
Deprecates the (apparently) unused and untested `nx.utils.is_list_of_ints` function. Uses of this function within networkx appears to have been replaced with `nx.utils.make_list_of_ints` in #3617.