### PR TITLE
Updates to slicing error message for reportviews

### DIFF
--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -187,7 +187,7 @@ class NodeView(Mapping, Set):
     def __getitem__(self, n):
         if isinstance(n, slice):
             raise nx.NetworkXError(
-                f"NodeView does not support slicing, try list(G.nodes)[{n.start}:{n.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.nodes)[{n.start}:{n.stop}]"
             )
         return self._nodes[n]
 
@@ -291,7 +291,7 @@ class NodeDataView(Set):
     def __getitem__(self, n):
         if isinstance(n, slice):
             raise nx.NetworkXError(
-                f"NodeDataView does not support slicing, try list(G.nodes.data())[{n.start}:{n.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.nodes.data())[{n.start}:{n.stop}]"
             )
         ddict = self._nodes[n]
         data = self._data
@@ -1023,7 +1023,7 @@ class OutEdgeView(Set, Mapping):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"EdgeView does not support slicing, try list(G.edges)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e.start}:{e.stop}]"
             )
         u, v = e
         return self._adjdict[u][v]
@@ -1212,7 +1212,7 @@ class OutMultiEdgeView(OutEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"OutMultiEdgeView does not support slicing, try list(G.nodes)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.nodes)[{e.start}:{e.stop}]"
             )
         u, v, k = e
         return self._adjdict[u][v][k]

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -187,7 +187,8 @@ class NodeView(Mapping, Set):
     def __getitem__(self, n):
         if isinstance(n, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.nodes)[{n}]"
+                f"{type(self).__name__} does not support slicing, "
+                f"try list(G.nodes)[{n.start}:{n.stop}:{n.step}]"
             )
         return self._nodes[n]
 
@@ -291,7 +292,8 @@ class NodeDataView(Set):
     def __getitem__(self, n):
         if isinstance(n, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.nodes.data())[{n}]"
+                f"{type(self).__name__} does not support slicing, "
+                f"try list(G.nodes.data())[{n.start}:{n.stop}:{n.step}]"
             )
         ddict = self._nodes[n]
         data = self._data
@@ -1023,7 +1025,8 @@ class OutEdgeView(Set, Mapping):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e}]"
+                f"{type(self).__name__} does not support slicing, "
+                f"try list(G.edges)[{e.start}:{e.stop}:{e.step}]"
             )
         u, v = e
         return self._adjdict[u][v]
@@ -1175,7 +1178,8 @@ class InEdgeView(OutEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e}]"
+                f"{type(self).__name__} does not support slicing, "
+                f"try list(G.in_edges)[{e.start}:{e.stop}:{e.step}]"
             )
         u, v = e
         return self._adjdict[v][u]
@@ -1216,7 +1220,8 @@ class OutMultiEdgeView(OutEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e}]"
+                f"{type(self).__name__} does not support slicing, "
+                f"try list(G.edges)[{e.start}:{e.stop}:{e.step}]"
             )
         u, v, k = e
         return self._adjdict[u][v][k]
@@ -1293,7 +1298,8 @@ class InMultiEdgeView(OutMultiEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e}]"
+                f"{type(self).__name__} does not support slicing, "
+                f"try list(G.in_edges)[{e.start}:{e.stop}:{e.step}]"
             )
         u, v, k = e
         return self._adjdict[v][u][k]

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -187,7 +187,7 @@ class NodeView(Mapping, Set):
     def __getitem__(self, n):
         if isinstance(n, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.nodes)[{n.start}:{n.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.nodes)[{n}]"
             )
         return self._nodes[n]
 
@@ -291,7 +291,7 @@ class NodeDataView(Set):
     def __getitem__(self, n):
         if isinstance(n, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.nodes.data())[{n.start}:{n.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.nodes.data())[{n}]"
             )
         ddict = self._nodes[n]
         data = self._data
@@ -1023,7 +1023,7 @@ class OutEdgeView(Set, Mapping):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e}]"
             )
         u, v = e
         return self._adjdict[u][v]
@@ -1175,7 +1175,7 @@ class InEdgeView(OutEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e}]"
             )
         u, v = e
         return self._adjdict[v][u]
@@ -1216,7 +1216,7 @@ class OutMultiEdgeView(OutEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e}]"
             )
         u, v, k = e
         return self._adjdict[u][v][k]
@@ -1293,7 +1293,7 @@ class InMultiEdgeView(OutMultiEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e}]"
             )
         u, v, k = e
         return self._adjdict[v][u][k]

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1291,5 +1291,9 @@ class InMultiEdgeView(OutMultiEdgeView):
             return False
 
     def __getitem__(self, e):
+        if isinstance(e, slice):
+            raise nx.NetworkXError(
+                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e.start}:{e.stop}]"
+            )
         u, v, k = e
         return self._adjdict[v][u][k]

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1173,6 +1173,10 @@ class InEdgeView(OutEdgeView):
             return False
 
     def __getitem__(self, e):
+        if isinstance(e, slice):
+            raise nx.NetworkXError(
+                f"{type(self).__name__} does not support slicing, try list(G.in_edges)[{e.start}:{e.stop}]"
+            )
         u, v = e
         return self._adjdict[v][u]
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1216,7 +1216,7 @@ class OutMultiEdgeView(OutEdgeView):
     def __getitem__(self, e):
         if isinstance(e, slice):
             raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, try list(G.nodes)[{e.start}:{e.stop}]"
+                f"{type(self).__name__} does not support slicing, try list(G.edges)[{e.start}:{e.stop}]"
             )
         u, v, k = e
         return self._adjdict[u][v][k]

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -1373,11 +1373,11 @@ class TestInMultiDegreeView(TestDegreeView):
         (rv.EdgeView, "list(G.edges"),
         # Directed EdgeViews
         (rv.InEdgeView, "list(G.in_edges"),
-        (rv.OutEdgeView, "list(G.out_edges"),
+        (rv.OutEdgeView, "list(G.edges"),
         # Multi EdgeViews
         (rv.MultiEdgeView, "list(G.edges"),
         (rv.InMultiEdgeView, "list(G.in_edges"),
-        (rv.OutMultiEdgeView, "list(G.out_edges"),
+        (rv.OutMultiEdgeView, "list(G.edges"),
     ),
 )
 def test_slicing_reportviews(reportview, err_msg_terms):

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -1,6 +1,7 @@
 import pytest
 
 import networkx as nx
+from networkx.classes import reportviews as rv
 from networkx.classes.reportviews import NodeDataView
 
 
@@ -1362,3 +1363,28 @@ class TestInMultiDegreeView(TestDegreeView):
         assert dvd[1] == 1
         assert dvd[2] == 1
         assert dvd[3] == 6
+
+
+@pytest.mark.parametrize(
+    ("reportview", "err_msg_terms"),
+    (
+        (rv.NodeView, "list(G.nodes"),
+        (rv.NodeDataView, "list(G.nodes.data"),
+        (rv.EdgeView, "list(G.edges"),
+        # Directed EdgeViews
+        (rv.InEdgeView, "list(G.in_edges"),
+        (rv.OutEdgeView, "list(G.out_edges"),
+        # Multi EdgeViews
+        (rv.MultiEdgeView, "list(G.edges"),
+        (rv.InMultiEdgeView, "list(G.in_edges"),
+        (rv.OutMultiEdgeView, "list(G.out_edges"),
+    ),
+)
+def test_slicing_reportviews(reportview, err_msg_terms):
+    G = nx.complete_graph(3)
+    view = reportview(G)
+    with pytest.raises(nx.NetworkXError) as exc:
+        view[0:2]
+    errmsg = str(exc.value)
+    assert type(view).__name__ in errmsg
+    assert err_msg_terms in errmsg


### PR DESCRIPTION
Follow-up to #4300 - I had intended to make the suggestions there, but didn't get to it in time.

This PR attempts to accomplish several things:
 - Fix a typo in OutMultiEdgeView: `list(G.nodes)` -> `list(G.edges)`
 - Modify the exception message so that the type of reportview is always correct, regardless of subclassing
 - Adds error messages to the InMultiEdgeView and InEdgeView
 - Modify the error message so that the full slice object is reported, instead of `{s.start}:{s.stop}`, which fails to include the `step` (if used).

The last bullet would be improved even further if there were a built-in for mapping slice objects back to their nice string representation (e.g. `slice(None, 10, 2)` -> `:10:2`). I'm not sure how to do this and didn't want to add a custom utility function for it.