### PR TITLE
Support `comments=None` in read/parse edgelist

### DIFF
--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -238,11 +238,14 @@ def parse_edgelist(
 
     G = nx.empty_graph(0, create_using)
     for line in lines:
-        p = line.find(comments)
-        if p >= 0:
-            line = line[:p]
-        if not line:
-            continue
+        try:  # Ignore case where comments=None
+            p = line.find(comments)
+            if p >= 0:
+                line = line[:p]
+            if not line:
+                continue
+        except TypeError:
+            pass
         # split line, should have 2 or more
         s = line.strip().split(delimiter)
         if len(s) < 2:

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -239,14 +239,12 @@ def parse_edgelist(
 
     G = nx.empty_graph(0, create_using)
     for line in lines:
-        try:  # Ignore case where comments=None
+        if comments is not None:
             p = line.find(comments)
             if p >= 0:
                 line = line[:p]
             if not line:
                 continue
-        except TypeError:
-            pass
         # split line, should have 2 or more
         s = line.strip().split(delimiter)
         if len(s) < 2:

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -183,7 +183,8 @@ def parse_edgelist(
     lines : list or iterator of strings
         Input data in edgelist format
     comments : string, optional
-       Marker for comment lines. Default is `'#'`
+       Marker for comment lines. Default is `'#'`. To specify that no character
+       should be treated as a comment, use ``comments=None``.
     delimiter : string, optional
        Separator for node labels. Default is `None`, meaning any whitespace.
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
@@ -317,7 +318,8 @@ def read_edgelist(
        opened in 'rb' mode.
        Filenames ending in .gz or .bz2 will be uncompressed.
     comments : string, optional
-       The character used to indicate the start of a comment.
+       The character used to indicate the start of a comment. To specify that
+       no character should be treated as a comment, use ``comments=None``.
     delimiter : string, optional
        The string used to separate values.  The default is whitespace.
     create_using : NetworkX graph constructor, optional (default=nx.Graph)

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -161,6 +161,14 @@ def test_parse_edgelist():
         nx.parse_edgelist(lines, nodetype=int, data=(("weight", float),))
 
 
+def test_comments_None():
+    edgelist = ["node#1 node#2", "node#2 node#3"]
+    # comments=None supported to ignore all comment characters
+    G = nx.parse_edgelist(edgelist, comments=None)
+    H = nx.Graph([e.split(" ") for e in edgelist])
+    assert edges_equal(G.edges, H.edges)
+
+
 class TestEdgelist:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Closes #4989

Adds support for `comments=None` to allow users to indicate that *no* character should be interpreted as indicating the start of a comment. This is a pretty niche case, but one could imagine a scenario where node names in an edgelist can be composed of a wide range of characters. If a user reading an edgelist wants to guarantee that part of a node string won't erroneously be taken as the start of a comment, they need to select a character to pass into the `comments` kwarg that is *not* used in any of the node names in the data file. Adding support for `comments=None` is a more straightforward solution for this case.