### PR TITLE
Fixing the layers ordering for multipartite_layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1083,6 +1083,9 @@ def multipartite_layout(G, subset_key="subset", align="vertical", scale=1, cente
             raise ValueError(msg)
         layers[layer] = [v] + layers.get(layer, [])
 
+    # sorting layers by subset key
+    layers = dict(sorted(layers.items()))
+
     pos = None
     nodes = []
 


### PR DESCRIPTION
A very small fix in the `multipartite_layout` function, from 11db137b93f8f0b605cb8cefbeab21720348b9f7 introduced a bug in which, if nodes weren't inserted into the graph by layout order (first nodes from layer 0, then nodes from layer 1, and so on...), the corresponding layers were not drawn in the right vertical or horizontal order when the `multipartite_layout` function was used.

If this isn't clear, I can provide a graphical example of the required output vs what was produced. I can also add a test to make sure this bug isn't introduced again.