### PR TITLE
Add example of topo_order kwarg to dag_longest_path

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -905,7 +905,7 @@ def dag_longest_path(G, weight="weight", default_weight=1, topo_order=None):
         The weight of edges that do not have a weight attribute
 
     topo_order: list or tuple, optional
-        A topological order for G (if None, the function will compute one)
+        A topological order for `G` (if None, the function will compute one)
 
     Returns
     -------
@@ -925,6 +925,17 @@ def dag_longest_path(G, weight="weight", default_weight=1, topo_order=None):
     >>> nx.dag_longest_path(DG)
     [0, 1, 2]
     >>> nx.dag_longest_path(DG, weight="cost")
+    [0, 2]
+
+    In the case where multiple valid topological orderings exist, `topo_order`
+    can be used to specify a specific ordering:
+
+    >>> DG = nx.DiGraph([(0, 1), (0, 2)])
+    >>> sorted(nx.all_topological_sorts(DG))  # Valid topological orderings
+    [[0, 1, 2], [0, 2, 1]]
+    >>> nx.dag_longest_path(DG, topo_order=[0, 1, 2])
+    [0, 1]
+    >>> nx.dag_longest_path(DG, topo_order=[0, 2, 1])
     [0, 2]
 
     See also


### PR DESCRIPTION
Implements the suggestion from #5712 to add an example of the `topo_order` kwarg to the `dag_longest_path` docstring.