### PR TITLE
Update MultiGraph.degree() docs: outdated return type

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -956,13 +956,10 @@ class DiGraph(Graph):
 
         Returns
         -------
-        If a single node is requested
-        deg : int
-            Degree of the node
-
-        OR if multiple nodes are requested
-        nd_iter : iterator
-            The iterator returns two-tuples of (node, degree).
+        DiDegreeView or int
+            If multiple nodes are requested (the default), returns a `DiDegreeView`
+            mapping nodes to their degree.
+            If a single node is requested, returns the degree of the node as an integer.
 
         See Also
         --------

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1400,12 +1400,10 @@ class Graph:
 
         Returns
         -------
-        If a single node is requested
-        deg : int
-            Degree of the node
-
-        OR if multiple nodes are requested
-        nd_view : A DegreeView object capable of iterating (node, degree) pairs
+        DegreeView or int
+            If multiple nodes are requested (the default), returns a `DegreeView`
+            mapping nodes to their degree.
+            If a single node is requested, returns the degree of the node as an integer.
 
         Examples
         --------

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -699,13 +699,10 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         Returns
         -------
-        If a single nodes is requested
-        deg : int
-            Degree of the node
-
-        OR if multiple nodes are requested
-        nd_iter : iterator
-            The iterator returns two-tuples of (node, degree).
+        DiMultiDegreeView or int
+            If multiple nodes are requested (the default), returns a `DiMultiDegreeView`
+            mapping nodes to their degree.
+            If a single node is requested, returns the degree of the node as an integer.
 
         See Also
         --------

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -929,9 +929,8 @@ class MultiGraph(Graph):
         Returns
         -------
         degree_view: MultiDegreeView
-        
-        If a single node is requested, returns an int - the degree of the node.
-        If multiple nodes are requested, returns an iterator of (node, degree) pairs.
+            If a single node is requested, returns an int - the degree of the node.
+            If multiple nodes are requested, returns an iterator of (node, degree) pairs.
 
         Examples
         --------

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -928,13 +928,7 @@ class MultiGraph(Graph):
 
         Returns
         -------
-        If a single node is requested
-        deg : int
-            Degree of the node, if a single node is passed as argument.
-
-        OR if multiple nodes are requested
-        nd_iter : iterator
-            The iterator returns two-tuples of (node, degree).
+        degree_view: MultiDegreeView
 
         Examples
         --------

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -929,6 +929,9 @@ class MultiGraph(Graph):
         Returns
         -------
         degree_view: MultiDegreeView
+        
+        If a single node is requested, returns an int - the degree of the node.
+        If multiple nodes are requested, returns an iterator of (node, degree) pairs.
 
         Examples
         --------

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -928,9 +928,10 @@ class MultiGraph(Graph):
 
         Returns
         -------
-        degree_view: MultiDegreeView
-            If a single node is requested, returns an int - the degree of the node.
-            If multiple nodes are requested, returns an iterator of (node, degree) pairs.
+        MultiDegreeView or int
+            If multiple nodes are requested (the default), returns a `MultiDegreeView`
+            mapping nodes to their degree.
+            If a single node is requested, returns the degree of the node as an integer.
 
         Examples
         --------


### PR DESCRIPTION
In the past, degree() used to return an int or an iterator. In networkx#2458, the implementation was changed, so that the function returns a MultiDegreeView object, but the function docs weren't updated accordingly.

This incorrect return type causes issues in PyCharm type hinting mechanism - it thinks the function returns an int.

![multigraph_degree_type](https://user-images.githubusercontent.com/83541313/163168833-598ca479-c420-49cd-875c-ad6634a1d7c3.jpg)

This PR updates the declared return type to be MultiDegreeView.

