### PR TITLE
doc: fix typos in docstring and comment

### DIFF
--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -138,7 +138,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
     function available (depending on the value of k and if the problem is
     weighted or unweighted) to search for a minimum weight subset of available
     edges that k-edge-connects G. In general, finding a k-edge-augmentation is
-    NP-hard, so solutions are not garuenteed to be minimal. Furthermore, a
+    NP-hard, so solutions are not guaranteed to be minimal. Furthermore, a
     k-edge-augmentation may not exist.
 
     Parameters

--- a/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py
@@ -88,7 +88,7 @@ def _check_edge_connectivity(G):
         ccs_local = fset(aux_graph.k_edge_components(k))
         ccs_subgraph = fset(aux_graph.k_edge_subgraphs(k))
 
-        # Check connectivity properties that should be garuenteed by the
+        # Check connectivity properties that should be guaranteed by the
         # algorithms.
         _assert_local_cc_edge_connectivity(G, ccs_local, k, memo)
         _assert_subgraph_edge_connectivity(G, ccs_subgraph, k)


### PR DESCRIPTION
No code changes, just a typo I noticed in the docs and one more typo in a comment that I found by searching the repo.