### PR TITLE
Fix triadic census

### DIFF
--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -268,26 +268,3 @@ def test_triandic_census_on_random_graph(N):
             tt: sum(1 for t in tbt.get(tt, []) if any(n in ns for n in t)) for tt in tc1
         }
         assert tc1 == tc2
-
-
-@pytest.mark.slow
-def test_triadic_census_on_directed_atlas():
-    for G in nx.graph_atlas_g():
-        edges = list(G.edges())
-        for i, (u, v) in enumerate(edges):
-            for elist in ([(u, v)], [(v, u)], [(u, v), (v, u)]):
-                DG = nx.DiGraph(edges[:i] + elist + edges[i + 1 :])
-                DG.add_nodes_from(G)
-                tc1 = nx.triadic_census(DG)
-                tbt = nx.triads_by_type(DG)
-                tc2 = {tt: len(tbt.get(tt, [])) for tt in tc1}
-                assert tc1 == tc2
-                # test single node nodelist
-                n = 0
-                tc_node = nx.triadic_census(DG, nodelist=[n])
-                tb_node = {tt: sum(1 for t in tbt.get(tt, []) if n in t) for tt in tc1}
-                assert tc_node == tb_node
-                for n in DG:
-                    tc1 = nx.triadic_census(DG, nodelist=[n])
-                    tc2 = {tt: sum(1 for t in tbt.get(tt, []) if n in t) for tt in tc1}
-                    assert tc1 == tc2

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -151,6 +151,42 @@ def test_triadic_census_short_path_nodelist():
         assert expected == {typ: cnt for typ, cnt in triad_census.items() if cnt > 0}
 
 
+def test_triadic_census_correct_nodelist_values():
+    G = nx.path_graph(5, create_using=nx.DiGraph)
+    with pytest.raises(ValueError):
+        nx.triadic_census(G, [1, 2, 2, 3])
+    with pytest.raises(ValueError):
+        nx.triadic_census(G, [1, 2, "a", 3])
+
+
+def test_triadic_census_tiny_graphs():
+    tc = nx.triadic_census(nx.empty_graph(0, create_using=nx.DiGraph))
+    assert {} == {typ: cnt for typ, cnt in tc.items() if cnt > 0}
+    tc = nx.triadic_census(nx.empty_graph(1, create_using=nx.DiGraph))
+    assert {} == {typ: cnt for typ, cnt in tc.items() if cnt > 0}
+    tc = nx.triadic_census(nx.empty_graph(2, create_using=nx.DiGraph))
+    assert {} == {typ: cnt for typ, cnt in tc.items() if cnt > 0}
+    tc = nx.triadic_census(nx.DiGraph([(1, 2)]))
+    assert {} == {typ: cnt for typ, cnt in tc.items() if cnt > 0}
+
+
+def test_triadic_census_selfloops():
+    GG = nx.path_graph("abc", create_using=nx.DiGraph)
+    expected = {"021C": 1}
+    for n in GG:
+        G = GG.copy()
+        G.add_edge(n, n)
+        tc = nx.triadic_census(G)
+        assert expected == {typ: cnt for typ, cnt in tc.items() if cnt > 0}
+
+    GG = nx.path_graph("abcde", create_using=nx.DiGraph)
+    tbt = nx.triads_by_type(GG)
+    for n in GG:
+        GG.add_edge(n, n)
+    tc = nx.triadic_census(GG)
+    assert tc == {tt: len(tbt[tt]) for tt in tc}
+
+
 def test_triadic_census_four_path():
     G = nx.path_graph("abcd", create_using=nx.DiGraph)
     expected = {"012": 2, "021C": 2}

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -139,6 +139,35 @@ def test_random_triad():
         assert nx.is_triad(nx.random_triad(G))
 
 
+def test_triadic_census_short_path_nodelist():
+    G = nx.path_graph("abc", create_using=nx.DiGraph)
+    expected = {"021C": 1}
+    a_triad_census = nx.triadic_census(G, nodelist=["a"])
+    assert expected == {typ: cnt for typ, cnt in a_triad_census.items() if cnt>0}
+    b_triad_census = nx.triadic_census(G, nodelist=["b"])
+    assert expected == {typ: cnt for typ, cnt in b_triad_census.items() if cnt>0}
+    c_triad_census = nx.triadic_census(G, nodelist=["c"])
+    assert expected == {typ: cnt for typ, cnt in c_triad_census.items() if cnt>0}
+
+def test_triadic_census_four_path():
+    G = nx.path_graph("abcd", create_using=nx.DiGraph)
+    expected = {"012": 2, "021C": 2}
+    triad_census = nx.triadic_census(G, nodelist=["a"])
+    #assert expected == {typ: cnt for typ, cnt in triad_census.items() if cnt>0}
+
+def test_triadic_census_four_path_nodelist():
+    G = nx.path_graph("abcd", create_using=nx.DiGraph)
+    expected_end = {"012": 2, "021C": 1}
+    expected_mid = {"012": 1, "021C": 2}
+    a_triad_census = nx.triadic_census(G, nodelist=["a"])
+    #assert expected_end == {typ: cnt for typ, cnt in a_triad_census.items() if cnt>0}
+    b_triad_census = nx.triadic_census(G, nodelist=["b"])
+    assert expected_mid == {typ: cnt for typ, cnt in b_triad_census.items() if cnt>0}
+    c_triad_census = nx.triadic_census(G, nodelist=["c"])
+    assert expected_mid == {typ: cnt for typ, cnt in c_triad_census.items() if cnt>0}
+    d_triad_census = nx.triadic_census(G, nodelist=["d"])
+    assert expected_end == {typ: cnt for typ, cnt in d_triad_census.items() if cnt>0}
+
 def test_triadic_census_nodelist():
     """Tests the triadic_census function."""
     G = nx.DiGraph()

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -151,9 +151,10 @@ def test_triadic_census_short_path_nodelist():
 
 def test_triadic_census_correct_nodelist_values():
     G = nx.path_graph(5, create_using=nx.DiGraph)
-    with pytest.raises(ValueError):
+    msg = r"nodelist includes duplicate nodes or nodes not in G"
+    with pytest.raises(ValueError, match=msg):
         nx.triadic_census(G, [1, 2, 2, 3])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg):
         nx.triadic_census(G, [1, 2, "a", 3])
 
 

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -6,8 +6,6 @@ import itertools
 from random import sample
 import networkx as nx
 
-TRIAD_NAMES = nx.triads.TRIAD_NAMES
-
 
 def test_triadic_census():
     """Tests the triadic_census function."""

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -174,7 +174,7 @@ def triadic_census(G, nodelist=None):
     """
     nodeset = set(G.nbunch_iter(nodelist))
     if nodelist is not None and len(nodelist) != len(nodeset):
-        raise ValueError("nodelist include duplicate nodes or nodes not in G")
+        raise ValueError("nodelist includes duplicate nodes or nodes not in G")
 
     N = len(G)
     Nnot = N - len(nodeset)  # can signal special counting for subset of nodes

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -167,94 +167,83 @@ def triadic_census(G, nodelist=None):
         http://vlado.fmf.uni-lj.si/pub/networks/doc/triads/triads.pdf
 
     """
-    # Initialize the count for each triad to be zero.
-    census = {name: 0 for name in TRIAD_NAMES}
+    # ignore nodelist duplicates and nodes not in G
+    # TODO:?? raise error if nodelist not unique or nodes not in G
+    nodelist = list(G.nbunch_iter(nodelist))
+    nodeset = set(nodelist)
     N = len(G)
+    Nnot = N - len(nodelist)  # can signal special counting for subset of nodes
 
-    if nodelist is None:
-        nodelist = list(G)
-        ordering = {n: i for i, n in enumerate(G)}
-        all_nodes = True
-    else:
-        # ignore duplicates and nodes not in G
-        nodeset = set(nodelist)
-        nodelist = list(G.nbunch_iter(nodeset))
-        num_nodes = len(nodelist)
-        # TODO: rasie error if nodelist not unique or nodes not in G
-        ordering = {n: i for i, n in enumerate(nodelist)}
-        ordering.update((n, i + num_nodes) for i, n in enumerate(G) if n not in nodeset)
-        all_nodes = len(nodelist) == len(G)
+    # create an ordering of nodes with nodelist nodes first
+    m = {n: i for i, n in enumerate(nodelist)}
+    if Nnot:
+        # add non-nodelist nodes later in the ordering
+        not_nodeset = G.nodes - nodeset
+        m.update((n, i + N) for i, n in enumerate(not_nodeset))
 
     # build all_neighbor dicts for easy counting
-    # After Python 3.8 can leave off these keys()
-    nbrs_dict = {n: G.pred[n].keys() | G.succ[n].keys() for n in G}
-    dbl_nbrs_dict = {n: G.pred[n].keys() & G.succ[n].keys() for n in G}
+    # After Python 3.8 can leave off these keys(). Speedup also using G._pred
+    # nbrs = {n: G._pred[n].keys() | G._succ[n].keys() for n in G}
+    nbrs = {n: G.pred[n].keys() | G.succ[n].keys() for n in G}
+    dbl_nbrs = {n: G.pred[n].keys() & G.succ[n].keys() for n in G}
 
+    if Nnot:
+        sgl_nbrs = {n: G.pred[n].keys() ^ G.succ[n].keys() for n in not_nodeset}
+        # find number of edges not incident to nodes in nodelist
+        sgl = sum(1 for n in not_nodeset for nbr in sgl_nbrs[n] if nbr not in nodeset)
+        sgl_edges_outside = sgl // 2
+        dbl = sum(1 for n in not_nodeset for nbr in dbl_nbrs[n] if nbr not in nodeset)
+        dbl_edges_outside = dbl // 2
+
+    # Initialize the count for each triad to be zero.
+    census = {name: 0 for name in TRIAD_NAMES}
     # Main loop over nodes
     for v in nodelist:
-        vnbrs = nbrs_dict[v]
+        vnbrs = nbrs[v]
+        dbl_vnbrs = dbl_nbrs[v]
+        if Nnot:
+            # set up counts of edges attached to v.
+            sgl_unbrs_bdy = sgl_unbrs_out = dbl_unbrs_bdy = dbl_unbrs_out = 0
         # TODO:  check for selfloops
-        dbl_vnbrs = dbl_nbrs_dict[v]
-        if not all_nodes:
-            # count edges incident to vnbrs
-            unbrs_in = 0  # unbrs within vnbrs
-            unbrs_out = 0  # unbrs outside of vnbrs
-            dbl_unbrs_in = 0
-            dbl_unbrs_out = 0
         for u in vnbrs:
-            if ordering[u] <= ordering[v]:
+            if m[u] <= m[v]:
                 continue
-            unbrs = nbrs_dict[u]
+            unbrs = nbrs[u]
             neighbors = (vnbrs | unbrs) - {u, v}
-            # Calculate dyadic triads instead of counting them.
+            # Count connected triads.
+            for w in neighbors:
+                if m[u] < m[w] or (m[v] < m[w] < m[u] and v not in nbrs[w]):
+                    code = _tricode(G, v, u, w)
+                    census[TRICODE_TO_NAME[code]] += 1
+
+            # Use a formula for dyadic triads with edge incident to v
             if u in dbl_vnbrs:
                 census["102"] += N - len(neighbors) - 2
             else:
                 census["012"] += N - len(neighbors) - 2
-            if not all_nodes:
-                # count edges incident to vnbrs
-                unbrs_in += len(unbrs & vnbrs)
-                unbrs_out += len(unbrs - vnbrs - {v})
-                dbl_unbrs = dbl_nbrs_dict[u]
-                dbl_unbrs_in += len(dbl_unbrs & vnbrs)
-                dbl_unbrs_out += len(dbl_unbrs - vnbrs - {v})
 
-            # Count connected triads.
-            for w in neighbors:
-                if ordering[u] < ordering[w] or (
-                    ordering[v] < ordering[w] < ordering[u] and v not in nbrs_dict[w]
-                ):
-                    code = _tricode(G, v, u, w)
-                    census[TRICODE_TO_NAME[code]] += 1
-        # Calculate dyads for node v when nodelist is not all nodes
-        # NOTE: these formulas could lead to double-counting when len(nodelist)>1
-        if not all_nodes:
-            dbl_edges = sum(len(nbrs) for nbrs in dbl_nbrs_dict.values()) // 2
-            sgl_edges = sum(len(nbrs) for nbrs in nbrs_dict.values()) // 2 - dbl_edges
-            sgl_unbrs = (unbrs_out - dbl_unbrs_out) + (unbrs_in - dbl_unbrs_in) // 2
-            census["012"] += sgl_edges - sgl_unbrs - (len(vnbrs) - len(dbl_vnbrs))
-            dbl = dbl_edges - dbl_unbrs_out - dbl_unbrs_in // 2 - len(dbl_vnbrs)
-            census["102"] += dbl
+            # Count edges attached to v. Subtract later to get triads with v isolated
+            # _out are (u,unbr) for unbrs outside boundary of nodeset
+            # _bdy are (u,unbr) for unbrs on boundary of nodeset (get double counted)
+            if Nnot and u not in nodeset:
+                sgl_unbrs = sgl_nbrs[u]
+                sgl_unbrs_bdy += len(sgl_unbrs & vnbrs - nodeset)
+                sgl_unbrs_out += len(sgl_unbrs - vnbrs - nodeset)
+                dbl_unbrs = dbl_nbrs[u]
+                dbl_unbrs_bdy += len(dbl_unbrs & vnbrs - nodeset)
+                dbl_unbrs_out += len(dbl_unbrs - vnbrs - nodeset)
+        # if nodelist is G.nodes, skip this b/c we will find the edge later.
+        if Nnot:
+            # Count edges outside nodelist not connected with v (v isolated triads)
+            census["012"] += sgl_edges_outside - (sgl_unbrs_out + sgl_unbrs_bdy // 2)
+            census["102"] += dbl_edges_outside - (dbl_unbrs_out + dbl_unbrs_bdy // 2)
 
     # calculate null triads: "003"
-    if all_nodes:
-        # null triads = total number of possible triads - all found triads
-        #
-        # Use integer division here, since we know this formula guarantees an
-        # integral value.
-        census["003"] = ((N * (N - 1) * (N - 2)) // 6) - sum(census.values())
-    else:
-        for v in nodelist:
-            vnbrs = nbrs_dict[v]
-            not_vnbrs = G.nodes() - vnbrs - {v}
-            triad_003_count = 0
-            for u in not_vnbrs:
-                # subtract 1 from len to not count node u
-                unbrs = nbrs_dict[u] - vnbrs
-                triad_003_count += len(not_vnbrs - unbrs) - 1
-                # triad_003_count += len(not_vnbrs - nbrs_dict[u]) - 1
-            triad_003_count //= 2
-            census["003"] += triad_003_count
+    # null triads = total number of possible triads - all found triads
+    total_triangles = (N * (N - 1) * (N - 2)) // 6
+    triangles_without_nodelist = (Nnot * (Nnot - 1) * (Nnot - 2)) // 6
+    total_census = total_triangles - triangles_without_nodelist
+    census["003"] = total_census - sum(census.values())
 
     return census
 

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -3,7 +3,6 @@
 # Copyright 2011 Alex Levenson <alex@isnotinvain.com>
 # Copyright 2011 Diederik van Liere <diederik.vanliere@rotman.utoronto.ca>
 """Functions for analyzing triads of a graph."""
-import pytest
 
 from itertools import combinations, permutations
 from collections import defaultdict


### PR DESCRIPTION
The goal of this PR is to fix the nodelist parameter for `triadic_census`. Closes #5557 

This first pair of commits add tests to show that the older code does not produce the correct results for some simple cases, and then add some changes to the algorithm to allow it to work with single node entries in the nodelist parameter.

What was needed is to revise the triads that have calculated counts instead of brute-force counts.  These are: '012', '102' and '003'.  It looks like the '003' special case code was fine.  But the '012' and '102' formulas calculated only the triads that involved an edge for a node in `nodelist`.  That means it misses any triads that have an edge between 2 nodes NOT in `nodelist` and an isolated node in `nodelist`. The case with no `nodelist` specified still works because no such missing triads exist... There aren't any edges between nodes not in nodelist because every node is in nodelist.  So, the default case for `nodelist` is fine, as suspected.

To correct for this, we need to add the missing triads using a formula for the number of edges not incident to neighbors of the node currently being counted. To wrap my head around this, I worked through the case with nodelist being a single node. An additional task is to count both the number of these edges and also whether they are bidirectional edges or single direction (the difference between '012' and '102' triads). 

I couldn't stop myself from some efficiency changes such as moving the computation of `G.pred[u] | G.succ[u]` outside the loop to avoid recomputing it many times. And I renamed some variables like `n` to `N` and `m` to `ordering`.

I've run it on all graphs with 7 or fewer nodes checking against the output of `triads_by_type()`, and I've run it on numerous random graphs with 10 nodes and a couple of random graphs with 100 and 1000 nodes. These tests are in the test file though some are marked as slow.

@r1ght0us  Are you able to check whether this version does what you wanted it to do? 