### PR TITLE
Fixes #5403: Errors on non-distinct bipartite node sets

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -24,6 +24,11 @@ Improvements
 ------------
 
 
+- `is_bipartite_node_set` now raises an exception when the tested nodes are
+  not distinct (previously this would not affect the outcome).
+  This is to avoid surprising behaviour when using node sets in other bipartite
+  algorithms, for example it yields incorrect results for `weighted_projected_graph`.
+
 API Changes
 -----------
 

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -5,6 +5,7 @@ Bipartite Graph Algorithms
 """
 import networkx as nx
 from networkx.algorithms.components import connected_components
+from networkx.exception import AmbiguousSolution
 
 __all__ = [
     "is_bipartite",
@@ -126,10 +127,21 @@ def is_bipartite_node_set(G, nodes):
 
     Notes
     -----
+    An exception is raised if the input nodes are not distinct, because in this
+    case some bipartite algorithms will yield incorrect results.
     For connected graphs the bipartite sets are unique.  This function handles
     disconnected graphs.
     """
     S = set(nodes)
+
+    if len(S) < len(nodes):
+        # this should maybe just return False?
+        raise AmbiguousSolution(
+            "The input node set contains duplicates.\n"
+            "This may lead to incorrect results when using it in bipartite algorithms.\n"
+            "Consider using set(nodes) as the input"
+        )
+
     for CC in (G.subgraph(c).copy() for c in connected_components(G)):
         X, Y = sets(CC)
         if not (

--- a/networkx/algorithms/bipartite/tests/test_basic.py
+++ b/networkx/algorithms/bipartite/tests/test_basic.py
@@ -51,6 +51,10 @@ class TestBipartiteBasic:
 
     def test_is_bipartite_node_set(self):
         G = nx.path_graph(4)
+
+        with pytest.raises(nx.AmbiguousSolution):
+            bipartite.is_bipartite_node_set(G, [1, 1, 2, 3])
+
         assert bipartite.is_bipartite_node_set(G, [0, 2])
         assert bipartite.is_bipartite_node_set(G, [1, 3])
         assert not bipartite.is_bipartite_node_set(G, [1, 2])

--- a/networkx/algorithms/bipartite/tests/test_project.py
+++ b/networkx/algorithms/bipartite/tests/test_project.py
@@ -1,4 +1,6 @@
 import networkx as nx
+import pytest
+
 from networkx.algorithms import bipartite
 from networkx.utils import nodes_equal, edges_equal
 
@@ -51,6 +53,10 @@ class TestBipartiteProject:
 
     def test_path_weighted_projected_graph(self):
         G = nx.path_graph(4)
+
+        with pytest.raises(nx.NetworkXAlgorithmError):
+            bipartite.weighted_projected_graph(G, [1, 2, 3, 3])
+
         P = bipartite.weighted_projected_graph(G, [1, 3])
         assert nodes_equal(list(P), [1, 3])
         assert edges_equal(list(P.edges()), [(1, 3)])

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -10,17 +10,17 @@ from networkx.algorithms.flow import preflow_push
 from networkx.algorithms.flow import shortest_augmenting_path
 from networkx.algorithms.flow import dinitz
 
-flow_funcs = [
+flow_funcs = {
     boykov_kolmogorov,
     dinitz,
     edmonds_karp,
     preflow_push,
     shortest_augmenting_path,
-]
-max_min_funcs = [nx.maximum_flow, nx.minimum_cut]
-flow_value_funcs = [nx.maximum_flow_value, nx.minimum_cut_value]
-interface_funcs = max_min_funcs + flow_value_funcs
-all_funcs = sum([flow_funcs, interface_funcs], [])
+}
+max_min_funcs = {nx.maximum_flow, nx.minimum_cut}
+flow_value_funcs = {nx.maximum_flow_value, nx.minimum_cut_value}
+interface_funcs = max_min_funcs & flow_value_funcs
+all_funcs = flow_funcs & interface_funcs
 
 
 def compute_cutset(G, partition):


### PR DESCRIPTION
- `is_bipartite_node_set` raises an exception if the node set is not distinct. This is to avoid unexpected errors or incorrect results when using bipartite algorithms, for instance `weighted_projected_graph`, where results can be out by a factor.
- `weighted_projected_graph` raises an exception if the node set is greater than or equal to the graph size. Previously the user recieved an enigmatic `ZeroDivisionError` in this case. 

Follows the discussion of #5403.

I think there's still some discussion to be had on whether `is_bipartite_node_set` should raise an exception or simply return `False` like it does for other invalid partitions.