### PR TITLE
Update degree_alg.py

### DIFF
--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -4,7 +4,7 @@ from networkx.utils.decorators import not_implemented_for
 __all__ = ["degree_centrality", "in_degree_centrality", "out_degree_centrality"]
 
 
-def degree_centrality(G):
+def degree_centrality(G,nbunch=None,weight=None):
     """Compute the degree centrality for nodes.
 
     The degree centrality for a node v is the fraction of nodes it
@@ -37,12 +37,12 @@ def degree_centrality(G):
         return {n: 1 for n in G}
 
     s = 1.0 / (len(G) - 1.0)
-    centrality = {n: d * s for n, d in G.degree()}
+    centrality = {n: d * s for n, d in G.degree(nbunch,weight)}
     return centrality
 
 
 @not_implemented_for("undirected")
-def in_degree_centrality(G):
+def in_degree_centrality(G,nbunch=None,weight=None):
     """Compute the in-degree centrality for nodes.
 
     The in-degree centrality for a node v is the fraction of nodes its
@@ -80,12 +80,12 @@ def in_degree_centrality(G):
         return {n: 1 for n in G}
 
     s = 1.0 / (len(G) - 1.0)
-    centrality = {n: d * s for n, d in G.in_degree()}
+    centrality = {n: d * s for n, d in G.in_degree(nbunch,weight)}
     return centrality
 
 
 @not_implemented_for("undirected")
-def out_degree_centrality(G):
+def out_degree_centrality(G,nbunch=None,weight=None):
     """Compute the out-degree centrality for nodes.
 
     The out-degree centrality for a node v is the fraction of nodes its
@@ -123,5 +123,5 @@ def out_degree_centrality(G):
         return {n: 1 for n in G}
 
     s = 1.0 / (len(G) - 1.0)
-    centrality = {n: d * s for n, d in G.out_degree()}
+    centrality = {n: d * s for n, d in G.out_degree(nbunch,weight)}
     return centrality


### PR DESCRIPTION
In the original degree_alg.py, edge weights are ignored when computing the degree centrality. 
I think the edge weights should be considered.  The annotation is as follows.
Parameters
        ----------
        nbunch : single node, container, or all nodes (default= all nodes)
            The view will only report edges incident to these nodes.

        weight : string or None, optional (default=None)
           The name of an edge attribute that holds the numerical value used
           as a weight.  If None, then each edge has weight 1.
           The degree is the sum of the edge weights adjacent to the node.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
