### PR TITLE
Remove deprecated function utils.empty_generator

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -74,9 +74,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="default_opener is deprecated"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="empty_generator is deprecated"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="make_str is deprecated"
     )
     warnings.filterwarnings(

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -25,7 +25,6 @@ np = nx.lazy_import("numpy")
 __all__ = [
     "is_string_like",
     "iterable",
-    "empty_generator",
     "flatten",
     "make_list_of_ints",
     "is_list_of_ints",
@@ -87,17 +86,6 @@ def iterable(obj):
     except:
         return False
     return True
-
-
-def empty_generator():
-    """Return a generator with no members.
-
-    .. deprecated:: 2.6
-    """
-    warnings.warn(
-        "empty_generator is deprecated and will be removed in v3.0.", DeprecationWarning
-    )
-    return (i for i in ())
 
 
 def flatten(obj, result=None):


### PR DESCRIPTION
Remove functions is small modular fashion so it's easy to revert them.
Bye bye `empty_generator`