### PR TITLE
Add workaround for pytest failures on 3.11b2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
 
     - name: Test NetworkX
       run: |
-        pytest --durations=10 --pyargs networkx
+        # NOTE: --assert=plain necessary to work around known pytest issue.
+        # See pytest-dev/pytest#10008
+        pytest --durations=10 --pyargs --assert=plain networkx
 
   default:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
Temporary workaround for pytest failures on 3.11b2. See #5679, pytest-dev/pytest#10008, and the [Python 3.11b2 release notes](https://www.python.org/downloads/release/python-3110b2/) for more info.