### PR TITLE
Limit number of threads used by OMP in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ jobs:
       - run:
           name: Build docs
           command: |
+            # NOTE: bad interaction w/ blas multithreading on circleci
+            export OMP_NUM_THREADS=1
             source venv/bin/activate
             make -C doc/ html
             make -C doc/ latexpdf LATEXOPTS="-file-line-error -halt-on-error"


### PR DESCRIPTION
May speed up any long-running examples that rely on numpy/scipy linalg.

See how the sphinx-gallery build goes in circleci, apply to other CI services if it has an effect.