### PR TITLE
Refactor linestyle test for FancyArrowPatches.

### DIFF
--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -160,9 +160,10 @@ def test_directed_edges_linestyle_default():
         (1, (1, 1)),  # edge with (offset, onoffseq) style
     ),
 )
-def test_directed_edges_linestyle_string(style):
-    """Tests support for strings specifying linestyles in ``draw_networkx_edges`` for
-    FancyArrowPatch outputs (e.g. directed edges)."""
+def test_directed_edges_linestyle_single_value(style):
+    """Tests support for specifying linestyles with a single value to be applied to
+    all edges in ``draw_networkx_edges`` for FancyArrowPatch outputs
+    (e.g. directed edges)."""
 
     G = nx.path_graph(4, create_using=nx.DiGraph)  # Graph with 3 edges
     pos = {n: (n, n) for n in range(len(G))}


### PR DESCRIPTION
Follow up to #5131

Reorganizes the testing of the `style` kwarg for `draw_networkx_edges`. There is a lot of discussion already in #5131, but to summarize:
 - Removes testing of edges drawn with `LineCollection` objects, since the parsing/cycling in that case is all handled by matplotlib internally
 - The above allows the removal of the `test_styles` function for simplification
 - Breaks one test up into 3: one for the default value, one for "singleton" style inputs (i.e. a single string or tuple), and one for sequences of inputs. All three are parametrized over the style input.