### PR TITLE
Fixes equidistant parameter for spiral layout whenever passed as True explicitly

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1003,6 +1003,7 @@ def spiral_layout(G, scale=1, center=None, dim=2, resolution=0.35, equidistant=F
         chord = 1
         step = 0.5
         theta = resolution
+        theta += chord / (step * theta)
         for _ in range(len(G)):
             r = step * theta
             theta += chord / r

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -964,7 +964,10 @@ def spiral_layout(G, scale=1, center=None, dim=2, resolution=0.35, equidistant=F
         The compactness of the spiral layout returned.
         Lower values result in more compressed spiral layouts.
     equidistant : bool
-        If True, nodes will be plotted equidistant from each other.
+        If True, nodes will be positioned equidistant from each other
+        by decreasing angle further from center.
+        If False or by default, nodes will be positioned at equal angles
+        from each other by increasing separation further from center.
 
     Returns
     -------

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -371,6 +371,16 @@ class TestLayout:
             distances_equidistant[1:], distances_equidistant[-1], atol=0.01
         )
 
+    @pytest.mark.mpl_image_compare
+    def test_paramter_equidistant_for_spiral_layout(self):
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure()
+        G = nx.path_graph(5)
+        pos = nx.spiral_layout(G, equidistant=True)
+        nx.draw(G, pos=pos)
+        return fig
+
     def test_rescale_layout_dict(self):
         G = nx.empty_graph()
         vpos = nx.random_layout(G, center=(1, 1))

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -371,15 +371,14 @@ class TestLayout:
             distances_equidistant[1:], distances_equidistant[-1], atol=0.01
         )
 
-    @pytest.mark.mpl_image_compare
-    def test_paramter_equidistant_for_spiral_layout(self):
-        import matplotlib.pyplot as plt
-
-        fig = plt.figure()
-        G = nx.path_graph(5)
+    def test_spiral_layout_equidistant(self):
+        G = nx.path_graph(10)
         pos = nx.spiral_layout(G, equidistant=True)
-        nx.draw(G, pos=pos)
-        return fig
+        # Extract individual node positions as an array
+        p = np.array(list(pos.values()))
+        # Elementwise-distance between node positions
+        dist = np.linalg.norm(p[1:] - p[:-1], axis=1)
+        assert np.allclose(np.diff(dist), 0, atol=1e-3)
 
     def test_rescale_layout_dict(self):
         G = nx.empty_graph()


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

Fixes #5211 

**Brief description of the change** 
Just by simple `print` statements between lines  as shown below, I could figure out that the measurements for the first node were off by some account , leading to the error 
```
        for _ in range(len(G)):
            print(theta)
            r = step * theta
            print(r)
            theta += chord / r
            pos.append([np.cos(theta) * r, np.sin(theta) * r])
```
The values of `theta` and `r` obtained on master are when number of node are `6` are as follows
```
theta = [0.175, 3.032142857142857, 3.1970427393572267, 3.353437270417054, 3.50253801680967, 3.6452916422094113]
r = [8.220459030036954, 0.9679057090890294, 0.9707783270266445, 0.9731756361695102, 0.975206931979123,
0.9769503470399769]
```
The differences are quite obvious as the first node stands out . Now this was happening because some computations being done from the second node wasn't being done for the first . Hence adding `theta += chord / (step * theta)` does it for us .We can see that the computations for the (n + 1)th node are now computations for the nth node 
```
theta = [3.032142857142857, 3.1970427393572267, 3.353437270417054, 3.50253801680967, 3.6452916422094113, 3.7824548788104067]
r = [0.9679057090890294, 0.9707783270266445, 0.9731756361695102, 0.975206931979123, 0.9769503470399769
0.9784632205154521]
# we can see the above arrays are shifted forms of the arrays reported previously . Hence this ensures the computations of the # first node is being done properly 
```
Some results 
1) **when nodes are 5**
![image](https://user-images.githubusercontent.com/87052487/155131125-560c13ab-f071-4379-9c2a-1eafeba603e8.png)
2) **when nodes are 10**
![image](https://user-images.githubusercontent.com/87052487/155131303-4cdab2dc-92f3-4afd-8221-abc54fad3091.png)
3) **when nodes are 100**
![image](https://user-images.githubusercontent.com/87052487/155131424-f118618e-6a4a-4b52-a885-b6363275060c.png)
**The last result on master**
![image](https://user-images.githubusercontent.com/87052487/155131512-17215c55-961b-4882-bc6c-0c12013d139a.png)


