### PR TITLE
Add regression test for ancestors & descedants with undirected graphs

### DIFF
--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -700,3 +700,10 @@ class TestDagToBranching:
     def test_multidigraph(self):
         with pytest.raises(nx.NetworkXNotImplemented):
             nx.dag_to_branching(nx.MultiDiGraph())
+
+
+def test_ancestors_descendants_undirected():
+    """Regression test to ensure anscestors and descendants work as expected on
+    undirected graphs."""
+    G = nx.path_graph(5)
+    nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}


### PR DESCRIPTION
`nx.ancestors` and `nx.descendants` currently work with undirected inputs, but there are currently no tests for undirected inputs. This PR adds a regression test so that a behavior change w/ undirected inputs would be caught in the test suite - see e.g. #5176 