### PR TITLE
Minor changes to speed up asynchronous label propagation for community detection.

### DIFF
--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -81,7 +81,7 @@ def asyn_lpa_communities(G, weight=None, seed=None):
             # making the algorithm asynchronous.
             label_freq = Counter()
             if weight is None:
-                label_freq.update([labels[v] for v in adj])
+                label_freq.update(map(labels.get, adj))
             else:
                 for v in adj:
                     label_freq.update({labels[v]: G.edges[node, v][weight]})

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -71,20 +71,24 @@ def asyn_lpa_communities(G, weight=None, seed=None):
         seed.shuffle(nodes)
 
         for node in nodes:
-            adj = G[node]
-            if not adj:
+
+            if not G[node]:
                 continue
 
             # Get label frequencies among adjacent nodes.
             # Depending on the order they are processed in,
             # some nodes will be in iteration t and others in t-1,
             # making the algorithm asynchronous.
-            label_freq = Counter()
             if weight is None:
-                label_freq.update(map(labels.get, adj))
+                # initialising a Counter from an iterator of labels is
+                # faster for getting unweighted label frequencies
+                label_freq = Counter(map(labels.get, G[node]))
             else:
-                for v in adj:
-                    label_freq.update({labels[v]: G.edges[node, v][weight]})
+                # updating a defaultdict is substantially faster
+                # for getting weighted label frequencies
+                label_freq = defaultdict(float)
+                for _, v, wt in G.edges(node, data=weight, default=1):
+                    label_freq[labels[v]] += wt
 
             # Get the labels that appear with maximum frequency.
             max_freq = max(label_freq.values())

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -64,31 +64,38 @@ def asyn_lpa_communities(G, weight=None, seed=None):
 
     labels = {n: i for i, n in enumerate(G)}
     cont = True
+
     while cont:
         cont = False
         nodes = list(G)
         seed.shuffle(nodes)
-        # Calculate the label for each node
+
         for node in nodes:
-            if len(G[node]) < 1:
+            adj = G[node]
+            if not adj:
                 continue
 
-            # Get label frequencies. Depending on the order they are processed
-            # in some nodes with be in t and others in t-1, making the
-            # algorithm asynchronous.
+            # Get label frequencies among adjacent nodes.
+            # Depending on the order they are processed in,
+            # some nodes will be in iteration t and others in t-1,
+            # making the algorithm asynchronous.
             label_freq = Counter()
-            for v in G[node]:
-                label_freq.update(
-                    {labels[v]: G.edges[node, v][weight] if weight else 1}
-                )
-            # Choose the label with the highest frecuency. If more than 1 label
-            # has the highest frecuency choose one randomly.
+            if weight is None:
+                label_freq.update([labels[v] for v in adj])
+            else:
+                for v in adj:
+                    label_freq.update({labels[v]: G.edges[node, v][weight]})
+
+            # Get the labels that appear with maximum frequency.
             max_freq = max(label_freq.values())
             best_labels = [
                 label for label, freq in label_freq.items() if freq == max_freq
             ]
 
-            # Continue until all nodes have a majority label
+            # If the node does not have one of the maximum frequency labels,
+            # randomly choose one of them and update the node's label.
+            # Continue the iteration as long as at least one node
+            # doesn't have a maximum frequency label.
             if labels[node] not in best_labels:
                 labels[node] = seed.choice(best_labels)
                 cont = True


### PR DESCRIPTION
The innermost loop of the asynchronous label propagation algorithm counts the frequencies of labels among a node's neighbours.

The current implementation initialises a collections.Counter object, loops through all neighbouring nodes, and adds each of them to the counter:

```
label_freq = Counter()
for v in G[node]:
        label_freq.update({labels[v]: G.edges[node, v][weight] if weight else 1})
```

In cases where the counts are not weighted, it is much more efficient to directly update the counter with a list of labels:

```
label_freq = Counter()
label_freq.update([labels[v] for v in G[node]])
```

A dummy script shows that the direct update from a list is more than 10x faster than the loop.

```
import random
from collections import Counter
random_list = [random.randrange(100) for _ in range(1000)]
simple_map = {v: v+1 for v in random_list}
```
```
%%timeit
counter1 = Counter()
counter1.update([simple_map[v] for v in random_list])
```
69.9 µs ± 994 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
%%timeit
counter2 = Counter()
for v in random_list:
    counter2.update({simple_map[v]:1})
```
826 µs ± 23.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

I also modified the skip-condition for nodes with zero neighbours to just use the clearer and more efficient boolean value of the adjacency list and re-ordered/adjusted the comments to better reflect what's happening in the code. 
