### PR TITLE
Remove deprecated function make_str

### DIFF
--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -16,7 +16,6 @@ Helper Functions
    flatten
    iterable
    make_list_of_ints
-   make_str
    generate_unique_node
    default_opener
    pairwise

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -77,9 +77,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="empty_generator is deprecated"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="make_str is deprecated"
-    )
-    warnings.filterwarnings(
         "ignore",
         category=DeprecationWarning,
         message="generate_unique_node is deprecated",

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -29,7 +29,6 @@ __all__ = [
     "flatten",
     "make_list_of_ints",
     "is_list_of_ints",
-    "make_str",
     "generate_unique_node",
     "default_opener",
     "dict_to_numpy_array",
@@ -167,17 +166,6 @@ def is_list_of_ints(intlist):
         if not isinstance(i, int):
             return False
     return True
-
-
-def make_str(x):
-    """Returns the string representation of t.
-
-    .. deprecated:: 2.6
-        This is deprecated and will be removed in NetworkX v3.0.
-    """
-    msg = "make_str is deprecated and will be removed in 3.0. Use str instead."
-    warnings.warn(msg, DeprecationWarning)
-    return str(x)
 
 
 def generate_unique_node():

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -16,7 +16,6 @@ from networkx.utils import (
     is_string_like,
     iterable,
     make_list_of_ints,
-    make_str,
     pairwise,
     powerlaw_sequence,
     to_tuple,
@@ -97,20 +96,6 @@ def test_random_number_distribution():
     # smoke test only
     z = powerlaw_sequence(20, exponent=2.5)
     z = discrete_sequence(20, distribution=[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3])
-
-
-def test_make_str_with_bytes():
-    x = "qualité"
-    y = make_str(x)
-    assert isinstance(y, str)
-    assert len(y) == 7
-
-
-def test_make_str_with_unicode():
-    x = "qualité"
-    y = make_str(x)
-    assert isinstance(y, str)
-    assert len(y) == 7
 
 
 class TestNumpyArray:


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `make_str`
