### PR TITLE
GDF file format support in readwrite

### DIFF
--- a/networkx/readwrite/__init__.py
+++ b/networkx/readwrite/__init__.py
@@ -55,6 +55,7 @@ from networkx.readwrite.graph6 import *
 from networkx.readwrite.gml import *
 from networkx.readwrite.graphml import *
 from networkx.readwrite.gexf import *
+from networkx.readwrite.gdf import *
 from networkx.readwrite.nx_shp import *
 from networkx.readwrite.json_graph import *
 from networkx.readwrite.text import *

--- a/networkx/readwrite/gdf.py
+++ b/networkx/readwrite/gdf.py
@@ -116,8 +116,7 @@ def gdf_split(line, types=None):
 
         buffer += character
 
-    if buffer:
-        values.append(buffer)
+    values.append(buffer)
 
     values = [value.strip() for value in values]
 
@@ -264,14 +263,30 @@ def write_gdf(G, path, encoding="utf-8", guess_types=True):
 
 
 @open_file(0, mode="r")
-def read_gdf(path):
-    """Read graph in GraphML format from a reader object
+def read_gdf(file):
+    """Read graph in GDF format from a file handler
 
     Parameters
     ----------
-    path : generator
-      A generator that yields a GDF network line by line, e.g. an open file
-      handler.
+    file
+      Open file reader from which GDF can be read
+
+    Returns
+    -------
+    graph : NetworkX graph
+      A Graph, as returned by `parse_gdf()` called on the file's full
+      contents.
+    """
+    return parse_gdf(file.read())
+
+
+def parse_gdf(gdf):
+    """Read graph in GDF format from a string
+
+    Parameters
+    ----------
+    gdf : string
+      A GDF file, as a string
 
     Returns
     -------
@@ -302,8 +317,12 @@ def read_gdf(path):
     node_index = 1
     is_directed = []
 
-    for line in path:
+    for line in gdf.split("\n"):
+        line = line.strip()
         line_num += 1
+
+        if not line:
+            continue
 
         if line.startswith("nodedef>"):
             # read node schema

--- a/networkx/readwrite/gdf.py
+++ b/networkx/readwrite/gdf.py
@@ -1,0 +1,313 @@
+"""Read and write graphs in GDF format.
+
+GDF (GUESS Data Format) is a simple file format for network files. It is
+supported by Gephi and GUESS, among others.
+
+Format
+------
+GDF is a plain-text format similar to CSV.  See
+https://gephi.org/users/supported-graph-formats/gdf-format/ for the
+specification and examples.
+"""
+import networkx as nx
+from networkx.utils import open_file
+import re
+
+
+def gdf_escape(value):
+    """Escape a value for inclusion in a GDF file
+
+    Parameters
+    ----------
+    value
+      A value to escape for inclusion in a GDF file
+
+    Returns
+    -------
+      The value, as an empty string if empty; as TRUE or FALSE (as strings) if
+      a boolean; as a string representation if an integer; or as a string
+      wrapped in single quotes with any single quotes inside the string slash-
+      escaped in other cases.
+
+    """
+    if value == "" or value is None:
+        return ""
+
+    if type(value) is bool:
+        return str(value).upper()
+
+    if type(value) is int:
+        return str(value)
+
+    return "'" + str(value).replace("'", "\\'").replace("\n", "\\n") + "'"
+
+
+def gdf_split(line, types=None):
+    """Parse a node or edge definition from a GDF file
+
+    Parses a line of values. Since values may be wrapped in single quotes, we
+    cannot simply split by commas. Instead, this implements a simple parser
+    that ignores single quotes unless escaped, and only splits on commas if
+    they are outside single quotes.
+
+    Parameters
+    ----------
+    line : str
+      Line of node or edge data to parse
+    types : list
+      A list of Gephi types in the same order as the values to be parsed, which
+      will be used to convert the values to the required type if possible. If
+      omitted, all values will be returned as strings. Values that cannot be
+      converted to the given type will be replaced with `None`.
+
+    Returns
+    -------
+    values : list
+      A list of parsed values, as strings.
+
+    """
+    buffer = ""
+    values = []
+    escape_open = False
+
+    while line:
+        character = line[0]
+        line = line[1:]
+
+        if character == "'":
+            if buffer and buffer[-1] == "\\":
+                buffer = buffer[:-1]
+            else:
+                escape_open = not escape_open
+                continue
+
+        if character == "," and not escape_open:
+            values.append(buffer)
+            buffer = ""
+            continue
+
+        buffer += character
+
+    if buffer:
+        values.append(buffer)
+
+    values = [value.strip() for value in values]
+
+    # convert to the required type
+    # this is sort of done on a best-effort bases - if the conversion fails,
+    # `None` is used instead. Unknown types are left as strings.
+    if types and len(types) == len(values):
+        for i, gdftype in enumerate(types):
+            if gdftype == "BOOLEAN":
+                values[i] = values[i].lower() == "true"
+            elif gdftype == "INTEGER" or gdftype.endswith("INT"):
+                try:
+                    values[i] = int(values[i])
+                except ValueError:
+                    values[i] = None
+            elif gdftype in ("FLOAT", "DOUBLE"):
+                try:
+                    values[i] = float(values[i])
+                except ValueError:
+                    values[i] = None
+
+    return values
+
+
+@open_file(1, mode="wb")
+def write_gdf(G, path, encoding="utf-8"):
+    """Write a NetworkX network as a GDF file to a given file path
+
+    Examples
+    --------
+    >>> nx.write_gdf(G, "network.gdf")
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX graph
+    path : file or string
+       File or filename to write.
+    encoding : string (optional)
+       Encoding for text data.
+
+    Notes
+    ----------
+    If the provided graph is a DiGraph or MultiDiGraph, the attribute
+    `directed` is set to `TRUE` for all edges. Otherwise, it is absent unless
+    it is specified explicitly in the edge's data.
+
+    If nodes have a `name` attribute in their data, the value of that attribute
+    is used as the node name in the GDF file. Otherwise, all nodes are given a
+    unique integer as their name.
+    """
+
+    def write_schema(component, path, columns):
+        schema = ",".join(columns)
+        path.write(("%sdef>%s\n" % (component, schema)).encode(encoding))
+
+    # determine node attributes to include
+    node_attributes = set()
+    name_map = {}
+    directed = type(G) in (nx.DiGraph, nx.MultiDiGraph)
+
+    for index, item_data in G.nodes(data=True):
+        node_attributes |= set(item_data.keys())
+        name_map[index] = item_data.get("name", index)
+
+    node_attributes.discard("name")
+    node_attributes = ["name", *sorted(node_attributes)]
+    write_schema("node", path, node_attributes)
+
+    # write nodes
+    for index, item_data in G.nodes(data=True):
+        if "name" in item_data:
+            del item_data["name"]
+
+        node_values = [gdf_escape(item_data.get(key)) for key in sorted(node_attributes) if key != "name"]
+        node_values.insert(0, gdf_escape(name_map[index]))
+        path.write((",".join(node_values) + "\n").encode(encoding))
+
+    # determine edge attributes to include
+    edge_attributes = set()
+    for from_index, to_index, edge_data in G.edges(data=True):
+        edge_attributes |= set(edge_data.keys())
+
+    edge_attributes.discard("node1")
+    edge_attributes.discard("node2")
+    if directed:
+        edge_attributes.add("directed")
+
+    edge_attributes = ["node1", "node2", *sorted(edge_attributes)]
+    write_schema("edge", path, edge_attributes)
+
+    # write edges
+    for from_index, to_index, edge_data in G.edges(data=True):
+        if directed:
+            edge_data["directed"] = True
+
+        edge_values = [gdf_escape(edge_data.get(key)) for key in sorted(edge_attributes) if key not in ("node1", "node2")]
+        edge_values.insert(0, gdf_escape(name_map[to_index]))
+        edge_values.insert(0, gdf_escape(name_map[from_index]))
+        path.write((",".join(edge_values) + "\n").encode(encoding))
+
+    # done!
+
+
+@open_file(0, mode="r")
+def read_gdf(path, encoding="utf-8"):
+    """Read graph in GraphML format from a reader object
+
+    Notes
+    ----------
+    The returned graph can be a Graph or a DiGraph. For it to be a DiGraph, all
+    edges must have a `directed` attribute, and the attribute must be set to
+    `True` for all of the edges.
+
+    Examples
+    --------
+    >>> with open("network.gdf") as infile:
+    >>>   G = nx.read_gdf(infile)
+
+    Parameters
+    ----------
+    path : generator
+      A generator that yields a GDF network line by line, e.g. an open file
+      handler.
+
+    Returns
+    -------
+    graph : NetworkX graph
+      The reconstructed graph. Any node and edge attributes, including
+      'name' for nodes and 'node1' and 'node2' for edges, are included as node
+      and edge data. Node IDs are not inferred from the GDF file, but will be
+      internally consistent (i.e. the edges will use the IDs for the
+      corresponding nodes, and so on).
+
+    """
+    reading_mode = None
+    node_attributes = []
+    node_types = []
+    edge_attributes = []
+    edge_types = []
+
+    G = nx.Graph()
+    line_num = 0
+    name_map = {}
+    node_index = 1
+
+    for line in path:
+        line_num += 1
+
+        if line.startswith("nodedef>"):
+            # read node schema
+            # *if* nodes are defined as having a type, store these as well so
+            # they can be used for parsing the values later
+            reading_mode = "node"
+            nodedef = re.sub(r"^nodedef>", "", line).strip()
+            for attribute in nodedef.split(","):
+                attribute = attribute.split(" ")
+                node_attributes.append(attribute[0])
+
+                if len(attribute) > 1:
+                    node_types.append(attribute[1])
+
+        elif line.startswith("edgedef>"):
+            # read edge schema
+            # identical to the node schema
+            reading_mode = "edge"
+            edgedef = re.sub(r"^edgedef>", "", line).strip()
+
+            for attribute in edgedef.split(","):
+                attribute = attribute.split(" ")
+                edge_attributes.append(attribute[0])
+
+                if len(attribute) > 1:
+                    edge_types.append(attribute[1])
+
+        elif reading_mode == "node":
+            # read node definitions
+            values = gdf_split(line, node_types)
+
+            if len(values) != len(node_attributes):
+                raise ImportError("Cannot parse GDF file: not all attributes specified for node on line %i" % line_num)
+
+            name = values[0]
+            name_map[name] = node_index
+
+            attributes = {node_attributes[i]: value for i, value in enumerate(values)}
+            G.add_nodes_from([(node_index, attributes)])
+            node_index += 1
+
+        elif reading_mode == "edge":
+            # read edge definitions
+            values = gdf_split(line, edge_types)
+
+            if len(values) != len(edge_attributes):
+                raise ImportError("Cannot parse GDF file: not all attributes specified for edge on line %i" % line_num)
+
+            node1 = values[0]
+            node2 = values[1]
+
+            if node1 not in name_map or node2 not in name_map:
+                raise ImportError("Cannot parse GDF file: edge references undefined node on line %i" % line_num)
+
+            attributes = {edge_attributes[i]: value for i, value in enumerate(values)}
+            G.add_edges_from([(name_map[node1], name_map[node2], attributes)])
+
+    # we can only know if the graph is directed *after* parsing the whole file
+    # since before that we don't know if all edges have their 'directed'
+    # attribute set to 'true', if they have one - so if that is the case, we
+    # re-create the graph here as a DiGraph
+    is_directed = False
+    if "directed" in edge_attributes:
+        for node1, node2, edge in G.edges(data=True):
+            is_directed = str(edge["directed"]).lower() == "true"
+
+    if is_directed:
+        DiG = nx.DiGraph()
+        DiG.add_nodes_from(G.nodes(data=True))
+        DiG.add_edges_from(G.edges(data=True))
+        return DiG
+    else:
+        return G

--- a/networkx/readwrite/gdf.py
+++ b/networkx/readwrite/gdf.py
@@ -1,15 +1,14 @@
 """Read and write graphs in GDF format.
 
 GDF (GUESS Data Format) is a simple file format for network files. It is
-supported by Gephi and GUESS, among others, and due to its simplicity it
-is used as a graph export format by research software like DMI-TCAT and
-4CAT.
+supported by Gephi and GUESS, among others, and due to its simplicity it is
+used as a graph export format by research software like DMI-TCAT and 4CAT.
 
 Format
 ------
-GDF is a plain-text format similar to CSV.  See
-https://gephi.org/users/supported-graph-formats/gdf-format/ for the
-specification and examples.
+GDF is a plain-text format that is sort of a mixture between CSV and SQL.  See
+https://gephi.org/users/supported-graph-formats/gdf-format/ for a specification
+and examples.
 """
 import networkx as nx
 from networkx.utils import open_file
@@ -35,13 +34,40 @@ def gdf_escape(value):
     if value == "" or value is None:
         return ""
 
-    if type(value) is bool:
+    elif type(value) is bool:
         return str(value).upper()
 
-    if type(value) is int:
+    elif type(value) in (int, float):
         return str(value)
 
     return "'" + str(value).replace("'", "\\'").replace("\n", "\\n") + "'"
+
+
+def gdf_guess(value):
+    """Try and guess GDF data type from given value
+
+    Parameters
+    ----------
+    value
+      The value to guess the type of
+
+    Returns
+    -------
+    value : string or None
+      The guessed value, as VARCHAR, DOUBLE, INTEGER or BOOLEAN. If no value
+      can be guessed, `None` is returned.
+
+    """
+    if type(value) is bool or (type(value) is str and value.lower() in ("true", "false")):
+        return "BOOLEAN"
+    elif type(value) is int or (type(value) is str and re.match(r"^[0-9]+$", value)):
+        return "INTEGER"
+    elif type(value) is float or (type(value) is str and re.match(r"^[0-9.]+$", value)):
+        return "DOUBLE"
+    elif type(value) is str and value:
+        return "VARCHAR"
+    else:
+        return None
 
 
 def gdf_split(line, types=None):
@@ -56,7 +82,7 @@ def gdf_split(line, types=None):
     ----------
     line : str
       Line of node or edge data to parse
-    types : list
+    types : list, optional
       A list of Gephi types in the same order as the values to be parsed, which
       will be used to convert the values to the required type if possible. If
       omitted, all values will be returned as strings. Values that cannot be
@@ -117,7 +143,7 @@ def gdf_split(line, types=None):
 
 
 @open_file(1, mode="wb")
-def write_gdf(G, path, encoding="utf-8"):
+def write_gdf(G, path, encoding="utf-8", guess_types=True):
     """Write a NetworkX network as a GDF file to a given file path
 
     Parameters
@@ -126,8 +152,13 @@ def write_gdf(G, path, encoding="utf-8"):
       A NetworkX graph
     path : file or string
        File or filename to write.
-    encoding : string (optional)
+    encoding : string, optional
        Encoding for text data.
+    guess_types : bool, optional
+        Whether to try and guess GDF types for node and edge attributes. If all
+        values for a given attribute are of the same time, the GDF data type
+        (VARCHAR, BOOLEAN, INTEGER or DOUBLE) will be inferred, else it will
+        not be set.
 
     Notes
     ----------
@@ -136,15 +167,21 @@ def write_gdf(G, path, encoding="utf-8"):
     it is specified explicitly in the edge's data.
 
     If nodes have a `name` attribute in their data, the value of that attribute
-    is used as the node name in the GDF file. Otherwise, all nodes are given a
-    unique integer as their name.
-    """
+    is used as the node name in the GDF file. Otherwise, all nodes use their
+    original ID as name.
 
-    def write_schema(component, path, columns):
-        schema = ",".join(columns)
-        path.write(("%sdef>%s\n" % (component, schema)).encode(encoding))
+    Graphs that are not a Graph, MultiGraph, DiGraph or MultiDiGraph will raise
+    a TypeError.
+    """
+    def write_schema(component, handle, columns, types):
+        schema = ",".join([column + types[i] for i, column in enumerate(columns)])
+        handle.write(("%sdef>%s\n" % (component, schema)).encode(encoding))
+
+    if type(G) not in (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph):
+        raise TypeError("Cannot write object of type %s as GDF file - must be standard Graph type" % type(G).__name__)
 
     # determine node attributes to include
+    # also create a map with 'name' attributes per node ID
     node_attributes = set()
     name_map = {}
     directed = type(G) in (nx.DiGraph, nx.MultiDiGraph)
@@ -153,15 +190,28 @@ def write_gdf(G, path, encoding="utf-8"):
         node_attributes |= set(item_data.keys())
         name_map[index] = item_data.get("name", index)
 
-    node_attributes.discard("name")
+    node_attributes.discard("name")  # move 'name' to front
     node_attributes = ["name", *sorted(node_attributes)]
-    write_schema("node", path, node_attributes)
+
+    # try to guess types if needed by seeing if all values for a given
+    # attribute map to the same GDF type, if so, use that one
+    node_types = ["" for attribute in node_attributes]
+    if guess_types:
+        for index, attribute in enumerate(node_attributes):
+            if index > 0:
+                guessed_types = [gdf_guess(node[1].get(attribute)) for node in G.nodes(data=True)]
+            else:
+                # node names are stored elsewhere
+                guessed_types = [gdf_guess(name) for name in name_map.values()]
+
+            type_test = list(set([t for t in guessed_types if t]))  # uniques
+            if len(type_test) == 1 and type_test[0] is not None:
+                node_types[index] = " " + type_test[0]
+
+    write_schema("node", path, node_attributes, node_types)
 
     # write nodes
     for index, item_data in G.nodes(data=True):
-        if "name" in item_data:
-            del item_data["name"]
-
         node_values = [gdf_escape(item_data.get(key)) for key in sorted(node_attributes) if key != "name"]
         node_values.insert(0, gdf_escape(name_map[index]))
         path.write((",".join(node_values) + "\n").encode(encoding))
@@ -171,20 +221,41 @@ def write_gdf(G, path, encoding="utf-8"):
     for from_index, to_index, edge_data in G.edges(data=True):
         edge_attributes |= set(edge_data.keys())
 
+    # standard attributes, the 'from' and 'to' nodes, are always at the front
     edge_attributes.discard("node1")
     edge_attributes.discard("node2")
     if directed:
         edge_attributes.add("directed")
 
     edge_attributes = ["node1", "node2", *sorted(edge_attributes)]
-    write_schema("edge", path, edge_attributes)
+
+    # try to guess types the same way as for nodes, with one exception: the
+    # 'directed' attribute is always a boolean if this is a directed graph
+    edge_types = ["" for attribute in edge_attributes]
+    if guess_types:
+        for index, attribute in enumerate(edge_attributes):
+            if directed and attribute == "directed":
+                # directed is always a boolean
+                guessed_types = ["BOOLEAN"]
+            elif index < 2:
+                # node names are stored elsewhere
+                guessed_types = [gdf_guess(name) for name in name_map.values()]
+            else:
+                guessed_types = [gdf_guess(edge[2].get(attribute)) for edge in G.edges(data=True)]
+
+            type_test = list(set([t for t in guessed_types if t]))
+            if len(type_test) == 1 and type_test[0] is not None:
+                edge_types[index] = " " + type_test[0]
+
+    write_schema("edge", path, edge_attributes, edge_types)
 
     # write edges
     for from_index, to_index, edge_data in G.edges(data=True):
         if directed:
             edge_data["directed"] = True
 
-        edge_values = [gdf_escape(edge_data.get(key)) for key in sorted(edge_attributes) if key not in ("node1", "node2")]
+        edge_values = [gdf_escape(edge_data.get(key)) for key in sorted(edge_attributes) if
+                       key not in ("node1", "node2")]
         edge_values.insert(0, gdf_escape(name_map[to_index]))
         edge_values.insert(0, gdf_escape(name_map[from_index]))
         path.write((",".join(edge_values) + "\n").encode(encoding))
@@ -193,14 +264,8 @@ def write_gdf(G, path, encoding="utf-8"):
 
 
 @open_file(0, mode="r")
-def read_gdf(path, encoding="utf-8"):
+def read_gdf(path):
     """Read graph in GraphML format from a reader object
-
-    Notes
-    ----------
-    The returned graph can be a Graph or a DiGraph. For it to be a DiGraph, all
-    edges must have a `directed` attribute, and the attribute must be set to
-    `True` for all of the edges.
 
     Parameters
     ----------
@@ -217,6 +282,13 @@ def read_gdf(path, encoding="utf-8"):
       internally consistent (i.e. the edges will use the IDs for the
       corresponding nodes, and so on).
 
+    Notes
+    ----------
+    The returned graph can be a Graph or a DiGraph. For it to be a DiGraph, all
+    edges must have a `directed` attribute, and the attribute must be set to
+    `True` for all of the edges.
+
+    If the graph cannot be parsed, a ValueError is raised.
     """
     reading_mode = None
     node_attributes = []
@@ -228,6 +300,7 @@ def read_gdf(path, encoding="utf-8"):
     line_num = 0
     name_map = {}
     node_index = 1
+    is_directed = []
 
     for line in path:
         line_num += 1
@@ -263,13 +336,13 @@ def read_gdf(path, encoding="utf-8"):
             values = gdf_split(line, node_types)
 
             if len(values) != len(node_attributes):
-                raise ImportError("Cannot parse GDF file: not all attributes specified for node on line %i" % line_num)
+                raise ValueError("Cannot parse GDF file: not all attributes specified for node on line %i" % line_num)
 
             name = values[0]
             name_map[name] = node_index
 
             attributes = {node_attributes[i]: value for i, value in enumerate(values)}
-            G.add_nodes_from([(node_index, attributes)])
+            G.add_node(node_index, **attributes)
             node_index += 1
 
         elif reading_mode == "edge":
@@ -277,27 +350,23 @@ def read_gdf(path, encoding="utf-8"):
             values = gdf_split(line, edge_types)
 
             if len(values) != len(edge_attributes):
-                raise ImportError("Cannot parse GDF file: not all attributes specified for edge on line %i" % line_num)
+                raise ValueError("Cannot parse GDF file: not all attributes specified for edge on line %i" % line_num)
 
             node1 = values[0]
             node2 = values[1]
 
             if node1 not in name_map or node2 not in name_map:
-                raise ImportError("Cannot parse GDF file: edge references undefined node on line %i" % line_num)
+                raise ValueError("Cannot parse GDF file: edge references undefined node on line %i" % line_num)
 
             attributes = {edge_attributes[i]: value for i, value in enumerate(values)}
-            G.add_edges_from([(name_map[node1], name_map[node2], attributes)])
+            G.add_edge(name_map[node1], name_map[node2], **attributes)
+            is_directed.append(str(attributes.get("directed")).lower() == "true")
 
     # we can only know if the graph is directed *after* parsing the whole file
     # since before that we don't know if all edges have their 'directed'
     # attribute set to 'true', if they have one - so if that is the case, we
     # re-create the graph here as a DiGraph
-    is_directed = False
-    if "directed" in edge_attributes:
-        for node1, node2, edge in G.edges(data=True):
-            is_directed = str(edge["directed"]).lower() == "true"
-
-    if is_directed:
+    if is_directed and all(is_directed):
         DiG = nx.DiGraph()
         DiG.add_nodes_from(G.nodes(data=True))
         DiG.add_edges_from(G.edges(data=True))

--- a/networkx/readwrite/gdf.py
+++ b/networkx/readwrite/gdf.py
@@ -1,7 +1,9 @@
 """Read and write graphs in GDF format.
 
 GDF (GUESS Data Format) is a simple file format for network files. It is
-supported by Gephi and GUESS, among others.
+supported by Gephi and GUESS, among others, and due to its simplicity it
+is used as a graph export format by research software like DMI-TCAT and
+4CAT.
 
 Format
 ------
@@ -118,10 +120,6 @@ def gdf_split(line, types=None):
 def write_gdf(G, path, encoding="utf-8"):
     """Write a NetworkX network as a GDF file to a given file path
 
-    Examples
-    --------
-    >>> nx.write_gdf(G, "network.gdf")
-
     Parameters
     ----------
     G : graph
@@ -203,11 +201,6 @@ def read_gdf(path, encoding="utf-8"):
     The returned graph can be a Graph or a DiGraph. For it to be a DiGraph, all
     edges must have a `directed` attribute, and the attribute must be set to
     `True` for all of the edges.
-
-    Examples
-    --------
-    >>> with open("network.gdf") as infile:
-    >>>   G = nx.read_gdf(infile)
 
     Parameters
     ----------

--- a/networkx/readwrite/tests/test_gdf.py
+++ b/networkx/readwrite/tests/test_gdf.py
@@ -38,7 +38,7 @@ nodedef>name,comma_foo,foo,num1,num2,quote_foo
 'third','bar,baz','bar',1,8.3,'bar\\'baz'
 edgedef>node1,node2,attribute_bar,attribute_foo
 'first','second',,'foo'
-'first','third',,
+'first','third',,,
 'second','third','bar',
 """
         cls.gdf_file_node_attr_error = """\

--- a/networkx/readwrite/tests/test_gdf.py
+++ b/networkx/readwrite/tests/test_gdf.py
@@ -38,7 +38,7 @@ nodedef>name,comma_foo,foo,num1,num2,quote_foo
 'third','bar,baz','bar',1,8.3,'bar\\'baz'
 edgedef>node1,node2,attribute_bar,attribute_foo
 'first','second',,'foo'
-'first','third',,,
+'first','third',,
 'second','third','bar',
 """
         cls.gdf_file_node_attr_error = """\

--- a/networkx/readwrite/tests/test_gdf.py
+++ b/networkx/readwrite/tests/test_gdf.py
@@ -1,0 +1,129 @@
+import pytest
+
+import networkx as nx
+from networkx.readwrite.gdf import read_gdf, write_gdf, gdf_split, gdf_escape
+from networkx.utils import edges_equal
+import tempfile
+
+
+class TestGDF:
+    @classmethod
+    def setup_class(cls):
+        cls.encoding = "utf-8"
+        cls.gdf_line = "'foo\\'bar','bar,baz',baz,'TRUE','25','9.8'\n"
+        cls.gdf_file_ok_directed = """\
+nodedef>name,comma_foo,foo,quote_foo
+'first','bar,baz','bar','bar\\'baz'
+'second','bar,baz','bar','bar\\'baz'
+'third','bar,baz','bar','bar\\'baz'
+edgedef>node1,node2,attribute_bar,attribute_foo,directed
+'first','second',,'foo',TRUE
+'first','third',,,TRUE
+'second','third','bar',,TRUE
+"""
+        cls.gdf_file_ok_undirected = """\
+nodedef>name,comma_foo,foo,quote_foo
+'first','bar,baz','bar','bar\\'baz'
+'second','bar,baz','bar','bar\\'baz'
+'third','bar,baz','bar','bar\\'baz'
+edgedef>node1,node2,attribute_bar,attribute_foo
+'first','second',,'foo'
+'first','third',,
+'second','third','bar',
+"""
+        cls.gdf_file_node_attr_error = """\
+nodedef>name,comma_foo,foo
+'first','bar,baz','bar','bar\\'baz'
+'second','bar,baz','bar','bar\\'baz'
+'third','bar,baz','bar','bar\\'baz'
+edgedef>node1,node2,attribute_bar,attribute_foo
+'first','second',,'foo'
+'first','third',,
+'second','third','bar',
+"""
+        cls.gdf_file_edge_attr_error = """\
+nodedef>name,comma_foo,foo,quote_foo
+'first','bar,baz','bar','bar\\'baz'
+'second','bar,baz','bar','bar\\'baz'
+'third','bar,baz','bar','bar\\'baz'
+edgedef>node1,node2,attribute_bar,attribute_foo
+'first','second',,'foo'
+'first','third',,
+'second','third','bar',
+"""
+        cls.G = nx.Graph()
+        cls.G.add_nodes_from([
+            (1, {"name": "first", "foo": "bar", "comma_foo": "bar,baz", "quote_foo": "bar'baz"}),
+            (2, {"name": "second", "foo": "bar", "comma_foo": "bar,baz", "quote_foo": "bar'baz"}),
+            (3, {"name": "third", "foo": "bar", "comma_foo": "bar,baz", "quote_foo": "bar'baz"})
+        ])
+        cls.G.add_edges_from([
+            (1, 2, {"attribute_foo": "foo"}),
+            (2, 3, {"attribute_bar": "bar"}),
+            (1, 3)
+        ])
+
+        cls.DiG = nx.DiGraph()
+        cls.DiG.add_nodes_from(cls.G.nodes(data=True))
+        cls.DiG.add_edges_from(cls.G.edges(data=True))
+
+    def test_gdf_split(self):
+        expected_naive = ["foo'bar", "bar,baz", "baz", "TRUE", "25", "9.8"]
+        expected_typed = ["foo'bar", "bar,baz", "baz", True, 25, 9.8]
+        types = ["VARCHAR", "VARCHAR", "VARCHAR", "BOOLEAN", "INTEGER", "FLOAT"]
+
+        assert expected_naive == gdf_split(self.gdf_line)
+        assert expected_typed == gdf_split(self.gdf_line, types)
+
+    def test_gdf_escape(self):
+        assert gdf_escape(True) == "TRUE"
+        assert gdf_escape(None) == ""
+        assert gdf_escape("") == ""
+        assert gdf_escape("foobar") == "'foobar'"
+        assert gdf_escape("foo,bar") == "'foo,bar'"
+        assert gdf_escape("foo'bar") == "'foo\\'bar'"
+
+    def test_read_gdf_undirected(self):
+        with tempfile.TemporaryFile("w+", encoding=self.encoding) as fake_file:
+            fake_file.write(self.gdf_file_ok_undirected)
+            fake_file.seek(0)
+            G = read_gdf(fake_file, encoding=self.encoding)
+
+        assert type(G) is nx.Graph
+        assert G.nodes(data=True) == self.G.nodes(data=True)
+        assert edges_equal(G.edges(), self.G.edges())
+
+    def test_read_gdf_directed(self):
+        with tempfile.TemporaryFile("w+", encoding=self.encoding) as fake_file:
+            fake_file.write(self.gdf_file_ok_directed)
+            fake_file.seek(0)
+            DiG = read_gdf(fake_file, encoding=self.encoding)
+
+        assert type(DiG) is nx.DiGraph
+        assert DiG.nodes(data=True) == self.DiG.nodes(data=True)
+        assert edges_equal(DiG.edges(), self.DiG.edges())
+
+    def test_read_gdf_node_exceptions(self):
+        with tempfile.TemporaryFile("w+", encoding=self.encoding) as fake_file:
+            fake_file.write(self.gdf_file_node_attr_error)
+            fake_file.seek(0)
+            pytest.raises(ImportError, read_gdf, fake_file, self.encoding)
+
+    def test_read_gdf_edge_exceptions(self):
+        with tempfile.TemporaryFile("w+", encoding=self.encoding) as fake_file:
+            fake_file.write(self.gdf_file_node_attr_error)
+            fake_file.seek(0)
+            pytest.raises(ImportError, read_gdf, fake_file, self.encoding)
+
+    def test_write_gdf_undirected(self):
+        with tempfile.TemporaryFile("w+b") as fake_file:
+            write_gdf(self.G, fake_file, encoding=self.encoding)
+            fake_file.seek(0)
+            fake_file.seek(0)
+            assert fake_file.read() == self.gdf_file_ok_undirected.encode(self.encoding)
+
+    def test_write_gdf_directed(self):
+        with tempfile.TemporaryFile("w+b") as fake_file:
+            write_gdf(self.DiG, fake_file, encoding=self.encoding)
+            fake_file.seek(0)
+            assert fake_file.read() == self.gdf_file_ok_directed.encode(self.encoding)


### PR DESCRIPTION
This PR adds support for the GDF network file format via the functions `read_gdf`, `parse_gdf`, `write_gdf` and `dump_gdf`.

An old issue #455 exists for this but was closed at the time because the two main applications known to use this format - Gephi and GUESS - also support other formats that NetworkX can read/write. However, some of the research software we use (e.g. [4CAT](github.com/digitalmethodsinitiative/4cat)) only supports GDF, and support for it in NetworkX would make it easier for people to use the output of that software, and would allow us to integrate NetworkX's functionality in our tools.

This is my first PR for NetworkX so please tell me if extra work would be needed before it can be merged!