### PR TITLE
Fix lowest_common_ancestors (issue #4942)

### DIFF
--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -269,7 +269,7 @@ def all_pairs_lowest_common_ancestor(G, pairs=None):
     ancestors = {}
     for v in dag:
         if pairs is None or v in pairset:
-            my_ancestors = nx.dag.ancestors(dag, v)
+            my_ancestors = nx.dag.ancestors(G, v)
             my_ancestors.add(v)
             ancestors[v] = sorted(my_ancestors, key=euler_tour_pos.get)
 

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -269,7 +269,7 @@ def all_pairs_lowest_common_ancestor(G, pairs=None):
     ancestors = {}
     for v in dag:
         if pairs is None or v in pairset:
-            my_ancestors = nx.dag.ancestors(G, v)
+            my_ancestors = nx.ancestors(G, v)
             my_ancestors.add(v)
             ancestors[v] = sorted(my_ancestors, key=euler_tour_pos.get)
 

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -294,11 +294,8 @@ class TestDAGLCA:
         assert ans == [((3, 3), 3)]
 
     def test_all_pairs_lowest_common_ancestor10(self):
-        """Test that it works on a small graph that previously revealed a bug."""
-        G = nx.DiGraph()
-        G.add_edge(0, 2)
-        G.add_edge(1, 2)
-        G.add_edge(2, 3)
+        """Test that it works on a small graph that previously revealed a bug gh-4942"""
+        G = nx.DiGraph([(0, 2), (1, 2), (2, 3)])
         ans = list(all_pairs_lca(G))
         assert len(ans) == 9
 

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -293,6 +293,15 @@ class TestDAGLCA:
         ans = list(all_pairs_lca(G))
         assert ans == [((3, 3), 3)]
 
+    def test_all_pairs_lowest_common_ancestor10(self):
+        """Test that it works on a small graph that previously revealed a bug."""
+        G = nx.DiGraph()
+        G.add_edge(0, 2)
+        G.add_edge(1, 2)
+        G.add_edge(2, 3)
+        ans = list(all_pairs_lca(G))
+        assert len(ans) == 9
+
     def test_lowest_common_ancestor1(self):
         """Test that the one-pair function works on default."""
         G = nx.DiGraph([(0, 1), (2, 1)])


### PR DESCRIPTION
This fixes the bug in `lowest_common_ancestors` using the [change](https://github.com/networkx/networkx/issues/4942#issuecomment-919675945) proposed by @dschult.

The discussion in issue #4942 includes an extra (naive) algorithm. Should we add this as an additional option, or perhaps just use it for testing?

We should also add a test case to make sure the bug doesn't reappear.