### PR TITLE
use issue templates to redirect to discussions tab, add a bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+<!-- If you have a general question about NetworkX, please use the discussions tab to create a new discussion -->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+
+### Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+### Expected Behavior
+<!--- Tell us what should happen -->
+
+### Steps to Reproduce
+<!--- Provide a minimal example that reproduces the bug -->
+
+### Environment
+<!--- Please provide details about your local environment -->
+Python version:
+NetworkX version:
+
+
+### Additional context
+<!--- Add any other context about the problem here, screenshots, etc. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: 'Please describe the problem you have encountered'
+---
+
 <!-- If you have a general question about NetworkX, please use the discussions tab to create a new discussion -->
 
 <!--- Provide a general summary of the issue in the Title above -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions about NetworkX
+    url: https://github.com/networkx/networkx/discussions/new?category=q-a
+    about: Ask questions about usage of NetworkX
+  - name: Discussions and Ideas
+    url: https://github.com/networkx/networkx/discussions
+    about: Talk about new algorithms, feature requests, show your latest application of networks.


### PR DESCRIPTION
Users will see a screen which asks them to make a choice between `Bug Report`, `Q-A`, `Discussions`, `Blank Issue` when they click on the `new issue` button on GitHub.