### PR TITLE
fix urllib import

### DIFF
--- a/examples/drawing/plot_custom_node_icons.py
+++ b/examples/drawing/plot_custom_node_icons.py
@@ -9,7 +9,7 @@ Example of using custom icons to represent nodes with matplotlib.
 import matplotlib.pyplot as plt
 import networkx as nx
 import PIL
-import urllib
+import urllib.request
 
 # Image URLs for graph nodes
 icon_urls = {

--- a/examples/graph/plot_football.py
+++ b/examples/graph/plot_football.py
@@ -12,7 +12,7 @@ Requires Internet connection to download the URL
 http://www-personal.umich.edu/~mejn/netdata/football.zip
 """
 
-import urllib.request as urllib
+import urllib.request
 import io
 import zipfile
 
@@ -21,7 +21,7 @@ import networkx as nx
 
 url = "http://www-personal.umich.edu/~mejn/netdata/football.zip"
 
-sock = urllib.urlopen(url)  # open URL
+sock = urllib.request.urlopen(url)  # open URL
 s = io.BytesIO(sock.read())  # read into BytesIO "file"
 sock.close()
 


### PR DESCRIPTION
This PR originally fixed `examples/drawing/plot_custom_node_icons.py` import *urllib* issue in #4790.

What find in discussion below is following,

1. That `examples/drawing/plot_custom_node_icons.py` will work in ipython, but if run with vanilla python, there will be an error `AttributeError: module 'urllib' has no attribute 'request'.`

2. `examples/graph/plot_football.py` also import *urllib*, but with a different workaround.

So now this PR is updated to cover both `examples/drawing/plot_custom_node_icons.py` and `examples/graph/plot_football.py`, regarding import *urllib*.


<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
