### PR TITLE
Feature for issue 5277

### DIFF
--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -58,6 +58,8 @@ def test_exceptions():
         G = nx.MultiDiGraph()
         G.add_node(0)
         tree_data(G, 0, attr="children", children="children", ident="children")
+    with pytest.raises(nx.NetworkXError, match="must be different."):
+        tree_graph({}, 0, attr="children", children="children", ident="children")
 
 
 # NOTE: To be removed when deprecation expires in 3.0

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -15,17 +15,19 @@ def test_graph():
 
 
 def test_graph_attributes():
-    G = nx.DiGraph()
+    G = nx.DiGraph(page="some text")
     G.add_nodes_from([1, 2, 3], color="red")
     G.add_edge(1, 2, foo=7)
     G.add_edge(1, 3, foo=10)
     G.add_edge(3, 4, foo=10)
     H = tree_graph(tree_data(G, 1))
     assert H.nodes[1]["color"] == "red"
+    assert H.graph["page"] == "some text"
 
     d = json.dumps(tree_data(G, 1))
     H = tree_graph(json.loads(d))
     assert H.nodes[1]["color"] == "red"
+    assert H.graph["page"] == "some text"
 
 
 def test_exceptions():
@@ -44,6 +46,18 @@ def test_exceptions():
         G = nx.MultiDiGraph()
         G.add_node(0)
         tree_data(G, 0, ident="node", children="node")
+    with pytest.raises(nx.NetworkXError, match="must be different."):
+        G = nx.MultiDiGraph()
+        G.add_node(0)
+        tree_data(G, 0, ident="node", attr="node")
+    with pytest.raises(nx.NetworkXError, match="must be different."):
+        G = nx.MultiDiGraph()
+        G.add_node(0)
+        tree_data(G, 0, attr="children", children="children")
+    with pytest.raises(nx.NetworkXError, match="must be different."):
+        G = nx.MultiDiGraph()
+        G.add_node(0)
+        tree_data(G, 0, attr="children", children="children", ident="children")
 
 
 # NOTE: To be removed when deprecation expires in 3.0

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -51,7 +51,7 @@ def tree_data(G, root, attrs=None, ident="id", children="children", attr="attr")
     Raises
     ------
     NetworkXError
-        If `children`, `ident` and `attr` attributes are identical.
+        If `children`, `ident`, and `attr` attributes are identical.
 
     Examples
     --------
@@ -163,6 +163,11 @@ def tree_graph(data, attrs=None, ident="id", children="children", attr="attr"):
     -------
     G : NetworkX DiGraph
 
+    Raises
+    ------
+    NetworkXError
+        If `children`, `ident`, and `attr` attributes are identical.
+        
     Examples
     --------
     >>> from networkx.readwrite import json_graph


### PR DESCRIPTION
Resolves #5277 by adding the "attr" parameter in the `networkx.readwrite.json_graph.tree_data` and `networkx.readwrite.json_graph.tree_graph` as:

```python
>>> import networkx as nx
>>> from networkx.readwrite import json_graph
>>> DG = nx.DiGraph(page="some text")
>>> DG.add_node(5434)
>>> print(DG.graph)
{'page': 'some text'}
>>> data = json_graph.tree_data(DG, root=5434)
>>> DG = json_graph.tree_graph(data)
>>> print(DG.graph)
{'page': 'some text'}
```