### PR TITLE
Add examples to compose operation

### DIFF
--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -310,9 +310,8 @@ def compose(G, H):
     >>> R.edges
     EdgeView([(0, 1), (0, 2), (1, 2)])
 
-    As indicated above, the attributes from H take precedent over attributes from G.
-    If you prefer another way of combining attributes, you can update them after the compose operation.
-    Consider the below graphs which have the nodes with the same labels, edge and node attributes:
+    By default, the attributes from `H` take precedent over attributes from `G`.
+    If you prefer another way of combining attributes, you can update them after the compose operation:
 
     >>> G = nx.Graph([('x', 'y', {'weight': 2.0}), ('x', 'z', {'weight': 1.0})])
     >>> H = nx.Graph([('x', 'y', {'weight': 10.0}), ('y', 'z', {'weight': -1.0})])

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -313,25 +313,29 @@ def compose(G, H):
     By default, the attributes from `H` take precedent over attributes from `G`.
     If you prefer another way of combining attributes, you can update them after the compose operation:
 
-    >>> G = nx.Graph([('x', 'y', {'weight': 2.0}), ('x', 'z', {'weight': 1.0})])
-    >>> H = nx.Graph([('x', 'y', {'weight': 10.0}), ('y', 'z', {'weight': -1.0})])
-    >>> nx.set_node_attributes(G, {'x': "dark", 'y': "light", 'z':"neon"}, name='color')
-    >>> nx.set_node_attributes(H, {'x': "green", 'y': "orange", 'z':"yellow"}, name='color')
+    >>> G = nx.Graph([("x", "y", {'weight': 2.0}), ("x", "z", {'weight': 1.0}), ("t", "x", {'weight': 100.0})])
+    >>> H = nx.Graph([("x", "y", {'weight': 10.0}), ("y", "z", {'weight': -1.0})])
+    >>> nx.set_node_attributes(G, {"x": "dark", "y": "light", "z":"neon", "t":"black"}, name="color")
+    >>> nx.set_node_attributes(H, {"x": "green", "y": "orange", "z":"yellow"}, name="color")
     >>> GcomposeH = nx.compose(G, H)
 
     Normally, color attribute values of nodes of GcomposeH come from H. We can workaround this as follows:
 
-    >>> node_data = {n: G.nodes[n].get('color') + " " + H.nodes[n].get('color') for n in G.nodes & H.nodes}
+    >>> node_data = {n: G.nodes[n].get('color', "") + " " + H.nodes[n].get('color', "") for n in G.nodes & H.nodes}
     >>> nx.set_node_attributes(GcomposeH, node_data, 'color')
-    >>> GcomposeH.nodes['x']['color']
-    'dark green'
+    >>> print(GcomposeH.nodes["x"]["color"])
+    >>> print(GcomposeH.nodes["t"]["color"])
+    dark green
+    black
 
     Similarly, we can update edge attributes after the compose operation in a way we prefer:
 
-    >>> edge_data = {e: G.edges[e].get('weight') * H.edges[e].get('weight') for e in G.edges & H.edges}
+    >>> edge_data = {e: G.edges[e].get('weight', 1) * H.edges[e].get('weight', 1) for e in G.edges & H.edges}
     >>> nx.set_edge_attributes(GcomposeH, edge_data, 'weight')
-    >>> GcomposeH.edges[('x', 'y')]['weight']
+    >>> print(GcomposeH.edges[("x", "y")]["weight"])
+    >>> print(GcomposeH.edges[("t", "x")]["weight"])
     20.0
+    100.0
     """
     return nx.compose_all([G, H])
 

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -313,18 +313,18 @@ def compose(G, H):
     By default, the attributes from `H` take precedent over attributes from `G`.
     If you prefer another way of combining attributes, you can update them after the compose operation:
 
-    >>> G = nx.Graph([("x", "y", {'weight': 2.0}), ("x", "z", {'weight': 1.0}), ("t", "x", {'weight': 100.0})])
-    >>> H = nx.Graph([("x", "y", {'weight': 10.0}), ("y", "z", {'weight': -1.0})])
-    >>> nx.set_node_attributes(G, {"x": "dark", "y": "light", "z":"neon", "t":"black"}, name="color")
-    >>> nx.set_node_attributes(H, {"x": "green", "y": "orange", "z":"yellow"}, name="color")
+    >>> G = nx.Graph([('x', 'y', {'weight': 2.0}), ('x', 'z', {'weight': 1.0}), ('t', 'x', {'weight': 100.0})])
+    >>> H = nx.Graph([('x', 'y', {'weight': 10.0}), ('y', 'z', {'weight': -1.0})])
+    >>> nx.set_node_attributes(G, {'x': 'dark', 'y': "light", 'z':"neon", 't':"black"}, name='color')
+    >>> nx.set_node_attributes(H, {'x': "green", 'y': "orange", 'z':"yellow"}, name='color')
     >>> GcomposeH = nx.compose(G, H)
 
     Normally, color attribute values of nodes of GcomposeH come from H. We can workaround this as follows:
 
     >>> node_data = {n: G.nodes[n].get('color', "") + " " + H.nodes[n].get('color', "") for n in G.nodes & H.nodes}
     >>> nx.set_node_attributes(GcomposeH, node_data, 'color')
-    >>> print(GcomposeH.nodes["x"]["color"])
-    >>> print(GcomposeH.nodes["t"]["color"])
+    >>> print(GcomposeH.nodes['x']['color'])
+    >>> print(GcomposeH.nodes['t']['color'])
     dark green
     black
 
@@ -332,8 +332,8 @@ def compose(G, H):
 
     >>> edge_data = {e: G.edges[e].get('weight', 1) * H.edges[e].get('weight', 1) for e in G.edges & H.edges}
     >>> nx.set_edge_attributes(GcomposeH, edge_data, 'weight')
-    >>> print(GcomposeH.edges[("x", "y")]["weight"])
-    >>> print(GcomposeH.edges[("t", "x")]["weight"])
+    >>> print(GcomposeH.edges[('x', 'y')]['weight'])
+    >>> print(GcomposeH.edges[('t', 'x')]['weight'])
     20.0
     100.0
     """

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -313,30 +313,30 @@ def compose(G, H):
     By default, the attributes from `H` take precedent over attributes from `G`.
     If you prefer another way of combining attributes, you can update them after the compose operation:
 
-    >>> G = nx.Graph([('x', 'y', {'weight': 2.0}), ('x', 'z', {'weight': 1.0}), ('t', 'x', {'weight': 100.0})])
-    >>> H = nx.Graph([('x', 'y', {'weight': 10.0}), ('y', 'z', {'weight': -1.0})])
-    >>> nx.set_node_attributes(G, {'x': 'dark', 'y': "light", 'z':"neon", 't':"black"}, name='color')
-    >>> nx.set_node_attributes(H, {'x': "green", 'y': "orange", 'z':"yellow"}, name='color')
+    >>> G = nx.Graph([(0, 1, {'weight': 2.0}), (3, 0, {'weight': 100.0})])
+    >>> H = nx.Graph([(0, 1, {'weight': 10.0}), (1, 2, {'weight': -1.0})])
+    >>> nx.set_node_attributes(G, {0: 'dark', 1: 'light', 3: 'black'}, name='color')
+    >>> nx.set_node_attributes(H, {0: 'green', 1: 'orange', 2: 'yellow'}, name='color')
     >>> GcomposeH = nx.compose(G, H)
 
     Normally, color attribute values of nodes of GcomposeH come from H. We can workaround this as follows:
 
-    >>> node_data = {n: G.nodes[n].get('color', "") + " " + H.nodes[n].get('color', "") for n in G.nodes & H.nodes}
+    >>> node_data = {n: G.nodes[n]['color'] + " " + H.nodes[n]['color'] for n in G.nodes & H.nodes}
     >>> nx.set_node_attributes(GcomposeH, node_data, 'color')
-    >>> print(GcomposeH.nodes['x']['color'])
+    >>> print(GcomposeH.nodes[0]['color'])
     dark green
 
-    >>> print(GcomposeH.nodes['t']['color'])
+    >>> print(GcomposeH.nodes[3]['color'])
     black
 
     Similarly, we can update edge attributes after the compose operation in a way we prefer:
 
-    >>> edge_data = {e: G.edges[e].get('weight', 1) * H.edges[e].get('weight', 1) for e in G.edges & H.edges}
+    >>> edge_data = {e: G.edges[e]['weight'] * H.edges[e]['weight'] for e in G.edges & H.edges}
     >>> nx.set_edge_attributes(GcomposeH, edge_data, 'weight')
-    >>> print(GcomposeH.edges[('x', 'y')]['weight'])
+    >>> print(GcomposeH.edges[(0, 1)]['weight'])
     20.0
 
-    >>> print(GcomposeH.edges[('t', 'x')]['weight'])
+    >>> print(GcomposeH.edges[(3, 0)]['weight'])
     100.0
     """
     return nx.compose_all([G, H])

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -309,6 +309,30 @@ def compose(G, H):
     NodeView((0, 1, 2))
     >>> R.edges
     EdgeView([(0, 1), (0, 2), (1, 2)])
+
+    As indicated above, the attributes from H take precedent over attributes from G.
+    If you prefer another way of combining attributes, you can update them after the compose operation.
+    Consider the below graphs which have the nodes with the same labels, edge and node attributes:
+
+    >>> G = nx.Graph([('x', 'y', {'weight': 2.0}), ('x', 'z', {'weight': 1.0})])
+    >>> H = nx.Graph([('x', 'y', {'weight': 10.0}), ('y', 'z', {'weight': -1.0})])
+    >>> nx.set_node_attributes(G, {'x': "dark", 'y': "light", 'z':"neon"}, name='color')
+    >>> nx.set_node_attributes(H, {'x': "green", 'y': "orange", 'z':"yellow"}, name='color')
+    >>> GcomposeH = nx.compose(G, H)
+
+    Normally, color attribute values of nodes of GcomposeH come from H. We can workaround this as follows:
+
+    >>> node_data = {n: G.nodes[n].get('color') + " " + H.nodes[n].get('color') for n in G.nodes & H.nodes}
+    >>> nx.set_node_attributes(GcomposeH, node_data, 'color')
+    >>> GcomposeH.nodes['x']['color']
+    'dark green'
+
+    Similarly, we can update edge attributes after the compose operation in a way we prefer:
+
+    >>> edge_data = {e: G.edges[e].get('weight') * H.edges[e].get('weight') for e in G.edges & H.edges}
+    >>> nx.set_edge_attributes(GcomposeH, edge_data, 'weight')
+    >>> GcomposeH.edges[('x', 'y')]['weight']
+    20.0
     """
     return nx.compose_all([G, H])
 

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -324,8 +324,9 @@ def compose(G, H):
     >>> node_data = {n: G.nodes[n].get('color', "") + " " + H.nodes[n].get('color', "") for n in G.nodes & H.nodes}
     >>> nx.set_node_attributes(GcomposeH, node_data, 'color')
     >>> print(GcomposeH.nodes['x']['color'])
-    >>> print(GcomposeH.nodes['t']['color'])
     dark green
+
+    >>> print(GcomposeH.nodes['t']['color'])
     black
 
     Similarly, we can update edge attributes after the compose operation in a way we prefer:
@@ -333,8 +334,9 @@ def compose(G, H):
     >>> edge_data = {e: G.edges[e].get('weight', 1) * H.edges[e].get('weight', 1) for e in G.edges & H.edges}
     >>> nx.set_edge_attributes(GcomposeH, edge_data, 'weight')
     >>> print(GcomposeH.edges[('x', 'y')]['weight'])
-    >>> print(GcomposeH.edges[('t', 'x')]['weight'])
     20.0
+
+    >>> print(GcomposeH.edges[('t', 'x')]['weight'])
     100.0
     """
     return nx.compose_all([G, H])


### PR DESCRIPTION
Closes #4485

I added examples that show how to update node/edge attributes after `compose` operation.
@dschult @rossbar 