### PR TITLE
DRAFT: Adding support for a GraphBLAS backend

### DIFF
--- a/networkx/graphblas/__init__.py
+++ b/networkx/graphblas/__init__.py
@@ -1,0 +1,1 @@
+from networkx.graphblas.algorithms import *

--- a/networkx/graphblas/algorithms/__init__.py
+++ b/networkx/graphblas/algorithms/__init__.py
@@ -1,0 +1,3 @@
+from networkx.graphblas.algorithms.cluster import *
+from networkx.graphblas.algorithms.link_analysis import *
+from networkx.graphblas.algorithms.reciprocity import *

--- a/networkx/graphblas/algorithms/cluster.py
+++ b/networkx/graphblas/algorithms/cluster.py
@@ -1,0 +1,81 @@
+from graphblas import binary
+from graphblas.semiring import plus_pair
+from graphblas_algorithms.algorithms.cluster import (
+    average_clustering_core, average_clustering_directed_core, clustering_core,
+    clustering_directed_core, single_clustering_core,
+    single_clustering_directed_core, single_triangle_core, transitivity_core,
+    transitivity_directed_core, triangles_core)
+from graphblas_algorithms.classes.digraph import to_graph
+from graphblas_algorithms.classes.graph import to_undirected_graph
+from graphblas_algorithms.utils import not_implemented_for
+
+from networkx import average_clustering as _nx_average_clustering
+from networkx import clustering as _nx_clustering
+
+
+@not_implemented_for("directed")
+def triangles(G, nodes=None):
+    G = to_undirected_graph(G, dtype=bool)
+    if len(G) == 0:
+        return {}
+    if nodes in G:
+        return single_triangle_core(G, nodes)
+    mask = G.list_to_mask(nodes)
+    result = triangles_core(G, mask=mask)
+    return G.vector_to_dict(result, mask=mask, fillvalue=0)
+
+
+def average_clustering(G, nodes=None, weight=None, count_zeros=True):
+    if weight is not None:
+        # TODO: Not yet implemented.  Clustering implemented only for unweighted.
+        return _nx_average_clustering(
+            G, nodes=nodes, weight=weight, count_zeros=count_zeros
+        )
+    G = to_graph(G, weight=weight)  # to directed or undirected
+    if len(G) == 0:
+        raise ZeroDivisionError()  # Not covered
+    mask = G.list_to_mask(nodes)
+    if G.is_directed():
+        func = average_clustering_directed_core
+    else:
+        func = average_clustering_core
+    if mask is None:
+        return G._cacheit(
+            f"average_clustering(count_zeros={count_zeros})",
+            func,
+            G,
+            count_zeros=count_zeros,
+        )
+    else:
+        return func(G, mask=mask, count_zeros=count_zeros)
+
+
+def clustering(G, nodes=None, weight=None):
+    if weight is not None:
+        # TODO: Not yet implemented.  Clustering implemented only for unweighted.
+        return _nx_clustering(G, nodes=nodes, weight=weight)
+    G = to_graph(G, weight=weight)  # to directed or undirected
+    if len(G) == 0:
+        return {}
+    if nodes in G:
+        if G.is_directed():
+            return single_clustering_directed_core(G, nodes)
+        else:
+            return single_clustering_core(G, nodes)
+    mask = G.list_to_mask(nodes)
+    if G.is_directed():
+        result = clustering_directed_core(G, mask=mask)
+    else:
+        result = clustering_core(G, mask=mask)
+    return G.vector_to_dict(result, mask=mask, fillvalue=0.0)
+
+
+def transitivity(G):
+    G = to_graph(G, dtype=bool)  # directed or undirected
+    if len(G) == 0:
+        return 0
+    if G.is_directed():
+        func = transitivity_directed_core
+    else:
+        func = transitivity_core
+    return G._cacheit("transitivity", func, G)

--- a/networkx/graphblas/algorithms/link_analysis/__init__.py
+++ b/networkx/graphblas/algorithms/link_analysis/__init__.py
@@ -1,0 +1,1 @@
+from networkx.graphblas.algorithms.link_analysis.pagerank_alg import *

--- a/networkx/graphblas/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/graphblas/algorithms/link_analysis/pagerank_alg.py
@@ -1,0 +1,44 @@
+from warnings import warn
+
+from graphblas import Vector, binary, unary
+from graphblas.semiring import plus_first, plus_times
+from graphblas_algorithms.algorithms.link_analysis.pagerank_alg import \
+    pagerank_core
+from graphblas_algorithms.classes.digraph import to_graph
+
+import networkx as nx
+
+
+def pagerank(
+    G,
+    alpha=0.85,
+    personalization=None,
+    max_iter=100,
+    tol=1e-06,
+    nstart=None,
+    weight="weight",
+    dangling=None,
+):
+    G = to_graph(G, weight=weight, dtype=float)
+    N = len(G)
+    if N == 0:
+        return {}
+    # We'll normalize initial, personalization, and dangling vectors later
+    x = G.dict_to_vector(nstart, dtype=float, name="nstart")
+    p = G.dict_to_vector(personalization, dtype=float, name="personalization")
+    row_degrees = G.get_property("plus_rowwise+")  # XXX: What about self-edges?
+    if dangling is not None and row_degrees.nvals < N:
+        dangling_weights = G.dict_to_vector(dangling, dtype=float, name="dangling")
+    else:
+        dangling_weights = None
+    result = pagerank_core(
+        G,
+        alpha=alpha,
+        personalization=p,
+        max_iter=max_iter,
+        tol=tol,
+        nstart=x,
+        dangling=dangling_weights,
+        row_degrees=row_degrees,
+    )
+    return G.vector_to_dict(result, fillvalue=0.0)

--- a/networkx/graphblas/algorithms/reciprocity.py
+++ b/networkx/graphblas/algorithms/reciprocity.py
@@ -1,0 +1,32 @@
+from graphblas import binary
+from graphblas_algorithms.algorithms.reciprocity import (
+    overall_reciprocity_core, reciprocity_core)
+from graphblas_algorithms.classes.digraph import to_directed_graph
+
+from networkx import NetworkXError
+from networkx.utils import not_implemented_for
+
+
+@not_implemented_for("undirected", "multigraph")
+def reciprocity(G, nodes=None):
+    if nodes is None:
+        return overall_reciprocity(G)
+    G = to_directed_graph(G, dtype=bool)
+    if nodes in G:
+        mask = G.list_to_mask([nodes])
+        result = reciprocity_core(G, mask=mask)
+        rv = result[G._key_to_id[nodes]].value
+        if rv is None:
+            raise NetworkXError("Not defined for isolated nodes.")
+        else:
+            return rv
+    else:
+        mask = G.list_to_mask(nodes)
+        result = reciprocity_core(G, mask=mask)
+        return G.vector_to_dict(result, mask=mask)
+
+
+@not_implemented_for("undirected", "multigraph")
+def overall_reciprocity(G):
+    G = to_directed_graph(G, dtype=bool)
+    return overall_reciprocity_core(G)


### PR DESCRIPTION
This a minimal draft PR to get the conversation rolling. I have moved bits of algorithms from https://github.com/python-graphblas/graphblas-algorithms (currently being developed by @eriknw) so that we can "natively" support a GraphBLAS backend. This does require people to have [suitesparse-graphblas](https://github.com/GraphBLAS/python-suitesparse-graphblas) available locally and pypi only has wheels for linux right now (that shouldn't be a big issue atleast right now I guess).
 
For the API bits, I was thinking of creating an independent submodule where users needs to explicitly call to use graphblas.

Current API in this PR and performance comparison with our current implementations:
``` python
In [1]: import networkx.graphblas as gnx

In [2]: import networkx as nx

In [3]: G = nx.erdos_renyi_graph(500, 0.8)

In [4]: %%timeit
   ...: gnx.average_clustering(G)
   ...: 
   ...: 
204 ms ± 2.49 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [5]: %%timeit
   ...: nx.average_clustering(G)
   ...: 
   ...: 
   ...: 
6.97 s ± 606 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %%timeit
   ...: gnx.transitivity(G)
   ...: 
   ...: 
177 ms ± 7.41 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [7]: %%timeit
   ...: nx.transitivity(G)
   ...: 
   ...: 
7.18 s ± 570 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [8]: %%timeit
   ...: nx.pagerank(G)
   ...: 
   ...: 
106 ms ± 2.85 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [9]: %%timeit
   ...: gnx.pagerank(G)
   ...: 
   ...: 
124 ms ± 2.88 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```