### PR TITLE
Add structured dtypes to `to_numpy_array`

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1271,8 +1271,12 @@ def to_numpy_array(
         If `nodelist` is ``None``, then the ordering is produced by ``G.nodes()``.
 
     dtype : NumPy data type, optional
-        A NumPy data type used to initialize the array.
-        If None, then the NumPy default is used.
+        A NumPy data type used to initialize the array. If None, then the NumPy
+        default is used. The dtype can be structured if `weight=None`, in which
+        case the dtype field names are used to look up edge attributes. The
+        result is a structured array where each named field in the dtype
+        corresponds to the adjaceny for that edge attribute. See examples for
+        details.
 
     order : {'C', 'F'}, optional
         Whether to store multidimensional data in C- or Fortran-contiguous
@@ -1287,7 +1291,8 @@ def to_numpy_array(
     weight : string or None optional (default = 'weight')
         The edge attribute that holds the numerical value used for
         the edge weight. If an edge does not have that attribute, then the
-        value 1 is used instead.
+        value 1 is used instead. `weight` must be ``None`` if a structured
+        dtype is used.
 
     nonedge : array_like (default = 0.0)
         The value used to represent non-edges in the adjaceny matrix.
@@ -1300,6 +1305,13 @@ def to_numpy_array(
     -------
     A : NumPy ndarray
         Graph adjacency matrix
+
+    Raises
+    ------
+    NetworkXError
+        If `dtype` is a structured dtype and `G` is a multigraph
+    ValueError
+        If `dtype` is a structured dtype and `weight` is not `None`
 
     See Also
     --------
@@ -1348,6 +1360,26 @@ def to_numpy_array(
     array([[0., 2., 0.],
            [1., 0., 0.],
            [0., 0., 4.]])
+
+    This function can also be used to create adjacency matrices for multiple
+    edge attributes with structured dtypes:
+
+    >>> G = nx.Graph()
+    >>> G.add_edge(0, 1, weight=10)
+    >>> G.add_edge(1, 2, cost=5)
+    >>> G.add_edge(2, 3, weight=3, cost=-4.0)
+    >>> dtype = np.dtype([("weight", int), ("cost", float)])
+    >>> A = nx.to_numpy_array(G, dtype=dtype, weight=None)
+    >>> A["weight"]
+    array([[ 0, 10,  0,  0],
+           [10,  0,  1,  0],
+           [ 0,  1,  0,  3],
+           [ 0,  0,  3,  0]])
+    >>> A["cost"]
+    array([[ 0.,  1.,  0.,  0.],
+           [ 1.,  0.,  5.,  0.],
+           [ 0.,  5.,  0., -4.],
+           [ 0.,  0., -4.,  0.]])
 
     """
     import numpy as np

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1404,7 +1404,7 @@ def to_numpy_array(
             # Map each attribute to the appropriate named field in the
             # structured dtype
             for attr in edge_attrs:
-                attr_data = [wt[attr] for wt in wts]
+                attr_data = [wt.get(attr, 1.0) for wt in wts]
                 A[attr][i, j] = attr_data
                 if not G.is_directed():
                     A[attr][j, i] = attr_data

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1372,8 +1372,14 @@ def to_numpy_array(
     # If dtype is structured and weight is None, use dtype field names as
     # edge attributes
     edge_attrs = None  # Only single edge attribute by default
-    if A.dtype.names and weight is None:
-        edge_attrs = dtype.names
+    if A.dtype.names:
+        if weight is None:
+            edge_attrs = dtype.names
+        else:
+            raise ValueError(
+                "Specifying `weight` not supported for structured dtypes\n."
+                "To create adjacency matrices from structured dtypes, use `weight=None`."
+            )
 
     # Map nodes to row/col in matrix
     idx = dict(zip(nodelist, range(nlen)))

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -566,14 +566,20 @@ def test_to_numpy_array_multiweight_reduction(func, expected):
     assert np.allclose(A, [[0, expected], [expected, 0]])
 
 
-def test_to_numpy_array_structured_dtype_attrs_from_fields():
+@pytest.mark.parametrize(
+    ("G, expected"),
+    [
+        (nx.Graph(), [[(0, 0), (10, 5)], [(10, 5), (0, 0)]]),
+        (nx.DiGraph(), [[(0, 0), (10, 5)], [(0, 0), (0, 0)]]),
+    ],
+)
+def test_to_numpy_array_structured_dtype_attrs_from_fields(G, expected):
     """When `dtype` is structured (i.e. has names) and `weight` is None, use
     the named fields of the dtype to look up edge attributes."""
-    G = nx.Graph()
     G.add_edge(0, 1, weight=10, cost=5.0)
     dtype = np.dtype([("weight", int), ("cost", int)])
     A = nx.to_numpy_array(G, dtype=dtype, weight=None)
-    expected = np.array([[(0, 0), (10, 5)], [(10, 5), (0, 0)]], dtype=dtype)
+    expected = np.asarray(expected, dtype=dtype)
     npt.assert_array_equal(A, expected)
 
 

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -564,3 +564,14 @@ def test_to_numpy_array_multiweight_reduction(func, expected):
     # Undirected case
     A = nx.to_numpy_array(G.to_undirected(), multigraph_weight=func, dtype=float)
     assert np.allclose(A, [[0, expected], [expected, 0]])
+
+
+def test_to_numpy_array_structured_dtype_attrs_from_fields():
+    """When `dtype` is structured (i.e. has names) and `weight` is None, use
+    the named fields of the dtype to look up edge attributes."""
+    G = nx.Graph()
+    G.add_edge(0, 1, weight=10, cost=5.0)
+    dtype = np.dtype([("weight", int), ("cost", int)])
+    A = nx.to_numpy_array(G, dtype=dtype, weight=None)
+    expected = np.array([[(0, 0), (10, 5)], [(10, 5), (0, 0)]], dtype=dtype)
+    npt.assert_array_equal(A, expected)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -626,6 +626,30 @@ def test_to_numpy_array_structured_dtype_multiple_fields(graph_type, edge):
         npt.assert_array_equal(A[attr], expected)
 
 
+@pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+def test_to_numpy_array_structured_dtype_scalar_nonedge(G):
+    G.add_edge(0, 1, weight=10)
+    dtype = np.dtype([("weight", float), ("cost", float)])
+    A = nx.to_numpy_array(G, dtype=dtype, weight=None, nonedge=np.nan)
+    for attr in dtype.names:
+        expected = nx.to_numpy_array(G, dtype=float, weight=attr, nonedge=np.nan)
+        npt.assert_array_equal(A[attr], expected)
+
+
+@pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+def test_to_numpy_array_structured_dtype_nonedge_ary(G):
+    """Similar to the scalar case, except has a different non-edge value for
+    each named field."""
+    G.add_edge(0, 1, weight=10)
+    dtype = np.dtype([("weight", float), ("cost", float)])
+    nonedges = np.array([(0, np.inf)], dtype=dtype)
+    A = nx.to_numpy_array(G, dtype=dtype, weight=None, nonedge=nonedges)
+    for attr in dtype.names:
+        nonedge = nonedges[attr]
+        expected = nx.to_numpy_array(G, dtype=float, weight=attr, nonedge=nonedge)
+        npt.assert_array_equal(A[attr], expected)
+
+
 def test_to_numpy_array_structured_dtype_with_weight_raises():
     """Using both a structured dtype (with named fields) and specifying a `weight`
     parameter is ambiguous."""

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -607,6 +607,18 @@ def test_to_numpy_array_structured_dtype_single_attr(field_name, expected_attr_v
     npt.assert_array_equal(A[field_name], expected)
 
 
+def test_to_numpy_array_structured_dtype_with_weight_raises():
+    """Using both a structured dtype (with named fields) and specifying a `weight`
+    parameter is ambiguous."""
+    G = nx.path_graph(3)
+    dtype = np.dtype([("weight", int), ("cost", int)])
+    exception_msg = "Specifying `weight` not supported for structured dtypes"
+    with pytest.raises(ValueError, match=exception_msg):
+        nx.to_numpy_array(G, dtype=dtype)  # Default is weight="weight"
+    with pytest.raises(ValueError, match=exception_msg):
+        nx.to_numpy_array(G, dtype=dtype, weight="cost")
+
+
 @pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
 def test_to_numpy_array_structured_multigraph_raises(graph_type):
     G = nx.path_graph(3, create_using=graph_type)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -577,6 +577,14 @@ def test_to_numpy_array_structured_dtype_attrs_from_fields():
     npt.assert_array_equal(A, expected)
 
 
+def test_to_numpy_array_structured_dtype_single_attr_default():
+    G = nx.path_graph(3)
+    dtype = np.dtype([("weight", float)])  # A single named field
+    A = nx.to_numpy_array(G, dtype=dtype, weight=None)
+    expected = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=float)
+    npt.assert_array_equal(A["weight"], expected)
+
+
 @pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
 def test_to_numpy_array_structured_multigraph_raises(graph_type):
     G = nx.path_graph(3, create_using=graph_type)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -607,6 +607,25 @@ def test_to_numpy_array_structured_dtype_single_attr(field_name, expected_attr_v
     npt.assert_array_equal(A[field_name], expected)
 
 
+@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+@pytest.mark.parametrize(
+    "edge",
+    [
+        (0, 1),  # No edge attributes
+        (0, 1, {"weight": 10}),  # One edge attr
+        (0, 1, {"weight": 5, "flow": -4}),  # Multiple but not all edge attrs
+        (0, 1, {"weight": 2.0, "cost": 10, "flow": -45}),  # All attrs
+    ],
+)
+def test_to_numpy_array_structured_dtype_multiple_fields(graph_type, edge):
+    G = graph_type([edge])
+    dtype = np.dtype([("weight", float), ("cost", float), ("flow", float)])
+    A = nx.to_numpy_array(G, dtype=dtype, weight=None)
+    for attr in dtype.names:
+        expected = nx.to_numpy_array(G, dtype=float, weight=attr)
+        npt.assert_array_equal(A[attr], expected)
+
+
 def test_to_numpy_array_structured_dtype_with_weight_raises():
     """Using both a structured dtype (with named fields) and specifying a `weight`
     parameter is ambiguous."""

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -585,6 +585,22 @@ def test_to_numpy_array_structured_dtype_single_attr_default():
     npt.assert_array_equal(A["weight"], expected)
 
 
+@pytest.mark.parametrize(
+    ("field_name", "expected_attr_val"),
+    [
+        ("weight", 1),
+        ("cost", 3),
+    ],
+)
+def test_to_numpy_array_structured_dtype_single_attr(field_name, expected_attr_val):
+    G = nx.Graph()
+    G.add_edge(0, 1, cost=3)
+    dtype = np.dtype([(field_name, float)])
+    A = nx.to_numpy_array(G, dtype=dtype, weight=None)
+    expected = np.array([[0, expected_attr_val], [expected_attr_val, 0]], dtype=float)
+    npt.assert_array_equal(A[field_name], expected)
+
+
 @pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
 def test_to_numpy_array_structured_multigraph_raises(graph_type):
     G = nx.path_graph(3, create_using=graph_type)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -575,3 +575,11 @@ def test_to_numpy_array_structured_dtype_attrs_from_fields():
     A = nx.to_numpy_array(G, dtype=dtype, weight=None)
     expected = np.array([[(0, 0), (10, 5)], [(10, 5), (0, 0)]], dtype=dtype)
     npt.assert_array_equal(A, expected)
+
+
+@pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
+def test_to_numpy_array_structured_multigraph_raises(graph_type):
+    G = nx.path_graph(3, create_using=graph_type)
+    dtype = np.dtype([("weight", int), ("cost", int)])
+    with pytest.raises(nx.NetworkXError, match="Structured arrays are not supported"):
+        nx.to_numpy_array(G, dtype=dtype, weight=None)


### PR DESCRIPTION
#5250 added generic dtype support, which means arrays can now be created with structured dtypes, opening the path for creating multi-attribute adjacency matrices, i.e. what `to_numpy_recarray` does. This PR shows how this feature could be implemented within `to_numpy_array`. It takes the same basic approach as `to_numpy_recarray`, where the attribute names are taken from the names of the dtype fields. This fully replicates the behavior of `to_numpy_recarray` and would allow it to be removed, which I think is worthwhile since recarrays are not really a first-class citizen in NumPy, just a convenience layer for accessing structured arrays.

The thing that I don't like about this approach is that it makes `to_numpy_array` less readable. I don't think there's a good way to loop through multiple attributes that wouldn't cause a performance hit for the single-attribute (e.g. `weight="weight"`) case, so it becomes necessary to have a special branch for the multiattribute processing.

Marking this as draft as it's intended as a discussion point, but still needs work re: API and way more testing.