### PR TITLE
Remove pdf latex builds of docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,6 @@ jobs:
             sudo apt-get install graphviz libgraphviz-dev
 
       - run:
-          name: Install TeX
-          command: |
-            sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
-
-      - run:
           name: Install pysal dependencies
           command: |
             sudo apt-get install libspatialindex-dev
@@ -63,8 +58,6 @@ jobs:
             export OMP_NUM_THREADS=1
             source venv/bin/activate
             make -C doc/ html
-            make -C doc/ latexpdf LATEXOPTS="-file-line-error -halt-on-error"
-            cp -a doc/build/latex/networkx_reference.pdf doc/build/html/_downloads/.
 
       - store_artifacts:
           path: doc/build/html

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,8 +22,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install graphviz graphviz-dev
-          sudo apt-get install texlive texlive-latex-extra latexmk texlive-xetex
-          sudo apt-get install fonts-freefont-otf xindy
           sudo apt-get install libspatialindex-dev
 
       - name: Install packages
@@ -56,8 +54,6 @@ jobs:
         run: |
           export DISPLAY=:99
           make -C doc/ html
-          make -C doc/ latexpdf LATEXOPTS="-file-line-error -halt-on-error"
-          cp -a doc/build/latex/networkx_reference.pdf doc/build/html/_downloads/.
 
       - name: Deploy docs
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This has been discussed before and it's currently a blocker of moving to myst_nb from nb2plots for code block directives in our documentation. Opening this just so we can get the ball rolling on this one and have a decision :)