### PR TITLE
Expand destringizer example in read_gml docstring

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -163,20 +163,19 @@ def read_gml(path, label="label", destringizer=None):
     --------
     >>> G = nx.path_graph(4)
     >>> nx.write_gml(G, "test.gml")
-    >>> H = nx.read_gml("test.gml")
 
-    >>> I = nx.MultiGraph()
-    >>> I.add_edge(1, 3, data = {'s': 1})
-    0
-    >>> print(I.nodes)
-    [1, 3]
-    >>> nx.write_gml(I, "test.gml")
-    >>> J = nx.read_gml("test.gml")
-    >>> K = nx.read_gml("test.gml", destringizer=int)
-    >>> print(J.nodes)
-    ['1', '3']
-    >>> print(K.nodes)
-    [1, 3]
+    GML values are interpreted as strings by default:
+
+    >>> H = nx.read_gml("test.gml")
+    >>> H.nodes
+    NodeView(('0', '1', '2', '3'))
+
+    When a `destringizer` is provided, GML values are converted to the provided type.
+    For example, integer nodes can be recovered as shown below:
+
+    >>> J = nx.read_gml("test.gml", destringizer=int)
+    >>> J.nodes
+    NodeView((0, 1, 2, 3))
 
     """
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -164,7 +164,19 @@ def read_gml(path, label="label", destringizer=None):
     >>> G = nx.path_graph(4)
     >>> nx.write_gml(G, "test.gml")
     >>> H = nx.read_gml("test.gml")
-    >>> I = nx.read_gml("test.gml", destringizer=int)
+
+    >>> I = nx.MultiGraph()
+    >>> I.add_edge(1, 3, data = {'s': 1})
+    >>> print(I.nodes)
+    [1, 3]
+    >>> nx.write_gml(I, "test.gml")
+    >>> J = nx.read_gml("test.gml")
+    >>> K = nx.read_gml("test.gml", destringizer=int)
+    >>> print(J.nodes)
+    ['1', '3']
+    >>> print(K.nodes)
+    [1, 3]
+
     """
 
     def filter_lines(lines):

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -167,6 +167,7 @@ def read_gml(path, label="label", destringizer=None):
 
     >>> I = nx.MultiGraph()
     >>> I.add_edge(1, 3, data = {'s': 1})
+    0
     >>> print(I.nodes)
     [1, 3]
     >>> nx.write_gml(I, "test.gml")


### PR DESCRIPTION
Add to the example showing read_gml with and without a destringizer.
Show the nodes of the graph created with read_gml will be str unless a
destringizer is specified. 

I looked around the repo to find multi-line examples but I'm not sure if 
this formatting is the most clear or that it follows convention in networkx. 
Please let me know if you have feedback on readability or formatting. 

Closes #4877
