### PR TITLE
Clustering for signed weighted graphs

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -3,7 +3,6 @@
 from itertools import chain
 from itertools import combinations
 from collections import Counter
-import numpy as np
 
 from networkx.utils import not_implemented_for
 
@@ -91,6 +90,8 @@ def _weighted_triangles_and_degree_iter(G, nodes=None, weight="weight"):
     So you may want to divide by 2.
 
     """
+    import numpy as np
+
     if weight is None or G.number_of_edges() == 0:
         max_weight = 1
     else:
@@ -164,6 +165,8 @@ def _directed_weighted_triangles_and_degree_iter(G, nodes=None, weight="weight")
     directed triangles so does not count triangles twice.
 
     """
+    import numpy as np
+
     if weight is None or G.number_of_edges() == 0:
         max_weight = 1
     else:
@@ -302,8 +305,7 @@ def clustering(G, nodes=None, weight=None):
 
     The value of :math:`c_u` is assigned to 0 if :math:`deg(u) < 2`.
 
-    Additionally, this weighted definition can be generalized to support signed graphs [3]_
-    by replacing unsigned weights with signed ones.
+    Additionally, this weighted definition has been generalized to support negative edge weights [3]_.
 
     For directed graphs, the clustering is similarly defined as the fraction
     of all possible directed triangles or geometric average of the subgraph

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -3,6 +3,7 @@
 from itertools import chain
 from itertools import combinations
 from collections import Counter
+from math import pow
 
 from networkx.utils import not_implemented_for
 
@@ -84,7 +85,7 @@ def _triangles_and_degree_iter(G, nodes=None):
 def _weighted_triangles_and_degree_iter(G, nodes=None, weight="weight"):
     """Return an iterator of (node, degree, weighted_triangles).
 
-    Used for weighted clustering.
+    Used for weighted (clustering).
     Note: this returns the geometric average weight of edges in the triangle.
     Also, each triangle is counted twice (each direction).
     So you may want to divide by 2.
@@ -102,6 +103,14 @@ def _weighted_triangles_and_degree_iter(G, nodes=None, weight="weight"):
     def wt(u, v):
         return G[u][v].get(weight, 1) / max_weight
 
+    def cubed_root(num):
+        if num > 0:
+            return pow(num, 1.0 / 3.0)
+        elif num < 0:
+            return -pow(abs(num), 1.0 / 3.0)
+        else:
+            return 0
+
     for i, nbrs in nodes_nbrs:
         inbrs = set(nbrs) - {i}
         weighted_triangles = 0
@@ -114,7 +123,7 @@ def _weighted_triangles_and_degree_iter(G, nodes=None, weight="weight"):
             # loop.
             wij = wt(i, j)
             weighted_triangles += sum(
-                (wij * wt(j, k) * wt(k, i)) ** (1 / 3) for k in inbrs & jnbrs
+                cubed_root(wij * wt(j, k) * wt(k, i)) for k in inbrs & jnbrs
             )
         yield (i, len(inbrs), 2 * weighted_triangles)
 
@@ -173,6 +182,14 @@ def _directed_weighted_triangles_and_degree_iter(G, nodes=None, weight="weight")
     def wt(u, v):
         return G[u][v].get(weight, 1) / max_weight
 
+    def cubed_root(num):
+        if num > 0:
+            return pow(num, 1.0 / 3.0)
+        elif num < 0:
+            return -pow(abs(num), 1.0 / 3.0)
+        else:
+            return 0
+
     for i, preds, succs in nodes_nbrs:
         ipreds = set(preds) - {i}
         isuccs = set(succs) - {i}
@@ -182,32 +199,32 @@ def _directed_weighted_triangles_and_degree_iter(G, nodes=None, weight="weight")
             jpreds = set(G._pred[j]) - {j}
             jsuccs = set(G._succ[j]) - {j}
             directed_triangles += sum(
-                (wt(j, i) * wt(k, i) * wt(k, j)) ** (1 / 3) for k in ipreds & jpreds
+                cubed_root(wt(j, i) * wt(k, i) * wt(k, j)) for k in ipreds & jpreds
             )
             directed_triangles += sum(
-                (wt(j, i) * wt(k, i) * wt(j, k)) ** (1 / 3) for k in ipreds & jsuccs
+                cubed_root(wt(j, i) * wt(k, i) * wt(j, k)) for k in ipreds & jsuccs
             )
             directed_triangles += sum(
-                (wt(j, i) * wt(i, k) * wt(k, j)) ** (1 / 3) for k in isuccs & jpreds
+                cubed_root(wt(j, i) * wt(i, k) * wt(k, j)) for k in isuccs & jpreds
             )
             directed_triangles += sum(
-                (wt(j, i) * wt(i, k) * wt(j, k)) ** (1 / 3) for k in isuccs & jsuccs
+                cubed_root(wt(j, i) * wt(i, k) * wt(j, k)) for k in isuccs & jsuccs
             )
 
         for j in isuccs:
             jpreds = set(G._pred[j]) - {j}
             jsuccs = set(G._succ[j]) - {j}
             directed_triangles += sum(
-                (wt(i, j) * wt(k, i) * wt(k, j)) ** (1 / 3) for k in ipreds & jpreds
+                cubed_root(wt(i, j) * wt(k, i) * wt(k, j)) for k in ipreds & jpreds
             )
             directed_triangles += sum(
-                (wt(i, j) * wt(k, i) * wt(j, k)) ** (1 / 3) for k in ipreds & jsuccs
+                cubed_root(wt(i, j) * wt(k, i) * wt(j, k)) for k in ipreds & jsuccs
             )
             directed_triangles += sum(
-                (wt(i, j) * wt(i, k) * wt(k, j)) ** (1 / 3) for k in isuccs & jpreds
+                cubed_root(wt(i, j) * wt(i, k) * wt(k, j)) for k in isuccs & jpreds
             )
             directed_triangles += sum(
-                (wt(i, j) * wt(i, k) * wt(j, k)) ** (1 / 3) for k in isuccs & jsuccs
+                cubed_root(wt(i, j) * wt(i, k) * wt(j, k)) for k in isuccs & jsuccs
             )
 
         dtotal = len(ipreds) + len(isuccs)
@@ -270,7 +287,7 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
     """
     c = clustering(G, nodes, weight=weight).values()
     if not count_zeros:
-        c = [v for v in c if v > 0]
+        c = [v for v in c if v != 0]
     return sum(c) / len(c)
 
 

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -3,7 +3,7 @@
 from itertools import chain
 from itertools import combinations
 from collections import Counter
-from numpy import cbrt
+import numpy as np
 
 from networkx.utils import not_implemented_for
 
@@ -115,7 +115,7 @@ def _weighted_triangles_and_degree_iter(G, nodes=None, weight="weight"):
             # loop.
             wij = wt(i, j)
             weighted_triangles += sum(
-                cbrt([(wij * wt(j, k) * wt(k, i)) for k in inbrs & jnbrs])
+                np.cbrt([(wij * wt(j, k) * wt(k, i)) for k in inbrs & jnbrs])
             )
         yield (i, len(inbrs), 2 * weighted_triangles)
 
@@ -183,32 +183,32 @@ def _directed_weighted_triangles_and_degree_iter(G, nodes=None, weight="weight")
             jpreds = set(G._pred[j]) - {j}
             jsuccs = set(G._succ[j]) - {j}
             directed_triangles += sum(
-                cbrt([(wt(j, i) * wt(k, i) * wt(k, j)) for k in ipreds & jpreds])
+                np.cbrt([(wt(j, i) * wt(k, i) * wt(k, j)) for k in ipreds & jpreds])
             )
             directed_triangles += sum(
-                cbrt([(wt(j, i) * wt(k, i) * wt(j, k)) for k in ipreds & jsuccs])
+                np.cbrt([(wt(j, i) * wt(k, i) * wt(j, k)) for k in ipreds & jsuccs])
             )
             directed_triangles += sum(
-                cbrt([(wt(j, i) * wt(i, k) * wt(k, j)) for k in isuccs & jpreds])
+                np.cbrt([(wt(j, i) * wt(i, k) * wt(k, j)) for k in isuccs & jpreds])
             )
             directed_triangles += sum(
-                cbrt([(wt(j, i) * wt(i, k) * wt(j, k)) for k in isuccs & jsuccs])
+                np.cbrt([(wt(j, i) * wt(i, k) * wt(j, k)) for k in isuccs & jsuccs])
             )
 
         for j in isuccs:
             jpreds = set(G._pred[j]) - {j}
             jsuccs = set(G._succ[j]) - {j}
             directed_triangles += sum(
-                cbrt([(wt(i, j) * wt(k, i) * wt(k, j)) for k in ipreds & jpreds])
+                np.cbrt([(wt(i, j) * wt(k, i) * wt(k, j)) for k in ipreds & jpreds])
             )
             directed_triangles += sum(
-                cbrt([(wt(i, j) * wt(k, i) * wt(j, k)) for k in ipreds & jsuccs])
+                np.cbrt([(wt(i, j) * wt(k, i) * wt(j, k)) for k in ipreds & jsuccs])
             )
             directed_triangles += sum(
-                cbrt([(wt(i, j) * wt(i, k) * wt(k, j)) for k in isuccs & jpreds])
+                np.cbrt([(wt(i, j) * wt(i, k) * wt(k, j)) for k in isuccs & jpreds])
             )
             directed_triangles += sum(
-                cbrt([(wt(i, j) * wt(i, k) * wt(j, k)) for k in isuccs & jsuccs])
+                np.cbrt([(wt(i, j) * wt(i, k) * wt(j, k)) for k in isuccs & jsuccs])
             )
 
         dtotal = len(ipreds) + len(isuccs)

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -167,13 +167,6 @@ class TestDirectedWeightedClustering:
         assert nx.clustering(G)[0] == 1.0 / 6.0
         assert nx.clustering(G, weight="weight")[0] == 1.0 / 12.0
 
-    def test_triangle_and_negative_edge(self):
-        G = nx.cycle_graph(3, create_using=nx.DiGraph())
-        G.add_edge(1, 2, weight=-1)
-        G.add_edge(0, 4, weight=2)
-        assert nx.clustering(G)[0] == 1.0 / 6.0
-        assert nx.clustering(G, weight="weight")[0] == -1.0 / 12.0
-
 
 class TestWeightedClustering:
     def test_clustering(self):
@@ -248,7 +241,7 @@ class TestWeightedClustering:
         assert nx.clustering(G)[0] == 1.0 / 3.0
         assert nx.clustering(G, weight="weight")[0] == 1.0 / 6.0
 
-    def test_triangle_and_negative_edge(self):
+    def test_triangle_and_signed_edge(self):
         G = nx.cycle_graph(3)
         G.add_edge(0, 1, weight=-1)
         G.add_edge(3, 0, weight=0)

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -167,6 +167,13 @@ class TestDirectedWeightedClustering:
         assert nx.clustering(G)[0] == 1.0 / 6.0
         assert nx.clustering(G, weight="weight")[0] == 1.0 / 12.0
 
+    def test_triangle_and_negative_edge(self):
+        G = nx.cycle_graph(3, create_using=nx.DiGraph())
+        G.add_edge(1, 2, weight=-1)
+        G.add_edge(0, 4, weight=2)
+        assert nx.clustering(G)[0] == 1.0 / 6.0
+        assert nx.clustering(G, weight="weight")[0] == -1.0 / 12.0
+
 
 class TestWeightedClustering:
     def test_clustering(self):
@@ -241,6 +248,13 @@ class TestWeightedClustering:
         assert nx.clustering(G)[0] == 1.0 / 3.0
         assert nx.clustering(G, weight="weight")[0] == 1.0 / 6.0
 
+    def test_triangle_and_negative_edge(self):
+        G = nx.cycle_graph(3)
+        G.add_edge(0, 1, weight=-1)
+        G.add_edge(3, 0, weight=0)
+        assert nx.clustering(G)[0] == 1.0 / 3.0
+        assert nx.clustering(G, weight="weight")[0] == -1.0 / 3.0
+
 
 class TestClustering:
     def test_clustering(self):
@@ -296,6 +310,20 @@ class TestClustering:
             5.0 / 6.0,
         ]
         assert nx.clustering(G, [1, 4]) == {1: 1.0, 4: 0.83333333333333337}
+
+    def test_k5_signed(self):
+        G = nx.complete_graph(5)
+        assert list(nx.clustering(G).values()) == [1, 1, 1, 1, 1]
+        assert nx.average_clustering(G) == 1
+        G.remove_edge(1, 2)
+        G.add_edge(0, 1, weight=-1)
+        assert list(nx.clustering(G, weight="weight").values()) == [
+            1.0 / 6.0,
+            -1.0 / 3.0,
+            1.0,
+            3.0 / 6.0,
+            3.0 / 6.0,
+        ]
 
 
 class TestTransitivity:
@@ -421,12 +449,27 @@ class TestSquareClustering:
         assert nx.square_clustering(G, [1])[1] == 1 / 3
 
 
-def test_average_clustering():
-    G = nx.cycle_graph(3)
-    G.add_edge(2, 3)
-    assert nx.average_clustering(G) == (1 + 1 + 1 / 3.0) / 4.0
-    assert nx.average_clustering(G, count_zeros=True) == (1 + 1 + 1 / 3.0) / 4.0
-    assert nx.average_clustering(G, count_zeros=False) == (1 + 1 + 1 / 3.0) / 3.0
+class TestAverageClustering:
+    def test_average_clustering(self):
+        G = nx.cycle_graph(3)
+        G.add_edge(2, 3)
+        assert nx.average_clustering(G) == (1 + 1 + 1 / 3.0) / 4.0
+        assert nx.average_clustering(G, count_zeros=True) == (1 + 1 + 1 / 3.0) / 4.0
+        assert nx.average_clustering(G, count_zeros=False) == (1 + 1 + 1 / 3.0) / 3.0
+
+    def test_average_clustering_signed(self):
+        G = nx.cycle_graph(3)
+        G.add_edge(2, 3)
+        G.add_edge(0, 1, weight=-1)
+        assert nx.average_clustering(G, weight="weight") == (-1 - 1 - 1 / 3.0) / 4.0
+        assert (
+            nx.average_clustering(G, weight="weight", count_zeros=True)
+            == (-1 - 1 - 1 / 3.0) / 4.0
+        )
+        assert (
+            nx.average_clustering(G, weight="weight", count_zeros=False)
+            == (-1 - 1 - 1 / 3.0) / 3.0
+        )
 
 
 class TestGeneralizedDegree:

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 
 class TestTriangles:
@@ -103,6 +104,10 @@ class TestDirectedClustering:
 
 
 class TestDirectedWeightedClustering:
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip("numpy")
+
     def test_clustering(self):
         G = nx.DiGraph()
         assert list(nx.clustering(G, weight="weight").values()) == []
@@ -169,6 +174,10 @@ class TestDirectedWeightedClustering:
 
 
 class TestWeightedClustering:
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip("numpy")
+
     def test_clustering(self):
         G = nx.Graph()
         assert list(nx.clustering(G, weight="weight").values()) == []
@@ -250,6 +259,10 @@ class TestWeightedClustering:
 
 
 class TestClustering:
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip("numpy")
+
     def test_clustering(self):
         G = nx.Graph()
         assert list(nx.clustering(G).values()) == []
@@ -443,6 +456,10 @@ class TestSquareClustering:
 
 
 class TestAverageClustering:
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip("numpy")
+
     def test_average_clustering(self):
         G = nx.cycle_graph(3)
         G.add_edge(2, 3)


### PR DESCRIPTION
The current code `(wt1 * wt2 * wt3) ** (1 / 3)` returns a complex number when the product of edge weights is negative. 

Negative edge weights can cause the `average_clustering` function to raise a `TypeError` when the parameter `count_zeroes = False`.

<details>
<summary>show testcases</summary>
Here are the graphs tested in `test_cluster.py`
`TestDirectedWeightedClustering::test_triangle_and_negative_edge`
![graph1](https://i.postimg.cc/QtLjpdtz/test-triangle-and-negative-edge-di.png)
`TestWeightedClustering::test_triangle_and_negative_edge`
![graph2](https://i.postimg.cc/g0LYXZYR/test-triangle-and-negative-edge-bi.png)
`TestClustering::test_k5_signed`
![graph3](https://i.postimg.cc/QChsyYck/test-k5-signed-bi.png)
`TestAverageClustering::test_average_clustering_signed`
![graph4](https://i.postimg.cc/rmSMg2Rw/test-average-clustering-signed-bi.png)
</details>

Please let me know if I am misunderstanding "clustering coefficients", if the current code is as intended, or if there is anything that should be changed.