### PR TITLE
Adds ```nx.bfs_layers``` method

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -377,9 +377,9 @@ def bfs_layers(G, sources):
     Parameters
     ----------
     G : NetworkX graph
-        A graph over which to find the layers using breadth first search.
+        A graph over which to find the layers using breadth-first search.
 
-    sources : list of nodes in `G`
+    sources : node in `G` or list of nodes in `G`
         Specify starting nodes for single source or multiple sources breadth-first search
 
     Yields
@@ -399,22 +399,25 @@ def bfs_layers(G, sources):
     >>> dict(enumerate(nx.bfs_layers(H, [1, 6])))
     {0: [1, 6], 1: [0, 3, 4, 2], 2: [5]}
     """
-    for source in list(sources):
-        if not G.has_node(source):
-            raise nx.NetworkXError(f"The node {source} is not in the graph.")
+    if sources in G:
+        sources = [sources]
 
     current_layer = list(sources)
     visited = set(sources)
 
+    for source in current_layer:
+        if source not in G:
+            raise nx.NetworkXError(f"The node {source} is not in the graph.")
+
     # this is basically BFS, except that the current layer only stores the nodes at
     while current_layer:
+        yield current_layer
         next_layer = list()
         for node in current_layer:
             for child in G[node]:
                 if child not in visited:
                     visited.add(child)
                     next_layer.append(child)
-        yield current_layer
         current_layer = next_layer
 
 

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -410,7 +410,7 @@ def bfs_layers(G, sources):
             raise nx.NetworkXError(f"The node {source} is not in the graph.")
 
     # this is basically BFS, except that the current layer only stores the nodes at
-    # the same distance from sources at each iteration
+    # same distance from sources at each iteration
     while current_layer:
         yield current_layer
         next_layer = list()

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -9,6 +9,7 @@ __all__ = [
     "bfs_predecessors",
     "bfs_successors",
     "descendants_at_distance",
+    "bfs_layers",
 ]
 
 
@@ -368,6 +369,62 @@ def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
         children = [c]
         parent = p
     yield (parent, children)
+
+
+def bfs_layers(G, sources, layer_limit=None):
+    """Returns all the layes of bfs traversal.
+    Parameters
+    ----------
+    G : NetworkX graph
+        A graph
+
+    source : node in `G` or list of nodes in `G`
+
+    layer_limit : int, optional(default=len(G))
+        Specify the maximum layer depth
+
+    Returns
+    -------
+    dict()
+        key is the distance of layers from the sources and value is the set of nodes in that layer
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> nx.bfs_layers(G, [0, 4])
+    {0: {0, 4}, 1: {1, 3}, 2: {2}}
+    >>> H = nx.Graph()
+    >>> H.add_edges_from([(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)])
+    >>> nx.bfs_layers(H, 1)
+    {0: {1}, 1: {0, 3, 4}, 2: {2}, 3: {5, 6}}
+    >>> nx.bfs_layers(H, [1, 6])
+    {0: {1, 6}, 1: {0, 2, 3, 4}, 2: {5}}
+    """
+    if sources in G:
+        sources = [sources]
+
+    if layer_limit is None:
+        layer_limit = len(G)
+
+    current_distance = 0
+    current_layer = {node for node in sources}
+    visited = {node for node in sources}
+    all_layers = dict()
+
+    # this is basically BFS, except that the current layer only stores the nodes at
+    # current_distance from source at each iteration
+    while current_distance < layer_limit and len(current_layer) != 0:
+        next_layer = set()
+        for node in current_layer:
+            for child in G[node]:
+                if child not in visited:
+                    visited.add(child)
+                    next_layer.add(child)
+        all_layers[current_distance] = current_layer
+        current_layer = next_layer
+        current_distance += 1
+
+    return all_layers
 
 
 def descendants_at_distance(G, source, distance):

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -371,60 +371,51 @@ def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
     yield (parent, children)
 
 
-def bfs_layers(G, sources, layer_limit=None):
-    """Returns all the layes of bfs traversal.
+def bfs_layers(G, sources):
+    """Returns an iterator of all the layers in breadth-first search traversal.
+
     Parameters
     ----------
     G : NetworkX graph
-        A graph
+        A graph over which to find the layers using breadth first search.
 
-    source : node in `G` or list of nodes in `G`
+    sources : list of nodes in `G`
+        Specify starting nodes for single source or multiple sources breadth-first search
 
-    layer_limit : int, optional(default=len(G))
-        Specify the maximum layer depth
-
-    Returns
+    Yields
     -------
-    dict()
-        key is the distance of layers from the sources and value is the set of nodes in that layer
+    layer: list of nodes
+        Yields list of nodes at the same distance from sources
 
     Examples
     --------
     >>> G = nx.path_graph(5)
-    >>> nx.bfs_layers(G, [0, 4])
-    {0: {0, 4}, 1: {1, 3}, 2: {2}}
+    >>> dict(enumerate(nx.bfs_layers(G, [0, 4])))
+    {0: [0, 4], 1: [1, 3], 2: [2]}
     >>> H = nx.Graph()
     >>> H.add_edges_from([(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)])
-    >>> nx.bfs_layers(H, 1)
-    {0: {1}, 1: {0, 3, 4}, 2: {2}, 3: {5, 6}}
-    >>> nx.bfs_layers(H, [1, 6])
-    {0: {1, 6}, 1: {0, 2, 3, 4}, 2: {5}}
+    >>> dict(enumerate(nx.bfs_layers(H, [1])))
+    {0: [1], 1: [0, 3, 4], 2: [2], 3: [5, 6]}
+    >>> dict(enumerate(nx.bfs_layers(H, [1, 6])))
+    {0: [1, 6], 1: [0, 3, 4, 2], 2: [5]}
     """
-    if sources in G:
-        sources = [sources]
+    for source in list(sources):
+        if not G.has_node(source):
+            raise nx.NetworkXError(f"The node {source} is not in the graph.")
 
-    if layer_limit is None:
-        layer_limit = len(G)
-
-    current_distance = 0
-    current_layer = {node for node in sources}
-    visited = {node for node in sources}
-    all_layers = dict()
+    current_layer = list(sources)
+    visited = set(sources)
 
     # this is basically BFS, except that the current layer only stores the nodes at
-    # current_distance from source at each iteration
-    while current_distance < layer_limit and len(current_layer) != 0:
-        next_layer = set()
+    while current_layer:
+        next_layer = list()
         for node in current_layer:
             for child in G[node]:
                 if child not in visited:
                     visited.add(child)
-                    next_layer.add(child)
-        all_layers[current_distance] = current_layer
+                    next_layer.append(child)
+        yield current_layer
         current_layer = next_layer
-        current_distance += 1
-
-    return all_layers
 
 
 def descendants_at_distance(G, source, distance):

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -410,6 +410,7 @@ def bfs_layers(G, sources):
             raise nx.NetworkXError(f"The node {source} is not in the graph.")
 
     # this is basically BFS, except that the current layer only stores the nodes at
+    # the same distance from sources at each iteration
     while current_layer:
         yield current_layer
         next_layer = list()

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -450,22 +450,11 @@ def descendants_at_distance(G, source, distance):
     >>> nx.descendants_at_distance(H, 5, 1)
     set()
     """
-    if not G.has_node(source):
+    if source not in G:
         raise nx.NetworkXError(f"The node {source} is not in the graph.")
-    current_distance = 0
-    current_layer = {source}
-    visited = {source}
 
-    # this is basically BFS, except that the current layer only stores the nodes at
-    # current_distance from source at each iteration
-    while current_distance < distance:
-        next_layer = set()
-        for node in current_layer:
-            for child in G[node]:
-                if child not in visited:
-                    visited.add(child)
-                    next_layer.add(child)
-        current_layer = next_layer
-        current_distance += 1
-
-    return current_layer
+    bfs_generator = nx.bfs_layers(G, source)
+    for i, layer in enumerate(bfs_generator):
+        if i == distance:
+            return set(layer)
+    return set()

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -51,6 +51,18 @@ class TestBFS:
         assert sorted(T.nodes()) == [1]
         assert sorted(T.edges()) == []
 
+    def test_bfs_layers(self):
+        assert dict(enumerate(nx.bfs_layers(self.G, [0]))) == {
+            0: [0],
+            1: [1],
+            2: [2, 3],
+            3: [4],
+        }
+
+    def test_bfs_layers_missing_source(self):
+        with pytest.raises(nx.NetworkXError):
+            next(nx.bfs_layers(self.G, ["abc"]))
+
     def test_descendants_at_distance(self):
         for distance, descendants in enumerate([{0}, {1}, {2, 3}, {4}]):
             assert nx.descendants_at_distance(self.G, 0, distance) == descendants
@@ -109,6 +121,24 @@ class TestBreadthLimitedSearch:
     def test_limited_bfs_edges(self):
         edges = nx.bfs_edges(self.G, source=9, depth_limit=4)
         assert list(edges) == [(9, 8), (9, 10), (8, 7), (7, 2), (2, 1), (2, 3)]
+
+    def test_bfs_layers(self):
+        assert dict(enumerate(nx.bfs_layers(self.G, [0]))) == {
+            0: [0],
+            1: [1],
+            2: [2],
+            3: [3, 7],
+            4: [4, 8],
+            5: [5, 9],
+            6: [6, 10],
+        }
+        assert dict(enumerate(nx.bfs_layers(self.D, [2]))) == {
+            0: [2],
+            1: [3, 7],
+            2: [8],
+            3: [9],
+            4: [10],
+        }
 
     def test_limited_descendants_at_distance(self):
         for distance, descendants in enumerate(

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -52,16 +52,20 @@ class TestBFS:
         assert sorted(T.edges()) == []
 
     def test_bfs_layers(self):
-        assert dict(enumerate(nx.bfs_layers(self.G, [0]))) == {
+        expected = {
             0: [0],
             1: [1],
             2: [2, 3],
             3: [4],
         }
+        assert dict(enumerate(nx.bfs_layers(self.G, sources=[0]))) == expected
+        assert dict(enumerate(nx.bfs_layers(self.G, sources=0))) == expected
 
     def test_bfs_layers_missing_source(self):
         with pytest.raises(nx.NetworkXError):
-            next(nx.bfs_layers(self.G, ["abc"]))
+            next(nx.bfs_layers(self.G, sources="abc"))
+        with pytest.raises(nx.NetworkXError):
+            next(nx.bfs_layers(self.G, sources=["abc"]))
 
     def test_descendants_at_distance(self):
         for distance, descendants in enumerate([{0}, {1}, {2, 3}, {4}]):
@@ -122,8 +126,8 @@ class TestBreadthLimitedSearch:
         edges = nx.bfs_edges(self.G, source=9, depth_limit=4)
         assert list(edges) == [(9, 8), (9, 10), (8, 7), (7, 2), (2, 1), (2, 3)]
 
-    def test_bfs_layers(self):
-        assert dict(enumerate(nx.bfs_layers(self.G, [0]))) == {
+    def test_limited_bfs_layers(self):
+        assert dict(enumerate(nx.bfs_layers(self.G, sources=[0]))) == {
             0: [0],
             1: [1],
             2: [2],
@@ -132,7 +136,7 @@ class TestBreadthLimitedSearch:
             5: [5, 9],
             6: [6, 10],
         }
-        assert dict(enumerate(nx.bfs_layers(self.D, [2]))) == {
+        assert dict(enumerate(nx.bfs_layers(self.D, sources=2))) == {
             0: [2],
             1: [3, 7],
             2: [8],


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
Adds ```bfs_layers``` method to [breadth_first_search.py](https://github.com/networkx/networkx/blob/main/networkx/algorithms/traversal/breadth_first_search.py).
```python3
def bfs_layers(G, sources):
    """Returns an iterator of all the layers in breadth-first search traversal.

    Parameters
    ----------
    G : NetworkX graph
        A graph over which to find the layers using breadth-first search.

    sources : node in `G` or list of nodes in `G`
        Specify starting nodes for single source or multiple sources breadth-first search

    Yields
    -------
    layer: list of nodes
        Yields list of nodes at the same distance from sources

    Examples
    --------
    >>> G = nx.path_graph(5)
    >>> dict(enumerate(nx.bfs_layers(G, [0, 4])))
    {0: [0, 4], 1: [1, 3], 2: [2]}
    >>> H = nx.Graph()
    >>> H.add_edges_from([(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)])
    >>> dict(enumerate(nx.bfs_layers(H, [1])))
    {0: [1], 1: [0, 3, 4], 2: [2], 3: [5, 6]}
    >>> dict(enumerate(nx.bfs_layers(H, [1, 6])))
    {0: [1, 6], 1: [0, 3, 4, 2], 2: [5]}
    """
    ...
```
ToDo:
- [x] adds `bfs_layers` method to the docs 
- [x] adds tests for the `bfs_layers` method 
- [x] changes the implementation of `descendents_at_distance` 