### PR TITLE
MAINT: remove deprecated numpy type aliases.

### DIFF
--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1215,7 +1215,7 @@ class TestWriteGraphML(BaseGraphML):
 
     def test_numpy_float(self):
         np = pytest.importorskip("numpy")
-        wt = np.float(3.4)
+        wt = np.float_(3.4)
         G = nx.Graph([(1, 2, {"weight": wt})])
         fd, fname = tempfile.mkstemp()
         self.writer(G, fname)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -130,23 +130,23 @@ class TestConvertNumpyMatrix:
         G = nx.from_numpy_matrix(A)
         assert type(G[0][0]["weight"]) == int
 
-        A = np.matrix([[1]]).astype(np.float)
+        A = np.matrix([[1]]).astype(float)
         G = nx.from_numpy_matrix(A)
         assert type(G[0][0]["weight"]) == float
 
-        A = np.matrix([[1]]).astype(np.str)
+        A = np.matrix([[1]]).astype(str)
         G = nx.from_numpy_matrix(A)
         assert type(G[0][0]["weight"]) == str
 
-        A = np.matrix([[1]]).astype(np.bool)
+        A = np.matrix([[1]]).astype(bool)
         G = nx.from_numpy_matrix(A)
         assert type(G[0][0]["weight"]) == bool
 
-        A = np.matrix([[1]]).astype(np.complex)
+        A = np.matrix([[1]]).astype(complex)
         G = nx.from_numpy_matrix(A)
         assert type(G[0][0]["weight"]) == complex
 
-        A = np.matrix([[1]]).astype(np.object)
+        A = np.matrix([[1]]).astype(object)
         pytest.raises(TypeError, nx.from_numpy_matrix, A)
 
         G = nx.cycle_graph(3)
@@ -332,23 +332,23 @@ class TestConvertNumpyArray:
         G = nx.from_numpy_array(A)
         assert type(G[0][0]["weight"]) == int
 
-        A = np.array([[1]]).astype(np.float)
+        A = np.array([[1]]).astype(float)
         G = nx.from_numpy_array(A)
         assert type(G[0][0]["weight"]) == float
 
-        A = np.array([[1]]).astype(np.str)
+        A = np.array([[1]]).astype(str)
         G = nx.from_numpy_array(A)
         assert type(G[0][0]["weight"]) == str
 
-        A = np.array([[1]]).astype(np.bool)
+        A = np.array([[1]]).astype(bool)
         G = nx.from_numpy_array(A)
         assert type(G[0][0]["weight"]) == bool
 
-        A = np.array([[1]]).astype(np.complex)
+        A = np.array([[1]]).astype(complex)
         G = nx.from_numpy_array(A)
         assert type(G[0][0]["weight"]) == complex
 
-        A = np.array([[1]]).astype(np.object)
+        A = np.array([[1]]).astype(object)
         pytest.raises(TypeError, nx.from_numpy_array, A)
 
     def test_from_numpy_array_dtype(self):


### PR DESCRIPTION
NumPy is [deprecating some type aliases in 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). We had used some of these aliases in the test suite - this PR replaces them with the corresponding Python or numpy scalar type. I grepped through the rest of NX as well and didn't notice any other instances.