### PR TITLE
Deprecate networkx.utils.empty_generator.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -53,6 +53,7 @@ Version 3.0
 * In ``utils/misc.py`` remove ``is_list_of_ints``.
 * In ``utils/misc.py`` remove ``consume``.
 * In ``utils/misc.py`` remove ``default_opener``.
+* In ``utils/misc.py`` remove ``empty_generator``.
 * Remove ``utils/contextmanagers.py`` and related tests.
 * In ``drawing/nx_agraph.py`` remove ``display_pygraphviz`` and related tests.
 * In ``algorithms/chordal.py`` replace ``chordal_graph_cliques`` with ``_chordal_graph_cliques``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -87,6 +87,8 @@ Deprecations
   Deprecate ``iterable``.
 - [`#4545 <https://github.com/networkx/networkx/pull/4545>`_]
   Deprecate ``generate_unique_node``.
+- [`#4599 <https://github.com/networkx/networkx/pull/4599>`_]
+  Deprecate ``empty_generator``.
 
 Contributors to this release
 ----------------------------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -4,7 +4,6 @@ from itertools import count
 import networkx as nx
 from networkx.utils import not_implemented_for
 from networkx.utils import pairwise
-from networkx.utils import empty_generator
 from networkx.algorithms.shortest_paths.weighted import _weight_function
 
 __all__ = [
@@ -228,15 +227,19 @@ def all_simple_paths(G, source, target, cutoff=None):
         except TypeError as e:
             raise nx.NodeNotFound(f"target node {target} not in graph") from e
     if source in targets:
-        return empty_generator()
+        return _empty_generator()
     if cutoff is None:
         cutoff = len(G) - 1
     if cutoff < 1:
-        return empty_generator()
+        return _empty_generator()
     if G.is_multigraph():
         return _all_simple_paths_multigraph(G, source, targets, cutoff)
     else:
         return _all_simple_paths_graph(G, source, targets, cutoff)
+
+
+def _empty_generator():
+    yield from ()
 
 
 def _all_simple_paths_graph(G, source, targets, cutoff):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -44,6 +44,9 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="default_opener is deprecated"
     )
     warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="empty_generator is deprecated"
+    )
+    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="make_str is deprecated"
     )
     warnings.filterwarnings(

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -68,7 +68,7 @@ def empty_generator():
         "empty_generator is deprecated and will be removed in v3.0.",
         DeprecationWarning,
     )
-    yield from ()
+    return (i for i in ())
 
 
 def flatten(obj, result=None):

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -60,7 +60,14 @@ def iterable(obj):
 
 
 def empty_generator():
-    """ Return a generator with no members """
+    """Return a generator with no members.
+
+    .. deprecated:: 2.6
+    """
+    warnings.warn(
+        "empty_generator is deprecated and will be removed in v3.0.",
+        DeprecationWarning,
+    )
     yield from ()
 
 


### PR DESCRIPTION
Related to #4224 

`networkx.utils` provides `empty_generator` to create an empty Generator object. The only use of this utility was in `all_simple_paths`. The motivation for deprecating this function is that it seems like it is not very specific to NetworkX and is generally achievable by various one-liners, e.g. `(x for x in ())`. IMO it makes more sense to deprecate than to test/document it - LMK what you think!

One tricky thing about this - the warning won't be emitted *on instantiation* of the generator object, but rather only if it is ever iterated over:

```python
>>> empty = nx.utils.empty_generator()  # Doesn't raise deprecation warning
>>> next(empty)
DeprecationWarning
Traceback
  ...
StopIteration
```

I think this is probably okay, but if we want to work out a way that the warning is raised on generator instantiation, I wasn't quite sure how to do that. Suggestions welcome!