### PR TITLE
Update docstring for to_pandas_edgelist and add edgekey parameter

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -67,3 +67,4 @@ Version 3.0
 * Remove ``copy`` method in the coreview Filtered-related classes and related tests.
 * In ``algorithms/link_analysis/pagerank_alg.py`` replace ``pagerank`` with ``pagerank_scipy``.
 * In ``algorithms/link_analysis/pagerank_alg.py`` rename ``pagerank_numpy`` as ``_pagerank_numpy``.
+* In ``convert_matrix.py`` remove ``order`` kwarg from ``to_pandas_edgelist`` and docstring

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -46,6 +46,9 @@ API Changes
   addition to the API change this may cause a performance regression for
   large graphs.
 
+- [`#4384 <https://github.com/networkx/networkx/pull/4384>`_]
+  Added edge_key parameter for MultiGraphs in to_pandas_edgelist
+
 Deprecations
 ------------
 
@@ -67,6 +70,8 @@ Deprecations
   Deprecate ``pagerank_numpy``, ``pagerank_scipy``.
 - [`#4355 <https://github.com/networkx/networkx/pull/4355>`_]
   Deprecate ``copy`` method in the coreview Filtered-related classes.
+- [`#4384 <https://github.com/networkx/networkx/pull/4384>`_]
+  Deprecate unused ``order`` parameter in to_pandas_edgelist.
 
 
 Contributors to this release

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -241,7 +241,9 @@ def to_pandas_edgelist(
 
     order : None
         An unused parameter mistakenly included in the function.
-        This is deprecated and will be removed in NetworkX v3.0.
+
+        .. deprecated:: 2.6
+            This is deprecated and will be removed in NetworkX v3.0.
 
     edge_key : str or int or None, optional (default=None)
         A valid column name (string or integer) for the edge keys (for the
@@ -280,22 +282,22 @@ def to_pandas_edgelist(
         edgelist = G.edges(data=True)
     else:
         edgelist = G.edges(nodelist, data=True)
-    source_nodes = [s for s, t, d in edgelist]
-    target_nodes = [t for s, t, d in edgelist]
+    source_nodes = [s for s, _, _ in edgelist]
+    target_nodes = [t for _, t, _ in edgelist]
 
-    all_attrs = set().union(*(d.keys() for s, t, d in edgelist))
+    all_attrs = set().union(*(d.keys() for _, _, d in edgelist))
     if source in all_attrs:
         raise nx.NetworkXError(f"Source name '{source}' is an edge attr name")
     if target in all_attrs:
         raise nx.NetworkXError(f"Target name '{target}' is an edge attr name")
 
     nan = float("nan")
-    edge_attr = {k: [d.get(k, nan) for s, t, d in edgelist] for k in all_attrs}
+    edge_attr = {k: [d.get(k, nan) for _, _, d in edgelist] for k in all_attrs}
 
     if G.is_multigraph() and edge_key is not None:
         if edge_key in all_attrs:
             raise nx.NetworkXError(f"Edge key name '{edge_key}' is an edge attr name")
-        edge_keys = [k for s, t, k in G.edges(keys=True)]
+        edge_keys = [k for _, _, k in G.edges(keys=True)]
         edgelistdict = {source: source_nodes, target: target_nodes, edge_key: edge_keys}
     else:
         edgelistdict = {source: source_nodes, target: target_nodes}

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -209,7 +209,13 @@ def from_pandas_adjacency(df, create_using=None):
 
 
 def to_pandas_edgelist(
-    G, source="source", target="target", nodelist=None, dtype=None, order=None
+    G,
+    source="source",
+    target="target",
+    nodelist=None,
+    dtype=None,
+    order=None,
+    edge_key=None,
 ):
     """Returns the graph edge list as a Pandas DataFrame.
 
@@ -228,6 +234,18 @@ def to_pandas_edgelist(
 
     nodelist : list, optional
        Use only nodes specified in nodelist
+
+    dtype : dtype, default None
+        Use to create the DataFrame. Data type to force.
+        Only a single dtype is allowed. If None, infer.
+
+    order : None
+        An unused parameter mistakenly included in the function.
+        This is deprecated and will be removed in NetworkX v3.0.
+
+    edge_key : str or int or None, optional (default=None)
+        A valid column name (string or integer) for the edge keys (for the
+        multigraph case). If None, edge keys are not stored in the DataFrame.
 
     Returns
     -------
@@ -248,6 +266,13 @@ def to_pandas_edgelist(
     0      A      B     1       7
     1      C      E     9      10
 
+    >>> G = nx.MultiGraph([('A', 'B', {'cost': 1}), ('A', 'B', {'cost': 9})])
+    >>> df = nx.to_pandas_edgelist(G, nodelist=['A', 'C'], edge_key='ekey')
+    >>> df[['source', 'target', 'cost', 'ekey']]
+      source target  cost  ekey
+    0      A      B     1     0
+    1      A      B     9     1
+
     """
     import pandas as pd
 
@@ -258,18 +283,25 @@ def to_pandas_edgelist(
     source_nodes = [s for s, t, d in edgelist]
     target_nodes = [t for s, t, d in edgelist]
 
-    all_keys = set().union(*(d.keys() for s, t, d in edgelist))
-    if source in all_keys:
+    all_attrs = set().union(*(d.keys() for s, t, d in edgelist))
+    if source in all_attrs:
         raise nx.NetworkXError(f"Source name '{source}' is an edge attr name")
-    if target in all_keys:
+    if target in all_attrs:
         raise nx.NetworkXError(f"Target name '{target}' is an edge attr name")
 
     nan = float("nan")
-    edge_attr = {k: [d.get(k, nan) for s, t, d in edgelist] for k in all_keys}
+    edge_attr = {k: [d.get(k, nan) for s, t, d in edgelist] for k in all_attrs}
 
-    edgelistdict = {source: source_nodes, target: target_nodes}
+    if G.is_multigraph() and edge_key is not None:
+        if edge_key in all_attrs:
+            raise nx.NetworkXError(f"Edge key name '{edge_key}' is an edge attr name")
+        edge_keys = [k for s, t, k in G.edges(keys=True)]
+        edgelistdict = {source: source_nodes, target: target_nodes, edge_key: edge_keys}
+    else:
+        edgelistdict = {source: source_nodes, target: target_nodes}
+
     edgelistdict.update(edge_attr)
-    return pd.DataFrame(edgelistdict)
+    return pd.DataFrame(edgelistdict, dtype=dtype)
 
 
 def from_pandas_edgelist(

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -2,7 +2,7 @@ import pytest
 
 np = pytest.importorskip("numpy")
 sp = pytest.importorskip("scipy")
-sparse = sp.sparse
+sp_sparse = sp.sparse
 npt = np.testing
 
 import networkx as nx
@@ -213,7 +213,7 @@ class TestConvertScipy:
         creating a multigraph.
 
         """
-        A = sparse.csr_matrix([[1, 1], [1, 2]])
+        A = sp_sparse.csr_matrix([[1, 1], [1, 2]])
         # First, with a simple graph, each integer entry in the adjacency
         # matrix is interpreted as the weight of a single edge in the graph.
         expected = nx.DiGraph()
@@ -253,7 +253,7 @@ class TestConvertScipy:
         :func:`networkx.from_scipy_sparse_matrix`.
 
         """
-        A = sparse.csr_matrix([[0, 1], [1, 0]])
+        A = sp_sparse.csr_matrix([[0, 1], [1, 0]])
         G = nx.from_scipy_sparse_matrix(A, create_using=nx.MultiGraph)
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, weight=1)
@@ -275,5 +275,5 @@ def test_from_scipy_sparse_matrix_formats(sparse_format):
             (2, 1, {"weight": 1}),
         ]
     )
-    A = sparse.coo_matrix([[0, 3, 2], [3, 0, 1], [2, 1, 0]]).asformat(sparse_format)
+    A = sp_sparse.coo_matrix([[0, 3, 2], [3, 0, 1], [2, 1, 0]]).asformat(sparse_format)
     assert_graphs_equal(expected, nx.from_scipy_sparse_matrix(A))


### PR DESCRIPTION
Builds on  #4106 which added docs for `edge_key` to `from_pandas_edgelist`.
This adds an edge_key parameter to `to_pandas_edgeslist`.

Also deprecates the unused `order` parameter in `to_pandas_edgelist`
add line to deprecations.rst to remind to remove.
