### PR TITLE
CI: xfail pydot tests.

### DIFF
--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -10,6 +10,7 @@ import pytest
 pydot = pytest.importorskip("pydot")
 
 
+@pytest.mark.xfail
 class TestPydot:
     def pydot_checks(self, G, prog):
         """


### PR DESCRIPTION
A second attempt at a temporary solution to the failing pydot tests due to its pyparsing dependency (see #5155, pydot/pydot#277 pyparsing/pyparsing#338).

Rather than alter dependency pinning which has proven to be fragile, the pydot tests can be xfailed which should both fix CI now *and* notify us when the pydot/pyparsing issue is fixed, because the xfailed tests will start passing again.