### PR TITLE
Link to guides

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,7 +138,7 @@ html_theme_options = {
             "icon": "fab fa-github-square",
         },
     ],
-    "external_links": [{"name": "NX Guides", "url": "https://networkx.org/nx-guides/"}],
+    "external_links": [{"name": "Guides", "url": "https://networkx.org/nx-guides/"}],
     "navbar_end": ["navbar-icon-links", "version"],
     "page_sidebar_items": ["search-field", "page-toc", "edit-this-page"],
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,6 +138,7 @@ html_theme_options = {
             "icon": "fab fa-github-square",
         },
     ],
+    "external_links": [{"name": "NX Guides", "url": "https://networkx.org/nx-guides/"}],
     "navbar_end": ["navbar-icon-links", "version"],
     "page_sidebar_items": ["search-field", "page-toc", "edit-this-page"],
 }

--- a/doc/developer/index.rst
+++ b/doc/developer/index.rst
@@ -1,7 +1,7 @@
 .. _developer:
 
-Developer Guide
-***************
+Developer
+*********
 
 .. only:: html
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -118,7 +118,7 @@ Bibliography
 
    install
    tutorial
-   auto_examples/index
    reference/index
-   developer/index
    release/index
+   developer/index
+   auto_examples/index

--- a/doc/release/index.rst
+++ b/doc/release/index.rst
@@ -1,5 +1,5 @@
-API changes
-***********
+Releases
+********
 
 We don't use semantic versioning.  The first number indicates that we have
 made a major API break (e.g., 1.x to 2.x), which has happened once and probably


### PR DESCRIPTION
This PR adds a link to https://networkx.org/nx-guides/ with the name `NX Guides` to the navbar:
![screenshot](https://user-images.githubusercontent.com/123428/118890595-d2c95a00-b8b3-11eb-9710-3076164a9f25.png)

Is there a better name?  E.g., `Tutorials and Guides`, `Interactive Tutorials and Guides`, `Interactive Guides`, etc.