### PR TITLE
More informative GraphML exceptions

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -429,7 +429,7 @@ class GraphML:
                 (np.intp, "int"),
             ] + types
 
-        self._xml_type = dict(types)
+        self.xml_type = dict(types)
         self.python_type = dict(reversed(a) for a in types)
 
     # This page says that data types in GraphML follow Java(TM).
@@ -447,9 +447,12 @@ class GraphML:
         1: True,
     }
 
-    def xml_type(self, key):
+    def get_xml_type(self, key):
+        """Wrapper around the xml_type dict that raises a more informative
+        exception message when a user attempts to use data of a type not
+        supported by GraphML."""
         try:
-            return self._xml_type[key]
+            return self.xml_type[key]
         except KeyError as e:
             raise TypeError(
                 f"GraphML does not support type {type(key)} as data values."
@@ -512,7 +515,7 @@ class GraphMLWriter(GraphML):
             types = self.attribute_types[(name, scope)]
 
             if len(types) > 1:
-                types = {self.xml_type(t) for t in types}
+                types = {self.get_xml_type(t) for t in types}
                 if "string" in types:
                     return str
                 elif "float" in types or "double" in types:
@@ -555,11 +558,11 @@ class GraphMLWriter(GraphML):
         Make a data element for an edge or a node. Keep a log of the
         type in the keys table.
         """
-        if element_type not in self._xml_type:
+        if element_type not in self.xml_type:
             raise nx.NetworkXError(
                 f"GraphML writer does not support {element_type} as data values."
             )
-        keyid = self.get_key(name, self.xml_type(element_type), scope, default)
+        keyid = self.get_key(name, self.get_xml_type(element_type), scope, default)
         data_element = self.myElement("data", key=keyid)
         data_element.text = str(value)
         return data_element
@@ -773,7 +776,7 @@ class GraphMLWriterLxml(GraphMLWriter):
         for k, v in graphdata.items():
             self.attribute_types[(str(k), "graph")].add(type(v))
         for k, v in graphdata.items():
-            element_type = self.xml_type(self.attr_type(k, "graph", v))
+            element_type = self.get_xml_type(self.attr_type(k, "graph", v))
             self.get_key(str(k), element_type, "graph", None)
         # Nodes and data
         for node, d in G.nodes(data=True):
@@ -781,7 +784,7 @@ class GraphMLWriterLxml(GraphMLWriter):
                 self.attribute_types[(str(k), "node")].add(type(v))
         for node, d in G.nodes(data=True):
             for k, v in d.items():
-                T = self.xml_type(self.attr_type(k, "node", v))
+                T = self.get_xml_type(self.attr_type(k, "node", v))
                 self.get_key(str(k), T, "node", node_default.get(k))
         # Edges and data
         if G.is_multigraph():
@@ -790,7 +793,7 @@ class GraphMLWriterLxml(GraphMLWriter):
                     self.attribute_types[(str(k), "edge")].add(type(v))
             for u, v, ekey, d in G.edges(keys=True, data=True):
                 for k, v in d.items():
-                    T = self.xml_type(self.attr_type(k, "edge", v))
+                    T = self.get_xml_type(self.attr_type(k, "edge", v))
                     self.get_key(str(k), T, "edge", edge_default.get(k))
         else:
             for u, v, d in G.edges(data=True):
@@ -798,7 +801,7 @@ class GraphMLWriterLxml(GraphMLWriter):
                     self.attribute_types[(str(k), "edge")].add(type(v))
             for u, v, d in G.edges(data=True):
                 for k, v in d.items():
-                    T = self.xml_type(self.attr_type(k, "edge", v))
+                    T = self.get_xml_type(self.attr_type(k, "edge", v))
                     self.get_key(str(k), T, "edge", edge_default.get(k))
 
         # Now add attribute keys to the xml file

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -765,7 +765,12 @@ class GraphMLWriterLxml(GraphMLWriter):
         for k, v in graphdata.items():
             self.attribute_types[(str(k), "graph")].add(type(v))
         for k, v in graphdata.items():
-            element_type = self.xml_type[self.attr_type(k, "graph", v)]
+            try:
+                element_type = self.xml_type[self.attr_type(k, "graph", v)]
+            except KeyError as e:
+                raise TypeError(
+                    f"GraphML does not support {type(v)} as data values."
+                ) from e
             self.get_key(str(k), element_type, "graph", None)
         # Nodes and data
         for node, d in G.nodes(data=True):

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1505,6 +1505,7 @@ class TestXMLGraphML(TestWriteGraphML):
 def test_exception_for_unsupported_datatype_node_attr():
     """Test that a detailed exception is raised when an attribute is of a type
     not supported by GraphML, e.g. a list"""
+    pytest.importorskip("lxml.etree")
     # node attribute
     G = nx.Graph()
     G.add_node(0, my_list_attribute=[0, 1, 2])
@@ -1516,6 +1517,7 @@ def test_exception_for_unsupported_datatype_node_attr():
 def test_exception_for_unsupported_datatype_edge_attr():
     """Test that a detailed exception is raised when an attribute is of a type
     not supported by GraphML, e.g. a list"""
+    pytest.importorskip("lxml.etree")
     # edge attribute
     G = nx.Graph()
     G.add_edge(0, 1, my_list_attribute=[0, 1, 2])
@@ -1527,6 +1529,7 @@ def test_exception_for_unsupported_datatype_edge_attr():
 def test_exception_for_unsupported_datatype_graph_attr():
     """Test that a detailed exception is raised when an attribute is of a type
     not supported by GraphML, e.g. a list"""
+    pytest.importorskip("lxml.etree")
     # graph attribute
     G = nx.Graph()
     G.graph["my_list_attribute"] = [0, 1, 2]

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1500,3 +1500,36 @@ class TestXMLGraphML(TestWriteGraphML):
     @classmethod
     def setup_class(cls):
         TestWriteGraphML.setup_class()
+
+
+def test_exception_for_unsupported_datatype_node_attr():
+    """Test that a detailed exception is raised when an attribute is of a type
+    not supported by GraphML, e.g. a list"""
+    # node attribute
+    G = nx.Graph()
+    G.add_node(0, my_list_attribute=[0, 1, 2])
+    fh = io.BytesIO()
+    with pytest.raises(TypeError, match="GraphML does not support"):
+        nx.write_graphml(G, fh)
+
+
+def test_exception_for_unsupported_datatype_edge_attr():
+    """Test that a detailed exception is raised when an attribute is of a type
+    not supported by GraphML, e.g. a list"""
+    # edge attribute
+    G = nx.Graph()
+    G.add_edge(0, 1, my_list_attribute=[0, 1, 2])
+    fh = io.BytesIO()
+    with pytest.raises(TypeError, match="GraphML does not support"):
+        nx.write_graphml(G, fh)
+
+
+def test_exception_for_unsupported_datatype_graph_attr():
+    """Test that a detailed exception is raised when an attribute is of a type
+    not supported by GraphML, e.g. a list"""
+    # graph attribute
+    G = nx.Graph()
+    G.graph["my_list_attribute"] = [0, 1, 2]
+    fh = io.BytesIO()
+    with pytest.raises(TypeError, match="GraphML does not support"):
+        nx.write_graphml(G, fh)


### PR DESCRIPTION
Closes #5024

Modifies how the dict that defines supported GraphML types is accessed so that an informative exception is raised if a user tries to save an attribute of an unsupported type.

This solution is technically backward incompatible, as it changes the (currently public) `xml_types` attr of the `GraphML` class from a dict to a method. The reason for doing it this way is that it provides an easy way to ensure that the exception is raised for all of node, edge, and graph attrs. If this is a problem though, we can always go with the clunkier (but backward compatible) approach which would add try-excepts each time the dict is accessed. LMK what you think!