### PR TITLE
Deprecate `make_small_graph` and `make_small_undirected_graph`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -101,3 +101,5 @@ Version 3.0
   the associated FutureWarning.
 * In ``networkx/convert_matrix.py`` remove ``from_scipy_sparse_matrix`` and
   ``to_scipy_sparse_matrix``.
+* In ``networkx/generators/small.py`` remove ``make_small_graph`` and
+  ``make_small_undirected_graph``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -62,6 +62,9 @@ Deprecations
 - [`#5262 <https://github.com/networkx/networkx/pull/5262>`_]
   Deprecate ``to_scipy_sparse_matrix`` and ``from_scipy_sparse_matrix`` in
   favor of ``to_scipy_sparse_array`` and ``from_scipy_sparse_array``, respectively.
+- [`#5283 <https://github.com/networkx/networkx/pull/5283>`_]
+  Deprecate ``make_small_graph`` and ``make_small_undirected_graph`` from the
+  ``networkx.generators.small`` module.
 
 
 Merged PRs

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -225,6 +225,9 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\nfind_cores"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message=r"\n\nmake_small_.*"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -63,8 +63,26 @@ def make_small_undirected_graph(graph_description, create_using=None):
     """
     Return a small undirected graph described by graph_description.
 
+    .. deprecated:: 2.7
+
+       make_small_undirected_graph is deprecated and will be removed in
+       version 3.0. If "ltype" == "adjacencylist", convert the list to a dict
+       and use `from_dict_of_lists`. If "ltype" == "edgelist", use
+       `from_edgelist`.
+
     See make_small_graph.
     """
+    import warnings
+
+    msg = (
+        "\n\nmake_small_undirected_graph is deprecated and will be removed in "
+        "version 3.0.\n"
+        "If `ltype` == 'adjacencylist', convert `xlist` to a dict and use\n"
+        "`from_dict_of_lists` instead.\n"
+        "If `ltype` == 'edgelist', use `from_edgelist` instead."
+    )
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+
     G = empty_graph(0, create_using)
     if G.is_directed():
         raise NetworkXError("Directed Graph not supported")
@@ -74,6 +92,13 @@ def make_small_undirected_graph(graph_description, create_using=None):
 def make_small_graph(graph_description, create_using=None):
     """
     Return the small graph described by graph_description.
+
+    .. deprecated:: 2.7
+
+       make_small_graph is deprecated and will be removed in
+       version 3.0. If "ltype" == "adjacencylist", convert the list to a dict
+       and use `from_dict_of_lists`. If "ltype" == "edgelist", use
+       `from_edgelist`.
 
     graph_description is a list of the form [ltype,name,n,xlist]
 
@@ -105,6 +130,15 @@ def make_small_graph(graph_description, create_using=None):
 
     Use the create_using argument to choose the graph class/type.
     """
+    import warnings
+
+    msg = (
+        "\n\nmake_small_graph is deprecated and will be removed in version 3.0.\n"
+        "If `ltype` == 'adjacencylist', convert `xlist` to a dict and use\n"
+        "`from_dict_of_lists` instead.\n"
+        "If `ltype` == 'edgelist', use `from_edgelist` instead."
+    )
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
     if graph_description[0] not in ("adjacencylist", "edgelist"):
         raise NetworkXError("ltype must be either adjacencylist or edgelist")


### PR DESCRIPTION
Closes #5266.

This PR depends on #5267, so marking as draft until that's in.