### PR TITLE
TST: Increase test coverage of convert_matrix

### DIFF
--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -1,7 +1,5 @@
 import pytest
 
-np = pytest.importorskip("numpy")
-np_assert_equal = np.testing.assert_equal
 import numpy as np
 import numpy.testing as npt
 
@@ -123,9 +121,9 @@ class TestConvertNumpyMatrix:
         WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3)) for n in range(3))
         P4 = path_graph(4)
         A = nx.to_numpy_matrix(P4)
-        np_assert_equal(A, nx.to_numpy_matrix(WP4, weight=None))
-        np_assert_equal(0.5 * A, nx.to_numpy_matrix(WP4))
-        np_assert_equal(0.3 * A, nx.to_numpy_matrix(WP4, weight="other"))
+        npt.assert_equal(A, nx.to_numpy_matrix(WP4, weight=None))
+        npt.assert_equal(0.5 * A, nx.to_numpy_matrix(WP4))
+        npt.assert_equal(0.3 * A, nx.to_numpy_matrix(WP4, weight="other"))
 
     def test_from_numpy_matrix_type(self):
         A = np.matrix([[1]])
@@ -325,9 +323,9 @@ class TestConvertNumpyArray:
         WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3)) for n in range(3))
         P4 = path_graph(4)
         A = nx.to_numpy_array(P4)
-        np_assert_equal(A, nx.to_numpy_array(WP4, weight=None))
-        np_assert_equal(0.5 * A, nx.to_numpy_array(WP4))
-        np_assert_equal(0.3 * A, nx.to_numpy_array(WP4, weight="other"))
+        npt.assert_equal(A, nx.to_numpy_array(WP4, weight=None))
+        npt.assert_equal(0.5 * A, nx.to_numpy_array(WP4))
+        npt.assert_equal(0.3 * A, nx.to_numpy_array(WP4, weight="other"))
 
     def test_from_numpy_array_type(self):
         A = np.array([[1]])

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -2,6 +2,7 @@ import pytest
 
 np = pytest.importorskip("numpy")
 np_assert_equal = np.testing.assert_equal
+import numpy.testing as npt
 
 import networkx as nx
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
@@ -360,16 +361,6 @@ class TestConvertNumpyArray:
         assert G[0][0]["cost"] == 2
         assert G[0][0]["weight"] == 1.0
 
-    def test_to_numpy_recarray(self):
-        G = nx.Graph()
-        G.add_edge(1, 2, weight=7.0, cost=5)
-        A = nx.to_numpy_recarray(G, dtype=[("weight", float), ("cost", int)])
-        assert sorted(A.dtype.names) == ["cost", "weight"]
-        assert A.weight[0, 1] == 7.0
-        assert A.weight[0, 0] == 0.0
-        assert A.cost[0, 1] == 5
-        assert A.cost[0, 0] == 0
-
     def test_numpy_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, weight=7)
@@ -447,3 +438,79 @@ class TestConvertNumpyArray:
         G = nx.MultiGraph(nx.complete_graph(3))
         A = nx.to_numpy_array(G, dtype=int)
         assert A.dtype == int
+
+
+@pytest.fixture
+def recarray_test_graph():
+    G = nx.Graph()
+    G.add_edge(1, 2, weight=7.0, cost=5)
+    return G
+
+
+def test_to_numpy_recarray(recarray_test_graph):
+    A = nx.to_numpy_recarray(
+        recarray_test_graph, dtype=[("weight", float), ("cost", int)]
+    )
+    assert sorted(A.dtype.names) == ["cost", "weight"]
+    assert A.weight[0, 1] == 7.0
+    assert A.weight[0, 0] == 0.0
+    assert A.cost[0, 1] == 5
+    assert A.cost[0, 0] == 0
+    with pytest.raises(AttributeError, match="has no attribute"):
+        A.color[0, 1]
+
+
+def test_to_numpy_recarray_default_dtype(recarray_test_graph):
+    A = nx.to_numpy_recarray(recarray_test_graph)
+    assert A.dtype.names == ("weight",)
+    assert A.weight[0, 0] == 0
+    assert A.weight[0, 1] == 7
+    with pytest.raises(AttributeError, match="has no attribute"):
+        A.cost[0, 1]
+
+
+def test_to_numpy_recarray_directed(recarray_test_graph):
+    G = recarray_test_graph.to_directed()
+    G.remove_edge(2, 1)
+    A = nx.to_numpy_recarray(G, dtype=[("weight", float), ("cost", int)])
+    npt.assert_array_equal(A.weight, np.array([[0, 7.0], [0, 0]]))
+    npt.assert_array_equal(A.cost, np.array([[0, 5], [0, 0]]))
+
+
+def test_to_numpy_recarray_default_dtype_no_weight():
+    G = nx.Graph()
+    G.add_edge(0, 1, color="red")
+    with pytest.raises(KeyError):
+        A = nx.to_numpy_recarray(G)
+    A = nx.to_numpy_recarray(G, dtype=[("color", "U8")])
+    assert A.color[0, 1] == "red"
+
+
+@pytest.fixture
+def recarray_nodelist_test_graph():
+    G = nx.Graph()
+    G.add_edges_from(
+        [
+            (0, 1, {"weight": 1.0}),
+            (0, 2, {"weight": 2.0}),
+            (1, 2, {"weight": 0.5}),
+        ]
+    )
+    return G
+
+
+def test_to_numpy_recarray_nodelist(recarray_nodelist_test_graph):
+    A = nx.to_numpy_recarray(recarray_nodelist_test_graph, nodelist=[0, 1])
+    npt.assert_array_equal(A.weight, np.array([[0, 1], [1, 0]]))
+
+
+@pytest.mark.parametrize(
+    ("nodelist", "errmsg"),
+    (
+        ([2, 3], "in nodelist is not in G"),
+        ([1, 1], "nodelist contains duplicates"),
+    ),
+)
+def test_to_numpy_recarray_bad_nodelist(recarray_nodelist_test_graph, nodelist, errmsg):
+    with pytest.raises(nx.NetworkXError, match=errmsg):
+        A = nx.to_numpy_recarray(recarray_nodelist_test_graph, nodelist=nodelist)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -1,7 +1,7 @@
 import pytest
 
-import numpy as np
-import numpy.testing as npt
+np = pytest.importorskip("numpy")
+npt = np.testing
 
 import networkx as nx
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -284,3 +284,21 @@ class TestConvertPandas:
                 edge_attr=True,
                 create_using=nx.MultiGraph(),
             )
+
+
+def test_to_pandas_adjacency_with_nodelist():
+    G = nx.complete_graph(5)
+    nodelist = [1, 4]
+    expected = pd.DataFrame([[0, 1], [1, 0]], index=nodelist, columns=nodelist)
+    pd.testing.assert_frame_equal(
+        expected, nx.to_pandas_adjacency(G, nodelist, dtype=int)
+    )
+
+
+def test_to_pandas_edgelist_with_nodelist():
+    G = nx.Graph()
+    G.add_edges_from([(0, 1), (1, 2), (1, 3)], weight=2.0)
+    G.add_edge(0, 5, weight=100)
+    df = nx.to_pandas_edgelist(G, nodelist=[1, 2])
+    assert 0 not in df["source"].to_numpy()
+    assert 100 not in df["weight"].to_numpy()

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -289,7 +289,9 @@ class TestConvertPandas:
 def test_to_pandas_adjacency_with_nodelist():
     G = nx.complete_graph(5)
     nodelist = [1, 4]
-    expected = pd.DataFrame([[0, 1], [1, 0]], index=nodelist, columns=nodelist)
+    expected = pd.DataFrame(
+        [[0, 1], [1, 0]], dtype=int, index=nodelist, columns=nodelist
+    )
     pd.testing.assert_frame_equal(
         expected, nx.to_pandas_adjacency(G, nodelist, dtype=int)
     )

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -1,19 +1,16 @@
 import pytest
 
+np = pytest.importorskip("numpy")
+sp = pytest.importorskip("scipy")
+sparse = sp.sparse
+npt = np.testing
+
 import networkx as nx
 from networkx.testing import assert_graphs_equal
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 
 
-class TestConvertNumpy:
-    @classmethod
-    def setup_class(cls):
-        global np, sp, sparse, np_assert_equal
-        np = pytest.importorskip("numpy")
-        sp = pytest.importorskip("scipy")
-        sparse = sp.sparse
-        np_assert_equal = np.testing.assert_equal
-
+class TestConvertScipy:
     def setup_method(self):
         self.G1 = barbell_graph(10, 3)
         self.G2 = cycle_graph(10, create_using=nx.DiGraph)
@@ -118,11 +115,11 @@ class TestConvertNumpy:
         WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3)) for n in range(3))
         P4 = path_graph(4)
         A = nx.to_scipy_sparse_matrix(P4)
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
-        np_assert_equal(0.5 * A.todense(), nx.to_scipy_sparse_matrix(WP4).todense())
-        np_assert_equal(
+        npt.assert_equal(0.5 * A.todense(), nx.to_scipy_sparse_matrix(WP4).todense())
+        npt.assert_equal(
             0.3 * A.todense(), nx.to_scipy_sparse_matrix(WP4, weight="other").todense()
         )
 
@@ -131,37 +128,37 @@ class TestConvertNumpy:
         WP4.add_edges_from((n, n + 1, dict(weight=0.5, other=0.3)) for n in range(3))
         P4 = path_graph(4)
         A = nx.to_scipy_sparse_matrix(P4, format="csr")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
         A = nx.to_scipy_sparse_matrix(P4, format="csc")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
         A = nx.to_scipy_sparse_matrix(P4, format="coo")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
         A = nx.to_scipy_sparse_matrix(P4, format="bsr")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
         A = nx.to_scipy_sparse_matrix(P4, format="lil")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
         A = nx.to_scipy_sparse_matrix(P4, format="dia")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
         A = nx.to_scipy_sparse_matrix(P4, format="dok")
-        np_assert_equal(
+        npt.assert_equal(
             A.todense(), nx.to_scipy_sparse_matrix(WP4, weight=None).todense()
         )
 
@@ -182,7 +179,7 @@ class TestConvertNumpy:
         G = nx.Graph()
         G.add_node(1)
         M = nx.to_scipy_sparse_matrix(G)
-        np_assert_equal(M.todense(), np.matrix([[0]]))
+        npt.assert_equal(M.todense(), np.matrix([[0]]))
 
     def test_ordering(self):
         G = nx.DiGraph()
@@ -190,25 +187,25 @@ class TestConvertNumpy:
         G.add_edge(2, 3)
         G.add_edge(3, 1)
         M = nx.to_scipy_sparse_matrix(G, nodelist=[3, 2, 1])
-        np_assert_equal(M.todense(), np.matrix([[0, 0, 1], [1, 0, 0], [0, 1, 0]]))
+        npt.assert_equal(M.todense(), np.matrix([[0, 0, 1], [1, 0, 0], [0, 1, 0]]))
 
     def test_selfloop_graph(self):
         G = nx.Graph([(1, 1)])
         M = nx.to_scipy_sparse_matrix(G)
-        np_assert_equal(M.todense(), np.matrix([[1]]))
+        npt.assert_equal(M.todense(), np.matrix([[1]]))
 
         G.add_edges_from([(2, 3), (3, 4)])
         M = nx.to_scipy_sparse_matrix(G, nodelist=[2, 3, 4])
-        np_assert_equal(M.todense(), np.matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]]))
+        npt.assert_equal(M.todense(), np.matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]]))
 
     def test_selfloop_digraph(self):
         G = nx.DiGraph([(1, 1)])
         M = nx.to_scipy_sparse_matrix(G)
-        np_assert_equal(M.todense(), np.matrix([[1]]))
+        npt.assert_equal(M.todense(), np.matrix([[1]]))
 
         G.add_edges_from([(2, 3), (3, 4)])
         M = nx.to_scipy_sparse_matrix(G, nodelist=[2, 3, 4])
-        np_assert_equal(M.todense(), np.matrix([[0, 1, 0], [0, 0, 1], [0, 0, 0]]))
+        npt.assert_equal(M.todense(), np.matrix([[0, 1, 0], [0, 0, 1], [0, 0, 0]]))
 
     def test_from_scipy_sparse_matrix_parallel_edges(self):
         """Tests that the :func:`networkx.from_scipy_sparse_matrix` function

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -261,3 +261,22 @@ class TestConvertNumpy:
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, weight=1)
         assert_graphs_equal(G, expected)
+
+
+@pytest.mark.parametrize("sparse_format", ("csr", "csc", "dok"))
+def test_from_scipy_sparse_matrix_formats(sparse_format):
+    """Test all formats supported by _generate_weighted_edges."""
+    # trinode complete graph with non-uniform edge weights
+    expected = nx.Graph()
+    expected.add_edges_from(
+        [
+            (0, 1, {"weight": 3}),
+            (0, 2, {"weight": 2}),
+            (1, 0, {"weight": 3}),
+            (1, 2, {"weight": 1}),
+            (2, 0, {"weight": 2}),
+            (2, 1, {"weight": 1}),
+        ]
+    )
+    A = sparse.coo_matrix([[0, 3, 2], [3, 0, 1], [2, 1, 0]]).asformat(sparse_format)
+    assert_graphs_equal(expected, nx.from_scipy_sparse_matrix(A))


### PR DESCRIPTION
This PR increases the test coverage of the `convert_matrix` module to 100%.

It would be nice to also clean up these test modules (e.g. get rid of importorskip for numpy, scipy, etc.), but I only focused on the coverage in this PR.