### PR TITLE
Page number for Katz centrality reference

### DIFF
--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -298,7 +298,7 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
     ----------
     .. [1] Mark E. J. Newman:
        Networks: An Introduction.
-       Oxford University Press, USA, 2010, p. 720.
+       Oxford University Press, USA, 2010, p. 173.
     .. [2] Leo Katz:
        A New Status Index Derived from Sociometric Index.
        Psychometrika 18(1):39–43, 1953


### PR DESCRIPTION
Minor fix for Katz centrality documentation. Page referenced in `Networks, An Introduction` appears wrong when I went to read the reference:

![image](https://user-images.githubusercontent.com/3595025/123522067-fb99f780-d688-11eb-9b3b-707542aa22ee.png)
