### PR TITLE
DOC: Update documentation to include callables for weight argument

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -51,10 +51,15 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
         Ending node for path. If not specified, compute shortest
         paths to all possible nodes.
 
-    weight : None or string, optional (default = None)
+    weight : None, string or function, optional (default = None)
         If None, every edge has weight/distance/cost 1.
         If a string, use this edge attribute as the edge weight.
         Any edge attribute not present defaults to 1.
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly
+        three positional arguments: the two endpoints of an edge and
+        the dictionary of edge attributes for that edge.
+        The function must return a number.
 
     method : string, optional (default = 'dijkstra')
         The algorithm to use to compute the path.
@@ -182,10 +187,15 @@ def shortest_path_length(G, source=None, target=None, weight=None, method="dijks
         If not specified, compute shortest path lengths using all nodes as
         target nodes.
 
-    weight : None or string, optional (default = None)
+    weight : None, string or function, optional (default = None)
         If None, every edge has weight/distance/cost 1.
         If a string, use this edge attribute as the edge weight.
         Any edge attribute not present defaults to 1.
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly
+        three positional arguments: the two endpoints of an edge and
+        the dictionary of edge attributes for that edge.
+        The function must return a number.
 
     method : string, optional (default = 'dijkstra')
         The algorithm to use to compute the path length.
@@ -320,10 +330,15 @@ def average_shortest_path_length(G, weight=None, method=None):
     ----------
     G : NetworkX graph
 
-    weight : None or string, optional (default = None)
-       If None, every edge has weight/distance/cost 1.
-       If a string, use this edge attribute as the edge weight.
-       Any edge attribute not present defaults to 1.
+    weight : None, string or function, optional (default = None)
+        If None, every edge has weight/distance/cost 1.
+        If a string, use this edge attribute as the edge weight.
+        Any edge attribute not present defaults to 1.
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly
+        three positional arguments: the two endpoints of an edge and
+        the dictionary of edge attributes for that edge.
+        The function must return a number.
 
     method : string, optional (default = 'unweighted' or 'djikstra')
         The algorithm to use to compute the path lengths.
@@ -422,10 +437,15 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
     target : node
        Ending node for path.
 
-    weight : None or string, optional (default = None)
-       If None, every edge has weight/distance/cost 1.
-       If a string, use this edge attribute as the edge weight.
-       Any edge attribute not present defaults to 1.
+    weight : None, string or function, optional (default = None)
+        If None, every edge has weight/distance/cost 1.
+        If a string, use this edge attribute as the edge weight.
+        Any edge attribute not present defaults to 1.
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly
+        three positional arguments: the two endpoints of an edge and
+        the dictionary of edge attributes for that edge.
+        The function must return a number.
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1468,8 +1468,18 @@ def bellman_ford_path(G, source, target, weight="weight"):
     target : node
         Ending node
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight
+    weight : string or function (default="weight")
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number.
 
     Returns
     -------
@@ -1517,8 +1527,18 @@ def bellman_ford_path_length(G, source, target, weight="weight"):
     target : node label
         ending node for path
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight
+    weight : string or function (default="weight")
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number.
 
     Returns
     -------
@@ -1574,8 +1594,18 @@ def single_source_bellman_ford_path(G, source, weight="weight"):
     source : node
         Starting node for path.
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight
+    weight : string or function (default="weight")
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number.
 
     Returns
     -------
@@ -1619,8 +1649,18 @@ def single_source_bellman_ford_path_length(G, source, weight="weight"):
     source : node label
         Starting node for path
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight.
+    weight : string or function (default="weight")
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number.
 
     Returns
     -------
@@ -1760,8 +1800,18 @@ def all_pairs_bellman_ford_path_length(G, weight="weight"):
     ----------
     G : NetworkX graph
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight
+    weight : string or function (default="weight")
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number.
 
     Returns
     -------
@@ -1804,8 +1854,18 @@ def all_pairs_bellman_ford_path(G, weight="weight"):
     ----------
     G : NetworkX graph
 
-    weight: string, optional (default='weight')
-        Edge data key corresponding to the edge weight
+    weight : string or function (default="weight")
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number.
 
     Returns
     -------


### PR DESCRIPTION
While going through some of the docs I saw that the documentation doesn't accurately represent what the `weight` argument can do. We can pass in a function callable to the `weight` argument too for these methods. 