### PR TITLE
Move a few imports inside functions to improve import speed of the library

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -67,9 +67,10 @@ from networkx.readwrite import *
 # Need to test with SciPy, when available
 import networkx.algorithms
 from networkx.algorithms import *
-import networkx.linalg
 
+import networkx.linalg
 from networkx.linalg import *
+
 from networkx.testing.test import run as test
 
 import networkx.drawing

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -4,34 +4,6 @@ import math
 import networkx as nx
 from networkx.utils import py_random_state
 
-# Accommodates for both SciPy and non-SciPy implementations..
-try:
-    from scipy.special import zeta as _zeta
-
-    def zeta(x, q, tolerance):
-        return _zeta(x, q)
-
-
-except ImportError:
-
-    def zeta(x, q, tolerance):
-        """The Hurwitz zeta function, or the Riemann zeta function of two
-        arguments.
-
-        ``x`` must be greater than one and ``q`` must be positive.
-
-        This function repeatedly computes subsequent partial sums until
-        convergence, as decided by ``tolerance``.
-        """
-        z = 0
-        z_prev = -float("inf")
-        k = 0
-        while abs(z - z_prev) > tolerance:
-            z_prev = z
-            z += 1 / ((k + q) ** x)
-            k += 1
-        return z
-
 
 __all__ = [
     "caveman_graph",
@@ -725,9 +697,33 @@ def _powerlaw_sequence(gamma, low, high, condition, length, max_iters, seed):
     raise nx.ExceededMaxIterations("Could not create power law sequence")
 
 
-# TODO Needs documentation.
+def _hurwitz_zeta(x, q, tolerance):
+    """The Hurwitz zeta function, or the Riemann zeta function of two arguments.
+
+    ``x`` must be greater than one and ``q`` must be positive.
+
+    This function repeatedly computes subsequent partial sums until
+    convergence, as decided by ``tolerance``.
+    """
+    z = 0
+    z_prev = -float("inf")
+    k = 0
+    while abs(z - z_prev) > tolerance:
+        z_prev = z
+        z += 1 / ((k + q) ** x)
+        k += 1
+    return z
+
+
 def _generate_min_degree(gamma, average_degree, max_degree, tolerance, max_iters):
     """Returns a minimum degree from the given average degree."""
+    # Defines zeta function whether or not Scipy is available
+    try:
+        from scipy.special import zeta
+    except ImportError:
+        def zeta(x, q):
+            return _hurwitz_zeta(x, q, tolerance)
+
     min_deg_top = max_degree
     min_deg_bot = 1
     min_deg_mid = (min_deg_top - min_deg_bot) / 2 + min_deg_bot
@@ -738,7 +734,7 @@ def _generate_min_degree(gamma, average_degree, max_degree, tolerance, max_iters
             raise nx.ExceededMaxIterations("Could not match average_degree")
         mid_avg_deg = 0
         for x in range(int(min_deg_mid), max_degree + 1):
-            mid_avg_deg += (x ** (-gamma + 1)) / zeta(gamma, min_deg_mid, tolerance)
+            mid_avg_deg += (x ** (-gamma + 1)) / zeta(gamma, min_deg_mid)
         if mid_avg_deg > average_degree:
             min_deg_top = min_deg_mid
             min_deg_mid = (min_deg_top - min_deg_bot) / 2 + min_deg_bot

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -721,6 +721,7 @@ def _generate_min_degree(gamma, average_degree, max_degree, tolerance, max_iters
     try:
         from scipy.special import zeta
     except ImportError:
+
         def zeta(x, q):
             return _hurwitz_zeta(x, q, tolerance)
 

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -6,13 +6,6 @@ from itertools import accumulate, combinations, product
 from math import sqrt
 import math
 
-try:
-    from scipy.spatial import cKDTree as KDTree
-except ImportError:
-    _is_scipy_available = False
-else:
-    _is_scipy_available = True
-
 import networkx as nx
 from networkx.utils import nodes_or_number, py_random_state
 
@@ -36,31 +29,29 @@ def euclidean(x, y):
     return sqrt(sum((a - b) ** 2 for a, b in zip(x, y)))
 
 
-def _fast_edges(G, radius, p):
+def geometric_edges(G, radius, p):
     """Returns edge list of node pairs within `radius` of each other
-       using scipy KDTree and Minkowski distance metric `p`
 
-    Requires scipy to be installed.
+    Radius uses Minkowski distance metric `p`.
+    If scipy available, use scipy KDTree to speed computation.
     """
-    pos = nx.get_node_attributes(G, "pos")
-    nodes, coords = list(zip(*pos.items()))
-    kdtree = KDTree(coords)  # Cannot provide generator.
-    edge_indexes = kdtree.query_pairs(radius, p)
-    edges = ((nodes[u], nodes[v]) for u, v in edge_indexes)
-    return edges
-
-
-def _slow_edges(G, radius, p):
-    """Returns edge list of node pairs within `radius` of each other
-       using Minkowski distance metric `p`
-
-    Works without scipy, but in `O(n^2)` time.
-    """
-    # TODO This can be parallelized.
-    edges = []
-    for (u, pu), (v, pv) in combinations(G.nodes(data="pos"), 2):
-        if sum(abs(a - b) ** p for a, b in zip(pu, pv)) <= radius ** p:
-            edges.append((u, v))
+    try:
+        from scipy.spatial import cKDTree as KDTree
+    except ImportError:
+        KDTree = None
+    nodes_pos = G.nodes(data="pos")
+    if KDTree is not None:
+        nodes, coords = list(zip(*nodes_pos))
+        kdtree = KDTree(coords)  # Cannot provide generator.
+        edge_indexes = kdtree.query_pairs(radius, p)
+        edges = ((nodes[u], nodes[v]) for u, v in edge_indexes)
+        return edges
+    # no scipy KDTree so compute by for-loop
+    edges = [
+        (u, v)
+        for (u, pu), (v, pv) in combinations(nodes_pos, 2)
+        if sum(abs(a - b) ** p for a, b in zip(pu, pv)) <= radius ** p
+    ]
     return edges
 
 
@@ -152,12 +143,7 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2, seed=None):
         pos = {v: [seed.random() for i in range(dim)] for v in nodes}
     nx.set_node_attributes(G, pos, "pos")
 
-    if _is_scipy_available:
-        edges = _fast_edges(G, radius, p)
-    else:
-        edges = _slow_edges(G, radius, p)
-    G.add_edges_from(edges)
-
+    G.add_edges_from(geometric_edges(G, radius, p))
     return G
 
 
@@ -281,25 +267,12 @@ def soft_random_geometric_graph(
         def p_dist(dist):
             return math.exp(-dist)
 
-    def should_join(pair):
-        u, v = pair
-        u_pos, v_pos = pos[u], pos[v]
-        dist = (sum(abs(a - b) ** p for a, b in zip(u_pos, v_pos))) ** (1 / p)
-        # Check if dist <= radius parameter. This check is redundant if scipy
-        # is available and _fast_edges routine is used, but provides the
-        # check in case scipy is not available and all edge combinations
-        # need to be checked
-        if dist <= radius:
-            return seed.random() < p_dist(dist)
-        else:
-            return False
+    def should_join(edge):
+        u, v = edge
+        dist = (sum(abs(a - b) ** p for a, b in zip(pos[u], pos[v]))) ** (1 / p)
+        return seed.random() < p_dist(dist)
 
-    if _is_scipy_available:
-        edges = _fast_edges(G, radius, p)
-        G.add_edges_from(filter(should_join, edges))
-    else:
-        G.add_edges_from(filter(should_join, combinations(G, 2)))
-
+    G.add_edges_from(filter(should_join, geometric_edges(G, radius, p)))
     return G
 
 
@@ -683,7 +656,7 @@ def thresholded_random_geometric_graph(
         A dictionary keyed by node with node positions as values.
     weight : dict, optional
         Node weights as a dictionary of numbers keyed by node.
-    p : float, optional
+    p : float, optional (default 2)
         Which Minkowski distance metric to use.  `p` has to meet the condition
         ``1 <= p <= infinity``.
 
@@ -765,32 +738,13 @@ def thresholded_random_geometric_graph(
     if pos is None:
         pos = {v: [seed.random() for i in range(dim)] for v in nodes}
     # If no distance metric is provided, use Euclidean distance.
-
     nx.set_node_attributes(G, weight, "weight")
     nx.set_node_attributes(G, pos, "pos")
 
-    # Returns ``True`` if and only if the nodes whose attributes are
-    # ``du`` and ``dv`` should be joined, according to the threshold
-    # condition and node pairs are within the maximum connection
-    # distance, ``radius``.
-    def should_join(pair):
-        u, v = pair
-        u_weight, v_weight = weight[u], weight[v]
-        u_pos, v_pos = pos[u], pos[v]
-        dist = (sum(abs(a - b) ** p for a, b in zip(u_pos, v_pos))) ** (1 / p)
-        # Check if dist is <= radius parameter. This check is redundant if
-        # scipy is available and _fast_edges routine is used, but provides
-        # the check in case scipy is not available and all edge combinations
-        # need to be checked
-        if dist <= radius:
-            return theta <= u_weight + v_weight
-        else:
-            return False
-
-    if _is_scipy_available:
-        edges = _fast_edges(G, radius, p)
-        G.add_edges_from(filter(should_join, edges))
-    else:
-        G.add_edges_from(filter(should_join, combinations(G, 2)))
-
+    edges = (
+        (u, v)
+        for u, v in geometric_edges(G, radius, p)
+        if weight[u] + weight[v] >= theta
+    )
+    G.add_edges_from(edges)
     return G

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -42,7 +42,8 @@ def geometric_edges(G, radius, p):
         # no scipy KDTree so compute by for-loop
         radius_p = radius ** p
         edges = [
-            (u, v) for (u, pu), (v, pv) in combinations(nodes_pos, 2)
+            (u, v)
+            for (u, pu), (v, pv) in combinations(nodes_pos, 2)
             if sum(abs(a - b) ** p for a, b in zip(pu, pv)) <= radius_p
         ]
         return edges

--- a/networkx/generators/intersection.py
+++ b/networkx/generators/intersection.py
@@ -2,7 +2,6 @@
 Generators for random intersection graphs.
 """
 import networkx as nx
-from networkx.algorithms import bipartite
 from networkx.utils import py_random_state
 
 __all__ = [
@@ -41,6 +40,8 @@ def uniform_random_intersection_graph(n, m, p, seed=None):
        An equivalence theorem relating the evolution of the g(n, m, p)
        and g(n, p) models. Random Struct. Algorithms 16, 2 (2000), 156–176.
     """
+    from networkx.algorithms import bipartite
+
     G = bipartite.random_graph(n, m, p, seed)
     return nx.projected_graph(G, range(n))
 

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -16,8 +16,6 @@ be found about `Triangular Tiling`_, and `Square, Hex and Triangle Grids`_
 from math import sqrt
 
 from networkx.classes import set_node_attributes
-from networkx.algorithms.minors import contracted_nodes
-from networkx.algorithms.operators.product import cartesian_product
 from networkx.exception import NetworkXError
 from networkx.relabel import relabel_nodes
 from networkx.utils import flatten, nodes_or_number, pairwise, iterable
@@ -125,6 +123,8 @@ def grid_graph(dim, periodic=False):
     >>> len(G)
     6
     """
+    from networkx.algorithms.operators.product import cartesian_product
+
     if not dim:
         return empty_graph(0)
 
@@ -242,6 +242,8 @@ def triangular_lattice_graph(
     H.add_edges_from(((i, j), (i + 1, j + 1)) for j in rows[1:m:2] for i in cols[:N])
     H.add_edges_from(((i + 1, j), (i, j + 1)) for j in rows[:m:2] for i in cols[:N])
     # identify boundary nodes if periodic
+    from networkx.algorithms.minors import contracted_nodes
+
     if periodic is True:
         for i in cols:
             H = contracted_nodes(H, (i, 0), (i, m))
@@ -335,6 +337,8 @@ def hexagonal_lattice_graph(
     G.remove_node((n, (M + 1) * (n % 2)))
 
     # identify boundary nodes if periodic
+    from networkx.algorithms.minors import contracted_nodes
+
     if periodic:
         for i in cols[:n]:
             G = contracted_nodes(G, (i, 0), (i, M))

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -7,17 +7,8 @@ from networkx.utils import not_implemented_for
 from networkx.utils import reverse_cuthill_mckee_ordering
 from networkx.utils import random_state
 
-try:
-    from numpy import array, asarray, dot, ndarray, ones, sqrt, zeros, atleast_2d
-    from numpy.linalg import norm, qr
-    from scipy.linalg import eigh, inv
-    from scipy.linalg.blas import dasum, daxpy, ddot
-    from scipy.sparse import csc_matrix, spdiags
-    from scipy.sparse.linalg import eigsh, lobpcg
 
-    __all__ = ["algebraic_connectivity", "fiedler_vector", "spectral_ordering"]
-except ImportError:
-    __all__ = []
+__all__ = ["algebraic_connectivity", "fiedler_vector", "spectral_ordering"]
 
 
 class _PCGSolver:
@@ -41,18 +32,20 @@ class _PCGSolver:
         self._M = M or (lambda x: x.copy())
 
     def solve(self, B, tol):
-        B = asarray(B)
-        X = ndarray(B.shape, order="F")
+        B = np.asarray(B)
+        X = np.ndarray(B.shape, order="F")
         for j in range(B.shape[1]):
             X[:, j] = self._solve(B[:, j], tol)
         return X
 
     def _solve(self, b, tol):
+        from scipy.linalg.blas import dasum, daxpy, ddot
+
         A = self._A
         M = self._M
         tol *= dasum(b)
         # Initialize.
-        x = zeros(b.shape)
+        x = np.zeros(b.shape)
         r = b.copy()
         z = M(r)
         rz = ddot(r, z)
@@ -98,26 +91,21 @@ class _LUSolver:
     """
 
     def __init__(self, A):
-        self._LU = self._splu(A)
-
-    def solve(self, B, tol=None):
-        B = asarray(B)
-        X = ndarray(B.shape, order="F")
-        for j in range(B.shape[1]):
-            X[:, j] = self._LU.solve(B[:, j])
-        return X
-
-    try:
         from scipy.sparse.linalg import splu
 
-        _splu = partial(
-            splu,
+        self._LU = splu(
+            A,
             permc_spec="MMD_AT_PLUS_A",
             diag_pivot_thresh=0.0,
             options={"Equil": True, "SymmetricMode": True},
         )
-    except ImportError:
-        _splu = None
+
+    def solve(self, B, tol=None):
+        B = np.asarray(B)
+        X = np.ndarray(B.shape, order="F")
+        for j in range(B.shape[1]):
+            X[:, j] = self._LU.solve(B[:, j])
+        return X
 
 
 def _preprocess_graph(G, weight):
@@ -152,7 +140,7 @@ def _rcm_estimate(G, nodelist):
     order = reverse_cuthill_mckee_ordering(G)
     n = len(nodelist)
     index = dict(zip(nodelist, range(n)))
-    x = ndarray(n, dtype=float)
+    x = np.ndarray(n, dtype=float)
     for i, u in enumerate(order):
         x[index[u]] = i
     x -= (n - 1) / 2.0
@@ -193,12 +181,17 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         As this is for Fiedler vectors, the zero eigenvalue (and
         constant eigenvector) are avoided.
     """
+    from numpy.linalg import norm, qr
+    from scipy.linalg import eigh, inv
+    from scipy.linalg.blas import dasum, daxpy
+    from scipy.sparse import csc_matrix, spdiags
+
     n = X.shape[0]
 
     if normalized:
         # Form the normalized Laplacian matrix and determine the eigenvector of
         # its nullspace.
-        e = sqrt(L.diagonal())
+        e = np.sqrt(L.diagonal())
         D = spdiags(1.0 / e, [0], n, n, format="csr")
         L = D * L * D
         e *= 1.0 / norm(e, 2)
@@ -207,22 +200,22 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
 
         def project(X):
             """Make X orthogonal to the nullspace of L."""
-            X = asarray(X)
+            X = np.asarray(X)
             for j in range(X.shape[1]):
-                X[:, j] -= dot(X[:, j], e) * e
+                X[:, j] -= np.dot(X[:, j], e) * e
 
     else:
 
         def project(X):
             """Make X orthogonal to the nullspace of L."""
-            X = asarray(X)
+            X = np.asarray(X)
             for j in range(X.shape[1]):
                 X[:, j] -= X[:, j].sum() / n
 
     if method == "tracemin_pcg":
         D = L.diagonal().astype(float)
         solver = _PCGSolver(lambda x: L * x, lambda x: D * x)
-    elif method == "tracemin_chol" or method == "tracemin_lu":
+    elif method == "tracemin_lu" or method == "tracemin_chol":
         # Convert A to CSC to suppress SparseEfficiencyWarning.
         A = csc_matrix(L, dtype=float, copy=True)
         # Force A to be nonsingular. Since A is the Laplacian matrix of a
@@ -241,7 +234,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
     # Initialize.
     Lnorm = abs(L).sum(axis=1).flatten().max()
     project(X)
-    W = ndarray(X.shape, order="F")
+    W = np.ndarray(X.shape, order="F")
 
     while True:
         # Orthonormalize X.
@@ -263,7 +256,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         X = (inv(W.T @ X) @ W.T).T  # Preserves Fortran storage order.
         project(X)
 
-    return sigma, asarray(X)
+    return sigma, np.asarray(X)
 
 
 def _get_fiedler_func(method):
@@ -274,17 +267,20 @@ def _get_fiedler_func(method):
 
         def find_fiedler(L, x, normalized, tol, seed):
             q = 1 if method == "tracemin_pcg" else min(4, L.shape[0] - 1)
-            X = asarray(seed.normal(size=(q, L.shape[0]))).T
+            X = np.asarray(seed.normal(size=(q, L.shape[0]))).T
             sigma, X = _tracemin_fiedler(L, X, normalized, tol, method)
             return sigma[0], X[:, 0]
 
     elif method == "lanczos" or method == "lobpcg":
 
         def find_fiedler(L, x, normalized, tol, seed):
+            from scipy.sparse import csc_matrix, spdiags
+            from scipy.sparse.linalg import eigsh, lobpcg
+
             L = csc_matrix(L, dtype=float)
             n = L.shape[0]
             if normalized:
-                D = spdiags(1.0 / sqrt(L.diagonal()), [0], n, n, format="csc")
+                D = spdiags(1.0 / np.sqrt(L.diagonal()), [0], n, n, format="csc")
                 L = D * L * D
             if method == "lanczos" or n < 10:
                 # Avoid LOBPCG when n < 10 due to
@@ -293,13 +289,13 @@ def _get_fiedler_func(method):
                 sigma, X = eigsh(L, 2, which="SM", tol=tol, return_eigenvectors=True)
                 return sigma[1], X[:, 1]
             else:
-                X = asarray(atleast_2d(x).T)
+                X = np.asarray(np.atleast_2d(x).T)
                 M = spdiags(1.0 / L.diagonal(), [0], n, n)
-                Y = ones(n)
+                Y = np.ones(n)
                 if normalized:
                     Y /= D.diagonal()
                 sigma, X = lobpcg(
-                    L, X, M=M, Y=atleast_2d(Y).T, tol=tol, maxiter=n, largest=False
+                    L, X, M=M, Y=np.atleast_2d(Y).T, tol=tol, maxiter=n, largest=False
                 )
                 return sigma[0], X[:, 0]
 
@@ -378,6 +374,9 @@ def algebraic_connectivity(
     --------
     laplacian_matrix
     """
+    global np
+    import numpy as np
+
     if len(G) < 2:
         raise nx.NetworkXError("graph has less than two nodes.")
     G = _preprocess_graph(G, weight)
@@ -464,6 +463,9 @@ def fiedler_vector(
     --------
     laplacian_matrix
     """
+    global np
+    import numpy as np
+
     if len(G) < 2:
         raise nx.NetworkXError("graph has less than two nodes.")
     G = _preprocess_graph(G, weight)
@@ -471,7 +473,7 @@ def fiedler_vector(
         raise nx.NetworkXError("graph is not connected.")
 
     if len(G) == 2:
-        return array([1.0, -1.0])
+        return np.array([1.0, -1.0])
 
     find_fiedler = _get_fiedler_func(method)
     L = nx.laplacian_matrix(G)
@@ -546,6 +548,9 @@ def spectral_ordering(
     --------
     laplacian_matrix
     """
+    global np
+    import numpy as np
+
     if len(G) == 0:
         raise nx.NetworkXError("graph is empty.")
     G = _preprocess_graph(G, weight)

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -33,6 +33,7 @@ class _PCGSolver:
 
     def solve(self, B, tol):
         import numpy as np
+
         B = np.asarray(B)
         X = np.ndarray(B.shape, order="F")
         for j in range(B.shape[1]):
@@ -104,6 +105,7 @@ class _LUSolver:
 
     def solve(self, B, tol=None):
         import numpy as np
+
         B = np.asarray(B)
         X = np.ndarray(B.shape, order="F")
         for j in range(B.shape[1]):
@@ -140,6 +142,7 @@ def _preprocess_graph(G, weight):
 def _rcm_estimate(G, nodelist):
     """Estimate the Fiedler vector using the reverse Cuthill-McKee ordering."""
     import numpy as np
+
     G = G.subgraph(nodelist)
     order = reverse_cuthill_mckee_ordering(G)
     n = len(nodelist)
@@ -267,6 +270,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
 def _get_fiedler_func(method):
     """Returns a function that solves the Fiedler eigenvalue problem."""
     import numpy as np
+
     if method == "tracemin":  # old style keyword <v2.1
         method = "tracemin_pcg"
     if method in ("tracemin_pcg", "tracemin_chol", "tracemin_lu"):

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -32,6 +32,7 @@ class _PCGSolver:
         self._M = M or (lambda x: x.copy())
 
     def solve(self, B, tol):
+        import numpy as np
         B = np.asarray(B)
         X = np.ndarray(B.shape, order="F")
         for j in range(B.shape[1]):
@@ -39,6 +40,7 @@ class _PCGSolver:
         return X
 
     def _solve(self, b, tol):
+        import numpy as np
         from scipy.linalg.blas import dasum, daxpy, ddot
 
         A = self._A
@@ -101,6 +103,7 @@ class _LUSolver:
         )
 
     def solve(self, B, tol=None):
+        import numpy as np
         B = np.asarray(B)
         X = np.ndarray(B.shape, order="F")
         for j in range(B.shape[1]):
@@ -136,6 +139,7 @@ def _preprocess_graph(G, weight):
 
 def _rcm_estimate(G, nodelist):
     """Estimate the Fiedler vector using the reverse Cuthill-McKee ordering."""
+    import numpy as np
     G = G.subgraph(nodelist)
     order = reverse_cuthill_mckee_ordering(G)
     n = len(nodelist)
@@ -181,6 +185,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         As this is for Fiedler vectors, the zero eigenvalue (and
         constant eigenvector) are avoided.
     """
+    import numpy as np
     from numpy.linalg import norm, qr
     from scipy.linalg import eigh, inv
     from scipy.linalg.blas import dasum, daxpy
@@ -261,6 +266,7 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
 
 def _get_fiedler_func(method):
     """Returns a function that solves the Fiedler eigenvalue problem."""
+    import numpy as np
     if method == "tracemin":  # old style keyword <v2.1
         method = "tracemin_pcg"
     if method in ("tracemin_pcg", "tracemin_chol", "tracemin_lu"):
@@ -374,9 +380,6 @@ def algebraic_connectivity(
     --------
     laplacian_matrix
     """
-    global np
-    import numpy as np
-
     if len(G) < 2:
         raise nx.NetworkXError("graph has less than two nodes.")
     G = _preprocess_graph(G, weight)
@@ -463,7 +466,6 @@ def fiedler_vector(
     --------
     laplacian_matrix
     """
-    global np
     import numpy as np
 
     if len(G) < 2:
@@ -548,9 +550,6 @@ def spectral_ordering(
     --------
     laplacian_matrix
     """
-    global np
-    import numpy as np
-
     if len(G) == 0:
         raise nx.NetworkXError("graph is empty.")
     G = _preprocess_graph(G, weight)

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -193,47 +193,48 @@ class GEXF:
     }
     versions["1.2draft"] = d
 
-    types = [
-        (int, "integer"),
-        (float, "float"),
-        (float, "double"),
-        (bool, "boolean"),
-        (list, "string"),
-        (dict, "string"),
-        (int, "long"),
-        (str, "liststring"),
-        (str, "anyURI"),
-        (str, "string"),
-    ]
-
-    # These additions to types allow writing numpy types
-    try:
-        import numpy as np
-    except ImportError:
-        pass
-    else:
-        # prepend so that python types are created upon read (last entry wins)
+    def construct_types(self):
         types = [
-            (np.float64, "float"),
-            (np.float32, "float"),
-            (np.float16, "float"),
-            (np.float_, "float"),
-            (np.int_, "int"),
-            (np.int8, "int"),
-            (np.int16, "int"),
-            (np.int32, "int"),
-            (np.int64, "int"),
-            (np.uint8, "int"),
-            (np.uint16, "int"),
-            (np.uint32, "int"),
-            (np.uint64, "int"),
-            (np.int_, "int"),
-            (np.intc, "int"),
-            (np.intp, "int"),
-        ] + types
+            (int, "integer"),
+            (float, "float"),
+            (float, "double"),
+            (bool, "boolean"),
+            (list, "string"),
+            (dict, "string"),
+            (int, "long"),
+            (str, "liststring"),
+            (str, "anyURI"),
+            (str, "string"),
+        ]
 
-    xml_type = dict(types)
-    python_type = dict(reversed(a) for a in types)
+        # These additions to types allow writing numpy types
+        try:
+            import numpy as np
+        except ImportError:
+            pass
+        else:
+            # prepend so that python types are created upon read (last entry wins)
+            types = [
+                (np.float64, "float"),
+                (np.float32, "float"),
+                (np.float16, "float"),
+                (np.float_, "float"),
+                (np.int_, "int"),
+                (np.int8, "int"),
+                (np.int16, "int"),
+                (np.int32, "int"),
+                (np.int64, "int"),
+                (np.uint8, "int"),
+                (np.uint16, "int"),
+                (np.uint32, "int"),
+                (np.uint64, "int"),
+                (np.int_, "int"),
+                (np.intc, "int"),
+                (np.intp, "int"),
+            ] + types
+
+        self.xml_type = dict(types)
+        self.python_type = dict(reversed(a) for a in types)
 
     # http://www.w3.org/TR/xmlschema-2/#boolean
     convert_bool = {
@@ -265,6 +266,7 @@ class GEXFWriter(GEXF):
     def __init__(
         self, graph=None, encoding="utf-8", prettyprint=True, version="1.2draft"
     ):
+        self.construct_types()
         self.prettyprint = prettyprint
         self.encoding = encoding
         self.set_version(version)
@@ -674,6 +676,7 @@ class GEXFReader(GEXF):
     # Class to read GEXF format files
     # use read_gexf() function
     def __init__(self, node_type=None, version="1.2draft"):
+        self.construct_types()
         self.node_type = node_type
         # assume simple graph and test for multigraph on read
         self.simple_graph = True

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -354,45 +354,46 @@ class GraphML:
         ]
     )
 
-    types = [
-        (int, "integer"),  # for Gephi GraphML bug
-        (str, "yfiles"),
-        (str, "string"),
-        (int, "int"),
-        (int, "long"),
-        (float, "float"),
-        (float, "double"),
-        (bool, "boolean"),
-    ]
-
-    # These additions to types allow writing numpy types
-    try:
-        import numpy as np
-    except:
-        pass
-    else:
-        # prepend so that python types are created upon read (last entry wins)
+    def construct_types(self):
         types = [
-            (np.float64, "float"),
-            (np.float32, "float"),
-            (np.float16, "float"),
-            (np.float_, "float"),
-            (np.int_, "int"),
-            (np.int8, "int"),
-            (np.int16, "int"),
-            (np.int32, "int"),
-            (np.int64, "int"),
-            (np.uint8, "int"),
-            (np.uint16, "int"),
-            (np.uint32, "int"),
-            (np.uint64, "int"),
-            (np.int_, "int"),
-            (np.intc, "int"),
-            (np.intp, "int"),
-        ] + types
+            (int, "integer"),  # for Gephi GraphML bug
+            (str, "yfiles"),
+            (str, "string"),
+            (int, "int"),
+            (int, "long"),
+            (float, "float"),
+            (float, "double"),
+            (bool, "boolean"),
+        ]
 
-    xml_type = dict(types)
-    python_type = dict(reversed(a) for a in types)
+        # These additions to types allow writing numpy types
+        try:
+            import numpy as np
+        except:
+            pass
+        else:
+            # prepend so that python types are created upon read (last entry wins)
+            types = [
+                (np.float64, "float"),
+                (np.float32, "float"),
+                (np.float16, "float"),
+                (np.float_, "float"),
+                (np.int_, "int"),
+                (np.int8, "int"),
+                (np.int16, "int"),
+                (np.int32, "int"),
+                (np.int64, "int"),
+                (np.uint8, "int"),
+                (np.uint16, "int"),
+                (np.uint32, "int"),
+                (np.uint64, "int"),
+                (np.int_, "int"),
+                (np.intc, "int"),
+                (np.intp, "int"),
+            ] + types
+
+        self.xml_type = dict(types)
+        self.python_type = dict(reversed(a) for a in types)
 
     # This page says that data types in GraphML follow Java(TM).
     #  http://graphml.graphdrawing.org/primer/graphml-primer.html#AttributesDefinition
@@ -419,6 +420,7 @@ class GraphMLWriter(GraphML):
         infer_numeric_types=False,
         named_key_ids=False,
     ):
+        self.construct_types()
         from xml.etree.ElementTree import Element
 
         self.myElement = Element
@@ -639,6 +641,7 @@ class GraphMLWriterLxml(GraphMLWriter):
         infer_numeric_types=False,
         named_key_ids=False,
     ):
+        self.construct_types()
         import lxml.etree as lxmletree
 
         self.myElement = lxmletree.Element
@@ -767,6 +770,7 @@ class GraphMLReader(GraphML):
     """Read a GraphML document.  Produces NetworkX graph objects."""
 
     def __init__(self, node_type=str, edge_key_type=int, force_multigraph=False):
+        self.construct_types()
         self.node_type = node_type
         self.edge_key_type = edge_key_type
         self.multigraph = force_multigraph  # If False, test for multiedges

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -509,8 +509,9 @@ class GraphMLWriter(GraphML):
         type in the keys table.
         """
         if element_type not in self.xml_type:
-            msg = f"GraphML writer does not support {element_type} as data values."
-            raise nx.NetworkXError(msg)
+            raise nx.NetworkXError(
+                f"GraphML writer does not support {element_type} as data values."
+            )
         keyid = self.get_key(name, self.xml_type[element_type], scope, default)
         data_element = self.myElement("data", key=keyid)
         data_element.text = str(value)


### PR DESCRIPTION
Some of the imports are at the module level still -- instead of inside a function.
This negates our efforts at lazy importing, thus increasing import time (by a very small amount but users are still complaining).

Fixes #2900 

I will take another look at this in light of #4277 before it should be merged.

Feedback? @pb-cDunn