### PR TITLE
Get rid of invalid escape sequences causing DeprecationWarnings

### DIFF
--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -12,7 +12,7 @@ __all__ = [
 
 
 def greedy_modularity_communities(G, weight=None, resolution=1):
-    """Find communities in G using greedy modularity maximization.
+    r"""Find communities in G using greedy modularity maximization.
 
     This function uses Clauset-Newman-Moore greedy modularity maximization [2]_.
     This method currently supports the Graph class.
@@ -224,7 +224,7 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
 
 
 def naive_greedy_modularity_communities(G, resolution=1):
-    """Find communities in G using greedy modularity maximization.
+    r"""Find communities in G using greedy modularity maximization.
 
     This implementation is O(n^4), much slower than alternatives, but it is
     provided as an easy-to-understand reference implementation.

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1492,7 +1492,7 @@ def _n_choose_k(n, k):
 
 
 def panther_similarity(G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None):
-    """Returns the Panther similarity of nodes in the graph `G` to node ``v``.
+    r"""Returns the Panther similarity of nodes in the graph `G` to node ``v``.
 
     Panther is a similarity metric that says "two objects are considered
     to be similar if they frequently appear on the same paths." [1]_.

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -125,7 +125,7 @@ def draw(G, pos=None, ax=None, **kwds):
 
 
 def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
-    """Draw the graph G using Matplotlib.
+    r"""Draw the graph G using Matplotlib.
 
     Draw the graph with Matplotlib with options for node positions,
     labeling, titles, and many other drawing features.
@@ -497,7 +497,7 @@ def draw_networkx_edges(
     min_source_margin=0,
     min_target_margin=0,
 ):
-    """Draw the edges of the graph G.
+    r"""Draw the edges of the graph G.
 
     This draws only the edges of the graph G.
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -278,7 +278,7 @@ def circular_ladder_graph(n, create_using=None):
 
 
 def circulant_graph(n, offsets, create_using=None):
-    """Returns the circulant graph $Ci_n(x_1, x_2, ..., x_m)$ with $n$ nodes.
+    r"""Returns the circulant graph $Ci_n(x_1, x_2, ..., x_m)$ with $n$ nodes.
 
     The circulant graph $Ci_n(x_1, ..., x_m)$ consists of $n$ nodes $0, ..., n-1$
     such that node $i$ is connected to nodes $(i + x) \mod n$ and $(i - x) \mod n$


### PR DESCRIPTION
When running the test suite, there are new deprecation warnings about invalid escape sequences.
This is from LaTeX math in some docstrings, which often feature backslashes, e.g. `\gamma`.
The simplest way to get rid of these warnings is to convert the docstrings into raw strings.