### PR TITLE
Add FutureWarning to `attr_matrix` to notify users of return type change

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -101,3 +101,6 @@ Version 3.0
   the associated FutureWarning.
 * In ``networkx/convert_matrix.py`` remove ``from_scipy_sparse_matrix`` and
   ``to_scipy_sparse_matrix``.
+* In ``networkx/linalg/attrmatrix.py`` remove the FutureWarning, update the
+  return type by removing ``np.asmatrix``, and update the docstring to
+  reflect that the function returns a ``numpy.ndarray`` instance.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -44,9 +44,12 @@ API Changes
   `~networkx.drawing.layout.rescale_layout_dict` are now `numpy.ndarray` objects
   instead of tuples. This makes the return type of ``rescale_layout_dict``
   consistent with that of all of the other layout functions.
-- A ``FutureWarning`` has been added to ``google_matrix`` to indicated that the
+- A ``FutureWarning`` has been added to ``google_matrix`` to indicate that the
   return type will change from a ``numpy.matrix`` object to a ``numpy.ndarray``
   in NetworkX 3.0.
+- A ``FutureWarning`` has been added to ``attr_matrix`` to indicate that the
+  return type will change from a ``numpy.matrix`` object to a ``numpy.ndarray``
+  object in NetworkX 3.0.
 
 Deprecations
 ------------

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -225,6 +225,7 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\nfind_cores"
     )
+    warnings.filterwarnings("ignore", category=FutureWarning, message="attr_matrix")
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -298,6 +298,17 @@ def attr_matrix(
     if normalized:
         M /= M.sum(axis=1).reshape((N, 1))
 
+    import warnings
+
+    warnings.warn(
+        (
+            "attr_matrix will return an numpy.ndarray instead of a numpy.matrix "
+            "in NetworkX 3.0."
+        ),
+        category=FutureWarning,
+        stacklevel=2,
+    )
+    # TODO: Remove asmatrix in NetworkX 3.0
     M = np.asmatrix(M)
 
     if rc_order is None:


### PR DESCRIPTION
The `attr_matrix` function currently returns a `numpy.matrix`. One of the goals for NetworkX 3.0 is to remove uses of `numpy.matrix` in favor of array semantics, so this PR adds a `FutureWarning` that the return type will change from `np.matrix` to `np.ndarray` in NetworkX 3.0.

Another option would be to return a `scipy.sparse` array object (and then deprecate the `attr_sparse_matrix` function - see #5195 ). Either way, I think we definitely want to remove the usage of `np.matrix`.