### PR TITLE
Unpin pygeos

### DIFF
--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -4,7 +4,6 @@ Cartopy>=0.18
 shapely
 # Required for Cartopy
 osmnx>=0.16
-geopandas>=0.8.2
 momepy>=0.4
 contextily>=1.0
 mayavi>=4.7

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -4,7 +4,7 @@ Cartopy>=0.18
 shapely
 # Required for Cartopy
 osmnx>=0.16
-pygeos==0.8
+geopandas>=0.8.2
 momepy>=0.4
 contextily>=1.0
 mayavi>=4.7


### PR DESCRIPTION
Fixes #4562 

Un-pin pygeos and set lower bound for geopandas to a version that supports pygeos 0.9.