### PR TITLE
move partition checking outside private _quotient_graph function

### DIFF
--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -51,6 +51,12 @@ def equivalence_classes(iterable, relation):
         Duplicate elements will be ignored so it makes the most sense for
         `iterable` to be a :class:`set`.
 
+    Notes
+    -----
+    This function does not check that `relation` represents an equivalence
+    relation. You can check that your equivalence classes provide a partition
+    using `is_partition`.
+
     Examples
     --------
     Let `X` be the set of integers from `0` to `9`, and consider an equivalence
@@ -296,6 +302,10 @@ def quotient_graph(
     if callable(partition):
         # equivalence_classes always return partition of whole G.
         partition = equivalence_classes(G, partition)
+        if not nx.community.is_partition(G, partition):
+            raise nx.NetworkXException(
+                "Input `partition` is not an equivalence relation for nodes of G"
+            )
         return _quotient_graph(
             G, partition, edge_relation, node_data, edge_data, relabel, create_using
         )
@@ -311,6 +321,9 @@ def quotient_graph(
     partition_nodes = set().union(*partition)
     if len(partition_nodes) != len(G):
         G = G.subgraph(partition_nodes)
+    # Each node in the graph/subgraph must be in exactly one block.
+    if not nx.community.is_partition(G, partition):
+        raise NetworkXException("each node must be in exactly one part of `partition`")
     return _quotient_graph(
         G, partition, edge_relation, node_data, edge_data, relabel, create_using
     )
@@ -325,9 +338,7 @@ def _quotient_graph(
     relabel=False,
     create_using=None,
 ):
-    # Each node in the graph must be in exactly one block.
-    if any(sum(1 for b in partition if v in b) != 1 for v in G):
-        raise NetworkXException("each node must be in exactly one block")
+    """Construct the quotient graph assuming inout has been checked"""
     if create_using is None:
         H = G.__class__()
     else:

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -338,7 +338,7 @@ def _quotient_graph(
     relabel=False,
     create_using=None,
 ):
-    """Construct the quotient graph assuming inout has been checked"""
+    """Construct the quotient graph assuming input has been checked"""
     if create_using is None:
         H = G.__class__()
     else:


### PR DESCRIPTION
Making the private function free from argument checking may allow Louvain method code to call the private version to avoid argument checking because we know the inputs are ok.
