### PR TITLE
Improve code coverage for cuts.py

### DIFF
--- a/networkx/algorithms/cuts.py
+++ b/networkx/algorithms/cuts.py
@@ -32,11 +32,11 @@ def cut_size(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
-    T : sequence
-        A sequence of nodes in `G`. If not specified, this is taken to
+    T : container
+        A container of nodes in `G`. If not specified, this is taken to
         be the set complement of `S`.
 
     weight : object
@@ -93,8 +93,8 @@ def volume(G, S, weight=None):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -135,11 +135,11 @@ def normalized_cut_size(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
-    T : sequence
-        A sequence of nodes in `G`.
+    T : container
+        A container of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -187,11 +187,11 @@ def conductance(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
-    T : sequence
-        A sequence of nodes in `G`.
+    T : container
+        A container of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -234,11 +234,11 @@ def edge_expansion(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
-    T : sequence
-        A sequence of nodes in `G`.
+    T : container
+        A container of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -280,11 +280,11 @@ def mixing_expansion(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
-    T : sequence
-        A sequence of nodes in `G`.
+    T : container
+        A container of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -327,8 +327,8 @@ def node_expansion(G, S):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
     Returns
     -------
@@ -366,8 +366,8 @@ def boundary_expansion(G, S):
     ----------
     G : NetworkX graph
 
-    S : sequence
-        A sequence of nodes in `G`.
+    S : container
+        A container of nodes in `G`.
 
     Returns
     -------

--- a/networkx/algorithms/cuts.py
+++ b/networkx/algorithms/cuts.py
@@ -32,11 +32,11 @@ def cut_size(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
-    T : container
-        A container of nodes in `G`. If not specified, this is taken to
+    T : collection
+        A collection of nodes in `G`. If not specified, this is taken to
         be the set complement of `S`.
 
     weight : object
@@ -93,8 +93,8 @@ def volume(G, S, weight=None):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -135,11 +135,11 @@ def normalized_cut_size(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
-    T : container
-        A container of nodes in `G`.
+    T : collection
+        A collection of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -187,11 +187,11 @@ def conductance(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
-    T : container
-        A container of nodes in `G`.
+    T : collection
+        A collection of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -234,11 +234,11 @@ def edge_expansion(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
-    T : container
-        A container of nodes in `G`.
+    T : collection
+        A collection of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -280,11 +280,11 @@ def mixing_expansion(G, S, T=None, weight=None):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
-    T : container
-        A container of nodes in `G`.
+    T : collection
+        A collection of nodes in `G`.
 
     weight : object
         Edge attribute key to use as weight. If not specified, edges
@@ -327,8 +327,8 @@ def node_expansion(G, S):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
     Returns
     -------
@@ -366,8 +366,8 @@ def boundary_expansion(G, S):
     ----------
     G : NetworkX graph
 
-    S : container
-        A container of nodes in `G`.
+    S : collection
+        A collection of nodes in `G`.
 
     Returns
     -------

--- a/networkx/algorithms/tests/test_cuts.py
+++ b/networkx/algorithms/tests/test_cuts.py
@@ -87,8 +87,7 @@ class TestNormalizedCutSize:
         expected = 2 * ((1 / 4) + (1 / 2))
         assert expected == size
         # Test with no input T
-        size_no_T = nx.normalized_cut_size(G, S)
-        assert expected == size_no_T
+        assert expected == nx.normalized_cut_size(G, S)
 
     def test_directed(self):
         G = nx.DiGraph([(0, 1), (1, 2), (2, 3)])
@@ -99,8 +98,7 @@ class TestNormalizedCutSize:
         expected = 2 * ((1 / 2) + (1 / 1))
         assert expected == size
         # Test with no input T
-        size_no_T = nx.normalized_cut_size(G, S)
-        assert expected == size_no_T
+        assert expected == nx.normalized_cut_size(G, S)
 
 
 class TestConductance:
@@ -119,9 +117,7 @@ class TestConductance:
         G2 = nx.barbell_graph(3, 0)
         # There is only one cut edge, and each set has volume seven.
         S2 = {0, 1, 2}
-        conductance_no_T = nx.conductance(G2, S2)
-        expected2 = 1 / 7
-        assert expected2 == conductance_no_T
+        assert nx.conductance(G2, S2) == 1 / 7
 
 
 class TestEdgeExpansion:
@@ -135,8 +131,7 @@ class TestEdgeExpansion:
         expected = 1 / 5
         assert expected == expansion
         # Test with no input T
-        expansion_no_T = nx.edge_expansion(G, S)
-        assert expected == expansion_no_T
+        assert expected == nx.edge_expansion(G, S)
 
 
 class TestNodeExpansion:

--- a/networkx/algorithms/tests/test_cuts.py
+++ b/networkx/algorithms/tests/test_cuts.py
@@ -83,10 +83,11 @@ class TestNormalizedCutSize:
         S = {1, 2}
         T = set(G) - S
         size = nx.normalized_cut_size(G, S, T)
-        size_no_T = nx.normalized_cut_size(G, S)
         # The cut looks like this: o-{-o--o-}-o
         expected = 2 * ((1 / 4) + (1 / 2))
         assert expected == size
+        # Test with no input T
+        size_no_T = nx.normalized_cut_size(G, S)
         assert expected == size_no_T
 
     def test_directed(self):
@@ -94,10 +95,11 @@ class TestNormalizedCutSize:
         S = {1, 2}
         T = set(G) - S
         size = nx.normalized_cut_size(G, S, T)
-        size_no_T = nx.normalized_cut_size(G, S)
         # The cut looks like this: o-{->o-->o-}->o
         expected = 2 * ((1 / 2) + (1 / 1))
         assert expected == size
+        # Test with no input T
+        size_no_T = nx.normalized_cut_size(G, S)
         assert expected == size_no_T
 
 
@@ -106,17 +108,19 @@ class TestConductance:
 
     def test_graph(self):
         G = nx.barbell_graph(5, 0)
-        G2 = nx.barbell_graph(3, 0)
         # Consider the singleton sets containing the "bridge" nodes.
         # There is only one cut edge, and each set has volume five.
         S = {4}
         T = {5}
-        S2 = {0, 1, 2}
         conductance = nx.conductance(G, S, T)
-        conductance_no_T = nx.conductance(G2, S2)
         expected = 1 / 5
-        expected2 = 1 / 7
         assert expected == conductance
+        # Test with no input T
+        G2 = nx.barbell_graph(3, 0)
+        # There is only one cut edge, and each set has volume seven.
+        S2 = {0, 1, 2}
+        conductance_no_T = nx.conductance(G2, S2)
+        expected2 = 1 / 7
         assert expected2 == conductance_no_T
 
 
@@ -128,9 +132,10 @@ class TestEdgeExpansion:
         S = set(range(5))
         T = set(G) - S
         expansion = nx.edge_expansion(G, S, T)
-        expansion_no_T = nx.edge_expansion(G, S)
         expected = 1 / 5
         assert expected == expansion
+        # Test with no input T
+        expansion_no_T = nx.edge_expansion(G, S)
         assert expected == expansion_no_T
 
 

--- a/networkx/algorithms/tests/test_cuts.py
+++ b/networkx/algorithms/tests/test_cuts.py
@@ -66,6 +66,11 @@ class TestVolume:
         G = nx.MultiDiGraph(edges * 2)
         assert nx.volume(G, {0, 1}) == 4
 
+    def test_barbell(self):
+        G = nx.barbell_graph(3, 0)
+        assert nx.volume(G, {0, 1, 2}) == 7
+        assert nx.volume(G, {3, 4, 5}) == 7
+
 
 class TestNormalizedCutSize:
     """Unit tests for the :func:`~networkx.normalized_cut_size`
@@ -78,18 +83,22 @@ class TestNormalizedCutSize:
         S = {1, 2}
         T = set(G) - S
         size = nx.normalized_cut_size(G, S, T)
+        size_no_T = nx.normalized_cut_size(G, S)
         # The cut looks like this: o-{-o--o-}-o
         expected = 2 * ((1 / 4) + (1 / 2))
         assert expected == size
+        assert expected == size_no_T
 
     def test_directed(self):
         G = nx.DiGraph([(0, 1), (1, 2), (2, 3)])
         S = {1, 2}
         T = set(G) - S
         size = nx.normalized_cut_size(G, S, T)
+        size_no_T = nx.normalized_cut_size(G, S)
         # The cut looks like this: o-{->o-->o-}->o
         expected = 2 * ((1 / 2) + (1 / 1))
         assert expected == size
+        assert expected == size_no_T
 
 
 class TestConductance:
@@ -97,13 +106,18 @@ class TestConductance:
 
     def test_graph(self):
         G = nx.barbell_graph(5, 0)
+        G2 = nx.barbell_graph(3, 0)
         # Consider the singleton sets containing the "bridge" nodes.
         # There is only one cut edge, and each set has volume five.
         S = {4}
         T = {5}
+        S2 = {0, 1, 2}
         conductance = nx.conductance(G, S, T)
+        conductance_no_T = nx.conductance(G2, S2)
         expected = 1 / 5
+        expected2 = 1 / 7
         assert expected == conductance
+        assert expected2 == conductance_no_T
 
 
 class TestEdgeExpansion:
@@ -114,8 +128,10 @@ class TestEdgeExpansion:
         S = set(range(5))
         T = set(G) - S
         expansion = nx.edge_expansion(G, S, T)
+        expansion_no_T = nx.edge_expansion(G, S)
         expected = 1 / 5
         assert expected == expansion
+        assert expected == expansion_no_T
 
 
 class TestNodeExpansion:


### PR DESCRIPTION
Here I added some tests to test_cuts.py to improve code coverage. It should be at 100% now. I also change the term "sequence" to"container" in cuts.py. This is because the documentation refers to the inputs of the functions as sets and sets are unordered and therefore are not sequences.