### PR TITLE
Gallery Example: MPL annotation on top of network

### DIFF
--- a/examples/drawing/plot_mpl_annotations.py
+++ b/examples/drawing/plot_mpl_annotations.py
@@ -3,7 +3,7 @@
 Annotations with Matplotlib
 =================
 
-Use matplotlib to annotate on top of a network
+Example of using matplotlib to place annotations on top of a network
 """
 
 import matplotlib.pyplot as plt
@@ -12,7 +12,7 @@ import networkx as nx
 import urllib.request
 import io
 
-# Image URLs for graph images
+# Image URLs for graph nodes
 URLs = [
     {'type': 'router', 'URL': 'https://www.materialui.co/materialIcons/hardware/router_black_144x144.png'},
     {'type': 'switch', 'URL': 'https://www.materialui.co/materialIcons/action/dns_black_144x144.png'},
@@ -54,8 +54,8 @@ icon_size = 0.05
 icon_center = icon_size / 2.0
 
 for n in G.nodes:
-    xf, yf = tr_figure(pos[n])  # figure coordinates
-    xa, ya = tr_axes((xf, yf))  # axes coordinates
+    xf, yf = tr_figure(pos[n])
+    xa, ya = tr_axes((xf, yf))
     a = plt.axes([xa - icon_center, ya - icon_center, icon_size, icon_size])
     a.imshow(G.nodes[n]['image'])
     a.axis('off')

--- a/examples/drawing/plot_mpl_annotations.py
+++ b/examples/drawing/plot_mpl_annotations.py
@@ -1,0 +1,62 @@
+"""
+=================
+Annotations with Matplotlib
+=================
+
+Use matplotlib to annotate on top of a network
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.image as mpimg
+import networkx as nx
+import urllib.request
+import io
+
+# Image URLs for graph images
+URLs = [
+    {'type': 'router', 'URL': 'https://www.materialui.co/materialIcons/hardware/router_black_144x144.png'},
+    {'type': 'switch', 'URL': 'https://www.materialui.co/materialIcons/action/dns_black_144x144.png'},
+    {'type': 'PC', 'URL': 'https://www.materialui.co/materialIcons/hardware/computer_black_144x144.png'}
+]
+
+# Import images from URLS into a collection
+images = {}
+for u in URLs:
+    with urllib.request.urlopen(u['URL']) as url:
+        image = mpimg.imread(io.BytesIO(url.read()))
+        images[u['type']] = image
+
+# Generate the computer network graph
+G = nx.Graph()
+
+G.add_node("router", image=images['router'])
+for i in range(1, 4):
+    G.add_node("switch_" + str(i), image=images['switch'])
+    for j in range(1, 4):
+        G.add_node("PC_" + str(i) + "_" + str(j), image=images['PC'])
+
+G.add_edge("router", "switch_1")
+G.add_edge("router", "switch_2")
+G.add_edge("router", "switch_3")
+for u in range(1, 4):
+    for v in range(1, 4):
+        G.add_edge("switch_" + str(u), "PC_" + str(u) + "_" + str(v))
+
+pos = nx.spring_layout(G)
+fig, ax = plt.subplots()
+nx.draw_networkx_edges(G, pos=pos, ax=ax)
+
+tr_figure = ax.transData.transform
+tr_axes = fig.transFigure.inverted().transform
+
+# Draw the images on top of the graph
+icon_size = 0.05
+icon_center = icon_size / 2.0
+
+for n in G.nodes:
+    xf, yf = tr_figure(pos[n])  # figure coordinates
+    xa, ya = tr_axes((xf, yf))  # axes coordinates
+    a = plt.axes([xa - icon_center, ya - icon_center, icon_size, icon_size])
+    a.imshow(G.nodes[n]['image'])
+    a.axis('off')
+plt.show()


### PR DESCRIPTION
The following code is intended to address issue number #4623

This adds an example of drawing a network and annotating with matplotlib. 

For this example, we create a simple server topology with a router, 3 switches and 3 PCs per switch. We then replace each node with an image of the respective device, as shown below:

![myplot](https://user-images.githubusercontent.com/24524053/108859668-bf2c9100-75ed-11eb-83ad-76166cbb6cbd.png)
