### PR TITLE
Revert "Add temporary pyparsing pin to fix CI."

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,5 +1,3 @@
 lxml>=4.5
 pygraphviz>=1.7
 pydot>=1.4.1
-# Temporary fix for gh-5155
-pyparsing==3.0.0


### PR DESCRIPTION
Reverts networkx/networkx#5156

There is now a conflict in `packaging` with the new pyparsing, and they have pinned to pyparsing < 3, which causes problems for our fix. Removing the pin here should mean that we default to the `packaging` pin, which should keep the `pyparsing`/`pydot` problems at bay.

Closes #5157 