### PR TITLE
TST: Boost test coverage of nx_pylab module

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -438,8 +438,6 @@ def draw_networkx_nodes(
         xy = np.asarray([pos[v] for v in nodelist])
     except KeyError as e:
         raise nx.NetworkXError(f"Node {e} has no position.") from e
-    except ValueError as e:
-        raise nx.NetworkXError("Bad value in node positions.") from e
 
     if isinstance(alpha, Iterable):
         node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -312,3 +312,14 @@ def test_draw_edges_min_source_target_margins(node_shape):
     assert padded_extent[0] > default_extent[0]
     # And the rightmost extent of the edge, further to the left
     assert padded_extent[1] < default_extent[1]
+
+
+def test_apply_alpha():
+    """Test apply_alpha when there is a mismatch between the number of
+    supplied colors and elements.
+    """
+    nodelist = [0, 1, 2]
+    colorlist = ["r", "g", "b"]
+    alpha = 0.5
+    rgba_colors = nx.drawing.nx_pylab.apply_alpha(colorlist, alpha, nodelist)
+    assert all(rgba_colors[:, -1] == alpha)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -257,3 +257,10 @@ def test_draw_nodes_missing_node_from_position():
     pos = {0: (0, 0), 1: (1, 1)}  # No position for node 2
     with pytest.raises(nx.NetworkXError, match="has no position"):
         nx.draw_networkx_nodes(G, pos)
+
+
+def test_draw_edges_warns_on_arrow_and_arrowstyle():
+    G = nx.Graph([(0, 1)])
+    pos = {0: (0, 0), 1: (1, 1)}
+    with pytest.warns(Warning, match="arrows will be ignored"):
+        nx.draw_networkx_edges(G, pos, arrowstyle="-|>", arrows=False)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -250,3 +250,10 @@ class TestPylab:
         # see issue #4129
         np = pytest.importorskip("numpy")
         nx.draw_networkx(self.G, edgelist=np.array([(0, 2), (0, 3)]))
+
+
+def test_draw_nodes_missing_node_from_position():
+    G = nx.path_graph(3)
+    pos = {0: (0, 0), 1: (1, 1)}  # No position for node 2
+    with pytest.raises(nx.NetworkXError, match="has no position"):
+        nx.draw_networkx_nodes(G, pos)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -266,7 +266,10 @@ def test_draw_edges_warns_on_arrow_and_arrowstyle():
         nx.draw_networkx_edges(G, pos, arrowstyle="-|>", arrows=False)
 
 
-def test_draw_edges_min_source_target_margins():
+# NOTE: parametrizing on marker to test both branches of internal
+# nx.draw_networkx_edges.to_marker_edge function
+@pytest.mark.parametrize("node_shape", ("o", "s"))
+def test_draw_edges_min_source_target_margins(node_shape):
     """Test that there is a wider gap between the node and the start of an
     incident edge when min_source_margin is specified.
 
@@ -289,12 +292,17 @@ def test_draw_edges_min_source_target_margins():
     pos = {0: (0, 0), 1: (1, 0)}  # horizontal layout
     # Get leftmost and rightmost points of the FancyArrowPatch object
     # representing the edge between nodes 0 and 1 (in pixel coordinates)
-    default_patch = nx.draw_networkx_edges(G, pos, ax=ax)[0]
+    default_patch = nx.draw_networkx_edges(G, pos, ax=ax, node_shape=node_shape)[0]
     default_extent = default_patch.get_extents().corners()[::2, 0]
     # Now, do the same but with "padding" for the source and target via the
     # min_{source/target}_margin kwargs
     padded_patch = nx.draw_networkx_edges(
-        G, pos, ax=ax, min_source_margin=100, min_target_margin=100
+        G,
+        pos,
+        ax=ax,
+        node_shape=node_shape,
+        min_source_margin=100,
+        min_target_margin=100,
     )[0]
     padded_extent = padded_patch.get_extents().corners()[::2, 0]
 

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -198,6 +198,7 @@ class TestPylab:
     def test_axes(self):
         fig, ax = plt.subplots()
         nx.draw(self.G, ax=ax)
+        nx.draw_networkx_edge_labels(self.G, nx.circular_layout(self.G), ax=ax)
 
     def test_empty_graph(self):
         G = nx.Graph()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -264,3 +264,42 @@ def test_draw_edges_warns_on_arrow_and_arrowstyle():
     pos = {0: (0, 0), 1: (1, 1)}
     with pytest.warns(Warning, match="arrows will be ignored"):
         nx.draw_networkx_edges(G, pos, arrowstyle="-|>", arrows=False)
+
+
+def test_draw_edges_min_source_target_margins():
+    """Test that there is a wider gap between the node and the start of an
+    incident edge when min_source_margin is specified.
+
+    This test checks that the use of min_{source/target}_margin kwargs result
+    in shorter (more padding) between the edges and source and target nodes.
+    As a crude visual example, let 's' and 't' represent source and target
+    nodes, respectively:
+
+       Default:
+       s-----------------------------t
+
+       With margins:
+       s   -----------------------   t
+
+    """
+    # Create a single axis object to get consistent pixel coords across
+    # multiple draws
+    fig, ax = plt.subplots()
+    G = nx.Graph([(0, 1)])
+    pos = {0: (0, 0), 1: (1, 0)}  # horizontal layout
+    # Get leftmost and rightmost points of the FancyArrowPatch object
+    # representing the edge between nodes 0 and 1 (in pixel coordinates)
+    default_patch = nx.draw_networkx_edges(G, pos, ax=ax)[0]
+    default_extent = default_patch.get_extents().corners()[::2, 0]
+    # Now, do the same but with "padding" for the source and target via the
+    # min_{source/target}_margin kwargs
+    padded_patch = nx.draw_networkx_edges(
+        G, pos, ax=ax, min_source_margin=100, min_target_margin=100
+    )[0]
+    padded_extent = padded_patch.get_extents().corners()[::2, 0]
+
+    # With padding, the left-most extent of the edge should be further to the
+    # right
+    assert padded_extent[0] > default_extent[0]
+    # And the rightmost extent of the edge, further to the left
+    assert padded_extent[1] < default_extent[1]


### PR DESCRIPTION
Boosts the test coverage of `nx.drawing.nx_pylab` to 100%, minus the lines mentioned in #4374, which will be addressed separately after discussion of that issue.

Two points that I'd like to call attention to for review:
 1) I've removed an `except` branch from nx_pylab in 59cc4c6 because I couldn't come up with a test case that would raise a ValueError here. I checked the `blame` and couldn't find any motivating case that way either. Please LMK if you have an idea of what case this branch was originally designed to detect.
 2) The test I added in 9fe21a3 is a bit of a departure from most of the tests of `nx_pylab` in that I've tried to test the behavior of the visualization. On the one hand, this is nice, but it's also more detailed and arguably harder to grok. In addition, the test performs checks on data in pixel space, which feels like it might be fragile --- I'm not sure about best-practices for testing visualizations. In any case I'd love to hear what you think - if it's too complicated or fragile, I'm happy to replace it with a simpler smoke test.