### PR TITLE
Improve plotting of self-loops

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -699,9 +699,9 @@ def draw_networkx_edges(
             # check if we need to do a self-loop
             if np.all(posA == posB):
                 # Self-loops are scaled by node size or edge width
-                shell = 0.5*kwargs["shrinkA"]
-                vshift = 2*max(kwargs["shrinkA"], 3*esize)
-                hshift = 0.7*vshift
+                shell = 0.5 * kwargs["shrinkA"]
+                vshift = 2 * max(kwargs["shrinkA"], 3 * esize)
+                hshift = 0.7 * vshift
                 # this is called with _screen space_ values so covert back
                 # to data space
                 ds = np.asarray([-shell, shell])
@@ -782,7 +782,7 @@ def draw_networkx_edges(
 
     # update view
     padx, pady = 0.05 * w, 0.05 * h
-    corners = (minx - padx, miny - pady), (maxx + padx, maxy + 2*pady)
+    corners = (minx - padx, miny - pady), (maxx + padx, maxy + pady)
     ax.update_datalim(corners)
     ax.autoscale_view()
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -694,27 +694,25 @@ def draw_networkx_edges(
 
     base_connection_style = mpl.patches.ConnectionStyle(connectionstyle)
 
-    # Fallback for self-loop scale. Left outside of _connectionstyle so it is
-    # only computed once
-    max_nodesize = np.array(node_size).max()
-
     def _connectionstyle(esize):
         def cs(posA, posB, *args, **kwargs):
             # check if we need to do a self-loop
             if np.all(posA == posB):
                 # Self-loops are scaled by node size or edge width
-                shell = 2*kwargs["shrinkA"]
+                shell = 0.5*kwargs["shrinkA"]
                 vshift = 2*max(kwargs["shrinkA"], 3*esize)
                 hshift = 0.7*vshift
                 # this is called with _screen space_ values so covert back
                 # to data space
+                ds = np.asarray([-shell, shell])
+                dt = np.asarray([shell, shell])
                 s1 = np.asarray([-hshift, vshift])
                 s2 = np.asarray([hshift, vshift])
 
-                p1 = ax.transData.inverted().transform(posA + np.asarray([-shell, shell]))
+                p1 = ax.transData.inverted().transform(posA + ds)
                 p2 = ax.transData.inverted().transform(posA + s1)
                 p3 = ax.transData.inverted().transform(posA + s2)
-                p4 = ax.transData.inverted().transform(posA + np.asarray([shell, shell]))
+                p4 = ax.transData.inverted().transform(posA + dt)
 
                 path = [p1, p2, p3, p4]
 
@@ -729,6 +727,7 @@ def draw_networkx_edges(
 
     # FancyArrowPatch doesn't handle color strings
     arrow_colors = mpl.colors.colorConverter.to_rgba_array(edge_color, alpha)
+
     for i, (src, dst) in enumerate(edge_pos):
         x1, y1 = src
         x2, y2 = dst
@@ -783,7 +782,7 @@ def draw_networkx_edges(
 
     # update view
     padx, pady = 0.05 * w, 0.05 * h
-    corners = (minx - padx, miny - pady), (maxx + padx, maxy + pady)
+    corners = (minx - padx, miny - pady), (maxx + padx, maxy + 2*pady)
     ax.update_datalim(corners)
     ax.autoscale_view()
 


### PR DESCRIPTION
This is a proposal to update the way self-loops are currently plotted.
I find the current plot slightly strange since the arrow does not end on the node and the loop does not rescale upon zoom contrary to the other edges.

![Current behavior from master](https://user-images.githubusercontent.com/8523051/105377984-a48c8400-5c0b-11eb-8946-51549c963ed5.png)

Since drawing correct circles is complex and error prone, I propose to reshape the loops as triangles and scale them based on node or edge size.

```python
import networkx as nx
import matplotlib.pyplot as plt

g = nx.DiGraph()

g.add_nodes_from(range(5))

g.add_edges_from(
    [(0, 0), (0, 1), (1, 2), (2, 0), (2, 2), (2, 3), (3, 1), (3, 4), (4, 4)])

fig, axes = plt.subplots(2, 2)

ns = [40, 80, 60, 100, 120]
es = [5, 1, 2, 3, 1, 5, 5, 4, 2]

h = nx.Graph()
h.add_node(0)
h.add_edge(0, 0)

nx.draw(g, ax=axes[0, 0], node_size=ns)
nx.draw_circular(g, ax=axes[0, 1], node_size=ns[::-1])
nx.draw_shell(g, ax=axes[1, 0], node_size=ns, width=es)
nx.draw(h, ax=axes[1, 1])

plt.show()
```

![example of how the new self-loops look on three graph plots and one with a single node](https://user-images.githubusercontent.com/8523051/105377320-f54fad00-5c0a-11eb-8f69-fe31667702ef.png)

There is still one thing i did not figure out, which is how to prevent them from getting out of the view... any help on that side would be appreciated.