### PR TITLE
Added forceatlas2 layout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "networkx/drawing/fa2"]
+	path = networkx/drawing/fa2
+	url = https://github.com/cvanelteren/forceatlas2/

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -26,6 +26,7 @@ from networkx.drawing.layout import (
     spring_layout,
     random_layout,
     planar_layout,
+    forceatlas2_layout,
 )
 import warnings
 
@@ -43,6 +44,7 @@ __all__ = [
     "draw_spring",
     "draw_planar",
     "draw_shell",
+    "draw_forceatlas2",
 ]
 
 
@@ -1281,6 +1283,22 @@ def draw_planar(G, **kwargs):
         function.
     """
     draw(G, planar_layout(G), **kwargs)
+
+
+def draw_forceatlas2(G, **kwargs):
+    """Draw the graph G with a spring layout.
+
+    Parameters
+    ----------
+    G : graph
+        A networkx graph
+
+    kwargs : optional keywords
+        See networkx.draw_networkx() for a description of optional keywords,
+        with the exception of the pos parameter which is not used by this
+        function.
+    """
+    return draw(G, forceatlas2_layout(G, **kwargs))
 
 
 def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ packages = [
     "networkx.classes",
     "networkx.generators",
     "networkx.drawing",
+    "networkx.drawing.fa2.fa2",
     "networkx.linalg",
     "networkx.readwrite",
     "networkx.readwrite.json_graph",
@@ -92,6 +93,7 @@ packages = [
     "networkx.testing",
     "networkx.utils",
 ]
+
 
 docdirbase = "share/doc/networkx-%s" % version
 # add basic documentation
@@ -167,6 +169,7 @@ extras_require = {
     dep: parse_requirements_file("requirements/" + dep + ".txt")
     for dep in ["default", "developer", "doc", "extra", "test"]
 }
+
 
 with open("README.rst", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ def parse_requirements_file(filename):
     return requires
 
 
-install_requires = []
+install_requires = ["fa2 @ git+https://github.com/cvanelteren/forceatlas2.git"]
 extras_require = {
     dep: parse_requirements_file("requirements/" + dep + ".txt")
     for dep in ["default", "developer", "doc", "extra", "test"]


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
# Added forceatlas 2 layout
I've added the ForceAtlas2 layout from gephi that was implemented by [bhargavchippada](https://github.com/bhargavchippada) with linLog merge from [victorbenichoux](https://github.com/victorbenichoux). The ForceAtlas2 layout forms a fast alternative for spring layout and work particularly well for large graphs. It originates from gephi and is a good addition to the networkx toolkit.

Best wishes,
C
