### PR TITLE
[nx_pylab] fix StopIteration, if empty dict is passed for labels.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1125,17 +1125,20 @@ def draw_networkx_edge_labels(
 
     if ax is None:
         ax = plt.gca()
-    if edge_labels is None or len(edge_labels) == 0:
+    if edge_labels is None:
         labels = {(u, v): d for u, v, d in G.edges(data=True)}
     else:
         labels = edge_labels
         # Informative exception for multiedges
         try:
-            (u, v), d = next(iter(labels.items()))
+            (u, v), d = next(iter(labels.items()))  # ensures no edge key provided
         except ValueError as err:
             raise nx.NetworkXError(
                 "draw_networkx_edge_labels does not support multiedges."
             ) from err
+        except StopIteration:
+            pass
+
     text_items = {}
     for (n1, n2), label in labels.items():
         (x1, y1) = pos[n1]

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1058,7 +1058,7 @@ def draw_networkx_edge_labels(
         A dictionary with nodes as keys and positions as values.
         Positions should be sequences of length 2.
 
-    edge_labels : dictionary (default={})
+    edge_labels : dictionary (default=None)
         Edge labels in a dictionary of labels keyed by edge two-tuple.
         Only labels for the keys in the dictionary are drawn.
 
@@ -1125,7 +1125,7 @@ def draw_networkx_edge_labels(
 
     if ax is None:
         ax = plt.gca()
-    if edge_labels is None:
+    if edge_labels is None or len(edge_labels) == 0:
         labels = {(u, v): d for u, v, d in G.edges(data=True)}
     else:
         labels = edge_labels

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1131,7 +1131,7 @@ def draw_networkx_edge_labels(
         labels = edge_labels
         # Informative exception for multiedges
         try:
-            (u, v), d = next(iter(labels.items()))  # ensures no edge key provided
+            (u, v) = next(iter(labels))  # ensures no edge key provided
         except ValueError as err:
             raise nx.NetworkXError(
                 "draw_networkx_edge_labels does not support multiedges."

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -413,6 +413,7 @@ def test_labels_and_colors():
     nx.draw_networkx_labels(G, pos, labels, font_size=16)
     nx.draw_networkx_edge_labels(G, pos, edge_labels=None, rotate=False)
     nx.draw_networkx_edge_labels(G, pos, edge_labels={(4, 5): "4-5"})
+    nx.draw_networkx_edge_labels(G, pos, edge_labels={})
     # plt.show()
 
 

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -413,7 +413,6 @@ def test_labels_and_colors():
     nx.draw_networkx_labels(G, pos, labels, font_size=16)
     nx.draw_networkx_edge_labels(G, pos, edge_labels=None, rotate=False)
     nx.draw_networkx_edge_labels(G, pos, edge_labels={(4, 5): "4-5"})
-    nx.draw_networkx_edge_labels(G, pos, edge_labels={})
     # plt.show()
 
 
@@ -717,3 +716,11 @@ def test_draw_networkx_edge_label_multiedge_exception():
     pos = {n: (n, n) for n in G}
     with pytest.raises(nx.NetworkXError, match=exception_msg):
         nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels)
+
+
+def test_draw_networkx_edge_label_empty_dict():
+    """Regression test for draw_networkx_edge_labels with empty dict. See
+    gh-5372."""
+    G = nx.path_graph(3)
+    pos = {n: (n, n) for n in G.nodes}
+    assert nx.draw_networkx_edge_labels(G, pos, edge_labels={}) == {}


### PR DESCRIPTION
The new detection for multi-edge labels raises, if an empty dict
was passed. Before this detection that was fine, because the loop
iterating over the passed labels just passed.

Added small test as well.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
