### PR TITLE
Remove unused import

### DIFF
--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -58,7 +58,6 @@ References
 """
 
 from collections import deque
-from typing import AbstractSet
 
 import networkx as nx
 from networkx.utils import not_implemented_for, UnionFind


### PR DESCRIPTION
This is leftover from the MyPy cleanup - there is a stray import of `AbstractSet` from the typing module that is no longer used.

Note that there is also another instance where objects from the typing module are used in `networkx/readwrite/gml` to define a `NamedTuple`. I think this syntax is more clear than the `namedtuple` constructor, so I'm inclined to leave it.