### PR TITLE
Fix performance issue in nx.edge_boundary

### DIFF
--- a/networkx/algorithms/boundary.py
+++ b/networkx/algorithms/boundary.py
@@ -65,7 +65,7 @@ def edge_boundary(G, nbunch1, nbunch2=None, data=False, keys=False, default=None
     the interest of speed and generality, that is not required here.
 
     """
-    nset1 = {v for v in G if v in nbunch1}
+    nset1 = {n for n in nbunch1 if n in G}
     # Here we create an iterator over edges incident to nodes in the set
     # `nset1`. The `Graph.edges()` method does not provide a guarantee
     # on the orientation of the edges, so our algorithm below must


### PR DESCRIPTION
Before, `nset1` was created by iterating over nodes in `G` and checking for membership in `nbunch1`. However, `nbunch1` can be any iterable, so checking for membership is O(n) in the worst case. Instead, iterating over `nbunch1` and checking for membership in `G` should fix this performance issue.