### PR TITLE
`descendants_at_distance` also for non-DiGraphs

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -374,7 +374,7 @@ def descendants_at_distance(G, source, distance):
 
     Parameters
     ----------
-    G : NetworkX Graph
+    G : NetworkX graph
         A graph
     source : node in `G`
     distance : the distance of the wanted nodes from `source`

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -374,8 +374,8 @@ def descendants_at_distance(G, source, distance):
 
     Parameters
     ----------
-    G : NetworkX DiGraph
-        A directed graph
+    G : NetworkX Graph
+        A graph
     source : node in `G`
     distance : the distance of the wanted nodes from `source`
 


### PR DESCRIPTION
I think there is no reason to limit `descendants_at_distance` to DiGraphs. My change affects the documentation only.  If I am wrong, maybe a check would make sense.