### PR TITLE
Remove deprecated function iterable

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -24,7 +24,6 @@ np = nx.lazy_import("numpy")
 
 __all__ = [
     "is_string_like",
-    "iterable",
     "empty_generator",
     "flatten",
     "make_list_of_ints",
@@ -67,26 +66,6 @@ def is_string_like(obj):  # from John Hunter, types-free version
     )
     warnings.warn(msg, DeprecationWarning)
     return isinstance(obj, str)
-
-
-def iterable(obj):
-    """Return True if obj is iterable with a well-defined len().
-
-    .. deprecated:: 2.6
-        This is deprecated and will be removed in NetworkX v3.0.
-    """
-    msg = (
-        "iterable is deprecated and will be removed in 3.0."
-        "Use isinstance(obj, (collections.abc.Iterable, collections.abc.Sized)) instead."
-    )
-    warnings.warn(msg, DeprecationWarning)
-    if hasattr(obj, "__iter__"):
-        return True
-    try:
-        len(obj)
-    except:
-        return False
-    return True
 
 
 def empty_generator():

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -14,7 +14,6 @@ from networkx.utils import (
     flatten,
     groups,
     is_string_like,
-    iterable,
     make_list_of_ints,
     make_str,
     pairwise,
@@ -66,22 +65,6 @@ def test_is_string_like():
     assert is_string_like("aaaa")
     assert not is_string_like(None)
     assert not is_string_like(123)
-
-
-def test_iterable():
-    assert not iterable(None)
-    assert not iterable(10)
-    assert iterable([1, 2, 3])
-    assert iterable((1, 2, 3))
-    assert iterable({1: "A", 2: "X"})
-    assert iterable("ABC")
-
-
-def test_graph_iterable():
-    K = nx.complete_graph(10)
-    assert iterable(K)
-    assert iterable(K.nodes())
-    assert iterable(K.edges())
 
 
 def test_make_list_of_ints():


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `iterable`