### PR TITLE
Use from_dict_of_lists instead of make_small_graph in generators.small

### DIFF
--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -1026,7 +1026,5 @@ def tutte_graph(create_using=None):
         },
         create_using=create_using,
     )
-    if G.is_directed():
-        raise NetworkXError("Directed Graph not supported")
     G.name = "Tutte's Graph"
     return G

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -204,13 +204,11 @@ def bull_graph(create_using=None):
     .. [1] https://en.wikipedia.org/wiki/Bull_graph.
 
     """
-    description = [
-        "adjacencylist",
-        "Bull Graph",
-        5,
-        [[2, 3], [1, 3, 4], [1, 2, 5], [2], [3]],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {0: [1, 2], 1: [0, 2, 3], 2: [0, 1, 4], 3: [1], 4: [2]},
+        create_using=create_using,
+    )
+    G.name = "Bull Graph"
     return G
 
 
@@ -238,26 +236,22 @@ def chvatal_graph(create_using=None):
     .. [2] https://mathworld.wolfram.com/ChvatalGraph.html
 
     """
-    description = [
-        "adjacencylist",
-        "Chvatal Graph",
-        12,
-        [
-            [2, 5, 7, 10],
-            [3, 6, 8],
-            [4, 7, 9],
-            [5, 8, 10],
-            [6, 9],
-            [11, 12],
-            [11, 12],
-            [9, 12],
-            [11],
-            [11, 12],
-            [],
-            [],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 4, 6, 9],
+            1: [2, 5, 7],
+            2: [3, 6, 8],
+            3: [4, 7, 9],
+            4: [5, 8],
+            5: [10, 11],
+            6: [10, 11],
+            7: [8, 11],
+            8: [10],
+            9: [10, 11],
+        },
+        create_using=create_using,
+    )
+    G.name = "Chvatal Graph"
     return G
 
 
@@ -286,22 +280,20 @@ def cubical_graph(create_using=None):
     .. [1] https://en.wikipedia.org/wiki/Cube#Cubical_graph
 
     """
-    description = [
-        "adjacencylist",
-        "Platonic Cubical Graph",
-        8,
-        [
-            [2, 4, 5],
-            [1, 3, 8],
-            [2, 4, 7],
-            [1, 3, 6],
-            [1, 6, 8],
-            [4, 5, 7],
-            [3, 6, 8],
-            [2, 5, 7],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 3, 4],
+            1: [0, 2, 7],
+            2: [1, 3, 6],
+            3: [0, 2, 5],
+            4: [0, 5, 7],
+            5: [3, 4, 6],
+            6: [2, 5, 7],
+            7: [1, 4, 6],
+        },
+        create_using=create_using,
+    )
+    G.name = ("Platonic Cubical Graph",)
     return G
 
 
@@ -355,13 +347,10 @@ def diamond_graph(create_using=None):
     ----------
     .. [1] https://mathworld.wolfram.com/DiamondGraph.html
     """
-    description = [
-        "adjacencylist",
-        "Diamond Graph",
-        4,
-        [[2, 3], [1, 3, 4], [1, 2, 4], [2, 3]],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {0: [1, 2], 1: [0, 2, 3], 2: [0, 1, 3], 3: [1, 2]}, create_using=create_using
+    )
+    G.name = "Diamond Graph"
     return G
 
 
@@ -537,13 +526,11 @@ def house_graph(create_using=None):
     ----------
     .. [1] https://mathworld.wolfram.com/HouseGraph.html
     """
-    description = [
-        "adjacencylist",
-        "House Graph",
-        5,
-        [[2, 3], [1, 4], [1, 4, 5], [2, 3, 5], [3, 4]],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {0: [1, 2], 1: [0, 3], 2: [0, 3, 4], 3: [1, 2, 4], 4: [2, 3]},
+        create_using=create_using,
+    )
+    G.name = "House Graph"
     return G
 
 
@@ -569,13 +556,9 @@ def house_x_graph(create_using=None):
     ----------
     .. [1] https://mathworld.wolfram.com/HouseGraph.html
     """
-    description = [
-        "adjacencylist",
-        "House-with-X-inside Graph",
-        5,
-        [[2, 3, 4], [1, 3, 4], [1, 2, 4, 5], [1, 2, 3, 5], [3, 4]],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = house_graph(create_using)
+    G.add_edges_from([(0, 3), (1, 2)])
+    G.name = "House-with-X-inside Graph"
     return G
 
 
@@ -601,26 +584,22 @@ def icosahedral_graph(create_using=None):
     ----------
     .. [1] https://mathworld.wolfram.com/IcosahedralGraph.html
     """
-    description = [
-        "adjacencylist",
-        "Platonic Icosahedral Graph",
-        12,
-        [
-            [2, 6, 8, 9, 12],
-            [3, 6, 7, 9],
-            [4, 7, 9, 10],
-            [5, 7, 10, 11],
-            [6, 7, 11, 12],
-            [7, 12],
-            [],
-            [9, 10, 11, 12],
-            [10],
-            [11],
-            [12],
-            [],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 5, 7, 8, 11],
+            1: [2, 5, 6, 8],
+            2: [3, 6, 8, 9],
+            3: [4, 6, 9, 10],
+            4: [5, 6, 10, 11],
+            5: [6, 11],
+            7: [8, 9, 10, 11],
+            8: [9],
+            9: [10],
+            10: [11],
+        },
+        create_using=create_using,
+    )
+    G.name = "Platonic Icosahedral Graph"
     return G
 
 
@@ -654,24 +633,22 @@ def krackhardt_kite_graph(create_using=None):
        35 (2): 342–369. doi:10.2307/2393394. JSTOR 2393394. June 1990.
 
     """
-    description = [
-        "adjacencylist",
-        "Krackhardt Kite Social Network",
-        10,
-        [
-            [2, 3, 4, 6],
-            [1, 4, 5, 7],
-            [1, 4, 6],
-            [1, 2, 3, 5, 6, 7],
-            [2, 4, 7],
-            [1, 3, 4, 7, 8],
-            [2, 4, 5, 6, 8],
-            [6, 7, 9],
-            [8, 10],
-            [9],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 2, 3, 5],
+            1: [0, 3, 4, 6],
+            2: [0, 3, 5],
+            3: [0, 1, 2, 4, 5, 6],
+            4: [1, 3, 6],
+            5: [0, 2, 3, 6, 7],
+            6: [1, 3, 4, 5, 7],
+            7: [5, 6, 8],
+            8: [7, 9],
+            9: [8],
+        },
+        create_using=create_using,
+    )
+    G.name = "Krackhardt Kite Social Network"
     return G
 
 
@@ -729,13 +706,11 @@ def octahedral_graph(create_using=None):
     .. [2] https://en.wikipedia.org/wiki/Tur%C3%A1n_graph#Special_cases
 
     """
-    description = [
-        "adjacencylist",
-        "Platonic Octahedral Graph",
-        6,
-        [[2, 3, 4, 5], [3, 4, 6], [5, 6], [5, 6], [6], []],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {0: [1, 2, 3, 4], 1: [2, 3, 5], 2: [4, 5], 3: [4, 5], 4: [5]},
+        create_using=create_using,
+    )
+    G.name = "Platonic Octahedral Graph"
     return G
 
 
@@ -785,24 +760,22 @@ def petersen_graph(create_using=None):
     .. [1] https://en.wikipedia.org/wiki/Petersen_graph
     .. [2] https://www.win.tue.nl/~aeb/drg/graphs/Petersen.html
     """
-    description = [
-        "adjacencylist",
-        "Petersen Graph",
-        10,
-        [
-            [2, 5, 6],
-            [1, 3, 7],
-            [2, 4, 8],
-            [3, 5, 9],
-            [4, 1, 10],
-            [1, 8, 9],
-            [2, 9, 10],
-            [3, 6, 10],
-            [4, 6, 7],
-            [5, 7, 8],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 4, 5],
+            1: [0, 2, 6],
+            2: [1, 3, 7],
+            3: [2, 4, 8],
+            4: [3, 0, 9],
+            5: [0, 7, 8],
+            6: [1, 8, 9],
+            7: [2, 5, 9],
+            8: [3, 5, 6],
+            9: [4, 6, 7],
+        },
+        create_using=create_using,
+    )
+    G.name = "Petersen Graph"
     return G
 
 
@@ -891,38 +864,35 @@ def truncated_cube_graph(create_using=None):
     .. [2] https://www.coolmath.com/reference/polyhedra-truncated-cube
 
     """
-    description = [
-        "adjacencylist",
-        "Truncated Cube Graph",
-        24,
-        [
-            [2, 3, 5],
-            [12, 15],
-            [4, 5],
-            [7, 9],
-            [6],
-            [17, 19],
-            [8, 9],
-            [11, 13],
-            [10],
-            [18, 21],
-            [12, 13],
-            [15],
-            [14],
-            [22, 23],
-            [16],
-            [20, 24],
-            [18, 19],
-            [21],
-            [20],
-            [24],
-            [22],
-            [23],
-            [24],
-            [],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 2, 4],
+            1: [11, 14],
+            2: [3, 4],
+            3: [6, 8],
+            4: [5],
+            5: [16, 18],
+            6: [7, 8],
+            7: [10, 12],
+            8: [9],
+            9: [17, 20],
+            10: [11, 12],
+            11: [14],
+            12: [13],
+            13: [21, 22],
+            14: [15],
+            15: [19, 23],
+            16: [17, 18],
+            17: [20],
+            18: [19],
+            19: [23],
+            20: [21],
+            21: [22],
+            22: [23],
+        },
+        create_using=create_using,
+    )
+    G.name = "Truncated Cube Graph"
     return G
 
 
@@ -950,7 +920,6 @@ def truncated_tetrahedron_graph(create_using=None):
 
     """
     G = path_graph(12, create_using)
-    #    G.add_edges_from([(1,3),(1,10),(2,7),(4,12),(5,12),(6,8),(9,11)])
     G.add_edges_from([(0, 2), (0, 9), (1, 6), (3, 11), (4, 11), (5, 7), (8, 10)])
     G.name = "Truncated Tetrahedron Graph"
     return G
@@ -981,58 +950,52 @@ def tutte_graph(create_using=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Tutte_graph
     """
-    description = [
-        "adjacencylist",
-        "Tutte's Graph",
-        46,
-        [
-            [2, 3, 4],
-            [5, 27],
-            [11, 12],
-            [19, 20],
-            [6, 34],
-            [7, 30],
-            [8, 28],
-            [9, 15],
-            [10, 39],
-            [11, 38],
-            [40],
-            [13, 40],
-            [14, 36],
-            [15, 16],
-            [35],
-            [17, 23],
-            [18, 45],
-            [19, 44],
-            [46],
-            [21, 46],
-            [22, 42],
-            [23, 24],
-            [41],
-            [25, 28],
-            [26, 33],
-            [27, 32],
-            [34],
-            [29],
-            [30, 33],
-            [31],
-            [32, 34],
-            [33],
-            [],
-            [],
-            [36, 39],
-            [37],
-            [38, 40],
-            [39],
-            [],
-            [],
-            [42, 45],
-            [43],
-            [44, 46],
-            [45],
-            [],
-            [],
-        ],
-    ]
-    G = make_small_undirected_graph(description, create_using)
+    G = nx.from_dict_of_lists(
+        {
+            0: [1, 2, 3],
+            1: [4, 26],
+            2: [10, 11],
+            3: [18, 19],
+            4: [5, 33],
+            5: [6, 29],
+            6: [7, 27],
+            7: [8, 14],
+            8: [9, 38],
+            9: [10, 37],
+            10: [39],
+            11: [12, 39],
+            12: [13, 35],
+            13: [14, 15],
+            14: [34],
+            15: [16, 22],
+            16: [17, 44],
+            17: [18, 43],
+            18: [45],
+            19: [20, 45],
+            20: [21, 41],
+            21: [22, 23],
+            22: [40],
+            23: [24, 27],
+            24: [25, 32],
+            25: [26, 31],
+            26: [33],
+            27: [28],
+            28: [29, 32],
+            29: [30],
+            30: [31, 33],
+            31: [32],
+            34: [35, 38],
+            35: [36],
+            36: [37, 39],
+            37: [38],
+            40: [41, 44],
+            41: [42],
+            42: [43, 45],
+            43: [44],
+        },
+        create_using=create_using,
+    )
+    if G.is_directed():
+        raise NetworkXError("Directed Graph not supported")
+    G.name = "Tutte's Graph"
     return G

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -30,6 +30,7 @@ __all__ = [
     "tutte_graph",
 ]
 
+from functools import wraps
 import networkx as nx
 from networkx.generators.classic import (
     empty_graph,
@@ -38,6 +39,24 @@ from networkx.generators.classic import (
     complete_graph,
 )
 from networkx.exception import NetworkXError
+
+
+def _raise_on_directed(func):
+    """
+    A decorator which inspects the `create_using` argument and raises a
+    NetworkX exception when `create_using` is a DiGraph (class or instance) for
+    graph generators that do not support directed outputs.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if kwargs.get("create_using") is not None:
+            G = nx.empty_graph(create_using=kwargs["create_using"])
+            if G.is_directed():
+                raise NetworkXError("Directed Graph not supported")
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 def make_small_undirected_graph(graph_description, create_using=None):
@@ -180,6 +199,7 @@ def LCF_graph(n, shift_list, repeats, create_using=None):
 # -------------------------------------------------------------------------------
 
 
+@_raise_on_directed
 def bull_graph(create_using=None):
     """
     Returns the Bull Graph
@@ -212,6 +232,7 @@ def bull_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def chvatal_graph(create_using=None):
     """
     Returns the Chvátal Graph
@@ -255,6 +276,7 @@ def chvatal_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def cubical_graph(create_using=None):
     """
     Returns the 3-regular Platonic Cubical Graph
@@ -326,6 +348,7 @@ def desargues_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def diamond_graph(create_using=None):
     """
     Returns the Diamond graph
@@ -505,6 +528,7 @@ def hoffman_singleton_graph():
     return G
 
 
+@_raise_on_directed
 def house_graph(create_using=None):
     """
     Returns the House graph (square with triangle on top)
@@ -534,6 +558,7 @@ def house_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def house_x_graph(create_using=None):
     """
     Returns the House graph with a cross inside the house square.
@@ -562,6 +587,7 @@ def house_x_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def icosahedral_graph(create_using=None):
     """
     Returns the Platonic Icosahedral graph.
@@ -603,6 +629,7 @@ def icosahedral_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def krackhardt_kite_graph(create_using=None):
     """
     Returns the Krackhardt Kite Social Network.
@@ -680,6 +707,7 @@ def moebius_kantor_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def octahedral_graph(create_using=None):
     """
     Returns the Platonic Octahedral graph.
@@ -736,6 +764,7 @@ def pappus_graph():
     return G
 
 
+@_raise_on_directed
 def petersen_graph(create_using=None):
     """
     Returns the Petersen graph.
@@ -839,6 +868,7 @@ def tetrahedral_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def truncated_cube_graph(create_using=None):
     """
     Returns the skeleton of the truncated cube.
@@ -925,6 +955,7 @@ def truncated_tetrahedron_graph(create_using=None):
     return G
 
 
+@_raise_on_directed
 def tutte_graph(create_using=None):
     """
     Returns the Tutte graph.

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -205,6 +205,9 @@ class TestGeneratorsSmall:
         nx.tutte_graph,
     ),
 )
-def tests_raises_with_directed_create_using(fn):
+@pytest.mark.parametrize(
+    "create_using", (nx.DiGraph, nx.MultiDiGraph, nx.DiGraph([(0, 1)]))
+)
+def tests_raises_with_directed_create_using(fn, create_using):
     with pytest.raises(nx.NetworkXError, match="Directed Graph not supported"):
-        fn(create_using=nx.DiGraph)
+        fn(create_using=create_using)

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -186,3 +186,25 @@ class TestGeneratorsSmall:
         pytest.raises(nx.NetworkXError, nx.tutte_graph, create_using=nx.DiGraph)
         MG = nx.tutte_graph(create_using=nx.MultiGraph)
         assert sorted(MG.edges()) == sorted(G.edges())
+
+
+@pytest.mark.parametrize(
+    "fn",
+    (
+        nx.bull_graph,
+        nx.chvatal_graph,
+        nx.cubical_graph,
+        nx.diamond_graph,
+        nx.house_graph,
+        nx.house_x_graph,
+        nx.icosahedral_graph,
+        nx.krackhardt_kite_graph,
+        nx.octahedral_graph,
+        nx.petersen_graph,
+        nx.truncated_cube_graph,
+        nx.tutte_graph,
+    ),
+)
+def tests_raises_with_directed_create_using(fn):
+    with pytest.raises(nx.NetworkXError, match="Directed Graph not supported"):
+        fn(create_using=nx.DiGraph)


### PR DESCRIPTION
Related to the question in #5266 - there are many internal uses of `make_small_graph` to generate some of the named graphs in the `generators.small` module. In these use-cases, `make_small_graph` is used to generate graphs from a list-of-list adjacency representation. This PR refactors the functions to use `nx.from_dict_of_lists`, which is a more generic function for constructing graphs from adjacency info.

The `create_using` behavior is not currently tested for the `small` graphs (except `tutte_graph`). I added a regression test to verify that the graph generators that don't currently directed outputs continue to raise an exception when `create_using` is some form of directed graph. To cut down on the amount of boilerplate, I implemented this check in a decorator; if this adds too much complexity I'm happy to do something simpler, especially since these graph generators are relatively cheap to begin with.