### PR TITLE
API: always use list of FancyArrowPatch rather than LineCollection

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -36,7 +36,7 @@ API Changes
   In `to_*_array/matrix`, nodes in nodelist but not in G now raise an exception.
   Use G.add_nodes_from(nodelist) to add them to G before converting.
 
-- [ ]
+- [`#4360  <https://github.com/networkx/networkx/pull/4360>`_]
   Internally `.nx_pylab.draw_networkx_edges` now always generates a
   list of `matplotlib.patches.FancyArrowPatch` rather than using
   a `matplotlib.collections.LineCollection` for un-directed graphs.  This

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -36,6 +36,14 @@ API Changes
   In `to_*_array/matrix`, nodes in nodelist but not in G now raise an exception.
   Use G.add_nodes_from(nodelist) to add them to G before converting.
 
+- [ ]
+  Internally `.nx_pylab.draw_networkx_edges` now always generates a
+  list of `matplotlib.patches.FancyArrowPatch` rather than using
+  a `matplotlib.collections.LineCollection` for un-directed graphs.  This
+  unifies interface for all types of graphs.  In
+  addition to the API change this may cause a performance regression for
+  large graphs.
+
 Deprecations
 ------------
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -25,6 +25,7 @@ from networkx.drawing.layout import (
     random_layout,
     planar_layout,
 )
+import warnings
 
 __all__ = [
     "draw",
@@ -480,13 +481,13 @@ def draw_networkx_edges(
     edge_color="k",
     style="solid",
     alpha=None,
-    arrowstyle="-|>",
+    arrowstyle=None,
     arrowsize=10,
     edge_cmap=None,
     edge_vmin=None,
     edge_vmax=None,
     ax=None,
-    arrows=True,
+    arrows=None,
     label=None,
     node_size=300,
     nodelist=None,
@@ -536,11 +537,15 @@ def draw_networkx_edges(
        Draw the graph in the specified Matplotlib axes.
 
     arrows : bool, optional (default=True)
-       For directed graphs, if True draw arrowheads.
+       For directed graphs, if True draw arrowheads by default.  Ignored
+       if *arrowstyle* is passed.
+
        Note: Arrows will be the same color as edges.
 
-    arrowstyle : str, optional (default='-|>')
-       For directed graphs, choose the style of the arrow heads.
+    arrowstyle : str, optional (default=None)
+       For directed graphs and *arrows==True* defaults to ``'-|>'`` otherwise
+       defaults to ``'-'``.
+
        See :py:class: `matplotlib.patches.ArrowStyle` for more
        options.
 
@@ -566,19 +571,17 @@ def draw_networkx_edges(
 
     Returns
     -------
-    matplotlib.collection.LineCollection
-        `LineCollection` of the edges
-
     list of matplotlib.patches.FancyArrowPatch
         `FancyArrowPatch` instances of the directed edges
-
-    Depending whether the drawing includes arrows or not.
 
     Notes
     -----
     For directed graphs, arrows are drawn at the head end.  Arrows can be
-    turned off with keyword arrows=False. Be sure to include `node_size` as a
-    keyword argument; arrows are drawn considering the size of nodes.
+    turned off with keyword arrows=False or by passing an arrowstyle without
+    an arrow on the end.
+
+    Be sure to include `node_size` as a keyword argument; arrows are
+    drawn considering the size of nodes.
 
     Examples
     --------
@@ -602,12 +605,26 @@ def draw_networkx_edges(
     draw_networkx_nodes()
     draw_networkx_labels()
     draw_networkx_edge_labels()
+
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import colorConverter, Colormap, Normalize
     from matplotlib.collections import LineCollection
     from matplotlib.patches import FancyArrowPatch
     import numpy as np
+
+    if arrowstyle is not None and arrows is not None:
+        warnings.warn(
+            f"You passed both arrowstyle={arrowstyle} and "
+            f"arrows={arrows}.  Because you set a non-default "
+            "*arrowstyle*, arrows will be ignored."
+        )
+
+    if arrowstyle is None:
+        if G.is_directed() and arrows:
+            arrowstyle = "-|>"
+        else:
+            arrowstyle = "-"
 
     if ax is None:
         ax = plt.gca()
@@ -649,99 +666,76 @@ def draw_networkx_edges(
         color_normal = Normalize(vmin=edge_vmin, vmax=edge_vmax)
         edge_color = [edge_cmap(color_normal(e)) for e in edge_color]
 
-    if not G.is_directed() or not arrows:
-        edge_collection = LineCollection(
-            edge_pos,
-            colors=edge_color,
-            linewidths=width,
-            antialiaseds=(1,),
+    # Note: Waiting for someone to implement arrow to intersection with
+    # marker.  Meanwhile, this works well for polygons with more than 4
+    # sides and circle.
+
+    def to_marker_edge(marker_size, marker):
+        if marker in "s^>v<d":  # `large` markers need extra space
+            return np.sqrt(2 * marker_size) / 2
+        else:
+            return np.sqrt(marker_size) / 2
+
+    # Draw arrows with `matplotlib.patches.FancyarrowPatch`
+    arrow_collection = []
+    mutation_scale = arrowsize  # scale factor of arrow head
+
+    # FancyArrowPatch doesn't handle color strings
+    arrow_colors = colorConverter.to_rgba_array(edge_color, alpha)
+    for i, (src, dst) in enumerate(edge_pos):
+        x1, y1 = src
+        x2, y2 = dst
+        shrink_source = 0  # space from source to tail
+        shrink_target = 0  # space from  head to target
+        if np.iterable(node_size):  # many node sizes
+            source, target = edgelist[i][:2]
+            source_node_size = node_size[nodelist.index(source)]
+            target_node_size = node_size[nodelist.index(target)]
+            shrink_source = to_marker_edge(source_node_size, node_shape)
+            shrink_target = to_marker_edge(target_node_size, node_shape)
+        else:
+            shrink_source = shrink_target = to_marker_edge(node_size, node_shape)
+
+        if shrink_source < min_source_margin:
+            shrink_source = min_source_margin
+
+        if shrink_target < min_target_margin:
+            shrink_target = min_target_margin
+
+        if len(arrow_colors) == len(edge_pos):
+            arrow_color = arrow_colors[i]
+        elif len(arrow_colors) == 1:
+            arrow_color = arrow_colors[0]
+        else:  # Cycle through colors
+            arrow_color = arrow_colors[i % len(arrow_colors)]
+
+        if np.iterable(width):
+            if len(width) == len(edge_pos):
+                line_width = width[i]
+            else:
+                line_width = width[i % len(width)]
+        else:
+            line_width = width
+
+        arrow = FancyArrowPatch(
+            (x1, y1),
+            (x2, y2),
+            arrowstyle=arrowstyle,
+            shrinkA=shrink_source,
+            shrinkB=shrink_target,
+            mutation_scale=mutation_scale,
+            color=arrow_color,
+            linewidth=line_width,
+            connectionstyle=connectionstyle,
             linestyle=style,
-            transOffset=ax.transData,
-            alpha=alpha,
-        )
+            zorder=1,
+        )  # arrows go behind nodes
 
-        edge_collection.set_cmap(edge_cmap)
-        edge_collection.set_clim(edge_vmin, edge_vmax)
-
-        edge_collection.set_zorder(1)  # edges go behind nodes
-        edge_collection.set_label(label)
-        ax.add_collection(edge_collection)
-
-        return edge_collection
-
-    arrow_collection = None
-
-    if G.is_directed() and arrows:
-        # Note: Waiting for someone to implement arrow to intersection with
-        # marker.  Meanwhile, this works well for polygons with more than 4
-        # sides and circle.
-
-        def to_marker_edge(marker_size, marker):
-            if marker in "s^>v<d":  # `large` markers need extra space
-                return np.sqrt(2 * marker_size) / 2
-            else:
-                return np.sqrt(marker_size) / 2
-
-        # Draw arrows with `matplotlib.patches.FancyarrowPatch`
-        arrow_collection = []
-        mutation_scale = arrowsize  # scale factor of arrow head
-
-        # FancyArrowPatch doesn't handle color strings
-        arrow_colors = colorConverter.to_rgba_array(edge_color, alpha)
-        for i, (src, dst) in enumerate(edge_pos):
-            x1, y1 = src
-            x2, y2 = dst
-            shrink_source = 0  # space from source to tail
-            shrink_target = 0  # space from  head to target
-            if np.iterable(node_size):  # many node sizes
-                source, target = edgelist[i][:2]
-                source_node_size = node_size[nodelist.index(source)]
-                target_node_size = node_size[nodelist.index(target)]
-                shrink_source = to_marker_edge(source_node_size, node_shape)
-                shrink_target = to_marker_edge(target_node_size, node_shape)
-            else:
-                shrink_source = shrink_target = to_marker_edge(node_size, node_shape)
-
-            if shrink_source < min_source_margin:
-                shrink_source = min_source_margin
-
-            if shrink_target < min_target_margin:
-                shrink_target = min_target_margin
-
-            if len(arrow_colors) == len(edge_pos):
-                arrow_color = arrow_colors[i]
-            elif len(arrow_colors) == 1:
-                arrow_color = arrow_colors[0]
-            else:  # Cycle through colors
-                arrow_color = arrow_colors[i % len(arrow_colors)]
-
-            if np.iterable(width):
-                if len(width) == len(edge_pos):
-                    line_width = width[i]
-                else:
-                    line_width = width[i % len(width)]
-            else:
-                line_width = width
-
-            arrow = FancyArrowPatch(
-                (x1, y1),
-                (x2, y2),
-                arrowstyle=arrowstyle,
-                shrinkA=shrink_source,
-                shrinkB=shrink_target,
-                mutation_scale=mutation_scale,
-                color=arrow_color,
-                linewidth=line_width,
-                connectionstyle=connectionstyle,
-                linestyle=style,
-                zorder=1,
-            )  # arrows go behind nodes
-
-            # There seems to be a bug in matplotlib to make collections of
-            # FancyArrowPatch instances. Until fixed, the patches are added
-            # individually to the axes instance.
-            arrow_collection.append(arrow)
-            ax.add_patch(arrow)
+        # There seems to be a bug in matplotlib to make collections of
+        # FancyArrowPatch instances. Until fixed, the patches are added
+        # individually to the axes instance.
+        arrow_collection.append(arrow)
+        ax.add_patch(arrow)
 
     # update view
     minx = np.amin(np.ravel(edge_pos[:, :, 0]))

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -609,7 +609,6 @@ def draw_networkx_edges(
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import colorConverter, Colormap, Normalize
-    from matplotlib.collections import LineCollection
     from matplotlib.patches import FancyArrowPatch
     import numpy as np
 
@@ -633,10 +632,7 @@ def draw_networkx_edges(
         edgelist = list(G.edges())
 
     if len(edgelist) == 0:  # no edges!
-        if not G.is_directed() or not arrows:
-            return LineCollection(None)
-        else:
-            return []
+        return []
 
     if nodelist is None:
         nodelist = list(G.nodes())

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -205,7 +205,7 @@ class TestPylab:
 
     def test_draw_empty_nodes_return_values(self):
         # See Issue #3833
-        from matplotlib.collections import PathCollection, LineCollection
+        from matplotlib.collections import PathCollection
 
         G = nx.Graph([(1, 2), (2, 3)])
         DG = nx.DiGraph([(1, 2), (2, 3)])
@@ -213,16 +213,11 @@ class TestPylab:
         assert isinstance(nx.draw_networkx_nodes(G, pos, nodelist=[]), PathCollection)
         assert isinstance(nx.draw_networkx_nodes(DG, pos, nodelist=[]), PathCollection)
 
-        # drawing empty edges either return an empty LineCollection or empty list.
-        assert isinstance(
-            nx.draw_networkx_edges(G, pos, edgelist=[], arrows=True), LineCollection
-        )
-        assert isinstance(
-            nx.draw_networkx_edges(G, pos, edgelist=[], arrows=False), LineCollection
-        )
-        assert isinstance(
-            nx.draw_networkx_edges(DG, pos, edgelist=[], arrows=False), LineCollection
-        )
+        # drawing empty edges used to return an empty LineCollection or empty list.
+        # Now it is always an empty list (because edges are now lists of FancyArrows)
+        assert nx.draw_networkx_edges(G, pos, edgelist=[], arrows=True) == []
+        assert nx.draw_networkx_edges(G, pos, edgelist=[], arrows=False) == []
+        assert nx.draw_networkx_edges(DG, pos, edgelist=[], arrows=False) == []
         assert nx.draw_networkx_edges(DG, pos, edgelist=[], arrows=True) == []
 
     def test_multigraph_edgelist_tuples(self):


### PR DESCRIPTION
draw_networkx_edges used touse a LineCollection (presumably for
performance reasons) when drawing un-directed graphs and generate many
FancyArrowPatch objects when drawing directed graphs.  This resulted
in issues due to return type instability (#3337) and inconsistency
with handling the input (#3398).

closes #3398
closes #3337

Later commit adds ability to draw a self-loop edge.
closes #2024
