### PR TITLE
Rm unnecessary input validation from moral_graph.

### DIFF
--- a/networkx/algorithms/moral.py
+++ b/networkx/algorithms/moral.py
@@ -49,9 +49,6 @@ def moral_graph(G):
            In Proceedings of the Eleventh conference on Uncertainty
            in artificial intelligence (UAI'95)
     """
-    if G is None:
-        raise ValueError("Expected NetworkX graph!")
-
     H = G.to_undirected()
     for preds in G.pred.values():
         predecessors_combinations = itertools.combinations(preds, r=2)


### PR DESCRIPTION
Just something I noticed when looking at #5633 ...

I don't think this validation is necessary - in fact, I don't think it's possible to hit this branch since the `not_implemented_for` will catch any non-graph inputs first and raise an `AttributeError`.