### PR TITLE
Deprecate hub_matrix and authority_matrix

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -74,3 +74,4 @@ Version 3.0
 * In ``convert_matrix.py`` remove ``order`` kwarg from ``to_pandas_edgelist`` and docstring
 * Remove ``readwrite/json_graph/jit.py`` and related tests.
 * In ``utils/misc.py`` remove ``generate_unique_node`` and related tests.
+* In ``algorithms/link_analysis/hits_alg.py`` remove ``hub_matrix`` and ``authority_matrix``

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -94,6 +94,8 @@ Deprecations
   Deprecate ``generate_unique_node``.
 - [`#4599 <https://github.com/networkx/networkx/pull/4599>`_]
   Deprecate ``empty_generator``.
+- [`#4617 <https://github.com/networkx/networkx/pull/4617>`_]
+  Deprecate ``hub_matrix`` and ``authority_matrix``
 
 Contributors to this release
 ----------------------------

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -180,11 +180,14 @@ def hits_numpy(G, normalized=True):
 
     if len(G) == 0:
         return {}, {}
-    H = nx.hub_matrix(G, list(G))
+    adj_ary = nx.to_numpy_array(G)
+    # Hub matrix
+    H = adj_ary @ adj_ary.T
     e, ev = np.linalg.eig(H)
     m = e.argsort()[-1]  # index of maximum eigenvalue
     h = np.array(ev[:, m]).flatten()
-    A = nx.authority_matrix(G, list(G))
+    # Authority matrix
+    A = adj_ary.T @ adj_ary
     e, ev = np.linalg.eig(A)
     m = e.argsort()[-1]  # index of maximum eigenvalue
     a = np.array(ev[:, m]).flatten()

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -188,7 +188,7 @@ def hits_numpy(G, normalized=True):
     The ``hubs`` and ``authority`` matrices are computed from the adjancency
     matrix:
 
-    >>> adj_ary = nx.to_numpy_adjacency(G)
+    >>> adj_ary = nx.to_numpy_array(G)
     >>> hubs_matrix = adj_ary @ adj_ary.T
     >>> authority_matrix = adj_ary.T @ adj_ary
 

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -120,13 +120,39 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
 
 
 def authority_matrix(G, nodelist=None):
-    """Returns the HITS authority matrix."""
+    """Returns the HITS authority matrix.
+
+    .. deprecated:: 2.6
+    """
+    import warnings
+
+    msg = (
+        "\nauthority_matrix is deprecated as of version 2.6 and will be removed "
+        "in version 3.0.\n"
+        "The authority matrix can be computed by::\n"
+        "    >>> M = nx.to_numpy_array(G, nodelist=nodelist)\n"
+        "    >>> M.T @ M"
+    )
+    warnings.warn(msg, UserWarning)
     M = nx.to_numpy_array(G, nodelist=nodelist)
     return M.T @ M
 
 
 def hub_matrix(G, nodelist=None):
-    """Returns the HITS hub matrix."""
+    """Returns the HITS hub matrix.
+
+    .. deprecated:: 2.6
+    """
+    import warnings
+
+    msg = (
+        "\nhub_matrix is deprecated as of version 2.6 and will be removed "
+        "in version 3.0.\n"
+        "The hub matrix can be computed by::\n"
+        "    >>> M = nx.to_numpy_array(G, nodelist=nodelist)\n"
+        "    >>> M @ M.T"
+    )
+    warnings.warn(msg, UserWarning)
     M = nx.to_numpy_array(G, nodelist=nodelist)
     return M @ M.T
 

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -184,13 +184,11 @@ def hits_numpy(G, normalized=True):
     # Hub matrix
     H = adj_ary @ adj_ary.T
     e, ev = np.linalg.eig(H)
-    m = e.argsort()[-1]  # index of maximum eigenvalue
-    h = np.array(ev[:, m]).flatten()
+    h = ev[:, np.argmax(e)]  # eigenvector corresponding to the maximum eigenvalue
     # Authority matrix
     A = adj_ary.T @ adj_ary
     e, ev = np.linalg.eig(A)
-    m = e.argsort()[-1]  # index of maximum eigenvalue
-    a = np.array(ev[:, m]).flatten()
+    a = ev[:, np.argmax(e)]  # eigenvector corresponding to the maximum eigenvalue
     if normalized:
         h = h / h.sum()
         a = a / a.sum()

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -155,7 +155,21 @@ def hits_numpy(G, normalized=True):
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> h, a = nx.hits(G)
+
+    The `hubs` and `authorities` are given by the eigenvectors corresponding to the
+    maximum eigenvalues of the hubs_matrix and the authority_matrix, respectively.
+
+    The ``hubs`` and ``authority`` matrices are computed from the adjancency
+    matrix:
+
+    >>> adj_ary = nx.to_numpy_adjacency(G)
+    >>> hubs_matrix = adj_ary @ adj_ary.T
+    >>> authority_matrix = adj_ary.T @ adj_ary
+
+    `hits_numpy` maps the eigenvector corresponding to the maximum eigenvalue
+    of the respective matrices to the nodes in `G`:
+
+    >>> hubs, authority = hits_numpy(G)
 
     Notes
     -----

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -133,7 +133,7 @@ def authority_matrix(G, nodelist=None):
         "    >>> M = nx.to_numpy_array(G, nodelist=nodelist)\n"
         "    >>> M.T @ M"
     )
-    warnings.warn(msg, UserWarning)
+    warnings.warn(msg, DeprecationWarning)
     M = nx.to_numpy_array(G, nodelist=nodelist)
     return M.T @ M
 
@@ -152,7 +152,7 @@ def hub_matrix(G, nodelist=None):
         "    >>> M = nx.to_numpy_array(G, nodelist=nodelist)\n"
         "    >>> M @ M.T"
     )
-    warnings.warn(msg, UserWarning)
+    warnings.warn(msg, DeprecationWarning)
     M = nx.to_numpy_array(G, nodelist=nodelist)
     return M @ M.T
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -41,6 +41,12 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="is_string_like is deprecated"
     )
     warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\nauthority_matrix"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\nhub_matrix"
+    )
+    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="default_opener is deprecated"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
Related to #4091 - adds deprecation to `hub_matrix` and `authority_matrix` from the `hits_alg` module. As noted in the linked issue, the functions are primarily pedagogical, so I updated the `hits_numpy` docstring example with a section showing how the two matrices are computed. I also tried to provide a detailed deprecation warning message to illustrate how the hub and authority matrices can be computed from a given Graph.

This addresses part of #4091, but it would still be nice to have a gallery example illustrating the hits algorithm. I don't have a compelling example, so I will leave it for a followup PR. However, if anyone does have a nice example, feel free to push to this branch!