### PR TITLE
Break astar ties using heuristic value

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -14,6 +14,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
     using the A* ("A-star") algorithm.
 
     There may be more than one shortest path.  This returns only one.
+    Ties are broken based on the heuristic value (the smaller, the better).
 
     Parameters
     ----------


### PR DESCRIPTION
I changed A* tiebreaking to rely on the heuristic value of a node, and only then on the counter. This makes it significantly faster when dealing with searches where the path is "clear" to the algorithm, upwards of X10 faster than the current tiebreaker.

An alternative could be to allow the user to choose the tiebreaking via an additional optional parameter specifying if to tiebreak via heuristic value or not. Or even give the user the option to list a function which will recieve the current node, the target node, and will return a tuple specifying the tiebreaking value (while still using the counter to make sure no two elements are the same).

