### PR TITLE
fix typo

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -45,7 +45,7 @@ def __getattr__(name):
             "directly:\n\n"
             "    import yaml\n\n"
             "    with open('path_for_yaml_output', 'w') as fh:\n"
-            "        yaml.dump(G_to_be_yaml, path_for_yaml_output, **kwds)\n\n"
+            "        yaml.dump(G_to_be_yaml, fh)\n\n"
             "This message will be removed in NetworkX 3.0."
         )
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/networkx/readwrite/__init__.py
+++ b/networkx/readwrite/__init__.py
@@ -38,7 +38,7 @@ def __getattr__(name):
             "directly:\n\n"
             "    import yaml\n\n"
             "    with open('path_for_yaml_output', 'w') as fh:\n"
-            "        yaml.dump(G_to_be_yaml, path_for_yaml_output, **kwds)\n\n"
+            "        yaml.dump(G_to_be_yaml, fh)\n\n"
             "This message will be removed in NetworkX 3.0."
         )
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -53,7 +53,8 @@ def __getattr__(name):
             "directly:\n\n"
             "    import yaml\n\n"
             "    with open('path_for_yaml_output', 'w') as fh:\n"
-            "        yaml.dump(G_to_be_yaml, path_for_yaml_output, **kwds)\n\n"
+            "        yaml.dump(G_to_be_yaml, fh, **kwds)\n\n"
+#             "        yaml.dump(G_to_be_yaml, fh)\n\n"
             "This message will be removed in NetworkX 3.0."
         )
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/networkx/readwrite/nx_yaml.py
+++ b/networkx/readwrite/nx_yaml.py
@@ -53,8 +53,7 @@ def __getattr__(name):
             "directly:\n\n"
             "    import yaml\n\n"
             "    with open('path_for_yaml_output', 'w') as fh:\n"
-            "        yaml.dump(G_to_be_yaml, fh, **kwds)\n\n"
-#             "        yaml.dump(G_to_be_yaml, fh)\n\n"
+            "        yaml.dump(G_to_be_yaml, fh)\n\n"
             "This message will be removed in NetworkX 3.0."
         )
     raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
I think there is at least one typo.

The first one is `path_for_yaml_output` should be substituted as `fh` for sure.

The second one is `**kwds` could be removed, but I`m not so sure, someone can decide on it.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
