### PR TITLE
Potential resolution to full paths to functions in docs

### DIFF
--- a/doc/_templates/autosummary/base.rst
+++ b/doc/_templates/autosummary/base.rst
@@ -1,0 +1,5 @@
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/doc/developer/nxeps/nxep-0002.rst
+++ b/doc/developer/nxeps/nxep-0002.rst
@@ -310,6 +310,7 @@ Resolution
 To make slicing intuitive for new users, we went ahead with **Option 1** in the
 discussion above. Users will now see `NetworkXError` when they try to slice a
 `*View` object.::
+
    >>> G.edges()[0:10]
    Traceback (most recent call last)
       ...


### PR DESCRIPTION
Related to #4855 

The pydata-sphinx-theme appears to construct the sidebars elements in the docs directly from the html toctree elements. So, one way to address the "full paths in the sidebar" problem would be to modify the templates that the toctrees are constructed from for the files generated by autosummary.

This PR illustrates this approach by overriding the default autosummary template to use the specific `objname` var instead of the `fullname`. This "fixes" the sidebar problem, but also has other effects. For example, the titles of the autogenerated pages no longer include the full path, just the function/class name. Whether or not this is an improvement is in the eye of the beholder.

This is a pretty invasive solution to the problem that may have more subtle effects, since it involves changing the default template for all autogenerated docs. It would be nice to have a more specific solution that only effected the sidebar elements, but as of now I don't think the theme supports this - I'll open an issue there to see if there is a better solution. In the meantime, any feedback on the results here would be welcome!