### PR TITLE
Fix for PR #4378

### DIFF
--- a/examples/drawing/plot_random_geometric_graph.py
+++ b/examples/drawing/plot_random_geometric_graph.py
@@ -28,7 +28,7 @@ for n in pos:
 p = dict(nx.single_source_shortest_path_length(G, ncenter))
 
 plt.figure(figsize=(8, 8))
-nx.draw_networkx_edges(G, pos, nodelist=[ncenter], alpha=0.4)
+nx.draw_networkx_edges(G, pos, alpha=0.4)
 nx.draw_networkx_nodes(
     G,
     pos,


### PR DESCRIPTION
The recent change in behavior of `node_list` kwarg in draw_networkx_edges (#4374) resulted in the edges disappearing for our gallery example (``examples/drawing/plot_random_geometric_graph.py``):
![Figure_2](https://user-images.githubusercontent.com/123428/103430625-e41aff80-4b7a-11eb-91ea-be0256f55c24.png)

I don't understand what the intention of including ``nodelist=[ncenter]`` to the call to ``nx.draw_networkx_edges``.  As far as I could tell it just drew all the edges in 2.5.
![Figure_1](https://user-images.githubusercontent.com/123428/103430655-25131400-4b7b-11eb-82d3-b6eca96052d2.png)

Removing it results in on master:
![Figure_3](https://user-images.githubusercontent.com/123428/103430658-2fcda900-4b7b-11eb-9ada-83df4d1994b8.png)

