### PR TITLE
Remove deprecated function utils.to_tuple

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -235,7 +235,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="to_numpy_recarray"
     )
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="info")
-    warnings.filterwarnings("ignore", category=DeprecationWarning, message="to_tuple")
     # create_using for scale_free_graph
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="The create_using argument"

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -40,7 +40,6 @@ __all__ = [
     "consume",
     "pairwise",
     "groups",
-    "to_tuple",
     "create_random_state",
     "create_py_random_state",
     "PythonRandomInterface",
@@ -432,31 +431,6 @@ def groups(many_to_one):
     for v, k in many_to_one.items():
         one_to_many[k].add(v)
     return dict(one_to_many)
-
-
-def to_tuple(x):
-    """Converts lists to tuples.
-
-    .. deprecated:: 2.8
-
-       to_tuple is deprecated and will be removed in NetworkX 3.0.
-
-    Examples
-    --------
-    >>> from networkx.utils import to_tuple
-    >>> a_list = [1, 2, [1, 4]]
-    >>> to_tuple(a_list)
-    (1, 2, (1, 4))
-    """
-    warnings.warn(
-        "to_tuple is deprecated and will be removed in NetworkX 3.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    if not isinstance(x, (tuple, list)):
-        return x
-    return tuple(map(to_tuple, x))
 
 
 def create_random_state(random_state=None):

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -19,7 +19,6 @@ from networkx.utils import (
     make_str,
     pairwise,
     powerlaw_sequence,
-    to_tuple,
 )
 from networkx.utils.misc import _dict_to_numpy_array1, _dict_to_numpy_array2
 
@@ -193,23 +192,6 @@ def test_groups():
     expected = {0: {"a", "b"}, 1: {"c", "d"}, 2: {"e"}}
     assert actual == expected
     assert {} == groups({})
-
-
-def test_to_tuple():
-    a_list = [1, 2, [1, 3]]
-    actual = to_tuple(a_list)
-    expected = (1, 2, (1, 3))
-    assert actual == expected
-
-    a_tuple = (1, 2)
-    actual = to_tuple(a_tuple)
-    expected = a_tuple
-    assert actual == expected
-
-    a_mix = (1, 2, [1, 3])
-    actual = to_tuple(a_mix)
-    expected = (1, 2, (1, 3))
-    assert actual == expected
 
 
 def test_create_random_state():


### PR DESCRIPTION
bye bye `to_tuple`