### PR TITLE
Fix bfs_predecessors to reverse edges for directed graphs

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -289,7 +289,11 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
     edge_bfs
     """
     for s, t in bfs_edges(
-        G, source, depth_limit=depth_limit, sort_neighbors=sort_neighbors
+        G,
+        source,
+        reverse=G.is_directed(),
+        depth_limit=depth_limit,
+        sort_neighbors=sort_neighbors,
     ):
         yield (t, s)
 

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -271,7 +271,7 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
     >>> nx.add_path(N, [0, 1, 2, 3, 4, 7])
     >>> nx.add_path(N, [3, 5, 6, 7])
     >>> print(sorted(nx.bfs_predecessors(N, source=2)))
-    [(3, 2), (4, 3), (5, 3), (6, 5), (7, 4)]
+    [(0, 1), (1, 2)]
 
     Notes
     -----

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -16,6 +16,22 @@ class TestBFS:
     def test_predecessor(self):
         assert dict(nx.bfs_predecessors(self.G, source=0)) == {1: 0, 2: 1, 3: 1, 4: 2}
 
+    def test_predecessor_directed_graph(self):
+        # We have a directed graph that looks like this:
+        #        3   4
+        #        ↓   ↓
+        #        1   2
+        #         ↘ ↙
+        #          0
+        G = nx.DiGraph()
+        G.add_edges_from([(3, 1), (1, 0), (4, 2), (2, 0)])
+        assert sorted(nx.bfs_predecessors(G, source=0)) == [
+            (1, 0),
+            (2, 0),
+            (3, 1),
+            (4, 2),
+        ]
+
     def test_bfs_tree(self):
         T = nx.bfs_tree(self.G, source=0)
         assert sorted(T.nodes()) == sorted(self.G.nodes())

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -18,18 +18,20 @@ class TestBFS:
 
     def test_predecessor_directed_graph(self):
         # We have a directed graph that looks like this:
-        #        3   4
+        #        0   2
         #        ↓   ↓
-        #        1   2
+        #        1   3
         #         ↘ ↙
-        #          0
+        #          4
+        #          ↓
+        #          5
         G = nx.DiGraph()
-        G.add_edges_from([(3, 1), (1, 0), (4, 2), (2, 0)])
-        assert sorted(nx.bfs_predecessors(G, source=0)) == [
-            (1, 0),
-            (2, 0),
-            (3, 1),
-            (4, 2),
+        G.add_edges_from([(0, 1), (2, 3), (1, 4), (3, 4), (4, 5)])
+        assert sorted(nx.bfs_predecessors(G, source=4)) == [
+            (0, 1),
+            (1, 4),
+            (2, 3),
+            (3, 4),
         ]
 
     def test_bfs_tree(self):


### PR DESCRIPTION
This may be a misunderstanding on my part, but I believe bfs_predecessors is broken for directed graphs. Here is a sample code showing a simple example where `G.predecessors` correctly returns the predecessors, but the `nx.bfs_predecessors` fails to:

```
import networkx as nx
G = nx.DiGraph()
G.add_edges_from([(1, 0), (2, 0)])
nx.draw_networkx(G, with_labels=True)
print(list(G.predecessors(0)), list(nx.bfs_predecessors(G, 0)))
[1, 2] []
```
![image](https://user-images.githubusercontent.com/963909/103021179-c06f0e00-4517-11eb-850a-6e80aea88157.png)


I attached a patch .with a simple fix for this.