### PR TITLE
Eulerian path fix

### DIFF
--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -213,7 +213,7 @@ def eulerian_circuit(G, source=None, keys=False):
         yield from _simplegraph_eulerian_circuit(G, source)
 
 
-def has_eulerian_path(G):
+def has_eulerian_path(G, source = None):
     """Return True iff `G` has an Eulerian path.
 
     An Eulerian path is a path in a graph which uses each edge of a graph
@@ -261,6 +261,8 @@ def has_eulerian_path(G):
                 unbalanced_ins += 1
             elif outs[v] - ins[v] == 1:
                 unbalanced_outs += 1
+                if source is not None and source != v: #added
+                    return False    #added
             elif ins[v] != outs[v]:
                 return False
 
@@ -293,10 +295,11 @@ def eulerian_path(G, source=None, keys=False):
     Warning: If `source` provided is not the start node of an Euler path
     will raise error even if an Euler Path exists.
     """
-    if not has_eulerian_path(G):
+    if not has_eulerian_path(G, source): #changed
         raise nx.NetworkXError("Graph has no Eulerian paths.")
     if G.is_directed():
-        G = G.reverse()
+        #G = G.reverse()???
+        G = G.copy()
     else:
         G = G.copy()
     if source is None:

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -236,6 +236,9 @@ def has_eulerian_path(G, source=None):
     G : NetworkX Graph
         The graph to find an euler path in.
 
+    source : node, optional
+        Starting node for circuit.
+
     Returns
     -------
     Bool : True if G has an eulerian path.
@@ -323,11 +326,17 @@ def eulerian_path(G, source=None, keys=False):
             source = _find_path_start(G)
         if G.is_multigraph():
             if keys:
-                yield from reversed([(v, u, k) for u, v, k in _multigraph_eulerian_circuit(G, source)])
+                yield from reversed(
+                    [(v, u, k) for u, v, k in _multigraph_eulerian_circuit(G, source)]
+                )
             else:
-                yield from reversed([(v, u) for u, v, k in _multigraph_eulerian_circuit(G, source)])
+                yield from reversed(
+                    [(v, u) for u, v, k in _multigraph_eulerian_circuit(G, source)]
+                )
         else:
-            yield from reversed([(v, u) for u, v in _simplegraph_eulerian_circuit(G, source)])
+            yield from reversed(
+                [(v, u) for u, v in _simplegraph_eulerian_circuit(G, source)]
+            )
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -171,6 +171,31 @@ class TestEulerianPath:
         for e1, e2 in zip(x, nx.eulerian_path(nx.DiGraph(x))):
             assert e1 == e2
 
+    def test_eulerian_path_straight_link(self):
+        G = nx.DiGraph()
+        result = [(1, 2), (2, 3), (3, 4), (4, 5)]
+        G.add_edges_from(result)
+        assert result == list(nx.eulerian_path(G))
+        assert result == list(nx.eulerian_path(G, source=1))
+
+    def test_eulerian_path_multigraph(self):
+        G = nx.MultiDiGraph()
+        result = [(2, 1), (1, 2), (2, 3), (3, 4), (4, 3)]
+        G.add_edges_from(result)
+        assert result == list(nx.eulerian_path(G))
+        assert result == list(nx.eulerian_path(G, source=2))
+
+    def test_eulerian_path_eulerian_circuit(self):
+        G = nx.DiGraph()
+        result = [(1, 2), (2, 3), (3, 4), (4, 1)]
+        result2 = [(2, 3), (3, 4), (4, 1), (1, 2)]
+        result3 = [(3, 4), (4, 1), (1, 2), (2, 3)]
+        G.add_edges_from(result)
+        assert result == list(nx.eulerian_path(G))
+        assert result == list(nx.eulerian_path(G, source=1))
+        assert result2 == list(nx.eulerian_path(G, source=2))
+        assert result3 == list(nx.eulerian_path(G, source=3))
+
 
 class TestEulerize:
     def test_disconnected(self):

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -150,6 +150,22 @@ class TestHasEulerianPath:
         G.add_node(3)
         assert nx.has_eulerian_path(G)
 
+    def test_has_eulerian_path_not_weakly_connected(self):
+        G = nx.DiGraph()
+        H = nx.Graph()
+        G.add_edges_from([(0, 1), (2, 3), (3, 2)])
+        H.add_edges_from([(0, 1), (2, 3), (3, 2)])
+        assert not nx.has_eulerian_path(G)
+        assert not nx.has_eulerian_path(H)
+
+    def test_has_eulerian_path_unbalancedins_more_than_one(self):
+        G = nx.DiGraph()
+        H = nx.Graph()
+        G.add_edges_from([(0, 1), (2, 3)])
+        H.add_edges_from([(0, 1), (2, 3)])
+        assert not nx.has_eulerian_path(G)
+        assert not nx.has_eulerian_path(H)
+
 
 class TestFindPathStart:
     def testfind_path_start(self):

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -179,6 +179,10 @@ class TestEulerianPath:
         assert result == list(nx.eulerian_path(G, source=1))
         with pytest.raises(nx.NetworkXError):
             list(nx.eulerian_path(G, source=3))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=4))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=5))
 
     def test_eulerian_path_multigraph(self):
         G = nx.MultiDiGraph()
@@ -188,6 +192,8 @@ class TestEulerianPath:
         assert result == list(nx.eulerian_path(G, source=2))
         with pytest.raises(nx.NetworkXError):
             list(nx.eulerian_path(G, source=3))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=4))
 
     def test_eulerian_path_eulerian_circuit(self):
         G = nx.DiGraph()
@@ -210,6 +216,8 @@ class TestEulerianPath:
         assert result2 == list(nx.eulerian_path(G, source=5))
         with pytest.raises(nx.NetworkXError):
             list(nx.eulerian_path(G, source=3))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=2))
 
     def test_eulerian_path_multigraph_undirected(self):
         G = nx.MultiGraph()
@@ -219,6 +227,9 @@ class TestEulerianPath:
         assert result == list(nx.eulerian_path(G, source=2))
         with pytest.raises(nx.NetworkXError):
             list(nx.eulerian_path(G, source=3))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=1))
+
 
 class TestEulerize:
     def test_disconnected(self):

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -177,13 +177,17 @@ class TestEulerianPath:
         G.add_edges_from(result)
         assert result == list(nx.eulerian_path(G))
         assert result == list(nx.eulerian_path(G, source=1))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=3))
 
     def test_eulerian_path_multigraph(self):
         G = nx.MultiDiGraph()
-        result = [(2, 1), (1, 2), (2, 3), (3, 4), (4, 3)]
+        result = [(2, 1), (1, 2), (2, 1), (1, 2), (2, 3), (3, 4), (4, 3)]
         G.add_edges_from(result)
         assert result == list(nx.eulerian_path(G))
         assert result == list(nx.eulerian_path(G, source=2))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=3))
 
     def test_eulerian_path_eulerian_circuit(self):
         G = nx.DiGraph()
@@ -196,6 +200,25 @@ class TestEulerianPath:
         assert result2 == list(nx.eulerian_path(G, source=2))
         assert result3 == list(nx.eulerian_path(G, source=3))
 
+    def test_eulerian_path_undirected(self):
+        G = nx.Graph()
+        result = [(1, 2), (2, 3), (3, 4), (4, 5)]
+        result2 = [(5, 4), (4, 3), (3, 2), (2, 1)]
+        G.add_edges_from(result)
+        assert list(nx.eulerian_path(G)) in (result, result2)
+        assert result == list(nx.eulerian_path(G, source=1))
+        assert result2 == list(nx.eulerian_path(G, source=5))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=3))
+
+    def test_eulerian_path_multigraph_undirected(self):
+        G = nx.MultiGraph()
+        result = [(2, 1), (1, 2), (2, 1), (1, 2), (2, 3), (3, 4)]
+        G.add_edges_from(result)
+        assert result == list(nx.eulerian_path(G))
+        assert result == list(nx.eulerian_path(G, source=2))
+        with pytest.raises(nx.NetworkXError):
+            list(nx.eulerian_path(G, source=3))
 
 class TestEulerize:
     def test_disconnected(self):


### PR DESCRIPTION
Fixes #3976 

The example outlined in issue #3976 gives incorrect answers for different source values. After analyzing the source code, I found several reasons for this. First, eulerian_path calls has_eulerian_path to check if the graph has an eulerian path before proceeding. However, this initial check did not take the source into account. In this pull request, I updated has_eulerian_path so that it has a source input.

Second, if a graph has an eulerian path starting at a particular source, doing eulerian_path (G, source) gives us an incorrect pathing because reverse() changes the source of the resultant graph. To counter this, I had to re-find the source if the graph was not an eulerian circuit, and even if the source was given.

Finally, if the graph was undirected, reverse() was replaced by copy() and thus, the pathing I was getting from simple graph eulerian circuit or multigraph eulerian circuit was not in the right order. I had to change the order in the yield function.

I added several tests to test_euler to check if everything was fixed by the new commits.
