### PR TITLE
Discussion: introducing some keyword-only args for NX 3.0

### DIFF
--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -51,7 +51,7 @@ def spectral_bipartivity(G, nodes=None, weight="weight"):
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist, weight=weight)
+    A = nx.to_numpy_array(G, nodelist=nodelist, weight=weight)
     expA = sp.linalg.expm(A)
     expmA = sp.linalg.expm(-A)
     coshA = 0.5 * (expA + expmA)

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -87,7 +87,7 @@ def subgraph_centrality_exp(G):
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist=nodelist)
     # convert to 0-1 matrix
     A[A != 0.0] = 1
     expA = sp.linalg.expm(A)
@@ -174,7 +174,7 @@ def subgraph_centrality(G):
     import numpy as np
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist=nodelist)
     # convert to 0-1 matrix
     A[np.nonzero(A)] = 1
     w, v = np.linalg.eigh(A)
@@ -259,7 +259,7 @@ def communicability_betweenness_centrality(G):
 
     nodelist = list(G)  # ordering of nodes in matrix
     n = len(nodelist)
-    A = nx.to_numpy_array(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist=nodelist)
     # convert to 0-1 matrix
     A[np.nonzero(A)] = 1
     expA = sp.linalg.expm(A)

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -68,7 +68,7 @@ def communicability(G):
     import numpy as np
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist=nodelist)
     # convert to 0-1 matrix
     A[A != 0.0] = 1
     w, vec = np.linalg.eigh(A)
@@ -147,7 +147,7 @@ def communicability_exp(G):
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist)
+    A = nx.to_numpy_array(G, nodelist=nodelist)
     # convert to 0-1 matrix
     A[A != 0.0] = 1
     # communicability matrix

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -63,7 +63,7 @@ def floyd_warshall_numpy(G, nodelist=None, weight="weight"):
     # To handle cases when an edge has weight=0, we must make sure that
     # nonedges are not given the value 0 as well.
     A = nx.to_numpy_array(
-        G, nodelist, multigraph_weight=min, weight=weight, nonedge=np.inf
+        G, nodelist=nodelist, multigraph_weight=min, weight=weight, nonedge=np.inf
     )
     n, m = A.shape
     np.fill_diagonal(A, 0)  # diagonal elements should be zero

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -44,6 +44,7 @@ __all__ = [
 
 def to_pandas_adjacency(
     G,
+    *,
     nodelist=None,
     dtype=None,
     order=None,
@@ -148,7 +149,7 @@ def to_pandas_adjacency(
     return pd.DataFrame(data=M, index=nodelist, columns=nodelist)
 
 
-def from_pandas_adjacency(df, create_using=None):
+def from_pandas_adjacency(df, *, create_using=None):
     r"""Returns a graph from Pandas DataFrame.
 
     The Pandas DataFrame is interpreted as an adjacency matrix for the graph.
@@ -210,6 +211,7 @@ def from_pandas_adjacency(df, create_using=None):
 
 def to_pandas_edgelist(
     G,
+    *,
     source="source",
     target="target",
     nodelist=None,
@@ -308,6 +310,7 @@ def to_pandas_edgelist(
 
 def from_pandas_edgelist(
     df,
+    *,
     source="source",
     target="target",
     edge_attr=None,
@@ -376,7 +379,9 @@ def from_pandas_edgelist(
     0       4     7  A  D
     1       7     1  B  A
     2      10     9  C  E
-    >>> G = nx.from_pandas_edgelist(df, 0, "b", ["weight", "cost"])
+    >>> G = nx.from_pandas_edgelist(
+    ...     df, source=0, target="b", edge_attr=["weight", "cost"]
+    ... )
     >>> G["E"]["C"]["weight"]
     10
     >>> G["E"]["C"]["cost"]
@@ -471,6 +476,7 @@ def from_pandas_edgelist(
 
 def to_numpy_matrix(
     G,
+    *,
     nodelist=None,
     dtype=None,
     order=None,
@@ -592,7 +598,7 @@ def to_numpy_matrix(
     return M
 
 
-def from_numpy_matrix(A, parallel_edges=False, create_using=None):
+def from_numpy_matrix(A, *, parallel_edges=False, create_using=None):
     """Returns a graph from numpy matrix.
 
     The numpy matrix is interpreted as an adjacency matrix for the graph.
@@ -688,7 +694,7 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
 
 
 @not_implemented_for("multigraph")
-def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
+def to_numpy_recarray(G, *, nodelist=None, dtype=None, order=None):
     """Returns the graph adjacency matrix as a NumPy recarray.
 
     Parameters
@@ -768,7 +774,9 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
     return M.view(np.recarray)
 
 
-def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format="csr"):
+def to_scipy_sparse_matrix(
+    G, *, nodelist=None, dtype=None, weight="weight", format="csr"
+):
     """Returns the graph adjacency matrix as a SciPy sparse matrix.
 
     Parameters
@@ -964,7 +972,7 @@ def _generate_weighted_edges(A):
 
 
 def from_scipy_sparse_matrix(
-    A, parallel_edges=False, create_using=None, edge_attribute="weight"
+    A, *, parallel_edges=False, create_using=None, edge_attribute="weight"
 ):
     """Creates a new graph from an adjacency matrix given as a SciPy sparse
     matrix.
@@ -1070,6 +1078,7 @@ def from_scipy_sparse_matrix(
 
 def to_numpy_array(
     G,
+    *,
     nodelist=None,
     dtype=None,
     order=None,
@@ -1252,7 +1261,7 @@ def to_numpy_array(
     return A
 
 
-def from_numpy_array(A, parallel_edges=False, create_using=None):
+def from_numpy_array(A, *, parallel_edges=False, create_using=None):
     """Returns a graph from a 2D NumPy array.
 
     The 2D NumPy array is interpreted as an adjacency matrix for the graph.

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -36,12 +36,14 @@ class TestConvertPandas:
                 ("A", "D", {"cost": 7, "weight": 4}),
             ]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", True)
+        G = nx.from_pandas_edgelist(self.df, source=0, target="b", edge_attr=True)
         assert graphs_equal(G, Gtrue)
         # MultiGraph
         MGtrue = nx.MultiGraph(Gtrue)
         MGtrue.add_edge("A", "D", cost=16, weight=4)
-        MG = nx.from_pandas_edgelist(self.mdf, 0, "b", True, nx.MultiGraph())
+        MG = nx.from_pandas_edgelist(
+            self.mdf, source=0, target="b", edge_attr=True, create_using=nx.MultiGraph
+        )
         assert graphs_equal(MG, MGtrue)
 
     def test_from_edgelist_multi_attr(self):
@@ -52,7 +54,9 @@ class TestConvertPandas:
                 ("A", "D", {"cost": 7, "weight": 4}),
             ]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", ["weight", "cost"])
+        G = nx.from_pandas_edgelist(
+            self.df, source=0, target="b", edge_attr=["weight", "cost"]
+        )
         assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_multi_attr_incl_target(self):
@@ -63,7 +67,9 @@ class TestConvertPandas:
                 ("A", "D", {0: "A", "b": "D", "weight": 4}),
             ]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", [0, "b", "weight"])
+        G = nx.from_pandas_edgelist(
+            self.df, source=0, target="b", edge_attr=[0, "b", "weight"]
+        )
         assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_multidigraph_and_edge_attr(self):
@@ -110,7 +116,7 @@ class TestConvertPandas:
                 ("A", "D", {"weight": 4}),
             ]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", "weight")
+        G = nx.from_pandas_edgelist(self.df, source=0, target="b", edge_attr="weight")
         assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_int_attr_name(self):
@@ -118,34 +124,30 @@ class TestConvertPandas:
         Gtrue = nx.Graph(
             [("E", "C", {0: "C"}), ("B", "A", {0: "B"}), ("A", "D", {0: "A"})]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", 0)
+        G = nx.from_pandas_edgelist(self.df, source=0, target="b", edge_attr=0)
         assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist_invalid_attr(self):
-        pytest.raises(
-            nx.NetworkXError, nx.from_pandas_edgelist, self.df, 0, "b", "misspell"
-        )
-        pytest.raises(nx.NetworkXError, nx.from_pandas_edgelist, self.df, 0, "b", 1)
+        with pytest.raises(nx.NetworkXError):
+            nx.from_pandas_edgelist(self.df, source=0, target="b", edge_attr="misspell")
+        with pytest.raises(nx.NetworkXError):
+            nx.from_pandas_edgelist(self.df, source=0, target="b", edge_attr=1)
         # see Issue #3562
         edgeframe = pd.DataFrame([[0, 1], [1, 2], [2, 0]], columns=["s", "t"])
-        pytest.raises(
-            nx.NetworkXError, nx.from_pandas_edgelist, edgeframe, "s", "t", True
-        )
-        pytest.raises(
-            nx.NetworkXError, nx.from_pandas_edgelist, edgeframe, "s", "t", "weight"
-        )
-        pytest.raises(
-            nx.NetworkXError,
-            nx.from_pandas_edgelist,
-            edgeframe,
-            "s",
-            "t",
-            ["weight", "size"],
-        )
+        with pytest.raises(nx.NetworkXError):
+            nx.from_pandas_edgelist(edgeframe, source="s", target="t", edge_attr=True)
+        with pytest.raises(nx.NetworkXError):
+            nx.from_pandas_edgelist(
+                edgeframe, source="s", target="t", edge_attr="weight"
+            )
+        with pytest.raises(nx.NetworkXError):
+            nx.from_pandas_edgelist(
+                edgeframe, source="s", target="t", edge_attr=["weight", "size"]
+            )
 
     def test_from_edgelist_no_attr(self):
         Gtrue = nx.Graph([("E", "C", {}), ("B", "A", {}), ("A", "D", {})])
-        G = nx.from_pandas_edgelist(self.df, 0, "b")
+        G = nx.from_pandas_edgelist(self.df, source=0, target="b")
         assert graphs_equal(G, Gtrue)
 
     def test_from_edgelist(self):
@@ -286,7 +288,9 @@ class TestConvertPandas:
                 ("A", "D", {"cost": 7, "weight": 4}),
             ]
         )
-        G = nx.from_pandas_edgelist(self.df, 0, "b", True, edge_key="weight")
+        G = nx.from_pandas_edgelist(
+            self.df, source=0, target="b", edge_attr=True, edge_key="weight"
+        )
         assert graphs_equal(G, Gtrue)
 
     def test_nonexisting_edgekey_raises(self):
@@ -308,7 +312,7 @@ def test_to_pandas_adjacency_with_nodelist():
         [[0, 1], [1, 0]], dtype=int, index=nodelist, columns=nodelist
     )
     pd.testing.assert_frame_equal(
-        expected, nx.to_pandas_adjacency(G, nodelist, dtype=int)
+        expected, nx.to_pandas_adjacency(G, nodelist=nodelist, dtype=int)
     )
 
 


### PR DESCRIPTION
Related to #4100

As an experiment, I converted the `convert_matrix` module to use keyword-only args to see what it would take and how disruptive the changes would be within NX (as a proxy for how disruptive the change would be for general users).

I naively chose to be very aggressive in specifying what must be kwarg-only: basically, I made it so that every keyword argument (i.e. that has a default value) *must* be named when calling the function. Some observations from this experiment:

#### Switching to keyword-only arguments is likely to break people

As expected, making this switch did break some tests and some internal usages of e.g. `nx.to_numpy_array` in other NetworkX functions. For example, about half of the tests in the `test_pandas.py` suite fail due to the keyword-only requirement on things like:

```python
nx.from_pandas_edgelist(df, 0, "b", ["weight", "cost"])
```

Of course, failing on things like this is kind of the point, because the above code is not easy to understand without looking up the `from_pandas_edgelist` signature, whereas the function call that obeys the kwarg-only requirements is much more readable:

```python
nx.from_pandas_edgelist(df, source=0, target="b", edge_attr=["weight", "cost"])
```

Nevertheless, I think this indicates that switching to keyword-only arguments is likely to catch people out and raise a lot of new `TypeErrors` on previously working code.

#### Deciding which arguments exactly should be keyword only is going to be tricky

In this experiment, I made all of the arguments after the first kwarg-only. This is because all of the conversion functions follow the same general pattern where the first argument is the main data structure to be acted upon (a graph, a numpy array, scipy sparse matrix, etc.) and all of the other arguments are optional. For cases like the pandas conversion functions above I think this made sense, as it's not at all clear what the 2nd and 3rd positional arguments represent without additional context.

However, for e.g. the `to_numpy_array` case, making the `nodelist` argument keyword only caused quite a few failures on internal uses of `to_numpy_array` in other nx functions. There, the common pattern seemed to be:

```python
nodelist = [1, 4]
ary = nx.to_numpy_array(G, nodelist)
```

Forcing `nodelist` to be kwarg only causes the above to fail, requiring `nx.to_numpy_array(G, nodelist=nodelist)` instead. Based on the number of places this usage pattern shows up, it seems like there is a pretty strong convention that the 2nd positional argument of the `to_*` conversion functions is `nodelist`. This highlights one of the challenges in deciding where the kwarg-only cutoff should be. My general sense is that we should not be overly aggressive in making things kwarg-only if it will be disruptive without any obvious benefit.

#### Takeaways

My thoughts after conducting this experiment:
 - I think there should be an NXEP to clearly layout the motivation and general approach to introducing the keyword only requirement. I suspect that even the most seemingly-obvious/innocuous changes are going to cause new failures for some users, and it would be very beneficial to have a design doc to help frame any discussions.
 - Also, because of the potential for breakage, any kwarg-only modifications to signatures should coincide with a major release
 - My feeling is that we should be cognizant of how disruptive any change could be, and when in doubt to error on the side of caution. For instance, having conducted this experiment I would advocate for `to_numpy_array(G, nodelist=None, *, ...)` instead of `to_numpy_array(G, *, nodelist=None, ...)`.