### PR TITLE
Default to lightmode for documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,7 +135,7 @@ html_theme_options = {
         },
     ],
     "external_links": [{"name": "Guides", "url": "https://networkx.org/nx-guides/"}],
-    "navbar_end": ["navbar-icon-links", "version"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links", "version"],
     "page_sidebar_items": ["search-field", "page-toc", "edit-this-page"],
 }
 html_sidebars = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -188,6 +188,7 @@ html_context = {
         "latest": "devel (latest)",
         "stable": "current (stable)",
     },
+    "default_mode": "light",
 }
 
 # Options for LaTeX output

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -52,7 +52,9 @@ def extrema_bounding(G, compute="diameter"):
     NetworkXError
         If the graph consists of multiple components
     ValueError
-        If `compute` is not one of "diameter", "radius", "periphery", "center", or "eccentricities".
+        If `compute` is not one of "diameter", "radius", "periphery", "center",
+        or "eccentricities".
+
     Notes
     -----
     This algorithm was proposed in the following papers:


### PR DESCRIPTION
Closes #5714.

Sets the default documentation theme back to light mode, but adds a toggle to the navbar to allow users to try the dark mode theme if they wish. I advocate for defaulting to light mode until we've had time to investigate how well dark mode works for the docs and whether there's anything that needs to be tweaked (darkmode logo, banners, pygments (syntax highlighting) themes, etc.)