### PR TITLE
Add temporary pyparsing pin to fix CI.

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,3 +1,5 @@
 lxml>=4.5
 pygraphviz>=1.7
 pydot>=1.4.1
+# Temporary fix for gh-5155
+pyparsing==3.0.0


### PR DESCRIPTION
Closes #5155.

Note this is just a temporary fix for CI. NetworkX doesn't depend on pyparsing directly so we should remove this pin as soon as there's a fix upstream. I will create a tracking issue for this and milestone it so it doesn't slip through the cracks.