### PR TITLE
Fix typo smallworld.omega

### DIFF
--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -336,7 +336,7 @@ def omega(G, niter=100, nrand=10, seed=None):
     Returns
     -------
     omega : float
-        The small-work coefficient (omega)
+        The small-world coefficient (omega)
 
     Notes
     -----


### PR DESCRIPTION
Fixed typo in description of smallworld.omega algorithm.

small-work --> small-world

(This is my first contribution to any project on GitHub. I've followed the contribution guidelines and hope I have done everything correctly!)