### PR TITLE
Remove "networkx" from top-level networkx namespace

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -53,36 +53,36 @@ def __getattr__(name):
 
 # These are import orderwise
 from networkx.exception import *
-import networkx.utils
 
-import networkx.classes.filters
-import networkx.classes
+from networkx import utils
+
+from networkx import classes
+from networkx.classes import filters
 from networkx.classes import *
 
-import networkx.convert
+from networkx import convert
 from networkx.convert import *
 
-import networkx.convert_matrix
+from networkx import convert_matrix
 from networkx.convert_matrix import *
 
-
-import networkx.relabel
+from networkx import relabel
 from networkx.relabel import *
 
-import networkx.generators
+from networkx import generators
 from networkx.generators import *
 
-import networkx.readwrite
+from networkx import readwrite
 from networkx.readwrite import *
 
 # Need to test with SciPy, when available
-import networkx.algorithms
+from networkx import algorithms
 from networkx.algorithms import *
 
-import networkx.linalg
+from networkx import linalg
 from networkx.linalg import *
 
 from networkx.testing.test import run as test
 
-import networkx.drawing
+from networkx import drawing
 from networkx.drawing import *

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -58,27 +58,27 @@ from networkx.algorithms.wiener import *
 
 # Make certain subpackages available to the user as direct imports from
 # the `networkx` namespace.
-import networkx.algorithms.approximation
-import networkx.algorithms.assortativity
-import networkx.algorithms.bipartite
-import networkx.algorithms.node_classification
-import networkx.algorithms.centrality
-import networkx.algorithms.chordal
-import networkx.algorithms.cluster
-import networkx.algorithms.clique
-import networkx.algorithms.components
-import networkx.algorithms.connectivity
-import networkx.algorithms.community
-import networkx.algorithms.coloring
-import networkx.algorithms.flow
-import networkx.algorithms.isomorphism
-import networkx.algorithms.link_analysis
-import networkx.algorithms.lowest_common_ancestors
-import networkx.algorithms.operators
-import networkx.algorithms.shortest_paths
-import networkx.algorithms.tournament
-import networkx.algorithms.traversal
-import networkx.algorithms.tree
+from networkx.algorithms import approximation
+from networkx.algorithms import assortativity
+from networkx.algorithms import bipartite
+from networkx.algorithms import node_classification
+from networkx.algorithms import centrality
+from networkx.algorithms import chordal
+from networkx.algorithms import cluster
+from networkx.algorithms import clique
+from networkx.algorithms import components
+from networkx.algorithms import connectivity
+from networkx.algorithms import community
+from networkx.algorithms import coloring
+from networkx.algorithms import flow
+from networkx.algorithms import isomorphism
+from networkx.algorithms import link_analysis
+from networkx.algorithms import lowest_common_ancestors
+from networkx.algorithms import operators
+from networkx.algorithms import shortest_paths
+from networkx.algorithms import tournament
+from networkx.algorithms import traversal
+from networkx.algorithms import tree
 
 # Make certain functions from some of the previous subpackages available
 # to the user as direct imports from the `networkx` namespace.

--- a/networkx/classes/__init__.py
+++ b/networkx/classes/__init__.py
@@ -6,8 +6,8 @@ from .ordered import *
 
 from .function import *
 
-import networkx.classes.filters
+from networkx.classes import filters
 
-import networkx.classes.coreviews
-import networkx.classes.graphviews
-import networkx.classes.reportviews
+from networkx.classes import coreviews
+from networkx.classes import graphviews
+from networkx.classes import reportviews

--- a/networkx/linalg/__init__.py
+++ b/networkx/linalg/__init__.py
@@ -1,13 +1,13 @@
 from networkx.linalg.attrmatrix import *
-import networkx.linalg.attrmatrix
+from networkx.linalg import attrmatrix
 from networkx.linalg.spectrum import *
-import networkx.linalg.spectrum
+from networkx.linalg import spectrum
 from networkx.linalg.graphmatrix import *
-import networkx.linalg.graphmatrix
+from networkx.linalg import graphmatrix
 from networkx.linalg.laplacianmatrix import *
-import networkx.linalg.laplacianmatrix
+from networkx.linalg import laplacianmatrix
 from networkx.linalg.algebraicconnectivity import *
 from networkx.linalg.modularitymatrix import *
-import networkx.linalg.modularitymatrix
+from networkx.linalg import modularitymatrix
 from networkx.linalg.bethehessianmatrix import *
-import networkx.linalg.bethehessianmatrix
+from networkx.linalg import bethehessianmatrix

--- a/networkx/tests/test_import.py
+++ b/networkx/tests/test_import.py
@@ -1,6 +1,6 @@
 import pytest
 
 
-def test_namespace_alias():
+def test_namespace():
     with pytest.raises(ImportError):
         from networkx import nx

--- a/networkx/tests/test_import.py
+++ b/networkx/tests/test_import.py
@@ -1,6 +1,11 @@
 import pytest
 
 
-def test_namespace():
+def test_namespace_alias():
     with pytest.raises(ImportError):
         from networkx import nx
+
+
+def test_namespace_nesting():
+    with pytest.raises(ImportError):
+        from networkx import networkx


### PR DESCRIPTION
Followup to #4839. This was originally attempted there, but ultimately ended up seemingly like a more complicated issue.

The goal is to prevent `networkx` from being imported in the top-level `networkx` namespace. In other words, this should not be possible: `from networkx import networkx`. See the discussion in #4839 for original discussion and some ideas for how to probe/fix this problem.