### PR TITLE
Catch ':' explicitly while working with pydot

### DIFF
--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -98,12 +98,56 @@ class TestPydot:
         H = nx.nx_pydot.read_dot(fh)
         assert graphs_equal(G, H)
 
-    def test_pydot_issue_258(self):
-        G = nx.Graph([("Example:A", 1)])
-        with pytest.raises(ValueError):
-            nx.nx_pydot.to_pydot(G)
-        with pytest.raises(ValueError):
-            nx.nx_pydot.pydot_layout(G)
-        G = nx.Graph([('"Example:A"', 1)])
-        layout = nx.nx_pydot.pydot_layout(G)
-        assert isinstance(layout, dict)
+
+def test_pydot_issue_258():
+    G = nx.Graph([("Example:A", 1)])
+    with pytest.raises(ValueError):
+        nx.nx_pydot.to_pydot(G)
+    with pytest.raises(ValueError):
+        nx.nx_pydot.pydot_layout(G)
+
+    G = nx.Graph()
+    G.add_node("1.2", style="filled", fillcolor="red:yellow")
+    with pytest.raises(ValueError):
+        nx.nx_pydot.to_pydot(G)
+    G.remove_node("1.2")
+    G.add_node("1.2", style="filled", fillcolor='"red:yellow"')
+    assert (
+        G.nodes.data() == nx.nx_pydot.from_pydot(nx.nx_pydot.to_pydot(G)).nodes.data()
+    )
+
+    G = nx.DiGraph()
+    G.add_edge("1", "2", foo="bar:1")
+    with pytest.raises(ValueError):
+        nx.nx_pydot.to_pydot(G)
+    G = nx.DiGraph()
+    G.add_edge("1", "2", foo='"bar:1"')
+    assert G["1"]["2"] == nx.nx_pydot.from_pydot(nx.nx_pydot.to_pydot(G))["1"]["2"]
+
+    G = nx.MultiGraph()
+    G.add_edge("1", "2", foo="b:1")
+    G.add_edge("1", "2", bar="foo:foo")
+    with pytest.raises(ValueError):
+        nx.nx_pydot.to_pydot(G)
+    G = nx.MultiGraph()
+    G.add_edge("1", "2", foo='"b:1"')
+    G.add_edge("1", "2", bar='"foo:foo"')
+    # Keys as integers aren't preserved in the conversion. They are read as strings.
+    assert [attr for _, _, attr in G.edges.data()] == [
+        attr
+        for _, _, attr in nx.nx_pydot.from_pydot(nx.nx_pydot.to_pydot(G)).edges.data()
+    ]
+
+    G = nx.Graph()
+    G.add_edge("1", "2")
+    G["1"]["2"]["f:oo"] = "bar"
+    with pytest.raises(ValueError):
+        nx.nx_pydot.to_pydot(G)
+    G = nx.Graph()
+    G.add_edge("1", "2")
+    G["1"]["2"]['"f:oo"'] = "bar"
+    assert G["1"]["2"] == nx.nx_pydot.from_pydot(nx.nx_pydot.to_pydot(G))["1"]["2"]
+
+    G = nx.Graph([('"Example:A"', 1)])
+    layout = nx.nx_pydot.pydot_layout(G)
+    assert isinstance(layout, dict)


### PR DESCRIPTION
pydot has it's own mechanism to deal with quoting string and we shouldn't try to change that.

In https://github.com/networkx/networkx/pull/5667 I added a catch all which didn't work with the internal system of pydot as it adds quotes for some strings.

In this PR I am explicitly looking for `:` and if someone provides a node/edge name/attribute without the double quotes it will fail on the them gracefully. But this change should keep on working for people who were depending on pydot to add quotes to their strings.
