### PR TITLE
importorskip scipy instead of numpy for total spanning tree

### DIFF
--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -375,7 +375,7 @@ def test_random_spanning_tree_multiplicative_small():
     """
     from math import exp
 
-    pytest.importorskip("numpy")
+    pytest.importorskip("scipy")
 
     gamma = {
         (0, 1): -0.6383,
@@ -499,7 +499,7 @@ def test_random_spanning_tree_additive_small():
     """
     Sample a single spanning tree from the additive method.
     """
-    pytest.importorskip("numpy")
+    pytest.importorskip("scipy")
 
     edges = {
         (0, 1): 1,


### PR DESCRIPTION
fixes https://github.com/networkx/networkx/issues/5692

To catch this we would have to run a CI pipeline with numpy but without scipy. I don't think we should be doing that as it takes up too much CI time, so just adding a fix and no test.