### PR TITLE
Fix assort

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -75,9 +75,23 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     """
     if nodes is None:
         nodes = G.nodes
-    degrees = set([d for n, d in G.degree(nodes, weight=weight)])
+
+    degrees = None
+
+    if G.is_directed():
+        degree_method = {"out": G.out_degree, "in": G.in_degree}
+
+        degrees = set([d for _, d in degree_method[x](nodes, weight=weight)])
+
+        if y != x:
+            degrees.update([d for _, d in degree_method[y](nodes, weight=weight)])
+    else:
+        degrees = set([d for _, d in G.degree(nodes, weight=weight)])
+
     mapping = {d: i for i, d, in enumerate(degrees)}
+
     M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight, mapping=mapping)
+
     return numeric_ac(M, mapping=mapping)
 
 

--- a/networkx/algorithms/assortativity/tests/base_test.py
+++ b/networkx/algorithms/assortativity/tests/base_test.py
@@ -44,6 +44,8 @@ class BaseTestDegreeMixing:
         cls.P4 = nx.path_graph(4)
         cls.D = nx.DiGraph()
         cls.D.add_edges_from([(0, 2), (0, 3), (1, 3), (2, 3)])
+        cls.D2 = nx.DiGraph()
+        cls.D2.add_edges_from([(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3), (4, 2)])
         cls.M = nx.MultiGraph()
         nx.add_path(cls.M, range(4))
         cls.M.add_edge(0, 1)

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -22,6 +22,10 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         r = nx.degree_assortativity_coefficient(self.D)
         np.testing.assert_almost_equal(r, -0.57735, decimal=4)
 
+    def test_degree_assortativity_directed2(self):
+        r = nx.degree_assortativity_coefficient(self.D2)
+        np.testing.assert_almost_equal(r, 0.14852, decimal=4)
+
     def test_degree_assortativity_multigraph(self):
         r = nx.degree_assortativity_coefficient(self.M)
         np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
@@ -33,6 +37,10 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
     def test_degree_pearson_assortativity_directed(self):
         r = nx.degree_pearson_correlation_coefficient(self.D)
         np.testing.assert_almost_equal(r, -0.57735, decimal=4)
+
+    def test_degree_pearson_assortativity_directed2(self):
+        r = nx.degree_pearson_correlation_coefficient(self.D2)
+        np.testing.assert_almost_equal(r, 0.14852, decimal=4)
 
     def test_degree_pearson_assortativity_multigraph(self):
         r = nx.degree_pearson_correlation_coefficient(self.M)


### PR DESCRIPTION
This PR fixes #4998 by correcting the degree mapping for directed graphs in order to compute the assortativity properly with ``degree_assortativity_coefficient``.