### PR TITLE
Updates to greedy_modularity_communities docs

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -108,3 +108,6 @@ Version 3.0
   ``make_small_undirected_graph``.
 * In ``convert_matrix.py`` remove ``to_numpy_recarray``.
 * In ``classes/function.py`` remove ``info``.
+* In ``algorithms/community/modularity_max.py``, remove the deprecated
+  ``n_communities`` parameter from the ``greedy_modularity_communities``
+  function.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -31,6 +31,10 @@ API Changes
 Deprecations
 ------------
 
+- [`#5227 <https://github.com/networkx/networkx/pull/5227>`_]
+  Deprecate the ``n_communities`` parameter name in ``greedy_modularity_communities``
+  in favor of ``cutoff``.
+
 
 Merged PRs
 ----------

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -272,9 +272,11 @@ def greedy_modularity_communities(
         If ``None``, don't force it to continue beyond a maximum.
 
     n_communities : int or None, optional (default=None)
-    .. deprecated:: 3.0
-       The `n_communities` parameter is deprecated - use `cutoff` and/or
-       `best_n` to set bounds on the desired number of communities instead.
+
+        .. deprecated:: 3.0
+           The `n_communities` parameter is deprecated - use `cutoff` and/or
+           `best_n` to set bounds on the desired number of communities instead.
+
         A minimum number of communities below which the merging process stops.
         The process stops at this number of communities even if modularity
         is not maximized. The goal is to let the user stop the process early.


### PR DESCRIPTION
Followup to #5227

Adds note to developer docs about the parameter deprecation. This should also include a release note, but that will depend on which release this is included in. If #5227 is to be included in the 2.7.2 release, then a deprecation note should be added to the 2.7.2 release note. To be discussed...