### PR TITLE
Add weisfeiler lehman subgraph hashing

### DIFF
--- a/doc/reference/algorithms/graph_hashing.rst
+++ b/doc/reference/algorithms/graph_hashing.rst
@@ -7,3 +7,4 @@ Graph Hashing
    :toctree: generated/
 
    weisfeiler_lehman_graph_hash
+   weisfeiler_lehman_hash_subgraphs

--- a/doc/reference/algorithms/graph_hashing.rst
+++ b/doc/reference/algorithms/graph_hashing.rst
@@ -7,4 +7,4 @@ Graph Hashing
    :toctree: generated/
 
    weisfeiler_lehman_graph_hash
-   weisfeiler_lehman_hash_subgraphs
+   weisfeiler_lehman_subgraph_hashes

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,6 +19,13 @@ Highlights
 This release is the result of X of work with over X pull requests by
 X contributors. Highlights include:
 
+Warning: Hash values observed in outputs of `weisfeiler_lehman_graph_hash` 
+have changed from version 2.6 -> 2.7 onwards, due to bug fixes 
+[discussed here](https://github.com/networkx/networkx/pull/4946#issuecomment-914623654). 
+This means that comparing graph hashes of hashes before and after version 2.7 
+could wrongly fail an isomorphism test (isomorphicgraphs always have matching 
+Weisfeiler-Lehman hashes). Users are advised to recalculate any stored graph 
+hashes they may have on upgrading.
 
 Improvements
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,13 +19,17 @@ Highlights
 This release is the result of X of work with over X pull requests by
 X contributors. Highlights include:
 
-Warning: Hash values observed in outputs of `weisfeiler_lehman_graph_hash` 
-have changed from version 2.6 -> 2.7 onwards, due to bug fixes 
-[discussed here](https://github.com/networkx/networkx/pull/4946#issuecomment-914623654). 
-This means that comparing graph hashes of hashes before and after version 2.7 
-could wrongly fail an isomorphism test (isomorphicgraphs always have matching 
-Weisfeiler-Lehman hashes). Users are advised to recalculate any stored graph 
-hashes they may have on upgrading.
+.. warning::
+   Hash values observed in outputs of 
+   `~networkx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash`
+   have changed in version 2.7 due to bug fixes. See gh-4946_ for details.
+   This means that comparing hashes of the same graph computed with different
+   versions of NetworkX (i.e. before and after version 2.7)
+   could wrongly fail an isomorphism test (isomorphic graphs always have matching
+   Weisfeiler-Lehman hashes). Users are advised to recalculate any stored graph
+   hashes they may have on upgrading.
+
+.. _gh-4946: https://github.com/networkx/networkx/pull/4946#issuecomment-914623654
 
 Improvements
 ------------

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -16,7 +16,7 @@ def _hash_label(label, digest_size):
 
 def _init_node_labels(G, edge_attr, node_attr):
     if node_attr:
-        return {u: str(G.nodes[u][node_attr]) for u in G.nodes()}
+        return {u: str(dd[node_attr]) for u, dd in G.nodes(data=True)}
     elif edge_attr:
         return {u: "" for u in G}
     else:

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -5,7 +5,6 @@ For now, only Weisfeiler-Lehman hashing is implemented.
 """
 
 from collections import Counter, defaultdict
-from copy import Error
 from hashlib import blake2b
 
 __all__ = ["weisfeiler_lehman_graph_hash", "weisfeiler_lehman_subgraph_hashes"]
@@ -19,9 +18,9 @@ def _init_node_labels(G, edge_attr, node_attr):
     if node_attr:
         return {u: str(G.nodes[u][node_attr]) for u in G.nodes()}
     elif edge_attr:
-        return {u: "" for u in G.nodes()}
+        return {u: "" for u in G}
     else:
-        return {u: str(G.degree(u)) for u in G.nodes()}
+        return {u: str(deg) for u, deg in G.degree()}
 
 
 def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):
@@ -30,9 +29,9 @@ def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):
     the labels of each node's neighbors.
     """
     label_list = [node_labels[node]]
-    for nei in G.neighbors(node):
-        prefix = "" if not edge_attr else str(G[node][nei][edge_attr])
-        label_list.append(prefix + node_labels[nei])
+    for nbr in G.neighbors(node):
+        prefix = "" if edge_attr is None else str(G[node][nbr][edge_attr])
+        label_list.append(prefix + node_labels[nbr])
     return "".join(sorted(label_list))
 
 

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -261,7 +261,7 @@ def weisfeiler_lehman_subgraph_hashes(
     Similarity between hashes does not imply similarity between graphs.
 
     References
-    -------
+    ----------
     .. [1] Shervashidze, Nino, Pascal Schweitzer, Erik Jan Van Leeuwen,
        Kurt Mehlhorn, and Karsten M. Borgwardt. Weisfeiler Lehman
        Graph Kernels. Journal of Machine Learning Research. 2011.

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -28,11 +28,11 @@ def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):
     Compute new labels for given node by aggregating
     the labels of each node's neighbors.
     """
-    label_list = [node_labels[node]]
+    label_list = []
     for nbr in G.neighbors(node):
         prefix = "" if edge_attr is None else str(G[node][nbr][edge_attr])
         label_list.append(prefix + node_labels[nbr])
-    return "".join(sorted(label_list))
+    return node_labels[node] + "".join(sorted(label_list))
 
 
 def weisfeiler_lehman_graph_hash(
@@ -100,17 +100,17 @@ def weisfeiler_lehman_graph_hash(
     Omitting the `edge_attr` option, results in identical hashes.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1)
-    '3108a936907b3ee3704642f9eeab34fe'
+    '7bc4dde9a09d0b94c5097b219891d81a'
     >>> nx.weisfeiler_lehman_graph_hash(G2)
-    '3108a936907b3ee3704642f9eeab34fe'
+    '7bc4dde9a09d0b94c5097b219891d81a'
 
     With edge labels, the graphs are no longer assigned
     the same hash digest.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1, edge_attr="label")
-    'd0819438f9cc0cd60ea93a6c70c2f939'
+    'c653d85538bcf041d88c011f4f905f10'
     >>> nx.weisfeiler_lehman_graph_hash(G2, edge_attr="label")
-    '43e9b18eeb859b669ad2269ecc6d43bf'
+    '3dcd84af1ca855d0eff3c978d88e7ec7'
 
     Notes
     -----
@@ -160,9 +160,12 @@ def weisfeiler_lehman_graph_hash(
 def weisfeiler_lehman_subgraph_hashes(
     G, edge_attr=None, node_attr=None, iterations=3, digest_size=16
 ):
-    """Return a dictionary indexed by node, giving a list of Weisfeiler-Lehman
-    (WL) hashes for each subgraph originating from each node, ordered by
-    iteration depth.
+    """
+    Return a dictionary of subgraph hashes by node.
+
+    The dictionary is keyed by node to a list of hashes in increasingly
+    sized induced subgraphs containing the nodes within 2*k edges
+    of the key node for increasing integer k until all nodes are included.
 
     The function iteratively aggregates and hashes neighbourhoods of each node.
     This is achieved for each step by replacing for each node its label from
@@ -235,9 +238,9 @@ def weisfeiler_lehman_subgraph_hashes(
     the hash sequence of depth 3 for node 1 in G1 and node 5 in G2 are similar:
 
     >>> g1_hashes[1]
-    ['a93b64973cfc8897', 'c82391d740bfbe09', 'd45fb49e284520c3']
+    ['a93b64973cfc8897', 'db1b43ae35a1878f', '57872a7d2059c1c0']
     >>> g2_hashes[5]
-    ['a93b64973cfc8897', 'c82391d740bfbe09', '3f26cdb3d5ad86e7']
+    ['a93b64973cfc8897', 'db1b43ae35a1878f', '1716d2a4012fa4bc']
 
     The first 2 WL subgraph hashes match. From this we can conclude that it's very
     likely the neighborhood of 4 hops around these nodes are isomorphic: each

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -1,3 +1,4 @@
+from networkx.generators import directed
 import pytest
 import networkx as nx
 
@@ -37,10 +38,27 @@ def test_directed():
         G_directed = nx.gn_graph(10 + r, seed=100 + i)
         G_undirected = nx.to_undirected(G_directed)
 
-        h_directed = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
-        h_undirected = nx.weisfeiler_lehman_subgraph_hashes(G_undirected)
+        h_directed = nx.weisfeiler_lehman_graph_hash(G_directed)
+        h_undirected = nx.weisfeiler_lehman_graph_hash(G_undirected)
 
         assert h_directed != h_undirected
+
+
+def test_reversed():
+    """
+    A directed graph with no bi-directional edges should yield different a graph hash
+    to the same graph taken with edge directions reversed if there are no hash collisions.
+    Here we test a cycle graph which is the minimal counterexample
+    """
+    G = nx.cycle_graph(5, create_using=nx.DiGraph)
+    nx.set_node_attributes(G, {n: str(n) for n in G.nodes()}, name="label")
+
+    G_reversed = G.reverse()
+
+    h = nx.weisfeiler_lehman_graph_hash(G, node_attr="label")
+    h_reversed = nx.weisfeiler_lehman_graph_hash(G_reversed, node_attr="label")
+
+    assert h != h_reversed
 
 
 def test_isomorphic():
@@ -253,7 +271,7 @@ def hexdigest_sizes_correct(a, digest_size):
     return all(list_digest_sizes_correct(hashes) for hashes in a.values())
 
 
-def test_empty_graph():
+def test_empty_graph_subgraph_hash():
     """ "
     empty graphs should give empty dict subgraph hashes regardless of other params
     """
@@ -272,7 +290,7 @@ def test_empty_graph():
     assert subgraph_hashes5 == {}
 
 
-def test_directed():
+def test_directed_subgraph_hash():
     """
     A directed graph with no bi-directional edges should yield different subgraph hashes
     to the same graph taken as undirected, if all hashes don't collide.
@@ -288,7 +306,24 @@ def test_directed():
         assert directed_subgraph_hashes != undirected_subgraph_hashes
 
 
-def test_isomorphic():
+def test_reversed_subgraph_hash():
+    """
+    A directed graph with no bi-directional edges should yield different subgraph hashes
+    to the same graph taken with edge directions reversed if there are no hash collisions.
+    Here we test a cycle graph which is the minimal counterexample
+    """
+    G = nx.cycle_graph(5, create_using=nx.DiGraph)
+    nx.set_node_attributes(G, {n: str(n) for n in G.nodes()}, name="label")
+
+    G_reversed = G.reverse()
+
+    h = nx.weisfeiler_lehman_subgraph_hashes(G, node_attr="label")
+    h_reversed = nx.weisfeiler_lehman_subgraph_hashes(G_reversed, node_attr="label")
+
+    assert h != h_reversed
+
+
+def test_isomorphic_subgraph_hash():
     """
     the subgraph hashes should be invariant to node-relabeling when the output is reindexed
     by the same mapping and all hashes don't collide.
@@ -305,7 +340,7 @@ def test_isomorphic():
         assert g1_subgraph_hashes == {-1 * k: v for k, v in g2_subgraph_hashes.items()}
 
 
-def test_isomorphic_edge_attr():
+def test_isomorphic_edge_attr_subgraph_hash():
     """
     Isomorphic graphs with differing edge attributes should yield different subgraph
     hashes if the 'edge_attr' argument is supplied and populated in the graph, and
@@ -350,7 +385,7 @@ def test_isomorphic_edge_attr():
         }
 
 
-def test_missing_edge_attr():
+def test_missing_edge_attr_subgraph_hash():
     """
     If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
     we should raise a KeyError
@@ -362,7 +397,7 @@ def test_missing_edge_attr():
     )
 
 
-def test_isomorphic_node_attr():
+def test_isomorphic_node_attr_subgraph_hash():
     """
     Isomorphic graphs with differing node attributes should yield different subgraph
     hashes if the 'node_attr' argument is supplied and populated in the graph, and
@@ -407,7 +442,7 @@ def test_isomorphic_node_attr():
         }
 
 
-def test_missing_node_attr():
+def test_missing_node_attr_subgraph_hash():
     """
     If the 'node_attr' argument is supplied but is missing from a node in the graph,
     we should raise a KeyError
@@ -602,7 +637,7 @@ def test_iteration_depth_node_edge_attr():
         assert is_subiteration(depth3, depth5)
 
 
-def test_digest_size():
+def test_digest_size_subgraph_hash():
     """
     The hash string lengths should be as expected for a variety of graphs and
     digest sizes

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -1,624 +1,621 @@
 import pytest
 import networkx as nx
 
+# Unit tests for the :func:`~networkx.weisfeiler_lehman_graph_hash` function
 
-def _relabel_graph(G, f=lambda x: -1 * x):
+
+def test_empty_graph_hash():
     """
-    relabels graph nodes by a given relabeling function on integers.
-    By default it flips the sign of the labels (Note this is a self-inverse).
-    Returns the relabeled graph, with the original left intact.
+    empty graphs should give hashes regardless of other params
     """
-    return nx.relabel_nodes(G, {u: f(u) for u in G.nodes()})
+    G1 = nx.empty_graph()
+    G2 = nx.empty_graph()
+
+    h1 = nx.weisfeiler_lehman_graph_hash(G1)
+    h2 = nx.weisfeiler_lehman_graph_hash(G2)
+    h3 = nx.weisfeiler_lehman_graph_hash(G2, edge_attr="edge_attr1")
+    h4 = nx.weisfeiler_lehman_graph_hash(G2, node_attr="node_attr1")
+    h5 = nx.weisfeiler_lehman_graph_hash(
+        G2, edge_attr="edge_attr1", node_attr="node_attr1"
+    )
+    h6 = nx.weisfeiler_lehman_graph_hash(G2, iterations=10)
+
+    assert h1 == h2
+    assert h1 == h3
+    assert h1 == h4
+    assert h1 == h5
+    assert h1 == h6
 
 
-def _relabel_dict(dic, f=lambda x: -1 * x):
+def test_directed():
     """
-    relabels dictionary keys by a given relabeling function on integers.
-    By default it flips the sign of the labels (Note this is a self-inverse).
-    Returns the relabeled dictionary, with the original left intact.
+    A directed graph with no bi-directional edges should yield different a graph hash
+    to the same graph taken as undirected if there are no hash collisions.
     """
-    return {f(k): v for k, v in dic.items()}
+    r = 10
+    for i in range(r):
+        G_directed = nx.gn_graph(10 + r, seed=100 + i)
+        G_undirected = nx.to_undirected(G_directed)
+
+        h_directed = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
+        h_undirected = nx.weisfeiler_lehman_subgraph_hashes(G_undirected)
+
+        assert h_directed != h_undirected
 
 
-class TestFullGraphHash:
-    """Unit tests for the :func:`~networkx.weisfeiler_lehman_graph_hash` function"""
+def test_isomorphic():
+    """
+    graph hashes should be invariant to node-relabeling (when the output is reindexed
+    by the same mapping)
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=200 + i)
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
 
-    def test_empty_graph_hash(self):
-        """
-        empty graphs should give hashes regardless of other params
-        """
-        G1 = nx.empty_graph()
-        G2 = nx.empty_graph()
+        g1_hash = nx.weisfeiler_lehman_graph_hash(G1)
+        g2_hash = nx.weisfeiler_lehman_graph_hash(G2)
 
-        h1 = nx.weisfeiler_lehman_graph_hash(G1)
-        h2 = nx.weisfeiler_lehman_graph_hash(G2)
-        h3 = nx.weisfeiler_lehman_graph_hash(G2, edge_attr="edge_attr1")
-        h4 = nx.weisfeiler_lehman_graph_hash(G2, node_attr="node_attr1")
-        h5 = nx.weisfeiler_lehman_graph_hash(
+        assert g1_hash == g2_hash
+
+
+def test_isomorphic_edge_attr():
+    """
+    Isomorphic graphs with differing edge attributes should yield different graph
+    hashes if the 'edge_attr' argument is supplied and populated in the graph,
+    and there are no hash collisions.
+    The output should still be invariant to node-relabeling
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=300 + i)
+
+        for a, b in G1.edges:
+            G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+            G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+        g1_hash_with_edge_attr1 = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="edge_attr1"
+        )
+        g1_hash_with_edge_attr2 = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="edge_attr2"
+        )
+        g1_hash_no_edge_attr = nx.weisfeiler_lehman_graph_hash(G1, edge_attr=None)
+
+        assert g1_hash_with_edge_attr1 != g1_hash_no_edge_attr
+        assert g1_hash_with_edge_attr2 != g1_hash_no_edge_attr
+        assert g1_hash_with_edge_attr1 != g1_hash_with_edge_attr2
+
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
+
+        g2_hash_with_edge_attr1 = nx.weisfeiler_lehman_graph_hash(
+            G2, edge_attr="edge_attr1"
+        )
+        g2_hash_with_edge_attr2 = nx.weisfeiler_lehman_graph_hash(
+            G2, edge_attr="edge_attr2"
+        )
+
+        assert g1_hash_with_edge_attr1 == g2_hash_with_edge_attr1
+        assert g1_hash_with_edge_attr2 == g2_hash_with_edge_attr2
+
+
+def test_missing_edge_attr():
+    """
+    If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
+    we should raise a KeyError
+    """
+    G = nx.Graph()
+    G.add_edges_from([(1, 2, {"edge_attr1": "a"}), (1, 3, {})])
+    pytest.raises(KeyError, nx.weisfeiler_lehman_graph_hash, G, edge_attr="edge_attr1")
+
+
+def test_isomorphic_node_attr():
+    """
+    Isomorphic graphs with differing node attributes should yield different graph
+    hashes if the 'node_attr' argument is supplied and populated in the graph, and
+    there are no hash collisions.
+    The output should still be invariant to node-relabeling
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=400 + i)
+
+        for u in G1.nodes():
+            G1.nodes[u]["node_attr1"] = f"{u}-1"
+            G1.nodes[u]["node_attr2"] = f"{u}-2"
+
+        g1_hash_with_node_attr1 = nx.weisfeiler_lehman_graph_hash(
+            G1, node_attr="node_attr1"
+        )
+        g1_hash_with_node_attr2 = nx.weisfeiler_lehman_graph_hash(
+            G1, node_attr="node_attr2"
+        )
+        g1_hash_no_node_attr = nx.weisfeiler_lehman_graph_hash(G1, node_attr=None)
+
+        assert g1_hash_with_node_attr1 != g1_hash_no_node_attr
+        assert g1_hash_with_node_attr2 != g1_hash_no_node_attr
+        assert g1_hash_with_node_attr1 != g1_hash_with_node_attr2
+
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
+
+        g2_hash_with_node_attr1 = nx.weisfeiler_lehman_graph_hash(
+            G2, node_attr="node_attr1"
+        )
+        g2_hash_with_node_attr2 = nx.weisfeiler_lehman_graph_hash(
+            G2, node_attr="node_attr2"
+        )
+
+        assert g1_hash_with_node_attr1 == g2_hash_with_node_attr1
+        assert g1_hash_with_node_attr2 == g2_hash_with_node_attr2
+
+
+def test_missing_node_attr():
+    """
+    If the 'node_attr' argument is supplied but is missing from a node in the graph,
+    we should raise a KeyError
+    """
+    G = nx.Graph()
+    G.add_nodes_from([(1, {"node_attr1": "a"}), (2, {})])
+    G.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 4)])
+    pytest.raises(KeyError, nx.weisfeiler_lehman_graph_hash, G, node_attr="node_attr1")
+
+
+def test_isomorphic_edge_attr_and_node_attr():
+    """
+    Isomorphic graphs with differing node attributes should yield different graph
+    hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in
+    the graph, and there are no hash collisions.
+    The output should still be invariant to node-relabeling
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
+
+        for u in G1.nodes():
+            G1.nodes[u]["node_attr1"] = f"{u}-1"
+            G1.nodes[u]["node_attr2"] = f"{u}-2"
+
+        for a, b in G1.edges:
+            G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+            G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+        g1_hash_edge1_node1 = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="edge_attr1", node_attr="node_attr1"
+        )
+        g1_hash_edge2_node2 = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="edge_attr2", node_attr="node_attr2"
+        )
+        g1_hash_edge1_node2 = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="edge_attr1", node_attr="node_attr2"
+        )
+        g1_hash_no_attr = nx.weisfeiler_lehman_graph_hash(G1)
+
+        assert g1_hash_edge1_node1 != g1_hash_no_attr
+        assert g1_hash_edge2_node2 != g1_hash_no_attr
+        assert g1_hash_edge1_node1 != g1_hash_edge2_node2
+        assert g1_hash_edge1_node2 != g1_hash_edge2_node2
+        assert g1_hash_edge1_node2 != g1_hash_edge1_node1
+
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
+
+        g2_hash_edge1_node1 = nx.weisfeiler_lehman_graph_hash(
             G2, edge_attr="edge_attr1", node_attr="node_attr1"
         )
-        h6 = nx.weisfeiler_lehman_graph_hash(G2, iterations=10)
-
-        assert h1 == h2
-        assert h1 == h3
-        assert h1 == h4
-        assert h1 == h5
-        assert h1 == h6
-
-    def test_directed(self):
-        """
-        A directed graph with no bi-directional edges should yield different a graph hash
-        to the same graph taken as undirected if there are no hash collisions.
-        """
-        r = 10
-        for i in range(r):
-            G_directed = nx.gn_graph(10 + r, seed=100 + i)
-            G_undirected = nx.to_undirected(G_directed)
-
-            h_directed = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
-            h_undirected = nx.weisfeiler_lehman_subgraph_hashes(G_undirected)
-
-            assert h_directed != h_undirected
-
-    def test_isomorphic(self):
-        """
-        graph hashes should be invariant to node-relabeling (when the output is reindexed
-        by the same mapping)
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=200 + i)
-            G2 = _relabel_graph(G1)
-
-            g1_hash = nx.weisfeiler_lehman_graph_hash(G1)
-            g2_hash = nx.weisfeiler_lehman_graph_hash(G2)
-
-            assert g1_hash == g2_hash
-
-    def test_isomorphic_edge_attr(self):
-        """
-        Isomorphic graphs with differing edge attributes should yield different graph
-        hashes if the 'edge_attr' argument is supplied and populated in the graph,
-        and there are no hash collisions.
-        The output should still be invariant to node-relabeling
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=300 + i)
-
-            for a, b in G1.edges:
-                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
-                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
-
-            g1_hash_with_edge_attr1 = nx.weisfeiler_lehman_graph_hash(
-                G1, edge_attr="edge_attr1"
-            )
-            g1_hash_with_edge_attr2 = nx.weisfeiler_lehman_graph_hash(
-                G1, edge_attr="edge_attr2"
-            )
-            g1_hash_no_edge_attr = nx.weisfeiler_lehman_graph_hash(G1, edge_attr=None)
-
-            assert g1_hash_with_edge_attr1 != g1_hash_no_edge_attr
-            assert g1_hash_with_edge_attr2 != g1_hash_no_edge_attr
-            assert g1_hash_with_edge_attr1 != g1_hash_with_edge_attr2
-
-            G2 = _relabel_graph(G1)
-
-            g2_hash_with_edge_attr1 = nx.weisfeiler_lehman_graph_hash(
-                G2, edge_attr="edge_attr1"
-            )
-            g2_hash_with_edge_attr2 = nx.weisfeiler_lehman_graph_hash(
-                G2, edge_attr="edge_attr2"
-            )
-
-            assert g1_hash_with_edge_attr1 == g2_hash_with_edge_attr1
-            assert g1_hash_with_edge_attr2 == g2_hash_with_edge_attr2
-
-    def test_missing_edge_attr(self):
-        """
-        If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
-        we should raise a KeyError
-        """
-        G = nx.Graph()
-        G.add_edges_from([(1, 2, {"edge_attr1": "a"}), (1, 3, {})])
-        pytest.raises(
-            KeyError, nx.weisfeiler_lehman_graph_hash, G, edge_attr="edge_attr1"
+        g2_hash_edge2_node2 = nx.weisfeiler_lehman_graph_hash(
+            G2, edge_attr="edge_attr2", node_attr="node_attr2"
         )
 
-    def test_isomorphic_node_attr(self):
-        """
-        Isomorphic graphs with differing node attributes should yield different graph
-        hashes if the 'node_attr' argument is supplied and populated in the graph, and
-        there are no hash collisions.
-        The output should still be invariant to node-relabeling
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=400 + i)
+        assert g1_hash_edge1_node1 == g2_hash_edge1_node1
+        assert g1_hash_edge2_node2 == g2_hash_edge2_node2
 
-            for u in G1.nodes():
-                G1.nodes[u]["node_attr1"] = f"{u}-1"
-                G1.nodes[u]["node_attr2"] = f"{u}-2"
 
-            g1_hash_with_node_attr1 = nx.weisfeiler_lehman_graph_hash(
-                G1, node_attr="node_attr1"
-            )
-            g1_hash_with_node_attr2 = nx.weisfeiler_lehman_graph_hash(
-                G1, node_attr="node_attr2"
-            )
-            g1_hash_no_node_attr = nx.weisfeiler_lehman_graph_hash(G1, node_attr=None)
+def test_digest_size():
+    """
+    The hash string lengths should be as expected for a variety of graphs and
+    digest sizes
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G = nx.erdos_renyi_graph(n, p * i, seed=1000 + i)
 
-            assert g1_hash_with_node_attr1 != g1_hash_no_node_attr
-            assert g1_hash_with_node_attr2 != g1_hash_no_node_attr
-            assert g1_hash_with_node_attr1 != g1_hash_with_node_attr2
+        h16 = nx.weisfeiler_lehman_graph_hash(G)
+        h32 = nx.weisfeiler_lehman_graph_hash(G, digest_size=32)
 
-            G2 = _relabel_graph(G1)
+        assert h16 != h32
+        assert len(h16) == 16 * 2
+        assert len(h32) == 32 * 2
 
-            g2_hash_with_node_attr1 = nx.weisfeiler_lehman_graph_hash(
-                G2, node_attr="node_attr1"
-            )
-            g2_hash_with_node_attr2 = nx.weisfeiler_lehman_graph_hash(
-                G2, node_attr="node_attr2"
-            )
 
-            assert g1_hash_with_node_attr1 == g2_hash_with_node_attr1
-            assert g1_hash_with_node_attr2 == g2_hash_with_node_attr2
+# Unit tests for the :func:`~networkx.weisfeiler_lehman_hash_subgraphs` function
 
-    def test_missing_node_attr(self):
-        """
-        If the 'node_attr' argument is supplied but is missing from a node in the graph,
-        we should raise a KeyError
-        """
-        G = nx.Graph()
-        G.add_nodes_from([(1, {"node_attr1": "a"}), (2, {})])
-        G.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 4)])
-        pytest.raises(
-            KeyError, nx.weisfeiler_lehman_graph_hash, G, node_attr="node_attr1"
+
+def is_subiteration(a, b):
+    """
+    returns True if that each hash sequence in 'a' is a prefix for
+    the corresponding sequence indexed by the same node in 'b'.
+    """
+    return all(b[node][: len(hashes)] == hashes for node, hashes in a.items())
+
+
+def hexdigest_sizes_correct(a, digest_size):
+    """
+    returns True if all hex digest sizes are the expected length in a node:subgraph-hashes
+    dictionary. Hex digest string length == 2 * bytes digest length since each pair of hex
+    digits encodes 1 byte (https://docs.python.org/3/library/hashlib.html)
+    """
+    hexdigest_size = digest_size * 2
+    list_digest_sizes_correct = lambda l: all(len(x) == hexdigest_size for x in l)
+    return all(list_digest_sizes_correct(hashes) for hashes in a.values())
+
+
+def test_empty_graph():
+    """ "
+    empty graphs should give empty dict subgraph hashes regardless of other params
+    """
+    G = nx.empty_graph()
+
+    subgraph_hashes1 = nx.weisfeiler_lehman_subgraph_hashes(G)
+    subgraph_hashes2 = nx.weisfeiler_lehman_subgraph_hashes(G, edge_attr="edge_attr")
+    subgraph_hashes3 = nx.weisfeiler_lehman_subgraph_hashes(G, node_attr="edge_attr")
+    subgraph_hashes4 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=2)
+    subgraph_hashes5 = nx.weisfeiler_lehman_subgraph_hashes(G, digest_size=64)
+
+    assert subgraph_hashes1 == {}
+    assert subgraph_hashes2 == {}
+    assert subgraph_hashes3 == {}
+    assert subgraph_hashes4 == {}
+    assert subgraph_hashes5 == {}
+
+
+def test_directed():
+    """
+    A directed graph with no bi-directional edges should yield different subgraph hashes
+    to the same graph taken as undirected, if all hashes don't collide.
+    """
+    r = 10
+    for i in range(r):
+        G_directed = nx.gn_graph(10 + r, seed=100 + i)
+        G_undirected = nx.to_undirected(G_directed)
+
+        directed_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
+        undirected_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G_undirected)
+
+        assert directed_subgraph_hashes != undirected_subgraph_hashes
+
+
+def test_isomorphic():
+    """
+    the subgraph hashes should be invariant to node-relabeling when the output is reindexed
+    by the same mapping and all hashes don't collide.
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=200 + i)
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
+
+        g1_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G1)
+        g2_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G2)
+
+        assert g1_subgraph_hashes == {-1 * k: v for k, v in g2_subgraph_hashes.items()}
+
+
+def test_isomorphic_edge_attr():
+    """
+    Isomorphic graphs with differing edge attributes should yield different subgraph
+    hashes if the 'edge_attr' argument is supplied and populated in the graph, and
+    all hashes don't collide.
+    The output should still be invariant to node-relabeling
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=300 + i)
+
+        for a, b in G1.edges:
+            G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+            G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+        g1_hash_with_edge_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, edge_attr="edge_attr1"
+        )
+        g1_hash_with_edge_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, edge_attr="edge_attr2"
+        )
+        g1_hash_no_edge_attr = nx.weisfeiler_lehman_subgraph_hashes(G1, edge_attr=None)
+
+        assert g1_hash_with_edge_attr1 != g1_hash_no_edge_attr
+        assert g1_hash_with_edge_attr2 != g1_hash_no_edge_attr
+        assert g1_hash_with_edge_attr1 != g1_hash_with_edge_attr2
+
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
+
+        g2_hash_with_edge_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+            G2, edge_attr="edge_attr1"
+        )
+        g2_hash_with_edge_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G2, edge_attr="edge_attr2"
         )
 
-    def test_isomorphic_edge_attr_and_node_attr(self):
-        """
-        Isomorphic graphs with differing node attributes should yield different graph
-        hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in
-        the graph, and there are no hash collisions.
-        The output should still be invariant to node-relabeling
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
-
-            for u in G1.nodes():
-                G1.nodes[u]["node_attr1"] = f"{u}-1"
-                G1.nodes[u]["node_attr2"] = f"{u}-2"
-
-            for a, b in G1.edges:
-                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
-                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
-
-            g1_hash_edge1_node1 = nx.weisfeiler_lehman_graph_hash(
-                G1, edge_attr="edge_attr1", node_attr="node_attr1"
-            )
-            g1_hash_edge2_node2 = nx.weisfeiler_lehman_graph_hash(
-                G1, edge_attr="edge_attr2", node_attr="node_attr2"
-            )
-            g1_hash_edge1_node2 = nx.weisfeiler_lehman_graph_hash(
-                G1, edge_attr="edge_attr1", node_attr="node_attr2"
-            )
-            g1_hash_no_attr = nx.weisfeiler_lehman_graph_hash(G1)
-
-            assert g1_hash_edge1_node1 != g1_hash_no_attr
-            assert g1_hash_edge2_node2 != g1_hash_no_attr
-            assert g1_hash_edge1_node1 != g1_hash_edge2_node2
-            assert g1_hash_edge1_node2 != g1_hash_edge2_node2
-            assert g1_hash_edge1_node2 != g1_hash_edge1_node1
-
-            G2 = _relabel_graph(G1)
-
-            g2_hash_edge1_node1 = nx.weisfeiler_lehman_graph_hash(
-                G2, edge_attr="edge_attr1", node_attr="node_attr1"
-            )
-            g2_hash_edge2_node2 = nx.weisfeiler_lehman_graph_hash(
-                G2, edge_attr="edge_attr2", node_attr="node_attr2"
-            )
-
-            assert g1_hash_edge1_node1 == g2_hash_edge1_node1
-            assert g1_hash_edge2_node2 == g2_hash_edge2_node2
-
-    def test_digest_size(self):
-        """
-        The hash string lengths should be as expected for a variety of graphs and
-        digest sizes
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G = nx.erdos_renyi_graph(n, p * i, seed=1000 + i)
-
-            h16 = nx.weisfeiler_lehman_graph_hash(G)
-            h32 = nx.weisfeiler_lehman_graph_hash(G, digest_size=32)
-
-            assert h16 != h32
-            assert len(h16) == 16 * 2
-            assert len(h32) == 32 * 2
+        assert g1_hash_with_edge_attr1 == {
+            -1 * k: v for k, v in g2_hash_with_edge_attr1.items()
+        }
+        assert g1_hash_with_edge_attr2 == {
+            -1 * k: v for k, v in g2_hash_with_edge_attr2.items()
+        }
 
 
-class TestSubgraphHashes:
-    """Unit tests for the :func:`~networkx.weisfeiler_lehman_hash_subgraphs` function"""
+def test_missing_edge_attr():
+    """
+    If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
+    we should raise a KeyError
+    """
+    G = nx.Graph()
+    G.add_edges_from([(1, 2, {"edge_attr1": "a"}), (1, 3, {})])
+    pytest.raises(
+        KeyError, nx.weisfeiler_lehman_subgraph_hashes, G, edge_attr="edge_attr1"
+    )
 
-    @staticmethod
-    def is_subiteration(a, b):
-        """
-        returns True if that each hash sequence in 'a' is a prefix for
-        the corresponding sequence indexed by the same node in 'b'.
-        """
-        return all(b[node][: len(hashes)] == hashes for node, hashes in a.items())
 
-    @staticmethod
-    def hexdigest_sizes_correct(a, digest_size):
-        """
-        returns True if all hex digest sizes are the expected length in a node:subgraph-hashes
-        dictionary. Hex digest string length == 2 * bytes digest length since each pair of hex
-        digits encodes 1 byte (https://docs.python.org/3/library/hashlib.html)
-        """
-        hexdigest_size = digest_size * 2
-        list_digest_sizes_correct = lambda l: all(len(x) == hexdigest_size for x in l)
-        return all(list_digest_sizes_correct(hashes) for hashes in a.values())
+def test_isomorphic_node_attr():
+    """
+    Isomorphic graphs with differing node attributes should yield different subgraph
+    hashes if the 'node_attr' argument is supplied and populated in the graph, and
+    all hashes don't collide.
+    The output should still be invariant to node-relabeling
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=400 + i)
 
-    def test_empty_graph(self):
-        """ "
-        empty graphs should give empty dict subgraph hashes regardless of other params
-        """
-        G = nx.empty_graph()
+        for u in G1.nodes():
+            G1.nodes[u]["node_attr1"] = f"{u}-1"
+            G1.nodes[u]["node_attr2"] = f"{u}-2"
 
-        subgraph_hashes1 = nx.weisfeiler_lehman_subgraph_hashes(G)
-        subgraph_hashes2 = nx.weisfeiler_lehman_subgraph_hashes(
-            G, edge_attr="edge_attr"
+        g1_hash_with_node_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, node_attr="node_attr1"
         )
-        subgraph_hashes3 = nx.weisfeiler_lehman_subgraph_hashes(
-            G, node_attr="edge_attr"
+        g1_hash_with_node_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, node_attr="node_attr2"
         )
-        subgraph_hashes4 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=2)
-        subgraph_hashes5 = nx.weisfeiler_lehman_subgraph_hashes(G, digest_size=64)
+        g1_hash_no_node_attr = nx.weisfeiler_lehman_subgraph_hashes(G1, node_attr=None)
 
-        assert subgraph_hashes1 == dict()
-        assert subgraph_hashes2 == dict()
-        assert subgraph_hashes3 == dict()
-        assert subgraph_hashes4 == dict()
-        assert subgraph_hashes5 == dict()
+        assert g1_hash_with_node_attr1 != g1_hash_no_node_attr
+        assert g1_hash_with_node_attr2 != g1_hash_no_node_attr
+        assert g1_hash_with_node_attr1 != g1_hash_with_node_attr2
 
-    def test_directed(self):
-        """
-        A directed graph with no bi-directional edges should yield different subgraph hashes
-        to the same graph taken as undirected, if all hashes don't collide.
-        """
-        r = 10
-        for i in range(r):
-            G_directed = nx.gn_graph(10 + r, seed=100 + i)
-            G_undirected = nx.to_undirected(G_directed)
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
 
-            directed_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
-            undirected_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(
-                G_undirected
-            )
-
-            assert directed_subgraph_hashes != undirected_subgraph_hashes
-
-    def test_isomorphic(self):
-        """
-        the subgraph hashes should be invariant to node-relabeling when the output is reindexed
-        by the same mapping and all hashes don't collide.
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=200 + i)
-            G2 = _relabel_graph(G1)
-
-            g1_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G1)
-            g2_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G2)
-
-            assert g1_subgraph_hashes == _relabel_dict(g2_subgraph_hashes)
-
-    def test_isomorphic_edge_attr(self):
-        """
-        Isomorphic graphs with differing edge attributes should yield different subgraph
-        hashes if the 'edge_attr' argument is supplied and populated in the graph, and
-        all hashes don't collide.
-        The output should still be invariant to node-relabeling
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=300 + i)
-
-            for a, b in G1.edges:
-                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
-                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
-
-            g1_hash_with_edge_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, edge_attr="edge_attr1"
-            )
-            g1_hash_with_edge_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, edge_attr="edge_attr2"
-            )
-            g1_hash_no_edge_attr = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, edge_attr=None
-            )
-
-            assert g1_hash_with_edge_attr1 != g1_hash_no_edge_attr
-            assert g1_hash_with_edge_attr2 != g1_hash_no_edge_attr
-            assert g1_hash_with_edge_attr1 != g1_hash_with_edge_attr2
-
-            G2 = _relabel_graph(G1)
-
-            g2_hash_with_edge_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
-                G2, edge_attr="edge_attr1"
-            )
-            g2_hash_with_edge_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G2, edge_attr="edge_attr2"
-            )
-
-            assert g1_hash_with_edge_attr1 == _relabel_dict(g2_hash_with_edge_attr1)
-            assert g1_hash_with_edge_attr2 == _relabel_dict(g2_hash_with_edge_attr2)
-
-    def test_missing_edge_attr(self):
-        """
-        If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
-        we should raise a KeyError
-        """
-        G = nx.Graph()
-        G.add_edges_from([(1, 2, {"edge_attr1": "a"}), (1, 3, {})])
-        pytest.raises(
-            KeyError, nx.weisfeiler_lehman_subgraph_hashes, G, edge_attr="edge_attr1"
+        g2_hash_with_node_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+            G2, node_attr="node_attr1"
+        )
+        g2_hash_with_node_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G2, node_attr="node_attr2"
         )
 
-    def test_isomorphic_node_attr(self):
-        """
-        Isomorphic graphs with differing node attributes should yield different subgraph
-        hashes if the 'node_attr' argument is supplied and populated in the graph, and
-        all hashes don't collide.
-        The output should still be invariant to node-relabeling
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=400 + i)
+        assert g1_hash_with_node_attr1 == {
+            -1 * k: v for k, v in g2_hash_with_node_attr1.items()
+        }
+        assert g1_hash_with_node_attr2 == {
+            -1 * k: v for k, v in g2_hash_with_node_attr2.items()
+        }
 
-            for u in G1.nodes():
-                G1.nodes[u]["node_attr1"] = f"{u}-1"
-                G1.nodes[u]["node_attr2"] = f"{u}-2"
 
-            g1_hash_with_node_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, node_attr="node_attr1"
-            )
-            g1_hash_with_node_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, node_attr="node_attr2"
-            )
-            g1_hash_no_node_attr = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, node_attr=None
-            )
+def test_missing_node_attr():
+    """
+    If the 'node_attr' argument is supplied but is missing from a node in the graph,
+    we should raise a KeyError
+    """
+    G = nx.Graph()
+    G.add_nodes_from([(1, {"node_attr1": "a"}), (2, {})])
+    G.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 4)])
+    pytest.raises(
+        KeyError, nx.weisfeiler_lehman_subgraph_hashes, G, node_attr="node_attr1"
+    )
 
-            assert g1_hash_with_node_attr1 != g1_hash_no_node_attr
-            assert g1_hash_with_node_attr2 != g1_hash_no_node_attr
-            assert g1_hash_with_node_attr1 != g1_hash_with_node_attr2
 
-            G2 = _relabel_graph(G1)
+def test_isomorphic_edge_attr_and_node_attr():
+    """
+    Isomorphic graphs with differing node attributes should yield different subgraph
+    hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in
+    the graph, and all hashes don't collide
+    The output should still be invariant to node-relabeling
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
 
-            g2_hash_with_node_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
-                G2, node_attr="node_attr1"
-            )
-            g2_hash_with_node_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G2, node_attr="node_attr2"
-            )
+        for u in G1.nodes():
+            G1.nodes[u]["node_attr1"] = f"{u}-1"
+            G1.nodes[u]["node_attr2"] = f"{u}-2"
 
-            assert g1_hash_with_node_attr1 == _relabel_dict(g2_hash_with_node_attr1)
-            assert g1_hash_with_node_attr2 == _relabel_dict(g2_hash_with_node_attr2)
+        for a, b in G1.edges:
+            G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+            G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
 
-    def test_missing_node_attr(self):
-        """
-        If the 'node_attr' argument is supplied but is missing from a node in the graph,
-        we should raise a KeyError
-        """
-        G = nx.Graph()
-        G.add_nodes_from([(1, {"node_attr1": "a"}), (2, {})])
-        G.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 4)])
-        pytest.raises(
-            KeyError, nx.weisfeiler_lehman_subgraph_hashes, G, node_attr="node_attr1"
+        g1_hash_edge1_node1 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, edge_attr="edge_attr1", node_attr="node_attr1"
+        )
+        g1_hash_edge2_node2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, edge_attr="edge_attr2", node_attr="node_attr2"
+        )
+        g1_hash_edge1_node2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G1, edge_attr="edge_attr1", node_attr="node_attr2"
+        )
+        g1_hash_no_attr = nx.weisfeiler_lehman_subgraph_hashes(G1)
+
+        assert g1_hash_edge1_node1 != g1_hash_no_attr
+        assert g1_hash_edge2_node2 != g1_hash_no_attr
+        assert g1_hash_edge1_node1 != g1_hash_edge2_node2
+        assert g1_hash_edge1_node2 != g1_hash_edge2_node2
+        assert g1_hash_edge1_node2 != g1_hash_edge1_node1
+
+        G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
+
+        g2_hash_edge1_node1 = nx.weisfeiler_lehman_subgraph_hashes(
+            G2, edge_attr="edge_attr1", node_attr="node_attr1"
+        )
+        g2_hash_edge2_node2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G2, edge_attr="edge_attr2", node_attr="node_attr2"
         )
 
-    def test_isomorphic_edge_attr_and_node_attr(self):
-        """
-        Isomorphic graphs with differing node attributes should yield different subgraph
-        hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in
-        the graph, and all hashes don't collide
-        The output should still be invariant to node-relabeling
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
+        assert g1_hash_edge1_node1 == {
+            -1 * k: v for k, v in g2_hash_edge1_node1.items()
+        }
+        assert g1_hash_edge2_node2 == {
+            -1 * k: v for k, v in g2_hash_edge2_node2.items()
+        }
 
-            for u in G1.nodes():
-                G1.nodes[u]["node_attr1"] = f"{u}-1"
-                G1.nodes[u]["node_attr2"] = f"{u}-2"
 
-            for a, b in G1.edges:
-                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
-                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+def test_iteration_depth():
+    """
+    All nodes should have the correct number of subgraph hashes in the output when
+    using degree as initial node labels
+    Subsequent iteration depths for the same graph should be additive for each node
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G = nx.erdos_renyi_graph(n, p * i, seed=600 + i)
 
-            g1_hash_edge1_node1 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, edge_attr="edge_attr1", node_attr="node_attr1"
-            )
-            g1_hash_edge2_node2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, edge_attr="edge_attr2", node_attr="node_attr2"
-            )
-            g1_hash_edge1_node2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G1, edge_attr="edge_attr1", node_attr="node_attr2"
-            )
-            g1_hash_no_attr = nx.weisfeiler_lehman_subgraph_hashes(G1)
+        depth3 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=3)
+        depth4 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=4)
+        depth5 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=5)
 
-            assert g1_hash_edge1_node1 != g1_hash_no_attr
-            assert g1_hash_edge2_node2 != g1_hash_no_attr
-            assert g1_hash_edge1_node1 != g1_hash_edge2_node2
-            assert g1_hash_edge1_node2 != g1_hash_edge2_node2
-            assert g1_hash_edge1_node2 != g1_hash_edge1_node1
+        assert all(len(hashes) == 3 for hashes in depth3.values())
+        assert all(len(hashes) == 4 for hashes in depth4.values())
+        assert all(len(hashes) == 5 for hashes in depth5.values())
 
-            G2 = _relabel_graph(G1)
+        assert is_subiteration(depth3, depth4)
+        assert is_subiteration(depth4, depth5)
+        assert is_subiteration(depth3, depth5)
 
-            g2_hash_edge1_node1 = nx.weisfeiler_lehman_subgraph_hashes(
-                G2, edge_attr="edge_attr1", node_attr="node_attr1"
-            )
-            g2_hash_edge2_node2 = nx.weisfeiler_lehman_subgraph_hashes(
-                G2, edge_attr="edge_attr2", node_attr="node_attr2"
-            )
 
-            assert g1_hash_edge1_node1 == _relabel_dict(g2_hash_edge1_node1)
-            assert g1_hash_edge2_node2 == _relabel_dict(g2_hash_edge2_node2)
+def test_iteration_depth_edge_attr():
+    """
+    All nodes should have the correct number of subgraph hashes in the output when
+    setting initial node labels empty and using an edge attribute when aggregating
+    neighborhoods.
+    Subsequent iteration depths for the same graph should be additive for each node
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G = nx.erdos_renyi_graph(n, p * i, seed=700 + i)
 
-    def test_iteration_depth(self):
-        """
-        All nodes should have the correct number of subgraph hashes in the output when
-        using degree as initial node labels
-        Subsequent iteration depths for the same graph should be additive for each node
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G = nx.erdos_renyi_graph(n, p * i, seed=600 + i)
+        for a, b in G.edges:
+            G[a][b]["edge_attr1"] = f"{a}-{b}-1"
 
-            depth3 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=3)
-            depth4 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=4)
-            depth5 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=5)
+        depth3 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr1", iterations=3
+        )
+        depth4 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr1", iterations=4
+        )
+        depth5 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr1", iterations=5
+        )
 
-            assert all(len(hashes) == 3 for hashes in depth3.values())
-            assert all(len(hashes) == 4 for hashes in depth4.values())
-            assert all(len(hashes) == 5 for hashes in depth5.values())
+        assert all(len(hashes) == 3 for hashes in depth3.values())
+        assert all(len(hashes) == 4 for hashes in depth4.values())
+        assert all(len(hashes) == 5 for hashes in depth5.values())
 
-            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
-            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
-            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+        assert is_subiteration(depth3, depth4)
+        assert is_subiteration(depth4, depth5)
+        assert is_subiteration(depth3, depth5)
 
-    def test_iteration_depth_edge_attr(self):
-        """
-        All nodes should have the correct number of subgraph hashes in the output when
-        setting initial node labels empty and using an edge attribute when aggregating
-        neighborhoods.
-        Subsequent iteration depths for the same graph should be additive for each node
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G = nx.erdos_renyi_graph(n, p * i, seed=700 + i)
 
-            for a, b in G.edges:
-                G[a][b]["edge_attr1"] = f"{a}-{b}-1"
+def test_iteration_depth_node_attr():
+    """
+    All nodes should have the correct number of subgraph hashes in the output when
+    setting initial node labels to an attribute.
+    Subsequent iteration depths for the same graph should be additive for each node
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G = nx.erdos_renyi_graph(n, p * i, seed=800 + i)
 
-            depth3 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, edge_attr="edge_attr1", iterations=3
-            )
-            depth4 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, edge_attr="edge_attr1", iterations=4
-            )
-            depth5 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, edge_attr="edge_attr1", iterations=5
-            )
+        for u in G.nodes():
+            G.nodes[u]["node_attr1"] = f"{u}-1"
 
-            assert all(len(hashes) == 3 for hashes in depth3.values())
-            assert all(len(hashes) == 4 for hashes in depth4.values())
-            assert all(len(hashes) == 5 for hashes in depth5.values())
+        depth3 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, node_attr="node_attr1", iterations=3
+        )
+        depth4 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, node_attr="node_attr1", iterations=4
+        )
+        depth5 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, node_attr="node_attr1", iterations=5
+        )
 
-            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
-            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
-            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+        assert all(len(hashes) == 3 for hashes in depth3.values())
+        assert all(len(hashes) == 4 for hashes in depth4.values())
+        assert all(len(hashes) == 5 for hashes in depth5.values())
 
-    def test_iteration_depth_node_attr(self):
-        """
-        All nodes should have the correct number of subgraph hashes in the output when
-        setting initial node labels to an attribute.
-        Subsequent iteration depths for the same graph should be additive for each node
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G = nx.erdos_renyi_graph(n, p * i, seed=800 + i)
+        assert is_subiteration(depth3, depth4)
+        assert is_subiteration(depth4, depth5)
+        assert is_subiteration(depth3, depth5)
 
-            for u in G.nodes():
-                G.nodes[u]["node_attr1"] = f"{u}-1"
 
-            depth3 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, node_attr="node_attr1", iterations=3
-            )
-            depth4 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, node_attr="node_attr1", iterations=4
-            )
-            depth5 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, node_attr="node_attr1", iterations=5
-            )
+def test_iteration_depth_node_edge_attr():
+    """
+    All nodes should have the correct number of subgraph hashes in the output when
+    setting initial node labels to an attribute and also using an edge attribute when
+    aggregating neighborhoods.
+    Subsequent iteration depths for the same graph should be additive for each node
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G = nx.erdos_renyi_graph(n, p * i, seed=900 + i)
 
-            assert all(len(hashes) == 3 for hashes in depth3.values())
-            assert all(len(hashes) == 4 for hashes in depth4.values())
-            assert all(len(hashes) == 5 for hashes in depth5.values())
+        for u in G.nodes():
+            G.nodes[u]["node_attr1"] = f"{u}-1"
 
-            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
-            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
-            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+        for a, b in G.edges:
+            G[a][b]["edge_attr1"] = f"{a}-{b}-1"
 
-    def test_iteration_depth_node_edge_attr(self):
-        """
-        All nodes should have the correct number of subgraph hashes in the output when
-        setting initial node labels to an attribute and also using an edge attribute when
-        aggregating neighborhoods.
-        Subsequent iteration depths for the same graph should be additive for each node
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G = nx.erdos_renyi_graph(n, p * i, seed=900 + i)
+        depth3 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=3
+        )
+        depth4 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=4
+        )
+        depth5 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=5
+        )
 
-            for u in G.nodes():
-                G.nodes[u]["node_attr1"] = f"{u}-1"
+        assert all(len(hashes) == 3 for hashes in depth3.values())
+        assert all(len(hashes) == 4 for hashes in depth4.values())
+        assert all(len(hashes) == 5 for hashes in depth5.values())
 
-            for a, b in G.edges:
-                G[a][b]["edge_attr1"] = f"{a}-{b}-1"
+        assert is_subiteration(depth3, depth4)
+        assert is_subiteration(depth4, depth5)
+        assert is_subiteration(depth3, depth5)
 
-            depth3 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=3
-            )
-            depth4 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=4
-            )
-            depth5 = nx.weisfeiler_lehman_subgraph_hashes(
-                G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=5
-            )
 
-            assert all(len(hashes) == 3 for hashes in depth3.values())
-            assert all(len(hashes) == 4 for hashes in depth4.values())
-            assert all(len(hashes) == 5 for hashes in depth5.values())
+def test_digest_size():
+    """
+    The hash string lengths should be as expected for a variety of graphs and
+    digest sizes
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G = nx.erdos_renyi_graph(n, p * i, seed=1000 + i)
 
-            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
-            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
-            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+        digest_size16_hashes = nx.weisfeiler_lehman_subgraph_hashes(G)
+        digest_size32_hashes = nx.weisfeiler_lehman_subgraph_hashes(G, digest_size=32)
 
-    def test_digest_size(self):
-        """
-        The hash string lengths should be as expected for a variety of graphs and
-        digest sizes
-        """
-        n, r = 100, 10
-        p = 1.0 / r
-        for i in range(1, r + 1):
-            G = nx.erdos_renyi_graph(n, p * i, seed=1000 + i)
+        assert digest_size16_hashes != digest_size32_hashes
 
-            digest_size16_hashes = nx.weisfeiler_lehman_subgraph_hashes(G)
-            digest_size32_hashes = nx.weisfeiler_lehman_subgraph_hashes(
-                G, digest_size=32
-            )
-
-            assert digest_size16_hashes != digest_size32_hashes
-
-            assert TestSubgraphHashes.hexdigest_sizes_correct(digest_size16_hashes, 16)
-            assert TestSubgraphHashes.hexdigest_sizes_correct(digest_size32_hashes, 32)
+        assert hexdigest_sizes_correct(digest_size16_hashes, 16)
+        assert hexdigest_sizes_correct(digest_size32_hashes, 32)

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -1,42 +1,624 @@
+import pytest
 import networkx as nx
 
 
-def test_empty_graph_hash():
-    G1 = nx.empty_graph()
-    G2 = nx.empty_graph()
-
-    h1 = nx.weisfeiler_lehman_graph_hash(G1)
-    h2 = nx.weisfeiler_lehman_graph_hash(G2)
-
-    assert h1 == h2
-
-
-def test_relabel():
-    G1 = nx.Graph()
-    G1.add_edges_from(
-        [
-            (1, 2, {"label": "A"}),
-            (2, 3, {"label": "A"}),
-            (3, 1, {"label": "A"}),
-            (1, 4, {"label": "B"}),
-        ]
-    )
-    h_before = nx.weisfeiler_lehman_graph_hash(G1, edge_attr="label")
-
-    G2 = nx.relabel_nodes(G1, {u: -1 * u for u in G1.nodes()})
-
-    h_after = nx.weisfeiler_lehman_graph_hash(G2, edge_attr="label")
-
-    assert h_after == h_before
+def _relabel_graph(G, f=lambda x: -1 * x):
+    """
+    relabels graph nodes by a given relabeling function on integers.
+    By default it flips the sign of the labels (Note this is a self-inverse).
+    Returns the relabeled graph, with the original left intact.
+    """
+    return nx.relabel_nodes(G, {u: f(u) for u in G.nodes()})
 
 
-def test_directed():
-    G1 = nx.DiGraph()
-    G1.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 5)])
+def _relabel_dict(dic, f=lambda x: -1 * x):
+    """
+    relabels dictionary keys by a given relabeling function on integers.
+    By default it flips the sign of the labels (Note this is a self-inverse).
+    Returns the relabeled dictionary, with the original left intact.
+    """
+    return {f(k): v for k, v in dic.items()}
 
-    h_directed = nx.weisfeiler_lehman_graph_hash(G1)
 
-    G2 = G1.to_undirected()
-    h_undirected = nx.weisfeiler_lehman_graph_hash(G2)
+class TestFullGraphHash:
+    """Unit tests for the :func:`~networkx.weisfeiler_lehman_graph_hash` function"""
 
-    assert h_directed != h_undirected
+    def test_empty_graph_hash(self):
+        """
+        empty graphs should give hashes regardless of other params
+        """
+        G1 = nx.empty_graph()
+        G2 = nx.empty_graph()
+
+        h1 = nx.weisfeiler_lehman_graph_hash(G1)
+        h2 = nx.weisfeiler_lehman_graph_hash(G2)
+        h3 = nx.weisfeiler_lehman_graph_hash(G2, edge_attr="edge_attr1")
+        h4 = nx.weisfeiler_lehman_graph_hash(G2, node_attr="node_attr1")
+        h5 = nx.weisfeiler_lehman_graph_hash(
+            G2, edge_attr="edge_attr1", node_attr="node_attr1"
+        )
+        h6 = nx.weisfeiler_lehman_graph_hash(G2, iterations=10)
+
+        assert h1 == h2
+        assert h1 == h3
+        assert h1 == h4
+        assert h1 == h5
+        assert h1 == h6
+
+    def test_directed(self):
+        """
+        A directed graph with no bi-directional edges should yield different a graph hash
+        to the same graph taken as undirected if there are no hash collisions.
+        """
+        r = 10
+        for i in range(r):
+            G_directed = nx.gn_graph(10 + r, seed=100 + i)
+            G_undirected = nx.to_undirected(G_directed)
+
+            h_directed = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
+            h_undirected = nx.weisfeiler_lehman_subgraph_hashes(G_undirected)
+
+            assert h_directed != h_undirected
+
+    def test_isomorphic(self):
+        """
+        graph hashes should be invariant to node-relabeling (when the output is reindexed
+        by the same mapping)
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=200 + i)
+            G2 = _relabel_graph(G1)
+
+            g1_hash = nx.weisfeiler_lehman_graph_hash(G1)
+            g2_hash = nx.weisfeiler_lehman_graph_hash(G2)
+
+            assert g1_hash == g2_hash
+
+    def test_isomorphic_edge_attr(self):
+        """
+        Isomorphic graphs with differing edge attributes should yield different graph
+        hashes if the 'edge_attr' argument is supplied and populated in the graph,
+        and there are no hash collisions.
+        The output should still be invariant to node-relabeling
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=300 + i)
+
+            for a, b in G1.edges:
+                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+            g1_hash_with_edge_attr1 = nx.weisfeiler_lehman_graph_hash(
+                G1, edge_attr="edge_attr1"
+            )
+            g1_hash_with_edge_attr2 = nx.weisfeiler_lehman_graph_hash(
+                G1, edge_attr="edge_attr2"
+            )
+            g1_hash_no_edge_attr = nx.weisfeiler_lehman_graph_hash(G1, edge_attr=None)
+
+            assert g1_hash_with_edge_attr1 != g1_hash_no_edge_attr
+            assert g1_hash_with_edge_attr2 != g1_hash_no_edge_attr
+            assert g1_hash_with_edge_attr1 != g1_hash_with_edge_attr2
+
+            G2 = _relabel_graph(G1)
+
+            g2_hash_with_edge_attr1 = nx.weisfeiler_lehman_graph_hash(
+                G2, edge_attr="edge_attr1"
+            )
+            g2_hash_with_edge_attr2 = nx.weisfeiler_lehman_graph_hash(
+                G2, edge_attr="edge_attr2"
+            )
+
+            assert g1_hash_with_edge_attr1 == g2_hash_with_edge_attr1
+            assert g1_hash_with_edge_attr2 == g2_hash_with_edge_attr2
+
+    def test_missing_edge_attr(self):
+        """
+        If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
+        we should raise a KeyError
+        """
+        G = nx.Graph()
+        G.add_edges_from([(1, 2, {"edge_attr1": "a"}), (1, 3, {})])
+        pytest.raises(
+            KeyError, nx.weisfeiler_lehman_graph_hash, G, edge_attr="edge_attr1"
+        )
+
+    def test_isomorphic_node_attr(self):
+        """
+        Isomorphic graphs with differing node attributes should yield different graph
+        hashes if the 'node_attr' argument is supplied and populated in the graph, and
+        there are no hash collisions.
+        The output should still be invariant to node-relabeling
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=400 + i)
+
+            for u in G1.nodes():
+                G1.nodes[u]["node_attr1"] = f"{u}-1"
+                G1.nodes[u]["node_attr2"] = f"{u}-2"
+
+            g1_hash_with_node_attr1 = nx.weisfeiler_lehman_graph_hash(
+                G1, node_attr="node_attr1"
+            )
+            g1_hash_with_node_attr2 = nx.weisfeiler_lehman_graph_hash(
+                G1, node_attr="node_attr2"
+            )
+            g1_hash_no_node_attr = nx.weisfeiler_lehman_graph_hash(G1, node_attr=None)
+
+            assert g1_hash_with_node_attr1 != g1_hash_no_node_attr
+            assert g1_hash_with_node_attr2 != g1_hash_no_node_attr
+            assert g1_hash_with_node_attr1 != g1_hash_with_node_attr2
+
+            G2 = _relabel_graph(G1)
+
+            g2_hash_with_node_attr1 = nx.weisfeiler_lehman_graph_hash(
+                G2, node_attr="node_attr1"
+            )
+            g2_hash_with_node_attr2 = nx.weisfeiler_lehman_graph_hash(
+                G2, node_attr="node_attr2"
+            )
+
+            assert g1_hash_with_node_attr1 == g2_hash_with_node_attr1
+            assert g1_hash_with_node_attr2 == g2_hash_with_node_attr2
+
+    def test_missing_node_attr(self):
+        """
+        If the 'node_attr' argument is supplied but is missing from a node in the graph,
+        we should raise a KeyError
+        """
+        G = nx.Graph()
+        G.add_nodes_from([(1, {"node_attr1": "a"}), (2, {})])
+        G.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 4)])
+        pytest.raises(
+            KeyError, nx.weisfeiler_lehman_graph_hash, G, node_attr="node_attr1"
+        )
+
+    def test_isomorphic_edge_attr_and_node_attr(self):
+        """
+        Isomorphic graphs with differing node attributes should yield different graph
+        hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in
+        the graph, and there are no hash collisions.
+        The output should still be invariant to node-relabeling
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
+
+            for u in G1.nodes():
+                G1.nodes[u]["node_attr1"] = f"{u}-1"
+                G1.nodes[u]["node_attr2"] = f"{u}-2"
+
+            for a, b in G1.edges:
+                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+            g1_hash_edge1_node1 = nx.weisfeiler_lehman_graph_hash(
+                G1, edge_attr="edge_attr1", node_attr="node_attr1"
+            )
+            g1_hash_edge2_node2 = nx.weisfeiler_lehman_graph_hash(
+                G1, edge_attr="edge_attr2", node_attr="node_attr2"
+            )
+            g1_hash_edge1_node2 = nx.weisfeiler_lehman_graph_hash(
+                G1, edge_attr="edge_attr1", node_attr="node_attr2"
+            )
+            g1_hash_no_attr = nx.weisfeiler_lehman_graph_hash(G1)
+
+            assert g1_hash_edge1_node1 != g1_hash_no_attr
+            assert g1_hash_edge2_node2 != g1_hash_no_attr
+            assert g1_hash_edge1_node1 != g1_hash_edge2_node2
+            assert g1_hash_edge1_node2 != g1_hash_edge2_node2
+            assert g1_hash_edge1_node2 != g1_hash_edge1_node1
+
+            G2 = _relabel_graph(G1)
+
+            g2_hash_edge1_node1 = nx.weisfeiler_lehman_graph_hash(
+                G2, edge_attr="edge_attr1", node_attr="node_attr1"
+            )
+            g2_hash_edge2_node2 = nx.weisfeiler_lehman_graph_hash(
+                G2, edge_attr="edge_attr2", node_attr="node_attr2"
+            )
+
+            assert g1_hash_edge1_node1 == g2_hash_edge1_node1
+            assert g1_hash_edge2_node2 == g2_hash_edge2_node2
+
+    def test_digest_size(self):
+        """
+        The hash string lengths should be as expected for a variety of graphs and
+        digest sizes
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G = nx.erdos_renyi_graph(n, p * i, seed=1000 + i)
+
+            h16 = nx.weisfeiler_lehman_graph_hash(G)
+            h32 = nx.weisfeiler_lehman_graph_hash(G, digest_size=32)
+
+            assert h16 != h32
+            assert len(h16) == 16 * 2
+            assert len(h32) == 32 * 2
+
+
+class TestSubgraphHashes:
+    """Unit tests for the :func:`~networkx.weisfeiler_lehman_hash_subgraphs` function"""
+
+    @staticmethod
+    def is_subiteration(a, b):
+        """
+        returns True if that each hash sequence in 'a' is a prefix for
+        the corresponding sequence indexed by the same node in 'b'.
+        """
+        return all(b[node][: len(hashes)] == hashes for node, hashes in a.items())
+
+    @staticmethod
+    def hexdigest_sizes_correct(a, digest_size):
+        """
+        returns True if all hex digest sizes are the expected length in a node:subgraph-hashes
+        dictionary. Hex digest string length == 2 * bytes digest length since each pair of hex
+        digits encodes 1 byte (https://docs.python.org/3/library/hashlib.html)
+        """
+        hexdigest_size = digest_size * 2
+        list_digest_sizes_correct = lambda l: all(len(x) == hexdigest_size for x in l)
+        return all(list_digest_sizes_correct(hashes) for hashes in a.values())
+
+    def test_empty_graph(self):
+        """ "
+        empty graphs should give empty dict subgraph hashes regardless of other params
+        """
+        G = nx.empty_graph()
+
+        subgraph_hashes1 = nx.weisfeiler_lehman_subgraph_hashes(G)
+        subgraph_hashes2 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, edge_attr="edge_attr"
+        )
+        subgraph_hashes3 = nx.weisfeiler_lehman_subgraph_hashes(
+            G, node_attr="edge_attr"
+        )
+        subgraph_hashes4 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=2)
+        subgraph_hashes5 = nx.weisfeiler_lehman_subgraph_hashes(G, digest_size=64)
+
+        assert subgraph_hashes1 == dict()
+        assert subgraph_hashes2 == dict()
+        assert subgraph_hashes3 == dict()
+        assert subgraph_hashes4 == dict()
+        assert subgraph_hashes5 == dict()
+
+    def test_directed(self):
+        """
+        A directed graph with no bi-directional edges should yield different subgraph hashes
+        to the same graph taken as undirected, if all hashes don't collide.
+        """
+        r = 10
+        for i in range(r):
+            G_directed = nx.gn_graph(10 + r, seed=100 + i)
+            G_undirected = nx.to_undirected(G_directed)
+
+            directed_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G_directed)
+            undirected_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(
+                G_undirected
+            )
+
+            assert directed_subgraph_hashes != undirected_subgraph_hashes
+
+    def test_isomorphic(self):
+        """
+        the subgraph hashes should be invariant to node-relabeling when the output is reindexed
+        by the same mapping and all hashes don't collide.
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=200 + i)
+            G2 = _relabel_graph(G1)
+
+            g1_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G1)
+            g2_subgraph_hashes = nx.weisfeiler_lehman_subgraph_hashes(G2)
+
+            assert g1_subgraph_hashes == _relabel_dict(g2_subgraph_hashes)
+
+    def test_isomorphic_edge_attr(self):
+        """
+        Isomorphic graphs with differing edge attributes should yield different subgraph
+        hashes if the 'edge_attr' argument is supplied and populated in the graph, and
+        all hashes don't collide.
+        The output should still be invariant to node-relabeling
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=300 + i)
+
+            for a, b in G1.edges:
+                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+            g1_hash_with_edge_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, edge_attr="edge_attr1"
+            )
+            g1_hash_with_edge_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, edge_attr="edge_attr2"
+            )
+            g1_hash_no_edge_attr = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, edge_attr=None
+            )
+
+            assert g1_hash_with_edge_attr1 != g1_hash_no_edge_attr
+            assert g1_hash_with_edge_attr2 != g1_hash_no_edge_attr
+            assert g1_hash_with_edge_attr1 != g1_hash_with_edge_attr2
+
+            G2 = _relabel_graph(G1)
+
+            g2_hash_with_edge_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+                G2, edge_attr="edge_attr1"
+            )
+            g2_hash_with_edge_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G2, edge_attr="edge_attr2"
+            )
+
+            assert g1_hash_with_edge_attr1 == _relabel_dict(g2_hash_with_edge_attr1)
+            assert g1_hash_with_edge_attr2 == _relabel_dict(g2_hash_with_edge_attr2)
+
+    def test_missing_edge_attr(self):
+        """
+        If the 'edge_attr' argument is supplied but is missing from an edge in the graph,
+        we should raise a KeyError
+        """
+        G = nx.Graph()
+        G.add_edges_from([(1, 2, {"edge_attr1": "a"}), (1, 3, {})])
+        pytest.raises(
+            KeyError, nx.weisfeiler_lehman_subgraph_hashes, G, edge_attr="edge_attr1"
+        )
+
+    def test_isomorphic_node_attr(self):
+        """
+        Isomorphic graphs with differing node attributes should yield different subgraph
+        hashes if the 'node_attr' argument is supplied and populated in the graph, and
+        all hashes don't collide.
+        The output should still be invariant to node-relabeling
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=400 + i)
+
+            for u in G1.nodes():
+                G1.nodes[u]["node_attr1"] = f"{u}-1"
+                G1.nodes[u]["node_attr2"] = f"{u}-2"
+
+            g1_hash_with_node_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, node_attr="node_attr1"
+            )
+            g1_hash_with_node_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, node_attr="node_attr2"
+            )
+            g1_hash_no_node_attr = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, node_attr=None
+            )
+
+            assert g1_hash_with_node_attr1 != g1_hash_no_node_attr
+            assert g1_hash_with_node_attr2 != g1_hash_no_node_attr
+            assert g1_hash_with_node_attr1 != g1_hash_with_node_attr2
+
+            G2 = _relabel_graph(G1)
+
+            g2_hash_with_node_attr1 = nx.weisfeiler_lehman_subgraph_hashes(
+                G2, node_attr="node_attr1"
+            )
+            g2_hash_with_node_attr2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G2, node_attr="node_attr2"
+            )
+
+            assert g1_hash_with_node_attr1 == _relabel_dict(g2_hash_with_node_attr1)
+            assert g1_hash_with_node_attr2 == _relabel_dict(g2_hash_with_node_attr2)
+
+    def test_missing_node_attr(self):
+        """
+        If the 'node_attr' argument is supplied but is missing from a node in the graph,
+        we should raise a KeyError
+        """
+        G = nx.Graph()
+        G.add_nodes_from([(1, {"node_attr1": "a"}), (2, {})])
+        G.add_edges_from([(1, 2), (2, 3), (3, 1), (1, 4)])
+        pytest.raises(
+            KeyError, nx.weisfeiler_lehman_subgraph_hashes, G, node_attr="node_attr1"
+        )
+
+    def test_isomorphic_edge_attr_and_node_attr(self):
+        """
+        Isomorphic graphs with differing node attributes should yield different subgraph
+        hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in
+        the graph, and all hashes don't collide
+        The output should still be invariant to node-relabeling
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
+
+            for u in G1.nodes():
+                G1.nodes[u]["node_attr1"] = f"{u}-1"
+                G1.nodes[u]["node_attr2"] = f"{u}-2"
+
+            for a, b in G1.edges:
+                G1[a][b]["edge_attr1"] = f"{a}-{b}-1"
+                G1[a][b]["edge_attr2"] = f"{a}-{b}-2"
+
+            g1_hash_edge1_node1 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, edge_attr="edge_attr1", node_attr="node_attr1"
+            )
+            g1_hash_edge2_node2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, edge_attr="edge_attr2", node_attr="node_attr2"
+            )
+            g1_hash_edge1_node2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G1, edge_attr="edge_attr1", node_attr="node_attr2"
+            )
+            g1_hash_no_attr = nx.weisfeiler_lehman_subgraph_hashes(G1)
+
+            assert g1_hash_edge1_node1 != g1_hash_no_attr
+            assert g1_hash_edge2_node2 != g1_hash_no_attr
+            assert g1_hash_edge1_node1 != g1_hash_edge2_node2
+            assert g1_hash_edge1_node2 != g1_hash_edge2_node2
+            assert g1_hash_edge1_node2 != g1_hash_edge1_node1
+
+            G2 = _relabel_graph(G1)
+
+            g2_hash_edge1_node1 = nx.weisfeiler_lehman_subgraph_hashes(
+                G2, edge_attr="edge_attr1", node_attr="node_attr1"
+            )
+            g2_hash_edge2_node2 = nx.weisfeiler_lehman_subgraph_hashes(
+                G2, edge_attr="edge_attr2", node_attr="node_attr2"
+            )
+
+            assert g1_hash_edge1_node1 == _relabel_dict(g2_hash_edge1_node1)
+            assert g1_hash_edge2_node2 == _relabel_dict(g2_hash_edge2_node2)
+
+    def test_iteration_depth(self):
+        """
+        All nodes should have the correct number of subgraph hashes in the output when
+        using degree as initial node labels
+        Subsequent iteration depths for the same graph should be additive for each node
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G = nx.erdos_renyi_graph(n, p * i, seed=600 + i)
+
+            depth3 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=3)
+            depth4 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=4)
+            depth5 = nx.weisfeiler_lehman_subgraph_hashes(G, iterations=5)
+
+            assert all(len(hashes) == 3 for hashes in depth3.values())
+            assert all(len(hashes) == 4 for hashes in depth4.values())
+            assert all(len(hashes) == 5 for hashes in depth5.values())
+
+            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
+            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
+            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+
+    def test_iteration_depth_edge_attr(self):
+        """
+        All nodes should have the correct number of subgraph hashes in the output when
+        setting initial node labels empty and using an edge attribute when aggregating
+        neighborhoods.
+        Subsequent iteration depths for the same graph should be additive for each node
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G = nx.erdos_renyi_graph(n, p * i, seed=700 + i)
+
+            for a, b in G.edges:
+                G[a][b]["edge_attr1"] = f"{a}-{b}-1"
+
+            depth3 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, edge_attr="edge_attr1", iterations=3
+            )
+            depth4 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, edge_attr="edge_attr1", iterations=4
+            )
+            depth5 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, edge_attr="edge_attr1", iterations=5
+            )
+
+            assert all(len(hashes) == 3 for hashes in depth3.values())
+            assert all(len(hashes) == 4 for hashes in depth4.values())
+            assert all(len(hashes) == 5 for hashes in depth5.values())
+
+            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
+            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
+            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+
+    def test_iteration_depth_node_attr(self):
+        """
+        All nodes should have the correct number of subgraph hashes in the output when
+        setting initial node labels to an attribute.
+        Subsequent iteration depths for the same graph should be additive for each node
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G = nx.erdos_renyi_graph(n, p * i, seed=800 + i)
+
+            for u in G.nodes():
+                G.nodes[u]["node_attr1"] = f"{u}-1"
+
+            depth3 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, node_attr="node_attr1", iterations=3
+            )
+            depth4 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, node_attr="node_attr1", iterations=4
+            )
+            depth5 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, node_attr="node_attr1", iterations=5
+            )
+
+            assert all(len(hashes) == 3 for hashes in depth3.values())
+            assert all(len(hashes) == 4 for hashes in depth4.values())
+            assert all(len(hashes) == 5 for hashes in depth5.values())
+
+            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
+            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
+            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+
+    def test_iteration_depth_node_edge_attr(self):
+        """
+        All nodes should have the correct number of subgraph hashes in the output when
+        setting initial node labels to an attribute and also using an edge attribute when
+        aggregating neighborhoods.
+        Subsequent iteration depths for the same graph should be additive for each node
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G = nx.erdos_renyi_graph(n, p * i, seed=900 + i)
+
+            for u in G.nodes():
+                G.nodes[u]["node_attr1"] = f"{u}-1"
+
+            for a, b in G.edges:
+                G[a][b]["edge_attr1"] = f"{a}-{b}-1"
+
+            depth3 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=3
+            )
+            depth4 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=4
+            )
+            depth5 = nx.weisfeiler_lehman_subgraph_hashes(
+                G, edge_attr="edge_attr1", node_attr="node_attr1", iterations=5
+            )
+
+            assert all(len(hashes) == 3 for hashes in depth3.values())
+            assert all(len(hashes) == 4 for hashes in depth4.values())
+            assert all(len(hashes) == 5 for hashes in depth5.values())
+
+            assert TestSubgraphHashes.is_subiteration(depth3, depth4)
+            assert TestSubgraphHashes.is_subiteration(depth4, depth5)
+            assert TestSubgraphHashes.is_subiteration(depth3, depth5)
+
+    def test_digest_size(self):
+        """
+        The hash string lengths should be as expected for a variety of graphs and
+        digest sizes
+        """
+        n, r = 100, 10
+        p = 1.0 / r
+        for i in range(1, r + 1):
+            G = nx.erdos_renyi_graph(n, p * i, seed=1000 + i)
+
+            digest_size16_hashes = nx.weisfeiler_lehman_subgraph_hashes(G)
+            digest_size32_hashes = nx.weisfeiler_lehman_subgraph_hashes(
+                G, digest_size=32
+            )
+
+            assert digest_size16_hashes != digest_size32_hashes
+
+            assert TestSubgraphHashes.hexdigest_sizes_correct(digest_size16_hashes, 16)
+            assert TestSubgraphHashes.hexdigest_sizes_correct(digest_size32_hashes, 32)


### PR DESCRIPTION
## Changes
- add a new method `weisfeiler_lehman_hash_subgraphs`, and refactored `weisfeiler_lehman_hash_graph` so the two methods share common steps and are more efficient.
- added docstring with example for `weisfeiler_lehman_hash_subgraphs`
- added test class for `weisfeiler_lehman_hash_subgraphs` with randomly generated graphs for each test
- replaced tests for  `weisfeiler_lehman_hash_graph`  to be aligned with the coverage of tests for `weisfeiler_lehman_hash_subgraphs`

## Description
The current `weisfeiler_lehman_hash_graph` returns a hash for a graph, but sometimes it is useful to keep the subgraph hashes induced by k-hops from each node generated by the iterations along the way. For example when building general WL graph kernels [1] or in the popular 'Graph2Vec' algorithm [2] where these subgraph hashes are viewed as 'words' in the graph to build features from. Non-isomorphic graphs may have different graph hashes but may share lots of subgraph hashes, implying that locally the graphs are similar.

As a result I've added the `weisfeiler_lehman_hash_subgraphs` method which returns a dictionary indexed by node of subgraph hash lists in order of iteration depth.  Similarly to `weisfeiler_lehman_hash_graph`, the user can choose to set: initial node labels for the hashing, an edge attribute used in neighborhood aggregations, iteration depth, or hash digest size with optional keyword arguments.


### References
[1] W-L graph kernels https://www.jmlr.org/papers/volume12/shervashidze11a/shervashidze11a.pdf
[2]  Graph2Vec: https://arxiv.org/abs/1707.05005

Possibly of interest to @cgoliver & @rossbar, authors of the original implementation here.