### PR TITLE
Fix automatic documenting of class methods via autosummary

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -1,0 +1,33 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree: generated/
+
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :toctree: generated/
+
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -14,7 +14,9 @@
       :toctree: generated/
 
    {% for item in methods %}
-      ~{{ name }}.{{ item }}
+       {% if item != "__init__" %}
+          ~{{ name }}.{{ item }}
+       {% endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/doc/reference/algorithms/isomorphism.ismags.rst
+++ b/doc/reference/algorithms/isomorphism.ismags.rst
@@ -11,13 +11,6 @@ ISMAGS object
 .. currentmodule:: networkx.algorithms.isomorphism
 
 .. autosummary::
-    :toctree: generated/
+   :toctree: generated/
 
-     ISMAGS
-     ISMAGS.analyze_symmetry
-     ISMAGS.is_isomorphic
-     ISMAGS.subgraph_is_isomorphic
-     ISMAGS.isomorphisms_iter
-     ISMAGS.subgraph_isomorphisms_iter
-     ISMAGS.largest_common_subgraph
-
+   ISMAGS

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -1076,6 +1076,8 @@ class argmap:
         sig : argmap.Signature
             The Signature of f
 
+        Notes
+        -----
         The Signature is a namedtuple with names:
 
             name : a unique version of the name of the decorated function
@@ -1084,8 +1086,8 @@ class argmap:
             call_sig : a string used as code to call the decorated function
             names : a dict keyed by argument name and index to the argument's name
             n_positional : the number of positional arguments in the signature
-            args : the name of the VAR_POSITIONAL argument if any, i.e. *theseargs
-            kwargs : the name of the VAR_KEYWORDS argument if any, i.e. **kwargs
+            args : the name of the VAR_POSITIONAL argument if any, i.e. \*theseargs
+            kwargs : the name of the VAR_KEYWORDS argument if any, i.e. \*\*kwargs
 
         These named attributes of the signature are used in `assemble` and `compile`
         to construct a string of source code for the decorated function.


### PR DESCRIPTION
In the documentation currently, when a class is added to an `.. autosummary` directive, the docstring for the class itself is automatically generated for the reference docs, but any methods/attributes are not. For example, see the [docs for the argmap class](https://networkx.org/documentation/latest/reference/generated/networkx.utils.decorators.argmap.html#networkx.utils.decorators.argmap.__init__). The `__init__` method is automatically documented and embedded in the page (though in this case it doesn't have a docstring) while all of the other methods (`assemble`, `compile`, and `signature`) don't link to their respective docstrings.

The reason for this is that the default class template for `autosummary` is missing the `:toctree:` option, which is what signals to sphinx that `sphinx-autogen` should be used to autogenerate stubs for the items listed in the autosummary. This (and related) seems to be a pretty common feature request (see e.g. sphinx-doc/sphinx#7912) but is not (yet) built in to sphinx.

However, the linked issue also illustrates how we could achieve the desired behavior by overriding the default autosummary class template. This PR implements this approach by adding `:toctree:` to the default `.. autosummary` directive that enumerates class methods and attributes. This will autogenerate stubs for all class methods/attributes automatically, instead of having to indicate them manually (as was previously done in the docs for ISMAGS). I've chosen to preserve the default behavior of handling the `__init__` method specially (i.e. the `__init__` docstring is generated+rendered under the class docstring instead of in the `Methods` section) but that's easy to change if we want.