### PR TITLE
Use igraph 0.9

### DIFF
--- a/examples/external/plot_igraph.py
+++ b/examples/external/plot_igraph.py
@@ -29,10 +29,9 @@ plt.show()
 # convert to igraph
 g = ig.Graph.from_networkx(G)
 
-## TODO: uncomment this once python-igraph 0.9 is released
 # igraph draw
-# layout = g.layout()
-# ig.plot(g, layout=layout)
+layout = g.layout()
+ig.plot(g, layout=layout)
 
 # %%
 # igraph to NetworkX

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -9,4 +9,4 @@ contextily>=1.0
 mayavi>=4.7
 seaborn>=0.11
 cairocffi>=1.2
-python-igraph>=0.8.3
+python-igraph>=0.9


### PR DESCRIPTION
Sphinx-gallery hangs on the igraph plot.  When I run this locally, it displays the igraph plot; but it hangs until I close the plot.  After manually closing the plot, sphinx-gallery doesn't find the PNG file.  We may need a python-igraph sphinx-gallery scrapper.

@rossbar Could you take a quick look (when you have a chance) and see if there is an easy fix or whether we need to make changes to python-igraph to get this working?