### PR TITLE
Algorithm to get IN and OUT component of a directed graph

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -396,3 +396,160 @@ def condensation(G, scc=None):
     # Add a list of members (ie original nodes) to each node (ie scc) in C.
     nx.set_node_attributes(C, members, "members")
     return C
+
+
+@not_implemented_for("undirected")
+def in_component(G, scc_comp):
+    """Generate the IN component of a graph with respect to
+    a given strongly connected component.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        A directed graph.
+
+    scc_comp : set
+        A set of nodes belonging to a strongly connected
+        component of G.
+
+    Returns
+    -------
+    set
+        A set of nodes belonging to the IN component with
+        respect to `scc_comp`.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G is undirected.
+
+    Notes
+    -----
+    The IN component is part of the Web's graph structure as
+    described by Broder et al.[1]_.
+
+    References
+    ----------
+    .. [1] Graph structure in the web,
+       A. Broder, R. Kumar, F. Maghoul, P. Raghavan,
+       S. Rajagopalan, R. Stata, A. Tomkins, J. Wiener
+       Computer Networks, 33(1-6):309-320, (2000).
+
+    """
+    return in_or_out_component(G, scc_comp, comp_type="in")
+
+
+@not_implemented_for("undirected")
+def out_component(G, scc_comp):
+    """Generate the OUT component of a graph with respect to
+    a given strongly connected component.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        A directed graph.
+
+    scc_comp : set
+        A set of nodes belonging to a strongly connected
+        component of G.
+
+    Returns
+    -------
+    set
+        A set of nodes belonging to the OUT component with
+        respect to `scc_comp`.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G is undirected.
+
+    Notes
+    -----
+    The OUT component is part of the Web's graph structure as
+    described by Broder et al.[1]_.
+
+    References
+    ----------
+    .. [1] Graph structure in the web,
+       A. Broder, R. Kumar, F. Maghoul, P. Raghavan,
+       S. Rajagopalan, R. Stata, A. Tomkins, J. Wiener
+       Computer Networks, 33(1-6):309-320, (2000).
+
+    """
+    return in_or_out_component(G, scc_comp, comp_type="out")
+
+
+@not_implemented_for("undirected")
+def in_or_out_component(G, scc_comp, comp_type):
+    """Generate the IN/OUT component of a graph with respect to
+    a given strongly connected component.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        A directed graph.
+
+    scc_comp : set
+        A set of nodes belonging to a strongly connected
+        component of G.
+
+    comp_type : str
+        Specify which component to return. If 'in', returns
+        the IN component. If 'out', returns the OUT component.
+
+    Returns
+    -------
+    comp : set
+        A set of nodes belonging to the IN/OUT component with
+        respect to `scc_comp`.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G is undirected.
+
+    ValueError
+        If `comp_type` is neither 'in' nor 'out'.
+
+    Notes
+    -----
+    The IN/OUT component is part of the Web's graph structure as
+    described by Broder et al.[1]_.
+
+    References
+    ----------
+    .. [1] Graph structure in the web,
+       A. Broder, R. Kumar, F. Maghoul, P. Raghavan,
+       S. Rajagopalan, R. Stata, A. Tomkins, J. Wiener
+       Computer Networks, 33(1-6):309-320, (2000).
+
+    """
+    import random
+
+    # Gets a random node from the strongly connected component
+    # as a root for executing BFS.
+    random_scc_node = random.sample(scc_comp, 1)[0]
+
+    visited = [random_scc_node]
+    queue = [random_scc_node]
+    while queue:
+        node = queue.pop(0)
+
+        if comp_type == "in":
+            neighbors = G.predecessors(node)
+        elif comp_type == "out":
+            neighbors = G.successors(node)
+        else:
+            raise ValueError("Expect `comp_type` to be 'in' or 'out'.")
+
+        for n in neighbors:
+            if n not in visited:
+                visited.append(n)
+                queue.append(n)
+
+    # `visited` contains the IN/OUT component together with the
+    # strongly connected component. Use set difference to just
+    # get the IN/OUT component.
+    comp = set(visited).difference(scc_comp)
+    return comp

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -9,6 +9,9 @@ __all__ = [
     "strongly_connected_components_recursive",
     "kosaraju_strongly_connected_components",
     "condensation",
+    "in_component",
+    "out_component",
+    "in_or_out_component",
 ]
 
 
@@ -529,7 +532,7 @@ def in_or_out_component(G, scc_comp, comp_type):
 
     # Gets a random node from the strongly connected component
     # as a root for executing BFS.
-    random_scc_node = random.sample(scc_comp, 1)[0]
+    random_scc_node = random.sample(list(scc_comp), 1)[0]
 
     visited = [random_scc_node]
     queue = [random_scc_node]

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -202,3 +202,27 @@ class TestStronglyConnected:
             assert len(seen & component) == 0
             seen.update(component)
             component.clear()
+
+    def test_in_component(self):
+        G = nx.DiGraph({0: [1], 1: [2], 2: [3], 3: [1, 4]})
+        C = {frozenset([0])}
+        scc_comp = max(nx.strongly_connected_components(G), key=len)
+        in_comp = nx.in_component(G, scc_comp)
+        assert {frozenset(in_comp)} == C
+
+    def test_out_component(self):
+        G = nx.DiGraph({0: [1], 1: [2], 2: [3], 3: [1, 4]})
+        C = {frozenset([4])}
+        scc_comp = max(nx.strongly_connected_components(G), key=len)
+        out_comp = nx.out_component(G, scc_comp)
+        assert {frozenset(out_comp)} == C
+
+    def test_in_or_out_component(self):
+        G = nx.DiGraph({0: [1], 1: [2], 2: [3], 3: [1, 4]})
+        C_in = {frozenset([0])}
+        C_out = {frozenset([4])}
+        scc_comp = max(nx.strongly_connected_components(G), key=len)
+        in_comp = nx.in_or_out_component(G, scc_comp, comp_type="in")
+        out_comp = nx.in_or_out_component(G, scc_comp, comp_type="out")
+        assert {frozenset(in_comp)} == C_in
+        assert {frozenset(out_comp)} == C_out


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

I have added functions to extract the IN and OUT components of a directed graph (that contains a strongly connected component) using a simple random-start BFS. The IN and OUT components are those as described in this [paper by Broder et al][1]. 

This is my first PR in NetworkX, so I apologize beforehand if my code is badly written. In particular, I was having a lot of thoughts on how to properly refactor the `in_component` and `out_component` as their code content share a lot of similar lines. I look forward to hearing from the community on how to do this correctly as I am here to learn.

Some future work that I am considering are:
1. Add more tests.
2. Algorithm to compute TENDRILS and TUBE (refer to Broder et al.).
3. Uniting these components under a single Bow-tie diagram (defined by these IN, OUT, TENDRILS, TUBE components) function.

[1]: http://snap.stanford.edu/class/cs224w-readings/broder00bowtie.pdf
