### PR TITLE
Add additional libraries to intersphinx mapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -197,6 +197,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
 }
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -194,8 +194,9 @@ latex_appendices = ["tutorial"]
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
-    "https://numpy.org/doc/stable/": None,
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "matplotlib": ("https://matplotlib.org", None),
 }
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -146,12 +146,11 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
 
     arrowstyle : str, optional (default='-|>')
         For directed graphs, choose the style of the arrowsheads.
-        See :py:class: `matplotlib.patches.ArrowStyle` for more
-        options.
+        See `matplotlib.patches.ArrowStyle` for more options.
 
     arrowsize : int, optional (default=10)
        For directed graphs, choose the size of the arrow head head's length and
-       width. See :py:class: `matplotlib.patches.FancyArrowPatch` for attribute
+       width. See `matplotlib.patches.FancyArrowPatch` for attribute
        `mutation_scale` for more info.
 
     with_labels :  bool, optional (default=True)
@@ -546,19 +545,18 @@ def draw_networkx_edges(
        For directed graphs and *arrows==True* defaults to ``'-|>'`` otherwise
        defaults to ``'-'``.
 
-       See :py:class: `matplotlib.patches.ArrowStyle` for more
-       options.
+       See `matplotlib.patches.ArrowStyle` for more options.
 
     arrowsize : int, optional (default=10)
        For directed graphs, choose the size of the arrow head head's length and
-       width. See :py:class: `matplotlib.patches.FancyArrowPatch` for attribute
+       width. See `matplotlib.patches.FancyArrowPatch` for attribute
        `mutation_scale` for more info.
 
     connectionstyle : str, optional (default=None)
        Pass the connectionstyle parameter to create curved arc of rounding
        radius rad. For example, connectionstyle='arc3,rad=0.2'.
-       See :py:class: `matplotlib.patches.ConnectionStyle` and
-       :py:class: `matplotlib.patches.FancyArrowPatch` for more info.
+       See `matplotlib.patches.ConnectionStyle` and
+       `matplotlib.patches.FancyArrowPatch` for more info.
 
     label : [None| string]
        Label for legend


### PR DESCRIPTION
Something I noticed when reviewing `draw_networkx_edges` - there were references to matplotlib classes for which the links were not being built because matplotlib wasn't in intersphinx mapping. I went ahead and added pandas and scipy too since they're default requirements and there are likely (or at least could be) references to their documentation.

Also removed some unnecessary `:py:class:` instances from `nx_pylab` docstrings.