### PR TITLE
Modify and document behavior of nodelist param in draw_networkx_edges.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -556,6 +556,19 @@ def draw_networkx_edges(
        See `matplotlib.patches.ConnectionStyle` and
        `matplotlib.patches.FancyArrowPatch` for more info.
 
+    node_size : scalar or array, optional (default=300)
+       Size of nodes. Though the nodes are not drawn with this function, the
+       node size is used in determining edge positioning.
+
+    nodelist : list, optional (default=G.nodes())
+       Only draw edges that are in `edgelist` and that lie between nodes in
+       `nodelist`. Any edges in `edgelist` incident on nodes that are *not* in
+       `nodelist` will not be drawn.
+
+    node_shape :  string, optional (default='o')
+       The marker used for nodes, used in determining edge positioning.
+       Specification is as a `matplotlib.markers` marker, e.g. one of 'so^>v<dph8'.
+
     label : [None| string]
        Label for legend
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -628,11 +628,15 @@ def draw_networkx_edges(
     if edgelist is None:
         edgelist = list(G.edges())
 
-    if len(edgelist) == 0:  # no edges!
-        return []
-
     if nodelist is None:
         nodelist = list(G.nodes())
+    else:
+        # Remove any edges where both endpoints are not in node list
+        nodeset = set(nodelist)
+        edgelist = [(u, v) for u, v in edgelist if (u in nodeset) and (v in nodeset)]
+
+    if len(edgelist) == 0:  # no edges!
+        return []
 
     # FancyArrowPatch handles color=None different from LineCollection
     if edge_color is None:

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -312,6 +312,8 @@ def test_draw_edges_min_source_target_margins(node_shape):
     assert padded_extent[0] > default_extent[0]
     # And the rightmost extent of the edge, further to the left
     assert padded_extent[1] < default_extent[1]
+    # NOTE: Prevent axes objects from impacting other tests via plt.gca
+    plt.delaxes(ax)
 
 
 def test_apply_alpha():

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -323,3 +323,21 @@ def test_apply_alpha():
     alpha = 0.5
     rgba_colors = nx.drawing.nx_pylab.apply_alpha(colorlist, alpha, nodelist)
     assert all(rgba_colors[:, -1] == alpha)
+
+
+@pytest.mark.parametrize(
+    ("nodelist", "expected_num_edges"),
+    (
+        ([], 0),
+        ([1], 0),
+        ([1, 2], 1),
+        ([0, 1, 2, 3], 6),
+    ),
+)
+def test_draw_edges_with_nodelist(nodelist, expected_num_edges):
+    """Test that edges that contain a node in `nodelist` are not drawn by
+    draw_networkx_edges. See gh-4374.
+    """
+    G = nx.complete_graph(5)
+    edge_patches = nx.draw_networkx_edges(G, nx.circular_layout(G), nodelist=nodelist)
+    assert len(edge_patches) == expected_num_edges


### PR DESCRIPTION
Closes #4374

Prevents edges whose endpoints are not in `nodelist` from being drawn by `draw_networkx_edges` (see #4374 for more details).

Also documents missing `node*` parameters in `draw_networkx_edges` docstring.