### PR TITLE
fix bug for directed graphs

### DIFF
--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -250,7 +250,7 @@ def _one_level(G, m, partition, resolution=1, is_directed=False, seed=None):
                             out_degree * Stot_in[nbr_com]
                             + in_degree * Stot_out[nbr_com]
                         )
-                        / m
+                        / (2*m)
                     )
                 else:
                     gain = 2 * wt - resolution * (Stot[nbr_com] * degree) / m


### PR DESCRIPTION
if you read the original document for directed louvain (https://hal.archives-ouvertes.fr/hal-01231784/document), you'll see that in section 2, the equation for gain in the undirected case (delta Q) has a factor of 2 divided into both sides of the equation, whereas the directed case has that factor missing from both sides. In the previous code here, the factor was missing from only the first fraction, so I also "remove" it here to balance things out. Equivalently, this makes "resolution" twice as effective as before, thereby matching its strength in the undirected case

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
