### PR TITLE
Remove `_mat_spect_approx` in favor of simpler procedure

### DIFF
--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -161,7 +161,11 @@ def spectral_graph_forge(G, alpha, transformation="identity", seed=None):
     if transformation == "modularity":
         B -= K.T @ K / K.sum()
 
-    B = _mat_spect_approx(B, level, sorteigs=True, absolute=True)
+    # Compute low-rank approximation of B
+    evals, evecs = np.linalg.eigh(B)
+    k = np.argsort(np.abs(evals))[::-1]  # indices of evals in descending order
+    evecs[:, k[np.arange(level, n)]] = 0  # set smallest eigenvectors to 0
+    B = evecs @ np.diag(evals) @ evecs.T
 
     if transformation == "modularity":
         B += K.T @ K / K.sum()

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -7,67 +7,6 @@ from networkx.utils import np_random_state
 __all__ = ["spectral_graph_forge"]
 
 
-def _mat_spect_approx(A, level, sorteigs=True, reverse=False, absolute=True):
-    """Returns the low-rank approximation of the given matrix A
-
-    Parameters
-    ----------
-    A : 2D numpy array
-    level : integer
-        It represents the fixed rank for the output approximation matrix
-    sorteigs : boolean
-        Whether eigenvectors should be sorted according to their associated
-        eigenvalues before removing the firsts of them
-    reverse : boolean
-        Whether eigenvectors list should be reversed before removing the firsts
-        of them
-    absolute : boolean
-        Whether eigenvectors should be sorted considering the absolute values
-        of the corresponding eigenvalues
-
-    Returns
-    -------
-    B : 2D numpy array
-        low-rank approximation of A
-
-    Notes
-    -----
-    Low-rank matrix approximation is about finding a fixed rank matrix close
-    enough to the input one with respect to a given norm (distance).
-    In the case of real symmetric input matrix and euclidean distance, the best
-    low-rank approximation is given by the sum of first eigenvector matrices.
-
-    References
-    ----------
-    ..  [1] G. Eckart and G. Young, The approximation of one matrix by another
-            of lower rank
-    ..  [2] L. Mirsky, Symmetric gauge functions and unitarily invariant norms
-
-    """
-    import numpy as np
-
-    d, V = np.linalg.eigh(A)
-    d = np.ravel(d)
-    n = len(d)
-    if sorteigs:
-        if absolute:
-            k = np.argsort(np.abs(d))
-        else:
-            k = np.argsort(d)
-        # ordered from the lowest to the highest
-    else:
-        k = range(n)
-    if not reverse:
-        k = np.flipud(k)
-
-    z = np.zeros(n)
-    for i in range(level, n):
-        V[:, k[i]] = z
-
-    B = V @ np.diag(d) @ V.T
-    return B
-
-
 @np_random_state(3)
 def spectral_graph_forge(G, alpha, transformation="identity", seed=None):
     """Returns a random simple graph with spectrum resembling that of `G`


### PR DESCRIPTION
In the `spectral_graph_forge` module there is an internal helper function called `_mat_spect_approx` which is used in the `spectral_graph_forge` algorithm. AFAICT, the purpose of the helper is to compute a low-rank approximation of a matrix from the eigenvectors that correspond to the `n` largest eigenvalues of the matrix.

The procedure seems straightforward enough, but I found the implementation in `_mat_spect_approx` to be quite confusing; especially since there are a lot of unused parameters in the function. There are several keyword arguments in the helper function that are never changed from their default value when the function is used, which means that the function itself has a bunch of extra logic and branches that are never hit. In addition, the interpretation of some of the parameters is counterintuitive. For example, there is a line similar to:

```python
if not reversed:
    k = np.flip(k)
```

... which is reverses the order of the array! Only after carefully reading the rest of the function does it become clear that `reverse` is meant in the context of whether the eigenvalues should be sorted in ascending or descending order.

Since none of this logic is used, I propose to eliminate the internal helper function entirely and replace it with the simplest implementation as it's currently run. I think this will make the code slightly easier to understand. 