### PR TITLE
Only compute shortest path lengths when used

### DIFF
--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -277,17 +277,27 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
            https://doi.org/10.1038/s41598-019-57304-y
     """
 
-    spl = dict(nx.shortest_path_length(G))
-    inf = float("inf")
+    # When alpha == 1, the CCPA score simplifies to the number of common neighbors.
+    if alpha == 1:
 
-    def predict(u, v):
-        if u == v:
-            raise nx.NetworkXAlgorithmError("Self links are not supported")
-        path_len = spl[u].get(v, inf)
+        def predict(u, v):
+            if u == v:
+                raise nx.NetworkXAlgorithmError("Self links are not supported")
 
-        return alpha * sum(1 for _ in nx.common_neighbors(G, u, v)) + (1 - alpha) * (
-            G.number_of_nodes() / path_len
-        )
+            return sum(1 for _ in nx.common_neighbors(G, u, v))
+
+    else:
+        spl = dict(nx.shortest_path_length(G))
+        inf = float("inf")
+
+        def predict(u, v):
+            if u == v:
+                raise nx.NetworkXAlgorithmError("Self links are not supported")
+            path_len = spl[u].get(v, inf)
+
+            return alpha * sum(1 for _ in nx.common_neighbors(G, u, v)) + (
+                1 - alpha
+            ) * (G.number_of_nodes() / path_len)
 
     return _apply_prediction(G, predict, ebunch)
 


### PR DESCRIPTION
### What's done?

This PR adds a branch in `common_neighbor_centrality` to introduce a simple performance optimization. Computing `nx.shortest_path_length(G)` is extremely computationally expensive, so we should avoid this call, especially if the corresponding result isn't used.

### Rationale
When `alpha = 1`, the expression:  
```python
(1 - alpha) * (G.number_of_nodes() / path_len)
```
evaluates to 0.

As such, `path_len`, and consequently `spl` aren't being used.

`alpha = 1` is a common enough configuration for the parameter that I feel this optimization is justified. The tradeoff is between the complexity of the newly introduced code and the performance benefit of avoiding computing shortest path legnths.

I believe the tradeoff has a clear winner.

### Approach

This PR tries to avoid the computationally expensive call to generate all shortest path lengths when `alpha = 1` to improve performance of the call.

I'm not a seasoned Python developer, so I'm open to making this change more _Pythonic_.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
