### PR TITLE
Use Pillow for viewing AGraph output and deprecate default_opener

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -52,6 +52,7 @@ Version 3.0
 * In ``utils/misc.py`` remove ``iterable``.
 * In ``utils/misc.py`` remove ``is_list_of_ints``.
 * In ``utils/misc.py`` remove ``consume``.
+* In ``utils/misc.py`` remove ``default_opener``.
 * Remove ``utils/contextmanagers.py`` and related tests.
 * In ``drawing/nx_agraph.py`` remove ``display_pygraphviz`` and related tests.
 * In ``algorithms/chordal.py`` replace ``chordal_graph_cliques`` with ``_chordal_graph_cliques``.

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -41,6 +41,9 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="is_string_like is deprecated"
     )
     warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="default_opener is deprecated"
+    )
+    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="make_str is deprecated"
     )
     warnings.filterwarnings(

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -19,6 +19,7 @@ See Also
 """
 import os
 import tempfile
+from PIL import Image
 import networkx as nx
 
 __all__ = [
@@ -324,7 +325,7 @@ def view_pygraphviz(
         The filename used to save the image.  If None, save to a temporary
         file.  File formats are the same as those from pygraphviz.agraph.draw.
     show : bool, default = True
-        Whether to display the graph with `networkx.utils.default_opener`,
+        Whether to display the graph with :mod:`PIL.Image.show`,
         default is `True`. If `False`, the rendered graph is still available
         at `path`.
 
@@ -434,7 +435,7 @@ def view_pygraphviz(
 
     # Show graph in a new window (depends on platform configuration)
     if show:
-        nx.utils.default_opener(path.name)
+        Image.open(path.name).show()
 
     return path.name, A
 
@@ -468,7 +469,8 @@ def display_pygraphviz(graph, path, format=None, prog=None, args=""):
     warnings.warn(
         "display_pygraphviz is deprecated and will be removed in NetworkX 3.0. "
         "To view a graph G using pygraphviz, use nx.nx_agraph.view_pygraphviz(G). "
-        "To view a graph from file, consider nx.utils.default_opener(filename).",
+        "To view a graph from file, consider an image processing libary like "
+        "`Pillow`, e.g. ``PIL.Image.open(path.name).show()``",
         DeprecationWarning,
     )
     if format is None:
@@ -482,4 +484,4 @@ def display_pygraphviz(graph, path, format=None, prog=None, args=""):
     # We must close the file before viewing it.
     graph.draw(path, format, prog, args)
     path.close()
-    nx.utils.default_opener(filename)
+    Image.open(filename).show()

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -19,7 +19,6 @@ See Also
 """
 import os
 import tempfile
-from PIL import Image
 import networkx as nx
 
 __all__ = [
@@ -435,6 +434,8 @@ def view_pygraphviz(
 
     # Show graph in a new window (depends on platform configuration)
     if show:
+        from PIL import Image
+
         Image.open(path.name).show()
 
     return path.name, A
@@ -464,6 +465,7 @@ def display_pygraphviz(graph, path, format=None, prog=None, args=""):
     calls if you experience problems.
 
     """
+    from PIL import Image
     import warnings
 
     warnings.warn(

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -239,12 +239,3 @@ class TestAGraph:
         pos = list(pos.values())
         assert len(pos) == 5
         assert len(pos[0]) == 3
-
-    def test_display_pygraphviz_deprecation_warning(self):
-        G = nx.complete_graph(2)
-        path_name, A = nx.nx_agraph.view_pygraphviz(G, show=False)
-        # Monkeypatch default_opener to prevent window opening
-        nx.utils.default_opener = lambda x: None
-        with pytest.warns(DeprecationWarning, match="display_pygraphviz is deprecated"):
-            with open(path_name, "wb") as fh:
-                nx.nx_agraph.display_pygraphviz(A, fh, prog="dot")

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -158,12 +158,23 @@ def generate_unique_node():
 def default_opener(filename):
     """Opens `filename` using system's default program.
 
+    .. deprecated:: 2.6
+       default_opener is deprecated and will be removed in version 3.0.
+       Consider an image processing library to open images, such as Pillow::
+
+           from PIL import Image
+           Image.open(filename).show()
+
     Parameters
     ----------
     filename : str
         The path of the file to be opened.
 
     """
+    warnings.warn(
+        "default_opener is deprecated and will be removed in version 3.0. ",
+        DeprecationWarning,
+    )
     from subprocess import call
 
     cmds = {


### PR DESCRIPTION
`networkx.utilities.misc` has the `default_opener` function which is used in `nx_agraph` to display the results of drawing with pygraphviz. The pygraphviz drawing functionality writes an image to file, and `default_opener` is used to open that file using the default image viewing utility on various platforms.

Now that matplotlib is a default dependency, `Pillow` should be installed by default, so we can instead rely on the purpose-built Pillow utilities to display images from file. If this is an acceptable alternative, then `default_opener` can be deprecated.