### PR TITLE
Fixing Tarjan's strongly connected components algorithm implementation to have O(|E|+|V|) time complexity instead of O(|E|^2/V)

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -75,6 +75,7 @@ def strongly_connected_components(G):
     scc_found = set()
     scc_queue = []
     i = 0  # Preorder counter
+    neighbors = {v: iter(G[v]) for v in G}
     for source in G:
         if source not in scc_found:
             queue = [source]
@@ -84,7 +85,7 @@ def strongly_connected_components(G):
                     i = i + 1
                     preorder[v] = i
                 done = True
-                for w in G[v]:
+                for w in neighbors[v]:
                     if w not in preorder:
                         queue.append(w)
                         done = False


### PR DESCRIPTION
### The issue
The previous implementation traversed the same edges multiple times harming the overall time complexity of the algorithm.
This is because if we look at the following lines in current implementation:
```
for w in neighbors[v]:
    if w not in preorder:
```
the for loop is executed once for each neighbor of `v`, and therefor the if statement is executed a quadratic number of time per vertex (quadratic in the amount of neighbors). This can lead to cubical complexity with respect to the nodes in the worst case. Moreover, it can be proven that the complexity is `O(E^2/V)` which can be cubical on the vertices as long as the amount of edges is quadratical with respect to the amount of nodes (See complexity proof below).

### The change
In order to avoid traversing the same neighbors every time, we can store a neighbor iterator per vertex instead of iterating the list from the beginning every time. The change consists in only two lines:

```
neighbors = {v: iter(G[v]) for v in G}
...
for w in neighbors[v]:
```

### Testing

I did a couple of experiments to test the running time in practise, for example:
```
>> G = fast_gnp_random_graph(100, 0.01, directed=1)
>> len(G)
100
>> len(G.edges) # not really dense
101
>> l1 = list(strongly_connected_components(G))
>> l2 = list(strongly_connected_components2(G))
>> l1 == l2
True
>> len(l1) # many components, almost single node components
92
>>import time
  def test_scc(f):
       s = time.time()
       list(f(G))
       e = time.time()
       return e - s
>> sum(test_scc(strongly_connected_components) for _ in range(100000))
31.160969018936157
>> sum(test_scc(strongly_connected_components2) for _ in range(100000)) # 20% faster
25.84955143928528
```

### Complexity proof
![image](https://user-images.githubusercontent.com/13503925/151702228-e1c9bb22-9be0-458c-be9b-e61fb4660423.png)
(https://docs.google.com/document/d/168EXjtMR8ge3Z-cfdl8X9HxESHsgBmAJDVicUZ7q_5o)