### PR TITLE
Update imports to use lazy imports

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -259,20 +259,27 @@ Guidelines
   and widely-used.  New default dependencies should be easy to install on all
   platforms, widely-used in the community, and have demonstrated potential for
   wide-spread use in NetworkX.
-* Use the following import conventions::
+* We use a lazy import system so users without e.g. numpy can still use NetworkX.
+  Use the following import conventions::
 
-   import numpy as np
-   import scipy as sp
-   import matplotlib as mpl
-   import matplotlib.pyplot as plt
-   import pandas as pd
    import networkx as nx
+   np = nx.lazy_import("numpy")  # instead of import numpy as np
+   sp = nx.lazy_import("scipy")
+   mpl = nx.lazy_import("matplotlib")
+   plt = nx.lazy_import("matplotlib.pyplot")
+   pd = nx.lazy_import("pandas")
+
+* For subpackage importing we use notation to indicate the source of the subpackage.
+  For example, many libraries have a ``linalg`` subpackage: ``nx.linalg``,
+  ``np.linalg``, ``sp.linalg``, ``sp.sparse.linalg``.
+  We use an import pattern that makes the origin of a particular ``linalg`` explicit.
 
   After importing `sp`` for ``scipy``::
 
-   import scipy as sp
+   sp = nx.lazy_import("scipy")
 
-  use the following imports::
+  use the following import idioms. These should be used **within**
+  the functions that they will be used or the lazy loading expires::
 
    import scipy.linalg  # call as sp.linalg
    import scipy.sparse  # call as sp.sparse
@@ -280,9 +287,6 @@ Guidelines
    import scipy.stats  # call as sp.stats
    import scipy.optimize  # call as sp.optimize
 
-  For example, many libraries have a ``linalg`` subpackage: ``nx.linalg``,
-  ``np.linalg``, ``sp.linalg``, ``sp.sparse.linalg``. The above import
-  pattern makes the origin of any particular instance of ``linalg`` explicit.
 
 * Use the decorator ``not_implemented_for`` in ``networkx/utils/decorators.py``
   to designate that a function doesn't accept 'directed', 'undirected',

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -9,8 +9,8 @@ from networkx.algorithms.assortativity.pairs import node_degree_xy
 
 import networkx as nx
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "degree_pearson_correlation_coefficient",

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -7,6 +7,11 @@ from networkx.algorithms.assortativity.mixing import (
 )
 from networkx.algorithms.assortativity.pairs import node_degree_xy
 
+import networkx as nx
+
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = [
     "degree_pearson_correlation_coefficient",
     "degree_assortativity_coefficient",
@@ -150,7 +155,6 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
-    import scipy as sp
     import scipy.stats  # call as sp.stats
 
     xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
@@ -283,8 +287,6 @@ def attribute_ac(M):
 def numeric_ac(M, mapping):
     # M is a numpy matrix or array
     # numeric assortativity coefficient, pearsonr
-    import numpy as np
-
     if M.sum() != 1.0:
         M = M / float(M.sum())
     nx, ny = M.shape  # nx=ny

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -7,7 +7,7 @@ import itertools
 from networkx.convert_matrix import _generate_weighted_edges
 import networkx as nx
 
-sp = nx.lazy_imports.load("scipy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["biadjacency_matrix", "from_biadjacency_matrix"]
 

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -8,6 +8,7 @@ from networkx.convert_matrix import _generate_weighted_edges
 import networkx as nx
 
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
 
 __all__ = ["biadjacency_matrix", "from_biadjacency_matrix"]
 
@@ -75,8 +76,6 @@ def biadjacency_matrix(
     .. [2] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
-    import scipy.sparse  # call as sp.sparse
-
     nlen = len(row_order)
     if nlen == 0:
         raise nx.NetworkXError("row_order is empty list")

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -7,6 +7,8 @@ import itertools
 from networkx.convert_matrix import _generate_weighted_edges
 import networkx as nx
 
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["biadjacency_matrix", "from_biadjacency_matrix"]
 
 
@@ -73,7 +75,6 @@ def biadjacency_matrix(
     .. [2] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     nlen = len(row_order)

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -3,7 +3,7 @@ Spectral bipartivity measure.
 """
 import networkx as nx
 
-sp = nx.lazy_imports.load("scipy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["spectral_bipartivity"]
 

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -3,6 +3,8 @@ Spectral bipartivity measure.
 """
 import networkx as nx
 
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["spectral_bipartivity"]
 
 
@@ -47,7 +49,6 @@ def spectral_bipartivity(G, nodes=None, weight="weight"):
     .. [1] E. Estrada and J. A. Rodríguez-Velázquez, "Spectral measures of
        bipartivity in complex networks", PhysRev E 72, 046105 (2005)
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -12,8 +12,8 @@ from networkx.utils import (
     py_random_state,
 )
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "current_flow_betweenness_centrality",

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -12,6 +12,9 @@ from networkx.utils import (
     py_random_state,
 )
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = [
     "current_flow_betweenness_centrality",
     "approximate_current_flow_betweenness_centrality",
@@ -96,8 +99,6 @@ def approximate_current_flow_betweenness_centrality(
        LNCS 3404, pp. 533-544. Springer-Verlag, 2005.
        https://doi.org/10.1007/978-3-540-31856-9_44
     """
-    import numpy as np
-
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
     solvername = {

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -3,7 +3,7 @@ import networkx as nx
 from networkx.algorithms.centrality.flow_matrix import flow_matrix_row
 from networkx.utils import not_implemented_for, reverse_cuthill_mckee_ordering
 
-np = nx.lazy_imports.load("numpy")
+np = nx.lazy_import("numpy")
 
 __all__ = [
     "current_flow_betweenness_centrality_subset",

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -3,6 +3,8 @@ import networkx as nx
 from networkx.algorithms.centrality.flow_matrix import flow_matrix_row
 from networkx.utils import not_implemented_for, reverse_cuthill_mckee_ordering
 
+np = nx.lazy_imports.load("numpy")
+
 __all__ = [
     "current_flow_betweenness_centrality_subset",
     "edge_current_flow_betweenness_centrality_subset",
@@ -90,7 +92,6 @@ def current_flow_betweenness_centrality_subset(
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
     from networkx.utils import reverse_cuthill_mckee_ordering
-    import numpy as np
 
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
@@ -197,8 +198,6 @@ def edge_current_flow_betweenness_centrality_subset(
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    import numpy as np
-
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
     n = G.number_of_nodes()

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -4,6 +4,9 @@ import math
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["eigenvector_centrality", "eigenvector_centrality_numpy"]
 
 
@@ -212,8 +215,6 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
        Networks: An Introduction.
        Oxford University Press, USA, 2010, pp. 169.
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse.linalg  # call as sp.sparse.linalg
 
     if len(G) == 0:

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -4,8 +4,8 @@ import math
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["eigenvector_centrality", "eigenvector_centrality_numpy"]
 

--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -2,11 +2,13 @@
 # Lazy computations for inverse Laplacian and flow-matrix rows.
 import networkx as nx
 
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
+sp.sparse.linalg = nx.lazy_import("scipy.sparse.linalg")  # call as sp.sparse.linalg
+
 
 def flow_matrix_row(G, weight=None, dtype=float, solver="lu"):
     # Generate a row of the current-flow matrix
-    import numpy as np
-
     solvername = {
         "full": FullInverseLaplacian,
         "lu": SuperLUInverseLaplacian,
@@ -34,9 +36,6 @@ def flow_matrix_row(G, weight=None, dtype=float, solver="lu"):
 # inverse laplacian matrix
 class InverseLaplacian:
     def __init__(self, L, width=None, dtype=None):
-        global np
-        import numpy as np
-
         (n, n) = L.shape
         self.dtype = dtype
         self.n = n
@@ -94,9 +93,6 @@ class FullInverseLaplacian(InverseLaplacian):
 
 class SuperLUInverseLaplacian(InverseLaplacian):
     def init_solver(self, L):
-        import scipy as sp
-        import scipy.sparse.linalg  # call as sp.sparse.linalg
-
         self.lusolve = sp.sparse.linalg.factorized(self.L1.tocsc())
 
     def solve_inverse(self, r):
@@ -112,10 +108,6 @@ class SuperLUInverseLaplacian(InverseLaplacian):
 
 class CGInverseLaplacian(InverseLaplacian):
     def init_solver(self, L):
-        global sp
-        import scipy as sp
-        import scipy.sparse.linalg  # call as sp.sparse.linalg
-
         ilu = sp.sparse.linalg.spilu(self.L1.tocsc())
         n = self.n - 1
         self.M = sp.sparse.linalg.LinearOperator(shape=(n, n), matvec=ilu.solve)

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -4,7 +4,7 @@ import math
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
+np = nx.lazy_import("numpy")
 
 __all__ = ["katz_centrality", "katz_centrality_numpy"]
 

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -4,6 +4,8 @@ import math
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+np = nx.lazy_imports.load("numpy")
+
 __all__ = ["katz_centrality", "katz_centrality_numpy"]
 
 
@@ -304,8 +306,6 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
        Psychometrika 18(1):39–43, 1953
        https://link.springer.com/content/pdf/10.1007/BF02289026.pdf
     """
-    import numpy as np
-
     if len(G) == 0:
         return {}
     try:

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -33,7 +33,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
+np = nx.lazy_import("numpy")
 
 # Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
 """ Second order centrality measure."""

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -33,6 +33,8 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+np = nx.lazy_imports.load("numpy")
+
 # Authors: Erwan Le Merrer (erwan.lemerrer@technicolor.com)
 """ Second order centrality measure."""
 
@@ -95,8 +97,6 @@ def second_order_centrality(G):
        "Second order centrality: Distributed assessment of nodes criticity in
        complex networks", Elsevier Computer Communications 34(5):619-628, 2011.
     """
-    import numpy as np
-
     n = len(G)
 
     if n == 0:

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -4,6 +4,9 @@ Subraph centrality and communicability betweenness.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = [
     "subgraph_centrality_exp",
     "subgraph_centrality",
@@ -83,7 +86,6 @@ def subgraph_centrality_exp(G):
     ['1 3.90', '2 3.90', '3 3.64', '4 3.71', '5 3.64', '6 3.71', '7 3.64', '8 3.90']
     """
     # alternative implementation that calculates the matrix exponential
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix
@@ -171,8 +173,6 @@ def subgraph_centrality(G):
        https://arxiv.org/abs/cond-mat/0504730
 
     """
-    import numpy as np
-
     nodelist = list(G)  # ordering of nodes in matrix
     A = nx.to_numpy_array(G, nodelist)
     # convert to 0-1 matrix
@@ -253,8 +253,6 @@ def communicability_betweenness_centrality(G):
     >>> print([f"{node} {cbc[node]:0.2f}" for node in sorted(cbc)])
     ['0 0.03', '1 0.45', '2 0.51', '3 0.45', '4 0.40', '5 0.19', '6 0.03']
     """
-    import numpy as np
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -4,8 +4,8 @@ Subraph centrality and communicability betweenness.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "subgraph_centrality_exp",

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -4,8 +4,8 @@ Communicability.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["communicability", "communicability_exp"]
 

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -4,6 +4,9 @@ Communicability.
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["communicability", "communicability_exp"]
 
 
@@ -65,8 +68,6 @@ def communicability(G):
     >>> G = nx.Graph([(0, 1), (1, 2), (1, 5), (5, 4), (2, 4), (2, 3), (4, 3), (3, 6)])
     >>> c = nx.communicability(G)
     """
-    import numpy as np
-
     nodelist = list(G)  # ordering of nodes in matrix
     A = nx.to_numpy_array(G, nodelist)
     # convert to 0-1 matrix
@@ -143,7 +144,6 @@ def communicability_exp(G):
     >>> G = nx.Graph([(0, 1), (1, 2), (1, 5), (5, 4), (2, 4), (2, 3), (4, 3), (3, 6)])
     >>> c = nx.communicability_exp(G)
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     nodelist = list(G)  # ordering of nodes in matrix

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -1,7 +1,10 @@
 """Graph diameter, radius, eccentricity and other properties."""
-
 import networkx as nx
 from networkx.utils import not_implemented_for
+
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
+sp.sparse.linalg = nx.lazy_import("scipy.sparse.linalg")
 
 __all__ = [
     "extrema_bounding",
@@ -521,10 +524,6 @@ def resistance_distance(G, nodeA, nodeB, weight=None, invert_weight=True):
     Mathematisch Instituut, Universiteit Leiden, Leiden, Netherlands, 2016
     Available: `Link to thesis <https://www.universiteitleiden.nl/binaries/content/assets/science/mi/scripties/master/vos_vaya_master.pdf>`_
     """
-    import numpy as np
-    import scipy as sp
-    import scipy.sparse.linalg  # call as sp.sparse.linalg
-
     if not nx.is_connected(G):
         msg = "Graph G must be strongly connected."
         raise nx.NetworkXError(msg)

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -2,8 +2,8 @@
 """
 import networkx as nx
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["hits", "hits_numpy", "hits_scipy", "authority_matrix", "hub_matrix"]
 

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -2,6 +2,9 @@
 """
 import networkx as nx
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["hits", "hits_numpy", "hits_scipy", "authority_matrix", "hub_matrix"]
 
 
@@ -69,8 +72,6 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse.linalg  # call as sp.sparse.linalg
 
     if len(G) == 0:
@@ -245,7 +246,6 @@ def hits_numpy(G, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import numpy as np
     import warnings
 
     warnings.warn(
@@ -349,7 +349,6 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import numpy as np
     import warnings
 
     warnings.warn(

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -4,6 +4,8 @@ import networkx as nx
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse.linalg = nx.lazy_import("scipy.sparse.linalg")  # call as sp.sparse.linalg
+
 
 __all__ = ["hits", "hits_numpy", "hits_scipy", "authority_matrix", "hub_matrix"]
 
@@ -72,8 +74,6 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import scipy.sparse.linalg  # call as sp.sparse.linalg
-
     if len(G) == 0:
         return {}, {}
     A = nx.adjacency_matrix(G, nodelist=list(G), dtype=float)

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -2,8 +2,8 @@
 from warnings import warn
 import networkx as nx
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["pagerank", "pagerank_numpy", "pagerank_scipy", "google_matrix"]
 

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -4,6 +4,8 @@ import networkx as nx
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
+
 
 __all__ = ["pagerank", "pagerank_numpy", "pagerank_scipy", "google_matrix"]
 
@@ -458,8 +460,6 @@ def pagerank_scipy(
     """
     msg = "networkx.pagerank_scipy is deprecated and will be removed in NetworkX 3.0, use networkx.pagerank instead."
     warn(msg, DeprecationWarning, stacklevel=2)
-    import scipy.sparse  # call as sp.sparse
-
     N = len(G)
     if N == 0:
         return {}

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -2,6 +2,9 @@
 from warnings import warn
 import networkx as nx
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["pagerank", "pagerank_numpy", "pagerank_scipy", "google_matrix"]
 
 
@@ -231,8 +234,6 @@ def google_matrix(
     --------
     pagerank, pagerank_numpy, pagerank_scipy
     """
-    import numpy as np
-
     # TODO: Remove this warning in version 3.0
     import warnings
 
@@ -349,8 +350,6 @@ def pagerank_numpy(G, alpha=0.85, personalization=None, weight="weight", danglin
     """
     msg = "networkx.pagerank_numpy is deprecated and will be removed in NetworkX 3.0, use networkx.pagerank instead."
     warn(msg, DeprecationWarning, stacklevel=2)
-    import numpy as np
-
     if len(G) == 0:
         return {}
     M = google_matrix(
@@ -459,8 +458,6 @@ def pagerank_scipy(
     """
     msg = "networkx.pagerank_scipy is deprecated and will be removed in NetworkX 3.0, use networkx.pagerank instead."
     warn(msg, DeprecationWarning, stacklevel=2)
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     N = len(G)

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -3,7 +3,7 @@ import networkx as nx
 
 np = pytest.importorskip("numpy")
 sp = pytest.importorskip("scipy")
-import scipy.sparse  # call as sp.sparse
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
 
 from networkx.algorithms.link_analysis.hits_alg import _hits_python
 

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -11,6 +11,9 @@ import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.node_classification.utils import _get_label_info
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["harmonic_function"]
 
 
@@ -56,8 +59,6 @@ def harmonic_function(G, max_iter=30, label_name="label"):
     Semi-supervised learning using gaussian fields and harmonic functions.
     In ICML (Vol. 3, pp. 912-919).
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     X = nx.to_scipy_sparse_array(G)  # adjacency matrix

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -11,8 +11,8 @@ import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.node_classification.utils import _get_label_info
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["harmonic_function"]
 

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -13,6 +13,7 @@ from networkx.algorithms.node_classification.utils import _get_label_info
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
 
 __all__ = ["harmonic_function"]
 
@@ -59,8 +60,6 @@ def harmonic_function(G, max_iter=30, label_name="label"):
     Semi-supervised learning using gaussian fields and harmonic functions.
     In ICML (Vol. 3, pp. 912-919).
     """
-    import scipy.sparse  # call as sp.sparse
-
     X = nx.to_scipy_sparse_array(G)  # adjacency matrix
     labels, label_dict = _get_label_info(G, label_name)
 

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -11,6 +11,9 @@ import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.node_classification.utils import _get_label_info
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["local_and_global_consistency"]
 
 
@@ -58,8 +61,6 @@ def local_and_global_consistency(G, alpha=0.99, max_iter=30, label_name="label")
     Learning with local and global consistency.
     Advances in neural information processing systems, 16(16), 321-328.
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     X = nx.to_scipy_sparse_array(G)  # adjacency matrix

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -11,8 +11,8 @@ import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.node_classification.utils import _get_label_info
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["local_and_global_consistency"]
 

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -13,6 +13,8 @@ from networkx.algorithms.node_classification.utils import _get_label_info
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
+
 
 __all__ = ["local_and_global_consistency"]
 
@@ -61,8 +63,6 @@ def local_and_global_consistency(G, alpha=0.99, max_iter=30, label_name="label")
     Learning with local and global consistency.
     Advances in neural information processing systems, 16(16), 321-328.
     """
-    import scipy.sparse  # call as sp.sparse
-
     X = nx.to_scipy_sparse_array(G)  # adjacency matrix
     labels, label_dict = _get_label_info(G, label_name)
 

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -21,8 +21,8 @@ import warnings
 
 import networkx as nx
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "graph_edit_distance",

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -12,14 +12,17 @@ and/or `optimize_edit_paths`.
 At the same time, I encourage capable people to investigate
 alternative GED algorithms, in order to improve the choices available.
 """
-
 from functools import reduce
 from itertools import product
 import math
 from operator import mul
 import time
 import warnings
+
 import networkx as nx
+
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
 
 __all__ = [
     "graph_edit_distance",
@@ -667,9 +670,6 @@ def optimize_edit_paths(
 
     """
     # TODO: support DiGraph
-
-    import numpy as np
-    import scipy as sp
     import scipy.optimize  # call as sp.optimize
 
     class CostMatrix:
@@ -1300,8 +1300,6 @@ def simrank_similarity(
            International Conference on Knowledge Discovery and Data Mining,
            pp. 538--543. ACM Press, 2002.
     """
-    import numpy as np
-
     nodelist = list(G)
     s_indx = None if source is None else nodelist.index(source)
     t_indx = None if target is None else nodelist.index(target)
@@ -1457,8 +1455,6 @@ def _simrank_similarity_numpy(
     #
     # where C is the importance factor, A is the column normalized
     # adjacency matrix, and I is the identity matrix.
-    import numpy as np
-
     adjacency_matrix = nx.to_numpy_array(G)
 
     # column-normalize the ``adjacency_matrix``
@@ -1562,8 +1558,6 @@ def panther_similarity(G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None
            on Knowledge Discovery and Data Mining (Vol. 2015-August, pp. 1445–1454).
            Association for Computing Machinery. https://doi.org/10.1145/2783258.2783267.
     """
-    import numpy as np
-
     num_nodes = G.number_of_nodes()
     if num_nodes < k:
         warnings.warn(
@@ -1666,8 +1660,6 @@ def generate_random_paths(G, sample_size, path_length=5, index_map=None):
            on Knowledge Discovery and Data Mining (Vol. 2015-August, pp. 1445–1454).
            Association for Computing Machinery. https://doi.org/10.1145/2783258.2783267.
     """
-    import numpy as np
-
     # Calculate transition probabilities between
     # every pair of vertices according to Eq. (3)
     adj_mat = nx.to_numpy_array(G)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -328,7 +328,6 @@ needs_scipy = [
     "linalg/graphmatrix.py",
     "linalg/modularitymatrix.py",
     "linalg/spectrum.py",
-    "utils/rcm.py",
 ]
 needs_matplotlib = ["drawing/nx_pylab.py"]
 needs_pandas = ["convert_matrix.py"]

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -29,9 +29,9 @@ from collections import defaultdict
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
-pd = nx.lazy_imports.load("pandas")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+pd = nx.lazy_import("pandas")
+sp = nx.lazy_import("scipy")
 
 
 __all__ = [

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -25,8 +25,14 @@ nx_agraph, nx_pydot
 import itertools
 import warnings
 from collections import defaultdict
+
 import networkx as nx
 from networkx.utils import not_implemented_for
+
+np = nx.lazy_imports.load("numpy")
+pd = nx.lazy_imports.load("pandas")
+sp = nx.lazy_imports.load("scipy")
+
 
 __all__ = [
     "from_numpy_matrix",
@@ -135,8 +141,6 @@ def to_pandas_adjacency(
     2  0  0  4
 
     """
-    import pandas as pd
-
     M = to_numpy_array(
         G,
         nodelist=nodelist,
@@ -279,8 +283,6 @@ def to_pandas_edgelist(
     1      A      B     9     1
 
     """
-    import pandas as pd
-
     if nodelist is None:
         edgelist = G.edges(data=True)
     else:
@@ -580,8 +582,6 @@ def to_numpy_matrix(
         DeprecationWarning,
     )
 
-    import numpy as np
-
     A = to_numpy_array(
         G,
         nodelist=nodelist,
@@ -737,8 +737,6 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
      [5 0]]
 
     """
-    import numpy as np
-
     if dtype is None:
         dtype = [("weight", float)]
 
@@ -851,9 +849,6 @@ def to_scipy_sparse_array(G, nodelist=None, dtype=None, weight="weight", format=
     .. [1] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
-    import scipy as sp
-    import scipy.sparse  # call as sp.sparse
-
     if len(G) == 0:
         raise nx.NetworkXError("Graph has no nodes or edges")
 
@@ -985,9 +980,6 @@ def to_scipy_sparse_matrix(G, nodelist=None, dtype=None, weight="weight", format
     .. [1] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
-    import scipy as sp
-    import scipy.sparse
-
     warnings.warn(
         (
             "\n\nThe scipy.sparse array containers will be used instead of matrices\n"
@@ -1350,8 +1342,6 @@ def to_numpy_array(
            [0., 0., 4.]])
 
     """
-    import numpy as np
-
     if nodelist is None:
         nodelist = list(G)
     nlen = len(nodelist)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -32,6 +32,7 @@ from networkx.utils import not_implemented_for
 np = nx.lazy_import("numpy")
 pd = nx.lazy_import("pandas")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")
 
 
 __all__ = [

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -18,6 +18,9 @@ Warning: Most layout routines have only been tested in 2-dimensions.
 import networkx as nx
 from networkx.utils import np_random_state
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = [
     "bipartite_layout",
     "circular_layout",
@@ -37,8 +40,6 @@ __all__ = [
 
 def _process_params(G, center, dim):
     # Some boilerplate code.
-    import numpy as np
-
     if not isinstance(G, nx.Graph):
         empty_graph = nx.Graph()
         empty_graph.add_nodes_from(G)
@@ -95,8 +96,6 @@ def random_layout(G, center=None, dim=2, seed=None):
     >>> pos = nx.random_layout(G)
 
     """
-    import numpy as np
-
     G, center = _process_params(G, center, dim)
     pos = seed.rand(len(G), dim) + center
     pos = pos.astype(np.float32)
@@ -147,8 +146,6 @@ def circular_layout(G, scale=1, center=None, dim=2):
     try to minimize edge crossings.
 
     """
-    import numpy as np
-
     if dim < 2:
         raise ValueError("cannot handle dimensions < 2")
 
@@ -221,8 +218,6 @@ def shell_layout(G, nlist=None, rotate=None, scale=1, center=None, dim=2):
     try to minimize edge crossings.
 
     """
-    import numpy as np
-
     if dim != 2:
         raise ValueError("can only handle 2 dimensions")
 
@@ -307,9 +302,6 @@ def bipartite_layout(
     try to minimize edge crossings.
 
     """
-
-    import numpy as np
-
     if align not in ("vertical", "horizontal"):
         msg = "align must be either vertical or horizontal."
         raise ValueError(msg)
@@ -437,8 +429,6 @@ def spring_layout(
     # The same using longer but equivalent function name
     >>> pos = nx.fruchterman_reingold_layout(G)
     """
-    import numpy as np
-
     G, center = _process_params(G, center, dim)
 
     if fixed is not None:
@@ -505,8 +495,6 @@ def _fruchterman_reingold(
 ):
     # Position nodes in adjacency matrix A using Fruchterman-Reingold
     # Entry point for NetworkX graph is fruchterman_reingold_layout()
-    import numpy as np
-
     try:
         nnodes, _ = A.shape
     except AttributeError as err:
@@ -568,8 +556,6 @@ def _sparse_fruchterman_reingold(
     # Position nodes in adjacency matrix A using Fruchterman-Reingold
     # Entry point for NetworkX graph is fruchterman_reingold_layout()
     # Sparse version
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     try:
@@ -678,8 +664,6 @@ def kamada_kawai_layout(
     >>> G = nx.path_graph(4)
     >>> pos = nx.kamada_kawai_layout(G)
     """
-    import numpy as np
-
     G, center = _process_params(G, center, dim)
     nNodes = len(G)
     if nNodes == 0:
@@ -716,9 +700,6 @@ def _kamada_kawai_solve(dist_mtx, pos_arr, dim):
     # Anneal node locations based on the Kamada-Kawai cost-function,
     # using the supplied matrix of preferred inter-node distances,
     # and starting locations.
-
-    import numpy as np
-    import scipy as sp
     import scipy.optimize  # call as sp.optimize
 
     meanwt = 1e-3
@@ -805,8 +786,6 @@ def spectral_layout(G, weight="weight", scale=1, center=None, dim=2):
     eigenvalue solver (ARPACK).
     """
     # handle some special cases that break the eigensolvers
-    import numpy as np
-
     G, center = _process_params(G, center, dim)
 
     if len(G) <= 2:
@@ -842,8 +821,6 @@ def spectral_layout(G, weight="weight", scale=1, center=None, dim=2):
 def _spectral(A, dim=2):
     # Input adjacency matrix A
     # Uses dense eigenvalue solver from numpy
-    import numpy as np
-
     try:
         nnodes, _ = A.shape
     except AttributeError as err:
@@ -864,8 +841,6 @@ def _sparse_spectral(A, dim=2):
     # Input adjacency matrix A
     # Uses sparse eigenvalue solver from scipy
     # Could use multilevel methods here, see Koren "On spectral graph drawing"
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
     import scipy.sparse.linalg  # call as sp.sparse.linalg
 
@@ -922,8 +897,6 @@ def planar_layout(G, scale=1, center=None, dim=2):
     >>> G = nx.path_graph(4)
     >>> pos = nx.planar_layout(G)
     """
-    import numpy as np
-
     if dim != 2:
         raise ValueError("can only handle 2 dimensions")
 
@@ -986,8 +959,6 @@ def spiral_layout(G, scale=1, center=None, dim=2, resolution=0.35, equidistant=F
     This algorithm currently only works in two dimensions.
 
     """
-    import numpy as np
-
     if dim != 2:
         raise ValueError("can only handle 2 dimensions")
 
@@ -1059,8 +1030,6 @@ def multipartite_layout(G, subset_key="subset", align="vertical", scale=1, cente
     have subset_key data, they will be placed in the corresponding layers.
 
     """
-    import numpy as np
-
     if align not in ("vertical", "horizontal"):
         msg = "align must be either vertical or horizontal."
         raise ValueError(msg)
@@ -1170,8 +1139,6 @@ def rescale_layout_dict(pos, scale=1):
     --------
     rescale_layout
     """
-    import numpy as np
-
     if not pos:  # empty_graph
         return {}
     pos_v = np.array(list(pos.values()))

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -18,8 +18,8 @@ Warning: Most layout routines have only been tested in 2-dimensions.
 import networkx as nx
 from networkx.utils import np_random_state
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "bipartite_layout",

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -20,6 +20,10 @@ from networkx.utils import np_random_state
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
+sp.sparse.linalg = nx.lazy_import("scipy.sparse.linalg")  # call as sp.sparse.linalg
+sp.optimize = nx.lazy_import("scipy.optimize")  # call as sp.optimize
+
 
 __all__ = [
     "bipartite_layout",
@@ -556,8 +560,6 @@ def _sparse_fruchterman_reingold(
     # Position nodes in adjacency matrix A using Fruchterman-Reingold
     # Entry point for NetworkX graph is fruchterman_reingold_layout()
     # Sparse version
-    import scipy.sparse  # call as sp.sparse
-
     try:
         nnodes, _ = A.shape
     except AttributeError as err:
@@ -700,8 +702,6 @@ def _kamada_kawai_solve(dist_mtx, pos_arr, dim):
     # Anneal node locations based on the Kamada-Kawai cost-function,
     # using the supplied matrix of preferred inter-node distances,
     # and starting locations.
-    import scipy.optimize  # call as sp.optimize
-
     meanwt = 1e-3
     costargs = (np, 1 / (dist_mtx + np.eye(dist_mtx.shape[0]) * 1e-3), meanwt, dim)
 
@@ -841,9 +841,6 @@ def _sparse_spectral(A, dim=2):
     # Input adjacency matrix A
     # Uses sparse eigenvalue solver from scipy
     # Could use multilevel methods here, see Koren "On spectral graph drawing"
-    import scipy.sparse  # call as sp.sparse
-    import scipy.sparse.linalg  # call as sp.sparse.linalg
-
     try:
         nnodes, _ = A.shape
     except AttributeError as err:

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -20,8 +20,11 @@ See Also
  - DOT Language:  http://www.graphviz.org/doc/info/lang.html
 """
 from locale import getpreferredencoding
-from networkx.utils import open_file
+
 import networkx as nx
+from networkx.utils import open_file
+
+pydot = nx.lazy_imports.load("pydot")
 
 __all__ = [
     "write_dot",
@@ -67,8 +70,6 @@ def read_dot(path):
     Use `G = nx.Graph(read_dot(path))` to return a :class:`Graph` instead of a
     :class:`MultiGraph`.
     """
-    import pydot
-
     data = path.read()
 
     # List of one or more "pydot.Dot" instances deserialized from this file.
@@ -185,8 +186,6 @@ def to_pydot(N):
     -----
 
     """
-    import pydot
-
     # set Graphviz graph type
     if N.is_directed():
         graph_type = "digraph"
@@ -301,8 +300,6 @@ def pydot_layout(G, prog="neato", root=None):
         G_layout = {H.nodes[n]['node_label']: p for n, p in H_layout.items()}
 
     """
-    import pydot
-
     P = to_pydot(G)
     if root is not None:
         P.set("root", str(root))

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -24,7 +24,7 @@ from locale import getpreferredencoding
 import networkx as nx
 from networkx.utils import open_file
 
-pydot = nx.lazy_imports.load("pydot")
+pydot = nx.lazy_import("pydot")
 
 __all__ = [
     "write_dot",

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -21,8 +21,8 @@ import warnings
 
 import networkx as nx
 
-np = nx.lazy_imports.load("numpy")
-mpl = nx.lazy_imports.load("matplotlib")
+np = nx.lazy_import("numpy")
+mpl = nx.lazy_import("matplotlib")
 
 from networkx.drawing.layout import (
     shell_layout,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -17,7 +17,13 @@ See Also
  - :obj:`matplotlib.patches.FancyArrowPatch`
 """
 from numbers import Number
+import warnings
+
 import networkx as nx
+
+np = nx.lazy_imports.load("numpy")
+mpl = nx.lazy_imports.load("matplotlib")
+
 from networkx.drawing.layout import (
     shell_layout,
     circular_layout,
@@ -27,7 +33,6 @@ from networkx.drawing.layout import (
     random_layout,
     planar_layout,
 )
-import warnings
 
 __all__ = [
     "draw",
@@ -437,8 +442,6 @@ def draw_networkx_nodes(
     draw_networkx_edge_labels
     """
     from collections.abc import Iterable
-    import numpy as np
-    import matplotlib as mpl
     import matplotlib.collections  # call as mpl.collections
     import matplotlib.pyplot as plt
 
@@ -667,8 +670,6 @@ def draw_networkx_edges(
     draw_networkx_edge_labels
 
     """
-    import numpy as np
-    import matplotlib as mpl
     import matplotlib.colors  # call as mpl.colors
     import matplotlib.patches  # call as mpl.patches
     import matplotlib.collections  # call as mpl.collections
@@ -1122,7 +1123,6 @@ def draw_networkx_edge_labels(
     draw_networkx_labels
     """
     import matplotlib.pyplot as plt
-    import numpy as np
 
     if ax is None:
         ax = plt.gca()
@@ -1349,8 +1349,6 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
 
     """
     from itertools import islice, cycle
-    import numpy as np
-    import matplotlib as mpl
     import matplotlib.colors  # call as mpl.colors
     import matplotlib.cm  # call as mpl.cm
 

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -4,6 +4,9 @@
 import networkx as nx
 from networkx.utils import np_random_state
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["spectral_graph_forge"]
 
 
@@ -44,8 +47,6 @@ def _mat_spect_approx(A, level, sorteigs=True, reverse=False, absolute=True):
     ..  [2] L. Mirsky, Symmetric gauge functions and unitarily invariant norms
 
     """
-    import numpy as np
-
     d, V = np.linalg.eigh(A)
     d = np.ravel(d)
     n = len(d)
@@ -140,8 +141,6 @@ def spectral_graph_forge(G, alpha, transformation="identity", seed=None):
     >>> H = nx.spectral_graph_forge(G, 0.3)
     >>>
     """
-    import numpy as np
-    import scipy as sp
     import scipy.stats  # call as sp.stats
 
     available_transformations = ["identity", "modularity"]

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -4,8 +4,8 @@
 import networkx as nx
 from networkx.utils import np_random_state
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["spectral_graph_forge"]
 

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -128,6 +128,15 @@ def lazy_import(fullname):
     except:
         pass
 
+    # handle subpackage imports
+    subnames = fullname.split(".")
+    if len(subnames) > 1:
+        firstname = subnames[0]
+        spec = importlib.util.find_spec(firstname)
+        if spec is None:
+            # module not found so just use firstname
+            fullname = firstname
+
     # Not previously loaded -- look it up
     spec = importlib.util.find_spec(fullname)
 
@@ -169,3 +178,12 @@ class DelayedImportErrorModule(types.ModuleType):
             "Reporting was Lazy -- delayed until module attributes accessed.\n"
             f"Most likely, {spec.name} is not installed"
         )
+
+    def __setattribute__(self, attr, value):
+        if not isinstance(value, DelayedImportErrorModule):
+            raise ModuleNotFoundError(
+                f"Delayed Report: module named '{spec.name}' not found.\n"
+                "Reporting was Lazy -- delayed until module attributes accessed.\n"
+                f"Most likely, {spec.name} is not installed"
+            )
+        super().__setattribute__(attr, value)

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -7,6 +7,9 @@ from networkx.utils import not_implemented_for
 from networkx.utils import reverse_cuthill_mckee_ordering
 from networkx.utils import np_random_state
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["algebraic_connectivity", "fiedler_vector", "spectral_ordering"]
 
 
@@ -31,8 +34,6 @@ class _PCGSolver:
         self._M = M
 
     def solve(self, B, tol):
-        import numpy as np
-
         # Densifying step - can this be kept sparse?
         B = np.asarray(B)
         X = np.ndarray(B.shape, order="F")
@@ -41,8 +42,6 @@ class _PCGSolver:
         return X
 
     def _solve(self, b, tol):
-        import numpy as np
-        import scipy as sp
         import scipy.linalg.blas  # call as sp.linalg.blas
 
         A = self._A
@@ -80,7 +79,6 @@ class _LUSolver:
     """
 
     def __init__(self, A):
-        import scipy as sp
         import scipy.sparse.linalg  # call as sp.sparse.linalg
 
         self._LU = sp.sparse.linalg.splu(
@@ -91,8 +89,6 @@ class _LUSolver:
         )
 
     def solve(self, B, tol=None):
-        import numpy as np
-
         B = np.asarray(B)
         X = np.ndarray(B.shape, order="F")
         for j in range(B.shape[1]):
@@ -128,8 +124,6 @@ def _preprocess_graph(G, weight):
 
 def _rcm_estimate(G, nodelist):
     """Estimate the Fiedler vector using the reverse Cuthill-McKee ordering."""
-    import numpy as np
-
     G = G.subgraph(nodelist)
     order = reverse_cuthill_mckee_ordering(G)
     n = len(nodelist)
@@ -175,8 +169,6 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         As this is for Fiedler vectors, the zero eigenvalue (and
         constant eigenvector) are avoided.
     """
-    import numpy as np
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
     import scipy.linalg.blas  # call as sp.linalg.blas
     import scipy.sparse  # call as sp.sparse
@@ -254,8 +246,6 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
 
 def _get_fiedler_func(method):
     """Returns a function that solves the Fiedler eigenvalue problem."""
-    import numpy as np
-
     if method == "tracemin":  # old style keyword <v2.1
         method = "tracemin_pcg"
     if method in ("tracemin_pcg", "tracemin_lu"):
@@ -269,7 +259,6 @@ def _get_fiedler_func(method):
     elif method == "lanczos" or method == "lobpcg":
 
         def find_fiedler(L, x, normalized, tol, seed):
-            import scipy as sp
             import scipy.sparse  # call as sp.sparse
             import scipy.sparse.linalg  # call as sp.sparse.linalg
 
@@ -458,8 +447,6 @@ def fiedler_vector(
     --------
     laplacian_matrix
     """
-    import numpy as np
-
     if len(G) < 2:
         raise nx.NetworkXError("graph has less than two nodes.")
     G = _preprocess_graph(G, weight)

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -9,6 +9,9 @@ from networkx.utils import np_random_state
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.linalg.blas = nx.lazy_import("scipy.linalg.blas")
+sp.sparse.linalg = nx.lazy_import("scipy.sparse.linalg")  # call as sp.sparse.linalg
+
 
 __all__ = ["algebraic_connectivity", "fiedler_vector", "spectral_ordering"]
 
@@ -42,8 +45,6 @@ class _PCGSolver:
         return X
 
     def _solve(self, b, tol):
-        import scipy.linalg.blas  # call as sp.linalg.blas
-
         A = self._A
         M = self._M
         tol *= sp.linalg.blas.dasum(b)
@@ -79,8 +80,6 @@ class _LUSolver:
     """
 
     def __init__(self, A):
-        import scipy.sparse.linalg  # call as sp.sparse.linalg
-
         self._LU = sp.sparse.linalg.splu(
             A,
             permc_spec="MMD_AT_PLUS_A",
@@ -169,10 +168,6 @@ def _tracemin_fiedler(L, X, normalized, tol, method):
         As this is for Fiedler vectors, the zero eigenvalue (and
         constant eigenvector) are avoided.
     """
-    import scipy.linalg  # call as sp.linalg
-    import scipy.linalg.blas  # call as sp.linalg.blas
-    import scipy.sparse  # call as sp.sparse
-
     n = X.shape[0]
 
     if normalized:
@@ -259,9 +254,6 @@ def _get_fiedler_func(method):
     elif method == "lanczos" or method == "lobpcg":
 
         def find_fiedler(L, x, normalized, tol, seed):
-            import scipy.sparse  # call as sp.sparse
-            import scipy.sparse.linalg  # call as sp.sparse.linalg
-
             L = sp.sparse.csc_array(L, dtype=float)
             n = L.shape[0]
             if normalized:

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -7,8 +7,8 @@ from networkx.utils import not_implemented_for
 from networkx.utils import reverse_cuthill_mckee_ordering
 from networkx.utils import np_random_state
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["algebraic_connectivity", "fiedler_vector", "spectral_ordering"]
 

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -5,6 +5,8 @@ import networkx as nx
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
+
 
 __all__ = ["attr_matrix", "attr_sparse_matrix"]
 
@@ -427,8 +429,6 @@ def attr_sparse_matrix(
         (blue, blue) is 0   # there are no edges with blue endpoints
 
     """
-    import scipy.sparse  # call as sp.sparse
-
     edge_value = _edge_value(G, edge_attr)
     node_value = _node_value(G, node_attr)
 

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -1,6 +1,10 @@
 """
     Functions for constructing matrix-like objects from graph attributes.
 """
+import networkx.lazy_imports as lazy
+
+np = lazy.load("numpy")
+sp = lazy.load("scipy")
 
 __all__ = ["attr_matrix", "attr_sparse_matrix"]
 
@@ -267,8 +271,6 @@ def attr_matrix(
         (blue, blue) is 0   # there are no edges with blue endpoints
 
     """
-    import numpy as np
-
     edge_value = _edge_value(G, edge_attr)
     node_value = _node_value(G, node_attr)
 
@@ -425,8 +427,6 @@ def attr_sparse_matrix(
         (blue, blue) is 0   # there are no edges with blue endpoints
 
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     edge_value = _edge_value(G, edge_attr)

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -1,10 +1,10 @@
 """
     Functions for constructing matrix-like objects from graph attributes.
 """
-import networkx.lazy_imports as lazy
+import networkx as nx
 
-np = lazy.load("numpy")
-sp = lazy.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["attr_matrix", "attr_sparse_matrix"]
 

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -2,7 +2,7 @@
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-sp = nx.lazy_imports.load("scipy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["bethe_hessian_matrix"]
 

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -2,6 +2,8 @@
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["bethe_hessian_matrix"]
 
 
@@ -60,7 +62,6 @@ def bethe_hessian_matrix(G, r=None, nodelist=None):
        "Estimating the number of communities in networks by spectral methods"
        arXiv:1507.00827, 2015.
     """
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     if nodelist is None:

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -3,6 +3,8 @@ import networkx as nx
 from networkx.utils import not_implemented_for
 
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
+
 
 __all__ = ["bethe_hessian_matrix"]
 
@@ -62,8 +64,6 @@ def bethe_hessian_matrix(G, r=None, nodelist=None):
        "Estimating the number of communities in networks by spectral methods"
        arXiv:1507.00827, 2015.
     """
-    import scipy.sparse  # call as sp.sparse
-
     if nodelist is None:
         nodelist = list(G)
     if r is None:

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -3,7 +3,7 @@ Adjacency matrix and incidence matrix of graphs.
 """
 import networkx as nx
 
-sp = nx.lazy_imports.load("scipy")
+sp = nx.lazy_import("scipy")
 
 __all__ = ["incidence_matrix", "adj_matrix", "adjacency_matrix"]
 

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -4,6 +4,7 @@ Adjacency matrix and incidence matrix of graphs.
 import networkx as nx
 
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")  # call as sp.sparse
 
 __all__ = ["incidence_matrix", "adj_matrix", "adjacency_matrix"]
 
@@ -58,8 +59,6 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
     .. [1] Gil Strang, Network applications: A = incidence matrix,
        http://videolectures.net/mit18085f07_strang_lec03/
     """
-    import scipy.sparse  # call as sp.sparse
-
     if nodelist is None:
         nodelist = list(G)
     if edgelist is None:

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -3,6 +3,8 @@ Adjacency matrix and incidence matrix of graphs.
 """
 import networkx as nx
 
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = ["incidence_matrix", "adj_matrix", "adjacency_matrix"]
 
 
@@ -56,7 +58,6 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
     .. [1] Gil Strang, Network applications: A = incidence matrix,
        http://videolectures.net/mit18085f07_strang_lec03/
     """
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     if nodelist is None:

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -3,6 +3,9 @@
 import networkx as nx
 from networkx.utils import not_implemented_for
 
+np = nx.lazy_imports.load("numpy")
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = [
     "laplacian_matrix",
     "normalized_laplacian_matrix",
@@ -46,7 +49,6 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
     normalized_laplacian_matrix
     laplacian_spectrum
     """
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     if nodelist is None:
@@ -118,8 +120,6 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
        Laplacian, Electronic Journal of Linear Algebra, Volume 16, pp. 90-98,
        March 2007.
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     if nodelist is None:
@@ -211,8 +211,6 @@ def directed_laplacian_matrix(
        Laplacians and the Cheeger inequality for directed graphs.
        Annals of Combinatorics, 9(1), 2005
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
     import scipy.sparse.linalg  # call as sp.sparse.linalg
 
@@ -307,7 +305,6 @@ def directed_combinatorial_laplacian_matrix(
        Laplacians and the Cheeger inequality for directed graphs.
        Annals of Combinatorics, 9(1), 2005
     """
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
     import scipy.sparse.linalg  # call as sp.sparse.linalg
 
@@ -375,8 +372,6 @@ def _transition_matrix(G, nodelist=None, weight="weight", walk_type=None, alpha=
     NetworkXError
         If walk_type not specified or alpha not in valid range
     """
-    import numpy as np
-    import scipy as sp
     import scipy.sparse  # call as sp.sparse
 
     if walk_type is None:

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -3,8 +3,8 @@
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-np = nx.lazy_imports.load("numpy")
-sp = nx.lazy_imports.load("scipy")
+np = nx.lazy_import("numpy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "laplacian_matrix",

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -5,6 +5,9 @@ from networkx.utils import not_implemented_for
 
 np = nx.lazy_import("numpy")
 sp = nx.lazy_import("scipy")
+sp.sparse = nx.lazy_import("scipy.sparse")
+sp.sparse.linalg = nx.lazy_import("scipy.sparse.linalg")
+
 
 __all__ = [
     "laplacian_matrix",
@@ -49,8 +52,6 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
     normalized_laplacian_matrix
     laplacian_spectrum
     """
-    import scipy.sparse  # call as sp.sparse
-
     if nodelist is None:
         nodelist = list(G)
     A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, format="csr")
@@ -120,8 +121,6 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
        Laplacian, Electronic Journal of Linear Algebra, Volume 16, pp. 90-98,
        March 2007.
     """
-    import scipy.sparse  # call as sp.sparse
-
     if nodelist is None:
         nodelist = list(G)
     A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, format="csr")
@@ -211,9 +210,6 @@ def directed_laplacian_matrix(
        Laplacians and the Cheeger inequality for directed graphs.
        Annals of Combinatorics, 9(1), 2005
     """
-    import scipy.sparse  # call as sp.sparse
-    import scipy.sparse.linalg  # call as sp.sparse.linalg
-
     # NOTE: P has type ndarray if walk_type=="pagerank", else csr_array
     P = _transition_matrix(
         G, nodelist=nodelist, weight=weight, walk_type=walk_type, alpha=alpha
@@ -305,9 +301,6 @@ def directed_combinatorial_laplacian_matrix(
        Laplacians and the Cheeger inequality for directed graphs.
        Annals of Combinatorics, 9(1), 2005
     """
-    import scipy.sparse  # call as sp.sparse
-    import scipy.sparse.linalg  # call as sp.sparse.linalg
-
     P = _transition_matrix(
         G, nodelist=nodelist, weight=weight, walk_type=walk_type, alpha=alpha
     )
@@ -329,8 +322,6 @@ def directed_combinatorial_laplacian_matrix(
         stacklevel=2,
     )
     # TODO: Rm np.asmatrix for networkx 3.0
-    import numpy as np
-
     return np.asmatrix(Phi - (Phi @ P + P.T @ Phi) / 2.0)
 
 
@@ -372,8 +363,6 @@ def _transition_matrix(G, nodelist=None, weight="weight", walk_type=None, alpha=
     NetworkXError
         If walk_type not specified or alpha not in valid range
     """
-    import scipy.sparse  # call as sp.sparse
-
     if walk_type is None:
         if nx.is_strongly_connected(G):
             if nx.is_aperiodic(G):

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -3,7 +3,7 @@ Eigenvalue spectrum of graphs.
 """
 import networkx as nx
 
-sp = nx.lazy_imports.load("scipy")
+sp = nx.lazy_import("scipy")
 
 __all__ = [
     "laplacian_spectrum",

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -3,6 +3,8 @@ Eigenvalue spectrum of graphs.
 """
 import networkx as nx
 
+sp = nx.lazy_imports.load("scipy")
+
 __all__ = [
     "laplacian_spectrum",
     "adjacency_spectrum",
@@ -38,7 +40,6 @@ def laplacian_spectrum(G, weight="weight"):
     --------
     laplacian_matrix
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     return sp.linalg.eigvalsh(nx.laplacian_matrix(G, weight=weight).todense())
@@ -70,7 +71,6 @@ def normalized_laplacian_spectrum(G, weight="weight"):
     --------
     normalized_laplacian_matrix
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     return sp.linalg.eigvalsh(
@@ -104,7 +104,6 @@ def adjacency_spectrum(G, weight="weight"):
     --------
     adjacency_matrix
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     return sp.linalg.eigvals(nx.adjacency_matrix(G, weight=weight).todense())
@@ -132,7 +131,6 @@ def modularity_spectrum(G):
     .. [1] M. E. J. Newman, "Modularity and community structure in networks",
        Proc. Natl. Acad. Sci. USA, vol. 103, pp. 8577-8582, 2006.
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     if G.is_directed():
@@ -167,7 +165,6 @@ def bethe_hessian_spectrum(G, r=None):
        "Spectral clustering of graphs with the bethe hessian",
        Advances in Neural Information Processing Systems. 2014.
     """
-    import scipy as sp
     import scipy.linalg  # call as sp.linalg
 
     return sp.linalg.eigvalsh(nx.bethe_hessian_matrix(G, r).todense())

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -18,7 +18,7 @@ class TestConvertPandas:
         self.df = df
 
         mdf = pd.DataFrame([[4, 16, "A", "D"]], columns=["weight", "cost", 0, "b"])
-        self.mdf = df.append(mdf)
+        self.mdf = pd.concat([df, mdf])
 
     def test_exceptions(self):
         G = pd.DataFrame(["a"])  # adj

--- a/networkx/tests/test_lazy_imports.py
+++ b/networkx/tests/test_lazy_imports.py
@@ -48,6 +48,28 @@ def test_lazy_import_impact_on_sys_modules():
     assert "numpy" in sys.modules
 
 
+def test_lazy_import_subpackages():
+    sp = lazy.lazy_import("scipy")
+    sp.sparse = lazy.lazy_import("scipy.sparse")
+    if isinstance(sp, lazy.DelayedImportErrorModule):
+        try:
+            sp.sparse.diags
+            assert False
+        except ModuleNotFoundError:
+            pass
+    else:
+        sp.sparse.diags
+
+    anything_not_real = lazy.lazy_import("anything_not_real")
+    anything_not_real.subpkg = lazy.lazy_import("anything_not_real.subpkg")
+    assert type(anything_not_real) == lazy.DelayedImportErrorModule
+    try:
+        anything_not_real.subpkg
+        assert False
+    except ModuleNotFoundError:
+        pass
+
+
 def test_lazy_import_nonbuiltins():
     sp = lazy.lazy_import("scipy")
     np = lazy.lazy_import("numpy")


### PR DESCRIPTION
This PR changes the idiom `import numpy as np` within each function by moving it to the top of the module and using `np = nx.lazy_import("numpy")`, with similar treatment for the other libraries.

Another PR will change the NetworkX loading process to ensure lazy loading of all internal packages (subpackages).