### PR TITLE
De-Regression: eagerly evaluate not_implemented_for in decorated generators

### DIFF
--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1142,9 +1142,9 @@ def _compat_shuffle(rng, input):
     rng.shuffle(input)
 
 
+@py_random_state(4)
 @not_implemented_for("multigraph")
 @not_implemented_for("directed")
-@py_random_state(4)
 def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
     """Greedy algorithm for finding a k-edge-augmentation
 

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1142,9 +1142,9 @@ def _compat_shuffle(rng, input):
     rng.shuffle(input)
 
 
-@py_random_state(4)
 @not_implemented_for("multigraph")
 @not_implemented_for("directed")
+@py_random_state(4)
 def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
     """Greedy algorithm for finding a k-edge-augmentation
 

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -485,11 +485,6 @@ finally:
  pass#"""
         )
 
-    def nop(self):
-        print(foo.__argmap__.assemble(foo.__wrapped__))
-        argmap._lazy_compile(foo)
-        print(foo._code)
-
     def test_immediate_raise(self):
         @not_implemented_for("directed")
         def yield_nodes(G):
@@ -497,9 +492,6 @@ finally:
 
         G = nx.Graph([(1, 2)])
         D = nx.DiGraph()
-
-        print([*yield_nodes(G)])
-        print(yield_nodes._code)
 
         # test first call (argmap is compiled and executed)
         with pytest.raises(nx.NetworkXNotImplemented):

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -489,3 +489,29 @@ finally:
         print(foo.__argmap__.assemble(foo.__wrapped__))
         argmap._lazy_compile(foo)
         print(foo._code)
+
+    def test_immediate_raise(self):
+        @not_implemented_for("directed")
+        def yield_nodes(G):
+            yield from G
+
+        G = nx.Graph([(1, 2)])
+        D = nx.DiGraph()
+
+        print([*yield_nodes(G)])
+        print(yield_nodes._code)
+
+        # test first call (argmap is compiled and executed)
+        with pytest.raises(nx.NetworkXNotImplemented):
+            node_iter = yield_nodes(D)
+
+        # test second call (argmap is only executed)
+        with pytest.raises(nx.NetworkXNotImplemented):
+            node_iter = yield_nodes(D)
+
+        # ensure that generators still make generators
+        node_iter = yield_nodes(G)
+        next(node_iter)
+        next(node_iter)
+        with pytest.raises(StopIteration):
+            next(node_iter)


### PR DESCRIPTION
See issue #5520 for details.

~Work in progress, needs doc updates.~

~Also, there's an issue where `open_file` and `not_implemented_for` are like oil and water -- specifically `not_implemented_for` is like oil and should go on top.  This isn't currently an issue in the codebase but should be addressed before it causes an obnoxious bug (see #5520 for discussion)~