### PR TITLE
Temporary fix for failing tests w/ scipy1.9.

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -676,7 +676,9 @@ def held_karp_ascent(G, weight="weight"):
                     n_count -= 1
                 a_eq[len(G)][arb_count] = 1
                 arb_count += 1
-            program_result = optimize.linprog(c, A_eq=a_eq, b_eq=b_eq)
+            program_result = optimize.linprog(
+                c, A_eq=a_eq, b_eq=b_eq, method="interior-point"
+            )
             bool_result = program_result.x >= 0
             if program_result.status == 0 and np.sum(bool_result) == len(
                 minimum_1_arborescences


### PR DESCRIPTION
SciPy 1.9 (currently in rc1) switches the default `method` for `sp.optimize.linprog` from `internal-point` to `highs`. The new method results in a slight behavior change in that `None` is returned when `linprog` fails instead of an array of zeros.

This temporary fix switches back to the scipy1.8 default method, which warns but doesn't result in an exception raise. In the longer run this needs to be revisited as it turns out our held-karp test cases all result in failed optimizations from `optimize.linprog`. I'll create a separate issue for that.

See also scipy/scipy#16466