### PR TITLE
[fix] for negative_edge_cycle incorrect call of bellman_ford

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -338,6 +338,14 @@ class TestWeightedPath(WeightedTestBase):
         G.add_edge(9, 10)
         pytest.raises(ValueError, nx.bidirectional_dijkstra, G, 8, 10)
 
+    def test_negative_edge_cycle_custom_weight_key(self):
+        d = nx.DiGraph()
+        d.add_node("a")
+        d.add_node("b")
+        d.add_edge("a", "b", w=-2)
+        d.add_edge("b", "a", w=-1)
+        assert nx.negative_edge_cycle(d, weight="w")
+
     def test_weight_function(self):
         """Tests that a callable weight is interpreted as a weight
         function instead of an edge attribute.
@@ -349,6 +357,7 @@ class TestWeightedPath(WeightedTestBase):
         G.adj[0][2]["weight"] = 10
         G.adj[0][1]["weight"] = 1
         G.adj[1][2]["weight"] = 1
+
         # The weight function will take the multiplicative inverse of
         # the weights on the edges. This way, weights that were large
         # before now become small and vice versa.
@@ -414,6 +423,7 @@ class TestDijkstraPathLength:
         G.adj[0][2]["weight"] = 10
         G.adj[0][1]["weight"] = 1
         G.adj[1][2]["weight"] = 1
+
         # The weight function will take the multiplicative inverse of
         # the weights on the edges. This way, weights that were large
         # before now become small and vice versa.

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -340,8 +340,6 @@ class TestWeightedPath(WeightedTestBase):
 
     def test_negative_edge_cycle_custom_weight_key(self):
         d = nx.DiGraph()
-        d.add_node("a")
-        d.add_node("b")
         d.add_edge("a", "b", w=-2)
         d.add_edge("b", "a", w=-1)
         assert nx.negative_edge_cycle(d, weight="w")

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1965,7 +1965,9 @@ def negative_edge_cycle(G, weight="weight", heuristic=True):
     G.add_edges_from([(newnode, n) for n in G])
 
     try:
-        bellman_ford_predecessor_and_distance(G, newnode, weight, heuristic=heuristic)
+        bellman_ford_predecessor_and_distance(
+            G, newnode, weight=weight, heuristic=heuristic
+        )
     except nx.NetworkXUnbounded:
         return True
     finally:


### PR DESCRIPTION
Use keyword argument instead of positional argument to avoid argument mismatch.
Affected function: `negative_edge_cycle`

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
