### PR TITLE
Remove check/comment for scipy 1.1 behavior.

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -898,9 +898,7 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
         M = sp.sparse.coo_matrix((d, (r, c)), shape=(nlen, nlen), dtype=dtype)
     try:
         return M.asformat(format)
-    # From Scipy 1.1.0, asformat will throw a ValueError instead of an
-    # AttributeError if the format if not recognized.
-    except (AttributeError, ValueError) as err:
+    except ValueError as err:
         raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from err
 
 


### PR DESCRIPTION
Minor cleanup of old code designed to catch a behavior change around scipy 1.1. The minimum required `scipy` version for NetworkX is now well above 1.1, so I think it's safe to remove the extra check/comment.