### PR TITLE
Improve reproducibilty of geometric graphs

### DIFF
--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -52,7 +52,7 @@ def geometric_edges(G, radius, p):
     nodes, coords = list(zip(*nodes_pos))
     kdtree = sp.spatial.cKDTree(coords)  # Cannot provide generator.
     edge_indexes = kdtree.query_pairs(radius, p)
-    edges = [(nodes[u], nodes[v]) for u, v in edge_indexes]
+    edges = [(nodes[u], nodes[v]) for u, v in sorted(edge_indexes)]
     return edges
 
 


### PR DESCRIPTION
Since on different versions of python `sp.spatial.cKDTree` gives the edge indices in different order, it becomes impossible to reproduce exactly the same graph, even when passing the same random number generator state.

This PR solves the problem by sorting the`edge_indexes` after getting the result from cKDTree.

Closes #4767
