### PR TITLE
Add removal of edges from planar embeddings

### DIFF
--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -1001,6 +1001,47 @@ class PlanarEmbedding(nx.DiGraph):
         self[start_node][cw_reference]["ccw"] = end_node
         self[start_node][end_node]["ccw"] = reference_neighbor
 
+    def remove_half_edge(self, start_node, end_node):
+        """Removes a half-edge from start_node to end_node.
+
+        Referencing half edges are updated i.e. the 'ccw' and 'cw' of the edges clockwise and counter-clockwise to
+        (start_node,end_node) are updated.
+
+        Parameters
+        ----------
+        start_node : node
+            Start node of removed edge.
+        end_node : node
+            End node of removed edge.
+
+        Raises
+        ------
+        NetworkXException
+            If the edge to be removed does not exist.
+
+        See Also
+        --------
+        add_half_edge_ccw
+        add_half_edge_cw
+        add_half_edge_first
+        """
+        if not self.has_edge(start_node, end_node):
+            raise nx.NetworkXError(f"The edge {start_node}-{end_node} not in graph.")
+        if self.out_degree(start_node) == 1:
+            self.remove_edge(start_node, end_node)
+            self.nodes[start_node]['first_nbr'] = None
+        else:
+            cw_node = self[start_node][end_node]['cw']
+            ccw_node = self[start_node][end_node]['ccw']
+            # Remove the edge
+            self.remove_edge(start_node, end_node)
+            # and update the clockwise and counter-clockwise edges to remove references to the edge.
+            self[start_node][cw_node]['ccw'] = ccw_node
+            self[start_node][ccw_node]['cw'] = cw_node
+            # If we removed the edge to the first neighbour to a new adjacent vertex
+            if end_node == self.nodes[start_node]['first_nbr']:
+                self.nodes[start_node]['first_nbr'] = cw_node
+
     def connect_components(self, v, w):
         """Adds half-edges for (v, w) and (w, v) at some position.
 

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -1038,7 +1038,7 @@ class PlanarEmbedding(nx.DiGraph):
             # and update the clockwise and counter-clockwise edges to remove references to the edge.
             self[start_node][cw_node]['ccw'] = ccw_node
             self[start_node][ccw_node]['cw'] = cw_node
-            # If we removed the edge to the first neighbour to a new adjacent vertex
+            # If we removed the edge to the first neighbour, update first_nbr to a new adjacent vertex
             if end_node == self.nodes[start_node]['first_nbr']:
                 self.nodes[start_node]['first_nbr'] = cw_node
 

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -1031,18 +1031,18 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(f"The edge {start_node}-{end_node} not in graph.")
         if self.out_degree(start_node) == 1:
             self.remove_edge(start_node, end_node)
-            self.nodes[start_node]['first_nbr'] = None
+            self.nodes[start_node]["first_nbr"] = None
         else:
-            cw_node = self[start_node][end_node]['cw']
-            ccw_node = self[start_node][end_node]['ccw']
+            cw_node = self[start_node][end_node]["cw"]
+            ccw_node = self[start_node][end_node]["ccw"]
             # Remove the edge
             self.remove_edge(start_node, end_node)
             # and update the clockwise and counter-clockwise edges to remove references to the edge.
-            self[start_node][cw_node]['ccw'] = ccw_node
-            self[start_node][ccw_node]['cw'] = cw_node
+            self[start_node][cw_node]["ccw"] = ccw_node
+            self[start_node][ccw_node]["cw"] = cw_node
             # If we removed the edge to the first neighbour, update first_nbr to a new adjacent vertex
-            if end_node == self.nodes[start_node]['first_nbr']:
-                self.nodes[start_node]['first_nbr'] = cw_node
+            if end_node == self.nodes[start_node]["first_nbr"]:
+                self.nodes[start_node]["first_nbr"] = cw_node
 
     def remove_planar_node(self, n):
         """Remove node n, preserving the embedding structure.
@@ -1063,7 +1063,6 @@ class PlanarEmbedding(nx.DiGraph):
         See Also
         --------
         remove_node
-
         """
         if not self.has_node(n):
             raise nx.NetworkXError(f"The node {n} not in graph.")

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -1,4 +1,6 @@
+import itertools
 from collections import defaultdict
+
 import networkx as nx
 
 __all__ = ["check_planarity", "PlanarEmbedding"]
@@ -1041,6 +1043,34 @@ class PlanarEmbedding(nx.DiGraph):
             # If we removed the edge to the first neighbour, update first_nbr to a new adjacent vertex
             if end_node == self.nodes[start_node]['first_nbr']:
                 self.nodes[start_node]['first_nbr'] = cw_node
+
+    def remove_planar_node(self, n):
+        """Remove node n, preserving the embedding structure.
+
+        Removes the node n and all adjacent edges.
+        Attempting to remove a non-existent node will raise an exception.
+
+        Parameters
+        ----------
+        n : node
+           A node in the graph
+
+        Raises
+        ------
+        NetworkXError
+           If n is not in the graph.
+
+        See Also
+        --------
+        remove_node
+
+        """
+        if not self.has_node(n):
+            raise nx.NetworkXError(f"The node {n} not in graph.")
+        adj_edges = list(itertools.chain(self.out_edges(n), self.in_edges(n)))
+        for (u, v) in adj_edges:
+            self.remove_half_edge(u, v)
+        self.remove_node(n)
 
     def connect_components(self, v, w):
         """Adds half-edges for (v, w) and (w, v) at some position.

--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -1,8 +1,9 @@
 import pytest
+
 import networkx as nx
+from networkx.algorithms.planarity import check_planarity_recursive
 from networkx.algorithms.planarity import get_counterexample
 from networkx.algorithms.planarity import get_counterexample_recursive
-from networkx.algorithms.planarity import check_planarity_recursive
 
 
 class TestLRPlanarity:
@@ -397,6 +398,34 @@ class TestPlanarEmbeddingClass:
             embedding.add_half_edge_first(1, 2)
             # Invalid structure because other half edge is missing
             embedding.check_structure()
+
+    def test_removal_never_existing_edge(self):
+        with pytest.raises(nx.NetworkXError):
+            embedding = nx.PlanarEmbedding()
+            embedding.add_half_edge_first(1, 2)
+            embedding.add_half_edge_first(2, 1)
+            embedding.remove_half_edge(1, 3)
+
+    def test_removal_previously_existing_edge(self):
+        with pytest.raises(nx.NetworkXError):
+            embedding = nx.PlanarEmbedding()
+            embedding.add_half_edge_first(1, 2)
+            embedding.add_half_edge_first(2, 1)
+            embedding.remove_half_edge(1, 2)
+            embedding.remove_half_edge(1, 2)
+
+    def test_successful_edge_removal(self):
+        embedding = self.get_star_embedding(3)
+        embedding.remove_half_edge(0, 2)
+        embedding.remove_half_edge(2, 0)
+        embedding.check_structure()
+        assert set(embedding.edges) == {(0, 1), (1, 0)}
+        assert set(embedding.nodes) == {0, 1, 2}
+        assert embedding.nodes[2]['first_nbr'] is None
+        assert embedding.nodes[1]['first_nbr'] == 0
+        assert embedding.nodes[0]['first_nbr'] == 1
+        assert embedding.get_edge_data(0, 1) == {'cw': 1, 'ccw': 1}
+        assert embedding.get_edge_data(1, 0) == {'cw': 0, 'ccw': 0}
 
     def test_not_fulfilling_euler_formula(self):
         with pytest.raises(nx.NetworkXException):

--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -1,9 +1,8 @@
 import pytest
-
 import networkx as nx
-from networkx.algorithms.planarity import check_planarity_recursive
 from networkx.algorithms.planarity import get_counterexample
 from networkx.algorithms.planarity import get_counterexample_recursive
+from networkx.algorithms.planarity import check_planarity_recursive
 
 
 class TestLRPlanarity:
@@ -421,11 +420,11 @@ class TestPlanarEmbeddingClass:
         embedding.check_structure()
         assert set(embedding.edges) == {(0, 1), (1, 0)}
         assert set(embedding.nodes) == {0, 1, 2}
-        assert embedding.nodes[2]['first_nbr'] is None
-        assert embedding.nodes[1]['first_nbr'] == 0
-        assert embedding.nodes[0]['first_nbr'] == 1
-        assert embedding.get_edge_data(0, 1) == {'cw': 1, 'ccw': 1}
-        assert embedding.get_edge_data(1, 0) == {'cw': 0, 'ccw': 0}
+        assert embedding.nodes[2]["first_nbr"] is None
+        assert embedding.nodes[1]["first_nbr"] == 0
+        assert embedding.nodes[0]["first_nbr"] == 1
+        assert embedding.get_edge_data(0, 1) == {"cw": 1, "ccw": 1}
+        assert embedding.get_edge_data(1, 0) == {"cw": 0, "ccw": 0}
 
     def test_removal_never_existing_node(self):
         with pytest.raises(nx.NetworkXError):
@@ -448,8 +447,8 @@ class TestPlanarEmbeddingClass:
         embedding.check_structure()
         assert set(embedding.edges) == set([])
         assert set(embedding.nodes) == {1, 2}
-        assert embedding.nodes[2]['first_nbr'] is None
-        assert embedding.nodes[1]['first_nbr'] is None
+        assert embedding.nodes[2]["first_nbr"] is None
+        assert embedding.nodes[1]["first_nbr"] is None
 
     def test_not_fulfilling_euler_formula(self):
         with pytest.raises(nx.NetworkXException):

--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -427,6 +427,30 @@ class TestPlanarEmbeddingClass:
         assert embedding.get_edge_data(0, 1) == {'cw': 1, 'ccw': 1}
         assert embedding.get_edge_data(1, 0) == {'cw': 0, 'ccw': 0}
 
+    def test_removal_never_existing_node(self):
+        with pytest.raises(nx.NetworkXError):
+            embedding = nx.PlanarEmbedding()
+            embedding.add_half_edge_first(0, 1)
+            embedding.add_half_edge_first(1, 0)
+            embedding.remove_planar_node(2)
+
+    def test_removal_previously_existing_node(self):
+        with pytest.raises(nx.NetworkXError):
+            embedding = nx.PlanarEmbedding()
+            embedding.add_half_edge_first(0, 1)
+            embedding.add_half_edge_first(1, 0)
+            embedding.remove_planar_node(1)
+            embedding.remove_planar_node(1)
+
+    def test_successful_node_remove(self):
+        embedding = self.get_star_embedding(3)
+        embedding.remove_planar_node(0)
+        embedding.check_structure()
+        assert set(embedding.edges) == set([])
+        assert set(embedding.nodes) == {1, 2}
+        assert embedding.nodes[2]['first_nbr'] is None
+        assert embedding.nodes[1]['first_nbr'] is None
+
     def test_not_fulfilling_euler_formula(self):
         with pytest.raises(nx.NetworkXException):
             embedding = nx.PlanarEmbedding()


### PR DESCRIPTION
I have added a way to remove half edges and node from planar embeddings in a way that preserves the structure.

Notes:

- I'm not a fan of the name remove_planar_node but couldn't think of anything better to differentiate from remove_node
- The use of itertools in remove_planar_node is probably a bit over the top, would appreciate feedback on what should be used

Thanks