### PR TITLE
Replace internal `close` fn with `math.isclose`.

### DIFF
--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -251,7 +251,7 @@ Examples
 >>> from operator import eq
 >>> from math import isclose
 >>> from networkx.algorithms.isomorphism import generic_node_match
->>> nm = generic_node_match("weight", 1.0, close)
+>>> nm = generic_node_match("weight", 1.0, isclose)
 >>> nm = generic_node_match("color", "red", eq)
 >>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [isclose, eq])
 
@@ -311,7 +311,7 @@ def generic_multiedge_match(attr, default, op):
     >>> from operator import eq
     >>> from math import isclose
     >>> from networkx.algorithms.isomorphism import generic_node_match
-    >>> nm = generic_node_match("weight", 1.0, close)
+    >>> nm = generic_node_match("weight", 1.0, isclose)
     >>> nm = generic_node_match("color", "red", eq)
     >>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [isclose, eq])
     ...

--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -3,6 +3,7 @@ edge_match functions to use during isomorphism checks.
 """
 from itertools import permutations
 import types
+import math
 
 __all__ = [
     "categorical_node_match",
@@ -37,24 +38,9 @@ def allclose(x, y, rtol=1.0000000000000001e-05, atol=1e-08):
     """
     # assume finite weights, see numpy.allclose() for reference
     for xi, yi in zip(x, y):
-        if not (abs(xi - yi) <= atol + rtol * abs(yi)):
+        if not math.isclose(xi, yi, rel_tol=rtol, abs_tol=atol):
             return False
     return True
-
-
-def close(x, y, rtol=1.0000000000000001e-05, atol=1e-08):
-    """Returns True if x and y are sufficiently close.
-
-    Parameters
-    ----------
-    rtol : float
-        The relative error tolerance.
-    atol : float
-        The absolute error tolerance.
-
-    """
-    # assume finite weights, see numpy.allclose() for reference
-    return abs(x - y) <= atol + rtol * abs(y)
 
 
 categorical_doc = """
@@ -176,8 +162,11 @@ def numerical_node_match(attr, default, rtol=1.0000000000000001e-05, atol=1e-08)
     if isinstance(attr, str):
 
         def match(data1, data2):
-            return close(
-                data1.get(attr, default), data2.get(attr, default), rtol=rtol, atol=atol
+            return math.isclose(
+                data1.get(attr, default),
+                data2.get(attr, default),
+                rel_tol=rtol,
+                abs_tol=atol,
             )
 
     else:
@@ -260,11 +249,11 @@ match : function
 Examples
 --------
 >>> from operator import eq
->>> from networkx.algorithms.isomorphism.matchhelpers import close
+>>> from math import isclose
 >>> from networkx.algorithms.isomorphism import generic_node_match
 >>> nm = generic_node_match("weight", 1.0, close)
 >>> nm = generic_node_match("color", "red", eq)
->>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [close, eq])
+>>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [isclose, eq])
 
 """
 
@@ -320,11 +309,11 @@ def generic_multiedge_match(attr, default, op):
     Examples
     --------
     >>> from operator import eq
-    >>> from networkx.algorithms.isomorphism.matchhelpers import close
+    >>> from math import isclose
     >>> from networkx.algorithms.isomorphism import generic_node_match
     >>> nm = generic_node_match("weight", 1.0, close)
     >>> nm = generic_node_match("color", "red", eq)
-    >>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [close, eq])
+    >>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [isclose, eq])
     ...
 
     """

--- a/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py
@@ -3,6 +3,7 @@
 """
 
 from operator import eq
+import math
 
 import networkx as nx
 import networkx.algorithms.isomorphism as iso
@@ -150,7 +151,7 @@ class TestEdgeMatch_MultiGraph:
             self.emg2 = iso.generic_multiedge_match(
                 ["color", "weight", "size"],
                 ["red", 1, 0.5],
-                [eq, eq, iso.matchhelpers.close],
+                [eq, eq, math.isclose],
             )
         else:
             self.em = iso.numerical_edge_match("weight", 1)
@@ -160,7 +161,7 @@ class TestEdgeMatch_MultiGraph:
             self.emg2 = iso.generic_edge_match(
                 ["color", "weight", "size"],
                 ["red", 1, 0.5],
-                [eq, eq, iso.matchhelpers.close],
+                [eq, eq, math.isclose],
             )
 
     def test_weights_only(self):


### PR DESCRIPTION
There is an internal function called `close` defined in `isomorphism/matchhelpers` that appears to duplicate the functionality of the built-in `math.isclose`. I think it would be an improvement to use the built-in instead.

The safest thing to do would probably be to deprecate it (or add a `__getattr__` exception) since it doesn't follow the "private" naming-convention (i.e. starting with an underscore); however, I've simply removed it in this PR since it wasn't in the `__all__` for the module. I'm leaning towards deprecating instead, but wanted to see what others thought for this particular case.

Note also that there is an internal implementation of `allclose` which mirrors the element-wise behavior of `numpy.allclose`. Switching to the `numpy` function would inject a numpy dependency into the isomorphism package, so I decided to leave it in (though I'm tempted to add a `FutureWarning` and make it a private function `allclose` -> `_allclose`).