### PR TITLE
improve group betweenness centrality

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -225,7 +225,7 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
         else:  # use Dijkstra's algorithm
             S, P, sigma, D = _single_source_dijkstra_path_basic(G, s, weight)
         # accumulation
-        betweenness, delta = _accumulate_edges(betweenness, S, P, sigma, s)
+        betweenness = _accumulate_edges(betweenness, S, P, sigma, s)
     # rescaling
     for n in G:  # remove nodes to only return edges
         del betweenness[n]

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -124,14 +124,14 @@ def betweenness_centrality(
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma = _single_source_shortest_path_basic(G, s)
+            S, P, sigma, D = _single_source_shortest_path_basic(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma = _single_source_dijkstra_path_basic(G, s, weight)
+            S, P, sigma, D = _single_source_dijkstra_path_basic(G, s, weight)
         # accumulation
         if endpoints:
-            betweenness = _accumulate_endpoints(betweenness, S, P, sigma, s)
+            betweenness, delta = _accumulate_endpoints(betweenness, S, P, sigma, s)
         else:
-            betweenness = _accumulate_basic(betweenness, S, P, sigma, s)
+            betweenness, delta = _accumulate_basic(betweenness, S, P, sigma, s)
     # rescaling
     betweenness = _rescale(
         betweenness,
@@ -221,11 +221,11 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma = _single_source_shortest_path_basic(G, s)
+            S, P, sigma, D = _single_source_shortest_path_basic(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma = _single_source_dijkstra_path_basic(G, s, weight)
+            S, P, sigma, D = _single_source_dijkstra_path_basic(G, s, weight)
         # accumulation
-        betweenness = _accumulate_edges(betweenness, S, P, sigma, s)
+        betweenness, delta = _accumulate_edges(betweenness, S, P, sigma, s)
     # rescaling
     for n in G:  # remove nodes to only return edges
         del betweenness[n]
@@ -268,7 +268,7 @@ def _single_source_shortest_path_basic(G, s):
             if D[w] == Dv + 1:  # this is a shortest path, count paths
                 sigma[w] += sigmav
                 P[w].append(v)  # predecessors
-    return S, P, sigma
+    return S, P, sigma, D
 
 
 def _single_source_dijkstra_path_basic(G, s, weight):
@@ -303,7 +303,7 @@ def _single_source_dijkstra_path_basic(G, s, weight):
             elif vw_dist == seen[w]:  # handle equal paths
                 sigma[w] += sigma[v]
                 P[w].append(v)
-    return S, P, sigma
+    return S, P, sigma, D
 
 
 def _accumulate_basic(betweenness, S, P, sigma, s):
@@ -315,7 +315,7 @@ def _accumulate_basic(betweenness, S, P, sigma, s):
             delta[v] += sigma[v] * coeff
         if w != s:
             betweenness[w] += delta[w]
-    return betweenness
+    return betweenness, delta
 
 
 def _accumulate_endpoints(betweenness, S, P, sigma, s):
@@ -328,7 +328,7 @@ def _accumulate_endpoints(betweenness, S, P, sigma, s):
             delta[v] += sigma[v] * coeff
         if w != s:
             betweenness[w] += delta[w] + 1
-    return betweenness
+    return betweenness, delta
 
 
 def _accumulate_edges(betweenness, S, P, sigma, s):

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -124,9 +124,9 @@ def betweenness_centrality(
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma, D = _single_source_shortest_path_basic(G, s)
+            S, P, sigma, _ = _single_source_shortest_path_basic(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma, D = _single_source_dijkstra_path_basic(G, s, weight)
+            S, P, sigma, _ = _single_source_dijkstra_path_basic(G, s, weight)
         # accumulation
         if endpoints:
             betweenness, delta = _accumulate_endpoints(betweenness, S, P, sigma, s)
@@ -221,9 +221,9 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma, D = _single_source_shortest_path_basic(G, s)
+            S, P, sigma, _ = _single_source_shortest_path_basic(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma, D = _single_source_dijkstra_path_basic(G, s, weight)
+            S, P, sigma, _ = _single_source_dijkstra_path_basic(G, s, weight)
         # accumulation
         betweenness = _accumulate_edges(betweenness, S, P, sigma, s)
     # rescaling

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -102,9 +102,9 @@ def betweenness_centrality_subset(G, sources, targets, normalized=False, weight=
     for s in sources:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma, D = shortest_path(G, s)
+            S, P, sigma, _ = shortest_path(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma, D = dijkstra(G, s, weight)
+            S, P, sigma, _ = dijkstra(G, s, weight)
         b = _accumulate_subset(b, S, P, sigma, s, targets)
     b = _rescale(b, len(G), normalized=normalized, directed=G.is_directed())
     return b
@@ -182,9 +182,9 @@ def edge_betweenness_centrality_subset(
     for s in sources:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma, D = shortest_path(G, s)
+            S, P, sigma, _ = shortest_path(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma, D = dijkstra(G, s, weight)
+            S, P, sigma, _ = dijkstra(G, s, weight)
         b = _accumulate_edges_subset(b, S, P, sigma, s, targets)
     for n in G:  # remove nodes to only return edges
         del b[n]

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -102,9 +102,9 @@ def betweenness_centrality_subset(G, sources, targets, normalized=False, weight=
     for s in sources:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma = shortest_path(G, s)
+            S, P, sigma, D = shortest_path(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma = dijkstra(G, s, weight)
+            S, P, sigma, D = dijkstra(G, s, weight)
         b = _accumulate_subset(b, S, P, sigma, s, targets)
     b = _rescale(b, len(G), normalized=normalized, directed=G.is_directed())
     return b
@@ -182,9 +182,9 @@ def edge_betweenness_centrality_subset(
     for s in sources:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma = shortest_path(G, s)
+            S, P, sigma, D = shortest_path(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma = dijkstra(G, s, weight)
+            S, P, sigma, D = dijkstra(G, s, weight)
         b = _accumulate_edges_subset(b, S, P, sigma, s, targets)
     for n in G:  # remove nodes to only return edges
         del b[n]

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -7,7 +7,7 @@ from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.centrality.betweenness import (
     _single_source_shortest_path_basic,
     _single_source_dijkstra_path_basic,
-    _accumulate_endpoints
+    _accumulate_endpoints,
 )
 
 
@@ -64,8 +64,9 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
 
     Returns
     -------
-    betweenness : list of floats
-       The list of group betweenness centrality of the groups C.
+    betweenness : list of floats or float
+       If C is a list with single group then return a float. If C is a list with
+       several groups then return a list of group betweenness centralities.
 
     See Also
     --------
@@ -217,14 +218,14 @@ def _group_preprocessing(G, set_v, weight):
                 # if node is connected to the two group nodes than continue
                 if group_node2 in D[node] and group_node1 in D[node]:
                     if (
-                            D[node][group_node2]
-                            == D[node][group_node1] + D[group_node1][group_node2]
+                        D[node][group_node2]
+                        == D[node][group_node1] + D[group_node1][group_node2]
                     ):
                         PB[group_node1][group_node2] += (
-                                delta[node][group_node2]
-                                * sigma[node][group_node1]
-                                * sigma[group_node1][group_node2]
-                                / sigma[node][group_node2]
+                            delta[node][group_node2]
+                            * sigma[node][group_node1]
+                            * sigma[group_node1][group_node2]
+                            / sigma[node][group_node2]
                         )
     return PB, sigma, D
 

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -100,12 +100,9 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
 
     """
     GBC = []  # initialize betweenness
-    V = set(G)  # set of nodes in G
 
     #  check weather C contains one or many groups
-    if not any(isinstance(el, list) for el in C) and not any(
-        isinstance(el, set) for el in C
-    ):
+    if any(el in G for el in C):
         C = [C]
     set_v = {node for group in C for node in group}
     if set_v - G.nodes:  # element(s) of C not in G

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -121,10 +121,19 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
         for group_node2 in set_v:
             for node in G:
                 # if node isn't connected to the two group nodes than continue
-                if D[node][group_node2] != float("inf") or D[node][group_node1] != float("inf"):
-                    if D[node][group_node2] == D[node][group_node1] + D[group_node1][group_node2]:
-                        PB[group_node1][group_node2] += delta[node][group_node2]*sigma[node][group_node1] * \
-                                                        sigma[group_node1][group_node2]/sigma[node][group_node2]
+                if D[node][group_node2] != float("inf") or D[node][
+                    group_node1
+                ] != float("inf"):
+                    if (
+                            D[node][group_node2]
+                            == D[node][group_node1] + D[group_node1][group_node2]
+                    ):
+                        PB[group_node1][group_node2] += (
+                            delta[node][group_node2]
+                            * sigma[node][group_node1]
+                            * sigma[group_node1][group_node2]
+                            / sigma[node][group_node2]
+                        )
 
     # the algorithm for each group
     for group in C:
@@ -143,7 +152,7 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
                     dxyv = 0
                     dvxy = 0
                     if not (
-                            sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[y][v] == 0
+                        sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[y][v] == 0
                     ):
                         if D[x][v] == D[x][y] + D[y][v]:
                             dxyv = 1.0 * sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
@@ -191,7 +200,6 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
             if not G.is_directed():
                 scale *= 2
             GBC_group *= scale
-
 
         GBC.append(GBC_group)
     return GBC

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -178,6 +178,10 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
             scale = 1 / ((v - c) * (v - c - 1))
             GBC_group *= scale
 
+        # If undirected than count only the undirected edged
+        elif not G.is_directed():
+            GBC_group /= 2
+
         GBC.append(GBC_group)
     if list_of_groups:
         return GBC

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -125,7 +125,8 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
             S, P, sigma[s], D[s] = _single_source_dijkstra_path_basic(G, s, weight)
         betweenness, delta[s] = _accumulate_endpoints(betweenness, S, P, sigma[s], s)
         for i in delta[s].keys():  # add the paths from s to i and rescale sigma
-            delta[s][i] += 1
+            if s != i:
+                delta[s][i] += 1
             sigma[s][i] = sigma[s][i] / 2
     # building the path betweenness matrix only for nodes that appear in the group
     PB = dict.fromkeys(G)

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -103,7 +103,8 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     V = set(G)  # set of nodes in G
 
     #  check weather C contains one or many groups
-    if not any(isinstance(el, list) for el in C) and not any(isinstance(el, set) for el in C):
+    if not any(isinstance(el, list) for el in C) and not any(
+            isinstance(el, set) for el in C):
         C = [C]
     set_v = {node for group in C for node in group}
     if set_v - G.nodes:  # element(s) of C not in G

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -113,41 +113,9 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     set_v = {node for group in C for node in group}
     if set_v - G.nodes:  # element(s) of C not in G
         raise nx.NodeNotFound(f"The node(s) {set_v - G.nodes} are in C but not in G.")
+
     # pre-processing
-    sigma = {}
-    delta = {}
-    D = {}
-    betweenness = dict.fromkeys(G, 0)
-    for s in G:
-        if weight is None:  # use BFS
-            S, P, sigma[s], D[s] = _single_source_shortest_path_basic(G, s)
-        else:  # use Dijkstra's algorithm
-            S, P, sigma[s], D[s] = _single_source_dijkstra_path_basic(G, s, weight)
-        betweenness, delta[s] = _accumulate_endpoints(betweenness, S, P, sigma[s], s)
-        for i in delta[s].keys():  # add the paths from s to i and rescale sigma
-            if s != i:
-                delta[s][i] += 1
-            sigma[s][i] = sigma[s][i] / 2
-    # building the path betweenness matrix only for nodes that appear in the group
-    PB = dict.fromkeys(G)
-    for group_node1 in set_v:
-        PB[group_node1] = dict.fromkeys(G, 0.0)
-        for group_node2 in set_v:
-            if group_node2 not in D[group_node1]:
-                continue
-            for node in G:
-                # if node is connected to the two group nodes than continue
-                if group_node2 in D[node] and group_node1 in D[node]:
-                    if (
-                        D[node][group_node2]
-                        == D[node][group_node1] + D[group_node1][group_node2]
-                    ):
-                        PB[group_node1][group_node2] += (
-                            delta[node][group_node2]
-                            * sigma[node][group_node1]
-                            * sigma[group_node1][group_node2]
-                            / sigma[node][group_node2]
-                        )
+    PB, sigma, D = _group_preprocessing(G, set_v, weight)
 
     # the algorithm for each group
     for group in C:
@@ -201,7 +169,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
             if scale == 0:
                 for group_node1 in group:
                     for node in G:
-                        if D[group_node1][node] != float("inf") and node != group_node1:
+                        if node in D[group_node1] and node != group_node1:
                             if node in group:
                                 scale += 1
                             else:
@@ -221,79 +189,45 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     else:
         return GBC[0]
 
-"""
-def _single_source_shortest_path_basic(G, s):
-    S = []
-    P = {}
-    for v in G:
-        P[v] = []
-    sigma = dict.fromkeys(G, 0.0)  # sigma[v]=0 for v in G
-    D = dict.fromkeys(G, float("inf"))
-    sigma[s] = 1.0
-    D[s] = 0
-    Q = [s]
-    while Q:  # use BFS to find shortest paths
-        v = Q.pop(0)
-        S.append(v)
-        Dv = D[v]
-        sigmav = sigma[v]
-        for w in G[v]:
-            if D[w] == float("inf"):
-                Q.append(w)
-                D[w] = Dv + 1
-            if D[w] == Dv + 1:  # this is a shortest path, count paths
-                sigma[w] += sigmav
-                P[w].append(v)  # predecessors
 
-    # accumulate
-    delta = dict.fromkeys(S, 0)
-    while S:
-        w = S.pop()
-        coeff = (1 + delta[w]) / sigma[w]
-        for v in P[w]:
-            delta[v] += sigma[v] * coeff
-        if w != s:
-            delta[w] += 1  # count the path from w to s
-    return D, sigma, delta
+def _group_preprocessing(G, set_v, weight):
+    sigma = {}
+    delta = {}
+    D = {}
+    betweenness = dict.fromkeys(G, 0)
+    for s in G:
+        if weight is None:  # use BFS
+            S, P, sigma[s], D[s] = _single_source_shortest_path_basic(G, s)
+        else:  # use Dijkstra's algorithm
+            S, P, sigma[s], D[s] = _single_source_dijkstra_path_basic(G, s, weight)
+        betweenness, delta[s] = _accumulate_endpoints(betweenness, S, P, sigma[s], s)
+        for i in delta[s].keys():  # add the paths from s to i and rescale sigma
+            if s != i:
+                delta[s][i] += 1
+            if weight is not None:
+                sigma[s][i] = sigma[s][i] / 2
+    # building the path betweenness matrix only for nodes that appear in the group
+    PB = dict.fromkeys(G)
+    for group_node1 in set_v:
+        PB[group_node1] = dict.fromkeys(G, 0.0)
+        for group_node2 in set_v:
+            if group_node2 not in D[group_node1]:
+                continue
+            for node in G:
+                # if node is connected to the two group nodes than continue
+                if group_node2 in D[node] and group_node1 in D[node]:
+                    if (
+                            D[node][group_node2]
+                            == D[node][group_node1] + D[group_node1][group_node2]
+                    ):
+                        PB[group_node1][group_node2] += (
+                                delta[node][group_node2]
+                                * sigma[node][group_node1]
+                                * sigma[group_node1][group_node2]
+                                / sigma[node][group_node2]
+                        )
+    return PB, sigma, D
 
-
-def _single_source_dijkstra_path_basic(G, s, weight):
-    S = []
-    P = dict.fromkeys(G, [])
-    sigma = dict.fromkeys(G, 0.0)  # sigma[v]=0 for v in G
-    D = dict.fromkeys(G, float("inf"))
-    D[s] = 0
-    P[s] = []
-    sigma[s] = 1.0
-    push = heappush
-    pop = heappop
-    Q = []  # use Q as heap with (distance,node id) tuples
-    push(Q, (D[s], s))
-    while Q:
-        (dist, v) = pop(Q)
-        S.append(v)
-        for w, edgedata in G[v].items():
-            if D[w] > D[v] + edgedata.get(weight, 1):
-                D[w] = D[v] + edgedata.get(weight, 1)
-                push(Q, (D[w], w))
-                P[w] = []
-                sigma[w] = 0
-            if D[w] == D[v] + edgedata.get(weight, 1):  # handle equal paths
-                sigma[w] += sigma[v]
-                P[w].append(v)
-
-    # accumulate
-    delta = dict.fromkeys(S, 0)
-    while S:
-        w = S.pop()
-        coeff = (1 + delta[w]) / sigma[w]
-        for v in P[w]:
-            delta[v] += sigma[v] * coeff
-        if w != s:
-            delta[w] += 1  # count the path from w to s
-    return D, sigma, delta
-
-"""
 def group_closeness_centrality(G, S, weight=None):
     r"""Compute the group closeness centrality for a group of nodes.
 

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -1,6 +1,5 @@
 """Group centrality measures."""
 from heapq import heappush, heappop
-from itertools import count
 from copy import deepcopy
 
 import networkx as nx
@@ -16,7 +15,7 @@ __all__ = [
 ]
 
 
-def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=None):
+def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=False):
     r"""Compute the group betweenness centrality for a group of nodes.
 
     Group betweenness centrality of a group of nodes $C$ is the sum of the

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -120,9 +120,11 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
         PB[group_node1] = dict.fromkeys(G, 0.0)
         for group_node2 in set_v:
             for node in G:
-                if D[node][group_node2] != float("inf") or D[node][group_node1] != float("inf"):  # if node isn't connected to the two group nodes than continue
+                # if node isn't connected to the two group nodes than continue
+                if D[node][group_node2] != float("inf") or D[node][group_node1] != float("inf"):
                     if D[node][group_node2] == D[node][group_node1] + D[group_node1][group_node2]:
-                        PB[group_node1][group_node2] += delta[node][group_node2]*sigma[node][group_node1]*sigma[group_node1][group_node2]/sigma[node][group_node2]
+                        PB[group_node1][group_node2] += delta[node][group_node2]*sigma[node][group_node1] * \
+                                                        sigma[group_node1][group_node2]/sigma[node][group_node2]
 
     # the algorithm for each group
     for group in C:
@@ -140,7 +142,9 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
                     dxvy = 0
                     dxyv = 0
                     dvxy = 0
-                    if not (sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[y][v] == 0):
+                    if not (
+                            sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[y][v] == 0
+                    ):
                         if D[x][v] == D[x][y] + D[y][v]:
                             dxyv = 1.0 * sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
                         if D[x][y] == D[x][v] + D[v][y]:
@@ -168,9 +172,9 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
             # are connected to the group's nodes and deduce them
             if nx.is_directed(G):
                 if nx.is_strongly_connected(G):
-                    scale = (c * (2 * v - c - 1))
+                    scale = c * (2 * v - c - 1)
             elif nx.is_connected(G):
-                scale = (c * (2 * v - c - 1))
+                scale = c * (2 * v - c - 1)
             if scale == 0:
                 for group_node1 in group:
                     for node in G:

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -228,6 +228,7 @@ def _group_preprocessing(G, set_v, weight):
                         )
     return PB, sigma, D
 
+
 def group_closeness_centrality(G, S, weight=None):
     r"""Compute the group closeness centrality for a group of nodes.
 

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -125,8 +125,8 @@ def group_betweenness_centrality(G, C, normalized=False, endpoints=True, weight=
                     group_node1
                 ] != float("inf"):
                     if (
-                            D[node][group_node2]
-                            == D[node][group_node1] + D[group_node1][group_node2]
+                        D[node][group_node2]
+                        == D[node][group_node1] + D[group_node1][group_node2]
                     ):
                         PB[group_node1][group_node2] += (
                             delta[node][group_node2]

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -104,7 +104,8 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
 
     #  check weather C contains one or many groups
     if not any(isinstance(el, list) for el in C) and not any(
-            isinstance(el, set) for el in C):
+        isinstance(el, set) for el in C
+    ):
         C = [C]
     set_v = {node for group in C for node in group}
     if set_v - G.nodes:  # element(s) of C not in G

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -65,7 +65,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     Returns
     -------
     betweenness : list of floats or float
-       If C is a list with single group then return a float. If C is a list with
+       If C is a single group then return a float. If C is a list with
        several groups then return a list of group betweenness centralities.
 
     See Also

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -74,7 +74,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     Notes
     -----
     Group betweenness centrality is described in [1]_ and its importance discussed in [3]_.
-    initial implementation of the algorithm is mentioned in [2]_. This function uses
+    The initial implementation of the algorithm is mentioned in [2]_. This function uses
      an improved algorithm presented in [4]_.
 
     The number of nodes in the group must be a maximum of n - 2 where `n`
@@ -178,7 +178,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
             scale = 1 / ((v - c) * (v - c - 1))
             GBC_group *= scale
 
-        # If undirected than count only the undirected edged
+        # If undirected than count only the undirected edges
         elif not G.is_directed():
             GBC_group /= 2
 

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -121,6 +121,8 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     for group_node1 in set_v:
         PB[group_node1] = dict.fromkeys(G, 0.0)
         for group_node2 in set_v:
+            if D[group_node1][group_node2] == float("inf"):
+                continue
             for node in G:
                 # if node isn't connected to the two group nodes than continue
                 if D[node][group_node2] != float("inf") or D[node][
@@ -154,7 +156,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                     dxyv = 0
                     dvxy = 0
                     if not (
-                        sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[y][v] == 0
+                        sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[v][y] == 0
                     ):
                         if D[x][v] == D[x][y] + D[y][v]:
                             dxyv = 1.0 * sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]

--- a/networkx/algorithms/centrality/percolation.py
+++ b/networkx/algorithms/centrality/percolation.py
@@ -93,9 +93,9 @@ def percolation_centrality(G, attribute="percolation", states=None, weight=None)
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma, D = shortest_path(G, s)
+            S, P, sigma, _ = shortest_path(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma, D = dijkstra(G, s, weight)
+            S, P, sigma, _ = dijkstra(G, s, weight)
         # accumulation
         percolation = _accumulate_percolation(
             percolation, G, S, P, sigma, s, states, p_sigma_x_t

--- a/networkx/algorithms/centrality/percolation.py
+++ b/networkx/algorithms/centrality/percolation.py
@@ -93,9 +93,9 @@ def percolation_centrality(G, attribute="percolation", states=None, weight=None)
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS
-            S, P, sigma = shortest_path(G, s)
+            S, P, sigma, D = shortest_path(G, s)
         else:  # use Dijkstra's algorithm
-            S, P, sigma = dijkstra(G, s, weight)
+            S, P, sigma, D = dijkstra(G, s, weight)
         # accumulation
         percolation = _accumulate_percolation(
             percolation, G, S, P, sigma, s, states, p_sigma_x_t

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -10,7 +10,7 @@ import networkx as nx
 class TestGroupBetweennessCentrality:
     def test_group_betweenness_single_node(self):
         """
-            Group betweenness centrality for single node group
+        Group betweenness centrality for single node group
         """
         G = nx.path_graph(5)
         C = [1]
@@ -22,8 +22,8 @@ class TestGroupBetweennessCentrality:
 
     def test_group_betweenness_normalized(self):
         """
-            Group betweenness centrality for group with more than
-            1 node and normalized
+        Group betweenness centrality for group with more than
+        1 node and normalized
         """
         G = nx.path_graph(5)
         C = [1, 3]
@@ -66,14 +66,14 @@ class TestGroupBetweennessCentrality:
 
     def test_group_betweenness_node_not_in_graph(self):
         """
-            Node(s) in C not in graph, raises NodeNotFound exception
+        Node(s) in C not in graph, raises NodeNotFound exception
         """
         with pytest.raises(nx.NodeNotFound):
             b = nx.group_betweenness_centrality(nx.path_graph(5), [6, 7, 8])
 
     def test_group_betweenness_directed_weighted(self):
         """
-            Group betweenness centrality in a directed and weighted graph
+        Group betweenness centrality in a directed and weighted graph
         """
         G = nx.DiGraph()
         G.add_edge(1, 0, weight=1)
@@ -92,7 +92,7 @@ class TestGroupBetweennessCentrality:
 class TestGroupClosenessCentrality:
     def test_group_closeness_single_node(self):
         """
-            Group closeness centrality for a single node group
+        Group closeness centrality for a single node group
         """
         G = nx.path_graph(5)
         c = nx.group_closeness_centrality(G, [1])
@@ -101,7 +101,7 @@ class TestGroupClosenessCentrality:
 
     def test_group_closeness_disconnected(self):
         """
-            Group closeness centrality for a disconnected graph
+        Group closeness centrality for a disconnected graph
         """
         G = nx.Graph()
         G.add_nodes_from([1, 2, 3, 4])
@@ -111,8 +111,8 @@ class TestGroupClosenessCentrality:
 
     def test_group_closeness_multiple_node(self):
         """
-            Group closeness centrality for a group with more than
-            1 node
+        Group closeness centrality for a group with more than
+        1 node
         """
         G = nx.path_graph(4)
         c = nx.group_closeness_centrality(G, [1, 2])
@@ -121,7 +121,7 @@ class TestGroupClosenessCentrality:
 
     def test_group_closeness_node_not_in_graph(self):
         """
-            Node(s) in S not in graph, raises NodeNotFound exception
+        Node(s) in S not in graph, raises NodeNotFound exception
         """
         with pytest.raises(nx.NodeNotFound):
             c = nx.group_closeness_centrality(nx.path_graph(5), [6, 7, 8])
@@ -130,7 +130,7 @@ class TestGroupClosenessCentrality:
 class TestGroupDegreeCentrality:
     def test_group_degree_centrality_single_node(self):
         """
-            Group degree centrality for a single node group
+        Group degree centrality for a single node group
         """
         G = nx.path_graph(4)
         d = nx.group_degree_centrality(G, [1])
@@ -139,8 +139,8 @@ class TestGroupDegreeCentrality:
 
     def test_group_degree_centrality_multiple_node(self):
         """
-            Group degree centrality for group with more than
-            1 node
+        Group degree centrality for group with more than
+        1 node
         """
         G = nx.Graph()
         G.add_nodes_from([1, 2, 3, 4, 5, 6, 7, 8])
@@ -153,7 +153,7 @@ class TestGroupDegreeCentrality:
 
     def test_group_in_degree_centrality(self):
         """
-            Group in-degree centrality in a DiGraph
+        Group in-degree centrality in a DiGraph
         """
         G = nx.DiGraph()
         G.add_nodes_from([1, 2, 3, 4, 5, 6, 7, 8])
@@ -166,7 +166,7 @@ class TestGroupDegreeCentrality:
 
     def test_group_out_degree_centrality(self):
         """
-            Group out-degree centrality in a DiGraph
+        Group out-degree centrality in a DiGraph
         """
         G = nx.DiGraph()
         G.add_nodes_from([1, 2, 3, 4, 5, 6, 7, 8])
@@ -179,7 +179,7 @@ class TestGroupDegreeCentrality:
 
     def test_group_degree_centrality_node_not_in_graph(self):
         """
-            Node(s) in S not in graph, raises NetworkXError
+        Node(s) in S not in graph, raises NetworkXError
         """
         with pytest.raises(nx.NetworkXError):
             b = nx.group_degree_centrality(nx.path_graph(5), [6, 7, 8])

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -39,9 +39,7 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(7)
         C = [[0, 1, 6], [0, 1, 5]]
-        b = nx.group_betweenness_centrality(
-            G, C, weight=None, normalized=False
-        )
+        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
         b_answer = [0.0, 6.0]
         assert b == b_answer
 
@@ -51,9 +49,7 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
-        b = nx.group_betweenness_centrality(
-            G, C, weight=None, normalized=False
-        )
+        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
         b_answer = [0.0]
         assert b == b_answer
 
@@ -64,9 +60,7 @@ class TestGroupBetweennessCentrality:
         G = nx.path_graph(5)
         G.remove_edge(0, 1)
         C = [1]
-        b = nx.group_betweenness_centrality(
-            G, C, weight=None, normalized=False
-        )
+        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
         b_answer = [0.0]
         assert b == b_answer
 
@@ -90,9 +84,7 @@ class TestGroupBetweennessCentrality:
         G.add_edge(4, 3, weight=6)
         G.add_edge(2, 4, weight=7)
         C = [1, 2]
-        b = nx.group_betweenness_centrality(
-            G, C, weight="weight", normalized=False
-        )
+        b = nx.group_betweenness_centrality(G, C, weight="weight", normalized=False)
         b_answer = [5.0]
         assert b == b_answer
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -14,8 +14,8 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.path_graph(5)
         C = [1]
-        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
-        b_answer = 3.0
+        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False, endpoints=False)
+        b_answer = [6.0]
         assert b == b_answer
 
     def test_group_betweenness_normalized(self):
@@ -25,8 +25,18 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.path_graph(5)
         C = [1, 3]
-        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=True)
-        b_answer = 1.0
+        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=True, endpoints=False)
+        b_answer = [2.0]
+        assert b == b_answer
+
+    def test_two_group_betweenness_value_zero(self):
+        """
+            Group betweenness centrality value of 0
+        """
+        G = nx.cycle_graph(7)
+        C = [[0, 1, 6], [0, 1, 5]]
+        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False)
+        b_answer = [0.0, 6.0]
         assert b == b_answer
 
     def test_group_betweenness_value_zero(self):
@@ -35,8 +45,8 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
-        b = nx.group_betweenness_centrality(G, C, weight=None)
-        b_answer = 0.0
+        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False)
+        b_answer = [0.0]
         assert b == b_answer
 
     def test_group_betweenness_disconnected_graph(self):
@@ -46,8 +56,8 @@ class TestGroupBetweennessCentrality:
         G = nx.path_graph(5)
         G.remove_edge(0, 1)
         C = [1]
-        b = nx.group_betweenness_centrality(G, C, weight=None)
-        b_answer = 0.0
+        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False)
+        b_answer = [0.0]
         assert b == b_answer
 
     def test_group_betweenness_node_not_in_graph(self):
@@ -56,6 +66,23 @@ class TestGroupBetweennessCentrality:
         """
         with pytest.raises(nx.NodeNotFound):
             b = nx.group_betweenness_centrality(nx.path_graph(5), [6, 7, 8])
+
+    def test_group_betweenness_directed_weighted(self):
+        """
+            Group betweenness centrality in a directed and weighted graph
+        """
+        G = nx.DiGraph()
+        G.add_edge(1, 0, weight=1)
+        G.add_edge(0, 2, weight=2)
+        G.add_edge(1, 2, weight=3)
+        G.add_edge(3, 1, weight=4)
+        G.add_edge(2, 3, weight=1)
+        G.add_edge(4, 3, weight=6)
+        G.add_edge(2, 4, weight=7)
+        C = [1, 2]
+        b = nx.group_betweenness_centrality(G, C, weight='weight', endpoints=False)
+        b_answer = [5.0]
+        assert b == b_answer
 
 
 class TestGroupClosenessCentrality:

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -39,7 +39,7 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(7)
         C = [[0, 1, 6], [0, 1, 5]]
-        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False)
+        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False, normalized=False)
         b_answer = [0.0, 6.0]
         assert b == b_answer
 
@@ -49,7 +49,7 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
-        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False)
+        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False, normalized=False)
         b_answer = [0.0]
         assert b == b_answer
 
@@ -60,7 +60,7 @@ class TestGroupBetweennessCentrality:
         G = nx.path_graph(5)
         G.remove_edge(0, 1)
         C = [1]
-        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False)
+        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False, normalized=False)
         b_answer = [0.0]
         assert b == b_answer
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -17,7 +17,19 @@ class TestGroupBetweennessCentrality:
         b = nx.group_betweenness_centrality(
             G, C, weight=None, normalized=False, endpoints=False
         )
-        b_answer = 6.0
+        b_answer = 3.0
+        assert b == b_answer
+
+    def test_group_betweenness_with_endpoints(self):
+        """
+        Group betweenness centrality for single node group
+        """
+        G = nx.path_graph(5)
+        C = [1]
+        b = nx.group_betweenness_centrality(
+            G, C, weight=None, normalized=False, endpoints=True
+        )
+        b_answer = 7.0
         assert b == b_answer
 
     def test_group_betweenness_normalized(self):
@@ -40,7 +52,7 @@ class TestGroupBetweennessCentrality:
         G = nx.cycle_graph(7)
         C = [[0, 1, 6], [0, 1, 5]]
         b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
-        b_answer = [0.0, 6.0]
+        b_answer = [0.0, 3.0]
         assert b == b_answer
 
     def test_group_betweenness_value_zero(self):

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -14,7 +14,9 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.path_graph(5)
         C = [1]
-        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False, endpoints=False)
+        b = nx.group_betweenness_centrality(
+            G, C, weight=None, normalized=False, endpoints=False
+        )
         b_answer = [6.0]
         assert b == b_answer
 
@@ -25,13 +27,15 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.path_graph(5)
         C = [1, 3]
-        b = nx.group_betweenness_centrality(G, C, weight=None, normalized=True, endpoints=False)
+        b = nx.group_betweenness_centrality(
+            G, C, weight=None, normalized=True, endpoints=False
+        )
         b_answer = [2.0]
         assert b == b_answer
 
     def test_two_group_betweenness_value_zero(self):
         """
-            Group betweenness centrality value of 0
+        Group betweenness centrality value of 0
         """
         G = nx.cycle_graph(7)
         C = [[0, 1, 6], [0, 1, 5]]
@@ -41,7 +45,7 @@ class TestGroupBetweennessCentrality:
 
     def test_group_betweenness_value_zero(self):
         """
-            Group betweenness centrality value of 0
+        Group betweenness centrality value of 0
         """
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
@@ -51,7 +55,7 @@ class TestGroupBetweennessCentrality:
 
     def test_group_betweenness_disconnected_graph(self):
         """
-            Group betweenness centrality in a disconnected graph
+        Group betweenness centrality in a disconnected graph
         """
         G = nx.path_graph(5)
         G.remove_edge(0, 1)
@@ -80,7 +84,7 @@ class TestGroupBetweennessCentrality:
         G.add_edge(4, 3, weight=6)
         G.add_edge(2, 4, weight=7)
         C = [1, 2]
-        b = nx.group_betweenness_centrality(G, C, weight='weight', endpoints=False)
+        b = nx.group_betweenness_centrality(G, C, weight="weight", endpoints=False)
         b_answer = [5.0]
         assert b == b_answer
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -17,7 +17,7 @@ class TestGroupBetweennessCentrality:
         b = nx.group_betweenness_centrality(
             G, C, weight=None, normalized=False, endpoints=False
         )
-        b_answer = [6.0]
+        b_answer = 6.0
         assert b == b_answer
 
     def test_group_betweenness_normalized(self):
@@ -30,7 +30,7 @@ class TestGroupBetweennessCentrality:
         b = nx.group_betweenness_centrality(
             G, C, weight=None, normalized=True, endpoints=False
         )
-        b_answer = [2.0]
+        b_answer = 2.0
         assert b == b_answer
 
     def test_two_group_betweenness_value_zero(self):
@@ -50,7 +50,7 @@ class TestGroupBetweennessCentrality:
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
         b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
-        b_answer = [0.0]
+        b_answer = 0.0
         assert b == b_answer
 
     def test_group_betweenness_disconnected_graph(self):
@@ -61,7 +61,7 @@ class TestGroupBetweennessCentrality:
         G.remove_edge(0, 1)
         C = [1]
         b = nx.group_betweenness_centrality(G, C, weight=None, normalized=False)
-        b_answer = [0.0]
+        b_answer = 0.0
         assert b == b_answer
 
     def test_group_betweenness_node_not_in_graph(self):
@@ -85,7 +85,7 @@ class TestGroupBetweennessCentrality:
         G.add_edge(2, 4, weight=7)
         C = [1, 2]
         b = nx.group_betweenness_centrality(G, C, weight="weight", normalized=False)
-        b_answer = [5.0]
+        b_answer = 5.0
         assert b == b_answer
 
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -69,7 +69,7 @@ class TestGroupBetweennessCentrality:
         Node(s) in C not in graph, raises NodeNotFound exception
         """
         with pytest.raises(nx.NodeNotFound):
-            b = nx.group_betweenness_centrality(nx.path_graph(5), [6, 7, 8])
+            b = nx.group_betweenness_centrality(nx.path_graph(5), [4, 7, 8])
 
     def test_group_betweenness_directed_weighted(self):
         """

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -39,7 +39,9 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(7)
         C = [[0, 1, 6], [0, 1, 5]]
-        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False, normalized=False)
+        b = nx.group_betweenness_centrality(
+            G, C, weight=None, endpoints=False, normalized=False
+        )
         b_answer = [0.0, 6.0]
         assert b == b_answer
 
@@ -49,7 +51,9 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
-        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False, normalized=False)
+        b = nx.group_betweenness_centrality(
+            G, C, weight=None, endpoints=False, normalized=False
+        )
         b_answer = [0.0]
         assert b == b_answer
 
@@ -60,7 +64,9 @@ class TestGroupBetweennessCentrality:
         G = nx.path_graph(5)
         G.remove_edge(0, 1)
         C = [1]
-        b = nx.group_betweenness_centrality(G, C, weight=None, endpoints=False, normalized=False)
+        b = nx.group_betweenness_centrality(
+            G, C, weight=None, endpoints=False, normalized=False
+        )
         b_answer = [0.0]
         assert b == b_answer
 
@@ -84,7 +90,9 @@ class TestGroupBetweennessCentrality:
         G.add_edge(4, 3, weight=6)
         G.add_edge(2, 4, weight=7)
         C = [1, 2]
-        b = nx.group_betweenness_centrality(G, C, weight="weight", endpoints=False)
+        b = nx.group_betweenness_centrality(
+            G, C, weight="weight", endpoints=False, normalized=False
+        )
         b_answer = [5.0]
         assert b == b_answer
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -30,7 +30,7 @@ class TestGroupBetweennessCentrality:
         b = nx.group_betweenness_centrality(
             G, C, weight=None, normalized=True, endpoints=False
         )
-        b_answer = 2.0
+        b_answer = 1.0
         assert b == b_answer
 
     def test_two_group_betweenness_value_zero(self):

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -40,7 +40,7 @@ class TestGroupBetweennessCentrality:
         G = nx.cycle_graph(7)
         C = [[0, 1, 6], [0, 1, 5]]
         b = nx.group_betweenness_centrality(
-            G, C, weight=None, endpoints=False, normalized=False
+            G, C, weight=None, normalized=False
         )
         b_answer = [0.0, 6.0]
         assert b == b_answer
@@ -52,7 +52,7 @@ class TestGroupBetweennessCentrality:
         G = nx.cycle_graph(6)
         C = [0, 1, 5]
         b = nx.group_betweenness_centrality(
-            G, C, weight=None, endpoints=False, normalized=False
+            G, C, weight=None, normalized=False
         )
         b_answer = [0.0]
         assert b == b_answer
@@ -65,7 +65,7 @@ class TestGroupBetweennessCentrality:
         G.remove_edge(0, 1)
         C = [1]
         b = nx.group_betweenness_centrality(
-            G, C, weight=None, endpoints=False, normalized=False
+            G, C, weight=None, normalized=False
         )
         b_answer = [0.0]
         assert b == b_answer
@@ -91,7 +91,7 @@ class TestGroupBetweennessCentrality:
         G.add_edge(2, 4, weight=7)
         C = [1, 2]
         b = nx.group_betweenness_centrality(
-            G, C, weight="weight", endpoints=False, normalized=False
+            G, C, weight="weight", normalized=False
         )
         b_answer = [5.0]
         assert b == b_answer


### PR DESCRIPTION
In this PR I improved the group betweenness centrality algorithm by using the algorithm of Puzis et al. "Fast algorithm for successive computation of group betweenness centrality".

In the previous implementation of the algorithm, for each pair of source - target non - group nodes permutation, all the shortest paths were found and if one of them go through one of the nodes in the group then the group betweenness centrality increases. This was done for each group.

Here I used Pusiz et al. implementation, which finds the GBC with running time of $O(K^3)$ for each group (k is the number of nodes in the group) and with a preprocessing time of $O(mn)$ for all the groups.

This unable us to find the GBC of many groups in one preprocessing step.
Furthermore, the article shows how to find the prominent group of size k (the group with the highest GBC among those with size k), which I would add in future PR.
