### PR TITLE
switch alias direction of spring_layout and fruchterman_reingold_layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -343,7 +343,7 @@ def bipartite_layout(
 
 
 @random_state(10)
-def fruchterman_reingold_layout(
+def spring_layout(
     G,
     k=None,
     pos=None,
@@ -401,7 +401,8 @@ def fruchterman_reingold_layout(
 
     weight : string or None   optional (default='weight')
         The edge attribute that holds the numerical value used for
-        the edge weight.  If None, then all edge weights are 1.
+        the edge weight.  Larger means a stronger attractive force.
+        If None, then all edge weights are 1.
 
     scale : number or None (default: 1)
         Scale factor for positions. Not used unless `fixed is None`.
@@ -494,7 +495,7 @@ def fruchterman_reingold_layout(
     return pos
 
 
-spring_layout = fruchterman_reingold_layout
+fruchterman_reingold_layout = spring_layout
 
 
 @random_state(7)


### PR DESCRIPTION
This allows the `source` link to appear on the docs for this function.
I believe it shouldn't affect performance/behavior in any way.

Fixes:  #4819 