### PR TITLE
Fix min_edge_cover in special cases (#5538)  and correct documentation

### DIFF
--- a/networkx/algorithms/covering.py
+++ b/networkx/algorithms/covering.py
@@ -56,6 +56,8 @@ def min_edge_cover(G, matching_algorithm=None):
     Minimum edge cover for bipartite graph can also be found using the
     function present in :mod:`networkx.algorithms.bipartite.covering`
     """
+    if len(G) == 0:
+        return set()
     if nx.number_of_isolates(G) > 0:
         # ``min_cover`` does not exist as there is an isolated node
         raise nx.NetworkXException(
@@ -66,11 +68,12 @@ def min_edge_cover(G, matching_algorithm=None):
     maximum_matching = matching_algorithm(G)
     # ``min_cover`` is superset of ``maximum_matching``
     try:
-        min_cover = set(
-            maximum_matching.items()
-        )  # bipartite matching case returns dict
+        # bipartite matching algs return dict so convert if needed
+        min_cover = set(maximum_matching.items())
+        bipartite_cover = True
     except AttributeError:
         min_cover = maximum_matching
+        bipartite_cover = False
     # iterate for uncovered nodes
     uncovered_nodes = set(G) - {v for u, v in min_cover} - {u for u, v in min_cover}
     for v in uncovered_nodes:
@@ -82,7 +85,8 @@ def min_edge_cover(G, matching_algorithm=None):
         # multigraph.)
         u = arbitrary_element(G[v])
         min_cover.add((u, v))
-        min_cover.add((v, u))
+        if bipartite_cover:
+            min_cover.add((v, u))
     return min_cover
 
 

--- a/networkx/algorithms/covering.py
+++ b/networkx/algorithms/covering.py
@@ -12,36 +12,42 @@ __all__ = ["min_edge_cover", "is_edge_cover"]
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 def min_edge_cover(G, matching_algorithm=None):
-    """Returns a set of edges which constitutes
-    the minimum edge cover of the graph.
+    """Returns the min cardinality edge cover of the graph as a set of edges.
 
     A smallest edge cover can be found in polynomial time by finding
     a maximum matching and extending it greedily so that all nodes
-    are covered.
+    are covered. This function follows that process. A maximum matching
+    algorithm can be specified for the first step of the algorithm.
+    The resulting set may return a set with one 2-tuple for each edge,
+    (the usual case) or with both 2-tuples `(u, v)` and `(v, u)` for
+    each edge. The latter is only done when a bipartite matching algorithm
+    is specified as `matching_algorithm`.
 
     Parameters
     ----------
     G : NetworkX graph
-        An undirected bipartite graph.
+        An undirected graph.
 
     matching_algorithm : function
-        A function that returns a maximum cardinality matching in a
-        given bipartite graph. The function must take one input, the
-        graph ``G``, and return a dictionary mapping each node to its
-        mate. If not specified,
+        A function that returns a maximum cardinality matching for `G`.
+        The function must take one input, the graph `G`, and return
+        either a set of edges (with only one direction for the pair of nodes)
+        or a dictionary mapping each node to its mate. If not specified,
+        :func:`~networkx.algorithms.matching.max_weight_matching` is used.
+        Common bipartite matching functions include
         :func:`~networkx.algorithms.bipartite.matching.hopcroft_karp_matching`
-        will be used. Other possibilities include
-        :func:`~networkx.algorithms.bipartite.matching.eppstein_matching`,
-        or matching algorithms in the
-        :mod:`networkx.algorithms.matching` module.
+        or
+        :func:`~networkx.algorithms.bipartite.matching.eppstein_matching`.
 
     Returns
     -------
     min_cover : set
 
-        It contains all the edges of minimum edge cover
-        in form of tuples. It contains both the edges `(u, v)` and `(v, u)`
-        for given nodes `u` and `v` among the edges of minimum edge cover.
+        A set of the edges in a minimum edge cover in the form of tuples.
+        It contains only one of the equivalent 2-tuples `(u, v)` and `(v, u)`
+        for each edge. If a bipartite method is used to compute the matching,
+        the returned set contains both the 2-tuples `(u, v)` and `(v, u)`
+        for each edge of a minimum edge cover.
 
     Notes
     -----
@@ -53,8 +59,10 @@ def min_edge_cover(G, matching_algorithm=None):
     is bounded by the worst-case running time of the function
     ``matching_algorithm``.
 
-    Minimum edge cover for bipartite graph can also be found using the
-    function present in :mod:`networkx.algorithms.bipartite.covering`
+    Minimum edge cover for `G` can also be found using the `min_edge_covering`
+    function in :mod:`networkx.algorithms.bipartite.covering` which is
+    simply this function with a default matching algorithm of
+    :func:`~networkx.algorithms.bipartite.matching.hopcraft_karp_matching`
     """
     if len(G) == 0:
         return set()

--- a/networkx/algorithms/tests/test_covering.py
+++ b/networkx/algorithms/tests/test_covering.py
@@ -17,7 +17,7 @@ class TestMinEdgeCover:
         G = nx.Graph([(0, 1)])
         assert nx.min_edge_cover(G) in ({(0, 1)}, {(1, 0)})
 
-    def test_graph_single_edge(self):
+    def test_graph_two_edge_path(self):
         G = nx.path_graph(3)
         min_cover = nx.min_edge_cover(G)
         assert len(min_cover) == 2

--- a/networkx/algorithms/tests/test_covering.py
+++ b/networkx/algorithms/tests/test_covering.py
@@ -14,27 +14,43 @@ class TestMinEdgeCover:
         assert nx.min_edge_cover(G) == {(0, 0)}
 
     def test_graph_single_edge(self):
-        G = nx.Graph()
-        G.add_edge(0, 1)
+        G = nx.Graph([(0, 1)])
         assert nx.min_edge_cover(G) in ({(0, 1)}, {(1, 0)})
+
+    def test_graph_single_edge(self):
+        G = nx.path_graph(3)
+        min_cover = nx.min_edge_cover(G)
+        assert len(min_cover) == 2
+        for u, v in G.edges:
+            assert (u, v) in min_cover or (v, u) in min_cover
 
     def test_bipartite_explicit(self):
         G = nx.Graph()
         G.add_nodes_from([1, 2, 3, 4], bipartite=0)
         G.add_nodes_from(["a", "b", "c"], bipartite=1)
         G.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c"), (4, "a")])
+        # Use bipartite method by prescribing the algorithm
         min_cover = nx.min_edge_cover(
             G, nx.algorithms.bipartite.matching.eppstein_matching
         )
-        min_cover2 = nx.min_edge_cover(G)
         assert nx.is_edge_cover(G, min_cover)
         assert len(min_cover) == 8
+        # Use the default method which is not specialized for bipartite
+        min_cover2 = nx.min_edge_cover(G)
+        assert nx.is_edge_cover(G, min_cover2)
+        assert len(min_cover2) == 4
 
-    def test_complete_graph(self):
+    def test_complete_graph_even(self):
         G = nx.complete_graph(10)
         min_cover = nx.min_edge_cover(G)
         assert nx.is_edge_cover(G, min_cover)
         assert len(min_cover) == 5
+
+    def test_complete_graph_odd(self):
+        G = nx.complete_graph(11)
+        min_cover = nx.min_edge_cover(G)
+        assert nx.is_edge_cover(G, min_cover)
+        assert len(min_cover) == 6
 
 
 class TestIsEdgeCover:


### PR DESCRIPTION
Fixes the defect described in #5538 while maintaining the current discrepancy between `matching` APIs for bipartite and non-bipartite matching functions. bipartite returns a matching dict of mates, while non-bipartite returns the matching as a set of edges.  

That means that the corrected `min_edge_covering` still returns two types of sets -- if a bipartite matching algorithm is used, it returns a set with both 2-tuples for each edge; while if a non-bipartite matching algorithm is used, it returns a set with one 2-tuple for each edge.  It seems like this should be changed too. And I could add that to this PR or to a separate PR.

This PR also updates the documentation which e.g. currently says that this function only works for bipartite graphs.