### PR TITLE
Update distance parameter description.

### DIFF
--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -52,7 +52,6 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True):
       path calculations. If `None` (the default), all edges are assumed to have
       a distance of 1. No check is performed to ensure that edges have the
       provided attribute.
-      
 
     wf_improved : bool, optional (default=True)
       If True, scale by the fraction of nodes reachable. This gives the

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -49,9 +49,9 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True):
 
     distance : edge attribute key, optional (default=None)
       Use the specified edge attribute as the edge distance in shortest
-      path calculations. If `None` (the default), all edges are assumed to have
-      a distance of 1. No check is performed to ensure that edges have the
-      provided attribute.
+      path calculations.  If `None` (the default) all edges have a distance of 1. 
+      Absent edge attributes are assigned a distance of 1. Note that no check
+      is performed to ensure that edges have the provided attribute.
 
     wf_improved : bool, optional (default=True)
       If True, scale by the fraction of nodes reachable. This gives the

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -49,7 +49,10 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True):
 
     distance : edge attribute key, optional (default=None)
       Use the specified edge attribute as the edge distance in shortest
-      path calculations
+      path calculations. If `None` (the default), all edges are assumed to have
+      a distance of 1. No check is performed to ensure that edges have the
+      provided attribute.
+      
 
     wf_improved : bool, optional (default=True)
       If True, scale by the fraction of nodes reachable. This gives the

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -49,7 +49,7 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True):
 
     distance : edge attribute key, optional (default=None)
       Use the specified edge attribute as the edge distance in shortest
-      path calculations.  If `None` (the default) all edges have a distance of 1. 
+      path calculations.  If `None` (the default) all edges have a distance of 1.
       Absent edge attributes are assigned a distance of 1. Note that no check
       is performed to ensure that edges have the provided attribute.
 


### PR DESCRIPTION
Alternative to #5695.

Update the description of the  parameter in the
closeness_centrality function to note that by default, the edge
distances (weights) are assumed to be 1, and that no input
validation is performed.

Closes #3880