### PR TITLE
Possible fix for floating point KeyError in greedy_modularity_communities

### DIFF
--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -10,6 +10,7 @@ __all__ = [
     "_naive_greedy_modularity_communities",
 ]
 
+_SIG_FIGS=6
 
 def greedy_modularity_communities(G, weight=None, resolution=1):
     r"""Find communities in G using greedy modularity maximization.
@@ -92,8 +93,8 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
     a = [k[i] * q0 for i in range(N)]
     dq_dict = {
         i: {
-            j: 2 * q0 * G.get_edge_data(i, j).get(weight, 1.0)
-            - 2 * resolution * k[i] * k[j] * q0 * q0
+            j: round(2 * q0 * G.get_edge_data(i, j).get(weight, 1.0)
+            - 2 * resolution * k[i] * k[j] * q0 * q0, _SIG_FIGS)
             for j in [node_for_label[u] for u in G.neighbors(label_for_node[i])]
             if j != i
         }
@@ -150,12 +151,12 @@ def greedy_modularity_communities(G, weight=None, resolution=1):
         for k in all_set:
             # Calculate new dq value
             if k in both_set:
-                dq_jk = dq_dict[j][k] + dq_dict[i][k]
+                dq_jk = round(dq_dict[j][k] + dq_dict[i][k],_SIG_FIGS)
             elif k in j_set:
-                dq_jk = dq_dict[j][k] - 2.0 * resolution * a[i] * a[k]
+                dq_jk = round(dq_dict[j][k] - 2.0 * resolution * a[i] * a[k],_SIG_FIGS)
             else:
                 # k in i_set
-                dq_jk = dq_dict[i][k] - 2.0 * resolution * a[j] * a[k]
+                dq_jk = round(dq_dict[i][k] - 2.0 * resolution * a[j] * a[k], _SIG_FIGS)
             # Update rows j and k
             for row, col in [(j, k), (k, j)]:
                 # Save old value for finding heap index

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -14,26 +14,27 @@ __all__ = [
 class _HeapProxy:
     def __init__(self, dq, i, j):
         self.data = (dq, i, j)
-        self.priority, *self.edge = self.data
-    
+        self.priority = dq
+        self.edge = (i, j)
+
     def __lt__(self, other):
         return self.priority < other.priority
-    
+
     def __gt__(self, other):
         return self.priority > other.priority
-    
+
     def __eq__(self, other):
         return self.edge == other.edge
-    
+
     def __hash__(self):
         return hash(self.edge)
-    
-    def __getitem__(self, key):
-        return self.data[key]
-    
+
+    def __getitem__(self, indx):
+        return self.data[indx]
+
     def __iter__(self):
         return iter(self.data)
-    
+
 
 def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1):
     r"""Find communities in G using greedy modularity maximization.
@@ -144,7 +145,8 @@ def greedy_modularity_communities(G, weight=None, resolution=1, n_communities=1)
         for i in range(N)
     }
     dq_heap = [
-        MappedQueue([_HeapProxy(-dq, i, j) for j, dq in dq_dict[i].items()]) for i in range(N)
+        MappedQueue([_HeapProxy(-dq, i, j) for j, dq in dq_dict[i].items()])
+        for i in range(N)
     ]
     H = MappedQueue([dq_heap[i].h[0] for i in range(N) if len(dq_heap[i]) > 0])
 


### PR DESCRIPTION
As per #4992, the existing implementation of `greedy_modularity_communities()` causes intermittent `KeyError`s due to its using a floating point number `dq` as one element of a dict key. One simple fix is to round `dq` to a reasonable number of significant figures.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
