### PR TITLE
Warning comment for float weights in betweenness.py

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -104,7 +104,7 @@ def betweenness_centrality(
     are floating point numbers (overflows and roundoff errors can
     cause problems). As a workaround you can use integer numbers by
     multiplying the relevant edge attributes by a convenient
-    constant factor (eg 100).
+    constant factor (eg 100) and converting to integers.
 
     References
     ----------

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -99,6 +99,12 @@ def betweenness_centrality(
     then we are only counting the paths in one direction. They are
     undirected paths but we are counting them in a directed way.
     To count them as undirected paths, each should count as half a path.
+    
+    This algorithm is not guaranteed to work if edge weights or demands
+    are floating point numbers (overflows and roundoff errors can
+    cause problems). As a workaround you can use integer numbers by
+    multiplying the relevant edge attributes by a convenient
+    constant factor (eg 100).
 
     References
     ----------

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -99,11 +99,10 @@ def betweenness_centrality(
     then we are only counting the paths in one direction. They are
     undirected paths but we are counting them in a directed way.
     To count them as undirected paths, each should count as half a path.
-    
-    This algorithm is not guaranteed to work if edge weights or demands
-    are floating point numbers (overflows and roundoff errors can
-    cause problems). As a workaround you can use integer numbers by
-    multiplying the relevant edge attributes by a convenient
+
+    This algorithm is not guaranteed to be correct if edge weights
+    are floating point numbers. As a workaround you can use integer
+    numbers by multiplying the relevant edge attributes by a convenient
     constant factor (eg 100) and converting to integers.
 
     References


### PR DESCRIPTION
Both equality and unequality comparison of distances in at least `_single_source_dijkstra_path_basic` produce wrong results on some graphs because limited machine precision might produce overflow and roundoff errors.

I have added a warning comment for this.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
