### PR TITLE
Add coreview objects to documentation

### DIFF
--- a/doc/reference/classes/index.rst
+++ b/doc/reference/classes/index.rst
@@ -59,6 +59,25 @@ Graph Views
    subgraph_view
    reverse_view
 
+Core Views
+==========
+
+.. automodule:: networkx.classes.coreviews
+.. autosummary::
+   :toctree: generated/
+
+   AtlasView
+   AdjacencyView
+   MultiAdjacencyView
+   UnionAtlas
+   UnionAdjacency
+   UnionMultiInner
+   UnionMultiAdjacency
+   FilterAtlas
+   FilterAdjacency
+   FilterMultiInner
+   FilterMultiAdjacency
+
 Filters
 =======
 

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -1,4 +1,6 @@
-"""
+"""Views of core data structures such as nested Mappings (e.g. dict-of-dicts).
+These ``Views`` often restrict element access, with either the entire view or
+layers of nested mappings being read-only.
 """
 import warnings
 from collections.abc import Mapping


### PR DESCRIPTION
Adds the `coreviews` module and all classes defined therein to the reference guide.

A few things I was unsure about:
 - Where to add this to the documentation. I went with `reference/classes/index.rst` because it felt like it fit in with `Graph Views` and `Filters` sections, though it is unfortunate that it gets nested under "Graph Types" top-level heading.
 - I tried to briefly summarize the `coreviews` module in the module docstring (which provides the summary for this section in the reference guide), but I'm sure that could be massively improved.
 - The `Filter*View` objects are all missing class docstrings, so the generated documentation for these classes is bad. Maybe they should be removed from the `autosummary` (at least for now)?

Closes #4397