### PR TITLE
Avoid building previews of docs unless docs were modified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,8 @@ jobs:
       - run:
           name: Check whether docs modified
           command: |
-            git branch -a
-            git fetch origin master --depth=1
             COUNT=$(git diff --name-status origin/master.. | grep 'doc/' | wc -l)
-            if [[ $COUNT -eq 0 ]];
+            if [[ $COUNT -eq 0 ]]; then
               circleci-agent step halt
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Check whether docs modified
           command: |
-            COUNT=$(git diff --name-status origin/master.. | grep 'doc/' | wc -l)
+            COUNT=$(git diff --name-status origin/master.. | { grep 'doc/' || true; } | wc -l)
             if [[ $COUNT -eq 0 ]]; then
               circleci-agent step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,10 @@ jobs:
       - run:
           name: Check whether docs modified
           command: |
-            git remote add origin https://github.com/networkx/networkx
-            git fetch origin master --depth=1
-            COUNT=$(git diff --name-status origin/master.. | grep 'doc/' | wc -l)
+            git remote -v
+            git remote add upstream https://github.com/networkx/networkx
+            git fetch upstream master --depth=1
+            COUNT=$(git diff --name-status upstream/master.. | grep 'doc/' | wc -l)
             if [[ $ct -eq 0 ]];
               circleci-agent step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,16 @@ jobs:
       - checkout
 
       - run:
+          name: Check whether docs modified
+          command: |
+            git remote add origin https://github.com/networkx/networkx
+            git fetch origin master --depth=1
+            COUNT=$(git diff --name-status origin/master.. | grep 'doc/' | wc -l)
+            if [[ $ct -eq 0 ]];
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Update apt-get
           command: |
             sudo apt-get update
@@ -34,7 +44,7 @@ jobs:
           name: Install pysal dependencies
           command: |
             sudo apt-get install libspatialindex-dev
-      
+
       - run:
           name: Install mayavi dependencies
           command : |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,10 @@ jobs:
       - run:
           name: Check whether docs modified
           command: |
-            git remote -v
-            git remote add upstream https://github.com/networkx/networkx
-            git fetch upstream master --depth=1
-            COUNT=$(git diff --name-status upstream/master.. | grep 'doc/' | wc -l)
-            if [[ $ct -eq 0 ]];
+            git branch -a
+            git fetch origin master --depth=1
+            COUNT=$(git diff --name-status origin/master.. | grep 'doc/' | wc -l)
+            if [[ $COUNT -eq 0 ]];
               circleci-agent step halt
             fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,12 @@ name: test
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+    - 'doc/**'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+    - 'doc/**'
 
 jobs:
 


### PR DESCRIPTION
The motivation here is to speed up our testing pipeline by not scheduling unnecessary builds (in this case, previews of docs when they weren't modified).

It can be argued that the docs should always be built, because (rarely) you may want to see how gallery examples changed in response to code.

If so, the change to the GitHub Action may still be useful: do not re-run the *test suite* unless something outside the docs got changed.