### PR TITLE
Updating average_clustering() documentation - Issue #4734

### DIFF
--- a/networkx/algorithms/approximation/clustering_coefficient.py
+++ b/networkx/algorithms/approximation/clustering_coefficient.py
@@ -37,6 +37,11 @@ def average_clustering(G, trials=1000, seed=None):
     c : float
         Approximated average clustering coefficient.
 
+    Examples
+    --------
+    >>> from networkx.algorithms import approximation
+    >>> approximation.average_clustering(G, trials=1000, seed=None)
+
     References
     ----------
     .. [1] Schank, Thomas, and Dorothea Wagner. Approximating clustering


### PR DESCRIPTION
Redoing this, because couldn't figure out why a documentation test caused the CI systems to fail last time around.
