### PR TITLE
Fix a few broken links in the html docs

### DIFF
--- a/doc/developer/nxeps/nxep-0002.rst
+++ b/doc/developer/nxeps/nxep-0002.rst
@@ -16,10 +16,10 @@ Abstract
 Iterating over a subset of nodes or edges in a graph is a very common 
 operation in networkx analysis.
 The graph classes in NetworkX (e.g. :class:`~networkx.Graph`,
-:class:`~newtorkx.DiGraph`, :class:`~networkx.MultiGraph`, etc.) expose the
-node and edge data of the graph via :meth:`nodes` and :meth:`edges`, which 
-return dict view objects, `NodeView` (or `NodeDataView`) and `EdgeView` 
-(or `EdgeDataView`), respectively.
+:class:`~networkx.DiGraph`, :class:`~networkx.MultiGraph`, etc.) expose the
+node and edge data of the graph via :meth:`~networkx.Graph.nodes` and
+:meth:`~networkx.Graph.edges`, which return dict view objects, `NodeView`
+(or `NodeDataView`) and `EdgeView` (or `EdgeDataView`), respectively.
 The node and edge `View` classes have dict-like semantics for item access,
 returning the data dict corresponding to a given node or edge.
 This NXEP proposes adding support for slicing to the relevant node & edge

--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -59,9 +59,9 @@ def average_degree_connectivity(
     >>> nx.k_nearest_neighbors(G, weight="weight")
     {1: 2.0, 2: 1.75}
 
-    See also
+    See Also
     --------
-    neighbors_average_degree
+    average_neighbor_degree
 
     Notes
     -----

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -56,7 +56,6 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     --------
     attribute_assortativity_coefficient
     numeric_assortativity_coefficient
-    neighbor_connectivity
     degree_mixing_dict
     degree_mixing_matrix
 

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -24,10 +24,10 @@ def degree_centrality(G, nodes):
 
     See Also
     --------
-    betweenness_centrality,
-    closeness_centrality,
-    sets,
-    is_bipartite
+    betweenness_centrality
+    closeness_centrality
+    :func:`~networkx.algorithms.bipartite.basic.sets`
+    :func:`~networkx.algorithms.bipartite.basic.is_bipartite`
 
     Notes
     -----
@@ -122,10 +122,10 @@ def betweenness_centrality(G, nodes):
 
     See Also
     --------
-    degree_centrality,
-    closeness_centrality,
-    sets,
-    is_bipartite
+    degree_centrality
+    closeness_centrality
+    :func:`~networkx.algorithms.bipartite.basic.sets`
+    :func:`~networkx.algorithms.bipartite.basic.is_bipartite`
 
     Notes
     -----
@@ -194,10 +194,10 @@ def closeness_centrality(G, nodes, normalized=True):
 
     See Also
     --------
-    betweenness_centrality,
+    betweenness_centrality
     degree_centrality
-    sets,
-    is_bipartite
+    :func:`~networkx.algorithms.bipartite.basic.sets`
+    :func:`~networkx.algorithms.bipartite.basic.is_bipartite`
 
     Notes
     -----

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -96,8 +96,8 @@ def latapy_clustering(G, nodes=None, mode="dot"):
     See Also
     --------
     robins_alexander_clustering
-    square_clustering
     average_clustering
+    networkx.algorithms.cluster.square_clustering
 
     References
     ----------
@@ -239,7 +239,7 @@ def robins_alexander_clustering(G):
     See Also
     --------
     latapy_clustering
-    square_clustering
+    networkx.algorithms.cluster.square_clustering
 
     References
     ----------


### PR DESCRIPTION
Chipping away at the link warnings when running sphinx in nit-picky mode.

For reference: you can have sphinx report broken links when building like so: `make SPHINXOPTS=-n html`. You should also comment out the `default_role = obj` from `conf.py` (there is a strange interplay between the rtd theme, numpydoc, and sphinx here... not quite sure what's the best way to resolve it so skipping over the details for now). Doing so, I get about 540 broken links (on de9c66ff). This PR should reduce that number by 8.