### PR TITLE
Fix Python 3.10 deprecation warning

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -206,7 +206,7 @@ def dense_gnm_random_graph(n, m, seed=None):
     .. [1] Donald E. Knuth, The Art of Computer Programming,
         Volume 2/Seminumerical algorithms, Third Edition, Addison-Wesley, 1997.
     """
-    mmax = n * (n - 1) / 2
+    mmax = n * (n - 1) // 2
     if m >= mmax:
         G = complete_graph(n)
     else:


### PR DESCRIPTION
Running the full test suite (with all dependencies) w/ Python 3.10 resulted in a new DeprecationWarning from `randrange`, which will require integer input in Python 3.12:

```
networkx/generators/tests/test_random_graphs.py: 4830 warnings
  repos/networkx/networkx/generators/random_graphs.py:223: DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
    if seed.randrange(mmax - t) < m - k:
```

This PR fixes the warning by switching to integer division for computing `mmax`.