### PR TITLE
TST: be more explicit about instance comparison.

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -148,7 +148,7 @@ class TestEdgelist:
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname)
         H2 = bipartite.read_edgelist(fname)
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
@@ -173,7 +173,7 @@ class TestEdgelist:
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -324,7 +324,7 @@ class HistoricalTests:
         H = G.copy()  # copy
         assert H.adj == G.adj
         assert H.name == G.name
-        assert H != G
+        assert H is not G
 
     def test_subgraph(self):
         G = self.G()
@@ -341,7 +341,7 @@ class HistoricalTests:
             )
 
             DG = G.to_directed()
-            assert DG != G  # directed copy or copy
+            assert DG is not G  # directed copy or copy
 
             assert DG.is_directed()
             assert DG.name == G.name
@@ -364,7 +364,7 @@ class HistoricalTests:
                 [("A", "B"), ("A", "C"), ("B", "D"), ("C", "B"), ("C", "D")]
             )
             UG = G.to_undirected()  # to_undirected
-            assert UG != G
+            assert UG is not G
             assert not UG.is_directed()
             assert G.is_directed()
             assert UG.name == G.name

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -85,7 +85,7 @@ class TestAdjlist:
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname)
         H2 = nx.read_adjlist(fname)
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -97,7 +97,7 @@ class TestAdjlist:
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, create_using=nx.DiGraph())
         H2 = nx.read_adjlist(fname, create_using=nx.DiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -109,7 +109,7 @@ class TestAdjlist:
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, nodetype=int)
         H2 = nx.read_adjlist(fname, nodetype=int)
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -121,7 +121,7 @@ class TestAdjlist:
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -133,7 +133,7 @@ class TestAdjlist:
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -196,7 +196,7 @@ class TestMultilineAdjlist:
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname)
         H2 = nx.read_multiline_adjlist(fname)
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -208,7 +208,7 @@ class TestMultilineAdjlist:
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
         H2 = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -220,7 +220,7 @@ class TestMultilineAdjlist:
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname, nodetype=int)
         H2 = nx.read_multiline_adjlist(fname, nodetype=int)
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -234,7 +234,7 @@ class TestMultilineAdjlist:
         H2 = nx.read_multiline_adjlist(
             fname, nodetype=int, create_using=nx.MultiGraph()
         )
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -250,7 +250,7 @@ class TestMultilineAdjlist:
         H2 = nx.read_multiline_adjlist(
             fname, nodetype=int, create_using=nx.MultiDiGraph()
         )
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -250,7 +250,7 @@ class TestEdgelist:
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname)
         H2 = nx.read_edgelist(fname)
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
@@ -263,7 +263,7 @@ class TestEdgelist:
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, create_using=nx.DiGraph())
         H2 = nx.read_edgelist(fname, create_using=nx.DiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
@@ -288,7 +288,7 @@ class TestEdgelist:
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
@@ -300,7 +300,7 @@ class TestEdgelist:
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
-        assert H != H2  # they should be different graphs
+        assert H is not H2  # they should be different graphs
         assert_nodes_equal(list(H), list(G))
         assert_edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)


### PR DESCRIPTION
Some tests relied on `!=` to check whether or not two Graph instances where the same object. This PR updates these lines to `is not` instead, which I think is more idiomatic. Inspired by the discussion in #4746.