### PR TITLE
Fix numeric and degree assortativity coefficient calculation

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -73,8 +73,12 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
-    M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight)
-    return numeric_ac(M)
+    if nodes is None:
+        nodes = G.nodes
+    degrees = set([G.degree(weight=weight)[n] for n in nodes])
+    mapping = {d: i for i, d, in enumerate(degrees)}
+    M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight, mapping=mapping)
+    return numeric_ac(M, mapping=mapping)
 
 
 def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, nodes=None):
@@ -223,8 +227,12 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     .. [1] M. E. J. Newman, Mixing patterns in networks
            Physical Review E, 67 026126, 2003
     """
-    a = numeric_mixing_matrix(G, attribute, nodes)
-    return numeric_ac(a)
+    if nodes is None:
+        nodes = G.nodes
+    vals = set(G.nodes[n][attribute] for n in nodes)
+    mapping = {d: i for i, d, in enumerate(vals)}
+    M = attribute_mixing_matrix(G, attribute, nodes, mapping=mapping)
+    return numeric_ac(M, mapping)
 
 
 def attribute_ac(M):
@@ -254,7 +262,7 @@ def attribute_ac(M):
     return r
 
 
-def numeric_ac(M):
+def numeric_ac(M, mapping):
     # M is a numpy matrix or array
     # numeric assortativity coefficient, pearsonr
     import numpy as np
@@ -262,12 +270,13 @@ def numeric_ac(M):
     if M.sum() != 1.0:
         M = M / float(M.sum())
     nx, ny = M.shape  # nx=ny
-    x = np.arange(nx)
-    y = np.arange(ny)
+    x = np.array(list(mapping.keys()))
+    y = x  # x and y have the same support
+    idx = list(mapping.values())
     a = M.sum(axis=0)
     b = M.sum(axis=1)
-    vara = (a * x ** 2).sum() - ((a * x).sum()) ** 2
-    varb = (b * x ** 2).sum() - ((b * x).sum()) ** 2
+    vara = (a[idx] * x ** 2).sum() - ((a[idx] * x).sum()) ** 2
+    varb = (b[idx] * x ** 2).sum() - ((b[idx] * x).sum()) ** 2
     xy = np.outer(x, y)
-    ab = np.outer(a, b)
+    ab = np.outer(a[idx], b[idx])
     return (xy * (M - ab)).sum() / np.sqrt(vara * varb)

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -231,7 +231,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
         nodes = G.nodes
     vals = set(G.nodes[n][attribute] for n in nodes)
     mapping = {d: i for i, d, in enumerate(vals)}
-    M = attribute_mixing_matrix(G, attribute, nodes, mapping=mapping)
+    M = attribute_mixing_matrix(G, attribute, nodes, mapping)
     return numeric_ac(M, mapping)
 
 

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -276,7 +276,7 @@ def numeric_ac(M, mapping):
     a = M.sum(axis=0)
     b = M.sum(axis=1)
     vara = (a[idx] * x ** 2).sum() - ((a[idx] * x).sum()) ** 2
-    varb = (b[idx] * x ** 2).sum() - ((b[idx] * x).sum()) ** 2
+    varb = (b[idx] * y ** 2).sum() - ((b[idx] * y).sum()) ** 2
     xy = np.outer(x, y)
     ab = np.outer(a[idx], b[idx])
     return (xy * (M - ab)).sum() / np.sqrt(vara * varb)

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -75,7 +75,7 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     """
     if nodes is None:
         nodes = G.nodes
-    degrees = set([G.degree(weight=weight)[n] for n in nodes])
+    degrees = set([d for n, d in G.degree(nodes, weight=weight)])
     mapping = {d: i for i, d, in enumerate(degrees)}
     M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight, mapping=mapping)
     return numeric_ac(M, mapping=mapping)

--- a/networkx/algorithms/assortativity/tests/base_test.py
+++ b/networkx/algorithms/assortativity/tests/base_test.py
@@ -52,6 +52,10 @@ class BaseTestDegreeMixing:
         cls.W = nx.Graph()
         cls.W.add_edges_from([(0, 3), (1, 3), (2, 3)], weight=0.5)
         cls.W.add_edge(0, 2, weight=1)
+        S1 = nx.star_graph(4)
+        S2 = nx.star_graph(4)
+        cls.DS = nx.disjoint_union(S1, S2)
+        cls.DS.add_edge(4, 5)
 
 
 class BaseTestNumericMixing:
@@ -70,3 +74,10 @@ class BaseTestNumericMixing:
         F.add_edge(0, 2, weight=1)
         nx.set_node_attributes(F, dict(F.degree(weight="weight")), "margin")
         cls.F = F
+
+        M = nx.Graph()
+        M.add_nodes_from([1, 2], margin=-1)
+        M.add_nodes_from([3], margin=1)
+        M.add_nodes_from([4], margin=2)
+        M.add_edges_from([(3, 4), (1, 2), (1, 3)])
+        cls.M = M

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -42,6 +42,10 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         r = nx.degree_assortativity_coefficient(self.W, weight="weight")
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)
 
+    def test_degree_assortativity_double_star(self):
+        r = nx.degree_assortativity_coefficient(self.DS)
+        np.testing.assert_almost_equal(r, -0.9339, decimal=4)
+
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
     def test_attribute_assortativity_undirected(self):
@@ -91,3 +95,7 @@ class TestNumericMixingCorrelation(BaseTestNumericMixing):
     def test_numeric_assortativity_float(self):
         r = nx.numeric_assortativity_coefficient(self.F, "margin")
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)
+
+    def test_numeric_assortativity_mixed(self):
+        r = nx.numeric_assortativity_coefficient(self.M, "margin")
+        np.testing.assert_almost_equal(r, 0.4340, decimal=4)


### PR DESCRIPTION
It fixes #4776 and wrong assortativity coefficient calculation in some cases that follow PR #4851.

A cause of the issue is in `numeric_ac` in [correlation.py](https://github.com/networkx/networkx/blob/main/networkx/algorithms/assortativity/correlation.py). Before my fixes in `numeric_ac`
```python
x = np.arange(nx)
y = np.arange(ny)
```
we create supports for random variables x and y. We assume that node values are integer and coincide with mixing matrix indices — 0 is in the first row/column, 1 is in the second row/column and so on. But after PR #4851, node values can also be negative or float. In such cases we need to know a mixing matrix indices for each unique pair of values. After my fixes, supports of x and y contain all node values, not only integers. The same for degree assortativity coefficient calculation.

Note that the PR #4851 version also correctly calculates assortativity coefficient in the case of *equal intervals* between support values due to normalization (in fact, this is a correlation between x and y, not covariance). For example, it correctly calculates a degree assortativity coefficient for float node degrees `[0, 0.5, 1, 1.5]` or an assortativity coefficient for mixed node values `[-1, 0, 1, 2]`.  But in #4776 we have a graph with node values `[-1, 1, 2]` and then the old coefficient is incorrect. I added tests that check cases with non-equal intervals between support values — one for degree and one for node values.