### PR TITLE
add recommended venv directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ networkx.egg-info/
 # Vim's swap files
 *.sw[op]
 
-#Spyder project file
+# Spyder project file
 .spyderproject
 
 # PyCharm project file
@@ -53,3 +53,6 @@ networkx.egg-info/
 
 # PyTest Cache
 .pytest_cache
+
+# Virtual environment directory
+networkx-dev/


### PR DESCRIPTION
CONTRIBUTING.rst recommends creating a virtual env in the directory
`networkx-dev/`. This change adds that directory to `.gitignore`

Fixes #4618 - recommended virtual env name should be in .gitignore
