### PR TITLE
Verify edges are valid in is_matching()

### DIFF
--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -93,8 +93,11 @@ def is_matching(G, matching):
     if isinstance(matching, dict):
         matching = matching_dict_to_set(matching)
 
-    if not all(G.has_edge(*edge) for edge in matching):
-        return False
+    for edge in matching:
+        if len(edge) != 2:
+            return False
+        if not G.has_edge(*edge):
+            return False
 
     # TODO This is parallelizable.
     return all(len(set(e1) & set(e2)) == 0 for e1, e2 in combinations(matching, 2))

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -92,6 +92,10 @@ def is_matching(G, matching):
     """
     if isinstance(matching, dict):
         matching = matching_dict_to_set(matching)
+
+    if not all(G.has_edge(*edge) for edge in matching):
+        return False
+
     # TODO This is parallelizable.
     return all(len(set(e1) & set(e2)) == 0 for e1, e2 in combinations(matching, 2))
 

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -411,10 +411,11 @@ class TestIsMatching:
     def test_invalid_edge(self):
         G = nx.path_graph(4)
         assert not nx.is_matching(G, {(0, 3), (1, 2)})
-        assert not nx.is_matching(G, {(0, 4)}
+        assert not nx.is_matching(G, {(0, 4)})
         G = nx.path_graph(4, create_using=nx.DiGraph)
         assert nx.is_matching(G, {(0, 1)})
         assert not nx.is_matching(G, {(1, 0)})
+
 
 class TestIsMaximalMatching:
     """Unit tests for the

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -411,7 +411,10 @@ class TestIsMatching:
     def test_invalid_edge(self):
         G = nx.path_graph(4)
         assert not nx.is_matching(G, {(0, 3), (1, 2)})
-
+        assert not nx.is_matching(G, {(0, 4)}
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        assert nx.is_matching(G, {(0, 1)})
+        assert not nx.is_matching(G, {(1, 0)})
 
 class TestIsMaximalMatching:
     """Unit tests for the

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -408,6 +408,10 @@ class TestIsMatching:
         G = nx.path_graph(4)
         assert not nx.is_matching(G, {(0, 1), (1, 2), (2, 3)})
 
+    def test_invalid_edge(self):
+        G = nx.path_graph(4)
+        assert not nx.is_matching(G, {(0, 3), (1, 2)})
+
 
 class TestIsMaximalMatching:
     """Unit tests for the


### PR DESCRIPTION
Previously the is_matching() function was never checking the edges in
the provided matching against the graph, it would just validate there
were no shared endpoints. The graph object passed in to the function was
never used. This commit updates the function to check that all the edges
in the matching are valid and present in the provided graph before
checking if the are no shared endpoints.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
