### PR TITLE
Pin upper bound on decorator for 2.6 release.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-decorator>=5.0.7
+decorator>=5.0.7,<6
 numpy>=1.19; platform_python_implementation!='PyPy' and python_version<'3.10'
 scipy>=1.5,!=1.6.1; platform_python_implementation!='PyPy' and python_version<'3.10'
 matplotlib>=3.3; platform_python_implementation!='PyPy' and python_version<'3.10'


### PR DESCRIPTION
Adds upper bound to decorator dependency in preparation for 2.6 release.

Addresses #4732 in the short term for the 2.6 release.