### PR TITLE
Speed up unionfind a bit by not adding root node in the path

### DIFF
--- a/networkx/utils/union_find.py
+++ b/networkx/utils/union_find.py
@@ -53,11 +53,12 @@ class UnionFind:
             return object
 
         # find path of objects leading to the root
-        path = [object]
+        path = []
         root = self.parents[object]
-        while root != path[-1]:
-            path.append(root)
-            root = self.parents[root]
+        while root != object:
+            path.append(object)
+            object = root
+            root = self.parents[object]
 
         # compress the path and return
         for ancestor in path:


### PR DESCRIPTION
As suggested by @dschult in https://github.com/networkx/networkx/pull/4810, but FWIW it doesn't have that much of difference in speed. I'm +0 on this.