### PR TITLE
Compute `is_strongly_connected` lazily

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -350,7 +350,7 @@ def is_strongly_connected(G):
             """Connectivity is undefined for the null graph."""
         )
 
-    return len(list(strongly_connected_components(G))[0]) == len(G)
+    return len(next(strongly_connected_components(G))) == len(G)
 
 
 @not_implemented_for("undirected")


### PR DESCRIPTION
The PR computes strongly connected components lazily. This approach avoids the need of computing all strongly connected components and yields performance increase of graphs having more strongly connected components. The following example is based on directed path graph:

<img width="642" alt="image" src="https://user-images.githubusercontent.com/827060/174404452-c986092a-7799-40ee-ba93-609b556b21c0.png">


```python
import timeit
vertices = [1, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 50000]
times = []
for i in vertices:
    times.append(timeit.timeit(stmt='nx.is_strongly_connected(G)', setup=f'import networkx as nx; G = nx.path_graph({i}, create_using=nx.DiGraph)', number=100))
````