### PR TITLE
Add random_spanning_tree to documentation

### DIFF
--- a/doc/reference/algorithms/tree.rst
+++ b/doc/reference/algorithms/tree.rst
@@ -59,6 +59,7 @@ Spanning Trees
 
    minimum_spanning_tree
    maximum_spanning_tree
+   random_spanning_tree
    minimum_spanning_edges
    maximum_spanning_edges
    SpanningTreeIterator


### PR DESCRIPTION
When I created #5656 I forgot to add `random_spanning_tree` to `tree.rst` so it does not appear in the documentation.
