### PR TITLE
Remove deprecated function utils.default_opener

### DIFF
--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -17,7 +17,6 @@ Helper Functions
    iterable
    make_list_of_ints
    generate_unique_node
-   default_opener
    pairwise
    groups
    create_random_state

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -68,9 +68,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\nhub_matrix"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="default_opener is deprecated"
-    )
-    warnings.filterwarnings(
         "ignore",
         category=DeprecationWarning,
         message="generate_unique_node is deprecated",

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -28,7 +28,6 @@ __all__ = [
     "make_list_of_ints",
     "is_list_of_ints",
     "generate_unique_node",
-    "default_opener",
     "dict_to_numpy_array",
     "dict_to_numpy_array1",
     "dict_to_numpy_array2",
@@ -148,38 +147,6 @@ def generate_unique_node():
     msg = "generate_unique_node is deprecated and will be removed in 3.0. Use uuid.uuid4 instead."
     warnings.warn(msg, DeprecationWarning)
     return str(uuid.uuid4())
-
-
-def default_opener(filename):
-    """Opens `filename` using system's default program.
-
-    .. deprecated:: 2.6
-       default_opener is deprecated and will be removed in version 3.0.
-       Consider an image processing library to open images, such as Pillow::
-
-           from PIL import Image
-           Image.open(filename).show()
-
-    Parameters
-    ----------
-    filename : str
-        The path of the file to be opened.
-
-    """
-    warnings.warn(
-        "default_opener is deprecated and will be removed in version 3.0. ",
-        DeprecationWarning,
-    )
-    from subprocess import call
-
-    cmds = {
-        "darwin": ["open"],
-        "linux": ["xdg-open"],
-        "linux2": ["xdg-open"],
-        "win32": ["cmd.exe", "/C", "start", ""],
-    }
-    cmd = cmds[sys.platform] + [filename]
-    call(cmd)
 
 
 def dict_to_numpy_array(d, mapping=None):


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `default_opener`