### PR TITLE
Implement directed edge swap

### DIFF
--- a/doc/reference/algorithms/swap.rst
+++ b/doc/reference/algorithms/swap.rst
@@ -7,5 +7,6 @@ Swap
    :toctree: generated/
 
    double_edge_swap
+   directed_edge_swap
    connected_double_edge_swap
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -22,7 +22,8 @@ X contributors. Highlights include:
 
 Improvements
 ------------
-
+- [`#5663 <https://github.com/networkx/networkx/pull/5663>`_]
+  Implements edge swapping for directed graphs.
 
 API Changes
 -----------

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -26,7 +26,7 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
        A directed graph
 
     nswap : integer (optional, default=1)
-       Number of three-edge swaps to perform
+       Number of three-edge (directed) swaps to perform
 
     max_tries : integer (optional)
        Maximum number of attempts to swap edges
@@ -38,7 +38,7 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     Returns
     -------
     G : DiGraph
-       The graph after triple-edge swaps.
+       The graph after the edges are swapped.
 
     Raises
     ------

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -23,7 +23,7 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     Parameters
     ----------
     G : DiGraph
-       An directed graph
+       A directed graph
 
     nswap : integer (optional, default=1)
        Number of three-edge swaps to perform

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -33,8 +33,12 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
 
     References
     ----------
-    .. [1] https://math.stackexchange.com/questions/22272
-    .. [2] https://arxiv.org/pdf/0905.4913.pdf
+    .. [1] Erdős, Péter L., et al. “A Simple Havel-Hakimi Type Algorithm to Realize
+           Graphical Degree Sequences of Directed Graphs.” ArXiv:0905.4913 [Math],
+           Jan. 2010. https://doi.org/10.48550/arXiv.0905.4913.
+    .. [2] “Combinatorics - Reaching All Possible Simple Directed Graphs with a given
+           Degree Sequence with 2-Edge Swaps.” Mathematics Stack Exchange,
+           https://math.stackexchange.com/questions/22272/. Accessed 30 May 2022.
     """
     if not G.is_directed():
         raise nx.NetworkXError(

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -86,11 +86,8 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
         tries += 1
 
         if tries > max_tries:
-            e = (
-                f"Maximum number of swap attempts ({tries}) exceeded "
-                f"before desired swaps achieved ({nswap})."
-            )
-            raise nx.NetworkXAlgorithmError(e)
+            msg = f"Maximum number of swap attempts ({tries}) exceeded before desired swaps achieved ({nswap})."
+            raise nx.NetworkXAlgorithmError(msg)
 
         # If the given node doesn't have any out edges, then there isn't anything to swap
         if G.out_degree(start) == 0:

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -29,7 +29,7 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     nswap : integer (optional, default=1)
        Number of three-edge (directed) swaps to perform
 
-    max_tries : integer (optional)
+    max_tries : integer (optional, default=100)
        Maximum number of attempts to swap edges
 
     seed : integer, random_state, or None (default)

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -95,16 +95,19 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
         if G.out_degree(start) == 0:
             continue
         second = seed.choice(list(G.succ[start]))
+        if start == second:
+            continue
 
         if G.out_degree(second) == 0:
             continue
         third = seed.choice(list(G.succ[second]))
+        if second == third:
+            continue
 
         if G.out_degree(third) == 0:
             continue
         fourth = seed.choice(list(G.succ[third]))
-
-        if start == second or second == third or third == fourth:
+        if third == fourth:
             continue
 
         if (

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -31,7 +31,6 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     https://math.stackexchange.com/questions/22272
     https://arxiv.org/pdf/0905.4913.pdf
     """
-    # TODO which classes of graph should work? Only DiGraphs?
     if not G.is_directed():
         raise nx.NetworkXError("directed_edge_swap() is only defined for directed graphs.")
     if nswap > max_tries:
@@ -39,7 +38,6 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     if len(G) < 4:
         raise nx.NetworkXError("Graph has less than four nodes.")
 
-    # TODO should this be based solely on in/out degree, or is total degree alright?
     # Instead of choosing uniformly at random from a generated edge list,
     # this algorithm chooses nonuniformly from the set of nodes with
     # probability weighted by degree.
@@ -76,7 +74,6 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
             n += 1
             continue
 
-        # TODO do OutEdgeViews have constant time membership checking i.e. are they dicts?
         if ((start, third) not in G.out_edges(start) and
             (second, fourth) not in G.out_edges(second) and
             (third, second) not in G.out_edges(third)):

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -8,12 +8,17 @@ import networkx as nx
 
 __all__ = ["double_edge_swap", "connected_double_edge_swap", "directed_edge_swap"]
 
+
 @py_random_state(3)
 def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     """Swap three edges in a directed graph while keeping the node degrees fixed.
 
+    A directed edge swap swaps three edges such that a -> b -> c -> d becomes
+    a -> c -> b -> d. This pattern of swapping allows all possible states with the
+    same in- and out-degree distribution in a directed graph to be reached.
 
-
+    If the swap would create parallel edges (e.g. if a -> c already existed in the
+    previous example), another attempt is made to find a suitable trio of edges.
 
     Returns
     -------
@@ -32,7 +37,9 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     https://arxiv.org/pdf/0905.4913.pdf
     """
     if not G.is_directed():
-        raise nx.NetworkXError("directed_edge_swap() is only defined for directed graphs.")
+        raise nx.NetworkXError(
+            "directed_edge_swap() is only defined for directed graphs."
+        )
     if nswap > max_tries:
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
     if len(G) < 4:
@@ -68,23 +75,23 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
             continue
         _, fourth = seed.choice(list(G.out_edges(third)))
 
-        if (start == second or
-            second == third or
-            third == fourth):
+        if start == second or second == third or third == fourth:
             n += 1
             continue
 
-        if ((start, third) not in G.out_edges(start) and
-            (second, fourth) not in G.out_edges(second) and
-            (third, second) not in G.out_edges(third)):
-           # Swap nodes
-           G.add_edge(start, third)
-           G.add_edge(third, second)
-           G.add_edge(second, fourth)
-           G.remove_edge(start, second)
-           G.remove_edge(second, third)
-           G.remove_edge(third, fourth)
-           swapcount += 1
+        if (
+            (start, third) not in G.out_edges(start)
+            and (second, fourth) not in G.out_edges(second)
+            and (third, second) not in G.out_edges(third)
+        ):
+            # Swap nodes
+            G.add_edge(start, third)
+            G.add_edge(third, second)
+            G.add_edge(second, fourth)
+            G.remove_edge(start, second)
+            G.remove_edge(second, third)
+            G.remove_edge(third, fourth)
+            swapcount += 1
 
         if n >= max_tries:
             e = (

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -10,7 +10,7 @@ __all__ = ["double_edge_swap", "connected_double_edge_swap", "directed_edge_swap
 
 
 @py_random_state(3)
-def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
+def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     """Swap three edges in a directed graph while keeping the node degrees fixed.
 
     A directed edge swap swaps three edges such that a -> b -> c -> d becomes

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -20,6 +20,21 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     If the swap would create parallel edges (e.g. if a -> c already existed in the
     previous example), another attempt is made to find a suitable trio of edges.
 
+    Parameters
+    ----------
+    G : DiGraph
+       An directed graph
+
+    nswap : integer (optional, default=1)
+       Number of three-edge swaps to perform
+
+    max_tries : integer (optional)
+       Maximum number of attempts to swap edges
+
+    seed : integer, random_state, or None (default)
+        Indicator of random number generation state.
+        See :ref:`Randomness<randomness>`.
+
     Returns
     -------
     G : DiGraph
@@ -42,7 +57,8 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
     """
     if not G.is_directed():
         raise nx.NetworkXError(
-            "directed_edge_swap() is only defined for directed graphs."
+            "directed_edge_swap() is only defined for directed graphs. Use double_edge_swap "
+            "instead"
         )
     if nswap > max_tries:
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
@@ -148,7 +164,9 @@ def double_edge_swap(G, nswap=1, max_tries=100, seed=None):
     The graph G is modified in place.
     """
     if G.is_directed():
-        raise nx.NetworkXError("double_edge_swap() not defined for directed graphs.")
+        raise nx.NetworkXError(
+            "double_edge_swap() not defined for directed graphs. Use directed_edge_swap instead."
+        )
     if nswap > max_tries:
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
     if len(G) < 4:

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -2,7 +2,6 @@
 """
 
 import math
-import random
 from networkx.utils import py_random_state
 
 import networkx as nx
@@ -52,27 +51,24 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
 
     while swapcount < nswap:
         # choose source node index from discrete distribution
-        start_index = discrete_sequence(1, cdistribution=cdf, seed=seed)
+        start_index = discrete_sequence(1, cdistribution=cdf, seed=seed)[0]
         start = keys[start_index]
 
         # If the given node doesn't have any out edges, then there isn't anything to swap
-        if len(start.out_edges) == 0:
+        if G.out_degree(start) == 0:
             n += 1
             continue
+        _, second = seed.choice(list(G.out_edges(start)))
 
-        # TODO is using `random` okay, or is there a preferred way of sampling edges
-        # TODO also, how does random interact with py_random_state? Is this okay?
-        _, second = random.sample(start.out_edges, 1)
-
-        if len(second.out_edges) == 0:
+        if G.out_degree(second) == 0:
             n += 1
             continue
-        _, third = random.sample(second.out_edges, 1)
+        _, third = seed.choice(list(G.out_edges(second)))
 
-        if len(third.out_edges) == 0:
+        if G.out_degree(third) == 0:
             n += 1
             continue
-        _, fourth = random.sample(third.out_edges, 1)
+        _, fourth = seed.choice(list(G.out_edges(third)))
 
         if (start == second or
             second == third or
@@ -81,9 +77,9 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
             continue
 
         # TODO do OutEdgeViews have constant time membership checking i.e. are they dicts?
-        if ((start, third) not in start.out_edges and
-            (second, fourth) not in second.out_edges and
-            (third, second) not in third.out_edges):
+        if ((start, third) not in G.out_edges(start) and
+            (second, fourth) not in G.out_edges(second) and
+            (third, second) not in G.out_edges(third)):
            # Swap nodes
            G.add_edge(start, third)
            G.add_edge(third, second)

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -10,6 +10,7 @@ __all__ = ["double_edge_swap", "connected_double_edge_swap", "directed_edge_swap
 
 
 @py_random_state(3)
+@nx.utils.not_implemented_for("undirected")
 def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     """Swap three edges in a directed graph while keeping the node degrees fixed.
 
@@ -64,11 +65,6 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
            Degree Sequence with 2-Edge Swaps.” Mathematics Stack Exchange,
            https://math.stackexchange.com/questions/22272/. Accessed 30 May 2022.
     """
-    if not G.is_directed():
-        raise nx.NetworkXError(
-            "directed_edge_swap() is only defined for directed graphs. Use double_edge_swap "
-            "instead"
-        )
     if nswap > max_tries:
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
     if len(G) < 4:

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -40,6 +40,15 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     G : DiGraph
        The graph after triple-edge swaps.
 
+    Raises
+    ------
+    NetworkXError
+        If `G` is not directed, or
+        If nswap > max_tries, or
+        If there are fewer than 4 nodes in `G`
+    NetworkXAlgorithmError
+        If the number of swap attempts exceeds `max_tries` before `nswap` swaps are made
+
     Notes
     -----
     Does not enforce any connectivity constraints.

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -92,23 +92,23 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
         # If the given node doesn't have any out edges, then there isn't anything to swap
         if G.out_degree(start) == 0:
             continue
-        _, second = seed.choice(list(G.out_edges(start)))
+        second = seed.choice(list(G.succ[start]))
 
         if G.out_degree(second) == 0:
             continue
-        _, third = seed.choice(list(G.out_edges(second)))
+        third = seed.choice(list(G.succ[second]))
 
         if G.out_degree(third) == 0:
             continue
-        _, fourth = seed.choice(list(G.out_edges(third)))
+        fourth = seed.choice(list(G.succ[third]))
 
         if start == second or second == third or third == fourth:
             continue
 
         if (
-            (start, third) not in G.out_edges(start)
-            and (second, fourth) not in G.out_edges(second)
-            and (third, second) not in G.out_edges(third)
+            third not in G.succ[start]
+            and fourth not in G.succ[second]
+            and second not in G.succ[third]
         ):
             # Swap nodes
             G.add_edge(start, third)

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -33,8 +33,8 @@ def directed_edge_swap(G, nswap=1, max_tries=100, seed=None):
 
     References
     ----------
-    https://math.stackexchange.com/questions/22272
-    https://arxiv.org/pdf/0905.4913.pdf
+    .. [1] https://math.stackexchange.com/questions/22272
+    .. [2] https://arxiv.org/pdf/0905.4913.pdf
     """
     if not G.is_directed():
         raise nx.NetworkXError(

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -61,6 +61,8 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     .. [1] Erdős, Péter L., et al. “A Simple Havel-Hakimi Type Algorithm to Realize
            Graphical Degree Sequences of Directed Graphs.” ArXiv:0905.4913 [Math],
            Jan. 2010. https://doi.org/10.48550/arXiv.0905.4913.
+           Published  2010 in Elec. J. Combinatorics (17(1)). R66.
+           http://www.combinatorics.org/Volume_17/PDF/v17i1r66.pdf
     .. [2] “Combinatorics - Reaching All Possible Simple Directed Graphs with a given
            Degree Sequence with 2-Edge Swaps.” Mathematics Stack Exchange,
            https://math.stackexchange.com/questions/22272/. Accessed 30 May 2022.

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -83,7 +83,7 @@ def test_directed_edge_swap_tries():
         )
 
 
-def test_directed_edge_directed():
+def test_directed_exception_undirected():
     graph = nx.Graph([(0, 1), (2, 3)])
     with pytest.raises(nx.NetworkXNotImplemented):
         G = nx.directed_edge_swap(graph)

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -79,7 +79,7 @@ def test_directed_edge_swap_small():
 def test_directed_edge_swap_tries():
     with pytest.raises(nx.NetworkXError):
         G = nx.directed_edge_swap(
-            nx.gnp_random_graph(3, 0.5, directed=True), nswap=1, max_tries=0
+            nx.path_graph(3, create_using=nx.DiGraph), nswap=1, max_tries=0
         )
 
 

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -4,21 +4,24 @@ import networkx as nx
 # import random
 # random.seed(0)
 
+
 def test_directed_edge_swap():
-    graph = nx.gnp_random_graph(200, .5, directed=True)
+    graph = nx.gnp_random_graph(200, 0.5, directed=True)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
     G = nx.directed_edge_swap(graph, 40, max_tries=500)
-    assert in_degrees == sorted((n, d) for n, d  in G.in_degree())
+    assert in_degrees == sorted((n, d) for n, d in G.in_degree())
     assert out_degrees == sorted((n, d) for n, d in G.out_degree())
 
+
 def test_directed_edge_swap_seed():
-    graph = nx.gnp_random_graph(200, .5, directed=True)
+    graph = nx.gnp_random_graph(200, 0.5, directed=True)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
     G = nx.directed_edge_swap(graph, 40, max_tries=500, seed=1)
-    assert in_degrees == sorted((n, d) for n, d  in G.in_degree())
+    assert in_degrees == sorted((n, d) for n, d in G.in_degree())
     assert out_degrees == sorted((n, d) for n, d in G.out_degree())
+
 
 def test_double_edge_swap():
     graph = nx.barabasi_albert_graph(200, 1)
@@ -70,12 +73,14 @@ def test_connected_double_edge_swap_star_low_window_threshold():
 
 def test_directed_edge_swap_small():
     with pytest.raises(nx.NetworkXError):
-        G = nx.directed_edge_swap(nx.gnp_random_graph(3, .5, directed=True))
+        G = nx.directed_edge_swap(nx.gnp_random_graph(3, 0.5, directed=True))
 
 
 def test_directed_edge_swap_tries():
     with pytest.raises(nx.NetworkXError):
-        G = nx.directed_edge_swap(nx.gnp_random_graph(3, .5, directed=True), nswap=1, max_tries=0)
+        G = nx.directed_edge_swap(
+            nx.gnp_random_graph(3, 0.5, directed=True), nswap=1, max_tries=0
+        )
 
 
 def test_directed_edge_directed():
@@ -86,7 +91,9 @@ def test_directed_edge_directed():
 
 def test_directed_edge_max_tries():
     with pytest.raises(nx.NetworkXAlgorithmError):
-        G = nx.directed_edge_swap(nx.complete_graph(4, nx.DiGraph()), nswap=1, max_tries=5)
+        G = nx.directed_edge_swap(
+            nx.complete_graph(4, nx.DiGraph()), nswap=1, max_tries=5
+        )
 
 
 def test_double_edge_swap_small():

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -85,7 +85,7 @@ def test_directed_edge_swap_tries():
 
 def test_directed_edge_directed():
     graph = nx.Graph([(0, 1), (2, 3)])
-    with pytest.raises(nx.NetworkXError, match="only defined for directed graphs."):
+    with pytest.raises(nx.NetworkXNotImplemented):
         G = nx.directed_edge_swap(graph)
 
 

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -5,18 +5,18 @@ import networkx as nx
 # random.seed(0)
 
 def test_directed_edge_swap():
-    graph = nx.erdos_reyni_graph(200, .5, directed=True)
+    graph = nx.gnp_random_graph(200, .5, directed=True)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
-    G = nx.directed_edge_swap(graph, 40)
+    G = nx.directed_edge_swap(graph, 40, max_tries=500)
     assert in_degrees == sorted((n, d) for n, d  in G.in_degree())
     assert out_degrees == sorted((n, d) for n, d in G.out_degree())
 
 def test_directed_edge_swap_seed():
-    graph = nx.erdos_reyni_graph(200, .5, directed=True)
+    graph = nx.gnp_random_graph(200, .5, directed=True)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
-    G = nx.directed_edge_swap(graph, 40, seed=1)
+    G = nx.directed_edge_swap(graph, 40, max_tries=500, seed=1)
     assert in_degrees == sorted((n, d) for n, d  in G.in_degree())
     assert out_degrees == sorted((n, d) for n, d in G.out_degree())
 
@@ -70,12 +70,12 @@ def test_connected_double_edge_swap_star_low_window_threshold():
 
 def test_directed_edge_swap_small():
     with pytest.raises(nx.NetworkXError):
-        G = nx.directed_edge_swap(nx.erdos_reyni_graph(3, .5, directed=True))
+        G = nx.directed_edge_swap(nx.gnp_random_graph(3, .5, directed=True))
 
 
 def test_directed_edge_swap_tries():
     with pytest.raises(nx.NetworkXError):
-        G = nx.directed_edge_swap(nx.erdos_reyni_graph(3, .5, directed=True), nswap=1, max_tries=0)
+        G = nx.directed_edge_swap(nx.gnp_random_graph(3, .5, directed=True), nswap=1, max_tries=0)
 
 
 def test_directed_edge_directed():
@@ -84,9 +84,9 @@ def test_directed_edge_directed():
         G = nx.directed_edge_swap(graph)
 
 
-def test_double_edge_max_tries():
+def test_directed_edge_max_tries():
     with pytest.raises(nx.NetworkXAlgorithmError):
-        G = nx.double_edge_swap(nx.complete_graph(4, nx.DiGraph()), nswap=1, max_tries=5)
+        G = nx.directed_edge_swap(nx.complete_graph(4, nx.DiGraph()), nswap=1, max_tries=5)
 
 
 def test_double_edge_swap_small():

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -4,6 +4,21 @@ import networkx as nx
 # import random
 # random.seed(0)
 
+def test_directed_edge_swap():
+    graph = nx.erdos_reyni_graph(200, .5, directed=True)
+    in_degrees = sorted((n, d) for n, d in graph.in_degree())
+    out_degrees = sorted((n, d) for n, d in graph.out_degree())
+    G = nx.directed_edge_swap(graph, 40)
+    assert in_degrees == sorted((n, d) for n, d  in G.in_degree())
+    assert out_degrees == sorted((n, d) for n, d in G.out_degree())
+
+def test_directed_edge_swap_seed():
+    graph = nx.erdos_reyni_graph(200, .5, directed=True)
+    in_degrees = sorted((n, d) for n, d in graph.in_degree())
+    out_degrees = sorted((n, d) for n, d in graph.out_degree())
+    G = nx.directed_edge_swap(graph, 40, seed=1)
+    assert in_degrees == sorted((n, d) for n, d  in G.in_degree())
+    assert out_degrees == sorted((n, d) for n, d in G.out_degree())
 
 def test_double_edge_swap():
     graph = nx.barabasi_albert_graph(200, 1)
@@ -51,6 +66,27 @@ def test_connected_double_edge_swap_star_low_window_threshold():
     G = nx.connected_double_edge_swap(graph, 1, _window_threshold=0, seed=4)
     assert nx.is_connected(graph)
     assert degrees == sorted(d for n, d in graph.degree())
+
+
+def test_directed_edge_swap_small():
+    with pytest.raises(nx.NetworkXError):
+        G = nx.directed_edge_swap(nx.erdos_reyni_graph(3, .5, directed=True))
+
+
+def test_directed_edge_swap_tries():
+    with pytest.raises(nx.NetworkXError):
+        G = nx.directed_edge_swap(nx.erdos_reyni_graph(3, .5, directed=True), nswap=1, max_tries=0)
+
+
+def test_directed_edge_directed():
+    graph = nx.Graph([(0, 1), (2, 3)])
+    with pytest.raises(nx.NetworkXError, match="only defined for directed graphs."):
+        G = nx.directed_edge_swap(graph)
+
+
+def test_double_edge_max_tries():
+    with pytest.raises(nx.NetworkXAlgorithmError):
+        G = nx.double_edge_swap(nx.complete_graph(4, nx.DiGraph()), nswap=1, max_tries=5)
 
 
 def test_double_edge_swap_small():

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -73,7 +73,7 @@ def test_connected_double_edge_swap_star_low_window_threshold():
 
 def test_directed_edge_swap_small():
     with pytest.raises(nx.NetworkXError):
-        G = nx.directed_edge_swap(nx.gnp_random_graph(3, 0.5, directed=True))
+        G = nx.directed_edge_swap(nx.path_graph(3, create_using=nx.DiGraph)
 
 
 def test_directed_edge_swap_tries():

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -1,20 +1,8 @@
 import pytest
 import networkx as nx
 
-# import random
-# random.seed(0)
-
 
 def test_directed_edge_swap():
-    graph = nx.path_graph(200, create_using=nx.DiGraph)
-    in_degrees = sorted((n, d) for n, d in graph.in_degree())
-    out_degrees = sorted((n, d) for n, d in graph.out_degree())
-    G = nx.directed_edge_swap(graph, nswap=40, max_tries=500)
-    assert in_degrees == sorted((n, d) for n, d in G.in_degree())
-    assert out_degrees == sorted((n, d) for n, d in G.out_degree())
-
-
-def test_directed_edge_swap_seed():
     graph = nx.path_graph(200, create_using=nx.DiGraph)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -6,7 +6,7 @@ import networkx as nx
 
 
 def test_directed_edge_swap():
-    graph = nx.gnp_random_graph(200, 0.5, directed=True)
+    graph = nx.path_graph(200, create_using=nx.DiGraph)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
     G = nx.directed_edge_swap(graph, nswap=40, max_tries=500)
@@ -15,7 +15,7 @@ def test_directed_edge_swap():
 
 
 def test_directed_edge_swap_seed():
-    graph = nx.gnp_random_graph(200, 0.5, directed=True)
+    graph = nx.path_graph(200, create_using=nx.DiGraph)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
     G = nx.directed_edge_swap(graph, nswap=40, max_tries=500, seed=1)
@@ -73,7 +73,7 @@ def test_connected_double_edge_swap_star_low_window_threshold():
 
 def test_directed_edge_swap_small():
     with pytest.raises(nx.NetworkXError):
-        G = nx.directed_edge_swap(nx.path_graph(3, create_using=nx.DiGraph)
+        G = nx.directed_edge_swap(nx.path_graph(3, create_using=nx.DiGraph))
 
 
 def test_directed_edge_swap_tries():

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -9,7 +9,7 @@ def test_directed_edge_swap():
     graph = nx.gnp_random_graph(200, 0.5, directed=True)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
-    G = nx.directed_edge_swap(graph, 40, max_tries=500)
+    G = nx.directed_edge_swap(graph, nswap=40, max_tries=500)
     assert in_degrees == sorted((n, d) for n, d in G.in_degree())
     assert out_degrees == sorted((n, d) for n, d in G.out_degree())
 
@@ -18,7 +18,7 @@ def test_directed_edge_swap_seed():
     graph = nx.gnp_random_graph(200, 0.5, directed=True)
     in_degrees = sorted((n, d) for n, d in graph.in_degree())
     out_degrees = sorted((n, d) for n, d in graph.out_degree())
-    G = nx.directed_edge_swap(graph, 40, max_tries=500, seed=1)
+    G = nx.directed_edge_swap(graph, nswap=40, max_tries=500, seed=1)
     assert in_degrees == sorted((n, d) for n, d in G.in_degree())
     assert out_degrees == sorted((n, d) for n, d in G.out_degree())
 


### PR DESCRIPTION
I'm working on a project where I'll be swapping edges to build a baseline distribution of graphs. However, the graphs are directed, so [double_edge_swap](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.swap.double_edge_swap.html) doesn't work. I found an old issue ([#490](https://github.com/networkx/networkx/issues/490)) that mentions a three-edge swapping solution from [this paper](https://arxiv.org/pdf/0905.4913.pdf). This PR implements that algorithm, documents it, and adds tests.

A few questions:
- I named the new method `directed_edge_swap` to differentiate it from the other two swapping functions. Is that a reasonable name, or should it be `triple_edge_swap`?
- Is there a recommended method/citation style for adding references to the documentation? 
- The new method avoids creating parallel edges to allow it to work with DiGraph objects, but this leads to situations where it won't perform a swap that would be valid in a MultiDiGraph. I did it that way to be consistent with `double_edge_swap`, but wanted to make sure that that is the intended behavior since neither `double_edge_swap` nor the new `directed_edge_swap` prohibit Multi*[Di]Graph objects. 
- When I edit `release_dev.rst`, should this be listed as an improvement or an API change?