### PR TITLE
Replace generate_unique_node internally where not needed

### DIFF
--- a/networkx/algorithms/flow/capacityscaling.py
+++ b/networkx/algorithms/flow/capacityscaling.py
@@ -8,14 +8,12 @@ from itertools import chain
 from math import log
 import networkx as nx
 from ...utils import BinaryHeap
-from ...utils import generate_unique_node
 from ...utils import not_implemented_for
 from ...utils import arbitrary_element
 
 
 def _detect_unboundedness(R):
     """Detect infinite-capacity negative cycles."""
-    s = generate_unique_node()
     G = nx.DiGraph()
     G.add_nodes_from(R)
 

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -8,7 +8,6 @@ from networkx.utils import (
     arbitrary_element,
     not_implemented_for,
     UnionFind,
-    generate_unique_node,
 )
 
 __all__ = [
@@ -217,7 +216,12 @@ def all_pairs_lowest_common_ancestor(G, pairs=None):
         super_root = None
     else:
         G = G.copy()
-        super_root = root = generate_unique_node()
+        # find unused node
+        root = -1
+        while root in G:
+            root -= 1
+        # use that as the super_root below all sources
+        super_root = root
         for source in sources:
             G.add_edge(root, source)
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -6,7 +6,6 @@ from collections import deque
 from heapq import heappush, heappop
 from itertools import count
 import networkx as nx
-from networkx.utils import generate_unique_node
 from networkx.algorithms.shortest_paths.generic import _build_paths_from_predecessors
 
 
@@ -1946,7 +1945,11 @@ def negative_edge_cycle(G, weight="weight", heuristic=True):
     every node, and starting bellman_ford_predecessor_and_distance on that
     node.  It then removes that extra node.
     """
-    newnode = generate_unique_node()
+    # find unused node to use temporarily
+    newnode = -1
+    while newnode in G:
+        newnode -= 1
+    # connect it to all nodes
     G.add_edges_from([(newnode, n) for n in G])
 
     try:

--- a/networkx/generators/trees.py
+++ b/networkx/generators/trees.py
@@ -2,7 +2,6 @@
 from collections import defaultdict
 
 import networkx as nx
-from networkx.utils import generate_unique_node
 from networkx.utils import py_random_state
 
 __all__ = ["prefix_tree", "random_tree"]
@@ -128,7 +127,7 @@ def prefix_tree(paths):
             # We need to relabel each child with a unique name. To do
             # this we simply change each key in the dictionary to be a
             # (key, uuid) pair.
-            new_head = generate_unique_node()
+            new_head = len(B)
             # Ensure the new child knows the name of the old child so
             # that the user can recover the mapping to the original
             # nodes.
@@ -138,9 +137,9 @@ def prefix_tree(paths):
 
     # Initialize the prefix tree with a root node and a nil node.
     T = nx.DiGraph()
-    root = generate_unique_node()
-    T.add_node(root, source=None)
     T.add_node(NIL, source=NIL)
+    root = len(T)
+    T.add_node(root, source=None)
     # Populate the tree.
     _helper(paths, root, T)
     return T, root


### PR DESCRIPTION
Relates to #4224
Relates to #4454

All internal uses of generate_unique_node are better served using
more specific methods to choose a node. Two uses end up finding
an unused node by counting down from -1 until the integer is not
a node. I'm not sure that justifies a utility function to do that
so I haven't implemented one, but we could make one (or a graph method)
with api: `generated_unused_node(G)` or maybe `G.find_unused_node()`.

I like the idiom:
```python
# find a node that is not in G
node = -1
while node in G:
    node -= 1
```