### PR TITLE
Deprecate consume

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -50,6 +50,7 @@ Version 3.0
 * In ``utils/misc.py`` remove ``make_str`` and related tests.
 * In ``utils/misc.py`` remove ``is_iterator``.
 * In ``utils/misc.py`` remove ``is_list_of_ints``.
+* In ``utils/misc.py`` remove ``consume``.
 * Remove ``utils/contextmanagers.py`` and related tests.
 * In ``drawing/nx_agraph.py`` remove ``display_pygraphviz`` and related tests.
 * In ``algorithms/chordal.py`` replace ``chordal_graph_cliques`` with ``_chordal_graph_cliques``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -74,6 +74,8 @@ Deprecations
   Deprecate unused ``order`` parameter in to_pandas_edgelist.
 - [`#4428 <https://github.com/networkx/networkx/pull/4428>`_]
   Deprecate ``jit_data`` and ``jit_graph``.
+- [`#4449 <https://github.com/networkx/networkx/pull/4449>`_]
+  Deprecate ``consume``.
 
 Contributors to this release
 ----------------------------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -17,7 +17,6 @@ import networkx as nx
 from networkx.algorithms.traversal.breadth_first_search import descendants_at_distance
 from networkx.generators.trees import NIL
 from networkx.utils import arbitrary_element
-from networkx.utils import consume
 from networkx.utils import pairwise
 from networkx.utils import not_implemented_for
 
@@ -84,7 +83,8 @@ def ancestors(G, source):
 def has_cycle(G):
     """Decides whether the directed graph has a cycle."""
     try:
-        consume(topological_sort(G))
+        # Feed the entire iterator into a zero-length deque.
+        deque(topological_sort(G), maxlen=0)
     except nx.NetworkXUnfeasible:
         return True
     else:

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -1,11 +1,17 @@
 from itertools import combinations, permutations
+from collections import deque
 
 import pytest
 
 import networkx as nx
 from networkx.testing.utils import assert_edges_equal
-from networkx.utils import consume
 from networkx.utils import pairwise
+
+# Recipe from the itertools documentation.
+def _consume(iterator):
+    "Consume the iterator entirely."
+    # Feed the entire iterator into a zero-length deque.
+    deque(iterator, maxlen=0)
 
 
 class TestDagLongestPath:
@@ -100,7 +106,7 @@ class TestDAG:
         DG.add_edge(3, 2)
 
         for algorithm in [nx.topological_sort, nx.lexicographical_topological_sort]:
-            pytest.raises(nx.NetworkXUnfeasible, consume, algorithm(DG))
+            pytest.raises(nx.NetworkXUnfeasible, _consume, algorithm(DG))
 
         DG.remove_edge(2, 3)
 
@@ -133,12 +139,12 @@ class TestDAG:
                 14: [15],
             }
         )
-        pytest.raises(nx.NetworkXUnfeasible, consume, nx.topological_sort(DG))
+        pytest.raises(nx.NetworkXUnfeasible, _consume, nx.topological_sort(DG))
 
         assert not nx.is_directed_acyclic_graph(DG)
 
         DG.remove_edge(1, 2)
-        consume(nx.topological_sort(DG))
+        _consume(nx.topological_sort(DG))
         assert nx.is_directed_acyclic_graph(DG)
 
     def test_topological_sort3(self):
@@ -157,13 +163,13 @@ class TestDAG:
         validate(list(nx.topological_sort(DG)))
 
         DG.add_edge(14, 1)
-        pytest.raises(nx.NetworkXUnfeasible, consume, nx.topological_sort(DG))
+        pytest.raises(nx.NetworkXUnfeasible, _consume, nx.topological_sort(DG))
 
     def test_topological_sort4(self):
         G = nx.Graph()
         G.add_edge(1, 2)
         # Only directed graphs can be topologically sorted.
-        pytest.raises(nx.NetworkXError, consume, nx.topological_sort(G))
+        pytest.raises(nx.NetworkXError, _consume, nx.topological_sort(G))
 
     def test_topological_sort5(self):
         G = nx.DiGraph()

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -101,6 +101,7 @@ def set_warnings():
     )
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="jit_data")
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="jit_graph")
+    warnings.filterwarnings("ignore", category=DeprecationWarning, message="consume")
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -255,6 +255,11 @@ def arbitrary_element(iterable):
 def consume(iterator):
     "Consume the iterator entirely."
     # Feed the entire iterator into a zero-length deque.
+    msg = (
+        "consume is deprecated and will be removed in version 3.0. "
+        "Use ``collections.deque(iterator, maxlen=0)`` instead."
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     deque(iterator, maxlen=0)
 
 


### PR DESCRIPTION
We only use this in one place and it has a one-line body.

See #4224.