### PR TITLE
Pin upper bound of decorator dep.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-decorator>=4.4
+decorator>=4.4,<5
 numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.10'
 scipy>=1.5,!=1.6.1; platform_python_implementation!='PyPy' and python_version<'3.10'
 matplotlib>=3.3; platform_python_implementation!='PyPy' and python_version<'3.10'


### PR DESCRIPTION
Not sure if we want to introduce this upper bound or just wait for micheles/decorator#103 to be resolved. It'd be nice to get the CI test suite back up and functional, but if the fix is imminent we can just be patient and not have to deal with adding/removing pins like this.

On a side note, it would've been nice to catch this before the new major dependency release. We run the test suite against pre-releases of the main dependencies but `decorator` must not have had a release candidate. Maybe we could consider running against the development branch of dependency projects instead? That could also help catch things like #4626.