### PR TITLE
Multiply rooted graph similarity

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -141,11 +141,11 @@ def graph_edit_distance(
         cost of 1 is used.  If edge_ins_cost is not specified then
         default edge insertion cost of 1 is used.
 
-    roots : 2-tuple
-        Tuple where first element is a node in G1 and the second
+    roots : 2-tuple or list of 2-tuples
+        Tuples where first element is a node in G1 and the second
         is a node in G2.
         These nodes are forced to be matched in the comparison to
-        allow comparison between rooted graphs.
+        allow comparison between multiply vertex-rooted graphs.
 
     upper_bound : numeric
         Maximum edit distance to consider.  Return None if no edit
@@ -166,8 +166,10 @@ def graph_edit_distance(
     >>> G2 = nx.star_graph(5)
     >>> nx.graph_edit_distance(G1, G2, roots=(0, 0))
     0.0
-    >>> nx.graph_edit_distance(G1, G2, roots=(1, 0))
+    >>> nx.graph_edit_distance(G1, G2, roots=[(1, 0)])
     8.0
+    >>> nx.graph_edit_distance(G1, G2, roots=[(0, 1), (4,2)])
+    7.0
 
     See Also
     --------
@@ -220,6 +222,8 @@ def optimal_edit_paths(
     edge_del_cost=None,
     edge_ins_cost=None,
     upper_bound=None,
+    roots=None,
+    timeout=None,
 ):
     """Returns all minimum-cost edit paths transforming G1 to G2.
 
@@ -312,6 +316,16 @@ def optimal_edit_paths(
     upper_bound : numeric
         Maximum edit distance to consider.
 
+    roots : 2-tuple or list of 2-tuples
+        Tuples where first element is a node in G1 and the second
+        is a node in G2.
+        These nodes are forced to be matched in the comparison to
+        allow comparison between multiply vertex-rooted graphs.
+
+    timeout : numeric
+        Maximum number of seconds to execute.
+        After timeout is met, the current best GED is returned.
+
     Returns
     -------
     edit_paths : list of tuples (node_edit_path, edge_edit_path)
@@ -361,6 +375,9 @@ def optimal_edit_paths(
         edge_ins_cost,
         upper_bound,
         False,
+        roots,
+        timeout,
+
     ):
         # assert bestcost is None or cost <= bestcost
         if bestcost is not None and cost < bestcost:
@@ -382,6 +399,8 @@ def optimize_graph_edit_distance(
     edge_del_cost=None,
     edge_ins_cost=None,
     upper_bound=None,
+    roots=None,
+    timeout=None,
 ):
     """Returns consecutive approximations of GED (graph edit distance)
     between graphs G1 and G2.
@@ -476,6 +495,16 @@ def optimize_graph_edit_distance(
     upper_bound : numeric
         Maximum edit distance to consider.
 
+    roots : 2-tuple or list of 2-tuples
+        Tuples where first element is a node in G1 and the second
+        is a node in G2.
+        These nodes are forced to be matched in the comparison to
+        allow comparison between multiply vertex-rooted graphs.
+
+    timeout : numeric
+        Maximum number of seconds to execute.
+        After timeout is met, the current best GED is returned.
+
     Returns
     -------
     Generator of consecutive approximations of graph edit distance.
@@ -516,6 +545,8 @@ def optimize_graph_edit_distance(
         edge_ins_cost,
         upper_bound,
         True,
+        roots,
+        timeout,
     ):
         yield cost
 
@@ -634,11 +665,11 @@ def optimize_edit_paths(
         decreasing cost.  Otherwise, return all edit paths of cost
         less than or equal to the previous minimum cost.
 
-    roots : 2-tuple
-        Tuple where first element is a node in G1 and the second
+    roots : 2-tuple or list of 2-tuples
+        Tuples where first element is a node in G1 and the second
         is a node in G2.
         These nodes are forced to be matched in the comparison to
-        allow comparison between rooted graphs.
+        allow comparison between multiply vertex-rooted graphs.
 
     timeout : numeric
         Maximum number of seconds to execute.
@@ -1049,13 +1080,14 @@ def optimize_edit_paths(
 
     initial_cost = 0
     if roots:
-        root_u, root_v = roots
-        if root_u not in pending_u or root_v not in pending_v:
-            raise nx.NodeNotFound("Root node not in graph.")
+        roots = [roots] if type(roots) == tuple else roots
+        for root_u, root_v in roots:
+            if root_u not in pending_u or root_v not in pending_v:
+                raise nx.NodeNotFound("Root node not in graph.")
 
-        # remove roots from pending
-        pending_u.remove(root_u)
-        pending_v.remove(root_v)
+            # remove roots from pending
+            pending_u.remove(root_u)
+            pending_v.remove(root_v)
 
     # cost matrix of vertex mappings
     m = len(pending_u)
@@ -1070,7 +1102,8 @@ def optimize_edit_paths(
             ]
         ).reshape(m, n)
         if roots:
-            initial_cost = node_subst_cost(G1.nodes[root_u], G2.nodes[root_v])
+            initial_cost = sum(
+                [node_subst_cost(G1.nodes[root_u], G2.nodes[root_v]) for root_u, root_v in roots])
     elif node_match:
         C[0:m, 0:n] = np.array(
             [
@@ -1080,7 +1113,8 @@ def optimize_edit_paths(
             ]
         ).reshape(m, n)
         if roots:
-            initial_cost = 1 - node_match(G1.nodes[root_u], G2.nodes[root_v])
+            initial_cost = sum(
+                [1 - node_match(G1.nodes[root_u], G2.nodes[root_v]) for root_u, root_v in roots])
     else:
         # all zeroes
         pass
@@ -1182,7 +1216,7 @@ def optimize_edit_paths(
 
     # Now go!
 
-    done_uv = [] if roots is None else [roots]
+    done_uv = [] if roots is None else roots
 
     for vertex_path, edge_path, cost in get_edit_paths(
         done_uv, pending_u, pending_v, Cv, [], pending_g, pending_h, Ce, initial_cost

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -223,7 +223,6 @@ def optimal_edit_paths(
     edge_ins_cost=None,
     upper_bound=None,
     roots=None,
-    timeout=None,
 ):
     """Returns all minimum-cost edit paths transforming G1 to G2.
 
@@ -322,10 +321,6 @@ def optimal_edit_paths(
         These nodes are forced to be matched in the comparison to
         allow comparison between multiply vertex-rooted graphs.
 
-    timeout : numeric
-        Maximum number of seconds to execute.
-        After timeout is met, the current best GED is returned.
-
     Returns
     -------
     edit_paths : list of tuples (node_edit_path, edge_edit_path)
@@ -376,7 +371,6 @@ def optimal_edit_paths(
         upper_bound,
         False,
         roots,
-        timeout,
 
     ):
         # assert bestcost is None or cost <= bestcost
@@ -400,7 +394,6 @@ def optimize_graph_edit_distance(
     edge_ins_cost=None,
     upper_bound=None,
     roots=None,
-    timeout=None,
 ):
     """Returns consecutive approximations of GED (graph edit distance)
     between graphs G1 and G2.
@@ -501,10 +494,6 @@ def optimize_graph_edit_distance(
         These nodes are forced to be matched in the comparison to
         allow comparison between multiply vertex-rooted graphs.
 
-    timeout : numeric
-        Maximum number of seconds to execute.
-        After timeout is met, the current best GED is returned.
-
     Returns
     -------
     Generator of consecutive approximations of graph edit distance.
@@ -546,7 +535,6 @@ def optimize_graph_edit_distance(
         upper_bound,
         True,
         roots,
-        timeout,
     ):
         yield cost
 

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -45,15 +45,17 @@ class TestSimilarity:
     def test_graph_edit_distance_roots_and_timeout(self):
         G0 = nx.star_graph(5)
         G1 = G0.copy()
-        pytest.raises(ValueError, graph_edit_distance, G0, G1, roots=[2])
-        pytest.raises(ValueError, graph_edit_distance, G0, G1, roots=[2, 3, 4])
+        pytest.raises(TypeError, graph_edit_distance, G0, G1, roots=[2])
+        pytest.raises(ValueError, graph_edit_distance, G0, G1, roots=(2, ))
+        pytest.raises(ValueError, graph_edit_distance, G0, G1, roots=(2, 3, 4))
         pytest.raises(nx.NodeNotFound, graph_edit_distance, G0, G1, roots=(9, 3))
-        pytest.raises(nx.NodeNotFound, graph_edit_distance, G0, G1, roots=(3, 9))
+        pytest.raises(nx.NodeNotFound, graph_edit_distance, G0, G1, roots=[(1, 1), (3, 9)])
         pytest.raises(nx.NodeNotFound, graph_edit_distance, G0, G1, roots=(9, 9))
         assert graph_edit_distance(G0, G1, roots=(1, 2)) == 0
-        assert graph_edit_distance(G0, G1, roots=(0, 1)) == 8
+        assert graph_edit_distance(G0, G1, roots=[(0, 1)]) == 8
         assert graph_edit_distance(G0, G1, roots=(1, 2), timeout=5) == 0
         assert graph_edit_distance(G0, G1, roots=(0, 1), timeout=5) == 8
+        assert graph_edit_distance(G0, G1, roots=[(0, 1), [4, 2]], timeout=5) == 7
         assert graph_edit_distance(G0, G1, roots=(0, 1), timeout=0.0001) is None
         # test raise on 0 timeout
         pytest.raises(nx.NetworkXError, graph_edit_distance, G0, G1, timeout=0)


### PR DESCRIPTION
Adding support for multiple roots in all similarity algorithms.
 - `optimize_edit_paths` and `graph_edit_distance` had support for a single root, I've extended the functionality to support multiple roots (multiply vertex-rooted graphs)
 - `optimize_graph_edit_distance` and `optimal_edit_paths`  actually use `optimize_edit_paths` to search for results but didn't have support for roots, I've added it to those methods as well.
