### PR TITLE
fixes Github Actions failures

### DIFF
--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -102,5 +102,5 @@ def read_yaml(path):
     except ImportError as e:
         raise ImportError("read_yaml() requires PyYAML: http://pyyaml.org/") from e
 
-    G = yaml.load(path, Loader=yaml.FullLoader)
+    G = yaml.load(path, Loader=yaml.Loader)
     return G


### PR DESCRIPTION
Github Actions failing due to new release of [pyyaml==5.4](https://pypi.org/project/PyYAML/#history) this change will ensure that version 5.3 is used.  There may be a better/simpler way to account for this issue, just let me know.