### PR TITLE
CI: Add mayavi conf to travis and GH for doc deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,6 +27,12 @@ jobs:
         python3 -m venv ~/venv
         source ~/venv/bin/activate
 
+    - name: Mayavi setup
+      run: |
+        sudo apt-get --no-install-recommends install -y libxkbcommon-x11-0 optipng libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 xcb libxcb-xfixes0 libxcb-xinerama0 libxcb-shape0
+        echo "export DISPLAY=:99" >> $BASH_ENV
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x200x24 -ac +extension GLX +render -noreset;
+
     - name: Install packages
       run: |
         pip install --upgrade pip wheel setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ matrix:
           - libgeos-dev
           - libproj-dev
           - libspatialindex-dev
+          - libxkbcommon-x11-0
+          - optipng
+          - libxcb-icccm4
+          - libxcb-image0
+          - libxcb-keysyms1
+          - libxcb-randr0
+          - libxcb-render-util0
+          - xcb libxcb-xfixes0
+          - libxcb-xinerama0
+          - libxcb-shape0
 
 before_install:
   # prepare the system to install prerequisites or dependencies

--- a/tools/travis/linux_install.sh
+++ b/tools/travis/linux_install.sh
@@ -10,7 +10,7 @@ source ~/venv/bin/activate
 if [[ "${EXTRA_DEPS}" == 1 ]]; then
 
   # Setup virtual framebuffer for headless mayavi
-  echo "export DISPLAY=:99" >> $BASH_ENV
+  export DISPLAY=:99
   /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x200x24 -ac +extension GLX +render -noreset;
 
   # needed to build Python binding for GDAL

--- a/tools/travis/linux_install.sh
+++ b/tools/travis/linux_install.sh
@@ -9,6 +9,10 @@ source ~/venv/bin/activate
 
 if [[ "${EXTRA_DEPS}" == 1 ]]; then
 
+  # Setup virtual framebuffer for headless mayavi
+  echo "export DISPLAY=:99" >> $BASH_ENV
+  /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x200x24 -ac +extension GLX +render -noreset;
+
   # needed to build Python binding for GDAL
   export CPLUS_INCLUDE_PATH=/usr/include/gdal
   export C_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
Followup to #4297 - adds configuration for headless mayavi to both gh-actions and travis configuration.