### PR TITLE
Add a Q&A to the contributor FAQ about algorithm acceptance policy.

### DIFF
--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -126,4 +126,4 @@ Q: What is the policy for deciding whether to include a new algorithm?
 There is no official policy setting explicit inclusion criteria for new
 algorithms in NetworkX. New algorithms are more likely to be included if they
 have been published and are cited by others. More important than number of
-citations is how well proposed additions fit the project :doc:`mission_and_values`.
+citations is how well proposed additions fit the project :ref:`mission and values <values>`.

--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -126,4 +126,4 @@ Q: What is the policy for deciding whether to include a new algorithm?
 There is no official policy setting explicit inclusion criteria for new
 algorithms in NetworkX. New algorithms are more likely to be included if they
 have been published and are cited by others. More important than number of
-citations is how well proposed additions fit the project :ref:`mission_and_values`
+citations is how well proposed additions fit the project :ref:`mission_and_values`.

--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -119,3 +119,11 @@ For example, from the NetworkX source directory:
 
    $ grep -r "def kamada_kawai_layout" .
    ./networkx/drawing/layout.py:def kamada_kawai_layout(
+
+Q: What is the policy for deciding whether to include a new algorithm?
+----------------------------------------------------------------------
+
+There is no official policy setting explicit inclusion criteria for new
+algorithms in NetworkX. New algorithms are more likely to be included if they
+have been published and are cited by others. More important than number of
+citations is how well proposed additions fit the project :doc:`mission_and_values`.

--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -126,4 +126,4 @@ Q: What is the policy for deciding whether to include a new algorithm?
 There is no official policy setting explicit inclusion criteria for new
 algorithms in NetworkX. New algorithms are more likely to be included if they
 have been published and are cited by others. More important than number of
-citations is how well proposed additions fit the project :ref:`mission and values <values>`.
+citations is how well proposed additions fit the project :ref:`mission_and_values`


### PR DESCRIPTION
Mostly states that there is no "official" policy, but that algorithms should be published (and preferrably cited) to warrant inclusion in NetworkX. Also adds a link to the Mission & Values docs to give more high-level guidance.