### PR TITLE
Optimize prim for mst

### DIFF
--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -306,7 +306,7 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
                     msg = f"NaN found as an edge weight. Edge {(u, v, d)}"
                     raise ValueError(msg)
                 push(frontier, (wt, next(c), u, v, d))
-        while frontier:
+        while nodes and frontier:
             if is_multigraph:
                 W, _, u, v, k, d = pop(frontier)
             else:


### PR DESCRIPTION
The current implementation of Prim's algorithm in `prim_mst_edges` is inefficient: it keeps iterating over all the edges in the frontier even though all the nodes in the graph have been added to the tree.
This version allows the algorithm to return as soon as the MST has been computed, allowing for a major speedup on large graphs.

### Quick benchmarks

Some quick benchmarks on a randomly generated complete graph of N nodes showed:

- the new version is 2x faster for N=1000
- the new version is 3.5x faster for N=2000
- no performance deterioration was measured for small graph sizes (N=5, N=50, N=100)

<details>
  <summary>Click to show code used for random complete graph generation</summary>
  
```
import random
import networkx as nx
N = 500

G = nx.complete_graph(N)
for (u,v,w) in G.edges(data=True):
    w['weight'] = random.random()
```
</details>

