### PR TITLE
Update matching functions for error validation and speed

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -54,8 +54,7 @@ API Changes
 - A ``FutureWarning`` has been added to ``attr_matrix`` to indicate that the
   return type will change from a ``numpy.matrix`` object to a ``numpy.ndarray``
   object in NetworkX 3.0.
-- 
-  The `is_*_matching` functions now raise exceptions for nodes not in G in any edge
+- The `is_*_matching` functions now raise exceptions for nodes not in G in any edge
 
 Deprecations
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -54,6 +54,8 @@ API Changes
 - A ``FutureWarning`` has been added to ``attr_matrix`` to indicate that the
   return type will change from a ``numpy.matrix`` object to a ``numpy.ndarray``
   object in NetworkX 3.0.
+- 
+  The `is_*_matching` functions now raise exceptions for nodes not in G in any edge
 
 Deprecations
 ------------

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -314,8 +314,6 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
     paths and the "primal-dual" method for finding a matching of maximum
     weight, both methods invented by Jack Edmonds [1]_.
 
-    See Also
-    --------
     Bipartite graphs can also be matched using the functions present in
     :mod:`networkx.algorithms.bipartite.matching`.
 

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -421,19 +421,40 @@ class TestIsMatching:
         assert nx.is_matching(G, {(0, 1), (3, 2)})
         assert nx.is_matching(G, {(1, 0), (3, 2)})
 
-    def test_valid(self):
+    def test_valid_matching(self):
         G = nx.path_graph(4)
         assert nx.is_matching(G, {(0, 1), (2, 3)})
 
-    def test_invalid(self):
+    def test_invalid_input(self):
+        error = nx.NetworkXError
+        G = nx.path_graph(4)
+        # edge to node not in G
+        raises(error, nx.is_matching, G, {(0, 5), (2, 3)})
+        # edge not a 2-tuple
+        raises(error, nx.is_matching, G, {(0, 1, 2), (2, 3)})
+        raises(error, nx.is_matching, G, {(0,), (2, 3)})
+
+    def test_selfloops(self):
+        error = nx.NetworkXError
+        G = nx.path_graph(4)
+        # selfloop for node not in G
+        raises(error, nx.is_matching, G, {(5, 5), (2, 3)})
+        # selfloop edge not in G
+        assert not nx.is_matching(G, {(0, 0), (1, 2), (2, 3)})
+        # selfloop edge in G
+        G.add_edge(0, 0)
+        assert not nx.is_matching(G, {(0, 0), (1, 2), (2, 3)})
+
+    def test_invalid_matching(self):
         G = nx.path_graph(4)
         assert not nx.is_matching(G, {(0, 1), (1, 2), (2, 3)})
 
     def test_invalid_edge(self):
         G = nx.path_graph(4)
         assert not nx.is_matching(G, {(0, 3), (1, 2)})
-        assert not nx.is_matching(G, {(0, 4)})
-        G = nx.path_graph(4, create_using=nx.DiGraph)
+        raises(nx.NetworkXError, nx.is_matching, G, {(0, 55)})
+
+        G = nx.DiGraph(G.edges)
         assert nx.is_matching(G, {(0, 1)})
         assert not nx.is_matching(G, {(1, 0)})
 


### PR DESCRIPTION
Expand tests
Change API to raise NetworkXError when matching involves nodes not in G
Update is_*_matching to 100+ times faster.

Still need to:

- [x] consider moving away from representing matchings as sets of frozensets.
- [ ] look to speed up max_weight_matching
- [x] improve tests
- [x] correct and improve documentation