### PR TITLE
Connected graph generation with Havel-Hakimi

### DIFF
--- a/doc/reference/algorithms/graphical.rst
+++ b/doc/reference/algorithms/graphical.rst
@@ -10,6 +10,7 @@ Graphical degree sequence
    is_digraphical
    is_multigraphical
    is_pseudographical
+   is_potentially_connected
    is_valid_degree_sequence_havel_hakimi
    is_valid_degree_sequence_erdos_gallai
 

--- a/networkx/algorithms/graphical.py
+++ b/networkx/algorithms/graphical.py
@@ -1,6 +1,7 @@
 """Test sequences for graphiness.
 """
 import heapq
+
 import networkx as nx
 
 __all__ = [
@@ -10,6 +11,7 @@ __all__ = [
     "is_digraphical",
     "is_valid_degree_sequence_erdos_gallai",
     "is_valid_degree_sequence_havel_hakimi",
+    "is_potentially_connected",
 ]
 
 
@@ -63,6 +65,49 @@ def is_graphical(sequence, method="eg"):
         msg = "`method` must be 'eg' or 'hh'"
         raise nx.NetworkXException(msg)
     return valid
+
+
+def is_potentially_connected(sequence, method="eg"):
+    """Returns True if sequence is a a potentially connected degree sequence.
+
+    A degree sequence is potentially connected if some connected graph can realize it.
+
+    Parameters
+    ----------
+    sequence : list or iterable container
+        A sequence of integer node degrees
+
+    method : "eg" | "hh"  (default: 'eg')
+        The method internally used to check if the degree sequence is graphical.
+        "eg" corresponds to the Erdős-Gallai algorithm, and
+        "hh" to the Havel-Hakimi algorithm.
+
+    Returns
+    -------
+    valid : bool
+        True if the sequence is a potentially connected degree sequence and False if not.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(4)
+    >>> sequence = (d for n, d in G.degree())
+    >>> nx.is_potentially_connected(sequence)
+    True
+
+    References
+    ----------
+    Claude Berge, Graphs and Hypergraphs, 117-118
+    """
+    dsum = 0
+    n = 0
+    for deg in sequence:
+        if deg == 0:
+            return False
+        dsum += deg
+        n += 1
+    if dsum >= 2 * (n - 1):
+        return is_graphical(sequence, method=method)
+    return False
 
 
 def _basic_graphical_tests(deg_sequence):

--- a/networkx/algorithms/tests/test_graphical.py
+++ b/networkx/algorithms/tests/test_graphical.py
@@ -160,3 +160,26 @@ def test_numpy_degree_sequence():
     ds = np.array([1.1, 2, 2, 2, 1], dtype=np.float64)
     pytest.raises(nx.NetworkXException, nx.is_graphical, ds, "eg")
     pytest.raises(nx.NetworkXException, nx.is_graphical, ds, "hh")
+
+
+def test_valid_potentially_connected1():
+    r = 3
+    h = 8
+    G = nx.balanced_tree(r, h)
+    deg = (d for n, d in G.degree())
+    assert nx.is_potentially_connected(deg, "eg")
+    assert nx.is_potentially_connected(deg, "hh")
+
+
+@pytest.mark.parametrize("method", ["eg", "hh"])
+def test_valid_potentially_connected2(method):
+    assert nx.is_potentially_connected([], method)
+    assert nx.is_potentially_connected([1, 1, 2, 2, 2], method)
+
+
+@pytest.mark.parametrize("method", ["eg", "hh"])
+def test_invalid_potentially_connected(method):
+    assert nx.is_potentially_connected([0], method) == False
+    assert nx.is_potentially_connected([1, 2, -1], method) == False
+    assert nx.is_potentially_connected([1, 1, 0], method) == False
+    assert nx.is_potentially_connected([1, 1, 1, 1], method) == False

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -438,7 +438,7 @@ def expected_degree_graph(w, seed=None, selfloops=True):
     return G
 
 
-def havel_hakimi_graph(deg_sequence, create_using=None):
+def havel_hakimi_graph(deg_sequence, create_using=None, force_connected=False):
     """Returns a simple graph with given degree sequence constructed
     using the Havel-Hakimi algorithm.
 
@@ -449,24 +449,28 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
         Graph type to create. If graph instance, then cleared before populated.
         Directed graphs are not allowed.
+    force_connected: boll (default=False)
+        If set to True, will build a connected graph.
 
     Raises
     ------
     NetworkXException
-        For a non-graphical degree sequence (i.e. one
-        not realizable by some simple graph).
+        For a non-realizable degree sequence (i.e. one
+        not realizable by some simple graph, or by a connected
+        graph if connected=True).
 
     Notes
     -----
     The Havel-Hakimi algorithm constructs a simple graph by
-    successively connecting the node of highest degree to other nodes
+    successively extracting a node and connecting it to other nodes
     of highest degree, resorting remaining nodes by degree, and
     repeating the process. The resulting graph has a high
     degree-associativity.  Nodes are labeled 1,.., len(deg_sequence),
     corresponding to their position in deg_sequence.
 
     The basic algorithm is from Hakimi [1]_ and was generalized by
-    Kleitman and Wang [2]_.
+    Kleitman and Wang [2]_. A slight modification in the stub selection
+    to create a connected graph was introduced by Horvát and Szabolcs [3]_.
 
     References
     ----------
@@ -476,8 +480,13 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
     .. [2] Kleitman D.J. and Wang D.L.
        Algorithms for Constructing Graphs and Digraphs with Given Valences
        and Factors  Discrete Mathematics, 6(1), pp. 79-88 (1973)
+    .. [3] Horvát, Szabolcs, and Carl D. Modes.
+       Connectedness matters: Construction and exact random
+       sampling of connected graphs (2020).
     """
-    if not nx.is_graphical(deg_sequence):
+    if (
+        force_connected and not nx.is_potentially_connected(deg_sequence)
+    ) or not nx.is_graphical(deg_sequence):
         raise nx.NetworkXError("Invalid degree sequence")
 
     p = len(deg_sequence)
@@ -485,12 +494,12 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
     if G.is_directed():
         raise nx.NetworkXError("Directed graphs are not supported")
     num_degs = [[] for i in range(p)]
-    dmax, dsum, n = 0, 0, 0
+    dmax, dmin, dsum, n = 0, float("inf"), 0, 0
     for d in deg_sequence:
         # Process only the non-zero integers
         if d > 0:
             num_degs[d].append(n)
-            dmax, dsum, n = max(dmax, d), dsum + d, n + 1
+            dmax, dmin, dsum, n = max(dmax, d), min(dmin, d), dsum + d, n + 1
     # Return graph if no edges
     if n == 0:
         return G
@@ -505,14 +514,20 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
         # not graphical
         if dmax > n - 1:
             raise nx.NetworkXError("Non-graphical integer sequence")
-
-        # Remove largest stub in list
-        source = num_degs[dmax].pop()
+        # Remove selected stub in list
+        if force_connected:
+            while len(num_degs[dmin]) == 0:
+                dmin += 1
+            source = num_degs[dmin].pop()
+            dstub = dmin
+        else:
+            source = num_degs[dmax].pop()
+            dstub = dmax
         n -= 1
-        # Reduce the next dmax largest stubs
+        # Reduce the next dstub largest stubs
         mslen = 0
         k = dmax
-        for i in range(dmax):
+        for i in range(dstub):
             while len(num_degs[k]) == 0:
                 k -= 1
             target = num_degs[k].pop()
@@ -524,6 +539,7 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
         # Add back to the list any nonzero stubs that were removed
         for i in range(mslen):
             (stubval, stubtarget) = modstubs[i]
+            dmin = min(stubval, dmin)
             num_degs[stubval].append(stubtarget)
             n += 1
 

--- a/networkx/generators/tests/test_degree_seq.py
+++ b/networkx/generators/tests/test_degree_seq.py
@@ -163,6 +163,23 @@ def test_havel_hakimi_construction():
     pytest.raises(nx.NetworkXError, nx.havel_hakimi_graph, z, create_using=nx.DiGraph())
 
 
+def test_connected_havel_hakimi_construction():
+    z = [0, 1, 1]
+    pytest.raises(nx.NetworkXError, nx.havel_hakimi_graph, z, force_connected=True)
+
+    # Make sure the graph is built without errors
+    z = [2, 2, 2]
+    nx.havel_hakimi_graph(z, force_connected=True)
+
+    # Make sure the graph is connected
+    z = [1, 1, 2, 2, 2]
+    assert nx.is_connected(nx.havel_hakimi_graph(z, force_connected=True))
+    z = [1, 1, 1, 2, 2, 3]
+    assert nx.is_connected(nx.havel_hakimi_graph(z, force_connected=True))
+    z = [5, 1, 2, 2, 1, 2, 1, 1, 1]
+    assert nx.is_connected(nx.havel_hakimi_graph(z, force_connected=True))
+
+
 def test_directed_havel_hakimi():
     # Test range of valid directed degree sequences
     n, r = 100, 10


### PR DESCRIPTION
This PR:
* Adds a new `is_potentially_connected` function, which checks whether there exists a connected graph realizing a degree sequence.
* Modifies the `havel_hakimi_graph` algorithm to allow for connected graph generation.

#### Notes:
`dmin` is still partially computed even when not necessary in `havel_hakimi_graph` , as the code seemed more readable to me without the extra conditionals. Let me know if you'd prefer a clean separation between both cases. 
I'm also not sure whether `is_potentially_connected` belongs in `graphical.py`.