### PR TITLE
Add direct link to github networkx org sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: [networkx]
 custom: https://numfocus.org/donate-to-networkx


### PR DESCRIPTION
If someone clicks on the `<3 Sponsor` button top of the repo in https://github.com/networkx/networkx/ this change will let them directly sign up via GitHub sponsors and it will take them to https://github.com/sponsors/networkx (which we need to update). 