### PR TITLE
Revert "Add workaround for pytest failures on 3.11b2"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,7 @@ jobs:
 
     - name: Test NetworkX
       run: |
-        # NOTE: --assert=plain necessary to work around known pytest issue.
-        # See pytest-dev/pytest#10008
-        pytest --durations=10 --pyargs --assert=plain networkx
+        pytest --durations=10 --pyargs networkx
 
   default:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
Reverts networkx/networkx#5680

This should no longer be necessary with Python 3.11b3 out.