### PR TITLE
More numpy.matrix cleanups for NX2.7

### DIFF
--- a/examples/algorithms/plot_rcm.py
+++ b/examples/algorithms/plot_rcm.py
@@ -15,7 +15,7 @@ import seaborn as sns
 import networkx as nx
 
 
-# build low-bandwidth numpy matrix
+# build low-bandwidth matrix
 G = nx.grid_2d_graph(3, 3)
 rcm = list(nx.utils.reverse_cuthill_mckee_ordering(G))
 print("ordering", rcm)

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -281,7 +281,7 @@ def attribute_ac(M):
 
 
 def numeric_ac(M, mapping):
-    # M is a numpy matrix or array
+    # M is a 2D numpy array
     # numeric assortativity coefficient, pearsonr
     import numpy as np
 

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -35,8 +35,8 @@ def floyd_warshall_numpy(G, nodelist=None, weight="weight"):
 
     Returns
     -------
-    distance : NumPy matrix
-        A matrix of shortest path distances between nodes.
+    distance : 2D numpy.ndarray
+        A numpy array of shortest path distances between nodes.
         If there is no path between two nodes the value is Inf.
 
     Notes

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1421,12 +1421,12 @@ def _simrank_similarity_numpy(
 
     Returns
     -------
-    similarity : numpy matrix, numpy array or float
+    similarity : numpy array or float
         If ``source`` and ``target`` are both ``None``, this returns a
-        Matrix containing SimRank scores of the nodes.
+        2D array containing SimRank scores of the nodes.
 
         If ``source`` is not ``None`` but ``target`` is, this returns an
-        Array containing SimRank scores of ``source`` and that
+        1D array containing SimRank scores of ``source`` and that
         node.
 
         If neither ``source`` nor ``target`` is ``None``, this returns

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -38,8 +38,8 @@ class DiGraph(Graph):
         Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
-        dict of dicts, dict of lists, NetworkX graph, NumPy matrix
-        or 2d ndarray, SciPy sparse matrix, or PyGraphviz graph.
+        dict of dicts, dict of lists, NetworkX graph, 2D NumPy array, SciPy
+        sparse matrix, or PyGraphviz graph.
 
     attr : keyword arguments, optional (default= no attributes)
         Attributes to add to graph as key=value pairs.
@@ -274,8 +274,8 @@ class DiGraph(Graph):
             Data to initialize graph.  If None (default) an empty
             graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
-            packages are installed the data can also be a NumPy matrix
-            or 2d ndarray, a SciPy sparse matrix, or a PyGraphviz graph.
+            packages are installed the data can also be a 2D NumPy array, a
+            SciPy sparse matrix, or a PyGraphviz graph.
 
         attr : keyword arguments, optional (default= no attributes)
             Attributes to add to graph as key=value pairs.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -39,8 +39,8 @@ class Graph:
         Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
-        dict of dicts, dict of lists, NetworkX graph, NumPy matrix
-        or 2d ndarray, SciPy sparse matrix, or PyGraphviz graph.
+        dict of dicts, dict of lists, NetworkX graph, 2D NumPy array, SciPy
+        sparse matrix, or PyGraphviz graph.
 
     attr : keyword arguments, optional (default= no attributes)
         Attributes to add to graph as key=value pairs.
@@ -295,8 +295,8 @@ class Graph:
             Data to initialize graph. If None (default) an empty
             graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
-            packages are installed the data can also be a NumPy matrix
-            or 2d ndarray, a SciPy sparse matrix, or a PyGraphviz graph.
+            packages are installed the data can also be a 2D NumPy array, a
+            SciPy sparse matrix, or a PyGraphviz graph.
 
         attr : keyword arguments, optional (default= no attributes)
             Attributes to add to graph as key=value pairs.

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -38,8 +38,8 @@ class MultiDiGraph(MultiGraph, DiGraph):
         Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
-        dict of dicts, dict of lists, NetworkX graph, NumPy matrix
-        or 2d ndarray, SciPy sparse matrix, or PyGraphviz graph.
+        dict of dicts, dict of lists, NetworkX graph, 2D NumPy array, SciPy
+        sparse matrix, or PyGraphviz graph.
 
     multigraph_input : bool or None (default None)
         Note: Only used when `incoming_graph_data` is a dict.
@@ -288,8 +288,8 @@ class MultiDiGraph(MultiGraph, DiGraph):
             Data to initialize graph.  If incoming_graph_data=None (default)
             an empty graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
-            packages are installed the data can also be a NumPy matrix
-            or 2d ndarray, a SciPy sparse matrix, or a PyGraphviz graph.
+            packages are installed the data can also be a 2D NumPy array, a
+            SciPy sparse matrix, or a PyGraphviz graph.
 
         multigraph_input : bool or None (default None)
             Note: Only used when `incoming_graph_data` is a dict.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -32,8 +32,8 @@ class MultiGraph(Graph):
         Data to initialize graph. If None (default) an empty
         graph is created.  The data can be any format that is supported
         by the to_networkx_graph() function, currently including edge list,
-        dict of dicts, dict of lists, NetworkX graph, NumPy matrix
-        or 2d ndarray, SciPy sparse matrix, or PyGraphviz graph.
+        dict of dicts, dict of lists, NetworkX graph, 2D NumPy array,
+        SciPy sparse matrix, or PyGraphviz graph.
 
     multigraph_input : bool or None (default None)
         Note: Only used when `incoming_graph_data` is a dict.
@@ -297,8 +297,8 @@ class MultiGraph(Graph):
             Data to initialize graph.  If incoming_graph_data=None (default)
             an empty graph is created.  The data can be an edge list, or any
             NetworkX graph object.  If the corresponding optional Python
-            packages are installed the data can also be a NumPy matrix
-            or 2d ndarray, a SciPy sparse matrix, or a PyGraphviz graph.
+            packages are installed the data can also be a 2D NumPy array, a
+            SciPy sparse matrix, or a PyGraphviz graph.
 
         multigraph_input : bool or None (default None)
             Note: Only used when `incoming_graph_data` is a dict.

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -55,8 +55,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
          iterator (e.g. itertools.chain) that produces edges
          generator of edges
          Pandas DataFrame (row per edge)
-         numpy matrix
-         numpy ndarray
+         2D numpy array
          scipy sparse matrix
          pygraphviz agraph
 

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -143,7 +143,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                 return nx.from_numpy_array(data, create_using=create_using)
             except Exception as err:
                 raise nx.NetworkXError(
-                    "Input is not a correct numpy matrix or array."
+                    f"Failed to interpret array {data} as an adjacency matrix"
                 ) from err
     except ImportError:
         warnings.warn("numpy not found, skipping conversion test.", ImportWarning)

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -143,7 +143,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                 return nx.from_numpy_array(data, create_using=create_using)
             except Exception as err:
                 raise nx.NetworkXError(
-                    f"Failed to interpret array {data} as an adjacency matrix"
+                    f"Failed to interpret array as an adjacency matrix."
                 ) from err
     except ImportError:
         warnings.warn("numpy not found, skipping conversion test.", ImportWarning)

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -367,7 +367,7 @@ def _transition_matrix(G, nodelist=None, weight="weight", walk_type=None, alpha=
 
     Returns
     -------
-    P : NumPy matrix
+    P : numpy.ndarray
       transition matrix of G.
 
     Raises


### PR DESCRIPTION
I did a final check to make sure we had covered all instances of `numpy.matrix` in the codebase. From extensive grepping, there were a few left - mostly in docstrings, comments, and exception messages.

This PR corrects a few docstrings and removes as many explicit references to `numpy.matrix` objects as possible.