### PR TITLE
Partially revert #4378 - Modify behavior of nodelist param in draw_networkx_edges.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -566,10 +566,8 @@ def draw_networkx_edges(
         Size of nodes. Though the nodes are not drawn with this function, the
         node size is used in determining edge positioning.
 
-    nodelist : list (default=list(G))
-        Only draw edges that are in `edgelist` and that lie between nodes in
-        `nodelist`. Any edges in `edgelist` incident on nodes that are *not* in
-        `nodelist` will not be drawn.
+    nodelist : list, optional (default=G.nodes())
+       This provides the node order for the `node_size` array (if it is an array).
 
     node_shape :  string (default='o')
         The marker used for nodes, used in determining edge positioning.

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -641,15 +641,11 @@ def draw_networkx_edges(
     if edgelist is None:
         edgelist = list(G.edges())
 
-    if nodelist is None:
-        nodelist = list(G.nodes())
-    else:
-        # Remove any edges where both endpoints are not in node list
-        nodeset = set(nodelist)
-        edgelist = [(u, v) for u, v in edgelist if (u in nodeset) and (v in nodeset)]
-
     if len(edgelist) == 0:  # no edges!
         return []
+
+    if nodelist is None:
+        nodelist = list(G.nodes())
 
     # FancyArrowPatch handles color=None different from LineCollection
     if edge_color is None:

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -309,8 +309,6 @@ def test_draw_edges_min_source_target_margins(node_shape):
     assert padded_extent[0] > default_extent[0]
     # And the rightmost extent of the edge, further to the left
     assert padded_extent[1] < default_extent[1]
-    # NOTE: Prevent axes objects from impacting other tests via plt.gca
-    plt.delaxes(ax)
 
 
 def test_nonzero_selfloop_with_single_node():
@@ -358,21 +356,3 @@ def test_apply_alpha():
     alpha = 0.5
     rgba_colors = nx.drawing.nx_pylab.apply_alpha(colorlist, alpha, nodelist)
     assert all(rgba_colors[:, -1] == alpha)
-
-
-@pytest.mark.parametrize(
-    ("nodelist", "expected_num_edges"),
-    (
-        ([], 0),
-        ([1], 0),
-        ([1, 2], 1),
-        ([0, 1, 2, 3], 6),
-    ),
-)
-def test_draw_edges_with_nodelist(nodelist, expected_num_edges):
-    """Test that edges that contain a node in `nodelist` are not drawn by
-    draw_networkx_edges. See gh-4374.
-    """
-    G = nx.complete_graph(5)
-    edge_patches = nx.draw_networkx_edges(G, nx.circular_layout(G), nodelist=nodelist)
-    assert len(edge_patches) == expected_num_edges


### PR DESCRIPTION
Reverts the behavior changes of the `nodelist` kwarg in `draw_networkx_edges` - see #4505 for discussion and motivation.

Note that the docstring changes to `draw_networkx_edges` are retained. If preferred, I can do a full reversion of #4378 and re-introduce the docstring changes in a separate PR.