### PR TITLE
Build docs for deployment on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
       python: 3.7
       env:
       - OPTIONAL_DEPS=1
-      - BUILD_DOCS=1
       - DEPLOY_DOCS=1
       addons:
         apt:
@@ -53,7 +52,7 @@ before_install:
   - source tools/travis/before_install.sh
   - uname -a
   - printenv
-  - source tools/travis/linux_install.sh;
+  - source tools/travis/linux_install.sh
 
 install:
   # install required packages
@@ -61,9 +60,6 @@ install:
   - pip install --retries 3 ${PIP_FLAGS} -r requirements.txt
   - if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
       pip install --retries 3 ${PIP_FLAGS} -r requirements/extra.txt;
-    fi
-  - if [[ "${BUILD_DOCS}" == 1 ]]; then
-      pip install --retries 3 ${PIP_FLAGS} -r requirements/example.txt;
     fi
   # install networkx
   - printenv PWD
@@ -73,17 +69,15 @@ install:
   - pip list
 
 script:
-  - if [[ "${BUILD_DOCS}" == 1 ]]; then
-      source tools/travis/build_docs.sh;
-    else
-      source tools/travis/script.sh;
-    fi
+  - source tools/travis/script.sh
 
 after_success:
   - if [[ "${REPORT_COVERAGE}" == 1 ]]; then
       codecov;
     fi
-  - if [[ "${BUILD_DOCS}" == 1 && "${DEPLOY_DOCS}" == 1 ]]; then
+  - if [[ "${DEPLOY_DOCS}" == 1 && $TRAVIS_PULL_REQUEST == false && $TRAVIS_BRANCH == "master" ]]; then
+      pip install ${PIP_FLAGS} -r requirements/example.txt;
+      source tools/travis/build_docs.sh;
       source tools/travis/deploy_docs.sh;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - os: linux
       python: 3.6
       env:
-      - OPTIONAL_DEPS=1
+      - EXTRA_DEPS=1
       - MINIMUM_REQUIREMENTS=1
       - REPORT_COVERAGE=1
       addons:
@@ -21,7 +21,7 @@ matrix:
     - os: linux
       python: 3.7
       env:
-      - OPTIONAL_DEPS=1
+      - EXTRA_DEPS=1
       - DEPLOY_DOCS=1
       addons:
         apt:
@@ -36,7 +36,7 @@ matrix:
     - os: linux
       python: 3.7
       env:
-      - OPTIONAL_DEPS=1
+      - EXTRA_DEPS=1
       - PIP_FLAGS="--pre"
       addons:
         apt:
@@ -58,7 +58,7 @@ install:
   # install required packages
   - pip install --upgrade pip wheel setuptools
   - pip install --retries 3 ${PIP_FLAGS} -r requirements.txt
-  - if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
+  - if [[ "${EXTRA_DEPS}" == 1 ]]; then
       pip install --retries 3 ${PIP_FLAGS} -r requirements/extra.txt;
     fi
   # install networkx

--- a/tools/travis/deploy_docs.sh
+++ b/tools/travis/deploy_docs.sh
@@ -3,55 +3,51 @@
 set -e
 
 section "Deploy docs"
-if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_BRANCH == "master" && $BUILD_DOCS == 1 && $DEPLOY_DOCS == 1 ]]
-then
-    # "A deploy key is an SSH key that is stored on your server and grants access to a single GitHub repository.
-    # This key is attached directly to the repository instead of to a personal user account."
-    # -- https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys
-    #
-    # $ ssh-keygen -t ed25519 -C "Networkx Travis Bot" -f deploy-key
-    # Your identification has been saved in deploy-key.
-    # Your public key has been saved in deploy-key.pub.
-    #
-    # Add the deploy-key.pub contents to your repo's settings under Settings -> Deploy Keys.
-    # Encrypt the private deploy-key for Travis-CI and commit it to the repo
-    #
-    # $ gem install travis
-    # $ travis login
-    # $ travis encrypt-file deploy-key
-    # storing result as deploy-key.enc
-    #
-    # The ``travis encrypt-file deploy-key`` command provides the ``openssl`` command below.
+# "A deploy key is an SSH key that is stored on your server and grants access to a single GitHub repository.
+# This key is attached directly to the repository instead of to a personal user account."
+# -- https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys
+#
+# $ ssh-keygen -t ed25519 -C "Networkx Travis Bot" -f deploy-key
+# Your identification has been saved in deploy-key.
+# Your public key has been saved in deploy-key.pub.
+#
+# Add the deploy-key.pub contents to your repo's settings under Settings -> Deploy Keys.
+# Encrypt the private deploy-key for Travis-CI and commit it to the repo
+#
+# $ gem install travis
+# $ travis login
+# $ travis encrypt-file deploy-key
+# storing result as deploy-key.enc
+#
+# The ``travis encrypt-file deploy-key`` command provides the ``openssl`` command below.
 
-    # Decrypt the deploy-key with the Travis-CI key
-    openssl aes-256-cbc -K $encrypted_64abb7a9cf51_key -iv $encrypted_64abb7a9cf51_iv -in tools/travis/deploy-key.enc -out deploy-key -d
-    chmod 600 deploy-key
-    eval `ssh-agent -s`
-    ssh-add deploy-key
+# Decrypt the deploy-key with the Travis-CI key
+openssl aes-256-cbc -K $encrypted_64abb7a9cf51_key -iv $encrypted_64abb7a9cf51_iv -in tools/travis/deploy-key.enc -out deploy-key -d
+chmod 600 deploy-key
+eval `ssh-agent -s`
+ssh-add deploy-key
 
-    # Push the latest docs to the networkx/documentation repo (gh-pages branch)
-    GH_REF=git@github.com:networkx/documentation.git
-    echo "-- pushing docs --"
-    (
-    git config --global user.email "travis@travis-ci.com"
-    git config --global user.name "NetworkX Travis Bot"
+# Push the latest docs to the networkx/documentation repo (gh-pages branch)
+GH_REF=git@github.com:networkx/documentation.git
+echo "-- pushing docs --"
+(
+git config --global user.email "travis@travis-ci.com"
+git config --global user.name "NetworkX Travis Bot"
 
-    cd doc
-    git clone --quiet --branch=gh-pages --depth=1 ${GH_REF} ghpages_build
-    cd ghpages_build
+cd doc
+git clone --quiet --branch=gh-pages --depth=1 ${GH_REF} ghpages_build
+cd ghpages_build
 
-    # Overwrite previous commit
-    git rm -r latest
-    cp -a ../build/html latest
-    git add latest
-    git commit -m "Deploy GitHub Pages"
+# Overwrite previous commit
+git rm -r latest
+cp -a ../build/html latest
+git add latest
+git commit -m "Deploy GitHub Pages"
 
-    git push --force --quiet "${GH_REF}" gh-pages > /dev/null 2>&1
-    cd ../..
-    )
-else
-    echo "-- will only push docs from master --"
-fi
+git push --force --quiet "${GH_REF}" gh-pages > /dev/null 2>&1
+cd ../..
+)
+
 section_end "Deploy docs"
 
 set +e

--- a/tools/travis/linux_install.sh
+++ b/tools/travis/linux_install.sh
@@ -7,7 +7,7 @@ section "Linux install section"
 virtualenv -p python ~/venv
 source ~/venv/bin/activate
 
-if [[ "${OPTIONAL_DEPS}" == 1 ]]; then
+if [[ "${EXTRA_DEPS}" == 1 ]]; then
 
   # needed to build Python binding for GDAL
   export CPLUS_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
Now Travis will only build the docs when it needs to deploy them after the PR is merged to master.  This will make Travis run the tests on PRs faster and simplifies the travis config.