### PR TITLE
Handle self-loops for single self-loop (drawing)

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -705,6 +705,12 @@ def draw_networkx_edges(
     def _connectionstyle(posA, posB, *args, **kwargs):
         # check if we need to do a self-loop
         if np.all(posA == posB):
+            # Compute width and height from all node positions.
+            # Prevents patches with 0 extent when nodelist or edgelist contains
+            # a single value
+            allpos = np.asarray(list(pos.values()))
+            w = np.ptp(allpos[:, 0])
+            h = np.ptp(allpos[:, 1])
             # this is called with _screen space_ values so covert back
             # to data space
             data_loc = ax.transData.inverted().transform(posA)

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -702,19 +702,21 @@ def draw_networkx_edges(
 
     base_connection_style = mpl.patches.ConnectionStyle(connectionstyle)
 
+    # Fallback for self-loop scale. Left outside of _connectionstyle so it is
+    # only computed once
+    max_nodesize = np.array(node_size).max()
+
     def _connectionstyle(posA, posB, *args, **kwargs):
         # check if we need to do a self-loop
         if np.all(posA == posB):
-            # Compute width and height from all node positions.
-            # Prevents patches with 0 extent when nodelist or edgelist contains
-            # a single value
-            allpos = np.asarray(list(pos.values()))
-            w = np.ptp(allpos[:, 0])
-            h = np.ptp(allpos[:, 1])
+            # Self-loops are scaled by view extent, except in cases the extent
+            # is 0, e.g. for a single node. In this case, fall back to scaling
+            # by the maximum node size
+            selfloop_ht = 0.005 * max_nodesize if h == 0 else h
             # this is called with _screen space_ values so covert back
             # to data space
             data_loc = ax.transData.inverted().transform(posA)
-            v_shift = 0.1 * h
+            v_shift = 0.1 * selfloop_ht
             h_shift = v_shift * 0.5
             # put the top of the loop first so arrow is not hidden by node
             path = [

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -320,6 +320,25 @@ def test_draw_edges_min_source_target_margins(node_shape):
     plt.delaxes(ax)
 
 
+def test_nonzero_selfloop_with_single_edge_in_edgelist():
+    """Ensure that selfloop extent is non-zero when only a single edge is
+    specified in the edgelist.
+    """
+    # Create explicit axis object for test
+    fig, ax = plt.subplots()
+    # Graph with selfloop
+    G = nx.path_graph(2)
+    G.add_edge(1, 1)
+    pos = {n: (n, n) for n in G.nodes}
+    # Draw only the selfloop edge via the `edgelist` kwarg
+    patch = nx.draw_networkx_edges(G, pos, edgelist=[(1, 1)])[0]
+    # The resulting patch must have non-zero extent
+    bbox = patch.get_extents()
+    assert bbox.width > 0 and bbox.height > 0
+    # Cleanup
+    plt.delaxes(ax)
+
+
 def test_apply_alpha():
     """Test apply_alpha when there is a mismatch between the number of
     supplied colors and elements.

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -320,6 +320,23 @@ def test_draw_edges_min_source_target_margins(node_shape):
     plt.delaxes(ax)
 
 
+def test_nonzero_selfloop_with_single_node():
+    """Ensure that selfloop extent is non-zero when there is only one node."""
+    # Create explicit axis object for test
+    fig, ax = plt.subplots()
+    # Graph with single node + self loop
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_edge(0, 0)
+    # Draw
+    patch = nx.draw_networkx_edges(G, {0: (0, 0)})[0]
+    # The resulting patch must have non-zero extent
+    bbox = patch.get_extents()
+    assert bbox.width > 0 and bbox.height > 0
+    # Cleanup
+    plt.delaxes(ax)
+
+
 def test_nonzero_selfloop_with_single_edge_in_edgelist():
     """Ensure that selfloop extent is non-zero when only a single edge is
     specified in the edgelist.


### PR DESCRIPTION
Fixes a corner-case of the new self-loop drawing in `nx_pylab`.

The self-loop drawing code uses the width/height of the box formed by the edge positions to determine the size of the self-loop curve. The current code runs into problems if the user passes in an `edgelist` that contains only a single self-loop, as the computed width and height are then 0, which results in a FancyArrowPatch with 0 extent. Example:

```python
>>> G = nx.path_graph(2)
>>> G.add_edge(0, 0)
>>> pos = {n: (n, n) for n in G.nodes}
>>> nx.draw_networkx_nodes(G, pos)
>>> # Intend to draw only the self-loop
>>> nx.draw_networkx_edges(G, pos, edgelist=[(0, 0)])
```
**Expected**:
![expected](https://user-images.githubusercontent.com/1268991/101292864-f5b0f780-37c6-11eb-88f9-a5bb8f568c41.png)
**Observed**:
![obs](https://user-images.githubusercontent.com/1268991/101292835-c4d0c280-37c6-11eb-95bc-fb2dda859f29.png)



The fix proposed in this PR is to compute the width and height from *all* edge positions in the local scope of `_connectionstyle`.