### PR TITLE
[ENH] Find and verify a minimal D-separating set in DAG

### DIFF
--- a/networkx/algorithms/tests/test_d_separation.py
+++ b/networkx/algorithms/tests/test_d_separation.py
@@ -3,6 +3,7 @@ from itertools import combinations
 import pytest
 
 import networkx as nx
+from networkx.classes.digraph import DiGraph
 
 
 def path_graph():
@@ -156,3 +157,35 @@ def test_invalid_nodes_raise_error(asia_graph):
     """
     with pytest.raises(nx.NodeNotFound):
         nx.d_separated(asia_graph, {0}, {1}, {2})
+
+
+def test_minimal_sep_set_parents():
+    # Case 1:
+    # create a graph A -> B <- C
+    # B -> D -> E;
+    # B -> F;
+    # G -> E;
+    edge_list = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("B", "F"), ("G", "E")]
+    G = DiGraph(edge_list)
+
+    assert not nx.d_separated(G, "B", "E")
+
+    # minimal set of the corresponding graph
+    # for B and E should be (D,)
+    Zmin = nx.compute_minimal_separating_set(G, "B", "E")
+
+    # the minimal separating set should pass the test for minimality
+    assert nx.is_separating_set_minimal(G, "B", "E", Zmin)
+    assert Zmin == {"D"}
+
+    # Case 2:
+    # create a graph A -> B -> C
+    # B -> D -> C;
+    edge_list = [("A", "B"), ("B", "C"), ("B", "D"), ("D", "C")]
+    G = DiGraph(edge_list)
+    assert not nx.d_separated(G, "A", "C")
+    Zmin = nx.compute_minimal_separating_set(G, "A", "C")
+
+    # the minimal separating set should pass the test for minimality
+    assert nx.is_separating_set_minimal(G, "A", "C", Zmin)
+    assert Zmin == {"B"}

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -708,3 +708,17 @@ def test_ancestors_descendants_undirected():
     undirected graphs."""
     G = nx.path_graph(5)
     nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}
+
+
+def test_compute_v_structures():
+    edges = [(0, 1), (0, 2), (3, 2)]
+    G = nx.DiGraph(edges)
+
+    v_structs = nx.compute_v_structures(G)
+    assert len(v_structs) == 1
+    assert (0, 2, 3) in v_structs
+
+    edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
+    G = nx.DiGraph(edges)
+    v_structs = nx.compute_v_structures(G)
+    assert len(v_structs) == 2


### PR DESCRIPTION
## Summary
This addresses: https://github.com/networkx/networkx/discussions/5859

where I raised the issue of enhancing the `nx.algorithms.d_separated` submodule with additional two related algorithms.

1. for finding a minimal separating set, and 
2. the other is to verify that a separating set is indeed minimal in a DAG. 

In order to compute these, there are some operations that can be performed on a DAG:

1. moralizing a directed graph
2. computing the v-structure of a directed graph

## Misc.

Do I have to add a changelog here too?