### PR TITLE
BUG: Explicity import importlib.machinery

### DIFF
--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.machinery
 import importlib.util
 import types
 import os


### PR DESCRIPTION
fixes https://github.com/networkx/networkx/issues/5367

Tested this on fedora 35 and it works
```
# pip install https://github.com/mriduls/networkx/archive/importlib.zip
# python3 -c "import networkx"
```

We should probably have a 2.7.1 release too.