### PR TITLE
Update docstrings for dfs and bfs edges and fix cross links

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -108,10 +108,10 @@ def bfs_edges(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
         A function that takes the list of neighbors of given node as input, and
         returns an *iterator* over these neighbors but with custom ordering.
 
-    Returns
-    -------
-    edges: generator
-       A generator of edges in the breadth-first-search.
+    Yields
+    ------
+    edge: 2-tuple of nodes
+       Yields edges resulting from the breadth-first search.
 
     Examples
     --------
@@ -134,27 +134,30 @@ def bfs_edges(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
 
     Notes
     -----
-    The naming of this function is very similar to edge_bfs. The difference
-    is that 'edge_bfs' yields edges even if they extend back to an already
-    explored node while 'bfs_edges' yields the edges of the tree that results
+    The naming of this function is very similar to
+    :func:`~networkx.algorithms.traversal.edgebfs.edge_bfs`. The difference
+    is that ``edge_bfs`` yields edges even if they extend back to an already
+    explored node while this generator yields the edges of the tree that results
     from a breadth-first-search (BFS) so no edges are reported if they extend
-    to already explored nodes. That means 'edge_bfs' reports all edges while
-    'bfs_edges' only reports those traversed by a node-based BFS. Yet another
-    description is that 'bfs_edges' reports the edges traversed during BFS
-    while 'edge_bfs' reports all edges in the order they are explored.
+    to already explored nodes. That means ``edge_bfs`` reports all edges while
+    ``bfs_edges`` only reports those traversed by a node-based BFS. Yet another
+    description is that ``bfs_edges`` reports the edges traversed during BFS
+    while ``edge_bfs`` reports all edges in the order they are explored.
 
-    Based on http://www.ics.uci.edu/~eppstein/PADS/BFS.py.
-    by D. Eppstein, July 2004. The modifications
-    to allow depth limits based on the Wikipedia article
-    "`Depth-limited-search`_".
+    Based on the breadth-first search implementation in PADS [1]_
+    by D. Eppstein, July 2004; with modifications to allow depth limits
+    as described in [2]_.
 
-    .. _Depth-limited-search: https://en.wikipedia.org/wiki/Depth-limited_search
+    References
+    ----------
+    .. [1] http://www.ics.uci.edu/~eppstein/PADS/BFS.py.
+    .. [2] https://en.wikipedia.org/wiki/Depth-limited_search
 
     See Also
     --------
     bfs_tree
-    dfs_edges
-    edge_bfs
+    :func:`~networkx.algorithms.traversal.depth_first_search.dfs_edges`
+    :func:`~networkx.algorithms.traversal.edgebfs.edge_bfs`
 
     """
     if reverse and G.is_directed():

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -25,16 +25,16 @@ def dfs_edges(G, source=None, depth_limit=None):
     G : NetworkX graph
 
     source : node, optional
-       Specify starting node for depth-first search and return edges in
+       Specify starting node for depth-first search and yield edges in
        the component reachable from source.
 
     depth_limit : int, optional (default=len(G))
        Specify the maximum search depth.
 
-    Returns
-    -------
-    edges: generator
-       A generator of edges in the depth-first-search.
+    Yields
+    ------
+    edge: 2-tuple of nodes
+       Yields edges resulting from the depth-first-search.
 
     Examples
     --------

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -16,8 +16,9 @@ __all__ = [
 def dfs_edges(G, source=None, depth_limit=None):
     """Iterate over edges in a depth-first-search (DFS).
 
-    Perform a depth-first-search over the nodes of G and yield
-    the edges in order. This may not generate all edges in G (see edge_dfs).
+    Perform a depth-first-search over the nodes of `G` and yield
+    the edges in order. This may not generate all edges in `G`
+    (see `~networkx.algorithms.traversal.edgedfs.edge_dfs`).
 
     Parameters
     ----------

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -50,20 +50,22 @@ def dfs_edges(G, source=None, depth_limit=None):
     repeatedly until all components in the graph are searched.
 
     The implementation of this function is adapted from David Eppstein's
-    depth-first search function in `PADS`_, with modifications
+    depth-first search function in PADS [1]_, with modifications
     to allow depth limits based on the Wikipedia article
-    "`Depth-limited search`_".
-
-    .. _PADS: http://www.ics.uci.edu/~eppstein/PADS
-    .. _Depth-limited search: https://en.wikipedia.org/wiki/Depth-limited_search
+    "Depth-limited search" [2]_.
 
     See Also
     --------
     dfs_preorder_nodes
     dfs_postorder_nodes
     dfs_labeled_edges
-    edge_dfs
-    bfs_edges
+    :func:`~networkx.algorithms.traversal.edgedfs.edge_dfs`
+    :func:`~networkx.algorithms.traversal.breadth_first_search.bfs_edges`
+
+    References
+    ----------
+    .. [1] http://www.ics.uci.edu/~eppstein/PADS
+    .. [2] https://en.wikipedia.org/wiki/Depth-limited_search
     """
     if source is None:
         # edges for all components

--- a/networkx/algorithms/traversal/edgedfs.py
+++ b/networkx/algorithms/traversal/edgedfs.py
@@ -80,14 +80,14 @@ def edge_dfs(G, source=None, orientation=None):
     -----
     The goal of this function is to visit edges. It differs from the more
     familiar depth-first traversal of nodes, as provided by
-    :func:`networkx.algorithms.traversal.depth_first_search.dfs_edges`, in
+    :func:`~networkx.algorithms.traversal.depth_first_search.dfs_edges`, in
     that it does not stop once every node has been visited. In a directed graph
     with edges [(0, 1), (1, 2), (2, 1)], the edge (2, 1) would not be visited
     if not for the functionality provided by this function.
 
     See Also
     --------
-    dfs_edges
+    :func:`~networkx.algorithms.traversal.depth_first_search.dfs_edges`
 
     """
     nodes = list(G.nbunch_iter(source))


### PR DESCRIPTION
Some docstring improvements that may further help to address issues like #4899 

The main improvements include:
 * Fixing cross-references between the various algorithms both in the text and the `See Also` sections.
 * Converting `Returns` -> `Yields` for the edge generators
 * Adding a `References` for more nicely-formatted links to external references.

I only touched the docstrings directly linked-to from `dfs_edges`. I expect that similar improvements could be made to some of the other dfs/bfs functions. I'll either review them myself when I have more time or open an issue about it if you think these changes are worthwhile!