### PR TITLE
Use double-sided arrows by default for `arrows=True` w/ undirected graphs

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -152,7 +152,7 @@ def draw_networkx(G, pos=None, arrows=None, with_labels=True, **kwds):
 
     arrowstyle : str (default='-\|>' for directed graphs)
         For directed graphs, choose the style of the arrowsheads.
-        For undirected graphs default to '-'
+        For undirected graphs default to '<->'
 
         See `matplotlib.patches.ArrowStyle` for more options.
 
@@ -576,7 +576,7 @@ def draw_networkx_edges(
 
     arrowstyle : str (default='-\|>' for directed graphs)
         For directed graphs and `arrows==True` defaults to '-\|>',
-        For undirected graphs default to '-'.
+        For undirected graphs default to '<->'.
 
         See `matplotlib.patches.ArrowStyle` for more options.
 
@@ -681,16 +681,12 @@ def draw_networkx_edges(
     # undirected graphs (for performance reasons) and use FancyArrowPatches
     # for directed graphs.
     # The `arrows` keyword can be used to override the default behavior
-
-    if arrowstyle == None:
-        if G.is_directed():
-            arrowstyle = "-|>"
-        else:
-            arrowstyle = "-"
-
     use_linecollection = not G.is_directed()
     if arrows in (True, False):
         use_linecollection = not arrows
+
+    if arrowstyle == None:
+        arrowstyle = "-|>" if G.is_directed() else "<->"
 
     if ax is None:
         ax = plt.gca()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -751,3 +751,15 @@ def test_draw_networkx_edges_undirected_selfloop_colors():
     for fap, clr, slp in zip(ax.patches, edge_colors[-3:], sl_points):
         assert fap.get_path().contains_point(slp)
         assert mpl.colors.same_color(fap.get_edgecolor(), clr)
+    plt.delaxes(ax)
+
+
+def test_draw_networkx_edges_undirected_arrows():
+    """Default to double-ended arrows when graph is undirected and arrows=True."""
+    G = nx.Graph([(0, 1)])
+    pos = {n: (n, n) for n in G.nodes}
+    fig, ax = plt.subplots()
+
+    fap, *_ = nx.draw_networkx_edges(G, pos, arrows=True)
+    assert fap.get_arrowstyle().arrow == "<->"
+    plt.delaxes(ax)


### PR DESCRIPTION
Follow-up to #5514 to modify the default arrowstyle when `arrows=True` and `G` is undirected. The current behavior is arguably incorrect because `arrows=True` results in edges without arrows. The following example illustrates the proposed change:

```python
>>> G = nx.Graph([(0, 1)])
>>> pos = {n: (n, n) for n in G.nodes}
>>> nx.draw_networkx_edges(G, pos, arrows=True)
```

#### Current result

![current](https://user-images.githubusercontent.com/1268991/163593184-b8374aeb-3a01-49c0-9cc5-2a540cabd98e.png)

#### Proposed change

![double_sided](https://user-images.githubusercontent.com/1268991/163593103-aa533cf9-0c2a-4b87-86c4-9e7692cbafae.png)

#### Further details

This problem comes about because the `arrows` kwarg serves double-duty: it is used to specify whether or not to draw arrows, but is *also* used as a switch to determine whether edges are drawn with `LineCollection` or `FancyArrowPatch` objects. This is largely an implementation detail, but an important one because there is a big difference in performance between the two. It is possible to recover the current behavior with `nx.draw_networkx_edges(G, pos, arrows=True, arrowstyle="-")`, though there is almost no reason to do this[^1] as the result will look exactly the same as the `arrows=False` (default for undirected) case, but the drawing will be much slower.

[^1]: One reason would be if the user wanted to modify individual edges *after* they've been drawn.