### PR TITLE
O(n^2) -> O(n) implementation for scale_free_graph

### DIFF
--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -4,13 +4,12 @@ scale-free graphs.
 
 """
 
+import numbers
 from collections import Counter
 
 import networkx as nx
 from networkx.generators.classic import empty_graph
-from networkx.utils import discrete_sequence
-from networkx.utils import weighted_choice
-from networkx.utils import py_random_state
+from networkx.utils import discrete_sequence, py_random_state, weighted_choice
 
 __all__ = [
     "gn_graph",
@@ -278,11 +277,11 @@ def scale_free_graph(
     # pre-populate node state
     node_list = list(G.nodes())
 
-    # see if there already are int-based nodes
-    int_nodes = [n for n in node_list if type(n) == int]
-    if len(int_nodes) > 0:
+    # see if there already are number-based nodes
+    numeric_nodes = [n for n in node_list if isinstance(n, numbers.Number)]
+    if len(numeric_nodes) > 0:
         # set cursor for new nodes appropriately
-        cursor = max(int_nodes) + 1
+        cursor = max([int(n.real) for n in numeric_nodes]) + 1
     else:
         # or start at zero
         cursor = 0


### PR DESCRIPTION
I was trying to use `scale_free_graph` from `generators.directed` and noticed it drastically grew slower with number of nodes n, rendering it effectively useless for large numbers of nodes (e.g. 1M). Since the gist of the algorithm involves preferential attachment, and other networkx methods like the ones based on Barabási–Albert _are_ in fact fast, I took a look at the implementation. Parts of the current node sampling have O(n) time complexity, effectively rendering the generator as a whole O(n^2). I rewrote that sampling to be O(1), so now the generator itself is O(n).

**Changes**
Like e.g. the implementation for `barabasi_albert_graph` or `dual_barabasi_albert_graph`, the new implementation keeps simple lists of repeated nodes representing the in- and out-degrees so we can perform O(1) sampling with probabilities linear in those degrees. This suffices for the case that biases are zero.

Because the algorithm also needs to support nonzero biases, it would seem full weights have to be computed before each sample is drawn (based on current node degrees plus the biases), which would make the sampling O(n) again. I've solved this probabilistically with a two-step sampling mechanism that is once again O(1). **Note that we're not doing any approximations here**, the new implementation of the algorithm behaves exactly the same as the old one.

I've also added checks that the biases must be >= 0. This does not remove functionality because the current implementation would have been incorrect for biases < 0 anyways (if in doubt, please review the original cursor-based sampling function and imagine a negative bias < -1 to conclude the same). Furthermore, the referenced original paper (see https://www.microsoft.com/en-us/research/publication/directed-scale-free-graphs/) also sets biases >= 0 as a condition, so it probably should have been checked anyways (why that is indeed a sensible condition is another story which I think we should not get into currently, I would refer to the paper for now).

**Timing results**
`scale_free_graph(n, alpha=0.2, beta=0.6, gamma=0.2, delta_in=1, delta_out=1)`


| n         | old                 | new         | speedup | 
| ------ |:-------------:| ---------:|---------:|
| 1e+1   | 7.19 ms            | 168 µs    |  x50 |
| 1e+2   | 8.91 ms           | 1.15 ms   |  x10 |
| 1e+3    | 582 ms          |   11.2 ms |  x50 | 
| 1e+4    | 59.1 s             |  185 ms  |  x300 |
| 1e+5    | 100 m (est.)   |  1.94 s    |  x3000 |
| 1e+6    | 7 d (est.)        |  21.6 s    |  x30000 |

Couldn't find any related issues, apart from this SO post similarly complaining about _days_ of runtime:
https://stackoverflow.com/questions/56119399/quickly-generating-large-scale-free-graphs-with-networkx
