### PR TITLE
code and doc fix for square_clustering algorithm in cluster.py

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -425,9 +425,9 @@ def square_clustering(G, nodes=None):
 
     where :math:`q_v(u,w)` are the number of common neighbors of :math:`u` and
     :math:`w` other than :math:`v` (ie squares), and :math:`a_v(u,w) = (k_u -
-    (1+q_v(u,w)+\theta_{uv}))(k_w - (1+q_v(u,w)+\theta_{uw}))`, where
+    (1+q_v(u,w)+\theta_{uv})) + (k_w - (1+q_v(u,w)+\theta_{uw}))`, where
     :math:`\theta_{uw} = 1` if :math:`u` and :math:`w` are connected and 0
-    otherwise.
+    otherwise. [2]_
 
     Parameters
     ----------
@@ -462,6 +462,9 @@ def square_clustering(G, nodes=None):
     .. [1] Pedro G. Lind, Marta C. González, and Hans J. Herrmann. 2005
         Cycles and clustering in bipartite networks.
         Physical Review E (72) 056127.
+    .. [2] Zhang, Peng et al. Clustering Coefficient and Community Structure of
+        Bipartite Networks. Physica A: Statistical Mechanics and its Applications 387.27 (2008): 6869–6875.
+        https://arxiv.org/abs/0710.0117v1
     """
     if nodes is None:
         node_iter = G
@@ -477,7 +480,7 @@ def square_clustering(G, nodes=None):
             degm = squares + 1
             if w in G[u]:
                 degm += 1
-            potential += (len(G[u]) - degm) * (len(G[w]) - degm) + squares
+            potential += (len(G[u]) - degm) + (len(G[w]) - degm) + squares
         if potential > 0:
             clustering[v] /= potential
     if nodes in G:

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -354,18 +354,18 @@ class TestSquareClustering:
     def test_cubical(self):
         G = nx.cubical_graph()
         assert list(nx.square_clustering(G).values()) == [
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
+            1/3,
+            1/3,
+            1/3,
+            1/3,
+            1/3,
+            1/3,
+            1/3,
+            1/3,
         ]
-        assert list(nx.square_clustering(G, [1, 2]).values()) == [0.5, 0.5]
-        assert nx.square_clustering(G, [1])[1] == 0.5
-        assert nx.square_clustering(G, [1, 2]) == {1: 0.5, 2: 0.5}
+        assert list(nx.square_clustering(G, [1, 2]).values()) == [1/3, 1/3]
+        assert nx.square_clustering(G, [1])[1] == 1/3
+        assert nx.square_clustering(G, [1, 2]) == {1: 1/3, 2: 1/3}
 
     def test_k5(self):
         G = nx.complete_graph(5)
@@ -402,9 +402,23 @@ class TestSquareClustering:
         )
         G1 = G.subgraph([1, 2, 3, 4, 5, 13, 14, 15, 16])
         G2 = G.subgraph([1, 6, 7, 8, 9, 10, 11, 12])
-        assert nx.square_clustering(G, [1])[1] == 3 / 75.0
+        assert nx.square_clustering(G, [1])[1] == 3 / 43.0
         assert nx.square_clustering(G1, [1])[1] == 2 / 6.0
         assert nx.square_clustering(G2, [1])[1] == 1 / 5.0
+
+    def test_peng_square_clustering(self):
+        """Test eq2 for figure 1 Peng et al (2008)"""
+        G = nx.Graph(
+            [
+                (1, 2),
+                (1, 3),
+                (2, 4),
+                (3, 4),
+                (3, 5),
+                (3, 6),
+            ]
+        )
+        assert nx.square_clustering(G, [1])[1] == 1/3
 
 
 def test_average_clustering():

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -354,18 +354,18 @@ class TestSquareClustering:
     def test_cubical(self):
         G = nx.cubical_graph()
         assert list(nx.square_clustering(G).values()) == [
-            1/3,
-            1/3,
-            1/3,
-            1/3,
-            1/3,
-            1/3,
-            1/3,
-            1/3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
         ]
-        assert list(nx.square_clustering(G, [1, 2]).values()) == [1/3, 1/3]
-        assert nx.square_clustering(G, [1])[1] == 1/3
-        assert nx.square_clustering(G, [1, 2]) == {1: 1/3, 2: 1/3}
+        assert list(nx.square_clustering(G, [1, 2]).values()) == [1 / 3, 1 / 3]
+        assert nx.square_clustering(G, [1])[1] == 1 / 3
+        assert nx.square_clustering(G, [1, 2]) == {1: 1 / 3, 2: 1 / 3}
 
     def test_k5(self):
         G = nx.complete_graph(5)
@@ -418,7 +418,7 @@ class TestSquareClustering:
                 (3, 6),
             ]
         )
-        assert nx.square_clustering(G, [1])[1] == 1/3
+        assert nx.square_clustering(G, [1])[1] == 1 / 3
 
 
 def test_average_clustering():


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
Peng et al. propose a modification of the clustering coefficient based on the work of Pedro G. Lind et al. On page 3, They give a counterexample that shows the equation by Lind et al. gives the incorrect number of squares for a particular graph.

Basically it boils down to changing this code:

potential += (len(G[u]) - degm) * (len(G[w]) - degm) + squares

to this:

potential += (len(G[u]) - degm) + (len(G[w]) - degm) + squares


I also updated the documentation and the unit tests (and added a new unit test).