### PR TITLE
Remove unused logic in nonisomorphic_trees

### DIFF
--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -174,7 +174,6 @@ def _layout_to_matrix(layout):
 def _layout_to_graph(layout):
     """Create a NetworkX Graph for the tree specified by the
     given layout(level sequence)"""
-    result = [[0] * len(layout) for i in range(len(layout))]
     G = nx.Graph()
     stack = []
     for i in range(len(layout)):


### PR DESCRIPTION
This PR removes a line of code that is called, but doesn't do anything.

I noticed this when looking at the code for the currently longest running tests on the CI. I was checking to see if there was any small speedups that could be made in here (nothing that I saw that really that has any major impact, there might be a way to do the first step of `_split_tree` faster with a generator, two next calls, and a try/except StopIteration). But did I notice this one line that (unless I'm really missing something) doesn't seem to do anything. Removing it speeds up the test a tiny amount (but not in a noticeable way). Either way I thought I'd make a quick PR to clean it up.

This should be an obvious review and merge. The variable `result` is assigned to but never used (it even causes flake8 to raise a F841 error, so not sure why networkx dashboard linters aren't catching it). It also doesn't seem like the line has any side effects that could influence anything. It's just calling `len` on `layout`, so unless there is a fancy `__len__` method with side effects, I'm going to say this is safe to remove.

Anyway, I'm writing way too much for a PR of this size / scope. PTAL