### PR TITLE
Remove deprecated function utils.consume

### DIFF
--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -37,7 +37,6 @@ __all__ = [
     "dict_to_numpy_array2",
     "is_iterator",
     "arbitrary_element",
-    "consume",
     "pairwise",
     "groups",
     "to_tuple",
@@ -384,22 +383,6 @@ def arbitrary_element(iterable):
         raise ValueError("cannot return an arbitrary item from an iterator")
     # Another possible implementation is ``for x in iterable: return x``.
     return next(iter(iterable))
-
-
-# Recipe from the itertools documentation.
-def consume(iterator):
-    """Consume the iterator entirely.
-
-    .. deprecated:: 2.6
-        This is deprecated and will be removed in NetworkX v3.0.
-    """
-    # Feed the entire iterator into a zero-length deque.
-    msg = (
-        "consume is deprecated and will be removed in version 3.0. "
-        "Use ``collections.deque(iterator, maxlen=0)`` instead."
-    )
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    deque(iterator, maxlen=0)
 
 
 # Recipe from the itertools documentation.


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `consume`