### PR TITLE
Make HITS numpy and scipy private functions

### DIFF
--- a/doc/reference/algorithms/link_analysis.rst
+++ b/doc/reference/algorithms/link_analysis.rst
@@ -22,6 +22,3 @@ Hits
    :toctree: generated/
 
    hits
-   hits_numpy
-   hits_scipy
-

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -2,7 +2,7 @@
 """
 import networkx as nx
 
-__all__ = ["hits", "hits_numpy", "hits_scipy"]
+__all__ = ["hits"]
 
 
 def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
@@ -144,12 +144,8 @@ def _hits_python(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
     return h, a
 
 
-def hits_numpy(G, normalized=True):
+def _hits_numpy(G, normalized=True):
     """Returns HITS hubs and authorities values for nodes.
-
-    .. deprecated:: 2.6
-
-       hits_numpy is deprecated and will be removed in networkx 3.0.
 
     The HITS algorithm computes two numbers for a node.
     Authorities estimates the node value based on the incoming links.
@@ -207,18 +203,7 @@ def hits_numpy(G, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import warnings
-
     import numpy as np
-
-    warnings.warn(
-        (
-            "networkx.hits_numpy is deprecated and will be removed"
-            "in NetworkX 3.0, use networkx.hits instead."
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
     if len(G) == 0:
         return {}, {}
@@ -242,12 +227,9 @@ def hits_numpy(G, normalized=True):
     return hubs, authorities
 
 
-def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
+def _hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
     """Returns HITS hubs and authorities values for nodes.
 
-    .. deprecated:: 2.6
-
-       hits_scipy is deprecated and will be removed in networkx 3.0
 
     The HITS algorithm computes two numbers for a node.
     Authorities estimates the node value based on the incoming links.
@@ -312,18 +294,7 @@ def hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
        doi:10.1145/324133.324140.
        http://www.cs.cornell.edu/home/kleinber/auth.pdf.
     """
-    import warnings
-
     import numpy as np
-
-    warnings.warn(
-        (
-            "networkx.hits_scipy is deprecated and will be removed"
-            "in NetworkX 3.0, use networkx.hits instead."
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
     if len(G) == 0:
         return {}, {}

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -179,10 +179,11 @@ def _hits_numpy(G, normalized=True):
     >>> hubs_matrix = adj_ary @ adj_ary.T
     >>> authority_matrix = adj_ary.T @ adj_ary
 
-    `hits_numpy` maps the eigenvector corresponding to the maximum eigenvalue
+    `_hits_numpy` maps the eigenvector corresponding to the maximum eigenvalue
     of the respective matrices to the nodes in `G`:
 
-    >>> hubs, authority = nx.hits_numpy(G)
+    >>> from networkx.algorithms.link_analysis.hits_alg import _hits_numpy
+    >>> hubs, authority = _hits_numpy(G)
 
     Notes
     -----
@@ -260,8 +261,9 @@ def _hits_scipy(G, max_iter=100, tol=1.0e-6, nstart=None, normalized=True):
 
     Examples
     --------
+    >>> from networkx.algorithms.link_analysis.hits_alg import _hits_scipy
     >>> G = nx.path_graph(4)
-    >>> h, a = nx.hits(G)
+    >>> h, a = _hits_scipy(G)
 
     Notes
     -----

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -6,7 +6,11 @@ np = pytest.importorskip("numpy")
 sp = pytest.importorskip("scipy")
 import scipy.sparse  # call as sp.sparse
 
-from networkx.algorithms.link_analysis.hits_alg import _hits_python
+from networkx.algorithms.link_analysis.hits_alg import (
+    _hits_numpy,
+    _hits_python,
+    _hits_scipy,
+)
 
 # Example from
 # A. Langville and C. Meyer, "A survey of eigenvector methods of web
@@ -32,13 +36,13 @@ class TestHITS:
 
     def test_hits_numpy(self):
         G = self.G
-        h, a = nx.hits_numpy(G)
+        h, a = _hits_numpy(G)
         for n in G:
             assert h[n] == pytest.approx(G.h[n], abs=1e-4)
         for n in G:
             assert a[n] == pytest.approx(G.a[n], abs=1e-4)
 
-    @pytest.mark.parametrize("hits_alg", (nx.hits, nx.hits_scipy, _hits_python))
+    @pytest.mark.parametrize("hits_alg", (nx.hits, _hits_python, _hits_scipy))
     def test_hits(self, hits_alg):
         G = self.G
         h, a = hits_alg(G, tol=1.0e-08)
@@ -56,32 +60,21 @@ class TestHITS:
     def test_empty(self):
         G = nx.Graph()
         assert nx.hits(G) == ({}, {})
-        assert nx.hits_numpy(G) == ({}, {})
+        assert _hits_numpy(G) == ({}, {})
         assert _hits_python(G) == ({}, {})
-        assert nx.hits_scipy(G) == ({}, {})
+        assert _hits_scipy(G) == ({}, {})
 
     def test_hits_not_convergent(self):
         G = nx.path_graph(50)
         with pytest.raises(nx.PowerIterationFailedConvergence):
-            nx.hits_scipy(G, max_iter=1)
+            _hits_scipy(G, max_iter=1)
         with pytest.raises(nx.PowerIterationFailedConvergence):
             _hits_python(G, max_iter=1)
         with pytest.raises(nx.PowerIterationFailedConvergence):
-            nx.hits_scipy(G, max_iter=0)
+            _hits_scipy(G, max_iter=0)
         with pytest.raises(nx.PowerIterationFailedConvergence):
             _hits_python(G, max_iter=0)
         with pytest.raises(ValueError):
             nx.hits(G, max_iter=0)
         with pytest.raises(sp.sparse.linalg.ArpackNoConvergence):
             nx.hits(G, max_iter=1)
-
-
-@pytest.mark.parametrize("hits_alg", (nx.hits_numpy, nx.hits_scipy))
-def test_deprecation_warnings(hits_alg):
-    """Make sure deprecation warnings are raised.
-
-    To be removed when deprecations expire.
-    """
-    G = nx.DiGraph(nx.path_graph(4))
-    with pytest.warns(DeprecationWarning):
-        hits_alg(G)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -94,12 +94,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="`assert_graphs_equal`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="networkx.hits_scipy"
-    )
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="networkx.hits_numpy"
-    )
-    warnings.filterwarnings(
         "ignore",
         category=FutureWarning,
         message="google_matrix will return an np.ndarray instead of a np.matrix",


### PR DESCRIPTION
Okay this one may require some discussion.
Should we keep both implementations which use scipy?