### PR TITLE
Deprecate union name param

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -91,3 +91,4 @@ Version 3.0
 * In ``algorithms/assortativity/mixing.py`` remove ``numeric_mixing_matrix``.
 * In ``algorithms/assortativity/connectivity.py`` remove ``k_nearest_neighbors``.
 * In ``utils/decorators.py`` remove ``random_state``.
+* In ``algorithms/operators/binary.py`` remove ``name`` kwarg from ``union`` and docstring.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -44,6 +44,8 @@ Deprecations
 
 - [`#5055 <https://github.com/networkx/networkx/pull/5055>`_]
   Deprecate the ``random_state`` alias in favor of ``np_random_state``
+- [`#5099 <https://github.com/networkx/networkx/pull/5099>`_]
+  Deprecate the ``name`` kwarg from ``union`` as it isn't used.
 
 
 Merged PRs

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -32,6 +32,9 @@ def union(G, H, rename=(None, None), name=None):
     name : string
        Specify the name for the union graph
 
+       .. deprecated:: 2.7
+           This is deprecated and will be removed in version v3.0.
+
     Returns
     -------
     U : A union graph with the same type as G.
@@ -49,6 +52,15 @@ def union(G, H, rename=(None, None), name=None):
     --------
     disjoint_union
     """
+    if name is not None:
+        import warnings
+
+        warnings.warn(
+            "name parameter is deprecated and will be removed in version 3.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError("G and H must both be graphs or multigraphs.")
     # Union is the same type as G


### PR DESCRIPTION
As discussed on #5099 I created a separate PR to deprecate the unused `name` parameter from `union` function
