### PR TITLE
Remove deprecated function is_list_of_ints

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -27,7 +27,6 @@ __all__ = [
     "empty_generator",
     "flatten",
     "make_list_of_ints",
-    "is_list_of_ints",
     "generate_unique_node",
     "default_opener",
     "dict_to_numpy_array",
@@ -131,25 +130,6 @@ def make_list_of_ints(sequence):
             raise nx.NetworkXError(errmsg)
         sequence[indx] = ii
     return sequence
-
-
-def is_list_of_ints(intlist):
-    """Return True if list is a list of ints.
-
-    .. deprecated:: 2.6
-        This is deprecated and will be removed in NetworkX v3.0.
-    """
-    msg = (
-        "is_list_of_ints is deprecated and will be removed in 3.0."
-        "See also: ``networkx.utils.make_list_of_ints.``"
-    )
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    if not isinstance(intlist, list):
-        return False
-    for i in intlist:
-        if not isinstance(i, int):
-            return False
-    return True
 
 
 def generate_unique_node():


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `is_list_of_ints`