### PR TITLE
In `DiGraph.to_undirected`, remove not accessed variable

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1177,10 +1177,11 @@ class DiGraph(Graph):
         >>> list(G2.edges)
         [(0, 1)]
         """
+        graph_class = self.to_undirected_class()
         if as_view is True:
             return nx.graphviews.generic_graph_view(self, Graph)
         # deepcopy when not a view
-        G = Graph()
+        G = graph_class()
         G.graph.update(deepcopy(self.graph))
         G.add_nodes_from((n, deepcopy(d)) for n, d in self._node.items())
         if reciprocal is True:

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1179,7 +1179,7 @@ class DiGraph(Graph):
         """
         graph_class = self.to_undirected_class()
         if as_view is True:
-            return nx.graphviews.generic_graph_view(self, Graph)
+            return nx.graphviews.generic_graph_view(self, graph_class)
         # deepcopy when not a view
         G = graph_class()
         G.graph.update(deepcopy(self.graph))

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1177,7 +1177,6 @@ class DiGraph(Graph):
         >>> list(G2.edges)
         [(0, 1)]
         """
-        graph_class = self.to_undirected_class()
         if as_view is True:
             return nx.graphviews.generic_graph_view(self, Graph)
         # deepcopy when not a view

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -103,13 +103,6 @@ class BaseDiGraphTester(BaseGraphTester):
         H2 = H.to_undirected(as_view=True)
         assert H is H2._graph
 
-    def test_to_undirected(self):
-        G = nx.path_graph(2)
-        H = G.to_directed()
-        assert sorted(H.edges()) == [(0, 1), (1, 0)]
-        H2 = H.to_undirected()
-        assert H2.has_edge(0, 1)
-
     def test_to_undirected_reciprocal(self):
         G = self.Graph()
         G.add_edge(1, 2)

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -97,12 +97,6 @@ class BaseDiGraphTester(BaseGraphTester):
         assert G.size() == 6
         assert G.number_of_edges() == 6
 
-    def test_to_undirected_as_view(self):
-        G = nx.path_graph(2)
-        H = G.to_directed()
-        H2 = H.to_undirected(as_view=True)
-        assert H is H2._graph
-
     def test_to_undirected_reciprocal(self):
         G = self.Graph()
         G.add_edge(1, 2)

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -97,6 +97,19 @@ class BaseDiGraphTester(BaseGraphTester):
         assert G.size() == 6
         assert G.number_of_edges() == 6
 
+    def test_to_undirected_as_view(self):
+        G = nx.path_graph(2)
+        H = G.to_directed()
+        H2 = H.to_undirected(as_view=True)
+        assert H is H2._graph
+
+    def test_to_undirected(self):
+        G = nx.path_graph(2)
+        H = G.to_directed()
+        assert sorted(H.edges()) == [(0, 1), (1, 0)]
+        H2 = H.to_undirected()
+        assert H2.has_edge(0, 1)
+
     def test_to_undirected_reciprocal(self):
         G = self.Graph()
         G.add_edge(1, 2)

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -453,6 +453,53 @@ class BaseAttrGraphTester(BaseGraphTester):
         H = G.to_undirected()
         self.is_deepcopy(H, G)
 
+    def test_to_directed_as_view(self):
+        H = nx.path_graph(2, create_using=self.Graph)
+        H2 = H.to_directed(as_view=True)
+        assert H is H2._graph
+        assert H2.has_edge(0, 1)
+        assert H2.has_edge(1, 0) or H.is_directed()
+        pytest.raises(nx.NetworkXError, H2.add_node, -1)
+        pytest.raises(nx.NetworkXError, H2.add_edge, 1, 2)
+        H.add_edge(1, 2)
+        assert H2.has_edge(1, 2)
+        assert H2.has_edge(2, 1) or H.is_directed()
+
+    def test_to_undirected_as_view(self):
+        H = nx.path_graph(2, create_using=self.Graph)
+        H2 = H.to_undirected(as_view=True)
+        assert H is H2._graph
+        assert H2.has_edge(0, 1)
+        assert H2.has_edge(1, 0)
+        pytest.raises(nx.NetworkXError, H2.add_node, -1)
+        pytest.raises(nx.NetworkXError, H2.add_edge, 1, 2)
+        H.add_edge(1, 2)
+        assert H2.has_edge(1, 2)
+        assert H2.has_edge(2, 1)
+
+    def test_directed_class(self):
+        G = self.Graph()
+
+        class newGraph(G.to_undirected_class()):
+            def to_directed_class(self):
+                return newDiGraph
+
+            def to_undirected_class(self):
+                return newGraph
+
+        class newDiGraph(G.to_directed_class()):
+            def to_directed_class(self):
+                return newDiGraph
+
+            def to_undirected_class(self):
+                return newGraph
+
+        G = newGraph()
+        H = G.to_directed()
+        assert isinstance(H, newDiGraph)
+        H = G.to_undirected()
+        assert isinstance(H, newGraph)
+
     def test_to_directed(self):
         G = self.K3
         self.add_attributes(G)

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -494,7 +494,7 @@ class BaseAttrGraphTester(BaseGraphTester):
             def to_undirected_class(self):
                 return newGraph
 
-        G = newGraph()
+        G = newDiGraph() if G.is_directed() else newGraph()
         H = G.to_directed()
         assert isinstance(H, newDiGraph)
         H = G.to_undirected()


### PR DESCRIPTION
In `DiGraph.to_undirected`, local variable `graph_class` was defined but not used in this function. 
Though it is not a serious problem, this should be removed.
