### PR TITLE
DOC: Switch from napoleon to numpydoc sphinx extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,12 +19,12 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
     "nb2plots",
     "texext",
+    "numpydoc",
 ]
 
 # https://github.com/sphinx-gallery/sphinx-gallery
@@ -112,9 +112,6 @@ pygments_style = "sphinx"
 modindex_common_prefix = ["networkx."]
 
 doctest_global_setup = "import networkx as nx"
-
-# treat ``x, y : type`` as vars x and y instead of default ``y(x,) : type``
-napoleon_use_param = False
 
 # Options for HTML output
 # -----------------------

--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -23,7 +23,7 @@ def max_clique(G):
         The apx-maximum clique of the graph
 
     Notes
-    ------
+    -----
     A clique in an undirected graph G = (V, E) is a subset of the vertex set
     `C \subseteq V` such that for every two vertices in C there exists an edge
     connecting the two. This is equivalent to saying that the subgraph

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -70,8 +70,8 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
 
     See Also
     --------
-    write_edgelist()
-    generate_edgelist()
+    write_edgelist
+    generate_edgelist
     """
     for line in generate_edgelist(G, delimiter, data):
         line += "\n"

--- a/networkx/algorithms/centrality/load.py
+++ b/networkx/algorithms/centrality/load.py
@@ -35,7 +35,7 @@ def newman_betweenness_centrality(G, v=None, cutoff=None, normalized=True, weigh
 
     See Also
     --------
-    betweenness_centrality()
+    betweenness_centrality
 
     Notes
     -----

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -438,7 +438,7 @@ def complete_to_chordal_graph(G):
             The elimination ordering of nodes of G
 
     Notes
-    ------
+    -----
     There are different approaches to calculate the chordal
     enhancement of a graph. The algorithm used here is called
     MCS-M and gives at least minimal (local) triangulation of graph. Note

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -78,7 +78,7 @@ def kernighan_lin_bisection(G, partition=None, max_iter=10, weight="weight", see
         A pair of sets of nodes representing the bipartition.
 
     Raises
-    -------
+    ------
     NetworkXError
         If partition is not a valid partition of the nodes of the graph.
 

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -52,7 +52,7 @@ def asyn_lpa_communities(G, weight=None, seed=None):
         Iterable of communities given as sets of nodes.
 
     Notes
-    ------
+    -----
     Edge weight attributes must be numerical.
 
     References

--- a/networkx/algorithms/community/lukes.py
+++ b/networkx/algorithms/community/lukes.py
@@ -58,7 +58,7 @@ def lukes_partitioning(G, max_size: int, node_weight=None, edge_weight=None) -> 
         partition.
 
     Raises
-    -------
+    ------
     NotATree
         If G is not a tree.
     TypeError

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -186,13 +186,6 @@ def biconnected_components(G):
     NetworkXNotImplemented
         If the input graph is not undirected.
 
-    See Also
-    --------
-    k_components : this function is a special case where k=2
-    bridge_components : similar to this function, but is defined using
-        2-edge-connectivity instead of 2-node-connectivity.
-
-
     Examples
     --------
     >>> G = nx.lollipop_graph(5, 1)
@@ -228,6 +221,9 @@ def biconnected_components(G):
     is_biconnected
     articulation_points
     biconnected_component_edges
+    k_components : this function is a special case where k=2
+    bridge_components : similar to this function, but is defined using
+        2-edge-connectivity instead of 2-node-connectivity.
 
     Notes
     -----

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -46,8 +46,8 @@ def is_k_edge_connected(G, k):
     --------
     :func:`is_locally_k_edge_connected`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.barbell_graph(10, 0)
     >>> nx.is_k_edge_connected(G, k=1)
     True
@@ -102,8 +102,8 @@ def is_locally_k_edge_connected(G, s, t, k):
     --------
     :func:`is_k_edge_connected`
 
-    Example
-    -------
+    Examples
+    --------
     >>> from networkx.algorithms.connectivity import is_locally_k_edge_connected
     >>> G = nx.barbell_graph(10, 0)
     >>> is_locally_k_edge_connected(G, 5, 15, k=1)
@@ -204,8 +204,8 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
         produces a feasible solution, but provides no guarantees on the
         solution weight.
 
-    Example
-    -------
+    Examples
+    --------
     >>> # Unweighted cases
     >>> G = nx.path_graph((1, 2, 3, 4))
     >>> G.add_node(5)
@@ -220,8 +220,6 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
     >>> nx.edge_connectivity(G)
     4
 
-    Example
-    -------
     >>> # Weighted cases
     >>> G = nx.path_graph((1, 2, 3, 4))
     >>> G.add_node(5)
@@ -326,8 +324,8 @@ def partial_k_edge_augmentation(G, k, avail, weight=None):
     --------
     :func:`k_edge_augmentation`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.path_graph((1, 2, 3, 4, 5, 6, 7))
     >>> G.add_node(8)
     >>> avail = [(1, 3), (1, 4), (1, 5), (2, 4), (2, 5), (3, 5), (1, 8)]
@@ -547,8 +545,8 @@ def _lightest_meta_edges(mapping, avail_uv, avail_w):
     minimum weight edge bridging each k-edge-connected component so, we group
     the edges by meta-edge and take the lightest in each group.
 
-    Example
-    -------
+    Examples
+    --------
     >>> # Each group represents a meta-node
     >>> groups = ([1, 2, 3], [4, 5], [6])
     >>> mapping = {n: meta_n for meta_n, ns in enumerate(groups) for n in ns}
@@ -594,8 +592,8 @@ def unconstrained_one_edge_augmentation(G):
     :func:`one_edge_augmentation`
     :func:`k_edge_augmentation`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.Graph([(1, 2), (2, 3), (4, 5)])
     >>> G.add_nodes_from([6, 7, 8])
     >>> sorted(unconstrained_one_edge_augmentation(G))
@@ -646,8 +644,8 @@ def weighted_one_edge_augmentation(G, avail, weight=None, partial=False):
     :func:`one_edge_augmentation`
     :func:`k_edge_augmentation`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.Graph([(1, 2), (2, 3), (4, 5)])
     >>> G.add_nodes_from([6, 7, 8])
     >>> # any edge not in avail has an implicit weight of infinity
@@ -746,8 +744,8 @@ def unconstrained_bridge_augmentation(G):
     :func:`bridge_augmentation`
     :func:`k_edge_augmentation`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.path_graph((1, 2, 3, 4, 5, 6, 7))
     >>> sorted(unconstrained_bridge_augmentation(G))
     [(1, 7)]
@@ -880,8 +878,8 @@ def weighted_bridge_augmentation(G, avail, weight=None):
     :func:`bridge_augmentation`
     :func:`k_edge_augmentation`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.path_graph((1, 2, 3, 4))
     >>> # When the weights are equal, (1, 4) is the best
     >>> avail = [(1, 4, 1), (1, 3, 1), (2, 4, 1)]
@@ -1114,8 +1112,8 @@ def complement_edges(G):
     edge : tuple
         Edges in the complement of G
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.path_graph((1, 2, 3, 4))
     >>> sorted(complement_edges(G))
     [(1, 3), (1, 4), (2, 4)]
@@ -1187,8 +1185,8 @@ def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
     --------
     :func:`k_edge_augmentation`
 
-    Example
-    -------
+    Examples
+    --------
     >>> G = nx.path_graph((1, 2, 3, 4, 5, 6, 7))
     >>> sorted(greedy_k_edge_augmentation(G, k=2))
     [(1, 7)]

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -40,7 +40,7 @@ def k_edge_components(G, k):
        will have k-edge-connectivity in the graph G.
 
     See Also
-    -------
+    --------
     :func:`local_edge_connectivity`
     :func:`k_edge_subgraphs` : similar to this function, but the subgraph
         defined by the nodes must also have k-edge-connectivity.
@@ -64,8 +64,8 @@ def k_edge_components(G, k):
     run based on the chain decomposition.
     Otherwise, the algorithm from _[2] is used.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import itertools as it
     >>> from networkx.utils import pairwise
     >>> paths = [
@@ -124,7 +124,7 @@ def k_edge_subgraphs(G, k):
         of G that is k-edge-connected.
 
     See Also
-    -------
+    --------
     :func:`edge_connectivity`
     :func:`k_edge_components` : similar to this function, but nodes only
         need to have k-edge-connctivity within the graph G and the subgraphs
@@ -144,8 +144,8 @@ def k_edge_subgraphs(G, k):
     If k=1, or k=2 and the graph is undirected, then this simply calls
     `k_edge_components`.  Otherwise the algorithm from _[1] is used.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import itertools as it
     >>> from networkx.utils import pairwise
     >>> paths = [
@@ -223,8 +223,8 @@ def bridge_components(G):
     -----
     Bridge-connected components are also known as 2-edge-connected components.
 
-    Example
-    -------
+    Examples
+    --------
     >>> # The barbell graph with parameter zero has a single bridge
     >>> G = nx.barbell_graph(5, 0)
     >>> from networkx.algorithms.connectivity.edge_kcomponents import bridge_components
@@ -261,8 +261,8 @@ class EdgeComponentAuxGraph:
         k-edge-connected components.
         http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0136264
 
-    Example
-    -------
+    Examples
+    --------
     >>> import itertools as it
     >>> from networkx.utils import pairwise
     >>> from networkx.algorithms.connectivity import EdgeComponentAuxGraph
@@ -288,11 +288,10 @@ class EdgeComponentAuxGraph:
     >>> sorted(map(sorted, aux_graph.k_edge_components(k=4)))
     [[0], [1], [2], [3], [4], [5], [6], [7]]
 
-    Example
-    -------
-    >>> # The auxiliary graph is primarilly used for k-edge-ccs but it
-    >>> # can also speed up the queries of k-edge-subgraphs by refining the
-    >>> # search space.
+    The auxiliary graph is primarilly used for k-edge-ccs but it
+    can also speed up the queries of k-edge-subgraphs by refining the
+    search space.
+
     >>> import itertools as it
     >>> from networkx.utils import pairwise
     >>> from networkx.algorithms.connectivity import EdgeComponentAuxGraph
@@ -532,8 +531,8 @@ def general_k_edge_subgraphs(G, k):
         Technology 2012 480-–491.
         https://openproceedings.org/2012/conf/edbt/ZhouLYLCL12.pdf
 
-    Example
-    -------
+    Examples
+    --------
     >>> from networkx.utils import pairwise
     >>> paths = [
     ...     (11, 12, 13, 14, 11, 13, 14, 12),  # a 4-clique

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -40,13 +40,20 @@ True
 References
 ----------
 
-..  [1] Pearl, J.  (2009).  Causality.  Cambridge: Cambridge University Press.
+.. [1] Pearl, J.  (2009).  Causality.  Cambridge: Cambridge University Press.
 
-..  [2] Darwiche, A.  (2009).  Modeling and reasoning with Bayesian networks.  Cambridge: Cambridge University Press.
+.. [2] Darwiche, A.  (2009).  Modeling and reasoning with Bayesian networks. 
+   Cambridge: Cambridge University Press.
 
-..  [3] Shachter, R.  D.  (1998).  Bayes-ball: rational pastime (for determining irrelevance and requisite information in belief networks and influence diagrams).  In , Proceedings of the Fourteenth Conference on Uncertainty in Artificial Intelligence (pp.  480–487).  San Francisco, CA, USA: Morgan Kaufmann Publishers Inc.
+.. [3] Shachter, R.  D.  (1998).
+   Bayes-ball: rational pastime (for determining irrelevance and requisite
+   information in belief networks and influence diagrams).
+   In , Proceedings of the Fourteenth Conference on Uncertainty in Artificial
+   Intelligence (pp.  480–487).
+   San Francisco, CA, USA: Morgan Kaufmann Publishers Inc.
 
-..  [4] Koller, D., & Friedman, N. (2009). Probabilistic graphical models: principles and techniques. The MIT Press.
+.. [4] Koller, D., & Friedman, N. (2009).
+   Probabilistic graphical models: principles and techniques. The MIT Press.
 
 """
 

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -377,7 +377,7 @@ def eulerize(G):
     .. [1] J. Edmonds, E. L. Johnson.
        Matching, Euler tours and the Chinese postman.
        Mathematical programming, Volume 5, Issue 1 (1973), 111-114.
-       [2] https://en.wikipedia.org/wiki/Eulerian_path
+    .. [2] https://en.wikipedia.org/wiki/Eulerian_path
     .. [3] http://web.math.princeton.edu/math_alive/5/Notes1.pdf
 
     Examples

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -91,7 +91,7 @@ def weisfeiler_lehman_graph_hash(
     'f9e9cb01c6d2f3b17f83ffeaa24e5986'
 
     References
-    -------
+    ----------
     .. [1] Shervashidze, Nino, Pascal Schweitzer, Erik Jan Van Leeuwen,
        Kurt Mehlhorn, and Karsten M. Borgwardt. Weisfeiler Lehman
        Graph Kernels. Journal of Machine Learning Research. 2011.

--- a/networkx/algorithms/hybrid.py
+++ b/networkx/algorithms/hybrid.py
@@ -54,9 +54,9 @@ def kl_connected_subgraph(G, k, l, low_memory=False, same_as_graph=False):
 
     References
     ----------
-    .. [1]: Chung, Fan and Linyuan Lu. "The Small World Phenomenon in Hybrid
-            Power Law Graphs." *Complex Networks*. Springer Berlin Heidelberg,
-            2004. 89--104.
+    .. [1] Chung, Fan and Linyuan Lu. "The Small World Phenomenon in Hybrid
+           Power Law Graphs." *Complex Networks*. Springer Berlin Heidelberg,
+           2004. 89--104.
 
     """
     H = copy.deepcopy(G)  # subgraph we construct by removing from G
@@ -148,9 +148,9 @@ def is_kl_connected(G, k, l, low_memory=False):
 
     References
     ----------
-    .. [1]: Chung, Fan and Linyuan Lu. "The Small World Phenomenon in Hybrid
-            Power Law Graphs." *Complex Networks*. Springer Berlin Heidelberg,
-            2004. 89--104.
+    .. [1] Chung, Fan and Linyuan Lu. "The Small World Phenomenon in Hybrid
+           Power Law Graphs." *Complex Networks*. Springer Berlin Heidelberg,
+           2004. 89--104.
 
     """
     graphOK = True

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -53,8 +53,8 @@ def tree_all_pairs_lowest_common_ancestor(G, root=None, pairs=None):
 
     See Also
     --------
-    all_pairs_lowest_common_ancestor (similar routine for general DAGs)
-    lowest_common_ancestor           (just a single pair for general DAGs)
+    all_pairs_lowest_common_ancestor: similar routine for general DAGs
+    lowest_common_ancestor: just a single pair for general DAGs
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("LCA meaningless on null graphs.")

--- a/networkx/algorithms/moral.py
+++ b/networkx/algorithms/moral.py
@@ -23,7 +23,7 @@ def moral_graph(G):
         The undirected moralized graph of G
 
     Notes
-    ------
+    -----
     A moral graph is an undirected graph H = (V, E) generated from a
     directed Graph, where if a node has more than one parent node, edges
     between these parent nodes are inserted and all directed edges become

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -32,12 +32,12 @@ def harmonic_function(G, max_iter=30, label_name="label"):
         name of target labels to predict
 
     Returns
-    ----------
+    -------
     predicted : array, shape = [n_samples]
         Array of predicted labels
 
     Raises
-    ----------
+    ------
     NetworkXError
         If no nodes on `G` has `label_name`.
 
@@ -76,7 +76,7 @@ def harmonic_function(G, max_iter=30, label_name="label"):
             Array of pairs of node id and label id
 
         Returns
-        ----------
+        -------
         P : scipy sparse matrix, shape = [n_samples, n_samples]
             Propagation matrix
 
@@ -101,7 +101,7 @@ def harmonic_function(G, max_iter=30, label_name="label"):
             The number of classes (distinct labels) on the input graph
 
         Returns
-        ----------
+        -------
         B : array, shape = [n_samples, n_classes]
             Base matrix
         """

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -34,7 +34,7 @@ def local_and_global_consistency(G, alpha=0.99, max_iter=30, label_name="label")
         Name of target labels to predict
 
     Returns
-    ----------
+    -------
     predicted : array, shape = [n_samples]
         Array of predicted labels
 
@@ -81,7 +81,7 @@ def local_and_global_consistency(G, alpha=0.99, max_iter=30, label_name="label")
             Clamping factor
 
         Returns
-        ----------
+        -------
         S : scipy sparse matrix, shape = [n_samples, n_samples]
             Propagation matrix
 
@@ -107,7 +107,7 @@ def local_and_global_consistency(G, alpha=0.99, max_iter=30, label_name="label")
             The number of classes (distinct labels) on the input graph
 
         Returns
-        ----------
+        -------
         B : array, shape = [n_samples, n_classes]
             Base matrix
         """

--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -50,9 +50,9 @@ def non_randomness(G, k=None):
 
     References
     ----------
-     .. [1] Xiaowei Ying and Xintao Wu,
-            On Randomness Measures for Social Networks,
-            SIAM International Conference on Data Mining. 2009
+    .. [1] Xiaowei Ying and Xintao Wu,
+           On Randomness Measures for Social Networks,
+           SIAM International Conference on Data Mining. 2009
     """
     import numpy as np
 

--- a/networkx/algorithms/operators/unary.py
+++ b/networkx/algorithms/operators/unary.py
@@ -17,8 +17,8 @@ def complement(G):
     GC : A new graph.
 
     Notes
-    ------
-    Note that complement() does not create self-loops and also
+    -----
+    Note that `complement` does not create self-loops and also
     does not produce parallel edges for MultiGraphs.
 
     Graph, node, and edge data are not propagated to the new graph.

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -32,7 +32,7 @@ def floyd_warshall_numpy(G, nodelist=None, weight="weight"):
         will be Inf.
 
     Notes
-    ------
+    -----
     Floyd's algorithm is appropriate for finding shortest paths in
     dense graphs or graphs with negative weights when Dijkstra's
     algorithm fails. This algorithm can still fail if there are negative
@@ -91,7 +91,7 @@ def floyd_warshall_predecessor_and_distance(G, weight="weight"):
     ['s', 'x', 'u', 'v']
 
     Notes
-    ------
+    -----
     Floyd's algorithm is appropriate for finding shortest paths
     in dense graphs or graphs with negative weights when Dijkstra's algorithm
     fails.  This algorithm can still fail if there are negative cycles.
@@ -159,7 +159,7 @@ def reconstruct_path(source, target, predecessors):
        If source and target are the same, an empty list is returned
 
     Notes
-    ------
+    -----
     This function is meant to give more applicability to the
     floyd_warshall_predecessor_and_distance function
 
@@ -196,7 +196,7 @@ def floyd_warshall(G, weight="weight"):
        between nodes.
 
     Notes
-    ------
+    -----
     Floyd's algorithm is appropriate for finding shortest paths
     in dense graphs or graphs with negative weights when Dijkstra's algorithm
     fails.  This algorithm can still fail if there are negative cycles.

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -112,12 +112,12 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
 
     See Also
     --------
-    all_pairs_shortest_path()
-    all_pairs_dijkstra_path()
-    all_pairs_bellman_ford_path()
-    single_source_shortest_path()
-    single_source_dijkstra_path()
-    single_source_bellman_ford_path()
+    all_pairs_shortest_path
+    all_pairs_dijkstra_path
+    all_pairs_bellman_ford_path
+    single_source_shortest_path
+    single_source_dijkstra_path
+    single_source_bellman_ford_path
     """
     if method not in ("dijkstra", "bellman-ford"):
         # so we don't need to check in each branch later
@@ -247,12 +247,12 @@ def shortest_path_length(G, source=None, target=None, weight=None, method="dijks
 
     See Also
     --------
-    all_pairs_shortest_path_length()
-    all_pairs_dijkstra_path_length()
-    all_pairs_bellman_ford_path_length()
-    single_source_shortest_path_length()
-    single_source_dijkstra_path_length()
-    single_source_bellman_ford_path_length()
+    all_pairs_shortest_path_length
+    all_pairs_dijkstra_path_length
+    all_pairs_bellman_ford_path_length
+    single_source_shortest_path_length
+    single_source_dijkstra_path_length
+    single_source_bellman_ford_path_length
     """
     if method not in ("dijkstra", "bellman-ford"):
         # so we don't need to check in each branch later
@@ -464,9 +464,9 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
 
     See Also
     --------
-    shortest_path()
-    single_source_shortest_path()
-    all_pairs_shortest_path()
+    shortest_path
+    single_source_shortest_path
+    all_pairs_shortest_path
     """
     method = "unweighted" if weight is None else method
     if method == "unweighted":
@@ -515,11 +515,11 @@ def _build_paths_from_predecessors(sources, target, pred):
 
     See Also
     --------
-    shortest_path()
-    single_source_shortest_path()
-    all_pairs_shortest_path()
-    all_shortest_paths()
-    bellman_ford_path()
+    shortest_path
+    single_source_shortest_path
+    all_pairs_shortest_path
+    all_shortest_paths
+    bellman_ford_path
     """
     if target not in pred:
         raise nx.NetworkXNoPath(

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -451,7 +451,7 @@ def all_pairs_shortest_path(G, cutoff=None):
 
     See Also
     --------
-    floyd_warshall()
+    floyd_warshall
 
     """
     # TODO This can be trivially parallelized.

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -151,8 +151,9 @@ def dijkstra_path(G, source, target, weight="weight"):
 
     See Also
     --------
-    bidirectional_dijkstra(), bellman_ford_path()
-    single_source_dijkstra()
+    bidirectional_dijkstra
+    bellman_ford_path
+    single_source_dijkstra
     """
     (length, path) = single_source_dijkstra(G, source, target=target, weight=weight)
     return path
@@ -220,8 +221,9 @@ def dijkstra_path_length(G, source, target, weight="weight"):
 
     See Also
     --------
-    bidirectional_dijkstra(), bellman_ford_path_length()
-    single_source_dijkstra()
+    bidirectional_dijkstra
+    bellman_ford_path_length
+    single_source_dijkstra
 
     """
     if source == target:
@@ -291,7 +293,7 @@ def single_source_dijkstra_path(G, source, cutoff=None, weight="weight"):
 
     See Also
     --------
-    single_source_dijkstra(), single_source_bellman_ford()
+    single_source_dijkstra, single_source_bellman_ford
 
     """
     return multi_source_dijkstra_path(G, {source}, cutoff=cutoff, weight=weight)
@@ -361,7 +363,7 @@ def single_source_dijkstra_path_length(G, source, cutoff=None, weight="weight"):
 
     See Also
     --------
-    single_source_dijkstra(), single_source_bellman_ford_path_length()
+    single_source_dijkstra, single_source_bellman_ford_path_length
 
     """
     return multi_source_dijkstra_path_length(G, {source}, cutoff=cutoff, weight=weight)
@@ -457,9 +459,9 @@ def single_source_dijkstra(G, source, target=None, cutoff=None, weight="weight")
 
     See Also
     --------
-    single_source_dijkstra_path()
-    single_source_dijkstra_path_length()
-    single_source_bellman_ford()
+    single_source_dijkstra_path
+    single_source_dijkstra_path_length
+    single_source_bellman_ford
     """
     return multi_source_dijkstra(
         G, {source}, cutoff=cutoff, target=target, weight=weight
@@ -531,7 +533,7 @@ def multi_source_dijkstra_path(G, sources, cutoff=None, weight="weight"):
 
     See Also
     --------
-    multi_source_dijkstra(), multi_source_bellman_ford()
+    multi_source_dijkstra, multi_source_bellman_ford
 
     """
     length, path = multi_source_dijkstra(G, sources, cutoff=cutoff, weight=weight)
@@ -606,7 +608,7 @@ def multi_source_dijkstra_path_length(G, sources, cutoff=None, weight="weight"):
 
     See Also
     --------
-    multi_source_dijkstra()
+    multi_source_dijkstra
 
     """
     if not sources:
@@ -709,8 +711,8 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None, weight="weight")
 
     See Also
     --------
-    multi_source_dijkstra_path()
-    multi_source_dijkstra_path_length()
+    multi_source_dijkstra_path
+    multi_source_dijkstra_path_length
 
     """
     if not sources:
@@ -1085,7 +1087,7 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight="weight"):
 
     See Also
     --------
-    floyd_warshall(), all_pairs_bellman_ford_path()
+    floyd_warshall, all_pairs_bellman_ford_path
 
     """
     path = single_source_dijkstra_path
@@ -1380,7 +1382,7 @@ def bellman_ford_path(G, source, target, weight="weight"):
 
     See Also
     --------
-    dijkstra_path(), bellman_ford_path_length()
+    dijkstra_path, bellman_ford_path_length
     """
     length, path = single_source_bellman_ford(G, source, target=target, weight=weight)
     return path
@@ -1429,7 +1431,7 @@ def bellman_ford_path_length(G, source, target, weight="weight"):
 
     See Also
     --------
-    dijkstra_path_length(), bellman_ford_path()
+    dijkstra_path_length, bellman_ford_path
     """
     if source == target:
         return 0
@@ -1482,7 +1484,7 @@ def single_source_bellman_ford_path(G, source, weight="weight"):
 
     See Also
     --------
-    single_source_dijkstra(), single_source_bellman_ford()
+    single_source_dijkstra, single_source_bellman_ford
 
     """
     (length, path) = single_source_bellman_ford(G, source, weight=weight)
@@ -1534,7 +1536,7 @@ def single_source_bellman_ford_path_length(G, source, weight="weight"):
 
     See Also
     --------
-    single_source_dijkstra(), single_source_bellman_ford()
+    single_source_dijkstra, single_source_bellman_ford
 
     """
     weight = _weight_function(G, weight)
@@ -1599,9 +1601,9 @@ def single_source_bellman_ford(G, source, target=None, weight="weight"):
 
     See Also
     --------
-    single_source_dijkstra()
-    single_source_bellman_ford_path()
-    single_source_bellman_ford_path_length()
+    single_source_dijkstra
+    single_source_bellman_ford_path
+    single_source_bellman_ford_path_length
     """
     if source == target:
         return (0, [source])
@@ -1692,7 +1694,7 @@ def all_pairs_bellman_ford_path(G, weight="weight"):
 
     See Also
     --------
-    floyd_warshall(), all_pairs_dijkstra_path()
+    floyd_warshall, all_pairs_dijkstra_path
 
     """
     path = single_source_bellman_ford_path

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -173,7 +173,7 @@ def graph_edit_distance(
     --------
     optimal_edit_paths, optimize_graph_edit_distance,
 
-    is_isomorphic (test for graph edit distance of 0)
+    is_isomorphic: test for graph edit distance of 0
 
     References
     ----------

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -29,8 +29,8 @@ class AtlasView(Mapping):
 
     See Also
     ========
-    AdjacencyView - View into dict-of-dict-of-dict
-    MultiAdjacencyView - View into dict-of-dict-of-dict-of-dict
+    AdjacencyView: View into dict-of-dict-of-dict
+    MultiAdjacencyView: View into dict-of-dict-of-dict-of-dict
     """
 
     __slots__ = ("_atlas",)
@@ -72,8 +72,8 @@ class AdjacencyView(AtlasView):
 
     See Also
     ========
-    AtlasView - View into dict-of-dict
-    MultiAdjacencyView - View into dict-of-dict-of-dict-of-dict
+    AtlasView: View into dict-of-dict
+    MultiAdjacencyView: View into dict-of-dict-of-dict-of-dict
     """
 
     __slots__ = ()  # Still uses AtlasView slots names _atlas
@@ -94,8 +94,8 @@ class MultiAdjacencyView(AdjacencyView):
 
     See Also
     ========
-    AtlasView - View into dict-of-dict
-    AdjacencyView - View into dict-of-dict-of-dict
+    AtlasView: View into dict-of-dict
+    AdjacencyView: View into dict-of-dict-of-dict
     """
 
     __slots__ = ()  # Still uses AtlasView slots names _atlas
@@ -117,8 +117,8 @@ class UnionAtlas(Mapping):
 
     See Also
     ========
-    UnionAdjacency - View into dict-of-dict-of-dict
-    UnionMultiAdjacency - View into dict-of-dict-of-dict-of-dict
+    UnionAdjacency: View into dict-of-dict-of-dict
+    UnionMultiAdjacency: View into dict-of-dict-of-dict-of-dict
     """
 
     __slots__ = ("_succ", "_pred")
@@ -176,8 +176,8 @@ class UnionAdjacency(Mapping):
 
     See Also
     ========
-    UnionAtlas - View into dict-of-dict
-    UnionMultiAdjacency - View into dict-of-dict-of-dict-of-dict
+    UnionAtlas: View into dict-of-dict
+    UnionMultiAdjacency: View into dict-of-dict-of-dict-of-dict
     """
 
     __slots__ = ("_succ", "_pred")
@@ -224,9 +224,9 @@ class UnionMultiInner(UnionAtlas):
 
     See Also
     ========
-    UnionAtlas - View into dict-of-dict
-    UnionAdjacency - View into dict-of-dict-of-dict
-    UnionMultiAdjacency - View into dict-of-dict-of-dict-of-dict
+    UnionAtlas: View into dict-of-dict
+    UnionAdjacency:  View into dict-of-dict-of-dict
+    UnionMultiAdjacency:  View into dict-of-dict-of-dict-of-dict
     """
 
     __slots__ = ()  # Still uses UnionAtlas slots names _succ, _pred
@@ -254,8 +254,8 @@ class UnionMultiAdjacency(UnionAdjacency):
 
     See Also
     ========
-    UnionAtlas - View into dict-of-dict
-    UnionMultiInner - View into dict-of-dict-of-dict
+    UnionAtlas:  View into dict-of-dict
+    UnionMultiInner:  View into dict-of-dict-of-dict
     """
 
     __slots__ = ()  # Still uses UnionAdjacency slots names _succ, _pred

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -236,8 +236,7 @@ class DiGraph(Graph):
         Class to create a new graph structure in the `to_undirected` method.
         If `None`, a NetworkX class (Graph or MultiGraph) is used.
 
-    Examples
-    --------
+    **Subclassing Example**
 
     Create a low memory graph class that effectively disallows edge
     attributes by using a single attribute dict for all edges.
@@ -493,7 +492,7 @@ class DiGraph(Graph):
            A node in the graph
 
         Raises
-        -------
+        ------
         NetworkXError
            If n is not in the graph.
 
@@ -778,7 +777,7 @@ class DiGraph(Graph):
            A node in the graph
 
         Raises
-        -------
+        ------
         NetworkXError
            If n is not in the graph.
 
@@ -810,7 +809,7 @@ class DiGraph(Graph):
            A node in the graph
 
         Raises
-        -------
+        ------
         NetworkXError
            If n is not in the graph.
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -540,7 +540,7 @@ def create_empty_copy(G, with_data=True):
        Propagate Graph and Nodes data to the new graph.
 
     See Also
-    -----
+    --------
     empty_graph
 
     """

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -237,8 +237,7 @@ class Graph:
         Class to create a new graph structure in the `to_undirected` method.
         If `None`, a NetworkX class (Graph or MultiGraph) is used.
 
-    Examples
-    --------
+    **Subclassing Example**
 
     Create a low memory graph class that effectively disallows edge
     attributes by using a single attribute dict for all edges.
@@ -438,7 +437,8 @@ class Graph:
 
         See Also
         --------
-        number_of_nodes, order  which are identical
+        number_of_nodes: identical method
+        order: identical method
 
         Examples
         --------
@@ -591,7 +591,7 @@ class Graph:
            A node in the graph
 
         Raises
-        -------
+        ------
         NetworkXError
            If n is not in the graph.
 
@@ -762,7 +762,8 @@ class Graph:
 
         See Also
         --------
-        order, __len__  which are identical
+        order: identical method
+        __len__: identical method
 
         Examples
         --------
@@ -782,7 +783,8 @@ class Graph:
 
         See Also
         --------
-        number_of_nodes, __len__  which are identical
+        number_of_nodes: identical method
+        __len__: identical method
 
         Examples
         --------

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -252,9 +252,6 @@ class MultiDiGraph(MultiGraph, DiGraph):
         Class to create a new graph structure in the `to_undirected` method.
         If `None`, a NetworkX class (Graph or MultiGraph) is used.
 
-    Examples
-    --------
-
     Please see :mod:`~networkx.classes.ordered` for examples of
     creating graph subclasses by overwriting the base class `dict` with
     a dictionary-like object.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -245,9 +245,6 @@ class MultiGraph(Graph):
         Class to create a new graph structure in the `to_undirected` method.
         If `None`, a NetworkX class (Graph or MultiGraph) is used.
 
-    Examples
-    --------
-
     Please see :mod:`~networkx.classes.ordered` for examples of
     creating graph subclasses by overwriting the base class `dict` with
     a dictionary-like object.

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -132,7 +132,7 @@ def circular_layout(G, scale=1, center=None, dim=2):
         A dictionary of positions keyed by node
 
     Raises
-    -------
+    ------
     ValueError
         If dim < 2
 
@@ -205,7 +205,7 @@ def shell_layout(G, nlist=None, rotate=None, scale=1, center=None, dim=2):
         A dictionary of positions keyed by node
 
     Raises
-    -------
+    ------
     ValueError
         If dim != 2
 
@@ -977,12 +977,14 @@ def spiral_layout(G, scale=1, center=None, dim=2, resolution=0.35, equidistant=F
         Lower values result in more compressed spiral layouts.
     equidistant : bool
         If True, nodes will be plotted equidistant from each other.
+
     Returns
     -------
     pos : dict
         A dictionary of positions keyed by node
+
     Raises
-    -------
+    ------
     ValueError
         If dim != 2
 

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -261,7 +261,7 @@ def pydot_layout(G, prog="neato", root=None):
     """Create node positions using :mod:`pydot` and Graphviz.
 
     Parameters
-    --------
+    ----------
     G : Graph
         NetworkX graph to be laid out.
     prog : string  (default: 'neato')
@@ -272,7 +272,7 @@ def pydot_layout(G, prog="neato", root=None):
         The node of G from which to start some layout algorithms.
 
     Returns
-    --------
+    -------
     dict
         Dictionary of positions keyed by node.
 
@@ -288,7 +288,7 @@ def pydot_layout(G, prog="neato", root=None):
     representation and GraphViz could treat them as the same node.
     The layout may assign both nodes a single location. See Issue #1568
     If this occurs in your case, consider relabeling the nodes just
-    for the layout computation using something similar to:
+    for the layout computation using something similar to::
 
         H = nx.convert_node_labels_to_integers(G, label_attribute='node_label')
         H_layout = nx.nx_pydot.pydot_layout(G, prog='dot')

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -77,11 +77,11 @@ def draw(G, pos=None, ax=None, **kwds):
 
     See Also
     --------
-    draw_networkx()
-    draw_networkx_nodes()
-    draw_networkx_edges()
-    draw_networkx_labels()
-    draw_networkx_edge_labels()
+    draw_networkx
+    draw_networkx_nodes
+    draw_networkx_edges
+    draw_networkx_labels
+    draw_networkx_edge_labels
 
     Notes
     -----
@@ -144,7 +144,7 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
        For directed graphs, if True draw arrowheads.
        Note: Arrows will be the same color as edges.
 
-    arrowstyle : str, optional (default='-|>')
+    arrowstyle : str, optional (default='-\|>')
         For directed graphs, choose the style of the arrowsheads.
         See `matplotlib.patches.ArrowStyle` for more options.
 
@@ -251,11 +251,11 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
 
     See Also
     --------
-    draw()
-    draw_networkx_nodes()
-    draw_networkx_edges()
-    draw_networkx_labels()
-    draw_networkx_edge_labels()
+    draw
+    draw_networkx_nodes
+    draw_networkx_edges
+    draw_networkx_labels
+    draw_networkx_edge_labels
     """
     import matplotlib.pyplot as plt
 
@@ -414,11 +414,11 @@ def draw_networkx_nodes(
 
     See Also
     --------
-    draw()
-    draw_networkx()
-    draw_networkx_edges()
-    draw_networkx_labels()
-    draw_networkx_edge_labels()
+    draw
+    draw_networkx
+    draw_networkx_edges
+    draw_networkx_labels
+    draw_networkx_edge_labels
     """
     from collections.abc import Iterable
     import numpy as np
@@ -610,11 +610,11 @@ def draw_networkx_edges(
 
     See Also
     --------
-    draw()
-    draw_networkx()
-    draw_networkx_nodes()
-    draw_networkx_labels()
-    draw_networkx_edge_labels()
+    draw
+    draw_networkx
+    draw_networkx_nodes
+    draw_networkx_labels
+    draw_networkx_edge_labels
 
     """
     import numpy as np
@@ -880,11 +880,11 @@ def draw_networkx_labels(
 
     See Also
     --------
-    draw()
-    draw_networkx()
-    draw_networkx_nodes()
-    draw_networkx_edges()
-    draw_networkx_edge_labels()
+    draw
+    draw_networkx
+    draw_networkx_nodes
+    draw_networkx_edges
+    draw_networkx_edge_labels
     """
     import matplotlib.pyplot as plt
 
@@ -1014,11 +1014,11 @@ def draw_networkx_edge_labels(
 
     See Also
     --------
-    draw()
-    draw_networkx()
-    draw_networkx_nodes()
-    draw_networkx_edges()
-    draw_networkx_labels()
+    draw
+    draw_networkx
+    draw_networkx_nodes
+    draw_networkx_edges
+    draw_networkx_labels
     """
     import matplotlib.pyplot as plt
     import numpy as np

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -247,7 +247,7 @@ def soft_random_geometric_graph(
     ----------
     .. [1] Penrose, Mathew D. "Connectivity of soft random geometric graphs."
            The Annals of Applied Probability 26.2 (2016): 986-1028.
-       [2] scipy.stats -
+    .. [2] scipy.stats -
            https://docs.scipy.org/doc/scipy/reference/tutorial/stats.html
 
     """

--- a/networkx/generators/internet_as_graphs.py
+++ b/networkx/generators/internet_as_graphs.py
@@ -417,21 +417,22 @@ def random_internet_as_graph(n, seed=None):
     -----
     This algorithm returns an undirected graph resembling the Internet
     Autonomous System (AS) network, it uses the approach by Elmokashfi et al.
-    [1] and it grants the properties described in the related paper [1].
+    [1]_ and it grants the properties described in the related paper [1]_.
 
     Each node models an autonomous system, with an attribute 'type' specifying
     its kind; tier-1 (T), mid-level (M), customer (C) or content-provider (CP).
     Each edge models an ADV communication link (hence, bidirectional) with
     attributes:
-        - type: transit|peer, the kind of commercial agreement between nodes;
-        - customer: <node id>, the identifier of the node acting as customer
-            ('none' if type is peer).
+
+      - type: transit|peer, the kind of commercial agreement between nodes;
+      - customer: <node id>, the identifier of the node acting as customer
+        ('none' if type is peer).
 
     References
     ----------
-    [1] A. Elmokashfi, A. Kvalbein and C. Dovrolis, "On the Scalability of
-    BGP: The Role of Topology Growth," in IEEE Journal on Selected Areas
-    in Communications, vol. 28, no. 8, pp. 1250-1261, October 2010.
+    .. [1] A. Elmokashfi, A. Kvalbein and C. Dovrolis, "On the Scalability of
+       BGP: The Role of Topology Growth," in IEEE Journal on Selected Areas
+       in Communications, vol. 28, no. 8, pp. 1250-1261, October 2010.
     """
 
     GG = AS_graph_generator(n, seed)

--- a/networkx/generators/interval_graph.py
+++ b/networkx/generators/interval_graph.py
@@ -35,7 +35,7 @@ def interval_graph(intervals):
     [((-2, 3), (1, 4)), ((-2, 3), (2, 3)), ((1, 4), (2, 3)), ((1, 4), (4, 6))]
 
     Raises
-    --------
+    ------
     :exc:`TypeError`
         if `intervals` contains None or an element which is not
         collections.abc.Sequence or not a length of 2.

--- a/networkx/generators/mycielski.py
+++ b/networkx/generators/mycielski.py
@@ -48,7 +48,7 @@ def mycielskian(G, iterations=1):
         The Mycielskian of G after the specified number of iterations.
 
     Notes
-    ------
+    -----
     Graph, node, and edge data are not necessarily propagated to the new graph.
 
     """

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -196,7 +196,7 @@ def dense_gnm_random_graph(n, m, seed=None):
 
     See Also
     --------
-    gnm_random_graph()
+    gnm_random_graph
 
     Notes
     -----
@@ -319,7 +319,7 @@ def newman_watts_strogatz_graph(n, k, p, seed=None):
 
     See Also
     --------
-    watts_strogatz_graph()
+    watts_strogatz_graph
 
     References
     ----------
@@ -379,8 +379,8 @@ def watts_strogatz_graph(n, k, p, seed=None):
 
     See Also
     --------
-    newman_watts_strogatz_graph()
-    connected_watts_strogatz_graph()
+    newman_watts_strogatz_graph
+    connected_watts_strogatz_graph
 
     Notes
     -----
@@ -469,8 +469,8 @@ def connected_watts_strogatz_graph(n, k, p, tries=100, seed=None):
 
     See Also
     --------
-    newman_watts_strogatz_graph()
-    watts_strogatz_graph()
+    newman_watts_strogatz_graph
+    watts_strogatz_graph
 
     References
     ----------

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -36,7 +36,7 @@ def cytoscape_data(G, attrs=None):
 
     See Also
     --------
-    cytoscape_graph - convert a dictionary in cyjs format to a graph
+    cytoscape_graph: convert a dictionary in cyjs format to a graph
 
     References
     ----------
@@ -144,7 +144,7 @@ def cytoscape_graph(data, attrs=None):
 
     See Also
     --------
-    cytoscape_data - convert a NetworkX graph to a dict in cyjs format
+    cytoscape_data: convert a NetworkX graph to a dict in cyjs format
 
     References
     ----------

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -176,7 +176,7 @@ def parse_pajek(lines):
 
     See Also
     --------
-    read_pajek()
+    read_pajek
 
     """
     import shlex

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,6 +1,7 @@
 sphinx==3.3.1
 sphinx_rtd_theme==0.5.0
 sphinx-gallery==0.8.1
+numpydoc>=1.1
 pillow>=8.0
 nb2plots>=0.6
 texext>=0.6.6


### PR DESCRIPTION
**Motivation**

`numpydoc` and `sphinx.ext.napoleon` are two sphinx extensions that implement the [numpydoc docstring standard](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard). I propose switching to the `numpydoc` extension as it is a bit more strict about enforcing the standard, and catches things like when sections are mis-named, sections are repeated multiple times, etc. The more stringent enforcement of the standard also helps make the docstrings themselves more consistent, should help with working with other sphinx themes, and may improve compatibility with external tooling e.g. code highlighters/lexers. There are also some nice docstring validation features that will (hopefully) make it into the next release of numpydoc.

8d1c908 encapsulate the changes related to switching to numpydoc, and 758c65e fixes the warnings/errors raised by `numpydoc` during the sphinx-build process.