### PR TITLE
Improve test coverage of convert module

### DIFF
--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -78,14 +78,14 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                 create_using=create_using,
                 multigraph_input=data.is_multigraph(),
             )
-            if hasattr(data, "graph"):  # data.graph should be dict-like
-                result.graph.update(data.graph)
-            if hasattr(data, "nodes"):  # data.nodes should be dict-like
-                # result.add_node_from(data.nodes.items()) possible but
-                # for custom node_attr_dict_factory which may be hashable
-                # will be unexpected behavior
-                for n, dd in data.nodes.items():
-                    result._node[n].update(dd)
+            # data.graph should be dict-like
+            result.graph.update(data.graph)
+            # data.nodes should be dict-like
+            # result.add_node_from(data.nodes.items()) possible but
+            # for custom node_attr_dict_factory which may be hashable
+            # will be unexpected behavior
+            for n, dd in data.nodes.items():
+                result._node[n].update(dd)
             return result
         except Exception as e:
             raise nx.NetworkXError("Input is not a correct NetworkX graph.") from e

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -281,6 +281,7 @@ class TestConvert:
         # assert isinstance(h._node[1], custom_dict)
 
 
+<<<<<<< HEAD
 @pytest.mark.parametrize(
     "edgelist",
     (
@@ -314,3 +315,9 @@ def test_to_dict_of_dicts_with_edgedata_multigraph():
     # Multi edge data lost when edge_data is not None
     expected = {0: {1: 10}, 1: {0: 10}}
     assert nx.to_dict_of_dicts(G, edge_data=10) == expected
+
+
+def test_to_networkx_graph_non_edgelist():
+    invalid_edgelist = [1, 2, 3]
+    with pytest.raises(nx.NetworkXError, match="Input is not a valid edge list"):
+        nx.to_networkx_graph(invalid_edgelist)

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -281,7 +281,6 @@ class TestConvert:
         # assert isinstance(h._node[1], custom_dict)
 
 
-<<<<<<< HEAD
 @pytest.mark.parametrize(
     "edgelist",
     (


### PR DESCRIPTION
Try to improve test coverage of the `networkx/convert.py`. 

Todo:
 - Remove warnings on ImportError for numpy/scipy/pandas etc.
   * Tentatively in favor of leaving this as-is.
 - [x] Resolve expected behavior of `to_dict_of_dicts` for multigraphs (see #4305)