### PR TITLE
MAINT: Cleanup assortativity module, remove unused variables

### DIFF
--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 import networkx as nx
 
 __all__ = ["average_degree_connectivity", "k_nearest_neighbors"]

--- a/networkx/algorithms/assortativity/connectivity.py
+++ b/networkx/algorithms/assortativity/connectivity.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import networkx as nx
 
 __all__ = ["average_degree_connectivity", "k_nearest_neighbors"]
 
@@ -46,9 +47,10 @@ def average_degree_connectivity(
 
     Raises
     ------
-    ValueError
+    NetworkXError
         If either `source` or `target` are not one of 'in',
         'out', or 'in+out'.
+        If either `source` or `target` is passed for an undirected graph.
 
     Examples
     --------
@@ -72,9 +74,9 @@ def average_degree_connectivity(
     # First, determine the type of neighbors and the type of degree to use.
     if G.is_directed():
         if source not in ("in", "out", "in+out"):
-            raise ValueError('source must be one of "in", "out", or "in+out"')
+            raise nx.NetworkXError('source must be one of "in", "out", or "in+out"')
         if target not in ("in", "out", "in+out"):
-            raise ValueError('target must be one of "in", "out", or "in+out"')
+            raise nx.NetworkXError('target must be one of "in", "out", or "in+out"')
         direction = {"out": G.out_degree, "in": G.in_degree, "in+out": G.degree}
         neighbor_funcs = {
             "out": G.successors,
@@ -88,6 +90,10 @@ def average_degree_connectivity(
         # computing the weight of an edge.
         reverse = source == "in"
     else:
+        if source != "in+out" or target != "in+out":
+            raise nx.NetworkXError(
+                f"source and target arguments are only supported for directed graphs"
+            )
         source_degree = G.degree
         target_degree = G.degree
         neighbors = G.neighbors

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -1,8 +1,8 @@
 """Node assortativity coefficients and correlation measures.
 """
 from networkx.algorithms.assortativity.mixing import (
-    degree_mixing_matrix,
     attribute_mixing_matrix,
+    degree_mixing_matrix,
 )
 from networkx.algorithms.assortativity.pairs import node_degree_xy
 

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -149,11 +149,12 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
-    import scipy.stats
+    import scipy as sp
+    import scipy.stats  # call as sp.stats
 
     xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
     x, y = zip(*xy)
-    return scipy.stats.pearsonr(x, y)[0]
+    return sp.stats.pearsonr(x, y)[0]
 
 
 def attribute_assortativity_coefficient(G, attribute, nodes=None):

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -3,7 +3,6 @@
 from networkx.algorithms.assortativity.mixing import (
     degree_mixing_matrix,
     attribute_mixing_matrix,
-    numeric_mixing_matrix,
 )
 from networkx.algorithms.assortativity.pairs import node_degree_xy
 
@@ -96,7 +95,7 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     mapping = {d: i for i, d, in enumerate(degrees)}
     M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight, mapping=mapping)
 
-    return numeric_ac(M, mapping=mapping)
+    return _numeric_ac(M, mapping=mapping)
 
 
 def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, nodes=None):
@@ -150,12 +149,11 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
        Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
     """
-    import scipy as sp
-    import scipy.stats  # call as sp.stats
+    import scipy.stats
 
     xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
     x, y = zip(*xy)
-    return sp.stats.pearsonr(x, y)[0]
+    return scipy.stats.pearsonr(x, y)[0]
 
 
 def attribute_assortativity_coefficient(G, attribute, nodes=None):
@@ -250,7 +248,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     vals = {G.nodes[n][attribute] for n in nodes}
     mapping = {d: i for i, d, in enumerate(vals)}
     M = attribute_mixing_matrix(G, attribute, nodes, mapping)
-    return numeric_ac(M, mapping)
+    return _numeric_ac(M, mapping)
 
 
 def attribute_ac(M):
@@ -280,14 +278,13 @@ def attribute_ac(M):
     return r
 
 
-def numeric_ac(M, mapping):
+def _numeric_ac(M, mapping):
     # M is a numpy matrix or array
     # numeric assortativity coefficient, pearsonr
     import numpy as np
 
     if M.sum() != 1.0:
         M = M / float(M.sum())
-    nx, ny = M.shape  # nx=ny
     x = np.array(list(mapping.keys()))
     y = x  # x and y have the same support
     idx = list(mapping.values())

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -1,8 +1,8 @@
 """
 Mixing matrices for node attributes and degree.
 """
+from networkx.algorithms.assortativity.pairs import node_attribute_xy, node_degree_xy
 from networkx.utils import dict_to_numpy_array
-from networkx.algorithms.assortativity.pairs import node_degree_xy, node_attribute_xy
 
 __all__ = [
     "attribute_mixing_matrix",

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -292,7 +292,7 @@ def mixing_dict(xy, normalized=False):
         psum += 1
 
     if normalized:
-        for k, jdict in d.items():
+        for _, jdict in d.items():
             for j in jdict:
                 jdict[j] /= psum
     return d

--- a/networkx/algorithms/assortativity/neighbor_degree.py
+++ b/networkx/algorithms/assortativity/neighbor_degree.py
@@ -1,3 +1,5 @@
+import networkx as nx
+
 __all__ = ["average_neighbor_degree"]
 
 
@@ -48,6 +50,13 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
     d: dict
        A dictionary keyed by node with average neighbors degree value.
 
+    Raises
+    ------
+    NetworkXError
+        If either `source` or `target` are not one of 'in',
+        'out', or 'in+out'.
+        If either `source` or `target` is passed for an undirected graph.
+
     Examples
     --------
     >>> G = nx.path_graph(4)
@@ -82,14 +91,14 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
        "The architecture of complex weighted networks".
        PNAS 101 (11): 3747–3752 (2004).
     """
-    source_degree = G.degree
-    target_degree = G.degree
     if G.is_directed():
         if source == "in":
             source_degree = G.in_degree
         elif source == "out":
             source_degree = G.out_degree
-        elif source != "in+out":
+        elif source == "in+out":
+            source_degree = G.degree
+        else:
             raise nx.NetworkXError(
                 f"source argument {source} must be 'in', 'out' or 'in+out'"
             )
@@ -98,10 +107,19 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
             target_degree = G.in_degree
         elif target == "out":
             target_degree = G.out_degree
-        elif target != "in+out":
+        elif target == "in+out":
+            target_degree = G.degree
+        else:
             raise nx.NetworkXError(
                 f"target argument {target} must be 'in', 'out' or 'in+out'"
             )
+    else:
+        if source != "out" or target != "out":
+            raise nx.NetworkXError(
+                f"source and target arguments are only supported for directed graphs"
+            )
+        source_degree = G.degree
+        target_degree = G.degree
 
     # precompute target degrees -- should *not* be weighted degree
     tgt_deg = dict(target_degree())

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -48,7 +48,7 @@ def node_attribute_xy(G, attribute, nodes=None):
         if G.is_multigraph():
             for v, keys in nbrsdict.items():
                 vattr = Gnodes[v].get(attribute, None)
-                for _ in range(len(keys)):
+                for _ in keys:
                     yield (uattr, vattr)
         else:
             for v in nbrsdict:

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -48,10 +48,10 @@ def node_attribute_xy(G, attribute, nodes=None):
         if G.is_multigraph():
             for v, keys in nbrsdict.items():
                 vattr = Gnodes[v].get(attribute, None)
-                for k, d in keys.items():
+                for _ in range(len(keys)):
                     yield (uattr, vattr)
         else:
-            for v, eattr in nbrsdict.items():
+            for v in nbrsdict:
                 vattr = Gnodes[v].get(attribute, None)
                 yield (uattr, vattr)
 
@@ -99,10 +99,7 @@ def node_degree_xy(G, x="out", y="in", weight=None, nodes=None):
     representation (u, v) and (v, u), with the exception of self-loop edges
     which only appear once.
     """
-    if nodes is None:
-        nodes = set(G)
-    else:
-        nodes = set(nodes)
+    nodes = set(G) if nodes is None else set(nodes)
     if G.is_directed():
         direction = {"out": G.out_degree, "in": G.in_degree}
         xdeg = direction[x]
@@ -113,5 +110,5 @@ def node_degree_xy(G, x="out", y="in", weight=None, nodes=None):
     for u, degu in xdeg(nodes, weight=weight):
         # use G.edges to treat multigraphs correctly
         neighbors = (nbr for _, nbr in G.edges(u) if nbr in nodes)
-        for v, degv in ydeg(neighbors, weight=weight):
+        for _, degv in ydeg(neighbors, weight=weight):
             yield degu, degv

--- a/networkx/algorithms/assortativity/tests/test_connectivity.py
+++ b/networkx/algorithms/assortativity/tests/test_connectivity.py
@@ -120,14 +120,21 @@ class TestNeighborConnectivity:
             assert c == cw
 
     def test_invalid_source(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(nx.NetworkXError):
             G = nx.DiGraph()
             nx.average_degree_connectivity(G, source="bogus")
 
     def test_invalid_target(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(nx.NetworkXError):
             G = nx.DiGraph()
             nx.average_degree_connectivity(G, target="bogus")
+
+    def test_invalid_undirected_graph(self):
+        G = nx.Graph()
+        with pytest.raises(nx.NetworkXError):
+            nx.average_degree_connectivity(G, target="bogus")
+        with pytest.raises(nx.NetworkXError):
+            nx.average_degree_connectivity(G, source="bogus")
 
     def test_single_node(self):
         # TODO Is this really the intended behavior for providing a

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -5,12 +5,13 @@ pytest.importorskip("scipy")
 
 
 import networkx as nx
+from networkx.algorithms.assortativity.correlation import attribute_ac
+
 from .base_test import (
     BaseTestAttributeMixing,
     BaseTestDegreeMixing,
     BaseTestNumericMixing,
 )
-from networkx.algorithms.assortativity.correlation import attribute_ac
 
 
 class TestDegreeMixingCorrelation(BaseTestDegreeMixing):

--- a/networkx/algorithms/assortativity/tests/test_mixing.py
+++ b/networkx/algorithms/assortativity/tests/test_mixing.py
@@ -36,6 +36,7 @@ class TestDegreeMixingDict(BaseTestDegreeMixing):
     def test_degree_mixing_dict_weighted(self):
         d = nx.degree_mixing_dict(self.W, weight="weight")
         d_result = {0.5: {1.5: 1}, 1.5: {1.5: 6, 0.5: 1}}
+        assert d == d_result
 
 
 class TestDegreeMixingMatrix(BaseTestDegreeMixing):

--- a/networkx/algorithms/assortativity/tests/test_mixing.py
+++ b/networkx/algorithms/assortativity/tests/test_mixing.py
@@ -4,6 +4,7 @@ np = pytest.importorskip("numpy")
 
 
 import networkx as nx
+
 from .base_test import (
     BaseTestAttributeMixing,
     BaseTestDegreeMixing,

--- a/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
+++ b/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
+++ b/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
@@ -89,3 +89,15 @@ class TestAverageNeighbor:
         assert nd == 1.8
         nd = nx.average_neighbor_degree(G, weight="weight")[5]
         assert nd == pytest.approx(3.222222, abs=1e-5)
+
+    def test_error_invalid_source_target(self):
+        G = nx.path_graph(4)
+        with pytest.raises(nx.NetworkXError):
+            nx.average_neighbor_degree(G, "error")
+        with pytest.raises(nx.NetworkXError):
+            nx.average_neighbor_degree(G, "in", "error")
+        G = G.to_directed()
+        with pytest.raises(nx.NetworkXError):
+            nx.average_neighbor_degree(G, "error")
+        with pytest.raises(nx.NetworkXError):
+            nx.average_neighbor_degree(G, "in", "error")

--- a/networkx/algorithms/assortativity/tests/test_pairs.py
+++ b/networkx/algorithms/assortativity/tests/test_pairs.py
@@ -1,4 +1,5 @@
 import networkx as nx
+
 from .base_test import BaseTestAttributeMixing, BaseTestDegreeMixing
 
 


### PR DESCRIPTION
Raise errors instead of accepting invalid arguments silently

This would also help with less errors for folks using linters locally in their IDEs

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
