### PR TITLE
modularity_max: breaking the loop when given community size is reached

### DIFF
--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -73,8 +73,10 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
     q0 = 1.0 / (2.0 * m)
 
     if n_communities > N:
-        warnings.warn("Input n_communities is greater than number of nodes of G."
-                      "Falling back to default n_communities = 1.")
+        warnings.warn(
+            "Input n_communities is greater than number of nodes of G."
+            "Falling back to default n_communities = 1."
+        )
         n_communities = 1
 
 

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -79,7 +79,6 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
         )
         n_communities = 1
 
-
     # Map node labels to contiguous integers
     label_for_node = {i: v for i, v in enumerate(G.nodes())}
     node_for_label = {label_for_node[i]: i for i in range(N)}

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -4,6 +4,8 @@ from networkx.algorithms.community.quality import modularity
 
 from networkx.utils.mapped_queue import MappedQueue
 
+import warnings
+
 __all__ = [
     "greedy_modularity_communities",
     "naive_greedy_modularity_communities",

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -29,16 +29,21 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
     ----------
     G : NetworkX graph
     weight : string or None, optional (default=None)
-       The name of an edge attribute that holds the numerical value used
-       as a weight.  If None, then each edge has weight 1.
-       The degree is the sum of the edge weights adjacent to the node.
+        The name of an edge attribute that holds the numerical value used
+        as a weight.  If None, then each edge has weight 1.
+        The degree is the sum of the edge weights adjacent to the node.
+
+    resolution : float (default=1)
+        If resolution is less than 1, modularity favors larger communities.
+        Greater than 1 favors smaller communities.
+
     n_communities: int
-       Desired number of communities: the community merging process is
-       terminated once this number of communities is reached, or until
-       modularity can not be further increased. Must be between 1 and the
-       total number of nodes in `G`. Default is ``1``, meaning the community
-       merging process continues until all nodes are in the same community
-       or until the best community structure is found.
+        Desired number of communities: the community merging process is
+        terminated once this number of communities is reached, or until
+        modularity can not be further increased. Must be between 1 and the
+        total number of nodes in `G`. Default is ``1``, meaning the community
+        merging process continues until all nodes are in the same community
+        or until the best community structure is found.
 
     Returns
     -------

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -4,8 +4,6 @@ from networkx.algorithms.community.quality import modularity
 
 from networkx.utils.mapped_queue import MappedQueue
 
-import warnings
-
 __all__ = [
     "greedy_modularity_communities",
     "naive_greedy_modularity_communities",
@@ -21,7 +19,7 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
 
     Greedy modularity maximization begins with each node in its own community
     and joins the pair of communities that most increases modularity until no
-    such pair exists or until desired number of communities is reached.
+    such pair exists or until number of communities `n_communities` is reached.
 
     This function maximizes the generalized modularity, where `resolution`
     is the resolution parameter, often expressed as $\gamma$.
@@ -35,8 +33,12 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
        as a weight.  If None, then each edge has weight 1.
        The degree is the sum of the edge weights adjacent to the node.
     n_communities: int
-       desired number of communities, defaults to 1 and falls back to 1 if
-       the given number is larger than the initial amount of communities
+       Desired number of communities: the community merging process is
+       terminated once this number of communities is reached, or until
+       modularity can not be further increased. Must be between 1 and the
+       total number of nodes in `G`. Default is ``1``, meaning the community
+       merging process continues until all nodes are in the same community
+       or until the best community structure is found.
 
     Returns
     -------
@@ -72,12 +74,10 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
     m = sum([d.get("weight", 1) for u, v, d in G.edges(data=True)])
     q0 = 1.0 / (2.0 * m)
 
-    if n_communities > N:
-        warnings.warn(
-            "Input n_communities is greater than number of nodes of G."
-            "Falling back to default n_communities = 1."
+    if (n_communities < 1) or (n_communities > N):
+        raise ValueError(
+            f"n_communities must be between 1 and {len(G.nodes())}. Got {n_communities}"
         )
-        n_communities = 1
 
     # Map node labels to contiguous integers
     label_for_node = {i: v for i, v in enumerate(G.nodes())}

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -93,7 +93,7 @@ def test_n_communities_parameter():
     assert greedy_modularity_communities(G, n_communities=8) == expected
 
     # Aggregation to half order (number of nodes)
-    expected = [{k, k+1} for k in range(0, 8, 2)]
+    expected = [{k, k + 1} for k in range(0, 8, 2)]
     assert greedy_modularity_communities(G, n_communities=4) == expected
 
     # Default aggregation case (here, 2 communities emerge)

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -54,3 +54,19 @@ def test_resolution_parameter_impact():
     expected = [frozenset(range(8)), frozenset(range(8, 13))]
     assert greedy_modularity_communities(G, resolution=gamma) == expected
     assert naive_greedy_modularity_communities(G, resolution=gamma) == expected
+
+
+def test_n_communities_parameter():
+    G = nx.circular_ladder_graph(4)
+
+    # No aggregation:
+    expected = [{k} for k in range(8)]
+    assert greedy_modularity_communities(G, n_communities=8) == expected
+
+    # Aggregation to half order (number of nodes)
+    expected = [{k, k+1} for k in range(0, 8, 2)]
+    assert greedy_modularity_communities(G, n_communities=4) == expected
+
+    # Default aggregation case (here, 2 communities emerge)
+    expected = [frozenset(range(0, 4)), frozenset(range(4, 8))]
+    assert greedy_modularity_communities(G, n_communities=1) == expected


### PR DESCRIPTION
Hi; a small suggestion to allow breaking the greedy_modularity_max loop when a certain number of communities is reached. Nothing changes when using the default configuration, i.e. if the parameter is not specified... Would help for my work!