### PR TITLE
Update gml exporter to allow set property values

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -729,7 +729,7 @@ def generate_gml(G, stringizer=None):
                     yield from stringize(key, value, (), next_indent)
                 yield indent + "]"
             elif (
-                isinstance(value, (list, tuple))
+                isinstance(value, (list, tuple, set))
                 and key != "label"
                 and value
                 and not in_list


### PR DESCRIPTION
I was trying to export my graph to the gml format using `write_gml`. My node properties are using sets in their values so I was faced with the error:
```
File "/home/johannes/env/thesis/lib/python3.9/site-packages/networkx/readwrite/gml.py", line 745, in stringize
    raise NetworkXError(f"{value!r} is not a string")
networkx.exception.NetworkXError: {'e2', 'e23', 'e5', 'e17', 'e1'} is not a string
```
This small change fixes this issue. The importer then imports these as lists, however I do not think it can be implemented to convert to sets on import using the gml format. I am OK with this small issue as I can turn the property values back into sets after import.

Let me know if this is ok. It would make my life much easier.

Thanks for the awesome project :-)