### PR TITLE
Fix __setstate__ for OutEdgeView subclasses, read _adjdict from state

### DIFF
--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1286,8 +1286,8 @@ class InEdgeView(OutEdgeView):
     __slots__ = ()
 
     def __setstate__(self, state):
-        self._graph = G = state["_graph"]
-        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
+        self._graph = state["_graph"]
+        self._adjdict = state["_adjdict"]
         self._nodes_nbrs = self._adjdict.items
 
     dataview = InEdgeDataView
@@ -1398,8 +1398,8 @@ class InMultiEdgeView(OutMultiEdgeView):
     __slots__ = ()
 
     def __setstate__(self, state):
-        self._graph = G = state["_graph"]
-        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
+        self._graph = state["_graph"]
+        self._adjdict = state["_adjdict"]
         self._nodes_nbrs = self._adjdict.items
 
     dataview = InMultiEdgeDataView

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -1,3 +1,6 @@
+import pickle
+from copy import deepcopy
+
 import pytest
 
 import networkx as nx
@@ -1388,3 +1391,29 @@ def test_slicing_reportviews(reportview, err_msg_terms):
     errmsg = str(exc.value)
     assert type(view).__name__ in errmsg
     assert err_msg_terms in errmsg
+
+
+@pytest.mark.parametrize(
+    "graph", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
+)
+def test_cache_dict_get_set_state(graph):
+    G = nx.path_graph(5, graph())
+    G.nodes, G.edges, G.adj, G.degree
+    if G.is_directed():
+        G.pred, G.succ, G.in_edges, G.out_edges, G.in_degree, G.out_degree
+    cached_dict = G.__dict__
+    assert "nodes" in cached_dict
+    assert "edges" in cached_dict
+    assert "adj" in cached_dict
+    assert "degree" in cached_dict
+    if G.is_directed():
+        assert "pred" in cached_dict
+        assert "succ" in cached_dict
+        assert "in_edges" in cached_dict
+        assert "out_edges" in cached_dict
+        assert "in_degree" in cached_dict
+        assert "out_degree" in cached_dict
+
+    # Raises error if the cached properties and views do not work
+    pickle.loads(pickle.dumps(G, -1))
+    deepcopy(G)


### PR DESCRIPTION
This should fix https://github.com/networkx/networkx/issues/5655

The state written to disk was recently changes in https://github.com/networkx/networkx/pull/5614 for `OutEdgeView` but the sub-classes `InEdgeView` and `InMultiEdgeView` still depended on the old read mechanism from the Graph object itself, this PR changes it to read directly from the `_adjdict` state.