### PR TITLE
Remove instances of random.sample from sets (deprecated in Python 3.9)

### DIFF
--- a/networkx/algorithms/approximation/tests/test_maxcut.py
+++ b/networkx/algorithms/approximation/tests/test_maxcut.py
@@ -39,7 +39,7 @@ def test_one_exchange_basic():
     for (u, v, w) in G.edges(data=True):
         w["weight"] = random.randrange(-100, 100, 1) / 10
 
-    initial_cut = set(random.sample(G.nodes(), k=5))
+    initial_cut = set(random.sample(sorted(G.nodes()), k=5))
     cut_size, (set1, set2) = maxcut.one_exchange(
         G, initial_cut, weight="weight", seed=5
     )
@@ -71,7 +71,7 @@ def test_negative_weights():
     for (u, v, w) in G.edges(data=True):
         w["weight"] = -1 * random.random()
 
-    initial_cut = set(random.sample(G.nodes(), k=5))
+    initial_cut = set(random.sample(sorted(G.nodes()), k=5))
     cut_size, (set1, set2) = maxcut.one_exchange(G, initial_cut, weight="weight")
 
     # make sure it is a valid cut

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -120,7 +120,7 @@ def betweenness_centrality(
     if k is None:
         nodes = G
     else:
-        nodes = seed.sample(G.nodes(), k)
+        nodes = seed.sample(sorted(G.nodes()), k)
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -120,7 +120,7 @@ def betweenness_centrality(
     if k is None:
         nodes = G
     else:
-        nodes = seed.sample(sorted(G.nodes()), k)
+        nodes = seed.sample(list(G.nodes()), k)
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -36,7 +36,7 @@ def test_is_triad():
     G = nx.karate_club_graph()
     G = G.to_directed()
     for i in range(100):
-        nodes = sample(G.nodes(), 3)
+        nodes = sample(sorted(G.nodes()), 3)
         G2 = G.subgraph(nodes)
         assert nx.is_triad(G2)
 

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -395,7 +395,7 @@ def random_triad(G):
     G2 : subgraph
        A randomly selected triad (order-3 NetworkX DiGraph)
     """
-    nodes = sample(G.nodes(), 3)
+    nodes = sample(sorted(G.nodes()), 3)
     G2 = G.subgraph(nodes)
     return G2
 

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -395,7 +395,7 @@ def random_triad(G):
     G2 : subgraph
        A randomly selected triad (order-3 NetworkX DiGraph)
     """
-    nodes = sample(sorted(G.nodes()), 3)
+    nodes = sample(list(G.nodes()), 3)
     G2 = G.subgraph(nodes)
     return G2
 

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -367,7 +367,7 @@ def random_uniform_k_out_graph(n, k, self_loops=True, with_replacement=True, see
         def sample(v, nodes):
             if not self_loops:
                 nodes = nodes - {v}
-            return seed.sample(sorted(nodes), k)
+            return seed.sample(list(nodes), k)
 
     G = nx.empty_graph(n, create_using)
     nodes = set(G)

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -367,7 +367,7 @@ def random_uniform_k_out_graph(n, k, self_loops=True, with_replacement=True, see
         def sample(v, nodes):
             if not self_loops:
                 nodes = nodes - {v}
-            return seed.sample(nodes, k)
+            return seed.sample(sorted(nodes), k)
 
     G = nx.empty_graph(n, create_using)
     nodes = set(G)

--- a/networkx/generators/internet_as_graphs.py
+++ b/networkx/generators/internet_as_graphs.py
@@ -308,7 +308,7 @@ class AS_graph_generator:
                 node_options.remove(j)
 
         if len(node_options) > 0:
-            j = self.seed.sample(node_options, 1)[0]
+            j = self.seed.sample(sorted(node_options), 1)[0]
             self.add_edge(cp, j, "peer")
             self.G.nodes[cp]["peers"] += 1
             self.G.nodes[j]["peers"] += 1

--- a/networkx/generators/internet_as_graphs.py
+++ b/networkx/generators/internet_as_graphs.py
@@ -308,7 +308,7 @@ class AS_graph_generator:
                 node_options.remove(j)
 
         if len(node_options) > 0:
-            j = self.seed.sample(sorted(node_options), 1)[0]
+            j = self.seed.sample(list(node_options), 1)[0]
             self.add_edge(cp, j, "peer")
             self.G.nodes[cp]["peers"] += 1
             self.G.nodes[j]["peers"] += 1


### PR DESCRIPTION
Closes #4555

I took a conservative approach and used `sorted` to convert sets to lists. This may cause a performance hit, but I figured this was safer from the perspective of reproducibility, though I'm not sure it's necessary. In some circumstances it may be sufficient to simply convert to `list` directly.