### PR TITLE
Make to_numpy_array() work for graphs with complex weights

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -268,7 +268,7 @@ Guidelines
    import pandas as pd
    import networkx as nx
 
-  After importing `sp`` for ``scipy``::
+  After importing ``sp`` for ``scipy``::
 
    import scipy as sp
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1216,9 +1216,17 @@ def to_numpy_array(
     # will, in general, depend on the combinator function---sensible defaults
     # can be provided.
 
+    # Determine the lowest common dtype (necessary for edges with complex weights)
+    if not G.number_of_edges():
+        init_dtype = float
+    else:
+        u, v = next(iter(G.edges()))
+        edge_type = type(G[u][v].get(weight, 1))
+        init_dtype = np.find_common_type([], [float, edge_type])
+
     if G.is_multigraph():
         # Handle MultiGraphs and MultiDiGraphs
-        A = np.full((nlen, nlen), np.nan, order=order)
+        A = np.full((nlen, nlen), np.nan, order=order, dtype=init_dtype)
         # use numpy nan-aware operations
         operator = {sum: np.nansum, min: np.nanmin, max: np.nanmax}
         try:
@@ -1235,7 +1243,7 @@ def to_numpy_array(
                     A[j, i] = A[i, j]
     else:
         # Graph or DiGraph, this is much faster than above
-        A = np.full((nlen, nlen), np.nan, order=order)
+        A = np.full((nlen, nlen), np.nan, order=order, dtype=init_dtype)
         for u, nbrdict in G.adjacency():
             for v, d in nbrdict.items():
                 try:

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -397,6 +397,16 @@ class TestConvertNumpyArray:
         )
         assert graphs_equal(actual, expected)
 
+    def test_to_numpy_array_complex(self):
+        """Test that the :func:`networkx.to_numpy_array` function
+        works for complex weights.
+
+        """
+        A = np.array([[1 + 2j]])
+        G = nx.from_numpy_array(A)
+        A_again = nx.to_numpy_array(G)
+        assert A.item() == A_again.item()
+
     def test_symmetric(self):
         """Tests that a symmetric array has edges added only once to an
         undirected multigraph when using :func:`networkx.from_numpy_array`.


### PR DESCRIPTION
It was reported [in a question on Stack Overflow](https://stackoverflow.com/questions/70549211/how-to-convert-a-networkx-graph-with-complex-weights-to-a-matrix) that `to_numpy_array()` breaks for graphs with complex weights. The reason is that in https://github.com/networkx/networkx/blob/36d446bae7059d9a6b2db742f3b75457f89db032/networkx/convert_matrix.py#L1221

a double-dtype array is created by default, but then the complex weights cannot be assigned back to this array:
```py
>>> import numpy as np
>>> A = np.array([np.nan])
>>> A[0] = 42j
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can't convert complex to float
```
The documentation doesn't say anything about complex weights being excluded, and I couldn't come up with a reason why they should be. So I assume this is a bug.

I attempted to fix this by examining the first edge of the input graph (assuming there are any), and examining the type of the weight of that edge (if any). In most cases the lowest common type will be `np.float64` anyway (which would've been inferred from `np.nan`), but for complex weights this will get promoted typically to `np.complex128`.

I've also added a short regression test, and a fix for a simple (unrelated) typo. I'm not normally a networkx user and this is my first contribution here, so I might have put tests in the wrong place, or forgotten about edge cases (no pun intended).