### PR TITLE
Add multigraph betweenness

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -5,12 +5,12 @@ import warnings
 
 from networkx.utils import py_random_state
 from networkx.utils.decorators import not_implemented_for
+from networkx.algorithms.shortest_paths.weighted import _weight_function
 
 __all__ = ["betweenness_centrality", "edge_betweenness_centrality", "edge_betweenness"]
 
 
 @py_random_state(5)
-@not_implemented_for("multigraph")
 def betweenness_centrality(
     G, k=None, normalized=True, weight=None, endpoints=False, seed=None
 ):
@@ -147,7 +147,6 @@ def betweenness_centrality(
 
 
 @py_random_state(4)
-@not_implemented_for("multigraph")
 def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=None):
     r"""Compute betweenness centrality for edges.
 
@@ -277,6 +276,7 @@ def _single_source_shortest_path_basic(G, s):
 
 
 def _single_source_dijkstra_path_basic(G, s, weight):
+    weight = _weight_function(G, weight)
     # modified from Eppstein
     S = []
     P = {}
@@ -299,7 +299,7 @@ def _single_source_dijkstra_path_basic(G, s, weight):
         S.append(v)
         D[v] = dist
         for w, edgedata in G[v].items():
-            vw_dist = dist + edgedata.get(weight, 1)
+            vw_dist = dist + weight(v,w,edgedata)
             if w not in D and (w not in seen or vw_dist < seen[w]):
                 seen[w] = vw_dist
                 push(Q, (vw_dist, next(c), v, w))

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -404,6 +404,34 @@ def _rescale_e(betweenness, n, normalized, directed=False, k=None):
 
 @not_implemented_for("graph")
 def _get_edge_keys(G, weight):
+    r"""Similar to `_weight_function`. Returns a function that
+    returns the keys of edges with the lowest weight between
+    two nodes.
+
+    This function is only suitable for multigraphs.
+
+    Parameters
+    ----------
+    G : NetworkX graph.
+
+    weight : string or function
+        If it is callable, `weight` itself is returned. If it is a string,
+        it is assumed to be the name of the edge attribute that represents
+        the weight of an edge. In that case, a function is returned that
+        gets the edge weight according to the specified edge attribute.
+
+    Returns
+    -------
+    function
+        This function returns a callable that accepts exactly three inputs:
+        a node `u`, a node adjacent to the first one `v` and the edge attribute
+        dictionary `d` for the edge joining those nodes. That function returns
+        a list with integers representing the keys of those edges matching
+        the lowest `weight` of edges between `u` and `v`.
+
+    If any edge does not have an attribute with key `weight`, it is assumed to
+    have weight one.
+    """
     _weight = _weight_function(G, weight)
 
     def get_keys(u, v, d):
@@ -414,6 +442,26 @@ def _get_edge_keys(G, weight):
 
 
 def _add_edge_keys(G, betweenness, weight=None):
+    r"""Adds the corrected betweenness centrality (BC) values for multigraphs.
+
+    Parameters
+    ----------
+    G : NetworkX graph.
+
+    betweenness : dictionary
+        Dictionary mapping adjacent node tuples to betweenness centrality values.
+
+    weight : string or function
+        See `_get_edge_keys` for details. Defaults to `None`.
+
+    Returns
+    -------
+    edges : dictionary
+        The parameter `betweenness` including edges with keys and their
+        betweenness centrality values.
+
+    The BC value is divided among edges of equal weight.
+    """
     _keys = _get_edge_keys(G, weight)
     betweenness.update(dict.fromkeys(G.edges(keys=True), 0.0))
 

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -402,16 +402,23 @@ def _rescale_e(betweenness, n, normalized, directed=False, k=None):
     return betweenness
 
 
-def _add_edge_keys(G, betweenness, weight=None):
+@not_implemented_for("graph")
+def _get_edge_keys(G, weight):
     _weight = _weight_function(G, weight)
+
+    def get_keys(u, v, d):
+        w = _weight(u, v, d)
+        return [k for k in d if d[k].get(weight, 1) == w]
+
+    return get_keys
+
+
+def _add_edge_keys(G, betweenness, weight=None):
+    _keys = _get_edge_keys(G, weight)
     betweenness.update(dict.fromkeys(G.edges(keys=True), 0.0))
 
-    get_keys = lambda u, v, d: [
-        k for k in d if not weight or d[k].get(weight, 1) == _weight(u, v, d)
-    ]
-
     for u, v in G.edges():
-        keys = get_keys(u, v, G[u][v])
+        keys = _keys(u, v, G[u][v])
         for k in keys:
             betweenness[(u, v, k)] = betweenness[(u, v)] / len(keys)
 

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -147,6 +147,7 @@ def betweenness_centrality(
 
 
 @py_random_state(4)
+@not_implemented_for("multigraph")
 def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=None):
     r"""Compute betweenness centrality for edges.
 

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -238,9 +238,6 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
     )
     if G.is_multigraph():
         betweenness = _add_edge_keys(G, betweenness, weight=weight)
-        for e in G.edges():  # Remove edges without key
-            if e in betweenness:
-                del betweenness[e]
     return betweenness
 
 
@@ -469,5 +466,9 @@ def _add_edge_keys(G, betweenness, weight=None):
         keys = _keys(u, v, G[u][v])
         for k in keys:
             betweenness[(u, v, k)] = betweenness[(u, v)] / len(keys)
+
+    for e in G.edges():  # Remove edges without key
+        if e in betweenness:
+            del betweenness[e]
 
     return betweenness

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -426,8 +426,8 @@ def _get_edge_keys(G, weight):
         This function returns a callable that accepts exactly three inputs:
         a node `u`, a node adjacent to the first one `v` and the edge attribute
         dictionary `d` for the edge joining those nodes. That function returns
-        a list with integers representing the keys of those edges matching
-        the lowest `weight` of edges between `u` and `v`.
+        a list with edge keys of those edges matching the lowest `weight` of
+        edges between `u` and `v`.
 
     If any edge does not have an attribute with key `weight`, it is assumed to
     have weight one.

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -460,15 +460,12 @@ def _add_edge_keys(G, betweenness, weight=None):
     The BC value is divided among edges of equal weight.
     """
     _keys = _get_edge_keys(G, weight)
-    betweenness.update(dict.fromkeys(G.edges(keys=True), 0.0))
 
-    for u, v in G.edges():
+    edge_bc = dict.fromkeys(G.edges, 0.0)
+    for (u, v) in betweenness:
         keys = _keys(u, v, G[u][v])
+        bc = betweenness[(u, v)] / len(keys)
         for k in keys:
-            betweenness[(u, v, k)] = betweenness[(u, v)] / len(keys)
+            edge_bc[(u, v, k)] = bc
 
-    for e in G.edges():  # Remove edges without key
-        if e in betweenness:
-            del betweenness[e]
-
-    return betweenness
+    return edge_bc

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -427,7 +427,7 @@ def _add_edge_keys(G, betweenness, weight=None):
     for u, v in betweenness:
         d = G[u][v]
         wt = _weight(u, v, d)
-        keys = [k for k in d if d[k].get(weight, 1) == wt]
+        keys = [k for k in d if _weight(u, v, {k: d[k]}) == wt]
         bc = betweenness[(u, v)] / len(keys)
         for k in keys:
             edge_bc[(u, v, k)] = bc

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -411,7 +411,7 @@ def _add_edge_keys(G, betweenness, weight=None):
         Dictionary mapping adjacent node tuples to betweenness centrality values.
 
     weight : string or function
-        See `_get_edge_keys` for details. Defaults to `None`.
+        See `_weight_function´ for details. Defaults to `None`.
 
     Returns
     -------

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -3,9 +3,8 @@ import warnings
 
 from networkx.algorithms.centrality.betweenness import (
     _single_source_dijkstra_path_basic as dijkstra,
-)
-from networkx.algorithms.centrality.betweenness import (
     _single_source_shortest_path_basic as shortest_path,
+    _add_edge_keys,
 )
 
 __all__ = [
@@ -193,6 +192,11 @@ def edge_betweenness_centrality_subset(
     for n in G:  # remove nodes to only return edges
         del b[n]
     b = _rescale_e(b, len(G), normalized=normalized, directed=G.is_directed())
+    if G.is_multigraph():
+        b = _add_edge_keys(G, b, weight=weight)
+        for e in G.edges():  # Remove edges without key
+            if e in b:
+                del b[e]
     return b
 
 

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -194,9 +194,6 @@ def edge_betweenness_centrality_subset(
     b = _rescale_e(b, len(G), normalized=normalized, directed=G.is_directed())
     if G.is_multigraph():
         b = _add_edge_keys(G, b, weight=weight)
-        for e in G.edges():  # Remove edges without key
-            if e in b:
-                del b[e]
     return b
 
 

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -739,6 +739,7 @@ class TestWeightedEdgeBetweennessCentrality:
         """Edge betweenness centrality: normalized weighted multigraph"""
         eList = [
             (0, 1, 5),
+            (0, 1, 4),
             (0, 2, 4),
             (0, 3, 3),
             (0, 3, 3),
@@ -757,12 +758,13 @@ class TestWeightedEdgeBetweennessCentrality:
         b = nx.edge_betweenness_centrality(G, weight="weight", normalized=True)
         b_answer = {
             (0, 1, 0): 0.0,
+            (0, 1, 1): 0.5,
             (0, 2, 0): 1.0,
-            (0, 3, 0): 1.0,
-            (0, 3, 1): 1.0,
+            (0, 3, 0): 0.75,
+            (0, 3, 1): 0.75,
             (0, 4, 0): 1.0,
             (1, 2, 0): 2.0,
-            (1, 3, 0): 3.5,
+            (1, 3, 0): 3.0,
             (1, 3, 1): 0.0,
             (1, 4, 0): 1.5,
             (1, 4, 1): 0.0,

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -693,3 +693,78 @@ class TestWeightedEdgeBetweennessCentrality:
         norm = len(G) * (len(G) - 1) / 2
         for n in sorted(G.edges()):
             assert b[n] == pytest.approx(b_answer[n] / norm, abs=1e-7)
+
+    def test_weighted_multigraph(self):
+        eList = [
+            (0, 1, 5),
+            (0, 2, 4),
+            (0, 3, 3),
+            (0, 3, 3),
+            (0, 4, 2),
+            (1, 2, 4),
+            (1, 3, 1),
+            (1, 3, 2),
+            (1, 4, 3),
+            (1, 4, 4),
+            (2, 4, 5),
+            (3, 4, 4),
+            (3, 4, 4),
+        ]
+        G = nx.MultiGraph()
+        G.add_weighted_edges_from(eList)
+        b = nx.edge_betweenness_centrality(G, weight="weight", normalized=False)
+        b_answer = {
+            (0, 1, 0): 0.0,
+            (0, 2, 0): 1.0,
+            (0, 3, 0): 1.0,
+            (0, 3, 1): 1.0,
+            (0, 4, 0): 1.0,
+            (1, 2, 0): 2.0,
+            (1, 3, 0): 3.5,
+            (1, 3, 1): 0.0,
+            (1, 4, 0): 1.5,
+            (1, 4, 1): 0.0,
+            (2, 4, 0): 1.0,
+            (3, 4, 0): 0.25,
+            (3, 4, 1): 0.25,
+        }
+        for n in sorted(G.edges(keys=True)):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
+
+    def test_normalized_weighted_multigraph(self):
+        eList = [
+            (0, 1, 5),
+            (0, 2, 4),
+            (0, 3, 3),
+            (0, 3, 3),
+            (0, 4, 2),
+            (1, 2, 4),
+            (1, 3, 1),
+            (1, 3, 2),
+            (1, 4, 3),
+            (1, 4, 4),
+            (2, 4, 5),
+            (3, 4, 4),
+            (3, 4, 4),
+        ]
+        G = nx.MultiGraph()
+        G.add_weighted_edges_from(eList)
+        b = nx.edge_betweenness_centrality(G, weight="weight", normalized=True)
+        b_answer = {
+            (0, 1, 0): 0.0,
+            (0, 2, 0): 1.0,
+            (0, 3, 0): 1.0,
+            (0, 3, 1): 1.0,
+            (0, 4, 0): 1.0,
+            (1, 2, 0): 2.0,
+            (1, 3, 0): 3.5,
+            (1, 3, 1): 0.0,
+            (1, 4, 0): 1.5,
+            (1, 4, 1): 0.0,
+            (2, 4, 0): 1.0,
+            (3, 4, 0): 0.25,
+            (3, 4, 1): 0.25,
+        }
+        norm = len(G) * (len(G) - 1) / 2
+        for n in sorted(G.edges(keys=True)):
+            assert b[n] == pytest.approx(b_answer[n] / norm, abs=1e-7)

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -701,6 +701,7 @@ class TestWeightedEdgeBetweennessCentrality:
         """Edge betweenness centrality: weighted multigraph"""
         eList = [
             (0, 1, 5),
+            (0, 1, 4),
             (0, 2, 4),
             (0, 3, 3),
             (0, 3, 3),
@@ -719,12 +720,13 @@ class TestWeightedEdgeBetweennessCentrality:
         b = nx.edge_betweenness_centrality(G, weight="weight", normalized=False)
         b_answer = {
             (0, 1, 0): 0.0,
+            (0, 1, 1): 0.5,
             (0, 2, 0): 1.0,
-            (0, 3, 0): 1.0,
-            (0, 3, 1): 1.0,
+            (0, 3, 0): 0.75,
+            (0, 3, 1): 0.75,
             (0, 4, 0): 1.0,
             (1, 2, 0): 2.0,
-            (1, 3, 0): 3.5,
+            (1, 3, 0): 3.0,
             (1, 3, 1): 0.0,
             (1, 4, 0): 1.5,
             (1, 4, 1): 0.0,

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -56,6 +56,7 @@ class TestBetweennessCentrality:
             assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
 
     def test_sample_from_P3(self):
+        """Betweenness centrality: P3 sample"""
         G = nx.path_graph(3)
         b_answer = {0: 0.0, 1: 1.0, 2: 0.0}
         b = nx.betweenness_centrality(G, k=3, weight=None, normalized=False, seed=1)
@@ -636,6 +637,7 @@ class TestWeightedEdgeBetweennessCentrality:
             assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
 
     def test_weighted_graph(self):
+        """Edge betweenness centrality: weighted"""
         eList = [
             (0, 1, 5),
             (0, 2, 4),
@@ -665,6 +667,7 @@ class TestWeightedEdgeBetweennessCentrality:
             assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
 
     def test_normalized_weighted_graph(self):
+        """Edge betweenness centrality: normalized weighted"""
         eList = [
             (0, 1, 5),
             (0, 2, 4),
@@ -695,6 +698,7 @@ class TestWeightedEdgeBetweennessCentrality:
             assert b[n] == pytest.approx(b_answer[n] / norm, abs=1e-7)
 
     def test_weighted_multigraph(self):
+        """Edge betweenness centrality: weighted multigraph"""
         eList = [
             (0, 1, 5),
             (0, 2, 4),
@@ -732,6 +736,7 @@ class TestWeightedEdgeBetweennessCentrality:
             assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
 
     def test_normalized_weighted_multigraph(self):
+        """Edge betweenness centrality: normalized weighted multigraph"""
         eList = [
             (0, 1, 5),
             (0, 2, 4),

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -513,6 +513,44 @@ class TestWeightedBetweennessCentrality:
         for n in sorted(G):
             assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
 
+    def test_G3(self):
+        """Weighted betweenness centrality: G3"""
+        G = nx.MultiGraph(weighted_G())
+        es = list(G.edges(data=True))[::2]  # duplicate every other edge
+        G.add_edges_from(es)
+        b_answer = {0: 2.0, 1: 0.0, 2: 4.0, 3: 3.0, 4: 4.0, 5: 0.0}
+        b = nx.betweenness_centrality(G, weight="weight", normalized=False)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
+
+    def test_G4(self):
+        """Weighted betweenness centrality: G4"""
+        G = nx.MultiDiGraph()
+        G.add_weighted_edges_from(
+            [
+                ("s", "u", 10),
+                ("s", "x", 5),
+                ("s", "x", 6),
+                ("u", "v", 1),
+                ("u", "x", 2),
+                ("v", "y", 1),
+                ("v", "y", 1),
+                ("x", "u", 3),
+                ("x", "v", 5),
+                ("x", "y", 2),
+                ("x", "y", 3),
+                ("y", "s", 7),
+                ("y", "v", 6),
+                ("y", "v", 6),
+            ]
+        )
+
+        b_answer = {"y": 5.0, "x": 5.0, "s": 4.0, "u": 2.0, "v": 2.0}
+
+        b = nx.betweenness_centrality(G, weight="weight", normalized=False)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
+
 
 class TestEdgeBetweennessCentrality:
     def test_K5(self):


### PR DESCRIPTION
This PR adds betweenness centrality (BC) for multigraphs. The function ```betweenness_centrality``` is currently marked as ```@not_implemented_for("multigraph")``` however ```edge_betweenness_centrality``` is not even though it suffers from the same shortcomings. With this PR both functions should yield correct results.

The PR consists of three commits addressing issues with BC for multigraphs:

### Issues

**1. Edge betweenness centrality lacks ```not_implemented``` decorator**
The first commit marks ```èdge_betweenness_centrality``` as not implemented for multigraphs.
It suffers from the issues described below and should at least be marked correctly.

**2. Weighted betweenness centrality disregards weight of parallel edges**
The second commit resolves an issue regarding both betweenness for nodes and edges. For multigraphs ```G[v].items()``` returns ```w, edgedata``` like usual Graphs. However, ```edgedata``` differs in that it is first indexed by edge keys instead of weight keys. The implementation hence always calculates unweighted betweenness.

~~~python
>>> G = MultiGraph()
>>> G.add_edges_from(
            ((0, 1, {'w':20.8}), (1, 2, {'w':1.5}), (0, 2, {'w':1.8}))
            )
>>> edge_betweenness_centrality(G, weight='w')
{(0, 1): 0.3333333333333333,
(0, 2): 0.3333333333333333,
(1, 2): 0.3333333333333333}   
>>> # Correct would be: 0.0, 0.66.., 0.66...
~~~

For parallel edges we always have to consider the lowest weight. Fortunately, the weighted shortest paths module provides ```_weight_function```. Utilizing this import solves the issue.

However, this fix can only enable correct betweenness centrality for nodes. Edge betweenness centrality still suffers from the following issue.

**3. Edge betweenness centrality does not return edge keys**
Calculating edge betweenness centrality gives the values but not which edge key to apply them to.
This is especially a problem with the example given in [```set_edge_attributes```](https://networkx.org/documentation/stable/reference/generated/networkx.classes.function.set_edge_attributes.html). It does not work with multigraphs because of this design, however it would not fail to calculate the betweenness.

Also, parallel edges of equal weight should divide their value.

### Correctness

Correctness was checked using property based tests with a sample size of 1000. They are contained in my [other branch](https://github.com/pinselimo/networkx/tree/check-multigraph-betweenness) in ```examples/algorithms/betweenness/check_properties.py```.

```pytest``` has also been checked, although I haven't added additional tests so far. Give me a heads up if you deem them necessary.
And of course all code has been formatted with ```black```.

Thanks,
Simon