### PR TITLE
make lazy_import private and remove its internal use

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -12,7 +12,7 @@ __version__ = "3.0b1.dev0"
 
 
 # These are imported in order as listed
-from networkx.lazy_imports import lazy_import
+from networkx.lazy_imports import _lazy_import
 
 from networkx.exception import *
 

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -5,7 +5,7 @@ import os
 import sys
 import types
 
-__all__ = ["attach", "lazy_import"]
+__all__ = ["attach", "_lazy_import"]
 
 
 def attach(module_name, submodules=None, submod_attrs=None):
@@ -99,9 +99,27 @@ class DelayedImportErrorModule(types.ModuleType):
             )
 
 
-def lazy_import(fullname):
+def _lazy_import(fullname):
     """Return a lazily imported proxy for a module or library.
 
+    Warning
+    -------
+    Importing using this function can currently cause trouble
+    when the user tries to import from a subpackage of a module before
+    the package is fully imported. In particular, this idiom may not work:
+
+      np = lazy_import("numpy")
+      from numpy.lib import recfunctions
+
+    This is due to a difference in the way Python's LazyLoader handles
+    subpackage imports compared to the normal import process. Hopefully
+    we will get Python's LazyLoader to fix this, or find a workaround.
+    In the meantime, this is a potential problem.
+
+    The workaround is to import numpy before importing from the subpackage.
+
+    Notes
+    -----
     We often see the following pattern::
 
       def myfunc():

--- a/networkx/tests/test_lazy_imports.py
+++ b/networkx/tests/test_lazy_imports.py
@@ -8,8 +8,8 @@ import networkx.lazy_imports as lazy
 
 
 def test_lazy_import_basics():
-    math = lazy.lazy_import("math")
-    anything_not_real = lazy.lazy_import("anything_not_real")
+    math = lazy._lazy_import("math")
+    anything_not_real = lazy._lazy_import("anything_not_real")
 
     # Now test that accessing attributes does what it should
     assert math.sin(math.pi) == pytest.approx(0, 1e-6)
@@ -29,8 +29,8 @@ def test_lazy_import_basics():
 
 
 def test_lazy_import_impact_on_sys_modules():
-    math = lazy.lazy_import("math")
-    anything_not_real = lazy.lazy_import("anything_not_real")
+    math = lazy._lazy_import("math")
+    anything_not_real = lazy._lazy_import("anything_not_real")
 
     assert type(math) == types.ModuleType
     assert "math" in sys.modules
@@ -39,7 +39,7 @@ def test_lazy_import_impact_on_sys_modules():
 
     # only do this if numpy is installed
     np_test = pytest.importorskip("numpy")
-    np = lazy.lazy_import("numpy")
+    np = lazy._lazy_import("numpy")
     assert type(np) == types.ModuleType
     assert "numpy" in sys.modules
 
@@ -50,8 +50,8 @@ def test_lazy_import_impact_on_sys_modules():
 
 
 def test_lazy_import_nonbuiltins():
-    sp = lazy.lazy_import("scipy")
-    np = lazy.lazy_import("numpy")
+    sp = lazy._lazy_import("scipy")
+    np = lazy._lazy_import("numpy")
     if isinstance(sp, lazy.DelayedImportErrorModule):
         try:
             sp.pi

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -20,8 +20,6 @@ from itertools import chain, tee
 
 import networkx as nx
 
-np = nx.lazy_import("numpy")
-
 __all__ = [
     "flatten",
     "make_list_of_ints",

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -107,6 +107,8 @@ def _dict_to_numpy_array2(d, mapping=None):
     with optional mapping.
 
     """
+    import numpy as np
+
     if mapping is None:
         s = set(d.keys())
         for k, v in d.items():
@@ -125,6 +127,8 @@ def _dict_to_numpy_array2(d, mapping=None):
 
 def _dict_to_numpy_array1(d, mapping=None):
     """Convert a dictionary of numbers to a 1d numpy array with optional mapping."""
+    import numpy as np
+
     if mapping is None:
         s = set(d.keys())
         mapping = dict(zip(s, range(len(s))))
@@ -250,6 +254,8 @@ def create_random_state(random_state=None):
         if None or numpy.random, return the global random number generator used
         by numpy.random.
     """
+    import numpy as np
+
     if random_state is None or random_state is np.random:
         return np.random.mtrand._rand
     if isinstance(random_state, np.random.RandomState):
@@ -285,6 +291,8 @@ class PythonRandomInterface:
         return a + (b - a) * self._rng.random()
 
     def randrange(self, a, b=None):
+        import numpy as np
+
         if isinstance(self._rng, np.random.Generator):
             return self._rng.integers(a, b)
         return self._rng.randint(a, b)
@@ -292,6 +300,8 @@ class PythonRandomInterface:
     # NOTE: the numpy implementations of `choice` don't support strings, so
     # this cannot be replaced with self._rng.choice
     def choice(self, seq):
+        import numpy as np
+
         if isinstance(self._rng, np.random.Generator):
             idx = self._rng.integers(0, len(seq))
         else:
@@ -311,6 +321,8 @@ class PythonRandomInterface:
         return self._rng.choice(list(seq), size=(k,), replace=False)
 
     def randint(self, a, b):
+        import numpy as np
+
         if isinstance(self._rng, np.random.Generator):
             return self._rng.integers(a, b + 1)
         return self._rng.randint(a, b + 1)


### PR DESCRIPTION
A bug in lazy_import (see #5838) or in Python's LazyLoader causes trouble for direct import of subpackages after the lazy load but before the full load. We believe this stems from a difference in how LazyLoader imports to subpackages compared to the standard import process.  We are not sure whether this will need Python LazyLoader changes or if there is a workaround locally.  

This PR removes the use of this function in NetworkX (one place) and makes the function itself private (hopefully easy for people who still want to use it to convert for the new version of NX, but discouraging others from using it until we figure out a fix).

