### PR TITLE
Add informative exception for drawing multiedge labels.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1130,6 +1130,13 @@ def draw_networkx_edge_labels(
         labels = {(u, v): d for u, v, d in G.edges(data=True)}
     else:
         labels = edge_labels
+        # Informative exception for multiedges
+        try:
+            (u, v), d = next(iter(labels.items()))
+        except ValueError as err:
+            raise nx.NetworkXError(
+                "draw_networkx_edge_labels does not support multiedges."
+            ) from err
     text_items = {}
     for (n1, n2), label in labels.items():
         (x1, y1) = pos[n1]

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -675,3 +675,18 @@ def test_edgelist_kwarg_not_ignored():
     nx.draw(G, edgelist=[(0, 1), (1, 2)], ax=ax)  # Exclude self-loop from edgelist
     assert not ax.patches
     plt.delaxes(ax)
+
+
+def test_draw_networkx_edge_label_multiedge_exception():
+    """
+    draw_networkx_edge_labels should raise an informative error message when
+    the edge label includes keys
+    """
+    exception_msg = "draw_networkx_edge_labels does not support multiedges"
+    G = nx.MultiGraph()
+    G.add_edge(0, 1, weight=10)
+    G.add_edge(0, 1, weight=20)
+    edge_labels = nx.get_edge_attributes(G, "weight")  # Includes edge keys
+    pos = {n: (n, n) for n in G}
+    with pytest.raises(nx.NetworkXError, match=exception_msg):
+        nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels)


### PR DESCRIPTION
Closes #5294 

Improve the exception message when a user attempts to draw edge labels with multiedges that include keys (i.e. edges as 3-tuples).