### PR TITLE
Don't import other people's version.py

### DIFF
--- a/networkx/release.py
+++ b/networkx/release.py
@@ -148,7 +148,13 @@ def get_info(dynamic=True):
         # no vcs information will be provided.
         # sys.path.insert(0, basedir)
         try:
-            from version import date, date_info, version, version_info, vcs_info
+            from networkx.version import (
+                date,
+                date_info,
+                version,
+                version_info,
+                vcs_info,
+            )
         except ImportError:
             import_failed = True
             vcs_info = (None, (None, None))


### PR DESCRIPTION
fix #4288

When a repository calls import networkx it will
trigger a sequence of imports that will cause to
look for a version.py in the current working
directory. Because it is common for a repository to contain
a version.py, this will end up being executed.

The change guarantees that this library version.py is called.

Arguably, the line of code should not being called at all when
importing networkx.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
