### PR TITLE
Keep omega within [-1, 1] bounds

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -38,6 +38,8 @@ Improvements
 
 - [`#5216 <https://github.com/networkx/networkx/pull/5216>`_]
   Make ``omega()`` closer to the published algorithm. The value changes slightly.
+  The ``niter`` parameter default changes from 1->5 in ``lattice_reference()``
+  and from 100->5 in ``omega``.
 
 API Changes
 -----------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -36,6 +36,8 @@ X contributors. Highlights include:
 Improvements
 ------------
 
+- [`#5216 <https://github.com/networkx/networkx/pull/5216>`_]
+  Make ``omega()`` closer to the published algorithm. The value changes slightly.
 
 API Changes
 -----------

--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -114,7 +114,7 @@ def random_reference(G, niter=1, connectivity=True, seed=None):
 @py_random_state(4)
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-def lattice_reference(G, niter=1, D=None, connectivity=True, seed=None):
+def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
     """Latticize the given graph by swapping edges.
 
     Parameters
@@ -181,12 +181,12 @@ def lattice_reference(G, niter=1, D=None, connectivity=True, seed=None):
             D[v, :] = D[nnodes - v - 1, :][::-1]
 
     niter = niter * nedges
-    ntries = int(nnodes * nedges / (nnodes * (nnodes - 1) / 2))
-    swapcount = 0
+    # maximal number of rewiring attempts per 'niter'
+    max_attempts = int(nnodes * nedges / (nnodes * (nnodes - 1) / 2))
 
-    for i in range(niter):
+    for _ in range(niter):
         n = 0
-        while n < ntries:
+        while n < max_attempts:
             # pick two random edges without creating edge list
             # choose source node indices from discrete distribution
             (ai, ci) = discrete_sequence(2, cdistribution=cdf, seed=seed)
@@ -220,7 +220,6 @@ def lattice_reference(G, niter=1, D=None, connectivity=True, seed=None):
                         G.add_edge(a, b)
                         G.add_edge(c, d)
                     else:
-                        swapcount += 1
                         break
             n += 1
 
@@ -298,7 +297,7 @@ def sigma(G, niter=100, nrand=10, seed=None):
 @py_random_state(3)
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-def omega(G, niter=100, nrand=10, seed=None):
+def omega(G, niter=5, nrand=10, seed=None):
     """Returns the small-world coefficient (omega) of a graph
 
     The small-world coefficient of a graph G is:
@@ -320,12 +319,12 @@ def omega(G, niter=100, nrand=10, seed=None):
     G : NetworkX graph
         An undirected graph.
 
-    niter: integer (optional, default=100)
+    niter: integer (optional, default=5)
         Approximate number of rewiring per edge to compute the equivalent
         random graph.
 
     nrand: integer (optional, default=10)
-        Number of random graphs generated to compute the average clustering
+        Number of random graphs generated to compute the maximal clustering
         coefficient (Cr) and average shortest path length (Lr).
 
     seed : integer, random_state, or None (default)
@@ -354,15 +353,31 @@ def omega(G, niter=100, nrand=10, seed=None):
     # Compute the mean clustering coefficient and average shortest path length
     # for an equivalent random graph
     randMetrics = {"C": [], "L": []}
-    for i in range(nrand):
-        Gr = random_reference(G, niter=niter, seed=seed)
-        Gl = lattice_reference(G, niter=niter, seed=seed)
-        randMetrics["C"].append(nx.transitivity(Gl))
+
+    # Calculate initial average clustering coefficient which potentially will
+    # get replaced by higher clustering coefficients from generated lattice
+    # reference graphs
+    Cl = nx.average_clustering(G)
+
+    niter_lattice_reference = niter
+    niter_random_reference = niter * 2
+
+    for _ in range(nrand):
+        # Generate random graph
+        Gr = random_reference(G, niter=niter_random_reference, seed=seed)
         randMetrics["L"].append(nx.average_shortest_path_length(Gr))
 
-    C = nx.transitivity(G)
+        # Generate lattice graph
+        Gl = lattice_reference(G, niter=niter_lattice_reference, seed=seed)
+
+        # Replace old clustering coefficient, if clustering is higher in
+        # generated lattice reference
+        Cl_temp = nx.average_clustering(Gl)
+        if Cl_temp > Cl:
+            Cl = Cl_temp
+
+    C = nx.average_clustering(G)
     L = nx.average_shortest_path_length(G)
-    Cl = np.mean(randMetrics["C"])
     Lr = np.mean(randMetrics["L"])
 
     omega = (Lr / L) - (C / Cl)

--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -309,10 +309,10 @@ def omega(G, niter=5, nrand=10, seed=None):
     of an equivalent random graph and Cl is the average clustering coefficient
     of an equivalent lattice graph.
 
-    The small-world coefficient (omega) ranges between -1 and 1. Values close
-    to 0 means the G features small-world characteristics. Values close to -1
-    means G has a lattice shape whereas values close to 1 means G is a random
-    graph.
+    The small-world coefficient (omega) measures how much G is like a lattice
+    or a random graph. Negative values mean G is similar to a lattice whereas
+    positive values mean G is a random graph.
+    Values close to 0 mean that G has small-world characteristics.
 
     Parameters
     ----------

--- a/networkx/algorithms/tests/test_smallworld.py
+++ b/networkx/algorithms/tests/test_smallworld.py
@@ -59,3 +59,15 @@ def test_omega():
     print("omegas, omegal, omegar")
     print(omegas, omegal, omegar)
     assert omegal < omegas and omegas < omegar
+
+    # Test that omega lies within the [-1, 1] bounds
+    G_barbell = nx.barbell_graph(5, 1)
+    G_karate = nx.karate_club_graph()
+
+    omega_barbell = nx.omega(G_barbell)
+    omega_karate = nx.omega(G_karate, nrand=2)
+
+    omegas = (omegal, omegar, omegas, omega_barbell, omega_karate)
+
+    for o in omegas:
+        assert -1 <= o <= 1

--- a/networkx/algorithms/tests/test_smallworld.py
+++ b/networkx/algorithms/tests/test_smallworld.py
@@ -55,8 +55,6 @@ def test_omega():
     omegal = omega(Gl, niter=1, nrand=1, seed=rng)
     omegar = omega(Gr, niter=1, nrand=1, seed=rng)
     omegas = omega(Gs, niter=1, nrand=1, seed=rng)
-    print("omegas, omegal, omegar")
-    print(omegas, omegal, omegar)
     assert omegal < omegas and omegas < omegar
 
     # Test that omega lies within the [-1, 1] bounds


### PR DESCRIPTION
Closes #5064 

The problem of #5064 regards network examples, where the calculated small-world omega metric does not lie within the bounds of the specified [-1,1] intervall. In order to check where this is coming from, I tried to find any differences in the description of the calculation from the original paper to the implemented version. The following was changed in this PR:

- Changing from nx.transitivity to nx.clustering for the clustering coefficient
- Changing default values for niter and nrand. Note: niter=5 is specified for the lattice and niter=10 is specified for the random reference. And nrand_random=50 is mentioned in the section "Random and lattice network construction" for the random reference graph. nrand_lattice is not explicitly stated, which is why I leave the default value for nrand=10, as the computation of omega quickly becomes unfeasible, mostly due to the lattice calculation.
- Changing from average clustering to maximal clustering: In the original paper they only accept a new lattice reference graph, if the clustering in the generated graph is higher than that from the previos generated lattice. The aim of this procedure is to find a lattice reference with the maximum clustering while preserving the degree distribution of the original graph.
- Adding tests for some graphs to check if there lie within the bounds. I used the graph from the issue, the already used graphs in the testing function and added the karate graph. In a previous version I had various additional graphs, but the calculation took quite a while, which is why I kept the graph examples to a minimum in order to not blew up the test suite execution time.
