### PR TITLE
Point to the latest URL for the description.

### DIFF
--- a/doc/reference/glossary.rst
+++ b/doc/reference/glossary.rst
@@ -8,7 +8,7 @@ Glossary
    dictionary
       A Python dictionary maps keys to values. Also known as "hashes",
       or "associative arrays" in other programming languages.
-      See :ref:`the Python tutorial on dictionaries <tut-dictionaries>`
+      See :ref:`the Python tutorial on dictionaries <tut-dictionaries>`.
 
    edge
       Edges are either two-tuples of nodes `(u, v)` or three tuples of nodes

--- a/doc/reference/glossary.rst
+++ b/doc/reference/glossary.rst
@@ -8,7 +8,7 @@ Glossary
    dictionary
       A Python dictionary maps keys to values. Also known as "hashes",
       or "associative arrays" in other programming languages.
-      See https://docs.python.org/2/tutorial/datastructures.html#dictionaries
+      See https://docs.python.org/3/tutorial/datastructures.html#dictionaries
 
    edge
       Edges are either two-tuples of nodes `(u, v)` or three tuples of nodes

--- a/doc/reference/glossary.rst
+++ b/doc/reference/glossary.rst
@@ -8,7 +8,7 @@ Glossary
    dictionary
       A Python dictionary maps keys to values. Also known as "hashes",
       or "associative arrays" in other programming languages.
-      See https://docs.python.org/3/tutorial/datastructures.html#dictionaries
+      See :ref:`the Python tutorial on dictionaries <tut-dictionaries>`
 
    edge
       Edges are either two-tuples of nodes `(u, v)` or three tuples of nodes


### PR DESCRIPTION
Dear community,

This is a tiny patch though, 
point to 3.x document URL as Python 2.x has been deprecated a long time ago.

Thanks,

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
