### PR TITLE
Self ancestor is not found using lowest_common_ancestor

### DIFF
--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -289,7 +289,7 @@ class TestDAGLCA:
         # example from #4458
         G = nx.DiGraph([(1, 0), (2, 0), (3, 2), (4, 1), (4, 3)])
         for (i, j), a in all_pairs_lca(G):
-            if i==j:
+            if i == j:
                 assert a == i == j
 
     def test_all_pairs_lowest_common_ancestor9(self):

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -285,6 +285,13 @@ class TestDAGLCA:
         """Test that LCA on non-dags bails."""
         pytest.raises(nx.NetworkXError, all_pairs_lca, nx.DiGraph([(3, 4), (4, 3)]))
 
+    def test_all_pairs_lowest_common_ancestor_self_ancestor(self):
+        # example from #4458
+        G = nx.DiGraph([(1, 0), (2, 0), (3, 2), (4, 1), (4, 3)])
+        for (i, j), a in all_pairs_lca(G):
+            if i==j:
+                assert a == i == j
+
     def test_all_pairs_lowest_common_ancestor9(self):
         """Test that it works on non-empty graphs with no LCAs."""
         G = nx.DiGraph()
@@ -309,3 +316,8 @@ class TestDAGLCA:
         G = nx.DiGraph()
         G.add_node(3)
         assert nx.lowest_common_ancestor(G, 3, 3) == 3
+
+    def test_lowest_common_ancestor_self_ancestor(self):
+        # example from #4458
+        G = nx.DiGraph([(1, 0), (2, 0), (3, 2), (4, 1), (4, 3)])
+        assert nx.lowest_common_ancestor(G, 0, 0) == 0


### PR DESCRIPTION
This PR adds tests to show that `lowest_common_ancestor` and friends do not always work correctly when the 2 provided nodes are the same.  We should track down whether this is a corner case that can be fixed by special treatment, or a deeper bug in the implementation.

See #4458 
