### PR TITLE
Discussion: Add mypy to pre-commit hooks?

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+    -   id: mypy


### PR DESCRIPTION
A follow-up to #5127 which added a CI job that runs mypy for new PRs. We could also add `mypy` as a pre-commit hook so that contributors are notified of problems at commit-time rather than having to wait for CI to run.

This is similar to how `black` is incorporated into the workflow; however, there is one major difference between the mypy pre-commit hook and the `black`/`pyupgrade` hooks: `mypy` doesn't automatically fix errors! In other words, contributors might get caught in a situation where they're *forced* to deal with mypy problems locally before they can make/update a PR. IMO this is overly prohibitive, but I'm curious what others think.