### PR TITLE
signature change for `node_link` functions: for issue #5787

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -88,6 +88,11 @@ Version 3.0
 * In ``utils/misc.py`` remove ``to_tuple``.
 * In ``algorithms/matching.py``, remove parameter ``maxcardinality`` from ``min_weight_matching``.
 
+Version 3.1
+~~~~~~~~~~~
+* In ``readwrite/json_graph/node_link.py`` remove the ``attrs` keyword code 
+  and docstring in ``node_link_data`` and ``node_link_graph``. Also the associated tests.
+
 Version 3.2
 ~~~~~~~~~~~
 * In ``generators/directed.py`` remove the ``create_using`` keyword argument

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -142,6 +142,11 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="nx.nx_pydot"
     )
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="signature change for node_link functions",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -52,6 +52,9 @@ def node_link_data(
            The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
            `key` and `link`. in networkx 3.1
 
+           If the `attrs` keyword and the new keywords are both used in a single function call (not recommended)
+           the `attrs` keyword argument will take precedence.
+
            The values of the keywords must be unique.
 
     source : string
@@ -112,6 +115,7 @@ def node_link_data(
 
     To use `node_link_data` in conjunction with `node_link_graph`,
     the keyword names for the attributes must match.
+
 
     See Also
     --------
@@ -204,6 +208,9 @@ def node_link_graph(
 
            The `attrs` keyword argument will be replaced with the individual keywords: `source`, `target`, `name`,
            `key` and `link`. in networkx 3.1.
+
+           If the `attrs` keyword and the new keywords are both used in a single function call (not recommended)
+           the `attrs` keyword argument will take precedence.
 
            The values of the keywords must be unique.
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -115,15 +115,7 @@ def node_link_data(
         link = attrs["link"]
     # -------------------------------------------------- #
     multigraph = G.is_multigraph()
-    # Allow 'attrs' to keep default values.
-    if attrs is None:
-        attrs = _attrs
-    else:
-        attrs.update({k: v for (k, v) in _attrs.items() if k not in attrs})
-    name = attrs["name"]
-    source = attrs["source"]
-    target = attrs["target"]
-    links = attrs["link"]
+
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
     key = None if not multigraph else attrs["key"]
     if len({source, target, key}) < 3:

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -81,9 +81,7 @@ def node_link_data(
     >>> G = nx.Graph([("A", "B")])
     >>> data1 = json_graph.node_link_data(G)
     >>> H = nx.gn_graph(2)
-    >>> data2 = json_graph.node_link_data(
-    ...     H, {"link": "edges", "source": "from", "target": "to"}
-    ... )
+    >>> data2 = json_graph.node_link_data(H, link="edges", source="from", target="to"})
 
     To serialize with json
 
@@ -124,11 +122,11 @@ def node_link_data(
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-        source = attrs["source"]
-        target = attrs["target"]
-        name = attrs["name"]
-        key = attrs["key"]
-        link = attrs["link"]
+        source = attrs.get("source", "source")
+        target = attrs.get("target", "target")
+        name = attrs.get("name", "name")
+        key = attrs.get("key", "key")
+        link = attrs.get("link", "links")
     # -------------------------------------------------- #
     multigraph = G.is_multigraph()
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -92,19 +92,17 @@ def node_link_data(
 
         # TODO set the version number when feature will be removed.  3.???   (2x)
         msg = (
-            "\nThe `attrs` keyword argument of node_link_data is deprecated\n"
-            "and will be removed in networkx 3.???.\n"
-            "It is replaced with explicit `source`, `target`, `name`, \n"
-            "`key` and `link` keyword arguments.\n"
-            "To make this warning go away and ensure usage is forward\n"
-            "compatible, replace `attrs` with `**attrs` or with\n"
-            "the explicit keywords."
-            "for example:\n\n"
+            "\n\nThe `attrs` keyword argument of node_link_data is deprecated\n"
+            "and will be removed in networkx 3.???. It is replaced with explicit\n"
+            "keyword arguments: `source`, `target`, `name`, `key` and `link`.\n"
+            "To make this warning go away, and ensure usage is forward\n"
+            "compatible, replace `attrs` with the keywords. "
+            "For example:\n\n"
             "   >>> node_link_data(G, attrs={'target': 'foo', 'name': 'bar'})\n\n"
             "should instead be written as\n\n"
             "   >>> node_link_data(G, target='foo', name='bar')\n\n"
             "in networkx 3.???.\n"
-            "The default values of the keywords does not change."
+            "The default values of the keywords will not change.\n"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
@@ -197,19 +195,17 @@ def node_link_graph(
 
         # TODO set the version number when feature will be removed.  3.???   (2x)
         msg = (
-            "\nThe `attrs` keyword argument of node_link_graph is deprecated\n"
-            "and will be removed in networkx 3.???.\n"
-            "It is replaced with explicit `source`, `target`, `name`, \n"
-            "`key` and `link` keyword arguments.\n"
-            "To make this warning go away and ensure usage is forward\n"
-            "compatible, replace `attrs` with `**attrs` or with\n"
-            "the explicit keywords."
-            "for example:\n\n"
-            "   >>> node_link_graph(G, attrs={'target': 'foo', 'name': 'bar'})\n\n"
+            "\n\nThe `attrs` keyword argument of node_link_graph is deprecated\n"
+            "and will be removed in networkx 3.???. It is replaced with explicit\n"
+            "keyword arguments: `source`, `target`, `name`, `key` and `link`.\n"
+            "To make this warning go away, and ensure usage is forward\n"
+            "compatible, replace `attrs` with the keywords. "
+            "For example:\n\n"
+            "   >>> node_link_graph(data, attrs={'target': 'foo', 'name': 'bar'})\n\n"
             "should instead be written as\n\n"
-            "   >>> node_link_graph(G, target='foo', name='bar')\n\n"
+            "   >>> node_link_graph(data, target='foo', name='bar')\n\n"
             "in networkx 3.???.\n"
-            "The default values of the keywords does not change."
+            "The default values of the keywords will not change.\n"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -219,11 +219,6 @@ def node_link_graph(
         key = attrs["key"]
         link = attrs["link"]
     # -------------------------------------------------- #
-    # Allow 'attrs' to keep default values.
-    if attrs is None:
-        attrs = _attrs
-    else:
-        attrs.update({k: v for k, v in _attrs.items() if k not in attrs})
     multigraph = data.get("multigraph", multigraph)
     directed = data.get("directed", directed)
     if multigraph:
@@ -232,19 +227,16 @@ def node_link_graph(
         graph = nx.Graph()
     if directed:
         graph = graph.to_directed()
-    name = attrs["name"]
-    source = attrs["source"]
-    target = attrs["target"]
-    links = attrs["link"]
+
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
-    key = None if not multigraph else attrs["key"]
+    key = None if not multigraph else key
     graph.graph = data.get("graph", {})
     c = count()
     for d in data["nodes"]:
         node = _to_tuple(d.get(name, next(c)))
         nodedata = {str(k): v for k, v in d.items() if k != name}
         graph.add_node(node, **nodedata)
-    for d in data[links]:
+    for d in data[link]:
         src = tuple(d[source]) if isinstance(d[source], list) else d[source]
         tgt = tuple(d[target]) if isinstance(d[target], list) else d[target]
         if not multigraph:

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -47,10 +47,10 @@ def node_link_data(
         If some user-defined graph data use these attribute names as data keys,
         they may be silently dropped.
 
-        .. deprecated:: 2.8.5
+        .. deprecated:: 2.8.6
 
            The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
-           `key` and `link`. in networkx 3.???
+           `key` and `link`. in networkx 3.1
 
            The values of the keywords must be unique.
 
@@ -121,10 +121,9 @@ def node_link_data(
     if attrs is not None:
         import warnings
 
-        # TODO set the version number when feature will be removed.  3.???   (2x)
         msg = (
             "\n\nThe `attrs` keyword argument of node_link_data is deprecated\n"
-            "and will be removed in networkx 3.???. It is replaced with explicit\n"
+            "and will be removed in networkx 3.1. It is replaced with explicit\n"
             "keyword arguments: `source`, `target`, `name`, `key` and `link`.\n"
             "To make this warning go away, and ensure usage is forward\n"
             "compatible, replace `attrs` with the keywords. "
@@ -132,7 +131,7 @@ def node_link_data(
             "   >>> node_link_data(G, attrs={'target': 'foo', 'name': 'bar'})\n\n"
             "should instead be written as\n\n"
             "   >>> node_link_data(G, target='foo', name='bar')\n\n"
-            "in networkx 3.???.\n"
+            "in networkx 3.1.\n"
             "The default values of the keywords will not change.\n"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
@@ -201,10 +200,10 @@ def node_link_graph(
             dict(source='source', target='target', name='id',
                 key='key', link='links')
 
-        .. deprecated:: 2.8.5
+        .. deprecated:: 2.8.6
 
            The `attrs` keyword argument will be replaced with the individual keywords: `source`, `target`, `name`,
-           `key` and `link`. in networkx 3.???
+           `key` and `link`. in networkx 3.1.
 
            The values of the keywords must be unique.
 
@@ -264,10 +263,9 @@ def node_link_graph(
     if attrs is not None:
         import warnings
 
-        # TODO set the version number when feature will be removed.  3.???   (2x)
         msg = (
             "\n\nThe `attrs` keyword argument of node_link_graph is deprecated\n"
-            "and will be removed in networkx 3.???. It is replaced with explicit\n"
+            "and will be removed in networkx 3.1. It is replaced with explicit\n"
             "keyword arguments: `source`, `target`, `name`, `key` and `link`.\n"
             "To make this warning go away, and ensure usage is forward\n"
             "compatible, replace `attrs` with the keywords. "
@@ -275,7 +273,7 @@ def node_link_graph(
             "   >>> node_link_graph(data, attrs={'target': 'foo', 'name': 'bar'})\n\n"
             "should instead be written as\n\n"
             "   >>> node_link_graph(data, target='foo', name='bar')\n\n"
-            "in networkx 3.???.\n"
+            "in networkx 3.1.\n"
             "The default values of the keywords will not change.\n"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -52,8 +52,6 @@ def node_link_data(
            The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
            `key` and `link`. in networkx 3.???
 
-    >>> assert False # Is version number correct?
-
            The values of the keywords must be unique.
 
     source : string
@@ -81,16 +79,28 @@ def node_link_data(
     --------
     >>> G = nx.Graph([("A", "B")])
     >>> data1 = nx.node_link_data(G)
-    >>> H = nx.gn_graph(2)
-    >>> data2 = nx.node_link_data(H, link="edges", source="from", target="to")
+    >>> data1
+    {'directed': False, 'multigraph': False, 'graph': {}, 'nodes': [{'id': 'A'}, {'id': 'B'}], 'links': [{'source': 'A', 'target': 'B'}]}
 
     To serialize with json
 
     >>> import json
     >>> s1 = json.dumps(data1)
-    >>> s2 = json.dumps(
-    ...     data2, default={"link": "edges", "source": "from", "target": "to"}
-    ... )
+    >>> s1
+    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
+
+    Or, pass the graph and encoder function together in a single step, like this,
+
+    >>> s1 = json.dumps(G, default=nx.node_link_data)
+    >>> s1
+    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
+
+    The attribute names for storing NetworkX-internal graph data can be specified as keyword options.
+
+    >>> H = nx.gn_graph(2)
+    >>> data2 = nx.node_link_data(H, link="edges", source="from", target="to")
+    >>> data2
+    {'directed': True, 'multigraph': False, 'graph': {}, 'nodes': [{'id': 0}, {'id': 1}], 'edges': [{'from': 1, 'to': 0}]}
 
     Notes
     -----
@@ -188,7 +198,7 @@ def node_link_graph(
 
         .. deprecated:: 2.8.5
 
-           The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
+           The `attrs` keyword argument will be replaced with the individual keywords: `source`, `target`, `name`,
            `key` and `link`. in networkx 3.???
 
            The values of the keywords must be unique.
@@ -211,9 +221,23 @@ def node_link_graph(
 
     Examples
     --------
-    >>> G = nx.Graph([("A", "B")])
+    >>> G = nx.Graph([('A', 'B')])
     >>> data = nx.node_link_data(G)
+    >>> data
+    {'directed': False, 'multigraph': False, 'graph': {}, 'nodes': [{'id': 'A'}, {'id': 'B'}], 'links': [{'source': 'A', 'target': 'B'}]}
+
     >>> H = nx.node_link_graph(data)
+    >>> print(H.edges)
+    [('A', 'B')]
+
+    To serialize and deserialize a graph with json,
+
+    >>> import json
+    >>> d = json.dumps(node_link_data(G))
+    >>> H = node_link_graph(json.loads(d))
+    >>> print(G.edges, H.edges)
+    [('A', 'B')] [('A', 'B')]
+
 
     Notes
     -----

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -73,7 +73,7 @@ def node_link_data(
     Raises
     ------
     NetworkXError
-        If values in attrs are not unique.
+        If the values of 'source', 'target' and 'key' are not unique.
 
     Examples
     --------
@@ -82,15 +82,14 @@ def node_link_data(
     >>> data1
     {'directed': False, 'multigraph': False, 'graph': {}, 'nodes': [{'id': 'A'}, {'id': 'B'}], 'links': [{'source': 'A', 'target': 'B'}]}
 
-    To serialize with json
+    To serialize with JSON
 
     >>> import json
     >>> s1 = json.dumps(data1)
     >>> s1
     '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
 
-    Or, pass the graph and encoder function together in a single step,
-    like this,
+    A graph can also be serialized by passing `node_link_data` as an encoder function. The two methods are equivalent.
 
     >>> s1 = json.dumps(G, default=nx.node_link_data)
     >>> s1
@@ -112,7 +111,7 @@ def node_link_data(
     Attribute 'key' is only used for multigraphs.
 
     To use `node_link_data` in conjunction with `node_link_graph`,
-    the same keyword names for the attributes must be used in both.
+    the keyword names for the attributes must match.
 
     See Also
     --------
@@ -227,10 +226,15 @@ def node_link_graph(
 
     Examples
     --------
+
+    Create data in node-link format by converting a graph.
+
     >>> G = nx.Graph([('A', 'B')])
     >>> data = nx.node_link_data(G)
     >>> data
     {'directed': False, 'multigraph': False, 'graph': {}, 'nodes': [{'id': 'A'}, {'id': 'B'}], 'links': [{'source': 'A', 'target': 'B'}]}
+
+    Revert data in node-link format to a graph.
 
     >>> H = nx.node_link_graph(data)
     >>> print(H.edges)
@@ -249,8 +253,8 @@ def node_link_graph(
     -----
     Attribute 'key' is only used for multigraphs.
 
-    To use `node_link_graph` in conjunction with `node_link_data`,
-    the same keyword names for the attributes must be used in both.
+    To use `node_link_data` in conjunction with `node_link_graph`,
+    the keyword names for the attributes must match.
 
     See Also
     --------

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -191,6 +191,34 @@ def node_link_graph(
     --------
     node_link_data, adjacency_data, tree_data
     """
+    # ------ TODO: Remove between the lines after signature change is complete ----- #
+    if attrs is not None:
+        import warnings
+
+        # TODO set the version number when feature will be removed.  3.???   (2x)
+        msg = (
+            "\nThe `attrs` keyword argument of node_link_graph is deprecated\n"
+            "and will be removed in networkx 3.???.\n"
+            "It is replaced with explicit `source`, `target`, `name`, \n"
+            "`key` and `link` keyword arguments.\n"
+            "To make this warning go away and ensure usage is forward\n"
+            "compatible, replace `attrs` with `**attrs` or with\n"
+            "the explicit keywords."
+            "for example:\n\n"
+            "   >>> node_link_graph(G, attrs={'target': 'foo', 'name': 'bar'})\n\n"
+            "should instead be written as\n\n"
+            "   >>> node_link_graph(G, target='foo', name='bar')\n\n"
+            "in networkx 3.???.\n"
+            "The default values of the keywords does not change."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+        source = attrs["source"]
+        target = attrs["target"]
+        name = attrs["name"]
+        key = attrs["key"]
+        link = attrs["link"]
+    # -------------------------------------------------- #
     # Allow 'attrs' to keep default values.
     if attrs is None:
         attrs = _attrs

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -243,11 +243,11 @@ def node_link_graph(
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-        source = attrs["source"]
-        target = attrs["target"]
-        name = attrs["name"]
-        key = attrs["key"]
-        link = attrs["link"]
+        source = attrs.get("source", "source")
+        target = attrs.get("target", "target")
+        name = attrs.get("name", "name")
+        key = attrs.get("key", "key")
+        link = attrs.get("link", "links")
     # -------------------------------------------------- #
     multigraph = data.get("multigraph", multigraph)
     directed = data.get("directed", directed)

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -47,6 +47,24 @@ def node_link_data(
         If some user-defined graph data use these attribute names as data keys,
         they may be silently dropped.
 
+        .. deprecated:: 2.8.5
+
+           The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
+           `key` and `link`. in networkx 3.???
+
+           The values of the keywords must be unique.
+
+    source : string
+        A string that provides the 'source' attribute name for storing NetworkX-internal graph data.
+    target : string
+        A string that provides the 'target' attribute name for storing NetworkX-internal graph data.
+    name : string
+        A string that provides the 'name' attribute name for storing NetworkX-internal graph data.
+    key : string
+        A string that provides the 'key' attribute name for storing NetworkX-internal graph data.
+    link : string
+        A string that provides the 'link' attribute name for storing NetworkX-internal graph data.
+
     Returns
     -------
     data : dict
@@ -168,6 +186,24 @@ def node_link_graph(
 
             dict(source='source', target='target', name='id',
                 key='key', link='links')
+
+        .. deprecated:: 2.8.5
+
+           The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
+           `key` and `link`. in networkx 3.???
+
+           The values of the keywords must be unique.
+
+    source : string
+        A string that provides the 'source' attribute name for storing NetworkX-internal graph data.
+    target : string
+        A string that provides the 'target' attribute name for storing NetworkX-internal graph data.
+    name : string
+        A string that provides the 'name' attribute name for storing NetworkX-internal graph data.
+    key : string
+        A string that provides the 'key' attribute name for storing NetworkX-internal graph data.
+    link : string
+        A string that provides the 'link' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -81,7 +81,7 @@ def node_link_data(
     >>> G = nx.Graph([("A", "B")])
     >>> data1 = json_graph.node_link_data(G)
     >>> H = nx.gn_graph(2)
-    >>> data2 = json_graph.node_link_data(H, {link="edges", source="from", target="to"})
+    >>> data2 = json_graph.node_link_data(H, link="edges", source="from", target="to")
 
     To serialize with json
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -25,7 +25,9 @@ def _to_tuple(x):
     return tuple(map(_to_tuple, x))
 
 
-def node_link_data(G, attrs=None):
+def node_link_data(
+    G, attrs=None, source="source", target="target", name="id", key="key", link="links"
+):
     """Returns data in node-link format that is suitable for JSON serialization
     and use in Javascript documents.
 
@@ -84,6 +86,34 @@ def node_link_data(G, attrs=None):
     --------
     node_link_graph, adjacency_data, tree_data
     """
+    # ------ TODO: Remove between the lines after signature change is complete ----- #
+    if attrs is not None:
+        import warnings
+
+        # TODO set the version number when feature will be removed.  3.???   (2x)
+        msg = (
+            "\nThe `attrs` keyword argument of node_link_data is deprecated\n"
+            "and will be removed in networkx 3.???.\n"
+            "It is replaced with explicit `source`, `target`, `name`, \n"
+            "`key` and `link` keyword arguments.\n"
+            "To make this warning go away and ensure usage is forward\n"
+            "compatible, replace `attrs` with `**attrs` or with\n"
+            "the explicit keywords."
+            "for example:\n\n"
+            "   >>> node_link_data(G, attrs={'target': 'foo', 'name': 'bar'})\n\n"
+            "should instead be written as\n\n"
+            "   >>> node_link_data(G, target='foo', name='bar')\n\n"
+            "in networkx 3.???.\n"
+            "The default values of the keywords does not change."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+        source = attrs["source"]
+        target = attrs["target"]
+        name = attrs["name"]
+        key = attrs["key"]
+        link = attrs["link"]
+    # -------------------------------------------------- #
     multigraph = G.is_multigraph()
     # Allow 'attrs' to keep default values.
     if attrs is None:
@@ -117,7 +147,17 @@ def node_link_data(G, attrs=None):
     return data
 
 
-def node_link_graph(data, directed=False, multigraph=True, attrs=None):
+def node_link_graph(
+    data,
+    directed=False,
+    multigraph=True,
+    attrs=None,
+    source="source",
+    target="target",
+    name="id",
+    key="key",
+    link="links",
+):
     """Returns graph from node-link data format.
 
     Parameters

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -81,7 +81,7 @@ def node_link_data(
     >>> G = nx.Graph([("A", "B")])
     >>> data1 = json_graph.node_link_data(G)
     >>> H = nx.gn_graph(2)
-    >>> data2 = json_graph.node_link_data(H, link="edges", source="from", target="to"})
+    >>> data2 = json_graph.node_link_data(H, {link="edges", source="from", target="to"})
 
     To serialize with json
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -117,7 +117,7 @@ def node_link_data(
     multigraph = G.is_multigraph()
 
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
-    key = None if not multigraph else attrs["key"]
+    key = None if not multigraph else key
     if len({source, target, key}) < 3:
         raise nx.NetworkXError("Attribute names are not unique.")
     data = {
@@ -127,12 +127,12 @@ def node_link_data(
         "nodes": [dict(chain(G.nodes[n].items(), [(name, n)])) for n in G],
     }
     if multigraph:
-        data[links] = [
+        data[link] = [
             dict(chain(d.items(), [(source, u), (target, v), (key, k)]))
             for u, v, k, d in G.edges(keys=True, data=True)
         ]
     else:
-        data[links] = [
+        data[link] = [
             dict(chain(d.items(), [(source, u), (target, v)]))
             for u, v, d in G.edges(data=True)
         ]

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -52,6 +52,8 @@ def node_link_data(
            The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
            `key` and `link`. in networkx 3.???
 
+    >>> assert False # Is version number correct?
+
            The values of the keywords must be unique.
 
     source : string
@@ -77,11 +79,10 @@ def node_link_data(
 
     Examples
     --------
-    >>> from networkx.readwrite import json_graph
     >>> G = nx.Graph([("A", "B")])
-    >>> data1 = json_graph.node_link_data(G)
+    >>> data1 = nx.node_link_data(G)
     >>> H = nx.gn_graph(2)
-    >>> data2 = json_graph.node_link_data(H, link="edges", source="from", target="to")
+    >>> data2 = nx.node_link_data(H, link="edges", source="from", target="to")
 
     To serialize with json
 
@@ -210,10 +211,9 @@ def node_link_graph(
 
     Examples
     --------
-    >>> from networkx.readwrite import json_graph
     >>> G = nx.Graph([("A", "B")])
-    >>> data = json_graph.node_link_data(G)
-    >>> H = json_graph.node_link_graph(data)
+    >>> data = nx.node_link_data(G)
+    >>> H = nx.node_link_graph(data)
 
     Notes
     -----

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -89,13 +89,15 @@ def node_link_data(
     >>> s1
     '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
 
-    Or, pass the graph and encoder function together in a single step, like this,
+    Or, pass the graph and encoder function together in a single step,
+    like this,
 
     >>> s1 = json.dumps(G, default=nx.node_link_data)
     >>> s1
     '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
 
-    The attribute names for storing NetworkX-internal graph data can be specified as keyword options.
+    The attribute names for storing NetworkX-internal graph data can
+    be specified as keyword options.
 
     >>> H = nx.gn_graph(2)
     >>> data2 = nx.node_link_data(H, link="edges", source="from", target="to")
@@ -108,6 +110,9 @@ def node_link_data(
     attribute keys will be converted to strings in order to comply with JSON.
 
     Attribute 'key' is only used for multigraphs.
+
+    To use `node_link_data` in conjunction with `node_link_graph`,
+    the same keyword names for the attributes must be used in both.
 
     See Also
     --------
@@ -176,6 +181,7 @@ def node_link_graph(
     link="links",
 ):
     """Returns graph from node-link data format.
+    Useful for de-serialization from JSON.
 
     Parameters
     ----------
@@ -230,7 +236,7 @@ def node_link_graph(
     >>> print(H.edges)
     [('A', 'B')]
 
-    To serialize and deserialize a graph with json,
+    To serialize and deserialize a graph with JSON,
 
     >>> import json
     >>> d = json.dumps(node_link_data(G))
@@ -242,6 +248,9 @@ def node_link_graph(
     Notes
     -----
     Attribute 'key' is only used for multigraphs.
+
+    To use `node_link_graph` in conjunction with `node_link_data`,
+    the same keyword names for the attributes must be used in both.
 
     See Also
     --------

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -67,7 +67,7 @@ class TestNodeLink:
         assert H[1][2]["width"] == 7
 
     # TODO: To be removed when signature change complete
-    def test_exception(self):
+    def test_exception_dep(self):
         with pytest.raises(nx.NetworkXError):
             G = nx.MultiDiGraph()
             attrs = dict(name="node", source="node", target="node", key="node")

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -7,6 +7,56 @@ from networkx.readwrite.json_graph import node_link_data, node_link_graph
 
 
 class TestNodeLink:
+
+    # TODO: To be removed when signature change complete
+    def test_attrs_deprecation(recwarn):
+        G = nx.path_graph(3)
+
+        # No warnings when `attrs` kwarg not used
+        data = node_link_data(G)
+        H = node_link_graph(data)
+        assert len(recwarn) == 0
+
+        # Future warning raised with `attrs` kwarg
+        attrs = dict(
+            source="source", target="target", name="id", key="key", link="links"
+        )
+        with pytest.warns(DeprecationWarning):
+            data = node_link_data(G, attrs)
+        with pytest.warns(DeprecationWarning):
+            H = node_link_graph(data, attrs)
+
+    # TODO: To be removed when signature change complete
+    def test_custom_attrs_dep(self):
+        G = nx.path_graph(4)
+        G.add_node(1, color="red")
+        G.add_edge(1, 2, width=7)
+        G.graph[1] = "one"
+        G.graph["foo"] = "bar"
+
+        attrs = dict(
+            source="c_source",
+            target="c_target",
+            name="c_id",
+            key="c_key",
+            link="c_links",
+        )
+
+        H = node_link_graph(
+            node_link_data(G, attrs=attrs), multigraph=False, attrs=attrs
+        )
+        assert nx.is_isomorphic(G, H)
+        assert H.graph["foo"] == "bar"
+        assert H.nodes[1]["color"] == "red"
+        assert H[1][2]["width"] == 7
+
+    # TODO: To be removed when signature change complete
+    def test_exception(self):
+        with pytest.raises(nx.NetworkXError):
+            G = nx.MultiDiGraph()
+            attrs = dict(name="node", source="node", target="node", key="node")
+            node_link_data(G, attrs)
+
     def test_graph(self):
         G = nx.path_graph(4)
         H = node_link_graph(node_link_data(G))
@@ -68,7 +118,7 @@ class TestNodeLink:
         with pytest.raises(nx.NetworkXError):
             G = nx.MultiDiGraph()
             attrs = dict(name="node", source="node", target="node", key="node")
-            node_link_data(G, attrs)
+            node_link_data(G, **attrs)
 
     def test_string_ids(self):
         q = "qualité"
@@ -97,9 +147,7 @@ class TestNodeLink:
             link="c_links",
         )
 
-        H = node_link_graph(
-            node_link_data(G, attrs=attrs), multigraph=False, attrs=attrs
-        )
+        H = node_link_graph(node_link_data(G, **attrs), multigraph=False, **attrs)
         assert nx.is_isomorphic(G, H)
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -6,25 +6,24 @@ import networkx as nx
 from networkx.readwrite.json_graph import node_link_data, node_link_graph
 
 
+# TODO: To be removed when signature change complete
+def test_attrs_deprecation(recwarn):
+    G = nx.path_graph(3)
+
+    # No warnings when `attrs` kwarg not used
+    data = node_link_data(G)
+    H = node_link_graph(data)
+    assert len(recwarn) == 0
+
+    # Future warning raised with `attrs` kwarg
+    attrs = dict(source="source", target="target", name="id", key="key", link="links")
+    with pytest.warns(DeprecationWarning):
+        data = node_link_data(G, attrs)
+    with pytest.warns(DeprecationWarning):
+        H = node_link_graph(data, attrs)
+
+
 class TestNodeLink:
-
-    # TODO: To be removed when signature change complete
-    def test_attrs_deprecation(recwarn):
-        G = nx.path_graph(3)
-
-        # No warnings when `attrs` kwarg not used
-        data = node_link_data(G)
-        H = node_link_graph(data)
-        assert len(recwarn) == 0
-
-        # Future warning raised with `attrs` kwarg
-        attrs = dict(
-            source="source", target="target", name="id", key="key", link="links"
-        )
-        with pytest.warns(DeprecationWarning):
-            data = node_link_data(G, attrs)
-        with pytest.warns(DeprecationWarning):
-            H = node_link_graph(data, attrs)
 
     # TODO: To be removed when signature change complete
     def test_custom_attrs_dep(self):

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -17,10 +17,12 @@ def test_attrs_deprecation(recwarn):
 
     # Future warning raised with `attrs` kwarg
     attrs = dict(source="source", target="target", name="id", key="key", link="links")
-    with pytest.warns(DeprecationWarning):
-        data = node_link_data(G, attrs)
-    with pytest.warns(DeprecationWarning):
-        H = node_link_graph(data, attrs)
+    data = node_link_data(G, attrs=attrs)
+    assert len(recwarn) == 1
+
+    recwarn.clear()
+    H = node_link_graph(data, attrs=attrs)
+    assert len(recwarn) == 1
 
 
 class TestNodeLink:

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -51,6 +51,21 @@ class TestNodeLink:
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
 
+        # provide only a partial dictionary of keywords.
+        # This is similar to an example in the doc string
+        attrs = dict(
+            link="c_links",
+            source="c_source",
+            target="c_target",
+        )
+        H = node_link_graph(
+            node_link_data(G, attrs=attrs), multigraph=False, attrs=attrs
+        )
+        assert nx.is_isomorphic(G, H)
+        assert H.graph["foo"] == "bar"
+        assert H.nodes[1]["color"] == "red"
+        assert H[1][2]["width"] == 7
+
     # TODO: To be removed when signature change complete
     def test_exception(self):
         with pytest.raises(nx.NetworkXError):


### PR DESCRIPTION
Signature change for `node_link` functions resolves #5787.
Attributes are passed by keyword instead of a dictionary.

Not yet complete.
*** The deprecation warnings need to be edited to include the target version for the change ***

Tests
- Tests were added to check the new signature with keywords.
- A test was added to verify that the warning message is triggered when the old style signature is used.
- Tests that check the old style signatures were kept, but were tagged with TODO comments for deletion.

Docs
- The doc strings were updated with deprecation notices
- *** The examples in the doc strings still need updating.