### PR TITLE
MAINT: Add missing __all__'s to utils modules + test.

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -19,6 +19,30 @@ import uuid
 from itertools import tee, chain
 import networkx as nx
 
+__all__ = [
+    "is_string_like",
+    "iterable",
+    "empty_generator",
+    "flatten",
+    "make_list_of_ints",
+    "is_list_of_ints",
+    "make_str",
+    "generate_unique_node",
+    "default_opener",
+    "dict_to_numpy_array",
+    "dict_to_numpy_array1",
+    "dict_to_numpy_array2",
+    "is_iterator",
+    "arbitrary_element",
+    "consume",
+    "pairwise",
+    "groups",
+    "to_tuple",
+    "create_random_state",
+    "create_py_random_state",
+    "PythonRandomInterface",
+]
+
 
 # some cookbook stuff
 # used in deciding whether something is a bunch of nodes, edges, etc.

--- a/networkx/utils/random_sequence.py
+++ b/networkx/utils/random_sequence.py
@@ -7,6 +7,16 @@ import networkx as nx
 from networkx.utils import py_random_state
 
 
+__all__ = [
+    "powerlaw_sequence",
+    "zipf_rv",
+    "cumulative_distribution",
+    "discrete_sequence",
+    "random_weighted_sample",
+    "weighted_choice",
+]
+
+
 # The same helpers for choosing random sequences from distributions
 # uses Python's random module
 # https://docs.python.org/3/library/random.html

--- a/networkx/utils/tests/test__init.py
+++ b/networkx/utils/tests/test__init.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+def test_utils_namespace():
+    """Ensure objects are not unintentionally exposed in utils namespace."""
+    with pytest.raises(ImportError):
+        from networkx.utils import nx
+    with pytest.raises(ImportError):
+        from networkx.utils import sys
+    with pytest.raises(ImportError):
+        from networkx.utils import defaultdict, deque


### PR DESCRIPTION
Adds `__all__` attrs to modules in `utils` and adds a test to
ensure objects and aliases defined in `utils` modules are
not unintentionally exposed in the `utils` namespace.

Closes #4752 
