### PR TITLE
Deprecate `to_tuple`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -113,3 +113,4 @@ Version 3.0
   function.
 * In ``algorithms/distance_measures.py`` remove ``extrema_bounding``.
 * In ``utils/misc.py`` remove ``dict_to_numpy_array1`` and ``dict_to_numpy_array2``.
+* In ``utils/misc.py`` remove ``to_tuple``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -40,6 +40,8 @@ Deprecations
 - [`#5427 <https://github.com/networkx/networkx/pull/5427>`_]
   Deprecate ``dict_to_numpy_array1`` and ``dict_to_numpy_array2`` in favor of
   ``dict_to_numpy_array``, which handles both.
+- [`#5428 <https://github.com/networkx/networkx/pull/5428>`_]
+  Deprecate ``utils.misc.to_tuple``.
 
 
 Merged PRs

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -233,6 +233,7 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="to_numpy_recarray"
     )
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="info")
+    warnings.filterwarnings("ignore", category=DeprecationWarning, message="to_tuple")
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -1,11 +1,27 @@
 from itertools import chain, count
 import networkx as nx
-from networkx.utils import to_tuple
 
 __all__ = ["node_link_data", "node_link_graph"]
 
 
 _attrs = dict(source="source", target="target", name="id", key="key", link="links")
+
+
+def _to_tuple(x):
+    """Converts lists to tuples, including nested lists.
+
+    All other non-list inputs are passed through unmodified. This function is
+    intended to be used to convert potentially nested lists from json files
+    into valid nodes.
+
+    Examples
+    --------
+    >>> _to_tuple([1, 2, [3, 4]])
+    (1, 2, (3, 4))
+    """
+    if not isinstance(x, (tuple, list)):
+        return x
+    return tuple(map(_to_tuple, x))
 
 
 def node_link_data(G, attrs=None):
@@ -164,7 +180,7 @@ def node_link_graph(data, directed=False, multigraph=True, attrs=None):
     graph.graph = data.get("graph", {})
     c = count()
     for d in data["nodes"]:
-        node = to_tuple(d.get(name, next(c)))
+        node = _to_tuple(d.get(name, next(c)))
         nodedata = {str(k): v for k, v in d.items() if k != name}
         graph.add_node(node, **nodedata)
     for d in data[links]:

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -437,6 +437,10 @@ def groups(many_to_one):
 def to_tuple(x):
     """Converts lists to tuples.
 
+    .. deprecated:: 2.8
+
+       to_tuple is deprecated and will be removed in NetworkX 3.0.
+
     Examples
     --------
     >>> from networkx.utils import to_tuple
@@ -444,6 +448,12 @@ def to_tuple(x):
     >>> to_tuple(a_list)
     (1, 2, (1, 4))
     """
+    warnings.warn(
+        "to_tuple is deprecated and will be removed in NetworkX 3.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if not isinstance(x, (tuple, list)):
         return x
     return tuple(map(to_tuple, x))


### PR DESCRIPTION
Closes #5426

Moves `to_tuple` to a private, internal function in `json_graph.nodelink` and deprecates the public-facing function for removal in 3.0. See #5426 for discussion.