### PR TITLE
Remove deprecated function is_string_like

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -62,9 +62,6 @@ def set_warnings():
         message="literal_destringizer is deprecated",
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="is_string_like is deprecated"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\nauthority_matrix"
     )
     warnings.filterwarnings(

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -23,7 +23,6 @@ import networkx as nx
 np = nx.lazy_import("numpy")
 
 __all__ = [
-    "is_string_like",
     "iterable",
     "empty_generator",
     "flatten",
@@ -53,20 +52,6 @@ __all__ = [
 # some cookbook stuff
 # used in deciding whether something is a bunch of nodes, edges, etc.
 # see G.add_nodes and others in Graph Class in networkx/base.py
-
-
-def is_string_like(obj):  # from John Hunter, types-free version
-    """Check if obj is string.
-
-    .. deprecated:: 2.6
-        This is deprecated and will be removed in NetworkX v3.0.
-    """
-    msg = (
-        "is_string_like is deprecated and will be removed in 3.0."
-        "Use isinstance(obj, str) instead."
-    )
-    warnings.warn(msg, DeprecationWarning)
-    return isinstance(obj, str)
 
 
 def iterable(obj):

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -13,7 +13,6 @@ from networkx.utils import (
     discrete_sequence,
     flatten,
     groups,
-    is_string_like,
     iterable,
     make_list_of_ints,
     make_str,
@@ -60,12 +59,6 @@ def test_flatten(nested, result):
         assert len(val) == len(_result) == 20 + nexisting
 
     assert issubclass(type(val), tuple)
-
-
-def test_is_string_like():
-    assert is_string_like("aaaa")
-    assert not is_string_like(None)
-    assert not is_string_like(123)
 
 
 def test_iterable():


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.

Bye bye `is_string_like`