### PR TITLE
CI/MAINT: drop gdal tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,16 +22,13 @@ jobs:
     - name: Before install
       run: |
         sudo apt-get update
-        sudo apt-get install libgdal-dev graphviz graphviz-dev
+        sudo apt-get install graphviz graphviz-dev
 
     - name: Install packages
       run: |
-        pip install --upgrade pip wheel setuptools\<58
+        pip install --upgrade pip wheel setuptools
         pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
-        export CPLUS_INCLUDE_PATH=/usr/include/gdal
-        export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.0.4
         pip install .
         pip list
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -r requirements/extra.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.0.4
+        pip install gdal
         pip install .
         pip list
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -r requirements/extra.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal
+        pip install gdal==3.3.0
         pip install .
         pip list
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,12 +26,12 @@ jobs:
 
     - name: Install packages
       run: |
-        pip install --upgrade pip wheel setuptools
+        pip install --upgrade pip wheel setuptools\<58
         pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.3.0
+        pip install gdal==3.0.4
         pip install .
         pip list
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
         pip install -U -r requirements/doc.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.0.4
+        pip install gdal
         pip install .
         pip list
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,14 +29,14 @@ jobs:
 
     - name: Install packages
       run: |
-        pip install --upgrade pip wheel setuptools
+        pip install --upgrade pip wheel setuptools\<58
         pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
         pip install -r requirements/example.txt
         pip install -U -r requirements/doc.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal
+        pip install gdal==3.0.4
         pip install .
         pip list
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,21 +22,18 @@ jobs:
     - name: Before install
       run: |
         sudo apt-get update
-        sudo apt-get install libgdal-dev graphviz graphviz-dev
+        sudo apt-get install graphviz graphviz-dev
         sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex
         sudo apt-get install fonts-freefont-otf xindy
         sudo apt-get install libspatialindex-dev
 
     - name: Install packages
       run: |
-        pip install --upgrade pip wheel setuptools\<58
+        pip install --upgrade pip wheel setuptools
         pip install -r requirements/default.txt -r requirements/test.txt
         pip install -r requirements/extra.txt
         pip install -r requirements/example.txt
         pip install -U -r requirements/doc.txt
-        export CPLUS_INCLUDE_PATH=/usr/include/gdal
-        export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.0.4
         pip install .
         pip list
 


### PR DESCRIPTION
It looks like `gdal==3.0.4` is failing with the latest version of `setuptools`. Try removing this upper bound to see if CI gets unstuck.