### PR TITLE
Use xetex for uft8 latex backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Install TeX
           command: |
-            sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra libffcall-dev xindy
+            sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
 
       - run:
           name: Install cartopy dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Install TeX
           command: |
-            sudo apt-get install texlive texlive-latex-extra latexmk
+            sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra libffcall-dev xindy
 
       - run:
           name: Install cartopy dependencies

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libgdal-dev graphviz graphviz-dev
-        sudo apt-get install texlive texlive-latex-extra latexmk
+        sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex
+        sudo apt-get install fonts-freefont-otf xindy
         sudo apt-get install libgeos-dev libproj-dev
         sudo apt-get install libspatialindex-dev
         python3 -m venv ~/venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
           - texlive
           - texlive-latex-extra
           - latexmk
+          - texlive-xetex
+          - fonts-freefont-otf
+          - xindy
           - libgeos-dev
           - libproj-dev
           - libspatialindex-dev

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -170,6 +170,16 @@ htmlhelp_basename = "NetworkX"
 # Options for LaTeX output
 # ------------------------
 
+# Notes for customization
+# https://www.sphinx-doc.org/en/master/latex.html
+# https://github.com/sphinx-doc/sphinx/issues/4136
+
+# Use a latex engine allows for unicode characters in docstrings
+latex_engine = "xelatex"
+
+# Docs on xindy: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_use_xindy
+latex_use_xindy = True
+
 # The paper size ('letter' or 'a4').
 latex_paper_size = "letter"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -170,16 +170,8 @@ htmlhelp_basename = "NetworkX"
 # Options for LaTeX output
 # ------------------------
 
-# Notes for customization
-# https://www.sphinx-doc.org/en/master/latex.html
-# https://github.com/sphinx-doc/sphinx/issues/4136
-
-# Use a latex engine allows for unicode characters in docstrings
+# Use a latex engine that allows for unicode characters in docstrings
 latex_engine = "xelatex"
-
-# Docs on xindy: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_use_xindy
-latex_use_xindy = True
-
 # The paper size ('letter' or 'a4').
 latex_paper_size = "letter"
 


### PR DESCRIPTION
Closes #4325 This is a component of #4169

I finally settled on 

```python
latex_engine = "xelatex"
latex_use_xindy = False
```

Turns out xindy --- don't really know what that is --- was causing errors, and this setting allows xelatex to work (I think xindy is more a pdflatex thing?). 

This PR does not have any dependencies

This PR is depended on by  #4294, #4350, and #4327