### PR TITLE
strategy_saturation_largest_first now accepts partial colorings

### DIFF
--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -209,29 +209,44 @@ def strategy_saturation_largest_first(G, colors):
 
     """
     distinct_colors = {v: set() for v in G}
-    for i in range(len(G)):
-        # On the first time through, simply choose the node of highest degree.
-        if i == 0:
-            node = max(G, key=G.degree)
-            yield node
-            # Add the color 0 to the distinct colors set for each
-            # neighbors of that node.
-            for v in G[node]:
-                distinct_colors[v].add(0)
-        else:
-            # Compute the maximum saturation and the set of nodes that
-            # achieve that saturation.
-            saturation = {
-                v: len(c) for v, c in distinct_colors.items() if v not in colors
-            }
-            # Yield the node with the highest saturation, and break ties by
-            # degree.
-            node = max(saturation, key=lambda v: (saturation[v], G.degree(v)))
-            yield node
-            # Update the distinct color sets for the neighbors.
-            color = colors[node]
-            for v in G[node]:
-                distinct_colors[v].add(color)
+
+    # Add the node color assignments given in colors to the 
+    # distinct colors set for each neighbor of that node
+    for vertex, color in colors.items():
+        for neighbor in G[vertex]:
+            distinct_colors[neighbor].add(color)
+
+    # Check that the color assignments in colors are valid
+    # i.e. no neighboring nodes have the same color
+    if len(colors) >= 2:
+        for vertex, color in colors.items():
+            if color in distinct_colors[vertex]:
+                raise nx.NetworkXError('Neighboring vertices must have different colors')
+
+    # If 0 nodes have been colored, simply choose the node of highest degree.
+    if len(colors) == 0:
+        node = max(G, key=G.degree)
+        yield node
+        # Add the color 0 to the distinct colors set for each
+        # neighbor of that node.
+        for v in G[node]:
+            distinct_colors[v].add(0)
+
+    for i in range(len(G)-len(colors)):
+        # Compute the maximum saturation and the set of nodes that
+        # achieve that saturation.
+        saturation = {
+            v: len(c) for v, c in distinct_colors.items() if v not in colors
+        }
+        # Yield the node with the highest saturation, and break ties by
+        # degree.
+        node = max(saturation, key=lambda v: (saturation[v], G.degree(v)))
+        yield node
+        
+        # Update the distinct color sets for the neighbors.
+        color = colors[node]
+        for v in G[node]:
+            distinct_colors[v].add(color)
 
 
 #: Dictionary mapping name of a strategy as a string to the strategy function.

--- a/networkx/algorithms/coloring/tests/test_coloring.py
+++ b/networkx/algorithms/coloring/tests/test_coloring.py
@@ -3,7 +3,7 @@
 """
 
 import pytest
-
+import itertools
 import networkx as nx
 
 is_coloring = nx.algorithms.coloring.equitable_coloring.is_coloring
@@ -429,6 +429,44 @@ class TestColoring:
         )
         check_state(**params)
 
+    def test_strategy_saturation_largest_first(self):
+        
+        def color_remaining_nodes(G, colored_vertices):
+            color_assignments = []
+            aux_colored_vertices = {key:value for key,value in colored_vertices.items()}
+            scratch_iterator = nx.algorithms.coloring.greedy_coloring.strategy_saturation_largest_first(G, aux_colored_vertices)
+
+            for u in scratch_iterator:
+                # Set to keep track of colors of neighbours
+                neighbour_colors = {aux_colored_vertices[v] for v in G[u] if v in aux_colored_vertices}
+                # Find the first unused color.
+                for color in itertools.count():
+                    if color not in neighbour_colors:
+                        break
+                # Assign the new color to the current node.
+                aux_colored_vertices[u] = color
+                color_assignments.append((u,color))
+
+            return color_assignments, aux_colored_vertices
+
+        for G, _, _ in SPECIAL_TEST_CASES["saturation_largest_first"]:
+    
+            G = G()
+
+            # Get a full color assignment, (including the order in which nodes were colored)
+            colored_vertices = {}
+            full_color_assignment, full_colored_vertices = color_remaining_nodes(G, colored_vertices)
+
+            # for each node in the color assignment, add it to colored_vertices and re-run the function
+            for ind, (vertex, color) in enumerate(full_color_assignment):
+                colored_vertices[vertex] = color
+
+                partial_color_assignment, partial_colored_vertices = color_remaining_nodes(G, colored_vertices)
+
+                # check that the color assignment and order of remaining nodes are the same
+                assert full_color_assignment[ind+1:] == partial_color_assignment
+                assert full_colored_vertices == partial_colored_vertices
+                
 
 #  ############################  Utility functions ############################
 def verify_coloring(graph, coloring):


### PR DESCRIPTION
Amended functionality of strategy_saturation_largest_first so that the colors input can now be a partial coloring. This is so that the coloring of a partially-colored graph - in which the partial coloring is valid (the new code checks this) - can be completed using DSATUR. This reflects the functionality described in the docstring:
```
``colors`` is a dictionary mapping nodes of ``G`` to colors, for those nodes that have already been colored. 
```
See the discussion of this issue here: https://github.com/networkx/networkx/discussions/5884

There is also a test that checks (on two graphs) that if a partial coloring (of i nodes) matches the color assignments of the first i nodes given by the application of DSATUR to the uncolored graph, then the completed colorings also match.