### PR TITLE
Deprecate extrema bounding

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -111,3 +111,4 @@ Version 3.0
 * In ``algorithms/community/modularity_max.py``, remove the deprecated
   ``n_communities`` parameter from the ``greedy_modularity_communities``
   function.
+* In ``algorithms/distance_measures.py`` remove ``extrema_bounding``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -34,6 +34,9 @@ Deprecations
 - [`#5227 <https://github.com/networkx/networkx/pull/5227>`_]
   Deprecate the ``n_communities`` parameter name in ``greedy_modularity_communities``
   in favor of ``cutoff``.
+- [`#5422 <https://github.com/networkx/networkx/pull/5422>`_]
+  Deprecate ``extrema_bounding``. Use the related distance measures with
+  ``usebounds=True`` instead.
 
 
 Merged PRs

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -18,6 +18,12 @@ __all__ = [
 def extrema_bounding(G, compute="diameter"):
     """Compute requested extreme distance metric of undirected graph G
 
+    .. deprecated:: 2.8
+
+       extrema_bounding is deprecated and will be removed in NetworkX 3.0.
+       Use the corresponding distance measure with the `usebounds=True` option
+       instead.
+
     Computation is based on smart lower and upper bounds, and in practice
     linear in the number of nodes, rather than quadratic (except for some
     border cases such as complete graphs or circle shaped graphs).
@@ -65,6 +71,16 @@ def extrema_bounding(G, compute="diameter"):
     Real-World Graphs, Theoretical Computer Science 586: 59-80, 2015.
     doi: https://doi.org/10.1016/j.tcs.2015.02.033
     """
+    import warnings
+
+    msg = "extrema_bounding is deprecated and will be removed in networkx 3.0\n"
+    # NOTE: _extrema_bounding does input checking, so it is skipped here
+    if compute in {"diameter", "radius", "periphery", "center"}:
+        msg += f"Use nx.{compute}(G, usebounds=True) instead."
+    if compute == "eccentricities":
+        msg += f"Use nx.eccentricity(G) instead."
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     return _extrema_bounding(G, compute=compute)
 
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -65,6 +65,59 @@ def extrema_bounding(G, compute="diameter"):
     Real-World Graphs, Theoretical Computer Science 586: 59-80, 2015.
     doi: https://doi.org/10.1016/j.tcs.2015.02.033
     """
+    return _extrema_bounding(G, compute=compute)
+
+
+def _extrema_bounding(G, compute="diameter"):
+    """Compute requested extreme distance metric of undirected graph G
+
+    Computation is based on smart lower and upper bounds, and in practice
+    linear in the number of nodes, rather than quadratic (except for some
+    border cases such as complete graphs or circle shaped graphs).
+
+    Parameters
+    ----------
+    G : NetworkX graph
+       An undirected graph
+
+    compute : string denoting the requesting metric
+       "diameter" for the maximal eccentricity value,
+       "radius" for the minimal eccentricity value,
+       "periphery" for the set of nodes with eccentricity equal to the diameter,
+       "center" for the set of nodes with eccentricity equal to the radius,
+       "eccentricities" for the maximum distance from each node to all other nodes in G
+
+    Returns
+    -------
+    value : value of the requested metric
+       int for "diameter" and "radius" or
+       list of nodes for "center" and "periphery" or
+       dictionary of eccentricity values keyed by node for "eccentricities"
+
+    Raises
+    ------
+    NetworkXError
+        If the graph consists of multiple components
+    ValueError
+        If `compute` is not one of "diameter", "radius", "periphery", "center", or "eccentricities".
+    Notes
+    -----
+    This algorithm was proposed in the following papers:
+
+    F.W. Takes and W.A. Kosters, Determining the Diameter of Small World
+    Networks, in Proceedings of the 20th ACM International Conference on
+    Information and Knowledge Management (CIKM 2011), pp. 1191-1196, 2011.
+    doi: https://doi.org/10.1145/2063576.2063748
+
+    F.W. Takes and W.A. Kosters, Computing the Eccentricity Distribution of
+    Large Graphs, Algorithms 6(1): 100-118, 2013.
+    doi: https://doi.org/10.3390/a6010100
+
+    M. Borassi, P. Crescenzi, M. Habib, W.A. Kosters, A. Marino and F.W. Takes,
+    Fast Graph Diameter and Radius BFS-Based Computation in (Weakly Connected)
+    Real-World Graphs, Theoretical Computer Science 586: 59-80, 2015.
+    doi: https://doi.org/10.1016/j.tcs.2015.02.033
+    """
 
     # init variables
     degrees = dict(G.degree())  # start with the highest degree node
@@ -296,7 +349,7 @@ def diameter(G, e=None, usebounds=False):
     eccentricity
     """
     if usebounds is True and e is None and not G.is_directed():
-        return extrema_bounding(G, compute="diameter")
+        return _extrema_bounding(G, compute="diameter")
     if e is None:
         e = eccentricity(G)
     return max(e.values())
@@ -326,7 +379,7 @@ def periphery(G, e=None, usebounds=False):
     center
     """
     if usebounds is True and e is None and not G.is_directed():
-        return extrema_bounding(G, compute="periphery")
+        return _extrema_bounding(G, compute="periphery")
     if e is None:
         e = eccentricity(G)
     diameter = max(e.values())
@@ -353,7 +406,7 @@ def radius(G, e=None, usebounds=False):
        Radius of graph
     """
     if usebounds is True and e is None and not G.is_directed():
-        return extrema_bounding(G, compute="radius")
+        return _extrema_bounding(G, compute="radius")
     if e is None:
         e = eccentricity(G)
     return min(e.values())
@@ -383,7 +436,7 @@ def center(G, e=None, usebounds=False):
     periphery
     """
     if usebounds is True and e is None and not G.is_directed():
-        return extrema_bounding(G, compute="center")
+        return _extrema_bounding(G, compute="center")
     if e is None:
         e = eccentricity(G)
     radius = min(e.values())

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -5,12 +5,13 @@ import pytest
 
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
+from networkx.algorithms.distance_measures import _extrema_bounding
 
 
-def test_extrema_bounding_invalid_compute_kwarg():
+def test__extrema_bounding_invalid_compute_kwarg():
     G = nx.path_graph(3)
     with pytest.raises(ValueError, match="compute must be one of"):
-        nx.extrema_bounding(G, compute="spam")
+        _extrema_bounding(G, compute="spam")
 
 
 class TestDistance:

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -8,6 +8,15 @@ from networkx import convert_node_labels_to_integers as cnlti
 from networkx.algorithms.distance_measures import _extrema_bounding
 
 
+@pytest.mark.parametrize(
+    "compute", ("diameter", "radius", "periphery", "center", "eccentricities")
+)
+def test_extrema_bounding_deprecated(compute):
+    G = nx.complete_graph(3)
+    with pytest.deprecated_call():
+        nx.extrema_bounding(G, compute=compute)
+
+
 def test__extrema_bounding_invalid_compute_kwarg():
     G = nx.path_graph(3)
     with pytest.raises(ValueError, match="compute must be one of"):


### PR DESCRIPTION
Closes #5415

Marks `extrema_bounding` for deprecation in favor of the `usebounds` kwarg in the related distance functions. In other words, users should use `nx.diameter(G, usebounds=True)` instead of `nx.extrema_bounding(G, compute="diameter")`.