### PR TITLE
Update arrows default value in draw_networkx.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -124,7 +124,7 @@ def draw(G, pos=None, ax=None, **kwds):
     return
 
 
-def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
+def draw_networkx(G, pos=None, arrows=None, with_labels=True, **kwds):
     r"""Draw the graph G using Matplotlib.
 
     Draw the graph with Matplotlib with options for node positions,
@@ -142,7 +142,12 @@ def draw_networkx(G, pos=None, arrows=True, with_labels=True, **kwds):
         See :py:mod:`networkx.drawing.layout` for functions that
         compute node positions.
 
-    arrows : bool (default=True)
+    arrows : bool or None, optional (default=None)
+        If `None`, directed graphs draw arrowheads with
+        `~matplotlib.patches.FancyArrowPatch`, while undirected graphs draw edges
+        via `~matplotlib.collections.LineCollection` for speed.
+        If `True`, draw arrowheads with FancyArrowPatches (bendable and stylish).
+        If `False`, draw edges using LineCollection (linear and fast).
         For directed graphs, if True draw arrowheads.
         Note: Arrows will be the same color as edges.
 

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -401,3 +401,26 @@ def test_draw_edges_toggling_with_arrows_kwarg():
     edges = nx.draw_networkx_edges(DG, pos)
     assert len(edges) == len(G.edges)
     assert isinstance(edges[0], mpl.patches.FancyArrowPatch)
+
+
+def test_draw_networkx_arrows_default_undirected():
+    import matplotlib.collections
+
+    G = nx.path_graph(3)
+    fig, ax = plt.subplots()
+    nx.draw_networkx(G, ax=ax)
+    assert any(isinstance(c, mpl.collections.LineCollection) for c in ax.collections)
+    assert not ax.patches
+    plt.delaxes(ax)
+
+
+def test_draw_networkx_arrows_default_directed():
+    import matplotlib.collections
+
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    fig, ax = plt.subplots()
+    nx.draw_networkx(G, ax=ax)
+    assert not any(
+        isinstance(c, mpl.collections.LineCollection) for c in ax.collections
+    )
+    assert ax.patches

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -403,24 +403,27 @@ def test_draw_edges_toggling_with_arrows_kwarg():
     assert isinstance(edges[0], mpl.patches.FancyArrowPatch)
 
 
-def test_draw_networkx_arrows_default_undirected():
+@pytest.mark.parametrize("drawing_func", (nx.draw, nx.draw_networkx))
+def test_draw_networkx_arrows_default_undirected(drawing_func):
     import matplotlib.collections
 
     G = nx.path_graph(3)
     fig, ax = plt.subplots()
-    nx.draw_networkx(G, ax=ax)
+    drawing_func(G, ax=ax)
     assert any(isinstance(c, mpl.collections.LineCollection) for c in ax.collections)
     assert not ax.patches
     plt.delaxes(ax)
 
 
-def test_draw_networkx_arrows_default_directed():
+@pytest.mark.parametrize("drawing_func", (nx.draw, nx.draw_networkx))
+def test_draw_networkx_arrows_default_directed(drawing_func):
     import matplotlib.collections
 
     G = nx.path_graph(3, create_using=nx.DiGraph)
     fig, ax = plt.subplots()
-    nx.draw_networkx(G, ax=ax)
+    drawing_func(G, ax=ax)
     assert not any(
         isinstance(c, mpl.collections.LineCollection) for c in ax.collections
     )
     assert ax.patches
+    plt.delaxes(ax)


### PR DESCRIPTION
Followup to #4825 

In #4825 the `arrows` kwarg was switched from being a boolean to an optional boolean with `None` as the default value. This was correctly updated in `draw_networkx_edges`, but I forgot to update the default in `draw_networkx`! This results in all graphs drawn with `nx.draw` or `nx.draw_networkx` being drawn with arrows by default, which was a major oversight.

This PR should go in before the 2.6 release to avoid a behavior change from 2.5.