### PR TITLE
Add dtype argument to adjacency_matrix

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -87,3 +87,4 @@ Version 3.0
 * In ``utils/decorators.py`` remove ``preserve_random_state``.
 * In ``algorithms/community/quality.py`` remove ``coverage`` and ``performance``.
 * Remove ``testing``.
+* In ``linalg/graphmatrix.py`` remove ``adj_matrix``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -179,6 +179,8 @@ API Changes
 - [`#4843 <https://github.com/networkx/networkx/pull/4843>`_]
   The unused ``normalized`` parameter has been removed
   from ``communicability_betweeness_centrality``
+- [`#4850 <https://github.com/networkx/networkx/pull/4850>`_]
+  Added ``dtype`` parameter to adjacency_matrix
 
 Deprecations
 ------------
@@ -233,6 +235,8 @@ Deprecations
   Deprecate ``run``.
 - [`#4829 <https://github.com/networkx/networkx/pull/4829>`_]
   Deprecate ``assert_nodes_equal``, ``assert_edges_equal``, and ``assert_graphs_equal``.
+- [`#4850 <https://github.com/networkx/networkx/pull/4850>`_]
+  Deprecate ``adj_matrix``.
 
 Contributors
 ------------

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -322,7 +322,7 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
         except (TypeError, ValueError, AttributeError) as e:
             raise nx.NetworkXError("beta must be a number") from e
 
-    A = nx.adj_matrix(G, nodelist=nodelist, weight=weight).todense().T
+    A = nx.adjacency_matrix(G, nodelist=nodelist, weight=weight).todense().T
     n = A.shape[0]
     centrality = np.linalg.solve(np.eye(n, n) - (alpha * A), b)
     if normalized:

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -96,7 +96,7 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
     return A.asformat("csc")
 
 
-def adjacency_matrix(G, nodelist=None, weight="weight"):
+def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight"):
     """Returns adjacency matrix of G.
 
     Parameters
@@ -107,6 +107,10 @@ def adjacency_matrix(G, nodelist=None, weight="weight"):
     nodelist : list, optional
        The rows and columns are ordered according to the nodes in nodelist.
        If nodelist is None, then the ordering is produced by G.nodes().
+
+    dtype : NumPy data-type, optional
+        The desired data-type for the array.
+        If None, then the NumPy default is used.
 
     weight : string or None, optional (default='weight')
        The edge data key used to provide each value in the matrix.
@@ -150,7 +154,21 @@ def adjacency_matrix(G, nodelist=None, weight="weight"):
     to_dict_of_dicts
     adjacency_spectrum
     """
-    return nx.to_scipy_sparse_matrix(G, nodelist=nodelist, weight=weight)
+    return nx.to_scipy_sparse_matrix(G, nodelist=nodelist, dtype=dtype, weight=weight)
 
 
-adj_matrix = adjacency_matrix
+def _adj_matrix_warning(G, nodelist=None, dtype=None, weight="weight"):
+    import warnings
+
+    warnings.warn(
+        (
+            "adj_matrix is deprecated and will be removed in version 3.0.\n"
+            "Use `adjacency_matrix` instead\n"
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return adjacency_matrix(G, nodelist, dtype, weight)
+
+
+adj_matrix = _adj_matrix_warning

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -275,20 +275,23 @@ class TestGraphMatrix:
 
     def test_adjacency_matrix(self):
         "Conversion to adjacency matrix"
-        np.testing.assert_equal(nx.adj_matrix(self.G).todense(), self.A)
-        np.testing.assert_equal(nx.adj_matrix(self.MG).todense(), self.A)
-        np.testing.assert_equal(nx.adj_matrix(self.MG2).todense(), self.MG2A)
+        np.testing.assert_equal(nx.adjacency_matrix(self.G).todense(), self.A)
+        np.testing.assert_equal(nx.adjacency_matrix(self.MG).todense(), self.A)
+        np.testing.assert_equal(nx.adjacency_matrix(self.MG2).todense(), self.MG2A)
         np.testing.assert_equal(
-            nx.adj_matrix(self.G, nodelist=[0, 1]).todense(), self.A[:2, :2]
+            nx.adjacency_matrix(self.G, nodelist=[0, 1]).todense(), self.A[:2, :2]
         )
-        np.testing.assert_equal(nx.adj_matrix(self.WG).todense(), self.WA)
-        np.testing.assert_equal(nx.adj_matrix(self.WG, weight=None).todense(), self.A)
+        np.testing.assert_equal(nx.adjacency_matrix(self.WG).todense(), self.WA)
         np.testing.assert_equal(
-            nx.adj_matrix(self.MG2, weight=None).todense(), self.MG2A
-        )
-        np.testing.assert_equal(
-            nx.adj_matrix(self.WG, weight="other").todense(), 0.6 * self.WA
+            nx.adjacency_matrix(self.WG, weight=None).todense(), self.A
         )
         np.testing.assert_equal(
-            nx.adj_matrix(self.no_edges_G, nodelist=[1, 3]).todense(), self.no_edges_A
+            nx.adjacency_matrix(self.MG2, weight=None).todense(), self.MG2A
+        )
+        np.testing.assert_equal(
+            nx.adjacency_matrix(self.WG, weight="other").todense(), 0.6 * self.WA
+        )
+        np.testing.assert_equal(
+            nx.adjacency_matrix(self.no_edges_G, nodelist=[1, 3]).todense(),
+            self.no_edges_A,
         )

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -151,7 +151,7 @@ class TestConvertNumpyMatrix:
         pytest.raises(TypeError, nx.from_numpy_matrix, A)
 
         G = nx.cycle_graph(3)
-        A = nx.adj_matrix(G).todense()
+        A = nx.adjacency_matrix(G).todense()
         H = nx.from_numpy_matrix(A)
         assert all(type(m) == int and type(n) == int for m, n in H.edges())
         H = nx.from_numpy_array(A)


### PR DESCRIPTION
@dschult This adds a dtype argument to `adjacency_matrix` and deprecates `adj_matrix`.