### PR TITLE
Drop NumPy 1.19

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy>=1.19
+numpy>=1.20
 scipy>=1.8
 matplotlib>=3.4
 pandas>=1.3


### PR DESCRIPTION
https://numpy.org/neps/nep-0029-deprecation_policy.html