### PR TITLE
MAINT: Cleanup link analysis module, remove unused variables

### DIFF
--- a/networkx/algorithms/link_analysis/__init__.py
+++ b/networkx/algorithms/link_analysis/__init__.py
@@ -1,2 +1,2 @@
-from networkx.algorithms.link_analysis.pagerank_alg import *
 from networkx.algorithms.link_analysis.hits_alg import *
+from networkx.algorithms.link_analysis.pagerank_alg import *

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -245,8 +245,9 @@ def hits_numpy(G, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import numpy as np
     import warnings
+
+    import numpy as np
 
     warnings.warn(
         (
@@ -349,8 +350,9 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import numpy as np
     import warnings
+
+    import numpy as np
 
     warnings.warn(
         (

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -78,10 +78,10 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
     A = nx.adjacency_matrix(G, nodelist=list(G), dtype=float)
 
     if nstart is None:
-        u, s, vt = sp.sparse.linalg.svds(A, k=1, maxiter=max_iter, tol=tol)
+        _, _, vt = sp.sparse.linalg.svds(A, k=1, maxiter=max_iter, tol=tol)
     else:
         nstart = np.array(list(nstart.values()))
-        u, s, vt = sp.sparse.linalg.svds(A, k=1, v0=nstart, maxiter=max_iter, tol=tol)
+        _, _, vt = sp.sparse.linalg.svds(A, k=1, v0=nstart, maxiter=max_iter, tol=tol)
 
     a = vt.flatten().real
     h = A @ a
@@ -94,7 +94,7 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
 
 
 def _hits_python(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
-    if type(G) == nx.MultiGraph or type(G) == nx.MultiDiGraph:
+    if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
         raise Exception("hits() not defined for graphs with multiedges.")
     if len(G) == 0:
         return {}, {}
@@ -364,7 +364,7 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
     if len(G) == 0:
         return {}, {}
     A = nx.to_scipy_sparse_array(G, nodelist=list(G))
-    (n, m) = A.shape  # should be square
+    (n, _) = A.shape  # should be square
     ATA = A.T @ A  # authority matrix
     # choose fixed starting vector if not given
     if nstart is None:

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -86,8 +86,8 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
     a = vt.flatten().real
     h = A @ a
     if normalized:
-        h = h / h.sum()
-        a = a / a.sum()
+        h /= h.sum()
+        a /= a.sum()
     hubs = dict(zip(G, map(float, h)))
     authorities = dict(zip(G, map(float, a)))
     return hubs, authorities
@@ -270,11 +270,11 @@ def hits_numpy(G, normalized=True):
     e, ev = np.linalg.eig(A)
     a = ev[:, np.argmax(e)]  # eigenvector corresponding to the maximum eigenvalue
     if normalized:
-        h = h / h.sum()
-        a = a / a.sum()
+        h /= h.sum()
+        a /= a.sum()
     else:
-        h = h / h.max()
-        a = a / a.max()
+        h /= h.max()
+        a /= a.max()
     hubs = dict(zip(G, map(float, h)))
     authorities = dict(zip(G, map(float, a)))
     return hubs, authorities
@@ -373,7 +373,7 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
         x = np.ones((n, 1)) / n
     else:
         x = np.array([nstart.get(n, 0) for n in list(G)], dtype=float)
-        x = x / x.sum()
+        x /= x.sum()
 
     # power iteration on authority matrix
     i = 0
@@ -392,8 +392,8 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
     a = x.flatten()
     h = A @ a
     if normalized:
-        h = h / h.sum()
-        a = a / a.sum()
+        h /= h.sum()
+        a /= a.sum()
     hubs = dict(zip(G, map(float, h)))
     authorities = dict(zip(G, map(float, a)))
     return hubs, authorities

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -123,10 +123,7 @@ def _pagerank_python(
     if len(G) == 0:
         return {}
 
-    if not G.is_directed():
-        D = G.to_directed()
-    else:
-        D = G
+    D = G.to_directed()
 
     # Create a copy in (right) stochastic form
     W = nx.stochastic_graph(D, weight=weight)
@@ -481,7 +478,7 @@ def pagerank_scipy(
         x = np.repeat(1.0 / N, N)
     else:
         x = np.array([nstart.get(n, 0) for n in nodelist], dtype=float)
-        x = x / x.sum()
+        x /= x.sum()
 
     # Personalization vector
     if personalization is None:
@@ -490,7 +487,7 @@ def pagerank_scipy(
         p = np.array([personalization.get(n, 0) for n in nodelist], dtype=float)
         if p.sum() == 0:
             raise ZeroDivisionError
-        p = p / p.sum()
+        p /= p.sum()
     # Dangling nodes
     if dangling is None:
         dangling_weights = p

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,5 +1,6 @@
 """PageRank analysis of graph structure. """
 from warnings import warn
+
 import networkx as nx
 
 __all__ = ["pagerank", "pagerank_numpy", "pagerank_scipy", "google_matrix"]
@@ -231,10 +232,10 @@ def google_matrix(
     --------
     pagerank, pagerank_numpy, pagerank_scipy
     """
-    import numpy as np
-
     # TODO: Remove this warning in version 3.0
     import warnings
+
+    import numpy as np
 
     warnings.warn(
         "google_matrix will return an np.ndarray instead of a np.matrix in\n"

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -85,4 +85,4 @@ def test_deprecation_warnings(hits_alg):
     """
     G = nx.DiGraph(nx.path_graph(4))
     with pytest.warns(DeprecationWarning):
-        pr = hits_alg(G)
+        hits_alg(G)

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 np = pytest.importorskip("numpy")

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -80,7 +80,7 @@ class TestPageRank:
     def test_google_matrix(self):
         G = self.G
         M = nx.google_matrix(G, alpha=0.9, nodelist=sorted(G))
-        e, ev = np.linalg.eig(M.T)
+        _, ev = np.linalg.eig(M.T)
         p = np.array(ev[:, 0] / ev[:, 0].sum())[:, 0]
         for (a, b) in zip(p, self.G.pagerank.values()):
             assert a == pytest.approx(b, abs=1e-7)
@@ -216,4 +216,4 @@ def test_deprecation_warnings(pagerank_alg):
     """
     G = nx.DiGraph(nx.path_graph(4))
     with pytest.warns(DeprecationWarning):
-        pr = pagerank_alg(G, alpha=0.9)
+        pagerank_alg(G, alpha=0.9)

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -1,7 +1,8 @@
 import random
 
-import networkx as nx
 import pytest
+
+import networkx as nx
 
 np = pytest.importorskip("numpy")
 pytest.importorskip("scipy")


### PR DESCRIPTION
Remove more characters from our codebase.
Make linters like pylint, isort a bit more happier.

Tiny subjective nitpicks around the code.
