### PR TITLE
Deprecate Ordered graph classes

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -75,3 +75,5 @@ Version 3.0
 * Remove ``readwrite/json_graph/jit.py`` and related tests.
 * In ``utils/misc.py`` remove ``generate_unique_node`` and related tests.
 * In ``algorithms/link_analysis/hits_alg.py`` remove ``hub_matrix`` and ``authority_matrix``
+* In ``networkx.classes`` remove the ``ordered`` module and the four ``Ordered``
+  classes defined therein.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -96,6 +96,8 @@ Deprecations
   Deprecate ``empty_generator``.
 - [`#4617 <https://github.com/networkx/networkx/pull/4617>`_]
   Deprecate ``hub_matrix`` and ``authority_matrix``
+- [`#4629 <https://github.com/networkx/networkx/pull/4629>`_]
+  Deprecate the ``Ordered`` graph classes.
 
 Contributors to this release
 ----------------------------

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -1,4 +1,10 @@
 """
+
+.. deprecated:: 2.6
+
+   The ordered variants of graph classes in this module are deprecated and
+   will be removed in version 3.0.
+
 Consistently ordered variants of the default base classes.
 Note that if you are using Python 3.6+, you shouldn't need these classes
 because the dicts in Python 3.6+ are ordered.
@@ -28,6 +34,7 @@ subgraphs and replace with code similar to:
 
 """
 from collections import OrderedDict
+import warnings
 
 from .graph import Graph
 from .multigraph import MultiGraph
@@ -49,6 +56,25 @@ class OrderedGraph(Graph):
     adjlist_inner_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
 
+    def __init__(self, incoming_graph_data=None, **attr):
+        """
+        .. deprecated:: 2.6
+
+           OrderedGraph is deprecated and will be removed in version 3.0.
+           Use `Graph` instead, which guarantees order is preserved for
+           Python >= 3.7
+        """
+        warnings.warn(
+            (
+                "OrderedGraph is deprecated and will be removed in version 3.0.\n"
+                "Use `Graph` instead, which guarantees order is preserved for\n"
+                "Python >= 3.7\n"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super(OrderedGraph, self).__init__(incoming_graph_data, **attr)
+
 
 class OrderedDiGraph(DiGraph):
     """Consistently ordered variant of :class:`~networkx.DiGraph`."""
@@ -57,6 +83,25 @@ class OrderedDiGraph(DiGraph):
     adjlist_outer_dict_factory = OrderedDict
     adjlist_inner_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
+
+    def __init__(self, incoming_graph_data=None, **attr):
+        """
+        .. deprecated:: 2.6
+
+           OrderedDiGraph is deprecated and will be removed in version 3.0.
+           Use `DiGraph` instead, which guarantees order is preserved for
+           Python >= 3.7
+        """
+        warnings.warn(
+            (
+                "OrderedDiGraph is deprecated and will be removed in version 3.0.\n"
+                "Use `DiGraph` instead, which guarantees order is preserved for\n"
+                "Python >= 3.7\n"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super(OrderedDiGraph, self).__init__(incoming_graph_data, **attr)
 
 
 class OrderedMultiGraph(MultiGraph):
@@ -68,6 +113,25 @@ class OrderedMultiGraph(MultiGraph):
     edge_key_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
 
+    def __init__(self, incoming_graph_data=None, **attr):
+        """
+        .. deprecated:: 2.6
+
+           OrderedMultiGraph is deprecated and will be removed in version 3.0.
+           Use `MultiGraph` instead, which guarantees order is preserved for
+           Python >= 3.7
+        """
+        warnings.warn(
+            (
+                "OrderedMultiGraph is deprecated and will be removed in version 3.0.\n"
+                "Use `MultiGraph` instead, which guarantees order is preserved for\n"
+                "Python >= 3.7\n"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super(OrderedMultiGraph, self).__init__(incoming_graph_data, **attr)
+
 
 class OrderedMultiDiGraph(MultiDiGraph):
     """Consistently ordered variant of :class:`~networkx.MultiDiGraph`."""
@@ -77,3 +141,22 @@ class OrderedMultiDiGraph(MultiDiGraph):
     adjlist_inner_dict_factory = OrderedDict
     edge_key_dict_factory = OrderedDict
     edge_attr_dict_factory = OrderedDict
+
+    def __init__(self, incoming_graph_data=None, **attr):
+        """
+        .. deprecated:: 2.6
+
+           OrderedMultiDiGraph is deprecated and will be removed in version 3.0.
+           Use `MultiDiGraph` instead, which guarantees order is preserved for
+           Python >= 3.7
+        """
+        warnings.warn(
+            (
+                "OrderedMultiDiGraph is deprecated and will be removed in version 3.0.\n"
+                "Use `MultiDiGraph` instead, which guarantees order is preserved for\n"
+                "Python >= 3.7\n"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super(OrderedMultiDiGraph, self).__init__(incoming_graph_data, **attr)

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -49,7 +49,14 @@ __all__.extend(
 
 
 class OrderedGraph(Graph):
-    """Consistently ordered variant of :class:`~networkx.Graph`."""
+    """Consistently ordered variant of :class:`~networkx.Graph`.
+
+    .. deprecated:: 2.6
+
+       OrderedGraph is deprecated and will be removed in version 3.0.
+       Use `Graph` instead, which guarantees order is preserved for
+       Python >= 3.7
+    """
 
     node_dict_factory = OrderedDict
     adjlist_outer_dict_factory = OrderedDict
@@ -57,13 +64,6 @@ class OrderedGraph(Graph):
     edge_attr_dict_factory = OrderedDict
 
     def __init__(self, incoming_graph_data=None, **attr):
-        """
-        .. deprecated:: 2.6
-
-           OrderedGraph is deprecated and will be removed in version 3.0.
-           Use `Graph` instead, which guarantees order is preserved for
-           Python >= 3.7
-        """
         warnings.warn(
             (
                 "OrderedGraph is deprecated and will be removed in version 3.0.\n"
@@ -77,7 +77,14 @@ class OrderedGraph(Graph):
 
 
 class OrderedDiGraph(DiGraph):
-    """Consistently ordered variant of :class:`~networkx.DiGraph`."""
+    """Consistently ordered variant of :class:`~networkx.DiGraph`.
+
+    .. deprecated:: 2.6
+
+       OrderedDiGraph is deprecated and will be removed in version 3.0.
+       Use `DiGraph` instead, which guarantees order is preserved for
+       Python >= 3.7
+    """
 
     node_dict_factory = OrderedDict
     adjlist_outer_dict_factory = OrderedDict
@@ -85,13 +92,6 @@ class OrderedDiGraph(DiGraph):
     edge_attr_dict_factory = OrderedDict
 
     def __init__(self, incoming_graph_data=None, **attr):
-        """
-        .. deprecated:: 2.6
-
-           OrderedDiGraph is deprecated and will be removed in version 3.0.
-           Use `DiGraph` instead, which guarantees order is preserved for
-           Python >= 3.7
-        """
         warnings.warn(
             (
                 "OrderedDiGraph is deprecated and will be removed in version 3.0.\n"
@@ -105,7 +105,14 @@ class OrderedDiGraph(DiGraph):
 
 
 class OrderedMultiGraph(MultiGraph):
-    """Consistently ordered variant of :class:`~networkx.MultiGraph`."""
+    """Consistently ordered variant of :class:`~networkx.MultiGraph`.
+
+    .. deprecated:: 2.6
+
+       OrderedMultiGraph is deprecated and will be removed in version 3.0.
+       Use `MultiGraph` instead, which guarantees order is preserved for
+       Python >= 3.7
+    """
 
     node_dict_factory = OrderedDict
     adjlist_outer_dict_factory = OrderedDict
@@ -114,13 +121,6 @@ class OrderedMultiGraph(MultiGraph):
     edge_attr_dict_factory = OrderedDict
 
     def __init__(self, incoming_graph_data=None, **attr):
-        """
-        .. deprecated:: 2.6
-
-           OrderedMultiGraph is deprecated and will be removed in version 3.0.
-           Use `MultiGraph` instead, which guarantees order is preserved for
-           Python >= 3.7
-        """
         warnings.warn(
             (
                 "OrderedMultiGraph is deprecated and will be removed in version 3.0.\n"
@@ -134,7 +134,14 @@ class OrderedMultiGraph(MultiGraph):
 
 
 class OrderedMultiDiGraph(MultiDiGraph):
-    """Consistently ordered variant of :class:`~networkx.MultiDiGraph`."""
+    """Consistently ordered variant of :class:`~networkx.MultiDiGraph`.
+
+    .. deprecated:: 2.6
+
+       OrderedMultiDiGraph is deprecated and will be removed in version 3.0.
+       Use `MultiDiGraph` instead, which guarantees order is preserved for
+       Python >= 3.7
+    """
 
     node_dict_factory = OrderedDict
     adjlist_outer_dict_factory = OrderedDict
@@ -143,13 +150,6 @@ class OrderedMultiDiGraph(MultiDiGraph):
     edge_attr_dict_factory = OrderedDict
 
     def __init__(self, incoming_graph_data=None, **attr):
-        """
-        .. deprecated:: 2.6
-
-           OrderedMultiDiGraph is deprecated and will be removed in version 3.0.
-           Use `MultiDiGraph` instead, which guarantees order is preserved for
-           Python >= 3.7
-        """
         warnings.warn(
             (
                 "OrderedMultiDiGraph is deprecated and will be removed in version 3.0.\n"

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -28,6 +28,9 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(autouse=True)
 def set_warnings():
     warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message=r"Ordered.* is deprecated"
+    )
+    warnings.filterwarnings(
         "ignore",
         category=DeprecationWarning,
         message="literal_stringizer is deprecated",


### PR DESCRIPTION
Closes #4614 

Deprecate the `Ordered` variants of the four graph classes. Adds deprecation notices in the docs to the `networkx.class.ordered` module, as well as the class docstrings. Adds an `__init__` method to each `Ordered` class which is responsible for raising a `DeprecationWarning`, then delegates to the parent constructor.