### PR TITLE
Remove attr_dict from parameters list in the docstring

### DIFF
--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -367,9 +367,6 @@ class MultiDiGraph(MultiGraph, DiGraph):
             Nodes must be hashable (and not None) Python objects.
         key : hashable identifier, optional (default=lowest unused integer)
             Used to distinguish multiedges between a pair of nodes.
-        attr_dict : dictionary, optional (default= no attributes)
-            Dictionary of edge attributes.  Key/value pairs will
-            update existing data associated with the edge.
         attr : keyword arguments, optional
             Edge data (or labels or objects) can be assigned using
             keyword arguments.


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
`attr_dict` parameter in `MultiDiGraph.add_edge` was removed in https://github.com/networkx/networkx/commit/1b35e352daf740f115012427d53a48f460a62206

This PR updates the docstring to conform to the above-mentioned update.



