### PR TITLE
Docstrings for the small.py module

### DIFF
--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -185,7 +185,7 @@ def bull_graph(create_using=None):
     Returns the Bull Graph
 
     The Bull Graph has 5 nodes and 5 edges. It is a planar undirected
-    graph in the form of a triangle with two disjoint pendant edges [1]
+    graph in the form of a triangle with two disjoint pendant edges [1]_
     The name comes from the triangle and pendant edges representing
     respectively the body and legs of a bull.
 
@@ -216,11 +216,11 @@ def bull_graph(create_using=None):
 
 def chvatal_graph(create_using=None):
     """
-    Returns Chvátal Graph
+    Returns the Chvátal Graph
 
-    The Chvátal Graph is an Undirected graph with 12 nodes and 24 edges [1]
+    The Chvátal Graph is an undirected graph with 12 nodes and 24 edges [1]_.
     It has 370 distinct (directed) Hamiltonian cycles, giving a unique generalized
-    LCF notation of order 4, two of order 6 , and 43 of order 1. [2]
+    LCF notation of order 4, two of order 6 , and 43 of order 1 [2]_.
 
     Parameters
     ----------
@@ -230,12 +230,12 @@ def chvatal_graph(create_using=None):
     Returns
     -------
     G : networkx Graph
-        A Chvatal graph with 12 nodes and 24 edges
+        The Chvátal graph with 12 nodes and 24 edges
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Chv%C3%A1tal_graph
-    [2] https://mathworld.wolfram.com/ChvatalGraph.html
+    .. [1] https://en.wikipedia.org/wiki/Chv%C3%A1tal_graph
+    .. [2] https://mathworld.wolfram.com/ChvatalGraph.html
 
     """
     description = [
@@ -263,14 +263,13 @@ def chvatal_graph(create_using=None):
 
 def cubical_graph(create_using=None):
     """
-    Returns Cubical Grpah
+    Returns the 3-regular Platonic Cubical Graph
 
     The skeleton of the cube (the nodes and edges) form a graph, with 8
     nodes, and 12 edges. It is a special case of the hypercube graph.
     It is one of 5 Platonic graphs, each a skeleton of its
-    Platonic solid. [1]
+    Platonic solid [1]_.
     Such graphs arise in parallel processing in computers.
-
 
     Parameters
     ----------
@@ -308,12 +307,12 @@ def cubical_graph(create_using=None):
 
 def desargues_graph(create_using=None):
     """
-    Returns a Desargues Graph
+    Returns the Desargues Graph
 
-    Desargues Graph is a non-planar, distance-transitive cubic graph
-    with 20 nodes and 30 edges.[1]
+    The Desargues Graph is a non-planar, distance-transitive cubic graph
+    with 20 nodes and 30 edges [1]_.
     It is a symmetric graph. It can be represented in LCF notation
-    as [5,-5,9,-9]^5. [2]
+    as [5,-5,9,-9]^5 [2]_.
 
     Parameters
     ----------
@@ -327,8 +326,8 @@ def desargues_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Desargues_graph
-    [2] https://mathworld.wolfram.com/DesarguesGraph.html
+    .. [1] https://en.wikipedia.org/wiki/Desargues_graph
+    .. [2] https://mathworld.wolfram.com/DesarguesGraph.html
     """
     G = LCF_graph(20, [5, -5, 9, -9], 5, create_using)
     G.name = "Desargues Graph"
@@ -337,10 +336,10 @@ def desargues_graph(create_using=None):
 
 def diamond_graph(create_using=None):
     """
-    Returns diamond graph
+    Returns the Diamond graph
 
-    The diamond graph is  planar undirected graph on 4 nodes and 5 edges.
-    It is also sometimes known as the double triangle graph or kite graph [1]
+    The Diamond Graph is  planar undirected graph with 4 nodes and 5 edges.
+    It is also sometimes known as the double triangle graph or kite graph [1]_.
 
     Parameters
     ----------
@@ -354,7 +353,8 @@ def diamond_graph(create_using=None):
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/DiamondGraph.html"""
+    .. [1] https://mathworld.wolfram.com/DiamondGraph.html
+    """
     description = [
         "adjacencylist",
         "Diamond Graph",
@@ -369,10 +369,10 @@ def dodecahedral_graph(create_using=None):
     """
     Returns the Platonic Dodecahedral graph.
 
-    The dodecahedral graph has 20 nodes, 30 edges.The skeleton of the
-    dodecahedron form a graph. It is one of 5 Platonic graphs. [1]
+    The dodecahedral graph has 20 nodes and 30 edges. The skeleton of the
+    dodecahedron forms a graph. It is one of 5 Platonic graphs [1]_.
     It can be described in LCF notation as:
-    [10, 7, 4, -4, -7, 10, -4, 7, -7, 4]^2.[2]
+    ``[10, 7, 4, -4, -7, 10, -4, 7, -7, 4]^2`` [2]_.
 
     Parameters
     ----------
@@ -386,8 +386,8 @@ def dodecahedral_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Regular_dodecahedron#Dodecahedral_graph
-    [2] https://mathworld.wolfram.com/DodecahedralGraph.html
+    .. [1] https://en.wikipedia.org/wiki/Regular_dodecahedron#Dodecahedral_graph
+    .. [2] https://mathworld.wolfram.com/DodecahedralGraph.html
 
     """
     G = LCF_graph(20, [10, 7, 4, -4, -7, 10, -4, 7, -7, 4], 2, create_using)
@@ -400,9 +400,9 @@ def frucht_graph(create_using=None):
     Returns the Frucht Graph.
 
     The Frucht Graph is the smallest cubical graph whose
-    automorphism group consists only of the identity element.
-    It has 12 nodes and 18 edges and no non trivial symmetries.
-    It is planar and hamiltonian.
+    automorphism group consists only of the identity element [1]_.
+    It has 12 nodes and 18 edges and no nontrivial symmetries.
+    It is planar and Hamiltonian [2]_.
 
     Parameters
     ----------
@@ -416,8 +416,8 @@ def frucht_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Frucht_graph
-    [2] https://mathworld.wolfram.com/FruchtGraph.html
+    .. [1] https://en.wikipedia.org/wiki/Frucht_graph
+    .. [2] https://mathworld.wolfram.com/FruchtGraph.html
 
     """
     G = cycle_graph(7, create_using)
@@ -443,14 +443,14 @@ def frucht_graph(create_using=None):
 
 def heawood_graph(create_using=None):
     """
-    Returns the Heawood graph, a (3,6) cage.
+    Returns the Heawood Graph, a (3,6) cage.
 
-    The Heawood graph is an undirected graph with 14 nodes and 21 edges,
-    named after Percy John Heawood. [1]
-    It is cubic symmetric,nonplanar, Hamiltonian, and can be represented
-    in LCF notation as [5,-5]^7.[2]
+    The Heawood Graph is an undirected graph with 14 nodes and 21 edges,
+    named after Percy John Heawood [1]_.
+    It is cubic symmetric, nonplanar, Hamiltonian, and can be represented
+    in LCF notation as ``[5,-5]^7`` [2]_.
     It is the unique (3,6)-cage: the regular cubic graph of girth 6 with
-    minimal number of vertices. [3]
+    minimal number of vertices [3]_.
 
     Parameters
     ----------
@@ -464,9 +464,9 @@ def heawood_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Heawood_graph
-    [2] https://mathworld.wolfram.com/HeawoodGraph.html
-    [3] https://www.win.tue.nl/~aeb/graphs/Heawood.html
+    .. [1] https://en.wikipedia.org/wiki/Heawood_graph
+    .. [2] https://mathworld.wolfram.com/HeawoodGraph.html
+    .. [3] https://www.win.tue.nl/~aeb/graphs/Heawood.html
 
     """
     G = LCF_graph(14, [5, -5], 7, create_using)
@@ -480,28 +480,26 @@ def hoffman_singleton_graph():
 
     The Hoffman–Singleton graph is a symmetrical undirected graph
     with 50 nodes and 175 edges.
-    All indices lie in Z/5: that is, the integers mod 5. [1]
+    All indices lie in ``Z % 5``: that is, the integers mod 5 [1]_.
     It is the only regular graph of vertex degree 7, diameter 2, and girth 5.
     It is the unique (7,5)-cage graph and Moore graph, and contains many
-    copies of the Petersen graph. [2]
-    Construction from Pentagon and Pentagram: Take five pentagons Ph
-    and five pentagrams Qi . Join vertex j of Ph to vertex h·i+j of Qi.
-    (All indices are modulo 5.) [3]
-
-    Parameters
-    ----------
-    None
+    copies of the Petersen graph [2]_.
 
     Returns
     -------
     G : networkx Graph
         Hoffman–Singleton Graph with 50 nodes and 175 edges
 
+    Notes
+    -----
+    Constructed from pentagon and pentagram as follows: Take five pentagons $P_h$
+    and five pentagrams $Q_i$ . Join vertex $j$ of $P_h$ to vertex $h·i+j$ of $Q_i$ [3]_.
+
     References
     ----------
-    [1] https://blogs.ams.org/visualinsight/2016/02/01/hoffman-singleton-graph/
-    [2] https://mathworld.wolfram.com/Hoffman-SingletonGraph.html
-    [3] https://en.wikipedia.org/wiki/Hoffman%E2%80%93Singleton_graph
+    .. [1] https://blogs.ams.org/visualinsight/2016/02/01/hoffman-singleton-graph/
+    .. [2] https://mathworld.wolfram.com/Hoffman-SingletonGraph.html
+    .. [3] https://en.wikipedia.org/wiki/Hoffman%E2%80%93Singleton_graph
 
     """
     G = nx.Graph()
@@ -523,7 +521,7 @@ def house_graph(create_using=None):
     Returns the House graph (square with triangle on top)
 
     The house graph is a simple undirected graph with
-    5 nodes and 6 edges. [1]
+    5 nodes and 6 edges [1]_.
 
     Parameters
     ----------
@@ -533,12 +531,11 @@ def house_graph(create_using=None):
     Returns
     -------
     G : networkx Graph
-        House graph in the form of a square with a
-    triangle on top
+        House graph in the form of a square with a triangle on top
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/HouseGraph.html
+    .. [1] https://mathworld.wolfram.com/HouseGraph.html
     """
     description = [
         "adjacencylist",
@@ -554,9 +551,9 @@ def house_x_graph(create_using=None):
     """
     Returns the House graph with a cross inside the house square.
 
-    The house X-graph is the house graph plus the two edges connecting diagonally
+    The House X-graph is the House graph plus the two edges connecting diagonally
     opposite vertices of the square base. It is also one of the two graphs
-    obtained by removing two edges from the pentatope graph.
+    obtained by removing two edges from the pentatope graph [1]_.
 
     Parameters
     ----------
@@ -566,12 +563,11 @@ def house_x_graph(create_using=None):
     Returns
     -------
     G : networkx Graph
-        House graph in the form of a square with a
-    triangle on top
+        House graph with diagonal vertices connected
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/HouseGraph.html
+    .. [1] https://mathworld.wolfram.com/HouseGraph.html
     """
     description = [
         "adjacencylist",
@@ -589,7 +585,7 @@ def icosahedral_graph(create_using=None):
 
     The icosahedral graph has 12 nodes and 30 edges. It is a Platonic graph
     whose nodes have the connectivity of the icosahedron. It is undirected,
-    regular and Hamiltonian.
+    regular and Hamiltonian [1]_.
 
     Parameters
     ----------
@@ -603,7 +599,7 @@ def icosahedral_graph(create_using=None):
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/IcosahedralGraph.html
+    .. [1] https://mathworld.wolfram.com/IcosahedralGraph.html
     """
     description = [
         "adjacencylist",
@@ -633,10 +629,7 @@ def krackhardt_kite_graph(create_using=None):
     Returns the Krackhardt Kite Social Network.
 
     A 10 actor social network introduced by David Krackhardt
-    to illustrate: degree, betweenness, centrality, closeness, etc.
-    The traditional labeling is:
-    Andre=1, Beverley=2, Carol=3, Diane=4,
-    Ed=5, Fernando=6, Garth=7, Heather=8, Ike=9, Jane=10.
+    to illustrate different centrality measures [1]_.
 
     Parameters
     ----------
@@ -648,9 +641,17 @@ def krackhardt_kite_graph(create_using=None):
     G : networkx Graph
         Krackhardt Kite graph with 10 nodes and 18 edges
 
+    Notes
+    -----
+    The traditional labeling is:
+    Andre=1, Beverley=2, Carol=3, Diane=4,
+    Ed=5, Fernando=6, Garth=7, Heather=8, Ike=9, Jane=10.
+
     References
     ----------
-    [1] https://mathworld.wolfram.com/KrackhardtKite.html
+    .. [1] Krackhardt, David. "Assessing the Political Landscape: Structure,
+       Cognition, and Power in Organizations". Administrative Science Quarterly.
+       35 (2): 342–369. doi:10.2307/2393394. JSTOR 2393394. June 1990.
 
     """
     description = [
@@ -680,7 +681,7 @@ def moebius_kantor_graph(create_using=None):
 
     The Möbius-Kantor graph is the cubic symmetric graph on 16 nodes.
     Its LCF notation is [5,-5]^8, and it is isomorphic to the generalized
-    Petersen graph.[1]
+    Petersen graph [1]_.
 
     Parameters
     ----------
@@ -694,7 +695,7 @@ def moebius_kantor_graph(create_using=None):
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/Moebius-KantorGraph.html
+    .. [1] https://en.wikipedia.org/wiki/M%C3%B6bius%E2%80%93Kantor_graph
 
     """
     G = LCF_graph(16, [5, -5], 8, create_using)
@@ -707,10 +708,10 @@ def octahedral_graph(create_using=None):
     Returns the Platonic Octahedral graph.
 
     The octahedral graph is the 6-node 12-edge Platonic graph having the
-    connectivity of the octahedron.[1] If 6 couples go to a party,
+    connectivity of the octahedron [1]_. If 6 couples go to a party,
     and each person shakes hands with every person except his or her partner,
     then this graph describes the set of handshakes that take place;
-    for this reason it is also called the cocktail party graph.[2]
+    for this reason it is also called the cocktail party graph [2]_.
 
     Parameters
     ----------
@@ -724,8 +725,8 @@ def octahedral_graph(create_using=None):
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/OctahedralGraph.html
-    [2] https://en.wikipedia.org/wiki/Tur%C3%A1n_graph#Special_cases
+    .. [1] https://mathworld.wolfram.com/OctahedralGraph.html
+    .. [2] https://en.wikipedia.org/wiki/Tur%C3%A1n_graph#Special_cases
 
     """
     description = [
@@ -744,11 +745,7 @@ def pappus_graph():
 
     The Pappus graph is a cubic symmetric distance-regular graph with 18 nodes
     and 27 edges. It is Hamiltonian and can be represented in LCF notation as
-    [5,7,-7,7,-7,-5]^3
-
-    Parameters
-    ----------
-    None
+    [5,7,-7,7,-7,-5]^3 [1]_.
 
     Returns
     -------
@@ -757,7 +754,7 @@ def pappus_graph():
 
     References
     ----------
-    [1] https://mathworld.wolfram.com/PappusGraph.html
+    .. [1] https://en.wikipedia.org/wiki/Pappus_graph
     """
     G = LCF_graph(18, [5, 7, -7, 7, -7, -5], 3)
     G.name = "Pappus Graph"
@@ -768,10 +765,10 @@ def petersen_graph(create_using=None):
     """
     Returns the Petersen graph.
 
-    Peterson graph is cubic, undirected graph with 10 nodes and 15 edges.[1]
+    The Peterson graph is a cubic, undirected graph with 10 nodes and 15 edges [1]_.
     Julius Petersen constructed the graph as the smallest counterexample
     against the claim that a connected bridgeless cubic graph
-    has an edge colouring with three colours.[2]
+    has an edge colouring with three colours [2]_.
 
     Parameters
     ----------
@@ -785,8 +782,8 @@ def petersen_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Petersen_graph#cite_note-1
-    [2] https://www.win.tue.nl/~aeb/drg/graphs/Petersen.html
+    .. [1] https://en.wikipedia.org/wiki/Petersen_graph
+    .. [2] https://www.win.tue.nl/~aeb/drg/graphs/Petersen.html
     """
     description = [
         "adjacencylist",
@@ -813,8 +810,8 @@ def sedgewick_maze_graph(create_using=None):
     """
     Return a small maze with a cycle.
 
-    This is the maze used in Sedgewick,3rd Edition, Part 5, Graph
-    Algorithms, Chapter 18, e.g. Figure 18.2 and following.
+    This is the maze used in Sedgewick, 3rd Edition, Part 5, Graph
+    Algorithms, Chapter 18, e.g. Figure 18.2 and following [1]_.
     Nodes are numbered 0,..,7
 
     Parameters
@@ -829,7 +826,7 @@ def sedgewick_maze_graph(create_using=None):
 
     References
     ----------
-    Figure 18.2, Chapter 18, Graph Algorithms (3rd Ed), Sedgewick
+    .. [1] Figure 18.2, Chapter 18, Graph Algorithms (3rd Ed), Sedgewick
     """
     G = empty_graph(0, create_using)
     G.add_nodes_from(range(8))
@@ -845,9 +842,9 @@ def tetrahedral_graph(create_using=None):
     """
     Returns the 3-regular Platonic Tetrahedral graph.
 
-    Tetrahedral graph has 4 nodes and 6 edges.  It is a
+    Tetrahedral graph has 4 nodes and 6 edges. It is a
     special case of the complete graph, K4, and wheel graph, W4.
-    It is one of the 5 platonic graphs. [1]
+    It is one of the 5 platonic graphs [1]_.
 
     Parameters
     ----------
@@ -861,7 +858,7 @@ def tetrahedral_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Tetrahedron#Tetrahedral_graph
+    .. [1] https://en.wikipedia.org/wiki/Tetrahedron#Tetrahedral_graph
 
     """
     G = complete_graph(4, create_using)
@@ -873,10 +870,10 @@ def truncated_cube_graph(create_using=None):
     """
     Returns the skeleton of the truncated cube.
 
-    The truncated cube, is an Archimedean solid. It has 14 regular
-    faces (6 octagonal and 8 triangular), 36 edges and 24 nodes.[1]
+    The truncated cube is an Archimedean solid with 14 regular
+    faces (6 octagonal and 8 triangular), 36 edges and 24 nodes [1]_.
     The truncated cube is created by truncating (cutting off) the tips
-    of the cube one third of the way into each edge. [2]
+    of the cube one third of the way into each edge [2]_.
 
     Parameters
     ----------
@@ -890,8 +887,8 @@ def truncated_cube_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Truncated_cube
-    [2] https://www.coolmath.com/reference/polyhedra-truncated-cube
+    .. [1] https://en.wikipedia.org/wiki/Truncated_cube
+    .. [2] https://www.coolmath.com/reference/polyhedra-truncated-cube
 
     """
     description = [
@@ -933,9 +930,9 @@ def truncated_tetrahedron_graph(create_using=None):
     """
     Returns the skeleton of the truncated Platonic tetrahedron.
 
-    The truncated tetrahedron is an Archimedean solid. It has 4 regular hexagonal faces,
+    The truncated tetrahedron is an Archimedean solid with 4 regular hexagonal faces,
     4 equilateral triangle faces, 12 nodes and 18 edges. It can be constructed by truncating
-    all 4 vertices of a regular tetrahedron at one third of the original edge length.[1]
+    all 4 vertices of a regular tetrahedron at one third of the original edge length [1]_.
 
     Parameters
     ----------
@@ -949,7 +946,7 @@ def truncated_tetrahedron_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Truncated_tetrahedron
+    .. [1] https://en.wikipedia.org/wiki/Truncated_tetrahedron
 
     """
     G = path_graph(12, create_using)
@@ -963,12 +960,12 @@ def tutte_graph(create_using=None):
     """
     Returns the Tutte graph.
 
-    The Tutte graph is a cubic polyhedral, non-hamiltonian graph. It has
+    The Tutte graph is a cubic polyhedral, non-Hamiltonian graph. It has
     46 nodes and 69 edges.
     It is a counterexample to Tait's conjecture that every 3-regular polyhedron
     has a Hamiltonian cycle.
     It can be realized geometrically from a tetrahedron by multiply truncating
-    three of its vertices.[1]
+    three of its vertices [1]_.
 
     Parameters
     ----------
@@ -982,7 +979,7 @@ def tutte_graph(create_using=None):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Tutte_graph
+    .. [1] https://en.wikipedia.org/wiki/Tutte_graph
     """
     description = [
         "adjacencylist",

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -182,9 +182,12 @@ def LCF_graph(n, shift_list, repeats, create_using=None):
 
 def bull_graph(create_using=None):
     """
-    Creates a bull graph with 5 nodes and 5 edges.
-    "... the bull graph is a planar undirected graph with 5 vertices and 5 edges,
-          in the form of a triangle with two disjoint pendant edges" [1]
+    Returns the Bull Graph
+
+    The Bull Graph has 5 nodes and 5 edges. It is a planar undirected
+    graph in the form of a triangle with two disjoint pendant edges [1]
+    The name comes from the triangle and pendant edges representing
+    respectively the body and legs of a bull.
 
     Parameters
     ----------
@@ -213,9 +216,11 @@ def bull_graph(create_using=None):
 
 def chvatal_graph(create_using=None):
     """
-    Creates a undirected Chvatal graph with 12 nodes and 24 edges.
-    "The Chvátal graph is a quartic Hamiltonian graph on 12 nodes and 24 edges.
-        It has chromatic number 4, and girth 4 and unlabelled kernel number 3." [1]
+    Returns Chvátal Graph
+
+    The Chvátal Graph is an Undirected graph with 12 nodes and 24 edges [1]
+    It has 370 distinct (directed) Hamiltonian cycles, giving a unique generalized
+    LCF notation of order 4, two of order 6 , and 43 of order 1. [2]
 
     Parameters
     ----------
@@ -229,7 +234,8 @@ def chvatal_graph(create_using=None):
 
     References
     ----------
-    .. [1] https://digraph3.readthedocs.io/en/latest/_static/GraphDataSets/Chvatal.html
+    [1] https://en.wikipedia.org/wiki/Chv%C3%A1tal_graph
+    [2] https://mathworld.wolfram.com/ChvatalGraph.html
 
     """
     description = [
@@ -257,10 +263,14 @@ def chvatal_graph(create_using=None):
 
 def cubical_graph(create_using=None):
     """
-    Creates a undirected cubical graph with 12 nodes and 24 edges.
-    "The skeleton of the cube (the vertices and edges) form a graph, with 8 vertices, and 12 edges.
-       It is a special case of the hypercube graph. It is one of 5 Platonic graphs, each a skeleton
-       of its Platonic solid." [1]
+    Returns Cubical Grpah
+
+    The skeleton of the cube (the nodes and edges) form a graph, with 8
+    nodes, and 12 edges. It is a special case of the hypercube graph.
+    It is one of 5 Platonic graphs, each a skeleton of its
+    Platonic solid. [1]
+    Such graphs arise in parallel processing in computers.
+
 
     Parameters
     ----------
@@ -298,10 +308,12 @@ def cubical_graph(create_using=None):
 
 def desargues_graph(create_using=None):
     """
-    Creates Desargues Graph with 20 nodes and 30 edges using the LCF notation.
-    "... is a distance-transitive cubic graph with 20 vertices and 30 edges.
-    The Desargues graph is a symmetric graph: it has symmetries that take any
-    vertex to any other vertex and any edge to any other edge. " [1]
+    Returns a Desargues Graph
+
+    Desargues Graph is a non-planar, distance-transitive cubic graph
+    with 20 nodes and 30 edges.[1]
+    It is a symmetric graph. It can be represented in LCF notation
+    as [5,-5,9,-9]^5. [2]
 
     Parameters
     ----------
@@ -315,7 +327,8 @@ def desargues_graph(create_using=None):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Desargues_graph
+    [1] https://en.wikipedia.org/wiki/Desargues_graph
+    [2] https://mathworld.wolfram.com/DesarguesGraph.html
     """
     G = LCF_graph(20, [5, -5, 9, -9], 5, create_using)
     G.name = "Desargues Graph"
@@ -324,9 +337,10 @@ def desargues_graph(create_using=None):
 
 def diamond_graph(create_using=None):
     """
-    Creates Planar undirected graph with 4 nodes and 5 edges.
-    "The diamond graph is the simple graph on 4 nodes and 5 edges.
-    The diamond graph is also sometimes known as the double triangle graph" [1]
+    Returns diamond graph
+
+    The diamond graph is  planar undirected graph on 4 nodes and 5 edges.
+    It is also sometimes known as the double triangle graph or kite graph [1]
 
     Parameters
     ----------
@@ -340,7 +354,7 @@ def diamond_graph(create_using=None):
 
     References
     ----------
-    .. [1] https://mathworld.wolfram.com/DiamondGraph.html"""
+    [1] https://mathworld.wolfram.com/DiamondGraph.html"""
     description = [
         "adjacencylist",
         "Diamond Graph",
@@ -352,7 +366,30 @@ def diamond_graph(create_using=None):
 
 
 def dodecahedral_graph(create_using=None):
-    """Return the Platonic Dodecahedral graph."""
+    """
+    Returns the Platonic Dodecahedral graph.
+
+    The dodecahedral graph has 20 nodes, 30 edges.The skeleton of the
+    dodecahedron form a graph. It is one of 5 Platonic graphs. [1]
+    It can be described in LCF notation as:
+    [10, 7, 4, -4, -7, 10, -4, 7, -7, 4]^2.[2]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Dodecahedral Graph with 20 nodes and 30 edges
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Regular_dodecahedron#Dodecahedral_graph
+    [2] https://mathworld.wolfram.com/DodecahedralGraph.html
+
+    """
     G = LCF_graph(20, [10, 7, 4, -4, -7, 10, -4, 7, -7, 4], 2, create_using)
     G.name = "Dodecahedral Graph"
     return G
@@ -363,6 +400,23 @@ def frucht_graph(create_using=None):
 
     The Frucht Graph is the smallest cubical graph whose
     automorphism group consists only of the identity element.
+    It has 12 nodes and 18 edges and no non trivial symmetries.
+    It is planar and hamiltonian.
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Frucht Graph with 12 nodes and 18 edges
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Frucht_graph
+    [2] https://mathworld.wolfram.com/FruchtGraph.html
 
     """
     G = cycle_graph(7, create_using)
@@ -387,7 +441,33 @@ def frucht_graph(create_using=None):
 
 
 def heawood_graph(create_using=None):
-    """Return the Heawood graph, a (3,6) cage."""
+    """
+    Return the Heawood graph, a (3,6) cage.
+
+    The Heawood graph is an undirected graph with 14 nodes and 21 edges,
+    named after Percy John Heawood. [1]
+    It is cubic symmetric,nonplanar, Hamiltonian, and can be represented
+    in LCF notation as [5,-5]^7.[2]
+    It is the unique (3,6)-cage: the regular cubic graph of girth 6 with
+    minimal number of vertices. [3]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Heawood Graph with 14 nodes and 21 edges
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Heawood_graph
+    [2] https://mathworld.wolfram.com/HeawoodGraph.html
+    [3] https://www.win.tue.nl/~aeb/graphs/Heawood.html
+
+    """
     G = LCF_graph(14, [5, -5], 7, create_using)
     G.name = "Heawood Graph"
     return G

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -181,7 +181,26 @@ def LCF_graph(n, shift_list, repeats, create_using=None):
 
 
 def bull_graph(create_using=None):
-    """Returns the Bull graph."""
+    """
+    Creates a bull graph with 5 nodes and 5 edges.
+    "... the bull graph is a planar undirected graph with 5 vertices and 5 edges,
+          in the form of a triangle with two disjoint pendant edges" [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        A bull graph with 5 nodes
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Bull_graph.
+
+    """
     description = [
         "adjacencylist",
         "Bull Graph",
@@ -193,7 +212,26 @@ def bull_graph(create_using=None):
 
 
 def chvatal_graph(create_using=None):
-    """Returns the Chvátal graph."""
+    """
+    Creates a undirected Chvatal graph with 12 nodes and 24 edges.
+    "The Chvátal graph is a quartic Hamiltonian graph on 12 nodes and 24 edges.
+        It has chromatic number 4, and girth 4 and unlabelled kernel number 3." [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        A Chvatal graph with 12 nodes and 24 edges
+
+    References
+    ----------
+    .. [1] https://digraph3.readthedocs.io/en/latest/_static/GraphDataSets/Chvatal.html
+
+    """
     description = [
         "adjacencylist",
         "Chvatal Graph",
@@ -218,7 +256,27 @@ def chvatal_graph(create_using=None):
 
 
 def cubical_graph(create_using=None):
-    """Returns the 3-regular Platonic Cubical graph."""
+    """
+    Creates a undirected cubical graph with 12 nodes and 24 edges.
+    "The skeleton of the cube (the vertices and edges) form a graph, with 8 vertices, and 12 edges.
+       It is a special case of the hypercube graph. It is one of 5 Platonic graphs, each a skeleton
+       of its Platonic solid." [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        A cubical graph with 8 nodes and 12 edges
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Cube#Cubical_graph
+
+    """
     description = [
         "adjacencylist",
         "Platonic Cubical Graph",
@@ -239,14 +297,50 @@ def cubical_graph(create_using=None):
 
 
 def desargues_graph(create_using=None):
-    """Return the Desargues graph."""
+    """
+    Creates Desargues Graph with 20 nodes and 30 edges using the LCF notation.
+    "... is a distance-transitive cubic graph with 20 vertices and 30 edges.
+    The Desargues graph is a symmetric graph: it has symmetries that take any
+    vertex to any other vertex and any edge to any other edge. " [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Desargues Graph with 20 nodes and 30 edges
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Desargues_graph
+    """
     G = LCF_graph(20, [5, -5, 9, -9], 5, create_using)
     G.name = "Desargues Graph"
     return G
 
 
 def diamond_graph(create_using=None):
-    """Returns the Diamond graph."""
+    """
+    Creates Planar undirected graph with 4 nodes and 5 edges.
+    "The diamond graph is the simple graph on 4 nodes and 5 edges.
+    The diamond graph is also sometimes known as the double triangle graph" [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Diamond Graph with 4 nodes and 5 edges
+
+    References
+    ----------
+    .. [1] https://mathworld.wolfram.com/DiamondGraph.html"""
     description = [
         "adjacencylist",
         "Diamond Graph",

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -396,7 +396,8 @@ def dodecahedral_graph(create_using=None):
 
 
 def frucht_graph(create_using=None):
-    """Returns the Frucht Graph.
+    """
+    Returns the Frucht Graph.
 
     The Frucht Graph is the smallest cubical graph whose
     automorphism group consists only of the identity element.
@@ -442,7 +443,7 @@ def frucht_graph(create_using=None):
 
 def heawood_graph(create_using=None):
     """
-    Return the Heawood graph, a (3,6) cage.
+    Returns the Heawood graph, a (3,6) cage.
 
     The Heawood graph is an undirected graph with 14 nodes and 21 edges,
     named after Percy John Heawood. [1]
@@ -474,7 +475,35 @@ def heawood_graph(create_using=None):
 
 
 def hoffman_singleton_graph():
-    """Return the Hoffman-Singleton Graph."""
+    """
+    Returns the Hoffman-Singleton Graph.
+
+    The Hoffman–Singleton graph is a symmetrical undirected graph
+    with 50 nodes and 175 edges.
+    All indices lie in Z/5: that is, the integers mod 5. [1]
+    It is the only regular graph of vertex degree 7, diameter 2, and girth 5.
+    It is the unique (7,5)-cage graph and Moore graph, and contains many
+    copies of the Petersen graph. [2]
+    Construction from Pentagon and Pentagram: Take five pentagons Ph
+    and five pentagrams Qi . Join vertex j of Ph to vertex h·i+j of Qi.
+    (All indices are modulo 5.) [3]
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    G : networkx Graph
+        Hoffman–Singleton Graph with 50 nodes and 175 edges
+
+    References
+    ----------
+    [1] https://blogs.ams.org/visualinsight/2016/02/01/hoffman-singleton-graph/
+    [2] https://mathworld.wolfram.com/Hoffman-SingletonGraph.html
+    [3] https://en.wikipedia.org/wiki/Hoffman%E2%80%93Singleton_graph
+
+    """
     G = nx.Graph()
     for i in range(5):
         for j in range(5):
@@ -490,7 +519,27 @@ def hoffman_singleton_graph():
 
 
 def house_graph(create_using=None):
-    """Returns the House graph (square with triangle on top)."""
+    """
+    Returns the House graph (square with triangle on top)
+
+    The house graph is a simple undirected graph with
+    5 nodes and 6 edges. [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        House graph in the form of a square with a
+    triangle on top
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/HouseGraph.html
+    """
     description = [
         "adjacencylist",
         "House Graph",
@@ -502,7 +551,28 @@ def house_graph(create_using=None):
 
 
 def house_x_graph(create_using=None):
-    """Returns the House graph with a cross inside the house square."""
+    """
+    Returns the House graph with a cross inside the house square.
+
+    The house X-graph is the house graph plus the two edges connecting diagonally
+    opposite vertices of the square base. It is also one of the two graphs
+    obtained by removing two edges from the pentatope graph.
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        House graph in the form of a square with a
+    triangle on top
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/HouseGraph.html
+    """
     description = [
         "adjacencylist",
         "House-with-X-inside Graph",
@@ -514,7 +584,27 @@ def house_x_graph(create_using=None):
 
 
 def icosahedral_graph(create_using=None):
-    """Returns the Platonic Icosahedral graph."""
+    """
+    Returns the Platonic Icosahedral graph.
+
+    The icosahedral graph has 12 nodes and 30 edges. It is a Platonic graph
+    whose nodes have the connectivity of the icosahedron. It is undirected,
+    regular and Hamiltonian.
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Icosahedral graph with 12 nodes and 30 edges.
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/IcosahedralGraph.html
+    """
     description = [
         "adjacencylist",
         "Platonic Icosahedral Graph",
@@ -540,13 +630,27 @@ def icosahedral_graph(create_using=None):
 
 def krackhardt_kite_graph(create_using=None):
     """
-    Return the Krackhardt Kite Social Network.
+    Returns the Krackhardt Kite Social Network.
 
     A 10 actor social network introduced by David Krackhardt
     to illustrate: degree, betweenness, centrality, closeness, etc.
     The traditional labeling is:
     Andre=1, Beverley=2, Carol=3, Diane=4,
     Ed=5, Fernando=6, Garth=7, Heather=8, Ike=9, Jane=10.
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Krackhardt Kite graph with 10 nodes and 18 edges
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/KrackhardtKite.html
 
     """
     description = [
@@ -571,14 +675,59 @@ def krackhardt_kite_graph(create_using=None):
 
 
 def moebius_kantor_graph(create_using=None):
-    """Returns the Moebius-Kantor graph."""
+    """
+    Returns the Moebius-Kantor graph.
+
+    The Möbius-Kantor graph is the cubic symmetric graph on 16 nodes.
+    Its LCF notation is [5,-5]^8, and it is isomorphic to the generalized
+    Petersen graph.[1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Moebius-Kantor graph
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/Moebius-KantorGraph.html
+
+    """
     G = LCF_graph(16, [5, -5], 8, create_using)
     G.name = "Moebius-Kantor Graph"
     return G
 
 
 def octahedral_graph(create_using=None):
-    """Returns the Platonic Octahedral graph."""
+    """
+    Returns the Platonic Octahedral graph.
+
+    The octahedral graph is the 6-node 12-edge Platonic graph having the
+    connectivity of the octahedron.[1] If 6 couples go to a party,
+    and each person shakes hands with every person except his or her partner,
+    then this graph describes the set of handshakes that take place;
+    for this reason it is also called the cocktail party graph.[2]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Octahedral graph
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/OctahedralGraph.html
+    [2] https://en.wikipedia.org/wiki/Tur%C3%A1n_graph#Special_cases
+
+    """
     description = [
         "adjacencylist",
         "Platonic Octahedral Graph",
@@ -590,14 +739,55 @@ def octahedral_graph(create_using=None):
 
 
 def pappus_graph():
-    """Return the Pappus graph."""
+    """
+    Returns the Pappus graph.
+
+    The Pappus graph is a cubic symmetric distance-regular graph with 18 nodes
+    and 27 edges. It is Hamiltonian and can be represented in LCF notation as
+    [5,7,-7,7,-7,-5]^3
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    G : networkx Graph
+        Pappus graph
+
+    References
+    ----------
+    [1] https://mathworld.wolfram.com/PappusGraph.html
+    """
     G = LCF_graph(18, [5, 7, -7, 7, -7, -5], 3)
     G.name = "Pappus Graph"
     return G
 
 
 def petersen_graph(create_using=None):
-    """Returns the Petersen graph."""
+    """
+    Returns the Petersen graph.
+
+    Peterson graph is cubic, undirected graph with 10 nodes and 15 edges.[1]
+    Julius Petersen constructed the graph as the smallest counterexample
+    against the claim that a connected bridgeless cubic graph
+    has an edge colouring with three colours.[2]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Petersen graph
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Petersen_graph#cite_note-1
+    [2] https://www.win.tue.nl/~aeb/drg/graphs/Petersen.html
+    """
     description = [
         "adjacencylist",
         "Petersen Graph",
@@ -626,6 +816,20 @@ def sedgewick_maze_graph(create_using=None):
     This is the maze used in Sedgewick,3rd Edition, Part 5, Graph
     Algorithms, Chapter 18, e.g. Figure 18.2 and following.
     Nodes are numbered 0,..,7
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Small maze with a cycle
+
+    References
+    ----------
+    Figure 18.2, Chapter 18, Graph Algorithms (3rd Ed), Sedgewick
     """
     G = empty_graph(0, create_using)
     G.add_nodes_from(range(8))
@@ -638,14 +842,58 @@ def sedgewick_maze_graph(create_using=None):
 
 
 def tetrahedral_graph(create_using=None):
-    """Return the 3-regular Platonic Tetrahedral graph."""
+    """
+    Returns the 3-regular Platonic Tetrahedral graph.
+
+    Tetrahedral graph has 4 nodes and 6 edges.  It is a
+    special case of the complete graph, K4, and wheel graph, W4.
+    It is one of the 5 platonic graphs. [1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Tetrahedral Grpah
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Tetrahedron#Tetrahedral_graph
+
+    """
     G = complete_graph(4, create_using)
     G.name = "Platonic Tetrahedral graph"
     return G
 
 
 def truncated_cube_graph(create_using=None):
-    """Returns the skeleton of the truncated cube."""
+    """
+    Returns the skeleton of the truncated cube.
+
+    The truncated cube, is an Archimedean solid. It has 14 regular
+    faces (6 octagonal and 8 triangular), 36 edges and 24 nodes.[1]
+    The truncated cube is created by truncating (cutting off) the tips
+    of the cube one third of the way into each edge. [2]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Skeleton of the truncated cube
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Truncated_cube
+    [2] https://www.coolmath.com/reference/polyhedra-truncated-cube
+
+    """
     description = [
         "adjacencylist",
         "Truncated Cube Graph",
@@ -682,7 +930,28 @@ def truncated_cube_graph(create_using=None):
 
 
 def truncated_tetrahedron_graph(create_using=None):
-    """Returns the skeleton of the truncated Platonic tetrahedron."""
+    """
+    Returns the skeleton of the truncated Platonic tetrahedron.
+
+    The truncated tetrahedron is an Archimedean solid. It has 4 regular hexagonal faces,
+    4 equilateral triangle faces, 12 nodes and 18 edges. It can be constructed by truncating
+    all 4 vertices of a regular tetrahedron at one third of the original edge length.[1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Skeleton of the truncated tetrahedron
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Truncated_tetrahedron
+
+    """
     G = path_graph(12, create_using)
     #    G.add_edges_from([(1,3),(1,10),(2,7),(4,12),(5,12),(6,8),(9,11)])
     G.add_edges_from([(0, 2), (0, 9), (1, 6), (3, 11), (4, 11), (5, 7), (8, 10)])
@@ -691,7 +960,30 @@ def truncated_tetrahedron_graph(create_using=None):
 
 
 def tutte_graph(create_using=None):
-    """Returns the Tutte graph."""
+    """
+    Returns the Tutte graph.
+
+    The Tutte graph is a cubic polyhedral, non-hamiltonian graph. It has
+    46 nodes and 69 edges.
+    It is a counterexample to Tait's conjecture that every 3-regular polyhedron
+    has a Hamiltonian cycle.
+    It can be realized geometrically from a tetrahedron by multiply truncating
+    three of its vertices.[1]
+
+    Parameters
+    ----------
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
+
+    Returns
+    -------
+    G : networkx Graph
+        Tutte graph
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Tutte_graph
+    """
     description = [
         "adjacencylist",
         "Tutte's Graph",


### PR DESCRIPTION
Added docstrings in small.py with `Description`, `Parameters`, `Returns`, `References`  sections explaining the graphs.

Fixes #5213 