### PR TITLE
Change all Exception variable names from `e` to `err`

### DIFF
--- a/examples/subclass/plot_antigraph.py
+++ b/examples/subclass/plot_antigraph.py
@@ -65,8 +65,8 @@ class AntiGraph(Graph):
         """
         try:
             return iter(set(self.adj) - set(self.adj[n]) - {n})
-        except KeyError as e:
-            raise nx.NetworkXError(f"The node {n} is not in the graph.") from e
+        except KeyError as err:
+            raise nx.NetworkXError(f"The node {n} is not in the graph.") from err
 
     def degree(self, nbunch=None, weight=None):
         """Return an iterator for (node, degree) in the dense graph.

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -240,8 +240,8 @@ class _AntiGraph(nx.Graph):
         """
         try:
             return iter(set(self._adj) - set(self._adj[n]) - {n})
-        except KeyError as e:
-            raise NetworkXError(f"The node {n} is not in the graph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The node {n} is not in the graph.") from err
 
     class AntiAtlasView(Mapping):
         """An adjacency inner dict for AntiGraph"""

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -110,10 +110,10 @@ def latapy_clustering(G, nodes=None, mode="dot"):
 
     try:
         cc_func = modes[mode]
-    except KeyError as e:
+    except KeyError as err:
         raise nx.NetworkXError(
             "Mode for bipartite clustering must be: dot, min or max"
-        ) from e
+        ) from err
 
     if nodes is None:
         nodes = G

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -129,8 +129,8 @@ def generate_edgelist(G, delimiter=" ", data=True):
     """
     try:
         part0 = [n for n, d in G.nodes.items() if d["bipartite"] == 0]
-    except BaseException as e:
-        raise AttributeError("Missing node attribute `bipartite`") from e
+    except BaseException as err:
+        raise AttributeError("Missing node attribute `bipartite`") from err
     if data is True or data is False:
         for n in part0:
             for e in G.edges(n, data=data):
@@ -228,10 +228,10 @@ def parse_edgelist(
             try:
                 u = nodetype(u)
                 v = nodetype(v)
-            except BaseException as e:
+            except BaseException as err:
                 raise TypeError(
                     f"Failed to convert nodes {u},{v} " f"to type {nodetype}."
-                ) from e
+                ) from err
 
         if len(d) == 0 or data is False:
             # no data or data type specified
@@ -240,10 +240,10 @@ def parse_edgelist(
             # no edge types specified
             try:  # try to evaluate as dictionary
                 edgedata = dict(literal_eval(" ".join(d)))
-            except BaseException as e:
+            except BaseException as err:
                 raise TypeError(
                     f"Failed to convert edge data ({d})" f"to dictionary."
-                ) from e
+                ) from err
         else:
             # convert edge data to dictionary with specified keys and type
             if len(d) != len(data):
@@ -254,11 +254,11 @@ def parse_edgelist(
             for (edge_key, edge_type), edge_value in zip(data, d):
                 try:
                     edge_value = edge_type(edge_value)
-                except BaseException as e:
+                except BaseException as err:
                     raise TypeError(
                         f"Failed to convert {edge_key} data "
                         f"{edge_value} to type {edge_type}."
-                    ) from e
+                    ) from err
                 edgedata.update({edge_key: edge_value})
         G.add_node(u, bipartite=0)
         G.add_node(v, bipartite=1)

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -105,8 +105,8 @@ def biadjacency_matrix(
     M = sp.sparse.coo_matrix((data, (row, col)), shape=(nlen, mlen), dtype=dtype)
     try:
         return M.asformat(format)
-    except ValueError as e:
-        raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from e
+    except ValueError as err:
+        raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from err
 
 
 def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight"):

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -157,12 +157,12 @@ def katz_centrality(
 
     try:
         b = dict.fromkeys(G, float(beta))
-    except (TypeError, ValueError, AttributeError) as e:
+    except (TypeError, ValueError, AttributeError) as err:
         b = beta
         if set(beta) != set(G):
             raise nx.NetworkXError(
                 "beta dictionary " "must have a value for every node"
-            ) from e
+            ) from err
 
     # make up to max_iter iterations
     for i in range(max_iter):
@@ -319,8 +319,8 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
         nodelist = list(G)
         try:
             b = np.ones((len(nodelist), 1)) * float(beta)
-        except (TypeError, ValueError, AttributeError) as e:
-            raise nx.NetworkXError("beta must be a number") from e
+        except (TypeError, ValueError, AttributeError) as err:
+            raise nx.NetworkXError("beta must be a number") from err
 
     A = nx.adjacency_matrix(G, nodelist=nodelist, weight=weight).todense().T
     n = A.shape[0]

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -100,8 +100,8 @@ def kernighan_lin_bisection(G, partition=None, max_iter=10, weight="weight", see
     else:
         try:
             A, B = partition
-        except (TypeError, ValueError) as e:
-            raise nx.NetworkXError("partition must be two sets") from e
+        except (TypeError, ValueError) as err:
+            raise nx.NetworkXError("partition must be two sets") from err
         if not is_partition(G, (A, B)):
             raise nx.NetworkXError("partition invalid")
         side = [0] * n

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -985,9 +985,9 @@ def weighted_bridge_augmentation(G, avail, weight=None):
         # Note the original edges must be directed towards to root for the
         # branching to give us a bridge-augmentation.
         A = _minimum_rooted_branching(D, root)
-    except nx.NetworkXException as e:
+    except nx.NetworkXException as err:
         # If there is no branching then augmentation is not possible
-        raise nx.NetworkXUnfeasible("no 2-edge-augmentation possible") from e
+        raise nx.NetworkXUnfeasible("no 2-edge-augmentation possible") from err
 
     # For each edge e, in the branching that did not belong to the directed
     # tree T, add the corresponding edge that **GENERATED** it (this is not

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -212,8 +212,8 @@ def topological_generations(G):
             for child in G.neighbors(node):
                 try:
                     indegree_map[child] -= len(G[node][child]) if multigraph else 1
-                except KeyError as e:
-                    raise RuntimeError("Graph changed during iteration") from e
+                except KeyError as err:
+                    raise RuntimeError("Graph changed during iteration") from err
                 if indegree_map[child] == 0:
                     zero_indegree.append(child)
                     del indegree_map[child]
@@ -378,8 +378,8 @@ def lexicographical_topological_sort(G, key=None):
         for _, child in G.edges(node):
             try:
                 indegree_map[child] -= 1
-            except KeyError as e:
-                raise RuntimeError("Graph changed during iteration") from e
+            except KeyError as err:
+                raise RuntimeError("Graph changed during iteration") from err
             if indegree_map[child] == 0:
                 heapq.heappush(zero_indegree, create_tuple(child))
                 del indegree_map[child]

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -251,8 +251,8 @@ def eccentricity(G, v=None, sp=None):
             try:
                 length = sp[n]
                 L = len(length)
-            except TypeError as e:
-                raise nx.NetworkXError('Format of "sp" is invalid.') from e
+            except TypeError as err:
+                raise nx.NetworkXError('Format of "sp" is invalid.') from err
         if L != order:
             if G.is_directed():
                 msg = (

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -158,8 +158,8 @@ def intersection_array(G):
         for v in G:
             try:
                 i = path_length[u][v]
-            except KeyError as e:  # graph must be connected
-                raise nx.NetworkXError("Graph is not distance regular.") from e
+            except KeyError as err:  # graph must be connected
+                raise nx.NetworkXError("Graph is not distance regular.") from err
             # number of neighbors of v at a distance of i-1 from u
             c = len([n for n in G[v] if path_length[n][u] == i - 1])
             # number of neighbors of v at a distance of i+1 from u

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -582,5 +582,5 @@ def _community(G, u, community):
     node_u = G.nodes[u]
     try:
         return node_u[community]
-    except KeyError as e:
-        raise nx.NetworkXAlgorithmError("No community information") from e
+    except KeyError as err:
+        raise nx.NetworkXAlgorithmError("No community information") from err

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -875,9 +875,9 @@ class PlanarEmbedding(nx.DiGraph):
         for v in self:
             try:
                 sorted_nbrs = set(self.neighbors_cw_order(v))
-            except KeyError as e:
+            except KeyError as err:
                 msg = f"Bad embedding. Missing orientation for a neighbor of {v}"
-                raise nx.NetworkXException(msg) from e
+                raise nx.NetworkXException(msg) from err
 
             unsorted_nbrs = set(self[v])
             if sorted_nbrs != unsorted_nbrs:

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -233,8 +233,8 @@ def dijkstra_path_length(G, source, target, weight="weight"):
     length = _dijkstra(G, source, weight, target=target)
     try:
         return length[target]
-    except KeyError as e:
-        raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}") from e
+    except KeyError as err:
+        raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}") from err
 
 
 def single_source_dijkstra_path(G, source, cutoff=None, weight="weight"):
@@ -742,8 +742,8 @@ def multi_source_dijkstra(G, sources, target=None, cutoff=None, weight="weight")
         return (dist, paths)
     try:
         return (dist[target], paths[target])
-    except KeyError as e:
-        raise nx.NetworkXNoPath(f"No path to {target}.") from e
+    except KeyError as err:
+        raise nx.NetworkXNoPath(f"No path to {target}.") from err
 
 
 def _dijkstra(G, source, weight, pred=None, paths=None, cutoff=None, target=None):
@@ -1465,8 +1465,8 @@ def bellman_ford_path_length(G, source, target, weight="weight"):
 
     try:
         return length[target]
-    except KeyError as e:
-        raise nx.NetworkXNoPath(f"node {target} not reachable from {source}") from e
+    except KeyError as err:
+        raise nx.NetworkXNoPath(f"node {target} not reachable from {source}") from err
 
 
 def single_source_bellman_ford_path(G, source, weight="weight"):
@@ -1654,9 +1654,9 @@ def single_source_bellman_ford(G, source, target=None, weight="weight"):
         return (dist, paths)
     try:
         return (dist[target], paths[target])
-    except KeyError as e:
+    except KeyError as err:
         msg = f"Node {target} not reachable from {source}"
-        raise nx.NetworkXNoPath(msg) from e
+        raise nx.NetworkXNoPath(msg) from err
 
 
 def all_pairs_bellman_ford_path_length(G, weight="weight"):

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -224,8 +224,8 @@ def all_simple_paths(G, source, target, cutoff=None):
     else:
         try:
             targets = set(target)
-        except TypeError as e:
-            raise nx.NodeNotFound(f"target node {target} not in graph") from e
+        except TypeError as err:
+            raise nx.NodeNotFound(f"target node {target} not in graph") from err
     if source in targets:
         return _empty_generator()
     if cutoff is None:

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -59,8 +59,8 @@ def index_satisfying(iterable, condition):
     # exception.
     try:
         return i + 1
-    except NameError as e:
-        raise ValueError("iterable must be non-empty") from e
+    except NameError as err:
+        raise ValueError("iterable must be non-empty") from err
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -221,8 +221,8 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
     def remove_edge_with_key(self, key):
         try:
             u, v, _ = self.edge_index[key]
-        except KeyError as e:
-            raise KeyError(f"Invalid edge key {key!r}") from e
+        except KeyError as err:
+            raise KeyError(f"Invalid edge key {key!r}") from err
         else:
             del self.edge_index[key]
             self._cls.remove_edge(u, v, key)

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -435,9 +435,9 @@ def minimum_spanning_edges(
     """
     try:
         algo = ALGORITHMS[algorithm]
-    except KeyError as e:
+    except KeyError as err:
         msg = f"{algorithm} is not a valid choice for an algorithm."
-        raise ValueError(msg) from e
+        raise ValueError(msg) from err
 
     return algo(
         G, minimum=True, weight=weight, keys=keys, data=data, ignore_nan=ignore_nan
@@ -528,9 +528,9 @@ def maximum_spanning_edges(
     """
     try:
         algo = ALGORITHMS[algorithm]
-    except KeyError as e:
+    except KeyError as err:
         msg = f"{algorithm} is not a valid choice for an algorithm."
-        raise ValueError(msg) from e
+        raise ValueError(msg) from err
 
     return algo(
         G, minimum=False, weight=weight, keys=keys, data=data, ignore_nan=ignore_nan

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -519,8 +519,8 @@ class DiGraph(Graph):
         try:
             nbrs = self._succ[n]
             del self._node[n]
-        except KeyError as e:  # NetworkXError if n not in self
-            raise NetworkXError(f"The node {n} is not in the digraph.") from e
+        except KeyError as err:  # NetworkXError if n not in self
+            raise NetworkXError(f"The node {n} is not in the digraph.") from err
         for u in nbrs:
             del self._pred[u][n]  # remove all edges n-u in digraph
         del self._succ[n]  # remove node from succ
@@ -730,8 +730,8 @@ class DiGraph(Graph):
         try:
             del self._succ[u][v]
             del self._pred[v][u]
-        except KeyError as e:
-            raise NetworkXError(f"The edge {u}-{v} not in graph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The edge {u}-{v} not in graph.") from err
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -805,8 +805,8 @@ class DiGraph(Graph):
         """
         try:
             return iter(self._succ[n])
-        except KeyError as e:
-            raise NetworkXError(f"The node {n} is not in the digraph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The node {n} is not in the digraph.") from err
 
     # digraph definitions
     neighbors = successors
@@ -833,8 +833,8 @@ class DiGraph(Graph):
         """
         try:
             return iter(self._pred[n])
-        except KeyError as e:
-            raise NetworkXError(f"The node {n} is not in the digraph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The node {n} is not in the digraph.") from err
 
     @property
     def edges(self):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -175,8 +175,8 @@ def freeze(G):
     >>> G = nx.freeze(G)
     >>> try:
     ...     G.add_edge(4, 5)
-    ... except nx.NetworkXError as e:
-    ...     print(str(e))
+    ... except nx.NetworkXError as err:
+    ...     print(str(err))
     Frozen graph can't be modified
 
     Notes

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -617,8 +617,8 @@ class Graph:
         try:
             nbrs = list(adj[n])  # list handles self-loops (allows mutation)
             del self._node[n]
-        except KeyError as e:  # NetworkXError if n not in self
-            raise NetworkXError(f"The node {n} is not in the graph.") from e
+        except KeyError as err:  # NetworkXError if n not in self
+            raise NetworkXError(f"The node {n} is not in the graph.") from err
         for u in nbrs:
             del adj[u][n]  # remove all edges n-u in graph
         del adj[n]  # now remove node
@@ -1017,8 +1017,8 @@ class Graph:
             del self._adj[u][v]
             if u != v:  # self-loop needs only one entry removed
                 del self._adj[v][u]
-        except KeyError as e:
-            raise NetworkXError(f"The edge {u}-{v} is not in the graph") from e
+        except KeyError as err:
+            raise NetworkXError(f"The edge {u}-{v} is not in the graph") from err
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1251,8 +1251,8 @@ class Graph:
         """
         try:
             return iter(self._adj[n])
-        except KeyError as e:
-            raise NetworkXError(f"The node {n} is not in the graph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The node {n} is not in the graph.") from err
 
     @property
     def edges(self):
@@ -1911,8 +1911,8 @@ class Graph:
                     for n in nlist:
                         if n in adj:
                             yield n
-                except TypeError as e:
-                    exc, message = e, e.args[0]
+                except TypeError as err:
+                    exc, message = err, err.args[0]
                     # capture error for non-sequence/iterator nbunch.
                     if "iter" in message:
                         exc = NetworkXError(

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -334,10 +334,10 @@ class MultiDiGraph(MultiGraph, DiGraph):
                     incoming_graph_data, create_using=self, multigraph_input=True
                 )
                 self.graph.update(attr)
-            except Exception as e:
+            except Exception as err:
                 if multigraph_input is True:
                     raise nx.NetworkXError(
-                        f"converting multigraph_input raised:\n{type(e)}: {e}"
+                        f"converting multigraph_input raised:\n{type(err)}: {err}"
                     )
                 DiGraph.__init__(self, incoming_graph_data, **attr)
         else:
@@ -540,17 +540,17 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         try:
             d = self._adj[u][v]
-        except KeyError as e:
-            raise NetworkXError(f"The edge {u}-{v} is not in the graph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The edge {u}-{v} is not in the graph.") from err
         # remove the edge with specified data
         if key is None:
             d.popitem()
         else:
             try:
                 del d[key]
-            except KeyError as e:
+            except KeyError as err:
                 msg = f"The edge {u}-{v} with key {key} is not in the graph."
-                raise NetworkXError(msg) from e
+                raise NetworkXError(msg) from err
         if len(d) == 0:
             # remove the key entries if last edge
             del self._succ[u][v]

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -343,10 +343,10 @@ class MultiGraph(Graph):
                     incoming_graph_data, create_using=self, multigraph_input=True
                 )
                 self.graph.update(attr)
-            except Exception as e:
+            except Exception as err:
                 if multigraph_input is True:
                     raise nx.NetworkXError(
-                        f"converting multigraph_input raised:\n{type(e)}: {e}"
+                        f"converting multigraph_input raised:\n{type(err)}: {err}"
                     )
                 Graph.__init__(self, incoming_graph_data, **attr)
         else:
@@ -622,17 +622,17 @@ class MultiGraph(Graph):
         """
         try:
             d = self._adj[u][v]
-        except KeyError as e:
-            raise NetworkXError(f"The edge {u}-{v} is not in the graph.") from e
+        except KeyError as err:
+            raise NetworkXError(f"The edge {u}-{v} is not in the graph.") from err
         # remove the edge with specified data
         if key is None:
             d.popitem()
         else:
             try:
                 del d[key]
-            except KeyError as e:
+            except KeyError as err:
                 msg = f"The edge {u}-{v} with key {key} is not in the graph."
-                raise NetworkXError(msg) from e
+                raise NetworkXError(msg) from err
         if len(d) == 0:
             # remove the key entries if last edge
             del self._adj[u][v]

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -87,15 +87,15 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
             for n, dd in data.nodes.items():
                 result._node[n].update(dd)
             return result
-        except Exception as e:
-            raise nx.NetworkXError("Input is not a correct NetworkX graph.") from e
+        except Exception as err:
+            raise nx.NetworkXError("Input is not a correct NetworkX graph.") from err
 
     # pygraphviz  agraph
     if hasattr(data, "is_strict"):
         try:
             return nx.nx_agraph.from_agraph(data, create_using=create_using)
-        except Exception as e:
-            raise nx.NetworkXError("Input is not a correct pygraphviz graph.") from e
+        except Exception as err:
+            raise nx.NetworkXError("Input is not a correct pygraphviz graph.") from err
 
     # dict of dicts/lists
     if isinstance(data, dict):
@@ -103,15 +103,15 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
             return from_dict_of_dicts(
                 data, create_using=create_using, multigraph_input=multigraph_input
             )
-        except Exception as e:
+        except Exception as err:
             if multigraph_input is True:
                 raise nx.NetworkXError(
-                    f"converting multigraph_input raised:\n{type(e)}: {e}"
+                    f"converting multigraph_input raised:\n{type(err)}: {err}"
                 )
             try:
                 return from_dict_of_lists(data, create_using=create_using)
-            except Exception as e:
-                raise TypeError("Input is not known type.") from e
+            except Exception as err:
+                raise TypeError("Input is not known type.") from err
 
     # Pandas DataFrame
     try:
@@ -121,17 +121,17 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
             if data.shape[0] == data.shape[1]:
                 try:
                     return nx.from_pandas_adjacency(data, create_using=create_using)
-                except Exception as e:
+                except Exception as err:
                     msg = "Input is not a correct Pandas DataFrame adjacency matrix."
-                    raise nx.NetworkXError(msg) from e
+                    raise nx.NetworkXError(msg) from err
             else:
                 try:
                     return nx.from_pandas_edgelist(
                         data, edge_attr=True, create_using=create_using
                     )
-                except Exception as e:
+                except Exception as err:
                     msg = "Input is not a correct Pandas DataFrame edge-list."
-                    raise nx.NetworkXError(msg) from e
+                    raise nx.NetworkXError(msg) from err
     except ImportError:
         warnings.warn("pandas not found, skipping conversion test.", ImportWarning)
 
@@ -142,10 +142,10 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
         if isinstance(data, (np.matrix, np.ndarray)):
             try:
                 return nx.from_numpy_matrix(data, create_using=create_using)
-            except Exception as e:
+            except Exception as err:
                 raise nx.NetworkXError(
                     "Input is not a correct numpy matrix or array."
-                ) from e
+                ) from err
     except ImportError:
         warnings.warn("numpy not found, skipping conversion test.", ImportWarning)
 
@@ -156,10 +156,10 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
         if hasattr(data, "format"):
             try:
                 return nx.from_scipy_sparse_matrix(data, create_using=create_using)
-            except Exception as e:
+            except Exception as err:
                 raise nx.NetworkXError(
                     "Input is not a correct scipy sparse matrix type."
-                ) from e
+                ) from err
     except ImportError:
         warnings.warn("scipy not found, skipping conversion test.", ImportWarning)
 
@@ -170,8 +170,8 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     if isinstance(data, (Collection, Generator, Iterator)):
         try:
             return from_edgelist(data, create_using=create_using)
-        except Exception as e:
-            raise nx.NetworkXError("Input is not a valid edge list") from e
+        except Exception as err:
+            raise nx.NetworkXError("Input is not a valid edge list") from err
 
     raise nx.NetworkXError("Input is not a known data type for conversion.")
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -196,10 +196,10 @@ def from_pandas_adjacency(df, create_using=None):
 
     try:
         df = df[df.index]
-    except Exception as e:
+    except Exception as err:
         missing = list(set(df.index).difference(set(df.columns)))
         msg = f"{missing} not in columns"
-        raise nx.NetworkXError("Columns must match Indices.", msg) from e
+        raise nx.NetworkXError("Columns must match Indices.", msg) from err
 
     A = df.values
     G = from_numpy_array(A, create_using=create_using)
@@ -439,9 +439,9 @@ def from_pandas_edgelist(
 
     try:
         attribute_data = zip(*[df[col] for col in attr_col_headings])
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError) as err:
         msg = f"Invalid edge_attr argument: {edge_attr}"
-        raise nx.NetworkXError(msg) from e
+        raise nx.NetworkXError(msg) from err
 
     if g.is_multigraph():
         # => append the edge keys from the df to the bundled data
@@ -449,9 +449,9 @@ def from_pandas_edgelist(
             try:
                 multigraph_edge_keys = df[edge_key]
                 attribute_data = zip(attribute_data, multigraph_edge_keys)
-            except (KeyError, TypeError) as e:
+            except (KeyError, TypeError) as err:
                 msg = f"Invalid edge_key argument: {edge_key}"
-                raise nx.NetworkXError(msg) from e
+                raise nx.NetworkXError(msg) from err
 
         for s, t, attrs in zip(df[source], df[target], attribute_data):
             if edge_key is not None:
@@ -900,8 +900,8 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
         return M.asformat(format)
     # From Scipy 1.1.0, asformat will throw a ValueError instead of an
     # AttributeError if the format if not recognized.
-    except (AttributeError, ValueError) as e:
-        raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from e
+    except (AttributeError, ValueError) as err:
+        raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from err
 
 
 def _csr_gen_triples(A):
@@ -1225,8 +1225,8 @@ def to_numpy_array(
         operator = {sum: np.nansum, min: np.nanmin, max: np.nanmax}
         try:
             op = operator[multigraph_weight]
-        except Exception as e:
-            raise ValueError("multigraph_weight must be sum, min, or max") from e
+        except Exception as err:
+            raise ValueError("multigraph_weight must be sum, min, or max") from err
 
         for u, v, attrs in G.edges(data=True):
             if (u in nodeset) and (v in nodeset):
@@ -1358,8 +1358,8 @@ def from_numpy_array(A, parallel_edges=False, create_using=None):
     dt = A.dtype
     try:
         python_type = kind_to_python_type[dt.kind]
-    except Exception as e:
-        raise TypeError(f"Unknown numpy data type: {dt}") from e
+    except Exception as err:
+        raise TypeError(f"Unknown numpy data type: {dt}") from err
 
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n))

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -509,9 +509,9 @@ def _fruchterman_reingold(
 
     try:
         nnodes, _ = A.shape
-    except AttributeError as e:
+    except AttributeError as err:
         msg = "fruchterman_reingold() takes an adjacency matrix as input"
-        raise nx.NetworkXError(msg) from e
+        raise nx.NetworkXError(msg) from err
 
     if pos is None:
         # random initial positions
@@ -575,9 +575,9 @@ def _sparse_fruchterman_reingold(
 
     try:
         nnodes, _ = A.shape
-    except AttributeError as e:
+    except AttributeError as err:
         msg = "fruchterman_reingold() takes an adjacency matrix as input"
-        raise nx.NetworkXError(msg) from e
+        raise nx.NetworkXError(msg) from err
     # make sure we have a LIst of Lists representation
     try:
         A = A.tolil()
@@ -848,9 +848,9 @@ def _spectral(A, dim=2):
 
     try:
         nnodes, _ = A.shape
-    except AttributeError as e:
+    except AttributeError as err:
         msg = "spectral() takes an adjacency matrix as input"
-        raise nx.NetworkXError(msg) from e
+        raise nx.NetworkXError(msg) from err
 
     # form Laplacian matrix where D is diagonal of degrees
     D = np.identity(nnodes, dtype=A.dtype) * np.sum(A, axis=1)
@@ -873,9 +873,9 @@ def _sparse_spectral(A, dim=2):
 
     try:
         nnodes, _ = A.shape
-    except AttributeError as e:
+    except AttributeError as err:
         msg = "sparse_spectral() takes an adjacency matrix as input"
-        raise nx.NetworkXError(msg) from e
+        raise nx.NetworkXError(msg) from err
 
     # form Laplacian matrix
     data = np.asarray(A.sum(axis=1).T)

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -130,8 +130,10 @@ def to_agraph(N):
     """
     try:
         import pygraphviz
-    except ImportError as e:
-        raise ImportError("requires pygraphviz " "http://pygraphviz.github.io/") from e
+    except ImportError as err:
+        raise ImportError(
+            "requires pygraphviz " "http://pygraphviz.github.io/"
+        ) from err
     directed = N.is_directed()
     strict = nx.number_of_selfloops(N) == 0 and not N.is_multigraph()
     A = pygraphviz.AGraph(name=N.name, strict=strict, directed=directed)
@@ -198,10 +200,10 @@ def read_dot(path):
     """
     try:
         import pygraphviz
-    except ImportError as e:
+    except ImportError as err:
         raise ImportError(
             "read_dot() requires pygraphviz " "http://pygraphviz.github.io/"
-        ) from e
+        ) from err
     A = pygraphviz.AGraph(file=path)
     gr = from_agraph(A)
     A.clear()
@@ -279,8 +281,10 @@ def pygraphviz_layout(G, prog="neato", root=None, args=""):
     """
     try:
         import pygraphviz
-    except ImportError as e:
-        raise ImportError("requires pygraphviz " "http://pygraphviz.github.io/") from e
+    except ImportError as err:
+        raise ImportError(
+            "requires pygraphviz " "http://pygraphviz.github.io/"
+        ) from err
     if root is not None:
         args += f"-Groot={root}"
     A = to_agraph(G)

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -452,8 +452,8 @@ def draw_networkx_nodes(
 
     try:
         xy = np.asarray([pos[v] for v in nodelist])
-    except KeyError as e:
-        raise nx.NetworkXError(f"Node {e} has no position.") from e
+    except KeyError as err:
+        raise nx.NetworkXError(f"Node {err} has no position.") from err
 
     if isinstance(alpha, Iterable):
         node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -762,8 +762,8 @@ def complete_multipartite_graph(*subset_sizes):
     try:
         for (i, subset) in enumerate(subsets):
             G.add_nodes_from(subset, subset=i)
-    except TypeError as e:
-        raise NetworkXError("Arguments must be all ints or all iterables") from e
+    except TypeError as err:
+        raise NetworkXError("Arguments must be all ints or all iterables") from err
 
     # Across subsets, all nodes should be adjacent.
     # We can use itertools.combinations() because undirected.

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -75,10 +75,10 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
         try:
             ui = node_index[u]
             vi = node_index[v]
-        except KeyError as e:
+        except KeyError as err:
             raise nx.NetworkXError(
                 f"node {u} or {v} in edgelist " f"but not in nodelist"
-            ) from e
+            ) from err
         if weight is None:
             wt = 1
         else:

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -284,8 +284,8 @@ class TestAlgebraicConnectivity:
             ) == pytest.approx(sigma, abs=1e-7)
             x = nx.fiedler_vector(G, normalized=normalized, tol=1e-12, method=method)
             check_eigenvector(A, sigma, x)
-        except nx.NetworkXError as e:
-            if e.args not in (
+        except nx.NetworkXError as err:
+            if err.args not in (
                 ("Cholesky solver unavailable.",),
                 ("LU solver unavailable.",),
             ):
@@ -385,8 +385,8 @@ class TestSpectralOrdering:
         A = nx.laplacian_matrix(G).todense()
         try:
             order = nx.spectral_ordering(G, normalized=normalized, method=method)
-        except nx.NetworkXError as e:
-            if e.args not in (
+        except nx.NetworkXError as err:
+            if err.args not in (
                 ("Cholesky solver unavailable.",),
                 ("LU solver unavailable.",),
             ):

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -193,19 +193,18 @@ def parse_adjlist(
         if nodetype is not None:
             try:
                 u = nodetype(u)
-            except BaseException as e:
+            except BaseException as err:
                 raise TypeError(
                     f"Failed to convert node ({u}) to type " f"{nodetype}"
-                ) from e
+                ) from err
         G.add_node(u)
         if nodetype is not None:
             try:
                 vlist = list(map(nodetype, vlist))
-            except BaseException as e:
+            except BaseException as err:
                 raise TypeError(
-                    f"Failed to convert nodes ({','.join(vlist)}) "
-                    f"to type {nodetype}"
-                ) from e
+                    f"Failed to convert nodes ({','.join(vlist)}) to type {nodetype}"
+                ) from err
         G.add_edges_from([(u, v) for v in vlist])
     return G
 

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -256,10 +256,10 @@ def parse_edgelist(
             try:
                 u = nodetype(u)
                 v = nodetype(v)
-            except Exception as e:
+            except Exception as err:
                 raise TypeError(
                     f"Failed to convert nodes {u},{v} to type {nodetype}."
-                ) from e
+                ) from err
 
         if len(d) == 0 or data is False:
             # no data or data type specified
@@ -272,10 +272,10 @@ def parse_edgelist(
                 else:
                     edgedata_str = " ".join(d)
                 edgedata = dict(literal_eval(edgedata_str.strip()))
-            except Exception as e:
+            except Exception as err:
                 raise TypeError(
                     f"Failed to convert edge data ({d}) to dictionary."
-                ) from e
+                ) from err
         else:
             # convert edge data to dictionary with specified keys and type
             if len(d) != len(data):
@@ -286,11 +286,11 @@ def parse_edgelist(
             for (edge_key, edge_type), edge_value in zip(data, d):
                 try:
                     edge_value = edge_type(edge_value)
-                except Exception as e:
+                except Exception as err:
                     raise TypeError(
                         f"Failed to convert {edge_key} data {edge_value} "
                         f"to type {edge_type}."
-                    ) from e
+                    ) from err
                 edgedata.update({edge_key: edge_value})
         G.add_edge(u, v, **edgedata)
     return G

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -965,8 +965,8 @@ class GEXFReader(GEXF):
                 key = a.get("for")  # for is required
                 try:  # should be in our gexf_keys dictionary
                     title = gexf_keys[key]["title"]
-                except KeyError as e:
-                    raise nx.NetworkXError(f"No attribute defined for={key}.") from e
+                except KeyError as err:
+                    raise nx.NetworkXError(f"No attribute defined for={key}.") from err
                 atype = gexf_keys[key]["type"]
                 value = a.get("value")
                 if atype == "boolean":
@@ -1036,10 +1036,10 @@ def relabel_gexf_graph(G):
     # build mapping of node labels, do some error checking
     try:
         mapping = [(u, G.nodes[u]["label"]) for u in G]
-    except KeyError as e:
+    except KeyError as err:
         raise nx.NetworkXError(
             "Failed to relabel nodes: missing node labels found. Use relabel=False."
-        ) from e
+        ) from err
     x, y = zip(*mapping)
     if len(set(y)) != len(G):
         raise nx.NetworkXError(

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -107,8 +107,8 @@ def literal_destringizer(rep):
         orig_rep = rep
         try:
             return literal_eval(rep)
-        except SyntaxError as e:
-            raise ValueError(f"{orig_rep!r} is not a valid Python literal") from e
+        except SyntaxError as err:
+            raise ValueError(f"{orig_rep!r} is not a valid Python literal") from err
     else:
         raise ValueError(f"{rep!r} is not a string")
 
@@ -184,8 +184,8 @@ def read_gml(path, label="label", destringizer=None):
         for line in lines:
             try:
                 line = line.decode("ascii")
-            except UnicodeDecodeError as e:
-                raise NetworkXError("input is not ASCII-encoded") from e
+            except UnicodeDecodeError as err:
+                raise NetworkXError("input is not ASCII-encoded") from err
             if not isinstance(line, str):
                 lines = str(lines)
             if line and line[-1] == "\n":
@@ -249,8 +249,8 @@ def parse_gml(lines, label="label", destringizer=None):
         if isinstance(line, bytes):
             try:
                 line.decode("ascii")
-            except UnicodeDecodeError as e:
-                raise NetworkXError("input is not ASCII-encoded") from e
+            except UnicodeDecodeError as err:
+                raise NetworkXError("input is not ASCII-encoded") from err
         if not isinstance(line, str):
             line = str(line)
         return line
@@ -444,8 +444,8 @@ def parse_gml_lines(lines, label, destringizer):
     def pop_attr(dct, category, attr, i):
         try:
             return dct.pop(attr)
-        except KeyError as e:
-            raise NetworkXError(f"{category} #{i} has no {attr!r} attribute") from e
+        except KeyError as err:
+            raise NetworkXError(f"{category} #{i} has no {attr!r} attribute") from err
 
     nodes = graph.get("node", [])
     mapping = {}
@@ -742,10 +742,10 @@ def generate_gml(G, stringizer=None):
                 if stringizer:
                     try:
                         value = stringizer(value)
-                    except ValueError as e:
+                    except ValueError as err:
                         raise NetworkXError(
                             f"{value!r} cannot be converted into a string"
-                        ) from e
+                        ) from err
                 if not isinstance(value, str):
                     raise NetworkXError(f"{value!r} is not a string")
                 yield indent + key + ' "' + escape(value) + '"'

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -453,10 +453,10 @@ class GraphML:
         supported by GraphML."""
         try:
             return self.xml_type[key]
-        except KeyError as e:
+        except KeyError as err:
             raise TypeError(
                 f"GraphML does not support type {type(key)} as data values."
-            ) from e
+            ) from err
 
 
 class GraphMLWriter(GraphML):
@@ -965,8 +965,8 @@ class GraphMLReader(GraphML):
             try:
                 data_name = graphml_keys[key]["name"]
                 data_type = graphml_keys[key]["type"]
-            except KeyError as e:
-                raise nx.NetworkXError(f"Bad GraphML data: no key {key}") from e
+            except KeyError as err:
+                raise nx.NetworkXError(f"Bad GraphML data: no key {key}") from err
             text = data_element.text
             # assume anything with subelements is a yfiles extension
             if text is not None and len(list(data_element)) == 0:

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -99,8 +99,8 @@ def parse_leda(lines):
     for i in range(m):
         try:
             s, t, reversal, label = next(lines).split()
-        except BaseException as e:
-            raise NetworkXError(f"Too few fields in LEDA.GRAPH edge {i+1}") from e
+        except BaseException as err:
+            raise NetworkXError(f"Too few fields in LEDA.GRAPH edge {i+1}") from err
         # BEWARE: no handling of reversal edges
         G.add_edge(node[int(s)], node[int(t)], label=label[2:-2])
     return G

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -247,23 +247,23 @@ def parse_multiline_adjlist(
         try:
             (u, deg) = line.strip().split(delimiter)
             deg = int(deg)
-        except BaseException as e:
-            raise TypeError(f"Failed to read node and degree on line ({line})") from e
+        except BaseException as err:
+            raise TypeError(f"Failed to read node and degree on line ({line})") from err
         if nodetype is not None:
             try:
                 u = nodetype(u)
-            except BaseException as e:
+            except BaseException as err:
                 raise TypeError(
                     f"Failed to convert node ({u}) to " f"type {nodetype}"
-                ) from e
+                ) from err
         G.add_node(u)
         for i in range(deg):
             while True:
                 try:
                     line = next(lines)
-                except StopIteration as e:
+                except StopIteration as err:
                     msg = f"Failed to find neighbor for node ({u})"
-                    raise TypeError(msg) from e
+                    raise TypeError(msg) from err
                 p = line.find(comments)
                 if p >= 0:
                     line = line[:p]
@@ -278,17 +278,17 @@ def parse_multiline_adjlist(
             if nodetype is not None:
                 try:
                     v = nodetype(v)
-                except BaseException as e:
+                except BaseException as err:
                     raise TypeError(
                         f"Failed to convert node ({v}) " f"to type {nodetype}"
-                    ) from e
+                    ) from err
             if edgetype is not None:
                 try:
                     edgedata = {"weight": edgetype(data)}
-                except BaseException as e:
+                except BaseException as err:
                     raise TypeError(
                         f"Failed to convert edge data ({data}) " f"to type {edgetype}"
-                    ) from e
+                    ) from err
             else:
                 try:  # try to evaluate
                     edgedata = literal_eval(data)

--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -83,8 +83,8 @@ def read_shp(path, simplify=True, geom_attrs=True, strict=True):
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     try:
         from osgeo import ogr
-    except ImportError as e:
-        raise ImportError("read_shp requires OGR: http://www.gdal.org/") from e
+    except ImportError as err:
+        raise ImportError("read_shp requires OGR: http://www.gdal.org/") from err
 
     if not isinstance(path, str):
         return
@@ -159,10 +159,10 @@ def edges_from_line(geom, attrs, simplify=True, geom_attrs=True):
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     try:
         from osgeo import ogr
-    except ImportError as e:
+    except ImportError as err:
         raise ImportError(
             "edges_from_line requires OGR: " "http://www.gdal.org/"
-        ) from e
+        ) from err
 
     if geom.GetGeometryType() == ogr.wkbLineString:
         if simplify:
@@ -229,8 +229,8 @@ def write_shp(G, outdir):
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     try:
         from osgeo import ogr
-    except ImportError as e:
-        raise ImportError("write_shp requires OGR: http://www.gdal.org/") from e
+    except ImportError as err:
+        raise ImportError("write_shp requires OGR: http://www.gdal.org/") from err
     # easier to debug in python if ogr throws exceptions
     ogr.UseExceptions()
 

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -56,8 +56,8 @@ def generate_pajek(G):
         y = na.pop("y", 0.0)
         try:
             id = int(na.pop("id", nodenumber[n]))
-        except ValueError as e:
-            e.args += (
+        except ValueError as err:
+            err.args += (
                 (
                     "Pajek format requires 'id' to be an int()."
                     " Refer to the 'Relabeling nodes' section."

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -207,8 +207,8 @@ class TestShp:
         G.add_edge(1, 2, Wkt=line[0])
         try:
             nx.write_shp(G, tpath)
-        except Exception as e:
-            assert False, e
+        except Exception as err:
+            assert False, err
         shpdir = ogr.Open(tpath)
         self.checkgeom(shpdir.GetLayerByName("nodes"), points)
         self.checkgeom(shpdir.GetLayerByName("edges"), line)

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -133,11 +133,11 @@ def _relabel_inplace(G, mapping):
         D.remove_edges_from(nx.selfloop_edges(D))
         try:
             nodes = reversed(list(nx.topological_sort(D)))
-        except nx.NetworkXUnfeasible as e:
+        except nx.NetworkXUnfeasible as err:
             raise nx.NetworkXUnfeasible(
                 "The node label sets are overlapping and no ordering can "
                 "resolve the mapping. Use copy=True."
-            ) from e
+            ) from err
     else:
         # non-overlapping label sets
         nodes = old_labels

--- a/networkx/testing/test.py
+++ b/networkx/testing/test.py
@@ -34,8 +34,8 @@ def run(verbosity=1, doctest=False):
 
     try:
         code = pytest.main(pytest_args)
-    except SystemExit as exc:
-        code = exc.code
+    except SystemExit as err:
+        code = err.code
 
     return code == 0
 


### PR DESCRIPTION
This is to avoid the single letter variable name `e` which should be saved for an edge.
In some places, a function used `e` to be an exception in one place and an edge in another.

This could be merged as a PR, or cherry-picked for another PR like #5127 