### PR TITLE
Update extrema bounding method for compute="eccentricities" parameter

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -156,7 +156,8 @@ def extrema_bounding(G, compute="diameter"):
             ruled_out = set([])
 
         else:
-            msg = "The argument passed to compute parameter is invalid. Please enter one of the following extreme distance metrics: diameter, radius, periphery, center,eccentricities."
+            msg = "The argument passed to compute parameter is invalid. \
+            Please enter one of the following extreme distance metrics: diameter, radius, periphery, center, eccentricities."
             raise nx.NetworkXError(msg)
 
         ruled_out.update(i for i in candidates if ecc_lower[i] == ecc_upper[i])

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -156,8 +156,7 @@ def extrema_bounding(G, compute="diameter"):
             ruled_out = set([])
 
         else:
-            msg = "The argument passed to compute parameter is invalid. \
-            Please enter one of the following extreme distance metrics: diameter, radius, periphery, center, eccentricities."
+            msg = "Please enter one of the following extreme distance metrics: diameter, radius, periphery, center, eccentricities."
             raise nx.NetworkXError(msg)
 
         ruled_out.update(i for i in candidates if ecc_lower[i] == ecc_upper[i])

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -128,14 +128,12 @@ def extrema_bounding(G, compute="diameter"):
                 for i in candidates
                 if ecc_upper[i] <= maxlower and 2 * ecc_lower[i] >= maxupper
             }
-
         elif compute == "radius":
             ruled_out = {
                 i
                 for i in candidates
                 if ecc_lower[i] >= minupper and ecc_upper[i] + 1 <= 2 * minlower
             }
-
         elif compute == "periphery":
             ruled_out = {
                 i
@@ -143,7 +141,6 @@ def extrema_bounding(G, compute="diameter"):
                 if ecc_upper[i] < maxlower
                 and (maxlower == maxupper or ecc_lower[i] > maxupper)
             }
-
         elif compute == "center":
             ruled_out = {
                 i
@@ -151,12 +148,10 @@ def extrema_bounding(G, compute="diameter"):
                 if ecc_lower[i] > minupper
                 and (minlower == minupper or ecc_upper[i] + 1 < 2 * minlower)
             }
-
         elif compute == "eccentricities":
-            ruled_out = set([])
-
+            ruled_out = set()
         else:
-            msg = "Please enter one of the following extreme distance metrics: diameter, radius, periphery, center, eccentricities."
+            msg = "The argument passed to compute parameter is invalid. Please enter one of the following extreme distance metrics: 'diameter', 'radius', 'periphery', 'center', 'eccentricities'"
             raise nx.NetworkXError(msg)
 
         ruled_out.update(i for i in candidates if ecc_lower[i] == ecc_upper[i])

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -44,9 +44,9 @@ def extrema_bounding(G, compute="diameter"):
     Raises
     ------
     NetworkXError
-        If the graph consists of multiple components or
-        If the compute parameter is passed an invalid argument
-
+        If the graph consists of multiple components
+    ValueError
+        If `compute` is not one of "diameter", "radius", "periphery", "center", or "eccentricities".
     Notes
     -----
     This algorithm was proposed in the following papers:
@@ -151,8 +151,8 @@ def extrema_bounding(G, compute="diameter"):
         elif compute == "eccentricities":
             ruled_out = set()
         else:
-            msg = "The argument passed to compute parameter is invalid. Please enter one of the following extreme distance metrics: 'diameter', 'radius', 'periphery', 'center', 'eccentricities'"
-            raise nx.NetworkXError(msg)
+            msg = "compute must be one of 'diameter', 'radius', 'periphery', 'center', 'eccentricities'"
+            raise ValueError(msg)
 
         ruled_out.update(i for i in candidates if ecc_lower[i] == ecc_upper[i])
         candidates -= ruled_out

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -30,19 +30,22 @@ def extrema_bounding(G, compute="diameter"):
     compute : string denoting the requesting metric
        "diameter" for the maximal eccentricity value,
        "radius" for the minimal eccentricity value,
-       "periphery" for the set of nodes with eccentricity equal to the diameter
-       "center" for the set of nodes with eccentricity equal to the radius
+       "periphery" for the set of nodes with eccentricity equal to the diameter,
+       "center" for the set of nodes with eccentricity equal to the radius,
+       "eccentricities" for the maximum distance from each node to all other nodes in G
 
     Returns
     -------
     value : value of the requested metric
        int for "diameter" and "radius" or
-       list of nodes for "center" and "periphery"
+       list of nodes for "center" and "periphery" or
+       dictionary of eccentricity values keyed by node for "eccentricities"
 
     Raises
     ------
     NetworkXError
-        If the graph consists of multiple components
+        If the graph consists of multiple components or
+        If the compute parameter is passed an invalid argument
 
     Notes
     -----
@@ -150,7 +153,11 @@ def extrema_bounding(G, compute="diameter"):
             }
 
         elif compute == "eccentricities":
-            ruled_out = {}
+            ruled_out = set([])
+
+        else:
+            msg = "The argument passed to compute parameter is invalid. Please enter one of the following extreme distance metrics: 'diameter', 'radius', 'periphery', 'center', 'eccentricities'"
+            raise nx.NetworkXError(msg)
 
         ruled_out.update(i for i in candidates if ecc_lower[i] == ecc_upper[i])
         candidates -= ruled_out

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -156,7 +156,7 @@ def extrema_bounding(G, compute="diameter"):
             ruled_out = set([])
 
         else:
-            msg = "The argument passed to compute parameter is invalid. Please enter one of the following extreme distance metrics: 'diameter', 'radius', 'periphery', 'center', 'eccentricities'"
+            msg = "The argument passed to compute parameter is invalid. Please enter one of the following extreme distance metrics: diameter, radius, periphery, center,eccentricities."
             raise nx.NetworkXError(msg)
 
         ruled_out.update(i for i in candidates if ecc_lower[i] == ecc_upper[i])

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -7,6 +7,15 @@ import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
 
 
+class TestExtremaBounding:
+    """Test :func:`networkx.algorithms.distance_measures.extrema_bounding`."""
+
+    def test_extrema_bounding_invalid_compute_kwarg(self):
+        G = nx.path_graph(3)
+        with pytest.raises(ValueError, match="compute must be one of"):
+            nx.extrema_bounding(G, compute="spam")
+
+
 class TestDistance:
     def setup_method(self):
         G = cnlti(nx.grid_2d_graph(4, 4), first_label=1, ordering="sorted")

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -7,13 +7,10 @@ import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
 
 
-class TestExtremaBounding:
-    """Test :func:`networkx.algorithms.distance_measures.extrema_bounding`."""
-
-    def test_extrema_bounding_invalid_compute_kwarg(self):
-        G = nx.path_graph(3)
-        with pytest.raises(ValueError, match="compute must be one of"):
-            nx.extrema_bounding(G, compute="spam")
+def test_extrema_bounding_invalid_compute_kwarg():
+    G = nx.path_graph(3)
+    with pytest.raises(ValueError, match="compute must be one of"):
+        nx.extrema_bounding(G, compute="spam")
 
 
 class TestDistance:


### PR DESCRIPTION
Issue number: [#5402](https://github.com/networkx/networkx/issues/5402)

I have updated extrema_bounding function's documentation:
    - In parameters section, "eccentricities" is listed with explanation,
    - In returns section, eccentricities' return value is listed
    - In raises section, NetworkXError to be raised when compute parameter is passed an invalid argument is written
    
In extrema_bounding function, when compute parameter is passed  "eccentricities" argument, the ruled_out variable is set to an empyt set (rather than an empty dict). Moreover, if the compute parameter is not passed a valid extreme distance metric argument (not one of the 'diameter', 'radius', 'periphery', 'center', 'eccentricities'), a NetworkXError is raised with appropriate message.
