### PR TITLE
TST: Add decorator for testing import errors.

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -129,7 +129,7 @@ def to_agraph(N):
     try:
         import pygraphviz
     except ImportError as e:
-        raise ImportError("requires pygraphviz " "http://pygraphviz.github.io/") from e
+        raise ImportError("requires pygraphviz - http://pygraphviz.github.io/") from e
     directed = N.is_directed()
     strict = nx.number_of_selfloops(N) == 0 and not N.is_multigraph()
     A = pygraphviz.AGraph(name=N.name, strict=strict, directed=directed)
@@ -198,7 +198,7 @@ def read_dot(path):
         import pygraphviz
     except ImportError as e:
         raise ImportError(
-            "read_dot() requires pygraphviz " "http://pygraphviz.github.io/"
+            "read_dot() requires pygraphviz - http://pygraphviz.github.io/"
         ) from e
     A = pygraphviz.AGraph(file=path)
     gr = from_agraph(A)
@@ -278,7 +278,7 @@ def pygraphviz_layout(G, prog="neato", root=None, args=""):
     try:
         import pygraphviz
     except ImportError as e:
-        raise ImportError("requires pygraphviz " "http://pygraphviz.github.io/") from e
+        raise ImportError("requires pygraphviz - http://pygraphviz.github.io/") from e
     if root is not None:
         args += f"-Groot={root}"
     A = to_agraph(G)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -6,7 +6,12 @@ import pytest
 pygraphviz = pytest.importorskip("pygraphviz")
 
 
-from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
+from networkx.testing import (
+    assert_edges_equal,
+    assert_nodes_equal,
+    assert_graphs_equal,
+    missing_modules,
+)
 
 import networkx as nx
 
@@ -247,3 +252,27 @@ class TestAGraph:
         with pytest.warns(DeprecationWarning, match="display_pygraphviz is deprecated"):
             with open(path_name, "wb") as fh:
                 nx.nx_agraph.display_pygraphviz(A, fh, prog="dot")
+
+
+@missing_modules(["pygraphviz"])
+def test_to_agraph_import_error():
+    """Test ImportError is raised when pygraphviz not installed."""
+    G = nx.path_graph(2)
+    with pytest.raises(ImportError, match="requires pygraphviz"):
+        nx.nx_agraph.to_agraph(G)
+
+
+@missing_modules(["pygraphviz"])
+def test_read_dot_import_error():
+    """Test ImportError is raised when pygraphviz not installed."""
+    path = "none"
+    with pytest.raises(ImportError, match="requires pygraphviz"):
+        nx.nx_agraph.read_dot(path)
+
+
+@missing_modules(["pygraphviz"])
+def test_pygraphviz_layout_import_error():
+    """Test ImportError is raised when pygraphviz not installed."""
+    G = nx.path_graph(2)
+    with pytest.raises(ImportError, match="requires pygraphviz"):
+        nx.nx_agraph.pygraphviz_layout(G)

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -1,7 +1,12 @@
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
+from networkx.testing import (
+    assert_nodes_equal,
+    assert_edges_equal,
+    assert_graphs_equal,
+    missing_modules,
+)
 from networkx.convert import (
     to_networkx_graph,
     to_dict_of_dicts,
@@ -320,3 +325,21 @@ def test_to_networkx_graph_non_edgelist():
     invalid_edgelist = [1, 2, 3]
     with pytest.raises(nx.NetworkXError, match="Input is not a valid edge list"):
         nx.to_networkx_graph(invalid_edgelist)
+
+
+@missing_modules(["scipy"])
+def test_to_networkx_graph_warns_no_scipy():
+    with pytest.warns(ImportWarning, match="scipy not found"):
+        nx.to_networkx_graph([(0, 1)])
+
+
+@missing_modules(["pandas"])
+def test_to_networkx_graph_warns_no_pandas():
+    with pytest.warns(ImportWarning, match="pandas not found"):
+        nx.to_networkx_graph([(0, 1)])
+
+
+@missing_modules(["numpy"])
+def test_to_networkx_graph_warns_no_numpy():
+    with pytest.warns(ImportWarning, match="numpy not found"):
+        nx.to_networkx_graph([(0, 1)])


### PR DESCRIPTION
Adds a utility decorator called `missing_modules` that allows for the testing the expected raising of `ImportWarning`s and `ImportErrors`.

This was an idea I had when trying to design tests to improve test coverage. A common pattern is:

```python
try:
    import numpy as np
    <do something>
except ImportError:
    <do something else>
```

This PR adds a utility to try to make it easier to write tests for the `except` branches.

It would be nice to be able to remove the `try/except ImportError` pattern now that  `numpy`, `scipy`, etc. are dependencies. In the meantime this might be one approach to improving the ability to test these branches.

Use of the decorator is demonstrated to improve coverage of the coverage module.