### PR TITLE
Add durations flag to coverage run on CI.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,5 +34,5 @@ jobs:
 
     - name: Test NetworkX
       run: |
-        pytest --cov=networkx --runslow --doctest-modules --pyargs networkx
+        pytest --cov=networkx --runslow --doctest-modules --durations=20 --pyargs networkx
         codecov


### PR DESCRIPTION
This is the longest-running job so it'd be good to have a bit
more info on the test runtimes in github actions.