### PR TITLE
Deprecate `to_numpy_recarray`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -106,3 +106,4 @@ Version 3.0
   reflect that the function returns a ``numpy.ndarray`` instance.
 * In ``networkx/generators/small.py`` remove ``make_small_graph`` and
   ``make_small_undirected_graph``.
+* In ``networkx/convert_matrix.py`` remove ``to_numpy_recarray``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -72,6 +72,9 @@ Deprecations
 - [`#5283 <https://github.com/networkx/networkx/pull/5283>`_]
   Deprecate ``make_small_graph`` and ``make_small_undirected_graph`` from the
   ``networkx.generators.small`` module.
+- [`#5330 <https://github.com/networkx/networkx/pull/5330>`_]
+  Deprecate ``to_numpy_recarray`` in favor of ``to_numpy_array`` with a
+  structured dtype.
 
 
 Merged PRs

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -229,6 +229,9 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message=r"\n\nmake_small_.*"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="to_numpy_recarray"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -694,6 +694,12 @@ def from_numpy_matrix(A, parallel_edges=False, create_using=None):
 def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
     """Returns the graph adjacency matrix as a NumPy recarray.
 
+    .. deprecated:: 2.7
+
+       ``to_numpy_recarray`` is deprecated and will be removed in NetworkX 3.0.
+       Use ``nx.to_numpy_array(G, dtype=dtype, weight=None).view(np.recarray)``
+       instead.
+
     Parameters
     ----------
     G : graph
@@ -738,6 +744,17 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
 
     """
     import numpy as np
+    import warnings
+
+    warnings.warn(
+        (
+            "to_numpy_recarray is deprecated and will be removed in version 3.0.\n"
+            "Use to_numpy_array instead::\n\n"
+            "    nx.to_numpy_array(G, dtype=dtype, weight=None).view(np.recarray)"
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if dtype is None:
         dtype = [("weight", float)]

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -16,6 +16,10 @@ def test_from_numpy_matrix_deprecation():
     pytest.deprecated_call(nx.from_numpy_matrix, np.eye(2))
 
 
+def test_to_numpy_recarray_deprecation():
+    pytest.deprecated_call(nx.to_numpy_recarray, nx.Graph())
+
+
 class TestConvertNumpyMatrix:
     # TODO: This entire class can be removed when to/from_numpy_matrix
     # deprecation expires


### PR DESCRIPTION
Depends on #5324 so marking as draft for now.

Alternatively - `to_numpy_recarray` could still be deprecated *even if* the structured dtype support is not added to `to_numpy_array`, though then there would be a loss of functionality (and the warning messages here would have to change). 