### PR TITLE
Touchups to MG and MDG edges docstrings.

### DIFF
--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -569,14 +569,14 @@ class MultiDiGraph(MultiGraph, DiGraph):
         as well as edge attribute lookup. When called, it also provides
         an EdgeDataView object which allows control of access to edge
         attributes (but does not provide set-like operations).
-        Hence, `G.edges[u, v, k]['color']` provides the value of the color
-        attribute for edge from `u` to `v` with key `k` while
-        `for (u, v, k, c) in G.edges(data='color', default='red',
-        keys=True):` iterates through all the edges yielding the color
-        attribute with default `'red'` if no color attribute exists.
+        Hence, ``G.edges[u, v, k]['color']`` provides the value of the color
+        attribute for the edge from ``u`` to ``v`` with key ``k`` while
+        ``for (u, v, k, c) in G.edges(data='color', default='red', keys=True):``
+        iterates through all the edges yielding the color attribute with
+        default `'red'` if no color attribute exists.
 
         Edges are returned as tuples with optional data and keys
-        in the order (node, neighbor, key, data). If `keys=True` is not
+        in the order (node, neighbor, key, data). If ``keys=True`` is not
         provided, the tuples will just be (node, neighbor, data), but
         multiple tuples with the same node and neighbor will be
         generated when multiple edges between two nodes exist.
@@ -599,10 +599,10 @@ class MultiDiGraph(MultiGraph, DiGraph):
 
         Returns
         -------
-        edges : EdgeView
+        edges : OutMultiEdgeView
             A view of edge attributes, usually it iterates over (u, v)
             (u, v, k) or (u, v, k, d) tuples of edges, but can also be
-            used for attribute lookup as `edges[u, v, k]['foo']`.
+            used for attribute lookup as ``edges[u, v, k]['foo']``.
 
         Notes
         -----

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -763,17 +763,21 @@ class MultiGraph(Graph):
 
         edges(self, nbunch=None, data=False, keys=False, default=None)
 
-        The EdgeView provides set-like operations on the edge-tuples
+        The MultiEdgeView provides set-like operations on the edge-tuples
         as well as edge attribute lookup. When called, it also provides
         an EdgeDataView object which allows control of access to edge
         attributes (but does not provide set-like operations).
-        Hence, `G.edges[u, v, k]['color']` provides the value of the color
-        attribute for edge `(u, v, k)` while
-        `for (u, v, c) in G.edges(data='color', default='red'):`
-        iterates through all the edges yielding the color attribute.
+        Hence, ``G.edges[u, v, k]['color']`` provides the value of the color
+        attribute for the edge from ``u`` to ``v`` with key ``k`` while
+        ``for (u, v, k, c) in G.edges(data='color', keys=True, default="red"):``
+        iterates through all the edges yielding the color attribute with
+        default `'red'` if no color attribute exists.
 
         Edges are returned as tuples with optional data and keys
-        in the order (node, neighbor, key, data).
+        in the order (node, neighbor, key, data). If ``keys=True`` is not
+        provided, the tuples will just be (node, neighbor, data), but
+        multiple tuples with the same node and neighbor will be generated
+        when multiple edges exist between two nodes.
 
         Parameters
         ----------
@@ -795,7 +799,7 @@ class MultiGraph(Graph):
         edges : MultiEdgeView
             A view of edge attributes, usually it iterates over (u, v)
             (u, v, k) or (u, v, k, d) tuples of edges, but can also be
-            used for attribute lookup as `edges[u, v, k]['foo']`.
+            used for attribute lookup as ``edges[u, v, k]['foo']``.
 
         Notes
         -----
@@ -804,7 +808,7 @@ class MultiGraph(Graph):
 
         Examples
         --------
-        >>> G = nx.MultiGraph()  # or MultiDiGraph
+        >>> G = nx.MultiGraph()
         >>> nx.add_path(G, [0, 1, 2])
         >>> key = G.add_edge(2, 3, weight=5)
         >>> key2 = G.add_edge(2, 1, weight=2)  # multi-edge


### PR DESCRIPTION
Follow-up to #5389 to further refine the docstrings for the `edges` property of the MultiGraph and MultiDiGraph classes.

Closes #4962, which was already mostly addressed in #5389.