### PR TITLE
Rm `to_numpy_recarray`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -106,7 +106,6 @@ Version 3.0
   reflect that the function returns a ``numpy.ndarray`` instance.
 * In ``generators/small.py`` remove ``make_small_graph`` and
   ``make_small_undirected_graph``.
-* In ``convert_matrix.py`` remove ``to_numpy_recarray``.
 * In ``classes/function.py`` remove ``info``.
 * In ``algorithms/community/modularity_max.py``, remove the deprecated
   ``n_communities`` parameter from the ``greedy_modularity_communities``

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -231,9 +231,6 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message=r"\n\nmake_small_.*"
     )
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="to_numpy_recarray"
-    )
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="info")
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="to_tuple")
     # create_using for scale_free_graph

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -16,10 +16,6 @@ def test_from_numpy_matrix_deprecation():
     pytest.deprecated_call(nx.from_numpy_matrix, np.eye(2))
 
 
-def test_to_numpy_recarray_deprecation():
-    pytest.deprecated_call(nx.to_numpy_recarray, nx.Graph())
-
-
 class TestConvertNumpyMatrix:
     # TODO: This entire class can be removed when to/from_numpy_matrix
     # deprecation expires
@@ -170,16 +166,6 @@ class TestConvertNumpyMatrix:
         assert type(G[0][0]["cost"]) == int
         assert G[0][0]["cost"] == 2
         assert G[0][0]["weight"] == 1.0
-
-    def test_to_numpy_recarray(self):
-        G = nx.Graph()
-        G.add_edge(1, 2, weight=7.0, cost=5)
-        A = nx.to_numpy_recarray(G, dtype=[("weight", float), ("cost", int)])
-        assert sorted(A.dtype.names) == ["cost", "weight"]
-        assert A.weight[0, 1] == 7.0
-        assert A.weight[0, 0] == 0.0
-        assert A.cost[0, 1] == 5
-        assert A.cost[0, 0] == 0
 
     def test_numpy_multigraph(self):
         G = nx.MultiGraph()
@@ -432,75 +418,6 @@ class TestConvertNumpyArray:
         G = nx.MultiGraph(nx.complete_graph(3))
         A = nx.to_numpy_array(G, dtype=int)
         assert A.dtype == int
-
-
-@pytest.fixture
-def recarray_test_graph():
-    G = nx.Graph()
-    G.add_edge(1, 2, weight=7.0, cost=5)
-    return G
-
-
-def test_to_numpy_recarray(recarray_test_graph):
-    A = nx.to_numpy_recarray(
-        recarray_test_graph, dtype=[("weight", float), ("cost", int)]
-    )
-    assert sorted(A.dtype.names) == ["cost", "weight"]
-    assert A.weight[0, 1] == 7.0
-    assert A.weight[0, 0] == 0.0
-    assert A.cost[0, 1] == 5
-    assert A.cost[0, 0] == 0
-    with pytest.raises(AttributeError, match="has no attribute"):
-        A.color[0, 1]
-
-
-def test_to_numpy_recarray_default_dtype(recarray_test_graph):
-    A = nx.to_numpy_recarray(recarray_test_graph)
-    assert A.dtype.names == ("weight",)
-    assert A.weight[0, 0] == 0
-    assert A.weight[0, 1] == 7
-    with pytest.raises(AttributeError, match="has no attribute"):
-        A.cost[0, 1]
-
-
-def test_to_numpy_recarray_directed(recarray_test_graph):
-    G = recarray_test_graph.to_directed()
-    G.remove_edge(2, 1)
-    A = nx.to_numpy_recarray(G, dtype=[("weight", float), ("cost", int)])
-    np.testing.assert_array_equal(A.weight, np.array([[0, 7.0], [0, 0]]))
-    np.testing.assert_array_equal(A.cost, np.array([[0, 5], [0, 0]]))
-
-
-def test_to_numpy_recarray_default_dtype_no_weight():
-    G = nx.Graph()
-    G.add_edge(0, 1, color="red")
-    with pytest.raises(KeyError):
-        A = nx.to_numpy_recarray(G)
-    A = nx.to_numpy_recarray(G, dtype=[("color", "U8")])
-    assert A.color[0, 1] == "red"
-
-
-@pytest.fixture
-def recarray_nodelist_test_graph():
-    G = nx.Graph()
-    G.add_edges_from(
-        [(0, 1, {"weight": 1.0}), (0, 2, {"weight": 2.0}), (1, 2, {"weight": 0.5})]
-    )
-    return G
-
-
-def test_to_numpy_recarray_nodelist(recarray_nodelist_test_graph):
-    A = nx.to_numpy_recarray(recarray_nodelist_test_graph, nodelist=[0, 1])
-    np.testing.assert_array_equal(A.weight, np.array([[0, 1], [1, 0]]))
-
-
-@pytest.mark.parametrize(
-    ("nodelist", "errmsg"),
-    (([2, 3], "in nodelist is not in G"), ([1, 1], "nodelist contains duplicates")),
-)
-def test_to_numpy_recarray_bad_nodelist(recarray_nodelist_test_graph, nodelist, errmsg):
-    with pytest.raises(nx.NetworkXError, match=errmsg):
-        A = nx.to_numpy_recarray(recarray_nodelist_test_graph, nodelist=nodelist)
 
 
 @pytest.fixture


### PR DESCRIPTION
Remove deprecated function `to_numpy_recarray` for NX 3.0.