### PR TITLE
return earlier from `clique.graph_clique_number`

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -420,10 +420,10 @@ def graph_clique_number(G, cliques=None):
     maximal cliques.
 
     """
-    if cliques is None:
-        cliques = find_cliques(G)
     if len(G.nodes) < 1:
         return 0
+    if cliques is None:
+        cliques = find_cliques(G)
     return max([len(c) for c in cliques] or [1])
 
 


### PR DESCRIPTION
Fixes issue #4621 by moving an early return opportunity earlier into the
method call, potentially avoiding one function call to `find_cliques`
that otherwise returns early, itself
