### PR TITLE
Fix bug in selfloop drawing in draw_networkx_edges

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -852,10 +852,10 @@ def draw_networkx_edges(
     # Draw the edges
     if use_linecollection:
         edge_viz_obj = _draw_networkx_edges_line_collection()
-        # Make sure selfloop edges are also drawn.
-        edgelist = list(nx.selfloop_edges(G))
-        if edgelist:
-            edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in edgelist])
+        # Make sure selfloop edges are also drawn
+        selfloops_to_draw = [loop for loop in nx.selfloop_edges(G) if loop in edgelist]
+        if selfloops_to_draw:
+            edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in selfloops_to_draw])
             arrowstyle = "-"
             _draw_networkx_edges_fancy_arrow_patch()
     else:

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -423,3 +423,13 @@ def test_draw_networkx_arrows_default_directed(drawing_func):
     )
     assert ax.patches
     plt.delaxes(ax)
+
+
+def test_edgelist_kwarg_not_ignored():
+    # See gh-4994
+    G = nx.path_graph(3)
+    G.add_edge(0, 0)
+    fig, ax = plt.subplots()
+    nx.draw(G, edgelist=[(0, 1), (1, 2)], ax=ax)  # Exclude self-loop from edgelist
+    assert not ax.patches
+    plt.delaxes(ax)


### PR DESCRIPTION
Fixes #4994.

There is a bug in the current code where if a user tried to exclude self-loop drawing via the `edgelist` parameter, it would not work and the selfloops would be drawn anyways. This fixes that by only drawing selfloops when they are part of the original edgelist.