### PR TITLE
refactored code instances of neighbour to neighbor for consistency

### DIFF
--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -352,10 +352,10 @@ def greedy_color(G, strategy="largest_first", interchange=False):
         return _interchange.greedy_coloring_with_interchange(G, nodes)
     for u in nodes:
         # Set to keep track of colors of neighbours
-        neighbour_colors = {colors[v] for v in G[u] if v in colors}
+        neighbor_colors = {colors[v] for v in G[u] if v in colors}
         # Find the first unused color.
         for color in itertools.count():
-            if color not in neighbour_colors:
+            if color not in neighbor_colors:
                 break
         # Assign the new color to the current node.
         colors[u] = color

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -832,11 +832,11 @@ class ISMAGS:
             left_to_map = to_be_mapped - set(mapping.keys())
 
             new_candidates = candidates.copy()
-            sgn_neighbours = set(self.subgraph[sgn])
-            not_gn_neighbours = set(self.graph.nodes) - set(self.graph[gn])
+            sgn_neighbors = set(self.subgraph[sgn])
+            not_gn_neighbors = set(self.graph.nodes) - set(self.graph[gn])
             for sgn2 in left_to_map:
-                if sgn2 not in sgn_neighbours:
-                    gn2_options = not_gn_neighbours
+                if sgn2 not in sgn_neighbors:
+                    gn2_options = not_gn_neighbors
                 else:
                     # Get all edges to gn of the right color:
                     g_edges = self._edges_of_same_color(sgn, sgn2)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1434,8 +1434,8 @@ class Graph:
         >>> list(G.edges)
         []
         """
-        for neighbours_dict in self._adj.values():
-            neighbours_dict.clear()
+        for neighbors_dict in self._adj.values():
+            neighbors_dict.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/readwrite/json_graph/jit.py
+++ b/networkx/readwrite/json_graph/jit.py
@@ -94,10 +94,10 @@ def jit_data(G, indent=None, default=None):
         # adjacencies
         if G[node]:
             json_node["adjacencies"] = []
-            for neighbour in G[node]:
-                adjacency = {"nodeTo": neighbour}
+            for neighbor in G[node]:
+                adjacency = {"nodeTo": neighbor}
                 # adjacency data
-                adjacency["data"] = G.edges[node, neighbour]
+                adjacency["data"] = G.edges[node, neighbor]
                 json_node["adjacencies"].append(adjacency)
         json_graph.append(json_node)
     return json.dumps(json_graph, indent=indent, default=default)


### PR DESCRIPTION
I noticed that there were inconsistencies with the spelling of "neighbor" as "neighbour" when recently using your library, and I wanted to contribute back given it's hackoctoberfest and make some quick updates to the spelling for consistency, correcting the instances to the american versions (which is what I assume is the preffered in this repository)

These were all the instances of "neighbour" in the code according to my recursive grep search.