### PR TITLE
Sync up behavior of is_{type} for empty graphs

### DIFF
--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -340,7 +340,7 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
     It ignores any self loops.
     """
     if len(G) == 0:
-        raise nx.NetworkXError("Graph has no nodes.")
+        raise nx.NetworkXPointlessConcept("Graph has no nodes.")
     unnumbered = set(G)
     if s is None:
         s = arbitrary_element(G)

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -339,6 +339,8 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
 
     It ignores any self loops.
     """
+    if len(G) == 0:
+        raise nx.NetworkXError("Graph has no nodes.")
     unnumbered = set(G)
     if s is None:
         s = arbitrary_element(G)

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -186,9 +186,6 @@ class TestStronglyConnected:
             with pytest.deprecated_call():
                 next(nx.strongly_connected_components_recursive(G))
         pytest.raises(NetworkXNotImplemented, nx.is_strongly_connected, G)
-        pytest.raises(
-            nx.NetworkXPointlessConcept, nx.is_strongly_connected, nx.DiGraph()
-        )
         pytest.raises(NetworkXNotImplemented, nx.condensation, G)
 
     strong_cc_methods = (

--- a/networkx/algorithms/components/tests/test_weakly_connected.py
+++ b/networkx/algorithms/components/tests/test_weakly_connected.py
@@ -88,3 +88,9 @@ class TestWeaklyConnected:
             assert len(seen & component) == 0
             seen.update(component)
             component.clear()
+
+
+def test_is_weakly_connected_empty_graph_raises():
+    G = nx.DiGraph()
+    with pytest.raises(nx.NetworkXPointlessConcept, match="Connectivity is undefined"):
+        nx.is_weakly_connected(G)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -642,7 +642,7 @@ def is_aperiodic(G):
     if not G.is_directed():
         raise nx.NetworkXError("is_aperiodic not defined for undirected graphs")
     if len(G) == 0:
-        raise nx.NetworkXError("Graph has no nodes.")
+        raise nx.NetworkXPointlessConcept("Graph has no nodes.")
     s = arbitrary_element(G)
     levels = {s: 0}
     this_level = [s]

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -641,7 +641,8 @@ def is_aperiodic(G):
     """
     if not G.is_directed():
         raise nx.NetworkXError("is_aperiodic not defined for undirected graphs")
-
+    if len(G) == 0:
+        raise nx.NetworkXError("Graph has no nodes.")
     s = arbitrary_element(G)
     levels = {s: 0}
     this_level = [s]

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -148,7 +148,7 @@ def intersection_array(G):
     """
     # test for regular graph (all degrees must be equal)
     if len(G) == 0:
-        raise nx.NetworkXError("Graph has no nodes.")
+        raise nx.NetworkXPointlessConcept("Graph has no nodes.")
     degree = iter(G.degree())
     (_, k) = next(degree)
     for _, knext in degree:

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -147,6 +147,8 @@ def intersection_array(G):
     global_parameters
     """
     # test for regular graph (all degrees must be equal)
+    if len(G) == 0:
+        raise nx.NetworkXError("Graph has no nodes.")
     degree = iter(G.degree())
     (_, k) = next(degree)
     for _, knext in degree:

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -29,6 +29,8 @@ def is_regular(G):
     True
 
     """
+    if len(G) == 0:
+        raise nx.NetworkXError("Graph has no nodes.")
     n1 = nx.utils.arbitrary_element(G)
     if not G.is_directed():
         d1 = G.degree(n1)

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -30,7 +30,7 @@ def is_regular(G):
 
     """
     if len(G) == 0:
-        raise nx.NetworkXError("Graph has no nodes.")
+        raise nx.NetworkXPointlessConcept("Graph has no nodes.")
     n1 = nx.utils.arbitrary_element(G)
     if not G.is_directed():
         d1 = G.degree(n1)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -618,9 +618,15 @@ def test_is_aperiodic_selfloop():
     assert nx.is_aperiodic(G)
 
 
-def test_is_aperiodic_raise():
+def test_is_aperiodic_undirected_raises():
     G = nx.Graph()
     pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
+
+
+def test_is_aperiodic_empty_graph():
+    G = nx.empty_graph(create_using=nx.DiGraph)
+    with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes."):
+        nx.is_aperiodic(G)
 
 
 def test_is_aperiodic_bipartite():

--- a/networkx/algorithms/tests/test_distance_regular.py
+++ b/networkx/algorithms/tests/test_distance_regular.py
@@ -1,3 +1,5 @@
+import pytest
+
 import networkx as nx
 from networkx import is_strongly_regular
 
@@ -39,6 +41,13 @@ class TestDistanceRegular:
         b, c = nx.intersection_array(nx.icosahedral_graph())
         assert b == [5, 2, 1]
         assert c == [1, 2, 5]
+
+
+@pytest.mark.parametrize("f", (nx.is_distance_regular, nx.is_strongly_regular))
+def test_empty_graph_raises(f):
+    G = nx.Graph()
+    with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes"):
+        f(G)
 
 
 class TestStronglyRegular:

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -5,6 +5,13 @@ import pytest
 import networkx as nx
 
 
+@pytest.mark.parametrize("f", (nx.is_eulerian, nx.is_semieulerian))
+def test_empty_graph_raises(f):
+    G = nx.Graph()
+    with pytest.raises(nx.NetworkXPointlessConcept, match="Connectivity is undefined"):
+        f(G)
+
+
 class TestIsEulerian:
     def test_is_eulerian(self):
         assert nx.is_eulerian(nx.complete_graph(5))

--- a/networkx/algorithms/tests/test_regular.py
+++ b/networkx/algorithms/tests/test_regular.py
@@ -68,6 +68,12 @@ class TestIsRegular:
         assert reg.is_regular(g)
 
 
+def test_is_regular_empty_graph_raises():
+    G = nx.Graph()
+    with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes"):
+        nx.is_regular(G)
+
+
 class TestIsKRegular:
     def test_is_k_regular1(self):
         g = gen.cycle_graph(4)

--- a/networkx/algorithms/tree/tests/test_recognition.py
+++ b/networkx/algorithms/tree/tests/test_recognition.py
@@ -119,6 +119,12 @@ def test_emptybranch():
     assert not nx.is_arborescence(G)
 
 
+def test_is_branching_empty_graph_raises():
+    G = nx.DiGraph()
+    with pytest.raises(nx.NetworkXPointlessConcept, match="G has no nodes."):
+        nx.is_branching(G)
+
+
 def test_path():
     G = nx.DiGraph()
     nx.add_path(G, range(5))
@@ -160,3 +166,9 @@ def test_notarborescence2():
     G.add_edge(6, 4)
     assert not nx.is_branching(G)
     assert not nx.is_arborescence(G)
+
+
+def test_is_arborescense_empty_graph_raises():
+    G = nx.DiGraph()
+    with pytest.raises(nx.NetworkXPointlessConcept, match="G has no nodes."):
+        nx.is_arborescence(G)


### PR DESCRIPTION
Currently we get very different answers if we use a `nx.is_something()` method with an empty graph. This PR tries to sync them up. It's still not synced up, we should probably decide on one behavior.

Current:
- `is_aperiodic` -> StopIteration (empty digraph)
- `is_arborescence` -> NetworkXPointlessConcept: G has no nodes.
- `is_branching` -> NetworkXPointlessConcept: G has no nodes.
- `is_chordal` -> StopIteration
- `is_connected` -> NetworkXPointlessConcept: ('Connectivity is undefined ', 'for the null graph.')
- `is_distance_regular` -> StopIteration
- `is_eulerian` -> NetworkXPointlessConcept: ('Connectivity is undefined ', 'for the null graph.')
- `is_forest` -> NetworkXPointlessConcept: G has no nodes.
- `is_regular` -> StopIteration
- ` is_semiconnected` -> NetworkXPointlessConcept: Connectivity is undefined for the null graph.
- `is_semieulerian` -> NetworkXPointlessConcept: ('Connectivity is undefined ', 'for the null graph.')
- `is_strongly_connected` -> NetworkXPointlessConcept: Connectivity is undefined for the null graph.
- `is_strongly_regular` -> StopIteration
- `is_tree` -> NetworkXPointlessConcept: G has no nodes.
- `is_weakly_connected` -> NetworkXPointlessConcept: Connectivity is undefined for the null graph.

I have added a `nx.NetworkXError("Graph has no nodes.")` error for methods which were raising a `StopIteration` error. I could change this to `NetworkXPointlessConcept` if that makes more sense. Ideally I would like to see all of these methods returning uniform answers. Maybe there should be a decorator for this :me cringing: