### PR TITLE
Upgrade GDAL to 3.3 in GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -r requirements/extra.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.0.4
+        pip install gdal==3.3.0
         pip install .
         pip list
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
         pip install -U -r requirements/doc.txt
         export CPLUS_INCLUDE_PATH=/usr/include/gdal
         export C_INCLUDE_PATH=/usr/include/gdal
-        pip install gdal==3.0.4
+        pip install gdal==3.3.0
         pip install .
         pip list
 


### PR DESCRIPTION
GDAL < 3.3 calls the `use_2to3` from setuptools, which is no longer
available (since setuptools 58.0.2).
