### PR TITLE
Remove internal laplacian function in favor of laplacian_matrix.

### DIFF
--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -4,7 +4,6 @@ from networkx.algorithms.centrality.flow_matrix import (
     CGInverseLaplacian,
     flow_matrix_row,
     FullInverseLaplacian,
-    laplacian_sparse_matrix,
     SuperLUInverseLaplacian,
 )
 from networkx.utils import (
@@ -111,9 +110,8 @@ def approximate_current_flow_betweenness_centrality(
     # make a copy with integer labels according to rcm ordering
     # this could be done without a copy if we really wanted to
     H = nx.relabel_nodes(G, dict(zip(ordering, range(n))))
-    L = laplacian_sparse_matrix(
-        H, nodelist=range(n), weight=weight, dtype=dtype, format="csc"
-    )
+    L = nx.laplacian_matrix(H, nodelist=range(n), weight=weight).asformat("csc")
+    L = L.astype(dtype)
     C = solvername[solver](L, dtype=dtype)  # initialize solver
     betweenness = dict.fromkeys(H, 0.0)
     nb = (n - 1.0) * (n - 2.0)  # normalization factor

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -5,7 +5,6 @@ from networkx.utils import not_implemented_for, reverse_cuthill_mckee_ordering
 from networkx.algorithms.centrality.flow_matrix import (
     CGInverseLaplacian,
     FullInverseLaplacian,
-    laplacian_sparse_matrix,
     SuperLUInverseLaplacian,
 )
 
@@ -82,9 +81,8 @@ def current_flow_closeness_centrality(G, weight=None, dtype=float, solver="lu"):
     H = nx.relabel_nodes(G, dict(zip(ordering, range(n))))
     betweenness = dict.fromkeys(H, 0.0)  # b[v]=0 for v in H
     n = H.number_of_nodes()
-    L = laplacian_sparse_matrix(
-        H, nodelist=range(n), weight=weight, dtype=dtype, format="csc"
-    )
+    L = nx.laplacian_matrix(H, nodelist=range(n), weight=weight).asformat("csc")
+    L = L.astype(dtype)
     C2 = solvername[solver](L, width=1, dtype=dtype)  # initialize solver
     for v in H:
         col = C2.get_row(v)

--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -13,9 +13,8 @@ def flow_matrix_row(G, weight=None, dtype=float, solver="lu"):
         "cg": CGInverseLaplacian,
     }
     n = G.number_of_nodes()
-    L = laplacian_sparse_matrix(
-        G, nodelist=range(n), weight=weight, dtype=dtype, format="csc"
-    )
+    L = nx.laplacian_matrix(G, nodelist=range(n), weight=weight).asformat("csc")
+    L = L.astype(dtype)
     C = solvername[solver](L, dtype=dtype)  # initialize solver
     w = C.w  # w is the Laplacian matrix width
     # row-by-row flow matrix
@@ -130,18 +129,3 @@ class CGInverseLaplacian(InverseLaplacian):
         rhs = np.zeros(self.n, self.dtype)
         rhs[r] = 1
         return sp.sparse.linalg.cg(self.L1, rhs[1:], M=self.M, atol=0)[0]
-
-
-# graph laplacian, sparse version, will move to linalg/laplacianmatrix.py
-def laplacian_sparse_matrix(G, nodelist=None, weight=None, dtype=None, format="csr"):
-    import numpy as np
-    import scipy as sp
-    import scipy.sparse  # call as sp.sparse
-
-    A = nx.to_scipy_sparse_matrix(
-        G, nodelist=nodelist, weight=weight, dtype=dtype, format=format
-    )
-    (n, n) = A.shape
-    data = np.asarray(A.sum(axis=1).T)
-    D = sp.sparse.spdiags(data, 0, n, n, format=format)
-    return D - A


### PR DESCRIPTION
The `flow_matrix` module defines a `laplacian_sparse_matrix` helper-function that is used to calculate the Laplacian for the flow_betweenness centrality measures. The `laplacian_sparse_matrix` function duplicates the functionality of `nx.laplacian_matrix`, so I propose removing the former in favor of the latter.

Though not preceded by an underscore, `laplacian_sparse_matrix` is not exposed in any namespaces so I'm operating under the assumption that it is safe to remove it outright. I'm happy to deprecate it instead if others feel extra caution is warranted - LMK what you think!