### PR TITLE
Add FutureWarning in preparation for simplifying cytoscape function signatures.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -58,3 +58,6 @@ Version 3.0
 * In ``algorithms/community_modularity_max.py`` remove old name ``_naive_greedy_modularity_communities``.
 * In ``linalg/algebraicconnectivity.py`` remove ``_CholeskySolver`` and related code.
 * In ``convert_matrix.py`` remove ``to_numpy_matrix`` and ``from_numpy_matrix``.
+* In ``readwrite/json_graph/cytoscape.py``, change function signature for
+  ``cytoscape_graph`` and ``cytoscape_data`` to replace the ``attrs`` keyword
+  argument with explicit ``name`` and ``ident`` keyword args.

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -2,6 +2,7 @@ import networkx as nx
 
 __all__ = ["cytoscape_data", "cytoscape_graph"]
 
+# TODO: Remove in NX 3.0
 _attrs = dict(name="name", ident="id")
 
 
@@ -18,6 +19,11 @@ def cytoscape_data(G, attrs=None):
         ignored. Default is `None` which results in the default mapping
         ``dict(name="name", ident="id")``.
 
+        .. deprecated:: 2.6
+
+           The `attrs` keyword argument will be replaced with `name` and
+           `ident` in networkx 3.0
+
     Returns
     -------
     data: dict
@@ -26,7 +32,7 @@ def cytoscape_data(G, attrs=None):
     Raises
     ------
     NetworkXError
-        If values in `attrs` are not unique.
+        If the `name` and `ident` attributes are identical.
 
     See Also
     --------
@@ -48,13 +54,30 @@ def cytoscape_data(G, attrs=None):
        {'data': {'id': '1', 'value': 1, 'name': '1'}}],
       'edges': [{'data': {'source': 0, 'target': 1}}]}}
     """
+    # ------ TODO: Remove between the lines in 3.0 ----- #
     if attrs is None:
         attrs = _attrs
-    # Will raise if attrs is not dict-like
-    attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
+    else:
+        import warnings
+
+        msg = (
+            "\nThe function signature for cytoscape_data will change in "
+            "networkx 3.0.\n"
+            "The `attrs` keyword argument will be replaced with \n"
+            "explicit `name` and `ident` keyword arguments, e.g.\n\n"
+            "   >>> cytoscape_data(G, attrs={'name': 'foo', 'ident': 'bar'})\n\n"
+            "should instead be written as\n\n"
+            "   >>> cytoscape_data(G, name='foo', ident='bar')\n\n"
+            "in networkx 3.0.\n"
+            "The default values for 'name' and 'ident' will not change."
+        )
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+
+        attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
 
     name = attrs["name"]
     ident = attrs["ident"]
+    # -------------------------------------------------- #
 
     if name == ident:
         raise nx.NetworkXError("name and ident must be different.")
@@ -103,6 +126,11 @@ def cytoscape_graph(data, attrs=None):
         ignored. Default is `None` which results in the default mapping
         ``dict(name="name", ident="id")``.
 
+        .. deprecated:: 2.6
+
+           The `attrs` keyword argument will be replaced with `name` and
+           `ident` in networkx 3.0
+
     Returns
     -------
     graph : a NetworkX graph instance
@@ -112,7 +140,7 @@ def cytoscape_graph(data, attrs=None):
     Raises
     ------
     NetworkXError
-        If values in `attrs` are not unique.
+        If the `name` and `ident` attributes are identical.
 
     See Also
     --------
@@ -143,13 +171,30 @@ def cytoscape_graph(data, attrs=None):
     >>> G.edges(data=True)
     EdgeDataView([(0, 1, {'source': 0, 'target': 1})])
     """
+    # ------ TODO: Remove between the lines in 3.0 ----- #
     if attrs is None:
         attrs = _attrs
-    # Will raise if attrs is not dict-like
-    attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
+    else:
+        import warnings
+
+        msg = (
+            "\nThe function signature for cytoscape_data will change in "
+            "networkx 3.0.\n"
+            "The `attrs` keyword argument will be replaced with \n"
+            "explicit `name` and `ident` keyword arguments, e.g.\n\n"
+            "   >>> cytoscape_data(G, attrs={'name': 'foo', 'ident': 'bar'})\n\n"
+            "should instead be written as\n\n"
+            "   >>> cytoscape_data(G, name='foo', ident='bar')\n\n"
+            "in networkx 3.0.\n"
+            "The default values for 'name' and 'ident' will not change."
+        )
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+
+        attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
 
     name = attrs["name"]
     ident = attrs["ident"]
+    # -------------------------------------------------- #
 
     if name == ident:
         raise nx.NetworkXError("name and ident must be different.")

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -48,16 +48,16 @@ def cytoscape_data(G, attrs=None):
        {'data': {'id': '1', 'value': 1, 'name': '1'}}],
       'edges': [{'data': {'source': 0, 'target': 1}}]}}
     """
-    if not attrs:
+    if attrs is None:
         attrs = _attrs
-    else:
-        attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
+    # Will raise if attrs is not dict-like
+    attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
 
     name = attrs["name"]
     ident = attrs["ident"]
 
-    if len({name, ident}) < 2:
-        raise nx.NetworkXError("Attribute names are not unique.")
+    if name == ident:
+        raise nx.NetworkXError("name and ident must be different.")
 
     jsondata = {"data": list(G.graph.items())}
     jsondata["directed"] = G.is_directed()
@@ -143,16 +143,16 @@ def cytoscape_graph(data, attrs=None):
     >>> G.edges(data=True)
     EdgeDataView([(0, 1, {'source': 0, 'target': 1})])
     """
-    if not attrs:
+    if attrs is None:
         attrs = _attrs
-    else:
-        attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
+    # Will raise if attrs is not dict-like
+    attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
 
     name = attrs["name"]
     ident = attrs["ident"]
 
-    if len({ident, name}) < 2:
-        raise nx.NetworkXError("Attribute names are not unique.")
+    if name == ident:
+        raise nx.NetworkXError("name and ident must be different.")
 
     multigraph = data.get("multigraph")
     directed = data.get("directed")

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -5,6 +5,22 @@ import copy
 from networkx.readwrite.json_graph import cytoscape_data, cytoscape_graph
 
 
+# TODO: To be removed when signature change complete in 3.0
+def test_futurewarning():
+    G = nx.path_graph(3)
+    # No warnings when `attrs` kwarg not used
+    with pytest.warns(None) as record:
+        data = cytoscape_data(G)
+        H = cytoscape_graph(data)
+    assert len(record) == 0
+    # Future warning raised with `attrs` kwarg
+    attrs = {"name": "foo", "ident": "bar"}
+    with pytest.warns(FutureWarning):
+        data = cytoscape_data(G, attrs)
+    with pytest.warns(FutureWarning):
+        H = cytoscape_graph(data, attrs)
+
+
 class TestCytoscape:
     def test_graph(self):
         G = nx.path_graph(4)


### PR DESCRIPTION
Closes #4199 .

The biggest change here is the introduction of a FutureWarning to notify users of the function signature change in the cytoscape functions. Added a detailed warning about the change in API that would take affect in 3.0, but the current behavior & signature remains unmodified for now. I'm not sure if this is the best way to do this, but it is at least consistent with the deprecation policy. Might be worth adding a tracking issue with a 3.0 milestone if the FutureWarning approach is acceptable.