### PR TITLE
Update gexf website link in documentation

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -13,8 +13,8 @@ undirected edges together).
 
 Format
 ------
-GEXF is an XML format.  See https://gephi.org/gexf/format/schema.html for the
-specification and https://gephi.org/gexf/format/basic.html for examples.
+GEXF is an XML format.  See http://gexf.net/schema.html for the
+specification and http://gexf.net/basic.html for examples.
 """
 import itertools
 import time
@@ -80,8 +80,8 @@ def write_gexf(G, path, encoding="utf-8", prettyprint=True, version="1.2draft"):
 
     References
     ----------
-    .. [1] GEXF File Format, https://gephi.org/gexf/format/
-    .. [2] GEXF schema, https://gephi.org/gexf/format/schema.html
+    .. [1] GEXF File Format, http://gexf.net/
+    .. [2] GEXF schema, http://gexf.net/schema.html
     """
     writer = GEXFWriter(encoding=encoding, prettyprint=prettyprint, version=version)
     writer.add_graph(G)
@@ -103,7 +103,7 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
     prettyprint : bool (optional, default: True)
     If True use line breaks and indenting in output XML.
     version : string (default: 1.2draft)
-    Version of GEFX File Format (see https://gephi.org/gexf/format/schema.html)
+    Version of GEFX File Format (see http://gexf.net/schema.html)
     Supported values: "1.1draft", "1.2draft"
 
 
@@ -151,7 +151,7 @@ def read_gexf(path, node_type=None, relabel=False, version="1.2draft"):
        If True relabel the nodes to use the GEXF node "label" attribute
        instead of the node "id" attribute as the NetworkX node label.
     version : string (default: 1.2draft)
-    Version of GEFX File Format (see https://gephi.org/gexf/format/schema.html)
+    Version of GEFX File Format (see http://gexf.net/schema.html)
        Supported values: "1.1draft", "1.2draft"
 
     Returns
@@ -167,7 +167,7 @@ def read_gexf(path, node_type=None, relabel=False, version="1.2draft"):
 
     References
     ----------
-    .. [1] GEXF File Format, https://gephi.org/gexf/format/
+    .. [1] GEXF File Format, http://gexf.net/
     """
     reader = GEXFReader(node_type=node_type, version=version)
     if relabel:


### PR DESCRIPTION
Hi, we've recently put the GEXF website again into its own domain http://gexf.net/ so this documentation should be updated. Thanks!

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
