### PR TITLE
Clean up maximal_independent_set tests

### DIFF
--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -34,7 +34,12 @@ def test_florentine_family():
     G = nx.florentine_families_graph()
     indep = nx.maximal_independent_set(G, ["Medici", "Bischeri"])
     assert set(indep) == {
-        "Medici", "Bischeri", "Castellani", "Pazzi", "Ginori", "Lamberteschi"
+        "Medici",
+        "Bischeri",
+        "Castellani",
+        "Pazzi",
+        "Ginori",
+        "Lamberteschi",
     }
 
 

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -8,78 +8,48 @@ import networkx as nx
 import random
 
 
-class TestMaximalIndependantSet:
-    def setup(self):
-        self.florentine = nx.Graph()
-        self.florentine.add_edge("Acciaiuoli", "Medici")
-        self.florentine.add_edge("Castellani", "Peruzzi")
-        self.florentine.add_edge("Castellani", "Strozzi")
-        self.florentine.add_edge("Castellani", "Barbadori")
-        self.florentine.add_edge("Medici", "Barbadori")
-        self.florentine.add_edge("Medici", "Ridolfi")
-        self.florentine.add_edge("Medici", "Tornabuoni")
-        self.florentine.add_edge("Medici", "Albizzi")
-        self.florentine.add_edge("Medici", "Salviati")
-        self.florentine.add_edge("Salviati", "Pazzi")
-        self.florentine.add_edge("Peruzzi", "Strozzi")
-        self.florentine.add_edge("Peruzzi", "Bischeri")
-        self.florentine.add_edge("Strozzi", "Ridolfi")
-        self.florentine.add_edge("Strozzi", "Bischeri")
-        self.florentine.add_edge("Ridolfi", "Tornabuoni")
-        self.florentine.add_edge("Tornabuoni", "Guadagni")
-        self.florentine.add_edge("Albizzi", "Ginori")
-        self.florentine.add_edge("Albizzi", "Guadagni")
-        self.florentine.add_edge("Bischeri", "Guadagni")
-        self.florentine.add_edge("Guadagni", "Lamberteschi")
+def test_random_seed():
+    G = nx.empty_graph(5)
+    assert nx.maximal_independent_set(G, seed=1) == [1, 0, 3, 2, 4]
 
-    def test_random_seed(self):
-        G = nx.complete_graph(5)
-        for node in G:
-            assert nx.maximal_independent_set(G, [node], seed=1) == [node]
 
-    def test_K5(self):
-        """Maximal independent set: K5"""
-        G = nx.complete_graph(5)
-        for node in G:
-            assert nx.maximal_independent_set(G, [node]) == [node]
+@pytest.mark.parametrize("graph", [nx.complete_graph(5), nx.complete_graph(55)])
+def test_K5(graph):
+    """Maximal independent set for complete graphs"""
+    assert all(nx.maximal_independent_set(graph, [n]) == [n] for n in graph)
 
-    def test_K55(self):
-        """Maximal independent set: K55"""
-        G = nx.complete_graph(55)
-        for node in G:
-            assert nx.maximal_independent_set(G, [node]) == [node]
 
-    def test_exception(self):
-        """Bad input should raise exception."""
-        G = self.florentine
-        pytest.raises(nx.NetworkXUnfeasible, nx.maximal_independent_set, G, ["Smith"])
-        pytest.raises(
-            nx.NetworkXUnfeasible, nx.maximal_independent_set, G, ["Salviati", "Pazzi"]
-        )
+def test_exceptions():
+    """Bad input should raise exception."""
+    G = nx.florentine_families_graph()
+    pytest.raises(nx.NetworkXUnfeasible, nx.maximal_independent_set, G, ["Smith"])
+    pytest.raises(
+        nx.NetworkXUnfeasible, nx.maximal_independent_set, G, ["Salviati", "Pazzi"]
+    )
+    # MaximalIndependantSet is not implemented for directed graphs
+    pytest.raises(nx.NetworkXNotImplemented, nx.maximal_independent_set, nx.DiGraph(G))
 
-    def test_digraph_exception(self):
-        G = nx.DiGraph([(1, 2), (3, 4)])
-        pytest.raises(nx.NetworkXNotImplemented, nx.maximal_independent_set, G)
 
-    def test_florentine_family(self):
-        G = self.florentine
-        indep = nx.maximal_independent_set(G, ["Medici", "Bischeri"])
-        assert sorted(indep) == sorted(
-            ["Medici", "Bischeri", "Castellani", "Pazzi", "Ginori", "Lamberteschi"]
-        )
+def test_florentine_family():
+    G = nx.florentine_families_graph()
+    indep = nx.maximal_independent_set(G, ["Medici", "Bischeri"])
+    assert sorted(indep) == sorted(
+        ["Medici", "Bischeri", "Castellani", "Pazzi", "Ginori", "Lamberteschi"]
+    )
 
-    def test_bipartite(self):
-        G = nx.complete_bipartite_graph(12, 34)
-        indep = nx.maximal_independent_set(G, [4, 5, 9, 10])
-        assert sorted(indep) == list(range(12))
 
-    def test_random_graphs(self):
-        """Generate 50 random graphs of different types and sizes and
-        make sure that all sets are independent and maximal."""
-        for i in range(0, 50, 10):
-            G = nx.random_graphs.erdos_renyi_graph(i * 10 + 1, random.random())
-            IS = nx.maximal_independent_set(G)
-            assert not list(G.subgraph(IS).edges())
-            neighbors_of_MIS = set.union(*(set(G.neighbors(v)) for v in IS))
-            for v in set(G.nodes()).difference(IS):
-                assert v in neighbors_of_MIS
+def test_bipartite():
+    G = nx.complete_bipartite_graph(12, 34)
+    indep = nx.maximal_independent_set(G, [4, 5, 9, 10])
+    assert sorted(indep) == list(range(12))
+
+
+def test_random_graphs():
+    """Generate 5 random graphs of different types and sizes and
+    make sure that all sets are independent and maximal."""
+    for i in range(0, 50, 10):
+        G = nx.erdos_renyi_graph(i * 10 + 1, random.random())
+        IS = nx.maximal_independent_set(G)
+        assert G.subgraph(IS).number_of_edges() == 0
+        neighbors_of_MIS = set.union(*(set(G.neighbors(v)) for v in IS))
+        assert all(v in neighbors_of_MIS for v in set(G.nodes()).difference(IS))

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -33,9 +33,9 @@ def test_exceptions():
 def test_florentine_family():
     G = nx.florentine_families_graph()
     indep = nx.maximal_independent_set(G, ["Medici", "Bischeri"])
-    assert sorted(indep) == sorted(
-        ["Medici", "Bischeri", "Castellani", "Pazzi", "Ginori", "Lamberteschi"]
-    )
+    assert set(indep) == {
+        "Medici", "Bischeri", "Castellani", "Pazzi", "Ginori", "Lamberteschi"
+    }
 
 
 def test_bipartite():


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
I was fiddling around with [memray](https://github.com/bloomberg/memray) and maximal_independent_set tests popped up because of the randomised graph test.
Changed a couple of tests (empty_graph makes more sense to test out the seed) and removed the class structure. 
