### PR TITLE
Add docstring example for attr transfer to linegraph.

### DIFF
--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -43,6 +43,18 @@ def line_graph(G, create_using=None):
     >>> print(sorted(map(sorted, L.edges())))  # makes a 3-clique, K3
     [[(0, 1), (0, 2)], [(0, 1), (0, 3)], [(0, 2), (0, 3)]]
 
+    Edge attributes from `G` are not copied over as node attributes in `L`, but
+    attributes can be copied manually:
+
+    >>> G = nx.path_graph(4)
+    >>> G.add_edges_from((u, v, {"tot": u+v}) for u, v in G.edges)
+    >>> G.edges(data=True)
+    EdgeDataView([(0, 1, {'tot': 1}), (1, 2, {'tot': 3}), (2, 3, {'tot': 5})])
+    >>> H = nx.line_graph(G)
+    >>> H.add_nodes_from((node, G.edges[node]) for node in H)
+    >>> H.nodes(data=True)
+    NodeDataView({(0, 1): {'tot': 1}, (2, 3): {'tot': 5}, (1, 2): {'tot': 3}})
+
     Notes
     -----
     Graph, node, and edge data are not propagated to the new graph. For


### PR DESCRIPTION
Closes #4483 by adopting @dschult 's suggested docstring example.

Co-authored-by: Dan Schult <dschult@colgate.edu>