### PR TITLE
Mark two atsp tests as slow

### DIFF
--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -732,6 +732,7 @@ def test_sample_spanning_tree():
     assert nx.utils.edges_equal(solution.edges, sampled_tree.edges)
 
 
+@pytest.mark.slow
 def test_sample_spanning_tree_large_sample():
     """
     Sample a single spanning tree from the distribution created in the last test
@@ -1018,6 +1019,7 @@ def test_asadpour_empty_graph():
     pytest.raises(nx.NetworkXError, nx_app.asadpour_atsp, G)
 
 
+@pytest.mark.slow
 def test_asadpour_integral_held_karp():
     """
     This test uses an integral held karp solution and the held karp function


### PR DESCRIPTION
#4740 recently included a lot of really nice tests for the aTSP problem. Two of those tests in particular have [quite long runtimes](https://github.com/networkx/networkx/pull/4740#discussion_r693340037). This PR proposes to mark these tests as slow so that they are not run in the test suite by default.