### PR TITLE
updated documentation instances of neighbour to neighbor for consistency

### DIFF
--- a/networkx/algorithms/approximation/treewidth.py
+++ b/networkx/algorithms/approximation/treewidth.py
@@ -68,7 +68,7 @@ def treewidth_min_fill_in(G):
     """Returns a treewidth decomposition using the Minimum Fill-in heuristic.
 
     The heuristic chooses a node from the graph, where the number of edges
-    added turning the neighbourhood of the chosen node into clique is as
+    added turning the neighborhood of the chosen node into clique is as
     small as possible.
 
     Parameters
@@ -87,7 +87,7 @@ class MinDegreeHeuristic:
     """Implements the Minimum Degree heuristic.
 
     The heuristic chooses the nodes according to their degree
-    (number of neighbours), i.e., first the node with the lowest degree is
+    (number of neighbors), i.e., first the node with the lowest degree is
     chosen, then the graph is updated and the corresponding node is
     removed. Next, a new node with the lowest degree is chosen, and so on.
     """
@@ -133,7 +133,7 @@ def min_fill_in_heuristic(graph):
     """Implements the Minimum Degree heuristic.
 
     Returns the node from the graph, where the number of edges added when
-    turning the neighbourhood of the chosen node into clique is as small as
+    turning the neighborhood of the chosen node into clique is as small as
     possible. This algorithm chooses the nodes using the Minimum Fill-In
     heuristic. The running time of the algorithm is :math:`O(V^3)` and it uses
     additional constant memory."""
@@ -198,7 +198,7 @@ def treewidth_decomp(G, heuristic=min_fill_in_heuristic):
     # get first node from heuristic
     elim_node = heuristic(graph)
     while elim_node is not None:
-        # connect all neighbours with each other
+        # connect all neighbors with each other
         nbrs = graph[elim_node]
         for u, v in itertools.permutations(nbrs, 2):
             if v not in graph[u]:

--- a/networkx/algorithms/centrality/voterank_alg.py
+++ b/networkx/algorithms/centrality/voterank_alg.py
@@ -7,7 +7,7 @@ def voterank(G, number_of_nodes=None):
     """Select a list of influential nodes in a graph using VoteRank algorithm
 
     VoteRank [1]_ computes a ranking of the nodes in a graph G based on a
-    voting scheme. With VoteRank, all nodes vote for each of its in-neighbours
+    voting scheme. With VoteRank, all nodes vote for each of its in-neighbors
     and the node with the highest votes is elected iteratively. The voting
     ability of out-neighbors of elected nodes is decreased in subsequent turns.
 

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -254,7 +254,7 @@ def greedy_color(G, strategy="largest_first", interchange=False):
     """Color a graph using various strategies of greedy graph coloring.
 
     Attempts to color a graph using as few colors as possible, where no
-    neighbours of a node can have same color as the node itself. The
+    neighbors of a node can have same color as the node itself. The
     given strategy determines the order in which nodes are colored.
 
     The strategies are described in [1]_, and smallest-last is based on
@@ -351,7 +351,7 @@ def greedy_color(G, strategy="largest_first", interchange=False):
     if interchange:
         return _interchange.greedy_coloring_with_interchange(G, nodes)
     for u in nodes:
-        # Set to keep track of colors of neighbours
+        # Set to keep track of colors of neighbors
         neighbour_colors = {colors[v] for v in G[u] if v in colors}
         # Find the first unused color.
         for color in itertools.count():

--- a/networkx/algorithms/community/asyn_fluid.py
+++ b/networkx/algorithms/community/asyn_fluid.py
@@ -23,7 +23,7 @@ def asyn_fluidc(G, k, max_iter=100, seed=None):
     The algorithm proceeds as follows. First each of the initial k communities
     is initialized in a random vertex in the graph. Then the algorithm iterates
     over all vertices in a random order, updating the community of each vertex
-    based on its own community and the communities of its neighbours. This
+    based on its own community and the communities of its neighbors. This
     process is performed several times until convergence.
     At all times, each community has a total density of 1, which is equally
     distributed among the vertices it contains. If a vertex changes of
@@ -100,7 +100,7 @@ def asyn_fluidc(G, k, max_iter=100, seed=None):
                 com_counter.update({communities[vertex]: density[communities[vertex]]})
             except KeyError:
                 pass
-            # Gather neighbour vertex communities
+            # Gather neighbor vertex communities
             for v in G[vertex]:
                 try:
                     com_counter.update({communities[v]: density[communities[v]]})

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -177,7 +177,7 @@ def _most_frequent_labels(node, labeling, G):
         # accordingly, hence the immediate if statement.
         return {labeling[node]}
 
-    # Compute the frequencies of all neighbours of node
+    # Compute the frequencies of all neighbors of node
     freqs = Counter(labeling[q] for q in G[node])
     max_freq = max(freqs.values())
     return {label for label, freq in freqs.items() if freq == max_freq}

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -318,7 +318,7 @@ def k_corona(G, k, core_number=None):
     """Returns the k-corona of G.
 
     The k-corona is the subgraph of nodes in the k-core which have
-    exactly k neighbours in the k-core.
+    exactly k neighbors in the k-core.
 
     Parameters
     ----------

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -15,7 +15,7 @@ def weisfeiler_lehman_graph_hash(
 ):
     """Return Weisfeiler Lehman (WL) graph hash.
 
-    The function iteratively aggregates and hashes neighbourhoods of each node.
+    The function iteratively aggregates and hashes neighborhoods of each node.
     After each node's neighbors are hashed to obtain updated node labels,
     a hashed histogram of resulting labels is returned as the final hash.
 

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -259,7 +259,7 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
         # and w is a vertex in b.childs[wrap(i+1)].
 
         # If b is a top-level S-blossom,
-        # b.mybestedges is a list of least-slack edges to neighbouring
+        # b.mybestedges is a list of least-slack edges to neighboring
         # S-blossoms, or None if no such list has been computed yet.
         # This is used for efficient computation of delta3.
 
@@ -579,12 +579,12 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
             j += jstep
             while b.childs[j] != entrychild:
                 # Examine the vertices of the sub-blossom to see whether
-                # it is reachable from a neighbouring S-vertex outside the
+                # it is reachable from a neighboring S-vertex outside the
                 # expanding blossom.
                 bv = b.childs[j]
                 if label.get(bv) == 1:
                     # This sub-blossom just got label S through one of its
-                    # neighbours; leave it be.
+                    # neighbors; leave it be.
                     j += jstep
                     continue
                 if isinstance(bv, Blossom):
@@ -782,11 +782,11 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
                 v = queue.pop()
                 assert label[inblossom[v]] == 1
 
-                # Scan its neighbours:
+                # Scan its neighbors:
                 for w in G.neighbors(v):
                     if w == v:
                         continue  # ignore self-loops
-                    # w is a neighbour to v
+                    # w is a neighbor to v
                     bv = inblossom[v]
                     bw = inblossom[w]
                     if bv == bw:

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -554,7 +554,7 @@ def create_empty_copy(G, with_data=True):
 def info(G, n=None):
     """Return a summary of information for the graph G or a single node n.
 
-    The summary includes the number of nodes and edges, or neighbours for a single
+    The summary includes the number of nodes and edges, or neighbors for a single
     node.
 
     Parameters


### PR DESCRIPTION
I noticed that there were inconsistencies with the spelling of "neighbor" as "neighbour" when recently using your library, and I wanted to contribute back given it's hackoctoberfest and make some quick updates to the spelling for consistency, correcting the instances to the american versions (which is what I assume is the preffered in this repository)

These were all the instances of "neighbour" in the documentation according to my recursive grep search.