### PR TITLE
DOC: Fix copy-pasted docs for random_tournament and hamiltonian_path

### DIFF
--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -149,7 +149,7 @@ def random_tournament(n, seed=None):
     Returns
     -------
     G : DiGraph
-        A tournament on n nodes, with exactly one directed edge joining
+        A tournament on `n` nodes, with exactly one directed edge joining
         each pair of distinct nodes.
 
     Notes

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -111,8 +111,8 @@ def hamiltonian_path(G):
 
     Returns
     -------
-    bool
-        Whether the given graph is a tournament graph.
+    path : list
+        A list of nodes which form a Hamiltonian path in `G`.
 
     Notes
     -----
@@ -148,8 +148,9 @@ def random_tournament(n, seed=None):
 
     Returns
     -------
-    bool
-        Whether the given graph is a tournament graph.
+    G : DiGraph
+        A tournament on n nodes, with exactly one directed edge joining
+        each pair of distinct nodes.
 
     Notes
     -----


### PR DESCRIPTION
Looks like someone copy-pasted the docs for `random_tournament` and `hamiltonian_path` from `is_tournament` and forgot to change the return types.