### PR TITLE
Feature 3063

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ networkx.egg-info/
 
 # Virtual environment directory
 networkx-dev/
+venv/

--- a/networkx/readwrite/__init__.py
+++ b/networkx/readwrite/__init__.py
@@ -17,3 +17,4 @@ from networkx.readwrite.gexf import *
 from networkx.readwrite.nx_shp import *
 from networkx.readwrite.json_graph import *
 from networkx.readwrite.text import *
+from networkx.readwrite.nx_ete import *

--- a/networkx/readwrite/nx_ete.py
+++ b/networkx/readwrite/nx_ete.py
@@ -1,0 +1,136 @@
+"""
+****
+ETE
+****
+Read and write NetworkX graphs in ETE standard tree representation format.
+
+"ETE (Environment for Tree Exploration) is a Python programming toolkit
+that assists in the automated manipulation,
+analysis and visualization of phylogenetic trees.
+It uses the Newick format as one of the most widely used
+standard representation of trees in bioinformatics."
+See http://etetoolkit.org/ for documentation.
+
+Format
+------
+http://etetoolkit.org/docs/latest/tutorial/tutorial_trees.html#reading-and-writing-newick-trees
+
+"""
+
+__all__ = ["read_ete", "write_ete"]
+
+from networkx import is_tree, dfs_tree, Graph
+from networkx.utils import open_file
+
+
+@open_file(1, mode="w")
+def write_ete(G_to_be_ete, path_for_ete_output, root_node=None):
+    """Write graph G in Newick format to path.
+
+    The Newick format is one of the most widely used
+    standard representation of trees in bioinformatics [1]_.
+
+
+    Parameters
+    ----------
+    G_to_be_ete : graph
+       A NetworkX graph
+    path_for_ete_output : file or string
+       File or filename to write.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(42)
+    >>> nx.write_ete(G, "test_ete.txt")
+
+    References
+    ----------
+    .. [1] http://etetoolkit.org/docs/latest/tutorial/tutorial_trees.html#reading-and-writing-newick-trees
+    """
+
+    assert is_tree(G_to_be_ete), "write_ete() requires `G_to_be_ete` be a tree: %s" % (
+        "https://networkx.org/documentation/stable/reference/algorithms/tree.html"
+    )
+
+    try:
+        import ete3
+    except ImportError as e:
+        raise ImportError("to_ete() requires ete3: http://etetoolkit.org/") from e
+
+    if root_node is None:
+        root_node = list(G_to_be_ete.nodes)[0]
+
+    G_tree = dfs_tree(G_to_be_ete, source=root_node)
+
+    node2tree = dict()
+
+    for node_name, node_features in G_tree.nodes(data=True):
+        node2tree[node_name] = ete3.Tree(name=str(node_name))
+        node2tree[node_name].add_features(**node_features)
+
+    for parent, child in G_tree.edges:
+        node2tree[parent].add_child(child=node2tree[child])
+
+    tree = node2tree[root_node]
+
+    path_for_ete_output.write(
+        tree.write(features=list(tree.features - {"dist", "support"}))
+    )
+
+
+@open_file(0, mode="r")
+def read_ete(path):
+    """Read graph in Newick format from path.
+
+    The Newick format is one of the most widely used
+    standard representation of trees in bioinformatics [1]_.
+
+    Parameters
+    ----------
+    path : file or string
+       File or filename to read.
+
+    Returns
+    -------
+    G : NetworkX graph
+
+    Examples
+    --------
+    >>> G = nx.path_graph(42)
+    >>> nx.write_ete(G, "test_ete.txt")
+    >>> G = nx.read_yaml("test_ete.txt")
+
+    References
+    ----------
+    .. [1] http://etetoolkit.org/docs/latest/tutorial/tutorial_trees.html#reading-and-writing-newick-trees
+    """
+
+    try:
+        import ete3
+    except ImportError as e:
+        raise ImportError("to_ete() requires ete3: http://etetoolkit.org/") from e
+
+    file = [line for line in path]
+
+    tree = ete3.Tree(file[0])
+
+    G = Graph()
+
+    for tree_node in tree.iter_search_nodes():
+        node_name = tree_node.name
+        node_features = {
+            k: tree_node.k for k in tree_node.features - {"dist", "support"}
+        }
+
+        G.add_node(node_name, **node_features)
+
+    queue = [tree]
+
+    while queue:
+        parent = queue.pop(0)
+
+        for child in parent.children:
+            G.add_edge(parent.name, child.name)
+            queue.append(child)
+
+    return G

--- a/networkx/readwrite/nx_ete.py
+++ b/networkx/readwrite/nx_ete.py
@@ -22,8 +22,6 @@ __all__ = ["read_ete", "write_ete"]
 from networkx.utils import open_file
 import networkx as nx
 
-RESERVED_ETE3_TREE_NODE_NAME = ""
-
 
 @open_file(1, mode="w")
 def write_ete(G_to_be_ete, path_for_ete_output, root_node=None):
@@ -74,11 +72,12 @@ def write_ete(G_to_be_ete, path_for_ete_output, root_node=None):
     for parent, child in G_tree.edges:
         node2tree[parent].add_child(child=node2tree[child])
 
-    tree = ete3.Tree(name=RESERVED_ETE3_TREE_NODE_NAME)
-    tree.add_child(child=node2tree[root_node])
+    tree = node2tree[root_node]
 
     path_for_ete_output.write(
-        tree.write(features=list(tree.features - {"dist", "support"}))
+        tree.write(
+            features=list(tree.features - {"dist", "support"}), format_root_node=True
+        )
     )
 
 
@@ -121,9 +120,6 @@ def read_ete(path):
     G = nx.Graph()
 
     for tree_node in tree.iter_search_nodes():
-        if tree_node.name == RESERVED_ETE3_TREE_NODE_NAME:
-            continue
-
         node_name = tree_node.name
         node_features = {
             k: getattr(tree_node, k) for k in tree_node.features - {"dist", "support"}
@@ -137,10 +133,7 @@ def read_ete(path):
         parent = queue.pop(0)
 
         for child in parent.children:
-            if child.name != RESERVED_ETE3_TREE_NODE_NAME:
-                queue.append(child)
-
-                if parent.name != RESERVED_ETE3_TREE_NODE_NAME:
-                    G.add_edge(parent.name, child.name)
+            queue.append(child)
+            G.add_edge(parent.name, child.name)
 
     return G

--- a/networkx/readwrite/tests/test_ete.py
+++ b/networkx/readwrite/tests/test_ete.py
@@ -1,0 +1,46 @@
+"""
+    Unit tests for ete.
+"""
+
+import os
+import tempfile
+import pytest
+
+nx_ete = pytest.importorskip("nx_ete")
+
+import networkx as nx
+from networkx.testing import assert_edges_equal, assert_nodes_equal
+
+
+class TestETE:
+    @classmethod
+    def setup_class(cls):
+        cls.build_graphs()
+
+    @classmethod
+    def build_graphs(cls):
+        cls.G = nx.Graph(name="test")
+        e = [("a", "b"), ("b", "c"), ("c", "d"), ("d", "e"), ("e", "f"), ("a", "f")]
+        cls.G.add_edges_from(e)
+        cls.DG = nx.DiGraph(cls.G)
+        cls.MG = nx.MultiGraph(cls.G)
+
+    def assert_equal(self, G, data=False):
+        (fd, fname) = tempfile.mkstemp()
+        nx_ete.write_ete(G, fname)
+        Gin = nx_ete.read_ete(fname)
+
+        assert_nodes_equal(list(G), list(Gin))
+        assert_edges_equal(G.edges(data=data), Gin.edges(data=data))
+
+        os.close(fd)
+        os.unlink(fname)
+
+    def testUndirected(self):
+        self.assert_equal(self.G, data=False)
+
+    def testDirected(self):
+        self.assert_equal(self.DG, data=False)
+
+    def testMultiGraph(self):
+        self.assert_equal(self.MG, data=True)

--- a/networkx/readwrite/tests/test_ete.py
+++ b/networkx/readwrite/tests/test_ete.py
@@ -17,7 +17,7 @@ class TestETE:
 
     @classmethod
     def build_graphs(cls):
-        e = [("a", "b"), ("b", "c"), ("c", "d"), ("d", "e"), ("e", "f")]
+        e = [("a", "b"), ("a", "c"), ("b", "d"), ("b", "e"), ("c", "f")]
         cls.G = nx.Graph(name="test_undirected_graph")
         cls.DG = nx.DiGraph(name="test_directed_graph")
         cls.MG = nx.MultiGraph(name="test_multi_graph")

--- a/networkx/readwrite/tests/test_ete.py
+++ b/networkx/readwrite/tests/test_ete.py
@@ -6,8 +6,6 @@ import os
 import tempfile
 import pytest
 
-nx_ete = pytest.importorskip("nx_ete")
-
 import networkx as nx
 from networkx.testing import assert_edges_equal, assert_nodes_equal
 
@@ -19,16 +17,19 @@ class TestETE:
 
     @classmethod
     def build_graphs(cls):
-        cls.G = nx.Graph(name="test")
-        e = [("a", "b"), ("b", "c"), ("c", "d"), ("d", "e"), ("e", "f"), ("a", "f")]
+        e = [("a", "b"), ("b", "c"), ("c", "d"), ("d", "e"), ("e", "f")]
+        cls.G = nx.Graph(name="test_undirected_graph")
+        cls.DG = nx.DiGraph(name="test_directed_graph")
+        cls.MG = nx.MultiGraph(name="test_multi_graph")
+
         cls.G.add_edges_from(e)
-        cls.DG = nx.DiGraph(cls.G)
-        cls.MG = nx.MultiGraph(cls.G)
+        cls.DG.add_edges_from(e)
+        cls.MG.add_edges_from(e)
 
     def assert_equal(self, G, data=False):
         (fd, fname) = tempfile.mkstemp()
-        nx_ete.write_ete(G, fname)
-        Gin = nx_ete.read_ete(fname)
+        nx.write_ete(G, fname)
+        Gin = nx.read_ete(fname)
 
         assert_nodes_equal(list(G), list(Gin))
         assert_edges_equal(G.edges(data=data), Gin.edges(data=data))
@@ -36,11 +37,11 @@ class TestETE:
         os.close(fd)
         os.unlink(fname)
 
-    def testUndirected(self):
+    def test_undirected(self):
         self.assert_equal(self.G, data=False)
 
-    def testDirected(self):
+    def test_directed(self):
         self.assert_equal(self.DG, data=False)
 
-    def testMultiGraph(self):
+    def test_multigraph(self):
         self.assert_equal(self.MG, data=True)


### PR DESCRIPTION
Fixes #3063

Example
```Python
>>> G = nx.path_graph(42)
>>> nx.write_ete(G, "test_ete.txt")
>>> G = nx.read_ete("test_ete.txt")
```

All tests passed on OS Ubuntu 20.04 with 
```
Python   Version: 3.8.5
NetworkX Version: 2.6rc1.dev0
ete3     Version: 3.1.2
```

- source code: networkx/readwrite/nx_ete.py
- tests: networkx/readwrite/tests/test_ete.py

Important notes:

- In ETE [every tree has root even if the tree is conceptually considered as unrooted](http://etetoolkit.org/docs/latest/tutorial/tutorial_trees.html#root-node-on-unrooted-trees), thus `write_ete()` has `root_node` parameter.
    - If `root_node` is not specified, I consider to use first node of NetworkX Graph, but it is worth discussing.
- Also, the ETE Tree has no edge attributes, thus edge data will be lost after conversion from NetworkX Graph.
    - We can store edge information in the corresponding vertex data, but it is worth discussing.
- Since ETE [uses](http://etetoolkit.org/docs/latest/tutorial/tutorial_trees.html#reading-and-writing-newick-trees) the New Hampshire [Newick format](https://en.wikipedia.org/wiki/Newick_format), which is interpreted as a string, node names of NetworkX Graph are converted to `str`.
- ETE Tree has reserved node attributes `{'dist', 'name', 'support'}` and it is worth discussing how to work with them.