### PR TITLE
Use https links for conference.scipy.org

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,17 +34,17 @@ To cite NetworkX please use the following publication:
 
 Aric A. Hagberg, Daniel A. Schult and Pieter J. Swart,
 `"Exploring network structure, dynamics, and function using NetworkX"
-<http://conference.scipy.org/proceedings/SciPy2008/paper_2/>`_,
+<https://conference.scipy.org/proceedings/SciPy2008/paper_2/>`_,
 in
 `Proceedings of the 7th Python in Science Conference (SciPy2008)
-<http://conference.scipy.org/proceedings/SciPy2008/index.html>`_, Gäel
+<https://conference.scipy.org/proceedings/SciPy2008/index.html>`_, Gäel
 Varoquaux, Travis Vaught, and Jarrod Millman (Eds), (Pasadena, CA
 USA), pp. 11--15, Aug 2008
 
 .. only:: html
 
-   `PDF <http://conference.scipy.org/proceedings/SciPy2008/paper_2/full_text.pdf>`_
-   `BibTeX <http://conference.scipy.org/proceedings/SciPy2008/paper_2/reference.bib>`_
+   `PDF <https://conference.scipy.org/proceedings/SciPy2008/paper_2/full_text.pdf>`_
+   `BibTeX <https://conference.scipy.org/proceedings/SciPy2008/paper_2/reference.bib>`_
 
 Audience
 --------


### PR DESCRIPTION
The server reset from https://github.com/networkx/networkx/issues/5433 fixed the resolution issues, but both Firefox and Chromium refuse to play nice with the .`bib` file on this machine, apparently because they're concerned with the insecurity of the `http:` target. 

![ff_not_downloaded](https://user-images.githubusercontent.com/39198770/160680909-088938b7-a547-4aec-a45a-16cb6a1ad94e.png)

Both are happy to download the .bib from `https:...`. I've changed the PDF and .bib links to `https`.