### PR TITLE
Add dot io to readwrite

### DIFF
--- a/doc/reference/readwrite/dot.rst
+++ b/doc/reference/readwrite/dot.rst
@@ -1,7 +1,8 @@
 DOT 
 ===
-The DOT graph description language defines a file format that is most often
-used in the context of graph visualization with the Graphviz package.
+The `DOT graph description language <https://graphviz.org/doc/info/lang.html>`__
+defines a file format that is most often used in the context of graph
+visualization with the Graphviz package.
 NetworkX provides interfaces to Graphviz through two different external
 packages: ``pydot`` and :doc:`pygraphviz <pygraphviz:index>`, implemented in
 `~networkx.drawing.nx_pydot` and `~networkx.drawing.nx_agraph`

--- a/doc/reference/readwrite/dot.rst
+++ b/doc/reference/readwrite/dot.rst
@@ -1,0 +1,24 @@
+DOT 
+===
+The DOT graph description language defines a file format that is most often
+used in the context of graph visualization with the Graphviz package.
+NetworkX provides interfaces to Graphviz through two different external
+packages: `pydot` and `pygraphviz`, implemented in `nx_pydot` and `nx_agraph`
+respectively. If these packages are installed, NetworkX can be used to
+read and write files in DOT format.
+
+pydot
+-----
+.. currentmodule:: networkx.drawing.nx_pydot
+.. autosummary::
+
+   read_dot
+   write_dot
+
+pygraphviz
+----------
+.. currentmodule:: networkx.drawing.nx_agraph
+.. autosummary::
+
+   read_dot
+   write_dot

--- a/doc/reference/readwrite/dot.rst
+++ b/doc/reference/readwrite/dot.rst
@@ -3,7 +3,8 @@ DOT
 The DOT graph description language defines a file format that is most often
 used in the context of graph visualization with the Graphviz package.
 NetworkX provides interfaces to Graphviz through two different external
-packages: `pydot` and `pygraphviz`, implemented in `nx_pydot` and `nx_agraph`
+packages: ``pydot`` and :doc:`pygraphviz <pygraphviz:index>`, implemented in
+`~networkx.drawing.nx_pydot` and `~networkx.drawing.nx_agraph`
 respectively. If these packages are installed, NetworkX can be used to
 read and write files in DOT format.
 

--- a/doc/reference/readwrite/dot.rst
+++ b/doc/reference/readwrite/dot.rst
@@ -1,21 +1,13 @@
 DOT 
 ===
+
 The `DOT graph description language <https://graphviz.org/doc/info/lang.html>`__
 defines a file format that is most often used in the context of graph
-visualization with the Graphviz package.
-NetworkX provides interfaces to Graphviz through two different external
-packages: ``pydot`` and :doc:`pygraphviz <pygraphviz:index>`, implemented in
-`~networkx.drawing.nx_pydot` and `~networkx.drawing.nx_agraph`
-respectively. If these packages are installed, NetworkX can be used to
+visualization with `Graphviz <https://graphviz.org>`__.
+NetworkX provides an interface to Graphviz via :doc:`pygraphviz <pygraphviz:index>`,
+implemented in `~networkx.drawing.nx_agraph`.
+If ``pygraphviz`` is installed, `~networkx.drawing.nx_agraph` can be used to
 read and write files in DOT format.
-
-pydot
------
-.. currentmodule:: networkx.drawing.nx_pydot
-.. autosummary::
-
-   read_dot
-   write_dot
 
 pygraphviz
 ----------

--- a/doc/reference/readwrite/index.rst
+++ b/doc/reference/readwrite/index.rst
@@ -9,6 +9,7 @@ Reading and writing graphs
 
    adjlist
    multiline_adjlist
+   dot
    edgelist
    gexf
    gml


### PR DESCRIPTION
Addresses #4311, though probably doesn't close it.

[One of the suggestions](https://github.com/networkx/networkx/issues/4311#issuecomment-720019303) is to add NetworkX's functionality related to I/O from DOT files to the `readwrite` section of the refguide. This will make the DOT I/O functionality more discoverable for users who are interested in reading/writing graphs in DOT format. 