### PR TITLE
Refactor testing utilities

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -85,5 +85,4 @@ Version 3.0
 * In ``networkx.classes`` remove the ``ordered`` module and the four ``Ordered``
   classes defined therein.
 * In ``utils/decorators.py`` remove ``preserve_random_state``.
-* In ``testing/utils.py`` remove ``almost_equal``.
-* Remove ``testing/test.py``.
+* Remove ``testing``.

--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -22,7 +22,9 @@ Helper Functions
    pairwise
    groups
    create_random_state
-
+   nodes_equal
+   edges_equal
+   graphs_equal
 
 Data Structures and Algorithms
 ------------------------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -117,6 +117,8 @@ Deprecations
   Deprecate ``almost_equal``.
 - [`#4833 <https://github.com/networkx/networkx/pull/4833>`_]
   Deprecate ``run``.
+- [`#4829 <https://github.com/networkx/networkx/pull/4829>`_]
+  Deprecate ``assert_nodes_equal``, ``assert_edges_equal``, and ``assert_graphs_equal``.
 
 Contributors
 ------------

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -2,7 +2,7 @@ import pytest
 import networkx as nx
 from networkx.algorithms.approximation.steinertree import metric_closure
 from networkx.algorithms.approximation.steinertree import steiner_tree
-from networkx.testing.utils import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 class TestSteinerTree:
@@ -49,7 +49,7 @@ class TestSteinerTree:
             (5, 7, {"distance": 1, "path": [5, 7]}),
             (6, 7, {"distance": 11, "path": [6, 5, 7]}),
         ]
-        assert_edges_equal(list(M.edges(data=True)), mc)
+        assert edges_equal(list(M.edges(data=True)), mc)
 
     def test_steiner_tree(self):
         S = steiner_tree(self.G, self.term_nodes)
@@ -60,7 +60,7 @@ class TestSteinerTree:
             (3, 4, {"weight": 10}),
             (5, 7, {"weight": 1}),
         ]
-        assert_edges_equal(list(S.edges(data=True)), expected_steiner_tree)
+        assert edges_equal(list(S.edges(data=True)), expected_steiner_tree)
 
     def test_multigraph_steiner_tree(self):
         G = nx.MultiGraph()
@@ -80,4 +80,4 @@ class TestSteinerTree:
             (3, 5, 0, {"weight": 1}),
         ]
         T = steiner_tree(G, terminal_nodes)
-        assert_edges_equal(T.edges(data=True, keys=True), expected_edges)
+        assert edges_equal(T.edges(data=True, keys=True), expected_edges)

--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -7,7 +7,7 @@ import tempfile
 import os
 
 import networkx as nx
-from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 from networkx.algorithms import bipartite
 
 
@@ -35,7 +35,7 @@ class TestEdgelist:
 """
         bytesIO = io.BytesIO(s)
         G = bipartite.read_edgelist(bytesIO, nodetype=int)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
+        assert edges_equal(G.edges(), [(1, 2), (2, 3)])
 
     def test_read_edgelist_3(self):
         s = b"""\
@@ -46,11 +46,11 @@ class TestEdgelist:
 """
         bytesIO = io.BytesIO(s)
         G = bipartite.read_edgelist(bytesIO, nodetype=int, data=False)
-        assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
+        assert edges_equal(G.edges(), [(1, 2), (2, 3)])
 
         bytesIO = io.BytesIO(s)
         G = bipartite.read_edgelist(bytesIO, nodetype=int, data=True)
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"weight": 2.0}), (2, 3, {"weight": 3.0})]
         )
 
@@ -110,7 +110,7 @@ class TestEdgelist:
         fd, fname = tempfile.mkstemp()
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname)
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
         os.close(fd)
         os.unlink(fname)
 
@@ -138,7 +138,7 @@ class TestEdgelist:
         fd, fname = tempfile.mkstemp()
         bipartite.write_edgelist(G, fname, encoding="latin-1")
         H = bipartite.read_edgelist(fname, encoding="latin-1")
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
         os.close(fd)
         os.unlink(fname)
 
@@ -150,8 +150,8 @@ class TestEdgelist:
         H2 = bipartite.read_edgelist(fname)
         assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -162,8 +162,8 @@ class TestEdgelist:
         H = bipartite.read_edgelist(fname, nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -174,8 +174,8 @@ class TestEdgelist:
         H = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -7,7 +7,7 @@ sparse = pytest.importorskip("scipy.sparse")
 
 import networkx as nx
 from networkx.algorithms import bipartite
-from networkx.testing.utils import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 class TestBiadjacencyMatrix:
@@ -68,12 +68,12 @@ class TestBiadjacencyMatrix:
     def test_from_biadjacency_weight(self):
         M = sparse.csc_matrix([[1, 2], [0, 3]])
         B = bipartite.from_biadjacency_matrix(M)
-        assert_edges_equal(B.edges(), [(0, 2), (0, 3), (1, 3)])
+        assert edges_equal(B.edges(), [(0, 2), (0, 3), (1, 3)])
         B = bipartite.from_biadjacency_matrix(M, edge_attribute="weight")
         e = [(0, 2, {"weight": 1}), (0, 3, {"weight": 2}), (1, 3, {"weight": 3})]
-        assert_edges_equal(B.edges(data=True), e)
+        assert edges_equal(B.edges(data=True), e)
 
     def test_from_biadjacency_multigraph(self):
         M = sparse.csc_matrix([[1, 2], [0, 3]])
         B = bipartite.from_biadjacency_matrix(M, create_using=nx.MultiGraph())
-        assert_edges_equal(B.edges(), [(0, 2), (0, 3), (0, 3), (1, 3), (1, 3), (1, 3)])
+        assert edges_equal(B.edges(), [(0, 2), (0, 3), (0, 3), (1, 3), (1, 3), (1, 3)])

--- a/networkx/algorithms/bipartite/tests/test_project.py
+++ b/networkx/algorithms/bipartite/tests/test_project.py
@@ -1,89 +1,89 @@
 import networkx as nx
 from networkx.algorithms import bipartite
-from networkx.testing import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestBipartiteProject:
     def test_path_projected_graph(self):
         G = nx.path_graph(4)
         P = bipartite.projected_graph(G, [1, 3])
-        assert_nodes_equal(list(P), [1, 3])
-        assert_edges_equal(list(P.edges()), [(1, 3)])
+        assert nodes_equal(list(P), [1, 3])
+        assert edges_equal(list(P.edges()), [(1, 3)])
         P = bipartite.projected_graph(G, [0, 2])
-        assert_nodes_equal(list(P), [0, 2])
-        assert_edges_equal(list(P.edges()), [(0, 2)])
+        assert nodes_equal(list(P), [0, 2])
+        assert edges_equal(list(P.edges()), [(0, 2)])
 
     def test_path_projected_properties_graph(self):
         G = nx.path_graph(4)
         G.add_node(1, name="one")
         G.add_node(2, name="two")
         P = bipartite.projected_graph(G, [1, 3])
-        assert_nodes_equal(list(P), [1, 3])
-        assert_edges_equal(list(P.edges()), [(1, 3)])
+        assert nodes_equal(list(P), [1, 3])
+        assert edges_equal(list(P.edges()), [(1, 3)])
         assert P.nodes[1]["name"] == G.nodes[1]["name"]
         P = bipartite.projected_graph(G, [0, 2])
-        assert_nodes_equal(list(P), [0, 2])
-        assert_edges_equal(list(P.edges()), [(0, 2)])
+        assert nodes_equal(list(P), [0, 2])
+        assert edges_equal(list(P.edges()), [(0, 2)])
         assert P.nodes[2]["name"] == G.nodes[2]["name"]
 
     def test_path_collaboration_projected_graph(self):
         G = nx.path_graph(4)
         P = bipartite.collaboration_weighted_projected_graph(G, [1, 3])
-        assert_nodes_equal(list(P), [1, 3])
-        assert_edges_equal(list(P.edges()), [(1, 3)])
+        assert nodes_equal(list(P), [1, 3])
+        assert edges_equal(list(P.edges()), [(1, 3)])
         P[1][3]["weight"] = 1
         P = bipartite.collaboration_weighted_projected_graph(G, [0, 2])
-        assert_nodes_equal(list(P), [0, 2])
-        assert_edges_equal(list(P.edges()), [(0, 2)])
+        assert nodes_equal(list(P), [0, 2])
+        assert edges_equal(list(P.edges()), [(0, 2)])
         P[0][2]["weight"] = 1
 
     def test_directed_path_collaboration_projected_graph(self):
         G = nx.DiGraph()
         nx.add_path(G, range(4))
         P = bipartite.collaboration_weighted_projected_graph(G, [1, 3])
-        assert_nodes_equal(list(P), [1, 3])
-        assert_edges_equal(list(P.edges()), [(1, 3)])
+        assert nodes_equal(list(P), [1, 3])
+        assert edges_equal(list(P.edges()), [(1, 3)])
         P[1][3]["weight"] = 1
         P = bipartite.collaboration_weighted_projected_graph(G, [0, 2])
-        assert_nodes_equal(list(P), [0, 2])
-        assert_edges_equal(list(P.edges()), [(0, 2)])
+        assert nodes_equal(list(P), [0, 2])
+        assert edges_equal(list(P.edges()), [(0, 2)])
         P[0][2]["weight"] = 1
 
     def test_path_weighted_projected_graph(self):
         G = nx.path_graph(4)
         P = bipartite.weighted_projected_graph(G, [1, 3])
-        assert_nodes_equal(list(P), [1, 3])
-        assert_edges_equal(list(P.edges()), [(1, 3)])
+        assert nodes_equal(list(P), [1, 3])
+        assert edges_equal(list(P.edges()), [(1, 3)])
         P[1][3]["weight"] = 1
         P = bipartite.weighted_projected_graph(G, [0, 2])
-        assert_nodes_equal(list(P), [0, 2])
-        assert_edges_equal(list(P.edges()), [(0, 2)])
+        assert nodes_equal(list(P), [0, 2])
+        assert edges_equal(list(P.edges()), [(0, 2)])
         P[0][2]["weight"] = 1
 
     def test_path_weighted_projected_directed_graph(self):
         G = nx.DiGraph()
         nx.add_path(G, range(4))
         P = bipartite.weighted_projected_graph(G, [1, 3])
-        assert_nodes_equal(list(P), [1, 3])
-        assert_edges_equal(list(P.edges()), [(1, 3)])
+        assert nodes_equal(list(P), [1, 3])
+        assert edges_equal(list(P.edges()), [(1, 3)])
         P[1][3]["weight"] = 1
         P = bipartite.weighted_projected_graph(G, [0, 2])
-        assert_nodes_equal(list(P), [0, 2])
-        assert_edges_equal(list(P.edges()), [(0, 2)])
+        assert nodes_equal(list(P), [0, 2])
+        assert edges_equal(list(P.edges()), [(0, 2)])
         P[0][2]["weight"] = 1
 
     def test_star_projected_graph(self):
         G = nx.star_graph(3)
         P = bipartite.projected_graph(G, [1, 2, 3])
-        assert_nodes_equal(list(P), [1, 2, 3])
-        assert_edges_equal(list(P.edges()), [(1, 2), (1, 3), (2, 3)])
+        assert nodes_equal(list(P), [1, 2, 3])
+        assert edges_equal(list(P.edges()), [(1, 2), (1, 3), (2, 3)])
         P = bipartite.weighted_projected_graph(G, [1, 2, 3])
-        assert_nodes_equal(list(P), [1, 2, 3])
-        assert_edges_equal(list(P.edges()), [(1, 2), (1, 3), (2, 3)])
+        assert nodes_equal(list(P), [1, 2, 3])
+        assert edges_equal(list(P.edges()), [(1, 2), (1, 3), (2, 3)])
 
         P = bipartite.projected_graph(G, [0])
-        assert_nodes_equal(list(P), [0])
-        assert_edges_equal(list(P.edges()), [])
+        assert nodes_equal(list(P), [0])
+        assert edges_equal(list(P.edges()), [])
 
     def test_project_multigraph(self):
         G = nx.Graph()
@@ -92,11 +92,11 @@ class TestBipartiteProject:
         G.add_edge("a", 2)
         G.add_edge("b", 2)
         P = bipartite.projected_graph(G, "ab")
-        assert_edges_equal(list(P.edges()), [("a", "b")])
+        assert edges_equal(list(P.edges()), [("a", "b")])
         P = bipartite.weighted_projected_graph(G, "ab")
-        assert_edges_equal(list(P.edges()), [("a", "b")])
+        assert edges_equal(list(P.edges()), [("a", "b")])
         P = bipartite.projected_graph(G, "ab", multigraph=True)
-        assert_edges_equal(list(P.edges()), [("a", "b"), ("a", "b")])
+        assert edges_equal(list(P.edges()), [("a", "b"), ("a", "b")])
 
     def test_project_collaboration(self):
         G = nx.Graph()
@@ -118,13 +118,13 @@ class TestBipartiteProject:
         G.add_edge("A", 2)
         G.add_edge("B", 2)
         P = bipartite.projected_graph(G, "AB")
-        assert_edges_equal(list(P.edges()), [("A", "B")])
+        assert edges_equal(list(P.edges()), [("A", "B")])
         P = bipartite.weighted_projected_graph(G, "AB")
-        assert_edges_equal(list(P.edges()), [("A", "B")])
+        assert edges_equal(list(P.edges()), [("A", "B")])
         assert P["A"]["B"]["weight"] == 1
 
         P = bipartite.projected_graph(G, "AB", multigraph=True)
-        assert_edges_equal(list(P.edges()), [("A", "B")])
+        assert edges_equal(list(P.edges()), [("A", "B")])
 
         G = nx.DiGraph()
         G.add_edge("A", 1)
@@ -132,13 +132,13 @@ class TestBipartiteProject:
         G.add_edge("A", 2)
         G.add_edge(2, "B")
         P = bipartite.projected_graph(G, "AB")
-        assert_edges_equal(list(P.edges()), [("A", "B")])
+        assert edges_equal(list(P.edges()), [("A", "B")])
         P = bipartite.weighted_projected_graph(G, "AB")
-        assert_edges_equal(list(P.edges()), [("A", "B")])
+        assert edges_equal(list(P.edges()), [("A", "B")])
         assert P["A"]["B"]["weight"] == 2
 
         P = bipartite.projected_graph(G, "AB", multigraph=True)
-        assert_edges_equal(list(P.edges()), [("A", "B"), ("A", "B")])
+        assert edges_equal(list(P.edges()), [("A", "B"), ("A", "B")])
 
 
 class TestBipartiteWeightedProjection:
@@ -184,7 +184,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.weighted_projected_graph(self.G, "ABCDEF")
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -201,7 +201,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.weighted_projected_graph(self.N, "ABCDE")
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -217,7 +217,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.collaboration_weighted_projected_graph(self.G, "ABCDEF")
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -234,7 +234,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.collaboration_weighted_projected_graph(self.N, "ABCDE")
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -250,7 +250,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.weighted_projected_graph(self.G, "ABCDEF", ratio=True)
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -267,7 +267,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.weighted_projected_graph(self.N, "ABCDE", ratio=True)
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -283,7 +283,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.overlap_weighted_projected_graph(self.G, "ABCDEF", jaccard=False)
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -300,7 +300,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.overlap_weighted_projected_graph(self.N, "ABCDE", jaccard=False)
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -316,7 +316,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.overlap_weighted_projected_graph(self.G, "ABCDEF")
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in list(P.edges()):
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -333,7 +333,7 @@ class TestBipartiteWeightedProjection:
         Panswer = nx.Graph()
         Panswer.add_weighted_edges_from(edges)
         P = bipartite.overlap_weighted_projected_graph(self.N, "ABCDE")
-        assert_edges_equal(list(P.edges()), Panswer.edges())
+        assert edges_equal(list(P.edges()), Panswer.edges())
         for u, v in P.edges():
             assert P[u][v]["weight"] == Panswer[u][v]["weight"]
 
@@ -345,23 +345,23 @@ class TestBipartiteWeightedProjection:
         G = bipartite.generic_weighted_projected_graph(
             B, [0, 2, 4], weight_function=shared
         )
-        assert_nodes_equal(list(G), [0, 2, 4])
-        assert_edges_equal(
+        assert nodes_equal(list(G), [0, 2, 4])
+        assert edges_equal(
             list(list(G.edges(data=True))),
             [(0, 2, {"weight": 1}), (2, 4, {"weight": 1})],
         )
 
         G = bipartite.generic_weighted_projected_graph(B, [0, 2, 4])
-        assert_nodes_equal(list(G), [0, 2, 4])
-        assert_edges_equal(
+        assert nodes_equal(list(G), [0, 2, 4])
+        assert edges_equal(
             list(list(G.edges(data=True))),
             [(0, 2, {"weight": 1}), (2, 4, {"weight": 1})],
         )
         B = nx.DiGraph()
         nx.add_path(B, range(5))
         G = bipartite.generic_weighted_projected_graph(B, [0, 2, 4])
-        assert_nodes_equal(list(G), [0, 2, 4])
-        assert_edges_equal(
+        assert nodes_equal(list(G), [0, 2, 4])
+        assert edges_equal(
             list(G.edges(data=True)), [(0, 2, {"weight": 1}), (2, 4, {"weight": 1})]
         )
 
@@ -383,10 +383,10 @@ class TestBipartiteWeightedProjection:
         G = bipartite.generic_weighted_projected_graph(
             B, [0, 1], weight_function=jaccard
         )
-        assert_edges_equal(list(G.edges(data=True)), [(0, 1, {"weight": 1.0})])
+        assert edges_equal(list(G.edges(data=True)), [(0, 1, {"weight": 1.0})])
         G = bipartite.generic_weighted_projected_graph(
             B, [0, 1], weight_function=my_weight
         )
-        assert_edges_equal(list(G.edges(data=True)), [(0, 1, {"weight": 10})])
+        assert edges_equal(list(G.edges(data=True)), [(0, 1, {"weight": 10})])
         G = bipartite.generic_weighted_projected_graph(B, [0, 1])
-        assert_edges_equal(list(G.edges(data=True)), [(0, 1, {"weight": 2})])
+        assert edges_equal(list(G.edges(data=True)), [(0, 1, {"weight": 2})])

--- a/networkx/algorithms/minors/tests/test_contraction.py
+++ b/networkx/algorithms/minors/tests/test_contraction.py
@@ -2,7 +2,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 from networkx.utils import arbitrary_element
 
 
@@ -113,8 +113,8 @@ class TestQuotient:
         G = nx.path_graph(6)
         partition = [{0, 1}, {2, 3}, {4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -124,8 +124,8 @@ class TestQuotient:
         G = nx.path_graph(6)
         partition = {0: [0, 1], 2: [2, 3], 4: [4, 5]}
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -135,8 +135,8 @@ class TestQuotient:
         G = nx.path_graph(6)
         partition = {0: (0, 1), 2: (2, 3), 4: (4, 5)}
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -146,8 +146,8 @@ class TestQuotient:
         G = nx.path_graph(6)
         partition = {0: {0, 1}, 2: {2, 3}, 4: {4, 5}}
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -157,8 +157,8 @@ class TestQuotient:
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -169,8 +169,8 @@ class TestQuotient:
         nx.add_path(G, range(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -181,8 +181,8 @@ class TestQuotient:
         nx.add_path(G, range(6))
         partition = [{0, 1}, {2, 3}, {4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M:
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -200,8 +200,8 @@ class TestQuotient:
             G[i][i + 1]["weight"] = i + 1
         partition = [{0, 1}, {2, 3}, {4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M, [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         assert M[0][1]["weight"] == 2
         assert M[1][2]["weight"] == 4
         for n in M:
@@ -213,8 +213,8 @@ class TestQuotient:
         G = nx.barbell_graph(3, 0)
         partition = [{0, 1, 2}, {3, 4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1])
-        assert_edges_equal(M.edges(), [(0, 1)])
+        assert nodes_equal(M, [0, 1])
+        assert edges_equal(M.edges(), [(0, 1)])
         for n in M:
             assert M.nodes[n]["nedges"] == 3
             assert M.nodes[n]["nnodes"] == 3
@@ -226,8 +226,8 @@ class TestQuotient:
         G.add_edge(0, 5)
         partition = [{0, 1, 2}, {3, 4, 5}]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M, [0, 1])
-        assert_edges_equal(M.edges(), [(0, 1)])
+        assert nodes_equal(M, [0, 1])
+        assert edges_equal(M.edges(), [(0, 1)])
         assert M[0][1]["weight"] == 2
         for n in M:
             assert M.nodes[n]["nedges"] == 3
@@ -238,8 +238,8 @@ class TestQuotient:
         G = nx.path_graph(6)
         partition = [[0, 1], [2, 3], [4, 5]]
         M = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(M.nodes(), [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M.nodes(), [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M.nodes():
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -249,8 +249,8 @@ class TestQuotient:
         G = nx.MultiGraph(nx.path_graph(6))
         partition = [[0, 1], [2, 3], [4, 5]]
         M = nx.quotient_graph(G, partition, create_using=nx.MultiGraph(), relabel=True)
-        assert_nodes_equal(M.nodes(), [0, 1, 2])
-        assert_edges_equal(M.edges(), [(0, 1), (1, 2)])
+        assert nodes_equal(M.nodes(), [0, 1, 2])
+        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
         for n in M.nodes():
             assert M.nodes[n]["nedges"] == 1
             assert M.nodes[n]["nnodes"] == 2
@@ -260,13 +260,13 @@ class TestQuotient:
         G = nx.path_graph(6)
         partition = []
         H = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(H.nodes(), [])
-        assert_edges_equal(H.edges(), [])
+        assert nodes_equal(H.nodes(), [])
+        assert edges_equal(H.edges(), [])
 
         partition = [[0, 1], [2, 3], [5]]
         H = nx.quotient_graph(G, partition, relabel=True)
-        assert_nodes_equal(H.nodes(), [0, 1, 2])
-        assert_edges_equal(H.edges(), [(0, 1)])
+        assert nodes_equal(H.nodes(), [0, 1, 2])
+        assert edges_equal(H.edges(), [(0, 1)])
 
 
 class TestContraction:
@@ -323,7 +323,7 @@ class TestContraction:
         expected.add_edge(0, 1)
         expected.add_edge(0, 0)
         expected.add_edge(0, 0)
-        assert_edges_equal(actual.edges, expected.edges)
+        assert edges_equal(actual.edges, expected.edges)
 
     def test_multigraph_keys(self):
         """Tests that multiedge keys are reset in new graph."""
@@ -338,7 +338,7 @@ class TestContraction:
         expected.add_edge(0, 1, 2)  # keyed as 2 b/c 2 edges already in G
         expected.add_edge(0, 0, 0)
         expected.add_edge(0, 0, 1)  # this comes from (0, 2, 5)
-        assert_edges_equal(actual.edges, expected.edges)
+        assert edges_equal(actual.edges, expected.edges)
 
     def test_node_attributes(self):
         """Tests that node contraction preserves node attributes."""
@@ -390,12 +390,12 @@ class TestContraction:
         expected = nx.complete_graph([0, 2, 3])
         expected.add_edge(0, 0)
         expected.add_edge(0, 0)
-        assert_edges_equal(actual.edges, expected.edges)
+        assert edges_equal(actual.edges, expected.edges)
         actual = nx.contracted_nodes(G, 1, 0)
         expected = nx.complete_graph([1, 2, 3])
         expected.add_edge(1, 1)
         expected.add_edge(1, 1)
-        assert_edges_equal(actual.edges, expected.edges)
+        assert edges_equal(actual.edges, expected.edges)
 
     def test_undirected_edge_contraction(self):
         """Tests for edge contraction in an undirected graph."""

--- a/networkx/algorithms/minors/tests/test_contraction.py
+++ b/networkx/algorithms/minors/tests/test_contraction.py
@@ -2,8 +2,7 @@
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
-from networkx.utils import arbitrary_element
+from networkx.utils import arbitrary_element, nodes_equal, edges_equal
 
 
 class TestQuotient:

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -1,6 +1,6 @@
 import pytest
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 def test_union_all_attributes():
@@ -150,7 +150,7 @@ def test_union_all_and_compose_all():
 
     G = nx.union_all([G1, G2])
     H = nx.compose_all([G1, G2])
-    assert_edges_equal(G.edges(), H.edges())
+    assert edges_equal(G.edges(), H.edges())
     assert not G.has_edge("A", "1")
     pytest.raises(nx.NetworkXError, nx.union, K3, P3)
     H1 = nx.union_all([H, G1], rename=("H", "G1"))
@@ -188,7 +188,7 @@ def test_union_all_and_compose_all():
     assert not H1.has_edge("NB", "NA")
 
     G = nx.compose_all([G, G])
-    assert_edges_equal(G.edges(), H.edges())
+    assert edges_equal(G.edges(), H.edges())
 
     G2 = nx.union_all([G2, G2], rename=("", "copy"))
     assert sorted(G2.nodes()) == [

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -1,6 +1,6 @@
 import pytest
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 def test_union_attributes():
@@ -236,7 +236,7 @@ def test_union_and_compose():
 
     G = nx.union(G1, G2)
     H = nx.compose(G1, G2)
-    assert_edges_equal(G.edges(), H.edges())
+    assert edges_equal(G.edges(), H.edges())
     assert not G.has_edge("A", 1)
     pytest.raises(nx.NetworkXError, nx.union, K3, P3)
     H1 = nx.union(H, G1, rename=("H", "G1"))
@@ -274,7 +274,7 @@ def test_union_and_compose():
     assert not H1.has_edge("NB", "NA")
 
     G = nx.compose(G, G)
-    assert_edges_equal(G.edges(), H.edges())
+    assert edges_equal(G.edges(), H.edges())
 
     G2 = nx.union(G2, G2, rename=("", "copy"))
     assert sorted(G2.nodes()) == [

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -1,6 +1,6 @@
 import pytest
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 def test_tensor_product_raises():
@@ -375,7 +375,7 @@ def test_graph_power():
     G.add_edge(9, 2)
     H = nx.power(G, 2)
 
-    assert_edges_equal(
+    assert edges_equal(
         list(H.edges()),
         [
             (0, 1),

--- a/networkx/algorithms/tests/test_boundary.py
+++ b/networkx/algorithms/tests/test_boundary.py
@@ -3,7 +3,7 @@
 from itertools import combinations
 import pytest
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 from networkx import convert_node_labels_to_integers as cnlti
 
 
@@ -117,11 +117,11 @@ class TestEdgeBoundary:
         assert ilen(nx.edge_boundary(K10, [4, 5, 6, 7])) == 24
         assert ilen(nx.edge_boundary(K10, [3, 4, 5, 6, 7])) == 25
         assert ilen(nx.edge_boundary(K10, [8, 9, 10])) == 21
-        assert_edges_equal(
+        assert edges_equal(
             nx.edge_boundary(K10, [4, 5, 6], [9, 10]),
             [(4, 9), (4, 10), (5, 9), (5, 10), (6, 9), (6, 10)],
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.edge_boundary(K10, [1, 2, 3], [3, 4, 5]),
             [(1, 3), (1, 4), (1, 5), (2, 3), (2, 4), (2, 5), (3, 4), (3, 5)],
         )

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from networkx.testing.utils import assert_nodes_equal
+from networkx.utils import nodes_equal
 
 
 class TestCore:
@@ -57,10 +57,10 @@ class TestCore:
         nodes_by_core = [
             sorted([n for n in core if core[n] == val]) for val in range(4)
         ]
-        assert_nodes_equal(nodes_by_core[0], [21])
-        assert_nodes_equal(nodes_by_core[1], [17, 18, 19, 20])
-        assert_nodes_equal(nodes_by_core[2], [9, 10, 11, 12, 13, 14, 15, 16])
-        assert_nodes_equal(nodes_by_core[3], [1, 2, 3, 4, 5, 6, 7, 8])
+        assert nodes_equal(nodes_by_core[0], [21])
+        assert nodes_equal(nodes_by_core[1], [17, 18, 19, 20])
+        assert nodes_equal(nodes_by_core[2], [9, 10, 11, 12, 13, 14, 15, 16])
+        assert nodes_equal(nodes_by_core[3], [1, 2, 3, 4, 5, 6, 7, 8])
 
     def test_core_number(self):
         # smoke test real name
@@ -71,9 +71,9 @@ class TestCore:
         nodes_by_core = [
             sorted([n for n in core if core[n] == val]) for val in range(3)
         ]
-        assert_nodes_equal(nodes_by_core[0], [0])
-        assert_nodes_equal(nodes_by_core[1], [1, 3])
-        assert_nodes_equal(nodes_by_core[2], [2, 4, 5, 6])
+        assert nodes_equal(nodes_by_core[0], [0])
+        assert nodes_equal(nodes_by_core[1], [1, 3])
+        assert nodes_equal(nodes_by_core[2], [2, 4, 5, 6])
 
     def test_directed_find_cores(self):
         """core number had a bug for directed graphs found in issue #1959"""
@@ -171,9 +171,9 @@ class TestCore:
         nodes_by_layer = [
             sorted([n for n in layers if layers[n] == val]) for val in range(1, 7)
         ]
-        assert_nodes_equal(nodes_by_layer[0], [21])
-        assert_nodes_equal(nodes_by_layer[1], [17, 18, 19, 20])
-        assert_nodes_equal(nodes_by_layer[2], [10, 12, 13, 14, 15, 16])
-        assert_nodes_equal(nodes_by_layer[3], [9, 11])
-        assert_nodes_equal(nodes_by_layer[4], [1, 2, 4, 5, 6, 8])
-        assert_nodes_equal(nodes_by_layer[5], [3, 7])
+        assert nodes_equal(nodes_by_layer[0], [21])
+        assert nodes_equal(nodes_by_layer[1], [17, 18, 19, 20])
+        assert nodes_equal(nodes_by_layer[2], [10, 12, 13, 14, 15, 16])
+        assert nodes_equal(nodes_by_layer[3], [9, 11])
+        assert nodes_equal(nodes_by_layer[4], [1, 2, 4, 5, 6, 8])
+        assert nodes_equal(nodes_by_layer[5], [3, 7])

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -4,8 +4,7 @@ from collections import deque
 import pytest
 
 import networkx as nx
-from networkx.utils import edges_equal
-from networkx.utils import pairwise
+from networkx.utils import edges_equal, pairwise
 
 # Recipe from the itertools documentation.
 def _consume(iterator):

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -4,7 +4,7 @@ from collections import deque
 import pytest
 
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal
+from networkx.utils import edges_equal
 from networkx.utils import pairwise
 
 # Recipe from the itertools documentation.
@@ -283,14 +283,14 @@ class TestDAG:
     def test_transitive_closure(self):
         G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
         solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
-        assert_edges_equal(nx.transitive_closure(G).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G).edges(), solution)
         G = nx.DiGraph([(1, 2), (2, 3), (2, 4)])
         solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)]
-        assert_edges_equal(nx.transitive_closure(G).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G).edges(), solution)
         G = nx.DiGraph([(1, 2), (2, 3), (3, 1)])
         solution = [(1, 2), (2, 1), (2, 3), (3, 2), (1, 3), (3, 1)]
         soln = sorted(solution + [(n, n) for n in G])
-        assert_edges_equal(sorted(nx.transitive_closure(G).edges()), soln)
+        assert edges_equal(sorted(nx.transitive_closure(G).edges()), soln)
         G = nx.Graph([(1, 2), (2, 3), (3, 4)])
         pytest.raises(nx.NetworkXNotImplemented, nx.transitive_closure, G)
 
@@ -310,35 +310,35 @@ class TestDAG:
         G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
         solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
         soln = sorted(solution + [(n, n) for n in G])
-        assert_edges_equal(nx.transitive_closure(G).edges(), solution)
-        assert_edges_equal(nx.transitive_closure(G, False).edges(), solution)
-        assert_edges_equal(nx.transitive_closure(G, True).edges(), soln)
-        assert_edges_equal(nx.transitive_closure(G, None).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G, False).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G, True).edges(), soln)
+        assert edges_equal(nx.transitive_closure(G, None).edges(), solution)
 
         G = nx.DiGraph([(1, 2), (2, 3), (2, 4)])
         solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)]
         soln = sorted(solution + [(n, n) for n in G])
-        assert_edges_equal(nx.transitive_closure(G).edges(), solution)
-        assert_edges_equal(nx.transitive_closure(G, False).edges(), solution)
-        assert_edges_equal(nx.transitive_closure(G, True).edges(), soln)
-        assert_edges_equal(nx.transitive_closure(G, None).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G, False).edges(), solution)
+        assert edges_equal(nx.transitive_closure(G, True).edges(), soln)
+        assert edges_equal(nx.transitive_closure(G, None).edges(), solution)
 
         G = nx.DiGraph([(1, 2), (2, 3), (3, 1)])
         solution = sorted([(1, 2), (2, 1), (2, 3), (3, 2), (1, 3), (3, 1)])
         soln = sorted(solution + [(n, n) for n in G])
-        assert_edges_equal(sorted(nx.transitive_closure(G).edges()), soln)
-        assert_edges_equal(sorted(nx.transitive_closure(G, False).edges()), soln)
-        assert_edges_equal(sorted(nx.transitive_closure(G, None).edges()), solution)
-        assert_edges_equal(sorted(nx.transitive_closure(G, True).edges()), soln)
+        assert edges_equal(sorted(nx.transitive_closure(G).edges()), soln)
+        assert edges_equal(sorted(nx.transitive_closure(G, False).edges()), soln)
+        assert edges_equal(sorted(nx.transitive_closure(G, None).edges()), solution)
+        assert edges_equal(sorted(nx.transitive_closure(G, True).edges()), soln)
 
     def test_transitive_closure_dag(self):
         G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
         transitive_closure = nx.algorithms.dag.transitive_closure_dag
         solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
-        assert_edges_equal(transitive_closure(G).edges(), solution)
+        assert edges_equal(transitive_closure(G).edges(), solution)
         G = nx.DiGraph([(1, 2), (2, 3), (2, 4)])
         solution = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)]
-        assert_edges_equal(transitive_closure(G).edges(), solution)
+        assert edges_equal(transitive_closure(G).edges(), solution)
         G = nx.Graph([(1, 2), (2, 3), (3, 4)])
         pytest.raises(nx.NetworkXNotImplemented, transitive_closure, G)
 
@@ -358,11 +358,11 @@ class TestDAG:
         G = nx.DiGraph([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)])
         transitive_reduction = nx.algorithms.dag.transitive_reduction
         solution = [(1, 2), (2, 3), (3, 4)]
-        assert_edges_equal(transitive_reduction(G).edges(), solution)
+        assert edges_equal(transitive_reduction(G).edges(), solution)
         G = nx.DiGraph([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)])
         transitive_reduction = nx.algorithms.dag.transitive_reduction
         solution = [(1, 2), (2, 3), (2, 4)]
-        assert_edges_equal(transitive_reduction(G).edges(), solution)
+        assert edges_equal(transitive_reduction(G).edges(), solution)
         G = nx.Graph([(1, 2), (2, 3), (3, 4)])
         pytest.raises(nx.NetworkXNotImplemented, transitive_reduction, G)
 

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -13,7 +13,7 @@ def _test_func(G, ebunch, expected, predict_func, **kwargs):
 
     assert len(exp_dict) == len(res_dict)
     for p in exp_dict:
-        assert nx.testing.almost_equal(exp_dict[p], res_dict[p], places=7)
+        assert exp_dict[p] == pytest.approx(res_dict[p], abs=1e-7)
 
 
 class TestResourceAllocationIndex:

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -4,7 +4,7 @@ import math
 
 import networkx as nx
 from networkx.algorithms.matching import matching_dict_to_set
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 class TestMaxWeightMatching:
@@ -30,10 +30,10 @@ class TestMaxWeightMatching:
         """Single edge"""
         G = nx.Graph()
         G.add_edge(0, 1)
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G), matching_dict_to_set({0: 1, 1: 0})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({0: 1, 1: 0})
         )
 
@@ -42,11 +42,11 @@ class TestMaxWeightMatching:
         G = nx.Graph()
         G.add_edge("one", "two", weight=10)
         G.add_edge("two", "three", weight=11)
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G),
             matching_dict_to_set({"three": "two", "two": "three"}),
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G),
             matching_dict_to_set({"one": "two", "two": "one"}),
         )
@@ -57,16 +57,16 @@ class TestMaxWeightMatching:
         G.add_edge(1, 2, weight=5)
         G.add_edge(2, 3, weight=11)
         G.add_edge(3, 4, weight=5)
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G), matching_dict_to_set({2: 3, 3: 2})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G, 1), matching_dict_to_set({1: 2, 2: 1, 3: 4, 4: 3})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 2, 3: 4})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G, 1), matching_dict_to_set({1: 2, 3: 4})
         )
 
@@ -75,11 +75,11 @@ class TestMaxWeightMatching:
         G = nx.Graph()
         G.add_edge("one", "two", weight=10, abcd=11)
         G.add_edge("two", "three", weight=11, abcd=10)
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G, weight="abcd"),
             matching_dict_to_set({"one": "two", "two": "one"}),
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G, weight="abcd"),
             matching_dict_to_set({"three": "two"}),
         )
@@ -91,10 +91,10 @@ class TestMaxWeightMatching:
         G.add_edge(2, 3, weight=math.exp(1))
         G.add_edge(1, 3, weight=3.0)
         G.add_edge(1, 4, weight=math.sqrt(2.0))
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G), matching_dict_to_set({1: 4, 2: 3, 3: 2, 4: 1})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 4, 2: 3, 3: 2, 4: 1})
         )
 
@@ -106,16 +106,16 @@ class TestMaxWeightMatching:
         G.add_edge(2, 3, weight=1)
         G.add_edge(2, 4, weight=-1)
         G.add_edge(3, 4, weight=-6)
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G), matching_dict_to_set({1: 2, 2: 1})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.max_weight_matching(G, 1), matching_dict_to_set({1: 3, 2: 4, 3: 1, 4: 2})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 2, 3: 4})
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.min_weight_matching(G, 1), matching_dict_to_set({1: 2, 3: 4})
         )
 
@@ -124,13 +124,13 @@ class TestMaxWeightMatching:
         G = nx.Graph()
         G.add_weighted_edges_from([(1, 2, 8), (1, 3, 9), (2, 3, 10), (3, 4, 7)])
         answer = matching_dict_to_set({1: 2, 2: 1, 3: 4, 4: 3})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
         G.add_weighted_edges_from([(1, 6, 5), (4, 5, 6)])
         answer = matching_dict_to_set({1: 6, 2: 3, 3: 2, 4: 5, 5: 4, 6: 1})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_s_t_blossom(self):
         """Create S-blossom, relabel as T-blossom, use for augmentation:"""
@@ -139,19 +139,19 @@ class TestMaxWeightMatching:
             [(1, 2, 9), (1, 3, 8), (2, 3, 10), (1, 4, 5), (4, 5, 4), (1, 6, 3)]
         )
         answer = matching_dict_to_set({1: 6, 2: 3, 3: 2, 4: 5, 5: 4, 6: 1})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
         G.add_edge(4, 5, weight=3)
         G.add_edge(1, 6, weight=4)
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
         G.remove_edge(1, 6)
         G.add_edge(3, 6, weight=4)
         answer = matching_dict_to_set({1: 2, 2: 1, 3: 6, 4: 5, 5: 4, 6: 3})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nested_s_blossom(self):
         """Create nested S-blossom, use for augmentation:"""
@@ -192,8 +192,8 @@ class TestMaxWeightMatching:
             ]
         )
         answer = matching_dict_to_set({1: 2, 2: 1, 3: 4, 4: 3, 5: 6, 6: 5, 7: 8, 8: 7})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nested_s_blossom_expand(self):
         """Create nested S-blossom, augment, expand recursively:"""
@@ -213,8 +213,8 @@ class TestMaxWeightMatching:
             ]
         )
         answer = matching_dict_to_set({1: 2, 2: 1, 3: 5, 4: 6, 5: 3, 6: 4, 7: 8, 8: 7})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_s_blossom_relabel_expand(self):
         """Create S-blossom, relabel as T, expand:"""
@@ -232,8 +232,8 @@ class TestMaxWeightMatching:
             ]
         )
         answer = matching_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nested_s_blossom_relabel_expand(self):
         """Create nested S-blossom, relabel as T, expand:"""
@@ -252,8 +252,8 @@ class TestMaxWeightMatching:
             ]
         )
         answer = matching_dict_to_set({1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1})
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nasty_blossom1(self):
         """Create blossom, relabel as T in more than one way, expand,
@@ -276,8 +276,8 @@ class TestMaxWeightMatching:
         )
         ansdict = {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
         answer = matching_dict_to_set(ansdict)
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nasty_blossom2(self):
         """Again but slightly different:"""
@@ -298,8 +298,8 @@ class TestMaxWeightMatching:
         )
         ans = {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
         answer = matching_dict_to_set(ans)
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nasty_blossom_least_slack(self):
         """Create blossom, relabel as T, expand such that a new
@@ -322,8 +322,8 @@ class TestMaxWeightMatching:
         )
         ans = {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
         answer = matching_dict_to_set(ans)
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nasty_blossom_augmenting(self):
         """Create nested blossom, relabel as T in more than one way"""
@@ -362,8 +362,8 @@ class TestMaxWeightMatching:
             12: 11,
         }
         answer = matching_dict_to_set(ans)
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_nasty_blossom_expand_recursively(self):
         """Create nested S-blossom, relabel as S, expand recursively:"""
@@ -385,8 +385,8 @@ class TestMaxWeightMatching:
         )
         ans = {1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8}
         answer = matching_dict_to_set(ans)
-        assert_edges_equal(nx.max_weight_matching(G), answer)
-        assert_edges_equal(nx.min_weight_matching(G), answer)
+        assert edges_equal(nx.max_weight_matching(G), answer)
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
     def test_wrong_graph_type(self):
         error = nx.NetworkXNotImplemented

--- a/networkx/algorithms/tree/tests/test_coding.py
+++ b/networkx/algorithms/tree/tests/test_coding.py
@@ -3,8 +3,8 @@ from itertools import product
 
 import pytest
 import networkx as nx
-from networkx.testing import assert_nodes_equal
-from networkx.testing import assert_edges_equal
+from networkx.utils import nodes_equal
+from networkx.utils import edges_equal
 
 
 class TestPruferSequence:
@@ -46,24 +46,24 @@ class TestPruferSequence:
         # Example from Wikipedia.
         sequence = [3, 3, 3, 4]
         tree = nx.from_prufer_sequence(sequence)
-        assert_nodes_equal(list(tree), list(range(6)))
+        assert nodes_equal(list(tree), list(range(6)))
         edges = [(0, 3), (1, 3), (2, 3), (3, 4), (4, 5)]
-        assert_edges_equal(list(tree.edges()), edges)
+        assert edges_equal(list(tree.edges()), edges)
 
     def test_decoding2(self):
         # Example from "An Optimal Algorithm for Prufer Codes".
         sequence = [2, 4, 0, 1, 3, 3]
         tree = nx.from_prufer_sequence(sequence)
-        assert_nodes_equal(list(tree), list(range(8)))
+        assert nodes_equal(list(tree), list(range(8)))
         edges = [(0, 1), (0, 4), (1, 3), (2, 4), (2, 5), (3, 6), (3, 7)]
-        assert_edges_equal(list(tree.edges()), edges)
+        assert edges_equal(list(tree.edges()), edges)
 
     def test_inverse(self):
         """Tests that the encoding and decoding functions are inverses."""
         for T in nx.nonisomorphic_trees(4):
             T2 = nx.from_prufer_sequence(nx.to_prufer_sequence(T))
-            assert_nodes_equal(list(T), list(T2))
-            assert_edges_equal(list(T.edges()), list(T2.edges()))
+            assert nodes_equal(list(T), list(T2))
+            assert edges_equal(list(T.edges()), list(T2.edges()))
 
         for seq in product(range(4), repeat=2):
             seq2 = nx.to_prufer_sequence(nx.from_prufer_sequence(seq))
@@ -87,7 +87,7 @@ class TestNestedTuple:
         T = nx.full_rary_tree(2, 2 ** 3 - 1)
         expected = (((), ()), ((), ()))
         actual = nx.to_nested_tuple(T, 0)
-        assert_nodes_equal(expected, actual)
+        assert nodes_equal(expected, actual)
 
     def test_canonical_form(self):
         T = nx.Graph()
@@ -109,5 +109,5 @@ class TestNestedTuple:
         balanced = (((), ()), ((), ()))
         T = nx.from_nested_tuple(balanced, sensible_relabeling=True)
         edges = [(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)]
-        assert_nodes_equal(list(T), list(range(2 ** 3 - 1)))
-        assert_edges_equal(list(T.edges()), edges)
+        assert nodes_equal(list(T), list(range(2 ** 3 - 1)))
+        assert edges_equal(list(T.edges()), edges)

--- a/networkx/algorithms/tree/tests/test_coding.py
+++ b/networkx/algorithms/tree/tests/test_coding.py
@@ -3,8 +3,7 @@ from itertools import product
 
 import pytest
 import networkx as nx
-from networkx.utils import nodes_equal
-from networkx.utils import edges_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestPruferSequence:

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -3,7 +3,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_nodes_equal, assert_edges_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 def test_unknown_algorithm():
@@ -69,14 +69,14 @@ class MinimumSpanningTreeTestBase:
         # Edges from the spanning edges functions don't come in sorted
         # orientation, so we need to sort each edge individually.
         actual = sorted((min(u, v), max(u, v), d) for u, v, d in edges)
-        assert_edges_equal(actual, self.minimum_spanning_edgelist)
+        assert edges_equal(actual, self.minimum_spanning_edgelist)
 
     def test_maximum_edges(self):
         edges = nx.maximum_spanning_edges(self.G, algorithm=self.algo)
         # Edges from the spanning edges functions don't come in sorted
         # orientation, so we need to sort each edge individually.
         actual = sorted((min(u, v), max(u, v), d) for u, v, d in edges)
-        assert_edges_equal(actual, self.maximum_spanning_edgelist)
+        assert edges_equal(actual, self.maximum_spanning_edgelist)
 
     def test_without_data(self):
         edges = nx.minimum_spanning_edges(self.G, algorithm=self.algo, data=False)
@@ -84,7 +84,7 @@ class MinimumSpanningTreeTestBase:
         # orientation, so we need to sort each edge individually.
         actual = sorted((min(u, v), max(u, v)) for u, v in edges)
         expected = [(u, v) for u, v, d in self.minimum_spanning_edgelist]
-        assert_edges_equal(actual, expected)
+        assert edges_equal(actual, expected)
 
     def test_nan_weights(self):
         # Edge weights NaN never appear in the spanning tree. see #2164
@@ -95,7 +95,7 @@ class MinimumSpanningTreeTestBase:
         )
         actual = sorted((min(u, v), max(u, v)) for u, v in edges)
         expected = [(u, v) for u, v, d in self.minimum_spanning_edgelist]
-        assert_edges_equal(actual, expected)
+        assert edges_equal(actual, expected)
         # Now test for raising exception
         edges = nx.minimum_spanning_edges(
             G, algorithm=self.algo, data=False, ignore_nan=False
@@ -130,7 +130,7 @@ class MinimumSpanningTreeTestBase:
         )
         actual = sorted((min(u, v), max(u, v)) for u, v in edges)
         shift = [(u + 1, v + 1) for u, v, d in self.minimum_spanning_edgelist]
-        assert_edges_equal(actual, shift)
+        assert edges_equal(actual, shift)
 
     def test_isolated_node(self):
         # now try again with an isolated node
@@ -155,28 +155,28 @@ class MinimumSpanningTreeTestBase:
         )
         actual = sorted((min(u, v), max(u, v)) for u, v in edges)
         shift = [(u + 1, v + 1) for u, v, d in self.minimum_spanning_edgelist]
-        assert_edges_equal(actual, shift)
+        assert edges_equal(actual, shift)
 
     def test_minimum_tree(self):
         T = nx.minimum_spanning_tree(self.G, algorithm=self.algo)
         actual = sorted(T.edges(data=True))
-        assert_edges_equal(actual, self.minimum_spanning_edgelist)
+        assert edges_equal(actual, self.minimum_spanning_edgelist)
 
     def test_maximum_tree(self):
         T = nx.maximum_spanning_tree(self.G, algorithm=self.algo)
         actual = sorted(T.edges(data=True))
-        assert_edges_equal(actual, self.maximum_spanning_edgelist)
+        assert edges_equal(actual, self.maximum_spanning_edgelist)
 
     def test_disconnected(self):
         G = nx.Graph([(0, 1, dict(weight=1)), (2, 3, dict(weight=2))])
         T = nx.minimum_spanning_tree(G, algorithm=self.algo)
-        assert_nodes_equal(list(T), list(range(4)))
-        assert_edges_equal(list(T.edges()), [(0, 1), (2, 3)])
+        assert nodes_equal(list(T), list(range(4)))
+        assert edges_equal(list(T.edges()), [(0, 1), (2, 3)])
 
     def test_empty_graph(self):
         G = nx.empty_graph(3)
         T = nx.minimum_spanning_tree(G, algorithm=self.algo)
-        assert_nodes_equal(sorted(T), list(range(3)))
+        assert nodes_equal(sorted(T), list(range(3)))
         assert T.number_of_edges() == 0
 
     def test_attributes(self):
@@ -187,7 +187,7 @@ class MinimumSpanningTreeTestBase:
         G.graph["foo"] = "bar"
         T = nx.minimum_spanning_tree(G, algorithm=self.algo)
         assert T.graph == G.graph
-        assert_nodes_equal(T, G)
+        assert nodes_equal(T, G)
         for u, v in T.edges():
             assert T.adj[u][v] == G.adj[u][v]
 
@@ -198,11 +198,11 @@ class MinimumSpanningTreeTestBase:
         G.add_edge(1, 2, weight=1, distance=1)
         G.add_node(3)
         T = nx.minimum_spanning_tree(G, algorithm=self.algo, weight="distance")
-        assert_nodes_equal(sorted(T), list(range(4)))
-        assert_edges_equal(sorted(T.edges()), [(0, 2), (1, 2)])
+        assert nodes_equal(sorted(T), list(range(4)))
+        assert edges_equal(sorted(T.edges()), [(0, 2), (1, 2)])
         T = nx.maximum_spanning_tree(G, algorithm=self.algo, weight="distance")
-        assert_nodes_equal(sorted(T), list(range(4)))
-        assert_edges_equal(sorted(T.edges()), [(0, 1), (0, 2)])
+        assert nodes_equal(sorted(T), list(range(4)))
+        assert edges_equal(sorted(T.edges()), [(0, 1), (0, 2)])
 
 
 class TestBoruvka(MinimumSpanningTreeTestBase):
@@ -222,7 +222,7 @@ class TestBoruvka(MinimumSpanningTreeTestBase):
         # Edges from the spanning edges functions don't come in sorted
         # orientation, so we need to sort each edge individually.
         actual = sorted((min(u, v), max(u, v), d) for u, v, d in edges)
-        assert_edges_equal(actual, self.minimum_spanning_edgelist)
+        assert edges_equal(actual, self.minimum_spanning_edgelist)
 
 
 class MultigraphMSTTestBase(MinimumSpanningTreeTestBase):
@@ -238,7 +238,7 @@ class MultigraphMSTTestBase(MinimumSpanningTreeTestBase):
         G.add_edge(0, 1, key="b", weight=1)
         min_edges = nx.minimum_spanning_edges
         mst_edges = min_edges(G, algorithm=self.algo, data=False)
-        assert_edges_equal([(0, 1, "b")], list(mst_edges))
+        assert edges_equal([(0, 1, "b")], list(mst_edges))
 
     def test_multigraph_keys_max(self):
         """Tests that the maximum spanning edges of a multigraph
@@ -250,7 +250,7 @@ class MultigraphMSTTestBase(MinimumSpanningTreeTestBase):
         G.add_edge(0, 1, key="b", weight=1)
         max_edges = nx.maximum_spanning_edges
         mst_edges = max_edges(G, algorithm=self.algo, data=False)
-        assert_edges_equal([(0, 1, "a")], list(mst_edges))
+        assert edges_equal([(0, 1, "a")], list(mst_edges))
 
 
 class TestKruskal(MultigraphMSTTestBase):
@@ -275,11 +275,11 @@ class TestPrim(MultigraphMSTTestBase):
         G.add_edge(0, 1, key="a", weight=2)
         G.add_edge(0, 1, key="b", weight=1)
         T = nx.minimum_spanning_tree(G)
-        assert_edges_equal([(0, 1, 1)], list(T.edges(data="weight")))
+        assert edges_equal([(0, 1, 1)], list(T.edges(data="weight")))
 
     def test_multigraph_keys_tree_max(self):
         G = nx.MultiGraph()
         G.add_edge(0, 1, key="a", weight=2)
         G.add_edge(0, 1, key="b", weight=1)
         T = nx.maximum_spanning_tree(G)
-        assert_edges_equal([(0, 1, 2)], list(T.edges(data="weight")))
+        assert edges_equal([(0, 1, 2)], list(T.edges(data="weight")))

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -3,8 +3,7 @@
 """
 
 import networkx as nx
-from networkx.utils import nodes_equal
-from networkx.utils import edges_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestJoin:

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -3,8 +3,8 @@
 """
 
 import networkx as nx
-from networkx.testing import assert_nodes_equal
-from networkx.testing import assert_edges_equal
+from networkx.utils import nodes_equal
+from networkx.utils import edges_equal
 
 
 class TestJoin:
@@ -27,8 +27,8 @@ class TestJoin:
         T = nx.empty_graph(1)
         actual = nx.join([(T, 0)])
         expected = nx.path_graph(2)
-        assert_nodes_equal(list(expected), list(actual))
-        assert_edges_equal(list(expected.edges()), list(actual.edges()))
+        assert nodes_equal(list(expected), list(actual))
+        assert edges_equal(list(expected.edges()), list(actual.edges()))
 
     def test_basic(self):
         """Tests for joining multiple subtrees at a root node."""

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -2,7 +2,7 @@
 import pytest
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
-from networkx.testing import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class HistoricalTests:
@@ -258,22 +258,22 @@ class HistoricalTests:
         else:
             elist = [("A", "B"), ("A", "C"), ("B", "C"), ("B", "D")]
         # nbunch can be a list
-        assert_edges_equal(list(G.edges(["A", "B"])), elist)
+        assert edges_equal(list(G.edges(["A", "B"])), elist)
         # nbunch can be a set
-        assert_edges_equal(G.edges({"A", "B"}), elist)
+        assert edges_equal(G.edges({"A", "B"}), elist)
         # nbunch can be a graph
         G1 = self.G()
         G1.add_nodes_from("AB")
-        assert_edges_equal(G.edges(G1), elist)
+        assert edges_equal(G.edges(G1), elist)
         # nbunch can be a dict with nodes as keys
         ndict = {"A": "thing1", "B": "thing2"}
-        assert_edges_equal(G.edges(ndict), elist)
+        assert edges_equal(G.edges(ndict), elist)
         # nbunch can be a single node
-        assert_edges_equal(list(G.edges("A")), [("A", "B"), ("A", "C")])
-        assert_nodes_equal(sorted(G), ["A", "B", "C", "D"])
+        assert edges_equal(list(G.edges("A")), [("A", "B"), ("A", "C")])
+        assert nodes_equal(sorted(G), ["A", "B", "C", "D"])
 
         # nbunch can be nothing (whole graph)
-        assert_edges_equal(
+        assert edges_equal(
             list(G.edges()),
             [("A", "B"), ("A", "C"), ("B", "D"), ("C", "B"), ("C", "D")],
         )
@@ -330,8 +330,8 @@ class HistoricalTests:
         G = self.G()
         G.add_edges_from([("A", "B"), ("A", "C"), ("B", "D"), ("C", "B"), ("C", "D")])
         SG = G.subgraph(["A", "B", "D"])
-        assert_nodes_equal(list(SG), ["A", "B", "D"])
-        assert_edges_equal(list(SG.edges()), [("A", "B"), ("B", "D")])
+        assert nodes_equal(list(SG), ["A", "B", "D"])
+        assert edges_equal(list(SG.edges()), [("A", "B"), ("B", "D")])
 
     def test_to_directed(self):
         G = self.G()
@@ -400,7 +400,7 @@ class HistoricalTests:
         G.add_edges_from([("A", "B"), ("A", "C"), ("B", "D"), ("C", "B"), ("C", "D")])
         G.add_nodes_from("GJK")
         assert sorted(G.nodes()) == ["A", "B", "C", "D", "G", "J", "K"]
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(), [("A", "B"), ("A", "C"), ("B", "D"), ("C", "B"), ("C", "D")]
         )
 

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -1,7 +1,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_nodes_equal
+from networkx.utils import nodes_equal
 from .test_graph import BaseGraphTester, BaseAttrGraphTester
 from .test_graph import TestGraph as _TestGraph
 from .test_graph import TestEdgeSubgraph as _TestGraphEdgeSubgraph
@@ -128,7 +128,7 @@ class BaseDiGraphTester(BaseGraphTester):
         y = Foo()
         G = nx.DiGraph()
         G.add_edge(x, y)
-        assert_nodes_equal(G.nodes(), G.reverse().nodes())
+        assert nodes_equal(G.nodes(), G.reverse().nodes())
         assert [(y, x)] == list(G.reverse().edges())
 
 

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -1,7 +1,7 @@
 import random
 import pytest
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestFunction:
@@ -17,13 +17,13 @@ class TestFunction:
         self.DGedges = [(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2)]
 
     def test_nodes(self):
-        assert_nodes_equal(self.G.nodes(), list(nx.nodes(self.G)))
-        assert_nodes_equal(self.DG.nodes(), list(nx.nodes(self.DG)))
+        assert nodes_equal(self.G.nodes(), list(nx.nodes(self.G)))
+        assert nodes_equal(self.DG.nodes(), list(nx.nodes(self.DG)))
 
     def test_edges(self):
-        assert_edges_equal(self.G.edges(), list(nx.edges(self.G)))
+        assert edges_equal(self.G.edges(), list(nx.edges(self.G)))
         assert sorted(self.DG.edges()) == sorted(nx.edges(self.DG))
-        assert_edges_equal(
+        assert edges_equal(
             self.G.edges(nbunch=[0, 1, 3]), list(nx.edges(self.G, nbunch=[0, 1, 3]))
         )
         assert sorted(self.DG.edges(nbunch=[0, 1, 3])) == sorted(
@@ -31,15 +31,15 @@ class TestFunction:
         )
 
     def test_degree(self):
-        assert_edges_equal(self.G.degree(), list(nx.degree(self.G)))
+        assert edges_equal(self.G.degree(), list(nx.degree(self.G)))
         assert sorted(self.DG.degree()) == sorted(nx.degree(self.DG))
-        assert_edges_equal(
+        assert edges_equal(
             self.G.degree(nbunch=[0, 1]), list(nx.degree(self.G, nbunch=[0, 1]))
         )
         assert sorted(self.DG.degree(nbunch=[0, 1])) == sorted(
             nx.degree(self.DG, nbunch=[0, 1])
         )
-        assert_edges_equal(
+        assert edges_equal(
             self.G.degree(weight="weight"), list(nx.degree(self.G, weight="weight"))
         )
         assert sorted(self.DG.degree(weight="weight")) == sorted(
@@ -66,11 +66,11 @@ class TestFunction:
         G = self.G.copy()
         nlist = [12, 13, 14, 15]
         nx.add_star(G, nlist)
-        assert_edges_equal(G.edges(nlist), [(12, 13), (12, 14), (12, 15)])
+        assert edges_equal(G.edges(nlist), [(12, 13), (12, 14), (12, 15)])
 
         G = self.G.copy()
         nx.add_star(G, nlist, weight=2.0)
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(nlist, data=True),
             [
                 (12, 13, {"weight": 2.0}),
@@ -82,22 +82,22 @@ class TestFunction:
         G = self.G.copy()
         nlist = [12]
         nx.add_star(G, nlist)
-        assert_nodes_equal(G, list(self.G) + nlist)
+        assert nodes_equal(G, list(self.G) + nlist)
 
         G = self.G.copy()
         nlist = []
         nx.add_star(G, nlist)
-        assert_nodes_equal(G.nodes, self.Gnodes)
-        assert_edges_equal(G.edges, self.G.edges)
+        assert nodes_equal(G.nodes, self.Gnodes)
+        assert edges_equal(G.edges, self.G.edges)
 
     def test_add_path(self):
         G = self.G.copy()
         nlist = [12, 13, 14, 15]
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges(nlist), [(12, 13), (13, 14), (14, 15)])
+        assert edges_equal(G.edges(nlist), [(12, 13), (13, 14), (14, 15)])
         G = self.G.copy()
         nx.add_path(G, nlist, weight=2.0)
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(nlist, data=True),
             [
                 (12, 13, {"weight": 2.0}),
@@ -109,38 +109,38 @@ class TestFunction:
         G = self.G.copy()
         nlist = [None]
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges(nlist), [])
-        assert_nodes_equal(G, list(self.G) + [None])
+        assert edges_equal(G.edges(nlist), [])
+        assert nodes_equal(G, list(self.G) + [None])
 
         G = self.G.copy()
         nlist = iter([None])
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges([None]), [])
-        assert_nodes_equal(G, list(self.G) + [None])
+        assert edges_equal(G.edges([None]), [])
+        assert nodes_equal(G, list(self.G) + [None])
 
         G = self.G.copy()
         nlist = [12]
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges(nlist), [])
-        assert_nodes_equal(G, list(self.G) + [12])
+        assert edges_equal(G.edges(nlist), [])
+        assert nodes_equal(G, list(self.G) + [12])
 
         G = self.G.copy()
         nlist = iter([12])
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges([12]), [])
-        assert_nodes_equal(G, list(self.G) + [12])
+        assert edges_equal(G.edges([12]), [])
+        assert nodes_equal(G, list(self.G) + [12])
 
         G = self.G.copy()
         nlist = []
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges, self.G.edges)
-        assert_nodes_equal(G, list(self.G))
+        assert edges_equal(G.edges, self.G.edges)
+        assert nodes_equal(G, list(self.G))
 
         G = self.G.copy()
         nlist = iter([])
         nx.add_path(G, nlist)
-        assert_edges_equal(G.edges, self.G.edges)
-        assert_nodes_equal(G, list(self.G))
+        assert edges_equal(G.edges, self.G.edges)
+        assert nodes_equal(G, list(self.G))
 
     def test_add_cycle(self):
         G = self.G.copy()
@@ -172,13 +172,13 @@ class TestFunction:
         G = self.G.copy()
         nlist = [12]
         nx.add_cycle(G, nlist)
-        assert_nodes_equal(G, list(self.G) + nlist)
+        assert nodes_equal(G, list(self.G) + nlist)
 
         G = self.G.copy()
         nlist = []
         nx.add_cycle(G, nlist)
-        assert_nodes_equal(G.nodes, self.Gnodes)
-        assert_edges_equal(G.edges, self.G.edges)
+        assert nodes_equal(G.nodes, self.Gnodes)
+        assert edges_equal(G.edges, self.G.edges)
 
     def test_subgraph(self):
         assert (
@@ -212,12 +212,12 @@ class TestFunction:
 
     def test_create_empty_copy(self):
         G = nx.create_empty_copy(self.G, with_data=False)
-        assert_nodes_equal(G, list(self.G))
+        assert nodes_equal(G, list(self.G))
         assert G.graph == {}
         assert G._node == {}.fromkeys(self.G.nodes(), {})
         assert G._adj == {}.fromkeys(self.G.nodes(), {})
         G = nx.create_empty_copy(self.G)
-        assert_nodes_equal(G, list(self.G))
+        assert nodes_equal(G, list(self.G))
         assert G.graph == self.G.graph
         assert G._node == self.G._node
         assert G._adj == {}.fromkeys(self.G.nodes(), {})
@@ -684,9 +684,9 @@ def test_is_empty():
 def test_selfloops(graph_type):
     G = nx.complete_graph(3, create_using=graph_type)
     G.add_edge(0, 0)
-    assert_nodes_equal(nx.nodes_with_selfloops(G), [0])
-    assert_edges_equal(nx.selfloop_edges(G), [(0, 0)])
-    assert_edges_equal(nx.selfloop_edges(G, data=True), [(0, 0, {})])
+    assert nodes_equal(nx.nodes_with_selfloops(G), [0])
+    assert edges_equal(nx.selfloop_edges(G), [(0, 0)])
+    assert edges_equal(nx.selfloop_edges(G, data=True), [(0, 0, {})])
     assert nx.number_of_selfloops(G) == 1
 
 
@@ -697,17 +697,17 @@ def test_selfloop_edges_attr(graph_type):
     G = nx.complete_graph(3, create_using=graph_type)
     G.add_edge(0, 0)
     G.add_edge(1, 1, weight=2)
-    assert_edges_equal(
+    assert edges_equal(
         nx.selfloop_edges(G, data=True), [(0, 0, {}), (1, 1, {"weight": 2})]
     )
-    assert_edges_equal(nx.selfloop_edges(G, data="weight"), [(0, 0, None), (1, 1, 2)])
+    assert edges_equal(nx.selfloop_edges(G, data="weight"), [(0, 0, None), (1, 1, 2)])
 
 
 def test_selfloop_edges_multi_with_data_and_keys():
     G = nx.complete_graph(3, create_using=nx.MultiGraph)
     G.add_edge(0, 0, weight=10)
     G.add_edge(0, 0, weight=100)
-    assert_edges_equal(
+    assert edges_equal(
         nx.selfloop_edges(G, data="weight", keys=True),
         [(0, 0, 0, 10), (0, 0, 1, 100)],
     )

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -1,15 +1,10 @@
 import pickle
 import gc
 import platform
+import pytest
 
 import networkx as nx
-from networkx.testing.utils import (
-    assert_graphs_equal,
-    assert_edges_equal,
-    assert_nodes_equal,
-)
-
-import pytest
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 
 class BaseGraphTester:
@@ -82,9 +77,9 @@ class BaseGraphTester:
 
     def test_edges(self):
         G = self.K3
-        assert_edges_equal(G.edges(), [(0, 1), (0, 2), (1, 2)])
-        assert_edges_equal(G.edges(0), [(0, 1), (0, 2)])
-        assert_edges_equal(G.edges([0, 1]), [(0, 1), (0, 2), (1, 2)])
+        assert edges_equal(G.edges(), [(0, 1), (0, 2), (1, 2)])
+        assert edges_equal(G.edges(0), [(0, 1), (0, 2)])
+        assert edges_equal(G.edges([0, 1]), [(0, 1), (0, 2), (1, 2)])
         with pytest.raises(nx.NetworkXError):
             G.edges(-1)
 
@@ -103,13 +98,13 @@ class BaseGraphTester:
 
     def test_nbunch_iter(self):
         G = self.K3
-        assert_nodes_equal(G.nbunch_iter(), self.k3nodes)  # all nodes
-        assert_nodes_equal(G.nbunch_iter(0), [0])  # single node
-        assert_nodes_equal(G.nbunch_iter([0, 1]), [0, 1])  # sequence
+        assert nodes_equal(G.nbunch_iter(), self.k3nodes)  # all nodes
+        assert nodes_equal(G.nbunch_iter(0), [0])  # single node
+        assert nodes_equal(G.nbunch_iter([0, 1]), [0, 1])  # sequence
         # sequence with none in graph
-        assert_nodes_equal(G.nbunch_iter([-1]), [])
+        assert nodes_equal(G.nbunch_iter([-1]), [])
         # string sequence with none in graph
-        assert_nodes_equal(G.nbunch_iter("foo"), [])
+        assert nodes_equal(G.nbunch_iter("foo"), [])
         # node not in graph doesn't get caught upon creation of iterator
         bunch = G.nbunch_iter(-1)
         # but gets caught when iterator used
@@ -146,8 +141,8 @@ class BaseGraphTester:
     def test_selfloops(self):
         G = self.K3.copy()
         G.add_edge(0, 0)
-        assert_nodes_equal(nx.nodes_with_selfloops(G), [0])
-        assert_edges_equal(nx.selfloop_edges(G), [(0, 0)])
+        assert nodes_equal(nx.nodes_with_selfloops(G), [0])
+        assert edges_equal(nx.selfloop_edges(G), [(0, 0)])
         assert nx.number_of_selfloops(G) == 1
         G.remove_edge(0, 0)
         G.add_edge(0, 0)
@@ -169,12 +164,12 @@ class BaseAttrGraphTester(BaseGraphTester):
         assert sorted(d for n, d in G.degree(weight="weight")) == [2, 3, 5]
         assert dict(G.degree(weight="weight")) == {1: 2, 2: 5, 3: 3}
         assert G.degree(1, weight="weight") == 2
-        assert_nodes_equal((G.degree([1], weight="weight")), [(1, 2)])
+        assert nodes_equal((G.degree([1], weight="weight")), [(1, 2)])
 
-        assert_nodes_equal((d for n, d in G.degree(weight="other")), [3, 7, 4])
+        assert nodes_equal((d for n, d in G.degree(weight="other")), [3, 7, 4])
         assert dict(G.degree(weight="other")) == {1: 3, 2: 7, 3: 4}
         assert G.degree(1, weight="other") == 3
-        assert_edges_equal((G.degree([1], weight="other")), [(1, 3)])
+        assert edges_equal((G.degree([1], weight="other")), [(1, 3)])
 
     def add_attributes(self, G):
         G.graph["foo"] = []
@@ -354,12 +349,12 @@ class BaseAttrGraphTester(BaseGraphTester):
     def test_node_attr(self):
         G = self.K3.copy()
         G.add_node(1, foo="bar")
-        assert_nodes_equal(G.nodes(), [0, 1, 2])
-        assert_nodes_equal(G.nodes(data=True), [(0, {}), (1, {"foo": "bar"}), (2, {})])
+        assert nodes_equal(G.nodes(), [0, 1, 2])
+        assert nodes_equal(G.nodes(data=True), [(0, {}), (1, {"foo": "bar"}), (2, {})])
         G.nodes[1]["foo"] = "baz"
-        assert_nodes_equal(G.nodes(data=True), [(0, {}), (1, {"foo": "baz"}), (2, {})])
-        assert_nodes_equal(G.nodes(data="foo"), [(0, None), (1, "baz"), (2, None)])
-        assert_nodes_equal(
+        assert nodes_equal(G.nodes(data=True), [(0, {}), (1, {"foo": "baz"}), (2, {})])
+        assert nodes_equal(G.nodes(data="foo"), [(0, None), (1, "baz"), (2, None)])
+        assert nodes_equal(
             G.nodes(data="foo", default="bar"), [(0, "bar"), (1, "baz"), (2, "bar")]
         )
 
@@ -367,34 +362,34 @@ class BaseAttrGraphTester(BaseGraphTester):
         G = self.K3.copy()
         a = {"foo": "bar"}
         G.add_node(3, **a)
-        assert_nodes_equal(G.nodes(), [0, 1, 2, 3])
-        assert_nodes_equal(
+        assert nodes_equal(G.nodes(), [0, 1, 2, 3])
+        assert nodes_equal(
             G.nodes(data=True), [(0, {}), (1, {}), (2, {}), (3, {"foo": "bar"})]
         )
 
     def test_edge_lookup(self):
         G = self.Graph()
         G.add_edge(1, 2, foo="bar")
-        assert_edges_equal(G.edges[1, 2], {"foo": "bar"})
+        assert edges_equal(G.edges[1, 2], {"foo": "bar"})
 
     def test_edge_attr(self):
         G = self.Graph()
         G.add_edge(1, 2, foo="bar")
-        assert_edges_equal(G.edges(data=True), [(1, 2, {"foo": "bar"})])
-        assert_edges_equal(G.edges(data="foo"), [(1, 2, "bar")])
+        assert edges_equal(G.edges(data=True), [(1, 2, {"foo": "bar"})])
+        assert edges_equal(G.edges(data="foo"), [(1, 2, "bar")])
 
     def test_edge_attr2(self):
         G = self.Graph()
         G.add_edges_from([(1, 2), (3, 4)], foo="foo")
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"foo": "foo"}), (3, 4, {"foo": "foo"})]
         )
-        assert_edges_equal(G.edges(data="foo"), [(1, 2, "foo"), (3, 4, "foo")])
+        assert edges_equal(G.edges(data="foo"), [(1, 2, "foo"), (3, 4, "foo")])
 
     def test_edge_attr3(self):
         G = self.Graph()
         G.add_edges_from([(1, 2, {"weight": 32}), (3, 4, {"weight": 64})], foo="foo")
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True),
             [
                 (1, 2, {"foo": "foo", "weight": 32}),
@@ -404,27 +399,27 @@ class BaseAttrGraphTester(BaseGraphTester):
 
         G.remove_edges_from([(1, 2), (3, 4)])
         G.add_edge(1, 2, data=7, spam="bar", bar="foo")
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 7, "spam": "bar", "bar": "foo"})]
         )
 
     def test_edge_attr4(self):
         G = self.Graph()
         G.add_edge(1, 2, data=7, spam="bar", bar="foo")
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 7, "spam": "bar", "bar": "foo"})]
         )
         G[1][2]["data"] = 10  # OK to set data like this
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 10, "spam": "bar", "bar": "foo"})]
         )
 
         G.adj[1][2]["data"] = 20
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 20, "spam": "bar", "bar": "foo"})]
         )
         G.edges[1, 2]["data"] = 21  # another spelling, "edge"
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 21, "spam": "bar", "bar": "foo"})]
         )
         G.adj[1][2]["listdata"] = [20, 200]
@@ -436,7 +431,7 @@ class BaseAttrGraphTester(BaseGraphTester):
             "listdata": [20, 200],
             "weight": 20,
         }
-        assert_edges_equal(G.edges(data=True), [(1, 2, dd)])
+        assert edges_equal(G.edges(data=True), [(1, 2, dd)])
 
     def test_to_undirected(self):
         G = self.K3
@@ -474,10 +469,10 @@ class BaseAttrGraphTester(BaseGraphTester):
         G = self.K3.copy()
         G.add_edge(0, 0)
         G.add_edge(1, 1, weight=2)
-        assert_edges_equal(
+        assert edges_equal(
             nx.selfloop_edges(G, data=True), [(0, 0, {}), (1, 1, {"weight": 2})]
         )
-        assert_edges_equal(
+        assert edges_equal(
             nx.selfloop_edges(G, data="weight"), [(0, 0, None), (1, 1, 2)]
         )
 
@@ -657,9 +652,9 @@ class TestGraph(BaseAttrGraphTester):
     def test_edges_data(self):
         G = self.K3
         all_edges = [(0, 1, {}), (0, 2, {}), (1, 2, {})]
-        assert_edges_equal(G.edges(data=True), all_edges)
-        assert_edges_equal(G.edges(0, data=True), [(0, 1, {}), (0, 2, {})])
-        assert_edges_equal(G.edges([0, 1], data=True), all_edges)
+        assert edges_equal(G.edges(data=True), all_edges)
+        assert edges_equal(G.edges(0, data=True), [(0, 1, {}), (0, 2, {})])
+        assert edges_equal(G.edges([0, 1], data=True), all_edges)
         with pytest.raises(nx.NetworkXError):
             G.edges(-1, True)
 
@@ -723,9 +718,9 @@ class TestGraph(BaseAttrGraphTester):
         GG = G.copy()
         H = self.Graph()
         GG.update(H)
-        assert_graphs_equal(G, GG)
+        assert graphs_equal(G, GG)
         H.update(G)
-        assert_graphs_equal(H, G)
+        assert graphs_equal(H, G)
 
         # update nodes only
         H = self.Graph()

--- a/networkx/classes/tests/test_graphviews.py
+++ b/networkx/classes/tests/test_graphviews.py
@@ -1,7 +1,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 # Note: SubGraph views are not tested here. They have their own testing file
 
@@ -111,8 +111,8 @@ class TestToDirected:
     def test_already_directed(self):
         dd = nx.to_directed(self.dv)
         Mdd = nx.to_directed(self.Mdv)
-        assert_edges_equal(dd.edges, self.dv.edges)
-        assert_edges_equal(Mdd.edges, self.Mdv.edges)
+        assert edges_equal(dd.edges, self.dv.edges)
+        assert edges_equal(Mdd.edges, self.Mdv.edges)
 
     def test_pickle(self):
         import pickle
@@ -150,8 +150,8 @@ class TestToUndirected:
     def test_already_directed(self):
         uu = nx.to_undirected(self.uv)
         Muu = nx.to_undirected(self.Muv)
-        assert_edges_equal(uu.edges, self.uv.edges)
-        assert_edges_equal(Muu.edges, self.Muv.edges)
+        assert edges_equal(uu.edges, self.uv.edges)
+        assert edges_equal(Muu.edges, self.Muv.edges)
 
     def test_pickle(self):
         import pickle
@@ -207,8 +207,8 @@ class TestChainsOfViews:
 
         for G in self.graphs:
             H = pickle.loads(pickle.dumps(G, -1))
-            assert_edges_equal(H.edges, G.edges)
-            assert_nodes_equal(H.nodes, G.nodes)
+            assert edges_equal(H.edges, G.edges)
+            assert nodes_equal(H.nodes, G.nodes)
 
     def test_subgraph_of_subgraph(self):
         SGv = nx.subgraph(self.G, range(3, 7))
@@ -239,19 +239,19 @@ class TestChainsOfViews:
         assert RG._graph is self.G
         assert SSG._graph is self.G
         assert SG._graph is RG
-        assert_edges_equal(SG.edges, SSG.edges)
+        assert edges_equal(SG.edges, SSG.edges)
         # should be same as morphing the graph
         CG = self.G.copy()
         CG.remove_nodes_from(hide_nodes)
         CG.remove_edges_from(hide_edges)
-        assert_edges_equal(CG.edges(nodes), SSG.edges)
+        assert edges_equal(CG.edges(nodes), SSG.edges)
         CG.remove_nodes_from([0, 1, 2, 3])
-        assert_edges_equal(CG.edges, SSG.edges)
+        assert edges_equal(CG.edges, SSG.edges)
         # switch order: subgraph first, then restricted view
         SSSG = self.G.subgraph(nodes)
         RSG = nx.restricted_view(SSSG, hide_nodes, hide_edges)
         assert RSG._graph is not self.G
-        assert_edges_equal(RSG.edges, CG.edges)
+        assert edges_equal(RSG.edges, CG.edges)
 
     def test_subgraph_copy(self):
         for origG in self.graphs:

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -1,5 +1,5 @@
 import pytest
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 import networkx as nx
 from .test_multigraph import BaseMultiGraphTester
 from .test_multigraph import TestMultiGraph as _TestMultiGraph
@@ -156,9 +156,9 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         # the result is traversal order dependent so we
         # can't use the is_shallow() test here.
         try:
-            assert_edges_equal(H.edges(), [(0, 1), (1, 2), (2, 0)])
+            assert edges_equal(H.edges(), [(0, 1), (1, 2), (2, 0)])
         except AssertionError:
-            assert_edges_equal(H.edges(), [(0, 1), (1, 2), (1, 2), (2, 0)])
+            assert edges_equal(H.edges(), [(0, 1), (1, 2), (1, 2), (2, 0)])
         H = G.to_undirected()
         self.is_deep(H, G)
 

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -1,7 +1,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal
+from networkx.utils import edges_equal
 
 from .test_graph import BaseAttrGraphTester
 from .test_graph import TestGraph as _TestGraph
@@ -119,31 +119,31 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
         G = self.Graph()
         G.add_edge(1, 2, foo="bar")
         G.add_edge(1, 2, "key", foo="biz")
-        assert_edges_equal(G.edges[1, 2, 0], {"foo": "bar"})
-        assert_edges_equal(G.edges[1, 2, "key"], {"foo": "biz"})
+        assert edges_equal(G.edges[1, 2, 0], {"foo": "bar"})
+        assert edges_equal(G.edges[1, 2, "key"], {"foo": "biz"})
 
     def test_edge_attr4(self):
         G = self.Graph()
         G.add_edge(1, 2, key=0, data=7, spam="bar", bar="foo")
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 7, "spam": "bar", "bar": "foo"})]
         )
         G[1][2][0]["data"] = 10  # OK to set data like this
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 10, "spam": "bar", "bar": "foo"})]
         )
 
         G.adj[1][2][0]["data"] = 20
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 20, "spam": "bar", "bar": "foo"})]
         )
         G.edges[1, 2, 0]["data"] = 21  # another spelling, "edge"
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True), [(1, 2, {"data": 21, "spam": "bar", "bar": "foo"})]
         )
         G.adj[1][2][0]["listdata"] = [20, 200]
         G.adj[1][2][0]["weight"] = 20
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(data=True),
             [
                 (

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -139,6 +139,24 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="`almost_equal`"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="`assert_nodes_equal`"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="`assert_edges_equal`"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="`assert_graphs_equal`"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="networkx.hits_scipy"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="networkx.hits_numpy"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="preserve_random_state"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -6,7 +6,7 @@ import pytest
 pygraphviz = pytest.importorskip("pygraphviz")
 
 
-from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 import networkx as nx
 
@@ -20,8 +20,8 @@ class TestAGraph:
         return G
 
     def assert_equal(self, G1, G2):
-        assert_nodes_equal(G1.nodes(), G2.nodes())
-        assert_edges_equal(G1.edges(), G2.edges())
+        assert nodes_equal(G1.nodes(), G2.nodes())
+        assert edges_equal(G1.edges(), G2.edges())
         assert G1.graph["metal"] == G2.graph["metal"]
 
     def agraph_checks(self, G):
@@ -188,21 +188,21 @@ class TestAGraph:
         G = nx.Graph()
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A)
-        # assert_graphs_equal(G, H)
+        # assert graphs_equal(G, H)
         AA = nx.nx_agraph.to_agraph(H)
         HH = nx.nx_agraph.from_agraph(AA)
-        assert_graphs_equal(H, HH)
+        assert graphs_equal(H, HH)
         G.graph["graph"] = {}
         G.graph["node"] = {}
         G.graph["edge"] = {}
-        assert_graphs_equal(G, HH)
+        assert graphs_equal(G, HH)
 
     @pytest.mark.xfail(reason="integer->string node conversion in round trip")
     def test_round_trip_integer_nodes(self):
         G = nx.complete_graph(3)
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A)
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
 
     def test_graphviz_alias(self):
         G = self.build_graph(nx.Graph())

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -3,7 +3,7 @@ from io import StringIO
 import tempfile
 import os
 import networkx as nx
-from networkx.testing import assert_graphs_equal
+from networkx.utils import graphs_equal
 
 import pytest
 
@@ -36,7 +36,7 @@ class TestPydot:
         G2 = G.__class__(nx.nx_pydot.from_pydot(P))
 
         # Validate the original and resulting graphs to be the same.
-        assert_graphs_equal(G, G2)
+        assert graphs_equal(G, G2)
 
         fd, fname = tempfile.mkstemp()
 
@@ -77,7 +77,7 @@ class TestPydot:
         Hin = G.__class__(Hin)
 
         # Validate the original and resulting graphs to be the same.
-        assert_graphs_equal(G, Hin)
+        assert graphs_equal(G, Hin)
 
         os.close(fd)
         os.unlink(fname)
@@ -96,4 +96,4 @@ class TestPydot:
         nx.nx_pydot.write_dot(G, fh)
         fh.seek(0)
         H = nx.nx_pydot.read_dot(fh)
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)

--- a/networkx/generators/tests/test_atlas.py
+++ b/networkx/generators/tests/test_atlas.py
@@ -3,7 +3,7 @@ from itertools import groupby
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 from networkx import graph_atlas
 from networkx import graph_atlas_g
 from networkx.generators.atlas import NUM_GRAPHS
@@ -23,8 +23,8 @@ class TestAtlasGraph:
 
     def test_graph(self):
         G = graph_atlas(6)
-        assert_nodes_equal(G.nodes(), range(3))
-        assert_edges_equal(G.edges(), [(0, 1), (0, 2)])
+        assert nodes_equal(G.nodes(), range(3))
+        assert edges_equal(G.edges(), [(0, 1), (0, 2)])
 
 
 class TestAtlasGraphG:

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -10,8 +10,7 @@ import itertools
 import pytest
 import networkx as nx
 from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
-from networkx.utils import edges_equal
-from networkx.utils import nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 is_isomorphic = graph_could_be_isomorphic
 

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -10,8 +10,8 @@ import itertools
 import pytest
 import networkx as nx
 from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
-from networkx.testing import assert_edges_equal
-from networkx.testing import assert_nodes_equal
+from networkx.utils import edges_equal
+from networkx.utils import nodes_equal
 
 is_isomorphic = graph_could_be_isomorphic
 
@@ -135,7 +135,7 @@ class TestGeneratorClassic:
         )
 
         mb = nx.barbell_graph(m1, m2, create_using=nx.MultiGraph())
-        assert_edges_equal(mb.edges(), b.edges())
+        assert edges_equal(mb.edges(), b.edges())
 
     def test_binomial_tree(self):
         graphs = (None, nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)
@@ -154,10 +154,10 @@ class TestGeneratorClassic:
             assert nx.number_of_edges(g) == m * (m - 1) // 2
 
         mg = nx.complete_graph(m, create_using=nx.MultiGraph)
-        assert_edges_equal(mg.edges(), g.edges())
+        assert edges_equal(mg.edges(), g.edges())
 
         g = nx.complete_graph("abc")
-        assert_nodes_equal(g.nodes(), ["a", "b", "c"])
+        assert nodes_equal(g.nodes(), ["a", "b", "c"])
         assert g.size() == 3
 
     def test_complete_digraph(self):
@@ -179,18 +179,18 @@ class TestGeneratorClassic:
             nx.NetworkXError, nx.circular_ladder_graph, 5, create_using=nx.DiGraph
         )
         mG = nx.circular_ladder_graph(5, create_using=nx.MultiGraph)
-        assert_edges_equal(mG.edges(), G.edges())
+        assert edges_equal(mG.edges(), G.edges())
 
     def test_circulant_graph(self):
         # Ci_n(1) is the cycle graph for all n
         Ci6_1 = nx.circulant_graph(6, [1])
         C6 = nx.cycle_graph(6)
-        assert_edges_equal(Ci6_1.edges(), C6.edges())
+        assert edges_equal(Ci6_1.edges(), C6.edges())
 
         # Ci_n(1, 2, ..., n div 2) is the complete graph for all n
         Ci7 = nx.circulant_graph(7, [1, 2, 3])
         K7 = nx.complete_graph(7)
-        assert_edges_equal(Ci7.edges(), K7.edges())
+        assert edges_equal(Ci7.edges(), K7.edges())
 
         # Ci_6(1, 3) is K_3,3 i.e. the utility graph
         Ci6_1_3 = nx.circulant_graph(6, [1, 3])
@@ -199,9 +199,9 @@ class TestGeneratorClassic:
 
     def test_cycle_graph(self):
         G = nx.cycle_graph(4)
-        assert_edges_equal(G.edges(), [(0, 1), (0, 3), (1, 2), (2, 3)])
+        assert edges_equal(G.edges(), [(0, 1), (0, 3), (1, 2), (2, 3)])
         mG = nx.cycle_graph(4, create_using=nx.MultiGraph)
-        assert_edges_equal(mG.edges(), [(0, 1), (0, 3), (1, 2), (2, 3)])
+        assert edges_equal(mG.edges(), [(0, 1), (0, 3), (1, 2), (2, 3)])
         G = nx.cycle_graph(4, create_using=nx.DiGraph)
         assert not G.has_edge(2, 1)
         assert G.has_edge(1, 2)
@@ -217,10 +217,10 @@ class TestGeneratorClassic:
 
     def test_dorogovtsev_goltsev_mendes_graph(self):
         G = nx.dorogovtsev_goltsev_mendes_graph(0)
-        assert_edges_equal(G.edges(), [(0, 1)])
-        assert_nodes_equal(list(G), [0, 1])
+        assert edges_equal(G.edges(), [(0, 1)])
+        assert nodes_equal(list(G), [0, 1])
         G = nx.dorogovtsev_goltsev_mendes_graph(1)
-        assert_edges_equal(G.edges(), [(0, 1), (0, 2), (1, 2)])
+        assert edges_equal(G.edges(), [(0, 1), (0, 2), (1, 2)])
         assert nx.average_clustering(G) == 1.0
         assert sorted(nx.triangles(G).values()) == [1, 1, 1]
         G = nx.dorogovtsev_goltsev_mendes_graph(10)
@@ -316,7 +316,7 @@ class TestGeneratorClassic:
 
         g = nx.ladder_graph(2)
         mg = nx.ladder_graph(2, create_using=nx.MultiGraph)
-        assert_edges_equal(mg.edges(), g.edges())
+        assert edges_equal(mg.edges(), g.edges())
 
     def test_lollipop_graph(self):
         # number of nodes = m1 + m2
@@ -342,7 +342,7 @@ class TestGeneratorClassic:
         )
 
         mb = nx.lollipop_graph(m1, m2, create_using=nx.MultiGraph)
-        assert_edges_equal(mb.edges(), b.edges())
+        assert edges_equal(mb.edges(), b.edges())
 
         g = nx.lollipop_graph([1, 2, 3, 4], "abc")
         assert len(g) == 7
@@ -368,7 +368,7 @@ class TestGeneratorClassic:
         assert not dp.has_edge(1, 0)
 
         mp = nx.path_graph(10, create_using=nx.MultiGraph)
-        assert_edges_equal(mp.edges(), p.edges())
+        assert edges_equal(mp.edges(), p.edges())
 
         G = nx.path_graph("abc")
         assert len(G) == 3
@@ -391,7 +391,7 @@ class TestGeneratorClassic:
         pytest.raises(nx.NetworkXError, star_graph, 10, create_using=nx.DiGraph)
 
         ms = star_graph(10, create_using=nx.MultiGraph)
-        assert_edges_equal(ms.edges(), s.edges())
+        assert edges_equal(ms.edges(), s.edges())
 
         G = star_graph("abcdefg")
         assert len(G) == 7
@@ -423,7 +423,7 @@ class TestGeneratorClassic:
         pytest.raises(nx.NetworkXError, nx.wheel_graph, 10, create_using=nx.DiGraph)
 
         mg = nx.wheel_graph(10, create_using=nx.MultiGraph())
-        assert_edges_equal(mg.edges(), g.edges())
+        assert edges_equal(mg.edges(), g.edges())
 
         G = nx.wheel_graph("abc")
         assert len(G) == 3
@@ -433,15 +433,15 @@ class TestGeneratorClassic:
         """Tests that the complete 0-partite graph is the null graph."""
         G = nx.complete_multipartite_graph()
         H = nx.null_graph()
-        assert_nodes_equal(G, H)
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G, H)
+        assert edges_equal(G.edges(), H.edges())
 
     def test_complete_1_partite_graph(self):
         """Tests that the complete 1-partite graph is the empty graph."""
         G = nx.complete_multipartite_graph(3)
         H = nx.empty_graph(3)
-        assert_nodes_equal(G, H)
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G, H)
+        assert edges_equal(G.edges(), H.edges())
 
     def test_complete_2_partite_graph(self):
         """Tests that the complete 2-partite graph is the complete bipartite
@@ -450,8 +450,8 @@ class TestGeneratorClassic:
         """
         G = nx.complete_multipartite_graph(2, 3)
         H = nx.complete_bipartite_graph(2, 3)
-        assert_nodes_equal(G, H)
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G, H)
+        assert edges_equal(G.edges(), H.edges())
 
     def test_complete_multipartite_graph(self):
         """Tests for generating the complete multipartite graph."""

--- a/networkx/generators/tests/test_ego.py
+++ b/networkx/generators/tests/test_ego.py
@@ -4,7 +4,7 @@ ego graph
 """
 
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestGeneratorEgo:
@@ -19,21 +19,21 @@ class TestGeneratorEgo:
         assert nx.is_isomorphic(nx.star_graph(3), H)
         G = nx.path_graph(3)
         H = nx.ego_graph(G, 0)
-        assert_edges_equal(H.edges(), [(0, 1)])
+        assert edges_equal(H.edges(), [(0, 1)])
         H = nx.ego_graph(G, 0, undirected=True)
-        assert_edges_equal(H.edges(), [(0, 1)])
+        assert edges_equal(H.edges(), [(0, 1)])
         H = nx.ego_graph(G, 0, center=False)
-        assert_edges_equal(H.edges(), [])
+        assert edges_equal(H.edges(), [])
 
     def test_ego_distance(self):
         G = nx.Graph()
         G.add_edge(0, 1, weight=2, distance=1)
         G.add_edge(1, 2, weight=2, distance=2)
         G.add_edge(2, 3, weight=2, distance=1)
-        assert_nodes_equal(nx.ego_graph(G, 0, radius=3).nodes(), [0, 1, 2, 3])
+        assert nodes_equal(nx.ego_graph(G, 0, radius=3).nodes(), [0, 1, 2, 3])
         eg = nx.ego_graph(G, 0, radius=3, distance="weight")
-        assert_nodes_equal(eg.nodes(), [0, 1])
+        assert nodes_equal(eg.nodes(), [0, 1])
         eg = nx.ego_graph(G, 0, radius=3, distance="weight", undirected=True)
-        assert_nodes_equal(eg.nodes(), [0, 1])
+        assert nodes_equal(eg.nodes(), [0, 1])
         eg = nx.ego_graph(G, 0, radius=3, distance="distance")
-        assert_nodes_equal(eg.nodes(), [0, 1, 2])
+        assert nodes_equal(eg.nodes(), [0, 1, 2])

--- a/networkx/generators/tests/test_interval_graph.py
+++ b/networkx/generators/tests/test_interval_graph.py
@@ -6,7 +6,7 @@ import pytest
 
 import networkx as nx
 from networkx.generators.interval_graph import interval_graph
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 class TestIntervalGraph:
@@ -44,7 +44,7 @@ class TestIntervalGraph:
         actual_g = interval_graph(intervals)
 
         assert set(actual_g.nodes) == set(expected_graph.nodes)
-        assert_edges_equal(expected_graph, actual_g)
+        assert edges_equal(expected_graph, actual_g)
 
     def test_interval_graph_1(self):
         intervals = [(1, 2), (2, 3), (3, 4), (1, 4)]
@@ -62,7 +62,7 @@ class TestIntervalGraph:
         actual_g = interval_graph(intervals)
 
         assert set(actual_g.nodes) == set(expected_graph.nodes)
-        assert_edges_equal(expected_graph, actual_g)
+        assert edges_equal(expected_graph, actual_g)
 
     def test_interval_graph_2(self):
         intervals = [(1, 2), [3, 5], [6, 8], (9, 10)]
@@ -73,7 +73,7 @@ class TestIntervalGraph:
         actual_g = interval_graph(intervals)
 
         assert set(actual_g.nodes) == set(expected_graph.nodes)
-        assert_edges_equal(expected_graph, actual_g)
+        assert edges_equal(expected_graph, actual_g)
 
     def test_interval_graph_3(self):
         intervals = [(1, 4), [3, 5], [2.5, 4]]
@@ -89,7 +89,7 @@ class TestIntervalGraph:
         actual_g = interval_graph(intervals)
 
         assert set(actual_g.nodes) == set(expected_graph.nodes)
-        assert_edges_equal(expected_graph, actual_g)
+        assert edges_equal(expected_graph, actual_g)
 
     def test_interval_graph_4(self):
         """test all possible overlaps"""
@@ -141,4 +141,4 @@ class TestIntervalGraph:
         actual_g = interval_graph(intervals)
 
         assert set(actual_g.nodes) == set(expected_graph.nodes)
-        assert_edges_equal(expected_graph, actual_g)
+        assert edges_equal(expected_graph, actual_g)

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -3,7 +3,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 from itertools import product
 
 
@@ -76,7 +76,7 @@ class TestGrid2DGraph:
         assert nx.is_isomorphic(H, G)
         G = nx.grid_2d_graph(5, 6)
         H = nx.grid_2d_graph(range(5), range(6))
-        assert_edges_equal(H, G)
+        assert edges_equal(H, G)
 
 
 class TestGridGraph:

--- a/networkx/generators/tests/test_line.py
+++ b/networkx/generators/tests/test_line.py
@@ -2,7 +2,7 @@ import networkx as nx
 import pytest
 
 import networkx.generators.line as line
-from networkx.testing.utils import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 def test_node_func():
@@ -29,7 +29,7 @@ def test_edge_func():
     G.add_edge(2, 3)
     ef = line._edge_func(G)
     expected = [(1, 2), (2, 3)]
-    assert_edges_equal(ef(), expected)
+    assert edges_equal(ef(), expected)
 
     # digraph
     G = nx.MultiDiGraph()
@@ -74,19 +74,19 @@ class TestGeneratorLine:
         G = nx.DiGraph()
         G.add_edges_from([(0, 1), (1, 2), (2, 3)])
         L = nx.line_graph(G)
-        assert_edges_equal(L.edges(), [((0, 1), (1, 2)), ((1, 2), (2, 3))])
+        assert edges_equal(L.edges(), [((0, 1), (1, 2)), ((1, 2), (2, 3))])
 
     def test_create1(self):
         G = nx.DiGraph()
         G.add_edges_from([(0, 1), (1, 2), (2, 3)])
         L = nx.line_graph(G, create_using=nx.Graph())
-        assert_edges_equal(L.edges(), [((0, 1), (1, 2)), ((1, 2), (2, 3))])
+        assert edges_equal(L.edges(), [((0, 1), (1, 2)), ((1, 2), (2, 3))])
 
     def test_create2(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1), (1, 2), (2, 3)])
         L = nx.line_graph(G, create_using=nx.DiGraph())
-        assert_edges_equal(L.edges(), [((0, 1), (1, 2)), ((1, 2), (2, 3))])
+        assert edges_equal(L.edges(), [((0, 1), (1, 2)), ((1, 2), (2, 3))])
 
 
 class TestGeneratorInverseLine:

--- a/networkx/generators/tests/test_nonisomorphic_trees.py
+++ b/networkx/generators/tests/test_nonisomorphic_trees.py
@@ -6,7 +6,7 @@ Generators - Non Isomorphic Trees
 Unit tests for WROM algorithm generator in generators/nonisomorphic_trees.py
 """
 import networkx as nx
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 class TestGeneratorNonIsomorphicTrees:
@@ -48,9 +48,9 @@ class TestGeneratorNonIsomorphicTrees:
         def f(x):
             return list(nx.nonisomorphic_trees(x))
 
-        assert_edges_equal(f(3)[0].edges(), [(0, 1), (0, 2)])
-        assert_edges_equal(f(4)[0].edges(), [(0, 1), (0, 3), (1, 2)])
-        assert_edges_equal(f(4)[1].edges(), [(0, 1), (0, 2), (0, 3)])
+        assert edges_equal(f(3)[0].edges(), [(0, 1), (0, 2)])
+        assert edges_equal(f(4)[0].edges(), [(0, 1), (0, 3), (1, 2)])
+        assert edges_equal(f(4)[1].edges(), [(0, 1), (0, 2), (0, 3)])
 
     def test_nonisomorphic_trees_matrix(self):
         trees_2 = [[[0, 1], [1, 0]]]

--- a/networkx/generators/tests/test_spectral_graph_forge.py
+++ b/networkx/generators/tests/test_spectral_graph_forge.py
@@ -6,7 +6,7 @@ pytest.importorskip("scipy")
 
 from networkx import is_isomorphic
 from networkx.exception import NetworkXError
-from networkx.testing import assert_nodes_equal
+from networkx.utils import nodes_equal
 from networkx.generators.spectral_graph_forge import spectral_graph_forge
 from networkx.generators import karate_club_graph
 
@@ -19,28 +19,28 @@ def test_spectral_graph_forge():
     # common cases, just checking node number preserving and difference
     # between identity and modularity cases
     H = spectral_graph_forge(G, 0.1, transformation="identity", seed=seed)
-    assert_nodes_equal(G, H)
+    assert nodes_equal(G, H)
 
     I = spectral_graph_forge(G, 0.1, transformation="identity", seed=seed)
-    assert_nodes_equal(G, H)
+    assert nodes_equal(G, H)
     assert is_isomorphic(I, H)
 
     I = spectral_graph_forge(G, 0.1, transformation="modularity", seed=seed)
-    assert_nodes_equal(G, I)
+    assert nodes_equal(G, I)
 
     assert not is_isomorphic(I, H)
 
     # with all the eigenvectors, output graph is identical to the input one
     H = spectral_graph_forge(G, 1, transformation="modularity", seed=seed)
-    assert_nodes_equal(G, H)
+    assert nodes_equal(G, H)
     assert is_isomorphic(G, H)
 
     # invalid alpha input value, it is silently truncated in [0,1]
     H = spectral_graph_forge(G, -1, transformation="identity", seed=seed)
-    assert_nodes_equal(G, H)
+    assert nodes_equal(G, H)
 
     H = spectral_graph_forge(G, 10, transformation="identity", seed=seed)
-    assert_nodes_equal(G, H)
+    assert nodes_equal(G, H)
     assert is_isomorphic(G, H)
 
     # invalid transformation mode, checking the error raising

--- a/networkx/generators/tests/test_trees.py
+++ b/networkx/generators/tests/test_trees.py
@@ -1,6 +1,6 @@
-import networkx as nx
-from networkx.utils import arbitrary_element
 import pytest
+import networkx as nx
+from networkx.utils import arbitrary_element, graphs_equal
 
 
 @pytest.mark.parametrize("prefix_tree_fn", (nx.prefix_tree, nx.prefix_tree_recursive))
@@ -78,7 +78,7 @@ def test_basic_prefix_tree(prefix_tree_fn):
 )
 def test_implementations_consistent(strings):
     """Ensure results are consistent between prefix_tree implementations."""
-    nx.testing.assert_graphs_equal(
+    assert graphs_equal(
         nx.prefix_tree(strings),
         nx.prefix_tree_recursive(strings),
     )

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -6,7 +6,7 @@ import pytest
 import os
 import tempfile
 import networkx as nx
-from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 
 class TestAdjlist:
@@ -32,7 +32,7 @@ class TestAdjlist:
         bytesIO = io.BytesIO(s)
         G = nx.read_multiline_adjlist(bytesIO)
         adj = {"1": {"3": {}, "2": {}}, "3": {"1": {}}, "2": {"1": {}}}
-        assert_graphs_equal(G, nx.Graph(adj))
+        assert graphs_equal(G, nx.Graph(adj))
 
     def test_unicode(self):
         G = nx.Graph()
@@ -42,7 +42,7 @@ class TestAdjlist:
         fd, fname = tempfile.mkstemp()
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname)
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
         os.close(fd)
         os.unlink(fname)
 
@@ -66,7 +66,7 @@ class TestAdjlist:
         fd, fname = tempfile.mkstemp()
         nx.write_multiline_adjlist(G, fname, encoding="latin-1")
         H = nx.read_multiline_adjlist(fname, encoding="latin-1")
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
         os.close(fd)
         os.unlink(fname)
 
@@ -86,8 +86,8 @@ class TestAdjlist:
         H = nx.read_adjlist(fname)
         H2 = nx.read_adjlist(fname)
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -98,8 +98,8 @@ class TestAdjlist:
         H = nx.read_adjlist(fname, create_using=nx.DiGraph())
         H2 = nx.read_adjlist(fname, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -110,8 +110,8 @@ class TestAdjlist:
         H = nx.read_adjlist(fname, nodetype=int)
         H2 = nx.read_adjlist(fname, nodetype=int)
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -122,8 +122,8 @@ class TestAdjlist:
         H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -134,8 +134,8 @@ class TestAdjlist:
         H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -145,8 +145,8 @@ class TestAdjlist:
         nx.write_adjlist(G, fh, delimiter=":")
         fh.seek(0)
         H = nx.read_adjlist(fh, nodetype=int, delimiter=":")
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
 
 
 class TestMultilineAdjlist:
@@ -197,8 +197,8 @@ class TestMultilineAdjlist:
         H = nx.read_multiline_adjlist(fname)
         H2 = nx.read_multiline_adjlist(fname)
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -209,8 +209,8 @@ class TestMultilineAdjlist:
         H = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
         H2 = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -221,8 +221,8 @@ class TestMultilineAdjlist:
         H = nx.read_multiline_adjlist(fname, nodetype=int)
         H2 = nx.read_multiline_adjlist(fname, nodetype=int)
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -235,8 +235,8 @@ class TestMultilineAdjlist:
             fname, nodetype=int, create_using=nx.MultiGraph()
         )
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -251,8 +251,8 @@ class TestMultilineAdjlist:
             fname, nodetype=int, create_using=nx.MultiDiGraph()
         )
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -262,5 +262,5 @@ class TestMultilineAdjlist:
         nx.write_multiline_adjlist(G, fh, delimiter=":")
         fh.seek(0)
         H = nx.read_multiline_adjlist(fh, nodetype=int, delimiter=":")
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -8,7 +8,7 @@ import os
 import textwrap
 
 import networkx as nx
-from networkx.testing import assert_edges_equal, assert_nodes_equal, assert_graphs_equal
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 
 edges_no_data = textwrap.dedent(
@@ -81,13 +81,13 @@ _expected_edges_multiattr = [
 def test_read_edgelist_no_data(data, extra_kwargs):
     bytesIO = io.BytesIO(data.encode("utf-8"))
     G = nx.read_edgelist(bytesIO, nodetype=int, data=False, **extra_kwargs)
-    assert_edges_equal(G.edges(), [(1, 2), (2, 3)])
+    assert edges_equal(G.edges(), [(1, 2), (2, 3)])
 
 
 def test_read_weighted_edgelist():
     bytesIO = io.BytesIO(edges_with_values.encode("utf-8"))
     G = nx.read_weighted_edgelist(bytesIO, nodetype=int)
-    assert_edges_equal(G.edges(data=True), _expected_edges_weights)
+    assert edges_equal(G.edges(data=True), _expected_edges_weights)
 
 
 @pytest.mark.parametrize(
@@ -101,7 +101,7 @@ def test_read_weighted_edgelist():
 def test_read_edgelist_with_data(data, extra_kwargs, expected):
     bytesIO = io.BytesIO(data.encode("utf-8"))
     G = nx.read_edgelist(bytesIO, nodetype=int, **extra_kwargs)
-    assert_edges_equal(G.edges(data=True), expected)
+    assert edges_equal(G.edges(data=True), expected)
 
 
 @pytest.fixture
@@ -114,8 +114,8 @@ def example_graph():
 def test_parse_edgelist_no_data(example_graph):
     G = example_graph
     H = nx.parse_edgelist(["1 2", "2 3", "3 4"], nodetype=int)
-    assert_nodes_equal(G.nodes, H.nodes)
-    assert_edges_equal(G.edges, H.edges)
+    assert nodes_equal(G.nodes, H.nodes)
+    assert edges_equal(G.edges, H.edges)
 
 
 def test_parse_edgelist_with_data_dict(example_graph):
@@ -124,8 +124,8 @@ def test_parse_edgelist_with_data_dict(example_graph):
         ["1 2 {'weight': 3}", "2 3 {'weight': 27}", "3 4 {'weight': 3.0}"],
         nodetype=int,
     )
-    assert_nodes_equal(G.nodes, H.nodes)
-    assert_edges_equal(G.edges(data=True), H.edges(data=True))
+    assert nodes_equal(G.nodes, H.nodes)
+    assert edges_equal(G.edges(data=True), H.edges(data=True))
 
 
 def test_parse_edgelist_with_data_list(example_graph):
@@ -133,8 +133,8 @@ def test_parse_edgelist_with_data_list(example_graph):
     H = nx.parse_edgelist(
         ["1 2 3", "2 3 27", "3 4 3.0"], nodetype=int, data=(("weight", float),)
     )
-    assert_nodes_equal(G.nodes, H.nodes)
-    assert_edges_equal(G.edges(data=True), H.edges(data=True))
+    assert nodes_equal(G.nodes, H.nodes)
+    assert edges_equal(G.edges(data=True), H.edges(data=True))
 
 
 def test_parse_edgelist():
@@ -216,7 +216,7 @@ class TestEdgelist:
         fd, fname = tempfile.mkstemp()
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname)
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
         os.close(fd)
         os.unlink(fname)
 
@@ -240,7 +240,7 @@ class TestEdgelist:
         fd, fname = tempfile.mkstemp()
         nx.write_edgelist(G, fname, encoding="latin-1")
         H = nx.read_edgelist(fname, encoding="latin-1")
-        assert_graphs_equal(G, H)
+        assert graphs_equal(G, H)
         os.close(fd)
         os.unlink(fname)
 
@@ -252,8 +252,8 @@ class TestEdgelist:
         H2 = nx.read_edgelist(fname)
         assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -265,8 +265,8 @@ class TestEdgelist:
         H2 = nx.read_edgelist(fname, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -277,8 +277,8 @@ class TestEdgelist:
         H = nx.read_edgelist(fname, nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -289,8 +289,8 @@ class TestEdgelist:
         H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)
 
@@ -301,7 +301,7 @@ class TestEdgelist:
         H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         assert H is not H2  # they should be different graphs
-        assert_nodes_equal(list(H), list(G))
-        assert_edges_equal(list(H.edges()), list(G.edges()))
+        assert nodes_equal(list(H), list(G))
+        assert edges_equal(list(H.edges()), list(G.edges()))
         os.close(fd)
         os.unlink(fname)

--- a/networkx/readwrite/tests/test_gpickle.py
+++ b/networkx/readwrite/tests/test_gpickle.py
@@ -2,11 +2,7 @@ import os
 import tempfile
 
 import networkx as nx
-from networkx.testing.utils import (
-    assert_graphs_equal,
-    assert_edges_equal,
-    assert_nodes_equal,
-)
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 
 class TestGpickle:
@@ -53,9 +49,9 @@ class TestGpickle:
             (fd, fname) = tempfile.mkstemp()
             nx.write_gpickle(G, fname)
             Gin = nx.read_gpickle(fname)
-            assert_nodes_equal(list(G.nodes(data=True)), list(Gin.nodes(data=True)))
-            assert_edges_equal(list(G.edges(data=True)), list(Gin.edges(data=True)))
-            assert_graphs_equal(G, Gin)
+            assert nodes_equal(list(G.nodes(data=True)), list(Gin.nodes(data=True)))
+            assert edges_equal(list(G.edges(data=True)), list(Gin.edges(data=True)))
+            assert graphs_equal(G, Gin)
             os.close(fd)
             os.unlink(fname)
 
@@ -74,6 +70,6 @@ class TestGpickle:
                 nx.write_gpickle(G, f, 0)
                 f.seek(0)
                 Gin = nx.read_gpickle(f)
-                assert_nodes_equal(list(G.nodes(data=True)), list(Gin.nodes(data=True)))
-                assert_edges_equal(list(G.edges(data=True)), list(Gin.edges(data=True)))
-                assert_graphs_equal(G, Gin)
+                assert nodes_equal(list(G.nodes(data=True)), list(Gin.nodes(data=True)))
+                assert edges_equal(list(G.edges(data=True)), list(Gin.edges(data=True)))
+                assert graphs_equal(G, Gin)

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -4,8 +4,7 @@ import pytest
 
 import networkx as nx
 import networkx.readwrite.graph6 as g6
-from networkx.utils import edges_equal
-from networkx.utils import nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestGraph6Utils:

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -4,8 +4,8 @@ import pytest
 
 import networkx as nx
 import networkx.readwrite.graph6 as g6
-from networkx.testing.utils import assert_edges_equal
-from networkx.testing.utils import assert_nodes_equal
+from networkx.utils import edges_equal
+from networkx.utils import nodes_equal
 
 
 class TestGraph6Utils:
@@ -20,8 +20,8 @@ class TestFromGraph6Bytes:
     def test_from_graph6_bytes(self):
         data = b"DF{"
         G = nx.from_graph6_bytes(data)
-        assert_nodes_equal(G.nodes(), [0, 1, 2, 3, 4])
-        assert_edges_equal(
+        assert nodes_equal(G.nodes(), [0, 1, 2, 3, 4])
+        assert edges_equal(
             G.edges(), [(0, 3), (0, 4), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
         )
 
@@ -30,8 +30,8 @@ class TestFromGraph6Bytes:
         G = nx.from_graph6_bytes(data)
         fh = BytesIO(data)
         Gin = nx.read_graph6(fh)
-        assert_nodes_equal(G.nodes(), Gin.nodes())
-        assert_edges_equal(G.edges(), Gin.edges())
+        assert nodes_equal(G.nodes(), Gin.nodes())
+        assert edges_equal(G.edges(), Gin.edges())
 
 
 class TestReadGraph6:
@@ -100,8 +100,8 @@ class TestWriteGraph6:
             nx.write_graph6(G, f)
             f.seek(0)
             H = nx.read_graph6(f)
-            assert_nodes_equal(G.nodes(), H.nodes())
-            assert_edges_equal(G.edges(), H.edges())
+            assert nodes_equal(G.nodes(), H.nodes())
+            assert edges_equal(G.edges(), H.edges())
 
     def test_write_path(self):
         with tempfile.NamedTemporaryFile() as f:

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1,6 +1,6 @@
 import pytest
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 from networkx.readwrite.graphml import GraphMLWriter
 import io
 import tempfile
@@ -293,51 +293,51 @@ class TestReadGraphML(BaseGraphML):
     def test_read_simple_undirected_graphml(self):
         G = self.simple_undirected_graph
         H = nx.read_graphml(self.simple_undirected_fh)
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
         self.simple_undirected_fh.seek(0)
 
         PG = nx.parse_graphml(self.simple_undirected_data)
-        assert_nodes_equal(G.nodes(), PG.nodes())
-        assert_edges_equal(G.edges(), PG.edges())
+        assert nodes_equal(G.nodes(), PG.nodes())
+        assert edges_equal(G.edges(), PG.edges())
 
     def test_read_undirected_multigraph_graphml(self):
         G = self.undirected_multigraph
         H = nx.read_graphml(self.undirected_multigraph_fh)
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
         self.undirected_multigraph_fh.seek(0)
 
         PG = nx.parse_graphml(self.undirected_multigraph_data)
-        assert_nodes_equal(G.nodes(), PG.nodes())
-        assert_edges_equal(G.edges(), PG.edges())
+        assert nodes_equal(G.nodes(), PG.nodes())
+        assert edges_equal(G.edges(), PG.edges())
 
     def test_read_undirected_multigraph_no_multiedge_graphml(self):
         G = self.undirected_multigraph_no_multiedge
         H = nx.read_graphml(self.undirected_multigraph_no_multiedge_fh)
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
         self.undirected_multigraph_no_multiedge_fh.seek(0)
 
         PG = nx.parse_graphml(self.undirected_multigraph_no_multiedge_data)
-        assert_nodes_equal(G.nodes(), PG.nodes())
-        assert_edges_equal(G.edges(), PG.edges())
+        assert nodes_equal(G.nodes(), PG.nodes())
+        assert edges_equal(G.edges(), PG.edges())
 
     def test_read_undirected_multigraph_only_ids_for_multiedges_graphml(self):
         G = self.multigraph_only_ids_for_multiedges
         H = nx.read_graphml(self.multigraph_only_ids_for_multiedges_fh)
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
         self.multigraph_only_ids_for_multiedges_fh.seek(0)
 
         PG = nx.parse_graphml(self.multigraph_only_ids_for_multiedges_data)
-        assert_nodes_equal(G.nodes(), PG.nodes())
-        assert_edges_equal(G.edges(), PG.edges())
+        assert nodes_equal(G.nodes(), PG.nodes())
+        assert edges_equal(G.edges(), PG.edges())
 
     def test_read_attribute_graphml(self):
         G = self.attribute_graph
         H = nx.read_graphml(self.attribute_fh)
-        assert_nodes_equal(G.nodes(True), sorted(H.nodes(data=True)))
+        assert nodes_equal(G.nodes(True), sorted(H.nodes(data=True)))
         ge = sorted(G.edges(data=True))
         he = sorted(H.edges(data=True))
         for a, b in zip(ge, he):
@@ -494,7 +494,7 @@ class TestReadGraphML(BaseGraphML):
         nx.write_graphml(G, fh)
         fh.seek(0)
         H = nx.read_graphml(fh, node_type=int)
-        assert_edges_equal(G.edges(data=True, keys=True), H.edges(data=True, keys=True))
+        assert edges_equal(G.edges(data=True, keys=True), H.edges(data=True, keys=True))
         assert G._adj == H._adj
 
         Gadj = {
@@ -1073,9 +1073,9 @@ class TestWriteGraphML(BaseGraphML):
         H = nx.read_graphml(fh)
         fh.seek(0)
 
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
-        assert_edges_equal(G.edges(data=True), H.edges(data=True))
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
+        assert edges_equal(G.edges(data=True), H.edges(data=True))
         self.attribute_named_key_ids_fh.seek(0)
 
         xml = parse(fh)
@@ -1118,9 +1118,9 @@ class TestWriteGraphML(BaseGraphML):
         H = nx.read_graphml(fh)
         fh.seek(0)
 
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
-        assert_edges_equal(G.edges(data=True), H.edges(data=True))
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
+        assert edges_equal(G.edges(data=True), H.edges(data=True))
         self.attribute_numeric_type_fh.seek(0)
 
         xml = parse(fh)
@@ -1146,7 +1146,7 @@ class TestWriteGraphML(BaseGraphML):
         self.writer(G, fname)
         H = nx.read_graphml(fname)
         assert H.is_multigraph()
-        assert_edges_equal(G.edges(keys=True), H.edges(keys=True))
+        assert edges_equal(G.edges(keys=True), H.edges(keys=True))
         assert G._adj == H._adj
         os.close(fd)
         os.unlink(fname)
@@ -1162,8 +1162,8 @@ class TestWriteGraphML(BaseGraphML):
         self.writer(G, fh)
         fh.seek(0)
         H = nx.read_graphml(fh, node_type=int)
-        assert_nodes_equal(G.nodes(), H.nodes())
-        assert_edges_equal(G.edges(), H.edges())
+        assert nodes_equal(G.nodes(), H.nodes())
+        assert edges_equal(G.edges(), H.edges())
         assert G.graph == H.graph
 
     def test_mixed_type_attributes(self):

--- a/networkx/readwrite/tests/test_p2g.py
+++ b/networkx/readwrite/tests/test_p2g.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import io
 from networkx.readwrite.p2g import read_p2g, write_p2g
-from networkx.testing import assert_edges_equal
+from networkx.utils import edges_equal
 
 
 class TestP2G:
@@ -29,7 +29,7 @@ c
         assert G.name == "name"
         assert sorted(G) == ["a", "b", "c"]
         edges = [(str(u), str(v)) for u, v in G.edges()]
-        assert_edges_equal(G.edges(), [("a", "c"), ("a", "b"), ("c", "a"), ("c", "c")])
+        assert edges_equal(G.edges(), [("a", "c"), ("a", "b"), ("c", "a"), ("c", "c")])
 
     def test_write_p2g(self):
         s = b"""foo
@@ -58,4 +58,4 @@ c
         write_p2g(G, fh)
         fh.seek(0)
         H = read_p2g(fh)
-        assert_edges_equal(G.edges(), H.edges())
+        assert edges_equal(G.edges(), H.edges())

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -4,7 +4,7 @@ Pajek tests
 import networkx as nx
 import os
 import tempfile
-from networkx.testing import assert_edges_equal, assert_nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestPajek:
@@ -39,12 +39,12 @@ class TestPajek:
         data = """*Vertices 2\n1 "1"\n2 "2"\n*Edges\n1 2\n2 1"""
         G = nx.parse_pajek(data)
         assert sorted(G.nodes()) == ["1", "2"]
-        assert_edges_equal(G.edges(), [("1", "2"), ("1", "2")])
+        assert edges_equal(G.edges(), [("1", "2"), ("1", "2")])
 
     def test_parse_pajek(self):
         G = nx.parse_pajek(self.data)
         assert sorted(G.nodes()) == ["A1", "Bb", "C", "D2"]
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(),
             [
                 ("A1", "A1"),
@@ -62,7 +62,7 @@ class TestPajek:
         G = nx.parse_pajek(data)
         assert set(G.nodes()) == {"one", "two", "three"}
         assert G.nodes["two"] == {"id": "2"}
-        assert_edges_equal(
+        assert edges_equal(
             set(G.edges()),
             {("one", "one"), ("two", "one"), ("two", "two"), ("two", "three")},
         )
@@ -71,7 +71,7 @@ class TestPajek:
         G = nx.parse_pajek(self.data)
         Gin = nx.read_pajek(self.fname)
         assert sorted(G.nodes()) == sorted(Gin.nodes())
-        assert_edges_equal(G.edges(), Gin.edges())
+        assert edges_equal(G.edges(), Gin.edges())
         assert self.G.graph == Gin.graph
         for n in G:
             assert G.nodes[n] == Gin.nodes[n]
@@ -84,8 +84,8 @@ class TestPajek:
         nx.write_pajek(G, fh)
         fh.seek(0)
         H = nx.read_pajek(fh)
-        assert_nodes_equal(list(G), list(H))
-        assert_edges_equal(list(G.edges()), list(H.edges()))
+        assert nodes_equal(list(G), list(H))
+        assert edges_equal(list(G.edges()), list(H.edges()))
         # Graph name is left out for now, therefore it is not tested.
         # assert_equal(G.graph, H.graph)
 
@@ -124,6 +124,6 @@ class TestPajek:
         nx.write_pajek(G, fh)
         fh.seek(0)
         H = nx.read_pajek(fh)
-        assert_nodes_equal(list(G), list(H))
-        assert_edges_equal(list(G.edges()), list(H.edges()))
+        assert nodes_equal(list(G), list(H))
+        assert edges_equal(list(G.edges()), list(H.edges()))
         assert G.graph == H.graph

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -3,8 +3,7 @@ import tempfile
 import pytest
 
 import networkx as nx
-from networkx.utils import edges_equal
-from networkx.utils import nodes_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestSparseGraph6:

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -3,19 +3,19 @@ import tempfile
 import pytest
 
 import networkx as nx
-from networkx.testing.utils import assert_edges_equal
-from networkx.testing.utils import assert_nodes_equal
+from networkx.utils import edges_equal
+from networkx.utils import nodes_equal
 
 
 class TestSparseGraph6:
     def test_from_sparse6_bytes(self):
         data = b":Q___eDcdFcDeFcE`GaJ`IaHbKNbLM"
         G = nx.from_sparse6_bytes(data)
-        assert_nodes_equal(
+        assert nodes_equal(
             sorted(G.nodes()),
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
         )
-        assert_edges_equal(
+        assert edges_equal(
             G.edges(),
             [
                 (0, 1),
@@ -61,8 +61,8 @@ class TestSparseGraph6:
         G = nx.from_sparse6_bytes(data)
         fh = BytesIO(data)
         Gin = nx.read_sparse6(fh)
-        assert_nodes_equal(G.nodes(), Gin.nodes())
-        assert_edges_equal(G.edges(), Gin.edges())
+        assert nodes_equal(G.nodes(), Gin.nodes())
+        assert edges_equal(G.edges(), Gin.edges())
 
     def test_read_many_graph6(self):
         # Read many graphs into list
@@ -71,7 +71,7 @@ class TestSparseGraph6:
         glist = nx.read_sparse6(fh)
         assert len(glist) == 2
         for G in glist:
-            assert_nodes_equal(
+            assert nodes_equal(
                 G.nodes(),
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
             )
@@ -152,7 +152,7 @@ class TestWriteSparse6:
             gstr = gstr.getvalue().rstrip()
             g2 = nx.from_sparse6_bytes(gstr)
             assert g2.order() == g.order()
-            assert_edges_equal(g2.edges(), g.edges())
+            assert edges_equal(g2.edges(), g.edges())
 
     def test_no_directed_graphs(self):
         with pytest.raises(nx.NetworkXNotImplemented):

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -1,3 +1,4 @@
+import warnings
 from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 __all__ = [
@@ -9,8 +10,6 @@ __all__ = [
 
 
 def almost_equal(x, y, places=7):
-    import warnings
-
     warnings.warn(
         (
             "`almost_equal` is deprecated and will be removed in version 3.0.\n"
@@ -22,12 +21,33 @@ def almost_equal(x, y, places=7):
 
 
 def assert_nodes_equal(nodes1, nodes2):
+    warnings.warn(
+        (
+            "`assert_nodes_equal` is deprecated and will be removed in version 3.0.\n"
+            "Use `from networkx.utils import nodes_equal` and `assert nodes_equal` instead.\n"
+        ),
+        DeprecationWarning,
+    )
     assert nodes_equal(nodes1, nodes2)
 
 
 def assert_edges_equal(edges1, edges2):
+    warnings.warn(
+        (
+            "`assert_edges_equal` is deprecated and will be removed in version 3.0.\n"
+            "Use `from networkx.utils import edges_equal` and `assert edges_equal` instead.\n"
+        ),
+        DeprecationWarning,
+    )
     assert edges_equal(edges1, edges2)
 
 
 def assert_graphs_equal(graph1, graph2):
+    warnings.warn(
+        (
+            "`assert_graphs_equal` is deprecated and will be removed in version 3.0.\n"
+            "Use `from networkx.utils import graphs_equal` and `assert graphs_equal` instead.\n"
+        ),
+        DeprecationWarning,
+    )
     assert graphs_equal(graph1, graph2)

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -1,3 +1,5 @@
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
+
 __all__ = [
     "assert_nodes_equal",
     "assert_edges_equal",
@@ -29,65 +31,3 @@ def assert_edges_equal(edges1, edges2):
 
 def assert_graphs_equal(graph1, graph2):
     assert graphs_equal(graph1, graph2)
-
-
-def nodes_equal(nodes1, nodes2):
-    # Assumes iterables of nodes, or (node,datadict) tuples
-    nlist1 = list(nodes1)
-    nlist2 = list(nodes2)
-    try:
-        d1 = dict(nlist1)
-        d2 = dict(nlist2)
-    except (ValueError, TypeError):
-        d1 = dict.fromkeys(nlist1)
-        d2 = dict.fromkeys(nlist2)
-    return d1 == d2
-
-
-def edges_equal(edges1, edges2):
-    # Assumes iterables with u,v nodes as
-    # edge tuples (u,v), or
-    # edge tuples with data dicts (u,v,d), or
-    # edge tuples with keys and data dicts (u,v,k, d)
-    from collections import defaultdict
-
-    d1 = defaultdict(dict)
-    d2 = defaultdict(dict)
-    c1 = 0
-    for c1, e in enumerate(edges1):
-        u, v = e[0], e[1]
-        data = [e[2:]]
-        if v in d1[u]:
-            data = d1[u][v] + data
-        d1[u][v] = data
-        d1[v][u] = data
-    c2 = 0
-    for c2, e in enumerate(edges2):
-        u, v = e[0], e[1]
-        data = [e[2:]]
-        if v in d2[u]:
-            data = d2[u][v] + data
-        d2[u][v] = data
-        d2[v][u] = data
-    if c1 != c2:
-        return False
-    # can check one direction because lengths are the same.
-    for n, nbrdict in d1.items():
-        for nbr, datalist in nbrdict.items():
-            if n not in d2:
-                return False
-            if nbr not in d2[n]:
-                return False
-            d2datalist = d2[n][nbr]
-            for data in datalist:
-                if datalist.count(data) != d2datalist.count(data):
-                    return False
-    return True
-
-
-def graphs_equal(graph1, graph2):
-    return (
-        graph1.adj == graph2.adj
-        and graph1.nodes == graph2.nodes
-        and graph1.graph == graph2.graph
-    )

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -20,6 +20,18 @@ def almost_equal(x, y, places=7):
 
 
 def assert_nodes_equal(nodes1, nodes2):
+    assert nodes_equal(nodes1, nodes2)
+
+
+def assert_edges_equal(edges1, edges2):
+    assert edges_equal(edges1, edges2)
+
+
+def assert_graphs_equal(graph1, graph2):
+    assert graphs_equal(graph1, graph2)
+
+
+def nodes_equal(nodes1, nodes2):
     # Assumes iterables of nodes, or (node,datadict) tuples
     nlist1 = list(nodes1)
     nlist2 = list(nodes2)
@@ -29,10 +41,10 @@ def assert_nodes_equal(nodes1, nodes2):
     except (ValueError, TypeError):
         d1 = dict.fromkeys(nlist1)
         d2 = dict.fromkeys(nlist2)
-    assert d1 == d2
+    return d1 == d2
 
 
-def assert_edges_equal(edges1, edges2):
+def edges_equal(edges1, edges2):
     # Assumes iterables with u,v nodes as
     # edge tuples (u,v), or
     # edge tuples with data dicts (u,v,d), or
@@ -57,18 +69,25 @@ def assert_edges_equal(edges1, edges2):
             data = d2[u][v] + data
         d2[u][v] = data
         d2[v][u] = data
-    assert c1 == c2
+    if c1 != c2:
+        return False
     # can check one direction because lengths are the same.
     for n, nbrdict in d1.items():
         for nbr, datalist in nbrdict.items():
-            assert n in d2
-            assert nbr in d2[n]
+            if n not in d2:
+                return False
+            if nbr not in d2[n]:
+                return False
             d2datalist = d2[n][nbr]
             for data in datalist:
-                assert datalist.count(data) == d2datalist.count(data)
+                if datalist.count(data) != d2datalist.count(data):
+                    return False
+    return True
 
 
-def assert_graphs_equal(graph1, graph2):
-    assert graph1.adj == graph2.adj
-    assert graph1.nodes == graph2.nodes
-    assert graph1.graph == graph2.graph
+def graphs_equal(graph1, graph2):
+    return (
+        graph1.adj == graph2.adj
+        and graph1.nodes == graph2.nodes
+        and graph1.graph == graph2.graph
+    )

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -1,7 +1,7 @@
 import pytest
 
 import networkx as nx
-from networkx.testing import assert_nodes_equal, assert_edges_equal, assert_graphs_equal
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 from networkx.convert import (
     to_networkx_graph,
     to_dict_of_dicts,
@@ -27,11 +27,11 @@ class TestConvert:
 
             # Dict of [dicts, lists]
             GG = source(dod)
-            assert_graphs_equal(G, GG)
+            assert graphs_equal(G, GG)
             GW = to_networkx_graph(dod)
-            assert_graphs_equal(G, GW)
+            assert graphs_equal(G, GW)
             GI = nx.Graph(dod)
-            assert_graphs_equal(G, GI)
+            assert graphs_equal(G, GI)
 
             # With nodelist keyword
             P4 = nx.path_graph(4)
@@ -40,7 +40,7 @@ class TestConvert:
             P3.graph = {}
             dod = dest(P4, nodelist=[0, 1, 2])
             Gdod = nx.Graph(dod)
-            assert_graphs_equal(Gdod, P3)
+            assert graphs_equal(Gdod, P3)
 
     def test_exceptions(self):
         # NX graph
@@ -78,14 +78,14 @@ class TestConvert:
             # Dict of [dicts, lists]
             dod = dest(G)
             GG = source(dod)
-            assert_nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
-            assert_edges_equal(sorted(G.edges()), sorted(GG.edges()))
+            assert nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
+            assert edges_equal(sorted(G.edges()), sorted(GG.edges()))
             GW = to_networkx_graph(dod)
-            assert_nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
-            assert_edges_equal(sorted(G.edges()), sorted(GW.edges()))
+            assert nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
+            assert edges_equal(sorted(G.edges()), sorted(GW.edges()))
             GI = nx.Graph(dod)
-            assert_nodes_equal(sorted(G.nodes()), sorted(GI.nodes()))
-            assert_edges_equal(sorted(G.edges()), sorted(GI.edges()))
+            assert nodes_equal(sorted(G.nodes()), sorted(GI.nodes()))
+            assert edges_equal(sorted(G.edges()), sorted(GI.edges()))
 
             G = cycle_graph(10, create_using=nx.DiGraph)
             dod = dest(G)
@@ -108,11 +108,11 @@ class TestConvert:
         # Dict of dicts
         dod = to_dict_of_dicts(G)
         GG = from_dict_of_dicts(dod, create_using=nx.Graph)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GG.edges()))
+        assert nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(GG.edges()))
         GW = to_networkx_graph(dod, create_using=nx.Graph)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GW.edges()))
+        assert nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(GW.edges()))
         GI = nx.Graph(dod)
         assert sorted(G.nodes()) == sorted(GI.nodes())
         assert sorted(G.edges()) == sorted(GI.edges())
@@ -122,14 +122,14 @@ class TestConvert:
         GG = from_dict_of_lists(dol, create_using=nx.Graph)
         # dict of lists throws away edge data so set it to none
         enone = [(u, v, {}) for (u, v, d) in G.edges(data=True)]
-        assert_nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
-        assert_edges_equal(enone, sorted(GG.edges(data=True)))
+        assert nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
+        assert edges_equal(enone, sorted(GG.edges(data=True)))
         GW = to_networkx_graph(dol, create_using=nx.Graph)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
-        assert_edges_equal(enone, sorted(GW.edges(data=True)))
+        assert nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
+        assert edges_equal(enone, sorted(GW.edges(data=True)))
         GI = nx.Graph(dol)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GI.nodes()))
-        assert_edges_equal(enone, sorted(GI.edges(data=True)))
+        assert nodes_equal(sorted(G.nodes()), sorted(GI.nodes()))
+        assert edges_equal(enone, sorted(GI.edges(data=True)))
 
     def test_with_multiedges_self_loops(self):
         G = cycle_graph(10)
@@ -149,14 +149,14 @@ class TestConvert:
         # with self loops, OK
         dod = to_dict_of_dicts(XGS)
         GG = from_dict_of_dicts(dod, create_using=nx.Graph)
-        assert_nodes_equal(XGS.nodes(), GG.nodes())
-        assert_edges_equal(XGS.edges(), GG.edges())
+        assert nodes_equal(XGS.nodes(), GG.nodes())
+        assert edges_equal(XGS.edges(), GG.edges())
         GW = to_networkx_graph(dod, create_using=nx.Graph)
-        assert_nodes_equal(XGS.nodes(), GW.nodes())
-        assert_edges_equal(XGS.edges(), GW.edges())
+        assert nodes_equal(XGS.nodes(), GW.nodes())
+        assert edges_equal(XGS.edges(), GW.edges())
         GI = nx.Graph(dod)
-        assert_nodes_equal(XGS.nodes(), GI.nodes())
-        assert_edges_equal(XGS.edges(), GI.edges())
+        assert nodes_equal(XGS.nodes(), GI.nodes())
+        assert edges_equal(XGS.edges(), GI.edges())
 
         # Dict of lists
         # with self loops, OK
@@ -164,71 +164,71 @@ class TestConvert:
         GG = from_dict_of_lists(dol, create_using=nx.Graph)
         # dict of lists throws away edge data so set it to none
         enone = [(u, v, {}) for (u, v, d) in XGS.edges(data=True)]
-        assert_nodes_equal(sorted(XGS.nodes()), sorted(GG.nodes()))
-        assert_edges_equal(enone, sorted(GG.edges(data=True)))
+        assert nodes_equal(sorted(XGS.nodes()), sorted(GG.nodes()))
+        assert edges_equal(enone, sorted(GG.edges(data=True)))
         GW = to_networkx_graph(dol, create_using=nx.Graph)
-        assert_nodes_equal(sorted(XGS.nodes()), sorted(GW.nodes()))
-        assert_edges_equal(enone, sorted(GW.edges(data=True)))
+        assert nodes_equal(sorted(XGS.nodes()), sorted(GW.nodes()))
+        assert edges_equal(enone, sorted(GW.edges(data=True)))
         GI = nx.Graph(dol)
-        assert_nodes_equal(sorted(XGS.nodes()), sorted(GI.nodes()))
-        assert_edges_equal(enone, sorted(GI.edges(data=True)))
+        assert nodes_equal(sorted(XGS.nodes()), sorted(GI.nodes()))
+        assert edges_equal(enone, sorted(GI.edges(data=True)))
 
         # Dict of dicts
         # with multiedges, OK
         dod = to_dict_of_dicts(XGM)
         GG = from_dict_of_dicts(dod, create_using=nx.MultiGraph, multigraph_input=True)
-        assert_nodes_equal(sorted(XGM.nodes()), sorted(GG.nodes()))
-        assert_edges_equal(sorted(XGM.edges()), sorted(GG.edges()))
+        assert nodes_equal(sorted(XGM.nodes()), sorted(GG.nodes()))
+        assert edges_equal(sorted(XGM.edges()), sorted(GG.edges()))
         GW = to_networkx_graph(dod, create_using=nx.MultiGraph, multigraph_input=True)
-        assert_nodes_equal(sorted(XGM.nodes()), sorted(GW.nodes()))
-        assert_edges_equal(sorted(XGM.edges()), sorted(GW.edges()))
+        assert nodes_equal(sorted(XGM.nodes()), sorted(GW.nodes()))
+        assert edges_equal(sorted(XGM.edges()), sorted(GW.edges()))
         GI = nx.MultiGraph(dod)  # convert can't tell whether to duplicate edges!
-        assert_nodes_equal(sorted(XGM.nodes()), sorted(GI.nodes()))
+        assert nodes_equal(sorted(XGM.nodes()), sorted(GI.nodes()))
         # assert_not_equal(sorted(XGM.edges()), sorted(GI.edges()))
         assert not sorted(XGM.edges()) == sorted(GI.edges())
         GE = from_dict_of_dicts(dod, create_using=nx.MultiGraph, multigraph_input=False)
-        assert_nodes_equal(sorted(XGM.nodes()), sorted(GE.nodes()))
+        assert nodes_equal(sorted(XGM.nodes()), sorted(GE.nodes()))
         assert sorted(XGM.edges()) != sorted(GE.edges())
         GI = nx.MultiGraph(XGM)
-        assert_nodes_equal(sorted(XGM.nodes()), sorted(GI.nodes()))
-        assert_edges_equal(sorted(XGM.edges()), sorted(GI.edges()))
+        assert nodes_equal(sorted(XGM.nodes()), sorted(GI.nodes()))
+        assert edges_equal(sorted(XGM.edges()), sorted(GI.edges()))
         GM = nx.MultiGraph(G)
-        assert_nodes_equal(sorted(GM.nodes()), sorted(G.nodes()))
-        assert_edges_equal(sorted(GM.edges()), sorted(G.edges()))
+        assert nodes_equal(sorted(GM.nodes()), sorted(G.nodes()))
+        assert edges_equal(sorted(GM.edges()), sorted(G.edges()))
 
         # Dict of lists
         # with multiedges, OK, but better write as DiGraph else you'll
         # get double edges
         dol = to_dict_of_lists(G)
         GG = from_dict_of_lists(dol, create_using=nx.MultiGraph)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GG.edges()))
+        assert nodes_equal(sorted(G.nodes()), sorted(GG.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(GG.edges()))
         GW = to_networkx_graph(dol, create_using=nx.MultiGraph)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GW.edges()))
+        assert nodes_equal(sorted(G.nodes()), sorted(GW.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(GW.edges()))
         GI = nx.MultiGraph(dol)
-        assert_nodes_equal(sorted(G.nodes()), sorted(GI.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(GI.edges()))
+        assert nodes_equal(sorted(G.nodes()), sorted(GI.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(GI.edges()))
 
     def test_edgelists(self):
         P = nx.path_graph(4)
         e = [(0, 1), (1, 2), (2, 3)]
         G = nx.Graph(e)
-        assert_nodes_equal(sorted(G.nodes()), sorted(P.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(P.edges()))
-        assert_edges_equal(sorted(G.edges(data=True)), sorted(P.edges(data=True)))
+        assert nodes_equal(sorted(G.nodes()), sorted(P.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(P.edges()))
+        assert edges_equal(sorted(G.edges(data=True)), sorted(P.edges(data=True)))
 
         e = [(0, 1, {}), (1, 2, {}), (2, 3, {})]
         G = nx.Graph(e)
-        assert_nodes_equal(sorted(G.nodes()), sorted(P.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(P.edges()))
-        assert_edges_equal(sorted(G.edges(data=True)), sorted(P.edges(data=True)))
+        assert nodes_equal(sorted(G.nodes()), sorted(P.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(P.edges()))
+        assert edges_equal(sorted(G.edges(data=True)), sorted(P.edges(data=True)))
 
         e = ((n, n + 1) for n in range(3))
         G = nx.Graph(e)
-        assert_nodes_equal(sorted(G.nodes()), sorted(P.nodes()))
-        assert_edges_equal(sorted(G.edges()), sorted(P.edges()))
-        assert_edges_equal(sorted(G.edges(data=True)), sorted(P.edges(data=True)))
+        assert nodes_equal(sorted(G.nodes()), sorted(P.nodes()))
+        assert edges_equal(sorted(G.edges()), sorted(P.edges()))
+        assert edges_equal(sorted(G.edges(data=True)), sorted(P.edges(data=True)))
 
     def test_directed_to_undirected(self):
         edges1 = [(0, 1), (1, 2), (2, 0)]
@@ -260,7 +260,7 @@ class TestConvert:
     def test_to_edgelist(self):
         G = nx.Graph([(1, 1)])
         elist = nx.to_edgelist(G, nodelist=list(G))
-        assert_edges_equal(G.edges(data=True), elist)
+        assert edges_equal(G.edges(data=True), elist)
 
     def test_custom_node_attr_dict_safekeeping(self):
         class custom_dict(dict):

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -4,7 +4,7 @@ np = pytest.importorskip("numpy")
 
 import networkx as nx
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
-from networkx.testing.utils import assert_graphs_equal
+from networkx.utils import graphs_equal
 
 
 def test_to_numpy_matrix_deprecation():
@@ -201,9 +201,9 @@ class TestConvertNumpyMatrix:
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
         expected.add_edge(1, 1, weight=2)
         actual = nx.from_numpy_matrix(A, parallel_edges=True, create_using=nx.DiGraph)
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         actual = nx.from_numpy_matrix(A, parallel_edges=False, create_using=nx.DiGraph)
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         # Now each integer entry in the adjacency matrix is interpreted as the
         # number of parallel edges in the graph if the appropriate keyword
         # argument is specified.
@@ -213,7 +213,7 @@ class TestConvertNumpyMatrix:
         actual = nx.from_numpy_matrix(
             A, parallel_edges=True, create_using=nx.MultiDiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         expected = nx.MultiDiGraph()
         expected.add_edges_from(set(edges), weight=1)
         # The sole self-loop (edge 0) on vertex 1 should have weight 2.
@@ -221,7 +221,7 @@ class TestConvertNumpyMatrix:
         actual = nx.from_numpy_matrix(
             A, parallel_edges=False, create_using=nx.MultiDiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
 
     def test_symmetric(self):
         """Tests that a symmetric matrix has edges added only once to an
@@ -232,7 +232,7 @@ class TestConvertNumpyMatrix:
         G = nx.from_numpy_matrix(A, create_using=nx.MultiGraph)
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, weight=1)
-        assert_graphs_equal(G, expected)
+        assert graphs_equal(G, expected)
 
     def test_dtype_int_graph(self):
         """Test that setting dtype int actually gives an integer matrix.
@@ -375,9 +375,9 @@ class TestConvertNumpyArray:
         expected.add_weighted_edges_from([(u, v, 1) for (u, v) in edges])
         expected.add_edge(1, 1, weight=2)
         actual = nx.from_numpy_array(A, parallel_edges=True, create_using=nx.DiGraph)
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         actual = nx.from_numpy_array(A, parallel_edges=False, create_using=nx.DiGraph)
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         # Now each integer entry in the adjacency matrix is interpreted as the
         # number of parallel edges in the graph if the appropriate keyword
         # argument is specified.
@@ -387,7 +387,7 @@ class TestConvertNumpyArray:
         actual = nx.from_numpy_array(
             A, parallel_edges=True, create_using=nx.MultiDiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         expected = nx.MultiDiGraph()
         expected.add_edges_from(set(edges), weight=1)
         # The sole self-loop (edge 0) on vertex 1 should have weight 2.
@@ -395,7 +395,7 @@ class TestConvertNumpyArray:
         actual = nx.from_numpy_array(
             A, parallel_edges=False, create_using=nx.MultiDiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
 
     def test_symmetric(self):
         """Tests that a symmetric array has edges added only once to an
@@ -406,7 +406,7 @@ class TestConvertNumpyArray:
         G = nx.from_numpy_array(A, create_using=nx.MultiGraph)
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, weight=1)
-        assert_graphs_equal(G, expected)
+        assert graphs_equal(G, expected)
 
     def test_dtype_int_graph(self):
         """Test that setting dtype int actually gives an integer array.

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,8 +1,6 @@
 import pytest
 import networkx as nx
-from networkx.utils import nodes_equal
-from networkx.utils import edges_equal
-from networkx.utils import graphs_equal
+from networkx.utils import nodes_equal, edges_equal, graphs_equal
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,8 +1,8 @@
 import pytest
 import networkx as nx
-from networkx.testing import assert_nodes_equal
-from networkx.testing import assert_edges_equal
-from networkx.testing import assert_graphs_equal
+from networkx.utils import nodes_equal
+from networkx.utils import edges_equal
+from networkx.utils import graphs_equal
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
@@ -39,12 +39,12 @@ class TestConvertPandas:
             ]
         )
         G = nx.from_pandas_edgelist(self.df, 0, "b", True)
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
         # MultiGraph
         MGtrue = nx.MultiGraph(Gtrue)
         MGtrue.add_edge("A", "D", cost=16, weight=4)
         MG = nx.from_pandas_edgelist(self.mdf, 0, "b", True, nx.MultiGraph())
-        assert_graphs_equal(MG, MGtrue)
+        assert graphs_equal(MG, MGtrue)
 
     def test_from_edgelist_multi_attr(self):
         Gtrue = nx.Graph(
@@ -55,7 +55,7 @@ class TestConvertPandas:
             ]
         )
         G = nx.from_pandas_edgelist(self.df, 0, "b", ["weight", "cost"])
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_multi_attr_incl_target(self):
         Gtrue = nx.Graph(
@@ -66,7 +66,7 @@ class TestConvertPandas:
             ]
         )
         G = nx.from_pandas_edgelist(self.df, 0, "b", [0, "b", "weight"])
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_multidigraph_and_edge_attr(self):
         # example from issue #2374
@@ -101,8 +101,8 @@ class TestConvertPandas:
             edge_attr=["St", "Co", "Mi"],
             create_using=nx.MultiDiGraph,
         )
-        assert_graphs_equal(G1, Gtrue)
-        assert_graphs_equal(G2, Gtrue)
+        assert graphs_equal(G1, Gtrue)
+        assert graphs_equal(G2, Gtrue)
 
     def test_from_edgelist_one_attr(self):
         Gtrue = nx.Graph(
@@ -113,7 +113,7 @@ class TestConvertPandas:
             ]
         )
         G = nx.from_pandas_edgelist(self.df, 0, "b", "weight")
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_int_attr_name(self):
         # note: this also tests that edge_attr can be `source`
@@ -121,7 +121,7 @@ class TestConvertPandas:
             [("E", "C", {0: "C"}), ("B", "A", {0: "B"}), ("A", "D", {0: "A"})]
         )
         G = nx.from_pandas_edgelist(self.df, 0, "b", 0)
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_invalid_attr(self):
         pytest.raises(
@@ -148,7 +148,7 @@ class TestConvertPandas:
     def test_from_edgelist_no_attr(self):
         Gtrue = nx.Graph([("E", "C", {}), ("B", "A", {}), ("A", "D", {})])
         G = nx.from_pandas_edgelist(self.df, 0, "b")
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist(self):
         # Pandas DataFrame
@@ -162,11 +162,11 @@ class TestConvertPandas:
         edges = pd.DataFrame({"source": source, "target": target, "weight": weight})
 
         GG = nx.from_pandas_edgelist(edges, edge_attr="weight")
-        assert_nodes_equal(G.nodes(), GG.nodes())
-        assert_edges_equal(G.edges(), GG.edges())
+        assert nodes_equal(G.nodes(), GG.nodes())
+        assert edges_equal(G.edges(), GG.edges())
         GW = nx.to_networkx_graph(edges, create_using=nx.Graph)
-        assert_nodes_equal(G.nodes(), GW.nodes())
-        assert_edges_equal(G.edges(), GW.edges())
+        assert nodes_equal(G.nodes(), GW.nodes())
+        assert edges_equal(G.edges(), GW.edges())
 
     def test_to_edgelist_default_source_or_target_col_exists(self):
 
@@ -223,13 +223,13 @@ class TestConvertPandas:
         Gtrue = graph([(1, 1), (1, 2)])
         df = nx.to_pandas_edgelist(Gtrue)
         G = nx.from_pandas_edgelist(df, create_using=graph)
-        assert_graphs_equal(Gtrue, G)
+        assert graphs_equal(Gtrue, G)
         # adjacency
         adj = {1: {1: {"weight": 1}, 2: {"weight": 1}}, 2: {1: {"weight": 1}}}
         Gtrue = graph(adj)
         df = nx.to_pandas_adjacency(Gtrue, dtype=int)
         G = nx.from_pandas_adjacency(df, create_using=graph)
-        assert_graphs_equal(Gtrue, G)
+        assert graphs_equal(Gtrue, G)
 
     def test_from_adjacency_named(self):
         # example from issue #3105
@@ -271,7 +271,7 @@ class TestConvertPandas:
             edge_key="attr1",
             create_using=nx.MultiGraph(),
         )
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
         df_roundtrip = nx.to_pandas_edgelist(G, edge_key="attr1")
         df_roundtrip = df_roundtrip.sort_values("attr1")
@@ -289,7 +289,7 @@ class TestConvertPandas:
             ]
         )
         G = nx.from_pandas_edgelist(self.df, 0, "b", True, edge_key="weight")
-        assert_graphs_equal(G, Gtrue)
+        assert graphs_equal(G, Gtrue)
 
     def test_nonexisting_edgekey_raises(self):
         with pytest.raises(nx.exception.NetworkXError):

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -5,7 +5,7 @@ sp = pytest.importorskip("scipy")
 import scipy.sparse  # call as sp.sparse
 
 import networkx as nx
-from networkx.testing import assert_graphs_equal
+from networkx.utils import graphs_equal
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
 
 
@@ -230,11 +230,11 @@ class TestConvertScipy:
         actual = nx.from_scipy_sparse_matrix(
             A, parallel_edges=True, create_using=nx.DiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         actual = nx.from_scipy_sparse_matrix(
             A, parallel_edges=False, create_using=nx.DiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         # Now each integer entry in the adjacency matrix is interpreted as the
         # number of parallel edges in the graph if the appropriate keyword
         # argument is specified.
@@ -244,7 +244,7 @@ class TestConvertScipy:
         actual = nx.from_scipy_sparse_matrix(
             A, parallel_edges=True, create_using=nx.MultiDiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
         expected = nx.MultiDiGraph()
         expected.add_edges_from(set(edges), weight=1)
         # The sole self-loop (edge 0) on vertex 1 should have weight 2.
@@ -252,7 +252,7 @@ class TestConvertScipy:
         actual = nx.from_scipy_sparse_matrix(
             A, parallel_edges=False, create_using=nx.MultiDiGraph
         )
-        assert_graphs_equal(actual, expected)
+        assert graphs_equal(actual, expected)
 
     def test_symmetric(self):
         """Tests that a symmetric matrix has edges added only once to an
@@ -264,7 +264,7 @@ class TestConvertScipy:
         G = nx.from_scipy_sparse_matrix(A, create_using=nx.MultiGraph)
         expected = nx.MultiGraph()
         expected.add_edge(0, 1, weight=1)
-        assert_graphs_equal(G, expected)
+        assert graphs_equal(G, expected)
 
 
 @pytest.mark.parametrize("sparse_format", ("csr", "csc", "dok"))
@@ -283,4 +283,4 @@ def test_from_scipy_sparse_matrix_formats(sparse_format):
         ]
     )
     A = sp.sparse.coo_matrix([[0, 3, 2], [3, 0, 1], [2, 1, 0]]).asformat(sparse_format)
-    assert_graphs_equal(expected, nx.from_scipy_sparse_matrix(A))
+    assert graphs_equal(expected, nx.from_scipy_sparse_matrix(A))

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -1,7 +1,7 @@
 import pytest
 import networkx as nx
 from networkx.generators.classic import empty_graph
-from networkx.testing import assert_nodes_equal, assert_edges_equal
+from networkx.utils import nodes_equal, edges_equal
 
 
 class TestRelabel:
@@ -29,7 +29,7 @@ class TestRelabel:
         degH = (d for n, d in H.degree())
         degG = (d for n, d in G.degree())
         assert sorted(degH) == sorted(degG)
-        assert_nodes_equal(H.nodes(), [1000, 1001, 1002, 1003])
+        assert nodes_equal(H.nodes(), [1000, 1001, 1002, 1003])
 
         H = nx.convert_node_labels_to_integers(G, ordering="increasing degree")
         degH = (d for n, d in H.degree())
@@ -92,7 +92,7 @@ class TestRelabel:
         G.add_edges_from([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
         mapping = {"A": "aardvark", "B": "bear", "C": "cat", "D": "dog"}
         H = nx.relabel_nodes(G, mapping)
-        assert_nodes_equal(H.nodes(), ["aardvark", "bear", "cat", "dog"])
+        assert nodes_equal(H.nodes(), ["aardvark", "bear", "cat", "dog"])
 
     def test_relabel_nodes_function(self):
         G = nx.empty_graph()
@@ -103,13 +103,13 @@ class TestRelabel:
             return ord(n)
 
         H = nx.relabel_nodes(G, mapping)
-        assert_nodes_equal(H.nodes(), [65, 66, 67, 68])
+        assert nodes_equal(H.nodes(), [65, 66, 67, 68])
 
     def test_relabel_nodes_graph(self):
         G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
         mapping = {"A": "aardvark", "B": "bear", "C": "cat", "D": "dog"}
         H = nx.relabel_nodes(G, mapping)
-        assert_nodes_equal(H.nodes(), ["aardvark", "bear", "cat", "dog"])
+        assert nodes_equal(H.nodes(), ["aardvark", "bear", "cat", "dog"])
 
     def test_relabel_nodes_orderedgraph(self):
         G = nx.OrderedGraph()
@@ -123,39 +123,39 @@ class TestRelabel:
         G = nx.DiGraph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
         mapping = {"A": "aardvark", "B": "bear", "C": "cat", "D": "dog"}
         H = nx.relabel_nodes(G, mapping, copy=False)
-        assert_nodes_equal(H.nodes(), ["aardvark", "bear", "cat", "dog"])
+        assert nodes_equal(H.nodes(), ["aardvark", "bear", "cat", "dog"])
 
     def test_relabel_nodes_multigraph(self):
         G = nx.MultiGraph([("a", "b"), ("a", "b")])
         mapping = {"a": "aardvark", "b": "bear"}
         G = nx.relabel_nodes(G, mapping, copy=False)
-        assert_nodes_equal(G.nodes(), ["aardvark", "bear"])
-        assert_edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
+        assert nodes_equal(G.nodes(), ["aardvark", "bear"])
+        assert edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
 
     def test_relabel_nodes_multidigraph(self):
         G = nx.MultiDiGraph([("a", "b"), ("a", "b")])
         mapping = {"a": "aardvark", "b": "bear"}
         G = nx.relabel_nodes(G, mapping, copy=False)
-        assert_nodes_equal(G.nodes(), ["aardvark", "bear"])
-        assert_edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
+        assert nodes_equal(G.nodes(), ["aardvark", "bear"])
+        assert edges_equal(G.edges(), [("aardvark", "bear"), ("aardvark", "bear")])
 
     def test_relabel_isolated_nodes_to_same(self):
         G = nx.Graph()
         G.add_nodes_from(range(4))
         mapping = {1: 1}
         H = nx.relabel_nodes(G, mapping, copy=False)
-        assert_nodes_equal(H.nodes(), list(range(4)))
+        assert nodes_equal(H.nodes(), list(range(4)))
 
     def test_relabel_nodes_missing(self):
         G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
         mapping = {0: "aardvark"}
         # copy=True
         H = nx.relabel_nodes(G, mapping, copy=True)
-        assert_nodes_equal(H.nodes, G.nodes)
+        assert nodes_equal(H.nodes, G.nodes)
         # copy=False
         GG = G.copy()
         nx.relabel_nodes(G, mapping, copy=False)
-        assert_nodes_equal(G.nodes, GG.nodes)
+        assert nodes_equal(G.nodes, GG.nodes)
 
     def test_relabel_copy_name(self):
         G = nx.Graph()
@@ -181,13 +181,13 @@ class TestRelabel:
     def test_relabel_selfloop(self):
         G = nx.DiGraph([(1, 1), (1, 2), (2, 3)])
         G = nx.relabel_nodes(G, {1: "One", 2: "Two", 3: "Three"}, copy=False)
-        assert_nodes_equal(G.nodes(), ["One", "Three", "Two"])
+        assert nodes_equal(G.nodes(), ["One", "Three", "Two"])
         G = nx.MultiDiGraph([(1, 1), (1, 2), (2, 3)])
         G = nx.relabel_nodes(G, {1: "One", 2: "Two", 3: "Three"}, copy=False)
-        assert_nodes_equal(G.nodes(), ["One", "Three", "Two"])
+        assert nodes_equal(G.nodes(), ["One", "Three", "Two"])
         G = nx.MultiDiGraph([(1, 1)])
         G = nx.relabel_nodes(G, {1: 0}, copy=False)
-        assert_nodes_equal(G.nodes(), [0])
+        assert nodes_equal(G.nodes(), [0])
 
     def test_relabel_multidigraph_inout_merge_nodes(self):
         for MG in (nx.MultiGraph, nx.MultiDiGraph):

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -550,7 +550,7 @@ def nodes_equal(nodes1, nodes2):
 
     Parameters
     ----------
-    nodes1, nodes2 : iterables of nodes, or (node,datadict) tuples
+    nodes1, nodes2 : iterables of nodes, or (node, datadict) tuples
 
     Returns
     -------
@@ -573,10 +573,10 @@ def edges_equal(edges1, edges2):
 
     Parameters
     ----------
-    edges1, edges2 : iterables of with u,v nodes as
-        edge tuples (u,v), or
-        edge tuples with data dicts (u,v,d), or
-        edge tuples with keys and data dicts (u,v,k, d)
+    edges1, edges2 : iterables of with u, v nodes as
+        edge tuples (u, v), or
+        edge tuples with data dicts (u, v, d), or
+        edge tuples with keys and data dicts (u, v, k, d)
 
     Returns
     -------

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -546,7 +546,17 @@ def create_py_random_state(random_state=None):
 
 
 def nodes_equal(nodes1, nodes2):
-    # Assumes iterables of nodes, or (node,datadict) tuples
+    """Check if nodes are equal.
+
+    Parameters
+    ----------
+    nodes1, nodes2 : iterables of nodes, or (node,datadict) tuples
+
+    Returns
+    -------
+    bool
+        True if nodes are equal, False otherwise.
+    """
     nlist1 = list(nodes1)
     nlist2 = list(nodes2)
     try:
@@ -559,10 +569,20 @@ def nodes_equal(nodes1, nodes2):
 
 
 def edges_equal(edges1, edges2):
-    # Assumes iterables with u,v nodes as
-    # edge tuples (u,v), or
-    # edge tuples with data dicts (u,v,d), or
-    # edge tuples with keys and data dicts (u,v,k, d)
+    """Check if edges are equal.
+
+    Parameters
+    ----------
+    edges1, edges2 : iterables of with u,v nodes as
+        edge tuples (u,v), or
+        edge tuples with data dicts (u,v,d), or
+        edge tuples with keys and data dicts (u,v,k, d)
+
+    Returns
+    -------
+    bool
+        True if edges are equal, False otherwise.
+    """
     from collections import defaultdict
 
     d1 = defaultdict(dict)
@@ -600,6 +620,17 @@ def edges_equal(edges1, edges2):
 
 
 def graphs_equal(graph1, graph2):
+    """Check if graphs are equal.
+
+    Parameters
+    ----------
+    graph1, graph2 : graph
+
+    Returns
+    -------
+    bool
+        True if graphs are equal, False otherwise.
+    """
     return (
         graph1.adj == graph2.adj
         and graph1.nodes == graph2.nodes

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -548,6 +548,10 @@ def create_py_random_state(random_state=None):
 def nodes_equal(nodes1, nodes2):
     """Check if nodes are equal.
 
+    Equality here means equal as Python objects.
+    Node data must match if included.
+    The order of nodes is not relevant.
+
     Parameters
     ----------
     nodes1, nodes2 : iterables of nodes, or (node, datadict) tuples
@@ -570,6 +574,10 @@ def nodes_equal(nodes1, nodes2):
 
 def edges_equal(edges1, edges2):
     """Check if edges are equal.
+
+    Equality here means equal as Python objects.
+    Edge data must match if included.
+    The order of the edges is not relevant.
 
     Parameters
     ----------
@@ -621,6 +629,9 @@ def edges_equal(edges1, edges2):
 
 def graphs_equal(graph1, graph2):
     """Check if graphs are equal.
+
+    Equality here means equal as Python objects (not isomorphism).
+    Node, edge and graph data must match.
 
     Parameters
     ----------

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -41,6 +41,9 @@ __all__ = [
     "create_random_state",
     "create_py_random_state",
     "PythonRandomInterface",
+    "nodes_equal",
+    "edges_equal",
+    "graphs_equal",
 ]
 
 
@@ -540,3 +543,65 @@ def create_py_random_state(random_state=None):
         return random.Random(random_state)
     msg = f"{random_state} cannot be used to generate a random.Random instance"
     raise ValueError(msg)
+
+
+def nodes_equal(nodes1, nodes2):
+    # Assumes iterables of nodes, or (node,datadict) tuples
+    nlist1 = list(nodes1)
+    nlist2 = list(nodes2)
+    try:
+        d1 = dict(nlist1)
+        d2 = dict(nlist2)
+    except (ValueError, TypeError):
+        d1 = dict.fromkeys(nlist1)
+        d2 = dict.fromkeys(nlist2)
+    return d1 == d2
+
+
+def edges_equal(edges1, edges2):
+    # Assumes iterables with u,v nodes as
+    # edge tuples (u,v), or
+    # edge tuples with data dicts (u,v,d), or
+    # edge tuples with keys and data dicts (u,v,k, d)
+    from collections import defaultdict
+
+    d1 = defaultdict(dict)
+    d2 = defaultdict(dict)
+    c1 = 0
+    for c1, e in enumerate(edges1):
+        u, v = e[0], e[1]
+        data = [e[2:]]
+        if v in d1[u]:
+            data = d1[u][v] + data
+        d1[u][v] = data
+        d1[v][u] = data
+    c2 = 0
+    for c2, e in enumerate(edges2):
+        u, v = e[0], e[1]
+        data = [e[2:]]
+        if v in d2[u]:
+            data = d2[u][v] + data
+        d2[u][v] = data
+        d2[v][u] = data
+    if c1 != c2:
+        return False
+    # can check one direction because lengths are the same.
+    for n, nbrdict in d1.items():
+        for nbr, datalist in nbrdict.items():
+            if n not in d2:
+                return False
+            if nbr not in d2[n]:
+                return False
+            d2datalist = d2[n][nbr]
+            for data in datalist:
+                if datalist.count(data) != d2datalist.count(data):
+                    return False
+    return True
+
+
+def graphs_equal(graph1, graph2):
+    return (
+        graph1.adj == graph2.adj
+        and graph1.nodes == graph2.nodes
+        and graph1.graph == graph2.graph
+    )


### PR DESCRIPTION
As discussed in #4582, change `assert_edges_equal`, `assert_graphs_equal`, and `assert_nodes_equal` to be more pytest-idiomatic.  For example, `assert_edges_equal` becomes the Boolean function `edges_equal` and then the assert is done the testing file (i.e., `assert edges_equal(edges1, edges2)`).

This also makes these utility functions useful in nontesting situations where you want to compare edges, but not raise an exception based on the result.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
