### PR TITLE
Attempt to reverse slowdown from hasattr  needed for cached_property

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,6 +19,16 @@ Highlights
 This release is the result of X of work with over X pull requests by
 X contributors. Highlights include:
 
+Better speed from the core adjacency data structures and better syncing
+between G._succ and G._adj for directed G. We have always assumed that these
+attributes are pointing to the same object. But we did not enforce it well.
+If you have somehow worked around our attempts and are relying on these
+private attributes being allowed to be different from each other due to
+loopholes in our previous rules, you will have to look for other loopholes
+in our new rules (or subclass DiGraph to explicitly allow this).
+If you set G._succ or G._adj to new dictionary-like objects, you no longer
+have to set them both. Setting either will ensure the other is set as well.
+And the cached_properties G.adj and G.succ will be rest accordingly too.
 
 Improvements
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,16 +19,25 @@ Highlights
 This release is the result of X of work with over X pull requests by
 X contributors. Highlights include:
 
-Better speed from the core adjacency data structures and better syncing
-between G._succ and G._adj for directed G. We have always assumed that these
-attributes are pointing to the same object. But we did not enforce it well.
-If you have somehow worked around our attempts and are relying on these
-private attributes being allowed to be different from each other due to
-loopholes in our previous rules, you will have to look for other loopholes
-in our new rules (or subclass DiGraph to explicitly allow this).
-If you set G._succ or G._adj to new dictionary-like objects, you no longer
-have to set them both. Setting either will ensure the other is set as well.
-And the cached_properties G.adj and G.succ will be rest accordingly too.
+- Better syncing between G._succ and G._adj for directed G.
+  And slightly better speed from all the core adjacency data structures.
+  G.adj is now a cached_property while still having the cache reset when
+  G._adj is set to a new dict (which doesn't happen very often).
+  Note: We have always assumed that G._succ and G._adj point to the same
+  object. But we did not enforce it well. If you have somehow worked
+  around our attempts and are relying on these private attributes being
+  allowed to be different from each other due to loopholes in our previous
+  code, you will have to look for other loopholes in our new code
+  (or subclass DiGraph to explicitly allow this).
+- If your code sets G._succ or G._adj to new dictionary-like objects, you no longer
+  have to set them both. Setting either will ensure the other is set as well.
+  And the cached_properties G.adj and G.succ will be rest accordingly too.
+- If you use the presence of the attribute `_adj` as a criteria for the object
+  being a Graph instance, that code may need updating. The graph classes
+  themselves now have an attribute `_adj`. So, it is possible that whatever you
+  are checking might be a class rather than an instance. We suggest you check
+  for attribute `_adj` to verify it is like a NetworkX graph object or type and
+  then `type(obj) is type` to check if it is a class.
 
 Improvements
 ------------

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -813,7 +813,7 @@ def _dijkstra_multisource(
     as arguments. No need to explicitly return pred or paths.
 
     """
-    G_succ = G._succ if G.is_directed() else G._adj
+    G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
 
     push = heappush
     pop = heappop
@@ -1394,7 +1394,7 @@ def _inner_bellman_ford(
     pred_edge = {v: None for v in sources}
     recent_update = {v: nonexistent_edge for v in sources}
 
-    G_succ = G.succ if G.is_directed() else G.adj
+    G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
     inf = float("inf")
     n = len(G)
 
@@ -1978,10 +1978,7 @@ def goldberg_radzik(G, source, weight="weight"):
     if len(G) == 1:
         return {source: None}, {source: 0}
 
-    if G.is_directed():
-        G_succ = G.succ
-    else:
-        G_succ = G.adj
+    G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
 
     inf = float("inf")
     d = {u: inf for u in G}

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -19,12 +19,19 @@ __all__ = ["DiGraph"]
 
 
 class _CachedPropertyResetterAdjAndSucc:
-    """Data Descriptor class that resets two cached property objects: adj and succ
+    """Data Descriptor class that syncs and resets cached properties adj and succ
 
-    This assumes that the cached properties should be reset whenever the
-    attribute value is changed. The `__dict__` entries "_adj" and "_succ"
-    are both set to the same value (synced) and the cached_properties
-    "adj" and "succ" that refer to them are reset at that time.
+    The cached properties `adj` and `succ` are reset whenever `_adj` or `_succ`
+    are set to new objects. In addition, the attributes `_succ` and `_adj`
+    are synced so these two names point to the same object.
+
+    This object sits on a class and ensures that any instance of that
+    class clears its cached properties "succ" and "adj" whenever the
+    underlying instance attributes "_succ" or "_adj" are set to a new object.
+    It only affects the set process of the obj._adj and obj._succ attribute.
+    All get/del operations act as they normally would.
+
+    For info on Data Descriptors see: https://docs.python.org/3/howto/descriptor.html
     """
 
     def __set__(self, obj, value):
@@ -43,6 +50,14 @@ class _CachedPropertyResetterPred:
 
     This assumes that the ``cached_property`` ``G.pred`` should be reset whenever
     ``G._pred`` is set to a new value.
+
+    This object sits on a class and ensures that any instance of that
+    class clears its cached property "pred" whenever the underlying
+    instance attribute "_pred" is set to a new object. It only affects
+    the set process of the obj._pred attribute. All get/del operations
+    act as they normally would.
+
+    For info on Data Descriptors see: https://docs.python.org/3/howto/descriptor.html
     """
 
     def __set__(self, obj, value):

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -285,7 +285,7 @@ class DiGraph(Graph):
     a dictionary-like object.
     """
 
-    _adj = _CachedPropertyResetterAdjAndSucc()
+    _adj = _CachedPropertyResetterAdjAndSucc()  # type: ignore
     _succ = _CachedPropertyResetterAdjAndSucc()
     _pred = _CachedPropertyResetter()
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -314,19 +314,21 @@ class DiGraph(Graph):
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
         self._pred = self.adjlist_outer_dict_factory()  # predecessor
         self._succ = self._adj  # successor
-        # clear cached adjacency properties
-        if hasattr(self, "adj"):
-            delattr(self, "adj")
-        if hasattr(self, "pred"):
-            delattr(self, "pred")
-        if hasattr(self, "succ"):
-            delattr(self, "succ")
 
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name in ("_adj", "_succ"):
+            for property_name in ("adj", "succ"):
+                if property_name in self.__dict__:
+                    delattr(self, property_name)
+        elif name == "_pred" and "pred" in self.__dict__:
+            delattr(self, "pred")
 
     @cached_property
     def adj(self):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -330,9 +330,6 @@ class Graph:
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
-        # clear cached adjacency properties
-        if hasattr(self, "adj"):
-            delattr(self, "adj")
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
@@ -357,6 +354,12 @@ class Graph:
         For directed graphs, `G.adj` holds outgoing (successor) info.
         """
         return AdjacencyView(self._adj)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name == "_adj":
+            if "adj" in self.__dict__:
+                delattr(self, "adj")
 
     @property
     def name(self):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -24,6 +24,14 @@ class _CachedPropertyResetterAdj:
 
     This assumes that the ``cached_property`` ``G.adj`` should be reset whenever
     ``G._adj`` is set to a new value.
+
+    This object sits on a class and ensures that any instance of that
+    class clears its cached property "adj" whenever the underlying
+    instance attribute "_adj" is set to a new object. It only affects
+    the set process of the obj._adj attribute. All get/del operations
+    act as they normally would.
+
+    For info on Data Descriptors see: https://docs.python.org/3/howto/descriptor.html
     """
 
     def __set__(self, obj, value):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -19,26 +19,18 @@ from networkx.exception import NetworkXError
 __all__ = ["Graph"]
 
 
-class _CachedPropertyResetter:
-    """Data Descriptor class that resets a cached property when needed
+class _CachedPropertyResetterAdj:
+    """Data Descriptor class for _adj that resets ``adj`` cached_property when needed
 
-    This assumes that the cached property should be reset whenever an
-    attribute is changed that has the same name only prepended by a
-    single character (usually an underscore).  Thus cached_property G.adj
-    should be reset whenever G._adj is set to a new value.
+    This assumes that the ``cached_property`` ``G.adj`` should be reset whenever
+    ``G._adj`` is set to a new value.
     """
 
-    def __set_name__(self, owner, name):
-        self.name = name
-
     def __set__(self, obj, value):
-        od = vars(obj)
-        name = self.name
-        od[name] = value
-
-        prop_name = name[1:]  # remove leading underscore to get property name
-        if prop_name in od:
-            del od[prop_name]
+        od = obj.__dict__
+        od["_adj"] = value
+        if "adj" in od:
+            del od["adj"]
 
 
 class Graph:
@@ -286,7 +278,7 @@ class Graph:
     a dictionary-like object.
     """
 
-    _adj = _CachedPropertyResetter()
+    _adj = _CachedPropertyResetterAdj()
 
     node_dict_factory = dict
     node_attr_dict_factory = dict

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -56,11 +56,11 @@ def generic_graph_view(G, create_using=None):
         if G.is_directed():
             newG._succ = G._succ
             newG._pred = G._pred
-            newG._adj = G._succ
+            # newG._adj is synced with _succ
         else:
             newG._succ = G._adj
             newG._pred = G._adj
-            newG._adj = G._adj
+            # newG._adj is synced with _succ
     elif G.is_directed():
         if G.is_multigraph():
             newG._adj = UnionMultiAdjacency(G._succ, G._pred)
@@ -164,7 +164,7 @@ def subgraph_view(G, filter_node=no_filter, filter_edge=no_filter):
     if G.is_directed():
         newG._succ = Adj(G._succ, filter_node, filter_edge)
         newG._pred = Adj(G._pred, filter_node, reverse_edge)
-        newG._adj = newG._succ
+        # newG._adj is synced with _succ
     else:
         newG._adj = Adj(G._adj, filter_node, filter_edge)
     return newG
@@ -201,5 +201,5 @@ def reverse_view(G):
     """
     newG = generic_graph_view(G)
     newG._succ, newG._pred = G._pred, G._succ
-    newG._adj = newG._succ
+    # newG._adj is synced with _succ
     return newG

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -209,7 +209,7 @@ class TestDiGraph(BaseAttrDiGraphTester, _TestGraph):
         self.k3edges = [(0, 1), (0, 2), (1, 2)]
         self.k3nodes = [0, 1, 2]
         self.K3 = self.Graph()
-        self.K3._adj = self.K3._succ = self.k3adj
+        self.K3._succ = self.k3adj  # K3._adj is synced with K3._succ
         self.K3._pred = {0: {1: ed3, 2: ed5}, 1: {0: ed1, 2: ed6}, 2: {0: ed2, 1: ed4}}
         self.K3._node = {}
         self.K3._node[0] = {}
@@ -218,9 +218,9 @@ class TestDiGraph(BaseAttrDiGraphTester, _TestGraph):
 
         ed1, ed2 = ({}, {})
         self.P3 = self.Graph()
-        self.P3._adj = {0: {1: ed1}, 1: {2: ed2}, 2: {}}
-        self.P3._succ = self.P3._adj
+        self.P3._succ = {0: {1: ed1}, 1: {2: ed2}, 2: {}}
         self.P3._pred = {0: {}, 1: {0: ed1}, 2: {1: ed2}}
+        # P3._adj is synced with P3._succ
         self.P3._node = {}
         self.P3._node[0] = {}
         self.P3._node[1] = {}

--- a/networkx/classes/tests/test_digraph.py
+++ b/networkx/classes/tests/test_digraph.py
@@ -132,6 +132,22 @@ class BaseDiGraphTester(BaseGraphTester):
         assert nodes_equal(G.nodes(), G.reverse().nodes())
         assert [(y, x)] == list(G.reverse().edges())
 
+    def test_di_cache_reset(self):
+        G = self.K3.copy()
+        old_succ = G.succ
+        assert id(G.succ) == id(old_succ)
+        old_adj = G.adj
+        assert id(G.adj) == id(old_adj)
+
+        G._succ = {}
+        assert id(G.succ) != id(old_succ)
+        assert id(G.adj) != id(old_adj)
+
+        old_pred = G.pred
+        assert id(G.pred) == id(old_pred)
+        G._pred = {}
+        assert id(G.pred) != id(old_pred)
+
     def test_di_attributes_cached(self):
         G = self.K3.copy()
         assert id(G.in_edges) == id(G.in_edges)

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -171,6 +171,13 @@ class BaseGraphTester:
         G.add_edge(1, 1)
         G.remove_nodes_from([0, 1])
 
+    def test_cache_reset(self):
+        G = self.K3.copy()
+        old_adj = G.adj
+        assert id(G.adj) == id(old_adj)
+        G._adj = {}
+        assert id(G.adj) != id(old_adj)
+
     def test_attributes_cached(self):
         G = self.K3.copy()
         assert id(G.nodes) == id(G.nodes)

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -259,8 +259,8 @@ class TestMultiDiGraph(BaseMultiDiGraphTester, _TestMultiGraph):
         self.k3edges = [(0, 1), (0, 2), (1, 2)]
         self.k3nodes = [0, 1, 2]
         self.K3 = self.Graph()
-        self.K3._adj = {0: {}, 1: {}, 2: {}}
-        self.K3._succ = self.K3._adj
+        self.K3._succ = {0: {}, 1: {}, 2: {}}
+        # K3._adj is synced with K3._succ
         self.K3._pred = {0: {}, 1: {}, 2: {}}
         for u in self.k3nodes:
             for v in self.k3nodes:
@@ -433,14 +433,14 @@ class TestMultiDiGraphSubclass(TestMultiDiGraph):
         self.k3edges = [(0, 1), (0, 2), (1, 2)]
         self.k3nodes = [0, 1, 2]
         self.K3 = self.Graph()
-        self.K3._adj = self.K3.adjlist_outer_dict_factory(
+        self.K3._succ = self.K3.adjlist_outer_dict_factory(
             {
                 0: self.K3.adjlist_inner_dict_factory(),
                 1: self.K3.adjlist_inner_dict_factory(),
                 2: self.K3.adjlist_inner_dict_factory(),
             }
         )
-        self.K3._succ = self.K3._adj
+        # K3._adj is synced with K3._succ
         self.K3._pred = {0: {}, 1: {}, 2: {}}
         for u in self.k3nodes:
             for v in self.k3nodes:

--- a/networkx/classes/tests/test_special.py
+++ b/networkx/classes/tests/test_special.py
@@ -128,7 +128,8 @@ class TestThinDiGraph(BaseDiGraphTester):
         self.k3edges = [(0, 1), (0, 2), (1, 2)]
         self.k3nodes = [0, 1, 2]
         self.K3 = self.Graph()
-        self.K3._adj = self.K3._succ = self.k3adj
+        self.K3._succ = self.k3adj
+        # K3._adj is synced with K3._succ
         self.K3._pred = {0: {1: ed3, 2: ed5}, 1: {0: ed1, 2: ed6}, 2: {0: ed2, 1: ed4}}
         self.K3._node = {}
         self.K3._node[0] = {}
@@ -137,8 +138,8 @@ class TestThinDiGraph(BaseDiGraphTester):
 
         ed1, ed2 = (all_edge_dict, all_edge_dict)
         self.P3 = self.Graph()
-        self.P3._adj = {0: {1: ed1}, 1: {2: ed2}, 2: {}}
-        self.P3._succ = self.P3._adj
+        self.P3._succ = {0: {1: ed1}, 1: {2: ed2}, 2: {}}
+        # P3._adj is synced with P3._succ
         self.P3._pred = {0: {}, 1: {0: ed1}, 2: {1: ed2}}
         self.P3._node = {}
         self.P3._node[0] = {}

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -481,13 +481,14 @@ def empty_graph(n=0, create_using=None, default=Graph):
     """
     if create_using is None:
         G = default()
-    elif hasattr(create_using, "_adj"):
+    elif type(create_using) is type:
+        G = create_using()
+    elif not hasattr(create_using, "adj"):
+        raise TypeError("create_using is not a valid NetworkX graph type or instance")
+    else:
         # create_using is a NetworkX style Graph
         create_using.clear()
         G = create_using
-    else:
-        # try create_using as constructor
-        G = create_using()
 
     _, nodes = n
     G.add_nodes_from(nodes)

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -49,7 +49,7 @@ class TestGeneratorsDirected:
             gamma=0.3,
             delta_in=0.3,
             delta_out=0.1,
-            create_using=MultiDiGraph,
+            initial_graph=nx.cycle_graph(4, create_using=MultiDiGraph),
             seed=1,
         )
         pytest.raises(ValueError, scale_free_graph, 100, 0.5, 0.4, 0.3)


### PR DESCRIPTION
As discussed in #5796 there was a slowdown in e.g. `copy` when we changed the base classes to use `cached_property` instead of `property`.  This was due to the need to check whether to reset the cached property during `__init__`.  But it actually doesn't have to happen during `__init__`. So I have moved that check to the places in our codebase where we are replacing or changing `G._adj`/`G._succ`/`G._pred`. The danger is that we change `G._adj` and don't get an updated cached_property.  Within our codebase this is only needed inside `graphviews.py`.  It is hard to know how many users would be affected. If they swap out `G._adj` without resetting the cache property on `G.adj` then they might see some strange results where `G.adj` reports one thing while `G._adj` reports another.

We could avoid all this trouble by computing `G.adj` as an attribute instead of a property.  It would cause creation of the `AdjacencyView` during `__init__` rather than on the first lookup of `G.adj`. So some benchmarks might show a slowdown. Indeed, creating a graph would be slower by the amount of time needed to create the AdjView. Presumably that is more than the time to do a `hasattr` which caused the slowdown we are currently fixing. The tradeoff is between potential for users playing with private attributes to mix things up vs extra work creating each graph object. 

Note: I only really looked at the regression for `copy` assuming it would fix the others. We should check that the others don't have that slowdown after this change.