### PR TITLE
Add keep_multiple_directed_edges param

### DIFF
--- a/networkx/algorithms/tree/tests/test_recognition.py
+++ b/networkx/algorithms/tree/tests/test_recognition.py
@@ -1,5 +1,4 @@
 import pytest
-from typing import Optional
 
 import networkx as nx
 

--- a/networkx/algorithms/tree/tests/test_recognition.py
+++ b/networkx/algorithms/tree/tests/test_recognition.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Optional
 
 import networkx as nx
 
@@ -85,8 +86,8 @@ class TestTreeRecognition:
 
 
 class TestDirectedTreeRecognition(TestTreeRecognition):
-    graph = nx.DiGraph
-    multigraph = nx.MultiDiGraph
+    graph = nx.DiGraph # type: ignore
+    multigraph = nx.MultiDiGraph # type: ignore
 
 
 def test_disconnected_graph():

--- a/networkx/algorithms/tree/tests/test_recognition.py
+++ b/networkx/algorithms/tree/tests/test_recognition.py
@@ -86,8 +86,8 @@ class TestTreeRecognition:
 
 
 class TestDirectedTreeRecognition(TestTreeRecognition):
-    graph = nx.DiGraph # type: ignore
-    multigraph = nx.MultiDiGraph # type: ignore
+    graph = nx.DiGraph  # type: ignore
+    multigraph = nx.MultiDiGraph  # type: ignore
 
 
 def test_disconnected_graph():

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -287,7 +287,7 @@ class Graph:
         """
         return Graph
 
-    def __init__(self, incoming_graph_data=None, **attr):
+    def __init__(self, incoming_graph_data=None, keep_multiple_directed_edges=False, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 
         Parameters
@@ -298,6 +298,11 @@ class Graph:
             NetworkX graph object.  If the corresponding optional Python
             packages are installed the data can also be a 2D NumPy array, a
             SciPy sparse matrix, or a PyGraphviz graph.
+
+        keep_multiple_directed_edges : bool (default False)
+            When True, if `d` represents a digraph and G is a multigraph, each
+            directed edge between two nodes from `d` is treated as a separate edge
+            in the multigraph, regardless of direction
 
         attr : keyword arguments, optional (default= no attributes)
             Attributes to add to graph as key=value pairs.
@@ -335,7 +340,7 @@ class Graph:
             delattr(self, "adj")
         # attempt to load graph with data
         if incoming_graph_data is not None:
-            convert.to_networkx_graph(incoming_graph_data, create_using=self)
+            convert.to_networkx_graph(incoming_graph_data, create_using=self, keep_multiple_directed_edges=keep_multiple_directed_edges)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -287,7 +287,9 @@ class Graph:
         """
         return Graph
 
-    def __init__(self, incoming_graph_data=None, keep_multiple_directed_edges=False, **attr):
+    def __init__(
+        self, incoming_graph_data=None, keep_multiple_directed_edges=False, **attr
+    ):
         """Initialize a graph with edges, name, or graph attributes.
 
         Parameters
@@ -340,7 +342,11 @@ class Graph:
             delattr(self, "adj")
         # attempt to load graph with data
         if incoming_graph_data is not None:
-            convert.to_networkx_graph(incoming_graph_data, create_using=self, keep_multiple_directed_edges=keep_multiple_directed_edges)
+            convert.to_networkx_graph(
+                incoming_graph_data,
+                create_using=self,
+                keep_multiple_directed_edges=keep_multiple_directed_edges,
+            )
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -291,7 +291,7 @@ class MultiGraph(Graph):
         """
         return MultiGraph
 
-    def __init__(self, incoming_graph_data=None, multigraph_input=None, **attr):
+    def __init__(self, incoming_graph_data=None, multigraph_input=None, keep_multiple_directed_edges=False, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 
         Parameters
@@ -315,6 +315,11 @@ class MultiGraph(Graph):
             keyed by node to neighbors.
             If None, the treatment for True is tried, but if it fails,
             the treatment for False is tried.
+
+        keep_multiple_directed_edges : bool (default False)
+            When True, if `d` represents a digraph and G is a multigraph, each
+            directed edge between two nodes from `d` is treated as a separate edge
+            in the multigraph, regardless of direction
 
         attr : keyword arguments, optional (default= no attributes)
             Attributes to add to graph as key=value pairs.
@@ -353,7 +358,7 @@ class MultiGraph(Graph):
                     )
                 Graph.__init__(self, incoming_graph_data, **attr)
         else:
-            Graph.__init__(self, incoming_graph_data, **attr)
+            Graph.__init__(self, incoming_graph_data, keep_multiple_directed_edges=keep_multiple_directed_edges, **attr)
 
     @cached_property
     def adj(self):

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -291,7 +291,13 @@ class MultiGraph(Graph):
         """
         return MultiGraph
 
-    def __init__(self, incoming_graph_data=None, multigraph_input=None, keep_multiple_directed_edges=False, **attr):
+    def __init__(
+        self,
+        incoming_graph_data=None,
+        multigraph_input=None,
+        keep_multiple_directed_edges=False,
+        **attr,
+    ):
         """Initialize a graph with edges, name, or graph attributes.
 
         Parameters
@@ -358,7 +364,12 @@ class MultiGraph(Graph):
                     )
                 Graph.__init__(self, incoming_graph_data, **attr)
         else:
-            Graph.__init__(self, incoming_graph_data, keep_multiple_directed_edges=keep_multiple_directed_edges, **attr)
+            Graph.__init__(
+                self,
+                incoming_graph_data,
+                keep_multiple_directed_edges=keep_multiple_directed_edges,
+                **attr,
+            )
 
     @cached_property
     def adj(self):

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -31,7 +31,9 @@ __all__ = [
 ]
 
 
-def to_networkx_graph(data, create_using=None, multigraph_input=False, keep_multiple_directed_edges=False):
+def to_networkx_graph(
+    data, create_using=None, multigraph_input=False, keep_multiple_directed_edges=False
+):
     """Make a NetworkX graph from a known data structure.
 
     The preferred way to call this is automatically
@@ -82,7 +84,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False, keep_mult
                 data.adj,
                 create_using=create_using,
                 multigraph_input=data.is_multigraph(),
-                keep_multiple_directed_edges=keep_multiple_directed_edges
+                keep_multiple_directed_edges=keep_multiple_directed_edges,
             )
             # data.graph should be dict-like
             result.graph.update(data.graph)
@@ -368,7 +370,9 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     return dod
 
 
-def from_dict_of_dicts(d, create_using=None, multigraph_input=False, keep_multiple_directed_edges=False):
+def from_dict_of_dicts(
+    d, create_using=None, multigraph_input=False, keep_multiple_directed_edges=False
+):
     """Returns a graph from a dictionary of dictionaries.
 
     Parameters
@@ -453,7 +457,7 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False, keep_multip
                 for v, data in nbrs.items():
                     if keep_multiple_directed_edges:
                         # print(seen.count((u,v)))
-                        G.add_edge(u, v, key=seen.count((u,v)))
+                        G.add_edge(u, v, key=seen.count((u, v)))
                         G[u][v][0].update(data)
                         seen += [(v, u), (u, v)]
                     else:

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 
-def to_networkx_graph(data, create_using=None, multigraph_input=False):
+def to_networkx_graph(data, create_using=None, multigraph_input=False, keep_multiple_directed_edges=False):
     """Make a NetworkX graph from a known data structure.
 
     The preferred way to call this is automatically
@@ -69,6 +69,11 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
         If data and create_using are both multigraphs then create
         a multigraph from a multigraph.
 
+    keep_multiple_directed_edges : bool (default False)
+        When True, if `d` represents a digraph and G is a multigraph, each
+        directed edge between two nodes from `d` is treated as a separate edge
+        in the multigraph, regardless of direction
+
     """
     # NX graph
     if hasattr(data, "adj"):
@@ -77,6 +82,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                 data.adj,
                 create_using=create_using,
                 multigraph_input=data.is_multigraph(),
+                keep_multiple_directed_edges=keep_multiple_directed_edges
             )
             # data.graph should be dict-like
             result.graph.update(data.graph)
@@ -362,7 +368,7 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     return dod
 
 
-def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
+def from_dict_of_dicts(d, create_using=None, multigraph_input=False, keep_multiple_directed_edges=False):
     """Returns a graph from a dictionary of dictionaries.
 
     Parameters
@@ -379,6 +385,11 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
        node to neighbor to edge keys to edge data for multi-edges.
        Otherwise this routine assumes dict-of-dict-of-dict keyed by
        node to neighbor to edge data.
+
+    keep_multiple_directed_edges : bool (default False)
+        When True, if `d` represents a digraph and G is a multigraph, each
+        directed edge between two nodes from `d` is treated as a separate edge
+        in the multigraph, regardless of direction
 
     Examples
     --------
@@ -434,13 +445,23 @@ def from_dict_of_dicts(d, create_using=None, multigraph_input=False):
             # d can have both representations u-v, v-u in dict.  Only add one.
             # We don't need this check for digraphs since we add both directions,
             # or for Graph() since it is done implicitly (parallel edges not allowed)
-            seen = set()
+            if keep_multiple_directed_edges:
+                seen = list()
+            else:
+                seen = set()
             for u, nbrs in d.items():
                 for v, data in nbrs.items():
-                    if (u, v) not in seen:
-                        G.add_edge(u, v, key=0)
+                    if keep_multiple_directed_edges:
+                        # print(seen.count((u,v)))
+                        G.add_edge(u, v, key=seen.count((u,v)))
                         G[u][v][0].update(data)
-                    seen.add((v, u))
+                        seen += [(v, u), (u, v)]
+                    else:
+                        if (u, v) not in seen:
+                            G.add_edge(u, v, key=0)
+                            G[u][v][0].update(data)
+                        seen.add((v, u))
+        # elif G.is_directed() and condense_edges:
         else:
             G.add_edges_from(
                 ((u, v, data) for u, nbrs in d.items() for v, data in nbrs.items())


### PR DESCRIPTION
Intended to address #5618.

Adds a `keep_multiple_directed_edges` parameter (default False) that allows users to have the choice between preserving the current/existing behavior:
```
>>> DG = nx.DiGraph([(0, 1), (1, 0)])
>>> MG = nx.MultiGraph(DG, keep_multiple_directed_edges=False)
>>> MG.edges
MultiEdgeView([(0, 1, 0)])
```
or interpreting each directed edge as a separate edge in the multigraph, regardless of direction:
```
>>> DG = nx.DiGraph([(0, 1), (1, 0)])
>>> MG = nx.MultiGraph(DG, keep_multiple_directed_edges=True)
>>> MG.edges
MultiEdgeView([(0, 1, 0), (0, 1, 1)])
```