### PR TITLE
Revert "Cache edges, degree, adj properties of Graph classes (#5614)"

### DIFF
--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -280,7 +280,7 @@ class _AntiGraph(nx.Graph):
                 raise KeyError(node)
             return self._graph.AntiAtlasView(self._graph, node)
 
-    @cached_property
+    @property
     def adj(self):
         return self.AntiAdjacencyView(self)
 
@@ -311,7 +311,7 @@ class _AntiGraph(nx.Graph):
             # AntiGraph is a ThinGraph so all edges have weight 1
             return len(nbrs) + (n in nbrs)
 
-    @cached_property
+    @property
     def degree(self):
         """Returns an iterator for (node, degree) and degree for single node.
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1,6 +1,5 @@
 """Base class for directed graphs."""
 from copy import deepcopy
-from functools import cached_property
 
 import networkx as nx
 import networkx.convert as convert
@@ -314,13 +313,6 @@ class DiGraph(Graph):
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
         self._pred = self.adjlist_outer_dict_factory()  # predecessor
         self._succ = self._adj  # successor
-        # clear cached adjacency properties
-        if hasattr(self, "adj"):
-            delattr(self, "adj")
-        if hasattr(self, "pred"):
-            delattr(self, "pred")
-        if hasattr(self, "succ"):
-            delattr(self, "succ")
 
         # attempt to load graph with data
         if incoming_graph_data is not None:
@@ -328,7 +320,7 @@ class DiGraph(Graph):
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 
-    @cached_property
+    @property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -347,7 +339,7 @@ class DiGraph(Graph):
         """
         return AdjacencyView(self._succ)
 
-    @cached_property
+    @property
     def succ(self):
         """Graph adjacency object holding the successors of each node.
 
@@ -368,7 +360,7 @@ class DiGraph(Graph):
         """
         return AdjacencyView(self._succ)
 
-    @cached_property
+    @property
     def pred(self):
         """Graph adjacency object holding the predecessors of each node.
 
@@ -844,7 +836,7 @@ class DiGraph(Graph):
         except KeyError as err:
             raise NetworkXError(f"The node {n} is not in the digraph.") from err
 
-    @cached_property
+    @property
     def edges(self):
         """An OutEdgeView of the DiGraph as G.edges or G.edges().
 
@@ -908,13 +900,9 @@ class DiGraph(Graph):
         return OutEdgeView(self)
 
     # alias out_edges to edges
-    @cached_property
-    def out_edges(self):
-        return OutEdgeView(self)
+    out_edges = edges
 
-    out_edges.__doc__ = edges.__doc__
-
-    @cached_property
+    @property
     def in_edges(self):
         """An InEdgeView of the Graph as G.in_edges or G.in_edges().
 
@@ -945,7 +933,7 @@ class DiGraph(Graph):
         """
         return InEdgeView(self)
 
-    @cached_property
+    @property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 
@@ -989,7 +977,7 @@ class DiGraph(Graph):
         """
         return DiDegreeView(self)
 
-    @cached_property
+    @property
     def in_degree(self):
         """An InDegreeView for (node, in_degree) or in_degree for single node.
 
@@ -1036,7 +1024,7 @@ class DiGraph(Graph):
         """
         return InDegreeView(self)
 
-    @cached_property
+    @property
     def out_degree(self):
         """An OutDegreeView for (node, out_degree)
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -330,16 +330,13 @@ class Graph:
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
-        # clear cached adjacency properties
-        if hasattr(self, "adj"):
-            delattr(self, "adj")
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
 
-    @cached_property
+    @property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -1253,7 +1250,7 @@ class Graph:
         except KeyError as err:
             raise NetworkXError(f"The node {n} is not in the graph.") from err
 
-    @cached_property
+    @property
     def edges(self):
         """An EdgeView of the Graph as G.edges or G.edges().
 
@@ -1376,7 +1373,7 @@ class Graph:
         """
         return iter(self._adj.items())
 
-    @cached_property
+    @property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -1,6 +1,5 @@
 """Base class for MultiDiGraph."""
 from copy import deepcopy
-from functools import cached_property
 
 import networkx as nx
 import networkx.convert as convert
@@ -346,7 +345,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         else:
             DiGraph.__init__(self, incoming_graph_data, **attr)
 
-    @cached_property
+    @property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -365,7 +364,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return MultiAdjacencyView(self._succ)
 
-    @cached_property
+    @property
     def succ(self):
         """Graph adjacency object holding the successors of each node.
 
@@ -384,7 +383,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return MultiAdjacencyView(self._succ)
 
-    @cached_property
+    @property
     def pred(self):
         """Graph adjacency object holding the predecessors of each node.
 
@@ -569,7 +568,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             del self._succ[u][v]
             del self._pred[v][u]
 
-    @cached_property
+    @property
     def edges(self):
         """An OutMultiEdgeView of the Graph as G.edges or G.edges().
 
@@ -651,13 +650,9 @@ class MultiDiGraph(MultiGraph, DiGraph):
         return OutMultiEdgeView(self)
 
     # alias out_edges to edges
-    @cached_property
-    def out_edges(self):
-        return OutMultiEdgeView(self)
+    out_edges = edges
 
-    out_edges.__doc__ = edges.__doc__
-
-    @cached_property
+    @property
     def in_edges(self):
         """An InMultiEdgeView of the Graph as G.in_edges or G.in_edges().
 
@@ -691,7 +686,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return InMultiEdgeView(self)
 
-    @cached_property
+    @property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 
@@ -739,7 +734,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return DiMultiDegreeView(self)
 
-    @cached_property
+    @property
     def in_degree(self):
         """A DegreeView for (node, in_degree) or in_degree for single node.
 
@@ -790,7 +785,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         """
         return InMultiDegreeView(self)
 
-    @cached_property
+    @property
     def out_degree(self):
         """Returns an iterator for (node, out-degree) or out-degree for single node.
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -1,6 +1,5 @@
 """Base class for MultiGraph."""
 from copy import deepcopy
-from functools import cached_property
 
 import networkx as nx
 import networkx.convert as convert
@@ -355,7 +354,7 @@ class MultiGraph(Graph):
         else:
             Graph.__init__(self, incoming_graph_data, **attr)
 
-    @cached_property
+    @property
     def adj(self):
         """Graph adjacency object holding the neighbors of each node.
 
@@ -783,7 +782,7 @@ class MultiGraph(Graph):
         except KeyError:
             return False
 
-    @cached_property
+    @property
     def edges(self):
         """Returns an iterator over the edges.
 
@@ -936,7 +935,7 @@ class MultiGraph(Graph):
         except KeyError:
             return default
 
-    @cached_property
+    @property
     def degree(self):
         """A DegreeView for the Graph as G.degree or G.degree().
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1049,11 +1049,11 @@ class OutEdgeView(Set, Mapping):
     __slots__ = ("_adjdict", "_graph", "_nodes_nbrs")
 
     def __getstate__(self):
-        return {"_graph": self._graph, "_adjdict": self._adjdict}
+        return {"_graph": self._graph}
 
     def __setstate__(self, state):
-        self._graph = state["_graph"]
-        self._adjdict = state["_adjdict"]
+        self._graph = G = state["_graph"]
+        self._adjdict = G._succ if hasattr(G, "succ") else G._adj
         self._nodes_nbrs = self._adjdict.items
 
     @classmethod

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1287,8 +1287,8 @@ class InEdgeView(OutEdgeView):
     __slots__ = ()
 
     def __setstate__(self, state):
-        self._graph = state["_graph"]
-        self._adjdict = state["_adjdict"]
+        self._graph = G = state["_graph"]
+        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
         self._nodes_nbrs = self._adjdict.items
 
     dataview = InEdgeDataView
@@ -1399,8 +1399,8 @@ class InMultiEdgeView(OutMultiEdgeView):
     __slots__ = ()
 
     def __setstate__(self, state):
-        self._graph = state["_graph"]
-        self._adjdict = state["_adjdict"]
+        self._graph = G = state["_graph"]
+        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
         self._nodes_nbrs = self._adjdict.items
 
     dataview = InMultiEdgeDataView

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -132,15 +132,6 @@ class BaseDiGraphTester(BaseGraphTester):
         assert nodes_equal(G.nodes(), G.reverse().nodes())
         assert [(y, x)] == list(G.reverse().edges())
 
-    def test_di_attributes_cached(self):
-        G = self.K3.copy()
-        assert id(G.in_edges) == id(G.in_edges)
-        assert id(G.out_edges) == id(G.out_edges)
-        assert id(G.in_degree) == id(G.in_degree)
-        assert id(G.out_degree) == id(G.out_degree)
-        assert id(G.succ) == id(G.succ)
-        assert id(G.pred) == id(G.pred)
-
 
 class BaseAttrDiGraphTester(BaseDiGraphTester, BaseAttrGraphTester):
     def test_edges_data(self):

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -171,12 +171,9 @@ class BaseGraphTester:
         G.add_edge(1, 1)
         G.remove_nodes_from([0, 1])
 
-    def test_attributes_cached(self):
+    def test_nodes_cached(self):
         G = self.K3.copy()
         assert id(G.nodes) == id(G.nodes)
-        assert id(G.edges) == id(G.edges)
-        assert id(G.degree) == id(G.degree)
-        assert id(G.adj) == id(G.adj)
 
 
 class BaseAttrGraphTester(BaseGraphTester):
@@ -595,7 +592,6 @@ class TestGraph(BaseAttrGraphTester):
 
     def test_getitem(self):
         G = self.K3
-        assert G.adj[0] == {1: {}, 2: {}}
         assert G[0] == {1: {}, 2: {}}
         with pytest.raises(KeyError):
             G.__getitem__("j")

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -242,15 +242,6 @@ class BaseMultiDiGraphTester(BaseMultiGraphTester):
         assert sorted(R.edges()) == [(1, 0), (1, 0)]
         pytest.raises(nx.NetworkXError, R.remove_edge, 1, 0)
 
-    def test_di_attributes_cached(self):
-        G = self.K3.copy()
-        assert id(G.in_edges) == id(G.in_edges)
-        assert id(G.out_edges) == id(G.out_edges)
-        assert id(G.in_degree) == id(G.in_degree)
-        assert id(G.out_degree) == id(G.out_degree)
-        assert id(G.succ) == id(G.succ)
-        assert id(G.pred) == id(G.pred)
-
 
 class TestMultiDiGraph(BaseMultiDiGraphTester, _TestMultiGraph):
     def setup_method(self):

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -1,6 +1,3 @@
-import pickle
-from copy import deepcopy
-
 import pytest
 
 import networkx as nx
@@ -1391,29 +1388,3 @@ def test_slicing_reportviews(reportview, err_msg_terms):
     errmsg = str(exc.value)
     assert type(view).__name__ in errmsg
     assert err_msg_terms in errmsg
-
-
-@pytest.mark.parametrize(
-    "graph", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
-)
-def test_cache_dict_get_set_state(graph):
-    G = nx.path_graph(5, graph())
-    G.nodes, G.edges, G.adj, G.degree
-    if G.is_directed():
-        G.pred, G.succ, G.in_edges, G.out_edges, G.in_degree, G.out_degree
-    cached_dict = G.__dict__
-    assert "nodes" in cached_dict
-    assert "edges" in cached_dict
-    assert "adj" in cached_dict
-    assert "degree" in cached_dict
-    if G.is_directed():
-        assert "pred" in cached_dict
-        assert "succ" in cached_dict
-        assert "in_edges" in cached_dict
-        assert "out_edges" in cached_dict
-        assert "in_degree" in cached_dict
-        assert "out_degree" in cached_dict
-
-    # Raises error if the cached properties and views do not work
-    pickle.loads(pickle.dumps(G, -1))
-    deepcopy(G)


### PR DESCRIPTION
This reverts commit f50fc70b8cb6b4f5217a6d5505ba0e2b82b4761b and https://github.com/networkx/networkx/commit/d46c0c219f6082424074f077ef2c1e40a9ff7065

This change brought in a performance regression in core classes. I'm not a 100% sure if we should keep this change (cacheing) in 3.0 or not?

If we want to revert, this can also go into 2.8.5