### PR TITLE
Replace np.flip with indexing in layouts.

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -337,7 +337,7 @@ def bipartite_layout(
     pos = np.concatenate([top_pos, bottom_pos])
     pos = rescale_layout(pos, scale=scale) + center
     if align == "horizontal":
-        pos = np.flip(pos, 1)
+        pos = pos[:, ::-1]  # swap x and y coords
     pos = dict(zip(nodes, pos))
     return pos
 
@@ -1100,7 +1100,7 @@ def multipartite_layout(G, subset_key="subset", align="vertical", scale=1, cente
         nodes.extend(layer)
     pos = rescale_layout(pos, scale=scale) + center
     if align == "horizontal":
-        pos = np.flip(pos, 1)
+        pos = pos[:, ::-1]  # swap x and y coords
     pos = dict(zip(nodes, pos))
     return pos
 


### PR DESCRIPTION
Replaces the usage of `np.flip` with the equivalent indexing operations in the various layout functions.

In principle indexing is much faster than `flip` as there is no overhead for indexing:

```python
In [1]: a = np.random.random((10, 2))

In [2]: %timeit np.flip(a, 1)
1.62 µs ± 8.84 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [3]: %timeit a[:, ::-1]
169 ns ± 3.37 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

In practice this won't have any much positive impact on the performance of the layout functions as the coordinate swapping is unlikely to be a performance bottleneck. The main motivation for the change is more pedagogical - users are encourage to use indexing rather than the `flip` helpers when writing numpy code, so I propose to follow that practice in NetworkX!
