### PR TITLE
Remove deprecated function is_iterator

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -35,7 +35,6 @@ __all__ = [
     "dict_to_numpy_array",
     "dict_to_numpy_array1",
     "dict_to_numpy_array2",
-    "is_iterator",
     "arbitrary_element",
     "consume",
     "pairwise",
@@ -300,21 +299,6 @@ def _dict_to_numpy_array1(d, mapping=None):
         i = mapping[k1]
         a[i] = d[k1]
     return a
-
-
-def is_iterator(obj):
-    """Returns True if and only if the given object is an iterator object.
-
-    .. deprecated:: 2.6.0
-        Deprecated in favor of ``isinstance(obj, collections.abc.Iterator)``
-    """
-    msg = (
-        "is_iterator is deprecated and will be removed in version 3.0. "
-        "Use ``isinstance(obj, collections.abc.Iterator)`` instead."
-    )
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    has_next_attr = hasattr(obj, "__next__") or hasattr(obj, "next")
-    return iter(obj) is obj and has_next_attr
 
 
 def arbitrary_element(iterable):


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `is_iterator`