### PR TITLE
Add Generator support to create_py_random_state.

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -528,8 +528,8 @@ def create_py_random_state(random_state=None):
         generator used by `random`.
         if np.random package, return the global numpy random number
         generator wrapped in a PythonRandomInterface class.
-        if np.random.RandomState instance, return it wrapped in
-        PythonRandomInterface
+        if np.random.RandomState or np.random.Generator instance, return it
+        wrapped in PythonRandomInterface
         if a PythonRandomInterface instance, return it
     """
     import random
@@ -539,7 +539,7 @@ def create_py_random_state(random_state=None):
 
         if random_state is np.random:
             return PythonRandomInterface(np.random.mtrand._rand)
-        if isinstance(random_state, np.random.RandomState):
+        if isinstance(random_state, (np.random.RandomState, np.random.Generator)):
             return PythonRandomInterface(random_state)
         if isinstance(random_state, PythonRandomInterface):
             return random_state

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -239,9 +239,11 @@ def test_create_py_random_state():
     np = pytest.importorskip("numpy")
 
     rs = np.random.RandomState
+    rng = np.random.default_rng(1000)
     nprs = PythonRandomInterface
     assert isinstance(create_py_random_state(np.random), nprs)
     assert isinstance(create_py_random_state(rs(1)), nprs)
+    assert isinstance(create_py_random_state(rng), nprs)
     # test default rng input
     assert isinstance(PythonRandomInterface(), nprs)
 

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -240,10 +240,12 @@ def test_create_py_random_state():
 
     rs = np.random.RandomState
     rng = np.random.default_rng(1000)
+    rng_explicit = np.random.Generator(np.random.SFC64())
     nprs = PythonRandomInterface
     assert isinstance(create_py_random_state(np.random), nprs)
     assert isinstance(create_py_random_state(rs(1)), nprs)
     assert isinstance(create_py_random_state(rng), nprs)
+    assert isinstance(create_py_random_state(rng_explicit), nprs)
     # test default rng input
     assert isinstance(PythonRandomInterface(), nprs)
 


### PR DESCRIPTION
Follow up to #5336.

In adding support for `numpy.random.Generator`, I somehow forgot to also modify the `create_py_random_state` function which is called by the `@py_random_state` decorator.

This was a major oversight on my part since the majority of functions that use randomness are decorated with `py_random_state`, so without this most functions in NX won't work with `numpy.random.Generator`.  For this reason, I think it'd be good to get it into a 2.7 release if possible.