### PR TITLE
Make sympy extra dep

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,4 +2,3 @@ numpy>=1.19
 scipy>=1.8
 matplotlib>=3.4
 pandas>=1.3
-sympy>=1.0

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,3 +1,4 @@
 lxml>=4.6
 pygraphviz>=1.9
 pydot>=1.4.2
+sympy>=1.10


### PR DESCRIPTION
I made sympy an extra (not default) dependency as we had previously discussed not making things default dependencies until they are used a lot or for core functionality.

I also updated the minimum dependency from 1.0 to 1.10. This is a new dependency used by a single function that didn't exist before. I don't think there is any need to support a release of sympy that came out in 2016 and only claims to work on Python 3.5 or older.  (We only run on 3.8 or more recent).