### PR TITLE
Allow classes to relabel nodes -- casting

### DIFF
--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -114,9 +114,13 @@ def relabel_nodes(G, mapping, copy=True):
     --------
     convert_node_labels_to_integers
     """
-    # you can pass a function f(old_label)->new_label
+    # you can pass a function f(old_label) -> new_label
+    # or a class e.g. str(old_label) -> new_label
     # but we'll just make a dictionary here regardless
-    if not hasattr(mapping, "__getitem__"):
+    # To allow classes, we check if __getitem__ is a bound method using __self__
+    if not (
+        hasattr(mapping, "__getitem__") and hasattr(mapping.__getitem__, "__self__")
+    ):
         m = {n: mapping(n) for n in G}
     else:
         m = mapping

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -106,6 +106,12 @@ class TestRelabel:
         H = nx.relabel_nodes(G, mapping)
         assert nodes_equal(H.nodes(), [65, 66, 67, 68])
 
+    def test_relabel_nodes_classes(self):
+        G = nx.empty_graph()
+        G.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3)])
+        H = nx.relabel_nodes(G, str)
+        assert nodes_equal(H.nodes, ["0", "1", "2", "3"])
+
     def test_relabel_nodes_graph(self):
         G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])
         mapping = {"A": "aardvark", "B": "bear", "C": "cat", "D": "dog"}


### PR DESCRIPTION
Fixes #5896 

Currently classes like str/int and friends don't work in `nx.relabel_nodes` even though they are callable and functions do work. When we check for the attribute `__getitem__` to see if we can use a lookup to the mapping, we should also check that the `__getitem__` attribute is a bound method. If it is not, we can't use it as a mapping so we try calling `mapping` like a function.

Here's a test that ensures classes can be used to "cast" nodes to a new type.
It currently fails and this PR enables it.
```python
    def test_relabel_nodes_classes(self):
        G = nx.empty_graph()
        G.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3)])
        H = nx.relabel_nodes(G, str)
        assert nodes_equal(H.nodes, ["0", "1", "2", "3"])
```