### PR TITLE
Move factory attributes to the class instead of instance.

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -299,13 +299,6 @@ class DiGraph(Graph):
         {'day': 'Friday'}
 
         """
-        self.graph_attr_dict_factory = self.graph_attr_dict_factory
-        self.node_dict_factory = self.node_dict_factory
-        self.node_attr_dict_factory = self.node_attr_dict_factory
-        self.adjlist_outer_dict_factory = self.adjlist_outer_dict_factory
-        self.adjlist_inner_dict_factory = self.adjlist_inner_dict_factory
-        self.edge_attr_dict_factory = self.edge_attr_dict_factory
-
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # dictionary for node attr
         # We store two adjacency lists:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -320,13 +320,6 @@ class Graph:
         {'day': 'Friday'}
 
         """
-        self.graph_attr_dict_factory = self.graph_attr_dict_factory
-        self.node_dict_factory = self.node_dict_factory
-        self.node_attr_dict_factory = self.node_attr_dict_factory
-        self.adjlist_outer_dict_factory = self.adjlist_outer_dict_factory
-        self.adjlist_inner_dict_factory = self.adjlist_inner_dict_factory
-        self.edge_attr_dict_factory = self.edge_attr_dict_factory
-
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -328,7 +328,6 @@ class MultiDiGraph(MultiGraph, DiGraph):
         {'day': 'Friday'}
 
         """
-        self.edge_key_dict_factory = self.edge_key_dict_factory
         # multigraph_input can be None/True/False. So check "is not False"
         if isinstance(incoming_graph_data, dict) and multigraph_input is not False:
             DiGraph.__init__(self)

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -337,7 +337,6 @@ class MultiGraph(Graph):
         {'day': 'Friday'}
 
         """
-        self.edge_key_dict_factory = self.edge_key_dict_factory
         # multigraph_input can be None/True/False. So check "is not False"
         if isinstance(incoming_graph_data, dict) and multigraph_input is not False:
             Graph.__init__(self)


### PR DESCRIPTION
We originally had copied the class factory attributes to the instance for an attempt as speed-up.
It now looks like it is a small slowdown.  But perhaps more importantly given the minor impact of these speedups is that it should be easier to read the `__init__` function without getting hung up in all the factories. And trying to figure out why we would be copying them from the class to the instance anyway.   BTW my measure of the speed up is about 15-20% of the time to create a Graph object... but that is so small to start with that it probably isn't important.  Still, if this way is slightly faster and easier to read, maybe we should do it.

This has been separated from #5836 to ease review.