### PR TITLE
Add an algorithm to produce maximum induced d-club cluster graphs.

### DIFF
--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -15,6 +15,7 @@ from networkx.algorithms.covering import *
 from networkx.algorithms.cycles import *
 from networkx.algorithms.cuts import *
 from networkx.algorithms.d_separation import *
+from networkx.algorithms.d_fragmentation import *
 from networkx.algorithms.dag import *
 from networkx.algorithms.distance_measures import *
 from networkx.algorithms.distance_regular import *

--- a/networkx/algorithms/d_fragmentation.py
+++ b/networkx/algorithms/d_fragmentation.py
@@ -100,10 +100,7 @@ References
 """
 
 
-from typing import (
-    Dict,
-    Generator
-)
+from typing import Dict, Generator
 
 import networkx as nx
 from networkx.utils import not_implemented_for

--- a/networkx/algorithms/d_fragmentation.py
+++ b/networkx/algorithms/d_fragmentation.py
@@ -1,0 +1,378 @@
+"""
+Algorithm for computing a :math:s -club cluster graph (an undirected graph where
+all connected components have diameter at most :math:s) from a given graph :math:G.
+
+Given a positive integer :math:d, and an undirected simple graph :math:G,
+produce a d-club graph :math:G_d that is an induced subgraph
+of :math:G. Note that :math:G_d is not unique to :math:G.
+
+*d-fragmentation* is the process of removing a minimum number of edges from a
+graph :math:G such that the resultant graph is a *d-club* cluster graph. See [1]_ for a formal
+definition of a *d-club*.
+
+This implementation is for simple undirected forests and
+is based on the linear time algorithm presented in [2]_.
+
+
+Examples
+--------
+
+>>>
+>>> # A forest F with two trees.
+... F = nx.Graph()
+>>> F.add_edges_from(
+...     [
+...         ("a", "b"),
+...         ("a", "c"),
+...         ("c", "d"),
+...         ("b", "e"),
+...         ("b", "f"),
+...         ("f", "g"),
+...         ("f", "h"),
+...         ("f", "i"),
+...         ("j", "k"),
+...         ("j", "m"),
+...         ("k", "l"),
+...         ("m", "n"),
+...         ("m", "o"),
+...         ("m", "q"),
+...         ("q", "p"),
+...         ("q", "r"),
+...     ]
+... )
+>>>
+>>> d = 2
+>>> # A set of edges of minimum cardinality
+>>> # that must be deleted to obtain a maximum 2-club from F.
+>>> edge_cut = nx.d_fragmented(F, d)
+>>> edge_cut_list = list(edge_cut)
+>>> sz = len(edge_cut_list)
+>>> sz
+4
+>>> # Since a 2-club cluster subgraph is not unique
+>>> # the actual edge_cut may vary but the size of all
+>>> # minimum edge_cuts should be `sz`.
+
+>>> d = 3
+>>> # A set of edges of minimum cardinality
+>>> # that must be deleted to obtain a maximum 3-club from F.
+>>> edge_cut = nx.d_fragmented(F, d)
+>>> edge_cut_list = list(edge_cut)
+>>> sz = len(edge_cut_list)
+>>> sz
+2
+>>> # Since a 3-club cluster subgraph is not unique
+>>> # the actual edge_cut may vary but the size of all
+>>> # minimum edge_cuts should be `sz`.
+>>> d = 4
+>>> # A set of edges of minimum cardinality
+>>> # that must be deleted to obtain a maximum 4-club from F.
+>>> edge_cut = nx.d_fragmented(F, d)
+>>> edge_cut_list = list(edge_cut)
+>>> sz = len(edge_cut_list)
+>>> sz
+2
+>>> # Since a 4-club cluster subgraph is not unique
+>>> # the actual edge_cut may vary but the size of all
+>>> # minimum edge_cuts should be `sz`.
+>>>
+>>> d = 5
+>>> # A set of edges of minimum cardinality
+>>> # that must be deleted to obtain a maximum 5-club from F.
+>>> # Note that since the diameter of both the components is 5,
+>>> # it is already a 5-club cluster graph.
+>>> # Hence no edges need to be removed from F.
+>>>
+>>> edge_cut = nx.d_fragmented(F, d)
+>>> edge_cut_list = list(edge_cut)
+>>> sz = len(edge_cut_list)
+>>> sz
+0
+
+
+References
+----------
+
+..  [1] Schafer, A. (2009). Diploma Thesis. Friedrich Schiller University Jena Faculty of Mathematics and Computer Science. [Exact Algorithms for s-Club Finding and Related Problems](https://pure.mpg.de/rest/items/item_1587743_4/component/file_1587742/content)
+
+..  [2] Oellerman, O., Patel, A. (2020). The s-club deletion problem on various graph families. (Work in Progress). University of Winnipeg, Canada.
+
+"""
+
+
+from typing import (
+    Dict,
+    Generator
+)
+
+import networkx as nx
+from networkx.utils import not_implemented_for
+from networkx.algorithms.tree import recognition
+from networkx.algorithms import matching
+from networkx.algorithms.components import connected
+from operator import itemgetter
+
+
+__all__ = ["d_fragmented"]
+
+
+@not_implemented_for("directed", "multigraph")
+def _is_forest(G: nx.Graph) -> bool:
+    """
+    A local helper that determines if a given graph
+    is a forest (i.e. a collection of pair-wise disconnected trees).
+
+    Parameters
+    ----------
+    G: A networkX graph.
+
+    Returns
+    -------
+    True if G is a forest, False otherwise.
+    """
+    return recognition.is_forest(G)
+
+
+@not_implemented_for("directed", "multigraph")
+def d_fragmented(G: nx.Graph, d: int) -> Generator:
+    """
+    Given a simple undirected graph G, compute a
+    d-club cluster graph.
+
+    Parameters
+    ----------
+    G: A networkX graph instance.
+        Any simple undirected graph.
+    d: A non-negative int.
+        The club-size of a cluster graph.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        The case where G is not a Forest and d > 1 is not
+        supported.
+
+
+    Yields
+    -------
+    edge: Tuple
+        Tuples that represent undirected edges
+        between nodes of G.
+
+
+    Notes
+    ______
+
+    Runs in O(|V(G)|) if
+    G is a Forest (a collection of
+    pair-wise disconnected trees).
+    This algorithm is provided in
+    [1]_.
+
+    If G is not a Forest and d = 1,
+    then it relies on an efficient
+    implementation of maximum matching
+    algorithms in arbitrary graphs (like
+    Edmonds' blossom algorithm, or Micali-Vazirani Matching).
+
+    In this case, the implementation of Edmonds' blossom
+    algorithm (runs in O(|V|^2 * |E|)) is used
+    because it is available in networkX.
+
+    In contrast to that, Micali-Vazirani Matching
+    runs in O(sqrt(|V|) * |E|) which is significantly
+    faster but the algorithm itself is extremely complicated
+    to implement.
+
+
+    If more results are known, it is encouraged to add to this file
+    the support for more cases.
+
+    References
+    ----------
+    .. [1] Oellerman, O., Patel, A.,
+        The s-club deletion problem on various graph families,
+        University of Winnipeg, Canada, 2020.
+
+    """
+    if d < 0:
+        raise ValueError("Note d cannot be negative.")
+    elif d == 0:
+        yield from G.edges
+    elif _is_forest(G):
+        for comp in connected.connected_components(G):
+            h = G.subgraph(comp)
+            if len(h) > 1:
+                yield from iter(_d_fragment_tree(h, d))
+    elif d == 1:
+        # Note M is a maximum matching in G if and only if
+        # G[G-M] is a 1-fragmentation of G.
+        mwm = matching.max_weight_matching(G)
+        yield from iter(set(G.edges()) - set(mwm))
+    else:
+        # TODO: Implement d-fragmentation for arbitrary graphs
+
+        no_good_algorithm_known = """
+            If d > 1, then no fast algorithms of d-fragmentation are known for graphs that are not forests.
+            In fact, the problem of extracting a maximum d-club cluster graph from an arbitrary graph
+            for d >= 2 is known to be NP-Complete.
+
+            The current implementation only supports forests for d >= 1 or general graphs for d = 1.
+            If you know one, please consider adding it to NetworkX by following:
+
+            https://github.com/networkx/networkx/blob/master/CONTRIBUTING.rst
+        """
+        raise nx.exception.NetworkXNotImplemented(no_good_algorithm_known)
+
+
+def _is_leaf(G: nx.Graph, node):
+    """
+    Return True if node is a leaf,
+    False otherwise.
+    """
+
+    return len(list(G.neighbors(node))) == 1
+
+
+def _get_node_with_highest_degree(G: nx.Graph):
+    """
+    Get a random node from the vertex
+    set of the graph.
+    """
+    if len(list(G.nodes)) == 0:
+        raise ValueError("Empty graph has no nodes.")
+    heaviest_node = max(list(G.nodes), key=lambda x: G.degree[x])
+    return heaviest_node
+
+
+def _d_fragment_tree_helper(G: nx.Graph, parent, node, sub_ecc: Dict, d: int, edge_set):
+    """
+    A helper for recursive computation
+    of a d-club cluster graph from G.
+
+    Parameters
+    ----------
+    G: networkX.graph()
+        A Tree.
+    parent: node
+        Some vertex of G. It could be a sentinel as well if node is the root.
+    node: node
+        Some vertex of G. This cannot be sentinel.
+    sub_ecc: dict
+        A dictionary of computed eccentricities
+        for subtrees rooted at some vertex.
+    d: int
+        A positive int.
+    edge_set: Set
+        A set that collects the edges that
+        form an edge cut.
+
+    Returns
+    -------
+    sub_ecc, edge_set: Tuple
+        A tuple (sub_ecc, edge_set) where `sub_ecc`
+        is a populated dictionary of computed
+        eccentricities for subtrees rooted at some vertex
+        and `edge_set` is a minimum edge cut.
+    """
+    if _is_leaf(G, node):
+        sub_ecc[node] = 0
+    else:
+        for n in G.neighbors(node):
+            if n != parent:
+                _d_fragment_tree_helper(G, node, n, sub_ecc, d, edge_set)
+
+        ecc_values = []
+
+        for c in G.neighbors(node):
+            if c in sub_ecc and c != parent:
+                ecc_values.append((c, sub_ecc[c]))
+
+        values = sorted(ecc_values, key=itemgetter(1), reverse=True)
+
+        if len(values) == 1:
+            child, child_ecc = values[0]
+
+            if child_ecc >= d:
+                edge_set |= {(child, node)}
+                sub_ecc[node] = 0
+            else:
+                sub_ecc[node] = sub_ecc[child] + 1
+        else:
+            no_more = False
+
+            for _counter in range(len(values) - 1):
+                _first = values[_counter]
+                _second = values[_counter + 1]
+
+                child_first, ecc_first = _first
+                child_second, ecc_second = _second
+
+                if ecc_first + ecc_second + 2 >= d + 1:
+                    edge_set |= {(child_first, node)}
+                else:
+                    sub_ecc[node] = sub_ecc[child_first] + 1
+                    no_more = True
+                    break
+
+            if not no_more:
+                child_last, ecc_last = values[-1]
+                if ecc_last >= d:
+                    edge_set |= {(child_last, node)}
+                    sub_ecc[node] = 0
+                else:
+                    sub_ecc[node] = sub_ecc[child_last] + 1
+    return sub_ecc, edge_set
+
+
+def _d_fragment_tree(G: nx.Graph, d: int):
+    """
+    Compute the minimum edge cut
+    that transforms G into a
+    d-club cluster graph.
+
+    Parameters
+    ----------
+    G: A networkX graph.
+        A tree.
+    d: A non-negative int
+        The club-size for a cluster graph of G.
+
+    Returns
+    -------
+
+    """
+    node = _get_node_with_highest_degree(G)
+    sub_ecc = dict()
+    parent = -1
+    edge_set = set()
+    ecc, edges = _d_fragment_tree_helper(G, parent, node, sub_ecc, d, edge_set)
+    return edges
+
+
+# Leaving the following function commented
+# so that if more d-fragmentation algorithms are added
+# in future, then they can be tested locally.
+
+# def tester():
+#     adjacency = {
+#         0: {1, 6},
+#         1: {0, 3},
+#         2: {3},
+#         3: {1, 2},
+#         4: {7},
+#         5: {7},
+#         6: {0, 7},
+#         7: {4, 5, 6}
+#     }
+#
+#     def get_edges_from_adjacency(adj):
+#         return [(u, v) for u, nbrs in adj.items() for v in nbrs]
+#
+#     g = nx.Graph()
+#     g.update(edges=get_edges_from_adjacency(adjacency), nodes=adjacency)
+#
+#     # print(_is_forest(G))
+#     for edg in d_fragmented(g, 2):
+#         print(edg)
+#         pass

--- a/networkx/algorithms/tests/test_d_fragmentation.py
+++ b/networkx/algorithms/tests/test_d_fragmentation.py
@@ -1,0 +1,224 @@
+import pytest
+import networkx
+import networkx as nx
+import networkx.generators.trees as tree_constructors
+import networkx.algorithms.d_fragmentation as sut
+import random as rand
+from networkx.algorithms.shortest_paths.unweighted import single_source_shortest_path_length as sssp
+from networkx.algorithms.shortest_paths.unweighted import all_pairs_shortest_path_length as apsp
+from networkx.algorithms.tree import recognition
+from networkx.algorithms.components import connected
+import networkx.exception as nx_exceptions
+from networkx.generators.random_graphs import gnm_random_graph
+
+
+TREE_SIZE = {
+    'LOWER_BOUND': 1,
+    'UPPER_BOUND': 10000
+}
+
+# The value for d in the d-club.
+CLUB_SIZE = {
+    'LOWER_BOUND': 1,
+    'UPPER_BOUND': 50
+}
+
+
+def _get_random_number_from_bound(l_bound: int, u_bound: int):
+    assert min(l_bound, u_bound) >= 0
+    assert u_bound >= l_bound
+    return rand.randint(l_bound, u_bound)
+
+
+def _get_random_number_of_nodes():
+    return _get_random_number_from_bound(TREE_SIZE['LOWER_BOUND'], TREE_SIZE['UPPER_BOUND'])
+
+
+def _get_random_number_of_edges(nodes):
+    upper_edges = max(0, (nodes * (nodes - 1))//2)
+    # To get a sparse graph, we divide the upper bound of edges by a large
+    # enough number like 2**5.
+    return _get_random_number_from_bound(0, upper_edges // (2**5))
+
+
+def _get_random_club_size():
+    return _get_random_number_from_bound(CLUB_SIZE['LOWER_BOUND'], CLUB_SIZE['UPPER_BOUND'])
+
+
+def _get_random_tree():
+    num_nodes = _get_random_number_of_nodes()
+    return tree_constructors.random_tree(num_nodes)
+
+
+def _remove_edges(g: nx.Graph, edges_to_remove):
+    nx.freeze(g)
+    h = nx.Graph(g)
+    h.remove_edges_from(edges_to_remove)
+    return h
+
+
+def _get_random_node(G: nx.Graph):
+    it = list(G.nodes)
+    return it[0]
+
+
+def _get_non_tree_diameter(g: nx.Graph) -> int:
+    """
+
+    Parameters
+    ----------
+    g
+
+    Returns
+    -------
+
+    """
+    apsp_values = dict(apsp(g))
+
+    highest = 0
+
+    for x in g.nodes:
+        for y in g.nodes:
+            highest = max(highest, apsp_values[x][y])
+    return highest
+
+
+def _get_tree_diameter(tree: nx.Graph) -> int:
+    """
+    Calculate the diameter of the tree using the
+    classic two BFS/DFS approach.
+
+    Parameters
+    ----------
+    tree: An unweighted undirected simple Tree.
+
+    Returns
+    -------
+    The diameter of the tree.
+    """
+    start = _get_random_node(tree)
+    distances_from_start = sssp(tree, start)
+
+    if len(distances_from_start) == 0:
+        return 0
+
+    antipodal_one = max(distances_from_start, key=lambda x: distances_from_start[x])
+    distances_from_antipodal_one = sssp(tree, antipodal_one)
+    antipodal_two = max(distances_from_antipodal_one, key=lambda x: distances_from_antipodal_one[x])
+
+    return distances_from_antipodal_one[antipodal_two]
+
+
+def _get_diameters_of_components(g: nx.Graph):
+    """
+
+    Parameters
+    ----------
+    g: A networkX graph.
+
+    Returns
+    -------
+    The diameters of its connected components in some order.
+    """
+    for comp in connected.connected_components(g):
+        h = g.subgraph(comp)
+        if not recognition.is_tree(h):
+            yield _get_non_tree_diameter(h)
+        else:
+            yield _get_tree_diameter(h)
+
+
+def d_fragmentation_in_graphs(g: nx.Graph, d: int):
+    """
+    A testing helper that tests if the result of the
+    `d-fragmented` algorithm on g produces a d-club cluster graph.
+
+    A computation verification of optimality is through a brute force
+    in which, one tries removing every subset of size smaller than that
+    produced by `d-fragmented` and verifying if the resultant graph is
+    a d-club cluster graph.
+
+    Due to its exponential runtime, we rely on a proof of correctness
+    given in a (WIP) paper by Oellerman O., and Patel A. (2020).
+
+    Parameters
+    ----------
+    g: A networkX graph.
+    d: The size of the club.
+
+    Returns
+    -------
+    None
+
+    """
+    if d < 0:
+        with pytest.raises(ValueError):
+            sut.d_fragmented(g, d)
+        return
+    elif d == 0:
+        assert set(sut.d_fragmented(g, d)) == set(g.edges)
+        return
+    if not recognition.is_forest(g):
+        if d != 1:
+            with pytest.raises(networkx.exception.NetworkXNotImplemented) as e:
+                sut.d_fragmented(g, d)
+    chosen_edges = list(sut.d_fragmented(g, d))
+    h = _remove_edges(g, chosen_edges)
+    diam_list = list(_get_diameters_of_components(h))
+
+    # After removing the selected edge_set,
+    # check that the diameter in all the components
+    # of the resultant graph is at most d.
+    # Hence the resultant graph is a d-club cluster graph.
+
+    assert max(diam_list) <= d
+
+    return
+
+
+def test_multiple(count: int = 5):
+    """
+    Test the `d-fragmented` algorithm on
+    multiple random trees and graphs
+    on some order (defined in `TREE_SIZE`, and
+    `CLUB_SIZE`).
+
+    Parameters
+    ----------
+    count: The number of graphs to be tested.
+
+    Returns
+    -------
+    None
+    """
+    trees = int(count * 0.8)
+    non_trees = count - trees
+
+    # Check some random trees on some order.
+    for _ in range(trees):
+        g = _get_random_tree()
+        d = _get_random_club_size()
+        d_fragmentation_in_graphs(g, d)
+    # Check some random graphs on some order.
+    for _ in range(non_trees):
+        # There are only two cases really:
+        # d = 1 or d > 1.
+
+        # The current implementation only works for
+        # d = 1.
+        # If d > 1, then a NetworkXNotImplemented Exception
+        # is thrown.
+        d = _get_random_number_from_bound(1, 2)
+        n = _get_random_number_from_bound(1, 100)
+        m = _get_random_number_of_edges(n)
+        g = gnm_random_graph(n, m)
+        d_fragmentation_in_graphs(g, d)
+
+    print(f'Tested d-club cluster graphs for {trees:02d} random trees and {non_trees:02d} random graphs successfully!')
+
+    return
+
+
+if __name__ == '__main__':
+    test_multiple()
+    pass

--- a/networkx/algorithms/tests/test_d_fragmentation.py
+++ b/networkx/algorithms/tests/test_d_fragmentation.py
@@ -4,24 +4,22 @@ import networkx as nx
 import networkx.generators.trees as tree_constructors
 import networkx.algorithms.d_fragmentation as sut
 import random as rand
-from networkx.algorithms.shortest_paths.unweighted import single_source_shortest_path_length as sssp
-from networkx.algorithms.shortest_paths.unweighted import all_pairs_shortest_path_length as apsp
+from networkx.algorithms.shortest_paths.unweighted import (
+    single_source_shortest_path_length as sssp,
+)
+from networkx.algorithms.shortest_paths.unweighted import (
+    all_pairs_shortest_path_length as apsp,
+)
 from networkx.algorithms.tree import recognition
 from networkx.algorithms.components import connected
 import networkx.exception as nx_exceptions
 from networkx.generators.random_graphs import gnm_random_graph
 
 
-TREE_SIZE = {
-    'LOWER_BOUND': 1,
-    'UPPER_BOUND': 10000
-}
+TREE_SIZE = {"LOWER_BOUND": 1, "UPPER_BOUND": 10000}
 
 # The value for d in the d-club.
-CLUB_SIZE = {
-    'LOWER_BOUND': 1,
-    'UPPER_BOUND': 50
-}
+CLUB_SIZE = {"LOWER_BOUND": 1, "UPPER_BOUND": 50}
 
 
 def _get_random_number_from_bound(l_bound: int, u_bound: int):
@@ -31,18 +29,22 @@ def _get_random_number_from_bound(l_bound: int, u_bound: int):
 
 
 def _get_random_number_of_nodes():
-    return _get_random_number_from_bound(TREE_SIZE['LOWER_BOUND'], TREE_SIZE['UPPER_BOUND'])
+    return _get_random_number_from_bound(
+        TREE_SIZE["LOWER_BOUND"], TREE_SIZE["UPPER_BOUND"]
+    )
 
 
 def _get_random_number_of_edges(nodes):
-    upper_edges = max(0, (nodes * (nodes - 1))//2)
+    upper_edges = max(0, (nodes * (nodes - 1)) // 2)
     # To get a sparse graph, we divide the upper bound of edges by a large
     # enough number like 2**5.
-    return _get_random_number_from_bound(0, upper_edges // (2**5))
+    return _get_random_number_from_bound(0, upper_edges // (2 ** 5))
 
 
 def _get_random_club_size():
-    return _get_random_number_from_bound(CLUB_SIZE['LOWER_BOUND'], CLUB_SIZE['UPPER_BOUND'])
+    return _get_random_number_from_bound(
+        CLUB_SIZE["LOWER_BOUND"], CLUB_SIZE["UPPER_BOUND"]
+    )
 
 
 def _get_random_tree():
@@ -104,7 +106,9 @@ def _get_tree_diameter(tree: nx.Graph) -> int:
 
     antipodal_one = max(distances_from_start, key=lambda x: distances_from_start[x])
     distances_from_antipodal_one = sssp(tree, antipodal_one)
-    antipodal_two = max(distances_from_antipodal_one, key=lambda x: distances_from_antipodal_one[x])
+    antipodal_two = max(
+        distances_from_antipodal_one, key=lambda x: distances_from_antipodal_one[x]
+    )
 
     return distances_from_antipodal_one[antipodal_two]
 
@@ -214,11 +218,13 @@ def test_multiple(count: int = 5):
         g = gnm_random_graph(n, m)
         d_fragmentation_in_graphs(g, d)
 
-    print(f'Tested d-club cluster graphs for {trees:02d} random trees and {non_trees:02d} random graphs successfully!')
+    print(
+        f"Tested d-club cluster graphs for {trees:02d} random trees and {non_trees:02d} random graphs successfully!"
+    )
 
     return
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_multiple()
     pass


### PR DESCRIPTION

## An algorithm to produce maximum <img src="https://render.githubusercontent.com/render/math?math=\large d">-club cluster graphs as induced subgraphs.

### The theory that this PR is based on.

Given an undirected simple graph <img src="https://render.githubusercontent.com/render/math?math=\large G">, let <img src="https://render.githubusercontent.com/render/math?math=\large G_d"> denote an **induced subgraph** of <img src="https://render.githubusercontent.com/render/math?math=\large G"> with the following property:
- Every connected component <img src="https://render.githubusercontent.com/render/math?math=\large C"> of <img src="https://render.githubusercontent.com/render/math?math=\large G_d"> has diameter at most <img src="https://render.githubusercontent.com/render/math?math=\large d">.

Then <img src="https://render.githubusercontent.com/render/math?math=\large G_d"> is called a <img src="https://render.githubusercontent.com/render/math?math=\large d">-club cluster graph. Furthermore, if <img src="https://render.githubusercontent.com/render/math?math=\large G_d"> has the largest number of edges amongst all <img src="https://render.githubusercontent.com/render/math?math=\large d">-club cluster graphs of <img src="https://render.githubusercontent.com/render/math?math=\large G">, then

<img src="https://render.githubusercontent.com/render/math?math=\large\lambda_d(G) = |E(G)| - |E(G_d)|">

denotes the minimum number of edges to be deleted from <img src="https://render.githubusercontent.com/render/math?math=\large G"> to produce a <img src="https://render.githubusercontent.com/render/math?math=\large d">-club cluster graph.

### What does this PR include?
In this PR, I have added an algorithm to compute <img src="https://render.githubusercontent.com/render/math?math=\large\lambda_d(G)"> (along with a set of edges, i.e. a **minimum edge-cut**) if <img src="https://render.githubusercontent.com/render/math?math=\large G"> is a forest (i.e. a collection of pair-wise disjoint trees), or if <img src="https://render.githubusercontent.com/render/math?math=\large d=1"> and <img src="https://render.githubusercontent.com/render/math?math=\large G"> is a general graph.

- For forests, the implemented algorithm runs in <img src="https://render.githubusercontent.com/render/math?math=\large O(|V|\cdot\Delta(G))"> where <img src="https://render.githubusercontent.com/render/math?math=\large\Delta(G)"> denotes the largest degree of a vertex in <img src="https://render.githubusercontent.com/render/math?math=\large V(G)">.

- For general graphs <img src="https://render.githubusercontent.com/render/math?math=\large G"> where <img src="https://render.githubusercontent.com/render/math?math=\large d = 1">, the algorithm relies on an efficient implementation of Maximum Matching in General Graphs. It uses the **Edmond's Blossom algorithm** implemented in [`networkx.algorithms.matching`](https://github.com/networkx/networkx/blob/master/networkx/algorithms/matching.py) and due to that, it runs in <img src="https://render.githubusercontent.com/render/math?math=\large O(|V|^2 |E|)">

Multiple computational tests have been performed on random trees and random graphs to ensure that the algorithm produces a <img src="https://render.githubusercontent.com/render/math?math=\large d">-club cluster graph from <img src="https://render.githubusercontent.com/render/math?math=\large G">. Due to the exponential nature of an optimality test using the brute-force approach, we rely on the proof of correctness provided in a paper (currently WIP) by Oellermann, O., and Patel, A (2020).

### Some additional comments:

There is plenty of room for further advancement by considering other graph families <img src="https://render.githubusercontent.com/render/math?math=\large\mathcal{G}"> and implementing <img src="https://render.githubusercontent.com/render/math?math=\large\lambda_d(G)"> for <img src="https://render.githubusercontent.com/render/math?math=\large G \in \mathcal{G}">.

*FWIW, it is known that the problem of producing maximum induced <img src="https://render.githubusercontent.com/render/math?math=\large d">-club cluster graph for arbitrary graphs <img src="https://render.githubusercontent.com/render/math?math=\large G"> where <img src="https://render.githubusercontent.com/render/math?math=\large d \geq 2"> is **NP-Complete**.

A [Diploma Thesis of Alexander Shafer](https://pure.mpg.de/rest/items/item_1587743_4/component/file_1587742/content) has some interesting algorithms that one can implement to extend support for various other graph families like **Interval Graphs**, **Planar Graphs**, **Bipartite Graphs**, and graphs of **bounded Treewidth/Cliquewidth**.