### PR TITLE
Update `draw_<layout>` docstrings with usage examples

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1395,7 +1395,7 @@ def draw_shell(G, nlist=None, **kwargs):
     `~networkx.drawing.layout.shell_layout` directly and reuse the result::
 
         >>> G = nx.complete_graph(5)
-        >>> pos = nx.spring_layout(G)
+        >>> pos = nx.shell_layout(G)
         >>> nx.draw(G, pos=pos)  # Draw the original graph
         >>> # Draw a subgraph, reusing the same node positions
         >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -27,7 +27,6 @@ from networkx.drawing.layout import (
     random_layout,
     planar_layout,
 )
-import warnings
 
 __all__ = [
     "draw",

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1195,7 +1195,7 @@ def draw_circular(G, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.circular_layout(G), **kwargs)
+        nx.draw(G, pos=nx.circular_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1229,7 +1229,7 @@ def draw_kamada_kawai(G, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.kamada_kawai_layout(G), **kwargs)
+        nx.draw(G, pos=nx.kamada_kawai_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1263,7 +1263,7 @@ def draw_random(G, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.random_layout(G), **kwargs)
+        nx.draw(G, pos=nx.random_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1297,7 +1297,7 @@ def draw_spectral(G, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.spectral_layout(G), **kwargs)
+        nx.draw(G, pos=nx.spectral_layout(G), **kwargs)
 
     For more information about how node positions are determined, see
     `spectral_layout`.
@@ -1334,7 +1334,7 @@ def draw_spring(G, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.spring_layout(G), **kwargs)
+        nx.draw(G, pos=nx.spring_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1372,7 +1372,7 @@ def draw_shell(G, nlist=None, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.shell_layout(G, nlist=nlist), **kwargs)
+        nx.draw(G, pos=nx.shell_layout(G, nlist=nlist), **kwargs)
 
     Parameters
     ----------
@@ -1411,7 +1411,7 @@ def draw_planar(G, **kwargs):
 
     This is a convenience function equivalent to::
 
-        >>> nx.draw(G, pos=nx.planar_layout(G), **kwargs)
+        nx.draw(G, pos=nx.planar_layout(G), **kwargs)
 
     Parameters
     ----------

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1432,7 +1432,7 @@ def draw_planar(G, **kwargs):
     For repeated drawing it is much more efficient to call `planar_layout`
     directly and reuse the result::
 
-        >>> G = nx.complete_graph(5)
+        >>> G = nx.path_graph(5)
         >>> pos = nx.planar_layout(G)
         >>> nx.draw(G, pos=pos)  # Draw the original graph
         >>> # Draw a subgraph, reusing the same node positions

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1208,8 +1208,8 @@ def draw_circular(G, **kwargs):
     Notes
     -----
     The layout is computed each time this function is called. For
-    repeated drawing it is much more efficient to call `circular_layout`
-    directly and reuse the result::
+    repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.circular_layout` directly and reuse the result::
 
         >>> G = nx.complete_graph(5)
         >>> pos = nx.circular_layout(G)
@@ -1219,7 +1219,7 @@ def draw_circular(G, **kwargs):
 
     See Also
     --------
-    circular_layout
+    :func:`~networkx.drawing.layout.circular_layout`
     """
     draw(G, circular_layout(G), **kwargs)
 
@@ -1242,8 +1242,9 @@ def draw_kamada_kawai(G, **kwargs):
     Notes
     -----
     The layout is computed each time this function is called.
-    For repeated drawing it is much more efficient to call `kamada_kawai_layout`
-    directly and reuse the result::
+    For repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.kamada_kawai_layout` directly and reuse the
+    result::
 
         >>> G = nx.complete_graph(5)
         >>> pos = nx.kamada_kawai_layout(G)
@@ -1253,7 +1254,7 @@ def draw_kamada_kawai(G, **kwargs):
 
     See Also
     --------
-    kamada_kawai_layout
+    :func:`~networkx.drawing.layout.kamada_kawai_layout`
     """
     draw(G, kamada_kawai_layout(G), **kwargs)
 
@@ -1276,8 +1277,8 @@ def draw_random(G, **kwargs):
     Notes
     -----
     The layout is computed each time this function is called.
-    For repeated drawing it is much more efficient to call `random_layout`
-    directly and reuse the result::
+    For repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.random_layout` directly and reuse the result::
 
         >>> G = nx.complete_graph(5)
         >>> pos = nx.random_layout(G)
@@ -1287,7 +1288,7 @@ def draw_random(G, **kwargs):
 
     See Also
     --------
-    random_layout
+    :func:`~networkx.drawing.layout.random_layout`
     """
     draw(G, random_layout(G), **kwargs)
 
@@ -1300,7 +1301,7 @@ def draw_spectral(G, **kwargs):
         nx.draw(G, pos=nx.spectral_layout(G), **kwargs)
 
     For more information about how node positions are determined, see
-    `spectral_layout`.
+    `~networkx.drawing.layout.spectral_layout`.
 
     Parameters
     ----------
@@ -1313,8 +1314,8 @@ def draw_spectral(G, **kwargs):
     Notes
     -----
     The layout is computed each time this function is called.
-    For repeated drawing it is much more efficient to call `spectral_layout`
-    directly and reuse the result::
+    For repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.spectral_layout` directly and reuse the result::
 
         >>> G = nx.complete_graph(5)
         >>> pos = nx.spectral_layout(G)
@@ -1324,7 +1325,7 @@ def draw_spectral(G, **kwargs):
 
     See Also
     --------
-    spectral_layout
+    :func:`~networkx.drawing.layout.spectral_layout`
     """
     draw(G, spectral_layout(G), **kwargs)
 
@@ -1346,12 +1347,12 @@ def draw_spring(G, **kwargs):
 
     Notes
     -----
-    `spring_layout` is also the default layout for `draw`, so this function
-    is equivalent to `draw`.
+    `~networkx.drawing.layout.spring_layout` is also the default layout for
+    `draw`, so this function is equivalent to `draw`.
 
     The layout is computed each time this function is called.
-    For repeated drawing it is much more efficient to call `spring_layout`
-    directly and reuse the result::
+    For repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.spring_layout` directly and reuse the result::
 
         >>> G = nx.complete_graph(5)
         >>> pos = nx.spring_layout(G)
@@ -1362,7 +1363,7 @@ def draw_spring(G, **kwargs):
     See Also
     --------
     draw
-    spring_layout
+    :func:`~networkx.drawing.layout.spring_layout`
     """
     draw(G, spring_layout(G), **kwargs)
 
@@ -1382,7 +1383,7 @@ def draw_shell(G, nlist=None, **kwargs):
     nlist : list of list of nodes, optional
         A list containing lists of nodes representing the shells.
         Default is `None`, meaning all nodes are in a single shell.
-        See `shell_layout` for details.
+        See `~networkx.drawing.layout.shell_layout` for details.
 
     kwargs : optional keywords
         See `draw_networkx` for a description of optional keywords.
@@ -1390,8 +1391,8 @@ def draw_shell(G, nlist=None, **kwargs):
     Notes
     -----
     The layout is computed each time this function is called.
-    For repeated drawing it is much more efficient to call `shell_layout`
-    directly and reuse the result::
+    For repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.shell_layout` directly and reuse the result::
 
         >>> G = nx.complete_graph(5)
         >>> pos = nx.spring_layout(G)
@@ -1401,7 +1402,7 @@ def draw_shell(G, nlist=None, **kwargs):
 
     See Also
     --------
-    shell_layout
+    :func:`~networkx.drawing.layout.shell_layout`
     """
     draw(G, shell_layout(G, nlist=nlist), **kwargs)
 
@@ -1429,8 +1430,8 @@ def draw_planar(G, **kwargs):
     Notes
     -----
     The layout is computed each time this function is called.
-    For repeated drawing it is much more efficient to call `planar_layout`
-    directly and reuse the result::
+    For repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.planar_layout` directly and reuse the result::
 
         >>> G = nx.path_graph(5)
         >>> pos = nx.planar_layout(G)
@@ -1440,7 +1441,7 @@ def draw_planar(G, **kwargs):
 
     See Also
     --------
-    planar_layout
+    :func:`~networkx.drawing.layout.planar_layout`
     """
     draw(G, planar_layout(G), **kwargs)
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1368,22 +1368,42 @@ def draw_spring(G, **kwargs):
     draw(G, spring_layout(G), **kwargs)
 
 
-def draw_shell(G, **kwargs):
-    """Draw networkx graph with shell layout.
+def draw_shell(G, nlist=None, **kwargs):
+    """Draw networkx graph `G` with shell layout.
+
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.shell_layout(G, nlist=nlist), **kwargs)
 
     Parameters
     ----------
     G : graph
         A networkx graph
 
+    nlist : list of list of nodes, optional
+        A list containing lists of nodes representing the shells.
+        Default is `None`, meaning all nodes are in a single shell.
+        See `shell_layout` for details.
+
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Notes
+    -----
+    The layout is computed each time this function is called.
+    For repeated drawing it is much more efficient to call `shell_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.spring_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    shell_layout
     """
-    nlist = kwargs.get("nlist", None)
-    if nlist is not None:
-        del kwargs["nlist"]
     draw(G, shell_layout(G, nlist=nlist), **kwargs)
 
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1192,7 +1192,11 @@ def draw_networkx_edge_labels(
 
 
 def draw_circular(G, **kwargs):
-    """Draw the graph G with a circular layout.
+    """Draw the graph `G` with a circular layout.
+
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.circular_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1200,15 +1204,33 @@ def draw_circular(G, **kwargs):
         A networkx graph
 
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Notes
+    -----
+    The layout is computed each time this function is called. For
+    repeated drawing it is much more efficient to call `circular_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.circular_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    circular_layout
     """
     draw(G, circular_layout(G), **kwargs)
 
 
 def draw_kamada_kawai(G, **kwargs):
-    """Draw the graph G with a Kamada-Kawai force-directed layout.
+    """Draw the graph `G` with a Kamada-Kawai force-directed layout.
+
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.kamada_kawai_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1216,15 +1238,33 @@ def draw_kamada_kawai(G, **kwargs):
         A networkx graph
 
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Notes
+    -----
+    The layout is computed each time this function is called.
+    For repeated drawing it is much more efficient to call `kamada_kawai_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.kamada_kawai_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    kamada_kawai_layout
     """
     draw(G, kamada_kawai_layout(G), **kwargs)
 
 
 def draw_random(G, **kwargs):
-    """Draw the graph G with a random layout.
+    """Draw the graph `G` with a random layout.
+
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.random_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1232,20 +1272,36 @@ def draw_random(G, **kwargs):
         A networkx graph
 
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Notes
+    -----
+    The layout is computed each time this function is called.
+    For repeated drawing it is much more efficient to call `random_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.random_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    random_layout
     """
     draw(G, random_layout(G), **kwargs)
 
 
 def draw_spectral(G, **kwargs):
-    """Draw the graph G with a spectral 2D layout.
+    """Draw the graph `G` with a spectral 2D layout.
 
-    Using the unnormalized Laplacian, the layout shows possible clusters of
-    nodes which are an approximation of the ratio cut. The positions are the
-    entries of the second and third eigenvectors corresponding to the
-    ascending eigenvalues starting from the second one.
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.spectral_layout(G), **kwargs)
+
+    For more information about how node positions are determined, see
+    `spectral_layout`.
 
     Parameters
     ----------
@@ -1253,15 +1309,33 @@ def draw_spectral(G, **kwargs):
         A networkx graph
 
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Notes
+    -----
+    The layout is computed each time this function is called.
+    For repeated drawing it is much more efficient to call `spectral_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.spectral_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    spectral_layout
     """
     draw(G, spectral_layout(G), **kwargs)
 
 
 def draw_spring(G, **kwargs):
-    """Draw the graph G with a spring layout.
+    """Draw the graph `G` with a spring layout.
+
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.spring_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1269,9 +1343,27 @@ def draw_spring(G, **kwargs):
         A networkx graph
 
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Notes
+    -----
+    `spring_layout` is also the default layout for `draw`, so this function
+    is equivalent to `draw`.
+
+    The layout is computed each time this function is called.
+    For repeated drawing it is much more efficient to call `spring_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.spring_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    draw
+    spring_layout
     """
     draw(G, spring_layout(G), **kwargs)
 
@@ -1296,7 +1388,11 @@ def draw_shell(G, **kwargs):
 
 
 def draw_planar(G, **kwargs):
-    """Draw a planar networkx graph with planar layout.
+    """Draw a planar networkx graph `G` with planar layout.
+
+    This is a convenience function equivalent to::
+
+        >>> nx.draw(G, pos=nx.planar_layout(G), **kwargs)
 
     Parameters
     ----------
@@ -1304,9 +1400,28 @@ def draw_planar(G, **kwargs):
         A planar networkx graph
 
     kwargs : optional keywords
-        See networkx.draw_networkx() for a description of optional keywords,
-        with the exception of the pos parameter which is not used by this
-        function.
+        See `draw_networkx` for a description of optional keywords.
+
+    Raises
+    ------
+    NetworkXException
+        When `G` is not planar
+
+    Notes
+    -----
+    The layout is computed each time this function is called.
+    For repeated drawing it is much more efficient to call `planar_layout`
+    directly and reuse the result::
+
+        >>> G = nx.complete_graph(5)
+        >>> pos = nx.planar_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    See Also
+    --------
+    planar_layout
     """
     draw(G, planar_layout(G), **kwargs)
 


### PR DESCRIPTION
This PR adds to the existing `draw_<layout>` convenience functions to emphasize their intended use-case and highlight using the layout functions explicitly for more involved usages. I've done this primarily by adding a short line to the extended summary explaining what the convenience function wraps, as well as a `Notes` and `See Also` section that highlight other use-cases.

This also closes #5215 by updating the parameters and simplifying the argument parsing. Technically this is a change to the signature, but I don't think it needs any sort of warning as the behavior is equivalent.

This addresses most of https://github.com/networkx/networkx/discussions/5220#discussioncomment-1961800, though there is still the matter of adding convenience functions for the missing layouts, which I propose to do in a separate PR.