### PR TITLE
DOC: point towards web archive link in GML docs

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -22,7 +22,7 @@ specification.  For other data types, you need to explicitly supply a
 `stringizer`/`destringizer`.
 
 For additional documentation on the GML file format, please see the
-`GML website <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+`GML website <https://web.archive.org/web/20190207140002/http://www.fim.uni-passau.de/index.php?id=17297&L=1>`_.
 
 Several example graphs in GML format may be found on Mark Newman's
 `Network data page <http://www-personal.umich.edu/~mejn/netdata/>`_.
@@ -155,7 +155,7 @@ def read_gml(path, label="label", destringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <https://web.archive.org/web/20190207140002/http://www.fim.uni-passau.de/index.php?id=17297&L=1>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
 
@@ -226,7 +226,7 @@ def parse_gml(lines, label="label", destringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
     """
@@ -625,7 +625,7 @@ def generate_gml(G, stringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <https://web.archive.org/web/20190207140002/http://www.fim.uni-passau.de/index.php?id=17297&L=1>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
 
@@ -820,7 +820,7 @@ def write_gml(G, path, stringizer=None):
     sure to write GML format. In particular, underscores are not allowed in
     attribute names.
     For additional documentation on the GML file format, please see the
-    `GML url <http://www.infosun.fim.uni-passau.de/Graphlet/GML/gml-tr.html>`_.
+    `GML url <https://web.archive.org/web/20190207140002/http://www.fim.uni-passau.de/index.php?id=17297&L=1>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -226,7 +226,7 @@ def parse_gml(lines, label="label", destringizer=None):
     `stringizer`/`destringizer`.
 
     For additional documentation on the GML file format, please see the
-    `GML url <>`_.
+    `GML url <https://web.archive.org/web/20190207140002/http://www.fim.uni-passau.de/index.php?id=17297&L=1>`_.
 
     See the module docstring :mod:`networkx.readwrite.gml` for more details.
     """


### PR DESCRIPTION
The GML specification documentation is not available anymore on the linked website, use archive to points towards an older version of the website.