### PR TITLE
a hack to force self edges to be ignored on the first node inspected

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -745,18 +745,30 @@ def optimize_edit_paths(
         N = len(pending_h)
         # assert Ce.C.shape == (M + N, M + N)
 
-        g_ind = [
-            i
-            for i in range(M)
-            if pending_g[i][:2] == (u, u)
-            or any(pending_g[i][:2] in ((p, u), (u, p)) for p, q in matched_uv)
-        ]
-        h_ind = [
-            j
-            for j in range(N)
-            if pending_h[j][:2] == (v, v)
-            or any(pending_h[j][:2] in ((q, v), (v, q)) for p, q in matched_uv)
-        ]
+        # only attempt to match edges after one node match has been made
+        # this will stop self-edges on the first node being automatically deleted
+        # even when a substitution is the better option
+        if matched_uv:
+            g_ind = [
+                i
+                for i in range(M)
+                if pending_g[i][:2] == (u, u)
+                or any(
+                    pending_g[i][:2] in ((p, u), (u, p), (p, p)) for p, q in matched_uv
+                )
+            ]
+            h_ind = [
+                j
+                for j in range(N)
+                if pending_h[j][:2] == (v, v)
+                or any(
+                    pending_h[j][:2] in ((q, v), (v, q), (q, q)) for p, q in matched_uv
+                )
+            ]
+        else:
+            g_ind = []
+            h_ind = []
+
         m = len(g_ind)
         n = len(h_ind)
 
@@ -782,9 +794,9 @@ def optimize_edit_paths(
                             for p, q in matched_uv
                         ):
                             continue
-                    if g == (u, u):
+                    if g == (u, u) or any(g == (p, p) for p, q in matched_uv):
                         continue
-                    if h == (v, v):
+                    if h == (v, v) or any(h == (q, q) for p, q in matched_uv):
                         continue
                     C[k, l] = inf
 

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -895,27 +895,26 @@ class TestSimilarity:
         assert expected_paths == list(paths)
         assert expected_map == index_map
 
+    def test_symmetry_with_custom_matching():
+        print("G2 is edge (a,b) and G3 is edge (a,a)")
+        print("but node order for G2 is (a,b) while for G3 it is (b,a)")
 
-def test_symmetry_with_custom_matching():
-    print("G2 is edge (a,b) and G3 is edge (a,a)")
-    print("but node order for G2 is (a,b) while for G3 it is (b,a)")
+        a, b = "A", "B"
+        G2 = nx.Graph()
+        G2.add_nodes_from((a, b))
+        G2.add_edges_from([(a, b)])
+        G3 = nx.Graph()
+        G3.add_nodes_from((b, a))
+        G3.add_edges_from([(a, a)])
+        for G in (G2, G3):
+            for n in G:
+                G.nodes[n]["attr"] = n
+            for e in G.edges:
+                G.edges[e]["attr"] = e
+        match = lambda x, y: x == y
 
-    a, b = "A", "B"
-    G2 = nx.Graph()
-    G2.add_nodes_from((a, b))
-    G2.add_edges_from([(a, b)])
-    G3 = nx.Graph()
-    G3.add_nodes_from((b, a))
-    G3.add_edges_from([(a, a)])
-    for G in (G2, G3):
-        for n in G:
-            G.nodes[n]["attr"] = n
-        for e in G.edges:
-            G.edges[e]["attr"] = e
-    match = lambda x, y: x == y
+        print("Starting G2 to G3 GED calculation")
+        assert nx.graph_edit_distance(G2, G3, node_match=match, edge_match=match) == 1
 
-    print("Starting G2 to G3 GED calculation")
-    assert nx.graph_edit_distance(G2, G3, node_match=match, edge_match=match) == 1
-
-    print("Starting G3 to G2 GED calculation")
-    assert nx.graph_edit_distance(G3, G2, node_match=match, edge_match=match) == 1
+        print("Starting G3 to G2 GED calculation")
+        assert nx.graph_edit_distance(G3, G2, node_match=match, edge_match=match) == 1

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -894,3 +894,28 @@ class TestSimilarity:
 
         assert expected_paths == list(paths)
         assert expected_map == index_map
+
+
+def test_symmetry_with_custom_matching():
+    print("G2 is edge (a,b) and G3 is edge (a,a)")
+    print("but node order for G2 is (a,b) while for G3 it is (b,a)")
+
+    a, b = "A", "B"
+    G2 = nx.Graph()
+    G2.add_nodes_from((a, b))
+    G2.add_edges_from([(a, b)])
+    G3 = nx.Graph()
+    G3.add_nodes_from((b, a))
+    G3.add_edges_from([(a, a)])
+    for G in (G2, G3):
+        for n in G:
+            G.nodes[n]["attr"] = n
+        for e in G.edges:
+            G.edges[e]["attr"] = e
+    match = lambda x, y: x == y
+
+    print("Starting G2 to G3 GED calculation")
+    assert nx.graph_edit_distance(G2, G3, node_match=match, edge_match=match) == 1
+
+    print("Starting G3 to G2 GED calculation")
+    assert nx.graph_edit_distance(G3, G2, node_match=match, edge_match=match) == 1

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -895,7 +895,7 @@ class TestSimilarity:
         assert expected_paths == list(paths)
         assert expected_map == index_map
 
-    def test_symmetry_with_custom_matching():
+    def test_symmetry_with_custom_matching(self):
         print("G2 is edge (a,b) and G3 is edge (a,a)")
         print("but node order for G2 is (a,b) while for G3 it is (b,a)")
 


### PR DESCRIPTION
An attempt to resolve a dormant bug in the graph edit distance algorithm. The cited paper leaves the implementation of the edge matching up to the user. In the current implementation every time a new node in G1 is matched, self-edges on the newly matched node and every edge from the newly matched node to every other previously matched node in the search tree are inspected for potential edge matches in G2.

The issue arises when the first node matched has a self edge on it. The first node matched implicitly has no previous nodes matched and therefore no edges to any other nodes are inspected. This forces the self-edge to be deleted rather than being matched to an edge between two nodes.

This fix stops edge matching occurring on the first node match. Instead it is allowed only after at least one node match has already occurred.

For full disclosure one of the commented assert statements now fails but all tests pass. I think this is not quite ready to merge, but I was interested to get a second opinion.
