### PR TITLE
Fixed unused root argument in has_bridges

### DIFF
--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -70,7 +70,7 @@ def bridges(G, root=None):
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
     H_copy = H.copy()
-    if root is None:
+    if root is not None:
         H = H.subgraph(nx.node_connected_component(H, root)).copy()
     for u, v in H.edges():
         if (u, v) not in chain_edges and (v, u) not in chain_edges:

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -70,7 +70,7 @@ def bridges(G, root=None):
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
     H_copy = H.copy()
-    if root is None:
+    if root is not None:
         cc_root = nx.node_connected_component(H, root)
         for node in H.nodes():
             if node not in cc_root:

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -128,7 +128,7 @@ def has_bridges(G, root=None):
 
     """
     try:
-        next(bridges(G))
+        next(bridges(G, root=root))
     except StopIteration:
         return False
     else:

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -70,7 +70,7 @@ def bridges(G, root=None):
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
     H_copy = H.copy()
-    if root:
+    if root is None:
         cc_root = nx.node_connected_component(H, root)
         for node in H.nodes():
             if node not in cc_root:

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -70,12 +70,9 @@ def bridges(G, root=None):
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
     H_copy = H.copy()
-    if root is not None:
-        cc_root = nx.node_connected_component(H, root)
-        for node in H.nodes():
-            if node not in cc_root:
-                H_copy.remove_node(node)
-    for u, v in H_copy.edges():
+    if root:
+        H = H.subgraph(nx.node_connected_component(H, root)).copy()
+    for u, v in H.edges():
         if (u, v) not in chain_edges and (v, u) not in chain_edges:
             if multigraph and len(G[u][v]) > 1:
                 continue

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -69,7 +69,13 @@ def bridges(G, root=None):
     H = nx.Graph(G) if multigraph else G
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
-    for u, v in H.edges():
+    H_copy = H.copy()
+    if root:
+        cc_root = nx.node_connected_component(H, root)
+        for node in H.nodes():
+            if node not in cc_root:
+                H_copy.remove_node(node)
+    for u, v in H_copy.edges():
         if (u, v) not in chain_edges and (v, u) not in chain_edges:
             if multigraph and len(G[u][v]) > 1:
                 continue

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -70,7 +70,7 @@ def bridges(G, root=None):
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
     H_copy = H.copy()
-    if root:
+    if root is None:
         H = H.subgraph(nx.node_connected_component(H, root)).copy()
     for u, v in H.edges():
         if (u, v) not in chain_edges and (v, u) not in chain_edges:

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -143,7 +143,7 @@ def chain_decomposition(G, root=None):
 
     # Check if the root is in the graph G. If not, raise NodeNotFound
     if root is not None and root not in G:
-        raise nx.NodeNotFound("Root node %s is not in graph" % root)
+        raise nx.NodeNotFound(f"Root node {root} is not in graph")
 
     # Create a directed version of H that has the DFS edges directed
     # toward the root and the nontree edges directed away from the root

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -141,8 +141,7 @@ def chain_decomposition(G, root=None):
             u, v = v, G.nodes[v]["parent"]
         yield u, v
 
-    # Check if the root is in the graph G. If not, raise a NodeNotFound
-    # error.
+    # Check if the root is in the graph G. If not, raise NodeNotFound
     if root is not None and root not in G:
         raise nx.NodeNotFound("Root node %s is not in graph" % root)
 

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -141,6 +141,11 @@ def chain_decomposition(G, root=None):
             u, v = v, G.nodes[v]["parent"]
         yield u, v
 
+    # Check if the root is in the graph G. If not, raise a NodeNotFound
+    # error.
+    if root is not None and root not in G:
+        raise nx.NodeNotFound("Root node %s is not in graph" % root)
+
     # Create a directed version of H that has the DFS edges directed
     # toward the root and the nontree edges directed away from the root
     # (in each connected component).

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -1,5 +1,7 @@
 """Unit tests for bridge-finding algorithms."""
 
+import pytest
+
 import networkx as nx
 
 
@@ -49,6 +51,53 @@ class TestBridges:
         ]
         G = nx.MultiGraph(edges)
         assert list(nx.bridges(G)) == [(2, 3)]
+
+
+class TestHasBridges:
+    """Unit tests for the has bridges function."""
+
+    def test_single_bridge(self):
+        edges = [
+            # DFS tree edges.
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (3, 5),
+            (5, 6),
+            (6, 7),
+            (7, 8),
+            (5, 9),
+            (9, 10),
+            # Nontree edges.
+            (1, 3),
+            (1, 4),
+            (2, 5),
+            (5, 10),
+            (6, 8),
+        ]
+        G = nx.Graph(edges)
+        source = 1
+        has_bridges = nx.has_bridges(G, source)
+        assert has_bridges == True
+
+    def test_barbell_graph(self):
+        # The (3, 0) barbell graph has two triangles joined by a single edge.
+        G = nx.barbell_graph(3, 0)
+        source = 6
+        pytest.raises(nx.NodeNotFound, nx.has_bridges, G, source)
+
+    def test_multiedge_bridge(self):
+        edges = [
+            (0, 1),
+            (0, 2),
+            (1, 2),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (3, 4),
+        ]
+        G = nx.MultiGraph(edges)
+        assert nx.has_bridges(G) == True
 
 
 class TestLocalBridges:

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -101,6 +101,12 @@ class TestHasBridges:
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
         assert not nx.has_bridges(G)
 
+    def test_bridges_multiple_components(self):
+        G = nx.Graph()
+        nx.add_path(G, [0, 1, 2])  # One connected component
+        nx.add_path(G, [4, 5, 6])  # Another connected component
+        assert list(nx.bridges(G, root=4)) == [(4, 5), (5, 6)]
+
 
 class TestLocalBridges:
     """Unit tests for the local_bridge function."""

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -63,7 +63,7 @@ class TestHasBridges:
             (2, 3),
             (3, 4),
             (3, 5),
-            (5, 6),
+            (5, 6),  # The only bridge edge
             (6, 7),
             (7, 8),
             (5, 9),
@@ -76,15 +76,14 @@ class TestHasBridges:
             (6, 8),
         ]
         G = nx.Graph(edges)
-        source = 1
-        has_bridges = nx.has_bridges(G, source)
-        assert has_bridges == True
+        assert nx.has_bridges(G)  # Default root
+        assert nx.has_bridges(G, root=1)  # arbitrary root in G
 
-    def test_barbell_graph(self):
+    def test_has_bridges_raises_root_not_in_G(self):
         # The (3, 0) barbell graph has two triangles joined by a single edge.
         G = nx.barbell_graph(3, 0)
-        source = 6
-        pytest.raises(nx.NodeNotFound, nx.has_bridges, G, source)
+        with pytest.raises(nx.NodeNotFound):
+            nx.has_bridges(G, root=6)
 
     def test_multiedge_bridge(self):
         edges = [
@@ -97,8 +96,10 @@ class TestHasBridges:
             (3, 4),
         ]
         G = nx.MultiGraph(edges)
-        assert nx.has_bridges(G) == True
-
+        assert nx.has_bridges(G)
+        # Make every edge a multiedge
+        G.add_edges_from([(0, 1), (0, 2), (2, 3)])
+        assert not nx.has_bridges(G)
 
 class TestLocalBridges:
     """Unit tests for the local_bridge function."""

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -80,8 +80,8 @@ class TestHasBridges:
         assert nx.has_bridges(G, root=1)  # arbitrary root in G
 
     def test_has_bridges_raises_root_not_in_G(self):
-        # The (3, 0) barbell graph has two triangles joined by a single edge.
-        G = nx.barbell_graph(3, 0)
+        G = nx.Graph()
+        G.add_nodes_from([1, 2, 3])
         with pytest.raises(nx.NodeNotFound):
             nx.has_bridges(G, root=6)
 
@@ -100,6 +100,7 @@ class TestHasBridges:
         # Make every edge a multiedge
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
         assert not nx.has_bridges(G)
+
 
 class TestLocalBridges:
     """Unit tests for the local_bridge function."""

--- a/networkx/algorithms/tests/test_chains.py
+++ b/networkx/algorithms/tests/test_chains.py
@@ -1,6 +1,8 @@
 """Unit tests for the chain decomposition functions."""
 from itertools import cycle, islice
 
+import pytest
+
 import networkx as nx
 
 
@@ -129,3 +131,10 @@ class TestChainDecomposition:
         assert len(chains) == len(expected)
         for chain in chains:
             self.assertContainsChain(chain, expected)
+
+    def test_chain_decomposition_root_not_in_G(self):
+        """Test chain decomposition when root is not in graph"""
+        G = nx.Graph()
+        G.add_nodes_from([1, 2, 3])
+        with pytest.raises(nx.NodeNotFound):
+            nx.has_bridges(G, root=6)


### PR DESCRIPTION
This fixes #5636 and it is ready to merge!

1. I added the root argument in the `nx.bridges` call in the `has_bridges` function. 
2. I added tests for the `has_bridges` function since they were missing. 
3. I fixed the bridges function when there is more than one connected component. 
4. I added tests for chain decomposition function.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
