### PR TITLE
Update graphML docstring to include examples

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -81,7 +81,7 @@ def write_graphml_xml(
        For example, if edges have both int and float 'weight' attributes,
        we infer in GraphML that both are floats.
     named_key_ids : bool (optional)
-       If True use attr.name as value for key elements' id attribute.
+       If True use attr.name as value for node and edge data elements' key attribute.
     edge_id_from_attribute : dict key (optional)
         If provided, the graphml edge id is set by looking up the corresponding
         edge data attribute keyed by this parameter. If `None` or the key does not exist in edge data,
@@ -90,7 +90,23 @@ def write_graphml_xml(
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_graphml(G, "test.graphml")
+    >>> nx.write_graphml(G, "fourpath.graphml")
+
+    By default, key attributes in node and edge data tag are in the format of "d%i" (e.g. "d0").
+
+    If `named_key_ids` is True, the keys keep the same name as attr.name (e.g. "eid").
+
+    For example
+
+    >>> G = nx.path_graph(4)
+    >>> nx.set_edge_attributes(G, {e: str(e) for e in G.edges}, "eid")
+    >>> nx.write_graphml(G, "fourpath.graphml", named_key_ids=True)
+
+    The optional parameter `edge_id_from_attribute` allows the selection of an edge data attribute to be edge id.
+
+    >>> G = nx.path_graph(4)
+    >>> nx.set_edge_attributes(G, {e: str(e) for e in G.edges}, "eid")
+    >>> nx.write_graphml(G, "fourpath.graphml", edge_id_from_attribute="eid")
 
     Notes
     -----
@@ -139,7 +155,7 @@ def write_graphml_lxml(
        For example, if edges have both int and float 'weight' attributes,
        we infer in GraphML that both are floats.
     named_key_ids : bool (optional)
-       If True use attr.name as value for key elements' id attribute.
+       If True use attr.name as value for node and edge data elements' key attribute.
     edge_id_from_attribute : dict key (optional)
         If provided, the graphml edge id is set by looking up the corresponding
         edge data attribute keyed by this parameter. If `None` or the key does not exist in edge data,
@@ -148,7 +164,23 @@ def write_graphml_lxml(
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_graphml_lxml(G, "fourpath.graphml")
+    >>> nx.write_graphml(G, "fourpath.graphml")
+
+    By default, key attributes in node and edge data tag are in the format of "d%i" (e.g. "d0").
+
+    If `named_key_ids` is True, the keys keep the same name as attr.name (e.g. "eid").
+
+    For example
+
+    >>> G = nx.path_graph(4)
+    >>> nx.set_edge_attributes(G, {e: str(e) for e in G.edges}, "eid")
+    >>> nx.write_graphml(G, "fourpath.graphml", named_key_ids=True)
+
+    The optional parameter `edge_id_from_attribute` allows the selection of an edge data attribute to be edge id.
+
+    >>> G = nx.path_graph(4)
+    >>> nx.set_edge_attributes(G, {e: str(e) for e in G.edges}, "eid")
+    >>> nx.write_graphml(G, "fourpath.graphml", edge_id_from_attribute="eid")
 
     Notes
     -----
@@ -198,7 +230,7 @@ def generate_graphml(
     prettyprint : bool (optional)
        If True use line breaks and indenting in output XML.
     named_key_ids : bool (optional)
-       If True use attr.name as value for key elements' id attribute.
+       If True use attr.name as value for node and edge data elements' key attribute.
     edge_id_from_attribute : dict key (optional)
         If provided, the graphml edge id is set by looking up the corresponding
         edge data attribute keyed by this parameter. If `None` or the key does not exist in edge data,
@@ -207,9 +239,27 @@ def generate_graphml(
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> linefeed = chr(10)  # linefeed = \n
-    >>> s = linefeed.join(nx.generate_graphml(G))
+    >>> linefeed = chr(10)  # linefeed = \\n
+    >>> s = linefeed.join(nx.generate_graphml(G)) \n
     >>> for line in nx.generate_graphml(G):  # doctest: +SKIP
+    ...     print(line)
+
+    By default, key elements in node and edge data tag are in the format of "d%i" (e.g. "d0").
+
+    If `named_key_ids` is True, the keys keep the same name as attr.name (e.g. "eid").
+
+    For example
+
+    >>> G = nx.path_graph(4)
+    >>> nx.set_edge_attributes(G, {e: str(e) for e in G.edges}, "eid")
+    >>> for line in nx.generate_graphml(G, named_key_ids=True):
+    ...     print(line)
+
+    The optional parameter `edge_id_from_attribute` allows the selection of an edge data attribute to be edge id.
+
+    >>> G = nx.path_graph(4)
+    >>> nx.set_edge_attributes(G, {e: str(e) for e in G.edges}, "eid")
+    >>> for line in nx.generate_graphml(G , edge_id_from_attribute="eid"):
     ...     print(line)
 
     Notes
@@ -332,7 +382,7 @@ def parse_graphml(
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> linefeed = chr(10)  # linefeed = \n
+    >>> linefeed = chr(10)  # linefeed = \\n
     >>> s = linefeed.join(nx.generate_graphml(G))
     >>> H = nx.parse_graphml(s)
 


### PR DESCRIPTION
I include examples for `named_key_ids` and `edge_id_from_attribute` parameters in the docstring since the two parameters are hard to understand without specific examples. 

Also, I add an escape character to prevent  `\n` from taking action.
From
```python
>>> linefeed = chr(10)  # linefeed = \n
```
To
```python
>>> linefeed = chr(10)  # linefeed = \\n
```
