### PR TITLE
Arf layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1190,7 +1190,7 @@ def arf_layout(
     node_order = {node: i for i, node in enumerate(G)}
     for x, y in G.edges():
         if x != y:
-            idx, jdx = [node_order[i] for i in (x, y)]
+            idx, jdx = (node_order[i] for i in (x, y))
             K[idx, jdx] = a
 
     # vectorize values

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1112,47 +1112,47 @@ def multipartite_layout(G, subset_key="subset", align="vertical", scale=1, cente
 
 
 def arf_layout(
-    g, pos=None, b=1, alpha=1.1, etol=1e-6, dt=1e-3, max_iter=1000, seed=None
+    G,
+    pos=None,
+    scaling=1,
+    a=1.1,
+    etol=1e-6,
+    dt=1e-3,
+    max_iter=1000,
 ):
     """Arf layout for networkx
 
-    The  attractive   and  repulsive  forces   (arf)  layout (Geipel 2006)
-    improves  the spring  layout  in three  ways. First,  it
-    prevents  congestion of  highly connected  nodes due  to
-    strong forcing  between nodes.  Second, it  utilizes the
-    layout space  more effectively by preventing  large gaps
-    that  spring layout  tends  to create.  Lastly, the  arf
-    layout represents symmmetries in  the layout better than
+    The attractive and repulsive forces (arf) layout [1]
+    improves the spring layout in three ways. First, it
+    prevents congestion of highly connected nodes due to
+    strong forcing between nodes. Second, it utilizes the
+    layout space more effectively by preventing large gaps
+    that spring layout tends to create. Lastly, the arf
+    layout represents symmmetries in the layout better than
     the default spring layout.
 
     Parameters
     ----------
-    g : nx.Graph or nx.DiGraph
+    G : nx.Graph or nx.DiGraph
         Networkx graph.
     pos : dict
         Initial  position of  the nodes.  If set  to None  a
-        random layout will be used using seed as input.
-    b : float
-        Controls the radius of  the circular space the graph
-        layout will be plotted in.
-    alpha : float
-        Attraction scalar between edges. Should be larger than 1.
+        random layout will be used.
+    scaling : float
+        Scales the radius of the circular layout space.
+    a : float
+        Strength of springs between connected nodes. Should be larger than 1. The greater a, the clearer the separation ofunconnected sub clusters.
     etol : float
-        Termination tolerance
+        Graduent sum of spring forces must be larger than `etol` before succesful termination.
     dt : float
-        Integration factor
+        Time step for force differential equation simulations.
     max_iter : int
         Max iterations before termination of the algorithm.
-    seed : int, RandomState instance or None  optional (default=None)
-        Set the random state for deterministic node layouts.
-        If int, `seed` is the seed used by the random number generator,
-        if numpy.random.RandomState instance, `seed` is the random
-        number generator,
-        if None, the random number generator is the RandomState instance used
-        by numpy.random.
 
     References
-    - https://www.worldscientific.com/doi/abs/10.1142/S0129183107011558
+    .. [1] "Self-Organization Applied to Dynamic Network Layout", M. Geipel,
+            International Jounral of Modern Physics C, 2007, Vol 18, No 10, pp. 1537-1549.
+            https://doi.org/10.1142/S0129183107011558 https://arxiv.org/abs/0704.1748
 
     Returns
     -------

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1111,8 +1111,9 @@ def multipartite_layout(G, subset_key="subset", align="vertical", scale=1, cente
     return pos
 
 
-def arf_layout(g, pos = None, b = 1,  alpha = 1.1, etol = 1e-6, dt = 1e-3,
-        max_iter = 1000, seed = None):
+def arf_layout(
+    g, pos=None, b=1, alpha=1.1, etol=1e-6, dt=1e-3, max_iter=1000, seed=None
+):
     """Arf layout for networkx
 
     The  attractive   and  repulsive  forces   (arf)  layout (Geipel 2006)
@@ -1167,7 +1168,7 @@ def arf_layout(g, pos = None, b = 1,  alpha = 1.1, etol = 1e-6, dt = 1e-3,
     import numpy as np
 
     assert alpha > 1, "Alpha should be larger than 1"
-    pos_tmp = nx.random_layout(g, seed = seed)
+    pos_tmp = nx.random_layout(g, seed=seed)
     if pos is None:
         pos = pos_tmp.copy()
     else:
@@ -1191,20 +1192,20 @@ def arf_layout(g, pos = None, b = 1,  alpha = 1.1, etol = 1e-6, dt = 1e-3,
                 K[idx, jdx] = 1
     # vectorize values
     p = np.asarray(list(pos.values()))
-    bV = np.sqrt(N) * b # scaling constant for circular space
+    bV = np.sqrt(N) * b  # scaling constant for circular space
 
     # looping variables
     error = etol + 1
     n_iter = 0
     while error > etol:
         diff = p[:, None] - p[None]
-        A = np.linalg.norm(diff, axis = -1)[..., None]
+        A = np.linalg.norm(diff, axis=-1)[..., None]
         # attraction_force - repulsions force
         change = K[..., None] * diff - bV / A * diff
-        change = np.nansum(change, axis = 0)
+        change = np.nansum(change, axis=0)
         p += change * dt
 
-        error = np.linalg.norm(change, axis = -1).sum()
+        error = np.linalg.norm(change, axis=-1).sum()
         # error = abs(change).sum()
         if n_iter > max_iter:
             break
@@ -1251,7 +1252,6 @@ def rescale_layout(pos, scale=1):
         for i in range(pos.shape[1]):
             pos[:, i] *= scale / lim
     return pos
-
 
 
 def rescale_layout_dict(pos, scale=1):

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1115,8 +1115,14 @@ def arf_layout(g, pos = None, b = 1,  alpha = 1.1, etol = 1e-6, dt = 1e-3,
         max_iter = 1000, seed = None):
     """Arf layout for networkx
 
-    The  arf   (attractive  and  repulsive   forces)  layout
-    improves the spring layout in several ways.
+    The  attractive   and  repulsive  forces   (arf)  layout (Geipel 2006)
+    improves  the spring  layout  in three  ways. First,  it
+    prevents  congestion of  highly connected  nodes due  to
+    strong forcing  between nodes.  Second, it  utilizes the
+    layout space  more effectively by preventing  large gaps
+    that  spring layout  tends  to create.  Lastly, the  arf
+    layout represents symmmetries in  the layout better than
+    the default spring layout.
 
     Parameters
     ----------
@@ -1144,6 +1150,9 @@ def arf_layout(g, pos = None, b = 1,  alpha = 1.1, etol = 1e-6, dt = 1e-3,
         if None, the random number generator is the RandomState instance used
         by numpy.random.
 
+    References
+    - https://www.worldscientific.com/doi/abs/10.1142/S0129183107011558
+
     Returns
     -------
     pos : dict
@@ -1153,6 +1162,7 @@ def arf_layout(g, pos = None, b = 1,  alpha = 1.1, etol = 1e-6, dt = 1e-3,
     --------
     >>> G = nx.grid_graph((5, 5))
     >>> pos = nx.arf_layout(G)
+
     """
     import numpy as np
 

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1165,7 +1165,8 @@ def arf_layout(
     >>> pos = nx.arf_layout(G)
 
     """
-    import numpy as np, warnings
+    import numpy as np
+    import warnings
 
     if a <= 1:
         msg = "The parameter a should be larger than 1"

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1165,8 +1165,9 @@ def arf_layout(
     >>> pos = nx.arf_layout(G)
 
     """
-    import numpy as np
     import warnings
+
+    import numpy as np
 
     if a <= 1:
         msg = "The parameter a should be larger than 1"

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -418,6 +418,24 @@ class TestLayout:
         for k, v in expectation.items():
             assert (s_vpos[k] == v).all()
 
+    def test_arf_layout_partial_input_test(self):
+        """
+        Checks whether partial pos input still returns a proper position.
+        """
+        G = self.Gs
+        node = nx.utils.arbitrary_element(G)
+        pos = nx.circular_layout(G)
+        del pos[node]
+        pos = nx.arf_layout(G, pos=pos)
+        assert len(pos) == len(G)
+
+    def test_arf_layout_negative_a_check(self):
+        """
+        Checks input parameters correctly raises errors. For example,  `a` should be larger than 1
+        """
+        G = self.Gs
+        pytest.raises(ValueError, nx.arf_layout, G=G, a=-1)
+
 
 def test_multipartite_layout_nonnumeric_partition_labels():
     """See gh-5123."""
@@ -450,12 +468,3 @@ def test_multipartite_layout_layer_order():
     G.nodes["a"]["subset"] = "layer_0"  # Can't sort mixed strs/ints
     pos_nosort = nx.multipartite_layout(G)  # smoke test: this should not raise
     assert pos_nosort.keys() == pos.keys()
-
-    def test_arf_layout(self):
-        # check whether partial pos input still returns a proper position
-        G = self.Gs
-        node = nx.utils.arbitrary_element(G)
-        pos = nx.circular_layout(G)
-        del pos[node]
-        pos = nx.arf_layout(G, pos=pos)
-        assert len(pos) == len(G)

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -181,7 +181,6 @@ class TestLayout:
         pos = nx.circular_layout(self.Gi)
         npos = nx.arf_layout(self.Gi, pos=pos)
 
-
     def test_fixed_node_fruchterman_reingold(self):
         # Dense version (numpy based)
         pos = nx.circular_layout(self.Gi)

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -411,8 +411,6 @@ class TestLayout:
         for k, v in expectation.items():
             assert (s_vpos[k] == v).all()
         s_vpos = nx.rescale_layout_dict(vpos, scale=2)
-<<<<<<< HEAD
-
         expectation = {
             0: np.array((-2, -2)),
             1: np.array((2, 2)),

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -66,6 +66,7 @@ class TestLayout:
         nx.kamada_kawai_layout(G)
         nx.kamada_kawai_layout(G, dim=1)
         nx.kamada_kawai_layout(G, dim=3)
+        nx.arf_layout(G)
 
     def test_smoke_string(self):
         G = self.Gs
@@ -80,6 +81,7 @@ class TestLayout:
         nx.kamada_kawai_layout(G)
         nx.kamada_kawai_layout(G, dim=1)
         nx.kamada_kawai_layout(G, dim=3)
+        nx.arf_layout(G)
 
     def check_scale_and_center(self, pos, scale, center):
         center = np.array(center)
@@ -175,6 +177,11 @@ class TestLayout:
         pos = nx.circular_layout(self.Gi)
         npos = nx.fruchterman_reingold_layout(self.Gi, pos=pos)
 
+    def test_smoke_initial_pos_arf(self):
+        pos = nx.circular_layout(self.Gi)
+        npos = nx.arf_layout(self.Gi, pos=pos)
+
+
     def test_fixed_node_fruchterman_reingold(self):
         # Dense version (numpy based)
         pos = nx.circular_layout(self.Gi)
@@ -241,6 +248,8 @@ class TestLayout:
         vpos = nx.multipartite_layout(G, center=(1, 1))
         assert vpos == {}
         vpos = nx.kamada_kawai_layout(G, center=(1, 1))
+        assert vpos == {}
+        vpos = nx.arf_layout(G)
         assert vpos == {}
 
     def test_bipartite_layout(self):
@@ -402,6 +411,7 @@ class TestLayout:
         for k, v in expectation.items():
             assert (s_vpos[k] == v).all()
         s_vpos = nx.rescale_layout_dict(vpos, scale=2)
+<<<<<<< HEAD
 
         expectation = {
             0: np.array((-2, -2)),
@@ -443,3 +453,12 @@ def test_multipartite_layout_layer_order():
     G.nodes["a"]["subset"] = "layer_0"  # Can't sort mixed strs/ints
     pos_nosort = nx.multipartite_layout(G)  # smoke test: this should not raise
     assert pos_nosort.keys() == pos.keys()
+
+    def test_arf_layout(self):
+        # check whether partial pos input still returns a proper position
+        G = self.Gs
+        node = nx.utils.arbitrary_element(G)
+        pos = nx.circular_layout(G)
+        del pos[node]
+        pos = nx.arf_layout(G, pos=pos)
+        assert len(pos) == len(G)


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

Implements arf layout (Geipel 2006) which provides improvements over the traditional spring layout.
Short description

    The attractive and repulsive forces (arf) layout (Geipel
    2006) improves  the spring layout in  three ways. First,
    it prevents congestion of  highly connected nodes due to
    strong forcing  between nodes.  Second, it  utilizes the
    layout space  more effectively by preventing  large gaps
    that  spring layout  tends  to create.  Lastly, the  arf
    layout represents symmmetries in  the layout better than
    the default spring layout.

Example:
<details>
<summary>Plotting code </summary>

``` python
import networkx as nx, numpy as np, matplotlib.pyplot as plt
from functools import partial
graphs = [nx.krackhardt_kite_graph(),
          nx.florentine_families_graph(),
          nx.grid_graph((5,5)),
          nx.erdos_renyi_graph(100, 0.02, seed = 0)
          ]
fig, ax = plt.subplots(ncols = 2, nrows = 2, share = 0)

layouts = [partial(nx.arf_layout, alpha = 10, b = 5, seed = 0),
           partial(nx.spring_layout, seed = 0)]
centers = [np.array([-1.5, 0]), np.array([1.5, 0])]
for axi, g in zip(ax, graphs):
    for layout, center in zip(layouts, centers):
        pos = layout(g)
        pos = nx.rescale_layout_dict(pos)
        pos = {x: y + center for x, y in pos.items()}
        nx.draw(g, pos = pos,
                ax = axi, node_size = 10)
    axi.annotate("Spring", xy = [0.75, 1.02], xycoords = axi.transAxes,
        va = "center", ha = "center")
    axi.annotate("Arf", xy = [0.25, 1.02], xycoords = axi.transAxes,
        va = "center", ha = "center")
    axi.axis("equal")
fig.show()
```
</details>

![image](https://user-images.githubusercontent.com/19485143/182322237-8f7f73d7-dd38-42b3-be68-1a865c4dbc53.png)
