### PR TITLE
Bugfix for issue 5123

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1092,7 +1092,7 @@ def multipartite_layout(G, subset_key="subset", align="vertical", scale=1, cente
     nodes = []
 
     width = len(layers)
-    for i, layer in layers.items():
+    for i, layer in enumerate(layers.values()):
         height = len(layer)
         xs = np.repeat(i, height)
         ys = np.arange(0, height, dtype=float)

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -286,6 +286,9 @@ class TestLayout:
         sizes = (0, 5, 7, 2, 8)
         G = nx.complete_multipartite_graph(*sizes)
 
+        G.add_node("a", subset=5)
+        G.add_node("b", subset="s0")
+
         vpos = nx.multipartite_layout(G)
         assert len(vpos) == len(G)
 

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -286,9 +286,6 @@ class TestLayout:
         sizes = (0, 5, 7, 2, 8)
         G = nx.complete_multipartite_graph(*sizes)
 
-        G.add_node("a", subset=5)
-        G.add_node("b", subset="s0")
-
         vpos = nx.multipartite_layout(G)
         assert len(vpos) == len(G)
 
@@ -415,3 +412,15 @@ class TestLayout:
         }
         for k, v in expectation.items():
             assert (s_vpos[k] == v).all()
+
+
+def test_multipartite_layout_nonnumeric_partition_labels():
+    """See gh-5123."""
+    G = nx.Graph()
+    G.add_node(0, subset="s0")
+    G.add_node(1, subset="s0")
+    G.add_node(2, subset="s1")
+    G.add_node(3, subset="s1")
+    G.add_edges_from([(0, 2), (0, 3), (1, 2)])
+    pos = nx.multipartite_layout(G)
+    assert len(pos) == len(G)


### PR DESCRIPTION
`multipartite_layout()` was failing on graphs containing nodes with non-numeric partition labels because node coordinates were being created using the partition labels. Changed loop to use `enumerate()` so that node coordinates are generated from the index of the partition, not its label (per @LelioC 's fix [here](https://github.com/networkx/networkx/issues/5123)).  

I added test for nodes w/ non-numeric partition labels and non-numeric names to `test_multipartite_layout()`.

Closes #5123