### PR TITLE
Add an FAQ about assigning issues.

### DIFF
--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -43,8 +43,9 @@ Q: I've found an issue I'm interested in, can I have it assigned to me?
 NetworkX doesn't typically assign issues to contributors. If you find an issue
 or feature request on the issue tracker that you'd like to work on, you should
 first check the issue thread to see if there are any linked pull requests.
-If not, then feel free to open a new PR to address the issue - there's no need
-to ask for permission!
+If not, then feel free to open a new PR to address the issue - no need
+to ask for permission - and don't forget to reference the issue number in the PR
+comments so that others know you are now working on it!
 
 Q: How do I contribute an example to the Gallery?
 -------------------------------------------------

--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -37,6 +37,15 @@ That said, a few places to check for ideas on where to get started:
 
 .. _Algorithms discussion: https://github.com/networkx/networkx/discussions/categories/algorithms
 
+Q: I've found an issue I'm interested in, can I have it assigned to me?
+-----------------------------------------------------------------------
+
+NetworkX doesn't typically assign issues to contributors. If you find an issue
+or feature request on the issue tracker that you'd like to work on, you should
+first check the issue thread to see if there are any linked pull requests.
+If not, then feel free to open a new PR to address the issue - there's no need
+to ask for permission!
+
 Q: How do I contribute an example to the Gallery?
 -------------------------------------------------
 


### PR DESCRIPTION
Adds a Q&A to the new contributor FAQ clarifying that issues are not typically assigned to users.