### PR TITLE
Remove default dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade pip wheel setuptools
-            pip install -r requirements.txt
+            pip install -r requirements/default.txt -r requirements/test.txt
             pip install -r requirements/extra.txt
             pip install -r requirements/example.txt
             pip install -r requirements/doc.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install packages
       run: |
         pip install --upgrade pip wheel setuptools
-        pip install -r requirements.txt
+        pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install packages
       run: |
         pip install --upgrade pip wheel setuptools
-        pip install -r requirements.txt
+        pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
         pip install -r requirements/example.txt
         pip install -U -r requirements/doc.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install packages
       run: |
         python -m pip install --upgrade pip wheel setuptools
-        python -m pip install -r requirements.txt
+        python -m pip install -r requirements/default.txt -r requirements/test.txt
         python -m pip install .
         python -m pip list
 
@@ -45,7 +45,7 @@ jobs:
       run: |
         pip install --upgrade pip wheel setuptools
         pip install -r requirements/test.txt
-        pip install . --no-deps
+        pip install .
         pip list
 
     - name: Test NetworkX
@@ -81,7 +81,7 @@ jobs:
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: |
         pip install --upgrade pip wheel setuptools
-        pip install -r requirements.txt
+        pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
         pip install .
         pip list
@@ -91,7 +91,7 @@ jobs:
       run: |
         echo "C:\Program Files\Graphviz\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         python -m pip install --upgrade pip wheel setuptools
-        python -m pip install -r requirements.txt
+        python -m pip install -r requirements/default.txt -r requirements/test.txt
         python -m pip install --global-option=build_ext `
                               --global-option="-IC:\Program Files\Graphviz\include" `
                               --global-option="-LC:\Program Files\Graphviz\lib" `
@@ -120,7 +120,7 @@ jobs:
     - name: Install packages
       run: |
         pip install --upgrade pip wheel setuptools
-        pip install --pre -r requirements.txt
+        pip install --pre -r requirements/default.txt -r requirements/test.txt
         pip install .
         pip list
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,7 @@ Development Workflow
          # Activate it
          source networkx-dev/bin/activate
          # Install main development and runtime dependencies of networkx
-         pip install -r requirements.txt -r requirements/developer.txt
+         pip install -r requirements/default.txt -r requirements/test.txt -r requirements/developer.txt
          #
          # (Optional) Install pygraphviz, pydot, and gdal packages
          # These packages require that you have your system properly configured
@@ -74,7 +74,7 @@ Development Workflow
          # conda install -c conda-forge --file requirements/extra.txt
          #
          # Install networkx from source
-         pip install -e . --no-deps
+         pip install -e .
          # Test your installation
          PYTHONPATH=. pytest networkx
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,21 +21,21 @@ Install the released version
 
 Install the current release of ``networkx`` with ``pip``::
 
-    $ pip install networkx
+    $ pip install networkx[default]
 
 To upgrade to a newer release use the ``--upgrade`` flag::
 
-    $ pip install --upgrade networkx
+    $ pip install --upgrade networkx[default]
 
 If you do not have permission to install software systemwide, you can
 install into your user directory using the ``--user`` flag::
 
-    $ pip install --user networkx
+    $ pip install --user networkx[default]
 
 If you do not want to install our dependencies (e.g., ``numpy``, ``scipy``, etc.),
 you can use::
 
-    $ pip install networkx --no-deps
+    $ pip install networkx
 
 This may be helpful if you are using PyPy or you are working on a project that
 only needs a limited subset of our functionality and you want to limit the
@@ -47,7 +47,7 @@ Alternatively, you can manually download ``networkx`` from
 To install one of these versions, unpack it and run the following from the
 top-level source directory using the Terminal::
 
-    $ pip install .
+    $ pip install .[default]
 
 Install the development version
 -------------------------------
@@ -64,9 +64,9 @@ Then do::
 
     $ git clone https://github.com/networkx/networkx.git
     $ cd networkx
-    $ pip install -e .
+    $ pip install -e .[default]
 
-The ``pip install -e .`` command allows you to follow the development branch as
+The ``pip install -e .[default]`` command allows you to follow the development branch as
 it changes by creating links in the right places and installing the command
 line scripts to the appropriate locations.
 
@@ -95,7 +95,7 @@ version requirements.
 
 To install ``networkx`` and extra packages, do::
 
-    $ pip install networkx[extra]
+    $ pip install networkx[default,extra]
 
 To explicitly install all optional packages, do::
 

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -26,17 +26,6 @@ Default dependencies
 
 We no longer depend on the "decorator" library.
 
-NumPy, SciPy, Matplotlib, and Pandas are now default dependencies due to their
-central position in the scientific Python ecosystem and the fact that they
-provide self-contained, easy to install wheels for pip.
-While we've made these core libraries of the scientific Python ecosystem default dependencies,
-much of NetworkX still works without these libraries and we expect that to continue.
-Be assured that we test NetworkX with and without the dependencies,
-so if you do **not** use functions that depend on external libraries
-you can install NetworkX using pip with the `--no-deps` flag::
-
-    $ pip install networkx --no-deps
-
 Deprecated code
 ---------------
 

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -6,8 +6,7 @@ Preparing for the 3.0 release
 
 .. note::
    Much of the work leading to the NetworkX 3.0 release will be included
-   in the NetworkX 2.6 and 2.7 releases.  For example, we are changing our
-   default dependencies in the 2.6 release and we are deprecating a lot
+   in the NetworkX 2.6 and 2.7 releases.  For example, we are deprecating a lot
    of old code in the 2.6 and 2.7 releases.  This guide will discuss this
    ongoing work and will help you understand what changes you can make now
    to minimize the disruption caused by the move to 3.0.

--- a/doc/release/release_2.6.rst
+++ b/doc/release/release_2.6.rst
@@ -23,9 +23,8 @@ Highlights
 This release is the result of 11 months of work with over 363 pull requests by
 91 contributors. Highlights include:
 
-- Dropped support for Python 3.6.
-- NumPy, SciPy, Matplotlib, and pandas are now default requirements.
-- NetworkX no longer depends on the library "decorator".
+- Dropped support for Python 3.6
+- Dropped "decorator" library dependency
 - Improved example gallery
 - Removed code for supporting Jython/IronPython
 - The ``__str__`` method for graph objects is more informative and concise.

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -8,7 +8,7 @@ structure, dynamics, and functions of complex networks.
 See https://networkx.org for complete documentation.
 """
 
-__version__ = "2.7rc1.dev0"
+__version__ = "2.6.2.dev0"
 
 
 def __getattr__(name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
--r requirements/default.txt
--r requirements/test.txt

--- a/setup.py
+++ b/setup.py
@@ -162,10 +162,10 @@ def parse_requirements_file(filename):
     return requires
 
 
-install_requires = parse_requirements_file("requirements/default.txt")
+install_requires = []
 extras_require = {
     dep: parse_requirements_file("requirements/" + dep + ".txt")
-    for dep in ["developer", "doc", "extra", "test"]
+    for dep in ["default", "developer", "doc", "extra", "test"]
 }
 
 with open("README.rst", "r") as fh:


### PR DESCRIPTION
Having scipy as a default dependency introduce a circular build dependency issue for scipy:  https://github.com/scipy/scipy/issues/14335 and https://github.com/serge-sans-paille/pythran/issues/1837

This PR removes numpy, scipy, matplotlib, and pandas as "default" dependencies for NetworkX.  With this PR,
```
pip install networkx
```
requires installing no additional packages and we will ask users to install networkx via
```
pip install networkx[default]
```

I propose releasing networkx 2.6.2 with this PR merged and removing 2.6.0 and 2.6.1.  I would still like to figure out a way for users to install networkx with its "default" dependencies using only
```
pip install networkx
```
for 2.7.  Currently, I think we may want to release two packages on PyPI:
- ``networkx-core`` for libraries that only need a small subset of our functionality and that are not interested in installing extra packages
- ``networkx`` for end-users who don't care about which libraries we use to provide basic functionality.

Of course, we will need to think through this a bit and we may need to work with projects (like ``pythran``) that depend on us.