### PR TITLE
Add Mypy type checking infrastructure

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -3,7 +3,7 @@ name: Mypy
 on: [push, pull_request]
 
 jobs:
-  format:
+  type-check:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,8 +21,10 @@ jobs:
         run: |
           pip install --upgrade pip wheel setuptools
           pip install -r requirements/developer.txt
-          pip install .
+          # Rm below when yaml no longer a dep
+          pip install types-PyYAML
+          pip install -e .
           pip list
 
-      - name: run type check
+      - name: run mypy
         run: mypy -p networkx

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,28 @@
+name: Mypy
+
+on: [push, pull_request]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install -r requirements/developer.txt
+          pip install .
+          pip list
+
+      - name: run type check
+        run: mypy -p networkx

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 ignore_missing_imports = True
+exclude = reportviews|subgraphviews*

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
 ignore_missing_imports = True
-exclude = reportviews|subgraphviews*
+exclude = yaml|subgraphviews|reportviews*

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -213,7 +213,7 @@ class _AntiGraph(nx.Graph):
     def single_edge_dict(self):
         return self.all_edge_dict
 
-    edge_attr_dict_factory = single_edge_dict
+    edge_attr_dict_factory = single_edge_dict  # type: ignore
 
     def __getitem__(self, n):
         """Returns a dict of neighbors of node n in the dense graph.

--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -39,83 +39,84 @@ def test_christofides_ignore_selfloops():
 
 
 # set up graphs for other tests
-@classmethod
-def _setup_class(cls):
-    cls.DG = nx.DiGraph()
-    cls.DG.add_weighted_edges_from(
-        {
-            ("A", "B", 3),
-            ("A", "C", 17),
-            ("A", "D", 14),
-            ("B", "A", 3),
-            ("B", "C", 12),
-            ("B", "D", 16),
-            ("C", "A", 13),
-            ("C", "B", 12),
-            ("C", "D", 4),
-            ("D", "A", 14),
-            ("D", "B", 15),
-            ("D", "C", 2),
-        }
-    )
-    cls.DG_cycle = ["D", "C", "B", "A", "D"]
-    cls.DG_cost = 31.0
+class TestBase:
+    @classmethod
+    def setup_class(cls):
+        cls.DG = nx.DiGraph()
+        cls.DG.add_weighted_edges_from(
+            {
+                ("A", "B", 3),
+                ("A", "C", 17),
+                ("A", "D", 14),
+                ("B", "A", 3),
+                ("B", "C", 12),
+                ("B", "D", 16),
+                ("C", "A", 13),
+                ("C", "B", 12),
+                ("C", "D", 4),
+                ("D", "A", 14),
+                ("D", "B", 15),
+                ("D", "C", 2),
+            }
+        )
+        cls.DG_cycle = ["D", "C", "B", "A", "D"]
+        cls.DG_cost = 31.0
 
-    cls.DG2 = nx.DiGraph()
-    cls.DG2.add_weighted_edges_from(
-        {
-            ("A", "B", 3),
-            ("A", "C", 17),
-            ("A", "D", 14),
-            ("B", "A", 30),
-            ("B", "C", 2),
-            ("B", "D", 16),
-            ("C", "A", 33),
-            ("C", "B", 32),
-            ("C", "D", 34),
-            ("D", "A", 14),
-            ("D", "B", 15),
-            ("D", "C", 2),
-        }
-    )
-    cls.DG2_cycle = ["D", "A", "B", "C", "D"]
-    cls.DG2_cost = 53.0
+        cls.DG2 = nx.DiGraph()
+        cls.DG2.add_weighted_edges_from(
+            {
+                ("A", "B", 3),
+                ("A", "C", 17),
+                ("A", "D", 14),
+                ("B", "A", 30),
+                ("B", "C", 2),
+                ("B", "D", 16),
+                ("C", "A", 33),
+                ("C", "B", 32),
+                ("C", "D", 34),
+                ("D", "A", 14),
+                ("D", "B", 15),
+                ("D", "C", 2),
+            }
+        )
+        cls.DG2_cycle = ["D", "A", "B", "C", "D"]
+        cls.DG2_cost = 53.0
 
-    cls.unweightedUG = nx.complete_graph(5, nx.Graph())
-    cls.unweightedDG = nx.complete_graph(5, nx.DiGraph())
+        cls.unweightedUG = nx.complete_graph(5, nx.Graph())
+        cls.unweightedDG = nx.complete_graph(5, nx.DiGraph())
 
-    cls.incompleteUG = nx.Graph()
-    cls.incompleteUG.add_weighted_edges_from({(0, 1, 1), (1, 2, 3)})
-    cls.incompleteDG = nx.DiGraph()
-    cls.incompleteDG.add_weighted_edges_from({(0, 1, 1), (1, 2, 3)})
+        cls.incompleteUG = nx.Graph()
+        cls.incompleteUG.add_weighted_edges_from({(0, 1, 1), (1, 2, 3)})
+        cls.incompleteDG = nx.DiGraph()
+        cls.incompleteDG.add_weighted_edges_from({(0, 1, 1), (1, 2, 3)})
 
-    cls.UG = nx.Graph()
-    cls.UG.add_weighted_edges_from(
-        {
-            ("A", "B", 3),
-            ("A", "C", 17),
-            ("A", "D", 14),
-            ("B", "C", 12),
-            ("B", "D", 16),
-            ("C", "D", 4),
-        }
-    )
-    cls.UG_cycle = ["D", "C", "B", "A", "D"]
-    cls.UG_cost = 33.0
+        cls.UG = nx.Graph()
+        cls.UG.add_weighted_edges_from(
+            {
+                ("A", "B", 3),
+                ("A", "C", 17),
+                ("A", "D", 14),
+                ("B", "C", 12),
+                ("B", "D", 16),
+                ("C", "D", 4),
+            }
+        )
+        cls.UG_cycle = ["D", "C", "B", "A", "D"]
+        cls.UG_cost = 33.0
 
-    cls.UG2 = nx.Graph()
-    cls.UG2.add_weighted_edges_from(
-        {
-            ("A", "B", 1),
-            ("A", "C", 15),
-            ("A", "D", 5),
-            ("B", "C", 16),
-            ("B", "D", 8),
-            ("C", "D", 3),
-        }
-    )
-    cls.UG2_cycle = ["D", "C", "B", "A", "D"]
-    cls.UG2_cost = 25.0
+        cls.UG2 = nx.Graph()
+        cls.UG2.add_weighted_edges_from(
+            {
+                ("A", "B", 1),
+                ("A", "C", 15),
+                ("A", "D", 5),
+                ("B", "C", 16),
+                ("B", "D", 8),
+                ("C", "D", 3),
+            }
+        )
+        cls.UG2_cycle = ["D", "C", "B", "A", "D"]
+        cls.UG2_cost = 25.0
 
 
 def validate_solution(soln, cost, exp_soln, exp_cost):
@@ -128,9 +129,7 @@ def validate_symmetric_solution(soln, cost, exp_soln, exp_cost):
     assert cost == exp_cost
 
 
-class TestGreedyTSP:
-    setup_class = _setup_class
-
+class TestGreedyTSP(TestBase):
     def test_greedy(self):
         cycle = nx_app.greedy_tsp(self.DG, source="D")
         cost = sum(self.DG[n][nbr]["weight"] for n, nbr in pairwise(cycle))
@@ -170,8 +169,7 @@ class TestGreedyTSP:
         assert len(cycle) - 1 == len(G) == len(set(cycle))
 
 
-class TestSimulatedAnnealingTSP:
-    setup_class = _setup_class
+class TestSimulatedAnnealingTSP(TestBase):
     tsp = staticmethod(nx_app.simulated_annealing_tsp)
 
     def test_simulated_annealing_directed(self):

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -133,17 +133,17 @@ def generate_edgelist(G, delimiter=" ", data=True):
         raise AttributeError("Missing node attribute `bipartite`") from err
     if data is True or data is False:
         for n in part0:
-            for e in G.edges(n, data=data):
-                yield delimiter.join(map(str, e))
+            for edge in G.edges(n, data=data):
+                yield delimiter.join(map(str, edge))
     else:
         for n in part0:
             for u, v, d in G.edges(n, data=True):
-                e = [u, v]
+                edge = [u, v]
                 try:
-                    e.extend(d[k] for k in data)
+                    edge.extend(d[k] for k in data)
                 except KeyError:
                     pass  # missing data for this edge, should warn?
-                yield delimiter.join(map(str, e))
+                yield delimiter.join(map(str, edge))
 
 
 def parse_edgelist(

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -176,8 +176,8 @@ def katz_centrality(
             x[n] = alpha * x[n] + b[n]
 
         # check convergence
-        err = sum(abs(x[n] - xlast[n]) for n in x)
-        if err < nnodes * tol:
+        error = sum(abs(x[n] - xlast[n]) for n in x)
+        if error < nnodes * tol:
             if normalized:
                 # normalize vector
                 try:

--- a/networkx/algorithms/community/lukes.py
+++ b/networkx/algorithms/community/lukes.py
@@ -183,7 +183,7 @@ def lukes_partitioning(G, max_size: int, node_weight=None, edge_weight=None) -> 
         weight_of_x = safe_G.nodes[x_node][node_weight]
         best_value = 0
         best_partition = None
-        bp_buffer = dict()
+        bp_buffer = dict()  # type: ignore
         x_descendants = nx.descendants(t_G, x_node)
         for i_node in x_descendants:
             for j in range(weight_of_x, max_size + 1):

--- a/networkx/algorithms/community/lukes.py
+++ b/networkx/algorithms/community/lukes.py
@@ -17,7 +17,7 @@ PKEY = "partitions"
 CLUSTER_EVAL_CACHE_SIZE = 2048
 
 
-def _split_n_from(n: int, min_size_of_first_part: int):
+def _split_n_from(n, min_size_of_first_part):
     # splits j in two parts of which the first is at least
     # the second argument
     assert n >= min_size_of_first_part
@@ -25,7 +25,7 @@ def _split_n_from(n: int, min_size_of_first_part: int):
         yield p1, n - p1
 
 
-def lukes_partitioning(G, max_size: int, node_weight=None, edge_weight=None) -> list:
+def lukes_partitioning(G, max_size, node_weight=None, edge_weight=None):
 
     """Optimal partitioning of a weighted tree using the Lukes algorithm.
 
@@ -130,23 +130,23 @@ def lukes_partitioning(G, max_size: int, node_weight=None, edge_weight=None) -> 
                 return n
 
     @lru_cache(CLUSTER_EVAL_CACHE_SIZE)
-    def _value_of_cluster(cluster: frozenset):
+    def _value_of_cluster(cluster):
         valid_edges = [e for e in safe_G.edges if e[0] in cluster and e[1] in cluster]
         return sum(safe_G.edges[e][edge_weight] for e in valid_edges)
 
-    def _value_of_partition(partition: list):
+    def _value_of_partition(partition):
         return sum(_value_of_cluster(frozenset(c)) for c in partition)
 
     @lru_cache(CLUSTER_EVAL_CACHE_SIZE)
-    def _weight_of_cluster(cluster: frozenset):
+    def _weight_of_cluster(cluster):
         return sum(safe_G.nodes[n][node_weight] for n in cluster)
 
-    def _pivot(partition: list, node):
+    def _pivot(partition, node):
         ccx = [c for c in partition if node in c]
         assert len(ccx) == 1
         return ccx[0]
 
-    def _concatenate_or_merge(partition_1: list, partition_2: list, x, i, ref_weigth):
+    def _concatenate_or_merge(partition_1, partition_2, x, i, ref_weigth):
 
         ccx = _pivot(partition_1, x)
         cci = _pivot(partition_2, i)
@@ -183,7 +183,7 @@ def lukes_partitioning(G, max_size: int, node_weight=None, edge_weight=None) -> 
         weight_of_x = safe_G.nodes[x_node][node_weight]
         best_value = 0
         best_partition = None
-        bp_buffer = dict()  # type: ignore
+        bp_buffer = dict()
         x_descendants = nx.descendants(t_G, x_node)
         for i_node in x_descendants:
             for j in range(weight_of_x, max_size + 1):

--- a/networkx/algorithms/connectivity/__init__.py
+++ b/networkx/algorithms/connectivity/__init__.py
@@ -9,18 +9,3 @@ from .kcomponents import *
 from .kcutsets import *
 from .stoerwagner import *
 from .utils import *
-
-__all__ = sum(
-    [
-        connectivity.__all__,
-        cuts.__all__,
-        edge_augmentation.__all__,
-        edge_kcomponents.__all__,
-        disjoint_paths.__all__,
-        kcomponents.__all__,
-        kcutsets.__all__,
-        stoerwagner.__all__,
-        utils.__all__,
-    ],
-    [],
-)

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -67,7 +67,7 @@ __all__ = ["d_separated"]
 
 
 @not_implemented_for("undirected")
-def d_separated(G: nx.DiGraph, x: AbstractSet, y: AbstractSet, z: AbstractSet) -> bool:
+def d_separated(G, x, y, z):
     """
     Return whether node sets ``x`` and ``y`` are d-separated by ``z``.
 

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -19,7 +19,7 @@ flow_funcs = [
 ]
 max_min_funcs = [nx.maximum_flow, nx.minimum_cut]
 flow_value_funcs = [nx.maximum_flow_value, nx.minimum_cut_value]
-interface_funcs = sum([max_min_funcs, flow_value_funcs], [])
+interface_funcs = max_min_funcs + flow_value_funcs
 all_funcs = sum([flow_funcs, interface_funcs], [])
 
 

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -838,7 +838,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert pred[3] == 0
         assert dist == {0: 0, 1: 1, 2: 2, 3: 1}
 
-    def test_negative_weight(self):
+    def test_negative_weight_bf_path(self):
         G = nx.DiGraph()
         G.add_nodes_from("abcd")
         G.add_edge("a", "d", weight=0)

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -4,9 +4,7 @@ import networkx as nx
 
 from networkx.algorithms import find_cycle
 from networkx.algorithms import minimum_cycle_basis
-
-FORWARD = nx.algorithms.edgedfs.FORWARD
-REVERSE = nx.algorithms.edgedfs.REVERSE
+from networkx.algorithms.traversal.edgedfs import FORWARD, REVERSE
 
 
 class TestCycles:

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -455,7 +455,7 @@ def test_missing_node_attr_subgraph_hash():
     )
 
 
-def test_isomorphic_edge_attr_and_node_attr():
+def test_isomorphic_edge_attr_and_node_attr_subgraph_hash():
     """
     Isomorphic graphs with differing node attributes should yield different subgraph
     hashes if the 'node_attr' and 'edge_attr' argument is supplied and populated in

--- a/networkx/algorithms/tests/test_smallworld.py
+++ b/networkx/algorithms/tests/test_smallworld.py
@@ -7,7 +7,6 @@ import random
 from networkx import random_reference, lattice_reference, sigma, omega
 import networkx as nx
 
-rng = random.Random(0)
 rng = 42
 
 

--- a/networkx/algorithms/traversal/tests/test_edgebfs.py
+++ b/networkx/algorithms/traversal/tests/test_edgebfs.py
@@ -1,11 +1,7 @@
 import pytest
 
 import networkx as nx
-
-edge_bfs = nx.edge_bfs
-
-FORWARD = nx.algorithms.edgedfs.FORWARD
-REVERSE = nx.algorithms.edgedfs.REVERSE
+from networkx.algorithms.traversal.edgedfs import FORWARD, REVERSE
 
 
 class TestEdgeBFS:
@@ -16,42 +12,42 @@ class TestEdgeBFS:
 
     def test_empty(self):
         G = nx.Graph()
-        edges = list(edge_bfs(G))
+        edges = list(nx.edge_bfs(G))
         assert edges == []
 
     def test_graph_single_source(self):
         G = nx.Graph(self.edges)
         G.add_edge(4, 5)
-        x = list(edge_bfs(G, [0]))
+        x = list(nx.edge_bfs(G, [0]))
         x_ = [(0, 1), (0, 2), (1, 2), (1, 3)]
         assert x == x_
 
     def test_graph(self):
         G = nx.Graph(self.edges)
-        x = list(edge_bfs(G, self.nodes))
+        x = list(nx.edge_bfs(G, self.nodes))
         x_ = [(0, 1), (0, 2), (1, 2), (1, 3)]
         assert x == x_
 
     def test_digraph(self):
         G = nx.DiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes))
+        x = list(nx.edge_bfs(G, self.nodes))
         x_ = [(0, 1), (1, 0), (2, 0), (2, 1), (3, 1)]
         assert x == x_
 
     def test_digraph_orientation_invalid(self):
         G = nx.DiGraph(self.edges)
-        edge_iterator = edge_bfs(G, self.nodes, orientation="hello")
+        edge_iterator = nx.edge_bfs(G, self.nodes, orientation="hello")
         pytest.raises(nx.NetworkXError, list, edge_iterator)
 
     def test_digraph_orientation_none(self):
         G = nx.DiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes, orientation=None))
+        x = list(nx.edge_bfs(G, self.nodes, orientation=None))
         x_ = [(0, 1), (1, 0), (2, 0), (2, 1), (3, 1)]
         assert x == x_
 
     def test_digraph_orientation_original(self):
         G = nx.DiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes, orientation="original"))
+        x = list(nx.edge_bfs(G, self.nodes, orientation="original"))
         x_ = [
             (0, 1, FORWARD),
             (1, 0, FORWARD),
@@ -64,13 +60,13 @@ class TestEdgeBFS:
     def test_digraph2(self):
         G = nx.DiGraph()
         nx.add_path(G, range(4))
-        x = list(edge_bfs(G, [0]))
+        x = list(nx.edge_bfs(G, [0]))
         x_ = [(0, 1), (1, 2), (2, 3)]
         assert x == x_
 
     def test_digraph_rev(self):
         G = nx.DiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes, orientation="reverse"))
+        x = list(nx.edge_bfs(G, self.nodes, orientation="reverse"))
         x_ = [
             (1, 0, REVERSE),
             (2, 0, REVERSE),
@@ -83,13 +79,13 @@ class TestEdgeBFS:
     def test_digraph_rev2(self):
         G = nx.DiGraph()
         nx.add_path(G, range(4))
-        x = list(edge_bfs(G, [3], orientation="reverse"))
+        x = list(nx.edge_bfs(G, [3], orientation="reverse"))
         x_ = [(2, 3, REVERSE), (1, 2, REVERSE), (0, 1, REVERSE)]
         assert x == x_
 
     def test_multigraph(self):
         G = nx.MultiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes))
+        x = list(nx.edge_bfs(G, self.nodes))
         x_ = [(0, 1, 0), (0, 1, 1), (0, 1, 2), (0, 2, 0), (1, 2, 0), (1, 3, 0)]
         # This is an example of where hash randomization can break.
         # There are 3! * 2 alternative outputs, such as:
@@ -101,13 +97,13 @@ class TestEdgeBFS:
 
     def test_multidigraph(self):
         G = nx.MultiDiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes))
+        x = list(nx.edge_bfs(G, self.nodes))
         x_ = [(0, 1, 0), (1, 0, 0), (1, 0, 1), (2, 0, 0), (2, 1, 0), (3, 1, 0)]
         assert x == x_
 
     def test_multidigraph_rev(self):
         G = nx.MultiDiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes, orientation="reverse"))
+        x = list(nx.edge_bfs(G, self.nodes, orientation="reverse"))
         x_ = [
             (1, 0, 0, REVERSE),
             (1, 0, 1, REVERSE),
@@ -120,7 +116,7 @@ class TestEdgeBFS:
 
     def test_digraph_ignore(self):
         G = nx.DiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes, orientation="ignore"))
+        x = list(nx.edge_bfs(G, self.nodes, orientation="ignore"))
         x_ = [
             (0, 1, FORWARD),
             (1, 0, REVERSE),
@@ -133,13 +129,13 @@ class TestEdgeBFS:
     def test_digraph_ignore2(self):
         G = nx.DiGraph()
         nx.add_path(G, range(4))
-        x = list(edge_bfs(G, [0], orientation="ignore"))
+        x = list(nx.edge_bfs(G, [0], orientation="ignore"))
         x_ = [(0, 1, FORWARD), (1, 2, FORWARD), (2, 3, FORWARD)]
         assert x == x_
 
     def test_multidigraph_ignore(self):
         G = nx.MultiDiGraph(self.edges)
-        x = list(edge_bfs(G, self.nodes, orientation="ignore"))
+        x = list(nx.edge_bfs(G, self.nodes, orientation="ignore"))
         x_ = [
             (0, 1, 0, FORWARD),
             (1, 0, 0, REVERSE),

--- a/networkx/algorithms/traversal/tests/test_edgedfs.py
+++ b/networkx/algorithms/traversal/tests/test_edgedfs.py
@@ -1,11 +1,8 @@
 import pytest
 
 import networkx as nx
-
-edge_dfs = nx.algorithms.edge_dfs
-
-FORWARD = nx.algorithms.edgedfs.FORWARD
-REVERSE = nx.algorithms.edgedfs.REVERSE
+from networkx.algorithms import edge_dfs
+from networkx.algorithms.traversal.edgedfs import FORWARD, REVERSE
 
 # These tests can fail with hash randomization. The easiest and clearest way
 # to write these unit tests is for the edges to be output in an expected total

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -153,13 +153,13 @@ def subgraph_view(G, filter_node=no_filter, filter_edge=no_filter):
     if G.is_multigraph():
         Adj = FilterMultiAdjacency
 
-        def reverse_edge(u, v, k):  # type: ignore
+        def reverse_edge(u, v, k=None):
             return filter_edge(v, u, k)
 
     else:
         Adj = FilterAdjacency
 
-        def reverse_edge(u, v):  # type: ignore
+        def reverse_edge(u, v, k=None):
             return filter_edge(v, u)
 
     if G.is_directed():

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -153,13 +153,13 @@ def subgraph_view(G, filter_node=no_filter, filter_edge=no_filter):
     if G.is_multigraph():
         Adj = FilterMultiAdjacency
 
-        def reverse_edge(u, v, k):
+        def reverse_edge(u, v, k):  # type: ignore
             return filter_edge(v, u, k)
 
     else:
         Adj = FilterAdjacency
 
-        def reverse_edge(u, v):
+        def reverse_edge(u, v):  # type: ignore
             return filter_edge(v, u)
 
     if G.is_directed():

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -217,7 +217,7 @@ class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
     dol = {"a": ["b"]}
 
     multiple_edge = [("a", "b", "traits", etraits), ("a", "b", "graphics", egraphics)]
-    single_edge = [("a", "b", 0, {})]
+    single_edge = [("a", "b", 0, {})]  # type: ignore
     single_edge1 = [("a", "b", 0, edata)]
     single_edge2 = [("a", "b", 0, etraits)]
     single_edge3 = [("a", "b", 0, {"traits": etraits, "s": "foo"})]

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -556,8 +556,7 @@ def _fruchterman_reingold(
         pos += delta_pos
         # cool temperature
         t -= dt
-        err = np.linalg.norm(delta_pos) / nnodes
-        if err < threshold:
+        if (np.linalg.norm(delta_pos) / nnodes) < threshold:
             break
     return pos
 
@@ -631,8 +630,7 @@ def _sparse_fruchterman_reingold(
         pos += delta_pos
         # cool temperature
         t -= dt
-        err = np.linalg.norm(delta_pos) / nnodes
-        if err < threshold:
+        if (np.linalg.norm(delta_pos) / nnodes) < threshold:
             break
     return pos
 

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -114,12 +114,12 @@ def _node_func(G):
     """
     if G.is_multigraph():
 
-        def sorted_node(u, v, key):  # type: ignore
+        def sorted_node(u, v, key=None):
             return (u, v, key) if u <= v else (v, u, key)
 
     else:
 
-        def sorted_node(u, v):  # type: ignore
+        def sorted_node(u, v, key=None):
             return (u, v) if u <= v else (v, u)
 
     return sorted_node

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -114,12 +114,12 @@ def _node_func(G):
     """
     if G.is_multigraph():
 
-        def sorted_node(u, v, key):
+        def sorted_node(u, v, key):  # type: ignore
             return (u, v, key) if u <= v else (v, u, key)
 
     else:
 
-        def sorted_node(u, v):
+        def sorted_node(u, v):  # type: ignore
             return (u, v) if u <= v else (v, u)
 
     return sorted_node

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -999,14 +999,14 @@ class GraphMLReader(GraphML):
                     data["label"] = node_label.text
 
                 # check all the different types of edges avaivable in yEd.
-                for e in [
+                for edge_type in [
                     "PolyLineEdge",
                     "SplineEdge",
                     "QuadCurveEdge",
                     "BezierEdge",
                     "ArcEdge",
                 ]:
-                    pref = f"{{{self.NS_Y}}}{e}/{{{self.NS_Y}}}"
+                    pref = f"{{{self.NS_Y}}}{edge_type}/{{{self.NS_Y}}}"
                     edge_label = data_element.find(f"{pref}EdgeLabel")
                     if edge_label is not None:
                         break

--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -327,10 +327,10 @@ def write_shp(G, outdir):
     # New edge attribute write support merged into edge loop
     edge_fields = {}  # storage for field names and their data types
 
-    for e in G.edges(data=True):
-        data = G.get_edge_data(*e)
-        g = netgeometry(e, data)
-        attributes, edges = create_attributes(e[2], edge_fields, edges)
+    for edge in G.edges(data=True):
+        data = G.get_edge_data(*edge)
+        g = netgeometry(edge, data)
+        attributes, edges = create_attributes(edge[2], edge_fields, edges)
         create_feature(g, edges, attributes)
 
     nodes, edges = None, None

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -288,7 +288,7 @@ graph
 ]"""
         assert data == answer
 
-    def test_float_label(self):
+    def test_special_float_label(self):
         special_floats = [float("nan"), float("+inf"), float("-inf")]
         try:
             import numpy as np

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -92,10 +92,12 @@ def not_implemented_for(*graph_types):
 
 # To handle new extensions, define a function accepting a `path` and `mode`.
 # Then add the extension to _dispatch_dict.
-_dispatch_dict = defaultdict(lambda: open)  # type: ignore
-_dispatch_dict[".gz"] = gzip.open  # type: ignore
-_dispatch_dict[".bz2"] = bz2.BZ2File  # type: ignore
-_dispatch_dict[".gzip"] = gzip.open  # type: ignore
+fopeners = {
+    ".gz": gzip.open,
+    ".gzip": gzip.open,
+    ".bz2": bz2.BZ2File,
+}
+_dispatch_dict = defaultdict(lambda: open, **fopeners)  # type: ignore
 
 
 def open_file(path_arg, mode="r"):

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -92,10 +92,10 @@ def not_implemented_for(*graph_types):
 
 # To handle new extensions, define a function accepting a `path` and `mode`.
 # Then add the extension to _dispatch_dict.
-_dispatch_dict = defaultdict(lambda: open)
-_dispatch_dict[".gz"] = gzip.open
-_dispatch_dict[".bz2"] = bz2.BZ2File
-_dispatch_dict[".gzip"] = gzip.open
+_dispatch_dict = defaultdict(lambda: open)  # type: ignore
+_dispatch_dict[".gz"] = gzip.open  # type: ignore
+_dispatch_dict[".bz2"] = bz2.BZ2File  # type: ignore
+_dispatch_dict[".gzip"] = gzip.open  # type: ignore
 
 
 def open_file(path_arg, mode="r"):

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -1,3 +1,4 @@
 black==21.9b0
 pyupgrade>=2.29.0
 pre-commit>=2.15
+mypy>=0.910


### PR DESCRIPTION
The purpose of this PR is to evaluate the impact of adding the static type checker Mypy to the development workflow of NetworkX. This PR **does not add any type annotations**! The goal is to see what impact the static type checker has on the existing code base. Adding this infrastructure is the first step in enabling support for type annotations moving forward. This PR also aims to focus the discussion in #5073 and provide an objective accounting of what sort of things `mypy` catches in the NX codebase and how these issues can be fixed.

## Mypy errors in the existing code

The first step in the analysis is to ascertain what mypy reports on the existing codebase, which doesn't contain any type annotations (with the exception of one function). This can be done on `main` in an existing development environment as follows:

```bash
pip install mypy
pip install -e .  # A development install of networkx
mypy --ignore-missing-imports -p networkx
```

Note: the `--ignore-missing-imports` flag is necessary to suppress mypy errors from missing type annotations in dependencies (e.g. scipy). Note also that the `-p networkx` flag is preferable as it only runs the type checking on the installed `p`ackage, ignoring things like `setup.py`. The above incantation will limit the reported errors to those found specifically within the networkx codebase.

On a50c8e6d, this results in 53 mypy errors:

<details>
  <summary>Mypy errors (added lineno for convenience)</summary>
<pre>
<ol>
<li>networkx/readwrite/nx_shp.py:330: error: Assignment to variable "e" outside except: block</li>
<li>networkx/classes/reportviews.py:1327: error: Incompatible types in assignment (expression has type "Type[OutMultiEdgeDataView]", base class "OutEdgeView" defined the type as "Type[OutEdgeDataView]")</li>
<li>networkx/classes/reportviews.py:1379: error: Incompatible types in assignment (expression has type "Type[MultiEdgeDataView]", base class "OutEdgeView" defined the type as "Type[OutEdgeDataView]")</li>
<li>networkx/classes/reportviews.py:1405: error: Incompatible types in assignment (expression has type "Type[InMultiEdgeDataView]", base class "OutEdgeView" defined the type as "Type[OutEdgeDataView]")</li>
<li>networkx/utils/decorators.py:95: error: Need type annotation for "_dispatch_dict"</li>
<li>networkx/utils/decorators.py:96: error: Incompatible types in assignment (expression has type overloaded function, target has type overloaded function)</li>
<li>networkx/utils/decorators.py:97: error: Incompatible types in assignment (expression has type "Type[BZ2File]", target has type overloaded function)</li>
<li>networkx/utils/decorators.py:98: error: Incompatible types in assignment (expression has type overloaded function, target has type overloaded function)</li>
<li>networkx/readwrite/graphml.py:1002: error: Assignment to variable "e" outside except: block</li>
<li>networkx/generators/line.py:122: error: All conditional function variants must have identical signatures</li>
<li>networkx/classes/graphviews.py:162: error: All conditional function variants must have identical signatures</li>
<li>networkx/algorithms/d_separation.py:109: error: "AbstractSet[Any]" has no attribute "union"</li>
<li>networkx/algorithms/community/lukes.py:186: error: Need type annotation for "bp_buffer" (hint: "bp_buffer: Dict[<type>, <type>] = ...")</li>
<li>networkx/algorithms/bipartite/edgelist.py:136: error: Assignment to variable "e" outside except: block</li>
<li>networkx/algorithms/bipartite/edgelist.py:141: error: Assignment to variable "e" outside except: block</li>
<li>networkx/algorithms/approximation/kcomponents.py:216: error: Incompatible types in assignment (expression has type "Callable[[_AntiGraph], Any]", base class "Graph" defined the type as "Type[Dict[Any, Any]]")</li>
<li>networkx/algorithms/connectivity/__init__.py:13: error: Need type annotation for "__all__"</li>
<li>networkx/algorithms/connectivity/__init__.py:15: error: Name "connectivity" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:16: error: Name "cuts" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:17: error: Name "edge_augmentation" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:18: error: Name "edge_kcomponents" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:19: error: Name "disjoint_paths" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:20: error: Name "kcomponents" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:21: error: Name "kcutsets" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:22: error: Name "stoerwagner" is not defined</li>
<li>networkx/algorithms/connectivity/__init__.py:23: error: Name "utils" is not defined</li>
<li>networkx/readwrite/tests/test_gml.py:291: error: Name "test_float_label" already defined on line 274</li>
<li>networkx/classes/tests/test_subgraphviews.py:196: error: List item 0 has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_subgraphviews.py:196: error: List item 1 has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_subgraphviews.py:196: error: List item 2 has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_subgraphviews.py:197: error: Argument 1 to <set> has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_subgraphviews.py:197: error: Argument 2 to <set> has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_subgraphviews.py:197: error: Argument 3 to <set> has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_subgraphviews.py:197: error: Argument 4 to <set> has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, int]"</li>
<li>networkx/classes/tests/test_reportviews.py:1100: error: Incompatible types in assignment (expression has type "Type[DiDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/classes/tests/test_reportviews.py:1110: error: Incompatible types in assignment (expression has type "Type[OutDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/classes/tests/test_reportviews.py:1160: error: Incompatible types in assignment (expression has type "Type[InDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/classes/tests/test_reportviews.py:1210: error: Incompatible types in assignment (expression has type "Type[MultiDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/classes/tests/test_reportviews.py:1260: error: Incompatible types in assignment (expression has type "Type[DiMultiDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/classes/tests/test_reportviews.py:1270: error: Incompatible types in assignment (expression has type "Type[OutMultiDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/classes/tests/test_reportviews.py:1320: error: Incompatible types in assignment (expression has type "Type[InMultiDegreeView]", base class "TestDegreeView" defined the type as "Type[DegreeView]")</li>
<li>networkx/algorithms/traversal/tests/test_edgedfs.py:7: error: Module has no attribute "edgedfs"; maybe "edge_dfs" or "edge_bfs"?</li>
<li>networkx/algorithms/traversal/tests/test_edgedfs.py:8: error: Module has no attribute "edgedfs"; maybe "edge_dfs" or "edge_bfs"?</li>
<li>networkx/algorithms/traversal/tests/test_edgebfs.py:7: error: Module has no attribute "edgedfs"; maybe "edge_dfs" or "edge_bfs"?</li>
<li>networkx/algorithms/traversal/tests/test_edgebfs.py:8: error: Module has no attribute "edgedfs"; maybe "edge_dfs" or "edge_bfs"?</li>
<li>networkx/algorithms/tests/test_smallworld.py:11: error: Incompatible types in assignment (expression has type "int", variable has type "Random")</li>
<li>networkx/algorithms/tests/test_graph_hashing.py:458: error: Name "test_isomorphic_edge_attr_and_node_attr" already defined on line 184</li>
<li>networkx/algorithms/tests/test_cycles.py:8: error: Module has no attribute "edgedfs"; maybe "edge_dfs" or "edge_bfs"?</li>
<li>networkx/algorithms/tests/test_cycles.py:9: error: Module has no attribute "edgedfs"; maybe "edge_dfs" or "edge_bfs"?</li>
<li>networkx/algorithms/flow/tests/test_maxflow.py:22: error: Need type annotation for "interface_funcs"</li>
<li>networkx/algorithms/flow/tests/test_maxflow.py:23: error: Need type annotation for "all_funcs"</li>
<li>networkx/algorithms/approximation/tests/test_traveling_salesman.py:42: error: "classmethod" used with a non-method</li>
<li>networkx/classes/tests/test_multigraph.py:220: error: Need type annotation for "single_edge"</li>
</ol>
Found 53 errors in 22 files (checked 560 source files)
</pre>
</details>

Some of these errors are obvious bugs with easy fixes, some are the result of mypy having some style checking baked in, and others seem to be deeper issues related to some design patterns in NetworkX not necessarily agreeing with rules enforced by mypy, or issues surrounding inheritance. The remainder of the commits in this PR address the errors individually.

## Resolving MyPy errors

It should be noted that the universal way to suppress mypy errors is to ignore type checks on individual objects using `# type: ignore`. I tried my best to minimize this usage here and address errors directly rather than ignoring them.

Below is a table that maps the commit hash to which mypy error(s) the patches fix. Below the table is a bit more discussion on the various mypy errors.

### Summary

| commit | mypy err no | note |
| ------ | ----------- | ---- |
| c2b8061 | 42-45 |  Properly import sentinels from traversal.edgedfs. |
| 4cda3fd | 1, 9, 14, 15 |  mypy doesn't like variables named \"e\".  |
| 832cd96 | 12 |  Rm annotations from single function. |
| 9f282da | 27, 47 |  Fix name collisions in test suite. |
| 2b8bfc8 | 46 |  Rm unused random seed in test setup. |
| f0c1c87 | 17-26 |  Rm redundant __all__ specification. |
| 1e4a262 | 50, 51 |  Silence mypy error from sum(). Mypy bug? |
| 4276842 | 52 | Fix tsp test instantiation nit. |
| 8600277 | 10, 11 |  \"type: ignore\" to suppress conditional fn sigature errors. |
| 81bbe5b | 5-8, 13, 16, 53 |  Remaining \"type: ignore\" to appease mypy. |
| 7607f8c | 2-4, 28-41 | Configure mypy to ignore inheritance issues. |

I've broken down the errors in the `details` section into two categories: those that require minor changes, and those that might be more involved. I've also set the history so that each commit deals with a particular type of mypy error.

### Minor fixups
 -  c2b8061 fixes some import patterns, switching to importing objects from the correct module directly rather than making local variables that point to objects in a different namespace. A minor improvement IMO.
 - 4cda3fd: `mypy` doesn't allow `e` as a variable name unless it is bound to an exception in a try/except statement. IMO this is more of a style consideration than type-checking, and I'm a little surprised `mypy` is so opinionated about it. Nevertheless, it's easy enough to change to a more descriptive variable name.
 - 832cd96: It turns out there was at least [one function in NetworkX](https://github.com/networkx/networkx/blob/ead0e65bda59862e329f2e6f1da47919c6b07ca9/networkx/algorithms/d_separation.py#L70) that already had inline type annotations. The mypy errors could be fixed by `AbstractSet` -> `Set`, but I just removed them in this PR so that we're starting from a clean slate.
 - 9f282da: `mypy` identified a couple instances in the test suite where different tests had the same name. Fixed these here, which is an obvious minor improvement.
 - 2b8bfc8: The type checking also identified an unused local variable (in this case, an unused random number seed) in the test suite.
 - f0c1c87: There's [some discussion in 5073](https://github.com/networkx/networkx/pull/5073#discussion_r725312949) about a limitation in mypy in handling imported objects. However; AFAICT the `__all__` definition here is redundant so I just removed it.
 - 1e4a262: Not sure what's going on here - `mypy` complains about some lists that are defined by combining other lists using the `sum([l1, l2], [])` pattern. For whatever reason `mypy` stops complaining if I modify one of these definitions (but not the other). Maybe this is a mypy bug?
 - 4276842: Mypy identified a usage of the `@classmethod` decorator outside of a class. Fixed this by slightly reorganizing the TSP tests.
 - 81bbe5b: This represents the final set of mypy errors that I couldn't figure out how to "fix" without typing, so I ended up adding the `# type: ignore` to suppress them.

### Larger issues

There was a second class of mypy errors related to larger issues where potential paths forward were less obvious than the above. These were largely related to two things:
 1. Class inheritance.
 2. Mypy disallows conditionals that define functions with the same name but different signatures.

I'll start with the second point. Mypy disallows conditionally defining a function that has a different signature, e.g.

```python
if True:
    def myfunc(a):
        pass
else:
    def myfunc(a, b):
        pass
```
NetworkX uses this pattern in at least a couple places to deal with e.g. difference in edge lookup for graphs and multigraphs: 

https://github.com/networkx/networkx/blob/44680a2466c3c429d9c01f55d71952efbb09b25c/networkx/generators/line.py#L115-L123

There are ways to "hack" around this by restructuring the conditionals and/or renaming to get rid of the mypy errors, but they make the code less readable. There is already some discussion on how best to fix one of these instances in #4459 . Fixing these generically in a way that doesn't reduce the readability of the code wasn't immediately obvious to me, so I kicked the can by marking these with `# type: ignore` in 8600277

The last set of mypy errors were related to (implied) type collisions when overriding members of child classes. Some of these occur in the test suite and would be remedied by switching from a class-based structure to a more pytest-y/fixture-based design (which IMO is a good idea regardless of mypy). Others are related to core structures like those in `reportviews.py`. #5073 proposes one solution for solving these issues by tweaking the initialization of some of the view objects, pulling it out of `__init__` methods and into a `_create_attributes` method, but I'm not sure it improves the readability of the code. Since dealing with these inheritance-based typing issues struck me as more complicated than some of the others, I proposed to ignore them by `excluding` the files where they are defined from type checking in 4918c7e.

## Adding type checking to workflow

Finally, this PR adds `mypy` to the GH workflow: 737ebe3 and 4918c7e.

