### PR TITLE
Added ability to specify the mass of a node individually when using the Fruchterman-Reingold algorithm

### DIFF
--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -597,3 +597,12 @@ def test_mass_weighted_spring_layout():
     ) / len(same_mass_distances), (
         "The average distance to the 'heavy' node should be greater than it was when all nodes had the same mass."
     )
+
+
+def test_manual_sparse_algorithm_specification():
+    # Check that the sparse algorithm can be specified manually without error
+    G = nx.path_graph(4)
+    pos = nx.spring_layout(G, use_sparse_solver=True)
+    assert len(pos) == 4
+    pos = nx.spring_layout(G, use_sparse_solver=False)
+    assert len(pos) == 4


### PR DESCRIPTION
Added an optional input argument, `node_weight` to `spring_layout`. Given a string that is a node property this will treat it as the mass of the node for the purposes of calculating the anti-gravity force used in `spring_layout`. If none is given, it will continue to calculate it in the default manner. 

I find that when drawing certain graphs with large variations in the degrees of member nodes it is helpful for low-degree nodes to tend towards the edge of the drawing. This results in the high-degree nodes being pulled apart from each other as they are dragged along by their low-degree nodes, making the graph more readable.

For example, compare the two drawings of `G` here.
```
import networkx as nx
G = nx.hypercube_graph(5)
for node in G:
  G.nodes[node]['node_weight'] = 1

same_mass = nx.drawing.fruchterman_reingold_layout(G, node_weight='node_weight', seed=1)

G.nodes[(0,0,0,0,0)]['node_weight'] = 100
dif_mass = nx.drawing.fruchterman_reingold_layout(G, node_weight='node_weight', seed=1)

nx.draw(G, pos=same_mass, with_labels=False)
nx.draw(G, pos=dif_mass, with_labels=False)
```
