### PR TITLE
Refactor and improve test coverage for restricted_view and selfloop_edges

### DIFF
--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -210,11 +210,6 @@ class TestFunction:
             == nx.edge_subgraph(self.DG, [(1, 2), (0, 3)]).adj
         )
 
-    def test_restricted_view(self):
-        H = nx.restricted_view(self.G, [0, 2, 5], [(1, 2), (3, 4)])
-        assert set(H.nodes) == {1, 3, 4}
-        assert set(H.edges) == {(1, 1)}
-
     def test_create_empty_copy(self):
         G = nx.create_empty_copy(self.G, with_data=False)
         assert_nodes_equal(G, list(self.G))
@@ -752,3 +747,23 @@ def test_ispath():
         graph.add_edges_from(edges)
         assert nx.is_path(graph, valid_path)
         assert not nx.is_path(graph, invalid_path)
+
+
+@pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+def test_restricted_view(G):
+    G.add_edges_from([(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2)])
+    G.add_node(4)
+    H = nx.restricted_view(G, [0, 2, 5], [(1, 2), (3, 4)])
+    assert set(H.nodes()) == {1, 3, 4}
+    assert set(H.edges()) == {(1, 1)}
+
+
+@pytest.mark.parametrize("G", (nx.MultiGraph(), nx.MultiDiGraph()))
+def test_restricted_view_multi(G):
+    G.add_edges_from(
+        [(0, 1, 0), (0, 2, 0), (0, 3, 0), (0, 1, 1), (1, 0, 0), (1, 1, 0), (1, 2, 0)]
+    )
+    G.add_node(4)
+    H = nx.restricted_view(G, [0, 2, 5], [(1, 2, 0), (3, 4, 0)])
+    assert set(H.nodes()) == {1, 3, 4}
+    assert set(H.edges()) == {(1, 1)}

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -693,7 +693,7 @@ def test_selfloops(graph_type):
 @pytest.mark.parametrize(
     "graph_type", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 )
-def test_selfloops_attr(graph_type):
+def test_selfloop_edges_attr(graph_type):
     G = nx.complete_graph(3, create_using=graph_type)
     G.add_edge(0, 0)
     G.add_edge(1, 1, weight=2)
@@ -701,6 +701,16 @@ def test_selfloops_attr(graph_type):
         nx.selfloop_edges(G, data=True), [(0, 0, {}), (1, 1, {"weight": 2})]
     )
     assert_edges_equal(nx.selfloop_edges(G, data="weight"), [(0, 0, None), (1, 1, 2)])
+
+
+def test_selfloop_edges_multi_with_data_and_keys():
+    G = nx.complete_graph(3, create_using=nx.MultiGraph)
+    G.add_edge(0, 0, weight=10)
+    G.add_edge(0, 0, weight=100)
+    assert_edges_equal(
+        nx.selfloop_edges(G, data="weight", keys=True),
+        [(0, 0, 0, 10), (0, 0, 1, 100)],
+    )
 
 
 @pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph])


### PR DESCRIPTION
This PR increases the test coverage of the `functions` module to 100% and refactors one large selfloop test into several smaller tests.

 * 5f20f29 and a0f9d8b add tests to improve coverage of `restricted_view` and `selfloop_edges`, respectively
 * facee99 refactors `test_selfloops` into several smaller tests. 

facee99 is not critical to improving test coverage, so I'm happy to pull it out into a separate PR to make reviewing easier if desired.