### PR TITLE
Add FutureWarning about matrix->array output to `google_matrix`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -96,3 +96,6 @@ Version 3.0
 * In ``networkx/algorithms/node_classification/`` remove ``hmn.py``, ``lgc.py``,
   and ``utils.py`` after moving the functions defined therein into the newly created
   ``node_classification.py`` module, which will replace the current package.
+* In ``networkx/algorithms/link_analysis/pagerank_alg.py``, remove the
+  ``np.asmatrix`` wrappers on the return values of ``google_matrix`` and remove
+  the associated FutureWarning.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -44,6 +44,9 @@ API Changes
   `~networkx.drawing.layout.rescale_layout_dict` are now `numpy.ndarray` objects
   instead of tuples. This makes the return type of ``rescale_layout_dict``
   consistent with that of all of the other layout functions.
+- A ``FutureWarning`` has been added to ``google_matrix`` to indicated that the
+  return type will change from a ``numpy.matrix`` object to a ``numpy.ndarray``
+  in NetworkX 3.0.
 
 Deprecations
 ------------

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -236,10 +236,11 @@ def google_matrix(
     if nodelist is None:
         nodelist = list(G)
 
-    M = np.asmatrix(nx.to_numpy_array(G, nodelist=nodelist, weight=weight))
+    A = nx.to_numpy_array(G, nodelist=nodelist, weight=weight)
     N = len(G)
     if N == 0:
-        return M
+        # TODO: Remove np.asmatrix wrapper in version 3.0
+        return np.asmatrix(A)
 
     # Personalization vector
     if personalization is None:
@@ -257,15 +258,15 @@ def google_matrix(
         # Convert the dangling dictionary into an array in nodelist order
         dangling_weights = np.array([dangling.get(n, 0) for n in nodelist], dtype=float)
         dangling_weights /= dangling_weights.sum()
-    dangling_nodes = np.where(M.sum(axis=1) == 0)[0]
+    dangling_nodes = np.where(A.sum(axis=1) == 0)[0]
 
     # Assign dangling_weights to any dangling nodes (nodes with no out links)
-    for node in dangling_nodes:
-        M[node] = dangling_weights
+    A[dangling_nodes] = dangling_weights
 
-    M /= M.sum(axis=1)  # Normalize rows to sum to 1
+    A /= A.sum(axis=1)[:, np.newaxis]  # Normalize rows to sum to 1
 
-    return alpha * M + (1 - alpha) * p
+    # TODO: Remove np.asmatrix wrapper in version 3.0
+    return np.asmatrix(alpha * A + (1 - alpha) * p)
 
 
 def pagerank_numpy(G, alpha=0.85, personalization=None, weight="weight", dangling=None):

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -233,6 +233,16 @@ def google_matrix(
     """
     import numpy as np
 
+    # TODO: Remove this warning in version 3.0
+    import warnings
+
+    warnings.warn(
+        "google_matrix will return an np.ndarray instead of a np.matrix in\n"
+        "NetworkX version 3.0.",
+        FutureWarning,
+        stacklevel=2,
+    )
+
     if nodelist is None:
         nodelist = list(G)
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -176,6 +176,11 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="preserve_random_state"
     )
+    warnings.filterwarnings(
+        "ignore",
+        category=FutureWarning,
+        message="google_matrix will return an np.ndarray instead of a np.matrix",
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
[The `google_matrix` function](https://github.com/networkx/networkx/blob/4be27b6eb32b77ccc0242368e7a5cadaaa77e7af/networkx/algorithms/link_analysis/pagerank_alg.py#L175-L268) currently returns a `np.matrix` object and uses matrix semantics internally. This PR:
 1. Refactors the function to use array semantics internally, and wraps the outputs in `np.asmatrix` for compatibility.
 2. Adds a `FutureWarning` to warn users that the output type will change from `np.matrix` to `np.ndarray` in NetworkX 3.0

When the `FutureWarning` expires in version 3.0, the `np.asmatrix` wrappers can simply be removed.

Alternatively, one could do away with the FutureWarning and simply change the behavior now, but IMO it's safer to provide a `FutureWarning` given the behavior differences between matrix and array objects.