### PR TITLE
CI: add pytest-randomly workflow.

### DIFF
--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -4,6 +4,8 @@ on:
     # Run this workflow once a day
     - cron: "0 0 * * *"
 
+jobs:
+
   randomize-test-order:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -1,0 +1,25 @@
+name: Run test suite in random order
+on:
+  schedule:
+    # Run this workflow once a day
+    - cron: "0 0 * * *"
+
+  randomize-test-order:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install packages
+      run: |
+        pip install --upgrade pip wheel setuptools
+        pip install -r requirements.txt -r requirements/test.txt
+        pip install pytest-randomly
+        pip install .
+        pip list
+
+    - name: Run tests
+      run: pytest --doctest-modules --durations=10 --pyargs networkx

--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: "3.9"
 
     - name: Install packages
       run: |

--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install packages
       run: |
         pip install --upgrade pip wheel setuptools
-        pip install -r requirements.txt -r requirements/test.txt
+        pip install -r requirements/default.txt -r requirements/test.txt
         pip install pytest-randomly
         pip install .
         pip list

--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -1,5 +1,9 @@
 name: Run test suite in random order
 on:
+  pull_request:
+    branches:
+      - main
+
   schedule:
     # Run this workflow once a day
     - cron: "0 0 * * *"

--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -1,9 +1,5 @@
 name: Run test suite in random order
 on:
-  pull_request:
-    branches:
-      - main
-
   schedule:
     # Run this workflow once a day
     - cron: "0 0 * * *"


### PR DESCRIPTION
Adds a single workflow that runs the test suite with the tests executed in random order. This can help identify problems with poorly-designed tests.

On the one hand, adding this to CI can help improve the robustness of the test suite. OTOH, it can also introduce failures to PRs that are not related to the submitted changes.

One alternative could be to de-couple this from submitted PRs and just have a time or status-based workflow (e.g. run the workflow once a day). LMK if you think this is worthwhile to pursue!