### PR TITLE
TST: Fix error in katz centrality test setup.

### DIFF
--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -314,6 +314,7 @@ class TestKatzCentralityDirectedNumpy(TestKatzCentralityDirected):
         global np
         np = pytest.importorskip("numpy")
         pytest.importorskip("scipy")
+        super().setup_class()
 
     def test_katz_centrality_weighted(self):
         G = self.G


### PR DESCRIPTION
This is an example of the type of error that can be caught by `pytest-randomly`, see #4553.

Assuming you have NX set up for development (including the test requirements), the error that this PR fixes can be reproduced by:

```
pip install pytest-randomly
pytest --randomly-seed=3100993940 --pyargs networkx
```