### PR TITLE
Add matrix market to readwrite reference

### DIFF
--- a/doc/reference/readwrite/index.rst
+++ b/doc/reference/readwrite/index.rst
@@ -19,3 +19,4 @@ Reading and writing graphs
    sparsegraph6
    pajek
    nx_shp
+   matrix_market

--- a/doc/reference/readwrite/matrix_market.rst
+++ b/doc/reference/readwrite/matrix_market.rst
@@ -2,8 +2,8 @@
 Matrix Market Graph Format
 **************************
 
-The `Matrix Market`_ exchange format is a ASCII-encoded text-based file format
-described by Nist.
+The `Matrix Market`_ exchange format is a text-based file format described by
+NIST.
 Matrix Market supports both a **coordinate format** for sparse matrices and
 an **array format** for dense matrices.
 The :mod:`scipy.io` module provides the `scipy.io.mmread` and `scipy.io.mmwrite`

--- a/doc/reference/readwrite/matrix_market.rst
+++ b/doc/reference/readwrite/matrix_market.rst
@@ -1,0 +1,16 @@
+**************************
+Matrix Market Graph Format
+**************************
+
+The `Matrix Market`_ exchange format is a ASCII-encoded text-based file format
+described by Nist.
+Matrix Market supports both a **coordinate format** for sparse matrices and
+an **array format** for dense matrices.
+The :mod:`scipy.io` module provides the `scipy.io.mmread` and `scipy.io.mmwrite`
+functions to read and write data in Matrix Market format, respectively.
+These functions work with either `numpy.ndarray` or `scipy.sparse.coo_matrix`
+objects depending on whether the data is in **array** or **coordinate** format.
+These functions can be combined with those of NetworkX's :mod:`convert_matrix`
+module to read and write Graphs in Matrix Market format.
+
+.. _Matrix Market: https://math.nist.gov/MatrixMarket/formats.html

--- a/doc/reference/readwrite/matrix_market.rst
+++ b/doc/reference/readwrite/matrix_market.rst
@@ -1,6 +1,6 @@
-**************************
-Matrix Market Graph Format
-**************************
+*************
+Matrix Market
+*************
 
 The `Matrix Market`_ exchange format is a text-based file format described by
 NIST.

--- a/doc/reference/readwrite/matrix_market.rst
+++ b/doc/reference/readwrite/matrix_market.rst
@@ -10,7 +10,91 @@ The :mod:`scipy.io` module provides the `scipy.io.mmread` and `scipy.io.mmwrite`
 functions to read and write data in Matrix Market format, respectively.
 These functions work with either `numpy.ndarray` or `scipy.sparse.coo_matrix`
 objects depending on whether the data is in **array** or **coordinate** format.
-These functions can be combined with those of NetworkX's :mod:`convert_matrix`
+These functions can be combined with those of NetworkX's `~networkx.convert_matrix`
 module to read and write Graphs in Matrix Market format.
 
 .. _Matrix Market: https://math.nist.gov/MatrixMarket/formats.html
+
+Examples
+========
+
+Reading and writing graphs using Matrix Market's **array format** for dense
+matrices::
+
+    >>> import scipy as sp
+    >>> import scipy.io  # for mmread() and mmwrite()
+    >>> import io  # Use BytesIO as a stand-in for a Python file object
+    >>> fh = io.BytesIO()
+
+    >>> G = nx.complete_graph(5)
+    >>> a = nx.to_numpy_array(G)
+    >>> print(a)
+    [[0. 1. 1. 1. 1.]
+     [1. 0. 1. 1. 1.]
+     [1. 1. 0. 1. 1.]
+     [1. 1. 1. 0. 1.]
+     [1. 1. 1. 1. 0.]]
+
+    >>> # Write to file in Matrix Market array format
+    >>> sp.io.mmwrite(fh, a)
+    >>> print(fh.getvalue().decode('utf-8'))  # file contents
+    %%MatrixMarket matrix array real symmetric
+    %
+    5 5
+    0.0000000000000000e+00
+    1.0000000000000000e+00
+    1.0000000000000000e+00
+    1.0000000000000000e+00
+    1.0000000000000000e+00
+    0.0000000000000000e+00
+    1.0000000000000000e+00
+    1.0000000000000000e+00
+    1.0000000000000000e+00
+    0.0000000000000000e+00
+    1.0000000000000000e+00
+    1.0000000000000000e+00
+    0.0000000000000000e+00
+    1.0000000000000000e+00
+    0.0000000000000000e+00
+
+    >>> # Read from file
+    >>> fh.seek(0)
+    >>> H = nx.from_numpy_array(sp.io.mmread(fh))
+    >>> H.edges() == G.edges()
+    True
+
+Reading and writing graphs using Matrix Market's **coordinate format** for
+sparse matrices::
+
+    >>> import scipy as sp
+    >>> import scipy.io  # for mmread() and mmwrite()
+    >>> import io  # Use BytesIO as a stand-in for a Python file object
+    >>> fh = io.BytesIO()
+
+    >>> G = nx.path_graph(5)
+    >>> m = nx.to_scipy_sparse_matrix(G)
+    >>> print(m)
+      (0, 1)        1
+      (1, 0)        1
+      (1, 2)        1
+      (2, 1)        1
+      (2, 3)        1
+      (3, 2)        1
+      (3, 4)        1
+      (4, 3)        1
+
+    >>> sp.io.mmwrite(fh, m)
+    >>> print(fh.getvalue().decode('utf-8'))  # file contents
+    %%MatrixMarket matrix coordinate integer symmetric
+    %
+    5 5 4
+    2 1 1
+    3 2 1
+    4 3 1
+    5 4 1
+
+    >>> # Read from file
+    >>> fh.seek(0)
+    >>> H = nx.from_scipy_sparse_matrix(sp.io.mmread(fh))
+    >>> H.edges() == G.edges()
+    True


### PR DESCRIPTION
Adds an .rst stub to the readwrite docs in the reference guide to provide background and examples for I/O with the Matrix Market format using SciPy's built-in parsers.

Related to the discussion in https://github.com/networkx/networkx/pull/4922#issuecomment-866651631.