### PR TITLE
Add 'compressed' parameter to numeric_mixing_matrix and others

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -226,7 +226,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     .. [1] M. E. J. Newman, Mixing patterns in networks
            Physical Review E, 67 026126, 2003
     """
-    a = numeric_mixing_matrix(G, attribute, nodes)
+    a = numeric_mixing_matrix(G, attribute, nodes, compressed=True)
     return numeric_ac(a)
 
 

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -160,7 +160,7 @@ def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, normalized
     return a
 
 
-def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
+def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True, compressed=False):
     """Returns numeric mixing matrix for attribute.
 
     The attribute must be an integer.
@@ -179,6 +179,9 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
     normalized : bool (default=True)
        Return counts if False or probabilities if True.
 
+    compressed: bool (default=False)
+        Build the matrix without empty lines and columns
+
     Returns
     -------
     m: numpy array
@@ -188,8 +191,11 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
     s = set(d.keys())
     for k, v in d.items():
         s.update(v.keys())
-    m = max(s)
-    mapping = {x: x for x in range(m + 1)}
+    if compressed:
+        mapping = {x: i for x, i in zip(s, range(len(s)))}
+    else:
+        m = max(s)
+        mapping = {x: x for x in range(m + 1)}
     a = dict_to_numpy_array(d, mapping=mapping)
     if normalized:
         a = a / a.sum()


### PR DESCRIPTION
As for now, this is a pull-request to fix #4368 — the problem here was that `numeric_assortativity_coefficient` was generating a 20001x20001 matrix and doing operations on it. 
These calculations happen in `numeric_mixing_matrix`: we find the greatest value of the attributes and create a matrix of this size.

The solution is to omit empty lines: we already have a set of all used attribute values, and we already pass some kind of mapping to `dict_to_numpy_array` — why not make a matrix have only 'important' values? 

My approach does it by iterating through set elements and giving them a smallest possible index. In an extreme case such as #4368 matrix gets from 20001x20001 to just 2x2. In general this change should help with graphs with 'sparse' attribute values and have almost no impact on time in the worst case.

Not only that, this solution should now work well if attribute values can be negative or even not integers — I believe the only remaining requirement is that you should be able to make a set of them.


As for 'compressed' keyword: the default values is False, so everything should behave as it did before the commit. At the moment, `numeric_assortativity_coefficient` is the only place where `numeric_mixing_matrix` is used, and here it is ok to use compressed matrix.

I assume other assortativity algorithms may have a similar problem and solution, so maybe we should add 'compressed' option to something else. 
Yet, I didn't look into it as for now.