### PR TITLE
Add test Kernighan Lin Algorithm

### DIFF
--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -62,3 +62,14 @@ def test_multigraph():
         assert_partition_equal(
             [A, B], [{mapping[0], mapping[1]}, {mapping[2], mapping[3]}]
         )
+
+
+def test_max_iter_argument():
+    G = nx.Graph(
+        [("A", "B", {'weight': 1}), ("A", "C", {'weight': 2}), ("A", "D", {'weight': 3}), ("A", "E", {'weight': 2}),
+         ("A", "F", {'weight': 4}), ("B", "C", {'weight': 1}), ("B", "D", {'weight': 4}), ("B", "E", {'weight': 2}),
+         ("B", "F", {'weight': 1}), ("C", "D", {'weight': 3}), ("C", "E", {'weight': 2}), ("C", "F", {'weight': 1}),
+         ("D", "E", {'weight': 4}), ("D", "F", {'weight': 3}), ("E", "F", {'weight': 2})])
+    partition = ({"A", "B", "C"}, {"D", "E", "F"})
+    C = kernighan_lin_bisection(G, partition, max_iter=1)
+    assert_partition_equal(C, ({"A", "F", "C"}, {"D", "E", "B"}))

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -66,10 +66,24 @@ def test_multigraph():
 
 def test_max_iter_argument():
     G = nx.Graph(
-        [("A", "B", {'weight': 1}), ("A", "C", {'weight': 2}), ("A", "D", {'weight': 3}), ("A", "E", {'weight': 2}),
-         ("A", "F", {'weight': 4}), ("B", "C", {'weight': 1}), ("B", "D", {'weight': 4}), ("B", "E", {'weight': 2}),
-         ("B", "F", {'weight': 1}), ("C", "D", {'weight': 3}), ("C", "E", {'weight': 2}), ("C", "F", {'weight': 1}),
-         ("D", "E", {'weight': 4}), ("D", "F", {'weight': 3}), ("E", "F", {'weight': 2})])
+        [
+            ("A", "B", {"weight": 1}),
+            ("A", "C", {"weight": 2}),
+            ("A", "D", {"weight": 3}),
+            ("A", "E", {"weight": 2}),
+            ("A", "F", {"weight": 4}),
+            ("B", "C", {"weight": 1}),
+            ("B", "D", {"weight": 4}),
+            ("B", "E", {"weight": 2}),
+            ("B", "F", {"weight": 1}),
+            ("C", "D", {"weight": 3}),
+            ("C", "E", {"weight": 2}),
+            ("C", "F", {"weight": 1}),
+            ("D", "E", {"weight": 4}),
+            ("D", "F", {"weight": 3}),
+            ("E", "F", {"weight": 2}),
+        ]
+    )
     partition = ({"A", "B", "C"}, {"D", "E", "F"})
     C = kernighan_lin_bisection(G, partition, max_iter=1)
     assert_partition_equal(C, ({"A", "F", "C"}, {"D", "E", "B"}))


### PR DESCRIPTION
This is a proposal to fix issue #4415 . I added a test which calls kernighan_lin_bisection() with max_iter argument set to 1. 

Since the test case is a simple situation, the algorithm finds the minimal cut at first iteration. Before issue #4398 was fixed, the test I wrote would fail because loop on line 130 on kernighan_lin_bisection only maxe one swap ( the _kernighan_lin_sweep function was always returning 0 in second position). 

The test case I used can be found on page 7 here : http://users.ece.northwestern.edu/~haizhou/357/lec2.pdf

NB: This is my first time contributing so I would happy to have any feedbacks.  