### PR TITLE
Improve random graphs test suite for gnp and gnm generators (issue #5092)

### DIFF
--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -5,100 +5,111 @@ import networkx as nx
 import pytest
 
 
-class TestGnpRandomGraphs:
-
-    generators = [
+@pytest.mark.parametrize(
+    "generator",
+    [
         nx.gnp_random_graph,
         nx.fast_gnp_random_graph,
         nx.binomial_graph,
         nx.erdos_renyi_graph,
-    ]
+    ],
+)
+@pytest.mark.parametrize(
+    ("n", "p", "directed", "edges"),
+    [
+        (10, -1.1, False, 0),
+        (10, 1.1, False, 45),
+        (10, -1.1, True, 0),
+        (10, 1.1, True, 90),
+    ],
+)
+def test_basic_properties(generator, n, p, directed, edges):
+    G = generator(n, p, directed=directed)
+    assert len(G) == n
+    assert G.number_of_edges() == edges
+    assert G.is_directed() == directed
 
-    @pytest.mark.parametrize(
-        ("n", "p", "directed", "edges"),
-        [
-            (10, -1.1, False, 0),
-            (10, 1.1, False, 45),
-            (10, -1.1, True, 0),
-            (10, 1.1, True, 90),
-        ],
+
+@pytest.mark.parametrize(
+    "generator",
+    [
+        nx.gnp_random_graph,
+        nx.fast_gnp_random_graph,
+        nx.binomial_graph,
+        nx.erdos_renyi_graph,
+    ],
+)
+def test_all_edges_for_p_close_to_1(generator):
+    runs = 100
+    edges = sum(
+        [generator(10, 0.99999, directed=True).number_of_edges() for _ in range(runs)]
     )
-    def test_basic_properties(self, n, p, directed, edges):
-        for generator in self.generators:
-            G = generator(n, p, directed=directed)
-            assert len(G) == n
-            assert G.number_of_edges() == edges
-            assert G.is_directed() == directed
-
-    def test_all_edges_for_p_close_to_1(self):
-        runs = 100
-        for generator in self.generators:
-            edges = sum(
-                [
-                    generator(10, 0.99999, directed=True).number_of_edges()
-                    for _ in range(runs)
-                ]
-            )
-            assert abs(edges / float(runs) - 90) <= runs * 2.0 / 100
-
-    @pytest.mark.parametrize(
-        ("n", "p", "directed"),
-        [
-            (5, 0.2, False),
-            (5, 0.8, False),
-            (5, 0.2, True),
-            (5, 0.8, True),
-        ],
-    )
-    def test_edge_probability(self, n, p, directed):
-        runs = 5000
-        for generator in self.generators:
-            edge_counts = [[0] * n for _ in range(n)]
-            for i in range(runs):
-                G = generator(n, p, directed=directed)
-                for (v, w) in G.edges:
-                    edge_counts[v][w] += 1
-                    if not directed:
-                        edge_counts[w][v] += 1
-            for v in range(n):
-                for w in range(n):
-                    if v == w:
-                        # There should be no loops
-                        assert edge_counts[v][w] == 0
-                    else:
-                        # Each edge should have been generated with probability close to p
-                        assert abs(edge_counts[v][w] / float(runs) - p) <= 0.03
+    assert abs(edges / float(runs) - 90) <= runs * 2.0 / 100
 
 
-class TestGnmRandomGraphs:
+@pytest.mark.parametrize(
+    "generator",
+    [
+        nx.gnp_random_graph,
+        nx.fast_gnp_random_graph,
+        nx.binomial_graph,
+        nx.erdos_renyi_graph,
+    ],
+)
+@pytest.mark.parametrize(
+    ("n", "p", "directed"),
+    [
+        (5, 0.2, False),
+        (5, 0.8, False),
+        (5, 0.2, True),
+        (5, 0.8, True),
+    ],
+)
+def test_edge_probability(generator, n, p, directed):
+    runs = 5000
+    edge_counts = [[0] * n for _ in range(n)]
+    for i in range(runs):
+        G = generator(n, p, directed=directed)
+        for (v, w) in G.edges:
+            edge_counts[v][w] += 1
+            if not directed:
+                edge_counts[w][v] += 1
+    for v in range(n):
+        for w in range(n):
+            if v == w:
+                # There should be no loops
+                assert edge_counts[v][w] == 0
+            else:
+                # Each edge should have been generated with probability close to p
+                assert abs(edge_counts[v][w] / float(runs) - p) <= 0.03
 
-    generators = [nx.gnm_random_graph, nx.dense_gnm_random_graph]
 
-    @pytest.mark.parametrize(
-        ("n", "m", "edges"),
-        [
-            (10, 3, 3),
-            (10, 50, 45),
-        ],
-    )
-    def test_nodes_and_edges(self, n, m, edges):
-        for generator in self.generators:
-            G = generator(n, m)
-            assert len(G) == n
-            assert G.number_of_edges() == edges
+@pytest.mark.parametrize("generator", [nx.gnm_random_graph, nx.dense_gnm_random_graph])
+@pytest.mark.parametrize(
+    ("n", "m", "edges"),
+    [
+        (10, 3, 3),
+        (10, 50, 45),
+    ],
+)
+def test_nodes_and_edges(generator, n, m, edges):
+    G = generator(n, m)
+    assert len(G) == n
+    assert G.number_of_edges() == edges
 
-    @pytest.mark.parametrize(
-        ("n", "m", "edges"),
-        [
-            (10, 3, 3),
-            (10, 100, 90),
-            (10, -1, 0),
-        ],
-    )
-    def test_nodes_and_edges_directed(self, n, m, edges):
-        G = nx.gnm_random_graph(n, m, directed=True)
-        assert len(G) == n
-        assert G.number_of_edges() == edges
+
+@pytest.mark.parametrize(
+    ("n", "m", "edges"),
+    [
+        (10, 3, 3),
+        (10, 100, 90),
+        (10, -1, 0),
+    ],
+)
+def test_nodes_and_edges_directed(n, m, edges):
+    G = nx.gnm_random_graph(n, m, directed=True)
+    assert len(G) == n
+    assert G.number_of_edges() == edges
 
 
 class TestGeneratorsRandom:


### PR DESCRIPTION
Following the suggestions by @rossbar in #5092, I improved a part of the random graphs test suite by splitting the outer class in smaller units and adding tests parametrization in some cases.

This PR is limited to the tests related to the 'gnp' and 'gnm' random graph generators but can be actually extended for all the other generators as well.

I think much more work could be done to improve the tests but hopefully this can be a good way to start. Any comments or suggestions are welcome!