### PR TITLE
MAINT: Prim MST test didn't pass algorithm name to all unit tests

### DIFF
--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -265,14 +265,14 @@ class TestPrim(MultigraphMSTTestBase):
         G = nx.MultiGraph()
         G.add_edge(0, 1, key="a", weight=2)
         G.add_edge(0, 1, key="b", weight=1)
-        T = nx.minimum_spanning_tree(G)
+        T = nx.minimum_spanning_tree(G, algorithm=self.algo)
         assert edges_equal([(0, 1, 1)], list(T.edges(data="weight")))
 
     def test_multigraph_keys_tree_max(self):
         G = nx.MultiGraph()
         G.add_edge(0, 1, key="a", weight=2)
         G.add_edge(0, 1, key="b", weight=1)
-        T = nx.maximum_spanning_tree(G)
+        T = nx.maximum_spanning_tree(G, algorithm=self.algo)
         assert edges_equal([(0, 1, 2)], list(T.edges(data="weight")))
 
 


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
While reviewing https://github.com/networkx/networkx/pull/5455 I realized we weren't explicitly testing a couple of unit tests with `prim`'s algorithm.