### PR TITLE
Improve community metrics complexity and memory  (coverage and perfor…

### DIFF
--- a/doc/reference/algorithms/community.rst
+++ b/doc/reference/algorithms/community.rst
@@ -64,6 +64,7 @@ Measuring partitions
 
    coverage
    modularity
+   partition_quality
    performance
 
 Partitions via centrality measures

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -178,6 +178,7 @@ def performance(G, partition):
            <https://arxiv.org/abs/0906.0612>
 
     .. deprecated:: 2.6
+        See `nx.community.partition_quality`.
     """
     # Compute the number of intra-community edges and inter-community
     # edges.
@@ -234,6 +235,7 @@ def coverage(G, partition):
            <https://arxiv.org/abs/0906.0612>
 
     .. deprecated:: 2.6
+        See `nx.community.partition_quality`.
     """
     intra_edges = intra_community_edges(G, partition)
     total_edges = G.number_of_edges()
@@ -351,7 +353,7 @@ def partition_quality(G, partition):
 
     partition : sequence
         Partition of the nodes of `G`, represented as a sequence of
-        sets of nodes. Each block of the partition represents a
+        sets of nodes (blocks). Each block of the partition represents a
         community.
 
     Complexity

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -146,6 +146,9 @@ def inter_community_non_edges(G, partition):
 def performance(G, partition):
     """Returns the performance of a partition.
 
+    .. deprecated:: 2.6
+       Use `partition_quality` instead.
+
     The *performance* of a partition is the ratio of the number of
     intra-community edges plus inter-community non-edges with the total
     number of potential edges.
@@ -177,8 +180,6 @@ def performance(G, partition):
            *Physical Reports*, Volume 486, Issue 3--5 pp. 75--174
            <https://arxiv.org/abs/0906.0612>
 
-    .. deprecated:: 2.6
-        See `nx.community.partition_quality`.
     """
     # Compute the number of intra-community edges and inter-community
     # edges.
@@ -200,6 +201,9 @@ def performance(G, partition):
 @require_partition
 def coverage(G, partition):
     """Returns the coverage of a partition.
+
+    .. deprecated:: 2.6
+       Use `partition_quality` instead.
 
     The *coverage* of a partition is the ratio of the number of
     intra-community edges to the total number of edges in the graph.
@@ -234,8 +238,6 @@ def coverage(G, partition):
            *Physical Reports*, Volume 486, Issue 3--5 pp. 75--174
            <https://arxiv.org/abs/0906.0612>
 
-    .. deprecated:: 2.6
-        See `nx.community.partition_quality`.
     """
     intra_edges = intra_community_edges(G, partition)
     total_edges = G.number_of_edges()

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -4,7 +4,7 @@ communities).
 """
 
 from functools import wraps
-from itertools import product
+from itertools import product, combinations
 
 import networkx as nx
 from networkx import NetworkXError
@@ -394,10 +394,9 @@ def partition_quality(G, partition):
     # `performance` is not defined for multigraphs
     if not G.is_multigraph():
         # Iterate over the communities, quadratic, to calculate `possible_inter_community_edges`
-        possible_inter_community_edges = 0
-        for i in range(0, len(partition) - 1):
-            for j in range(i + 1, len(partition)):
-                possible_inter_community_edges += len(partition[i]) * len(partition[j])
+        possible_inter_community_edges = sum(
+            len(p1) * len(p2) for p1, p2 in combinations(partition, 2)
+        )
 
         if G.is_directed():
             possible_inter_community_edges *= 2
@@ -421,7 +420,7 @@ def partition_quality(G, partition):
         else:
             inter_community_non_edges -= 1
 
-    coverage = intra_community_edges / len(G.edges())
+    coverage = intra_community_edges / len(G.edges)
 
     if G.is_multigraph():
         performance = -1.0

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -349,6 +349,8 @@ def partition_quality(G, partition):
     intra-community edges plus inter-community non-edges with the total
     number of potential edges.
 
+    This algorithm has complexity $O(C^2 + L)$ where C is the number of communities and L is the number of links.
+
     Parameters
     ----------
     G : NetworkX graph
@@ -357,12 +359,6 @@ def partition_quality(G, partition):
         Partition of the nodes of `G`, represented as a sequence of
         sets of nodes (blocks). Each block of the partition represents a
         community.
-
-    Complexity
-    ----------
-    O(C^2 + L)
-        C = number of communities
-        L = links
 
     Returns
     -------

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -8,6 +8,7 @@ from networkx import barbell_graph
 from networkx.algorithms.community import coverage
 from networkx.algorithms.community import modularity
 from networkx.algorithms.community import performance
+from networkx.algorithms.community import partition_quality
 from networkx.algorithms.community.quality import inter_community_edges
 from networkx.testing import almost_equal
 
@@ -20,12 +21,14 @@ class TestPerformance:
         G = barbell_graph(3, 0)
         partition = [{0, 1, 4}, {2, 3, 5}]
         assert almost_equal(8 / 15, performance(G, partition))
+        assert almost_equal(8 / 15, partition_quality(G, partition)[1])
 
     def test_good_partition(self):
         """Tests that a good partition has a high performance measure."""
         G = barbell_graph(3, 0)
         partition = [{0, 1, 2}, {3, 4, 5}]
         assert almost_equal(14 / 15, performance(G, partition))
+        assert almost_equal(14 / 15, partition_quality(G, partition)[1])
 
 
 class TestCoverage:
@@ -36,12 +39,14 @@ class TestCoverage:
         G = barbell_graph(3, 0)
         partition = [{0, 1, 4}, {2, 3, 5}]
         assert almost_equal(3 / 7, coverage(G, partition))
+        assert almost_equal(3 / 7, partition_quality(G, partition)[0])
 
     def test_good_partition(self):
         """Tests that a good partition has a high coverage measure."""
         G = barbell_graph(3, 0)
         partition = [{0, 1, 2}, {3, 4, 5}]
         assert almost_equal(6 / 7, coverage(G, partition))
+        assert almost_equal(6 / 7, partition_quality(G, partition)[0])
 
 
 def test_modularity():


### PR DESCRIPTION
The original implementation of `performance` (described in https://arxiv.org/abs/0906.0612) creates the complement graph, `coverage` builds several subgraphs to calculate the intra-community-edges and the inter-community-non-edges.
This implementation does not build any additional graphs, the calculation is based solely on the edges of the graph, and its partition. Complexity: O(L + C^2) L - edges, C - number of communities

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
