### PR TITLE
Implement Dial's algorithm

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -922,3 +922,28 @@ class TestJohnsonAlgorithm(WeightedTestBase):
         validate_path(self.XG3, 0, 3, 15, nx.johnson(self.XG3)[0][3])
         validate_path(self.XG4, 0, 2, 4, nx.johnson(self.XG4)[0][2])
         validate_path(self.MXG4, 0, 2, 4, nx.johnson(self.MXG4)[0][2])
+
+
+class TestDialsAlgorithm(WeightedTestBase):
+    def test_missing_source(self):
+        with pytest.raises(nx.NodeNotFound):
+            G = nx.DiGraph()
+            nx.dial_predecessor_and_distance(G, 0)
+
+    def test_invalid_weights(self):
+        with pytest.raises(ValueError):
+            G = nx.DiGraph()
+            G.add_weighted_edges_from([(0, 1, 3.14)])
+            nx.dial_predecessor_and_distance(G, 0)
+
+    def test_graphs(self):
+        for graph, source, target, expected_distance in [
+            (self.XG, "s", "v", 9),
+            (self.MXG, "s", "v", 9),
+            (self.XG2, 1, 3, 4),
+            (self.XG3, 0, 3, 15),
+            (self.XG4, 0, 2, 4),
+            (self.MXG4, 0, 2, 4),
+        ]:
+            pred, distance = nx.dial_predecessor_and_distance(graph, source)
+            assert distance[target] == expected_distance


### PR DESCRIPTION
I would like to contribute an implementation of [Dial's algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants), which computes single-source shortest paths in graphs with non-negative integer edge weights. 

I have drafted a simple implementation which runs in *O(E+WV)* time using a bucket queue (where *W* is the maximum edge weight). This works well when *W* is a small constant.

Currently, the public API for shortest paths includes about a dozen different signatures for Dijkstra's algorithm. I have included just one for Dial's algorithm, `nx.dial_predecessors_and_distance`, but as with Dijkstra this relies on an internal function which can easily be used to support alternate signatures.

Open to feedback!