### PR TITLE
Add exception for unconnected graph

### DIFF
--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -35,6 +35,11 @@ def test_exceptions():
     with pytest.raises(TypeError, match="is not directed."):
         G = nx.path_graph(3)
         tree_data(G, 0)
+    with pytest.raises(TypeError, match="is not weakly connected."):
+        G = nx.path_graph(3, create_using=nx.DiGraph)
+        G.add_edge(2, 0)
+        G.add_node(3)
+        tree_data(G, 0)
     with pytest.raises(nx.NetworkXError, match="must be different."):
         G = nx.MultiDiGraph()
         G.add_node(0)

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -75,6 +75,8 @@ def tree_data(G, root, attrs=None, ident="id", children="children"):
         raise TypeError("G is not a tree.")
     if not G.is_directed():
         raise TypeError("G is not directed.")
+    if not nx.is_weakly_connected(G):
+        raise TypeError("G is not weakly connected.")
 
     # NOTE: to be removed in 3.0
     if attrs is not None:


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
Closes #5286.

This PR checks if the Graph is weakly connected to avoid the recursion error described in #5286 
Alternatively the issue could be solved by checking for cycles like this:
```Python3
try:
    nx.find_cycles(G, source=root)
    raise TypeError("G contains cycles")
except nx.NetworkXNoCycle:
    pass
```
but since it doesn't really make sense to create a tree from a graph that isn't connected I feel the `is_weakly_connected` choice is better.