### PR TITLE
Add gallery example for drawing self-loops.

### DIFF
--- a/examples/drawing/plot_selfloops.py
+++ b/examples/drawing/plot_selfloops.py
@@ -1,0 +1,29 @@
+"""
+==========
+Self-loops
+==========
+
+A self-loop is an edge that originates from and terminates the same node.
+This example shows how to draw self-loops with `nx_pylab`.
+
+"""
+import networkx as nx
+import matplotlib.pyplot as plt
+
+# Create a graph and add a self-loop to node 0
+G = nx.complete_graph(3, create_using=nx.DiGraph)
+G.add_edge(0, 0)
+pos = nx.circular_layout(G)
+
+# As of version 2.6, self-loops are drawn by default with the same styling as
+# other edges
+nx.draw(G, pos, with_labels=True)
+
+# Add self-loops to the remaining nodes
+edgelist = [(1, 1), (2, 2)]
+G.add_edges_from(edgelist)
+
+# Draw the newly added self-loops with different formatting
+nx.draw_networkx_edges(G, pos, edgelist=edgelist, arrowstyle="<|-", style="dashed")
+
+plt.show()


### PR DESCRIPTION
Inspired by and hopefully closes #4406

Adds an example related to drawing self-loops (with pylab) to the gallery.

I wasn't sure if it should be "selfloop" or "self-loop"... I went with the latter, but please correct me if that's the wrong terminology.