### PR TITLE
Fix fast_gnp_random_graph for directed graphs (issue #3389)

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -84,19 +84,24 @@ def fast_gnp_random_graph(n, p, seed=None, directed=False):
     if directed:
         G = nx.DiGraph(G)
         # Nodes in graph are from 0,n-1 (start with v as the first node index).
+
+        # For every (v, w) pair such that 0 <= v <= n-1 and 0 <= w <= n-2, the
+        # algorithm generates an edge with probability p.  We mustn't generate
+        # self loops; therefore if w >= v when adding an edge we add the edge
+        # from v to w+1 rather than to w.  This is also the reason why w has a
+        # maximum value of n-2 and not n-1.
         v = 0
         while v < n:
             lr = math.log(1.0 - seed.random())
             w = w + 1 + int(lr / lp)
-            if v == w:  # avoid self loops
-                w = w + 1
-            while v < n <= w:
-                w = w - n
+            while w >= n - 1 and v < n:
+                w = w - (n - 1)
                 v = v + 1
-                if v == w:  # avoid self loops
-                    w = w + 1
             if v < n:
-                G.add_edge(v, w)
+                if w >= v:
+                    G.add_edge(v, w + 1)
+                else:
+                    G.add_edge(v, w)
     else:
         # Nodes in graph are from 0,n-1 (start with v as the second node index).
         v = 1

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -78,33 +78,12 @@ def fast_gnp_random_graph(n, p, seed=None, directed=False):
     if p <= 0 or p >= 1:
         return nx.gnp_random_graph(n, p, seed=seed, directed=directed)
 
-    w = -1
     lp = math.log(1.0 - p)
 
     if directed:
         G = nx.DiGraph(G)
-        # Nodes in graph are from 0,n-1 (start with v as the first node index).
-
-        # For every (v, w) pair such that 0 <= v <= n-1 and 0 <= w <= n-2, the
-        # algorithm generates an edge with probability p.  We mustn't generate
-        # self loops; therefore if w >= v when adding an edge we add the edge
-        # from v to w+1 rather than to w.  This is also the reason why w has a
-        # maximum value of n-2 and not n-1.
-        v = 0
-        while v < n:
-            lr = math.log(1.0 - seed.random())
-            w = w + 1 + int(lr / lp)
-            while w >= n - 1 and v < n:
-                w = w - (n - 1)
-                v = v + 1
-            if v < n:
-                if w >= v:
-                    G.add_edge(v, w + 1)
-                else:
-                    G.add_edge(v, w)
-    else:
-        # Nodes in graph are from 0,n-1 (start with v as the second node index).
         v = 1
+        w = -1
         while v < n:
             lr = math.log(1.0 - seed.random())
             w = w + 1 + int(lr / lp)
@@ -112,7 +91,19 @@ def fast_gnp_random_graph(n, p, seed=None, directed=False):
                 w = w - v
                 v = v + 1
             if v < n:
-                G.add_edge(v, w)
+                G.add_edge(w, v)
+
+    # Nodes in graph are from 0,n-1 (start with v as the second node index).
+    v = 1
+    w = -1
+    while v < n:
+        lr = math.log(1.0 - seed.random())
+        w = w + 1 + int(lr / lp)
+        while w >= v and v < n:
+            w = w - v
+            v = v + 1
+        if v < n:
+            G.add_edge(v, w)
     return G
 
 

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -254,7 +254,7 @@ class TestGeneratorsRandom:
                 for directed in [False, True]:
                     edge_counts = [[0] * 5 for row in range(5)]
                     for i in range(runs):
-                        G = nx.generators.random_graphs.fast_gnp_random_graph(
+                        G = generator(
                             n, p, directed=directed
                         )
                         for (v, w) in G.edges:

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -254,9 +254,7 @@ class TestGeneratorsRandom:
                 for directed in [False, True]:
                     edge_counts = [[0] * 5 for row in range(5)]
                     for i in range(runs):
-                        G = generator(
-                            n, p, directed=directed
-                        )
+                        G = generator(n, p, directed=directed)
                         for (v, w) in G.edges:
                             edge_counts[v][w] += 1
                             if not directed:

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -247,6 +247,29 @@ class TestGeneratorsRandom:
                 edges += sum(1 for _ in generator(10, 0.99999, directed=True).edges())
             assert abs(edges / float(runs) - 90) <= runs * 2.0 / 100
 
+            # assert that edges are generated with correct probability
+            runs = 5000
+            n = 5
+            for p in [0.2, 0.8]:
+                for directed in [False, True]:
+                    edge_counts = [[0] * 5 for row in range(5)]
+                    for i in range(runs):
+                        G = nx.generators.random_graphs.fast_gnp_random_graph(
+                            n, p, directed=directed
+                        )
+                        for (v, w) in G.edges:
+                            edge_counts[v][w] += 1
+                            if not directed:
+                                edge_counts[w][v] += 1
+                    for v in range(n):
+                        for w in range(n):
+                            if v == w:
+                                # There should be no loops
+                                assert edge_counts[v][w] == 0
+                            else:
+                                # Each edge should have been generated with probability close to p
+                                assert abs(edge_counts[v][w] / float(runs) - p) <= 0.03
+
     def test_gnm(self):
         G = nx.gnm_random_graph(10, 3)
         assert len(G) == 10


### PR DESCRIPTION
This fixes #3389 with the change suggested by @proto-n in that issue.  I have generated hundreds of thousands of graphs to confirm that the edge counts are as expected.