### PR TITLE
Default to Prim's algorithm in mst

### DIFF
--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -53,14 +53,9 @@ class TestSteinerTree:
 
     def test_steiner_tree(self):
         S = steiner_tree(self.G, self.term_nodes)
-        expected_steiner_tree = [
-            (1, 2, {"weight": 10}),
-            (2, 3, {"weight": 10}),
-            (2, 7, {"weight": 1}),
-            (3, 4, {"weight": 10}),
-            (5, 7, {"weight": 1}),
-        ]
-        assert edges_equal(list(S.edges(data=True)), expected_steiner_tree)
+        for node in self.term_nodes:
+            assert node in S
+        assert sum(d["weight"] for u, v, d in S.edges(data=True)) == 32
 
     def test_multigraph_steiner_tree(self):
         G = nx.MultiGraph()

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -352,7 +352,7 @@ ALGORITHMS = {
 
 @not_implemented_for("directed")
 def minimum_spanning_edges(
-    G, algorithm="kruskal", weight="weight", keys=True, data=True, ignore_nan=False
+    G, algorithm="prim", weight="weight", keys=True, data=True, ignore_nan=False
 ):
     """Generate edges in a minimum spanning forest of an undirected
     weighted graph.
@@ -369,7 +369,7 @@ def minimum_spanning_edges(
 
     algorithm : string
        The algorithm to use when finding a minimum spanning tree. Valid
-       choices are 'kruskal', 'prim', or 'boruvka'. The default is 'kruskal'.
+       choices are 'kruskal', 'prim', or 'boruvka'. The default is 'prim'.
 
     weight : string
        Edge data key to use for weight (default 'weight').
@@ -446,7 +446,7 @@ def minimum_spanning_edges(
 
 @not_implemented_for("directed")
 def maximum_spanning_edges(
-    G, algorithm="kruskal", weight="weight", keys=True, data=True, ignore_nan=False
+    G, algorithm="prim", weight="weight", keys=True, data=True, ignore_nan=False
 ):
     """Generate edges in a maximum spanning forest of an undirected
     weighted graph.
@@ -463,7 +463,7 @@ def maximum_spanning_edges(
 
     algorithm : string
        The algorithm to use when finding a maximum spanning tree. Valid
-       choices are 'kruskal', 'prim', or 'boruvka'. The default is 'kruskal'.
+       choices are 'kruskal', 'prim', or 'boruvka'. The default is 'prim'.
 
     weight : string
        Edge data key to use for weight (default 'weight').
@@ -537,7 +537,7 @@ def maximum_spanning_edges(
     )
 
 
-def minimum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=False):
+def minimum_spanning_tree(G, weight="weight", algorithm="prim", ignore_nan=False):
     """Returns a minimum spanning tree or forest on an undirected graph `G`.
 
     Parameters
@@ -552,7 +552,7 @@ def minimum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=Fa
     algorithm : string
        The algorithm to use when finding a minimum spanning tree. Valid
        choices are 'kruskal', 'prim', or 'boruvka'. The default is
-       'kruskal'.
+       'prim'.
 
     ignore_nan : bool (default: False)
         If a NaN is found as an edge weight normally an exception is raised.
@@ -659,7 +659,7 @@ def partition_spanning_tree(
     return T
 
 
-def maximum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=False):
+def maximum_spanning_tree(G, weight="weight", algorithm="prim", ignore_nan=False):
     """Returns a maximum spanning tree or forest on an undirected graph `G`.
 
     Parameters
@@ -674,7 +674,7 @@ def maximum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=Fa
     algorithm : string
        The algorithm to use when finding a maximum spanning tree. Valid
        choices are 'kruskal', 'prim', or 'boruvka'. The default is
-       'kruskal'.
+       'prim'.
 
     ignore_nan : bool (default: False)
         If a NaN is found as an edge weight normally an exception is raised.


### PR DESCRIPTION
Following #5455, the prim algorithm is much faster.  I set out to benchmark it in order to figure out if it would make sense to change the default algorithm used in MST-related functions from Kruskal to Prim. 
To do so, I sampled 2000 points (n, p) uniformly at random in [5, 2000] x [0, 1], generated a G_{n,p} graph for each of these points, and ran both the Prim and Kruskal version of `nx.minimum_spanning_edges` on them.

The average measured speedup gained by using Prim was of 1.79, and detailed results can be found below:
![foo](https://user-images.githubusercontent.com/46298009/162063919-cb602bc9-cfdc-4007-ae60-3a68a524fb3c.png)
![bar](https://user-images.githubusercontent.com/46298009/162062167-4af4b756-6a5b-411a-9b53-b7e40065d838.png)

Similar results were found for N=3000 and N=5000.
<details>
  <summary>Code to reproduce benchmark</summary>
  
The following code runs in ~35 minutes on my machine.
```python
import networkx as nx
import matplotlib.pyplot as plt
import time
from tqdm import tqdm
from matplotlib import colors
from pylab import cm
import random
import numpy as np

plt.rc('axes', axisbelow=True)

# Run benchmark
res = {}
d = 0
N = 1000
for _ in tqdm(range(N)):
    n = random.randint(5,2000)
    p = random.uniform(0,1)
    G = nx.gnp_random_graph(n, p)
    # Prim
    start = time.perf_counter()
    list(nx.minimum_spanning_edges(G, algorithm="prim"))
    stop = time.perf_counter()
    prim_time = stop - start
    # Kruskal
    start = time.perf_counter()
    list(nx.minimum_spanning_edges(G, algorithm="kruskal"))
    stop = time.perf_counter()
    kruskal_time = stop - start
    conn = sum(d for n_prime, d in G.degree())/(n*(n-1))
    res[(n, conn, d)] = {"prim": prim_time, "kruskal": kruskal_time}
    d+=1
    #print(f"{n}, {conn:.2f}: {kruskal_time/prim_time}")

# Plot results
x,y,c = [],[],[]
for (N,C,_), r in res.items():
    x.append(N)
    y.append(C)
    c.append(r['kruskal']/r['prim'])

# Speedup distribution
plt.figure(figsize=(15,8))
plt.hist(c, bins=75, weights=np.zeros_like(c) + 1. / len(c))
plt.xlabel("Speedup obtained by using Prim instead of Kruskal")
plt.ylabel("Frequency")
plt.title("Speedup distribution")
plt.xticks(np.arange(0, 10, 1))
plt.show();

# Speedup depending on n and p
cmap = cm.get_cmap('RdYlGn', 20)
plt.figure(figsize=(15,8))
plt.grid(alpha=0.4)
plt.scatter(x=x, y=y, c=c, cmap=cmap, vmin=0, vmax=2)
plt.xlabel("Number of nodes $n$")
plt.ylabel("Edge frequency $p := \dfrac{num\_edges}{n(n-1)}$")
plt.title("Prim and Kruskal benchmarks on $G_{n,p}$ graphs")
cbar = plt.colorbar()
cbar.set_label("Prim speedup")
print(f"Average speedup: {sum(c)/len(c)}")
plt.show();
```
</details>
