### PR TITLE
Allows dictionary keys to have dots (.) in their keys during GML I/O

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -300,7 +300,7 @@ def parse_gml_lines(lines, label, destringizer):
 
     def tokenize():
         patterns = [
-            r"[A-Za-z][0-9A-Za-z_]*\b",  # keys
+            r"[A-Za-z][0-9A-Za-z_\.]*\b",  # keys
             # reals
             r"[+-]?(?:[0-9]*\.[0-9]+|[0-9]+\.[0-9]*|INF)(?:[Ee][+-]?[0-9]+)?",
             r"[+-]?[0-9]+",  # ints
@@ -682,7 +682,7 @@ def generate_gml(G, stringizer=None):
       ]
     ]
     """
-    valid_keys = re.compile("^[A-Za-z][0-9A-Za-z_]*$")
+    valid_keys = re.compile("^[A-Za-z][0-9A-Za-z_\.]*$")
 
     def stringize(key, value, ignored_keys, indent, in_list=False):
         if not isinstance(key, str):


### PR DESCRIPTION
While trying to [figure out GML serialisation](https://github.com/networkx/networkx/discussions/5233), I realised that GML dictionaries could not have keys that contained dots. This PR attempts to fix that.