### PR TITLE
Fixed inconsistent documentation for nbunch parameter in DiGraph.edges()

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -947,7 +947,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges from these nodes (outgoing if directed).
+            The view will only report edges incident to these nodes.
 
         weight : string or None, optional (default=None)
            The name of an edge attribute that holds the numerical value used
@@ -994,7 +994,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges from these nodes (outgoing if directed).
+            The view will only report edges incident to these nodes.
 
         weight : string or None, optional (default=None)
            The name of an edge attribute that holds the numerical value used
@@ -1041,7 +1041,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges from these nodes (outgoing if directed).
+            The view will only report edges incident to these nodes.
 
         weight : string or None, optional (default=None)
            The name of an edge attribute that holds the numerical value used

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -855,7 +855,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes (outgoing if directed).
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
@@ -911,7 +911,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes (outgoing if directed).
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
@@ -947,7 +947,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes (outgoing if directed).
 
         weight : string or None, optional (default=None)
            The name of an edge attribute that holds the numerical value used
@@ -994,7 +994,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes (outgoing if directed).
 
         weight : string or None, optional (default=None)
            The name of an edge attribute that holds the numerical value used
@@ -1041,7 +1041,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes (outgoing if directed).
 
         weight : string or None, optional (default=None)
            The name of an edge attribute that holds the numerical value used

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -891,9 +891,9 @@ class DiGraph(Graph):
         OutEdgeDataView([(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})])
         >>> G.edges.data("weight", default=1)
         OutEdgeDataView([(0, 1, 1), (1, 2, 1), (2, 3, 5)])
-        >>> G.edges([0, 2])  # only edges incident to these nodes
+        >>> G.edges([0, 2])  # only edges originating from these nodes
         OutEdgeDataView([(0, 1), (2, 3)])
-        >>> G.edges(0)  # only edges incident to a single node (use G.adj[0]?)
+        >>> G.edges(0)  # only edges from node 0
         OutEdgeDataView([(0, 1)])
 
         """

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -855,7 +855,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges from these nodes (outgoing if directed).
+            The view will only report edges from these nodes.
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
@@ -911,7 +911,7 @@ class DiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges from these nodes (outgoing if directed).
+            The view will only report edges incident to these nodes.
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1273,7 +1273,7 @@ class Graph:
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes.
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).
@@ -1304,9 +1304,9 @@ class Graph:
         EdgeDataView([(0, 1, {}), (1, 2, {}), (2, 3, {'weight': 5})])
         >>> G.edges.data("weight", default=1)
         EdgeDataView([(0, 1, 1), (1, 2, 1), (2, 3, 5)])
-        >>> G.edges([0, 3])  # only edges incident to these nodes
+        >>> G.edges([0, 3])  # only edges from these nodes
         EdgeDataView([(0, 1), (3, 2)])
-        >>> G.edges(0)  # only edges incident to a single node (use G.adj[0]?)
+        >>> G.edges(0)  # only edges from node 0
         EdgeDataView([(0, 1)])
         """
         return EdgeView(self)

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -578,7 +578,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes.
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -760,7 +760,7 @@ class MultiGraph(Graph):
         Parameters
         ----------
         nbunch : single node, container, or all nodes (default= all nodes)
-            The view will only report edges incident to these nodes.
+            The view will only report edges from these nodes.
         data : string or bool, optional (default=False)
             The edge attribute returned in 3-tuple (u, v, ddict[data]).
             If True, return edge attribute dict in 3-tuple (u, v, ddict).


### PR DESCRIPTION
Closes #4985 
On going through the code ,I found that the "nbunch" parameter has been used more than a couple of times and the description for all of those was misleading . Hence I have fixed the description of each of those as required.
