### PR TITLE
Add notes about NumPy/SciPy integration to NX 2->3 migration guide

### DIFF
--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -61,6 +61,7 @@ Replacing NumPy/SciPy matrices with arrays
 
 The ``numpy.matrix`` has long been discouraged due to significant departures
 from the ``ndarray`` interface, namely:
+
 - Matrices are always two-dimensional, leading to different results for common
   operations like indexing and broadcasting.
 - The multiplication operator is interpreted as matrix multiplication rather

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -34,8 +34,8 @@ structures (``Graph``, ``DiGraph``, etc.) and common algorithms, but some
 functionality, e.g. functions found in the ``networkx.linalg`` package, are
 only available if these additional libraries are installed.
 
-**TODO**: Generate a table showing dependencies of individual nx objects?
-Probably overkill...
+.. **TODO**: Generate a table showing dependencies of individual nx objects?
+.. Probably overkill...
 
 Improved integration with scientific Python
 -------------------------------------------
@@ -59,7 +59,7 @@ Supporting `numpy.random.Generator`
 NumPy v1.17 introduced a new interface for pseudo-random number generation.
 The `~networkx.utils.misc.py_random_state` and `~networkx.utils.misc.np_random_state`
 decorators have added support for the new `numpy.random.Generator` instances;
-in other words, the ``seed`` argument no accepts `numpy.random.Generator` instances::
+in other words, the ``seed`` argument now accepts `numpy.random.Generator` instances::
 
     >>> G = nx.barbell_graph(6, 2)
     >>> pos = nx.spring_layout(G, seed=np.random.default_rng(123456789))
@@ -77,15 +77,14 @@ of NetworkX (past and future), ``RandomState`` is recommended::
     >>> rng = np.random.RandomState(12345)
     >>> pos = nx.spring_layout(G, seed=rng)
 
-For new code or for situations where exact reproducibility are less important,
+For new code where exact stream-reproducibility is less important,
 ``Generator`` is recommended::
 
     >>>> rng = np.random.default_rng(12345)
     >>> pos = nx.spring_layout(G, seed=rng)
 
 .. note::  Exact reproducibility of random numbers with ``Generator`` is still
-   possible but may require the specification of specific versions of numpy
-   to be installed.
+   possible but may require specific versions of numpy to be installed.
 
 NumPy structured dtypes for multi-attribute adjacency matrices
 --------------------------------------------------------------

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -43,15 +43,58 @@ Improved integration with scientific Python
 NetworkX 3.0 includes several changes to improve and modernize the usage of
 ``numpy`` and ``scipy`` within networkx.
 
-**TODO** Flesh these bullets out
+- :ref:`Removal of matrix semantics <matrix-to-array>`_.
+  - Removing all uses of `numpy.matrix` in favor of `numpy.ndarray`.
+  - Adoption of the scipy.sparse **array** interface.
+- :ref:`NumPy or SciPy implementations of some algorithms by default
+  (e.g. pagerank) <scipy-default-impl>`_.
+- `numpy.random.Generator` support for random number generation.
+- :ref:`Replace recarray  support <recarray-to-structured>`_ with more generic
+  support for structured dtypes.
 
-- `numpy.random.Generator` support for random number generation
-- Replace explicit `numpy.recarray` support for more generic support of
-  structured dtypes
-- NumPy or SciPy implementations of some algorithms by default (e.g. pagerank)
-- Removal of matrix semantics
-  - Removing all uses of `numpy.matrix` in favor of `numpy.ndarray`
-  - Adoption of the scipy.sparse **array** interface
+.. _matrix-to-array:
+
+Replacing NumPy/SciPy matrices with arrays
+------------------------------------------
+
+The ``numpy.matrix`` has long been discouraged due to significant departures
+from the ``ndarray`` interface, namely:
+- Matrices are always two-dimensional, leading to different results for common
+  operations like indexing and broadcasting.
+- The multiplication operator is interpreted as matrix multiplication rather
+  than element-wise multiplication.
+
+These differences make code more difficult to understand and often require
+boilerplate in order to work with multiple formats.
+With the addition of a sparse array interface in scipy version 1.8, NetworkX
+3.0 has replaced all instances of scipy sparse matrices and numpy matrices
+in favor of their array counterparts.
+Any functions that returned either ``scipy.sparse.spmatrix`` or ``numpy.matrix``
+objects now return their corresponding array counterparts (``scipy.sparse._sparray``
+and ``numpy.ndarray``, respectively) and explicit conversion functions that
+resulted in matrix objects have been removed (e.g. ``to_numpy_matrix``).
+Users should expect all ``numpy`` and ``scipy.sparse`` objects to obey
+*array* semantics in NetworkX 3.X.
+
+.. _scipy-default-impl:
+
+Switch to NumPy/SciPy implementations by default for some algorithms
+--------------------------------------------------------------------
+
+Some networkx analysis algorithms can be implemented with very high performance
+using linear algebra, such as the ``pagerank`` algorithm.
+In NetworkX 2.0, there were multiple implementations of the ``pagerank``
+algorithm: ``pagerank`` (a pure-Python implementation), ``pagerank_numpy``
+(for dense adjacency matrices), and ``pagerank_scipy`` (sparse adjacency
+matrices).
+In all practical use-cases, the SciPy implementation vastly outperforms the
+others.
+In NetworkX 3.0, the `~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+function now uses the SciPy implementation by default.
+This means that calling ``nx.pagerank`` now requires SciPy to be installed.
+The original Python implementation is still available for pedagogical
+purposes as ``networkx.algorithms.link_analysis.pagerank_alg._pagerank_python``
+but is not exposed publicly to discourage it's use.
   
 Supporting `numpy.random.Generator`
 -----------------------------------
@@ -85,6 +128,8 @@ For new code where exact stream-reproducibility is less important,
 
 .. note::  Exact reproducibility of random numbers with ``Generator`` is still
    possible but may require specific versions of numpy to be installed.
+
+.. _recarray-to-structured:
 
 NumPy structured dtypes for multi-attribute adjacency matrices
 --------------------------------------------------------------
@@ -127,45 +172,6 @@ improving supported for array representations of multi-attribute adjacency::
            [10.,  0.,  5.],
            [ 0.,  5.,  0.]])
 
-Switch to NumPy/SciPy implementations by default for some algorithms
---------------------------------------------------------------------
-
-Some networkx analysis algorithms can be implemented with very high performance
-using linear algebra, such as the ``pagerank`` algorithm.
-In NetworkX 2.0, there were multiple implementations of the ``pagerank``
-algorithm: ``pagerank`` (a pure-Python implementation), ``pagerank_numpy``
-(for dense adjacency matrices), and ``pagerank_scipy`` (sparse adjacency
-matrices).
-In all practical use-cases, the SciPy implementation vastly outperforms the
-others.
-In NetworkX 3.0, the `~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
-function now uses the SciPy implementation by default.
-This means that calling ``nx.pagerank`` now requires SciPy to be installed.
-The original Python implementation is still available for pedagogical
-purposes as ``networkx.algorithms.link_analysis.pagerank_alg._pagerank_python``
-but is not exposed publicly to discourage it's use.
-
-Replacing NumPy/SciPy matrices with arrays
-------------------------------------------
-
-The ``numpy.matrix`` has long been discouraged due to significant departures
-from the ``ndarray`` interface, namely:
-- Matrices are always two-dimensional, leading to different results for common
-  operations like indexing and broadcasting.
-- The multiplication operator is interpreted as matrix multiplication rather
-  than element-wise multiplication.
-
-These differences make code more difficult to understand and often require
-boilerplate in order to work with multiple formats.
-With the addition of a sparse array interface in scipy version 1.8, NetworkX
-3.0 has replaced all instances of scipy sparse matrices and numpy matrices
-in favor of their array counterparts.
-Any functions that returned either ``scipy.sparse.spmatrix`` or ``numpy.matrix``
-objects now return their corresponding array counterparts (``scipy.sparse._sparray``
-and ``numpy.ndarray``, respectively) and explicit conversion functions that
-resulted in matrix objects have been removed (e.g. ``to_numpy_matrix``).
-Users should expect all ``numpy`` and ``scipy.sparse`` objects to obey
-*array* semantics in NetworkX 3.X.
 
 Deprecated code
 ---------------

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -126,6 +126,24 @@ improving supported for array representations of multi-attribute adjacency::
     array([[ 0., 10.,  0.],
            [10.,  0.,  5.],
            [ 0.,  5.,  0.]])
+
+Switch to NumPy/SciPy implementations by default for some algorithms
+--------------------------------------------------------------------
+
+Some networkx analysis algorithms can be implemented with very high performance
+using linear algebra, such as the ``pagerank`` algorithm.
+In NetworkX 2.0, there were multiple implementations of the ``pagerank``
+algorithm: ``pagerank`` (a pure-Python implementation), ``pagerank_numpy``
+(for dense adjacency matrices), and ``pagerank_scipy`` (sparse adjacency
+matrices).
+In all practical use-cases, the SciPy implementation vastly outperforms the
+others.
+In NetworkX 3.0, the `~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+function now uses the SciPy implementation by default.
+This means that calling ``nx.pagerank`` now requires SciPy to be installed.
+The original Python implementation is still available for pedagogical
+purposes as ``networkx.algorithms.link_analysis.pagerank_alg._pagerank_python``
+but is not exposed publicly to discourage it's use.
   
 Deprecated code
 ---------------

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -43,13 +43,15 @@ Improved integration with scientific Python
 NetworkX 3.0 includes several changes to improve and modernize the usage of
 ``numpy`` and ``scipy`` within networkx.
 
-- :ref:`Removal of matrix semantics <matrix-to-array>`_.
+- :ref:`Removal of matrix semantics <matrix-to-array>`.
+
   - Removing all uses of `numpy.matrix` in favor of `numpy.ndarray`.
   - Adoption of the scipy.sparse **array** interface.
+
 - :ref:`NumPy or SciPy implementations of some algorithms by default
-  (e.g. pagerank) <scipy-default-impl>`_.
+  (e.g. pagerank) <scipy-default-impl>`.
 - `numpy.random.Generator` support for random number generation.
-- :ref:`Replace recarray  support <recarray-to-structured>`_ with more generic
+- :ref:`Replace recarray  support <recarray-to-structured>` with more generic
   support for structured dtypes.
 
 .. _matrix-to-array:
@@ -179,8 +181,8 @@ Deprecated code
 The 2.6 release deprecates over 30 functions.
 See :ref:`networkx_2.6`.
 
-**TODO**: A table summarizing one deprecation per row w/ 3 columns: 1. the
-deprecated function, 2. the old usage, 3. the replacement usage.
+.. **TODO**: A table summarizing one deprecation per row w/ 3 columns: 1. the
+.. deprecated function, 2. the old usage, 3. the replacement usage.
 
 ---
 

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -6,8 +6,8 @@ Preparing for the 3.0 release
 
 .. note::
    Much of the work leading to the NetworkX 3.0 release will be included
-   in the NetworkX 2.6 and 2.7 releases.  For example, we are deprecating a lot
-   of old code in the 2.6 and 2.7 releases.  This guide will discuss this
+   in the NetworkX 2.6, 2.7, and 2.8 releases.  For example, we are deprecating a lot
+   of old code in these releases.  This guide will discuss this
    ongoing work and will help you understand what changes you can make now
    to minimize the disruption caused by the move to 3.0.
 
@@ -23,13 +23,85 @@ We plan to release 2.7 near the end of summer and 3.0 near the end of the year.
 Default dependencies
 --------------------
 
-We no longer depend on the "decorator" library.
+We no longer depend on the "decorator" library, thus NetworkX no longer has
+any dependencies.
+However, NetworkX 3.0 includes many changes and improvements centered around
+tighter integration with other scientific Python libraries; namely
+``numpy``, ``scipy``, ``matplotlib``, and ``pandas``.
+
+There are no dependencies for NetworkX's core funtionality, such as the data
+structures (``Graph``, ``DiGraph``, etc.) and common algorithms, but some
+functionality, e.g. functions found in the ``networkx.linalg`` package, are
+only available if these additional libraries are installed.
+
+**TODO**: Generate a table showing dependencies of individual nx objects?
+Probably overkill...
+
+Improved integration with scientific Python
+-------------------------------------------
+
+NetworkX 3.0 includes several changes to improve and modernize the usage of
+``numpy`` and ``scipy`` within networkx.
+
+**TODO** Flesh these bullets out
+
+- `numpy.random.Generator` support for random number generation
+- Replace explicit `numpy.recarray` support for more generic support of
+  structured dtypes
+- NumPy or SciPy implementations of some algorithms by default (e.g. pagerank)
+- Removal of matrix semantics
+  - Removing all uses of `numpy.matrix` in favor of `numpy.ndarray`
+  - Adoption of the scipy.sparse **array** interface
+  
+Supporting `numpy.random.Generator`
+-----------------------------------
+
+NumPy v1.17 introduced a new interface for pseudo-random number generation.
+The `~networkx.utils.misc.py_random_state` and `~networkx.utils.misc.np_random_state`
+decorators have added support for the new `numpy.random.Generator` instances;
+in other words, the ``seed`` argument no accepts `numpy.random.Generator` instances::
+
+    >>> G = nx.barbell_graph(6, 2)
+    >>> pos = nx.spring_layout(G, seed=np.random.default_rng(123456789))
+
+The `numpy.random.Generator` interface includes several improvements over the
+original `numpy.random.RandomState`, including better statistical properties
+and improved performance.
+However ``Generator`` is not stream-compatibile with ``RandomState`` and
+does not guarantee stream-compatibility with future versions of NumPy.
+Therefore, the best-practice is to be explicit when using random number
+generators.
+To guarantee **exact** reproducibility of random numbers across all versions
+of NetworkX (past and future), ``RandomState`` is recommended::
+
+    >>> rng = np.random.RandomState(12345)
+    >>> pos = nx.spring_layout(G, seed=rng)
+
+For new code or for situations where exact reproducibility are less important,
+``Generator`` is recommended::
+
+    >>>> rng = np.random.default_rng(12345)
+    >>> pos = nx.spring_layout(G, seed=rng)
+
+.. note::  Exact reproducibility of random numbers with ``Generator`` is still
+   possible but may require the specification of specific versions of numpy
+   to be installed.
+
+NumPy structured dtypes for multi-attribute adjacency matrices
+--------------------------------------------------------------
+
+Prior to NetworkX 3.0, multi-attribute adjacency matrices were supported
+through the ``nx.to_numpy_recarray`` conversion function.
+
 
 Deprecated code
 ---------------
 
 The 2.6 release deprecates over 30 functions.
 See :ref:`networkx_2.6`.
+
+**TODO**: A table summarizing one deprecation per row w/ 3 columns: 1. the
+deprecated function, 2. the old usage, 3. the replacement usage.
 
 ---
 

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -144,7 +144,29 @@ This means that calling ``nx.pagerank`` now requires SciPy to be installed.
 The original Python implementation is still available for pedagogical
 purposes as ``networkx.algorithms.link_analysis.pagerank_alg._pagerank_python``
 but is not exposed publicly to discourage it's use.
-  
+
+Replacing NumPy/SciPy matrices with arrays
+------------------------------------------
+
+The ``numpy.matrix`` has long been discouraged due to significant departures
+from the ``ndarray`` interface, namely:
+- Matrices are always two-dimensional, leading to different results for common
+  operations like indexing and broadcasting.
+- The multiplication operator is interpreted as matrix multiplication rather
+  than element-wise multiplication.
+
+These differences make code more difficult to understand and often require
+boilerplate in order to work with multiple formats.
+With the addition of a sparse array interface in scipy version 1.8, NetworkX
+3.0 has replaced all instances of scipy sparse matrices and numpy matrices
+in favor of their array counterparts.
+Any functions that returned either ``scipy.sparse.spmatrix`` or ``numpy.matrix``
+objects now return their corresponding array counterparts (``scipy.sparse._sparray``
+and ``numpy.ndarray``, respectively) and explicit conversion functions that
+resulted in matrix objects have been removed (e.g. ``to_numpy_matrix``).
+Users should expect all ``numpy`` and ``scipy.sparse`` objects to obey
+*array* semantics in NetworkX 3.X.
+
 Deprecated code
 ---------------
 

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -91,8 +91,42 @@ NumPy structured dtypes for multi-attribute adjacency matrices
 
 Prior to NetworkX 3.0, multi-attribute adjacency matrices were supported
 through the ``nx.to_numpy_recarray`` conversion function.
+`numpy.recarray` is a convenience wrapper around ``ndarray`` with structured
+dtypes.
+As such, thisconversion function has been removed in NetworkX 3.0 and support
+for structured dtypes has been added to ``to_numpy_array`` instead, generally
+improving supported for array representations of multi-attribute adjacency::
 
-
+    >>> import numpy as np
+    >>> edges = [
+    ...     (0, 1, {"weight": 10, "cost": 2}),
+    ...     (1, 2, {"weight": 5, "cost": 100})
+    ... ]
+    >>> G = nx.Graph(edges)
+    >>> # Create an adjacency matrix with "weight" and "cost" attributes
+    >>> dtype = np.dtype([("weight", float), ("cost", int)])
+    >>> A = nx.to_numpy_array(G, dtype=dtype, weight=None)
+    >>> A
+    array([[( 0.,   0), (10.,   2), ( 0.,   0)],
+           [(10.,   2), ( 0.,   0), ( 5., 100)],
+           [( 0.,   0), ( 5., 100), ( 0.,   0)]],
+          dtype=[('weight', '<f8'), ('cost', '<i8')])
+    >>> A["cost"]
+    array([[  0,   2,   0],
+           [  2,   0, 100],
+           [  0, 100,   0]])
+    >>> # The recarray interface can be recovered with ``view``
+    >>> A = nx.to_numpy_array(G, dtype=dtype, weight=None).view(np.recarray)
+    >>> A
+    rec.array([[( 0.,   0), (10.,   2), ( 0.,   0)],
+               [(10.,   2), ( 0.,   0), ( 5., 100)],
+               [( 0.,   0), ( 5., 100), ( 0.,   0)]],
+              dtype=[('weight', '<f8'), ('cost', '<i8')])
+    >>> A.weight
+    array([[ 0., 10.,  0.],
+           [10.,  0.,  5.],
+           [ 0.,  5.,  0.]])
+  
 Deprecated code
 ---------------
 

--- a/doc/release/migration_guide_from_2.x_to_3.0.rst
+++ b/doc/release/migration_guide_from_2.x_to_3.0.rst
@@ -18,7 +18,7 @@ Any issues with these can be discussed on the `mailing list
 
 The focus of 3.0 release is on addressing years of technical debt, modernizing our codebase,
 improving performance, and making it easier to contribute.
-We plan to release 2.7 near the end of summer and 3.0 near the end of the year.
+We plan to release 3.0 in the summer.
 
 Default dependencies
 --------------------


### PR DESCRIPTION
I've added a list along with some paragraph-length explanations of the numpy/scipy integration work we've been doing. The goal is to give a quick summary of the changes related to numpy/scipy and explain what users can expect for NX 3.0 on this front.