### PR TITLE
Consistent return type in dictionary output of rescale_layout and rescale_layout_dict

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1185,4 +1185,4 @@ def rescale_layout_dict(pos, scale=1):
         return {}
     pos_v = np.array(list(pos.values()))
     pos_v = rescale_layout(pos_v, scale=scale)
-    return {k: tuple(v) for k, v in zip(pos.keys(), pos_v)}
+    return {k: np.asarray(v) for k, v in zip(pos.keys(), pos_v)}


### PR DESCRIPTION
## Summary
Most layouts (if not all) return a dictionary of (key, value) pairs that are of type (<int | float | string| tuple>, <np.ndarray>), however the `rescale_dict_layout` function explicitly converts the value type to a `np.ndarray`. This PR fixes that problem.

## Problem
Removes conversion of value-type to tuple in `rescale_layout_dict` function.

## Example

```python
g = nx.erdos_renyi_graph(100, .3)
pos = nx.random_layout(g)
dict_pos = nx.rescale_layout_dict(pos, 100) # produces (key, value) -> (<node label type>, <np.ndarray>))
for k, v in pos.items():
    assert type(v) is type(dict_pos[k])
```



