### PR TITLE
PlanarEmbedding in autosummary instead of autoclass.

### DIFF
--- a/doc/reference/algorithms/planarity.rst
+++ b/doc/reference/algorithms/planarity.rst
@@ -7,5 +7,4 @@ Planarity
    :toctree: generated/
 
    check_planarity
-.. autoclass:: PlanarEmbedding
-   :members:
+   PlanarEmbedding


### PR DESCRIPTION
A minor organizational proposal for the `planarity` docs:

The `PlanarEmbedding` class is currently included in the ref guide with the `.. autoclass` directive, which dumps the entire docstring into the planarity summary page. If we instead just include it in the `.. autosummary`, it will be listed/linked to in the same manner as `check_planarity`. The full `PlanarEmbedding` class docstring will still be autogenerated & accessible, but it is linked to rather than embedded in the main planarity page. The methods/attributes of `PlanarEmbedding` are *also* summarized instead of embedded which should further improve the digestibility of the page.

This may also help with #5090 .