### PR TITLE
Drop Py3.6 support per NEP 29

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,10 +11,6 @@ environment:
     CACHE_DIR: "%LOCALAPPDATA%\\pip\\Cache"
 
   matrix:
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.7, 3.8, 3.9, pypy-3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,7 +1,7 @@
 Install
 =======
 
-NetworkX requires Python 3.6, 3.7, 3.8, or 3.9.  If you do not already
+NetworkX requires Python 3.7, 3.8, or 3.9.  If you do not already
 have a Python environment configured on your computer, please see the
 instructions for installing the full `scientific Python stack
 <https://scipy.org/install.html>`_.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -17,13 +17,14 @@ Highlights
 This release is the result of X of work with over X pull requests by
 X contributors. Highlights include:
 
+- Dropped support for Python 3.6.
 - NumPy, SciPy, Matplotlib, and pandas are now default requirements.
 
 Improvements
 ------------
 
 - [`#4319 <https://github.com/networkx/networkx/pull/4319>`_]
-pagerank uses scipy by default now.
+  pagerank uses scipy by default now.
 - [`#4317 <https://github.com/networkx/networkx/pull/4317>`_]
   New ``source`` argument to ``has_eulerian_path`` to look for path starting at
   source.

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -10,8 +10,8 @@ See https://networkx.org for complete documentation.
 
 import sys
 
-if sys.version_info[:2] < (3, 6):
-    m = "Python 3.6 or later is required for NetworkX (%d.%d detected)."
+if sys.version_info[:2] < (3, 7):
+    m = "Python 3.7 or later is required for NetworkX (%d.%d detected)."
     raise ImportError(m % sys.version_info[:2])
 del sys
 

--- a/networkx/release.py
+++ b/networkx/release.py
@@ -216,7 +216,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ if sys.argv[-1] == "setup.py":
     print("To install, run 'python setup.py install'")
     print()
 
-if sys.version_info[:2] < (3, 6):
+if sys.version_info[:2] < (3, 7):
     error = (
-        "NetworkX 2.5+ requires Python 3.6 or later (%d.%d detected). \n"
+        "NetworkX 2.6+ requires Python 3.7 or later (%d.%d detected). \n"
         "For Python 2.7, please install version 2.2 using: \n"
         "$ pip install 'networkx==2.2'" % sys.version_info[:2]
     )
@@ -162,6 +162,6 @@ if __name__ == "__main__":
         package_data=package_data,
         install_requires=install_requires,
         extras_require=extras_require,
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         zip_safe=False,
     )


### PR DESCRIPTION
Several of the core packages have decided to drop support for Python 3.6 on their next release.

scikit-image already has a release without Python 3.6 support:
- https://pypi.org/project/scikit-image/  (Dec. 15)

NumPy, SciPy, and Pandas already have release candidates without Python 3.6 support:
- https://pypi.org/project/numpy/1.20.0rc1/  (Dec. 3)
- https://pypi.org/project/scipy/1.6.0rc1/  (Dec. 10)
- https://pypi.org/project/pandas/1.2.0rc0/  (Dec. 8)

I am not sure when Matplotlib is planning to make a new release, but they've removed support for 3.6 from master already.
- https://github.com/matplotlib/matplotlib/pull/17662 (Jul. 6)

GH actions/setup-python now supports PyPy-3.7:
- https://github.com/actions/setup-python/pull/168

I recommend we also follow NEP 29 and drop 3.6 support (which is what this PR does).

For more information see:
- https://numpy.org/neps/nep-0029-deprecation_policy.html