### PR TITLE
Add weight to eccentricity

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -212,7 +212,7 @@ def extrema_bounding(G, compute="diameter"):
     return None
 
 
-def eccentricity(G, v=None, sp=None):
+def eccentricity(G, v=None, sp=None, weight=None):
     """Returns the eccentricity of nodes in G.
 
     The eccentricity of a node v is the maximum distance from v to
@@ -228,6 +228,9 @@ def eccentricity(G, v=None, sp=None):
 
     sp : dict of dicts, optional
        All pairs shortest path lengths as a dictionary of dictionaries
+    
+    weight : string, optional
+       Edge data key corresponding to the edge weight.
 
     Returns
     -------
@@ -245,7 +248,10 @@ def eccentricity(G, v=None, sp=None):
     e = {}
     for n in G.nbunch_iter(v):
         if sp is None:
-            length = nx.single_source_shortest_path_length(G, n)
+            if weight is None:
+                length = nx.single_source_shortest_path_length(G, n)
+            else:
+                length=nx.single_source_bellman_ford_path_length(G, n, weight)
             L = len(length)
         else:
             try:


### PR DESCRIPTION
## Motivation
As talked about in issue #5257 we want distance measurements to work for weighted graphs too. This is a draft I am working on.

## Explanation
Most distance measurements in `distance_measures.py` rely on the `eccentricity` method and the `extrema_bounding` method. Thus, the key is to incorporate weights into these methods. I have currently added weights to `eccentricity`. 

## Considerations

- Currently, I am using Bellman Ford for calculating weighted shortest paths to allow negative weights. Do we want to allow negative weights?
- The `weight` argument should be a string as the Bellman Ford method requires a string. However, if I am not mistaken, it can also take a weight function, as Dijkstras method implementation can, but this is not documented
- There is not much type checking happening for weights anywhere, should we incorporate it? If so, can someone explain or send me a link to read on how NetworkXErrors work?

## Plan
I want to get weights working for `eccentricity `first, and then add that to all the functions that use `eccentricity`. Afterwards, I will work on `extrema_bounding`