### PR TITLE
Bugfix - use node labels with get_edge_data() at greedy_modularity_community()

### DIFF
--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -43,7 +43,7 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
     --------
     >>> from networkx.algorithms.community import greedy_modularity_communities
     >>> G = nx.karate_club_graph()
-    >>> c = list(greedy_modularity_communities(G))
+    >>> c = greedy_modularity_communities(G)
     >>> sorted(c[0])
     [8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
 
@@ -251,9 +251,10 @@ def naive_greedy_modularity_communities(G, resolution=1):
 
     Examples
     --------
-    >>> from networkx.algorithms.community import greedy_modularity_communities
+    >>> from networkx.algorithms.community import \
+    ... naive_greedy_modularity_communities
     >>> G = nx.karate_club_graph()
-    >>> c = list(greedy_modularity_communities(G))
+    >>> c = naive_greedy_modularity_communities(G)
     >>> sorted(c[0])
     [8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
 

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -69,7 +69,7 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
 
     # Count nodes and edges
     N = len(G.nodes())
-    m = sum([d.get("weight", 1) for u, v, d in G.edges(data=True)])
+    m = sum([d.get(weight, 1) for u, v, d in G.edges(data=True)])
     q0 = 1.0 / (2.0 * m)
 
     # Map node labels to contiguous integers

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -28,10 +28,15 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
     Parameters
     ----------
     G : NetworkX graph
+
     weight : string or None, optional (default=None)
-       The name of an edge attribute that holds the numerical value used
-       as a weight.  If None, then each edge has weight 1.
-       The degree is the sum of the edge weights adjacent to the node.
+        The name of an edge attribute that holds the numerical value used
+        as a weight.  If None, then each edge has weight 1.
+        The degree is the sum of the edge weights adjacent to the node.
+
+    resolution : float (default=1)
+        If resolution is less than 1, modularity favors larger communities.
+        Greater than 1 favors smaller communities.
 
     Returns
     -------
@@ -242,6 +247,10 @@ def naive_greedy_modularity_communities(G, resolution=1):
     Parameters
     ----------
     G : NetworkX graph
+
+    resolution : float (default=1)
+        If resolution is less than 1, modularity favors larger communities.
+        Greater than 1 favors smaller communities.
 
     Returns
     -------

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -10,43 +10,33 @@ from networkx.algorithms.community import (
 @pytest.mark.parametrize(
     "func", (greedy_modularity_communities, naive_greedy_modularity_communities)
 )
-@pytest.mark.parametrize(
-    "G, expected",
-    [
-        (
-            nx.karate_club_graph(),
-            {
-                # john_a
-                frozenset(
-                    [8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
-                ),
-                # mr_hi
-                frozenset([0, 4, 5, 6, 10, 11, 16, 19]),
-                # overlap
-                frozenset([1, 2, 3, 7, 9, 12, 13, 17, 21]),
-            },
-        ),
-        (
-            nx.Graph(
-                [
-                    ("a", "b"),
-                    ("a", "c"),
-                    ("b", "c"),
-                    ("a", "d"),
-                    ("b", "d"),
-                    ("d", "e"),  # inter-community edge
-                    ("d", "f"),
-                    ("d", "g"),
-                    ("f", "g"),
-                    ("d", "e"),
-                    ("f", "e"),
-                ]
-            ),
-            {frozenset({"f", "g", "e", "d"}), frozenset({"a", "b", "c"})},
-        ),
-    ],
-)
-def test_modularity_communities(func, G, expected):
+def test_modularity_communities(func):
+    G = nx.karate_club_graph()
+    john_a = frozenset(
+        [8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
+    )
+    mr_hi = frozenset([0, 4, 5, 6, 10, 11, 16, 19])
+    overlap = frozenset([1, 2, 3, 7, 9, 12, 13, 17, 21])
+    expected = {john_a, overlap, mr_hi}
+    assert set(func(G)) == expected
+
+    # Using other than 0-starting contiguous integers as node-labels.
+    G = nx.Graph(
+        [
+            ("a", "b"),
+            ("a", "c"),
+            ("b", "c"),
+            ("a", "d"),
+            ("b", "d"),
+            ("d", "e"),  # inter-community edge
+            ("d", "f"),
+            ("d", "g"),
+            ("f", "g"),
+            ("d", "e"),
+            ("f", "e"),
+        ]
+    )
+    expected = {frozenset({"f", "g", "e", "d"}), frozenset({"a", "b", "c"})}
     assert set(func(G)) == expected
 
 

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -20,15 +20,19 @@ def test_modularity_communities(func):
     expected = {john_a, overlap, mr_hi}
     assert set(func(G)) == expected
 
+
+@pytest.mark.parametrize(
+    "func", (greedy_modularity_communities, naive_greedy_modularity_communities)
+)
+def test_modularity_communities_categorical_labels(func):
     # Using other than 0-starting contiguous integers as node-labels.
     G = nx.Graph(
         [
             ("a", "b"),
             ("a", "c"),
             ("b", "c"),
-            ("a", "d"),
-            ("b", "d"),
-            ("d", "e"),  # inter-community edge
+            ("b", "d"),  # inter-community edge
+            ("d", "e"),
             ("d", "f"),
             ("d", "g"),
             ("f", "g"),

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -3,7 +3,6 @@ import pytest
 import networkx as nx
 from networkx.algorithms.community import (
     greedy_modularity_communities,
-    modularity,
     naive_greedy_modularity_communities,
 )
 
@@ -11,16 +10,43 @@ from networkx.algorithms.community import (
 @pytest.mark.parametrize(
     "func", (greedy_modularity_communities, naive_greedy_modularity_communities)
 )
-def test_modularity_communities(func):
-    G = nx.karate_club_graph()
-
-    john_a = frozenset(
-        [8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
-    )
-    mr_hi = frozenset([0, 4, 5, 6, 10, 11, 16, 19])
-    overlap = frozenset([1, 2, 3, 7, 9, 12, 13, 17, 21])
-    expected = {john_a, overlap, mr_hi}
-
+@pytest.mark.parametrize(
+    "G, expected",
+    [
+        (
+            nx.karate_club_graph(),
+            {
+                # john_a
+                frozenset(
+                    [8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
+                ),
+                # mr_hi
+                frozenset([0, 4, 5, 6, 10, 11, 16, 19]),
+                # overlap
+                frozenset([1, 2, 3, 7, 9, 12, 13, 17, 21]),
+            },
+        ),
+        (
+            nx.Graph(
+                [
+                    ("a", "b"),
+                    ("a", "c"),
+                    ("b", "c"),
+                    ("a", "d"),
+                    ("b", "d"),
+                    ("d", "e"),  # inter-community edge
+                    ("d", "f"),
+                    ("d", "g"),
+                    ("f", "g"),
+                    ("d", "e"),
+                    ("f", "e"),
+                ]
+            ),
+            {frozenset({"f", "g", "e", "d"}), frozenset({"a", "b", "c"})},
+        ),
+    ],
+)
+def test_modularity_communities(func, G, expected):
     assert set(func(G)) == expected
 
 


### PR DESCRIPTION
This patch solves the following bug:

In ```greedy_modularity_communities()``` an encoder/decoder pair is used (```node_for_label``` & ```label_for_node```), in order to encode node-labels to contiguous integers, to use them as indexes. In order to access edge data with ```G.get_edge_data(i, j)```, ```i``` and ```j``` have to be node-labels of G and NOT their integer representations. 

The current tests are using ```nx.karate_club_graph()```, which already has contiguous integers (starting from 0) as labels and, thus, ```node_for_label``` is encoding to the same labels:

```bash
python -c "import networkx as nx; print(nx.karate_club_graph().nodes)"
```

```
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
```

and the case where node-labels are not contiguous integers is not covered.

### How to reproduce:

```python
import networkx as nx
from networkx.algorithms.community import greedy_modularity_communities

def main():
  G = nx.Graph()
  G.add_edges_from([
    ('a', 'b'), ('a', 'c'), ('b', 'c'), ('a', 'd'), ('b', 'd'),
    ('d', 'e'),
    ('d', 'f'), ('d', 'g'), ('f', 'g'), ('d', 'e'), ('f', 'e')
  ])

  c = greedy_modularity_communities(G)
  for i in c:
    print(i)

if __name__ == "__main__":
  main()
```

```
Traceback (most recent call last):
  File "/path/to/test_script.py", line 15, in <module>
    main()
  File "/path/to/test_script.py", line 12, in main
    c = greedy_modularity_communities(G)
  File "/path/to/networkx/algorithms/community/modularity_max.py", line 98, in greedy_modularity_communities
    dq_dict = {
  File "/path/to/networkx/algorithms/community/modularity_max.py", line 99, in <dictcomp>
    i: {
  File "/path/to/networkx/algorithms/community/modularity_max.py", line 100, in <dictcomp>
    j: 2 * q0 * G.get_edge_data(i, j).get(weight, 1.0)
AttributeError: 'NoneType' object has no attribute 'get'
```

### Expected

```
frozenset({'g', 'e', 'd', 'f'})
frozenset({'b', 'a', 'c'})
```
### Solution

This fix uses the decoder to access the real node-labels, while querying for edge data:

```python
G.get_edge_data(label_for_node[i], label_for_node[j])
```
