### PR TITLE
Characteristic polynomial

### DIFF
--- a/networkx/algorithms/polynomials.py
+++ b/networkx/algorithms/polynomials.py
@@ -13,7 +13,7 @@ from collections import deque
 import networkx as nx
 from networkx.utils import not_implemented_for
 
-__all__ = ["tutte_polynomial", "chromatic_polynomial"]
+__all__ = ["tutte_polynomial", "chromatic_polynomial", "characteristic_polynomial"]
 
 
 @not_implemented_for("directed")
@@ -288,3 +288,85 @@ def chromatic_polynomial(G):
             stack.append(G)
             stack.append(C)
     return polynomial
+
+
+def characteristic_polynomial(G):
+    r"""Returns the characteristic polynomial of `G`.
+
+    The characteristic polynomial `p_G(x)` is a fundamental graph polynomial
+    invariant in one variable that encodes information about the spectrum of a
+    graph [1]_.
+
+    Def 1: For a graph `G` of size `n` with adjacency matrix `A`, the
+    characteristic polynomial `p_G(x)` is a polynomial whose roots are the
+    eigenvalues of `A`. In particular:
+
+    .. math::
+
+        p_G(x) = det(xI - A) = \prod (x - \lamda_i)
+
+    where `I` is the `n \times n` identity matrix, and `\lamda_1,\dots,\lamdba_n`
+    are the eigenvalues of `A` [2]_.
+
+
+    Def 2: Let `[n]` be the set of integers from `1` to `n`. For a graph `G` of
+    size `n` with adjacency matrix `A`, a principal minor is a the determinant
+    of a submatrix of `A` obtained by taking rows `m_1, \dots, m_k` and columns
+    `m_1, \dots, m_k` of `A`, where `{\ m_1, \dots, m_k \} \subseteq [n]` (e.g.
+    for `n \geq 2` A[:2,:2] is a principal minor of `A`). Let `a_i` be the sum
+    of all principal minors of `A` of size `i \times i`. Then [3]_:
+
+    .. math::
+
+        p_G(x) = \sum_{i=0}^n (-1)^i a_i x^{n-i}
+
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    Returns
+    -------
+    instance of `sympy.core.add.Add`
+        A Sympy expression representing the characteristic polynomial for `G`.
+
+    Examples
+    --------
+    >>> C = nx.cycle_graph(5)
+    >>> nx.characteristic_polynomial(C)
+    x**5 - 5*x**3 + 5*x - 2
+
+    >>> G = nx.complete_graph(4)
+    >>> nx.characteristic_polynomial(G)
+    x**4 - 6*x**2 - 8*x - 3
+
+    Notes
+    -----
+    Directed graphs with the same characteristic polynomial are known as
+    cospectral [3]_. Due to Definition 2 above: `c_1 = 0`, `c_2` is the number
+    of edges of `G`, and `c_3` is twice the number of triangles of `G` [4]_.
+
+    References
+    ----------
+    .. [1] E. W. Weisstein
+       "Graph Spectrum"
+       MathWorld--A Wolfram Web Resource
+       https://mathworld.wolfram.com/GraphSpectrum.html
+    .. [2] A. Saberi,
+       "Matching Theory: Lecture 7"
+       http://web.stanford.edu/class/msande319/MatchingSpring19/lecture07.pdf
+    .. [3] A. Mowshowitz,
+       "The Characteristic Polynomial of a Graph"
+       Journal of Combinatorial Theory, 1972
+       https://www.sciencedirect.com/science/article/pii/0095895672900238
+    .. [4] H. Q. Ngo,
+       "Introduction to Algebraic Graph Theory"
+       https://cse.buffalo.edu/~hungngo/classes/2005/Expanders/notes/AGT-intro.pdf
+    """
+    import sympy
+
+    x = sympy.Symbol("x")
+    A = nx.adjacency_matrix(G)
+    M = sympy.SparseMatrix(A.todense())
+
+    return M.charpoly(x).as_expr()

--- a/networkx/algorithms/tests/test_polynomials.py
+++ b/networkx/algorithms/tests/test_polynomials.py
@@ -7,7 +7,7 @@ import networkx as nx
 sympy = pytest.importorskip("sympy")
 
 
-# Mapping of input graphs to a string representation of their tutte polynomials
+# Mapping of input graphs to a string representation of their polynomials
 _test_tutte_graphs = {
     nx.complete_graph(1): "1",
     nx.complete_graph(4): "x**3 + 3*x**2 + 4*x*y + 2*x + y**3 + 3*y**2 + 2*y",
@@ -21,6 +21,14 @@ _test_chromatic_graphs = {
     nx.cycle_graph(5): "x**5 - 5*x**4 + 10*x**3 - 10*x**2 + 4*x",
     nx.diamond_graph(): "x**4 - 5*x**3 + 8*x**2 - 4*x",
     nx.path_graph(5): "x**5 - 4*x**4 + 6*x**3 - 4*x**2 + x",
+}
+
+_test_characteristic_graphs = {
+    nx.complete_graph(1): "x",
+    nx.complete_graph(4): "x**4 - 6*x**2 - 8*x - 3",
+    nx.cycle_graph(5): "x**5 - 5*x**3 + 5*x - 2",
+    nx.diamond_graph(): "x**4 - 5*x**2 - 4*x",
+    nx.path_graph(5): "x**5 - 4*x**3 + 3*x",
 }
 
 
@@ -55,3 +63,8 @@ def test_chromatic_polynomial_disjoint(G):
     H = nx.disjoint_union(G, G)
     x_h = nx.chromatic_polynomial(H)
     assert sympy.simplify(x_g * x_g).equals(x_h)
+
+
+@pytest.mark.parametrize(("G", "expected"), _test_characteristic_graphs.items())
+def test_characteristic_polynomial(G, expected):
+    assert nx.characteristic_polynomial(G).equals(expected)


### PR DESCRIPTION
This PR implements the characteristic polynomial, continuing development of [graph polynomial algorithms](https://networkx.org/documentation/latest/reference/algorithms/polynomials.html?highlight=graph+polynomials).

I was curious how best to implement the matrix conversion. Sympy already [implements](https://github.com/sympy/sympy/blob/77f1d79c705da5e9b3dee456a14b1b4e92dd620c/sympy/matrices/determinant.py#L333) the [Samuelson-Berkowitz algorithm](https://en.wikipedia.org/wiki/Samuelson%E2%80%93Berkowitz_algorithm), which is fast, but doesn't take scipy's `csr_matrix` format. I considered the following three variants:

```
def chromatic_polynomial_method_1(G):
    x = sympy.Symbol("x")
    A = nx.adjacency_matrix(G)
    M = sympy.Matrix(A.todense())
    return M.charpoly(x).as_expr()

def chromatic_polynomial_method_2(G):
    n = len(G)
    x = sympy.Symbol("x")
    A = nx.adjacency_matrix(G)
    M = sympy.SparseMatrix(n, n, dict(A.todok()))
    return M.charpoly(x).as_expr()

def chromatic_polynomial_method_3(G):
    x = sympy.Symbol("x")
    A = nx.adjacency_matrix(G)
    M = sympy.SparseMatrix(A.todense())
    return M.charpoly(x).as_expr()
```

and took the average run time of binomial random graphs G(n, p) with n from 10 to 34, over p from 0.05 to 0.95 (increments of 0.05):

![benchmark](https://user-images.githubusercontent.com/12187602/173261607-cec53634-0cbc-4012-b35e-9c7fdc464c90.png)

Differences are negligible for small graphs, but method 3 (implemented in this commit) appears preferable as n grows.

Thank you!