### PR TITLE
spring_layout: ignore 'fixed' nodes not in the graph nodes

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -185,6 +185,8 @@ API Changes
   from ``communicability_betweeness_centrality``
 - [`#4850 <https://github.com/networkx/networkx/pull/4850>`_]
   Added ``dtype`` parameter to adjacency_matrix
+- [`#4867 <https://github.com/networkx/networkx/pull/4867>`_]
+  The function ``spring_layout`` now ignores 'fixed' nodes not in the graph
 
 Deprecations
 ------------

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -390,6 +390,7 @@ def spring_layout(
 
     fixed : list or None  optional (default=None)
         Nodes to keep fixed at initial position.
+        Nodes not in ``G.nodes`` are ignored.
         ValueError raised if `fixed` specified and `pos` not.
 
     iterations : int  optional (default=50)
@@ -447,7 +448,7 @@ def spring_layout(
             if node not in pos:
                 raise ValueError("nodes are fixed without positions given")
         nfixed = {node: i for i, node in enumerate(G)}
-        fixed = np.asarray([nfixed[node] for node in fixed])
+        fixed = np.asarray([nfixed[node] for node in fixed if node in nfixed])
 
     if pos is not None:
         # Determine size of existing domain to adjust initial positions


### PR DESCRIPTION
This pull request addresses the issue when `fixed` nodes passed to the `spring_layout` function are not in the original graph nodes. The current behavior: an unintuitive error is shown.

### Steps to reproduce

```python
import networkx as nx

graph = nx.Graph()
graph.add_nodes_from([1])
pos = {n: (0, 1) for n in [1, 2]}

nx.spring_layout(graph, fixed=[1, 2], pos=pos)
Traceback (most recent call last):
  File "<input>", line 7, in <module>
  File "<decorator-gen-736>", line 2, in fruchterman_reingold_layout
  File "/home/dizcza/miniconda3/envs/networkx/lib/python3.9/site-packages/networkx/utils/decorators.py", line 408, in _random_state
    return func(*new_args, **kwargs)
  File "/home/dizcza/miniconda3/envs/networkx/lib/python3.9/site-packages/networkx/drawing/layout.py", line 461, in fruchterman_reingold_layout
    fixed = np.asarray([nfixed[node] for node in fixed])
  File "/home/dizcza/miniconda3/envs/networkx/lib/python3.9/site-packages/networkx/drawing/layout.py", line 461, in <listcomp>
    fixed = np.asarray([nfixed[node] for node in fixed])
KeyError: 2

```

You may argue that the fix could be another raise error statement, however, it wouldn't be convenient because the user thinks in the following way: "`pos` dict can be a subset of the original nodes as well as it can have keys that are not in the original nodes. Therefore, I expect `fixed` parameter to behave in a similar manner."