### PR TITLE
Updated decorator requirement for #4718

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-decorator>=4.4,<5
+decorator>=5.0.7
 numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.10'
 scipy>=1.5,!=1.6.1; platform_python_implementation!='PyPy' and python_version<'3.10'
 matplotlib>=3.3; platform_python_implementation!='PyPy' and python_version<'3.10'


### PR DESCRIPTION
I'm maintaning the [`manim`](https://aur.archlinux.org/packages/manim/) AUR package, which depends on [`python-networkx`](https://archlinux.org/packages/community/any/python-networkx/). Due to #4718 being only solved for the latest version of [`python-decorator`](https://archlinux.org/packages/community/any/python-decorator/) in HEAD, I've started maintaining [`python-networkx-git`](https://aur.archlinux.org/packages/python-networkx-git/), which requieres [a manual patch](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-networkx-git#n23) for the `decorator` requierement version.

This small PR updates the requirements [stated by @dschult](https://github.com/networkx/networkx/issues/4718#issuecomment-819489576) so that other projects don't have to manually patch them.