### PR TITLE
Allow relabel_nodes mapping to have non-node keys that get ignored

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -49,6 +49,11 @@ API Changes
 - [`#4384 <https://github.com/networkx/networkx/pull/4384>`_]
   Added edge_key parameter for MultiGraphs in to_pandas_edgelist
 
+- [`#4466 <https://github.com/networkx/networkx/pull/4466>`_]
+  `relabel_nodes` used to raise a KeyError for a key in `mapping` that is not
+  a node in the graph, but it only did this when `copy` was `False`. Now
+  any keys in `mapping` which are not in the graph are ignored.
+
 Deprecations
 ------------
 

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -14,6 +14,7 @@ def relabel_nodes(G, mapping, copy=True):
     mapping : dictionary
        A dictionary with the old labels as keys and new labels as values.
        A partial mapping is allowed. Mapping 2 nodes to a single node is allowed.
+       Any non-node keys in the mapping are ignored.
 
     copy : bool (optional, default=True)
        If True return a copy, or if False relabel the nodes in place.
@@ -88,6 +89,7 @@ def relabel_nodes(G, mapping, copy=True):
     Notes
     -----
     Only the nodes specified in the mapping will be relabeled.
+    Any non-node keys in the mapping are ignored.
 
     The keyword setting copy=False modifies the graph in place.
     Relabel_nodes avoids naming collisions by building a
@@ -144,16 +146,14 @@ def _relabel_inplace(G, mapping):
     directed = G.is_directed()
 
     for old in nodes:
+        # Test that old is in both mapping and G, otherwise ignore.
         try:
             new = mapping[old]
+            G.add_node(new, **G.nodes[old])
         except KeyError:
             continue
         if new == old:
             continue
-        try:
-            G.add_node(new, **G.nodes[old])
-        except KeyError as e:
-            raise KeyError(f"Node {old} is not in the graph") from e
         if multigraph:
             new_edges = [
                 (new, new if old == target else target, key, data)

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -147,10 +147,15 @@ class TestRelabel:
         assert_nodes_equal(H.nodes(), list(range(4)))
 
     def test_relabel_nodes_missing(self):
-        with pytest.raises(KeyError):
-            G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
-            mapping = {0: "aardvark"}
-            G = nx.relabel_nodes(G, mapping, copy=False)
+        G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
+        mapping = {0: "aardvark"}
+        # copy=True
+        H = nx.relabel_nodes(G, mapping, copy=True)
+        assert_nodes_equal(H.nodes, G.nodes)
+        # copy=False
+        GG = G.copy()
+        nx.relabel_nodes(G, mapping, copy=False)
+        assert_nodes_equal(G.nodes, GG.nodes)
 
     def test_relabel_copy_name(self):
         G = nx.Graph()


### PR DESCRIPTION
Motivated by #4465 this PR allows the mapping used in `nx.relabel_nodes` to contain keys that are not nodes even when `copy=False`.  Previous behavior is that `copy=True` would ignore those keys and `copy=False` would raise a KeyError.

I'm not sure whether this needs to be Deprecated rather than changed because it would affect any user that relies on the KeyError "feature" to indicate whether the mapping has spurious keys. They can of course check for that with e.g. `if set(mapping)-set(G): raise KeyError`.  Still, maybe a note in the release_nodes is sufficient rather than a deprecation.
