### PR TITLE
Pygraphviz choco

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Before install (non-windows)
+    - name: Before install (Linux)
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install graphviz graphviz-dev
 
@@ -77,7 +77,7 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install graphviz
 
-    - name: Before install (windows)
+    - name: Before install (Windows)
       if: runner.os == 'Windows'
       run: choco install graphviz
 
@@ -99,7 +99,7 @@ jobs:
         python -m pip install --global-option=build_ext `
                               --global-option="-IC:\Program Files\Graphviz\include" `
                               --global-option="-LC:\Program Files\Graphviz\lib" `
-                              pygraphviz==1.7rc2
+                              pygraphviz
         python -m pip install -r requirements/extra.txt
         python -m pip install .
         python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
@@ -69,22 +69,40 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Before install
-      run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo apt-get update
-          sudo apt-get install graphviz graphviz-dev
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          brew install graphviz pkg-config
-        fi
+    - name: Before install (non-windows)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install graphviz graphviz-dev
 
-    - name: Install packages
+    - name: Before install (macOS)
+      if: runner.os == 'macOS'
+      run: brew install graphviz
+
+    - name: Before install (windows)
+      if: runner.os == 'Windows'
+      run: choco install graphviz
+
+    - name: Install packages (Linux and macOS)
+      if: runner.os == 'Linux' || runner.os == 'macOS'
       run: |
         pip install --upgrade pip wheel setuptools
         pip install -r requirements.txt
         pip install -r requirements/extra.txt
         pip install .
         pip list
+
+    - name: Install packages (windows)
+      if: runner.os == 'Windows'
+      run: |
+        echo "C:\Program Files\Graphviz\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        python -m pip install --upgrade pip wheel setuptools
+        python -m pip install -r requirements.txt
+        python -m pip install --global-option=build_ext `
+                              --global-option="-IC:\Program Files\Graphviz\include" `
+                              --global-option="-LC:\Program Files\Graphviz\lib" `
+                              pygraphviz==1.7rc2
+        python -m pip install -r requirements/extra.txt
+        python -m pip install .
+        python -m pip list
 
     - name: Test NetworkX
       run: |

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -42,6 +42,7 @@ class TestAGraph:
 
         with open(fname) as fh:
             Hin = nx.nx_agraph.read_dot(fh)
+        os.close(fd)
         os.unlink(fname)
         self.assert_equal(H, Hin)
 

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,5 +1,4 @@
 lxml>=4.5
-# TODO: remove rc2 when pygraphviz released
-pygraphviz==1.7rc2
+pygraphviz>=1.7
 pydot>=1.4.1
 pyyaml>=5.3

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,5 +1,5 @@
 lxml>=4.5
-# TODO: remove rc1 when pygraphviz released
-pygraphviz==1.7rc1
+# TODO: remove rc2 when pygraphviz released
+pygraphviz==1.7rc2
 pydot>=1.4.1
 pyyaml>=5.3


### PR DESCRIPTION
Bash and PowerShell have different syntax for line continuations and for ``for`` loops.  So you can not do something like
```
    - name: Before install
      run: |
        if [ "$RUNNER_OS" == "Linux" ]; then
          sudo apt-get update
          sudo apt-get install graphviz graphviz-dev
        elif [ "$RUNNER_OS" == "macOS" ]; then
          brew install graphviz
        elif [ "$RUNNER_OS" == "Windows" ]; then
          choco install graphviz
        fi
```
without also doing something like
```
  extra:
    runs-on: ${{ matrix.os }}
    defaults:
       run:
         shell: bash
```

That uses Bash for all OSes; but then Windows fails to build extension code because the development environment for Windows is not setup/configured for Git Bash.  It may be possible to get this working, but I decided to use the default shell for each OS.

This requires moving the logic that detects what OS you are running on outside of all the ``run`` steps.  For example,
```
    - name: Before install (macOS)
      if: runner.os == 'macOS'
      run: brew install graphviz
```
You can see more about context and expression syntax here:
- https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions

In particular, you can use these operators to do more complex checks:
- https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators

One thing that tripped me up a bit was the fact that double quotes are invalid.  That is, this prevents the whole ``test.yml`` workflow from even loading:
```
    - name: Before install (macOS)
      if: runner.os == "macOS"
      run: brew install graphviz
```