### PR TITLE
Compatibility updates from testing with numpy/scipy/pytest rc's

### DIFF
--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -73,7 +73,7 @@ class TestHITS:
             _hits_python(G, max_iter=0)
         with pytest.raises(ValueError):
             nx.hits(G, max_iter=0)
-        with pytest.raises(sp.sparse.linalg.eigen.arpack.ArpackNoConvergence):
+        with pytest.raises(sp.sparse.linalg.ArpackNoConvergence):
             nx.hits(G, max_iter=1)
 
 

--- a/networkx/algorithms/tests/test_node_classification_deprecations.py
+++ b/networkx/algorithms/tests/test_node_classification_deprecations.py
@@ -22,14 +22,20 @@ def test_lgc_deprecation_warning():
         from networkx.algorithms.node_classification import lgc
 
 
-def test_no_warn_on_function_or_package_import():
+def test_no_warn_on_function_import(recwarn):
     # Accessing the functions shouldn't raise any warning
-    with pytest.warns(None) as record:
-        from networkx.algorithms.node_classification import (
-            harmonic_function,
-            local_and_global_consistency,
-        )
-    assert len(record) == 0
-    with pytest.warns(None) as record:
-        from networkx.algorithms import node_classification
-    assert len(record) == 0
+    sys.modules.pop("networkx.algorithms.node_classification")
+    from networkx.algorithms.node_classification import (
+        harmonic_function,
+        local_and_global_consistency,
+    )
+
+    assert len(recwarn) == 0
+
+
+def test_no_warn_on_package_import(recwarn):
+    # Accessing the package shouldn't raise any warning
+    sys.modules.pop("networkx.algorithms.node_classification")
+    from networkx.algorithms import node_classification
+
+    assert len(recwarn) == 0

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -884,7 +884,7 @@ def _sparse_spectral(A, dim=2):
     # number of Lanczos vectors for ARPACK solver.What is the right scaling?
     ncv = max(2 * k + 1, int(np.sqrt(nnodes)))
     # return smallest k eigenvalues and eigenvectors
-    eigenvalues, eigenvectors = sp.sparse.linalg.eigen.eigsh(L, k, which="SM", ncv=ncv)
+    eigenvalues, eigenvectors = sp.sparse.linalg.eigsh(L, k, which="SM", ncv=ncv)
     index = np.argsort(eigenvalues)[1:k]  # 0 index is zero eigenvalue
     return np.real(eigenvectors[:, index])
 

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -383,13 +383,5 @@ class TestSpectralOrdering:
         nx.add_path(G, path, weight=5)
         G.add_edge(path[-1], path[0], weight=1)
         A = nx.laplacian_matrix(G).todense()
-        try:
-            order = nx.spectral_ordering(G, normalized=normalized, method=method)
-        except nx.NetworkXError as err:
-            if err.args not in (
-                ("Cholesky solver unavailable.",),
-                ("LU solver unavailable.",),
-            ):
-                raise
-        else:
-            assert order in expected_order
+        order = nx.spectral_ordering(G, normalized=normalized, method=method)
+        assert order in expected_order

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -6,13 +6,14 @@ from networkx.readwrite.json_graph import cytoscape_data, cytoscape_graph
 
 
 # TODO: To be removed when signature change complete in 3.0
-def test_attrs_deprecation():
+def test_attrs_deprecation(recwarn):
     G = nx.path_graph(3)
+
     # No warnings when `attrs` kwarg not used
-    with pytest.warns(None) as record:
-        data = cytoscape_data(G)
-        H = cytoscape_graph(data)
-    assert len(record) == 0
+    data = cytoscape_data(G)
+    H = cytoscape_graph(data)
+    assert len(recwarn) == 0
+
     # Future warning raised with `attrs` kwarg
     attrs = {"name": "foo", "ident": "bar"}
     with pytest.warns(DeprecationWarning):

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -42,13 +42,14 @@ def test_exceptions():
 
 
 # NOTE: To be removed when deprecation expires in 3.0
-def test_attrs_deprecation():
+def test_attrs_deprecation(recwarn):
     G = nx.path_graph(3, create_using=nx.DiGraph)
+
     # No warnings when `attrs` kwarg not used
-    with pytest.warns(None) as record:
-        data = tree_data(G, 0)
-        H = tree_graph(data)
-    assert len(record) == 0
+    data = tree_data(G, 0)
+    H = tree_graph(data)
+    assert len(recwarn) == 0
+
     # DeprecationWarning issued when `attrs` is used
     attrs = {"id": "foo", "children": "bar"}
     with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
A few minor cleanups and removal of usage-patterns that will result in DeprecationWarnings in the upcoming scipy/pytest releases. These were identified by running the test suite with the numpy-1.22rc2, scipy-1.8rc1, and pytest-7.0.0rc1.
 - Use the pytest `recwarn` fixture instead of `pytest.warns(None)`, which is deprecated in 7.0
 - Access various scipy.sparse.linalg tools from the `scipy.sparse.linalg` namespace, since many of the sparse.linalg subpackages have been made private.

