### PR TITLE
Rm passing ax.transOffset to LineCollection when drawing undirected edges

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -727,7 +727,6 @@ def draw_networkx_edges(
             linewidths=width,
             antialiaseds=(1,),
             linestyle=style,
-            transOffset=ax.transData,
             alpha=alpha,
         )
         edge_collection.set_cmap(edge_cmap)


### PR DESCRIPTION
From the discussion in #matplotlib/matplotlib#21517, ax.transOffset would have had no effect prior to matplotlib-3.5.0rc1. Looking at `blame` doesn't indicate any specific reason why the `transOffset` arg was passed to the LineCollection constructor - [this has been the case since `nx_pylab` was introduced](https://github.com/networkx/networkx/blame/3f478bba187e34a3bed6609be1bd9c21486fe875/networkx/drawing/nx_pylab.py#L316).

In principle, removing this should have no effect. I've built the docs locally and compared the NX gallery examples both with and without this change and didn't notice anything visually.

Closes gh-5167