### PR TITLE
Fixed wrong dict factory usage on MultiDiGraph

### DIFF
--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -481,7 +481,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             key = self.new_edge_key(u, v)
         if v in self._succ[u]:
             keydict = self._adj[u][v]
-            datadict = keydict.get(key, self.edge_key_dict_factory())
+            datadict = keydict.get(key, self.edge_attr_dict_factory())
             datadict.update(attr)
             keydict[key] = datadict
         else:

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -26,6 +26,11 @@ class BaseGraphTester:
 
     def test_nodes(self):
         G = self.K3
+        assert isinstance(G._node, G.node_dict_factory)
+        assert isinstance(G._adj, G.adjlist_outer_dict_factory)
+        assert all(
+            isinstance(adj, G.adjlist_inner_dict_factory) for adj in G._adj.values()
+        )
         assert sorted(G.nodes()) == self.k3nodes
         assert sorted(G.nodes(data=True)) == [(0, {}), (1, {}), (2, {})]
 
@@ -88,6 +93,7 @@ class BaseGraphTester:
 
     def test_edges(self):
         G = self.K3
+        assert isinstance(G._adj, G.adjlist_outer_dict_factory)
         assert edges_equal(G.edges(), [(0, 1), (0, 2), (1, 2)])
         assert edges_equal(G.edges(0), [(0, 1), (0, 2)])
         assert edges_equal(G.edges([0, 1]), [(0, 1), (0, 2), (1, 2)])
@@ -351,6 +357,7 @@ class BaseAttrGraphTester(BaseGraphTester):
     def test_graph_attr(self):
         G = self.K3.copy()
         G.graph["foo"] = "bar"
+        assert isinstance(G.graph, G.graph_attr_dict_factory)
         assert G.graph["foo"] == "bar"
         del G.graph["foo"]
         assert G.graph == {}
@@ -360,6 +367,9 @@ class BaseAttrGraphTester(BaseGraphTester):
     def test_node_attr(self):
         G = self.K3.copy()
         G.add_node(1, foo="bar")
+        assert all(
+            isinstance(d, G.node_attr_dict_factory) for u, d in G.nodes(data=True)
+        )
         assert nodes_equal(G.nodes(), [0, 1, 2])
         assert nodes_equal(G.nodes(data=True), [(0, {}), (1, {"foo": "bar"}), (2, {})])
         G.nodes[1]["foo"] = "baz"
@@ -386,6 +396,9 @@ class BaseAttrGraphTester(BaseGraphTester):
     def test_edge_attr(self):
         G = self.Graph()
         G.add_edge(1, 2, foo="bar")
+        assert all(
+            isinstance(d, G.edge_attr_dict_factory) for u, v, d in G.edges(data=True)
+        )
         assert edges_equal(G.edges(data=True), [(1, 2, {"foo": "bar"})])
         assert edges_equal(G.edges(data="foo"), [(1, 2, "bar")])
 

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -1,3 +1,5 @@
+from collections import UserDict
+
 import pytest
 from networkx.utils import edges_equal
 import networkx as nx
@@ -397,3 +399,46 @@ class TestEdgeSubgraph(_TestMultiGraphEdgeSubgraph):
         # the last edges.
         self.G = G
         self.H = G.edge_subgraph([(0, 1, 0), (3, 4, 1)])
+
+
+class CustomDictClass(UserDict):
+    pass
+
+
+class SubMultiDiGraph(nx.MultiDiGraph):
+    node_dict_factory = CustomDictClass
+    node_attr_dict_factory = CustomDictClass
+    adjlist_outer_dict_factory = CustomDictClass
+    adjlist_inner_dict_factory = CustomDictClass
+    edge_key_dict_factory = CustomDictClass
+    edge_attr_dict_factory = CustomDictClass
+    graph_attr_dict_factory = CustomDictClass
+
+
+class TestMultiDiGraphSubclass(TestMultiDiGraph):
+    def setup_method(self):
+        self.Graph = SubMultiDiGraph
+        # build K3
+        self.k3edges = [(0, 1), (0, 2), (1, 2)]
+        self.k3nodes = [0, 1, 2]
+        self.K3 = self.Graph()
+        self.K3._adj = self.K3.adjlist_outer_dict_factory(
+            {
+                0: self.K3.adjlist_inner_dict_factory(),
+                1: self.K3.adjlist_inner_dict_factory(),
+                2: self.K3.adjlist_inner_dict_factory(),
+            }
+        )
+        self.K3._succ = self.K3._adj
+        self.K3._pred = {0: {}, 1: {}, 2: {}}
+        for u in self.k3nodes:
+            for v in self.k3nodes:
+                if u == v:
+                    continue
+                d = {0: {}}
+                self.K3._succ[u][v] = d
+                self.K3._pred[v][u] = d
+        self.K3._node = self.K3.node_dict_factory()
+        self.K3._node[0] = self.K3.node_attr_dict_factory()
+        self.K3._node[1] = self.K3.node_attr_dict_factory()
+        self.K3._node[2] = self.K3.node_attr_dict_factory()

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -406,13 +406,13 @@ class CustomDictClass(UserDict):
 
 
 class SubMultiDiGraph(nx.MultiDiGraph):
-    node_dict_factory = CustomDictClass
-    node_attr_dict_factory = CustomDictClass
-    adjlist_outer_dict_factory = CustomDictClass
-    adjlist_inner_dict_factory = CustomDictClass
-    edge_key_dict_factory = CustomDictClass
-    edge_attr_dict_factory = CustomDictClass
-    graph_attr_dict_factory = CustomDictClass
+    node_dict_factory = CustomDictClass  # type: ignore
+    node_attr_dict_factory = CustomDictClass  # type: ignore
+    adjlist_outer_dict_factory = CustomDictClass  # type: ignore
+    adjlist_inner_dict_factory = CustomDictClass  # type: ignore
+    edge_key_dict_factory = CustomDictClass  # type: ignore
+    edge_attr_dict_factory = CustomDictClass  # type: ignore
+    graph_attr_dict_factory = CustomDictClass  # type: ignore
 
 
 class TestMultiDiGraphSubclass(TestMultiDiGraph):

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -122,6 +122,22 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
         assert edges_equal(G.edges[1, 2, 0], {"foo": "bar"})
         assert edges_equal(G.edges[1, 2, "key"], {"foo": "biz"})
 
+    def test_edge_attr(self):
+        G = self.Graph()
+        G.add_edge(1, 2, key="k1", foo="bar")
+        G.add_edge(1, 2, key="k2", foo="baz")
+        assert isinstance(G.get_edge_data(1, 2), G.edge_key_dict_factory)
+        assert all(
+            isinstance(d, G.edge_attr_dict_factory) for u, v, d in G.edges(data=True)
+        )
+        assert edges_equal(
+            G.edges(keys=True, data=True),
+            [(1, 2, "k1", {"foo": "bar"}), (1, 2, "k2", {"foo": "baz"})],
+        )
+        assert edges_equal(
+            G.edges(keys=True, data="foo"), [(1, 2, "k1", "bar"), (1, 2, "k2", "baz")]
+        )
+
     def test_edge_attr4(self):
         G = self.Graph()
         G.add_edge(1, 2, key=0, data=7, spam="bar", bar="foo")


### PR DESCRIPTION
Fixed the issue that the wrong dict factory on a MultiDiGraph was used for edge attributes (edge_key_dict_factory instead of edge_attr_dict_factory)

Extended tests to typecheck the dict factories and added a test that incorporates custom dict factories on a MultiDiGraph

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
