### PR TITLE
Error out when pydot fails to correctly parse node names

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -214,6 +214,11 @@ def to_pydot(N):
     for n, nodedata in N.nodes(data=True):
         str_nodedata = {k: str(v) for k, v in nodedata.items()}
         p = pydot.Node(str(n), **str_nodedata)
+        # Explicitly catch all node name parsing errors
+        if len(str(n)) != len(p.get_name()):
+            raise ValueError(
+                f"{str(n)} is not a valid node name while using pydot. Please refer https://github.com/pydot/pydot/issues/258"
+            )
         P.add_node(p)
 
     if N.is_multigraph():
@@ -333,6 +338,11 @@ def pydot_layout(G, prog="neato", root=None):
     node_pos = {}
     for n in G.nodes():
         pydot_node = pydot.Node(str(n)).get_name()
+        # Explicitly catch all node name parsing errors
+        if len(str(n)) != len(pydot_node):
+            raise ValueError(
+                f"{str(n)} is not a valid node name while using pydot. Please refer https://github.com/pydot/pydot/issues/258"
+            )
         node = Q.get_node(pydot_node)
 
         if isinstance(node, list):

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,11 +1,12 @@
 """Unit tests for pydot drawing functions."""
-from io import StringIO
-import tempfile
 import os
-import networkx as nx
-from networkx.utils import graphs_equal
+import tempfile
+from io import StringIO
 
 import pytest
+
+import networkx as nx
+from networkx.utils import graphs_equal
 
 pydot = pytest.importorskip("pydot")
 
@@ -96,3 +97,13 @@ class TestPydot:
         fh.seek(0)
         H = nx.nx_pydot.read_dot(fh)
         assert graphs_equal(G, H)
+
+    def test_pydot_issue_258(self):
+        G = nx.Graph([("Example:A", 1)])
+        with pytest.raises(ValueError):
+            nx.nx_pydot.to_pydot(G)
+        with pytest.raises(ValueError):
+            nx.nx_pydot.pydot_layout(G)
+        G = nx.Graph([('"Example:A"', 1)])
+        layout = nx.nx_pydot.pydot_layout(G)
+        assert isinstance(layout, dict)


### PR DESCRIPTION
Maybe we should error out gracefully when there is an issue with converting a python string (name of the node in the networkx object) to a pydot Node object.

This should help out with issues like https://github.com/networkx/networkx/issues/5662, https://github.com/networkx/networkx/issues/4663

Also this way we can probably catch other parsing errors, not just `:` ones.