### PR TITLE
Add support for finding maximal cliques containing a set of nodes

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -113,8 +113,8 @@ def find_cliques(G, nodes=None):
     list of nodes. It is an iterative implementation, so should not
     suffer from recursion depth issues.
 
-    This function can accept a list of nodes and only the maximal cliques
-    containing all of these nodes are returned. It can considerably speed up
+    This function accepts a list of `nodes` and only the maximal cliques
+    containing all of these `nodes` are returned. It can considerably speed up
     the running time if some specific cliques are desired.
 
     Parameters
@@ -247,8 +247,8 @@ def find_cliques_recursive(G, nodes=None):
     list of nodes. It is a recursive implementation, so may suffer from
     recursion depth issues.
 
-    This function can accept a list of nodes and only the maximal cliques
-    containing all of these nodes are returned. It can considerably speed up
+    This function accepts a list of `nodes` and only the maximal cliques
+    containing all of these `nodes` are returned. It can considerably speed up
     the running time if some specific cliques are desired.
 
     Parameters

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -105,8 +105,8 @@ def enumerate_all_cliques(G):
 def find_cliques(G, nodes=None):
     """Returns all maximal cliques in an undirected graph.
 
-    For each node *v*, a *maximal clique for v* is a largest complete
-    subgraph containing *v*. The largest maximal clique is sometimes
+    For each node *n*, a *maximal clique for n* is a largest complete
+    subgraph containing *n*. The largest maximal clique is sometimes
     called the *maximum clique*.
 
     This function returns an iterator over cliques, each of which is a
@@ -122,10 +122,9 @@ def find_cliques(G, nodes=None):
     G : NetworkX graph
         An undirected graph.
 
-    nodes : list, optional
-        If provided, the iterator returned will only iterate over *maximal
-        cliques* containing all nodes in `nodes`. If `nodes` isn't a clique
-        itself, an error is raised.
+    nodes : list, optional (default=None)
+        If provided, only yield *maximal cliques* containing all nodes in `nodes`.
+        If `nodes` isn't a clique itself, an error is raised.
 
     Returns
     -------
@@ -186,28 +185,24 @@ def find_cliques(G, nodes=None):
 
     adj = {u: {v for v in G[u] if v != u} for u in G}
 
-    subg = set(G)
+    # Initialize Q with the given nodes and subg, cand with their nbrs
+    Q = nodes[:] if nodes is not None else []
     cand = set(G)
-    stack = []
-
-    if nodes is None:
-        nodes = []
-
-    # Initialize Q with the given nodes
-    Q = nodes[:]
-    for node in nodes:
+    for node in Q:
         if node not in cand:
-            raise ValueError("The given `nodes` %s do not form a clique" % str(nodes))
-        subg &= adj[node]
+            raise ValueError(f"The given `nodes` {nodes} do not form a clique")
         cand &= adj[node]
 
-    if not subg:
+    if not cand:
         yield Q[:]
         return
 
+    subg = cand.copy()
+    stack = []
+    Q.append(None)
+
     u = max(subg, key=lambda u: len(cand & adj[u]))
     ext_u = cand - adj[u]
-    Q.append(None)
 
     try:
         while True:
@@ -255,17 +250,16 @@ def find_cliques_recursive(G, nodes=None):
     ----------
     G : NetworkX graph
 
-    nodes : list, optional
-        If provided, the iterator returned will only iterate over *maximal
-        cliques* containing all nodes in `nodes`. If `nodes` isn't a clique
-        itself, an error is raised.
+    nodes : list, optional (default=None)
+        If provided, only yield *maximal cliques* containing all nodes in `nodes`.
+        If `nodes` isn't a clique itself, an error is raised.
 
     Returns
     -------
     iterator
         An iterator over maximal cliques, each of which is a list of
         nodes in `G`. If `nodes` is provided, only the maximal cliques
-        containing all the nodes in `nodes` are returned. The order of
+        containing all the nodes in `nodes` are yielded. The order of
         cliques is arbitrary.
 
     See Also
@@ -317,22 +311,18 @@ def find_cliques_recursive(G, nodes=None):
 
     adj = {u: {v for v in G[u] if v != u} for u in G}
 
-    subg_init = set(G)
+    # Initialize Q with the given nodes and subg, cand with their nbrs
+    Q = nodes[:] if nodes is not None else []
     cand_init = set(G)
-
-    if nodes is None:
-        nodes = []
-
-    # Initialize Q with the given nodes
-    Q = nodes[:]
-    for node in nodes:
+    for node in Q:
         if node not in cand_init:
-            raise ValueError("The given `nodes` %s do not form a clique" % str(nodes))
-        subg_init &= adj[node]
+            raise ValueError(f"The given `nodes` {nodes} do not form a clique")
         cand_init &= adj[node]
 
-    if not subg_init:
+    if not cand_init:
         return iter([Q])
+
+    subg_init = cand_init.copy()
 
     def expand(subg, cand):
         u = max(subg, key=lambda u: len(cand & adj[u]))

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -134,6 +134,11 @@ def find_cliques(G, nodes=None):
         containing all the nodes in `nodes` are returned. The order of
         cliques is arbitrary.
 
+    Raises
+    ------
+    ValueError
+        If `nodes` is not a clique.
+
     See Also
     --------
     find_cliques_recursive
@@ -261,6 +266,11 @@ def find_cliques_recursive(G, nodes=None):
         nodes in `G`. If `nodes` is provided, only the maximal cliques
         containing all the nodes in `nodes` are yielded. The order of
         cliques is arbitrary.
+
+    Raises
+    ------
+    ValueError
+        If `nodes` is not a clique.
 
     See Also
     --------

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -37,34 +37,34 @@ class TestCliques:
         # all cliques are [[2, 6, 1, 3], [2, 6, 4], [5, 4, 7], [8, 9], [10, 11]]
 
         cl = list(nx.find_cliques(self.G, [2]))
-        # rcl = nx.find_cliques_recursive(self.G, [2])
+        rcl = nx.find_cliques_recursive(self.G, [2])
         expected = [[2, 6, 1, 3], [2, 6, 4]]
-        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, rcl)) == sorted(map(sorted, expected))
         assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
 
         cl = list(nx.find_cliques(self.G, [2, 3]))
-        # rcl = nx.find_cliques_recursive(self.G, [2, 3])
+        rcl = nx.find_cliques_recursive(self.G, [2, 3])
         expected = [[2, 6, 1, 3]]
-        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, rcl)) == sorted(map(sorted, expected))
         assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
 
         cl = list(nx.find_cliques(self.G, [2, 6, 4]))
-        # rcl = nx.find_cliques_recursive(self.G, [2, 6, 4])
+        rcl = nx.find_cliques_recursive(self.G, [2, 6, 4])
         expected = [[2, 6, 4]]
-        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, rcl)) == sorted(map(sorted, expected))
         assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
 
         cl = list(nx.find_cliques(self.G, [2, 6, 4]))
-        # rcl = nx.find_cliques_recursive(self.G, [2, 6, 4])
+        rcl = nx.find_cliques_recursive(self.G, [2, 6, 4])
         expected = [[2, 6, 4]]
-        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, rcl)) == sorted(map(sorted, expected))
         assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
 
         with pytest.raises(ValueError):
             list(nx.find_cliques(self.G, [2, 6, 4, 1]))
 
-        # with pytest.raises(ValueError):
-        #     list(nx.find_cliques_recursive(self.G, [2, 6, 4, 1]))
+        with pytest.raises(ValueError):
+            list(nx.find_cliques_recursive(self.G, [2, 6, 4, 1]))
 
     def test_clique_number(self):
         G = self.G

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -176,6 +176,8 @@ class TestCliques:
             10: 2,
             11: 2,
         }
+        assert nx.node_clique_number(G, [1, 2], cliques=self.cl) == {1: 4, 2: 4}
+        assert nx.node_clique_number(G, 1, cliques=self.cl) == 4
 
     def test_cliques_containing_node(self):
         G = self.G

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -33,6 +33,39 @@ class TestCliques:
         hcl = list(nx.find_cliques(self.H))
         assert sorted(map(sorted, hcl)) == [[1, 2], [1, 4, 5, 6], [2, 3], [3, 4, 6]]
 
+    def test_find_cliques3(self):
+        # all cliques are [[2, 6, 1, 3], [2, 6, 4], [5, 4, 7], [8, 9], [10, 11]]
+
+        cl = list(nx.find_cliques(self.G, [2]))
+        # rcl = nx.find_cliques_recursive(self.G, [2])
+        expected = [[2, 6, 1, 3], [2, 6, 4]]
+        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
+
+        cl = list(nx.find_cliques(self.G, [2, 3]))
+        # rcl = nx.find_cliques_recursive(self.G, [2, 3])
+        expected = [[2, 6, 1, 3]]
+        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
+
+        cl = list(nx.find_cliques(self.G, [2, 6, 4]))
+        # rcl = nx.find_cliques_recursive(self.G, [2, 6, 4])
+        expected = [[2, 6, 4]]
+        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
+
+        cl = list(nx.find_cliques(self.G, [2, 6, 4]))
+        # rcl = nx.find_cliques_recursive(self.G, [2, 6, 4])
+        expected = [[2, 6, 4]]
+        # assert sorted(map(sorted, cl)) == sorted(map(sorted, rcl))
+        assert sorted(map(sorted, cl)) == sorted(map(sorted, expected))
+
+        with pytest.raises(ValueError):
+            list(nx.find_cliques(self.G, [2, 6, 4, 1]))
+
+        # with pytest.raises(ValueError):
+        #     list(nx.find_cliques_recursive(self.G, [2, 6, 4, 1]))
+
     def test_clique_number(self):
         G = self.G
         assert nx.graph_clique_number(G) == 4


### PR DESCRIPTION
### Adapt `find_clique` to accept a set of starting nodes that all cliques must contain
Finding clique has an exponential running time.

It is common to want to find maximal cliques containing a **specific set of nodes**.
There **exists actually already a function**: `algorithms.clique.cliques_containing_node`.

Unfortunately, this function `cliques_containing_node` simply computes all cliques and filters them down to the ones containing the target node. This is very naive and unusable in practice.
Yet, the original clique algorithm of `algorithms.clique.find_cliques` can be quite easily adapted to start with our desired set of nodes. 

I adapted the initialization of the algorithm in `find_cliques` to use such a set of starting nodes. `find_cliques` now accepts a `nodes` argument, the same `cliques_containing_node` has.
There is no overhead complexity compared to a normal call where `nodes` is not provided and if `nodes` is specified, the clique algorithm is exponentially faster.

If this contribution seems appropriate, I would like to hear your thoughts on:
* `find_cliques` also has a recursive implementation; I should also adapt it to accept `nodes` to be consistent
* This enhancement makes `cliques_containing_node` obsolete [it was unusable and naive anyway]. It should be deprecated.

Thanks;
