### PR TITLE
DOC: Fix links, use DOI links, wayback machine where required

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -225,7 +225,7 @@ latex_appendices = ["tutorial"]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "geopandas": ("https://geopandas.org/", None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -231,6 +231,7 @@ intersphinx_mapping = {
     "geopandas": ("https://geopandas.org/", None),
     "pygraphviz": ("https://pygraphviz.github.io/documentation/stable/", None),
     "sphinx-gallery": ("https://sphinx-gallery.github.io/stable/", None),
+    "nx-guides": ("https://networkx.org/nx-guides/", None),
 }
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/doc/developer/nxeps/nxep-0000.rst
+++ b/doc/developer/nxeps/nxep-0000.rst
@@ -263,7 +263,7 @@ References and Footnotes
 
 .. [1] This historical record is available by the normal git commands
    for retrieving older revisions, and can also be browsed on
-   `GitHub <https://github.com/networkx/networkx/tree/main/doc/nxeps>`_.
+   `GitHub <https://github.com/networkx/networkx/tree/main/doc/developer/nxeps>`_.
 
 .. [2] The URL for viewing NXEPs on the web is
    https://networkx.org/documentation/latest/developer/nxeps/index.html

--- a/doc/developer/projects.rst
+++ b/doc/developer/projects.rst
@@ -57,8 +57,8 @@ Pedagogical Interactive Notebooks for Algorithms Implemented in NetworkX
 
 - Expected Outcome: A collection of Interactive Jupyter notebooks which
   explain and explore network algorithms to readers and users of NetworkX.
-  An example notebook about Random Geometric Graphs is available at
-  https://networkx.org/nx-guides/content/generators/geometric.html
+  For example, see this notebook on
+  :doc:`Random Geometric Graphs <content/generators/geometric>`
 
 - Complexity: Depending on the algorithms you are interested to work on.
 

--- a/doc/developer/projects.rst
+++ b/doc/developer/projects.rst
@@ -58,7 +58,7 @@ Pedagogical Interactive Notebooks for Algorithms Implemented in NetworkX
 - Expected Outcome: A collection of Interactive Jupyter notebooks which
   explain and explore network algorithms to readers and users of NetworkX.
   An example notebook about Random Geometric Graphs is available at
-  https://nbviewer.jupyter.org/github/networkx/notebooks/blob/main/generators/geometric.ipynb
+  https://networkx.org/nx-guides/content/generators/geometric.html
 
 - Complexity: Depending on the algorithms you are interested to work on.
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -565,7 +565,7 @@ Matplotlib
 >>> plt.show()
 
 command if you are not using matplotlib in interactive mode (see
-`Matplotlib FAQ <http://matplotlib.org/faq/installing_faq.html#matplotlib-compiled-fine-but-nothing-shows-up-when-i-use-it>`_
+`Matplotlib FAQ <https://matplotlib.org/stable/faq/installing_faq.html#matplotlib-compiled-fine-but-nothing-shows-up-when-i-use-it>`_
 ).
 
 .. nbplot::

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -565,8 +565,7 @@ Matplotlib
 >>> plt.show()
 
 command if you are not using matplotlib in interactive mode (see
-`Matplotlib FAQ <https://matplotlib.org/stable/faq/installing_faq.html#matplotlib-compiled-fine-but-nothing-shows-up-when-i-use-it>`_
-).
+:doc:`this Matplotlib FAQ <faq/installing_faq>`).
 
 .. nbplot::
 

--- a/examples/external/force/README.txt
+++ b/examples/external/force/README.txt
@@ -1,5 +1,5 @@
 Modified from the example at of D3
-http://mbostock.github.com/d3/ex/force.html
+https://bl.ocks.org/mbostock/4062045
 
 Run the file force.py to generate the force.json data file needed for this to work.
 

--- a/examples/graph/plot_napoleon_russian_campaign.py
+++ b/examples/graph/plot_napoleon_russian_campaign.py
@@ -4,8 +4,7 @@ Napoleon Russian Campaign
 =========================
 
 Minard's data from Napoleon's 1812-1813  Russian Campaign.
-http://www.math.yorku.ca/SCS/Gallery/minard/minard.txt
-
+https://web.archive.org/web/20080112042656/http://www.math.yorku.ca/SCS/Gallery/minard/minard.txt
 """
 
 import matplotlib.pyplot as plt

--- a/examples/graphviz_layout/plot_lanl_routes.py
+++ b/examples/graphviz_layout/plot_lanl_routes.py
@@ -7,7 +7,7 @@ Routes to LANL from 186 sites on the Internet.
 
 The data file can be found at:
 
-- https://github.com/networkx/networkx/blob/main/examples/drawing/lanl_routes.edgelist
+- https://github.com/networkx/networkx/blob/main/examples/graphviz_layout/lanl_routes.edgelist
 
 This example needs Graphviz and PyGraphviz.
 """

--- a/networkx/algorithms/approximation/clustering_coefficient.py
+++ b/networkx/algorithms/approximation/clustering_coefficient.py
@@ -49,7 +49,7 @@ def average_clustering(G, trials=1000, seed=None):
     .. [1] Schank, Thomas, and Dorothea Wagner. Approximating clustering
        coefficient and transitivity. Universität Karlsruhe, Fakultät für
        Informatik, 2004.
-       http://www.emis.ams.org/journals/JGAA/accepted/2005/SchankWagner2005.9.2.pdf
+       https://doi.org/10.5445/IR/1000001239
 
     """
     n = len(G)

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -94,12 +94,12 @@ def k_components(G, min_density=0.95):
 
     .. [2]  White, Douglas R., and Mark Newman (2001) A Fast Algorithm for
             Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
-            http://eclectic.ss.uci.edu/~drwhite/working.pdf
+            https://www.santafe.edu/research/results/working-papers/fast-approximation-algorithms-for-finding-node-ind
 
     .. [3]  Moody, J. and D. White (2003). Social cohesion and embeddedness:
             A hierarchical conception of social groups.
             American Sociological Review 68(1), 103--28.
-            http://www2.asanet.org/journals/ASRFeb03MoodyWhite.pdf
+            https://doi.org/10.2307/3088904
 
     """
     # Dictionary with connectivity level (k) as keys and a list of

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -780,7 +780,7 @@ def threshold_accepting_tsp(
     of times the outer and inner loop run respectively.
 
     For more information and how algorithm is inspired see:
-    http://en.wikipedia.org/wiki/Threshold_accepting
+    https://doi.org/10.1016/0021-9991(90)90201-B
 
     See Also
     --------

--- a/networkx/algorithms/approximation/treewidth.py
+++ b/networkx/algorithms/approximation/treewidth.py
@@ -25,7 +25,7 @@ There are two different functions for computing a tree decomposition:
       http://www.cs.uu.nl
 
 .. [3] K. Wang, Z. Lu, and J. Hicks *Treewidth*.
-      http://web.eecs.utk.edu/~cphillip/cs594_spring2015_projects/treewidth.pdf
+      https://web.archive.org/web/20210507025929/http://web.eecs.utk.edu/~cphill25/cs594_spring2015_projects/treewidth.pdf
 
 """
 

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -59,7 +59,7 @@ def degree_centrality(G, nodes):
     .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
         Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
-        http://www.steveborgatti.com/research/publications/bhaffiliations.pdf
+        https://dx.doi.org/10.4135/9781446294413.n28
     """
     top = set(nodes)
     bottom = set(G) - top
@@ -140,7 +140,7 @@ def betweenness_centrality(G, nodes):
     .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
         Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
-        http://www.steveborgatti.com/research/publications/bhaffiliations.pdf
+        https://dx.doi.org/10.4135/9781446294413.n28
     """
     top = set(nodes)
     bottom = set(G) - top
@@ -237,7 +237,7 @@ def closeness_centrality(G, nodes, normalized=True):
     .. [1] Borgatti, S.P. and Halgin, D. In press. "Analyzing Affiliation
         Networks". In Carrington, P. and Scott, J. (eds) The Sage Handbook
         of Social Network Analysis. Sage Publications.
-        http://www.steveborgatti.com/research/publications/bhaffiliations.pdf
+        https://dx.doi.org/10.4135/9781446294413.n28
     """
     closeness = {}
     path_length = nx.single_source_shortest_path_length

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -209,11 +209,11 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
     ----------
     .. [1]  A Faster Algorithm for Betweenness Centrality. Ulrik Brandes,
        Journal of Mathematical Sociology 25(2):163-177, 2001.
-       http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+       https://doi.org/10.1080/0022250X.2001.9990249
     .. [2] Ulrik Brandes: On Variants of Shortest-Path Betweenness
        Centrality and their Generic Computation.
        Social Networks 30(2):136-145, 2008.
-       http://www.inf.uni-konstanz.de/algo/publications/b-vspbc-08.pdf
+       https://doi.org/10.1016/j.socnet.2007.11.001
     """
     betweenness = dict.fromkeys(G, 0.0)  # b[v]=0 for v in G
     # b[e]=0 for e in G.edges()

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -94,11 +94,11 @@ def betweenness_centrality_subset(G, sources, targets, normalized=False, weight=
     ----------
     .. [1] Ulrik Brandes, A Faster Algorithm for Betweenness Centrality.
        Journal of Mathematical Sociology 25(2):163-177, 2001.
-       http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+       https://doi.org/10.1080/0022250X.2001.9990249
     .. [2] Ulrik Brandes: On Variants of Shortest-Path Betweenness
        Centrality and their Generic Computation.
        Social Networks 30(2):136-145, 2008.
-       http://www.inf.uni-konstanz.de/algo/publications/b-vspbc-08.pdf
+       https://doi.org/10.1016/j.socnet.2007.11.001
     """
     b = dict.fromkeys(G, 0.0)  # b[v]=0 for v in G
     for s in sources:
@@ -175,11 +175,11 @@ def edge_betweenness_centrality_subset(
     ----------
     .. [1] Ulrik Brandes, A Faster Algorithm for Betweenness Centrality.
        Journal of Mathematical Sociology 25(2):163-177, 2001.
-       http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+       https://doi.org/10.1080/0022250X.2001.9990249
     .. [2] Ulrik Brandes: On Variants of Shortest-Path Betweenness
        Centrality and their Generic Computation.
        Social Networks 30(2):136-145, 2008.
-       http://www.inf.uni-konstanz.de/algo/publications/b-vspbc-08.pdf
+       https://doi.org/10.1016/j.socnet.2007.11.001
     """
     b = dict.fromkeys(G, 0.0)  # b[v]=0 for v in G
     b.update(dict.fromkeys(G.edges(), 0.0))  # b[e] for e in G.edges()

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -88,7 +88,7 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True):
     ----------
     .. [1] Linton C. Freeman: Centrality in networks: I.
        Conceptual clarification. Social Networks 1:215-239, 1979.
-       http://leonidzhukov.ru/hse/2013/socialnetworks/papers/freeman79-centrality.pdf
+       https://doi.org/10.1016/0378-8733(78)90021-7
     .. [2] pg. 201 of Wasserman, S. and Faust, K.,
        Social Network Analysis: Methods and Applications, 1994,
        Cambridge University Press.
@@ -216,7 +216,7 @@ def incremental_closeness_centrality(
     ----------
     .. [1] Freeman, L.C., 1979. Centrality in networks: I.
        Conceptual clarification.  Social Networks 1, 215--239.
-       http://www.soc.ucsb.edu/faculty/friedkin/Syllabi/Soc146/Freeman78.PDF
+       https://doi.org/10.1016/0378-8733(78)90021-7
     .. [2] Sariyuce, A.E. ; Kaya, K. ; Saule, E. ; Catalyiirek, U.V. Incremental
        Algorithms for Closeness Centrality. 2013 IEEE International Conference on Big Data
        http://sariyuce.com/papers/bigdata13.pdf

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -95,7 +95,7 @@ def approximate_current_flow_betweenness_centrality(
        Centrality Measures Based on Current Flow.
        Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
-       http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
+       https://doi.org/10.1007/978-3-540-31856-9_44
     """
     import numpy as np
 
@@ -213,7 +213,7 @@ def current_flow_betweenness_centrality(
        Ulrik Brandes and Daniel Fleischer,
        Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
-       http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
+       https://doi.org/10.1007/978-3-540-31856-9_44
 
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
@@ -315,7 +315,7 @@ def edge_current_flow_betweenness_centrality(
        Ulrik Brandes and Daniel Fleischer,
        Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
-       http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
+       https://doi.org/10.1007/978-3-540-31856-9_44
 
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -84,7 +84,7 @@ def current_flow_betweenness_centrality_subset(
        Ulrik Brandes and Daniel Fleischer,
        Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
-       http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
+       https://doi.org/10.1007/978-3-540-31856-9_44
 
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
@@ -192,7 +192,7 @@ def edge_current_flow_betweenness_centrality_subset(
        Ulrik Brandes and Daniel Fleischer,
        Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
-       http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
+       https://doi.org/10.1007/978-3-540-31856-9_44
 
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -61,7 +61,7 @@ def current_flow_closeness_centrality(G, weight=None, dtype=float, solver="lu"):
        Centrality Measures Based on Current Flow.
        Proc. 22nd Symp. Theoretical Aspects of Computer Science (STACS '05).
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
-       http://algo.uni-konstanz.de/publications/bf-cmbcf-05.pdf
+       https://doi.org/10.1007/978-3-540-31856-9_44
 
     .. [2] Karen Stephenson and Marvin Zelen:
        Rethinking centrality: Methods and examples.

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -617,7 +617,7 @@ def group_closeness_centrality(G, S, weight=None):
        Measuring and Maximizing Group Closeness Centrality over
        Disk Resident Graphs.
        WWWConference Proceedings, 2014. 689-694.
-       http://wwwconference.org/proceedings/www2014/companion/p689.pdf
+       https://doi.org/10.1145/2567948.2579356
     """
     if G.is_directed():
         G = G.reverse()  # reverse view

--- a/networkx/algorithms/centrality/load.py
+++ b/networkx/algorithms/centrality/load.py
@@ -53,7 +53,7 @@ def newman_betweenness_centrality(G, v=None, cutoff=None, normalized=True, weigh
     .. [2] Kwang-Il Goh, Byungnam Kahng and Doochul Kim
        Universal behavior of Load Distribution in Scale-Free Networks.
        Physical Review Letters 87(27):1–4, 2001.
-       http://phya.snu.ac.kr/~dkim/PRL87278701.pdf
+       https://doi.org/10.1103/PhysRevLett.87.278701
     """
     if v is not None:  # only one node
         betweenness = 0.0

--- a/networkx/algorithms/centrality/percolation.py
+++ b/networkx/algorithms/centrality/percolation.py
@@ -78,7 +78,7 @@ def percolation_centrality(G, attribute="percolation", states=None, weight=None)
     .. [2] Ulrik Brandes:
        A Faster Algorithm for Betweenness Centrality.
        Journal of Mathematical Sociology 25(2):163-177, 2001.
-       http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+       https://doi.org/10.1080/0022250X.2001.9990249
     """
     percolation = dict.fromkeys(G, 0.0)  # b[v]=0 for v in G
 

--- a/networkx/algorithms/components/tests/test_biconnected.py
+++ b/networkx/algorithms/components/tests/test_biconnected.py
@@ -78,7 +78,7 @@ def test_biconnected_components_cycle():
 
 def test_biconnected_components1():
     # graph example from
-    # http://www.ibluemojo.com/school/articul_algorithm.html
+    # https://web.archive.org/web/20121229123447/http://www.ibluemojo.com/school/articul_algorithm.html
     edges = [
         (0, 1),
         (0, 5),

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1019,7 +1019,7 @@ def _minimum_rooted_branching(D, root):
     References
     ----------
     [1] Khuller, Samir (2002) Advanced Algorithms Lecture 24 Notes.
-    https://www.cs.umd.edu/class/spring2011/cmsc651/lec07.pdf
+    https://web.archive.org/web/20121030033722/https://www.cs.umd.edu/class/spring2011/cmsc651/lec07.pdf
     """
     rooted = D.copy()
     # root the graph by removing all predecessors to `root`.

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -111,7 +111,7 @@ def test_brandes_erlebach():
 
 def test_white_harary_1():
     # Figure 1b white and harary (2001)
-    # # http://eclectic.ss.uci.edu/~drwhite/sm-w23.PDF
+    # https://doi.org/10.1111/0081-1750.00098
     # A graph with high adhesion (edge connectivity) and low cohesion
     # (vertex connectivity)
     G = nx.disjoint_union(nx.complete_graph(4), nx.complete_graph(4))
@@ -130,7 +130,7 @@ def test_white_harary_1():
 
 def test_white_harary_2():
     # Figure 8 white and harary (2001)
-    # # http://eclectic.ss.uci.edu/~drwhite/sm-w23.PDF
+    # https://doi.org/10.1111/0081-1750.00098
     G = nx.disjoint_union(nx.complete_graph(4), nx.complete_graph(4))
     G.add_edge(0, 4)
     # kappa <= lambda <= delta

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -93,7 +93,7 @@ def test_brandes_erlebach_book():
 
 def test_white_harary_paper():
     # Figure 1b white and harary (2001)
-    # http://eclectic.ss.uci.edu/~drwhite/sm-w23.PDF
+    # https://doi.org/10.1111/0081-1750.00098
     # A graph with high adhesion (edge connectivity) and low cohesion
     # (node connectivity)
     G = nx.disjoint_union(nx.complete_graph(4), nx.complete_graph(4))

--- a/networkx/algorithms/connectivity/utils.py
+++ b/networkx/algorithms/connectivity/utils.py
@@ -32,7 +32,7 @@ def build_auxiliary_node_connectivity(G):
     .. [1] Kammer, Frank and Hanjo Taubig. Graph Connectivity. in Brandes and
         Erlebach, 'Network Analysis: Methodological Foundations', Lecture
         Notes in Computer Science, Volume 3418, Springer-Verlag, 2005.
-        http://www.informatik.uni-augsburg.de/thi/personen/kammer/Graph_Connectivity.pdf
+        https://doi.org/10.1007/978-3-540-31955-9_7
 
     """
     directed = G.is_directed()

--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -145,12 +145,12 @@ def boykov_kolmogorov(
            of min-cut/max-flow algorithms for energy minimization in vision.
            Pattern Analysis and Machine Intelligence, IEEE Transactions on,
            26(9), 1124-1137.
-           http://www.csd.uwo.ca/~yuri/Papers/pami04.pdf
+           https://doi.org/10.1109/TPAMI.2004.60
 
     .. [2] Vladimir Kolmogorov. Graph-based Algorithms for Multi-camera
            Reconstruction Problem. PhD thesis, Cornell University, CS Department,
            2003. pp. 109-114.
-           https://pub.ist.ac.at/~vnk/papers/thesis.pdf
+           https://web.archive.org/web/20170809091249/https://pub.ist.ac.at/~vnk/papers/thesis.pdf
 
     """
     R = boykov_kolmogorov_impl(G, s, t, capacity, residual, cutoff)

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -129,7 +129,7 @@ def dinitz(G, s, t, capacity="capacity", residual=None, value_only=False, cutoff
     .. [1] Dinitz' Algorithm: The Original Version and Even's Version.
            2006. Yefim Dinitz. In Theoretical Computer Science. Lecture
            Notes in Computer Science. Volume 3895. pp 218-240.
-           http://www.cs.bgu.ac.il/~dinitz/Papers/Dinitz_alg.pdf
+           https://doi.org/10.1007/11685654_10
 
     """
     R = dinitz_impl(G, s, t, capacity, residual, cutoff)

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -219,7 +219,7 @@ def is_isomorphic(G1, G2, node_match=None, edge_match=None):
        "An Improved Algorithm for Matching Large Graphs",
        3rd IAPR-TC15 Workshop  on Graph-based Representations in
        Pattern Recognition, Cuen, pp. 149-159, 2001.
-       http://amalfi.dis.unina.it/graph/db/papers/vf-algorithm.pdf
+       https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.101.5342
     """
     if G1.is_directed() and G2.is_directed():
         GM = nx.algorithms.isomorphism.DiGraphMatcher

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -116,7 +116,7 @@ References
       Algorithm for Matching Large Graphs", 3rd IAPR-TC15 Workshop
       on Graph-based Representations in Pattern Recognition, Cuen,
       pp. 149-159, 2001.
-      http://amalfi.dis.unina.it/graph/db/papers/vf-algorithm.pdf
+      https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.101.5342
 
 See Also
 --------

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -84,7 +84,7 @@ class TestWikipediaExample:
 
 
 class TestVF2GraphDB:
-    # http://amalfi.dis.unina.it/graph/db/
+    # https://web.archive.org/web/20090303210205/http://amalfi.dis.unina.it/graph/db/
 
     @staticmethod
     def create_graph(filename):

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -332,7 +332,7 @@ def triad_type(G):
     ----------
     .. [1] Snijders, T. (2012). "Transitivity and triads." University of
         Oxford.
-        http://www.stats.ox.ac.uk/snijders/Trans_Triads_ha.pdf
+        https://web.archive.org/web/20170830032057/http://www.stats.ox.ac.uk/~snijders/Trans_Triads_ha.pdf
     """
     if not is_triad(G):
         raise nx.NetworkXAlgorithmError("G is not a triad (order-3 DiGraph)")

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -978,7 +978,7 @@ def LFR_benchmark_graph(
     .. [1] "Benchmark graphs for testing community detection algorithms",
            Andrea Lancichinetti, Santo Fortunato, and Filippo Radicchi,
            Phys. Rev. E 78, 046110 2008
-    .. [2] http://santo.fortunato.googlepages.com/inthepress2
+    .. [2] https://www.santofortunato.net/resources
 
     """
     # Perform some basic parameter validation.

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -54,7 +54,7 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
     References
     ----------
     .. [1] Gil Strang, Network applications: A = incidence matrix,
-       http://academicearth.org/lectures/network-applications-incidence-matrix
+       http://videolectures.net/mit18085f07_strang_lec03/
     """
     import scipy as sp
     import scipy.sparse  # call as sp.sparse

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -76,7 +76,7 @@ def write_gexf(G, path, encoding="utf-8", prettyprint=True, version="1.2draft"):
     References
     ----------
     .. [1] GEXF File Format, https://gephi.org/gexf/format/
-    .. [2] GEXF viz schema 1.1, https://gephi.org/gexf/1.1draft/viz
+    .. [2] GEXF schema, https://gephi.org/gexf/format/schema.html
     """
     writer = GEXFWriter(encoding=encoding, prettyprint=prettyprint, version=version)
     writer.add_graph(G)


### PR DESCRIPTION
After a bunch of grep-ing, regex-ing and URL checking found a bunch of places where links where broken in the codebase and documentation. I'm sure I would have missed a bunch of them.

For slides, I have linked to a copy from wayback machine where possible.
For papers, I have linked to DOI where available.

PS: Maybe a tool like this exist? go through all the codebase and outputs broken links?