### PR TITLE
Optimisation of ancestors function

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -94,7 +94,13 @@ def ancestors(G, source):
     --------
     descendants
     """
-    return {child for parent, child in nx.bfs_edges(G, source, reverse=True)}
+    prev_nodes = [*G.predecessors(source)]
+    nodes = set(prev_nodes)
+    if not prev_nodes:
+        return set()
+    for prev_node in prev_nodes:
+        nodes |= ancestors(G, prev_node)
+    return nodes
 
 
 def has_cycle(G):


### PR DESCRIPTION
We came across a performance issue when finding the ancestors for a (very) large graph. We found that by using a recursive function we can ~half the time taken to return all the ancestors.

The code below was produced on Met Office time (by me) and I have permission to post it in a PR here (if it's useful at all :-))

```
import networkx as nx
import timeit
G = nx.OrderedDiGraph(
    [
        ("Breakfast", "Second Breakfast"),
        ("Breakfast", "Elevenses"),
        ("Breakfast", "Luncheon"),
        ("Breakfast", "Afternoon Tea"),
        ("Afternoon Tea", "Dinner"),
        ("Dinner", "Supper"),
        ("Dinner", "Dessert"),
    ]
)

def ancestors_old(G, source):
    return {child for parent, child in nx.bfs_edges(G, source, reverse=True)}

def ancestors_new(G, source):
    prev_nodes = [*G.predecessors(source)]
    nodes = set(prev_nodes)
    if not prev_nodes:
        return set()
    for prev_node in prev_nodes:
        nodes |= ancestors_new(G, prev_node)
    return nodes

ancestors_old_time = lambda : ancestors_old(G, "Supper")
ancestors_new_time = lambda : ancestors_new(G, "Supper")
```

```
>>> timeit.timeit(ancestors_old_time, number=100000)
0.4507244720007293
```

```
>>> timeit.timeit(ancestors_new_time, number=100000)
0.240865458996268
```

```
>>> ancestors_old_time() == ancestors_new_time()
True
```
