### PR TITLE
Refactor `to_numpy_array` with advanced indexing

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1176,7 +1176,7 @@ def to_numpy_array(
     # Input validation
     nodeset = set(nodelist)
     if nodeset - set(G):
-        raise nx.NetworkXError(f"Node {nodeset - set(G)} in nodelist is not in G")
+        raise nx.NetworkXError(f"Nodes {nodeset - set(G)} in nodelist is not in G")
     if len(nodeset) < nlen:
         raise nx.NetworkXError("nodelist contains duplicates.")
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1085,12 +1085,10 @@ def to_numpy_array(
 
     nodelist : list, optional
         The rows and columns are ordered according to the nodes in `nodelist`.
-        If `nodelist` is None, then the ordering is produced by G.nodes().
+        If `nodelist` is ``None``, then the ordering is produced by ``G.nodes()``.
 
     dtype : NumPy data type, optional
-        A valid single NumPy data type used to initialize the array.
-        This must be a simple type such as int or numpy.float64 and
-        not a compound data type (see to_numpy_recarray)
+        A NumPy data type used to initialize the array.
         If None, then the NumPy default is used.
 
     order : {'C', 'F'}, optional
@@ -1098,20 +1096,22 @@ def to_numpy_array(
         (row- or column-wise) order in memory. If None, then the NumPy default
         is used.
 
-    multigraph_weight : {sum, min, max}, optional
-        An operator that determines how weights in multigraphs are handled.
-        The default is to sum the weights of the multiple edges.
+    multigraph_weight : callable, optional
+        An function that determines how weights in multigraphs are handled.
+        The function should accept a sequence of weights and return a single
+        value. The default is to sum the weights of the multiple edges.
 
     weight : string or None optional (default = 'weight')
         The edge attribute that holds the numerical value used for
         the edge weight. If an edge does not have that attribute, then the
         value 1 is used instead.
 
-    nonedge : float (default = 0.0)
+    nonedge : array_like (default = 0.0)
+        The value used to represent non-edges in the adjaceny matrix.
         The array values corresponding to nonedges are typically set to zero.
         However, this could be undesirable if there are array values
         corresponding to actual edges that also have the value zero. If so,
-        one might prefer nonedges to have some other value, such as nan.
+        one might prefer nonedges to have some other value, such as ``nan``.
 
     Returns
     -------
@@ -1124,9 +1124,9 @@ def to_numpy_array(
 
     Notes
     -----
-    For directed graphs, entry i,j corresponds to an edge from i to j.
+    For directed graphs, entry ``i, j`` corresponds to an edge from ``i`` to ``j``.
 
-    Entries in the adjacency matrix are assigned to the weight edge attribute.
+    Entries in the adjacency matrix are given by the `weight` edge attribute.
     When an edge does not have a weight attribute, the value of the entry is
     set to the number 1.  For multiple (parallel) edges, the values of the
     entries are determined by the `multigraph_weight` parameter. The default is

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1188,7 +1188,8 @@ def to_numpy_array(
 
     # Map nodes to row/col in matrix
     idx = dict(zip(nodelist, range(nlen)))
-    G = G.subgraph(nodelist)
+    if len(nodelist) < len(G):
+        G = G.subgraph(nodelist).copy()
 
     # TODO: Add separate code paths for graph/multigraphs to speed up
     # non-multigraph case

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1191,13 +1191,19 @@ def to_numpy_array(
     if len(nodelist) < len(G):
         G = G.subgraph(nodelist).copy()
 
-    # TODO: Add separate code paths for graph/multigraphs to speed up
-    # non-multigraph case
-    d = defaultdict(list)
-    for u, v, wt in G.edges(data=weight, default=1.0):
-        d[(idx[u], idx[v])].append(wt)
-    i, j = np.array(list(d.keys())).T  # indices
-    wts = [multigraph_weight(ws) for ws in d.values()]  # reduced weights
+    # Collect all edge weights and reduce with `multigraph_weights`
+    if G.is_multigraph():
+        d = defaultdict(list)
+        for u, v, wt in G.edges(data=weight, default=1.0):
+            d[(idx[u], idx[v])].append(wt)
+        i, j = np.array(list(d.keys())).T  # indices
+        wts = [multigraph_weight(ws) for ws in d.values()]  # reduced weights
+    else:
+        i, j, wts = [], [], []
+        for u, v, wt in G.edges(data=weight, default=1.0):
+            i.append(idx[u])
+            j.append(idx[v])
+            wts.append(wt)
 
     # Set array values with advanced indexing
     A[i, j] = wts

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1184,8 +1184,8 @@ def to_numpy_array(
 
     A = np.full((nlen, nlen), fill_value=nonedge, dtype=dtype, order=order)
 
-    # Corner case: empty node list
-    if not nodelist:
+    # Corner cases: empty nodelist or graph without any edges
+    if nlen == 0 or G.number_of_edges() == 0:
         return A
 
     G = nx.convert_node_labels_to_integers(G.subgraph(nodelist))

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -532,3 +532,17 @@ def test_to_numpy_array_complex_weights(G, expected):
     G.add_edge(0, 1, weight=1 + 2j)
     A = nx.to_numpy_array(G, dtype=complex)
     npt.assert_array_equal(A, expected)
+
+
+def test_to_numpy_array_arbitrary_weights():
+    G = nx.DiGraph()
+    w = 922337203685477580102  # Out of range for int64
+    G.add_edge(0, 1, weight=922337203685477580102)  # val not representable by int64
+    A = nx.to_numpy_array(G, dtype=object)
+    expected = np.array([[0, w], [0, 0]], dtype=object)
+    npt.assert_array_equal(A, expected)
+
+    # Undirected
+    A = nx.to_numpy_array(G.to_undirected(), dtype=object)
+    expected = np.array([[0, w], [w, 0]], dtype=object)
+    npt.assert_array_equal(A, expected)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -1,6 +1,7 @@
 import pytest
 
 np = pytest.importorskip("numpy")
+npt = pytest.importorskip("numpy.testing")
 
 import networkx as nx
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
@@ -518,3 +519,16 @@ def test_to_numpy_array_multigraph_nodelist(multigraph_test_graph):
     A = nx.to_numpy_array(G, nodelist=[1, 2])
     assert A.shape == (2, 2)
     assert A[1, 0] == 77
+
+
+@pytest.mark.parametrize(
+    "G, expected",
+    [
+        (nx.Graph(), np.array([[0, 1 + 2j], [1 + 2j, 0]], dtype=complex)),
+        (nx.DiGraph(), np.array([[0, 1 + 2j], [0, 0]], dtype=complex)),
+    ],
+)
+def test_to_numpy_array_complex_weights(G, expected):
+    G.add_edge(0, 1, weight=1 + 2j)
+    A = nx.to_numpy_array(G, dtype=complex)
+    npt.assert_array_equal(A, expected)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -546,3 +546,21 @@ def test_to_numpy_array_arbitrary_weights():
     A = nx.to_numpy_array(G.to_undirected(), dtype=object)
     expected = np.array([[0, w], [w, 0]], dtype=object)
     npt.assert_array_equal(A, expected)
+
+
+@pytest.mark.parametrize(
+    "func, expected",
+    ((min, -1), (max, 10), (sum, 11), (np.mean, 11 / 3), (np.median, 2)),
+)
+def test_to_numpy_array_multiweight_reduction(func, expected):
+    """Test various functions for reducing multiedge weights."""
+    G = nx.MultiDiGraph()
+    weights = [-1, 2, 10.0]
+    for w in weights:
+        G.add_edge(0, 1, weight=w)
+    A = nx.to_numpy_array(G, multigraph_weight=func, dtype=float)
+    assert np.allclose(A, [[0, expected], [0, 0]])
+
+    # Undirected case
+    A = nx.to_numpy_array(G.to_undirected(), multigraph_weight=func, dtype=float)
+    assert np.allclose(A, [[0, expected], [expected, 0]])

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -498,12 +498,6 @@ def test_to_numpy_recarray_bad_nodelist(recarray_nodelist_test_graph, nodelist, 
         A = nx.to_numpy_recarray(recarray_nodelist_test_graph, nodelist=nodelist)
 
 
-def test_to_numpy_array_multigraph_weight():
-    G = nx.MultiGraph()
-    with pytest.raises(ValueError, match="must be sum, min, or max"):
-        nx.to_numpy_array(G, multigraph_weight=np.median)
-
-
 @pytest.fixture
 def multigraph_test_graph():
     G = nx.MultiGraph()


### PR DESCRIPTION
A different approach to constructing the adjacency matrix with numpy. Currently, `to_numpy_array` creates an internal array with float type with `np.nan` as a hard-coded sentinel value, that is then modified/replaced in a for-loop over the edges in the graph. As noted in #5245, this causes problems for numerical weights that are not safely castable to floats, such as complex numbers.

The approach in this PR is based on [@dschult's idea](https://github.com/networkx/networkx/pull/5245#issuecomment-1008215532) to use the dtype and user-specified sentinel directly in the array construction. This would avoid the hard-coded sentinel issue and would allow users to have e.g. complex weights by specifying so in the `dtype` argument. In fact, this approach should give the users access to the full range of numpy dtypes, including allowing arbitrary weights via `dtype=object`.

Another advantage of this approach is that it would allow arbitrary reduction functions to be used for reducing multiedge weights down to a single value. The current implementation is limited both by the fact that a) functions must ignore nans and b) the iterative approach, where intermediate values are stored in the array for each key, making reductions that depend on the entire set of weights for a single edge (e.g. mean or median) not feasible. This approach here removes this implementation, albeit at the cost of an extra intermediary data structure that remaps multiedge weights into a single container per edge.

There are still some things I'd like to do (add a fast path, fuzz the parameter types and add more tests), but I figured I'd put this out here now for feedback before I go too much further down this path. LMK what you think @dschult @adeak