### PR TITLE
Multigraph bridges

### DIFF
--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -13,7 +13,8 @@ def bridges(G, root=None):
 
     A *bridge* in a graph is an edge whose removal causes the number of
     connected components of the graph to increase.  Equivalently, a bridge is an
-    edge that does not belong to any cycle.
+    edge that does not belong to any cycle. Bridges are also known as cut-edges,
+    isthmuses, or cut arcs.
 
     Parameters
     ----------

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -57,16 +57,14 @@ def bridges(G, root=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29#Bridge-Finding_with_Chain_Decompositions
     """
-    multi_edges = []
-    if isinstance(G, nx.MultiGraph):
-        multi_edges = [
-            (e[0], e[1]) for e in G.edges if G.number_of_edges(e[0], e[1]) > 1
-        ]
-        G = nx.Graph(G)
-    chains = nx.chain_decomposition(G, root=root)
+    multigraph = G.is_multigraph()
+    H = nx.Graph(G) if multigraph else G
+    chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
-    for u, v in set(G.edges()) - set(multi_edges):
+    for u, v in H.edges():
         if (u, v) not in chain_edges and (v, u) not in chain_edges:
+            if multigraph and len(G[u][v]) > 1:
+                continue
             yield u, v
 
 

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -7,7 +7,6 @@ from networkx.utils import not_implemented_for
 __all__ = ["bridges", "has_bridges", "local_bridges"]
 
 
-@not_implemented_for("multigraph")
 @not_implemented_for("directed")
 def bridges(G, root=None):
     """Generate all bridges in a graph.
@@ -58,14 +57,23 @@ def bridges(G, root=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29#Bridge-Finding_with_Chain_Decompositions
     """
+    multi_edges = []
+    if isinstance(G, nx.MultiGraph):
+        multi_edges = [
+            (e[0], e[1]) for e in G.edges if G.number_of_edges(e[0], e[1]) > 1
+        ]
+        G = nx.Graph(G)
     chains = nx.chain_decomposition(G, root=root)
     chain_edges = set(chain.from_iterable(chains))
     for u, v in G.edges():
-        if (u, v) not in chain_edges and (v, u) not in chain_edges:
+        if (
+            (u, v) not in chain_edges
+            and (v, u) not in chain_edges
+            and (u, v) not in multi_edges
+        ):
             yield u, v
 
 
-@not_implemented_for("multigraph")
 @not_implemented_for("directed")
 def has_bridges(G, root=None):
     """Decide whether a graph has any bridges.

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -45,11 +45,11 @@ def bridges(G, root=None):
 
     Notes
     -----
-    This is an implementation of the algorithm described in _[1].  An edge is a
+    This is an implementation of the algorithm described in [1]_.  An edge is a
     bridge if and only if it is not contained in any chain. Chains are found
     using the :func:`networkx.chain_decomposition` function.
 
-    The algorithm described in _[1] requires a simple graph. If the provided
+    The algorithm described in [1]_ requires a simple graph. If the provided
     graph is a multigraph, we convert it to a simple graph and verify that any
     bridges discovered by the chain decomposition algorithm are not multi-edges.
 

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -49,6 +49,10 @@ def bridges(G, root=None):
     bridge if and only if it is not contained in any chain. Chains are found
     using the :func:`networkx.chain_decomposition` function.
 
+    The algorithm described in _[1] requires a simple graph. If the provided
+    graph is a multigraph, we convert it to a simple graph and verify that any
+    bridges discovered by the chain decomposition algorithm are not multi-edges.
+
     Ignoring polylogarithmic factors, the worst-case time complexity is the
     same as the :func:`networkx.chain_decomposition` function,
     $O(m + n)$, where $n$ is the number of nodes in the graph and $m$ is

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -65,12 +65,8 @@ def bridges(G, root=None):
         G = nx.Graph(G)
     chains = nx.chain_decomposition(G, root=root)
     chain_edges = set(chain.from_iterable(chains))
-    for u, v in G.edges():
-        if (
-            (u, v) not in chain_edges
-            and (v, u) not in chain_edges
-            and (u, v) not in multi_edges
-        ):
+    for u, v in set(G.edges()) - set(multi_edges):
+        if (u, v) not in chain_edges and (v, u) not in chain_edges:
             yield u, v
 
 

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -42,10 +42,10 @@ class TestBridges:
             (0, 1),
             (0, 2),
             (1, 2),
-            (1, 2), # should not impact bridges
+            (1, 2),
             (2, 3),
             (3, 4),
-            (3, 4)  # should not impact bridges
+            (3, 4),
         ]
         G = nx.MultiGraph(edges)
         assert list(nx.bridges(G)) == [(2, 3)]

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -37,6 +37,19 @@ class TestBridges:
         bridges = list(nx.bridges(G, source))
         assert bridges == [(2, 3)]
 
+    def test_multiedge_bridge(self):
+        edges = [
+            (0, 1),
+            (0, 2),
+            (1, 2),
+            (1, 2), # should not impact bridges
+            (2, 3),
+            (3, 4),
+            (3, 4)  # should not impact bridges
+        ]
+        G = nx.MultiGraph(edges)
+        assert list(nx.bridges(G)) == [(2, 3)]
+
 
 class TestLocalBridges:
     """Unit tests for the local_bridge function."""


### PR DESCRIPTION
This PR modifies `nx.bridges` to accommodate multigraphs. 

The fast bridge-finding algorithm used by `nx.bridges` ([Algorithm 1](https://arxiv.org/abs/1209.0700)) requires a simple graph. A bridge in a multigraph must have multiplicity one, so running the algorithm on the simple version of a multigraph and verifying that any discovered bridges are not multi-edges should be sufficient.