### PR TITLE
Adjust the usage of nodes_or_number decorator

### DIFF
--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -29,16 +29,17 @@ def complete_bipartite_graph(n1, n2, create_using=None):
 
     Parameters
     ----------
-    n1 : integer
-       Number of nodes for node set A.
-    n2 : integer
-       Number of nodes for node set B.
-    create_using : NetworkX graph instance, optional
+    n1, n2 : integer or iterable container of nodes
+        If integers, nodes are from `range(n1)` and `range(n1, n1 + n2)`.
+        If a container, the elements are the nodes.
+    create_using : NetworkX graph instance, (default: nx.Graph)
        Return graph of this type.
 
     Notes
     -----
-    Node labels are the integers 0 to `n_1 + n_2 - 1`.
+    Nodes are the integers 0 to `n1 + n2 - 1` unless either n1 or n2 are
+    containers of nodes. If only one of n1 or n2 are integers, that
+    integer is replaced by `range` of that integer.
 
     The nodes are assigned the attribute 'bipartite' with the value 0 or 1
     to indicate which bipartite set the node belongs to.
@@ -52,12 +53,14 @@ def complete_bipartite_graph(n1, n2, create_using=None):
 
     n1, top = n1
     n2, bottom = n2
-    if isinstance(n2, numbers.Integral):
+    if isinstance(n1, numbers.Integral) and isinstance(n2, numbers.Integral):
         bottom = [n1 + i for i in bottom]
     G.add_nodes_from(top, bipartite=0)
     G.add_nodes_from(bottom, bipartite=1)
+    if len(G) != len(top) + len(bottom):
+        raise nx.NetworkXError("Inputs n1 and n2 must contain distinct nodes")
     G.add_edges_from((u, v) for u in top for v in bottom)
-    G.graph["name"] = f"complete_bipartite_graph({n1},{n2})"
+    G.graph["name"] = f"complete_bipartite_graph({n1}, {n2})"
     return G
 
 

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -49,16 +49,6 @@ class TestGeneratorsBipartite:
             complete_bipartite_graph(7, 3, create_using=nx.DiGraph)
         with pytest.raises(nx.NetworkXError):
             complete_bipartite_graph(7, 3, create_using=nx.MultiDiGraph)
-        pytest.raises(
-            nx.NetworkXError, complete_bipartite_graph, 7, 3, create_using=nx.DiGraph
-        )
-        pytest.raises(
-            nx.NetworkXError,
-            complete_bipartite_graph,
-            7,
-            3,
-            create_using=nx.MultiDiGraph,
-        )
 
         mG = complete_bipartite_graph(7, 3, create_using=nx.MultiGraph)
         assert mG.is_multigraph()

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -1,4 +1,5 @@
 import pytest
+import numbers
 import networkx as nx
 from ..generators import (
     alternating_havel_hakimi_graph,
@@ -44,9 +45,10 @@ class TestGeneratorsBipartite:
             assert nx.number_of_nodes(G) == m1 + m2
             assert nx.number_of_edges(G) == m1 * m2
 
-        pytest.raises(
-            nx.NetworkXError, complete_bipartite_graph, 7, 3, create_using=nx.DiGraph
-        )
+        with pytest.raises(nx.NetworkXError):
+            complete_bipartite_graph(7, 3, create_using=nx.DiGraph)
+        with pytest.raises(nx.NetworkXError):
+            complete_bipartite_graph(7, 3, create_using=nx.MultiDiGraph)
         pytest.raises(
             nx.NetworkXError, complete_bipartite_graph, 7, 3, create_using=nx.DiGraph
         )
@@ -72,15 +74,21 @@ class TestGeneratorsBipartite:
         assert not mG.is_directed()
 
         # specify nodes rather than number of nodes
-        G = complete_bipartite_graph([1, 2], ["a", "b"])
-        has_edges = (
-            G.has_edge(1, "a")
-            & G.has_edge(1, "b")
-            & G.has_edge(2, "a")
-            & G.has_edge(2, "b")
-        )
-        assert has_edges
-        assert G.size() == 4
+        for n1, n2 in [([1, 2], "ab"), (3, 2), (3, "ab"), ("ab", 3)]:
+            G = complete_bipartite_graph(n1, n2)
+            if isinstance(n1, numbers.Integral):
+                if isinstance(n2, numbers.Integral):
+                    n2 = range(n1, n1 + n2)
+                n1 = range(n1)
+            elif isinstance(n2, numbers.Integral):
+                n2 = range(n2)
+            edges = {(u, v) for u in n1 for v in n2}
+            assert edges == set(G.edges)
+            assert G.size() == len(edges)
+
+        # raise when node sets are not distinct
+        for n1, n2 in [([1, 2], 3), (3, [1, 2]), ("abc", "bcd")]:
+            pytest.raises(nx.NetworkXError, complete_bipartite_graph, n1, n2)
 
     def test_configuration_model(self):
         aseq = []

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -254,7 +254,7 @@ def complete_graph(n, create_using=None):
     """
     _, nodes = n
     G = empty_graph(nodes, create_using)
-    if len(G) > 1:
+    if len(nodes) > 1:
         if G.is_directed():
             edges = itertools.permutations(nodes, 2)
         else:
@@ -623,11 +623,9 @@ def star_graph(n, create_using=None):
     if G.is_directed():
         raise NetworkXError("Directed Graph not supported")
 
-    if len(G) < 2:
-        return G
-
-    hub, *spokes = nodes
-    G.add_edges_from((hub, node) for node in spokes)
+    if len(nodes) > 1:
+        hub, *spokes = nodes
+        G.add_edges_from((hub, node) for node in spokes)
     return G
 
 
@@ -691,13 +689,11 @@ def wheel_graph(n, create_using=None):
     if G.is_directed():
         raise NetworkXError("Directed Graph not supported")
 
-    if len(nodes) < 2:
-        return G
-
-    hub, *rim = nodes
-    G.add_edges_from((hub, node) for node in rim)
-    if len(rim) > 1:
-        G.add_edges_from(pairwise(rim, cyclic=True))
+    if len(nodes) > 1:
+        hub, *rim = nodes
+        G.add_edges_from((hub, node) for node in rim)
+        if len(rim) > 1:
+            G.add_edges_from(pairwise(rim, cyclic=True))
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -222,7 +222,6 @@ def binomial_tree(n, create_using=None):
     return G
 
 
-@nodes_or_number(0)
 def complete_graph(n, create_using=None):
     """Return the complete graph `K_n` with n nodes.
 
@@ -252,13 +251,12 @@ def complete_graph(n, create_using=None):
     True
 
     """
-    n_name, nodes = n
-    G = empty_graph(n_name, create_using)
-    if len(nodes) > 1:
+    G = empty_graph(n, create_using)
+    if len(G) > 1:
         if G.is_directed():
-            edges = itertools.permutations(nodes, 2)
+            edges = itertools.permutations(G, 2)
         else:
-            edges = itertools.combinations(nodes, 2)
+            edges = itertools.combinations(G, 2)
         G.add_edges_from(edges)
     return G
 
@@ -350,7 +348,6 @@ def circulant_graph(n, offsets, create_using=None):
     return G
 
 
-@nodes_or_number(0)
 def cycle_graph(n, create_using=None):
     """Returns the cycle graph $C_n$ of cyclically connected nodes.
 
@@ -369,10 +366,8 @@ def cycle_graph(n, create_using=None):
     If create_using is directed, the direction is in increasing order.
 
     """
-    n_orig, nodes = n
-    G = empty_graph(nodes, create_using)
-    G.add_edges_from(pairwise(nodes))
-    G.add_edge(nodes[-1], nodes[0])
+    G = empty_graph(n, create_using)
+    G.add_edges_from(pairwise(G, cyclic=True))
     return G
 
 
@@ -579,7 +574,6 @@ def null_graph(create_using=None):
     return G
 
 
-@nodes_or_number(0)
 def path_graph(n, create_using=None):
     """Returns the Path graph `P_n` of linearly connected nodes.
 
@@ -592,9 +586,8 @@ def path_graph(n, create_using=None):
        Graph type to create. If graph instance, then cleared before populated.
 
     """
-    n_name, nodes = n
-    G = empty_graph(nodes, create_using)
-    G.add_edges_from(pairwise(nodes))
+    G = empty_graph(n, create_using)
+    G.add_edges_from(pairwise(G))
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -561,7 +561,7 @@ def lollipop_graph(m, n, create_using=None):
         G.add_edges_from(pairwise(n_nodes))
 
     if len(G) != M + N:
-        raise NetworkXError("Nodes must be distinct in containers m1 and m2")
+        raise NetworkXError("Nodes must be distinct in containers m and n")
 
     # connect ball to stick
     if M > 0 and N > 0:

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -222,6 +222,7 @@ def binomial_tree(n, create_using=None):
     return G
 
 
+@nodes_or_number(0)
 def complete_graph(n, create_using=None):
     """Return the complete graph `K_n` with n nodes.
 
@@ -251,12 +252,13 @@ def complete_graph(n, create_using=None):
     True
 
     """
-    G = empty_graph(n, create_using)
+    _, nodes = n
+    G = empty_graph(nodes, create_using)
     if len(G) > 1:
         if G.is_directed():
-            edges = itertools.permutations(G, 2)
+            edges = itertools.permutations(nodes, 2)
         else:
-            edges = itertools.combinations(G, 2)
+            edges = itertools.combinations(nodes, 2)
         G.add_edges_from(edges)
     return G
 
@@ -348,6 +350,7 @@ def circulant_graph(n, offsets, create_using=None):
     return G
 
 
+@nodes_or_number(0)
 def cycle_graph(n, create_using=None):
     """Returns the cycle graph $C_n$ of cyclically connected nodes.
 
@@ -366,8 +369,9 @@ def cycle_graph(n, create_using=None):
     If create_using is directed, the direction is in increasing order.
 
     """
-    G = empty_graph(n, create_using)
-    G.add_edges_from(pairwise(G, cyclic=True))
+    _, nodes = n
+    G = empty_graph(nodes, create_using)
+    G.add_edges_from(pairwise(nodes, cyclic=True))
     return G
 
 
@@ -486,7 +490,7 @@ def empty_graph(n=0, create_using=None, default=Graph):
         # try create_using as constructor
         G = create_using()
 
-    n_name, nodes = n
+    _, nodes = n
     G.add_nodes_from(nodes)
     return G
 
@@ -574,6 +578,7 @@ def null_graph(create_using=None):
     return G
 
 
+@nodes_or_number(0)
 def path_graph(n, create_using=None):
     """Returns the Path graph `P_n` of linearly connected nodes.
 
@@ -586,11 +591,13 @@ def path_graph(n, create_using=None):
        Graph type to create. If graph instance, then cleared before populated.
 
     """
-    G = empty_graph(n, create_using)
-    G.add_edges_from(pairwise(G))
+    _, nodes = n
+    G = empty_graph(nodes, create_using)
+    G.add_edges_from(pairwise(nodes))
     return G
 
 
+@nodes_or_number(0)
 def star_graph(n, create_using=None):
     """Return the star graph
 
@@ -609,16 +616,17 @@ def star_graph(n, create_using=None):
     The graph has n+1 nodes for integer n.
     So star_graph(3) is the same as star_graph(range(4)).
     """
-    G = empty_graph(n, create_using)
+    n, nodes = n
+    if isinstance(n, numbers.Integral):
+        nodes.append(n)  # there should be n+1 nodes
+    G = empty_graph(nodes, create_using)
     if G.is_directed():
         raise NetworkXError("Directed Graph not supported")
 
-    if isinstance(n, numbers.Integral):
-        G.add_node(n)  # there should be n+1 nodes
     if len(G) < 2:
         return G
 
-    hub, *spokes = G.nodes
+    hub, *spokes = nodes
     G.add_edges_from((hub, node) for node in spokes)
     return G
 
@@ -662,6 +670,7 @@ def turan_graph(n, r):
     return G
 
 
+@nodes_or_number(0)
 def wheel_graph(n, create_using=None):
     """Return the wheel graph
 
@@ -677,14 +686,15 @@ def wheel_graph(n, create_using=None):
 
     Node labels are the integers 0 to n - 1.
     """
-    G = empty_graph(n, create_using)
+    _, nodes = n
+    G = empty_graph(nodes, create_using)
     if G.is_directed():
         raise NetworkXError("Directed Graph not supported")
 
-    if len(G) == 0:
+    if len(nodes) < 2:
         return G
 
-    hub, *rim = G.nodes
+    hub, *rim = nodes
     G.add_edges_from((hub, node) for node in rim)
     if len(rim) > 1:
         G.add_edges_from(pairwise(rim, cyclic=True))

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -6,7 +6,7 @@ from itertools import accumulate, combinations, product
 import math
 
 import networkx as nx
-from networkx.utils import nodes_or_number, py_random_state
+from networkx.utils import py_random_state
 
 __all__ = [
     "geometric_edges",
@@ -107,7 +107,6 @@ def geometric_edges(G, radius, p):
 
 
 @py_random_state(5)
-@nodes_or_number(0)
 def random_geometric_graph(n, radius, dim=2, pos=None, p=2, seed=None):
     """Returns a random geometric graph in the unit cube of dimensions `dim`.
 
@@ -185,13 +184,11 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2, seed=None):
     #     return geographical_threshold_graph(nodes, theta=1, alpha=1,
     #                                         weight=half_radius)
     #
-    n_name, nodes = n
-    G = nx.Graph()
-    G.add_nodes_from(nodes)
+    G = nx.empty_graph(n)
     # If no positions are provided, choose uniformly random vectors in
     # Euclidean space of the specified dimension.
     if pos is None:
-        pos = {v: [seed.random() for i in range(dim)] for v in nodes}
+        pos = {v: [seed.random() for i in range(dim)] for v in G}
     nx.set_node_attributes(G, pos, "pos")
 
     G.add_edges_from(geometric_edges(G, radius, p))
@@ -199,7 +196,6 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2, seed=None):
 
 
 @py_random_state(6)
-@nodes_or_number(0)
 def soft_random_geometric_graph(
     n, radius, dim=2, pos=None, p=2, p_dist=None, seed=None
 ):
@@ -301,14 +297,12 @@ def soft_random_geometric_graph(
            https://docs.scipy.org/doc/scipy/reference/tutorial/stats.html
 
     """
-    n_name, nodes = n
-    G = nx.Graph()
+    G = nx.empty_graph(n)
     G.name = f"soft_random_geometric_graph({n}, {radius}, {dim})"
-    G.add_nodes_from(nodes)
     # If no positions are provided, choose uniformly random vectors in
     # Euclidean space of the specified dimension.
     if pos is None:
-        pos = {v: [seed.random() for i in range(dim)] for v in nodes}
+        pos = {v: [seed.random() for i in range(dim)] for v in G}
     nx.set_node_attributes(G, pos, "pos")
 
     # if p_dist function not supplied the default function is an exponential
@@ -328,7 +322,6 @@ def soft_random_geometric_graph(
 
 
 @py_random_state(7)
-@nodes_or_number(0)
 def geographical_threshold_graph(
     n, theta, dim=2, pos=None, weight=None, metric=None, p_dist=None, seed=None
 ):
@@ -444,9 +437,7 @@ def geographical_threshold_graph(
        in Algorithms and Models for the Web-Graph (WAW 2007),
        Antony Bonato and Fan Chung (Eds), pp. 209--216, 2007
     """
-    n_name, nodes = n
-    G = nx.Graph()
-    G.add_nodes_from(nodes)
+    G = nx.empty_graph(n)
     # If no weights are provided, choose them from an exponential
     # distribution.
     if weight is None:
@@ -454,7 +445,7 @@ def geographical_threshold_graph(
     # If no positions are provided, choose uniformly random vectors in
     # Euclidean space of the specified dimension.
     if pos is None:
-        pos = {v: [seed.random() for i in range(dim)] for v in nodes}
+        pos = {v: [seed.random() for i in range(dim)] for v in G}
     # If no distance metric is provided, use Euclidean distance.
     if metric is None:
         metric = math.dist
@@ -481,7 +472,6 @@ def geographical_threshold_graph(
 
 
 @py_random_state(6)
-@nodes_or_number(0)
 def waxman_graph(
     n, beta=0.4, alpha=0.1, L=None, domain=(0, 0, 1, 1), metric=None, seed=None
 ):
@@ -569,9 +559,7 @@ def waxman_graph(
     .. [1]  B. M. Waxman, *Routing of multipoint connections*.
        IEEE J. Select. Areas Commun. 6(9),(1988) 1617--1622.
     """
-    n_name, nodes = n
-    G = nx.Graph()
-    G.add_nodes_from(nodes)
+    G = nx.empty_graph(n)
     (xmin, ymin, xmax, ymax) = domain
     # Each node gets a uniformly random position in the given rectangle.
     pos = {v: (seed.uniform(xmin, xmax), seed.uniform(ymin, ymax)) for v in G}
@@ -677,7 +665,6 @@ def navigable_small_world_graph(n, p=1, q=1, r=2, dim=2, seed=None):
 
 
 @py_random_state(7)
-@nodes_or_number(0)
 def thresholded_random_geometric_graph(
     n, radius, theta, dim=2, pos=None, weight=None, p=2, seed=None
 ):
@@ -777,11 +764,8 @@ def thresholded_random_geometric_graph(
     .. [1] http://cole-maclean.github.io/blog/files/thesis.pdf
 
     """
-
-    n_name, nodes = n
-    G = nx.Graph()
+    G = nx.empty_graph(n)
     G.name = f"thresholded_random_geometric_graph({n}, {radius}, {theta}, {dim})"
-    G.add_nodes_from(nodes)
     # If no weights are provided, choose them from an exponential
     # distribution.
     if weight is None:
@@ -789,7 +773,7 @@ def thresholded_random_geometric_graph(
     # If no positions are provided, choose uniformly random vectors in
     # Euclidean space of the specified dimension.
     if pos is None:
-        pos = {v: [seed.random() for i in range(dim)] for v in nodes}
+        pos = {v: [seed.random() for i in range(dim)] for v in G}
     # If no distance metric is provided, use Euclidean distance.
     nx.set_node_attributes(G, weight, "weight")
     nx.set_node_attributes(G, pos, "pos")

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -179,8 +179,7 @@ def random_geometric_graph(n, radius, dim=2, pos=None, p=2, seed=None):
     # TODO Is this function just a special case of the geographical
     # threshold graph?
     #
-    #     n_name, nodes = n
-    #     half_radius = {v: radius / 2 for v in nodes}
+    #     half_radius = {v: radius / 2 for v in n}
     #     return geographical_threshold_graph(nodes, theta=1, alpha=1,
     #                                         weight=half_radius)
     #

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -159,6 +159,15 @@ class TestGeneratorClassic:
         assert nodes_equal(g.nodes(), ["a", "b", "c"])
         assert g.size() == 3
 
+        # creates a self-loop... should it? <backward compatible says yes>
+        g = nx.complete_graph("abcb")
+        assert nodes_equal(g.nodes(), ["a", "b", "c"])
+        assert g.size() == 4
+
+        g = nx.complete_graph("abcb", create_using=nx.MultiGraph)
+        assert nodes_equal(g.nodes(), ["a", "b", "c"])
+        assert g.size() == 6
+
     def test_complete_digraph(self):
         # complete_graph(m) is a connected graph with
         # m nodes and  m*(m+1)/2 edges
@@ -209,10 +218,16 @@ class TestGeneratorClassic:
         G = nx.cycle_graph("abc")
         assert len(G) == 3
         assert G.size() == 3
+        G = nx.cycle_graph("abcb")
+        assert len(G) == 3
+        assert G.size() == 2
         g = nx.cycle_graph("abc", nx.DiGraph)
         assert len(g) == 3
         assert g.size() == 3
         assert g.is_directed()
+        g = nx.cycle_graph("abcb", nx.DiGraph)
+        assert len(g) == 3
+        assert g.size() == 4
 
     def test_dorogovtsev_goltsev_mendes_graph(self):
         G = nx.dorogovtsev_goltsev_mendes_graph(0)
@@ -396,10 +411,19 @@ class TestGeneratorClassic:
         G = nx.path_graph("abc")
         assert len(G) == 3
         assert G.size() == 2
+        G = nx.path_graph("abcb")
+        assert len(G) == 3
+        assert G.size() == 2
         g = nx.path_graph("abc", nx.DiGraph)
         assert len(g) == 3
         assert g.size() == 2
         assert g.is_directed()
+        g = nx.path_graph("abcb", nx.DiGraph)
+        assert len(g) == 3
+        assert g.size() == 3
+
+        G = nx.path_graph((1, 2, 3, 2, 4))
+        assert G.has_edge(2, 4)
 
     def test_star_graph(self):
         assert is_isomorphic(nx.star_graph(""), nx.empty_graph(0))
@@ -416,6 +440,17 @@ class TestGeneratorClassic:
 
         ms = nx.star_graph(10, create_using=nx.MultiGraph)
         assert edges_equal(ms.edges(), s.edges())
+
+        G = nx.star_graph("abc")
+        assert len(G) == 3
+        assert G.size() == 2
+
+        G = nx.star_graph("abcb")
+        assert len(G) == 3
+        assert G.size() == 2
+        G = nx.star_graph("abcb", create_using=nx.MultiGraph)
+        assert len(G) == 3
+        assert G.size() == 3
 
         G = nx.star_graph("abcdefg")
         assert len(G) == 7
@@ -459,6 +494,13 @@ class TestGeneratorClassic:
         G = nx.wheel_graph("abc")
         assert len(G) == 3
         assert G.size() == 3
+
+        G = nx.wheel_graph("abcb")
+        assert len(G) == 3
+        assert G.size() == 4
+        G = nx.wheel_graph("abcb", nx.MultiGraph)
+        assert len(G) == 3
+        assert G.size() == 6
 
         # test non-int integers
         np = pytest.importorskip("numpy")

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -6,8 +6,8 @@ Generators - Classic
 Unit tests for various classic graph generators in generators/classic.py
 """
 import itertools
-
 import pytest
+
 import networkx as nx
 from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
 from networkx.utils import nodes_equal, edges_equal
@@ -317,35 +317,59 @@ class TestGeneratorClassic:
         mg = nx.ladder_graph(2, create_using=nx.MultiGraph)
         assert edges_equal(mg.edges(), g.edges())
 
-    def test_lollipop_graph(self):
+    def test_lollipop_graph_right_sizes(self):
         # number of nodes = m1 + m2
         # number of edges = nx.number_of_edges(nx.complete_graph(m1)) + m2
         for m1, m2 in [(3, 5), (4, 10), (3, 20)]:
-            b = nx.lollipop_graph(m1, m2)
-            assert nx.number_of_nodes(b) == m1 + m2
-            assert nx.number_of_edges(b) == m1 * (m1 - 1) / 2 + m2
+            G = nx.lollipop_graph(m1, m2)
+            assert nx.number_of_nodes(G) == m1 + m2
+            assert nx.number_of_edges(G) == m1 * (m1 - 1) / 2 + m2
+        for first, second in [("ab", ""), ("abc", "defg")]:
+            m1, m2 = len(first), len(second)
+            G = nx.lollipop_graph(first, second)
+            assert nx.number_of_nodes(G) == m1 + m2
+            assert nx.number_of_edges(G) == m1 * (m1 - 1) / 2 + m2
 
+    def test_lollipop_graph_exceptions(self):
         # Raise NetworkXError if m<2
+        pytest.raises(nx.NetworkXError, nx.lollipop_graph, -1, 2)
         pytest.raises(nx.NetworkXError, nx.lollipop_graph, 1, 20)
+        pytest.raises(nx.NetworkXError, nx.lollipop_graph, "", 20)
+        pytest.raises(nx.NetworkXError, nx.lollipop_graph, "a", 20)
 
         # Raise NetworkXError if n<0
         pytest.raises(nx.NetworkXError, nx.lollipop_graph, 5, -2)
 
+        # raise NetworkXError is create_using is a directed form of Graph
+        with pytest.raises(nx.NetworkXError):
+            nx.lollipop_graph(2, 20, create_using=nx.DiGraph)
+        with pytest.raises(nx.NetworkXError):
+            nx.lollipop_graph(2, 20, create_using=nx.MultiDiGraph)
+
+    def test_lollipop_graph_same_as_path_when_m1_is_2(self):
         # lollipop_graph(2,m) = path_graph(m+2)
-        for m1, m2 in [(2, 5), (2, 10), (2, 20)]:
-            b = nx.lollipop_graph(m1, m2)
-            assert is_isomorphic(b, nx.path_graph(m2 + 2))
+        for m1, m2 in [(2, 0), (2, 5), (2, 10), ("ab", 20)]:
+            G = nx.lollipop_graph(m1, m2)
+            assert is_isomorphic(G, nx.path_graph(m2 + 2))
 
-        pytest.raises(
-            nx.NetworkXError, nx.lollipop_graph, m1, m2, create_using=nx.DiGraph
-        )
+    def test_lollipop_graph_for_multigraph(self):
+        G = nx.lollipop_graph(5, 20)
+        MG = nx.lollipop_graph(5, 20, create_using=nx.MultiGraph)
+        assert edges_equal(MG.edges(), G.edges())
 
-        mb = nx.lollipop_graph(m1, m2, create_using=nx.MultiGraph)
-        assert edges_equal(mb.edges(), b.edges())
+    def test_lollipop_graph_mixing_input_types(self):
+        cases = [(4, "abc"), ("abcd", 3), ([1, 2, 3, 4], "abc"), ("abcd", [1, 2, 3])]
+        for m1, m2 in cases:
+            G = nx.lollipop_graph(m1, m2)
+            assert len(G) == 7
+            assert G.size() == 9
 
-        g = nx.lollipop_graph([1, 2, 3, 4], "abc")
-        assert len(g) == 7
-        assert g.size() == 9
+    def test_lollipop_graph_not_int_integer_inputs(self):
+        # test non-int integers
+        np = pytest.importorskip("numpy")
+        G = nx.lollipop_graph(np.int32(4), np.int64(3))
+        assert len(G) == 7
+        assert G.size() == 9
 
     def test_null_graph(self):
         assert nx.number_of_nodes(nx.null_graph()) == 0
@@ -378,23 +402,30 @@ class TestGeneratorClassic:
         assert g.is_directed()
 
     def test_star_graph(self):
-        star_graph = nx.star_graph
-        assert is_isomorphic(star_graph(0), nx.empty_graph(1))
-        assert is_isomorphic(star_graph(1), nx.path_graph(2))
-        assert is_isomorphic(star_graph(2), nx.path_graph(3))
-        assert is_isomorphic(star_graph(5), nx.complete_bipartite_graph(1, 5))
+        assert is_isomorphic(nx.star_graph(""), nx.empty_graph(0))
+        assert is_isomorphic(nx.star_graph([]), nx.empty_graph(0))
+        assert is_isomorphic(nx.star_graph(0), nx.empty_graph(1))
+        assert is_isomorphic(nx.star_graph(1), nx.path_graph(2))
+        assert is_isomorphic(nx.star_graph(2), nx.path_graph(3))
+        assert is_isomorphic(nx.star_graph(5), nx.complete_bipartite_graph(1, 5))
 
-        s = star_graph(10)
+        s = nx.star_graph(10)
         assert sorted(d for n, d in s.degree()) == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 10]
 
-        pytest.raises(nx.NetworkXError, star_graph, 10, create_using=nx.DiGraph)
+        pytest.raises(nx.NetworkXError, nx.star_graph, 10, create_using=nx.DiGraph)
 
-        ms = star_graph(10, create_using=nx.MultiGraph)
+        ms = nx.star_graph(10, create_using=nx.MultiGraph)
         assert edges_equal(ms.edges(), s.edges())
 
-        G = star_graph("abcdefg")
+        G = nx.star_graph("abcdefg")
         assert len(G) == 7
         assert G.size() == 6
+
+        # test non-int integers
+        np = pytest.importorskip("numpy")
+        G = nx.star_graph(np.int32(3))
+        assert len(G) == 4
+        assert G.size() == 3
 
     def test_trivial_graph(self):
         assert nx.number_of_nodes(nx.trivial_graph()) == 1
@@ -407,6 +438,7 @@ class TestGeneratorClassic:
 
     def test_wheel_graph(self):
         for n, G in [
+            ("", nx.null_graph()),
             (0, nx.null_graph()),
             (1, nx.empty_graph(1)),
             (2, nx.path_graph(2)),
@@ -425,6 +457,12 @@ class TestGeneratorClassic:
         assert edges_equal(mg.edges(), g.edges())
 
         G = nx.wheel_graph("abc")
+        assert len(G) == 3
+        assert G.size() == 3
+
+        # test non-int integers
+        np = pytest.importorskip("numpy")
+        G = nx.wheel_graph(np.int32(3))
         assert len(G) == 3
         assert G.size() == 3
 

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -355,7 +355,7 @@ class TestGeneratorClassic:
         # Raise NetworkXError if n<0
         pytest.raises(nx.NetworkXError, nx.lollipop_graph, 5, -2)
 
-        # raise NetworkXError is create_using is a directed form of Graph
+        # raise NetworkXError if create_using is directed
         with pytest.raises(nx.NetworkXError):
             nx.lollipop_graph(2, 20, create_using=nx.DiGraph)
         with pytest.raises(nx.NetworkXError):

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -456,7 +456,7 @@ class TestGeneratorClassic:
         assert len(G) == 7
         assert G.size() == 6
 
-        # test non-int integers
+    def test_non_int_integers_for_star_graph(self):
         np = pytest.importorskip("numpy")
         G = nx.star_graph(np.int32(3))
         assert len(G) == 4
@@ -502,7 +502,7 @@ class TestGeneratorClassic:
         assert len(G) == 3
         assert G.size() == 6
 
-        # test non-int integers
+    def test_non_int_integers_for_wheel_graph(self):
         np = pytest.importorskip("numpy")
         G = nx.wheel_graph(np.int32(3))
         assert len(G) == 3

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -68,6 +68,12 @@ class TestGrid2DGraph:
         H = nx.grid_2d_graph(4, 2, periodic=True, create_using=nx.MultiGraph())
         assert list(G.edges()) == list(H.edges())
 
+    def test_exceptions(self):
+        pytest.raises(nx.NetworkXError, nx.grid_2d_graph, -3, 2)
+        pytest.raises(nx.NetworkXError, nx.grid_2d_graph, 3, -2)
+        pytest.raises(TypeError, nx.grid_2d_graph, 3.3, 2)
+        pytest.raises(TypeError, nx.grid_2d_graph, 3, 2.2)
+
     def test_node_input(self):
         G = nx.grid_2d_graph(4, 2, periodic=True)
         H = nx.grid_2d_graph(range(4), range(2), periodic=True)

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -245,8 +245,7 @@ def nodes_or_number(which_args):
             nodes = tuple(n)
         else:
             if n < 0:
-                msg = f"Negative number of nodes not valid: {n}"
-                raise nx.NetworkXError(msg)
+                raise nx.NetworkXError(f"Negative number of nodes not valid: {n}")
         return (n, nodes)
 
     try:


### PR DESCRIPTION
Tweak the usage of nodes_or_number in a few functions.
See #5582
That issue revealed that a few functions test the result against `int` instead of `numbers.Integral` when processing the output of the `nodes_or_numbers` decorator.  That leads to an exception when e.g. numpy integers are used to indicate how many nodes to generate in a new graph. While investigating that issue, a few other corner cases were found -- listed in #5582. And it was found that `star_graph` and `wheel_graph` don't need the decorator because they immediately call `empty_graph` on the results.

The functions changed are:

- star_graph
- wheel_graph
- lollipop_graph
- complete_bipartite_graph

Other items that might be considered (not included in this first set of changes) are:  
- ~~Consider not using `nodes_or_numbers` in `lollipop_graph` and `complete_bipartite_graph` to simplify code.~~ (does it?) <- no it doesn't simplify the code.
- Changing variable names of the returned values from `nodes_or_number` to `_` when they are unused (this is the vast majority of cases).  
- Consider making an optional argument to the decorator to signal whether to return two objects (the original input and the list of nodes) or just the list of nodes (default).
