### PR TITLE
Add scipy-1.6.1 to blocklist.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 decorator>=4.4
 numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.10'
-scipy>=1.5; platform_python_implementation!='PyPy' and python_version<'3.10'
+scipy>=1.5,!=1.6.1; platform_python_implementation!='PyPy' and python_version<'3.10'
 matplotlib>=3.3; platform_python_implementation!='PyPy' and python_version<'3.10'
 pandas>=1.1; platform_python_implementation!='PyPy' and python_version<'3.10'


### PR DESCRIPTION
Temporary fix for #4626, at least for failing CI. Prevents scipy version 1.6.1 from being picked up by `pip`.

Avoid test failures due to change in behavior for default dtype when creating coo_matrices.