### PR TITLE
Add readwrite section to tutorial

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -597,4 +597,46 @@ node positions, or write the graph in dot format for further processing.
 
 See :doc:`/reference/drawing` for additional details.
 
+Reading and writing graphs
+--------------------------
+
+.. csv-table:: Supported file formats
+   :header: "Format", "Description"
+   :widths: 20, 40
+
+   "Adjacency list", "Each row 1st column as out-degree"
+   "Edge list", "2 column, source$\rightarrow$ target"
+   "DOT", "Graphviz format"
+   "GEXF", "XML implementation"
+   "GML", "Similar to DOT"
+   "GraphML", "XML implementation"
+   "LEDA", "Between edge list and Pajek"
+   "Pajek", "Edge list + node and edge attr"
+   "SparseGraph6", "Adjacency list variant"
+
+You can read and write NetworkX graphs as Python pickles.
+
+>>> import pickle
+>>> G = nx.path_graph(4)
+>>> with open('test.gpickle', 'wb') as f:
+...     pickle.dump(G, f, pickle.HIGHEST_PROTOCOL)
+... 
+>>> with open('test.gpickle', 'rb') as f:
+...     G = pickle.load(f)
+... 
+
+You can also read and write NetworkX graphs in YAML format
+using pyyaml.
+
+>>> import yaml
+>>> G = nx.path_graph(4)
+>>> with open('test.yaml', 'w') as f:
+...     yaml.dump(G, f)
+... 
+>>> with open('test.yaml', 'r') as f:
+...     G = yaml.load(f, Loader=yaml.FullLoader)
+... 
+
+See :doc:`/reference/readwrite` for additional details.
+
 .. code-links::

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -637,6 +637,6 @@ using pyyaml.
 ...     G = yaml.load(f, Loader=yaml.FullLoader)
 ... 
 
-See :doc:`/reference/readwrite` for additional details.
+See :doc:`/reference/readwrite/index` for additional details.
 
 .. code-links::

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -634,7 +634,7 @@ using pyyaml.
 ...     yaml.dump(G, f)
 ... 
 >>> with open('test.yaml', 'r') as f:
-...     G = yaml.load(f, Loader=yaml.FullLoader)
+...     G = yaml.load(f, Loader=yaml.Loader)
 ... 
 
 See :doc:`/reference/readwrite/index` for additional details.


### PR DESCRIPTION
As part of deprecating nx_yaml #4281 and gpickle #4282 I am drafting a readwrite section for the tutorial.  I am planning something short, but I would like it to be somewhat prescriptive.

So far I just have a table from the pydata talk and a short section on using yaml and pickle to save NX graphs.

Here are some resources I am looking at:
- https://gephi.org/users/supported-graph-formats/
- https://www.researchgate.net/publication/330185503_Overview_of_Standard_Graph_File_Formats
- https://arxiv.org/pdf/1503.02781.pdf
- Pitas, Ioannis (2016), "1.5 Graph storage formats and visualization", Graph-Based Social Media Analysis