### PR TITLE
Add validation for distance kwarg in closeness_centrality.

### DIFF
--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -104,6 +104,13 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True):
         G = G.reverse()  # create a reversed graph view
 
     if distance is not None:
+        # If `distance` is given, ensure that it is an attribute on at least
+        # one edge.
+        if {attr for _, _, attr in G.edges(data=distance)} == {None}:
+            raise ValueError(
+                f"No edges found with distance={distance}. "
+                "Use distance=None for the unweighted case."
+            )
         # use Dijkstra's algorithm with specified attribute as edge weight
         path_length = functools.partial(
             nx.single_source_dijkstra_path_length, weight=distance

--- a/networkx/algorithms/centrality/tests/test_closeness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_closeness_centrality.py
@@ -324,5 +324,3 @@ def test_distance_kwarg_is_not_edge_attr():
     # Correct distance attribute gives weighted closeness centrality
     weighted_cc = nx.closeness_centrality(G, distance="len")
     assert weighted_cc == {0: 0.375, 1: 0.5, 2: 0.5, 3: 0.375}
-
-    

--- a/networkx/algorithms/centrality/tests/test_closeness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_closeness_centrality.py
@@ -304,3 +304,25 @@ class TestClosenessCentrality:
             assert set(test_cc.items()) == set(real_cc.items())
 
             prev_cc = test_cc
+
+
+def test_distance_kwarg_is_not_edge_attr():
+    """If the distance kwarg is not None, at least one edge should have the
+    specified distance attribute. If not, then it's likely that the distance
+    kwarg was misspelled. See gh-3880."""
+    # A path graph w/ 4 nodes where the central edge twice as "long" as the others
+    G = nx.path_graph(4)
+    G[1][2]["len"] = 2
+
+    # Raise exception if distance is given but not an attr of any edge
+    with pytest.raises(ValueError, match="No edges found"):
+        nx.closeness_centrality(G, distance="not_a_valid_edge_attr")
+
+    # Default case gives unweighted closeness centrality
+    assert nx.closeness_centrality(G) == {0: 0.5, 1: 0.75, 2: 0.75, 3: 0.5}
+
+    # Correct distance attribute gives weighted closeness centrality
+    weighted_cc = nx.closeness_centrality(G, distance="len")
+    assert weighted_cc == {0: 0.375, 1: 0.5, 2: 0.5, 3: 0.375}
+
+    


### PR DESCRIPTION
Closes #3880

Validates that *at least one* edge in the graph has the `distance` parameter as an attribute in the case when `distance` is provided by the user. This should make the function more robust against e.g. misspellings or otherwise incorrect keys, at the cost of looping through all edges in the graph. Whether or not this is a tradeoff worth making I leave to others to decide. FWIW I would be okay with closing this and #3880 as a "won't fix" and perhaps just adding an admonishment to the docstring to be extra careful about the `distance` kwarg.