### PR TITLE
Delete old test

### DIFF
--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 import networkx as nx
 from networkx import NetworkXNotImplemented
@@ -204,29 +205,27 @@ class TestStronglyConnected:
             seen.update(component)
             component.clear()
 
+    def test_linear_time(self):
+        # See Issue #2831
+        count = 100  # base case
+        dg = nx.DiGraph()
+        dg.add_nodes_from([0, 1])
+        for i in range(2, count):
+            dg.add_node(i)
+            dg.add_edge(i, 1)
+            dg.add_edge(0, i)
+        t = time.time()
+        ret = tuple(nx.strongly_connected_components(dg))
+        dt = time.time() - t
 
-#    Commented out due to variability on Travis-CI hardware/operating systems
-#    def test_linear_time(self):
-#        # See Issue #2831
-#        count = 100  # base case
-#        dg = nx.DiGraph()
-#        dg.add_nodes_from([0, 1])
-#        for i in range(2, count):
-#            dg.add_node(i)
-#            dg.add_edge(i, 1)
-#            dg.add_edge(0, i)
-#        t = time.time()
-#        ret = tuple(nx.strongly_connected_components(dg))
-#        dt = time.time() - t
-#
-#        count = 200
-#        dg = nx.DiGraph()
-#        dg.add_nodes_from([0, 1])
-#        for i in range(2, count):
-#            dg.add_node(i)
-#            dg.add_edge(i, 1)
-#            dg.add_edge(0, i)
-#        t = time.time()
-#        ret = tuple(nx.strongly_connected_components(dg))
-#        dt2 = time.time() - t
-#        assert_less(dt2, dt * 2.3)  # should be 2 times longer for this graph
+        count = 200
+        dg = nx.DiGraph()
+        dg.add_nodes_from([0, 1])
+        for i in range(2, count):
+            dg.add_node(i)
+            dg.add_edge(i, 1)
+            dg.add_edge(0, i)
+        t = time.time()
+        ret = tuple(nx.strongly_connected_components(dg))
+        dt2 = time.time() - t
+        assert dt2 < dt * 2.3  # should be 2 times longer for this graph

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 import networkx as nx
 from networkx import NetworkXNotImplemented
@@ -204,28 +203,3 @@ class TestStronglyConnected:
             assert len(seen & component) == 0
             seen.update(component)
             component.clear()
-
-    def test_linear_time(self):
-        # See Issue #2831
-        count = 100  # base case
-        dg = nx.DiGraph()
-        dg.add_nodes_from([0, 1])
-        for i in range(2, count):
-            dg.add_node(i)
-            dg.add_edge(i, 1)
-            dg.add_edge(0, i)
-        t = time.time()
-        ret = tuple(nx.strongly_connected_components(dg))
-        dt = time.time() - t
-
-        count = 200
-        dg = nx.DiGraph()
-        dg.add_nodes_from([0, 1])
-        for i in range(2, count):
-            dg.add_node(i)
-            dg.add_edge(i, 1)
-            dg.add_edge(0, i)
-        t = time.time()
-        ret = tuple(nx.strongly_connected_components(dg))
-        dt2 = time.time() - t
-        assert dt2 < dt * 2.3  # should be 2 times longer for this graph


### PR DESCRIPTION
@dschult @rossbar I tried reenabling this in case Travis was the issue.  After looking into it more, I think we should just delete this test.  I noticed it wasn't consistent even on my laptop:
![time_strongly_connected_components](https://user-images.githubusercontent.com/123428/103486770-144de280-4db5-11eb-84ee-31493d0ffed0.png)
The code to produce the figure is here:  https://gist.github.com/jarrodmillman/a170d27fc8c5fcb5e03ff450e260ce42