### PR TITLE
Add Mehlhorn Steiner approximations

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -56,8 +56,8 @@ def metric_closure(G, weight="weight"):
     return M
 
 
-def _mehlhorn_steiner_tree(G, S, weight):
-    paths = nx.multi_source_dijkstra_path(G, S)
+def _mehlhorn_steiner_tree(G, terminal_nodes, weight):
+    paths = nx.multi_source_dijkstra_path(G, terminal_nodes)
 
     d_1 = {}
     s = {}
@@ -84,8 +84,14 @@ def _mehlhorn_steiner_tree(G, S, weight):
         for n1, n2 in pairwise(path):
             G_3.add_edge(n1, n2)
 
-    G_4 = nx.minimum_spanning_edges(G_3, data=False)
-    return G_4
+    G_3_mst = list(nx.minimum_spanning_edges(G_3, data=False))
+    if G.is_multigraph():
+        G_3_mst = (
+            (u, v, min(G[u][v], key=lambda k: G[u][v][k][weight])) for u, v in G_3_mst
+        )
+    G_4 = G.edge_subgraph(G_3_mst).copy()
+    _remove_nonterminal_leaves(G_4, terminal_nodes)
+    return G_4.edges()
 
 
 def _kou_steiner_tree(G, terminal_nodes, weight):

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -1,18 +1,9 @@
 from itertools import chain
 
 import networkx as nx
-from networkx.utils import pairwise, not_implemented_for
+from networkx.utils import not_implemented_for, pairwise
 
 __all__ = ["metric_closure", "steiner_tree"]
-
-
-class HeapEntry:
-    def __init__(self, comparator, data):
-        self.comparator = comparator
-        self.data = data
-
-    def __lt__(self, other):
-        return self.comparator < other.comparator
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -1,8 +1,7 @@
-from heapq import heappush, heappop
 from itertools import chain
 
 import networkx as nx
-from networkx.utils import pairwise, not_implemented_for, UnionFind
+from networkx.utils import pairwise, not_implemented_for
 
 __all__ = ["metric_closure", "steiner_tree"]
 
@@ -128,97 +127,7 @@ def _remove_nonterminal_leaves(G, terminals):
             G.remove_node(n)
 
 
-def _wu_steiner_tree(G, terminal_nodes, weight):
-    # Step 1
-    source = {q: q for q in terminal_nodes}
-    length = {q: 0 for q in terminal_nodes}
-    pred = {}
-
-    # Step 2
-    both_in_terminal_nodes = set()
-    priority_queue = []
-    for q in terminal_nodes:
-        for r in G.neighbors(q):
-            if r in terminal_nodes:
-                both_in_terminal_nodes.add(frozenset([q, r]))
-                continue
-            d_q_r = G[q][r].get(weight, 1)
-            heappush(priority_queue, HeapEntry(d_q_r, (r, d_q_r, q, None, None)))
-
-    for q, r in both_in_terminal_nodes:
-        d_q_r = G[q][r].get(weight, 1)
-        heappush(priority_queue, HeapEntry(d_q_r, (r, d_q_r, q, None, None)))
-
-    # Step 3
-    subtrees = UnionFind(terminal_nodes)
-    n_subtrees = len(terminal_nodes)
-
-    generalised_mst_edges = []
-
-    # Step 4
-    while n_subtrees != 1:
-        min_d = heappop(priority_queue)
-        t, d, s, p1, p2 = min_d.data
-        if t not in source:
-            # case 1
-            source[t] = s
-            if t not in pred:
-                pred[t] = s
-            length[t] = d
-            for r in G.neighbors(t):
-                if r not in source:
-                    d_t_r = G[t][r].get(weight, 1)
-                    heap_dist = d + d_t_r
-                    pred[r] = t
-                    heappush(
-                        priority_queue, HeapEntry(heap_dist, (r, heap_dist, s, t, None))
-                    )
-        elif subtrees[source[t]] == subtrees[s]:
-            # case 2
-            continue
-        else:
-            # case 3
-            if t in terminal_nodes:
-                # case 3.1
-                subtrees.union(t, s)
-                generalised_mst_edges.append((s, t, p1, p2))
-                n_subtrees -= 1
-            else:
-                # case 3.2
-                heappush(
-                    priority_queue,
-                    HeapEntry(d + length[t], (source[t], d + length[t], s, p1, t)),
-                )
-
-    # The edges identified in the generalised minimum spanning tree are paths in the original graph.
-    # Here, we find those paths (section 3).
-    steiner_tree_edges = []
-    for s, t, p1, p2 in generalised_mst_edges:
-        # Follow the heads back
-        for iterator in [p1, p2]:
-            while iterator in pred:
-                steiner_tree_edges.append((iterator, pred[iterator]))
-                iterator = pred[iterator]
-
-        # Deal with where the heads meet (figure 2)
-        if p1 is None:
-            p1 = s
-
-        if t in terminal_nodes:
-            if p2 is None:
-                p2 = t
-            steiner_tree_edges.append((p1, p2))
-        else:
-            steiner_tree_edges.append((p1, p2))
-            while t in pred:
-                steiner_tree_edges.append((t, pred[t]))
-                t = pred[t]
-
-    return steiner_tree_edges
-
-
 ALGORITHMS = {
-    "wu": _wu_steiner_tree,
     "kou": _kou_steiner_tree,
     "mehlhorn": _mehlhorn_steiner_tree,
 }
@@ -242,10 +151,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
     the subgraph of the metric closure of *G* induced by the terminal nodes,
     where the metric closure of *G* is the complete graph in which each edge is
     weighted by the shortest path distance between the nodes in *G*.
-    * `wu` [3]_ (runtime $O(|E|\log|V|)$) avoids calculating all-pairs shortest
-    paths. Instead, it initialises a forest of $|S|$ trees and merges them by
-    finding shortest paths between them, similar to Kruskal's algorithm.
-    * `mehlhorn` [4]_ (runtime $O(|E|+|V|\log|V|)$) modifies Kou et al.'s
+    * `mehlhorn` [3]_ (runtime $O(|E|+|V|\log|V|)$) modifies Kou et al.'s
     algorithm, beginning by finding the closest terminal node for each
     non-terminal. This data is used to create a complete graph containing only
     the terminal nodes, in which edge is weighted with the shortest path
@@ -266,7 +172,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
 
     method : string, optional (default = 'kou')
         The algorithm to use to approximate the Steiner tree.
-        Supported options: 'kou', 'wu', 'mehlhorn'.
+        Supported options: 'kou', 'mehlhorn'.
         Other inputs produce a ValueError.
 
     Returns
@@ -289,11 +195,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
            ‘A Fast Algorithm for Steiner Trees’.
            Acta Informatica 15 (2): 141–45.
            https://doi.org/10.1007/BF00288961.
-    .. [3] Wu, Y. F., P. Widmayer, and C. K. Wong. 1986.
-           ‘A Faster Approximation Algorithm for the Steiner Problem in Graphs’.
-           Acta Informatica 23 (2): 223–29.
-           https://doi.org/10.1007/BF00289500.
-    .. [4] Mehlhorn, Kurt. 1988.
+    .. [3] Mehlhorn, Kurt. 1988.
            ‘A Faster Approximation Algorithm for the Steiner Problem in Graphs’.
            Information Processing Letters 27 (3): 125–28.
            https://doi.org/10.1016/0020-0190(88)90066-X.
@@ -302,7 +204,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
         import warnings
 
         msg = (
-            "steiner_tree will change default method from 'kou' to 'wu'"
+            "steiner_tree will change default method from 'kou' to 'mehlhorn'"
             "in version 3.2.\nSet the `method` kwarg to remove this warning."
         )
         warnings.warn(msg, FutureWarning, stacklevel=4)

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -1,9 +1,20 @@
+import heapq
 from itertools import chain
 
-from networkx.utils import pairwise, not_implemented_for
+from networkx.utils import pairwise, not_implemented_for, UnionFind
+from heapq import heappush, heappop
 import networkx as nx
 
 __all__ = ["metric_closure", "steiner_tree"]
+
+
+class HeapEntry:
+    def __init__(self, comparator, data):
+        self.comparator = comparator
+        self.data = data
+
+    def __lt__(self, other):
+        return self.comparator < other.comparator
 
 
 @not_implemented_for("directed")
@@ -46,22 +57,172 @@ def metric_closure(G, weight="weight"):
     return M
 
 
+def mehlhorn_steiner_tree(G, S, weight):
+    paths = nx.multi_source_dijkstra_path(G, S)
+
+    d_1 = {}
+    s = {}
+    for v in G.nodes():
+        s[v] = paths[v][0]
+        d_1[(v, s[v])] = len(paths[v]) - 1
+
+    new_edges = {}
+    for e in G.edges(data=True):
+        u, v, data = e
+        weight_here = d_1[(u, s[u])] + data.get(weight, 1) + d_1[(v, s[v])]
+        key = tuple(sorted([s[u], s[v]]))
+        new_edges[key] = min(new_edges.get(key, float("inf")), weight_here)
+
+    G_1_prime = nx.Graph()
+    for (n1, n2), edge_weight in new_edges.items():
+        G_1_prime.add_edge(n1, n2, weight=edge_weight)
+
+    G_2 = nx.minimum_spanning_edges(G_1_prime, data=True)
+
+    G_3 = nx.Graph()
+    for u, v, d in G_2:
+        path = nx.shortest_path(G, u, v, weight)
+        for n1, n2 in pairwise(path):
+            G_3.add_edge(n1, n2)
+
+    G_4 = nx.minimum_spanning_edges(G_3, data=False)
+    return G_4
+
+
+def kou_steiner_tree(G, terminal_nodes, weight):
+    # H is the subgraph induced by terminal_nodes in the metric closure M of G.
+    M = metric_closure(G, weight=weight)
+    H = M.subgraph(terminal_nodes)
+    # Use the 'distance' attribute of each edge provided by M.
+    mst_edges = nx.minimum_spanning_edges(H, weight="distance", data=True)
+    # Create an iterator over each edge in each shortest path; repeats are okay
+    edges = chain.from_iterable(pairwise(d["path"]) for u, v, d in mst_edges)
+    return edges
+
+
+def wu_steiner_tree(G, terminal_nodes, weight):
+    # Step 1
+    source = {q: q for q in terminal_nodes}
+    length = {q: 0 for q in terminal_nodes}
+    pred = {}
+
+    # Step 2
+    both_in_terminal_nodes = set()
+    priority_queue = []
+    for q in terminal_nodes:
+        for r in G.neighbors(q):
+            if r in terminal_nodes:
+                both_in_terminal_nodes.add((min(r, q), max(r, q)))
+                continue
+            d_q_r = G[q][r].get(weight, 1)
+            heappush(priority_queue, HeapEntry(d_q_r, (r, d_q_r, q, None, None)))
+
+    for q, r in both_in_terminal_nodes:
+        d_q_r = G[q][r].get(weight, 1)
+        heappush(priority_queue, HeapEntry(d_q_r, (r, d_q_r, q, None, None)))
+
+    # Step 3
+    subtrees = UnionFind(terminal_nodes)
+    n_subtrees = len(terminal_nodes)
+
+    generalised_mst_edges = []
+
+    # Step 4
+    while n_subtrees != 1:
+        min_d = heappop(priority_queue)
+        t, d, s, p1, p2 = min_d.data
+        if t not in source:
+            # case 1
+            source[t] = s
+            if t not in pred:
+                pred[t] = s
+            length[t] = d
+            for r in G.neighbors(t):
+                if r not in source:
+                    d_t_r = G[t][r].get(weight, 1)
+                    heap_dist = d + d_t_r
+                    pred[r] = t
+                    heappush(
+                        priority_queue, HeapEntry(heap_dist, (r, heap_dist, s, t, None))
+                    )
+        elif subtrees[source[t]] == subtrees[s]:
+            # case 2
+            continue
+        else:
+            # case 3
+            if t in terminal_nodes:
+                # case 3.1
+                subtrees.union(t, s)
+                generalised_mst_edges.append((s, t, p1, p2))
+                n_subtrees -= 1
+            else:
+                # case 3.2
+                heapq.heappush(
+                    priority_queue,
+                    HeapEntry(d + length[t], (source[t], d + length[t], s, p1, t)),
+                )
+
+    # The edges identified in the generalised minimum spanning tree are paths in the original graph.
+    # Here, we find those paths (section 3).
+    steiner_tree_edges = []
+    for s, t, p1, p2 in generalised_mst_edges:
+        # Follow the heads back
+        for iterator in [p1, p2]:
+            while iterator in pred:
+                steiner_tree_edges.append((iterator, pred[iterator]))
+                iterator = pred[iterator]
+
+        # Deal with where the heads meet (figure 2)
+        if p1 is None:
+            p1 = s
+
+        if t in terminal_nodes:
+            if p2 is None:
+                p2 = t
+            steiner_tree_edges.append((p1, p2))
+        else:
+            steiner_tree_edges.append((p1, p2))
+            while t in pred:
+                steiner_tree_edges.append((t, pred[t]))
+                t = pred[t]
+
+    return steiner_tree_edges
+
+
+ALGORITHMS = {
+    "wu": wu_steiner_tree,
+    "kou": kou_steiner_tree,
+    "mehlhorn": mehlhorn_steiner_tree,
+}
+
+
 @not_implemented_for("directed")
-def steiner_tree(G, terminal_nodes, weight="weight"):
-    """Return an approximation to the minimum Steiner tree of a graph.
+def steiner_tree(G, terminal_nodes, weight="weight", method="kou"):
+    r"""Return an approximation to the minimum Steiner tree of a graph.
 
-    The minimum Steiner tree of `G` w.r.t a set of `terminal_nodes`
-    is a tree within `G` that spans those nodes and has minimum size
-    (sum of edge weights) among all such trees.
+    The minimum Steiner tree of `G` w.r.t a set of `terminal_nodes` (also *S*)
+    is a tree within `G` that spans those nodes and has minimum size (sum of
+    edge weights) among all such trees.
 
-    The minimum Steiner tree can be approximated by computing the minimum
-    spanning tree of the subgraph of the metric closure of *G* induced by the
-    terminal nodes, where the metric closure of *G* is the complete graph in
-    which each edge is weighted by the shortest path distance between the
-    nodes in *G* .
-    This algorithm produces a tree whose weight is within a (2 - (2 / t))
-    factor of the weight of the optimal Steiner tree where *t* is number of
-    terminal nodes.
+    The approximation algorithm is specified with the `method` keyword
+    argument. All three available algorithms produce a tree whose weight is
+    within a (2 - (2 / l)) factor of the weight of the optimal Steiner tree,
+    where *l* is the minimum number of leaf nodes across all possible Steiner
+    trees.
+
+    * `kou` [2]_ (runtime $O(|S| |V|^2)$) computes the minimum spanning tree of
+    the subgraph of the metric closure of *G* induced by the terminal nodes,
+    where the metric closure of *G* is the complete graph in which each edge is
+    weighted by the shortest path distance between the nodes in *G*.
+    * `wu` [3]_ (runtime $O(|E|\log|V|)$) avoids calculating all-pairs shortest
+    paths. Instead, it initialises a forest of $|S|$ trees and merges them by
+    finding shortest paths between them, similar to Kruskal's algorithm.
+    * `mehlhorn` [4]_ (runtime $O(|E|+|V|\log|V|)$) modifies Kou et al.'s
+    algorithm, beginning by finding the closest terminal node for each
+    non-terminal. This data is used to create a complete graph containing only
+    the terminal nodes, in which edge is weighted with the shortest path
+    distance between them. The algorithm then proceeds in the same way as Kou
+    et al..
 
     Parameters
     ----------
@@ -70,6 +231,15 @@ def steiner_tree(G, terminal_nodes, weight="weight"):
     terminal_nodes : list
          A list of terminal nodes for which minimum steiner tree is
          to be found.
+
+    weight : string (default = 'weight')
+        Use the edge attribute specified by this string as the edge weight.
+        Any edge attribute not present defaults to 1.
+
+    method : string, optional (default = 'kou')
+        The algorithm to use to approximate the Steiner tree.
+        Supported options: 'kou', 'wu', 'mehlhorn'.
+        Other inputs produce a ValueError.
 
     Returns
     -------
@@ -86,15 +256,27 @@ def steiner_tree(G, terminal_nodes, weight="weight"):
     References
     ----------
     .. [1] Steiner_tree_problem on Wikipedia.
-       https://en.wikipedia.org/wiki/Steiner_tree_problem
+           https://en.wikipedia.org/wiki/Steiner_tree_problem
+    .. [2] Kou, L., G. Markowsky, and L. Berman. 1981.
+           ‘A Fast Algorithm for Steiner Trees’.
+           Acta Informatica 15 (2): 141–45.
+           https://doi.org/10.1007/BF00288961.
+    .. [3] Wu, Y. F., P. Widmayer, and C. K. Wong. 1986.
+           ‘A Faster Approximation Algorithm for the Steiner Problem in Graphs’.
+           Acta Informatica 23 (2): 223–29.
+           https://doi.org/10.1007/BF00289500.
+    .. [4] Mehlhorn, Kurt. 1988.
+           ‘A Faster Approximation Algorithm for the Steiner Problem in Graphs’.
+           Information Processing Letters 27 (3): 125–28.
+           https://doi.org/10.1016/0020-0190(88)90066-X.
     """
-    # H is the subgraph induced by terminal_nodes in the metric closure M of G.
-    M = metric_closure(G, weight=weight)
-    H = M.subgraph(terminal_nodes)
-    # Use the 'distance' attribute of each edge provided by M.
-    mst_edges = nx.minimum_spanning_edges(H, weight="distance", data=True)
-    # Create an iterator over each edge in each shortest path; repeats are okay
-    edges = chain.from_iterable(pairwise(d["path"]) for u, v, d in mst_edges)
+    try:
+        algo = ALGORITHMS[method]
+    except KeyError as e:
+        msg = f"{method} is not a valid choice for an algorithm."
+        raise ValueError(msg) from e
+
+    edges = algo(G, terminal_nodes, weight)
     # For multigraph we should add the minimal weight edge keys
     if G.is_multigraph():
         edges = (

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -197,7 +197,7 @@ ALGORITHMS = {
 
 
 @not_implemented_for("directed")
-def steiner_tree(G, terminal_nodes, weight="weight", method="kou"):
+def steiner_tree(G, terminal_nodes, weight="weight", method=None):
     r"""Return an approximation to the minimum Steiner tree of a graph.
 
     The minimum Steiner tree of `G` w.r.t a set of `terminal_nodes` (also *S*)
@@ -270,6 +270,16 @@ def steiner_tree(G, terminal_nodes, weight="weight", method="kou"):
            Information Processing Letters 27 (3): 125–28.
            https://doi.org/10.1016/0020-0190(88)90066-X.
     """
+    if method is None:
+        import warnings
+
+        msg = (
+            "steiner_tree will change default method from 'kou' to 'wu'"
+            "in version 3.0.\nSet the `method` kwarg to remove this warning."
+        )
+        warnings.warn(msg, FutureWarning, stacklevel=4)
+        method = "kou"
+
     try:
         algo = ALGORITHMS[method]
     except KeyError as e:

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -274,7 +274,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
         import warnings
 
         msg = (
-            "steiner_tree will change default method from 'kou' to 'wu'"
+            "steiner_tree will change default method from 'kou' to 'wu' "
             "in version 3.0.\nSet the `method` kwarg to remove this warning."
         )
         warnings.warn(msg, FutureWarning, stacklevel=4)

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -68,7 +68,7 @@ class TestSteinerTree:
         cls.G2_term_nodes = [0, 2, 3]
         cls.G3_term_nodes = [1, 3, 5, 6, 8, 10, 11, 12, 13]
 
-        cls.methods = ["wu", "kou", "mehlhorn"]
+        cls.methods = ["kou", "mehlhorn"]
 
     def test_connected_metric_closure(self):
         G = self.G1.copy()

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -25,10 +25,48 @@ class TestSteinerTree:
         G2.add_edge(3, 5, weight=5)
         G2.add_edge(4, 5, weight=1)
 
+        G3 = nx.Graph()
+        G3.add_edge(1, 2, weight=8)
+        G3.add_edge(1, 9, weight=3)
+        G3.add_edge(1, 8, weight=6)
+        G3.add_edge(1, 10, weight=2)
+        G3.add_edge(1, 14, weight=3)
+        G3.add_edge(2, 3, weight=6)
+        G3.add_edge(3, 4, weight=3)
+        G3.add_edge(3, 10, weight=2)
+        G3.add_edge(3, 11, weight=1)
+        G3.add_edge(4, 5, weight=1)
+        G3.add_edge(4, 11, weight=1)
+        G3.add_edge(5, 6, weight=4)
+        G3.add_edge(5, 11, weight=2)
+        G3.add_edge(5, 12, weight=1)
+        G3.add_edge(5, 13, weight=3)
+        G3.add_edge(6, 7, weight=2)
+        G3.add_edge(6, 12, weight=3)
+        G3.add_edge(6, 13, weight=1)
+        G3.add_edge(7, 8, weight=3)
+        G3.add_edge(7, 9, weight=3)
+        G3.add_edge(7, 11, weight=5)
+        G3.add_edge(7, 13, weight=2)
+        G3.add_edge(7, 14, weight=4)
+        G3.add_edge(8, 9, weight=2)
+        G3.add_edge(9, 14, weight=1)
+        G3.add_edge(10, 11, weight=2)
+        G3.add_edge(10, 14, weight=1)
+        G3.add_edge(11, 12, weight=1)
+        G3.add_edge(11, 14, weight=7)
+        G3.add_edge(12, 14, weight=3)
+        G3.add_edge(12, 15, weight=1)
+        G3.add_edge(13, 14, weight=4)
+        G3.add_edge(13, 15, weight=1)
+        G3.add_edge(14, 15, weight=2)
+
         cls.G1 = G1
         cls.G2 = G2
+        cls.G3 = G3
         cls.G1_term_nodes = [1, 2, 3, 4, 5]
         cls.G2_term_nodes = [0, 2, 3]
+        cls.G3_term_nodes = [1, 3, 5, 6, 8, 10, 11, 12, 13]
 
         cls.methods = ["wu", "kou", "mehlhorn"]
 
@@ -96,11 +134,26 @@ class TestSteinerTree:
                     (3, 5, {"weight": 5}),
                 ],
             ],
+            [
+                [
+                    (1, 10, {"weight": 2}),
+                    (3, 10, {"weight": 2}),
+                    (3, 11, {"weight": 1}),
+                    (5, 12, {"weight": 1}),
+                    (6, 13, {"weight": 1}),
+                    (8, 9, {"weight": 2}),
+                    (9, 14, {"weight": 1}),
+                    (10, 14, {"weight": 1}),
+                    (11, 12, {"weight": 1}),
+                    (12, 15, {"weight": 1}),
+                    (13, 15, {"weight": 1}),
+                ]
+            ],
         ]
         for method in self.methods:
             for G, term_nodes, valid_trees in zip(
-                [self.G1, self.G2],
-                [self.G1_term_nodes, self.G2_term_nodes],
+                [self.G1, self.G2, self.G3],
+                [self.G1_term_nodes, self.G2_term_nodes, self.G3_term_nodes],
                 valid_steiner_trees,
             ):
                 S = steiner_tree(G, term_nodes, method=method)

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -114,7 +114,14 @@ class TestSteinerTree:
                 ],
                 [
                     (1, 2, {"weight": 10}),
+                    (2, 7, {"weight": 1}),
                     (3, 4, {"weight": 10}),
+                    (4, 5, {"weight": 10}),
+                    (5, 7, {"weight": 1}),
+                ],
+                [
+                    (1, 2, {"weight": 10}),
+                    (2, 3, {"weight": 10}),
                     (2, 7, {"weight": 1}),
                     (4, 5, {"weight": 10}),
                     (5, 7, {"weight": 1}),

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -18,6 +18,7 @@ class TestSteinerTree:
         G.add_edge(7, 5, weight=1)
         cls.G = G
         cls.term_nodes = [1, 2, 3, 4, 5]
+        cls.methods = ["wu", "kou", "mehlhorn"]
 
     def test_connected_metric_closure(self):
         G = self.G.copy()
@@ -52,15 +53,28 @@ class TestSteinerTree:
         assert edges_equal(list(M.edges(data=True)), mc)
 
     def test_steiner_tree(self):
-        S = steiner_tree(self.G, self.term_nodes)
-        expected_steiner_tree = [
-            (1, 2, {"weight": 10}),
-            (2, 3, {"weight": 10}),
-            (2, 7, {"weight": 1}),
-            (3, 4, {"weight": 10}),
-            (5, 7, {"weight": 1}),
+        valid_steiner_trees = [
+            [
+                (1, 2, {"weight": 10}),
+                (2, 3, {"weight": 10}),
+                (2, 7, {"weight": 1}),
+                (3, 4, {"weight": 10}),
+                (5, 7, {"weight": 1}),
+            ],
+            [
+                (1, 2, {"weight": 10}),
+                (3, 4, {"weight": 10}),
+                (2, 7, {"weight": 1}),
+                (4, 5, {"weight": 10}),
+                (5, 7, {"weight": 1}),
+            ],
         ]
-        assert edges_equal(list(S.edges(data=True)), expected_steiner_tree)
+        for method in self.methods:
+            S = steiner_tree(self.G, self.term_nodes, method=method)
+            assert any(
+                edges_equal(list(S.edges(data=True)), valid_tree)
+                for valid_tree in valid_steiner_trees
+            )
 
     def test_multigraph_steiner_tree(self):
         G = nx.MultiGraph()
@@ -79,5 +93,6 @@ class TestSteinerTree:
             (3, 4, 0, {"weight": 1}),
             (3, 5, 0, {"weight": 1}),
         ]
-        T = steiner_tree(G, terminal_nodes)
-        assert edges_equal(T.edges(data=True, keys=True), expected_edges)
+        for method in self.methods:
+            S = steiner_tree(G, terminal_nodes, method=method)
+            assert edges_equal(S.edges(data=True, keys=True), expected_edges)


### PR DESCRIPTION
Re discussion #5352 

This PR adds two new approximation algorithms for the Steiner tree problem: one from Wu et al. (1986), and another from Mehlhorn (1988). Both are asymptotically faster than the existing approximation from Kou et al. (1981).

One thing I haven't done is change the default algorithm from Kou's, although I think this would be desirable. I suggest setting Wu's as the default, as although the worst-case runtime is slower than Mehlhorn's, in practice I've found it to be faster. This is probably down to Mehlhorn requiring in all cases the shortest paths from all terminal nodes to all other nodes to be calculated; this is not the case with Wu's algorithm.

Any comments and feedback appreciated. 