### PR TITLE
quotient_graph doc fix

### DIFF
--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -128,10 +128,9 @@ def quotient_graph(
 
     edge_relation : Boolean function with two arguments
         This function must represent an edge relation on the *blocks* of
-        `G` in the partition induced by `node_relation`. It must
-        take two arguments, *B* and *C*, each one a set of nodes, and
-        return True exactly when there should be an edge joining
-        block *B* to block *C* in the returned graph.
+        the `partition` of `G`. It must take two arguments, *B* and *C*,
+        each one a set of nodes, and return True exactly when there should be
+        an edge joining block *B* to block *C* in the returned graph.
 
         If `edge_relation` is not specified, it is assumed to be the
         following relation. Block *B* is related to block *C* if and


### PR DESCRIPTION
Small fix to the documentation of `networkx.algorithms.minors.quotient_graph` which I think makes it a bit clearer. The docs refer to `node_relation` which isn't a parameter and isn't referred to elsewhere. Basically it should just be referring to the partition.