### PR TITLE
remove old attr keyword from json_graph/tree

### DIFF
--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -46,20 +46,3 @@ def test_exceptions():
         G = nx.MultiDiGraph()
         G.add_node(0)
         tree_data(G, 0, ident="node", children="node")
-
-
-# NOTE: To be removed when deprecation expires in 3.0
-def test_attrs_deprecation(recwarn):
-    G = nx.path_graph(3, create_using=nx.DiGraph)
-
-    # No warnings when `attrs` kwarg not used
-    data = tree_data(G, 0)
-    H = tree_graph(data)
-    assert len(recwarn) == 0
-
-    # DeprecationWarning issued when `attrs` is used
-    attrs = {"id": "foo", "children": "bar"}
-    with pytest.warns(DeprecationWarning):
-        data = tree_data(G, 0, attrs=attrs)
-    with pytest.warns(DeprecationWarning):
-        H = tree_graph(data, attrs=attrs)

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -5,8 +5,7 @@ import networkx as nx
 __all__ = ["tree_data", "tree_graph"]
 
 
-# NOTE: Remove attrs from signature in 3.0
-def tree_data(G, root, attrs=None, ident="id", children="children"):
+def tree_data(G, root, ident="id", children="children"):
     """Returns data in tree format that is suitable for JSON serialization
     and use in Javascript documents.
 
@@ -17,20 +16,6 @@ def tree_data(G, root, attrs=None, ident="id", children="children"):
 
     root : node
        The root of the tree
-
-    attrs : dict
-        A dictionary that contains two keys 'id' and 'children'. The
-        corresponding values provide the attribute names for storing
-        NetworkX-internal graph data. The values should be unique. Default
-        value: :samp:`dict(id='id', children='children')`.
-
-        If some user-defined graph data use these attribute names as data keys,
-        they may be silently dropped.
-
-        .. deprecated:: 2.6
-
-           The `attrs` keyword argument is replaced by `ident` and `children`
-           and will be removed in networkx 3.0
 
     ident : string
         Attribute name for storing NetworkX-internal graph data. `ident` must
@@ -79,28 +64,6 @@ def tree_data(G, root, attrs=None, ident="id", children="children"):
     if not nx.is_weakly_connected(G):
         raise TypeError("G is not weakly connected.")
 
-    # NOTE: to be removed in 3.0
-    if attrs is not None:
-        import warnings
-
-        msg = (
-            "\nThe `attrs` keyword argument of tree_data is deprecated\n"
-            "and will be removed in networkx 3.0.\n"
-            "It is replaced with explicit `ident` and `children` "
-            "keyword arguments.\n"
-            "To make this warning go away and ensure usage is forward\n"
-            "compatible, replace `attrs` with `ident` and `children,\n"
-            "for example:\n\n"
-            "    >>> tree_data(G, root, attrs={'id': 'foo', 'children': 'bar'})\n\n"
-            "should instead be written as\n\n"
-            "    >>> tree_data(G, root, ident='foo', children='bar')\n\n"
-            "The default values of 'id' and 'children' will not change."
-        )
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-        ident = attrs["id"]
-        children = attrs["children"]
-
     if ident == children:
         raise nx.NetworkXError("The values for `id` and `children` must be different.")
 
@@ -122,23 +85,13 @@ def tree_data(G, root, attrs=None, ident="id", children="children"):
     return data
 
 
-def tree_graph(data, attrs=None, ident="id", children="children"):
+def tree_graph(data, ident="id", children="children"):
     """Returns graph from tree data format.
 
     Parameters
     ----------
     data : dict
         Tree formatted graph data
-    attrs : dict
-        A dictionary that contains two keys 'id' and 'children'. The
-        corresponding values provide the attribute names for storing
-        NetworkX-internal graph data. The values should be unique. Default
-        value: :samp:`dict(id='id', children='children')`.
-
-        .. deprecated:: 2.6
-
-           The `attrs` keyword argument is replaced by `ident` and `children`
-           and will be removed in networkx 3.0
 
     ident : string
         Attribute name for storing NetworkX-internal graph data. `ident` must
@@ -164,26 +117,6 @@ def tree_graph(data, attrs=None, ident="id", children="children"):
     tree_data, node_link_data, adjacency_data
     """
     graph = nx.DiGraph()
-    if attrs is not None:
-        import warnings
-
-        msg = (
-            "\nThe `attrs` keyword argument of tree_graph is deprecated\n"
-            "and will be removed in networkx 3.0.\n"
-            "It is replaced with explicit `ident` and `children` "
-            "keyword arguments.\n"
-            "To make this warning go away and ensure usage is\n"
-            "forward compatible, replace `attrs` with `ident` and `children,\n"
-            "for example:\n\n"
-            "    >>> tree_graph(data, attrs={'id': 'foo', 'children': 'bar'})\n\n"
-            "should instead be written as\n\n"
-            "    >>> tree_graph(data, ident='foo', children='bar')\n\n"
-            "The default values of 'id' and 'children' will not change."
-        )
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-        ident = attrs["id"]
-        children = attrs["children"]
 
     def add_children(parent, children_):
         for data in children_:


### PR DESCRIPTION
Removes the deprecated `attr` keyword from `tree_graph` and `tree_data`.
