### PR TITLE
Compute `is_weakly_connected` lazily

### DIFF
--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -157,7 +157,7 @@ def is_weakly_connected(G):
             """Connectivity is undefined for the null graph."""
         )
 
-    return len(list(weakly_connected_components(G))[0]) == len(G)
+    return len(next(weakly_connected_components(G))) == len(G)
 
 
 def _plain_bfs(G, source):


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

This PR computes `is_weakly_connected` lazily. This can yield significant performance increase. E.g. for case of discrete graph:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/827060/174406999-1ce3f32f-b8c7-458a-bb20-ecfd155aa799.png">

```python
import timeit
vertices = [1, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 50000]
times = []
for i in vertices:
    times_patched.append(timeit.timeit(stmt='nx.is_weakly_connected(G)', setup=f'import networkx as nx; G = nx.DiGraph(); G.add_nodes_from(range({i}))', number=100))
```


