### PR TITLE
Correct mu parameter documentation for LFR

### DIFF
--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -859,7 +859,7 @@ def LFR_benchmark_graph(
         created graph. This value must be strictly greater than one.
 
     mu : float
-        Fraction of intra-community edges incident to each node. This
+        Fraction of inter-community edges incident to each node. This
         value must be in the interval [0, 1].
 
     average_degree : float


### PR DESCRIPTION
I've been using the networkx package and noticed this mistake on the LFR algorithm documentation.

As stated in [point 3](https://github.com/networkx/networkx/blob/ddf06e1e89b57ee6dcc139535b4a1544e6157f4c/networkx/generators/community.py#L838) in the algorithm for LFR generation, `(1 - \mu) \mathrm{deg}(u)` regards the intra-community degree of a node, which makes `mu` the fraction of inter-community degree.

Let me know if I have made a mistake in understanding this. Also, this is my first pull request, if there is anything missing just let me know. 🙂