### PR TITLE
Enhancement intersection function 3265

### DIFF
--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -130,10 +130,8 @@ def compose_all(graphs):
 
 
 def intersection_all(graphs):
-    """Returns a new graph that contains only the edges that exist in
+    """Returns a new graph that contains only the nodes and the edges that exist in
     all graphs.
-
-    All supplied graphs must have the same node set.
 
     Parameters
     ----------

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -137,7 +137,7 @@ def disjoint_union(G, H):
 
 
 def intersection(G, H):
-    """Returns a new graph that contains only the edges and the nodes that exist in
+    """Returns a new graph that contains only the nodes and the edges that exist in
     both G and H.
 
     Parameters
@@ -162,7 +162,6 @@ def intersection(G, H):
     >>> R.remove_nodes_from(n for n in G if n not in H)
     >>> R.remove_edges_from(e for e in G.edges if e not in H.egdes)
     """
-
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError("G and H must both be graphs or multigraphs.")
 

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -137,15 +137,13 @@ def disjoint_union(G, H):
 
 
 def intersection(G, H):
-    """Returns a new graph that contains only the edges that exist in
+    """Returns a new graph that contains only the edges and the nodes that exist in
     both G and H.
-
-    The node sets of H and G must be the same.
 
     Parameters
     ----------
     G,H : graph
-       A NetworkX graph.  G and H must have the same node sets.
+       A NetworkX graph. G and H can have different node sets but must be both graphs or both multigraphs.
 
     Returns
     -------
@@ -162,6 +160,7 @@ def intersection(G, H):
     >>> H = nx.path_graph(5)
     >>> R = G.copy()
     >>> R.remove_nodes_from(n for n in G if n not in H)
+    >>> R.remove_edges_from(e for e in G.edges if e not in H.egdes)
     """
 
     if not G.is_multigraph() == H.is_multigraph():
@@ -170,7 +169,6 @@ def intersection(G, H):
     # create new graph
     if set(G) != set(H):
         R = G.__class__()
-
         R.add_nodes_from(set(G.nodes).intersection(set(H.nodes)))
     else:
         R = nx.create_empty_copy(G)

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -160,7 +160,7 @@ def intersection(G, H):
     >>> H = nx.path_graph(5)
     >>> R = G.copy()
     >>> R.remove_nodes_from(n for n in G if n not in H)
-    >>> R.remove_edges_from(e for e in G.edges if e not in H.egdes)
+    >>> R.remove_edges_from(e for e in G.edges if e not in H.edges)
     """
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError("G and H must both be graphs or multigraphs.")

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -163,13 +163,17 @@ def intersection(G, H):
     >>> R = G.copy()
     >>> R.remove_nodes_from(n for n in G if n not in H)
     """
-    # create new graph
-    R = nx.create_empty_copy(G)
 
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError("G and H must both be graphs or multigraphs.")
+
+    # create new graph
     if set(G) != set(H):
-        raise nx.NetworkXError("Node sets of graphs are not equal")
+        R = G.__class__()
+
+        R.add_nodes_from(set(G.nodes).intersection(set(H.nodes)))
+    else:
+        R = nx.create_empty_copy(G)
 
     if G.number_of_edges() <= H.number_of_edges():
         if G.is_multigraph():

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -145,6 +145,11 @@ def intersection(G, H):
     G,H : graph
        A NetworkX graph. G and H can have different node sets but must be both graphs or both multigraphs.
 
+    Raises
+    ------
+    NetworkXError
+        If one is a MultiGraph and the other one is a graph.
+
     Returns
     -------
     GH : A new graph with the same type as G.

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -48,6 +48,26 @@ def test_intersection_all():
     assert sorted(I.edges()) == [(2, 3)]
 
 
+def test_intersection_all_different_node_sets():
+    G = nx.Graph()
+    H = nx.Graph()
+    R = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4, 6, 7])
+    G.add_edge(1, 2)
+    G.add_edge(2, 3)
+    G.add_edge(6, 7)
+    H.add_nodes_from([1, 2, 3, 4])
+    H.add_edge(2, 3)
+    H.add_edge(3, 4)
+    R.add_nodes_from([1, 2, 3, 4, 8, 9])
+    R.add_edge(2, 3)
+    R.add_edge(4, 1)
+    R.add_edge(8, 9)
+    I = nx.intersection_all([G, H, R])
+    assert set(I.nodes()) == {1, 2, 3, 4}
+    assert sorted(I.edges()) == [(2, 3)]
+
+
 def test_intersection_all_attributes():
     g = nx.Graph()
     g.add_node(0, x=4)
@@ -65,8 +85,23 @@ def test_intersection_all_attributes():
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == sorted(g.edges())
 
-    h.remove_node(0)
-    pytest.raises(nx.NetworkXError, nx.intersection, g, h)
+
+def test_intersection_all_attributes_different_node_sets():
+    g = nx.Graph()
+    g.add_node(0, x=4)
+    g.add_node(1, x=5)
+    g.add_edge(0, 1, size=5)
+    g.graph["name"] = "g"
+
+    h = g.copy()
+    g.add_node(2)
+    h.graph["name"] = "h"
+    h.graph["attr"] = "attr"
+    h.nodes[0]["x"] = 7
+
+    gh = nx.intersection_all([g, h])
+    assert set(gh.nodes()) == set(h.nodes())
+    assert sorted(gh.edges()) == sorted(g.edges())
 
 
 def test_intersection_all_multigraph_attributes():
@@ -79,6 +114,22 @@ def test_intersection_all_multigraph_attributes():
     h.add_edge(0, 1, key=3)
     gh = nx.intersection_all([g, h])
     assert set(gh.nodes()) == set(g.nodes())
+    assert set(gh.nodes()) == set(h.nodes())
+    assert sorted(gh.edges()) == [(0, 1)]
+    assert sorted(gh.edges(keys=True)) == [(0, 1, 0)]
+
+
+def test_intersection_all_multigraph_attributes_different_node_sets():
+    g = nx.MultiGraph()
+    g.add_edge(0, 1, key=0)
+    g.add_edge(0, 1, key=1)
+    g.add_edge(0, 1, key=2)
+    g.add_edge(1, 2, key=1)
+    g.add_edge(1, 2, key=2)
+    h = nx.MultiGraph()
+    h.add_edge(0, 1, key=0)
+    h.add_edge(0, 1, key=3)
+    gh = nx.intersection_all([g, h])
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == [(0, 1)]
     assert sorted(gh.edges(keys=True)) == [(0, 1, 0)]

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -84,9 +84,9 @@ def test_intersection_attributes_node_sets_different():
     h.graph["name"] = "h"
     h.graph["attr"] = "attr"
     h.nodes[0]["x"] = 7
+    h.remove_node(2)
 
     gh = nx.intersection(g, h)
-    assert set(gh.nodes()) == set(g.nodes())
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == sorted(g.edges())
 

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -39,6 +39,21 @@ def test_intersection():
     assert sorted(I.edges()) == [(2, 3)]
 
 
+def test_intersection_node_sets_different():
+    G = nx.Graph()
+    H = nx.Graph()
+    G.add_nodes_from([1, 2, 3, 4, 7])
+    G.add_edge(1, 2)
+    G.add_edge(2, 3)
+    H.add_nodes_from([1, 2, 3, 4, 5, 6])
+    H.add_edge(2, 3)
+    H.add_edge(3, 4)
+    H.add_edge(5, 6)
+    I = nx.intersection(G, H)
+    assert set(I.nodes()) == {1, 2, 3, 4}
+    assert sorted(I.edges()) == [(2, 3)]
+
+
 def test_intersection_attributes():
     g = nx.Graph()
     g.add_node(0, x=4)
@@ -57,7 +72,28 @@ def test_intersection_attributes():
     assert sorted(gh.edges()) == sorted(g.edges())
 
     h.remove_node(0)
-    pytest.raises(nx.NetworkXError, nx.intersection, g, h)
+
+
+#   pytest.raises(nx.NetworkXError, nx.intersection, g, h)
+
+
+def test_intersection_attributes_node_sets_different():
+    g = nx.Graph()
+    g.add_node(0, x=4)
+    g.add_node(1, x=5)
+    g.add_node(2, x=3)
+    g.add_edge(0, 1, size=5)
+    g.graph["name"] = "g"
+
+    h = g.copy()
+    h.graph["name"] = "h"
+    h.graph["attr"] = "attr"
+    h.nodes[0]["x"] = 7
+
+    gh = nx.intersection(g, h)
+    assert set(gh.nodes()) == set(g.nodes())
+    assert set(gh.nodes()) == set(h.nodes())
+    assert sorted(gh.edges()) == sorted(g.edges())
 
 
 def test_intersection_multigraph_attributes():
@@ -70,6 +106,22 @@ def test_intersection_multigraph_attributes():
     h.add_edge(0, 1, key=3)
     gh = nx.intersection(g, h)
     assert set(gh.nodes()) == set(g.nodes())
+    assert set(gh.nodes()) == set(h.nodes())
+    assert sorted(gh.edges()) == [(0, 1)]
+    assert sorted(gh.edges(keys=True)) == [(0, 1, 0)]
+
+
+def test_intersection_multigraph_attributes_node_set_different():
+    g = nx.MultiGraph()
+    g.add_edge(0, 1, key=0)
+    g.add_edge(0, 1, key=1)
+    g.add_edge(0, 1, key=2)
+    g.add_edge(0, 2, key=2)
+    g.add_edge(0, 2, key=1)
+    h = nx.MultiGraph()
+    h.add_edge(0, 1, key=0)
+    h.add_edge(0, 1, key=3)
+    gh = nx.intersection(g, h)
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == [(0, 1)]
     assert sorted(gh.edges(keys=True)) == [(0, 1, 0)]
@@ -133,7 +185,7 @@ def test_difference_attributes():
     assert sorted(gh.edges()) == []
 
     h.remove_node(0)
-    pytest.raises(nx.NetworkXError, nx.intersection, g, h)
+    # pytest.raises(nx.NetworkXError, nx.intersection, g, h)
 
 
 def test_difference_multigraph_attributes():

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -65,16 +65,11 @@ def test_intersection_attributes():
     h.graph["name"] = "h"
     h.graph["attr"] = "attr"
     h.nodes[0]["x"] = 7
-
     gh = nx.intersection(g, h)
+
     assert set(gh.nodes()) == set(g.nodes())
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == sorted(g.edges())
-
-    h.remove_node(0)
-
-
-#   pytest.raises(nx.NetworkXError, nx.intersection, g, h)
 
 
 def test_intersection_attributes_node_sets_different():
@@ -183,9 +178,6 @@ def test_difference_attributes():
     assert set(gh.nodes()) == set(g.nodes())
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == []
-
-    h.remove_node(0)
-    # pytest.raises(nx.NetworkXError, nx.intersection, g, h)
 
 
 def test_difference_multigraph_attributes():


### PR DESCRIPTION
This is a proposition to fix issue #3265 - Enhancement for the intersection of two graphs. 

The code does not raise a Value Error anymore when we try to intersect two graphs that don't have the same node sets. It now returns a graph which contains all the nodes that are the intersection of the two node sets and edges that are the intersection of the two edge sets.

I added a few tests and modified those which where expecting an error when running intersection function for two different node sets. I updated documentation accordingly.  