### PR TITLE
Deprecate iterable

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -49,6 +49,7 @@ Version 3.0
 * In ``utils/misc.py`` remove ``is_string_like`` and related tests.
 * In ``utils/misc.py`` remove ``make_str`` and related tests.
 * In ``utils/misc.py`` remove ``is_iterator``.
+* In ``utils/misc.py`` remove ``iterable``.
 * In ``utils/misc.py`` remove ``is_list_of_ints``.
 * In ``utils/misc.py`` remove ``consume``.
 * Remove ``utils/contextmanagers.py`` and related tests.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -34,11 +34,9 @@ API Changes
 
 - [`#4190 <https://github.com/networkx/networkx/pull/4190>`_]
   Removed ``tracemin_chol``.  Use ``tracemin_lu`` instead.
-
 - [`#4216 <https://github.com/networkx/networkx/pull/4216>`_]
   In `to_*_array/matrix`, nodes in nodelist but not in G now raise an exception.
   Use G.add_nodes_from(nodelist) to add them to G before converting.
-
 - [`#4360  <https://github.com/networkx/networkx/pull/4360>`_]
   Internally `.nx_pylab.draw_networkx_edges` now always generates a
   list of `matplotlib.patches.FancyArrowPatch` rather than using
@@ -46,7 +44,6 @@ API Changes
   unifies interface for all types of graphs.  In
   addition to the API change this may cause a performance regression for
   large graphs.
-
 - [`#4384 <https://github.com/networkx/networkx/pull/4384>`_]
   Added edge_key parameter for MultiGraphs in to_pandas_edgelist
 
@@ -77,6 +74,8 @@ Deprecations
   Deprecate ``jit_data`` and ``jit_graph``.
 - [`#4449 <https://github.com/networkx/networkx/pull/4449>`_]
   Deprecate ``consume``.
+- [`#4448 <https://github.com/networkx/networkx/pull/4448>`_]
+  Deprecate ``iterable``.
 
 Contributors to this release
 ----------------------------

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -102,6 +102,9 @@ def set_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="jit_data")
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="jit_graph")
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="consume")
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="iterable is deprecated"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -18,7 +18,7 @@ from math import sqrt
 from networkx.classes import set_node_attributes
 from networkx.exception import NetworkXError
 from networkx.relabel import relabel_nodes
-from networkx.utils import flatten, nodes_or_number, pairwise, iterable
+from networkx.utils import flatten, nodes_or_number, pairwise
 from networkx.generators.classic import cycle_graph
 from networkx.generators.classic import empty_graph
 from networkx.generators.classic import path_graph
@@ -67,9 +67,9 @@ def grid_2d_graph(m, n, periodic=False, create_using=None):
     G.add_edges_from(((i, j), (pi, j)) for pi, i in pairwise(rows) for j in cols)
     G.add_edges_from(((i, j), (i, pj)) for i in rows for pj, j in pairwise(cols))
 
-    if iterable(periodic):
+    try:
         periodic_r, periodic_c = periodic
-    else:
+    except TypeError:
         periodic_r = periodic_c = periodic
 
     if periodic_r and len(rows) > 2:
@@ -128,9 +128,9 @@ def grid_graph(dim, periodic=False):
     if not dim:
         return empty_graph(0)
 
-    if iterable(periodic):
+    try:
         func = (cycle_graph if p else path_graph for p in periodic)
-    else:
+    except TypeError:
         func = repeat(cycle_graph if periodic else path_graph)
 
     G = next(func)(dim[0])

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -12,7 +12,7 @@ can be accessed, for example, as
 """
 
 from collections import defaultdict, deque
-from collections.abc import Iterator
+from collections.abc import Iterator, Sized
 import warnings
 import sys
 import uuid
@@ -55,12 +55,12 @@ def empty_generator():
 
 def flatten(obj, result=None):
     """ Return flattened version of (possibly nested) iterable object. """
-    if not iterable(obj) or isinstance(obj, str):
+    if not isinstance(obj, Sized) or isinstance(obj, str):
         return obj
     if result is None:
         result = []
     for item in obj:
-        if not iterable(item) or isinstance(item, str):
+        if not isinstance(item, Sized) or isinstance(item, str):
             result.append(item)
         else:
             flatten(item, result)

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -12,7 +12,7 @@ can be accessed, for example, as
 """
 
 from collections import defaultdict, deque
-from collections.abc import Iterator, Sized
+from collections.abc import Iterable, Iterator, Sized
 import warnings
 import sys
 import uuid
@@ -37,7 +37,10 @@ def is_string_like(obj):  # from John Hunter, types-free version
 
 def iterable(obj):
     """ Return True if obj is iterable with a well-defined len()."""
-    msg = "iterable is deprecated and will be removed in 3.0."
+    msg = (
+        "iterable is deprecated and will be removed in 3.0."
+        "Use isinstance(obj, (collections.abc.Iterable, collections.abc.Sized)) instead."
+    )
     warnings.warn(msg, DeprecationWarning)
     if hasattr(obj, "__iter__"):
         return True
@@ -55,12 +58,12 @@ def empty_generator():
 
 def flatten(obj, result=None):
     """ Return flattened version of (possibly nested) iterable object. """
-    if not isinstance(obj, Sized) or isinstance(obj, str):
+    if not isinstance(obj, (Iterable, Sized)) or isinstance(obj, str):
         return obj
     if result is None:
         result = []
     for item in obj:
-        if not isinstance(item, Sized) or isinstance(item, str):
+        if not isinstance(item, (Iterable, Sized)) or isinstance(item, str):
             result.append(item)
         else:
             flatten(item, result)

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -37,6 +37,8 @@ def is_string_like(obj):  # from John Hunter, types-free version
 
 def iterable(obj):
     """ Return True if obj is iterable with a well-defined len()."""
+    msg = "iterable is deprecated and will be removed in 3.0."
+    warnings.warn(msg, DeprecationWarning)
     if hasattr(obj, "__iter__"):
         return True
     try:


### PR DESCRIPTION
This function added 10 years ago, so maybe it was needed for some Python 2 case that I can't recall.  If we are keeping it in, we should come up with an example of an ``obj`` such that

- ``hasattr(obj, "__iter__")`` is ``False``
- ``len(obj)`` doesn't raise an exception

and it makes sense to use it in ``flatten`` or ``generators/lattice.py``

See #4224.