### PR TITLE
TST: An approach to parametrizing read_edgelist tests.

### DIFF
--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -5,6 +5,7 @@ import pytest
 import io
 import tempfile
 import os
+import textwrap
 
 import networkx as nx
 from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
@@ -33,6 +34,97 @@ def test_parse_edgelist():
     with pytest.raises(TypeError, match="Failed to convert"):
         lines = ["1 2 't1'", "2 3 't3'", "3 4 't3'"]
         nx.parse_edgelist(lines, nodetype=int, data=(("weight", float),))
+edges_no_data = textwrap.dedent(
+    """
+    # comment line
+    1 2
+    # comment line
+    2 3
+    """
+)
+
+
+edges_with_values = textwrap.dedent(
+    """
+    # comment line
+    1 2 2.0
+    # comment line
+    2 3 3.0
+    """
+)
+
+
+edges_with_weight = textwrap.dedent(
+    """
+    # comment line
+    1 2 {'weight':2.0}
+    # comment line
+    2 3 {'weight':3.0}
+    """
+)
+
+
+edges_with_multiple_attrs = textwrap.dedent(
+    """
+    # comment line
+    1 2 {'weight':2.0, 'color':'green'}
+    # comment line
+    2 3 {'weight':3.0, 'color':'red'}
+    """
+)
+
+
+edges_with_multiple_attrs_csv = textwrap.dedent(
+    """
+    # comment line
+    1, 2, {'weight':2.0, 'color':'green'}
+    # comment line
+    2, 3, {'weight':3.0, 'color':'red'}
+    """
+)
+
+
+_expected_edges_weights = [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
+_expected_edges_multiattr = [
+    (1, 2, {"weight": 2.0, "color": "green"}),
+    (2, 3, {"weight": 3.0, "color": "red"}),
+]
+
+
+@pytest.mark.parametrize(
+    ("data", "extra_kwargs"),
+    (
+        (edges_no_data, {}),
+        (edges_with_values, {}),
+        (edges_with_weight, {}),
+        (edges_with_multiple_attrs, {}),
+        (edges_with_multiple_attrs_csv, {"delimiter": ","}),
+    ),
+)
+def test_read_edgelist_no_data(data, extra_kwargs):
+    bytesIO = io.BytesIO(data.encode("utf-8"))
+    G = nx.read_edgelist(bytesIO, nodetype=int, data=False, **extra_kwargs)
+    assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
+
+
+def test_read_weighted_edgelist():
+    bytesIO = io.BytesIO(edges_with_values.encode("utf-8"))
+    G = nx.read_weighted_edgelist(bytesIO, nodetype=int)
+    assert_edges_equal(G.edges(data=True), _expected_edges_weights)
+
+
+@pytest.mark.parametrize(
+    ("data", "extra_kwargs", "expected"),
+    (
+        (edges_with_weight, {}, _expected_edges_weights),
+        (edges_with_multiple_attrs, {}, _expected_edges_multiattr),
+        (edges_with_multiple_attrs_csv, {"delimiter": ","}, _expected_edges_multiattr),
+    ),
+)
+def test_read_edgelist_with_data(data, extra_kwargs, expected):
+    bytesIO = io.BytesIO(data.encode("utf-8"))
+    G = nx.read_edgelist(bytesIO, nodetype=int, **extra_kwargs)
+    assert_edges_equal(G.edges(data=True), expected)
 
 
 class TestEdgelist:
@@ -46,126 +138,6 @@ class TestEdgelist:
         cls.XG = nx.MultiGraph()
         cls.XG.add_weighted_edges_from([(1, 2, 5), (1, 2, 5), (1, 2, 1), (3, 3, 42)])
         cls.XDG = nx.MultiDiGraph(cls.XG)
-
-    def test_read_edgelist_1(self):
-        s = b"""\
-# comment line
-1 2
-# comment line
-2 3
-"""
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-    def test_read_edgelist_2(self):
-        s = b"""\
-# comment line
-1 2 2.0
-# comment line
-2 3 3.0
-"""
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        bytesIO = io.BytesIO(s)
-        G = nx.read_weighted_edgelist(bytesIO, nodetype=int)
-        assert_edges_equal(
-            G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
-        )
-
-    def test_read_edgelist_3(self):
-        s = b"""\
-# comment line
-1 2 {'weight':2.0}
-# comment line
-2 3 {'weight':3.0}
-"""
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
-        assert_edges_equal(
-            G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
-        )
-
-    def test_read_edgelist_4(self):
-        s = b"""\
-# comment line
-1 2 {'weight':2.0}
-# comment line
-2 3 {'weight':3.0}
-"""
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
-        assert_edges_equal(
-            G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
-        )
-
-        s = """\
-# comment line
-1 2 {'weight':2.0}
-# comment line
-2 3 {'weight':3.0}
-"""
-        StringIO = io.StringIO(s)
-        G = nx.read_edgelist(StringIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        StringIO = io.StringIO(s)
-        G = nx.read_edgelist(StringIO, nodetype=int, data=True)
-        assert_edges_equal(
-            G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
-        )
-
-    def test_read_edgelist_5(self):
-        s = b"""\
-# comment line
-1 2 {'weight':2.0, 'color':'green'}
-# comment line
-2 3 {'weight':3.0, 'color':'red'}
-"""
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=True)
-        assert_edges_equal(
-            G.edges(data=True),
-            [
-                (1, 2, {"weight": 2.0, "color": "green"}),
-                (2, 3, {"weight": 3.0, "color": "red"}),
-            ],
-        )
-
-    def test_read_edgelist_6(self):
-        s = b"""\
-# comment line
-1, 2, {'weight':2.0, 'color':'green'}
-# comment line
-2, 3, {'weight':3.0, 'color':'red'}
-"""
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=False, delimiter=",")
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
-
-        bytesIO = io.BytesIO(s)
-        G = nx.read_edgelist(bytesIO, nodetype=int, data=True, delimiter=",")
-        assert_edges_equal(
-            G.edges(data=True),
-            [
-                (1, 2, {"weight": 2.0, "color": "green"}),
-                (2, 3, {"weight": 3.0, "color": "red"}),
-            ],
-        )
 
     def test_write_edgelist_1(self):
         fh = io.BytesIO()


### PR DESCRIPTION
Parametrizes the tests related to edgelist reading and adds additional tests of `parse_edgelist`, originally authored by @AndrewEckart in #4192. The `parse_edgelist` tests complemented some additional tests added in #4310 - I moved all of the `parse_edgelist` tests so that they are all together while rebasing.

Closes #4127 