### PR TITLE
Don't use graph6 with directed graphs (#5443)

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -128,6 +128,8 @@ def from_graph6_bytes(bytes_in):
     return G
 
 
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
 def to_graph6_bytes(G, nodes=None, header=True):
     """Convert a simple undirected graph to bytes in graph6 format.
 

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -79,9 +79,10 @@ class TestWriteGraph6:
         # The expected encoding here was verified by Sage.
         assert result.getvalue() == b"N??F~z{~Fw^_~?~?^_?\n"
 
-    def test_no_directed_graphs(self):
+    @pytest.mark.parametrize("G", (nx.MultiGraph(), nx.DiGraph()))
+    def test_no_directed_or_multi_graphs(self, G):
         with pytest.raises(nx.NetworkXNotImplemented):
-            nx.write_graph6(nx.DiGraph(), BytesIO())
+            nx.write_graph6(G, BytesIO())
 
     def test_length(self):
         for i in list(range(13)) + [31, 47, 62, 63, 64, 72]:
@@ -141,8 +142,8 @@ class TestToGraph6Bytes:
         G = nx.complete_bipartite_graph(6, 9)
         assert g6.to_graph6_bytes(G, header=False) == b"N??F~z{~Fw^_~?~?^_?\n"
 
-    def test_no_directed_graphs(self):
-        G = nx.DiGraph()
+    @pytest.mark.parametrize("G", (nx.MultiGraph(), nx.DiGraph()))
+    def test_no_directed_or_multi_graphs(self, G):
         with pytest.raises(nx.NetworkXNotImplemented):
             g6.to_graph6_bytes(G)
 

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -108,13 +108,13 @@ class TestWriteGraph6:
             f.seek(0)
             assert f.read() == b">>graph6<<?\n"
 
-    def test_relabeling(self):
-        for edge in [(0, 1), (1, 2), (1, 42)]:
-            G = nx.Graph([edge])
-            f = BytesIO()
-            nx.write_graph6(G, f)
-            f.seek(0)
-            assert f.read() == b">>graph6<<A_\n"
+    @pytest.mark.parametrize("edge", ((0, 1), (1, 2), (1, 42)))
+    def test_relabeling(self, edge):
+        G = nx.Graph([edge])
+        f = BytesIO()
+        nx.write_graph6(G, f)
+        f.seek(0)
+        assert f.read() == b">>graph6<<A_\n"
 
 
 class TestToGraph6Bytes:
@@ -161,7 +161,7 @@ class TestToGraph6Bytes:
             assert nodes_equal(G.nodes(), H.nodes())
             assert edges_equal(G.edges(), H.edges())
 
-    def test_relabeling(self):
-        for edge in [(0, 1), (1, 2), (1, 42)]:
-            G = nx.Graph([edge])
-            assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"
+    @pytest.mark.parametrize("edge", ((0, 1), (1, 2), (1, 42)))
+    def test_relabeling(self, edge):
+        G = nx.Graph([edge])
+        assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -109,9 +109,59 @@ class TestWriteGraph6:
             assert f.read() == b">>graph6<<?\n"
 
     def test_relabeling(self):
-        G = nx.Graph([(0, 1)])
-        assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"
-        G = nx.Graph([(1, 2)])
-        assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"
-        G = nx.Graph([(1, 42)])
-        assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"
+        for edge in [(0, 1), (1, 2), (1, 42)]:
+            G = nx.Graph([edge])
+            f = BytesIO()
+            nx.write_graph6(G, f)
+            f.seek(0)
+            assert f.read() == b">>graph6<<A_\n"
+
+
+class TestToGraph6Bytes:
+    def test_null_graph(self):
+        G = nx.null_graph()
+        assert g6.to_graph6_bytes(G) == b">>graph6<<?\n"
+
+    def test_trivial_graph(self):
+        G = nx.trivial_graph()
+        assert g6.to_graph6_bytes(G) == b">>graph6<<@\n"
+
+    def test_complete_graph(self):
+        assert g6.to_graph6_bytes(nx.complete_graph(4)) == b">>graph6<<C~\n"
+
+    def test_large_complete_graph(self):
+        G = nx.complete_graph(67)
+        assert g6.to_graph6_bytes(G, header=False) == b"~?@B" + b"~" * 368 + b"w\n"
+
+    def test_no_header(self):
+        G = nx.complete_graph(4)
+        assert g6.to_graph6_bytes(G, header=False) == b"C~\n"
+
+    def test_complete_bipartite_graph(self):
+        G = nx.complete_bipartite_graph(6, 9)
+        assert g6.to_graph6_bytes(G, header=False) == b"N??F~z{~Fw^_~?~?^_?\n"
+
+    def test_no_directed_graphs(self):
+        G = nx.DiGraph()
+        with pytest.raises(nx.NetworkXNotImplemented):
+            g6.to_graph6_bytes(G)
+
+    def test_length(self):
+        for i in list(range(13)) + [31, 47, 62, 63, 64, 72]:
+            G = nx.random_graphs.gnm_random_graph(i, i * i // 4, seed=i)
+            # Strip the trailing newline.
+            gstr = g6.to_graph6_bytes(G, header=False).rstrip()
+            assert len(gstr) == ((i - 1) * i // 2 + 5) // 6 + (1 if i < 63 else 4)
+
+    def test_roundtrip(self):
+        for i in list(range(13)) + [31, 47, 62, 63, 64, 72]:
+            G = nx.random_graphs.gnm_random_graph(i, i * i // 4, seed=i)
+            data = g6.to_graph6_bytes(G)
+            H = nx.from_graph6_bytes(data.rstrip())
+            assert nodes_equal(G.nodes(), H.nodes())
+            assert edges_equal(G.edges(), H.edges())
+
+    def test_relabeling(self):
+        for edge in [(0, 1), (1, 2), (1, 42)]:
+            G = nx.Graph([edge])
+            assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"


### PR DESCRIPTION
I also added a few tests for the `to_graph6_bytes` method (they're very similar to those for the `write_graph6` method).

Closes #5443 