### PR TITLE
Deprecate scipy sparse matrix conversion functions

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -99,3 +99,5 @@ Version 3.0
 * In ``networkx/algorithms/link_analysis/pagerank_alg.py``, remove the
   ``np.asmatrix`` wrappers on the return values of ``google_matrix`` and remove
   the associated FutureWarning.
+* In ``networkx/convert_matrix.py`` remove ``from_scipy_sparse_matrix`` and
+  ``to_scipy_sparse_matrix``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -59,6 +59,9 @@ Deprecations
   Deprecate ``euclidean`` in favor of ``math.dist``.
 - [`#5166 <https://github.com/networkx/networkx/pull/5166>`_]
   Deprecate the ``hmn`` and ``lgc`` modules in ``node_classification``.
+- [`#5262 <https://github.com/networkx/networkx/pull/5262>`_]
+  Deprecate ``to_scipy_sparse_matrix`` and ``from_scipy_sparse_matrix`` in
+  favor of ``to_scipy_sparse_array`` and ``from_scipy_sparse_array``, respectively.
 
 
 Merged PRs

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -214,6 +214,11 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=FutureWarning, message="adjacency_matrix"
     )
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="\n\nThe scipy.sparse array containers",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -990,7 +990,7 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
     warnings.warn(
         (
             "\n\nThe scipy.sparse array containers will be used instead of matrices\n"
-            "in Networkx 3.0. Consider using `to_scipy_sparse_array` instead."
+            "in Networkx 3.0. Use `to_scipy_sparse_array` instead."
         ),
         DeprecationWarning,
         stacklevel=2,

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -987,6 +987,14 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
     import scipy as sp
     import scipy.sparse
 
+    warnings.warn(
+        (
+            "\n\nThe scipy.sparse array containers will be used instead of matrices\n"
+            "in Networkx 3.0. Consider using `to_scipy_sparse_array` instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
     A = to_scipy_sparse_array(
         G, nodelist=nodelist, dtype=dtype, weight=weight, format=format
     )
@@ -1061,6 +1069,14 @@ def from_scipy_sparse_matrix(
     AtlasView({0: {'weight': 1}, 1: {'weight': 1}})
 
     """
+    warnings.warn(
+        (
+            "\n\nThe scipy.sparse array containers will be used instead of matrices\n"
+            "in Networkx 3.0. Use `from_scipy_sparse_array` instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return from_scipy_sparse_array(
         A,
         parallel_edges=parallel_edges,

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -281,3 +281,13 @@ def test_from_scipy_sparse_array_formats(sparse_format):
     )
     A = sp.sparse.coo_array([[0, 3, 2], [3, 0, 1], [2, 1, 0]]).asformat(sparse_format)
     assert graphs_equal(expected, nx.from_scipy_sparse_array(A))
+
+
+# NOTE: remove when to/from_sparse_matrix deprecations expire
+def test_scipy_sparse_matrix_deprecations():
+    G = nx.path_graph(3)
+    msg = "\n\nThe scipy.sparse array containers will be used instead of matrices"
+    with pytest.warns(DeprecationWarning, match=msg):
+        M = nx.to_scipy_sparse_matrix(G)
+    with pytest.warns(DeprecationWarning, match=msg):
+        H = nx.from_scipy_sparse_matrix(M)


### PR DESCRIPTION
The scipy.sparse array alternatives that supersede `to_scipy_sparse_matrix` and `from_scipy_sparse_matrix` are added in #5139. This is a follow-on PR to deprecate `to/from_scipy_sparse_matrix`.

Note this depends on #5139, so the history & diffs are a mess - marking as draft for now; I will clean up the history after #5139 is in.