### PR TITLE
Cache edges, degree, adj properties of Graph classes

### DIFF
--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -1,6 +1,7 @@
 """ Fast approximation for k-component structure
 """
 import itertools
+from functools import cached_property
 from collections import defaultdict
 from collections.abc import Mapping
 
@@ -281,7 +282,7 @@ class _AntiGraph(nx.Graph):
                 raise KeyError(node)
             return self._graph.AntiAtlasView(self._graph, node)
 
-    @property
+    @cached_property
     def adj(self):
         return self.AntiAdjacencyView(self)
 
@@ -312,7 +313,7 @@ class _AntiGraph(nx.Graph):
             # AntiGraph is a ThinGraph so all edges have weight 1
             return len(nbrs) + (n in nbrs)
 
-    @property
+    @cached_property
     def degree(self):
         """Returns an iterator for (node, degree) and degree for single node.
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1,5 +1,6 @@
 """Base class for directed graphs."""
 from copy import deepcopy
+from functools import cached_property
 
 import networkx as nx
 from networkx.classes.graph import Graph
@@ -313,6 +314,13 @@ class DiGraph(Graph):
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
         self._pred = self.adjlist_outer_dict_factory()  # predecessor
         self._succ = self._adj  # successor
+        # clear cached adjacency properties
+        if hasattr(self, "adj"):
+            delattr(self, "adj")
+        if hasattr(self, "pred"):
+            delattr(self, "pred")
+        if hasattr(self, "succ"):
+            delattr(self, "succ")
 
         # attempt to load graph with data
         if incoming_graph_data is not None:
@@ -320,7 +328,7 @@ class DiGraph(Graph):
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 
-    @property
+    @cached_property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -339,7 +347,7 @@ class DiGraph(Graph):
         """
         return AdjacencyView(self._succ)
 
-    @property
+    @cached_property
     def succ(self):
         """Graph adjacency object holding the successors of each node.
 
@@ -360,7 +368,7 @@ class DiGraph(Graph):
         """
         return AdjacencyView(self._succ)
 
-    @property
+    @cached_property
     def pred(self):
         """Graph adjacency object holding the predecessors of each node.
 
@@ -836,7 +844,7 @@ class DiGraph(Graph):
         except KeyError as err:
             raise NetworkXError(f"The node {n} is not in the digraph.") from err
 
-    @property
+    @cached_property
     def edges(self):
         """An OutEdgeView of the DiGraph as G.edges or G.edges().
 
@@ -900,9 +908,13 @@ class DiGraph(Graph):
         return OutEdgeView(self)
 
     # alias out_edges to edges
-    out_edges = edges
+    @cached_property
+    def out_edges(self):
+        return OutEdgeView(self)
 
-    @property
+    out_edges.__doc__ = edges.__doc__
+
+    @cached_property
     def in_edges(self):
         """An InEdgeView of the Graph as G.in_edges or G.in_edges().
 
@@ -933,7 +945,7 @@ class DiGraph(Graph):
         """
         return InEdgeView(self)
 
-    @property
+    @cached_property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 
@@ -977,7 +989,7 @@ class DiGraph(Graph):
         """
         return DiDegreeView(self)
 
-    @property
+    @cached_property
     def in_degree(self):
         """An InDegreeView for (node, in_degree) or in_degree for single node.
 
@@ -1024,7 +1036,7 @@ class DiGraph(Graph):
         """
         return InDegreeView(self)
 
-    @property
+    @cached_property
     def out_degree(self):
         """An OutDegreeView for (node, out_degree)
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -330,13 +330,16 @@ class Graph:
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
+        # clear cached adjacency properties
+        if hasattr(self, "adj"):
+            delattr(self, "adj")
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 
-    @property
+    @cached_property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -1250,7 +1253,7 @@ class Graph:
         except KeyError as err:
             raise NetworkXError(f"The node {n} is not in the graph.") from err
 
-    @property
+    @cached_property
     def edges(self):
         """An EdgeView of the Graph as G.edges or G.edges().
 
@@ -1373,7 +1376,7 @@ class Graph:
         """
         return iter(self._adj.items())
 
-    @property
+    @cached_property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -1,5 +1,6 @@
 """Base class for MultiDiGraph."""
 from copy import deepcopy
+from functools import cached_property
 
 import networkx as nx
 from networkx.classes.digraph import DiGraph
@@ -345,7 +346,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         else:
             DiGraph.__init__(self, incoming_graph_data, **attr)
 
-    @property
+    @cached_property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -364,7 +365,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return MultiAdjacencyView(self._succ)
 
-    @property
+    @cached_property
     def succ(self):
         """Graph adjacency object holding the successors of each node.
 
@@ -383,7 +384,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return MultiAdjacencyView(self._succ)
 
-    @property
+    @cached_property
     def pred(self):
         """Graph adjacency object holding the predecessors of each node.
 
@@ -558,7 +559,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             del self._succ[u][v]
             del self._pred[v][u]
 
-    @property
+    @cached_property
     def edges(self):
         """An OutMultiEdgeView of the Graph as G.edges or G.edges().
 
@@ -640,9 +641,13 @@ class MultiDiGraph(MultiGraph, DiGraph):
         return OutMultiEdgeView(self)
 
     # alias out_edges to edges
-    out_edges = edges
+    @cached_property
+    def out_edges(self):
+        return OutMultiEdgeView(self)
 
-    @property
+    out_edges.__doc__ = edges.__doc__
+
+    @cached_property
     def in_edges(self):
         """An InMultiEdgeView of the Graph as G.in_edges or G.in_edges().
 
@@ -676,7 +681,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return InMultiEdgeView(self)
 
-    @property
+    @cached_property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 
@@ -724,7 +729,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return DiMultiDegreeView(self)
 
-    @property
+    @cached_property
     def in_degree(self):
         """A DegreeView for (node, in_degree) or in_degree for single node.
 
@@ -775,7 +780,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return InMultiDegreeView(self)
 
-    @property
+    @cached_property
     def out_degree(self):
         """Returns an iterator for (node, out-degree) or out-degree for single node.
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -1,5 +1,6 @@
 """Base class for MultiGraph."""
 from copy import deepcopy
+from functools import cached_property
 
 import networkx as nx
 from networkx.classes.graph import Graph
@@ -354,7 +355,7 @@ class MultiGraph(Graph):
         else:
             Graph.__init__(self, incoming_graph_data, **attr)
 
-    @property
+    @cached_property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -756,7 +757,7 @@ class MultiGraph(Graph):
         except KeyError:
             return False
 
-    @property
+    @cached_property
     def edges(self):
         """Returns an iterator over the edges.
 
@@ -905,7 +906,7 @@ class MultiGraph(Graph):
         except KeyError:
             return default
 
-    @property
+    @cached_property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1048,11 +1048,11 @@ class OutEdgeView(Set, Mapping):
     __slots__ = ("_adjdict", "_graph", "_nodes_nbrs")
 
     def __getstate__(self):
-        return {"_graph": self._graph}
+        return {"_graph": self._graph, "_adjdict": self._adjdict}
 
     def __setstate__(self, state):
-        self._graph = G = state["_graph"]
-        self._adjdict = G._succ if hasattr(G, "succ") else G._adj
+        self._graph = state["_graph"]
+        self._adjdict = state["_adjdict"]
         self._nodes_nbrs = self._adjdict.items
 
     @classmethod

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -131,6 +131,15 @@ class BaseDiGraphTester(BaseGraphTester):
         assert nodes_equal(G.nodes(), G.reverse().nodes())
         assert [(y, x)] == list(G.reverse().edges())
 
+    def test_di_attributes_cached(self):
+        G = self.K3.copy()
+        assert id(G.in_edges) == id(G.in_edges)
+        assert id(G.out_edges) == id(G.out_edges)
+        assert id(G.in_degree) == id(G.in_degree)
+        assert id(G.out_degree) == id(G.out_degree)
+        assert id(G.succ) == id(G.succ)
+        assert id(G.pred) == id(G.pred)
+
 
 class BaseAttrDiGraphTester(BaseDiGraphTester, BaseAttrGraphTester):
     def test_edges_data(self):

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -170,9 +170,12 @@ class BaseGraphTester:
         G.add_edge(1, 1)
         G.remove_nodes_from([0, 1])
 
-    def test_nodes_cached(self):
+    def test_attributes_cached(self):
         G = self.K3.copy()
         assert id(G.nodes) == id(G.nodes)
+        assert id(G.edges) == id(G.edges)
+        assert id(G.degree) == id(G.degree)
+        assert id(G.adj) == id(G.adj)
 
 
 class BaseAttrGraphTester(BaseGraphTester):
@@ -591,6 +594,7 @@ class TestGraph(BaseAttrGraphTester):
 
     def test_getitem(self):
         G = self.K3
+        assert G.adj[0] == {1: {}, 2: {}}
         assert G[0] == {1: {}, 2: {}}
         with pytest.raises(KeyError):
             G.__getitem__("j")

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -240,6 +240,15 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert sorted(R.edges()) == [(1, 0), (1, 0)]
         pytest.raises(nx.NetworkXError, R.remove_edge, 1, 0)
 
+    def test_di_attributes_cached(self):
+        G = self.K3.copy()
+        assert id(G.in_edges) == id(G.in_edges)
+        assert id(G.out_edges) == id(G.out_edges)
+        assert id(G.in_degree) == id(G.in_degree)
+        assert id(G.out_degree) == id(G.out_degree)
+        assert id(G.succ) == id(G.succ)
+        assert id(G.pred) == id(G.pred)
+
 
 class TestMultiDiGraph(BaseMultiDiGraphTester, _TestMultiGraph):
     def setup_method(self):

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -176,6 +176,13 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
             ],
         )
 
+    def test_attributes_cached(self):
+        G = self.K3.copy()
+        assert id(G.nodes) == id(G.nodes)
+        assert id(G.edges) == id(G.edges)
+        assert id(G.degree) == id(G.degree)
+        assert id(G.adj) == id(G.adj)
+
 
 class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
     def setup_method(self):

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -176,13 +176,6 @@ class BaseMultiGraphTester(BaseAttrGraphTester):
             ],
         )
 
-    def test_attributes_cached(self):
-        G = self.K3.copy()
-        assert id(G.nodes) == id(G.nodes)
-        assert id(G.edges) == id(G.edges)
-        assert id(G.degree) == id(G.degree)
-        assert id(G.adj) == id(G.adj)
-
 
 class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
     def setup_method(self):


### PR DESCRIPTION
Use cached_property for caching the view properties of graph classes (not `G.name` which can be changed and thus should be a regular non-cached property).

The changed properties include: G.edges, G.degree, G.adj  (and G.in_edges, G.out_edges, G.in_degree, G.out_degree, G.pred, G.succ).  Added tests that multiple calls return the same object (caching is successful). 

Changes to Graph, DiGraph, MultiGraph, MultiDiGraph and AntiGraph.  Also reportviews.py had to change one `__setstate__` function.
