### PR TITLE
Fix bug where changing a yielded component set breaks the component finding routine.

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -166,8 +166,8 @@ def kosaraju_strongly_connected_components(G, source=None):
             continue
         c = nx.dfs_preorder_nodes(G, r)
         new = {v for v in c if v not in seen}
-        yield new
         seen.update(new)
+        yield new
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -188,6 +188,22 @@ class TestStronglyConnected:
         )
         pytest.raises(NetworkXNotImplemented, nx.condensation, G)
 
+    strong_cc_methods = (
+        nx.strongly_connected_components,
+        nx.kosaraju_strongly_connected_components,
+        nx.strongly_connected_components_recursive,
+    )
+
+    @pytest.mark.parametrize("get_components", strong_cc_methods)
+    def test_connected_mutability(self, get_components):
+        DG = nx.path_graph(5, create_using=nx.DiGraph)
+        G = nx.disjoint_union(DG, DG)
+        seen = set()
+        for component in get_components(G):
+            assert len(seen & component) == 0
+            seen.update(component)
+            component.clear()
+
 
 #    Commented out due to variability on Travis-CI hardware/operating systems
 #    def test_linear_time(self):

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -76,3 +76,12 @@ class TestWeaklyConnected:
         pytest.raises(NetworkXNotImplemented, nx.weakly_connected_components, G)
         pytest.raises(NetworkXNotImplemented, nx.number_weakly_connected_components, G)
         pytest.raises(NetworkXNotImplemented, nx.is_weakly_connected, G)
+
+    def test_connected_mutability(self):
+        DG = nx.path_graph(5, create_using=nx.DiGraph)
+        G = nx.disjoint_union(DG, DG)
+        seen = set()
+        for component in nx.weakly_connected_components(G):
+            assert len(seen & component) == 0
+            seen.update(component)
+            component.clear()

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -60,8 +60,8 @@ def weakly_connected_components(G):
     for v in G:
         if v not in seen:
             c = set(_plain_bfs(G, v))
-            yield c
             seen.update(c)
+            yield c
 
 
 @not_implemented_for("undirected")
@@ -162,7 +162,7 @@ def _plain_bfs(G, source):
         nextlevel = set()
         for v in thislevel:
             if v not in seen:
-                yield v
                 seen.add(v)
                 nextlevel.update(Gsucc[v])
                 nextlevel.update(Gpred[v])
+                yield v


### PR DESCRIPTION
fix order of yield and seen.update in all connected components routines
Fixes #4331 
See also  #3859 & #3823 

A similar bug was fixed in March 2020 for connected components -- this fixes the directed versions of that bug.
We update the `seen` set with the component's nodes before yielding it so no longer has the problem reported in #4331 of changing the component set yielded makes the function report the same component again.