### PR TITLE
Fix small typo in `trophic_levels` documentation

### DIFF
--- a/networkx/algorithms/centrality/trophic.py
+++ b/networkx/algorithms/centrality/trophic.py
@@ -34,7 +34,7 @@ def trophic_levels(G, weight="weight"):
     Returns
     -------
     nodes : dict
-        Dictionary of nodes with trophic level as the vale.
+        Dictionary of nodes with trophic level as the value.
 
     References
     ----------


### PR DESCRIPTION
In return value description: "vale" -> "value"
