### PR TITLE
Deprecate k_nearest_neighbors

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -89,3 +89,4 @@ Version 3.0
 * In ``linalg/graphmatrix.py`` remove ``adj_matrix``.
 * In ``algorithms/similarity.py`` replace ``simrank_similarity`` with ``simrank_similarity_numpy``.
 * In ``algorithms/assortativity/mixing.py`` remove ``numeric_mixing_matrix``.
+* In ``algorithms/assortativity/connectivity.py`` remove ``k_nearest_neighbors``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -254,6 +254,8 @@ Deprecations
   Deprecate ``simrank_similarity_numpy``.
 - [`#4923 <https://github.com/networkx/networkx/pull/4923>`_]
   Deprecate ``numeric_mixing_matrix``.
+- [`#4931 <https://github.com/networkx/networkx/pull/4931>`_]
+  Deprecate ``k_nearest_neighbors``.
 
 Contributors
 ------------

--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -54,19 +54,14 @@ def average_degree_connectivity(
     --------
     >>> G = nx.path_graph(4)
     >>> G.edges[1, 2]["weight"] = 3
-    >>> nx.k_nearest_neighbors(G)
+    >>> nx.average_degree_connectivity(G)
     {1: 2.0, 2: 1.5}
-    >>> nx.k_nearest_neighbors(G, weight="weight")
+    >>> nx.average_degree_connectivity(G, weight="weight")
     {1: 2.0, 2: 1.75}
 
     See Also
     --------
     average_neighbor_degree
-
-    Notes
-    -----
-    This algorithm is sometimes called "k nearest neighbors" and is also
-    available as `k_nearest_neighbors`.
 
     References
     ----------
@@ -116,13 +111,22 @@ def average_degree_connectivity(
         dsum[k] += s
 
     # normalize
-    dc = {}
-    for k, avg in dsum.items():
-        dc[k] = avg
-        norm = dnorm[k]
-        if avg > 0 and norm > 0:
-            dc[k] /= norm
-    return dc
+    return {k: avg if dnorm[k] == 0 else avg / dnorm[k] for k, avg in dsum.items()}
 
 
-k_nearest_neighbors = average_degree_connectivity
+def k_nearest_neighbors(G, source="in+out", target="in+out", nodes=None, weight=None):
+    """Compute the average degree connectivity of graph.
+
+    .. deprecated 2.6
+
+      k_nearest_neighbors function is deprecated and will be removed in v3.0.
+      Use `average_degree_connectivity` instead.
+    """
+    import warnings
+
+    msg = (
+        "k_nearest_neighbors function is deprecated and will be removed in v3.0.\n"
+        "Use `average_degree_connectivity` instead."
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    return average_degree_connectivity(G, source, target, nodes, weight)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -41,6 +41,9 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(autouse=True)
 def set_warnings():
     warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="k_nearest_neighbors"
+    )
+    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="numeric_mixing_matrix"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
The function name `k_nearest_neighbors` isn't used n any of the cited papers, is the same name as used for commonly used machine learning algorithms (which are not related to this degree_correlation work.  Perhaps it came from "nearest neighbor degree" which **is** used in the papers, and does depend on "k", but importantly, is not called "k nearest neighbors".  Since this function name is simply an alias we should just redirect users to `average_degree_connectivity` which is the name used for the actual function definition.  That name is not great either given that there is a function `average_neighbor_degree`, but that naming discussion can be delayed to another PR. (see issue #4936)

This PR also fixes handling of degree/in_degree/out_degree for average_neighbor_degree and adds some very simple tests for it.   More testing is needed in this assortativity package.
