### PR TITLE
Fix assortativity coefficent calculation and tests

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -188,6 +188,10 @@ API Changes
   from ``communicability_betweeness_centrality``
 - [`#4850 <https://github.com/networkx/networkx/pull/4850>`_]
   Added ``dtype`` parameter to adjacency_matrix
+- [`#4851 <https://github.com/networkx/networkx/pull/4851>`_]
+  Output of `numeric_mixing_matrix` and `degree_mixing_matrix` no longer
+  includes rows with all entries zero by default. The functions now accept
+  a parameter `mapping` keyed by value to row index to identify each row.
 - [`#4867 <https://github.com/networkx/networkx/pull/4867>`_]
   The function ``spring_layout`` now ignores 'fixed' nodes not in the graph
 

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -187,15 +187,13 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
 
     Assortativity measures the similarity of connections
     in the graph with respect to the given numeric attribute.
-    The numeric attribute must be an integer.
 
     Parameters
     ----------
     G : NetworkX graph
 
     attribute : string
-        Node attribute key.  The corresponding attribute value must be an
-        integer.
+        Node attribute key.
 
     nodes: list or iterable (optional)
         Compute numeric assortativity only for attributes of nodes in

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -141,7 +141,7 @@ def degree_mixing_matrix(
        The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
-    
+
     mapping : dictionary, optional
        Mapping from node degree to integer index in matrix.
        If not specified, an arbitrary ordering will be used.

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -117,7 +117,9 @@ def degree_mixing_dict(G, x="out", y="in", weight=None, nodes=None, normalized=F
     return mixing_dict(xy_iter, normalized=normalized)
 
 
-def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, mapping=None, normalized=True):
+def degree_mixing_matrix(
+   G, x="out", y="in", weight=None, nodes=None, mapping=None, normalized=True
+):
     """Returns mixing matrix for attribute.
 
     Parameters
@@ -162,15 +164,13 @@ def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, mapping=No
 def numeric_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=True):
     """Returns numeric mixing matrix for attribute.
 
-    The attribute must be an integer.
-
     Parameters
     ----------
     G : graph
        NetworkX graph object.
 
     attribute : string
-       Node attribute key.  The corresponding attribute must be an integer.
+       Node attribute key.
 
     nodes: list or iterable (optional)
         Build the matrix only with nodes in container. The default is all nodes.

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -187,7 +187,7 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
     s = set(d.keys())
     for k, v in d.items():
         s.update(v.keys())
-    mapping = {x:i for i, x in enumerate(s)}
+    mapping = {x: i for i, x in enumerate(s)}
     a = dict_to_numpy_array(d, mapping=mapping)
     if normalized:
         a = a / a.sum()

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -118,7 +118,7 @@ def degree_mixing_dict(G, x="out", y="in", weight=None, nodes=None, normalized=F
 
 
 def degree_mixing_matrix(
-   G, x="out", y="in", weight=None, nodes=None, mapping=None, normalized=True
+    G, x="out", y="in", weight=None, nodes=None, mapping=None, normalized=True
 ):
     """Returns mixing matrix for attribute.
 
@@ -181,6 +181,15 @@ def numeric_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=Tru
 
     normalized : bool (default=True)
        Return counts if False or probabilities if True.
+
+    Notes
+    -----
+    If each node has a unique attribute value, the unnormalized mixing matrix
+    will be equal to the adjacency matrix. To get a denser mixing matrix,
+    the rounding can be performed ​​to form groups of nodes with equal values.
+    For example, the exact height of persons in cm (180.79155222, 163.9080892,
+    163.30095355, 167.99016217, 168.21590163, ...) can be rounded to (180, 163,
+    163, 168, 168, ...).
 
     Returns
     -------

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -152,7 +152,7 @@ def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, normalized
     s = set(d.keys())
     for k, v in d.items():
         s.update(v.keys())
-    mapping = {x:i for i, x in enumerate(s)}
+    mapping = {x: i for i, x in enumerate(s)}
     a = dict_to_numpy_array(d, mapping=mapping)
     if normalized:
         a = a / a.sum()

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -117,7 +117,7 @@ def degree_mixing_dict(G, x="out", y="in", weight=None, nodes=None, normalized=F
     return mixing_dict(xy_iter, normalized=normalized)
 
 
-def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, normalized=True):
+def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, mapping=None, normalized=True):
     """Returns mixing matrix for attribute.
 
     Parameters
@@ -139,6 +139,10 @@ def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, normalized
        The edge attribute that holds the numerical value used
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
+    
+    mapping : dictionary, optional
+       Mapping from node degree to integer index in matrix.
+       If not specified, an arbitrary ordering will be used.
 
     normalized : bool (default=True)
        Return counts if False or probabilities if True.
@@ -149,17 +153,13 @@ def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, normalized
        Counts, or joint probability, of occurrence of node degree.
     """
     d = degree_mixing_dict(G, x=x, y=y, nodes=nodes, weight=weight)
-    s = set(d.keys())
-    for k, v in d.items():
-        s.update(v.keys())
-    mapping = {x: i for i, x in enumerate(s)}
     a = dict_to_numpy_array(d, mapping=mapping)
     if normalized:
         a = a / a.sum()
     return a
 
 
-def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
+def numeric_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=True):
     """Returns numeric mixing matrix for attribute.
 
     The attribute must be an integer.
@@ -175,6 +175,10 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
     nodes: list or iterable (optional)
         Build the matrix only with nodes in container. The default is all nodes.
 
+    mapping : dictionary, optional
+       Mapping from node attribute to integer index in matrix.
+       If not specified, an arbitrary ordering will be used.
+
     normalized : bool (default=True)
        Return counts if False or probabilities if True.
 
@@ -183,15 +187,7 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
     m: numpy array
        Counts, or joint, probability of occurrence of node attribute pairs.
     """
-    d = attribute_mixing_dict(G, attribute, nodes)
-    s = set(d.keys())
-    for k, v in d.items():
-        s.update(v.keys())
-    mapping = {x: i for i, x in enumerate(s)}
-    a = dict_to_numpy_array(d, mapping=mapping)
-    if normalized:
-        a = a / a.sum()
-    return a
+    return attribute_mixing_matrix(G, attribute, nodes, mapping, normalized)
 
 
 def mixing_dict(xy, normalized=False):

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -78,6 +78,17 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
     -------
     m: numpy array
        Counts or joint probability of occurrence of attribute pairs.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(3)
+    >>> gender = {0: 'male', 1: 'female', 2: 'female'}
+    >>> nx.set_node_attributes(G, gender, 'gender')
+    >>> mapping = {'male': 0, 'female': 1}
+    >>> mix_mat = nx.attribute_mixing_matrix(G, 'gender', mapping=mapping)
+    >>> # mixing from male nodes to female nodes
+    >>> print(mix_mat[mapping['male'], mapping['female']])
+    0.25
     """
     d = attribute_mixing_dict(G, attribute, nodes)
     a = dict_to_numpy_array(d, mapping=mapping)
@@ -153,6 +164,15 @@ def degree_mixing_matrix(
     -------
     m: numpy array
        Counts, or joint probability, of occurrence of node degree.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> max_degree = max(dict(G.degree).values())
+    >>> mapping = {x: x for x in range(max_degree + 1)} # identity mapping
+    >>> mix_mat = nx.degree_mixing_matrix(G, mapping=mapping)
+    >>> mix_mat[2, 1] # mixing from node degree 2 to node degree 1
+    0.25
     """
     d = degree_mixing_dict(G, x=x, y=y, nodes=nodes, weight=weight)
     a = dict_to_numpy_array(d, mapping=mapping)

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -79,6 +79,20 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
     m: numpy array
        Counts or joint probability of occurrence of attribute pairs.
 
+    Notes
+    -----
+    If each node has a unique attribute value, the unnormalized mixing matrix
+    will be equal to the adjacency matrix. To get a denser mixing matrix,
+    the rounding can be performed to form groups of nodes with equal values.
+    For example, the exact height of persons in cm (180.79155222, 163.9080892,
+    163.30095355, 167.99016217, 168.21590163, ...) can be rounded to (180, 163,
+    163, 168, 168, ...).
+
+    Definitions of attribute mixing matrix vary on whether the matrix
+    should include rows for attribute values that don't arise. Here we
+    do not include such empty-rows. But you can force them to appear
+    by inputting a `mapping` that includes those values.
+
     Examples
     --------
     >>> G = nx.path_graph(3)
@@ -87,7 +101,7 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
     >>> mapping = {'male': 0, 'female': 1}
     >>> mix_mat = nx.attribute_mixing_matrix(G, 'gender', mapping=mapping)
     >>> # mixing from male nodes to female nodes
-    >>> print(mix_mat[mapping['male'], mapping['female']])
+    >>> mix_mat[mapping['male'], mapping['female']]
     0.25
     """
     d = attribute_mixing_dict(G, attribute, nodes)
@@ -129,7 +143,7 @@ def degree_mixing_dict(G, x="out", y="in", weight=None, nodes=None, normalized=F
 
 
 def degree_mixing_matrix(
-    G, x="out", y="in", weight=None, nodes=None, mapping=None, normalized=True
+    G, x="out", y="in", weight=None, nodes=None, normalized=True, mapping=None
 ):
     """Returns mixing matrix for attribute.
 
@@ -153,26 +167,40 @@ def degree_mixing_matrix(
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
 
+    normalized : bool (default=True)
+       Return counts if False or probabilities if True.
+
     mapping : dictionary, optional
        Mapping from node degree to integer index in matrix.
        If not specified, an arbitrary ordering will be used.
-
-    normalized : bool (default=True)
-       Return counts if False or probabilities if True.
 
     Returns
     -------
     m: numpy array
        Counts, or joint probability, of occurrence of node degree.
 
+    Notes
+    -----
+    Definitions of degree mixing matrix vary on whether the matrix
+    should include rows for degree values that don't arise. Here we
+    do not include such empty-rows. But you can force them to appear
+    by inputting a `mapping` that includes those values. See examples.
+
     Examples
     --------
-    >>> G = nx.path_graph(5)
-    >>> max_degree = max(dict(G.degree).values())
+    >>> G = nx.star_graph(3)
+    >>> mix_mat = nx.degree_mixing_matrix(G)
+    >>> mix_mat[0, 1]  # mixing from node degree 1 to node degree 3
+    0.5
+
+    If you want every possible degree to appear as a row, even if no nodes
+    have that degree, use `mapping` as follows,
+
+    >>> max_degree = max(deg for n, deg in G.degree)
     >>> mapping = {x: x for x in range(max_degree + 1)} # identity mapping
     >>> mix_mat = nx.degree_mixing_matrix(G, mapping=mapping)
-    >>> mix_mat[2, 1] # mixing from node degree 2 to node degree 1
-    0.25
+    >>> mix_mat[3, 1]  # mixing from node degree 3 to node degree 1
+    0.5
     """
     d = degree_mixing_dict(G, x=x, y=y, nodes=nodes, weight=weight)
     a = dict_to_numpy_array(d, mapping=mapping)
@@ -181,7 +209,7 @@ def degree_mixing_matrix(
     return a
 
 
-def numeric_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=True):
+def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True, mapping=None):
     """Returns numeric mixing matrix for attribute.
 
     Parameters
@@ -195,18 +223,18 @@ def numeric_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=Tru
     nodes: list or iterable (optional)
         Build the matrix only with nodes in container. The default is all nodes.
 
+    normalized : bool (default=True)
+       Return counts if False or probabilities if True.
+
     mapping : dictionary, optional
        Mapping from node attribute to integer index in matrix.
        If not specified, an arbitrary ordering will be used.
-
-    normalized : bool (default=True)
-       Return counts if False or probabilities if True.
 
     Notes
     -----
     If each node has a unique attribute value, the unnormalized mixing matrix
     will be equal to the adjacency matrix. To get a denser mixing matrix,
-    the rounding can be performed ​​to form groups of nodes with equal values.
+    the rounding can be performed to form groups of nodes with equal values.
     For example, the exact height of persons in cm (180.79155222, 163.9080892,
     163.30095355, 167.99016217, 168.21590163, ...) can be rounded to (180, 163,
     163, 168, 168, ...).
@@ -216,7 +244,9 @@ def numeric_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=Tru
     m: numpy array
        Counts, or joint, probability of occurrence of node attribute pairs.
     """
-    return attribute_mixing_matrix(G, attribute, nodes, mapping, normalized)
+    return attribute_mixing_matrix(
+        G, attribute, nodes=nodes, normalized=normalized, mapping=mapping
+    )
 
 
 def mixing_dict(xy, normalized=False):

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -152,8 +152,7 @@ def degree_mixing_matrix(G, x="out", y="in", weight=None, nodes=None, normalized
     s = set(d.keys())
     for k, v in d.items():
         s.update(v.keys())
-    m = max(s)
-    mapping = {x: x for x in range(m + 1)}
+    mapping = {x:i for i, x in enumerate(s)}
     a = dict_to_numpy_array(d, mapping=mapping)
     if normalized:
         a = a / a.sum()
@@ -188,8 +187,7 @@ def numeric_mixing_matrix(G, attribute, nodes=None, normalized=True):
     s = set(d.keys())
     for k, v in d.items():
         s.update(v.keys())
-    m = max(s)
-    mapping = {x: x for x in range(m + 1)}
+    mapping = {x:i for i, x in enumerate(s)}
     a = dict_to_numpy_array(d, mapping=mapping)
     if normalized:
         a = a / a.sum()

--- a/networkx/algorithms/assortativity/tests/base_test.py
+++ b/networkx/algorithms/assortativity/tests/base_test.py
@@ -68,5 +68,5 @@ class BaseTestNumericMixing:
         F = nx.Graph()
         F.add_edges_from([(0, 3), (1, 3), (2, 3)], weight=0.5)
         F.add_edge(0, 2, weight=1)
-        nx.set_node_attributes(F, dict(F.degree(weight='weight')), 'margin')
+        nx.set_node_attributes(F, dict(F.degree(weight="weight")), "margin")
         cls.F = F

--- a/networkx/algorithms/assortativity/tests/base_test.py
+++ b/networkx/algorithms/assortativity/tests/base_test.py
@@ -49,3 +49,24 @@ class BaseTestDegreeMixing:
         cls.M.add_edge(0, 1)
         cls.S = nx.Graph()
         cls.S.add_edges_from([(0, 0), (1, 1)])
+        cls.W = nx.Graph()
+        cls.W.add_edges_from([(0, 3), (1, 3), (2, 3)], weight=0.5)
+        cls.W.add_edge(0, 2, weight=1)
+
+
+class BaseTestNumericMixing:
+    @classmethod
+    def setup_class(cls):
+        N = nx.Graph()
+        N.add_nodes_from([0, 1], margin=-2)
+        N.add_nodes_from([2, 3], margin=-2)
+        N.add_nodes_from([4], margin=-3)
+        N.add_nodes_from([5], margin=-4)
+        N.add_edges_from([(0, 1), (2, 3), (0, 4), (2, 5)])
+        cls.N = N
+
+        F = nx.Graph()
+        F.add_edges_from([(0, 3), (1, 3), (2, 3)], weight=0.5)
+        F.add_edge(0, 2, weight=1)
+        nx.set_node_attributes(F, dict(F.degree(weight='weight')), 'margin')
+        cls.F = F

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -39,7 +39,7 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
 
     def test_degree_assortativity_weighted(self):
-        r = nx.degree_pearson_correlation_coefficient(self.W)
+        r = nx.degree_assortativity_coefficient(self.W, weight='weight')
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)
 
 

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -5,7 +5,11 @@ pytest.importorskip("scipy")
 
 
 import networkx as nx
-from .base_test import BaseTestAttributeMixing, BaseTestDegreeMixing
+from .base_test import (
+    BaseTestAttributeMixing, 
+    BaseTestDegreeMixing, 
+    BaseTestNumericMixing
+)
 from networkx.algorithms.assortativity.correlation import attribute_ac
 
 
@@ -33,6 +37,10 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
     def test_degree_pearson_assortativity_multigraph(self):
         r = nx.degree_pearson_correlation_coefficient(self.M)
         np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
+
+    def test_degree_assortativity_weighted(self):
+        r = nx.degree_pearson_correlation_coefficient(self.W)
+        np.testing.assert_almost_equal(r, -0.1429, decimal=4)
 
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
@@ -73,3 +81,13 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
         a = np.array([[50, 50, 0], [50, 50, 0], [0, 0, 2]])
         r = attribute_ac(a)
         np.testing.assert_almost_equal(r, 0.029, decimal=3)
+
+
+class TestNumericMixingCorrelation(BaseTestNumericMixing):
+    def test_numeric_assortativity_negative(self):
+        r = nx.numeric_assortativity_coefficient(self.N, 'margin')
+        np.testing.assert_almost_equal(r, -0.2903, decimal=4)
+
+    def test_numeric_assortativity_float(self):
+        r = nx.numeric_assortativity_coefficient(self.F, 'margin')
+        np.testing.assert_almost_equal(r, -0.1429, decimal=4)

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -6,9 +6,9 @@ pytest.importorskip("scipy")
 
 import networkx as nx
 from .base_test import (
-    BaseTestAttributeMixing, 
-    BaseTestDegreeMixing, 
-    BaseTestNumericMixing
+    BaseTestAttributeMixing,
+    BaseTestDegreeMixing,
+    BaseTestNumericMixing,
 )
 from networkx.algorithms.assortativity.correlation import attribute_ac
 
@@ -39,7 +39,7 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
 
     def test_degree_assortativity_weighted(self):
-        r = nx.degree_assortativity_coefficient(self.W, weight='weight')
+        r = nx.degree_assortativity_coefficient(self.W, weight="weight")
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)
 
 
@@ -85,9 +85,9 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
 
 class TestNumericMixingCorrelation(BaseTestNumericMixing):
     def test_numeric_assortativity_negative(self):
-        r = nx.numeric_assortativity_coefficient(self.N, 'margin')
+        r = nx.numeric_assortativity_coefficient(self.N, "margin")
         np.testing.assert_almost_equal(r, -0.2903, decimal=4)
 
     def test_numeric_assortativity_float(self):
-        r = nx.numeric_assortativity_coefficient(self.F, 'margin')
+        r = nx.numeric_assortativity_coefficient(self.F, "margin")
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)

--- a/networkx/algorithms/assortativity/tests/test_mixing.py
+++ b/networkx/algorithms/assortativity/tests/test_mixing.py
@@ -5,9 +5,9 @@ np = pytest.importorskip("numpy")
 
 import networkx as nx
 from .base_test import (
-    BaseTestAttributeMixing, 
-    BaseTestDegreeMixing, 
-    BaseTestNumericMixing
+    BaseTestAttributeMixing,
+    BaseTestDegreeMixing,
+    BaseTestNumericMixing,
 )
 
 
@@ -34,7 +34,7 @@ class TestDegreeMixingDict(BaseTestDegreeMixing):
         assert d == d_result
 
     def test_degree_mixing_dict_weighted(self):
-        d = nx.degree_mixing_dict(self.W, weight='weight')
+        d = nx.degree_mixing_dict(self.W, weight="weight")
         d_result = {0.5: {1.5: 1}, 1.5: {1.5: 6, 0.5: 1}}
 
 
@@ -84,21 +84,17 @@ class TestDegreeMixingMatrix(BaseTestDegreeMixing):
         np.testing.assert_equal(a, a_result / float(a_result.sum()))
 
     def test_degree_mixing_matrix_weighted(self):
-        a_result = np.array([[0., 1.],
-                             [1., 6.]]
-                            )
-        a = nx.degree_mixing_matrix(self.W, weight='weight', normalized=False)
+        a_result = np.array([[0.0, 1.0], [1.0, 6.0]])
+        a = nx.degree_mixing_matrix(self.W, weight="weight", normalized=False)
         np.testing.assert_equal(a, a_result)
-        a = nx.degree_mixing_matrix(self.W, weight='weight')
+        a = nx.degree_mixing_matrix(self.W, weight="weight")
         np.testing.assert_equal(a, a_result / float(a_result.sum()))
 
     def test_degree_mixing_matrix_mapping(self):
-        a_result = np.array([[6., 1.],
-                             [1., 0.]]
-                            )
+        a_result = np.array([[6.0, 1.0], [1.0, 0.0]])
         mapping = {0.5: 1, 1.5: 0}
         a = nx.degree_mixing_matrix(
-            self.W, weight='weight', normalized=False, mapping=mapping
+            self.W, weight="weight", normalized=False, mapping=mapping
         )
         np.testing.assert_equal(a, a_result)
 
@@ -165,10 +161,7 @@ class TestAttributeMixingMatrix(BaseTestAttributeMixing):
 class TestNumericMixingMatrix(BaseTestNumericMixing):
     def test_numeric_mixing_matrix_negative(self):
         mapping = {-2: 0, -3: 1, -4: 2}
-        a_result = np.array([[4., 1., 1.],
-                             [1., 0., 0.],
-                             [1., 0., 0.]]
-        )
+        a_result = np.array([[4.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
         a = nx.numeric_mixing_matrix(
             self.N, "margin", mapping=mapping, normalized=False
         )
@@ -178,9 +171,7 @@ class TestNumericMixingMatrix(BaseTestNumericMixing):
 
     def test_numeric_mixing_matrix_float(self):
         mapping = {0.5: 1, 1.5: 0}
-        a_result = np.array([[6., 1.],
-                             [1., 0.]]
-        )
+        a_result = np.array([[6.0, 1.0], [1.0, 0.0]])
         a = nx.numeric_mixing_matrix(
             self.F, "margin", mapping=mapping, normalized=False
         )

--- a/networkx/algorithms/assortativity/tests/test_mixing.py
+++ b/networkx/algorithms/assortativity/tests/test_mixing.py
@@ -4,7 +4,11 @@ np = pytest.importorskip("numpy")
 
 
 import networkx as nx
-from .base_test import BaseTestAttributeMixing, BaseTestDegreeMixing
+from .base_test import (
+    BaseTestAttributeMixing, 
+    BaseTestDegreeMixing, 
+    BaseTestNumericMixing
+)
 
 
 class TestDegreeMixingDict(BaseTestDegreeMixing):
@@ -28,6 +32,10 @@ class TestDegreeMixingDict(BaseTestDegreeMixing):
         d = nx.degree_mixing_dict(self.M)
         d_result = {1: {2: 1}, 2: {1: 1, 3: 3}, 3: {2: 3}}
         assert d == d_result
+
+    def test_degree_mixing_dict_weighted(self):
+        d = nx.degree_mixing_dict(self.W, weight='weight')
+        d_result = {0.5: {1.5: 1}, 1.5: {1.5: 6, 0.5: 1}}
 
 
 class TestDegreeMixingMatrix(BaseTestDegreeMixing):
@@ -68,13 +76,31 @@ class TestDegreeMixingMatrix(BaseTestDegreeMixing):
 
     def test_degree_mixing_matrix_selfloop(self):
         # fmt: off
-        a_result = np.array([[2]]
-                            )
+        a_result = np.array([[2]])
         # fmt: on
         a = nx.degree_mixing_matrix(self.S, normalized=False)
         np.testing.assert_equal(a, a_result)
         a = nx.degree_mixing_matrix(self.S)
         np.testing.assert_equal(a, a_result / float(a_result.sum()))
+
+    def test_degree_mixing_matrix_weighted(self):
+        a_result = np.array([[0., 1.],
+                             [1., 6.]]
+                            )
+        a = nx.degree_mixing_matrix(self.W, weight='weight', normalized=False)
+        np.testing.assert_equal(a, a_result)
+        a = nx.degree_mixing_matrix(self.W, weight='weight')
+        np.testing.assert_equal(a, a_result / float(a_result.sum()))
+
+    def test_degree_mixing_matrix_mapping(self):
+        a_result = np.array([[6., 1.],
+                             [1., 0.]]
+                            )
+        mapping = {0.5: 1, 1.5: 0}
+        a = nx.degree_mixing_matrix(
+            self.W, weight='weight', normalized=False, mapping=mapping
+        )
+        np.testing.assert_equal(a, a_result)
 
 
 class TestAttributeMixingDict(BaseTestAttributeMixing):
@@ -133,4 +159,31 @@ class TestAttributeMixingMatrix(BaseTestAttributeMixing):
         )
         np.testing.assert_equal(a, a_result)
         a = nx.attribute_mixing_matrix(self.M, "fish", mapping=mapping)
+        np.testing.assert_equal(a, a_result / float(a_result.sum()))
+
+
+class TestNumericMixingMatrix(BaseTestNumericMixing):
+    def test_numeric_mixing_matrix_negative(self):
+        mapping = {-2: 0, -3: 1, -4: 2}
+        a_result = np.array([[4., 1., 1.],
+                             [1., 0., 0.],
+                             [1., 0., 0.]]
+        )
+        a = nx.numeric_mixing_matrix(
+            self.N, "margin", mapping=mapping, normalized=False
+        )
+        np.testing.assert_equal(a, a_result)
+        a = nx.numeric_mixing_matrix(self.N, "margin", mapping=mapping)
+        np.testing.assert_equal(a, a_result / float(a_result.sum()))
+
+    def test_numeric_mixing_matrix_float(self):
+        mapping = {0.5: 1, 1.5: 0}
+        a_result = np.array([[6., 1.],
+                             [1., 0.]]
+        )
+        a = nx.numeric_mixing_matrix(
+            self.F, "margin", mapping=mapping, normalized=False
+        )
+        np.testing.assert_equal(a, a_result)
+        a = nx.numeric_mixing_matrix(self.F, "margin", mapping=mapping)
         np.testing.assert_equal(a, a_result / float(a_result.sum()))

--- a/networkx/algorithms/assortativity/tests/test_mixing.py
+++ b/networkx/algorithms/assortativity/tests/test_mixing.py
@@ -33,9 +33,8 @@ class TestDegreeMixingDict(BaseTestDegreeMixing):
 class TestDegreeMixingMatrix(BaseTestDegreeMixing):
     def test_degree_mixing_matrix_undirected(self):
         # fmt: off
-        a_result = np.array([[0, 0, 0],
-                             [0, 0, 2],
-                             [0, 2, 2]]
+        a_result = np.array([[0, 2],
+                             [2, 2]]
                             )
         # fmt: on
         a = nx.degree_mixing_matrix(self.P4, normalized=False)
@@ -45,10 +44,9 @@ class TestDegreeMixingMatrix(BaseTestDegreeMixing):
 
     def test_degree_mixing_matrix_directed(self):
         # fmt: off
-        a_result = np.array([[0, 0, 0, 0],
-                             [0, 0, 0, 2],
-                             [0, 1, 0, 1],
-                             [0, 0, 0, 0]]
+        a_result = np.array([[0, 0, 2],
+                             [1, 0, 1],
+                             [0, 0, 0]]
                             )
         # fmt: on
         a = nx.degree_mixing_matrix(self.D, normalized=False)
@@ -58,10 +56,9 @@ class TestDegreeMixingMatrix(BaseTestDegreeMixing):
 
     def test_degree_mixing_matrix_multigraph(self):
         # fmt: off
-        a_result = np.array([[0, 0, 0, 0],
-                             [0, 0, 1, 0],
-                             [0, 1, 0, 3],
-                             [0, 0, 3, 0]]
+        a_result = np.array([[0, 1, 0],
+                             [1, 0, 3],
+                             [0, 3, 0]]
                             )
         # fmt: on
         a = nx.degree_mixing_matrix(self.M, normalized=False)
@@ -71,9 +68,7 @@ class TestDegreeMixingMatrix(BaseTestDegreeMixing):
 
     def test_degree_mixing_matrix_selfloop(self):
         # fmt: off
-        a_result = np.array([[0, 0, 0],
-                             [0, 0, 0],
-                             [0, 0, 2]]
+        a_result = np.array([[2]]
                             )
         # fmt: on
         a = nx.degree_mixing_matrix(self.S, normalized=False)


### PR DESCRIPTION
This fixes some problems with assortativity coefficient calculation #3917, #4368, #4369, #4776. 

Here is my explanation of fixes. The question is what do we expect the `mapping` variable to actually *map*? I have read the whole `mixing.py` module, the original Newman's article https://arxiv.org/abs/cond-mat/0209450 and decided that the most natural way to define the `mapping` variable is as follows: 

*The `mapping` variable maps the unique nodes' attribute values to mixing matrix row and column indices.*

For example, if the network consists of nodes with the attribute "gender" of values "male" and "female", the `mapping` will be `{'female': 0, 'male': 1}`. In this terms, the entry [0, 1] of the normalized mixing matrix will contain the fraction of links that follow from female nodes to male nodes. Another example, nodes with the attribute "gender" contains integer values 0 (male), 1 (female). In this case, `mapping` will be `{1: 0, 0: 1}`. If the "gender" is decoded as -1 (male) and 1 (female), the `mapping` will be `{1: 0, -1: 1}`. As we see, this definition gives homogeneous and robust description of the mapping regardless of the values that decode underlying information.

Before my fixes, this definition holds only for categorical (strings) and positive integer values. After my fixes, this holds for categorical, integer, non-integer, positive, negative values (#4369, #4776). It works faster because we construct the mixing matrix that contains only non-zero rows and columns (#4368). In addition, there are no theoretical restrictions to use non-integer values for assortativity coefficient calculation. As follows from the original paper, the definition of the scalar assortativity coefficient is applicable for all scalar values, not only integers. Thereby, non-integer node degrees (in a weighted graph, #3917) are also feasible for calculation. 

I have also changed the tests removing extra rows and columns containing only zeros.