### PR TITLE
Update to_dict_of_dict edge_data

### DIFF
--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -250,7 +250,7 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
 
     edge_data : singleton, optional
        If provided, the value of the dictionary will be set to `edge_data` for
-       all edges. Usual numbers could be `1` or `True`. If `edge_data` is
+       all edges. Usual values could be `1` or `True`. If `edge_data` is
        `None` (the default), the edgedata in `G` is used, resulting in a
        dict-of-dict-of-dicts. If `G` is a MultiGraph, the result will be a
        dict-of-dict-of-dict-of-dicts. See Notes for an approach to customize
@@ -259,9 +259,9 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     Returns
     -------
     dod : dict
-       A dict-of-dict representation of `G`. Note that the level of
-       dictionary nesting depends on the type of `G` and the value of
-       `edge_data` (see Examples).
+       A nested dictionary representation of `G`. Note that the level of
+       nesting depends on the type of `G` and the value of `edge_data`
+       (see Examples).
 
     See Also
     --------
@@ -302,8 +302,8 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     {0: {1: {'weight': 1.0}, 2: {'weight': 1.0}},
      1: {0: {'weight': 1.0}, 2: {'weight': 2.0}},
      2: {1: {'weight': 2.0}, 0: {'weight': 1.0}}}
-    >>> d[1][2]
-    {'weight': 2.0}
+    >>> d[1][2]['weight']
+    2.0
 
     If `edge_data` is not `None`, edge data in the original graph (if any) is
     replaced:

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -248,13 +248,13 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     nodelist : list
        Use only nodes specified in nodelist
 
-    edge_data : singleton, optional
+    edge_data : scalar, optional
        If provided, the value of the dictionary will be set to `edge_data` for
        all edges. Usual values could be `1` or `True`. If `edge_data` is
        `None` (the default), the edgedata in `G` is used, resulting in a
        dict-of-dict-of-dicts. If `G` is a MultiGraph, the result will be a
        dict-of-dict-of-dict-of-dicts. See Notes for an approach to customize
-       handling edge data.
+       handling edge data. `edge_data` should *not* be a container.
 
     Returns
     -------
@@ -269,8 +269,7 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
 
     Notes
     -----
-    `edge_data` should *not* be a container. For a more custom approach to
-    handling edge data, try::
+    For a more custom approach to handling edge data, try::
 
         dod = {
             n: {
@@ -278,6 +277,9 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
             }
             for n, nbrdict in G.adj.items()
         }
+
+    where `custom` returns the desired edge data for each edge between `n` and
+    `nbr`, given existing edge data `dd`.
 
     Examples
     --------

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -279,3 +279,38 @@ class TestConvert:
         # this raise exception
         # h._node.update((n, dd.copy()) for n, dd in g.nodes.items())
         # assert isinstance(h._node[1], custom_dict)
+
+
+@pytest.mark.parametrize(
+    "edgelist",
+    (
+        # Graph with no edge data
+        [(0, 1), (1, 2)],
+        # Graph with edge data
+        [(0, 1, {"weight": 1.0}), (1, 2, {"weight": 2.0})],
+    ),
+)
+def test_to_dict_of_dicts_with_edgedata_param(edgelist):
+    G = nx.Graph()
+    G.add_edges_from(edgelist)
+    # Innermost dict value == edge_data when edge_data != None.
+    # In the case when G has edge data, it is overwritten
+    expected = {0: {1: 10}, 1: {0: 10, 2: 10}, 2: {1: 10}}
+    assert nx.to_dict_of_dicts(G, edge_data=10) == expected
+
+
+def test_to_dict_of_dicts_with_edgedata_and_nodelist():
+    G = nx.path_graph(5)
+    nodelist = [2, 3, 4]
+    expected = {2: {3: 10}, 3: {2: 10, 4: 10}, 4: {3: 10}}
+    assert nx.to_dict_of_dicts(G, nodelist=nodelist, edge_data=10) == expected
+
+
+def test_to_dict_of_dicts_with_edgedata_multigraph():
+    """Multi edge data overwritten when edge_data != None"""
+    G = nx.MultiGraph()
+    G.add_edge(0, 1, key="a")
+    G.add_edge(0, 1, key="b")
+    # Multi edge data lost when edge_data is not None
+    expected = {0: {1: 10}, 1: {0: 10}}
+    assert nx.to_dict_of_dicts(G, edge_data=10) == expected


### PR DESCRIPTION
Closes #4305 .

Updates the documentation of `to_dict_of_dicts` to better describe and provide examples for the `edge_data` kwarg. Also adds tests for the (previously uncovered) case when the `edge_data` kwarg is not `None`.