### PR TITLE
Safer repr format of variables

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -590,11 +590,11 @@ class MaxWeightClique(object):
         else:
             for v in G.nodes():
                 if weight not in G.nodes[v]:
-                    err = "Node {} does not have the requested weight field."
-                    raise KeyError(err.format(v))
+                    errmsg = f"Node {v!r} does not have the requested weight field."
+                    raise KeyError(errmsg)
                 if not isinstance(G.nodes[v][weight], int):
-                    err = "The '{}' field of node {} is not an integer."
-                    raise ValueError(err.format(weight, v))
+                    errmsg = f"The {weight!r} field of node {v!r} is not an integer."
+                    raise ValueError(errmsg)
             self.node_weights = {v: G.nodes[v][weight] for v in G.nodes()}
 
     def update_incumbent_if_improved(self, C, C_weight):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -391,7 +391,7 @@ class Graph:
         return "".join(
             [
                 type(self).__name__,
-                f" named '{self.name}'" if self.name else "",
+                f" named {self.name!r}" if self.name else "",
                 f" with {self.number_of_nodes()} nodes and {self.number_of_edges()} edges",
             ]
         )

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -287,16 +287,16 @@ def to_pandas_edgelist(
 
     all_attrs = set().union(*(d.keys() for _, _, d in edgelist))
     if source in all_attrs:
-        raise nx.NetworkXError(f"Source name '{source}' is an edge attr name")
+        raise nx.NetworkXError(f"Source name {source!r} is an edge attr name")
     if target in all_attrs:
-        raise nx.NetworkXError(f"Target name '{target}' is an edge attr name")
+        raise nx.NetworkXError(f"Target name {target!r} is an edge attr name")
 
     nan = float("nan")
     edge_attr = {k: [d.get(k, nan) for _, _, d in edgelist] for k in all_attrs}
 
     if G.is_multigraph() and edge_key is not None:
         if edge_key in all_attrs:
-            raise nx.NetworkXError(f"Edge key name '{edge_key}' is an edge attr name")
+            raise nx.NetworkXError(f"Edge key name {edge_key!r} is an edge attr name")
         edge_keys = [k for _, _, k in G.edges(keys=True)]
         edgelistdict = {source: source_nodes, target: target_nodes, edge_key: edge_keys}
     else:

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -152,7 +152,7 @@ def spectral_graph_forge(G, alpha, transformation="identity", seed=None):
     level = int(round(n * alpha))
 
     if transformation not in available_transformations:
-        msg = f"'{transformation}' is not a valid transformation. "
+        msg = f"{transformation!r} is not a valid transformation. "
         msg += f"Transformations: {available_transformations}"
         raise nx.NetworkXError(msg)
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -307,7 +307,7 @@ def _get_fiedler_func(method):
                 return sigma[0], X[:, 0]
 
     else:
-        raise nx.NetworkXError(f"unknown method '{method}'.")
+        raise nx.NetworkXError(f"unknown method {method!r}.")
 
     return find_fiedler
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -422,7 +422,7 @@ def parse_gml_lines(lines, label, destringizer):
         try:
             return dct.pop(attr)
         except KeyError as e:
-            raise NetworkXError(f"{category} #{i} has no '{attr}' attribute") from e
+            raise NetworkXError(f"{category} #{i} has no {attr!r} attribute") from e
 
     nodes = graph.get("node", [])
     mapping = {}


### PR DESCRIPTION
Replace `…'{x}'…` with `…{x!r}…` when formatting unknown string values. This will correctly escape quotes.
