### PR TITLE
Build docs with Py 3.9

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: '3.9'
 
     - name: Before install
       run: |


### PR DESCRIPTION
Rasterio doesn't have a wheel for Python 3.10 yet and
we don't want to manually build it.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
