### PR TITLE
modularity_max: provide labels to get_edge_data

### DIFF
--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -92,7 +92,9 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
     a = [k[i] * q0 for i in range(N)]
     dq_dict = {
         i: {
-            j: 2 * q0 * G.get_edge_data(i, j).get(weight, 1.0)
+            j: 2
+            * q0
+            * G.get_edge_data(label_for_node[i], label_for_node[j]).get(weight, 1.0)
             - 2 * resolution * k[i] * k[j] * q0 * q0
             for j in [node_for_label[u] for u in G.neighbors(label_for_node[i])]
             if j != i

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -26,13 +26,15 @@ def test_modularity_communities(func):
 
 def test_modularity_communities_weighted():
     G = nx.balanced_tree(2, 3)
+    mapping = {0: 15}
+    G = nx.relabel_nodes(G, mapping)
     for (a, b) in G.edges:
-        if ((a == 1) or (a == 2)) and (b != 0):
+        if ((a == 1) or (a == 2)) and (b != 15):
             G[a][b]["weight"] = 10.0
         else:
             G[a][b]["weight"] = 1.0
 
-    expected = [{0, 1, 3, 4, 7, 8, 9, 10}, {2, 5, 6, 11, 12, 13, 14}]
+    expected = [{15, 1, 3, 4, 7, 8, 9, 10}, {2, 5, 6, 11, 12, 13, 14}]
 
     assert greedy_modularity_communities(G, weight="weight") == expected
 

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -25,12 +25,11 @@ def test_modularity_communities(func):
 
 
 def test_greedy_modularity_communities_relabeled():
+    # Test for gh-4966
     G = nx.balanced_tree(2, 2)
     mapping = {0: "a", 1: "b", 2: "c", 3: "d", 4: "e", 5: "f", 6: "g", 7: "h"}
     G = nx.relabel_nodes(G, mapping)
-
     expected = [frozenset({"e", "d", "a", "b"}), frozenset({"c", "f", "g"})]
-
     assert greedy_modularity_communities(G) == expected
 
 

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -24,17 +24,25 @@ def test_modularity_communities(func):
     assert set(func(G)) == expected
 
 
+def test_greedy_modularity_communities_relabeled():
+    G = nx.balanced_tree(2, 2)
+    mapping = {0: "a", 1: "b", 2: "c", 3: "d", 4: "e", 5: "f", 6: "g", 7: "h"}
+    G = nx.relabel_nodes(G, mapping)
+
+    expected = [frozenset({"e", "d", "a", "b"}), frozenset({"c", "f", "g"})]
+
+    assert greedy_modularity_communities(G) == expected
+
+
 def test_modularity_communities_weighted():
     G = nx.balanced_tree(2, 3)
-    mapping = {0: 15}
-    G = nx.relabel_nodes(G, mapping)
     for (a, b) in G.edges:
-        if ((a == 1) or (a == 2)) and (b != 15):
+        if ((a == 1) or (a == 2)) and (b != 0):
             G[a][b]["weight"] = 10.0
         else:
             G[a][b]["weight"] = 1.0
 
-    expected = [{15, 1, 3, 4, 7, 8, 9, 10}, {2, 5, 6, 11, 12, 13, 14}]
+    expected = [{0, 1, 3, 4, 7, 8, 9, 10}, {2, 5, 6, 11, 12, 13, 14}]
 
     assert greedy_modularity_communities(G, weight="weight") == expected
 


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

Fixes [bug](https://github.com/networkx/networkx/issues/4966) which makes `greedy_modularity_communities` crash if the graph nodes have been relabeled. 