### PR TITLE
Remove assertion test method in favor of assert statements

### DIFF
--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -33,38 +33,35 @@ class TestConvertScipy:
         G.add_weighted_edges_from(ex)
         return G
 
-    def assert_isomorphic(self, G1, G2):
-        assert nx.is_isomorphic(G1, G2)
-
     def identity_conversion(self, G, A, create_using):
         GG = nx.from_scipy_sparse_matrix(A, create_using=create_using)
-        self.assert_isomorphic(G, GG)
+        assert nx.is_isomorphic(G, GG)
 
         GW = nx.to_networkx_graph(A, create_using=create_using)
-        self.assert_isomorphic(G, GW)
+        assert nx.is_isomorphic(G, GW)
 
         GI = nx.empty_graph(0, create_using).__class__(A)
-        self.assert_isomorphic(G, GI)
+        assert nx.is_isomorphic(G, GI)
 
         ACSR = A.tocsr()
         GI = nx.empty_graph(0, create_using).__class__(ACSR)
-        self.assert_isomorphic(G, GI)
+        assert nx.is_isomorphic(G, GI)
 
         ACOO = A.tocoo()
         GI = nx.empty_graph(0, create_using).__class__(ACOO)
-        self.assert_isomorphic(G, GI)
+        assert nx.is_isomorphic(G, GI)
 
         ACSC = A.tocsc()
         GI = nx.empty_graph(0, create_using).__class__(ACSC)
-        self.assert_isomorphic(G, GI)
+        assert nx.is_isomorphic(G, GI)
 
         AD = A.todense()
         GI = nx.empty_graph(0, create_using).__class__(AD)
-        self.assert_isomorphic(G, GI)
+        assert nx.is_isomorphic(G, GI)
 
         AA = A.toarray()
         GI = nx.empty_graph(0, create_using).__class__(AA)
-        self.assert_isomorphic(G, GI)
+        assert nx.is_isomorphic(G, GI)
 
     def test_shape(self):
         "Conversion from non-square sparse array."
@@ -98,7 +95,7 @@ class TestConvertScipy:
         nodelist = list(P3.nodes())
         A = nx.to_scipy_sparse_matrix(P4, nodelist=nodelist)
         GA = nx.Graph(A)
-        self.assert_isomorphic(GA, P3)
+        assert nx.is_isomorphic(GA, P3)
 
         pytest.raises(nx.NetworkXError, nx.to_scipy_sparse_matrix, P3, nodelist=[])
         # Test nodelist duplicates.


### PR DESCRIPTION
Minor cleanup: removes two unnecessary lines and converts test suite assertions to the preferred style (i.e. assert statements rather than using `assert_` functions).

This would also make it easier to refactor these tests using a non-OO design in the future.