### PR TITLE
Use pydata sphinx theme

### DIFF
--- a/doc/_static/networkx_banner.svg
+++ b/doc/_static/networkx_banner.svg
@@ -9,28 +9,26 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="480.62738"
-   height="124"
-   id="svg2"
+   width="119.00541mm"
+   height="26.772989mm"
+   viewBox="0 0 119.00541 26.772989"
    version="1.1"
+   id="svg1557"
    inkscape:version="0.92.4 (unknown)"
-   sodipodi:docname="networkx_logo.svg"
-   inkscape:export-filename="/home/jarrod/src/skimage-branding/logo/snake_logo.svg.png"
-   inkscape:export-xdpi="299.59576"
-   inkscape:export-ydpi="299.59576">
+   sodipodi:docname="networkx_banner.svg">
   <defs
-     id="defs4" />
+     id="defs1551" />
   <sodipodi:namedview
      id="base"
-     pagecolor="#00ffff"
+     pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0"
+     inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.979899"
-     inkscape:cx="179.9654"
-     inkscape:cy="123.76303"
-     inkscape:document-units="px"
+     inkscape:zoom="1.4"
+     inkscape:cx="238.50138"
+     inkscape:cy="-32.516569"
+     inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
@@ -43,7 +41,7 @@
      fit-margin-right="0"
      fit-margin-bottom="0" />
   <metadata
-     id="metadata7">
+     id="metadata1554">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -58,24 +56,17 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-37.697178,-359.71164)">
-    <circle
-       cy="455.39188"
-       cx="101.29218"
-       id="circle5038"
-       style="opacity:1;fill:#2c7fb8;fill-opacity:1;stroke:#2c7fb8;stroke-width:3.64346743;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       r="0" />
+     transform="translate(-11.556817,-12.2266)">
     <g
        id="g996-1"
-       transform="translate(16.361101,350.44641)"
-       style="fill:#ffffff">
+       transform="matrix(0.26458333,0,0,0.26458333,-2.2489386,8.0893424)">
       <text
          id="text3150-8"
          y="83.149475"
          x="163.22154"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none"
          xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:70px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';fill:#ffffff"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:70px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
            y="83.149475"
            x="163.22154"
            id="tspan3152-3"
@@ -84,76 +75,72 @@
          id="text3154-4"
          y="111.43372"
          x="167.75905"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none"
          xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.66666603px;line-height:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';fill:#ffffff"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.66666603px;line-height:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
            y="111.43372"
            x="167.75905"
            id="tspan3156-2"
            sodipodi:role="line">Network Analysis in Python</tspan></text>
     </g>
-    <rect
-       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.20263696;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.9228344;stroke-opacity:1"
-       id="rect849"
-       width="124"
-       height="124"
-       x="37.697178"
-       y="359.71164"
-       ry="23.913101" />
     <g
-       id="g4938-1"
-       transform="rotate(-20,1136.5903,212.48627)">
+       id="g4909"
+       transform="matrix(0.26458333,0,0,0.26458333,-2.8736486,-86.571652)">
       <circle
+         transform="rotate(-20)"
          style="opacity:1;fill:#ff7f0e;fill-opacity:1;stroke:none;stroke-width:4.04473829;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="path4144-3-5-3"
-         cx="97.5569"
-         cy="48.403671"
+         cx="-42.136234"
+         cy="425.194"
          r="14.62983" />
       <circle
+         transform="rotate(-20)"
          style="opacity:1;fill:none;fill-opacity:1;stroke:#2c7fb8;stroke-width:6.54949951;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="path4144-3"
-         cx="97.656326"
-         cy="48.636387"
+         cx="-42.036808"
+         cy="425.4267"
          r="22.590828" />
       <circle
+         transform="rotate(-20)"
          style="opacity:1;fill:none;fill-opacity:1;stroke:#2c7fb8;stroke-width:4.68222761;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="path4144-3-7-3"
-         cx="96.639366"
-         cy="97.094803"
+         cx="-43.053768"
+         cy="473.88513"
          r="12.229949" />
       <circle
+         transform="rotate(-20)"
          style="opacity:1;fill:none;fill-opacity:1;stroke:#2c7fb8;stroke-width:3.35354948;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="path4144-3-6-7"
-         cx="54.76812"
-         cy="48.636387"
+         cx="-84.925018"
+         cy="425.4267"
          r="8.75945" />
       <path
          style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2c7fb8;stroke-width:5.36567926;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 63.185898,48.636384 h 9.990055"
+         d="m 73.611215,425.93735 9.387581,-3.4168"
          id="path4218-9"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
       <path
          style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2c7fb8;stroke-width:7.49156427;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 97.656329,71.198716 V 85.146838"
+         d="m 113.7196,435.34942 4.77054,13.10695"
          id="path4218-6-8"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
       <circle
-         transform="matrix(-0.92498796,0.37999642,0.37999642,0.92498796,0,0)"
+         transform="matrix(-0.73923793,0.67344435,0.67344435,0.73923793,0,0)"
          r="8.75945"
-         cy="80.021042"
-         cx="-114.5796"
+         cy="375.46466"
+         cx="157.81384"
          id="circle1079-6"
          style="opacity:1;fill:none;fill-opacity:1;stroke:#2c7fb8;stroke-width:3.35354948;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path1081-7"
-         d="m 128.60612,33.677382 -9.24069,3.796184"
+         d="m 129.96983,389.50545 -7.38503,6.72775"
          style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2c7fb8;stroke-width:5.36567926;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <g
-         transform="matrix(0.57275306,0.33151313,0.33151313,-0.57275306,26.344182,102.46021)"
+         transform="matrix(0.65159599,0.11562736,0.11562736,-0.65159599,57.400159,489.11581)"
          id="g1103-0">
         <circle
            r="8.5899563"
@@ -170,7 +157,7 @@
       </g>
       <g
          id="g1109-4"
-         transform="matrix(-0.00228724,0.6617717,0.6617717,0.00228724,14.696129,-6.2089871)">
+         transform="matrix(0.1145481,0.65178659,0.65178659,-0.1145481,15.845354,381.11932)">
         <circle
            style="opacity:1;fill:none;fill-opacity:1;stroke:#2c7fb8;stroke-width:3.28865886;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="circle1105-8"
@@ -185,41 +172,44 @@
            sodipodi:nodetypes="cc" />
       </g>
       <circle
-         transform="matrix(-0.70866802,-0.70554209,-0.70554209,0.70866802,0,0)"
+         transform="matrix(-0.90723971,-0.42061396,-0.42061396,0.90723971,0,0)"
          style="opacity:1;fill:none;fill-opacity:1;stroke:#2c7fb8;stroke-width:2.17635441;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="circle1111-6"
-         cx="-140.73827"
-         cy="-35.71751"
+         cx="-307.58365"
+         cy="329.86111"
          r="5.6846242" />
       <path
          style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2c7fb8;stroke-width:3.48216701;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 121.06554,70.130613 -4.59447,-4.574205"
+         d="m 135.35175,426.33931 -5.88186,-2.72694"
          id="path1113-8"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
       <circle
+         transform="rotate(-20)"
          r="7.0025988"
-         cy="97.094803"
-         cx="96.639366"
+         cy="473.88513"
+         cx="-43.053768"
          id="circle1165-5"
          style="opacity:1;fill:#ff7f0e;fill-opacity:1;stroke:none;stroke-width:1.93602252;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <circle
+         transform="rotate(-20)"
          r="5.0957913"
-         cy="48.636387"
-         cx="54.76812"
+         cy="425.4267"
+         cx="-84.925018"
          id="circle1167-2"
          style="opacity:1;fill:#ff7f0e;fill-opacity:1;stroke:none;stroke-width:1.40884352;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <circle
+         transform="rotate(-20)"
          style="opacity:1;fill:#ff7f0e;fill-opacity:1;stroke:none;stroke-width:1.40884352;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="circle1169-1"
-         cx="136.39246"
-         cy="30.478661"
+         cx="-3.3006787"
+         cy="407.26898"
          r="5.0957913" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path1195-9"
-         d="M 119.80711,78.182827 107.19128,89.073705"
+         d="m 136.92323,434.33633 -8.1301,14.54894"
          style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2c7fb8;stroke-width:3.48216701;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
   </g>

--- a/doc/_templates/docs-navbar.html
+++ b/doc/_templates/docs-navbar.html
@@ -1,0 +1,20 @@
+{%- extends "pydata_sphinx_theme/docs-navbar.html" %}
+
+{%- block icon_links -%}
+<!-- begin version dropdown -->
+<ul class="navbar-nav">
+    <li class="mr-2 dropdown">
+        <button type="button" class="btn btn-{% if (build_dev_html|tobool) %}danger{% else %}primary{% endif %} btn-sm navbar-btn dropdown-toggle" id="dLabelMore" data-toggle="dropdown">
+            v{{ release }}
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dLabelMore">
+            {%- for ver, txt in versions_dropdown.items() %}
+            <li><a href="https://networkx.org/documentation/{{ ver }}/index.html">{{ txt }}</a></li>
+            {%- endfor %}
+        </ul>
+    </li>
+</ul>
+<!-- end version dropdown -->
+{%- include "icon-links.html" with context -%}
+{%- endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,10 +1,6 @@
 {% extends "!layout.html" %}
-{% block sidebartitle %}
-    <a href="https://networkx.org/">Project Homepage</a> |
-    <a href="https://github.com/networkx/networkx">Source Code</a>
-    {{ super() }}
-{% endblock %}
-{% block document %}
+
+{% block docs_body %}
     {% include "dev_banner.html" %}
     {{ super() }}
 {% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,5 @@
 from datetime import date
 from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
-import sphinx_rtd_theme
 from warnings import filterwarnings
 
 filterwarnings(
@@ -128,17 +127,24 @@ doctest_global_setup = "import networkx as nx"
 # Options for HTML output
 # -----------------------
 
-
-html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
+html_baseurl = "https://networkx.org/documentation/stable/"
+html_theme = "pydata_sphinx_theme"
 html_theme_options = {
-    "canonical_url": "https://networkx.org/documentation/stable/",
-    "navigation_depth": 3,
-    "logo_only": True,
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/networkx/networkx",
+            "icon": "fab fa-github-square",
+        },
+        {
+            "name": "Home Page",
+            "url": "https://networkx.org",
+            "icon": "fas fa-home",
+        },
+    ],
 }
 
-html_logo = "_static/networkx_logo.svg"
+html_logo = "_static/networkx_banner.svg"
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
@@ -175,6 +181,14 @@ html_use_opensearch = "https://networkx.org"
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "NetworkX"
+
+html_context = {
+    "versions_dropdown": {
+        "latest": "v2.6 (devel)",
+        "stable": "v2.5 (stable)",
+        "networkx-2.4": "v2.4",
+    },
+}
 
 # Options for LaTeX output
 # ------------------------

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,7 +1,7 @@
-sphinx==3.4.3
-sphinx_rtd_theme==0.5.1
+sphinx==3.5.4
+pydata-sphinx-theme==0.5.2
 sphinx-gallery==0.8.2
 numpydoc>=1.1
-pillow>=8.0
+pillow>=8.2
 nb2plots>=0.6
 texext>=0.6.6


### PR DESCRIPTION
NumPy, SciPy, and other projects are moving (or have moved) to using the [pydata sphinx theme](https://github.com/pydata/pydata-sphinx-theme) for documentation.  I believe it is nicer looking and, more importantly, will help us create a more unified scientific Python ecosystem.  We also know the maintainers, so we can easily help fix and improve the theme.

I plan to clean up a few things, but I wanted to get some feedback before putting too much more time in to this.  We could merge this as is and I could do the clean up in a separate PR or I could make the changes to this PR.  I slightly prefer merging this first, but I don't have a strong preference.