### PR TITLE
Store `G.adj` as a local variable to speed up `complement_edges(G)`

### DIFF
--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1124,7 +1124,7 @@ def complement_edges(G):
     >>> sorted(complement_edges(G))
     []
     """
-    adj = G.adj
+    adj = G._adj
     if G.is_directed():
         for u, v in it.combinations(G.nodes(), 2):
             if v not in adj[u]:

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1124,16 +1124,16 @@ def complement_edges(G):
     >>> sorted(complement_edges(G))
     []
     """
-    adj = G._adj
+    G_adj = G._adj  # Store as a variable to eliminate attribute lookup
     if G.is_directed():
         for u, v in it.combinations(G.nodes(), 2):
-            if v not in adj[u]:
+            if v not in G_adj[u]:
                 yield (u, v)
-            if u not in adj[v]:
+            if u not in G_adj[v]:
                 yield (v, u)
     else:
         for u, v in it.combinations(G.nodes(), 2):
-            if v not in adj[u]:
+            if v not in G_adj[u]:
                 yield (u, v)
 
 

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1124,15 +1124,16 @@ def complement_edges(G):
     >>> sorted(complement_edges(G))
     []
     """
+    adj = G.adj
     if G.is_directed():
         for u, v in it.combinations(G.nodes(), 2):
-            if v not in G.adj[u]:
+            if v not in adj[u]:
                 yield (u, v)
-            if u not in G.adj[v]:
+            if u not in adj[v]:
                 yield (v, u)
     else:
         for u, v in it.combinations(G.nodes(), 2):
-            if v not in G.adj[u]:
+            if v not in adj[u]:
                 yield (u, v)
 
 


### PR DESCRIPTION
As discussed in #3700, repetitive access to the `Graph.adj` property may degrade performance. This is the case for the current implementation of the `complement_edges` function located in `networkx.algorithms.connectivity.edge_augmentation.py`.

This PR includes a trivial change to store the adjacency view as a local variable instead of repeatedly accessing the property inside of a loop. This eliminates `(n choose 2)` function calls, so the performance gain can be noticeable.

Demo code (profiled line-by-line using [pprofile](https://pypi.org/project/pprofile/)):
```python
import pprofile
import networkx as nx
from networkx.algorithms.connectivity.edge_augmentation import complement_edges


if __name__ == "__main__":
    G = nx.complete_graph(1000)
    prof = pprofile.Profile()
    with prof():
        res = sorted(complement_edges(G))
    prof.dump_stats("stats.out")
```

Before change:
```
Total duration: 16.0684s
...
File: C:\Users\Andrew\Desktop\networkx\networkx\algorithms\connectivity\edge_augmentation.py
File duration: 5.00392s (31.14%)
Line #|      Hits|         Time| Time per hit|      %|Source code
------+----------+-------------+-------------+-------+-----------
...
  1103|         1|            0|            0|  0.00%|def complement_edges(G):
...
  1134|    499501|     0.654009|  1.30932e-06|  4.07%|        for u, v in it.combinations(G.nodes(), 2):
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\graph.py:661 nodes
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\reportviews.py:204 __call__
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\reportviews.py:184 __iter__
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\reportviews.py:181 __len__
  1135|    499500|      4.34991|  8.70854e-06| 27.07%|            if v not in G.adj[u]:
(call)|    499500|      3.27943|  6.56542e-06| 20.41%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\graph.py:338 adj
(call)|    499500|      3.41293|  6.83269e-06| 21.24%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\coreviews.py:81 __getitem__
(call)|    499500|      4.37214|  8.75304e-06| 27.21%|# C:\Users\Andrew\AppData\Local\Programs\Python\Python39\lib\_collections_abc.py:766 __contains__
  1136|         0|            0|            0|  0.00%|                yield (u, v)
```

After change: 
```
Total duration: 11.3651s
...
File: C:\Users\Andrew\Desktop\networkx\networkx\algorithms\connectivity\edge_augmentation.py
File duration: 3.71185s (32.66%)
Line #|      Hits|         Time| Time per hit|      %|Source code
------+----------+-------------+-------------+-------+-----------
...
  1103|         1|            0|            0|  0.00%|def complement_edges(G):
...
  1127|         1|            0|            0|  0.00%|    adj = G.adj
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\graph.py:338 adj
...
  1135|    499501|     0.528476|  1.05801e-06|  4.65%|        for u, v in it.combinations(G.nodes(), 2):
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\graph.py:661 nodes
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\reportviews.py:204 __call__
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\reportviews.py:184 __iter__
(call)|         1|            0|            0|  0.00%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\reportviews.py:181 __len__
  1136|    499500|      3.18338|  6.37312e-06| 28.01%|            if v not in adj[u]:
(call)|    499500|      3.24649|  6.49949e-06| 28.57%|# C:\Users\Andrew\Desktop\networkx\networkx\classes\coreviews.py:81 __getitem__
(call)|    499500|      4.40576|  8.82034e-06| 38.77%|# C:\Users\Andrew\AppData\Local\Programs\Python\Python39\lib\_collections_abc.py:766 __contains__
  1137|         0|            0|            0|  0.00%|                yield (u, v)
```