### PR TITLE
 Use isort with pre-commit to enforce import guidelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,10 @@ repos:
     rev: v1.12.1
     hooks:
     -   id: blacken-docs
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
+        name: isort (python)
+        args: ["--profile", "black", "--filter-files", "--skip", "__init__.py"]
+        files: ^networkx/

--- a/networkx/algorithms/approximation/clustering_coefficient.py
+++ b/networkx/algorithms/approximation/clustering_coefficient.py
@@ -1,5 +1,4 @@
-from networkx.utils import not_implemented_for
-from networkx.utils import py_random_state
+from networkx.utils import not_implemented_for, py_random_state
 
 __all__ = ["average_clustering"]
 

--- a/networkx/algorithms/approximation/dominating_set.py
+++ b/networkx/algorithms/approximation/dominating_set.py
@@ -11,8 +11,8 @@ incident to an endpoint of at least one edge in *F*.
 
 """
 
-from ..matching import maximal_matching
 from ...utils import not_implemented_for
+from ..matching import maximal_matching
 
 __all__ = ["min_weighted_dominating_set", "min_edge_dominating_set"]
 

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -1,16 +1,14 @@
 """ Fast approximation for k-component structure
 """
 import itertools
-from functools import cached_property
 from collections import defaultdict
 from collections.abc import Mapping
+from functools import cached_property
 
 import networkx as nx
+from networkx.algorithms.approximation import local_node_connectivity
 from networkx.exception import NetworkXError
 from networkx.utils import not_implemented_for
-
-from networkx.algorithms.approximation import local_node_connectivity
-
 
 __all__ = ["k_components"]
 

--- a/networkx/algorithms/approximation/maxcut.py
+++ b/networkx/algorithms/approximation/maxcut.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from networkx.utils.decorators import py_random_state, not_implemented_for
+from networkx.utils.decorators import not_implemented_for, py_random_state
 
 __all__ = ["randomized_partitioning", "one_exchange"]
 

--- a/networkx/algorithms/approximation/ramsey.py
+++ b/networkx/algorithms/approximation/ramsey.py
@@ -3,6 +3,7 @@ Ramsey numbers.
 """
 import networkx as nx
 from networkx.utils import not_implemented_for
+
 from ...utils import arbitrary_element
 
 __all__ = ["ramsey_R2"]

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -1,7 +1,7 @@
 from itertools import chain
 
-from networkx.utils import pairwise, not_implemented_for
 import networkx as nx
+from networkx.utils import not_implemented_for, pairwise
 
 __all__ = ["metric_closure", "steiner_tree"]
 

--- a/networkx/algorithms/approximation/tests/test_clique.py
+++ b/networkx/algorithms/approximation/tests/test_clique.py
@@ -2,10 +2,12 @@
 
 
 import networkx as nx
-from networkx.algorithms.approximation import max_clique
-from networkx.algorithms.approximation import clique_removal
-from networkx.algorithms.approximation import large_clique_size
-from networkx.algorithms.approximation import maximum_independent_set
+from networkx.algorithms.approximation import (
+    clique_removal,
+    large_clique_size,
+    max_clique,
+    maximum_independent_set,
+)
 
 
 def is_independent_set(G, nodes):

--- a/networkx/algorithms/approximation/tests/test_distance_measures.py
+++ b/networkx/algorithms/approximation/tests/test_distance_measures.py
@@ -2,6 +2,7 @@
 """
 
 import pytest
+
 import networkx as nx
 from networkx.algorithms.approximation import diameter
 

--- a/networkx/algorithms/approximation/tests/test_dominating_set.py
+++ b/networkx/algorithms/approximation/tests/test_dominating_set.py
@@ -1,6 +1,8 @@
 import networkx as nx
-from networkx.algorithms.approximation import min_weighted_dominating_set
-from networkx.algorithms.approximation import min_edge_dominating_set
+from networkx.algorithms.approximation import (
+    min_edge_dominating_set,
+    min_weighted_dominating_set,
+)
 
 
 class TestMinWeightDominatingSet:

--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -1,5 +1,6 @@
 # Test for approximation to k-components algorithm
 import pytest
+
 import networkx as nx
 from networkx.algorithms.approximation import k_components
 from networkx.algorithms.approximation.kcomponents import _AntiGraph, _same

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -1,7 +1,7 @@
 import pytest
+
 import networkx as nx
-from networkx.algorithms.approximation.steinertree import metric_closure
-from networkx.algorithms.approximation.steinertree import steiner_tree
+from networkx.algorithms.approximation.steinertree import metric_closure, steiner_tree
 from networkx.utils import edges_equal
 
 

--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -1,6 +1,8 @@
 """Unit tests for the traveling_salesman module."""
-import pytest
 import random
+
+import pytest
+
 import networkx as nx
 import networkx.algorithms.approximation as nx_app
 

--- a/networkx/algorithms/approximation/tests/test_treewidth.py
+++ b/networkx/algorithms/approximation/tests/test_treewidth.py
@@ -1,9 +1,14 @@
-import networkx as nx
-from networkx.algorithms.approximation import treewidth_min_degree
-from networkx.algorithms.approximation import treewidth_min_fill_in
-from networkx.algorithms.approximation.treewidth import min_fill_in_heuristic
-from networkx.algorithms.approximation.treewidth import MinDegreeHeuristic
 import itertools
+
+import networkx as nx
+from networkx.algorithms.approximation import (
+    treewidth_min_degree,
+    treewidth_min_fill_in,
+)
+from networkx.algorithms.approximation.treewidth import (
+    MinDegreeHeuristic,
+    min_fill_in_heuristic,
+)
 
 
 def is_tree_decomp(graph, decomp):

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -37,8 +37,7 @@ import math
 
 import networkx as nx
 from networkx.algorithms.tree.mst import random_spanning_tree
-
-from networkx.utils import py_random_state, not_implemented_for, pairwise
+from networkx.utils import not_implemented_for, pairwise, py_random_state
 
 __all__ = [
     "traveling_salesman_problem",
@@ -407,9 +406,8 @@ def asadpour_atsp(G, weight="weight", seed=None, source=None):
     >>> tour
     [0, 2, 1, 0]
     """
+    from math import ceil, exp
     from math import log as ln
-    from math import exp
-    from math import ceil
 
     # Check that G is a complete graph
     N = len(G) - 1

--- a/networkx/algorithms/approximation/treewidth.py
+++ b/networkx/algorithms/approximation/treewidth.py
@@ -29,12 +29,12 @@ There are two different functions for computing a tree decomposition:
 
 """
 
+import itertools
 import sys
+from heapq import heapify, heappop, heappush
 
 import networkx as nx
 from networkx.utils import not_implemented_for
-from heapq import heappush, heappop, heapify
-import itertools
 
 __all__ = ["treewidth_min_degree", "treewidth_min_fill_in"]
 

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -3,6 +3,7 @@
 """
 
 import itertools
+
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/bipartite/covering.py
+++ b/networkx/algorithms/bipartite/covering.py
@@ -1,8 +1,8 @@
 """ Functions related to graph covers."""
 
-from networkx.utils import not_implemented_for
 from networkx.algorithms.bipartite.matching import hopcroft_karp_matching
 from networkx.algorithms.covering import min_edge_cover as _min_edge_cover
+from networkx.utils import not_implemented_for
 
 __all__ = ["min_edge_cover"]
 

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -25,7 +25,7 @@ For each edge (u, v) the node u is assigned to part 0 and the node v to part 1.
 __all__ = ["generate_edgelist", "write_edgelist", "parse_edgelist", "read_edgelist"]
 
 import networkx as nx
-from networkx.utils import open_file, not_implemented_for
+from networkx.utils import not_implemented_for, open_file
 
 
 @open_file(1, mode="wb")

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -4,6 +4,7 @@ Generators and functions for bipartite graphs.
 import math
 import numbers
 from functools import reduce
+
 import networkx as nx
 from networkx.utils import nodes_or_number, py_random_state
 

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -39,9 +39,9 @@ edges included in the matching is minimal.
 import collections
 import itertools
 
-from networkx.algorithms.bipartite.matrix import biadjacency_matrix
-from networkx.algorithms.bipartite import sets as bipartite_sets
 import networkx as nx
+from networkx.algorithms.bipartite import sets as bipartite_sets
+from networkx.algorithms.bipartite.matrix import biadjacency_matrix
 
 __all__ = [
     "maximum_matching",

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -4,8 +4,9 @@ Biadjacency matrices
 ====================
 """
 import itertools
-from networkx.convert_matrix import _generate_weighted_edges
+
 import networkx as nx
+from networkx.convert_matrix import _generate_weighted_edges
 
 __all__ = ["biadjacency_matrix", "from_biadjacency_matrix"]
 

--- a/networkx/algorithms/bipartite/tests/test_centrality.py
+++ b/networkx/algorithms/bipartite/tests/test_centrality.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.algorithms import bipartite
 

--- a/networkx/algorithms/bipartite/tests/test_cluster.py
+++ b/networkx/algorithms/bipartite/tests/test_cluster.py
@@ -1,7 +1,8 @@
-import networkx as nx
 import pytest
-from networkx.algorithms.bipartite.cluster import cc_dot, cc_min, cc_max
+
+import networkx as nx
 import networkx.algorithms.bipartite as bipartite
+from networkx.algorithms.bipartite.cluster import cc_dot, cc_max, cc_min
 
 
 def test_pairwise_bipartite_cc_functions():

--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -1,14 +1,15 @@
 """
     Unit tests for bipartite edgelists.
 """
-import pytest
 import io
-import tempfile
 import os
+import tempfile
+
+import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
 from networkx.algorithms import bipartite
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
 class TestEdgelist:

--- a/networkx/algorithms/bipartite/tests/test_generators.py
+++ b/networkx/algorithms/bipartite/tests/test_generators.py
@@ -1,6 +1,9 @@
-import pytest
 import numbers
+
+import pytest
+
 import networkx as nx
+
 from ..generators import (
     alternating_havel_hakimi_graph,
     complete_bipartite_graph,

--- a/networkx/algorithms/bipartite/tests/test_matching.py
+++ b/networkx/algorithms/bipartite/tests/test_matching.py
@@ -1,15 +1,16 @@
 """Unit tests for the :mod:`networkx.algorithms.bipartite.matching` module."""
 import itertools
 
-import networkx as nx
-
 import pytest
 
-from networkx.algorithms.bipartite.matching import eppstein_matching
-from networkx.algorithms.bipartite.matching import hopcroft_karp_matching
-from networkx.algorithms.bipartite.matching import maximum_matching
-from networkx.algorithms.bipartite.matching import minimum_weight_full_matching
-from networkx.algorithms.bipartite.matching import to_vertex_cover
+import networkx as nx
+from networkx.algorithms.bipartite.matching import (
+    eppstein_matching,
+    hopcroft_karp_matching,
+    maximum_matching,
+    minimum_weight_full_matching,
+    to_vertex_cover,
+)
 
 
 class TestMatching:

--- a/networkx/algorithms/bipartite/tests/test_project.py
+++ b/networkx/algorithms/bipartite/tests/test_project.py
@@ -1,8 +1,8 @@
-import networkx as nx
 import pytest
 
+import networkx as nx
 from networkx.algorithms import bipartite
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestBipartiteProject:

--- a/networkx/algorithms/bipartite/tests/test_redundancy.py
+++ b/networkx/algorithms/bipartite/tests/test_redundancy.py
@@ -4,10 +4,8 @@
 
 import pytest
 
-from networkx import cycle_graph
-from networkx import NetworkXError
-from networkx.algorithms.bipartite import complete_bipartite_graph
-from networkx.algorithms.bipartite import node_redundancy
+from networkx import NetworkXError, cycle_graph
+from networkx.algorithms.bipartite import complete_bipartite_graph, node_redundancy
 
 
 def test_no_redundant_nodes():

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -1,12 +1,12 @@
 """Betweenness centrality measures."""
-from heapq import heappush, heappop
-from collections import deque
-from itertools import count
 import warnings
+from collections import deque
+from heapq import heappop, heappush
+from itertools import count
 
+from networkx.algorithms.shortest_paths.weighted import _weight_function
 from networkx.utils import py_random_state
 from networkx.utils.decorators import not_implemented_for
-from networkx.algorithms.shortest_paths.weighted import _weight_function
 
 __all__ = ["betweenness_centrality", "edge_betweenness_centrality", "edge_betweenness"]
 

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -1,10 +1,12 @@
 """Betweenness centrality measures for subsets of nodes."""
 import warnings
 
+from networkx.algorithms.centrality.betweenness import _add_edge_keys
 from networkx.algorithms.centrality.betweenness import (
     _single_source_dijkstra_path_basic as dijkstra,
+)
+from networkx.algorithms.centrality.betweenness import (
     _single_source_shortest_path_basic as shortest_path,
-    _add_edge_keys,
 )
 
 __all__ = [

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -2,6 +2,7 @@
 Closeness centrality measures.
 """
 import functools
+
 import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils.decorators import not_implemented_for

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -2,14 +2,14 @@
 import networkx as nx
 from networkx.algorithms.centrality.flow_matrix import (
     CGInverseLaplacian,
-    flow_matrix_row,
     FullInverseLaplacian,
     SuperLUInverseLaplacian,
+    flow_matrix_row,
 )
 from networkx.utils import (
     not_implemented_for,
-    reverse_cuthill_mckee_ordering,
     py_random_state,
+    reverse_cuthill_mckee_ordering,
 )
 
 __all__ = [

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -89,8 +89,9 @@ def current_flow_betweenness_centrality_subset(
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    from networkx.utils import reverse_cuthill_mckee_ordering
     import numpy as np
+
+    from networkx.utils import reverse_cuthill_mckee_ordering
 
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -1,12 +1,11 @@
 """Current-flow closeness centrality measures."""
 import networkx as nx
-
-from networkx.utils import not_implemented_for, reverse_cuthill_mckee_ordering
 from networkx.algorithms.centrality.flow_matrix import (
     CGInverseLaplacian,
     FullInverseLaplacian,
     SuperLUInverseLaplacian,
 )
+from networkx.utils import not_implemented_for, reverse_cuthill_mckee_ordering
 
 __all__ = ["current_flow_closeness_centrality", "information_centrality"]
 

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -2,13 +2,12 @@
 from copy import deepcopy
 
 import networkx as nx
-from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.centrality.betweenness import (
-    _single_source_shortest_path_basic,
-    _single_source_dijkstra_path_basic,
     _accumulate_endpoints,
+    _single_source_dijkstra_path_basic,
+    _single_source_shortest_path_basic,
 )
-
+from networkx.utils.decorators import not_implemented_for
 
 __all__ = [
     "group_betweenness_centrality",
@@ -339,8 +338,8 @@ def prominent_group(
        "Fast algorithm for successive computation of group betweenness centrality."
        https://journals.aps.org/pre/pdf/10.1103/PhysRevE.76.056709
     """
-    import pandas as pd
     import numpy as np
+    import pandas as pd
 
     if C is not None:
         C = set(C)

--- a/networkx/algorithms/centrality/percolation.py
+++ b/networkx/algorithms/centrality/percolation.py
@@ -1,7 +1,6 @@
 """Percolation centrality measures."""
 
 import networkx as nx
-
 from networkx.algorithms.centrality.betweenness import (
     _single_source_dijkstra_path_basic as dijkstra,
 )

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -1,7 +1,6 @@
 """Functions for computing reaching centrality of a node or a graph."""
 
 import networkx as nx
-
 from networkx.utils import pairwise
 
 __all__ = ["global_reaching_centrality", "local_reaching_centrality"]

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_closeness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_closeness_centrality.py
@@ -2,6 +2,7 @@
 Tests for closeness centrality.
 """
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
@@ -1,9 +1,8 @@
 import pytest
 
 import networkx as nx
-from networkx import edge_current_flow_betweenness_centrality as edge_current_flow
 from networkx import approximate_current_flow_betweenness_centrality as approximate_cfbc
-
+from networkx import edge_current_flow_betweenness_centrality as edge_current_flow
 
 np = pytest.importorskip("numpy")
 pytest.importorskip("scipy")

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py
@@ -4,9 +4,7 @@ pytest.importorskip("numpy")
 pytest.importorskip("scipy")
 
 import networkx as nx
-
 from networkx import edge_current_flow_betweenness_centrality as edge_current_flow
-
 from networkx import (
     edge_current_flow_betweenness_centrality_subset as edge_current_flow_subset,
 )

--- a/networkx/algorithms/centrality/tests/test_degree_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_degree_centrality.py
@@ -3,6 +3,7 @@
 """
 
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -1,4 +1,5 @@
 import math
+
 import pytest
 
 np = pytest.importorskip("numpy")

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -4,6 +4,7 @@ Tests for Group Centrality Measures
 
 
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_harmonic_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_harmonic_centrality.py
@@ -2,6 +2,7 @@
 Tests for degree centrality.
 """
 import pytest
+
 import networkx as nx
 from networkx.algorithms.centrality import harmonic_centrality
 

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_load_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_load_centrality.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_percolation_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_percolation_centrality.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/centrality/tests/test_subgraph.py
+++ b/networkx/algorithms/centrality/tests/test_subgraph.py
@@ -5,8 +5,8 @@ pytest.importorskip("scipy")
 
 import networkx as nx
 from networkx.algorithms.centrality.subgraph_alg import (
-    estrada_index,
     communicability_betweenness_centrality,
+    estrada_index,
     subgraph_centrality,
     subgraph_centrality_exp,
 )

--- a/networkx/algorithms/centrality/trophic.py
+++ b/networkx/algorithms/centrality/trophic.py
@@ -1,6 +1,5 @@
 """Trophic levels"""
 import networkx as nx
-
 from networkx.utils import not_implemented_for
 
 __all__ = ["trophic_levels", "trophic_differences", "trophic_incoherence_parameter"]

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -12,7 +12,6 @@ import networkx as nx
 from networkx.algorithms.components import connected_components
 from networkx.utils import arbitrary_element, not_implemented_for
 
-
 __all__ = [
     "is_chordal",
     "find_induced_nodes",

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -7,13 +7,11 @@ see the Wikipedia article on the clique problem [1]_.
 .. [1] clique problem:: https://en.wikipedia.org/wiki/Clique_problem
 
 """
-from collections import deque, defaultdict
-from itertools import chain
-from itertools import combinations
-from itertools import islice
+from collections import defaultdict, deque
+from itertools import chain, combinations, islice
+
 import networkx as nx
 from networkx.utils import not_implemented_for
-
 
 __all__ = [
     "find_cliques",

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -1,8 +1,7 @@
 """Algorithms to characterize the number of triangles in a graph."""
 
-from itertools import chain
-from itertools import combinations
 from collections import Counter
+from itertools import chain, combinations
 
 from networkx.utils import not_implemented_for
 

--- a/networkx/algorithms/coloring/equitable_coloring.py
+++ b/networkx/algorithms/coloring/equitable_coloring.py
@@ -2,8 +2,9 @@
 Equitable coloring of graphs with bounded degree.
 """
 
-import networkx as nx
 from collections import defaultdict
+
+import networkx as nx
 
 __all__ = ["equitable_color"]
 

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -1,13 +1,11 @@
 """
 Greedy graph coloring using various strategies.
 """
-from collections import defaultdict, deque
 import itertools
+from collections import defaultdict, deque
 
 import networkx as nx
-from networkx.utils import arbitrary_element
-from networkx.utils import py_random_state
-
+from networkx.utils import arbitrary_element, py_random_state
 
 __all__ = [
     "greedy_color",

--- a/networkx/algorithms/coloring/tests/test_coloring.py
+++ b/networkx/algorithms/coloring/tests/test_coloring.py
@@ -2,9 +2,9 @@
 
 """
 
-import networkx as nx
 import pytest
 
+import networkx as nx
 
 is_coloring = nx.algorithms.coloring.equitable_coloring.is_coloring
 is_equitable = nx.algorithms.coloring.equitable_coloring.is_equitable

--- a/networkx/algorithms/community/asyn_fluid.py
+++ b/networkx/algorithms/community/asyn_fluid.py
@@ -1,11 +1,10 @@
 """Asynchronous Fluid Communities algorithm for community detection."""
 
 from collections import Counter
-from networkx.exception import NetworkXError
+
 from networkx.algorithms.components import is_connected
-from networkx.utils import groups
-from networkx.utils import not_implemented_for
-from networkx.utils import py_random_state
+from networkx.exception import NetworkXError
+from networkx.utils import groups, not_implemented_for, py_random_state
 
 __all__ = ["asyn_fluidc"]
 

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 import networkx as nx
 
 __all__ = ["k_clique_communities"]

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -1,9 +1,10 @@
 """Functions for computing the Kernighan–Lin bipartition algorithm."""
 
-import networkx as nx
 from itertools import count
-from networkx.utils import not_implemented_for, py_random_state, BinaryHeap
+
+import networkx as nx
 from networkx.algorithms.community.community_utils import is_partition
+from networkx.utils import BinaryHeap, not_implemented_for, py_random_state
 
 __all__ = ["kernighan_lin_bisection"]
 

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -4,9 +4,7 @@ Label propagation community detection algorithms.
 from collections import Counter, defaultdict
 
 import networkx as nx
-from networkx.utils import groups
-from networkx.utils import not_implemented_for
-from networkx.utils import py_random_state
+from networkx.utils import groups, not_implemented_for, py_random_state
 
 __all__ = ["label_propagation_communities", "asyn_lpa_communities"]
 

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -1,7 +1,7 @@
 """Function for detecting communities based on Louvain Community Detection
 Algorithm"""
 
-from collections import deque, defaultdict
+from collections import defaultdict, deque
 
 import networkx as nx
 from networkx.algorithms.community import modularity

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -4,8 +4,8 @@ from collections import defaultdict
 
 import networkx as nx
 from networkx.algorithms.community.quality import modularity
-from networkx.utils.mapped_queue import MappedQueue
 from networkx.utils import not_implemented_for
+from networkx.utils.mapped_queue import MappedQueue
 
 __all__ = [
     "greedy_modularity_communities",

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -7,9 +7,9 @@ from itertools import combinations
 
 import networkx as nx
 from networkx import NetworkXError
+from networkx.algorithms.community.community_utils import is_partition
 from networkx.utils import not_implemented_for
 from networkx.utils.decorators import argmap
-from networkx.algorithms.community.community_utils import is_partition
 
 __all__ = ["coverage", "modularity", "performance", "partition_quality"]
 

--- a/networkx/algorithms/community/tests/test_asyn_fluid.py
+++ b/networkx/algorithms/community/tests/test_asyn_fluid.py
@@ -1,4 +1,5 @@
 import pytest
+
 from networkx import Graph, NetworkXError
 from networkx.algorithms.community.asyn_fluid import asyn_fluidc
 

--- a/networkx/algorithms/community/tests/test_centrality.py
+++ b/networkx/algorithms/community/tests/test_centrality.py
@@ -4,7 +4,6 @@ module.
 """
 from operator import itemgetter
 
-
 import networkx as nx
 from networkx.algorithms.community import girvan_newman
 

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -1,10 +1,12 @@
 """Unit tests for the :mod:`networkx.algorithms.community.kernighan_lin`
 module.
 """
+from itertools import permutations
+
 import pytest
+
 import networkx as nx
 from networkx.algorithms.community import kernighan_lin_bisection
-from itertools import permutations
 
 
 def assert_partition_equal(x, y):

--- a/networkx/algorithms/community/tests/test_label_propagation.py
+++ b/networkx/algorithms/community/tests/test_label_propagation.py
@@ -1,11 +1,12 @@
-from itertools import chain
-from itertools import combinations
+from itertools import chain, combinations
 
 import pytest
 
 import networkx as nx
-from networkx.algorithms.community import label_propagation_communities
-from networkx.algorithms.community import asyn_lpa_communities
+from networkx.algorithms.community import (
+    asyn_lpa_communities,
+    label_propagation_communities,
+)
 
 
 def test_directed_not_supported():

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -1,8 +1,8 @@
 import networkx as nx
 from networkx.algorithms.community import (
+    is_partition,
     louvain_communities,
     modularity,
-    is_partition,
     partition_quality,
 )
 

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -6,10 +6,12 @@ import pytest
 
 import networkx as nx
 from networkx import barbell_graph
-from networkx.algorithms.community import coverage
-from networkx.algorithms.community import modularity
-from networkx.algorithms.community import performance
-from networkx.algorithms.community import partition_quality
+from networkx.algorithms.community import (
+    coverage,
+    modularity,
+    partition_quality,
+    performance,
+)
 from networkx.algorithms.community.quality import inter_community_edges
 
 

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -1,5 +1,6 @@
 """Biconnected components and articulation points."""
 from itertools import chain
+
 from networkx.utils.decorators import not_implemented_for
 
 __all__ = [

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -1,6 +1,7 @@
 """Connected components."""
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
+
 from ...utils import arbitrary_element
 
 __all__ = [

--- a/networkx/algorithms/components/tests/test_attracting.py
+++ b/networkx/algorithms/components/tests/test_attracting.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx import NetworkXNotImplemented
 

--- a/networkx/algorithms/components/tests/test_biconnected.py
+++ b/networkx/algorithms/components/tests/test_biconnected.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx import NetworkXNotImplemented
 

--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -1,7 +1,8 @@
 import pytest
+
 import networkx as nx
-from networkx import convert_node_labels_to_integers as cnlti
 from networkx import NetworkXNotImplemented
+from networkx import convert_node_labels_to_integers as cnlti
 
 
 class TestConnected:

--- a/networkx/algorithms/components/tests/test_semiconnected.py
+++ b/networkx/algorithms/components/tests/test_semiconnected.py
@@ -1,6 +1,8 @@
 from itertools import chain
-import networkx as nx
+
 import pytest
+
+import networkx as nx
 
 
 class TestIsSemiconnected:

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx import NetworkXNotImplemented
 

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx import NetworkXNotImplemented
 

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -9,15 +9,17 @@ import networkx as nx
 
 # Define the default maximum flow function to use in all flow based
 # connectivity algorithms.
-from networkx.algorithms.flow import boykov_kolmogorov
-from networkx.algorithms.flow import dinitz
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import shortest_augmenting_path
-from networkx.algorithms.flow import build_residual_network
+from networkx.algorithms.flow import (
+    boykov_kolmogorov,
+    build_residual_network,
+    dinitz,
+    edmonds_karp,
+    shortest_augmenting_path,
+)
 
 default_flow_func = edmonds_karp
 
-from .utils import build_auxiliary_node_connectivity, build_auxiliary_edge_connectivity
+from .utils import build_auxiliary_edge_connectivity, build_auxiliary_node_connectivity
 
 __all__ = [
     "average_node_connectivity",

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -2,16 +2,16 @@
 Flow based cut algorithms
 """
 import itertools
+
 import networkx as nx
 
 # Define the default maximum flow function to use in all flow based
 # cut algorithms.
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import build_residual_network
+from networkx.algorithms.flow import build_residual_network, edmonds_karp
 
 default_flow_func = edmonds_karp
 
-from .utils import build_auxiliary_node_connectivity, build_auxiliary_edge_connectivity
+from .utils import build_auxiliary_edge_connectivity, build_auxiliary_node_connectivity
 
 __all__ = [
     "minimum_st_node_cut",

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -1,19 +1,20 @@
 """Flow based node and edge disjoint paths."""
 import networkx as nx
-from networkx.exception import NetworkXNoPath
 
 # Define the default maximum flow function to use for the undelying
 # maximum flow computations
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import preflow_push
-from networkx.algorithms.flow import shortest_augmenting_path
+from networkx.algorithms.flow import (
+    edmonds_karp,
+    preflow_push,
+    shortest_augmenting_path,
+)
+from networkx.exception import NetworkXNoPath
 
 default_flow_func = edmonds_karp
-# Functions to build auxiliary data structures.
-from .utils import build_auxiliary_node_connectivity
-from .utils import build_auxiliary_edge_connectivity
-
 from itertools import filterfalse as _filterfalse
+
+# Functions to build auxiliary data structures.
+from .utils import build_auxiliary_edge_connectivity, build_auxiliary_node_connectivity
 
 __all__ = ["edge_disjoint_paths", "node_disjoint_paths"]
 

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -12,11 +12,12 @@ See Also
 :mod:`edge_kcomponents` : algorithms for finding k-edge-connected components
 :mod:`connectivity` : algorithms for determening edge connectivity.
 """
-import math
 import itertools as it
+import math
+from collections import defaultdict, namedtuple
+
 import networkx as nx
 from networkx.utils import not_implemented_for, py_random_state
-from collections import defaultdict, namedtuple
 
 __all__ = ["k_edge_augmentation", "is_k_edge_connected", "is_locally_k_edge_connected"]
 

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -8,12 +8,12 @@ A k-edge-connected subgraph (k-edge-subgraph) is a maximal set of nodes in G,
 such that the subgraph of G defined by the nodes has an edge-connectivity at
 least k.
 """
-import networkx as nx
-from networkx.utils import arbitrary_element
-from networkx.utils import not_implemented_for
-from networkx.algorithms import bridges
-from functools import partial
 import itertools as it
+from functools import partial
+
+import networkx as nx
+from networkx.algorithms import bridges
+from networkx.utils import arbitrary_element, not_implemented_for
 
 __all__ = [
     "k_edge_components",

--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -6,10 +6,10 @@ from itertools import combinations
 from operator import itemgetter
 
 import networkx as nx
-from networkx.utils import not_implemented_for
 
 # Define the default maximum flow function.
 from networkx.algorithms.flow import edmonds_karp
+from networkx.utils import not_implemented_for
 
 default_flow_func = edmonds_karp
 

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -7,12 +7,13 @@ from itertools import combinations
 from operator import itemgetter
 
 import networkx as nx
-from .utils import build_auxiliary_node_connectivity
 from networkx.algorithms.flow import (
     build_residual_network,
     edmonds_karp,
     shortest_augmenting_path,
 )
+
+from .utils import build_auxiliary_node_connectivity
 
 default_flow_func = edmonds_karp
 

--- a/networkx/algorithms/connectivity/stoerwagner.py
+++ b/networkx/algorithms/connectivity/stoerwagner.py
@@ -4,9 +4,8 @@ Stoer-Wagner minimum cut algorithm.
 from itertools import islice
 
 import networkx as nx
-from ...utils import BinaryHeap
-from ...utils import not_implemented_for
-from ...utils import arbitrary_element
+
+from ...utils import BinaryHeap, arbitrary_element, not_implemented_for
 
 __all__ = ["stoer_wagner"]
 

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -1,10 +1,13 @@
 import itertools
+
 import pytest
 
 import networkx as nx
 from networkx.algorithms import flow
-from networkx.algorithms.connectivity import local_edge_connectivity
-from networkx.algorithms.connectivity import local_node_connectivity
+from networkx.algorithms.connectivity import (
+    local_edge_connectivity,
+    local_node_connectivity,
+)
 
 flow_funcs = [
     flow.boykov_kolmogorov,

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -2,8 +2,7 @@ import pytest
 
 import networkx as nx
 from networkx.algorithms import flow
-from networkx.algorithms.connectivity import minimum_st_edge_cut
-from networkx.algorithms.connectivity import minimum_st_node_cut
+from networkx.algorithms.connectivity import minimum_st_edge_cut, minimum_st_node_cut
 from networkx.utils import arbitrary_element
 
 flow_funcs = [

--- a/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
@@ -1,16 +1,18 @@
-import random
-import networkx as nx
 import itertools as it
-from networkx.utils import pairwise
+import random
+
 import pytest
+
+import networkx as nx
 from networkx.algorithms.connectivity import k_edge_augmentation
 from networkx.algorithms.connectivity.edge_augmentation import (
+    _unpack_available_edges,
     collapse,
     complement_edges,
-    is_locally_k_edge_connected,
     is_k_edge_connected,
-    _unpack_available_edges,
+    is_locally_k_edge_connected,
 )
+from networkx.utils import pairwise
 
 # This should be set to the largest k for which an efficient algorithm is
 # explicitly defined.

--- a/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py
@@ -1,10 +1,11 @@
-import networkx as nx
 import itertools as it
-import pytest
-from networkx.utils import pairwise
-from networkx.algorithms.connectivity import bridge_components, EdgeComponentAuxGraph
-from networkx.algorithms.connectivity.edge_kcomponents import general_k_edge_subgraphs
 
+import pytest
+
+import networkx as nx
+from networkx.algorithms.connectivity import EdgeComponentAuxGraph, bridge_components
+from networkx.algorithms.connectivity.edge_kcomponents import general_k_edge_subgraphs
+from networkx.utils import pairwise
 
 # ----------------
 # Helper functions

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -1,9 +1,10 @@
 # Test for Moody and White k-components algorithm
 import pytest
+
 import networkx as nx
 from networkx.algorithms.connectivity.kcomponents import (
-    build_k_number_dict,
     _consolidate,
+    build_k_number_dict,
 )
 
 ##

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -1,6 +1,7 @@
 # Jordi Torrents
 # Test for k-cutsets
 import itertools
+
 import pytest
 
 import networkx as nx

--- a/networkx/algorithms/connectivity/tests/test_stoer_wagner.py
+++ b/networkx/algorithms/connectivity/tests/test_stoer_wagner.py
@@ -1,6 +1,8 @@
 from itertools import chain
-import networkx as nx
+
 import pytest
+
+import networkx as nx
 
 
 def _check_partition(G, cut_value, partition, weight):

--- a/networkx/algorithms/covering.py
+++ b/networkx/algorithms/covering.py
@@ -1,10 +1,10 @@
 """ Functions related to graph covers."""
 
-import networkx as nx
-from networkx.utils import not_implemented_for, arbitrary_element
 from functools import partial
 from itertools import chain
 
+import networkx as nx
+from networkx.utils import arbitrary_element, not_implemented_for
 
 __all__ = ["min_edge_cover", "is_edge_cover"]
 

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -60,7 +60,7 @@ References
 from collections import deque
 
 import networkx as nx
-from networkx.utils import not_implemented_for, UnionFind
+from networkx.utils import UnionFind, not_implemented_for
 
 __all__ = ["d_separated"]
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -5,14 +5,14 @@ In general, these functions do not check for acyclic-ness, so it is up
 to the user to check for that.
 """
 
+import heapq
 from collections import deque
-from math import gcd
 from functools import partial
 from itertools import chain, product, starmap
-import heapq
+from math import gcd
 
 import networkx as nx
-from networkx.utils import arbitrary_element, pairwise, not_implemented_for
+from networkx.utils import arbitrary_element, not_implemented_for, pairwise
 
 __all__ = [
     "descendants",

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -6,6 +6,7 @@ Distance-regular graphs
 
 import networkx as nx
 from networkx.utils import not_implemented_for
+
 from .distance_measures import diameter
 
 __all__ = [

--- a/networkx/algorithms/dominance.py
+++ b/networkx/algorithms/dominance.py
@@ -3,6 +3,7 @@ Dominance algorithms.
 """
 
 from functools import reduce
+
 import networkx as nx
 from networkx.utils import not_implemented_for
 

--- a/networkx/algorithms/efficiency_measures.py
+++ b/networkx/algorithms/efficiency_measures.py
@@ -2,6 +2,7 @@
 
 import networkx as nx
 from networkx.exception import NetworkXNoPath
+
 from ..utils import not_implemented_for
 
 __all__ = ["efficiency", "local_efficiency", "global_efficiency"]

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -4,6 +4,7 @@ Eulerian circuits and graphs.
 from itertools import combinations
 
 import networkx as nx
+
 from ..utils import arbitrary_element, not_implemented_for
 
 __all__ = [

--- a/networkx/algorithms/flow/capacityscaling.py
+++ b/networkx/algorithms/flow/capacityscaling.py
@@ -6,10 +6,10 @@ __all__ = ["capacity_scaling"]
 
 from itertools import chain
 from math import log
+
 import networkx as nx
-from ...utils import BinaryHeap
-from ...utils import not_implemented_for
-from ...utils import arbitrary_element
+
+from ...utils import BinaryHeap, arbitrary_element, not_implemented_for
 
 
 def _detect_unboundedness(R):

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -6,6 +6,7 @@ __all__ = ["network_simplex"]
 
 from itertools import chain, islice, repeat
 from math import ceil, sqrt
+
 import networkx as nx
 from networkx.utils import not_implemented_for
 

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -4,13 +4,17 @@ Highest-label preflow-push algorithm for maximum flow problems.
 
 from collections import deque
 from itertools import islice
+
 import networkx as nx
+
 from ...utils import arbitrary_element
-from .utils import build_residual_network
-from .utils import CurrentEdge
-from .utils import detect_unboundedness
-from .utils import GlobalRelabelThreshold
-from .utils import Level
+from .utils import (
+    CurrentEdge,
+    GlobalRelabelThreshold,
+    Level,
+    build_residual_network,
+    detect_unboundedness,
+)
 
 __all__ = ["preflow_push"]
 

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -3,9 +3,11 @@ Shortest augmenting path algorithm for maximum flow problems.
 """
 
 from collections import deque
+
 import networkx as nx
-from .utils import build_residual_network, CurrentEdge
+
 from .edmondskarp import edmonds_karp_core
+from .utils import CurrentEdge, build_residual_network
 
 __all__ = ["shortest_augmenting_path"]
 

--- a/networkx/algorithms/flow/tests/test_gomory_hu.py
+++ b/networkx/algorithms/flow/tests/test_gomory_hu.py
@@ -1,12 +1,15 @@
 from itertools import combinations
+
 import pytest
 
 import networkx as nx
-from networkx.algorithms.flow import boykov_kolmogorov
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import preflow_push
-from networkx.algorithms.flow import shortest_augmenting_path
-from networkx.algorithms.flow import dinitz
+from networkx.algorithms.flow import (
+    boykov_kolmogorov,
+    dinitz,
+    edmonds_karp,
+    preflow_push,
+    shortest_augmenting_path,
+)
 
 flow_funcs = [
     boykov_kolmogorov,

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -3,12 +3,15 @@
 import pytest
 
 import networkx as nx
-from networkx.algorithms.flow import build_flow_dict, build_residual_network
-from networkx.algorithms.flow import boykov_kolmogorov
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import preflow_push
-from networkx.algorithms.flow import shortest_augmenting_path
-from networkx.algorithms.flow import dinitz
+from networkx.algorithms.flow import (
+    boykov_kolmogorov,
+    build_flow_dict,
+    build_residual_network,
+    dinitz,
+    edmonds_karp,
+    preflow_push,
+    shortest_augmenting_path,
+)
 
 flow_funcs = {
     boykov_kolmogorov,

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -2,15 +2,19 @@
 """
 
 import os
+
 import pytest
 
 import networkx as nx
-from networkx.algorithms.flow import build_flow_dict, build_residual_network
-from networkx.algorithms.flow import boykov_kolmogorov
-from networkx.algorithms.flow import dinitz
-from networkx.algorithms.flow import edmonds_karp
-from networkx.algorithms.flow import preflow_push
-from networkx.algorithms.flow import shortest_augmenting_path
+from networkx.algorithms.flow import (
+    boykov_kolmogorov,
+    build_flow_dict,
+    build_residual_network,
+    dinitz,
+    edmonds_karp,
+    preflow_push,
+    shortest_augmenting_path,
+)
 
 flow_funcs = [
     boykov_kolmogorov,

--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -1,6 +1,8 @@
-import networkx as nx
-import pytest
 import os
+
+import pytest
+
+import networkx as nx
 
 
 class TestMinCostFlow:

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -1,6 +1,8 @@
-import pytest
-import networkx as nx
 import os
+
+import pytest
+
+import networkx as nx
 
 
 @pytest.fixture

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -3,6 +3,7 @@ Utility classes and functions for network flow algorithms.
 """
 
 from collections import deque
+
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/graphical.py
+++ b/networkx/algorithms/graphical.py
@@ -1,6 +1,7 @@
 """Test sequences for graphiness.
 """
 import heapq
+
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/hybrid.py
+++ b/networkx/algorithms/hybrid.py
@@ -4,6 +4,7 @@ graphs.
 
 """
 import copy
+
 import networkx as nx
 
 __all__ = ["kl_connected_subgraph", "is_kl_connected"]

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -109,9 +109,9 @@ References
 
 __all__ = ["ISMAGS"]
 
-from collections import defaultdict, Counter
-from functools import reduce, wraps
 import itertools
+from collections import Counter, defaultdict
+from functools import reduce, wraps
 
 
 def are_all_equal(iterable):

--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -1,9 +1,9 @@
 """Functions which help end users define customize node_match and
 edge_match functions to use during isomorphism checks.
 """
-from itertools import permutations
-import types
 import math
+import types
+from itertools import permutations
 
 __all__ = [
     "categorical_node_match",

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -66,7 +66,8 @@ Handles directed and undirected graphs and graphs with parallel edges.
 """
 
 import networkx as nx
-from .isomorphvf2 import GraphMatcher, DiGraphMatcher
+
+from .isomorphvf2 import DiGraphMatcher, GraphMatcher
 
 __all__ = ["TimeRespectingGraphMatcher", "TimeRespectingDiGraphMatcher"]
 

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -3,6 +3,7 @@
 """
 
 import pytest
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -3,8 +3,8 @@
 """
 
 import os
-import struct
 import random
+import struct
 
 import networkx as nx
 from networkx.algorithms import isomorphism as iso

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -1,4 +1,5 @@
 from operator import eq
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 

--- a/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py
@@ -1,9 +1,10 @@
 """
     Tests for the temporal aspect of the Temporal VF2 isomorphism algorithm.
 """
+from datetime import date, datetime, timedelta
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
-from datetime import date, datetime, timedelta
 
 
 def provide_g1_edgelist():

--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -1,12 +1,12 @@
-import networkx as nx
 import random
 import time
-from networkx.classes.function import is_directed
 
+import networkx as nx
 from networkx.algorithms.isomorphism.tree_isomorphism import (
     rooted_tree_isomorphism,
     tree_isomorphism,
 )
+from networkx.classes.function import is_directed
 
 
 # have this work for graph

--- a/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py
@@ -2,8 +2,8 @@
     Tests for VF2 isomorphism algorithm for weighted graphs.
 """
 
-from operator import eq
 import math
+from operator import eq
 
 import networkx as nx
 import networkx.algorithms.isomorphism as iso

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Set
 from itertools import chain, count
 
 import networkx as nx
-from networkx.utils import arbitrary_element, not_implemented_for, UnionFind
+from networkx.utils import UnionFind, arbitrary_element, not_implemented_for
 
 __all__ = [
     "all_pairs_lowest_common_ancestor",

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -1,9 +1,9 @@
 """Functions for computing and verifying matchings in a graph."""
+from collections import Counter
+from itertools import combinations, repeat
+
 import networkx as nx
 from networkx.utils import not_implemented_for
-from collections import Counter
-from itertools import combinations
-from itertools import repeat
 
 __all__ = [
     "is_matching",

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -1,8 +1,5 @@
 """Provides functions for computing minors of a graph."""
-from itertools import chain
-from itertools import combinations
-from itertools import permutations
-from itertools import product
+from itertools import chain, combinations, permutations, product
 
 import networkx as nx
 from networkx import density

--- a/networkx/algorithms/minors/tests/test_contraction.py
+++ b/networkx/algorithms/minors/tests/test_contraction.py
@@ -2,7 +2,7 @@
 import pytest
 
 import networkx as nx
-from networkx.utils import arbitrary_element, nodes_equal, edges_equal
+from networkx.utils import arbitrary_element, edges_equal, nodes_equal
 
 
 class TestQuotient:

--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -3,8 +3,7 @@ Algorithm to find a maximal (not maximum) independent set.
 
 """
 import networkx as nx
-from networkx.utils import not_implemented_for
-from networkx.utils import py_random_state
+from networkx.utils import not_implemented_for, py_random_state
 
 __all__ = ["maximal_independent_set"]
 

--- a/networkx/algorithms/moral.py
+++ b/networkx/algorithms/moral.py
@@ -1,7 +1,8 @@
 r"""Function for computing the moral graph of a directed graph."""
 
-from networkx.utils import not_implemented_for
 import itertools
+
+from networkx.utils import not_implemented_for
 
 __all__ = ["moral_graph"]
 

--- a/networkx/algorithms/node_classification/hmn.py
+++ b/networkx/algorithms/node_classification/hmn.py
@@ -7,9 +7,8 @@ Semi-supervised learning using gaussian fields and harmonic functions.
 In ICML (Vol. 3, pp. 912-919).
 """
 import networkx as nx
-
-from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.node_classification.utils import _get_label_info
+from networkx.utils.decorators import not_implemented_for
 
 __all__ = ["harmonic_function"]
 

--- a/networkx/algorithms/node_classification/lgc.py
+++ b/networkx/algorithms/node_classification/lgc.py
@@ -7,9 +7,8 @@ Learning with local and global consistency.
 Advances in neural information processing systems, 16(16), 321-328.
 """
 import networkx as nx
-
-from networkx.utils.decorators import not_implemented_for
 from networkx.algorithms.node_classification.utils import _get_label_info
+from networkx.utils.decorators import not_implemented_for
 
 __all__ = ["local_and_global_consistency"]
 

--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -2,6 +2,7 @@ r""" Computation of graph non-randomness
 """
 
 import math
+
 import networkx as nx
 from networkx.utils import not_implemented_for
 

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -1,6 +1,7 @@
 """Operations on many graphs.
 """
 from itertools import zip_longest
+
 import networkx as nx
 
 __all__ = ["union_all", "compose_all", "disjoint_union_all", "intersection_all"]

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.utils import edges_equal
 

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.utils import edges_equal
 

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.utils import edges_equal
 

--- a/networkx/algorithms/operators/tests/test_unary.py
+++ b/networkx/algorithms/operators/tests/test_unary.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/planar_drawing.py
+++ b/networkx/algorithms/planar_drawing.py
@@ -1,6 +1,6 @@
-import networkx as nx
 from collections import defaultdict
 
+import networkx as nx
 
 __all__ = ["combinatorial_embedding_to_pos"]
 

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 import networkx as nx
 
 __all__ = ["check_planarity", "is_planar", "PlanarEmbedding"]

--- a/networkx/algorithms/polynomials.py
+++ b/networkx/algorithms/polynomials.py
@@ -9,6 +9,7 @@ extensive treatment is provided in [1]_.
    "Graph Polynomials"
 """
 from collections import deque
+
 import networkx as nx
 from networkx.utils import not_implemented_for
 

--- a/networkx/algorithms/reciprocity.py
+++ b/networkx/algorithms/reciprocity.py
@@ -1,5 +1,6 @@
 """Algorithms to calculate reciprocity in a directed graph."""
 from networkx import NetworkXError
+
 from ..utils import not_implemented_for
 
 __all__ = ["reciprocity", "overall_reciprocity"]

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -85,8 +85,7 @@ def k_factor(G, k, matching_weight="weight"):
        Information processing letters, 2009.
     """
 
-    from networkx.algorithms.matching import max_weight_matching
-    from networkx.algorithms.matching import is_perfect_matching
+    from networkx.algorithms.matching import is_perfect_matching, max_weight_matching
 
     class LargeKGadget:
         def __init__(self, k, degree, node, g):

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -1,7 +1,8 @@
 """Functions for computing rich-club coefficients."""
 
-import networkx as nx
 from itertools import accumulate
+
+import networkx as nx
 from networkx.utils import not_implemented_for
 
 __all__ = ["rich_club_coefficient"]

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -1,6 +1,6 @@
 """Shortest paths and path lengths using the A* ("A star") algorithm.
 """
-from heapq import heappush, heappop
+from heapq import heappop, heappush
 from itertools import count
 
 import networkx as nx

--- a/networkx/algorithms/shortest_paths/tests/test_dense.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 import networkx as nx
 
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -3,11 +3,11 @@ Shortest path algorithms for weighted graphs.
 """
 
 from collections import deque
-from heapq import heappush, heappop
+from heapq import heappop, heappush
 from itertools import count
+
 import networkx as nx
 from networkx.algorithms.shortest_paths.generic import _build_paths_from_predecessors
-
 
 __all__ = [
     "dijkstra_path",

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -13,12 +13,13 @@ At the same time, I encourage capable people to investigate
 alternative GED algorithms, in order to improve the choices available.
 """
 
-from functools import reduce
-from itertools import product
 import math
-from operator import mul
 import time
 import warnings
+from functools import reduce
+from itertools import product
+from operator import mul
+
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -1,10 +1,9 @@
-from heapq import heappush, heappop
+from heapq import heappop, heappush
 from itertools import count
 
 import networkx as nx
-from networkx.utils import not_implemented_for
-from networkx.utils import pairwise
 from networkx.algorithms.shortest_paths.weighted import _weight_function
+from networkx.utils import not_implemented_for, pairwise
 
 __all__ = [
     "all_simple_paths",

--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -15,8 +15,7 @@ For more information, see the Wikipedia article on small-world network [1]_.
 
 """
 import networkx as nx
-from networkx.utils import not_implemented_for
-from networkx.utils import py_random_state
+from networkx.utils import not_implemented_for, py_random_state
 
 __all__ = ["random_reference", "lattice_reference", "sigma", "omega"]
 
@@ -155,6 +154,7 @@ def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
        Science 296.5569 (2002): 910-913.
     """
     import numpy as np
+
     from networkx.utils import cumulative_distribution, discrete_sequence
 
     local_conn = nx.connectivity.local_edge_connectivity

--- a/networkx/algorithms/sparsifiers.py
+++ b/networkx/algorithms/sparsifiers.py
@@ -1,5 +1,6 @@
 """Functions for computing sparsifiers of graphs."""
 import math
+
 import networkx as nx
 from networkx.utils import not_implemented_for, py_random_state
 

--- a/networkx/algorithms/summarization.py
+++ b/networkx/algorithms/summarization.py
@@ -58,9 +58,9 @@ supports graphs with one edge type.
 For more information on graph summarization, see `Graph Summarization Methods
 and Applications: A Survey <https://dl.acm.org/doi/abs/10.1145/3186727>`_
 """
-import networkx as nx
 from collections import Counter, defaultdict
 
+import networkx as nx
 
 __all__ = ["dedensify", "snap_aggregation"]
 

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -2,9 +2,9 @@
 """
 
 import math
-from networkx.utils import py_random_state
 
 import networkx as nx
+from networkx.utils import py_random_state
 
 __all__ = ["double_edge_swap", "connected_double_edge_swap"]
 

--- a/networkx/algorithms/tests/test_boundary.py
+++ b/networkx/algorithms/tests/test_boundary.py
@@ -1,10 +1,12 @@
 """Unit tests for the :mod:`networkx.algorithms.boundary` module."""
 
 from itertools import combinations
+
 import pytest
+
 import networkx as nx
-from networkx.utils import edges_equal
 from networkx import convert_node_labels_to_integers as cnlti
+from networkx.utils import edges_equal
 
 
 class TestNodeBoundary:

--- a/networkx/algorithms/tests/test_chains.py
+++ b/networkx/algorithms/tests/test_chains.py
@@ -1,6 +1,5 @@
 """Unit tests for the chain decomposition functions."""
-from itertools import cycle
-from itertools import islice
+from itertools import cycle, islice
 
 import networkx as nx
 

--- a/networkx/algorithms/tests/test_chordal.py
+++ b/networkx/algorithms/tests/test_chordal.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
 

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -1,5 +1,6 @@
-import networkx as nx
 import pytest
+
+import networkx as nx
 
 
 class TestTriangles:

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -1,9 +1,8 @@
 import pytest
+
 import networkx
 import networkx as nx
-
-from networkx.algorithms import find_cycle
-from networkx.algorithms import minimum_cycle_basis
+from networkx.algorithms import find_cycle, minimum_cycle_basis
 from networkx.algorithms.traversal.edgedfs import FORWARD, REVERSE
 
 

--- a/networkx/algorithms/tests/test_d_separation.py
+++ b/networkx/algorithms/tests/test_d_separation.py
@@ -1,5 +1,7 @@
 from itertools import combinations
+
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -1,10 +1,11 @@
-from itertools import combinations, permutations
 from collections import deque
+from itertools import combinations, permutations
 
 import pytest
 
 import networkx as nx
 from networkx.utils import edges_equal, pairwise
+
 
 # Recipe from the itertools documentation.
 def _consume(iterator):

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -2,7 +2,6 @@ from random import Random
 
 import pytest
 
-
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
 from networkx.algorithms.distance_measures import _extrema_bounding

--- a/networkx/algorithms/tests/test_dominance.py
+++ b/networkx/algorithms/tests/test_dominance.py
@@ -1,5 +1,6 @@
-import networkx as nx
 import pytest
+
+import networkx as nx
 
 
 class TestImmediateDominators:

--- a/networkx/algorithms/tests/test_dominating.py
+++ b/networkx/algorithms/tests/test_dominating.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -1,6 +1,7 @@
-from networkx.generators import directed
 import pytest
+
 import networkx as nx
+from networkx.generators import directed
 
 # Unit tests for the :func:`~networkx.weisfeiler_lehman_graph_hash` function
 

--- a/networkx/algorithms/tests/test_graphical.py
+++ b/networkx/algorithms/tests/test_graphical.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,6 +1,6 @@
 import math
-
 from functools import partial
+
 import pytest
 
 import networkx as nx

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -1,5 +1,6 @@
-import pytest
 from itertools import chain, combinations, product
+
+import pytest
 
 import networkx as nx
 

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -1,6 +1,7 @@
-from itertools import permutations
-from pytest import raises
 import math
+from itertools import permutations
+
+from pytest import raises
 
 import networkx as nx
 from networkx.algorithms.matching import matching_dict_to_set

--- a/networkx/algorithms/tests/test_max_weight_clique.py
+++ b/networkx/algorithms/tests/test_max_weight_clique.py
@@ -2,8 +2,9 @@
 
 """
 
-import networkx as nx
 import pytest
+
+import networkx as nx
 
 
 class TestMaximumWeightClique:

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -3,9 +3,11 @@ Tests for maximal (not maximum) independent sets.
 
 """
 
-import pytest
-import networkx as nx
 import random
+
+import pytest
+
+import networkx as nx
 
 
 class TestMaximalIndependantSet:

--- a/networkx/algorithms/tests/test_moral.py
+++ b/networkx/algorithms/tests/test_moral.py
@@ -1,5 +1,4 @@
 import networkx as nx
-
 from networkx.algorithms.moral import moral_graph
 
 

--- a/networkx/algorithms/tests/test_node_classification_deprecations.py
+++ b/networkx/algorithms/tests/test_node_classification_deprecations.py
@@ -1,9 +1,9 @@
 """TODO: Remove this test module for version 3.0."""
 
 
-import pytest
 import sys
 
+import pytest
 
 # NOTE: It is necessary to prevent previous imports in the test suite from
 # "contaminating" the tests for the deprecation warnings by removing

--- a/networkx/algorithms/tests/test_non_randomness.py
+++ b/networkx/algorithms/tests/test_non_randomness.py
@@ -1,6 +1,6 @@
-import networkx as nx
-
 import pytest
+
+import networkx as nx
 
 np = pytest.importorskip("numpy")
 

--- a/networkx/algorithms/tests/test_planar_drawing.py
+++ b/networkx/algorithms/tests/test_planar_drawing.py
@@ -1,7 +1,9 @@
+import math
+
 import pytest
+
 import networkx as nx
 from networkx.algorithms.planar_drawing import triangulate_embedding
-import math
 
 
 def test_graph1():

--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -1,8 +1,11 @@
 import pytest
+
 import networkx as nx
-from networkx.algorithms.planarity import get_counterexample
-from networkx.algorithms.planarity import get_counterexample_recursive
-from networkx.algorithms.planarity import check_planarity_recursive
+from networkx.algorithms.planarity import (
+    check_planarity_recursive,
+    get_counterexample,
+    get_counterexample_recursive,
+)
 
 
 class TestLRPlanarity:

--- a/networkx/algorithms/tests/test_polynomials.py
+++ b/networkx/algorithms/tests/test_polynomials.py
@@ -1,7 +1,8 @@
 """Unit tests for the :mod:`networkx.algorithms.polynomials` module."""
 
-import networkx as nx
 import pytest
+
+import networkx as nx
 
 sympy = pytest.importorskip("sympy")
 

--- a/networkx/algorithms/tests/test_reciprocity.py
+++ b/networkx/algorithms/tests/test_reciprocity.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_regular.py
+++ b/networkx/algorithms/tests/test_regular.py
@@ -1,7 +1,7 @@
 import pytest
+
 import networkx
 import networkx as nx
-
 import networkx.algorithms.regular as reg
 import networkx.generators as gen
 

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -4,10 +4,11 @@ import pytest
 
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
-from networkx.algorithms.simple_paths import _bidirectional_dijkstra
-from networkx.algorithms.simple_paths import _bidirectional_shortest_path
-from networkx.utils import arbitrary_element
-from networkx.utils import pairwise
+from networkx.algorithms.simple_paths import (
+    _bidirectional_dijkstra,
+    _bidirectional_shortest_path,
+)
+from networkx.utils import arbitrary_element, pairwise
 
 
 class TestIsSimplePath:

--- a/networkx/algorithms/tests/test_smallworld.py
+++ b/networkx/algorithms/tests/test_smallworld.py
@@ -4,8 +4,8 @@ pytest.importorskip("numpy")
 
 import random
 
-from networkx import random_reference, lattice_reference, sigma, omega
 import networkx as nx
+from networkx import lattice_reference, omega, random_reference, sigma
 
 rng = 42
 

--- a/networkx/algorithms/tests/test_sparsifiers.py
+++ b/networkx/algorithms/tests/test_sparsifiers.py
@@ -1,8 +1,8 @@
 """Unit tests for the sparsifier computation functions."""
 import pytest
+
 import networkx as nx
 from networkx.utils import py_random_state
-
 
 _seed = 2
 

--- a/networkx/algorithms/tests/test_structuralholes.py
+++ b/networkx/algorithms/tests/test_structuralholes.py
@@ -1,6 +1,8 @@
 """Unit tests for the :mod:`networkx.algorithms.structuralholes` module."""
 import math
+
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_summarization.py
+++ b/networkx/algorithms/tests/test_summarization.py
@@ -2,6 +2,7 @@
 Unit tests for dedensification and graph summarization
 """
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 # import random

--- a/networkx/algorithms/tests/test_tournament.py
+++ b/networkx/algorithms/tests/test_tournament.py
@@ -1,15 +1,19 @@
 """Unit tests for the :mod:`networkx.algorithms.tournament` module."""
 from itertools import combinations
+
 import pytest
+
 from networkx import DiGraph
-from networkx.algorithms.tournament import is_reachable
-from networkx.algorithms.tournament import is_strongly_connected
-from networkx.algorithms.tournament import is_tournament
-from networkx.algorithms.tournament import random_tournament
-from networkx.algorithms.tournament import hamiltonian_path
-from networkx.algorithms.tournament import score_sequence
-from networkx.algorithms.tournament import tournament_matrix
-from networkx.algorithms.tournament import index_satisfying
+from networkx.algorithms.tournament import (
+    hamiltonian_path,
+    index_satisfying,
+    is_reachable,
+    is_strongly_connected,
+    is_tournament,
+    random_tournament,
+    score_sequence,
+    tournament_matrix,
+)
 
 
 def test_condition_not_satisfied():

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -1,9 +1,11 @@
 """Tests for the :mod:`networkx.algorithms.triads` module."""
 
-import pytest
-from collections import defaultdict
 import itertools
+from collections import defaultdict
 from random import sample
+
+import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/tests/test_wiener.py
+++ b/networkx/algorithms/tests/test_wiener.py
@@ -1,11 +1,7 @@
 """Unit tests for the :mod:`networkx.algorithms.wiener` module."""
 
 
-from networkx import complete_graph
-from networkx import DiGraph
-from networkx import empty_graph
-from networkx import path_graph
-from networkx import wiener_index
+from networkx import DiGraph, complete_graph, empty_graph, path_graph, wiener_index
 
 
 class TestWienerIndex:

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -2,6 +2,7 @@
 Threshold Graphs - Creation, manipulation and identification.
 """
 from math import sqrt
+
 import networkx as nx
 from networkx.utils import py_random_state
 

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -22,9 +22,7 @@ from itertools import combinations
 
 import networkx as nx
 from networkx.algorithms.simple_paths import is_simple_path as is_path
-from networkx.utils import arbitrary_element
-from networkx.utils import not_implemented_for
-from networkx.utils import py_random_state
+from networkx.utils import arbitrary_element, not_implemented_for, py_random_state
 
 __all__ = [
     "hamiltonian_path",

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -1,6 +1,7 @@
 """Basic algorithms for breadth-first searching the nodes of a graph."""
-import networkx as nx
 from collections import deque
+
+import networkx as nx
 
 __all__ = [
     "bfs_edges",

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -1,6 +1,7 @@
 """Basic algorithms for depth-first searching the nodes of a graph."""
-import networkx as nx
 from collections import defaultdict
+
+import networkx as nx
 
 __all__ = [
     "dfs_edges",

--- a/networkx/algorithms/traversal/edgebfs.py
+++ b/networkx/algorithms/traversal/edgebfs.py
@@ -7,6 +7,7 @@ Algorithms for a breadth-first traversal of edges in a graph.
 
 """
 from collections import deque
+
 import networkx as nx
 
 FORWARD = "forward"

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -1,7 +1,8 @@
 from functools import partial
-import networkx as nx
 
 import pytest
+
+import networkx as nx
 
 
 class TestBFS:

--- a/networkx/algorithms/tree/decomposition.py
+++ b/networkx/algorithms/tree/decomposition.py
@@ -1,9 +1,10 @@
 r"""Function for computing a junction tree of a graph."""
 
-import networkx as nx
-from networkx.utils import not_implemented_for
-from networkx.algorithms import moral, complete_to_chordal_graph, chordal_graph_cliques
 from itertools import combinations
+
+import networkx as nx
+from networkx.algorithms import chordal_graph_cliques, complete_to_chordal_graph, moral
+from networkx.utils import not_implemented_for
 
 __all__ = ["junction_tree"]
 

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -5,9 +5,9 @@ Algorithms for calculating min/max spanning trees/forests.
 from dataclasses import dataclass, field
 from enum import Enum
 from heapq import heappop, heappush
-from operator import itemgetter
 from itertools import count
 from math import isnan
+from operator import itemgetter
 from queue import PriorityQueue
 
 import networkx as nx

--- a/networkx/algorithms/tree/operations.py
+++ b/networkx/algorithms/tree/operations.py
@@ -1,9 +1,8 @@
 """Operations on trees."""
 from functools import partial
-from itertools import chain
+from itertools import accumulate, chain
 
 import networkx as nx
-from itertools import accumulate
 
 __all__ = ["join"]
 

--- a/networkx/algorithms/tree/recognition.py
+++ b/networkx/algorithms/tree/recognition.py
@@ -75,7 +75,6 @@ becomes a useful notion.
 
 import networkx as nx
 
-
 __all__ = ["is_arborescence", "is_branching", "is_forest", "is_tree"]
 
 

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -5,9 +5,7 @@ import pytest
 np = pytest.importorskip("numpy")
 
 import networkx as nx
-
-from networkx.algorithms.tree import branchings
-from networkx.algorithms.tree import recognition
+from networkx.algorithms.tree import branchings, recognition
 
 #
 # Explicitly discussed examples from Edmonds paper.

--- a/networkx/algorithms/tree/tests/test_coding.py
+++ b/networkx/algorithms/tree/tests/test_coding.py
@@ -2,8 +2,9 @@
 from itertools import product
 
 import pytest
+
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestPruferSequence:

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -3,7 +3,7 @@
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 def test_unknown_algorithm():

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -3,7 +3,7 @@
 """
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestJoin:

--- a/networkx/algorithms/tree/tests/test_recognition.py
+++ b/networkx/algorithms/tree/tests/test_recognition.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -4,8 +4,8 @@
 # Copyright 2011 Diederik van Liere <diederik.vanliere@rotman.utoronto.ca>
 """Functions for analyzing triads of a graph."""
 
-from itertools import combinations, permutations
 from collections import defaultdict
+from itertools import combinations, permutations
 from random import sample
 
 import networkx as nx

--- a/networkx/algorithms/wiener.py
+++ b/networkx/algorithms/wiener.py
@@ -2,8 +2,7 @@
 
 from itertools import chain
 
-from .components import is_connected
-from .components import is_strongly_connected
+from .components import is_connected, is_strongly_connected
 from .shortest_paths import shortest_path_length as spl
 
 __all__ = ["wiener_index"]

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -3,17 +3,17 @@ from copy import deepcopy
 from functools import cached_property
 
 import networkx as nx
-from networkx.classes.graph import Graph
+import networkx.convert as convert
 from networkx.classes.coreviews import AdjacencyView
+from networkx.classes.graph import Graph
 from networkx.classes.reportviews import (
-    OutEdgeView,
-    InEdgeView,
     DiDegreeView,
     InDegreeView,
+    InEdgeView,
     OutDegreeView,
+    OutEdgeView,
 )
 from networkx.exception import NetworkXError
-import networkx.convert as convert
 
 __all__ = ["DiGraph"]
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -5,9 +5,8 @@ from collections import Counter
 from itertools import chain
 
 import networkx as nx
-from networkx.utils import pairwise, not_implemented_for
-from networkx.classes.graphviews import subgraph_view, reverse_view
-
+from networkx.classes.graphviews import reverse_view, subgraph_view
+from networkx.utils import not_implemented_for, pairwise
 
 __all__ = [
     "nodes",

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -11,10 +11,10 @@ from copy import deepcopy
 from functools import cached_property
 
 import networkx as nx
-from networkx.classes.coreviews import AdjacencyView
-from networkx.classes.reportviews import NodeView, EdgeView, DegreeView
-from networkx.exception import NetworkXError
 import networkx.convert as convert
+from networkx.classes.coreviews import AdjacencyView
+from networkx.classes.reportviews import DegreeView, EdgeView, NodeView
+from networkx.exception import NetworkXError
 
 __all__ = ["Graph"]
 

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -23,18 +23,17 @@ the chain is tricky and much harder with restricted_views than
 with induced subgraphs.
 Often it is easiest to use .copy() to avoid chains.
 """
+import networkx as nx
 from networkx.classes.coreviews import (
+    FilterAdjacency,
+    FilterAtlas,
+    FilterMultiAdjacency,
     UnionAdjacency,
     UnionMultiAdjacency,
-    FilterAtlas,
-    FilterAdjacency,
-    FilterMultiAdjacency,
 )
 from networkx.classes.filters import no_filter
 from networkx.exception import NetworkXError
 from networkx.utils import not_implemented_for
-
-import networkx as nx
 
 __all__ = ["generic_graph_view", "subgraph_view", "reverse_view"]
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -3,18 +3,18 @@ from copy import deepcopy
 from functools import cached_property
 
 import networkx as nx
+import networkx.convert as convert
+from networkx.classes.coreviews import MultiAdjacencyView
 from networkx.classes.digraph import DiGraph
 from networkx.classes.multigraph import MultiGraph
-from networkx.classes.coreviews import MultiAdjacencyView
 from networkx.classes.reportviews import (
-    OutMultiEdgeView,
-    InMultiEdgeView,
     DiMultiDegreeView,
-    OutMultiDegreeView,
     InMultiDegreeView,
+    InMultiEdgeView,
+    OutMultiDegreeView,
+    OutMultiEdgeView,
 )
 from networkx.exception import NetworkXError
-import networkx.convert as convert
 
 __all__ = ["MultiDiGraph"]
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -3,11 +3,11 @@ from copy import deepcopy
 from functools import cached_property
 
 import networkx as nx
-from networkx.classes.graph import Graph
-from networkx.classes.coreviews import MultiAdjacencyView
-from networkx.classes.reportviews import MultiEdgeView, MultiDegreeView
-from networkx import NetworkXError
 import networkx.convert as convert
+from networkx import NetworkXError
+from networkx.classes.coreviews import MultiAdjacencyView
+from networkx.classes.graph import Graph
+from networkx.classes.reportviews import MultiDegreeView, MultiEdgeView
 
 __all__ = ["MultiGraph"]
 

--- a/networkx/classes/ordered.py
+++ b/networkx/classes/ordered.py
@@ -33,13 +33,13 @@ subgraphs and replace with code similar to:
     SG.add_edges_from((u, v) for (u, v) in G.edges() if u in SG if v in SG)
 
 """
-from collections import OrderedDict
 import warnings
+from collections import OrderedDict
 
-from .graph import Graph
-from .multigraph import MultiGraph
 from .digraph import DiGraph
+from .graph import Graph
 from .multidigraph import MultiDiGraph
+from .multigraph import MultiGraph
 
 __all__ = []
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -83,6 +83,7 @@ EdgeDataView
     The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 """
 from collections.abc import Mapping, Set
+
 import networkx as nx
 
 __all__ = [

--- a/networkx/classes/tests/historical_tests.py
+++ b/networkx/classes/tests/historical_tests.py
@@ -1,8 +1,9 @@
 """Original NetworkX graph tests"""
 import pytest
+
 import networkx as nx
 from networkx import convert_node_labels_to_integers as cnlti
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class HistoricalTests:

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -1,5 +1,6 @@
-import pytest
 import pickle
+
+import pytest
 
 import networkx as nx
 

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -2,9 +2,10 @@ import pytest
 
 import networkx as nx
 from networkx.utils import nodes_equal
-from .test_graph import BaseGraphTester, BaseAttrGraphTester
-from .test_graph import TestGraph as _TestGraph
+
+from .test_graph import BaseAttrGraphTester, BaseGraphTester
 from .test_graph import TestEdgeSubgraph as _TestGraphEdgeSubgraph
+from .test_graph import TestGraph as _TestGraph
 
 
 class BaseDiGraphTester(BaseGraphTester):

--- a/networkx/classes/tests/test_digraph_historical.py
+++ b/networkx/classes/tests/test_digraph_historical.py
@@ -1,5 +1,6 @@
 """Original NetworkX graph tests"""
 import pytest
+
 import networkx
 import networkx as nx
 

--- a/networkx/classes/tests/test_filters.py
+++ b/networkx/classes/tests/test_filters.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -1,7 +1,9 @@
 import random
+
 import pytest
+
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestFunction:

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -1,10 +1,11 @@
-import pickle
 import gc
+import pickle
 import platform
+
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
 class BaseGraphTester:

--- a/networkx/classes/tests/test_graphviews.py
+++ b/networkx/classes/tests/test_graphviews.py
@@ -1,7 +1,7 @@
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 # Note: SubGraph views are not tested here. They have their own testing file
 

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -1,11 +1,13 @@
 from collections import UserDict
 
 import pytest
-from networkx.utils import edges_equal
+
 import networkx as nx
+from networkx.utils import edges_equal
+
 from .test_multigraph import BaseMultiGraphTester
-from .test_multigraph import TestMultiGraph as _TestMultiGraph
 from .test_multigraph import TestEdgeSubgraph as _TestMultiGraphEdgeSubgraph
+from .test_multigraph import TestMultiGraph as _TestMultiGraph
 
 
 class BaseMultiDiGraphTester(BaseMultiGraphTester):

--- a/networkx/classes/tests/test_special.py
+++ b/networkx/classes/tests/test_special.py
@@ -1,11 +1,13 @@
 from collections import OrderedDict
+
 import networkx as nx
-from .test_graph import TestGraph as _TestGraph
-from .test_graph import BaseGraphTester
-from .test_digraph import TestDiGraph as _TestDiGraph
+
 from .test_digraph import BaseDiGraphTester
-from .test_multigraph import TestMultiGraph as _TestMultiGraph
+from .test_digraph import TestDiGraph as _TestDiGraph
+from .test_graph import BaseGraphTester
+from .test_graph import TestGraph as _TestGraph
 from .test_multidigraph import TestMultiDiGraph as _TestMultiDiGraph
+from .test_multigraph import TestMultiGraph as _TestMultiGraph
 
 
 def test_factories():

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -11,10 +11,12 @@ General guidelines for writing good tests:
   and add the module to the relevant entries below.
 
 """
-import pytest
-import networkx
 import sys
 import warnings
+
+import pytest
+
+import networkx
 
 
 def pytest_addoption(parser):

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -16,8 +16,9 @@ See Also
 nx_agraph, nx_pydot
 """
 import warnings
-import networkx as nx
 from collections.abc import Collection, Generator, Iterator
+
+import networkx as nx
 
 __all__ = [
     "to_networkx_graph",

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -28,6 +28,7 @@ nx_agraph, nx_pydot
 import itertools
 import warnings
 from collections import defaultdict
+
 import networkx as nx
 from networkx.utils import not_implemented_for
 
@@ -746,8 +747,9 @@ def to_numpy_recarray(G, nodelist=None, dtype=None, order=None):
      [5 0]]
 
     """
-    import numpy as np
     import warnings
+
+    import numpy as np
 
     warnings.warn(
         (

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -19,6 +19,7 @@ See Also
 """
 import os
 import tempfile
+
 import networkx as nx
 
 __all__ = [
@@ -469,8 +470,9 @@ def display_pygraphviz(graph, path, format=None, prog=None, args=""):
     calls if you experience problems.
 
     """
-    from PIL import Image
     import warnings
+
+    from PIL import Image
 
     warnings.warn(
         "display_pygraphviz is deprecated and will be removed in NetworkX 3.0. "

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -20,8 +20,9 @@ See Also
  - DOT Language:  http://www.graphviz.org/doc/info/lang.html
 """
 from locale import getpreferredencoding
-from networkx.utils import open_file
+
 import networkx as nx
+from networkx.utils import open_file
 
 __all__ = [
     "write_dot",

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -17,15 +17,16 @@ See Also
  - :obj:`matplotlib.patches.FancyArrowPatch`
 """
 from numbers import Number
+
 import networkx as nx
 from networkx.drawing.layout import (
-    shell_layout,
     circular_layout,
     kamada_kawai_layout,
+    planar_layout,
+    random_layout,
+    shell_layout,
     spectral_layout,
     spring_layout,
-    random_layout,
-    planar_layout,
 )
 
 __all__ = [
@@ -405,10 +406,11 @@ def draw_networkx_nodes(
     draw_networkx_edge_labels
     """
     from collections.abc import Iterable
-    import numpy as np
+
     import matplotlib as mpl
     import matplotlib.collections  # call as mpl.collections
     import matplotlib.pyplot as plt
+    import numpy as np
 
     if ax is None:
         ax = plt.gca()
@@ -636,13 +638,13 @@ def draw_networkx_edges(
     draw_networkx_edge_labels
 
     """
-    import numpy as np
     import matplotlib as mpl
+    import matplotlib.collections  # call as mpl.collections
     import matplotlib.colors  # call as mpl.colors
     import matplotlib.patches  # call as mpl.patches
-    import matplotlib.collections  # call as mpl.collections
     import matplotlib.path  # call as mpl.path
     import matplotlib.pyplot as plt
+    import numpy as np
 
     # The default behavior is to use LineCollection to draw edges for
     # undirected graphs (for performance reasons) and use FancyArrowPatches
@@ -1475,11 +1477,12 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
         Array containing RGBA format values for each of the node colours.
 
     """
-    from itertools import islice, cycle
-    import numpy as np
+    from itertools import cycle, islice
+
     import matplotlib as mpl
-    import matplotlib.colors  # call as mpl.colors
     import matplotlib.cm  # call as mpl.cm
+    import matplotlib.colors  # call as mpl.colors
+    import numpy as np
 
     # If we have been provided with a list of numbers as long as elem_list,
     # apply the color mapping.

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -1,14 +1,14 @@
 """Unit tests for PyGraphviz interface."""
 import os
 import tempfile
+
 import pytest
 
 pygraphviz = pytest.importorskip("pygraphviz")
 
 
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
-
 import networkx as nx
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
 class TestAGraph:

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -1,7 +1,7 @@
 """Unit tests for layout functions."""
-import networkx as nx
-
 import pytest
+
+import networkx as nx
 
 np = pytest.importorskip("numpy")
 pytest.importorskip("scipy")

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -1,6 +1,6 @@
 """Unit tests for matplotlib drawing functions."""
-import os
 import itertools
+import os
 
 import pytest
 
@@ -641,8 +641,8 @@ def test_draw_edges_toggling_with_arrows_kwarg():
       - ``arrows=True`` -> FancyArrowPatches
       - ``arrows=False`` -> LineCollection
     """
-    import matplotlib.patches
     import matplotlib.collections
+    import matplotlib.patches
 
     UG = nx.path_graph(3)
     DG = nx.path_graph(3, create_using=nx.DiGraph)

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -2,9 +2,9 @@
 Generators for the small graph atlas.
 """
 import gzip
-from itertools import islice
 import os
 import os.path
+from itertools import islice
 
 import networkx as nx
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -16,8 +16,7 @@ import numbers
 import networkx as nx
 from networkx.classes import Graph
 from networkx.exception import NetworkXError
-from networkx.utils import nodes_or_number
-from networkx.utils import pairwise
+from networkx.utils import nodes_or_number, pairwise
 
 __all__ = [
     "balanced_tree",

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -1,9 +1,9 @@
 """Generators for classes of graphs used in studying social networks."""
 import itertools
 import math
+
 import networkx as nx
 from networkx.utils import py_random_state
-
 
 __all__ = [
     "caveman_graph",

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -2,14 +2,12 @@
 """
 
 import heapq
-from itertools import chain
-from itertools import combinations
-from itertools import zip_longest
 import math
+from itertools import chain, combinations, zip_longest
 from operator import itemgetter
 
 import networkx as nx
-from networkx.utils import random_weighted_sample, py_random_state
+from networkx.utils import py_random_state, random_weighted_sample
 
 __all__ = [
     "configuration_model",

--- a/networkx/generators/duplication.py
+++ b/networkx/generators/duplication.py
@@ -6,8 +6,8 @@ generally inspired by biological networks.
 
 """
 import networkx as nx
-from networkx.utils import py_random_state
 from networkx.exception import NetworkXError
+from networkx.utils import py_random_state
 
 __all__ = ["partial_duplication_graph", "duplication_divergence_graph"]
 

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -2,6 +2,7 @@
 
 """
 import itertools
+
 import networkx as nx
 
 __all__ = ["margulis_gabber_galil_graph", "chordal_cycle_graph", "paley_graph"]

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -1,9 +1,9 @@
 """Generators for geometric graphs.
 """
 
+import math
 from bisect import bisect_left
 from itertools import accumulate, combinations, product
-import math
 
 import networkx as nx
 from networkx.utils import py_random_state

--- a/networkx/generators/interval_graph.py
+++ b/networkx/generators/interval_graph.py
@@ -2,6 +2,7 @@
 Generators for interval graph.
 """
 from collections.abc import Sequence
+
 import networkx as nx
 
 __all__ = ["interval_graph"]

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -13,16 +13,14 @@ be found about `Triangular Tiling`_, and `Square, Hex and Triangle Grids`_
 
 """
 
+from itertools import repeat
 from math import sqrt
 
 from networkx.classes import set_node_attributes
 from networkx.exception import NetworkXError
+from networkx.generators.classic import cycle_graph, empty_graph, path_graph
 from networkx.relabel import relabel_nodes
 from networkx.utils import flatten, nodes_or_number, pairwise
-from networkx.generators.classic import cycle_graph
-from networkx.generators.classic import empty_graph
-from networkx.generators.classic import path_graph
-from itertools import repeat
 
 __all__ = [
     "grid_2d_graph",

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -1,7 +1,7 @@
 """Functions for generating line graphs."""
-from itertools import combinations
 from collections import defaultdict
 from functools import partial
+from itertools import combinations
 
 import networkx as nx
 from networkx.utils import arbitrary_element

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -31,14 +31,15 @@ __all__ = [
 ]
 
 from functools import wraps
+
 import networkx as nx
-from networkx.generators.classic import (
-    empty_graph,
-    cycle_graph,
-    path_graph,
-    complete_graph,
-)
 from networkx.exception import NetworkXError
+from networkx.generators.classic import (
+    complete_graph,
+    cycle_graph,
+    empty_graph,
+    path_graph,
+)
 
 
 def _raise_on_directed(func):

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -3,8 +3,7 @@ graph.
 
 """
 
-from networkx.classes import DiGraph
-from networkx.classes import MultiDiGraph
+from networkx.classes import DiGraph, MultiDiGraph
 from networkx.utils import not_implemented_for
 
 __all__ = ["stochastic_graph"]

--- a/networkx/generators/tests/test_atlas.py
+++ b/networkx/generators/tests/test_atlas.py
@@ -3,11 +3,9 @@ from itertools import groupby
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
-from networkx import graph_atlas
-from networkx import graph_atlas_g
+from networkx import graph_atlas, graph_atlas_g
 from networkx.generators.atlas import NUM_GRAPHS
-from networkx.utils import pairwise
+from networkx.utils import edges_equal, nodes_equal, pairwise
 
 
 class TestAtlasGraph:

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -6,11 +6,12 @@ Generators - Classic
 Unit tests for various classic graph generators in generators/classic.py
 """
 import itertools
+
 import pytest
 
 import networkx as nx
 from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 is_isomorphic = graph_could_be_isomorphic
 

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -1,5 +1,6 @@
-import networkx as nx
 import pytest
+
+import networkx as nx
 
 
 def test_random_partition_graph():

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -4,14 +4,15 @@
 import pytest
 
 import networkx as nx
-from networkx.classes import Graph
-from networkx.classes import MultiDiGraph
-from networkx.generators.directed import gn_graph
-from networkx.generators.directed import gnr_graph
-from networkx.generators.directed import gnc_graph
-from networkx.generators.directed import random_k_out_graph
-from networkx.generators.directed import random_uniform_k_out_graph
-from networkx.generators.directed import scale_free_graph
+from networkx.classes import Graph, MultiDiGraph
+from networkx.generators.directed import (
+    gn_graph,
+    gnc_graph,
+    gnr_graph,
+    random_k_out_graph,
+    random_uniform_k_out_graph,
+    scale_free_graph,
+)
 
 
 class TestGeneratorsDirected:

--- a/networkx/generators/tests/test_duplication.py
+++ b/networkx/generators/tests/test_duplication.py
@@ -4,8 +4,10 @@
 import pytest
 
 from networkx.exception import NetworkXError
-from networkx.generators.duplication import duplication_divergence_graph
-from networkx.generators.duplication import partial_duplication_graph
+from networkx.generators.duplication import (
+    duplication_divergence_graph,
+    partial_duplication_graph,
+)
 
 
 class TestDuplicationDivergenceGraph:

--- a/networkx/generators/tests/test_ego.py
+++ b/networkx/generators/tests/test_ego.py
@@ -4,7 +4,7 @@ ego graph
 """
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestGeneratorEgo:

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -2,14 +2,15 @@
 
 """
 
-import networkx as nx
-from networkx import adjacency_matrix
-from networkx import number_of_nodes
-from networkx.generators.expanders import chordal_cycle_graph
-from networkx.generators.expanders import margulis_gabber_galil_graph
-from networkx.generators.expanders import paley_graph
-
 import pytest
+
+import networkx as nx
+from networkx import adjacency_matrix, number_of_nodes
+from networkx.generators.expanders import (
+    chordal_cycle_graph,
+    margulis_gabber_galil_graph,
+    paley_graph,
+)
 
 
 def test_margulis_gabber_galil_graph():

--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -1,6 +1,6 @@
-from itertools import combinations
 import math
 import random
+from itertools import combinations
 
 import networkx as nx
 

--- a/networkx/generators/tests/test_harary_graph.py
+++ b/networkx/generators/tests/test_harary_graph.py
@@ -4,9 +4,8 @@
 import pytest
 
 import networkx as nx
-from networkx.generators.harary_graph import hnm_harary_graph
-from networkx.generators.harary_graph import hkn_harary_graph
 from networkx.algorithms.isomorphism.isomorph import is_isomorphic
+from networkx.generators.harary_graph import hkn_harary_graph, hnm_harary_graph
 
 
 class TestHararyGraph:

--- a/networkx/generators/tests/test_internet_as_graphs.py
+++ b/networkx/generators/tests/test_internet_as_graphs.py
@@ -1,4 +1,5 @@
 from pytest import approx
+
 from networkx import is_connected, neighbors
 from networkx.generators.internet_as_graphs import random_internet_as_graph
 

--- a/networkx/generators/tests/test_intersection.py
+++ b/networkx/generators/tests/test_intersection.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/generators/tests/test_interval_graph.py
+++ b/networkx/generators/tests/test_interval_graph.py
@@ -2,6 +2,7 @@
 
 """
 import math
+
 import pytest
 
 import networkx as nx

--- a/networkx/generators/tests/test_joint_degree_seq.py
+++ b/networkx/generators/tests/test_joint_degree_seq.py
@@ -1,11 +1,12 @@
 import time
+
 from networkx.algorithms.assortativity import degree_mixing_dict
-from networkx.generators import powerlaw_cluster_graph, gnm_random_graph
+from networkx.generators import gnm_random_graph, powerlaw_cluster_graph
 from networkx.generators.joint_degree_seq import (
-    is_valid_joint_degree,
-    joint_degree_graph,
     directed_joint_degree_graph,
     is_valid_directed_joint_degree,
+    is_valid_joint_degree,
+    joint_degree_graph,
 )
 
 

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -1,10 +1,11 @@
 """Unit tests for the :mod:`networkx.generators.lattice` module."""
 
+from itertools import product
+
 import pytest
 
 import networkx as nx
 from networkx.utils import edges_equal
-from itertools import product
 
 
 class TestGrid2DGraph:

--- a/networkx/generators/tests/test_line.py
+++ b/networkx/generators/tests/test_line.py
@@ -1,6 +1,6 @@
-import networkx as nx
 import pytest
 
+import networkx as nx
 import networkx.generators.line as line
 from networkx.utils import edges_equal
 

--- a/networkx/generators/tests/test_random_clustered.py
+++ b/networkx/generators/tests/test_random_clustered.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx
 
 

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -1,7 +1,7 @@
 """Unit tests for the :mod:`networkx.generators.random_graphs` module."""
-import networkx as nx
 import pytest
 
+import networkx as nx
 
 _gnp_generators = [
     nx.gnp_random_graph,

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
 

--- a/networkx/generators/tests/test_spectral_graph_forge.py
+++ b/networkx/generators/tests/test_spectral_graph_forge.py
@@ -6,9 +6,9 @@ pytest.importorskip("scipy")
 
 from networkx import is_isomorphic
 from networkx.exception import NetworkXError
-from networkx.utils import nodes_equal
-from networkx.generators.spectral_graph_forge import spectral_graph_forge
 from networkx.generators import karate_club_graph
+from networkx.generators.spectral_graph_forge import spectral_graph_forge
+from networkx.utils import nodes_equal
 
 
 def test_spectral_graph_forge():

--- a/networkx/generators/tests/test_stochastic.py
+++ b/networkx/generators/tests/test_stochastic.py
@@ -1,5 +1,6 @@
 """Unit tests for the :mod:`networkx.generators.stochastic` module."""
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/generators/tests/test_sudoku.py
+++ b/networkx/generators/tests/test_sudoku.py
@@ -1,6 +1,7 @@
 """Unit tests for the :mod:`networkx.generators.sudoku_graph` module."""
 
 import pytest
+
 import networkx as nx
 
 

--- a/networkx/generators/tests/test_trees.py
+++ b/networkx/generators/tests/test_trees.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.utils import arbitrary_element, graphs_equal
 

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -1,10 +1,9 @@
 import importlib
 import importlib.util
 import inspect
-import types
 import os
 import sys
-
+import types
 
 __all__ = ["attach", "lazy_import"]
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -2,10 +2,13 @@
 Algebraic connectivity and Fiedler vectors of undirected graphs.
 """
 from functools import partial
+
 import networkx as nx
-from networkx.utils import not_implemented_for
-from networkx.utils import reverse_cuthill_mckee_ordering
-from networkx.utils import np_random_state
+from networkx.utils import (
+    not_implemented_for,
+    np_random_state,
+    reverse_cuthill_mckee_ordering,
+)
 
 __all__ = ["algebraic_connectivity", "fiedler_vector", "spectral_ordering"]
 

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -4,8 +4,8 @@ np = pytest.importorskip("numpy")
 pytest.importorskip("scipy")
 
 import networkx as nx
-from networkx.generators.degree_seq import havel_hakimi_graph
 from networkx.exception import NetworkXError
+from networkx.generators.degree_seq import havel_hakimi_graph
 
 
 def test_incidence_matrix_simple():

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -24,8 +24,8 @@ adjacency list (anything following the # in a line is a comment)::
 
 __all__ = ["generate_adjlist", "write_adjlist", "parse_adjlist", "read_adjlist"]
 
-from networkx.utils import open_file
 import networkx as nx
+from networkx.utils import open_file
 
 
 def generate_adjlist(G, delimiter=" "):

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -36,8 +36,8 @@ __all__ = [
     "write_weighted_edgelist",
 ]
 
-from networkx.utils import open_file
 import networkx as nx
+from networkx.utils import open_file
 
 
 def generate_edgelist(G, delimiter=" ", data=True):

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -18,17 +18,16 @@ specification and http://gexf.net/basic.html for examples.
 """
 import itertools
 import time
-
-import networkx as nx
-from networkx.utils import open_file
-
 from xml.etree.ElementTree import (
     Element,
     ElementTree,
     SubElement,
-    tostring,
     register_namespace,
+    tostring,
 )
+
+import networkx as nx
+from networkx.utils import open_file
 
 __all__ = ["write_gexf", "read_gexf", "relabel_gexf_graph", "generate_gexf"]
 

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -27,18 +27,18 @@ For additional documentation on the GML file format, please see the
 Several example graphs in GML format may be found on Mark Newman's
 `Network data page <http://www-personal.umich.edu/~mejn/netdata/>`_.
 """
-from io import StringIO
+import html.entities as htmlentitydefs
+import re
+import warnings
 from ast import literal_eval
 from collections import defaultdict
 from enum import Enum
+from io import StringIO
 from typing import Any, NamedTuple
+
 import networkx as nx
 from networkx.exception import NetworkXError
 from networkx.utils import open_file
-
-import warnings
-import re
-import html.entities as htmlentitydefs
 
 __all__ = ["read_gml", "parse_gml", "generate_gml", "write_gml"]
 

--- a/networkx/readwrite/gpickle.py
+++ b/networkx/readwrite/gpickle.py
@@ -27,10 +27,10 @@ See https://docs.python.org/3/library/pickle.html
 
 __all__ = ["read_gpickle", "write_gpickle"]
 
-from networkx.utils import open_file
-
 import pickle
 import warnings
+
+from networkx.utils import open_file
 
 
 @open_file(1, mode="wb")

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -14,7 +14,7 @@ from itertools import islice
 
 import networkx as nx
 from networkx.exception import NetworkXError
-from networkx.utils import open_file, not_implemented_for
+from networkx.utils import not_implemented_for, open_file
 
 __all__ = ["from_graph6_bytes", "read_graph6", "to_graph6_bytes", "write_graph6"]
 

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -43,7 +43,6 @@ for examples.
 import warnings
 from collections import defaultdict
 
-
 import networkx as nx
 from networkx.utils import open_file
 

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -1,4 +1,5 @@
 from itertools import chain
+
 import networkx as nx
 
 __all__ = ["adjacency_data", "adjacency_graph"]

--- a/networkx/readwrite/json_graph/jit.py
+++ b/networkx/readwrite/json_graph/jit.py
@@ -28,6 +28,7 @@ var json = [
 
 import json
 import warnings
+
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -1,4 +1,5 @@
 from itertools import chain, count
+
 import networkx as nx
 
 __all__ = ["node_link_data", "node_link_graph"]

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -1,5 +1,7 @@
 import json
+
 import pytest
+
 import networkx as nx
 from networkx.readwrite.json_graph import adjacency_data, adjacency_graph
 

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -1,7 +1,9 @@
-import json
-import pytest
-import networkx as nx
 import copy
+import json
+
+import pytest
+
+import networkx as nx
 from networkx.readwrite.json_graph import cytoscape_data, cytoscape_graph
 
 

--- a/networkx/readwrite/json_graph/tests/test_jit.py
+++ b/networkx/readwrite/json_graph/tests/test_jit.py
@@ -1,5 +1,7 @@
 import json
+
 import pytest
+
 import networkx as nx
 from networkx.readwrite.json_graph import jit_data, jit_graph
 

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -1,5 +1,7 @@
 import json
+
 import pytest
+
 import networkx as nx
 from networkx.readwrite.json_graph import node_link_data, node_link_graph
 

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -1,5 +1,7 @@
 import json
+
 import pytest
+
 import networkx as nx
 from networkx.readwrite.json_graph import tree_data, tree_graph
 

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -1,4 +1,5 @@
 from itertools import chain
+
 import networkx as nx
 
 __all__ = ["tree_data", "tree_graph"]

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -32,8 +32,8 @@ __all__ = [
     "read_multiline_adjlist",
 ]
 
-from networkx.utils import open_file
 import networkx as nx
+from networkx.utils import open_file
 
 
 def generate_multiline_adjlist(G, delimiter=" "):

--- a/networkx/readwrite/nx_shp.py
+++ b/networkx/readwrite/nx_shp.py
@@ -12,6 +12,7 @@ interoperability among Esri and other software products."
 See https://en.wikipedia.org/wiki/Shapefile for additional information.
 """
 import warnings
+
 import networkx as nx
 
 __all__ = ["read_shp", "write_shp"]

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -13,8 +13,8 @@ For more information, see the `sparse6`_ homepage.
 """
 import networkx as nx
 from networkx.exception import NetworkXError
-from networkx.utils import open_file, not_implemented_for
 from networkx.readwrite.graph6 import data_to_n, n_to_data
+from networkx.utils import not_implemented_for, open_file
 
 __all__ = ["from_sparse6_bytes", "read_sparse6", "to_sparse6_bytes", "write_sparse6"]
 

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -2,11 +2,13 @@
     Unit tests for adjlist.
 """
 import io
-import pytest
 import os
 import tempfile
+
+import pytest
+
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
 class TestAdjlist:

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -1,15 +1,15 @@
 """
     Unit tests for edgelists.
 """
-import pytest
 import io
-import tempfile
 import os
+import tempfile
 import textwrap
 
-import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
+import pytest
 
+import networkx as nx
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 edges_no_data = textwrap.dedent(
     """

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -1,5 +1,6 @@
 import io
 import time
+
 import pytest
 
 import networkx as nx

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -1,14 +1,16 @@
-from ast import literal_eval
 import codecs
-from contextlib import contextmanager
 import io
 import math
-import pytest
-import networkx as nx
-from networkx.readwrite.gml import literal_stringizer, literal_destringizer
 import os
 import tempfile
+from ast import literal_eval
+from contextlib import contextmanager
 from textwrap import dedent
+
+import pytest
+
+import networkx as nx
+from networkx.readwrite.gml import literal_destringizer, literal_stringizer
 
 
 class TestGraph:

--- a/networkx/readwrite/tests/test_gpickle.py
+++ b/networkx/readwrite/tests/test_gpickle.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
 class TestGpickle:

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -1,10 +1,11 @@
-from io import BytesIO
 import tempfile
+from io import BytesIO
+
 import pytest
 
 import networkx as nx
 import networkx.readwrite.graph6 as g6
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestGraph6Utils:

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1,10 +1,12 @@
-import pytest
-import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
-from networkx.readwrite.graphml import GraphMLWriter
 import io
-import tempfile
 import os
+import tempfile
+
+import pytest
+
+import networkx as nx
+from networkx.readwrite.graphml import GraphMLWriter
+from networkx.utils import edges_equal, nodes_equal
 
 
 class BaseGraphML:

--- a/networkx/readwrite/tests/test_leda.py
+++ b/networkx/readwrite/tests/test_leda.py
@@ -1,5 +1,6 @@
-import networkx as nx
 import io
+
+import networkx as nx
 
 
 class TestLEDA:

--- a/networkx/readwrite/tests/test_p2g.py
+++ b/networkx/readwrite/tests/test_p2g.py
@@ -1,5 +1,6 @@
-import networkx as nx
 import io
+
+import networkx as nx
 from networkx.readwrite.p2g import read_p2g, write_p2g
 from networkx.utils import edges_equal
 

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -1,10 +1,11 @@
 """
 Pajek tests
 """
-import networkx as nx
 import os
 import tempfile
-from networkx.utils import nodes_equal, edges_equal
+
+import networkx as nx
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestPajek:

--- a/networkx/readwrite/tests/test_shp.py
+++ b/networkx/readwrite/tests/test_shp.py
@@ -3,6 +3,7 @@
 
 import os
 import tempfile
+
 import pytest
 
 ogr = pytest.importorskip("osgeo.ogr")

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -1,9 +1,10 @@
-from io import BytesIO
 import tempfile
+from io import BytesIO
+
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestSparseGraph6:

--- a/networkx/readwrite/tests/test_text.py
+++ b/networkx/readwrite/tests/test_text.py
@@ -1,6 +1,8 @@
-import pytest
-import networkx as nx
 from textwrap import dedent
+
+import pytest
+
+import networkx as nx
 
 
 def test_directed_tree_str():

--- a/networkx/testing/tests/test_utils.py
+++ b/networkx/testing/tests/test_utils.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from networkx.testing import assert_graphs_equal, assert_edges_equal, assert_nodes_equal
+from networkx.testing import assert_edges_equal, assert_graphs_equal, assert_nodes_equal
 
 # thanks to numpy for this GenericTest class (numpy/testing/test_utils.py)
 

--- a/networkx/testing/utils.py
+++ b/networkx/testing/utils.py
@@ -1,5 +1,6 @@
 import warnings
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
+
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 __all__ = [
     "assert_nodes_equal",

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -1,15 +1,15 @@
 import pytest
 
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
 from networkx.convert import (
-    to_networkx_graph,
-    to_dict_of_dicts,
     from_dict_of_dicts,
-    to_dict_of_lists,
     from_dict_of_lists,
+    to_dict_of_dicts,
+    to_dict_of_lists,
+    to_networkx_graph,
 )
 from networkx.generators.classic import barbell_graph, cycle_graph
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
 class TestConvert:

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -1,6 +1,7 @@
 import pytest
+
 import networkx as nx
-from networkx.utils import nodes_equal, edges_equal, graphs_equal
+from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -5,8 +5,8 @@ sp = pytest.importorskip("scipy")
 import scipy.sparse  # call as sp.sparse
 
 import networkx as nx
-from networkx.utils import graphs_equal
 from networkx.generators.classic import barbell_graph, cycle_graph, path_graph
+from networkx.utils import graphs_equal
 
 
 class TestConvertScipy:

--- a/networkx/tests/test_exceptions.py
+++ b/networkx/tests/test_exceptions.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 
 # smoke tests for exceptions

--- a/networkx/tests/test_lazy_imports.py
+++ b/networkx/tests/test_lazy_imports.py
@@ -1,6 +1,7 @@
-import sys
 import importlib
+import sys
 import types
+
 import pytest
 
 import networkx.lazy_imports as lazy

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -1,7 +1,8 @@
 import pytest
+
 import networkx as nx
 from networkx.generators.classic import empty_graph
-from networkx.utils import nodes_equal, edges_equal
+from networkx.utils import edges_equal, nodes_equal
 
 
 class TestRelabel:

--- a/networkx/utils/contextmanagers.py
+++ b/networkx/utils/contextmanagers.py
@@ -1,5 +1,5 @@
-from contextlib import contextmanager
 import warnings
+from contextlib import contextmanager
 
 __all__ = ["reversed"]
 

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -1,14 +1,16 @@
+import bz2
+import collections
+import gzip
+import inspect
+import itertools
+import re
 from collections import defaultdict
-from os.path import splitext
 from contextlib import contextmanager
+from os.path import splitext
 from pathlib import Path
 
 import networkx as nx
-from networkx.utils import create_random_state, create_py_random_state
-
-import inspect, itertools, collections
-
-import re, gzip, bz2
+from networkx.utils import create_py_random_state, create_random_state
 
 __all__ = [
     "not_implemented_for",

--- a/networkx/utils/heaps.py
+++ b/networkx/utils/heaps.py
@@ -4,6 +4,7 @@ Min-heaps.
 
 from heapq import heappop, heappush
 from itertools import count
+
 import networkx as nx
 
 __all__ = ["MinHeap", "PairingHeap", "BinaryHeap"]

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -11,12 +11,12 @@ can be accessed, for example, as
 1
 """
 
-from collections import defaultdict, deque
-from collections.abc import Iterable, Iterator, Sized
-import warnings
 import sys
 import uuid
-from itertools import tee, chain
+import warnings
+from collections import defaultdict, deque
+from collections.abc import Iterable, Iterator, Sized
+from itertools import chain, tee
 
 import networkx as nx
 

--- a/networkx/utils/random_sequence.py
+++ b/networkx/utils/random_sequence.py
@@ -6,7 +6,6 @@ random selections.
 import networkx as nx
 from networkx.utils import py_random_state
 
-
 __all__ = [
     "powerlaw_sequence",
     "zipf_rv",

--- a/networkx/utils/rcm.py
+++ b/networkx/utils/rcm.py
@@ -5,6 +5,7 @@ from collections import deque
 from operator import itemgetter
 
 import networkx as nx
+
 from ..utils import arbitrary_element
 
 __all__ = ["cuthill_mckee_ordering", "reverse_cuthill_mckee_ordering"]

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -1,18 +1,19 @@
-import tempfile
 import os
 import pathlib
 import random
+import tempfile
 
 import pytest
 
 import networkx as nx
-from networkx.utils.decorators import open_file, not_implemented_for
 from networkx.utils.decorators import (
+    argmap,
+    not_implemented_for,
+    np_random_state,
+    open_file,
     preserve_random_state,
     py_random_state,
-    np_random_state,
     random_state,
-    argmap,
 )
 from networkx.utils.misc import PythonRandomInterface
 

--- a/networkx/utils/tests/test_heaps.py
+++ b/networkx/utils/tests/test_heaps.py
@@ -1,4 +1,5 @@
 import pytest
+
 import networkx as nx
 from networkx.utils import BinaryHeap, PairingHeap
 

--- a/networkx/utils/tests/test_mapped_queue.py
+++ b/networkx/utils/tests/test_mapped_queue.py
@@ -1,5 +1,6 @@
 import pytest
-from networkx.utils.mapped_queue import _HeapElement, MappedQueue
+
+from networkx.utils.mapped_queue import MappedQueue, _HeapElement
 
 
 def test_HeapElement_gtlt():

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -1,23 +1,24 @@
+import random
 from copy import copy
 
 import pytest
+
 import networkx as nx
-import random
 from networkx.utils import (
+    PythonRandomInterface,
     arbitrary_element,
     create_py_random_state,
     create_random_state,
-    discrete_sequence,
     dict_to_numpy_array,
+    discrete_sequence,
     flatten,
+    groups,
     is_string_like,
     iterable,
-    groups,
     make_list_of_ints,
     make_str,
     pairwise,
     powerlaw_sequence,
-    PythonRandomInterface,
     to_tuple,
 )
 from networkx.utils.misc import _dict_to_numpy_array1, _dict_to_numpy_array2

--- a/networkx/utils/tests/test_random_sequence.py
+++ b/networkx/utils/tests/test_random_sequence.py
@@ -1,9 +1,10 @@
 import pytest
+
 from networkx.utils import (
     powerlaw_sequence,
-    zipf_rv,
     random_weighted_sample,
     weighted_choice,
+    zipf_rv,
 )
 
 

--- a/networkx/utils/tests/test_rcm.py
+++ b/networkx/utils/tests/test_rcm.py
@@ -1,5 +1,5 @@
-from networkx.utils import reverse_cuthill_mckee_ordering
 import networkx as nx
+from networkx.utils import reverse_cuthill_mckee_ordering
 
 
 def test_reverse_cuthill_mckee():


### PR DESCRIPTION
Another precommit automation where we can stop thinking about what and how to do things.

This does not touch any of the `__init__.py` files.

(I thought of doing this after reading https://github.com/networkx/networkx/issues/2723)