### PR TITLE
CI: persist pip cache between circleci runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.8
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
             /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x200x24 -ac +extension GLX +render -noreset;
 
       - restore_cache:
-        keys:
-          - pip-cache-v1
+          keys:
+            - pip-cache-v1
 
       - run:
           name: Install Python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,18 +46,27 @@ jobs:
             echo "export DISPLAY=:99" >> $BASH_ENV
             /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x200x24 -ac +extension GLX +render -noreset;
 
+      - restore_cache:
+        keys:
+          - pip-cache-v1
+
       - run:
           name: Install Python dependencies
           command: |
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade pip wheel setuptools
-            pip install -r requirements.txt
-            pip install -r requirements/extra.txt
-            pip install -r requirements/example-requirements.txt
-            pip install -r requirements/example.txt
+            pip install -U -r requirements.txt
+            pip install -U -r requirements/extra.txt
+            pip install -U -r requirements/example-requirements.txt
+            pip install -U -r requirements/example.txt
             pip install -U -r requirements/doc.txt
             pip list
+
+      - save_cache:
+          key: pip-cache-v1
+          paths:
+            - ~/.cache/pip
 
       - run:
           name: Install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Install mayavi dependencies
           command : |
-            sudo apt-get --no-install-recommends install -y libxkbcommon-x11-0 optipng libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 xcb libxcb-xfixes0 libxcb-xinerama0 libxcb-shape0
+            sudo apt-get --no-install-recommends install -y libxkbcommon-x11-0 optipng libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 xcb libxcb-xfixes0 libxcb-xinerama0 libxcb-shape0 xvfb
 
       - run:
           name: Configure for headless mayavi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/python:3.8.5-buster
+      - image: cimg/python:3.9
 
     steps:
       - checkout


### PR DESCRIPTION
Currently, the pip install step of the docs build job on circleci takes ~2min each run, largely due to some wheels being built locally. This time-consuming step could be significantly improved by persisting the pip cache between CI runs. The approach taken here is to persist the cache between circleCI runs, and add an `--upgrade` flag to all of the dependency installs. This ensures that the newest versions of libraries are always grabbed and (hopefully) eliminates the need to manually manage the cache.