### PR TITLE
added extra condition for fancy arrow colors

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -697,6 +697,7 @@ def draw_networkx_edges(
     # FancyArrowPatch handles color=None different from LineCollection
     if edge_color is None:
         edge_color = "k"
+    edge_color_dict = dict(zip(map(tuple, edgelist), edge_color))
 
     # set edge positions
     edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in edgelist])
@@ -797,7 +798,7 @@ def draw_networkx_edges(
 
         # FancyArrowPatch doesn't handle color strings
         arrow_colors = mpl.colors.colorConverter.to_rgba_array(edge_color, alpha)
-        for i, (src, dst) in enumerate(edge_pos):
+        for i, (edge, (src, dst)) in enumerate(zip(fancy_edges, edge_pos)):
             x1, y1 = src
             x2, y2 = dst
             shrink_source = 0  # space from source to tail
@@ -826,9 +827,10 @@ def draw_networkx_edges(
                 arrow_color = arrow_colors[i]
             elif len(arrow_colors) == 1:
                 arrow_color = arrow_colors[0]
+            elif edge in edge_color_dict:
+                arrow_color = edge_color_dict[edge]
             else:  # Cycle through colors
                 arrow_color = arrow_colors[i % len(arrow_colors)]
-
             if np.iterable(width):
                 if len(width) == len(edge_pos):
                     line_width = width[i]
@@ -882,10 +884,12 @@ def draw_networkx_edges(
         # Make sure selfloop edges are also drawn
         selfloops_to_draw = [loop for loop in nx.selfloop_edges(G) if loop in edgelist]
         if selfloops_to_draw:
+            fancy_edges = selfloops_to_draw
             edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in selfloops_to_draw])
             arrowstyle = "-"
             _draw_networkx_edges_fancy_arrow_patch()
     else:
+        fancy_edges = [tuple(edge) for edge in edgelist]
         edge_viz_obj = _draw_networkx_edges_fancy_arrow_patch()
 
     # update view after drawing

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -697,7 +697,7 @@ def draw_networkx_edges(
     # FancyArrowPatch handles color=None different from LineCollection
     if edge_color is None:
         edge_color = "k"
-    edge_color_dict = dict(zip(map(tuple, edgelist), edge_color))
+    edgelist_tuple = list(map(tuple, edgelist))
 
     # set edge positions
     edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in edgelist])
@@ -798,7 +798,7 @@ def draw_networkx_edges(
 
         # FancyArrowPatch doesn't handle color strings
         arrow_colors = mpl.colors.colorConverter.to_rgba_array(edge_color, alpha)
-        for i, (edge, (src, dst)) in enumerate(zip(fancy_edges, edge_pos)):
+        for i, (src, dst) in zip(fancy_edges_indices, edge_pos):
             x1, y1 = src
             x2, y2 = dst
             shrink_source = 0  # space from source to tail
@@ -823,16 +823,15 @@ def draw_networkx_edges(
             if shrink_target < min_target_margin:
                 shrink_target = min_target_margin
 
-            if len(arrow_colors) == len(edge_pos):
+            if len(arrow_colors) > i:
                 arrow_color = arrow_colors[i]
             elif len(arrow_colors) == 1:
                 arrow_color = arrow_colors[0]
-            elif edge in edge_color_dict:
-                arrow_color = edge_color_dict[edge]
             else:  # Cycle through colors
                 arrow_color = arrow_colors[i % len(arrow_colors)]
+
             if np.iterable(width):
-                if len(width) == len(edge_pos):
+                if len(width) > i:
                     line_width = width[i]
                 else:
                     line_width = width[i % len(width)]
@@ -844,7 +843,7 @@ def draw_networkx_edges(
                 and not isinstance(style, str)
                 and not isinstance(style, tuple)
             ):
-                if len(style) == len(edge_pos):
+                if len(style) > i:
                     linestyle = style[i]
                 else:  # Cycle through styles
                     linestyle = style[i % len(style)]
@@ -884,12 +883,14 @@ def draw_networkx_edges(
         # Make sure selfloop edges are also drawn
         selfloops_to_draw = [loop for loop in nx.selfloop_edges(G) if loop in edgelist]
         if selfloops_to_draw:
-            fancy_edges = selfloops_to_draw
+            fancy_edges_indices = [
+                edgelist_tuple.index(loop) for loop in selfloops_to_draw
+            ]
             edge_pos = np.asarray([(pos[e[0]], pos[e[1]]) for e in selfloops_to_draw])
             arrowstyle = "-"
             _draw_networkx_edges_fancy_arrow_patch()
     else:
-        fancy_edges = [tuple(edge) for edge in edgelist]
+        fancy_edges_indices = range(len(edgelist))
         edge_viz_obj = _draw_networkx_edges_fancy_arrow_patch()
 
     # update view after drawing


### PR DESCRIPTION
While working with edge colors I found the following problem.

Suppose we have a simple undirected graph with loops. We want to draw it with specified `edge_color` argument as follows:

```python
edges = [(1, 3), (1, 2), (2, 3), (1, 1), (3, 3), (2, 2)]
edge_colors = ['pink', 'cyan', 'black', 'red', 'blue', 'green']
H = nx.Graph()
H.add_edges_from(edges)
nx.draw(H, edgelist=edges, edge_color=edge_colors, with_labels=True)
```
With `networkx` version `2.7.2rc1.dev0` we will have quite a strange result (colors of loops do not match the declared colors):

![image](https://user-images.githubusercontent.com/36994200/159562495-5571baad-c2ae-43cc-aef0-b5d7ad57225f.png)

The problem is [this part of ](https://github.com/networkx/networkx/blob/6a0b4faf09ec9d3d40ad93e2ec9b431d6bab5dc4/networkx/drawing/nx_pylab.py#L885) the `draw_networkx_edges`  function where we redefine `edge_pos`. So when we call the function `_draw_networkx_edges_fancy_arrow_patch` we skip both conditions `len(arrow_colors) == len(edge_pos)` and `len(arrow_colors) == 1` and cycle through colors. This wouldn't have been a problem if we hadn't defined colors for those loops but if we do, the result seems to be incorrect.

I suggest to change the function so we get the result like this:
![image](https://user-images.githubusercontent.com/36994200/159563759-362f9083-f71d-4767-a8f3-39af744bb203.png)



