### PR TITLE
Remove unused `normalized` parameter from communicability_betweenness_centrality

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -176,6 +176,9 @@ API Changes
 - [`#4786 <https://github.com/networkx/networkx/pull/4786>`_]
   Deprecate the ``attrs`` keyword argument in favor of explicit keyword
   arguments in the ``json_graph`` module.
+- [`#4843 <https://github.com/networkx/networkx/pull/4843>`_]
+  The unused ``normalized`` parameter has been removed
+  from ``communicability_betweeness_centrality``
 
 Deprecations
 ------------

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -188,7 +188,7 @@ def subgraph_centrality(G):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-def communicability_betweenness_centrality(G, normalized=True):
+def communicability_betweenness_centrality(G):
     r"""Returns subgraph communicability for all pairs of nodes in G.
 
     Communicability betweenness measure makes use of the number of walks
@@ -281,20 +281,10 @@ def communicability_betweenness_centrality(G, normalized=True):
         # put row and col back
         A[i, :] = row
         A[:, i] = col
-    # rescaling
-    cbc = _rescale(cbc, normalized=normalized)
-    return cbc
-
-
-def _rescale(cbc, normalized):
-    # helper to rescale betweenness centrality
-    if normalized is True:
-        order = len(cbc)
-        if order <= 2:
-            scale = None
-        else:
-            scale = 1.0 / ((order - 1.0) ** 2 - (order - 1.0))
-    if scale is not None:
+    # rescale when more than two nodes
+    order = len(cbc)
+    if order > 2:
+        scale = 1.0 / ((order - 1.0) ** 2 - (order - 1.0))
         for v in cbc:
             cbc[v] *= scale
     return cbc

--- a/networkx/algorithms/centrality/tests/test_subgraph.py
+++ b/networkx/algorithms/centrality/tests/test_subgraph.py
@@ -53,6 +53,25 @@ class TestSubgraph:
         comm200 = nx.subgraph_centrality(g200)
         comm200_exp = nx.subgraph_centrality_exp(g200)
 
+    def test_communicability_betweenness_centrality_small(self):
+        result = communicability_betweenness_centrality(nx.path_graph(2))
+        assert result == {0: 0, 1: 0}
+
+        result = communicability_betweenness_centrality(nx.path_graph(1))
+        assert result == {0: 0}
+
+        result = communicability_betweenness_centrality(nx.path_graph(0))
+        assert result == {}
+
+        answer = {0: 0.1411224421177313, 1: 1.0, 2: 0.1411224421177313}
+        result = communicability_betweenness_centrality(nx.path_graph(3))
+        for k, v in result.items():
+            assert answer[k] == pytest.approx(result[k], abs=1e-7)
+
+        result = communicability_betweenness_centrality(nx.complete_graph(3))
+        for k, v in result.items():
+            assert 0.49786143366223296 == pytest.approx(result[k], abs=1e-7)
+
     def test_communicability_betweenness_centrality(self):
         answer = {
             0: 0.07017447951484615,


### PR DESCRIPTION
Fixes #4171