### PR TITLE
Fix: Update louvain_partitions for threshold (update mod to new_mod in each level)

### DIFF
--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -185,6 +185,7 @@ def louvain_partitions(
         )
         if new_mod - mod <= threshold:
             return
+        mod = new_mod
         graph = _gen_graph(graph, inner_partition)
         partition, inner_partition, improvement = _one_level(
             graph, m, partition, resolution, is_directed, seed

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -110,3 +110,13 @@ def test_resolution():
     partition3 = louvain_communities(G, resolution=2, seed=12)
 
     assert len(partition1) <= len(partition2) <= len(partition3)
+
+def test_threshold():
+    G = nx.LFR_benchmark_graph(
+        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
+    )
+    partition = louvain_communities(G, threshold=0.2, seed=2)
+    mod = modularity(G, partition)
+
+    assert mod < 0.512
+

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -111,12 +111,14 @@ def test_resolution():
 
     assert len(partition1) <= len(partition2) <= len(partition3)
 
+
 def test_threshold():
     G = nx.LFR_benchmark_graph(
         250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
     )
-    partition = louvain_communities(G, threshold=0.2, seed=2)
-    mod = modularity(G, partition)
+    partition1 = louvain_communities(G, threshold=0.2, seed=2)
+    partition2 = louvain_communities(G, seed=2)
+    mod1 = modularity(G, partition1)
+    mod2 = modularity(G, partition2)
 
-    assert mod < 0.512
-
+    assert mod1 < 0.512 < mod2

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -121,4 +121,4 @@ def test_threshold():
     mod1 = modularity(G, partition1)
     mod2 = modularity(G, partition2)
 
-    assert mod1 < 0.512 < mod2
+    assert mod1 < mod2


### PR DESCRIPTION
Currently `threshold` in `louvain_partitions` does not work. This is because `mod` in the while loop (lines 181-191) is not updated since it is initialized with the modularity of the first partition (where each node is in a community that only has the node).