### PR TITLE
Fix disconnected graph bug in link prediction CCPA and add tests

### DIFF
--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -275,16 +275,19 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
            Sci Rep 10, 364 (2020).
            https://doi.org/10.1038/s41598-019-57304-y
     """
-    shortest_path = nx.shortest_path(G)
+
+    if not 0 <= alpha <= 1:
+        raise nx.NetworkXAlgorithmError("Alpha must be between 0 and 1")
+
+    spl = dict(nx.shortest_path_length(G))
 
     def predict(u, v):
-        try:
-            path_len = len(shortest_path[u][v])
-        except KeyError:
-            return 0
+        if u == v:
+            raise nx.NetworkXAlgorithmError("Self links are not supported")
+        path_len = spl[u].get(v, float("inf"))
 
         return alpha * len(list(nx.common_neighbors(G, u, v))) + (1 - alpha) * (
-            G.number_of_nodes() / (path_len - 1)
+            G.number_of_nodes() / path_len
         )
 
     return _apply_prediction(G, predict, ebunch)

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -278,8 +278,13 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
     shortest_path = nx.shortest_path(G)
 
     def predict(u, v):
+        try:
+            path_len = len(shortest_path[u][v])
+        except KeyError:
+            return 0
+
         return alpha * len(list(nx.common_neighbors(G, u, v))) + (1 - alpha) * (
-            G.number_of_nodes() / (len(shortest_path[u][v]) - 1)
+            G.number_of_nodes() / (path_len - 1)
         )
 
     return _apply_prediction(G, predict, ebunch)

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -246,7 +246,8 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
         Default value: None.
 
     alpha : Parameter defined for participation of Common Neighbor
-            and Centrality Algorithm share. Default value set to 0.8
+            and Centrality Algorithm share. Values for alpha should
+            normally be between 0 and 1. Default value set to 0.8
             because author found better performance at 0.8 for all the
             dataset.
             Default value: 0.8
@@ -275,9 +276,6 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
            Sci Rep 10, 364 (2020).
            https://doi.org/10.1038/s41598-019-57304-y
     """
-
-    if not 0 <= alpha <= 1:
-        raise nx.NetworkXAlgorithmError("Alpha must be between 0 and 1")
 
     spl = dict(nx.shortest_path_length(G))
     inf = float("inf")

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -280,13 +280,14 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
         raise nx.NetworkXAlgorithmError("Alpha must be between 0 and 1")
 
     spl = dict(nx.shortest_path_length(G))
+    inf = float("inf")
 
     def predict(u, v):
         if u == v:
             raise nx.NetworkXAlgorithmError("Self links are not supported")
-        path_len = spl[u].get(v, float("inf"))
+        path_len = spl[u].get(v, inf)
 
-        return alpha * len(list(nx.common_neighbors(G, u, v))) + (1 - alpha) * (
+        return alpha * sum(1 for _ in nx.common_neighbors(G, u, v)) + (1 - alpha) * (
             G.number_of_nodes() / path_len
         )
 

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -206,10 +206,14 @@ class TestCommonNeighborCentrality:
         G.add_nodes_from([0, 1])
         self.test(G, [(0, 1)], [(0, 1, 0)])
 
-    # Undefined behaviour
-    # def test_equal_nodes(self):
-    #    G = nx.complete_graph(4)
-    #    self.test(G, [(0, 0)], [(0, 0, 3 / math.log(3))])
+    def test_invalid_alpha(self):
+        G = nx.complete_graph(3)
+        assert pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], 1.1)
+        assert pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], -1)
+
+    def test_equal_nodes(self):
+        G = nx.complete_graph(4)
+        assert pytest.raises(nx.NetworkXAlgorithmError, self.test, G, [(0, 0)], [])
 
     def test_all_nonexistent_edges(self):
         G = nx.Graph()

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -206,11 +206,6 @@ class TestCommonNeighborCentrality:
         G.add_nodes_from([0, 1])
         self.test(G, [(0, 1)], [(0, 1, 0)])
 
-    def test_invalid_alpha(self):
-        G = nx.complete_graph(3)
-        assert pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], 1.1)
-        assert pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], -1)
-
     def test_equal_nodes(self):
         G = nx.complete_graph(4)
         assert pytest.raises(nx.NetworkXAlgorithmError, self.test, G, [(0, 0)], [])

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -184,21 +184,12 @@ class TestCommonNeighborCentrality:
         G = nx.star_graph(4)
         self.test(G, [(1, 2)], [(1, 2, 1.75)], alpha=0.5)
 
-    def test_notimplemented(self):
+    @pytest.parametrize(
+        'graph_type', (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)
+    )
+    def test_notimplemented(self, graph_type):
         assert pytest.raises(
-            nx.NetworkXNotImplemented, self.func, nx.DiGraph([(0, 1), (1, 2)]), [(0, 2)]
-        )
-        assert pytest.raises(
-            nx.NetworkXNotImplemented,
-            self.func,
-            nx.MultiGraph([(0, 1), (1, 2)]),
-            [(0, 2)],
-        )
-        assert pytest.raises(
-            nx.NetworkXNotImplemented,
-            self.func,
-            nx.MultiDiGraph([(0, 1), (1, 2)]),
-            [(0, 2)],
+            nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]
         )
 
     def test_no_common_neighbor(self):

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -184,9 +184,7 @@ class TestCommonNeighborCentrality:
         G = nx.star_graph(4)
         self.test(G, [(1, 2)], [(1, 2, 1.75)], alpha=0.5)
 
-    @pytest.parametrize(
-        'graph_type', (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)
-    )
+    @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
     def test_notimplemented(self, graph_type):
         assert pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -165,6 +165,58 @@ class TestAdamicAdarIndex:
         )
 
 
+class TestCommonNeighborCentrality:
+    @classmethod
+    def setup_class(cls):
+        cls.func = staticmethod(nx.common_neighbor_centrality)
+        cls.test = partial(_test_func, predict_func=cls.func)
+
+    def test_K5(self):
+        G = nx.complete_graph(5)
+        self.test(G, [(0, 1)], [(0, 1, 3.0)], alpha=1)
+        self.test(G, [(0, 1)], [(0, 1, 5.0)], alpha=0)
+
+    def test_P3(self):
+        G = nx.path_graph(3)
+        self.test(G, [(0, 2)], [(0, 2, 1.25)], alpha=0.5)
+
+    def test_S4(self):
+        G = nx.star_graph(4)
+        self.test(G, [(1, 2)], [(1, 2, 1.75)], alpha=0.5)
+
+    def test_notimplemented(self):
+        assert pytest.raises(
+            nx.NetworkXNotImplemented, self.func, nx.DiGraph([(0, 1), (1, 2)]), [(0, 2)]
+        )
+        assert pytest.raises(
+            nx.NetworkXNotImplemented,
+            self.func,
+            nx.MultiGraph([(0, 1), (1, 2)]),
+            [(0, 2)],
+        )
+        assert pytest.raises(
+            nx.NetworkXNotImplemented,
+            self.func,
+            nx.MultiDiGraph([(0, 1), (1, 2)]),
+            [(0, 2)],
+        )
+
+    def test_no_common_neighbor(self):
+        G = nx.Graph()
+        G.add_nodes_from([0, 1])
+        self.test(G, [(0, 1)], [(0, 1, 0)])
+
+    # Undefined behaviour
+    # def test_equal_nodes(self):
+    #    G = nx.complete_graph(4)
+    #    self.test(G, [(0, 0)], [(0, 0, 3 / math.log(3))])
+
+    def test_all_nonexistent_edges(self):
+        G = nx.Graph()
+        G.add_edges_from([(0, 1), (0, 2), (2, 3)])
+        self.test(G, None, [(0, 3, 1.5), (1, 2, 1.5), (1, 3, 2 / 3)], alpha=0.5)
+
+
 class TestPreferentialAttachment:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
(Note: the question at the bottom should be discussed and addressed before merging)

Fixes a bug where CCPA throws a KeyError due to there being no path between nodes. I assume that the method should return a score of 0 if there is no path between two nodes. I make this assumption based on this being a local neighbourhood similarity score based on common neighbours and shortest path. CCPA gives a higher score for nodes that have a small shortest path and a lower score for a longer shortest path. No shortest path means the nodes have no structural connection and also no common neighbours, thus a score of 0 is sensible. This is in line with other link prediction methods (based on common neighbours) which simply returns a score of 0 inherently, due to there being no common neighbours.

I suspect that this would normally have been caught if the method had tests. So I added tests. The bug fixed is covered by the "test_no_common_neighbor" test.

The behaviour can be replicated with the following code.
```python
import networkx as nx
G = nx.Graph()
G.add_nodes_from([0, 1])
list(nx.common_neighbor_centrality(G))
```
Expected behaviour, returns: `[(0, 1, 0)]` 
Observed behaviour, throws KeyError.

Before this is merged, I have a question. Other link prediction methods were tested on links between equal nodes (the `test_equal_nodes` test). CCPA in its current state throws a ZeroDivisionError on this test, since the shortest path is zero. I've added the test but commented it out. I'll adapt the test based on what we decide. 
It is less clear to me what a sensible score for equal nodes should be as I'm not familiar with any use case for such a prediction. I see at least two options:
1. Leave the functionality as is and modify the test to expect an exception. In this case, should the method call fail with an informative error and error message, which one?
2. Assume a score for this case. In this case, what would a sensible score be?