### PR TITLE
Fix typo in label propagation documentation

### DIFF
--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -112,7 +112,7 @@ def label_propagation_communities(G):
     """Generates community sets determined by label propagation
 
     Finds communities in `G` using a semi-synchronous label propagation
-    method[1]_. This method combines the advantages of both the synchronous
+    method [1]_. This method combines the advantages of both the synchronous
     and asynchronous models. Not implemented for directed graphs.
 
     Parameters


### PR DESCRIPTION
This PR fixes a simple documentation issue noted in #5587 