### PR TITLE
Fixes #3112 - Extends greedy_modularity_communities() to digraphs, multigraphs and multidigraphs

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -283,9 +283,9 @@ def modularity(G, communities, weight="weight", resolution=1):
         These node sets must represent a partition of G's nodes.
 
     weight : string or None, optional (default="weight")
-            The edge attribute that holds the numerical value used
-            as a weight. If None or an edge does not have that attribute,
-            then that edge has weight 1.
+        The edge attribute that holds the numerical value used
+        as a weight. If None or an edge does not have that attribute,
+        then that edge has weight 1.
 
     resolution : float (default=1)
         If resolution is less than 1, modularity favors larger communities.


### PR DESCRIPTION
This PR fixes #3112 . ```greedy_modularity_communities()``` is extended to ```DiGraph```'s, ```MultiGraph```'s and ```MultiDiGraph```'s. The formulas used can be found in the [paper](https://github.com/elplatt/Paper-CNM-Modularity/blob/master/paper.pdf) provided by @elplatt.

The bulk of the changes concerns the initialization of the data structures:
- ΔQ matrix (```dq_dict```). It holds the ΔQ of the merge of every pair of communities
- ```a``` dict. It contains the fraction of (total weight of the) ends of edges that are attached to vertices in each community
- ```b``` dict. It is introduced when the graph is directed and contains the fraction of (total weight of the) heads (in_degree) of edges that are attached to vertices in each community. In that case, ```a``` contains the fraction of (total weight of the) tails (out_degree) of edges that are attached to vertices in each community.

One more significant change consists in ```node_for_label``` and ```label_for_node``` encoder/decoder dicts being removed. Therefore, a, b and dq_heap became dicts, accessing their entries with the true node-labels, instead of an integer encoding. This way, the code got somewhat simpler.

For multigraphs, see [this comment](https://github.com/networkx/networkx/issues/3112#issuecomment-891014425).