### PR TITLE
Changes to rst files to make doctests pass

### DIFF
--- a/doc/developer/nxeps/nxep-0003.rst
+++ b/doc/developer/nxeps/nxep-0003.rst
@@ -149,27 +149,27 @@ Usage and Impact
 
 Users will build graphs using similar syntax as before with added flexibility.
 
-Create a wheel graph with 9 spokes (10 nodes):
+Create a wheel graph with 9 spokes (10 nodes)::
 
     >>> G = nx.wheel_graph(9)  # same as current code
 
-Construct a path graph using a MultiDiGraph data structure:
+Construct a path graph using a MultiDiGraph data structure::
 
     >>> MDG = nx.path_graph.MultiDiGraph([3, 4, 2, 5, 7, 6])
     >>> # current code:
     >>> MDG = nx.path_graph([3, 4, 2, 5, 7, 6], create_using=MultiDiGraph)
 
-Construct a star graph using a CustomGraph subclass of a NetworkX graph class.
+Construct a star graph using a CustomGraph subclass of a NetworkX graph class::
 
     >>> G = nx.star_graph.CustomGraph(9, MyCustomGraph)
     >>> # current code:
     >>> G = nx.star_graph(9, create_using=MyCustomGraph)
 
-Add a complete graph to an existing graph G:
+Add a complete graph to an existing graph G::
 
     >>> G.update(nx.complete_graph.edgelist(range(len(G) - 10, 20))
 
-Iterate over the edges of a randomly generated graph without storing it.
+Iterate over the edges of a randomly generated graph without storing it::
 
     >>> for u, v in nx.configuration_model_graph.edgelist(deg_sequence):
     >>>     process(u, v)

--- a/doc/developer/nxeps/nxep-0003.rst
+++ b/doc/developer/nxeps/nxep-0003.rst
@@ -149,27 +149,27 @@ Usage and Impact
 
 Users will build graphs using similar syntax as before with added flexibility.
 
-Create a wheel graph with 9 spokes (10 nodes)::
+Create a wheel graph with 9 spokes (10 nodes):
 
     >>> G = nx.wheel_graph(9)  # same as current code
 
-Construct a path graph using a MultiDiGraph data structure::
+Construct a path graph using a MultiDiGraph data structure:
 
     >>> MDG = nx.path_graph.MultiDiGraph([3, 4, 2, 5, 7, 6])
     >>> # current code:
     >>> MDG = nx.path_graph([3, 4, 2, 5, 7, 6], create_using=MultiDiGraph)
 
-Construct a star graph using a CustomGraph subclass of a NetworkX graph class::
+Construct a star graph using a CustomGraph subclass of a NetworkX graph class.
 
     >>> G = nx.star_graph.CustomGraph(9, MyCustomGraph)
     >>> # current code:
     >>> G = nx.star_graph(9, create_using=MyCustomGraph)
 
-Add a complete graph to an existing graph G::
+Add a complete graph to an existing graph G:
 
     >>> G.update(nx.complete_graph.edgelist(range(len(G) - 10, 20))
 
-Iterate over the edges of a randomly generated graph without storing it::
+Iterate over the edges of a randomly generated graph without storing it.
 
     >>> for u, v in nx.configuration_model_graph.edgelist(deg_sequence):
     >>>     process(u, v)

--- a/doc/reference/introduction.rst
+++ b/doc/reference/introduction.rst
@@ -276,11 +276,9 @@ computed with a layout function. The edges are lines between those dots.
 
    >>> import matplotlib.pyplot as plt
    >>> G = nx.cubical_graph()
-   >>> plt.subplot(121)
-   <matplotlib.axes._subplots.AxesSubplot object at ...>
+   >>> subax1 = plt.subplot(121)
    >>> nx.draw(G)   # default spring_layout
-   >>> plt.subplot(122)
-   <matplotlib.axes._subplots.AxesSubplot object at ...>
+   >>> subax2 = plt.subplot(122)
    >>> nx.draw(G, pos=nx.circular_layout(G), node_color='r', edge_color='b')
 
 See the :doc:`examples </auto_examples/index>` for more ideas.

--- a/doc/release/migration_guide_from_1.x_to_2.0.rst
+++ b/doc/release/migration_guide_from_1.x_to_2.0.rst
@@ -305,7 +305,6 @@ the node data structure if not done correctly. Code such as the following:
 used to work, even though it could cause errors if ``n`` was not a node in ``G``.
 That code will cause an error in v2.x.  Replace it with one of the more safe versions:
 
-    >>> G.node[n].update(H.node[n])  # works in both v1.x and v2.x
     >>> G.nodes[n].update(H.nodes[n])  # works in v2.x
 
 -------

--- a/doc/release/old_release_log.rst
+++ b/doc/release/old_release_log.rst
@@ -728,7 +728,7 @@ New features
   - include documentation in source package (doc)
   - tests can now be run with
      >>> import networkx
-     >>> networkx.test()
+     >>> networkx.test()  # doctest: +SKIP
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -142,13 +142,13 @@ At this stage the graph ``G`` consists of 8 nodes and 3 edges, as can be seen by
 
 .. nbplot::
 
-    >>> G = nx.DiGraph()
-    >>> G.add_edge(2, 1)   # adds the nodes in order 2, 1
-    >>> G.add_edge(1, 3)
-    >>> G.add_edge(2, 4)
-    >>> G.add_edge(1, 2)
-    >>> assert list(G.successors(2)) == [1, 4]
-    >>> assert list(G.edges) == [(2, 1), (2, 4), (1, 3), (1, 2)]
+    >>> DG = nx.DiGraph()
+    >>> DG.add_edge(2, 1)   # adds the nodes in order 2, 1
+    >>> DG.add_edge(1, 3)
+    >>> DG.add_edge(2, 4)
+    >>> DG.add_edge(1, 2)
+    >>> assert list(DG.successors(2)) == [1, 4]
+    >>> assert list(DG.edges) == [(2, 1), (2, 4), (1, 3), (1, 2)]
 
 Examining elements of a graph
 -----------------------------
@@ -553,17 +553,15 @@ To test if the import of ``networkx.drawing`` was successful draw ``G`` using on
 .. nbplot::
 
     >>> G = nx.petersen_graph()
-    >>> plt.subplot(121)
-    <matplotlib.axes._subplots.AxesSubplot object at ...>
+    >>> subax1 = plt.subplot(121)
     >>> nx.draw(G, with_labels=True, font_weight='bold')
-    >>> plt.subplot(122)
-    <matplotlib.axes._subplots.AxesSubplot object at ...>
+    >>> subax2 = plt.subplot(122)
     >>> nx.draw_shell(G, nlist=[range(5, 10), range(5)], with_labels=True, font_weight='bold')
 
 when drawing to an interactive display.  Note that you may need to issue a
 Matplotlib
 
->>> plt.show()
+>>> plt.show()  # doctest: +SKIP
 
 command if you are not using matplotlib in interactive mode (see
 :doc:`this Matplotlib FAQ <faq/installing_faq>`).
@@ -575,17 +573,13 @@ command if you are not using matplotlib in interactive mode (see
     ...     'node_size': 100,
     ...     'width': 3,
     ... }
-    >>> plt.subplot(221)
-    <matplotlib.axes._subplots.AxesSubplot object at ...>
+    >>> subax1 = plt.subplot(221)
     >>> nx.draw_random(G, **options)
-    >>> plt.subplot(222)
-    <matplotlib.axes._subplots.AxesSubplot object at ...>
+    >>> subax2 = plt.subplot(222)
     >>> nx.draw_circular(G, **options)
-    >>> plt.subplot(223)
-    <matplotlib.axes._subplots.AxesSubplot object at ...>
+    >>> subax3 = plt.subplot(223)
     >>> nx.draw_spectral(G, **options)
-    >>> plt.subplot(224)
-    <matplotlib.axes._subplots.AxesSubplot object at ...>
+    >>> subax4 = plt.subplot(224)
     >>> nx.draw_shell(G, nlist=[range(5,10), range(5)], **options)
 
 You can find additional options via :func:`~drawing.nx_pylab.draw_networkx` and

--- a/examples/subclass/plot_antigraph.py
+++ b/examples/subclass/plot_antigraph.py
@@ -96,8 +96,8 @@ class AntiGraph(Graph):
         Examples
         --------
         >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc
-        >>> list(G.degree(0))  # node 0 with degree 1
-        [(0, 1)]
+        >>> G.degree(0)  # node 0 with degree 1
+        1
         >>> list(G.degree([0, 1]))
         [(0, 1), (1, 2)]
 

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -77,17 +77,17 @@ def weisfeiler_lehman_graph_hash(
 
     Omitting the `edge_attr` option, results in identical hashes.
 
-    >>> weisfeiler_lehman_graph_hash(G1)
+    >>> nx.weisfeiler_lehman_graph_hash(G1)
     '0db442538bb6dc81d675bd94e6ebb7ca'
-    >>> weisfeiler_lehman_graph_hash(G2)
+    >>> nx.weisfeiler_lehman_graph_hash(G2)
     '0db442538bb6dc81d675bd94e6ebb7ca'
 
     With edge labels, the graphs are no longer assigned
     the same hash digest.
 
-    >>> weisfeiler_lehman_graph_hash(G1, edge_attr="label")
+    >>> nx.weisfeiler_lehman_graph_hash(G1, edge_attr="label")
     '408c18537e67d3e56eb7dc92c72cb79e'
-    >>> weisfeiler_lehman_graph_hash(G2, edge_attr="label")
+    >>> nx.weisfeiler_lehman_graph_hash(G2, edge_attr="label")
     'f9e9cb01c6d2f3b17f83ffeaa24e5986'
 
     References

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -224,7 +224,7 @@ def hits_numpy(G, normalized=True):
     `hits_numpy` maps the eigenvector corresponding to the maximum eigenvalue
     of the respective matrices to the nodes in `G`:
 
-    >>> hubs, authority = hits_numpy(G)
+    >>> hubs, authority = nx.hits_numpy(G)
 
     Notes
     -----

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1100,7 +1100,7 @@ class Graph:
         It you want to update the graph using an adjacency structure
         it is straightforward to obtain the edges/nodes from adjacency.
         The following examples provide common cases, your adjacency may
-        be slightly different and require tweaks of these examples.
+        be slightly different and require tweaks of these examples::
 
         >>> # dict-of-set/list/tuple
         >>> adj = {1: {2, 3}, 2: {1, 3}, 3: {1, 2}}

--- a/networkx/generators/trees.py
+++ b/networkx/generators/trees.py
@@ -78,7 +78,7 @@ def prefix_tree(paths):
         >>> list(T.edges)
         [(0, 1), (1, 2), (1, 4), (2, -1), (2, 3), (3, -1), (4, -1)]
 
-    The leaf nodes can be obtained as predecessors of the nil node.
+    The leaf nodes can be obtained as predecessors of the nil node::
 
         >>> root, NIL = 0, -1
         >>> list(T.predecessors(NIL))

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -314,27 +314,27 @@ def arbitrary_element(iterable):
     --------
     Arbitrary elements from common Iterable objects:
 
-    >>> arbitrary_element([1, 2, 3])  # list
+    >>> nx.utils.arbitrary_element([1, 2, 3])  # list
     1
-    >>> arbitrary_element((1, 2, 3))  # tuple
+    >>> nx.utils.arbitrary_element((1, 2, 3))  # tuple
     1
-    >>> arbitrary_element({1, 2, 3})  # set
+    >>> nx.utils.arbitrary_element({1, 2, 3})  # set
     1
     >>> d = {k: v for k, v in zip([1, 2, 3], [3, 2, 1])}
-    >>> arbitrary_element(d)  # dict_keys
+    >>> nx.utils.arbitrary_element(d)  # dict_keys
     1
-    >>> arbitrary_element(d.values())   # dict values
+    >>> nx.utils.arbitrary_element(d.values())   # dict values
     3
 
     `str` is also an Iterable:
 
-    >>> arbitrary_element("hello")
+    >>> nx.utils.arbitrary_element("hello")
     'h'
 
     :exc:`ValueError` is raised if `iterable` is an iterator:
 
     >>> iterator = iter([1, 2, 3])  # Iterator, *not* Iterable
-    >>> arbitrary_element(iterator)
+    >>> nx.utils.arbitrary_element(iterator)
     Traceback (most recent call last):
         ...
     ValueError: cannot return an arbitrary item from an iterator
@@ -345,9 +345,9 @@ def arbitrary_element(iterable):
     ordered, sequential calls will return the same value::
 
         >>> l = [1, 2, 3]
-        >>> arbitrary_element(l)
+        >>> nx.utils.arbitrary_element(l)
         1
-        >>> arbitrary_element(l)
+        >>> nx.utils.arbitrary_element(l)
         1
 
     """


### PR DESCRIPTION
- skip running the entire test quite as an example in old_release_log.rst
- capture output from subplot and rename DiGraph as DG in introduction.rst
- Remove one line from 1->2 migration rst file
    the line shows code that works for 1.x *and* 2.x.
    But it no longer works for all v2.x code.  Readers should just use the
    next line of code, so no reason to keep this in the file.
- add nx. prefix to doctest function calls
- rst double colons for example code
