### PR TITLE
Increased efficiency of UnionFind.__getitem__ slightly.

### DIFF
--- a/networkx/utils/union_find.py
+++ b/networkx/utils/union_find.py
@@ -60,7 +60,7 @@ class UnionFind:
             root = self.parents[root]
 
         # compress the path and return
-        for ancestor in path:
+        for ancestor in path[0:-1]:
             self.parents[ancestor] = root
         return root
 


### PR DESCRIPTION
The last element in `path` is the `root` itself.