### PR TITLE
Fixes read/write_gml with nan/inf attributes

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -311,7 +311,7 @@ def parse_gml_lines(lines, label, destringizer):
                         if i == 0:  # keys
                             value = group.rstrip()
                         elif i == 1:  # reals
-                            value = group.replace('_', '') # handle incoming nan
+                            value = group.replace("_", "")  # handle incoming nan
                             value = float(value)
                         elif i == 2:  # ints
                             value = int(group)
@@ -684,9 +684,9 @@ def generate_gml(G, stringizer=None):
                 # GML matches INF and NAN to keys, so prepend + to INF and _ to NAN
                 # so they can be correctly detected.  Use repr(float(*)) instead of
                 # string literal to future proof against changes to repr.
-                if text == repr(float('nan')).upper():
+                if text == repr(float("nan")).upper():
                     text = "_" + text
-                elif text == repr(float('inf')).upper():
+                elif text == repr(float("inf")).upper():
                     text = "+" + text
                 else:
                     # GML requires that a real literal contain a decimal point, but

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -288,7 +288,7 @@ def parse_gml_lines(lines, label, destringizer):
         patterns = [
             r"[A-Za-z][0-9A-Za-z_]*\b",  # keys
             # reals
-            r"[+-]?(?:[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)(?:[Ee][+-]?[0-9]+)?",
+            r"[+-]?(?:[0-9]*\.[0-9]+|[0-9]+\.[0-9]*|INF)(?:[Ee][+-]?[0-9]+)?|_NAN",
             r"[+-]?[0-9]+",  # ints
             r'".*?"',  # strings
             r"\[",  # dict start
@@ -311,7 +311,8 @@ def parse_gml_lines(lines, label, destringizer):
                         if i == 0:  # keys
                             value = group.rstrip()
                         elif i == 1:  # reals
-                            value = float(group)
+                            value = group.replace('_', '') # handle incoming nan
+                            value = float(value)
                         elif i == 2:  # ints
                             value = int(group)
                         else:
@@ -680,12 +681,19 @@ def generate_gml(G, stringizer=None):
                     yield indent + key + " " + str(value)
             elif isinstance(value, float):
                 text = repr(value).upper()
-                # GML requires that a real literal contain a decimal point, but
-                # repr may not output a decimal point when the mantissa is
-                # integral and hence needs fixing.
-                epos = text.rfind("E")
-                if epos != -1 and text.find(".", 0, epos) == -1:
-                    text = text[:epos] + "." + text[epos:]
+                # GML matches INF and NAN to keys, so prepend + to INF and _ to NAN
+                # so they can be correctly detected.
+                if text == "NAN":
+                    text = "_NAN"
+                elif text == "INF":
+                    text = "+INF"
+                else:
+                    # GML requires that a real literal contain a decimal point, but
+                    # repr may not output a decimal point when the mantissa is
+                    # integral and hence needs fixing.
+                    epos = text.rfind("E")
+                    if epos != -1 and text.find(".", 0, epos) == -1:
+                        text = text[:epos] + "." + text[epos:]
                 if key == "label":
                     yield indent + key + ' "' + text + '"'
                 else:

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -682,11 +682,12 @@ def generate_gml(G, stringizer=None):
             elif isinstance(value, float):
                 text = repr(value).upper()
                 # GML matches INF and NAN to keys, so prepend + to INF and _ to NAN
-                # so they can be correctly detected.
-                if text == "NAN":
-                    text = "_NAN"
-                elif text == "INF":
-                    text = "+INF"
+                # so they can be correctly detected.  Use repr(float(*)) instead of
+                # string literal to future proof against changes to repr.
+                if text == repr(float('nan')).upper():
+                    text = "_" + text
+                elif text == repr(float('inf')).upper():
+                    text = "+" + text
                 else:
                     # GML requires that a real literal contain a decimal point, but
                     # repr may not output a decimal point when the mantissa is


### PR DESCRIPTION
Fixes issue #4484 
Write floats inf as +INF and nan as _NAN for gml files.  Read +INF, -INF, _NAN as floats.