### PR TITLE
Fix missing import and tests for directed Laplacian functions

### DIFF
--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -196,6 +196,7 @@ def directed_laplacian_matrix(
     import numpy as np
     import scipy as sp
     import scipy.sparse  # call as sp.sparse
+    import scipy.sparse.linalg  # call as sp.sparse.linalg
 
     P = _transition_matrix(
         G, nodelist=nodelist, weight=weight, walk_type=walk_type, alpha=alpha
@@ -278,6 +279,7 @@ def directed_combinatorial_laplacian_matrix(
     """
     import scipy as sp
     import scipy.sparse  # call as sp.sparse
+    import scipy.sparse.linalg  # call as sp.sparse.linalg
 
     P = _transition_matrix(
         G, nodelist=nodelist, weight=weight, walk_type=walk_type, alpha=alpha

--- a/networkx/linalg/tests/test_laplacian.py
+++ b/networkx/linalg/tests/test_laplacian.py
@@ -90,155 +90,153 @@ class TestLaplacian:
             nx.normalized_laplacian_matrix(self.Gsl).todense(), Lsl, decimal=3
         )
 
-    def test_directed_laplacian(self):
-        "Directed Laplacian"
-        # Graph used as an example in Sec. 4.1 of Langville and Meyer,
-        # "Google's PageRank and Beyond". The graph contains dangling nodes, so
-        # the pagerank random walk is selected by directed_laplacian
-        G = nx.DiGraph()
-        G.add_edges_from(
-            (
-                (1, 2),
-                (1, 3),
-                (3, 1),
-                (3, 2),
-                (3, 5),
-                (4, 5),
-                (4, 6),
-                (5, 4),
-                (5, 6),
-                (6, 4),
-            )
+
+def test_directed_laplacian():
+    "Directed Laplacian"
+    # Graph used as an example in Sec. 4.1 of Langville and Meyer,
+    # "Google's PageRank and Beyond". The graph contains dangling nodes, so
+    # the pagerank random walk is selected by directed_laplacian
+    G = nx.DiGraph()
+    G.add_edges_from(
+        (
+            (1, 2),
+            (1, 3),
+            (3, 1),
+            (3, 2),
+            (3, 5),
+            (4, 5),
+            (4, 6),
+            (5, 4),
+            (5, 6),
+            (6, 4),
         )
-        # fmt: off
-        GL = np.array([[ 0.9833, -0.2941, -0.3882, -0.0291, -0.0231, -0.0261],
-                       [-0.2941,  0.8333, -0.2339, -0.0536, -0.0589, -0.0554],
-                       [-0.3882, -0.2339,  0.9833, -0.0278, -0.0896, -0.0251],
-                       [-0.0291, -0.0536, -0.0278,  0.9833, -0.4878, -0.6675],
-                       [-0.0231, -0.0589, -0.0896, -0.4878,  0.9833, -0.2078],
-                       [-0.0261, -0.0554, -0.0251, -0.6675, -0.2078,  0.9833]])
-        # fmt: on
-        L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-        np.testing.assert_almost_equal(L, GL, decimal=3)
+    )
+    # fmt: off
+    GL = np.array([[ 0.9833, -0.2941, -0.3882, -0.0291, -0.0231, -0.0261],
+                   [-0.2941,  0.8333, -0.2339, -0.0536, -0.0589, -0.0554],
+                   [-0.3882, -0.2339,  0.9833, -0.0278, -0.0896, -0.0251],
+                   [-0.0291, -0.0536, -0.0278,  0.9833, -0.4878, -0.6675],
+                   [-0.0231, -0.0589, -0.0896, -0.4878,  0.9833, -0.2078],
+                   [-0.0261, -0.0554, -0.0251, -0.6675, -0.2078,  0.9833]])
+    # fmt: on
+    L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
+    np.testing.assert_almost_equal(L, GL, decimal=3)
 
-        # Make the graph strongly connected, so we can use a random and lazy walk
-        G.add_edges_from(((2, 5), (6, 1)))
-        # fmt: off
-        GL = np.array([[ 1.    , -0.3062, -0.4714,  0.    ,  0.    , -0.3227],
-                       [-0.3062,  1.    , -0.1443,  0.    , -0.3162,  0.    ],
-                       [-0.4714, -0.1443,  1.    ,  0.    , -0.0913,  0.    ],
-                       [ 0.    ,  0.    ,  0.    ,  1.    , -0.5   , -0.5   ],
-                       [ 0.    , -0.3162, -0.0913, -0.5   ,  1.    , -0.25  ],
-                       [-0.3227,  0.    ,  0.    , -0.5   , -0.25  ,  1.    ]])
-        # fmt: on
-        L = nx.directed_laplacian_matrix(
-            G, alpha=0.9, nodelist=sorted(G), walk_type="random"
+    # Make the graph strongly connected, so we can use a random and lazy walk
+    G.add_edges_from(((2, 5), (6, 1)))
+    # fmt: off
+    GL = np.array([[ 1.    , -0.3062, -0.4714,  0.    ,  0.    , -0.3227],
+                   [-0.3062,  1.    , -0.1443,  0.    , -0.3162,  0.    ],
+                   [-0.4714, -0.1443,  1.    ,  0.    , -0.0913,  0.    ],
+                   [ 0.    ,  0.    ,  0.    ,  1.    , -0.5   , -0.5   ],
+                   [ 0.    , -0.3162, -0.0913, -0.5   ,  1.    , -0.25  ],
+                   [-0.3227,  0.    ,  0.    , -0.5   , -0.25  ,  1.    ]])
+    # fmt: on
+    L = nx.directed_laplacian_matrix(
+        G, alpha=0.9, nodelist=sorted(G), walk_type="random"
+    )
+    np.testing.assert_almost_equal(L, GL, decimal=3)
+
+    # fmt: off
+    GL = np.array([[ 0.5   , -0.1531, -0.2357,  0.    ,  0.    , -0.1614],
+                   [-0.1531,  0.5   , -0.0722,  0.    , -0.1581,  0.    ],
+                   [-0.2357, -0.0722,  0.5   ,  0.    , -0.0456,  0.    ],
+                   [ 0.    ,  0.    ,  0.    ,  0.5   , -0.25  , -0.25  ],
+                   [ 0.    , -0.1581, -0.0456, -0.25  ,  0.5   , -0.125 ],
+                   [-0.1614,  0.    ,  0.    , -0.25  , -0.125 ,  0.5   ]])  
+    # fmt: on
+    L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G), walk_type="lazy")
+    np.testing.assert_almost_equal(L, GL, decimal=3)
+
+    # Make a strongly connected periodic graph
+    G = nx.DiGraph()
+    G.add_edges_from(((1, 2), (2, 4), (4, 1), (1, 3), (3, 4)))
+    # fmt: off
+    GL = np.array([[ 0.5  , -0.176, -0.176, -0.25 ],
+                   [-0.176,  0.5  ,  0.   , -0.176],
+                   [-0.176,  0.   ,  0.5  , -0.176],
+                   [-0.25 , -0.176, -0.176,  0.5  ]])
+    # fmt: on
+    L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
+    np.testing.assert_almost_equal(L, GL, decimal=3)
+
+
+def test_directed_combinatorial_laplacian():
+    "Directed combinatorial Laplacian"
+    # Graph used as an example in Sec. 4.1 of Langville and Meyer,
+    # "Google's PageRank and Beyond". The graph contains dangling nodes, so
+    # the pagerank random walk is selected by directed_laplacian
+    G = nx.DiGraph()
+    G.add_edges_from(
+        (
+            (1, 2),
+            (1, 3),
+            (3, 1),
+            (3, 2),
+            (3, 5),
+            (4, 5),
+            (4, 6),
+            (5, 4),
+            (5, 6),
+            (6, 4),
         )
-        np.testing.assert_almost_equal(L, GL, decimal=3)
+    )
+    # fmt: off
+    GL = np.array([[ 0.0366, -0.0132, -0.0153, -0.0034, -0.0020, -0.0027],
+                   [-0.0132,  0.0450, -0.0111, -0.0076, -0.0062, -0.0069],
+                   [-0.0153, -0.0111,  0.0408, -0.0035, -0.0083, -0.0027],
+                   [-0.0034, -0.0076, -0.0035,  0.3688, -0.1356, -0.2187],
+                   [-0.0020, -0.0062, -0.0083, -0.1356,  0.2026, -0.0505],
+                   [-0.0027, -0.0069, -0.0027, -0.2187, -0.0505,  0.2815]])
+    # fmt: on
 
-        # fmt: off
-        GL = np.array([[ 0.5   , -0.1531, -0.2357,  0.    ,  0.    , -0.1614],
-                       [-0.1531,  0.5   , -0.0722,  0.    , -0.1581,  0.    ],
-                       [-0.2357, -0.0722,  0.5   ,  0.    , -0.0456,  0.    ],
-                       [ 0.    ,  0.    ,  0.    ,  0.5   , -0.25  , -0.25  ],
-                       [ 0.    , -0.1581, -0.0456, -0.25  ,  0.5   , -0.125 ],
-                       [-0.1614,  0.    ,  0.    , -0.25  , -0.125 ,  0.5   ]])  
-        # fmt: on
-        L = nx.directed_laplacian_matrix(
-            G, alpha=0.9, nodelist=sorted(G), walk_type="lazy"
-        )
-        np.testing.assert_almost_equal(L, GL, decimal=3)
+    L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
+    np.testing.assert_almost_equal(L, GL, decimal=3)
 
-        # Make a strongly connected periodic graph
-        G = nx.DiGraph()
-        G.add_edges_from(((1, 2), (2, 4), (4, 1), (1, 3), (3, 4)))
-        # fmt: off
-        GL = np.array([[ 0.5  , -0.176, -0.176, -0.25 ],
-                       [-0.176,  0.5  ,  0.   , -0.176],
-                       [-0.176,  0.   ,  0.5  , -0.176],
-                       [-0.25 , -0.176, -0.176,  0.5  ]])
-        # fmt: on
-        L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-        np.testing.assert_almost_equal(L, GL, decimal=3)
+    # Make the graph strongly connected, so we can use a random and lazy walk
+    G.add_edges_from(((2, 5), (6, 1)))
 
-    def test_directed_combinatorial_laplacian(self):
-        "Directed combinatorial Laplacian"
-        # Graph used as an example in Sec. 4.1 of Langville and Meyer,
-        # "Google's PageRank and Beyond". The graph contains dangling nodes, so
-        # the pagerank random walk is selected by directed_laplacian
-        G = nx.DiGraph()
-        G.add_edges_from(
-            (
-                (1, 2),
-                (1, 3),
-                (3, 1),
-                (3, 2),
-                (3, 5),
-                (4, 5),
-                (4, 6),
-                (5, 4),
-                (5, 6),
-                (6, 4),
-            )
-        )
-        # fmt: off
-        GL = np.array([[ 0.0366, -0.0132, -0.0153, -0.0034, -0.0020, -0.0027],
-                       [-0.0132,  0.0450, -0.0111, -0.0076, -0.0062, -0.0069],
-                       [-0.0153, -0.0111,  0.0408, -0.0035, -0.0083, -0.0027],
-                       [-0.0034, -0.0076, -0.0035,  0.3688, -0.1356, -0.2187],
-                       [-0.0020, -0.0062, -0.0083, -0.1356,  0.2026, -0.0505],
-                       [-0.0027, -0.0069, -0.0027, -0.2187, -0.0505,  0.2815]])
-        # fmt: on
+    # fmt: off
+    GL = np.array([[ 0.1395, -0.0349, -0.0465,  0.    ,  0.    , -0.0581],
+                   [-0.0349,  0.093 , -0.0116,  0.    , -0.0465,  0.    ],
+                   [-0.0465, -0.0116,  0.0698,  0.    , -0.0116,  0.    ],
+                   [ 0.    ,  0.    ,  0.    ,  0.2326, -0.1163, -0.1163],
+                   [ 0.    , -0.0465, -0.0116, -0.1163,  0.2326, -0.0581],
+                   [-0.0581,  0.    ,  0.    , -0.1163, -0.0581,  0.2326]])
+    # fmt: on
 
-        L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-        np.testing.assert_almost_equal(L, GL, decimal=3)
+    L = nx.directed_combinatorial_laplacian_matrix(
+        G, alpha=0.9, nodelist=sorted(G), walk_type="random"
+    )
+    np.testing.assert_almost_equal(L, GL, decimal=3)
 
-        # Make the graph strongly connected, so we can use a random and lazy walk
-        G.add_edges_from(((2, 5), (6, 1)))
+    # fmt: off
+    GL = np.array([[ 0.0698, -0.0174, -0.0233,  0.    ,  0.    , -0.0291],
+                   [-0.0174,  0.0465, -0.0058,  0.    , -0.0233,  0.    ],
+                   [-0.0233, -0.0058,  0.0349,  0.    , -0.0058,  0.    ],
+                   [ 0.    ,  0.    ,  0.    ,  0.1163, -0.0581, -0.0581],
+                   [ 0.    , -0.0233, -0.0058, -0.0581,  0.1163, -0.0291],
+                   [-0.0291,  0.    ,  0.    , -0.0581, -0.0291,  0.1163]])
+    # fmt: on
 
-        # fmt: off
-        GL = np.array([[ 0.1395, -0.0349, -0.0465,  0.    ,  0.    , -0.0581],
-                       [-0.0349,  0.093 , -0.0116,  0.    , -0.0465,  0.    ],
-                       [-0.0465, -0.0116,  0.0698,  0.    , -0.0116,  0.    ],
-                       [ 0.    ,  0.    ,  0.    ,  0.2326, -0.1163, -0.1163],
-                       [ 0.    , -0.0465, -0.0116, -0.1163,  0.2326, -0.0581],
-                       [-0.0581,  0.    ,  0.    , -0.1163, -0.0581,  0.2326]])
-        # fmt: on
+    L = nx.directed_combinatorial_laplacian_matrix(
+        G, alpha=0.9, nodelist=sorted(G), walk_type="lazy"
+    )
+    np.testing.assert_almost_equal(L, GL, decimal=3)
 
-        L = nx.directed_combinatorial_laplacian_matrix(
-            G, alpha=0.9, nodelist=sorted(G), walk_type="random"
-        )
-        np.testing.assert_almost_equal(L, GL, decimal=3)
+    E = nx.DiGraph(margulis_gabber_galil_graph(2))
+    L = nx.directed_combinatorial_laplacian_matrix(E)
+    # fmt: off
+    expected = np.array(
+        [[ 0.16666667, -0.08333333, -0.08333333,  0.        ],
+         [-0.08333333,  0.16666667,  0.        , -0.08333333],
+         [-0.08333333,  0.        ,  0.16666667, -0.08333333],
+         [ 0.        , -0.08333333, -0.08333333,  0.16666667]]
+    )
+    # fmt: on
+    np.testing.assert_almost_equal(L, expected, decimal=6)
 
-        # fmt: off
-        GL = np.array([[ 0.0698, -0.0174, -0.0233,  0.    ,  0.    , -0.0291],
-                       [-0.0174,  0.0465, -0.0058,  0.    , -0.0233,  0.    ],
-                       [-0.0233, -0.0058,  0.0349,  0.    , -0.0058,  0.    ],
-                       [ 0.    ,  0.    ,  0.    ,  0.1163, -0.0581, -0.0581],
-                       [ 0.    , -0.0233, -0.0058, -0.0581,  0.1163, -0.0291],
-                       [-0.0291,  0.    ,  0.    , -0.0581, -0.0291,  0.1163]])
-        # fmt: on
-
-        L = nx.directed_combinatorial_laplacian_matrix(
-            G, alpha=0.9, nodelist=sorted(G), walk_type="lazy"
-        )
-        np.testing.assert_almost_equal(L, GL, decimal=3)
-
-        E = nx.DiGraph(margulis_gabber_galil_graph(2))
-        L = nx.directed_combinatorial_laplacian_matrix(E)
-        # fmt: off
-        expected = np.array(
-            [[ 0.16666667, -0.08333333, -0.08333333,  0.        ],
-             [-0.08333333,  0.16666667,  0.        , -0.08333333],
-             [-0.08333333,  0.        ,  0.16666667, -0.08333333],
-             [ 0.        , -0.08333333, -0.08333333,  0.16666667]]
-        )
-        # fmt: on
-        np.testing.assert_almost_equal(L, expected, decimal=6)
-
-        with pytest.raises(nx.NetworkXError):
-            nx.directed_combinatorial_laplacian_matrix(
-                G, walk_type="pagerank", alpha=100
-            )
-        with pytest.raises(nx.NetworkXError):
-            nx.directed_combinatorial_laplacian_matrix(G, walk_type="silly")
+    with pytest.raises(nx.NetworkXError):
+        nx.directed_combinatorial_laplacian_matrix(G, walk_type="pagerank", alpha=100)
+    with pytest.raises(nx.NetworkXError):
+        nx.directed_combinatorial_laplacian_matrix(G, walk_type="silly")


### PR DESCRIPTION
Calling `nx.directed_laplacian_matrix` currently results in:

```python
>>> import networkx as nx
>>> G = nx.gn_graph(10)
>>> nx.directed_laplacian_matrix(G)
Traceback (most recent call last)
   ...
AttributeError: module 'scipy.sparse' has no attribute 'linalg'
```

This is because `directed_laplacian_matrix` and `directed_combinatorial_laplacian_matrix` are missing internal imports of the scipy.sparse.linalg subpackage.

Alarmingly, this was not caught by the test suite - likely due to imports persisting within the test class. Breaking the two test methods for the `directed` Laplacians out of the class into test functions is sufficient to catch the missing imports (this is the only change to the tests that I made for this PR).