### PR TITLE
Fix bad import pattern

### DIFF
--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -3,6 +3,8 @@
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+__all__ = ["chain_decomposition"]
+
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -1,5 +1,7 @@
 import networkx as nx
 
+__all__ = ["s_metric"]
+
 
 def s_metric(G, normalized=True):
     """Returns the s-metric of graph.

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -14,6 +14,8 @@ from networkx.classes.reportviews import (
 from networkx.exception import NetworkXError
 import networkx.convert as convert
 
+__all__ = ["DiGraph"]
+
 
 class DiGraph(Graph):
     """

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -15,6 +15,8 @@ from networkx.classes.reportviews import NodeView, EdgeView, DegreeView
 from networkx.exception import NetworkXError
 import networkx.convert as convert
 
+__all__ = ["Graph"]
+
 
 class Graph:
     """

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -14,6 +14,8 @@ from networkx.classes.reportviews import (
 )
 from networkx.exception import NetworkXError
 
+__all__ = ["MultiDiGraph"]
+
 
 class MultiDiGraph(MultiGraph, DiGraph):
     """A directed graph class that can store multiedges.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -7,6 +7,8 @@ from networkx.classes.coreviews import MultiAdjacencyView
 from networkx.classes.reportviews import MultiEdgeView, MultiDegreeView
 from networkx import NetworkXError
 
+__all__ = ["MultiGraph"]
+
 
 class MultiGraph(Graph):
     """

--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -2,6 +2,8 @@
 Text-based visual representations of graphs
 """
 
+__all__ = ["forest_str"]
+
 
 def forest_str(graph, with_labels=True, sources=None, write=None, ascii_only=False):
     """

--- a/networkx/tests/test_import.py
+++ b/networkx/tests/test_import.py
@@ -4,8 +4,3 @@ import pytest
 def test_namespace_alias():
     with pytest.raises(ImportError):
         from networkx import nx
-
-
-def test_namespace_nesting():
-    with pytest.raises(ImportError):
-        from networkx import networkx

--- a/networkx/tests/test_import.py
+++ b/networkx/tests/test_import.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_namespace():
+    with pytest.raises(ImportError):
+        from networkx import nx

--- a/networkx/tests/test_import.py
+++ b/networkx/tests/test_import.py
@@ -1,6 +1,11 @@
 import pytest
 
 
-def test_namespace():
+def test_namespace_alias():
     with pytest.raises(ImportError):
         from networkx import nx
+
+
+def test_namespace_nesting():
+    with pytest.raises(ImportError):
+        from networkx import networkx


### PR DESCRIPTION
**EDIT**: Partially addresses #4426; fixes `from networkx import nx` by adding some missing `__all__`'s to modules.

Original discussion (which attempted to tackle multiple issues at once) below.

---

Related to #4426 - attempting to fix bad import patterns like `from networkx import nx` or `from networkx import networkx`.

Adds tests for the two patterns mentioned above. Adding the `__all__` dunders to a couple modules where they were missing (found with `grep -L`) fixes the `from networkx import nx` problem, but I haven't been able to crack the second case in this first pass. Suggestions welcome!

If worse comes to worst, one hack-y solution would be to add `del networkx` to `networkx/__init__.py`; though IMO it would be preferable to find where/how `networkx` is being imported into itself and stop that from happening.

I'm marking with the 2.6 milestone for visibility. If we don't manage to figure out how to resolve the second test case, then the three courses of action I could see would be:
 1) Comment out the second test and merge as is. This at least fixes the `from networkx import nx` problem for the 2.6 release
 2) Add the hacky `del` to also resolve the `from networkx import networkx` issue for the 2.6 release.
 3) Bump everything to 3.0

My personal preference (assuming the 2nd case isn't solved before the release candidate) is option 1 - fix part of the problem, leave #4426 open and leave the other problem for a follow-on PR.