### PR TITLE
Fix edge drawing performance regression

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -820,6 +820,12 @@ def draw_networkx_edges(
     # Draw the edges
     if use_linecollection:
         edge_viz_obj = _draw_networkx_edges_line_collection()
+        # Make sure selfloop edges are also drawn.
+        edgelist = list(nx.selfloop_edges(G))
+        if edgelist:
+            edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in edgelist])
+            arrowstyle = "-"
+            _draw_networkx_edges_fancy_arrow_patch()
     else:
         edge_viz_obj = _draw_networkx_edges_fancy_arrow_patch()
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -718,14 +718,6 @@ def draw_networkx_edges(
         arrow_collection = []
         mutation_scale = arrowsize  # scale factor of arrow head
 
-        # compute view
-        minx = np.amin(np.ravel(edge_pos[:, :, 0]))
-        maxx = np.amax(np.ravel(edge_pos[:, :, 0]))
-        miny = np.amin(np.ravel(edge_pos[:, :, 1]))
-        maxy = np.amax(np.ravel(edge_pos[:, :, 1]))
-        w = maxx - minx
-        h = maxy - miny
-
         base_connection_style = mpl.patches.ConnectionStyle(connectionstyle)
 
         # Fallback for self-loop scale. Left outside of _connectionstyle so it is
@@ -819,26 +811,38 @@ def draw_networkx_edges(
             arrow_collection.append(arrow)
             ax.add_patch(arrow)
 
-        # update view
-        padx, pady = 0.05 * w, 0.05 * h
-        corners = (minx - padx, miny - pady), (maxx + padx, maxy + pady)
-        ax.update_datalim(corners)
-        ax.autoscale_view()
-
-        ax.tick_params(
-            axis="both",
-            which="both",
-            bottom=False,
-            left=False,
-            labelbottom=False,
-            labelleft=False,
-        )
-
         return arrow_collection
 
+    # compute initial view
+    minx = np.amin(np.ravel(edge_pos[:, :, 0]))
+    maxx = np.amax(np.ravel(edge_pos[:, :, 0]))
+    miny = np.amin(np.ravel(edge_pos[:, :, 1]))
+    maxy = np.amax(np.ravel(edge_pos[:, :, 1]))
+    w = maxx - minx
+    h = maxy - miny
+
+    # Draw the edges
     if use_linecollection:
-        return _draw_networkx_edges_line_collection()
-    return _draw_networkx_edges_fancy_arrow_patch()
+        edge_viz_obj = _draw_networkx_edges_line_collection()
+    else:
+        edge_viz_obj = _draw_networkx_edges_fancy_arrow_patch()
+
+    # update view after drawing
+    padx, pady = 0.05 * w, 0.05 * h
+    corners = (minx - padx, miny - pady), (maxx + padx, maxy + pady)
+    ax.update_datalim(corners)
+    ax.autoscale_view()
+
+    ax.tick_params(
+        axis="both",
+        which="both",
+        bottom=False,
+        left=False,
+        labelbottom=False,
+        labelleft=False,
+    )
+
+    return edge_viz_obj
 
 
 def draw_networkx_labels(

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -509,6 +509,7 @@ def draw_networkx_edges(
     connectionstyle="arc3",
     min_source_margin=0,
     min_target_margin=0,
+    use_linecollection=True,
 ):
     r"""Draw the edges of the graph G.
 
@@ -637,6 +638,7 @@ def draw_networkx_edges(
     import matplotlib as mpl
     import matplotlib.colors  # call as mpl.colors
     import matplotlib.patches  # call as mpl.patches
+    import matplotlib.collections  # call as mpl.collections
     import matplotlib.path  # call as mpl.path
     import matplotlib.pyplot as plt
 
@@ -683,12 +685,8 @@ def draw_networkx_edges(
         color_normal = mpl.colors.Normalize(vmin=edge_vmin, vmax=edge_vmax)
         edge_color = [edge_cmap(color_normal(e)) for e in edge_color]
 
-    if use_linecollection:
-        return _draw_networkx_edges_line_collection()
-    return _draw_networkx_edges_fancy_arrow_patch()
-
     def _draw_networkx_edges_line_collection():
-        edge_collection = LineCollection(
+        edge_collection = mpl.collections.LineCollection(
             edge_pos,
             colors=edge_color,
             linewidths=width,
@@ -837,6 +835,10 @@ def draw_networkx_edges(
         )
 
         return arrow_collection
+
+    if use_linecollection:
+        return _draw_networkx_edges_line_collection()
+    return _draw_networkx_edges_fancy_arrow_patch()
 
 
 def draw_networkx_labels(

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -495,7 +495,7 @@ def draw_networkx_edges(
     edge_color="k",
     style="solid",
     alpha=None,
-    arrowstyle=None,
+    arrowstyle="-|>",
     arrowsize=10,
     edge_cmap=None,
     edge_vmin=None,
@@ -509,7 +509,6 @@ def draw_networkx_edges(
     connectionstyle="arc3",
     min_source_margin=0,
     min_target_margin=0,
-    use_linecollection=True,
 ):
     r"""Draw the edges of the graph G.
 
@@ -555,13 +554,11 @@ def draw_networkx_edges(
 
     arrows : bool, optional (default=True)
         For directed graphs, if True set default to drawing arrowheads.
-        Otherwise set default to no arrowheads. Ignored if `arrowstyle` is set.
 
         Note: Arrows will be the same color as edges.
 
-    arrowstyle : str (default='-\|>' if directed else '-')
+    arrowstyle : str (default='-\|>')
         For directed graphs and `arrows==True` defaults to '-\|>',
-        otherwise defaults to '-'.
 
         See `matplotlib.patches.ArrowStyle` for more options.
 
@@ -642,11 +639,10 @@ def draw_networkx_edges(
     import matplotlib.path  # call as mpl.path
     import matplotlib.pyplot as plt
 
-    if arrowstyle is None:
-        if G.is_directed() and arrows:
-            arrowstyle = "-|>"
-        else:
-            arrowstyle = "-"
+    # Use LineCollection to draw edges by default, for performance reasons
+    use_linecollection = True
+    if G.is_directed() and arrows:
+        use_linecollection = False
 
     if ax is None:
         ax = plt.gca()

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -599,9 +599,9 @@ def draw_networkx_edges(
 
     Returns
     -------
-    list of matplotlib.patches.FancyArrowPatch or matplotlib.colections.LineCollection
+     matplotlib.colections.LineCollection or a list of matplotlib.patches.FancyArrowPatch
         If ``arrows=True``, a list of FancyArrowPatches is returned.
-        If 1`arrows=False``, a LineCollection is returned.
+        If ``arrows=False``, a LineCollection is returned.
         If ``arrows=None`` (the default), then a LineCollection is returned if
         `G` is undirected, otherwise returns a list of FancyArrowPatches.
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -599,8 +599,11 @@ def draw_networkx_edges(
 
     Returns
     -------
-    list of matplotlib.patches.FancyArrowPatch
-        `FancyArrowPatch` instances of the directed edges
+    list of matplotlib.patches.FancyArrowPatch or matplotlib.colections.LineCollection
+        If ``arrows=True``, a list of FancyArrowPatches is returned.
+        If 1`arrows=False``, a LineCollection is returned.
+        If ``arrows=None`` (the default), then a LineCollection is returned if
+        `G` is undirected, otherwise returns a list of FancyArrowPatches.
 
     Notes
     -----
@@ -610,6 +613,13 @@ def draw_networkx_edges(
 
     Be sure to include `node_size` as a keyword argument; arrows are
     drawn considering the size of nodes.
+
+    Self-loops are always drawn with `~matplotlib.patches.FancyArrowPatch`
+    regardless of the value of `arrows` or whether `G` is directed.
+    When ``arrows=False`` or ``arrows=None`` and `G` is undirected, the
+    FancyArrowPatches corresponding to the self-loops are not explicitly
+    returned. They should instead be accessed via the ``Axes.patches``
+    attribute (see examples).
 
     Examples
     --------
@@ -622,6 +632,16 @@ def draw_networkx_edges(
     >>> alphas = [0.3, 0.4, 0.5]
     >>> for i, arc in enumerate(arcs):  # change alpha values of arcs
     ...     arc.set_alpha(alphas[i])
+
+    The FancyArrowPatches corresponding to self-loops are not always
+    returned, but can always be accessed via the ``patches`` attribute of the
+    `matplotlib.Axes` object.
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
+    >>> G = nx.Graph([(0, 1), (0, 0)])  # Self-loop at node 0
+    >>> edge_collection = nx.draw_networkx_edges(G, pos=nx.circular_layout(G), ax=ax)
+    >>> self_loop_fap = ax.patches[0]
 
     Also see the NetworkX drawing examples at
     https://networkx.org/documentation/latest/auto_examples/index.html

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -501,7 +501,7 @@ def draw_networkx_edges(
     edge_vmin=None,
     edge_vmax=None,
     ax=None,
-    arrows=True,
+    arrows=None,
     label=None,
     node_size=300,
     nodelist=None,
@@ -552,10 +552,14 @@ def draw_networkx_edges(
     ax : Matplotlib Axes object, optional
         Draw the graph in the specified Matplotlib axes.
 
-    arrows : bool, optional (default=True)
-        For directed graphs, if True set default to drawing arrowheads.
+    arrows : bool or None, optional (default=None)
+        If `None`, directed graphs draw arrowheads with
+        `~matplotlib.patches.FancyArrowPatch`, while undirected graphs draw edges
+        via `~matplotlib.collections.LineCollection` for speed.
+        If `True`, draw arrowheads with FancyArrowPatches (bendable and stylish).
+        If `False`, draw edges using LineCollection (linear and fast).
 
-        Note: Arrows will be the same color as edges.
+        Note: Arrowheads will be the same color as edges.
 
     arrowstyle : str (default='-\|>')
         For directed graphs and `arrows==True` defaults to '-\|>',
@@ -639,10 +643,13 @@ def draw_networkx_edges(
     import matplotlib.path  # call as mpl.path
     import matplotlib.pyplot as plt
 
-    # Use LineCollection to draw edges by default, for performance reasons
-    use_linecollection = True
-    if G.is_directed() and arrows:
-        use_linecollection = False
+    # The default behavior is to use LineCollection to draw edges for
+    # undirected graphs (for performance reasons) and use FancyArrowPatches
+    # for directed graphs.
+    # The `arrows` keyword can be used to override the default behavior
+    use_linecollection = not G.is_directed()
+    if arrows in (True, False):
+        use_linecollection = not arrows
 
     if ax is None:
         ax = plt.gca()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -297,7 +297,7 @@ def test_draw_edges_min_source_target_margins(node_shape):
     # Create a single axis object to get consistent pixel coords across
     # multiple draws
     fig, ax = plt.subplots()
-    G = nx.Graph([(0, 1)])
+    G = nx.DiGraph([(0, 1)])
     pos = {0: (0, 0), 1: (1, 0)}  # horizontal layout
     # Get leftmost and rightmost points of the FancyArrowPatch object
     # representing the edge between nodes 0 and 1 (in pixel coordinates)
@@ -327,7 +327,7 @@ def test_nonzero_selfloop_with_single_node():
     # Create explicit axis object for test
     fig, ax = plt.subplots()
     # Graph with single node + self loop
-    G = nx.Graph()
+    G = nx.DiGraph()
     G.add_node(0)
     G.add_edge(0, 0)
     # Draw
@@ -346,7 +346,7 @@ def test_nonzero_selfloop_with_single_edge_in_edgelist():
     # Create explicit axis object for test
     fig, ax = plt.subplots()
     # Graph with selfloop
-    G = nx.path_graph(2)
+    G = nx.path_graph(2, create_using=nx.DiGraph)
     G.add_edge(1, 1)
     pos = {n: (n, n) for n in G.nodes}
     # Draw only the selfloop edge via the `edgelist` kwarg

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -387,7 +387,7 @@ def test_draw_edges_toggling_with_arrows_kwarg():
     # Use FancyArrowPatches when arrows=True, regardless of graph type
     for G in (UG, DG):
         edges = nx.draw_networkx_edges(G, pos, arrows=True)
-        assert len(edges) == 3
+        assert len(edges) == len(G.edges)
         assert isinstance(edges[0], mpl.patches.FancyArrowPatch)
 
     # Use LineCollection when arrows=False, regardless of graph type
@@ -399,5 +399,5 @@ def test_draw_edges_toggling_with_arrows_kwarg():
     edges = nx.draw_networkx_edges(UG, pos)
     assert isinstance(edges, mpl.collections.LineCollection)
     edges = nx.draw_networkx_edges(DG, pos)
-    assert len(edges) == 3
+    assert len(edges) == len(G.edges)
     assert isinstance(edges[0], mpl.patches.FancyArrowPatch)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -367,3 +367,37 @@ def test_apply_alpha():
     alpha = 0.5
     rgba_colors = nx.drawing.nx_pylab.apply_alpha(colorlist, alpha, nodelist)
     assert all(rgba_colors[:, -1] == alpha)
+
+
+def test_draw_edges_toggling_with_arrows_kwarg():
+    """
+    The `arrows` keyword argument is used as a 3-way switch to select which
+    type of object to use for drawing edges:
+      - ``arrows=None`` -> default (FancyArrowPatches for directed, else LineCollection)
+      - ``arrows=True`` -> FancyArrowPatches
+      - ``arrows=False`` -> LineCollection
+    """
+    import matplotlib.patches
+    import matplotlib.collections
+
+    UG = nx.path_graph(3)
+    DG = nx.path_graph(3, create_using=nx.DiGraph)
+    pos = {n: (n, n) for n in UG}
+
+    # Use FancyArrowPatches when arrows=True, regardless of graph type
+    for G in (UG, DG):
+        edges = nx.draw_networkx_edges(G, pos, arrows=True)
+        assert len(edges) == 3
+        assert isinstance(edges[0], mpl.patches.FancyArrowPatch)
+
+    # Use LineCollection when arrows=False, regardless of graph type
+    for G in (UG, DG):
+        edges = nx.draw_networkx_edges(G, pos, arrows=False)
+        assert isinstance(edges, mpl.collections.LineCollection)
+
+    # Default behavior when arrows=None: FAPs for directed, LC's for undirected
+    edges = nx.draw_networkx_edges(UG, pos)
+    assert isinstance(edges, mpl.collections.LineCollection)
+    edges = nx.draw_networkx_edges(DG, pos)
+    assert len(edges) == 3
+    assert isinstance(edges[0], mpl.patches.FancyArrowPatch)


### PR DESCRIPTION
#4360 switched all edge drawing from LineCollection (in some cases) to always using FancyArrowPatches. This enabled nice new features such as self-loop drawing #4370 and a consistent, iterable return type, which makes it easier for users to modify individual edges (as FancyArrowPatches) after they have been created by `draw_networkx_edges`.

One downside of removing LineCollection is a large performance regression for drawing edges in undirected graphs, see #4806.

This PR tries to get the best of both worlds by re-introducing LineCollection for faster edge drawing, while keeping all the nice features of #4370 including drawing self-loops and the ability to draw curved edges.

The basic approach is:
 1. Add back the LineCollection drawing functionality that was removed in #4360.
 2. Encapsulate the two different drawing methods in internal functions
 3. Investigate how to trigger the different drawing methods based on existing kwargs, e.g. `arrows`, `arrowstyle`, `connectionstyle` etc.