### PR TITLE
Fixes #4275 - Add comment to parallel betweenness example

### DIFF
--- a/examples/algorithms/plot_parallel_betweenness.py
+++ b/examples/algorithms/plot_parallel_betweenness.py
@@ -14,7 +14,7 @@ contribution to the betweenness centrality of the whole network.
 Note: The example output below shows that the non-parallel implementation is
 faster. This is a limitation of our CI/CD pipeline running on a single core.
 
-Depending on your setup, you may observe a 4x speed improvement.
+Depending on your setup, you will likely observe a speedup.
 """
 from multiprocessing import Pool
 import time

--- a/examples/algorithms/plot_parallel_betweenness.py
+++ b/examples/algorithms/plot_parallel_betweenness.py
@@ -10,8 +10,12 @@ The function betweenness centrality accepts a bunch of nodes and computes
 the contribution of those nodes to the betweenness centrality of the whole
 network. Here we divide the network in chunks of nodes and we compute their
 contribution to the betweenness centrality of the whole network.
-"""
 
+Note: The example output below shows that the non-parallel implementation is
+faster. This is a limitation of our CI/CD pipeline running on a single core.
+
+Depending on your setup, you may observe a 4x speed improvement.
+"""
 from multiprocessing import Pool
 import time
 import itertools


### PR DESCRIPTION
# Description

Add comment about single core CI/CD showing slower parallel output in example script.

Added text:

```
Note: The example output below shows that the non-parallel implementation is
faster. This is a limitation of our CI/CD pipeline running on a single core.

Depending on your setup, you may observe a 4x speed improvement.
```

Following the discussion in the ticket, I left the multiprocessing as-is because I think it probably makes MORE sense than using concurrent.futures.

Here was my output running the script:

```
⇒  python examples/algorithms/plot_parallel_betweenness.py

Computing betweenness centrality for:
Name:
Type: Graph
Number of nodes: 1000
Number of edges: 2991
Average degree:   5.9820
	Parallel version
		Time: 0.7211 seconds
		Betweenness centrality for node 0: 0.00201
	Non-Parallel version
		Time: 3.0109 seconds
		Betweenness centrality for node 0: 0.00201

Computing betweenness centrality for:
Name:
Type: Graph
Number of nodes: 1000
Number of edges: 5018
Average degree:  10.0360
	Parallel version
		Time: 0.8089 seconds
		Betweenness centrality for node 0: 0.00283
	Non-Parallel version
		Time: 3.8002 seconds
		Betweenness centrality for node 0: 0.00283

Computing betweenness centrality for:
Name:
Type: Graph
Number of nodes: 1000
Number of edges: 2000
Average degree:   4.0000
	Parallel version
		Time: 0.6724 seconds
		Betweenness centrality for node 0: 0.02636
	Non-Parallel version
		Time: 2.6978 seconds
		Betweenness centrality for node 0: 0.02636
```

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
