### PR TITLE
Update mapping logic in `relabel_nodes`

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -43,10 +43,17 @@ Improvements
 ------------
 - [`#5663 <https://github.com/networkx/networkx/pull/5663>`_]
   Implements edge swapping for directed graphs.
-- [`#5663 <https://github.com/networkx/networkx/pull/5883>`_]
+- [`#5883 <https://github.com/networkx/networkx/pull/5883>`_]
   Replace the implementation of ``lowest_common_ancestor`` and
   ``all_pairs_lowest_common_ancestor`` with a "naive" algorithm to fix
   several bugs and improve performance.
+- [`#5912 <https://github.com/networkx/networkx/pull/5912>`_]
+  The ``mapping`` argument of the ``relabel_nodes`` function can be either a
+  mapping or a function that creates a mapping. ``relabel_nodes`` first checks
+  whether the ``mapping`` is callable - if so, then it is used as a function.
+  This fixes a bug related for ``mapping=str`` and may change the behavior for
+  other ``mapping`` arguments that implement both ``__getitem__`` and
+  ``__call__``.
 
 API Changes
 -----------

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -1,5 +1,3 @@
-from collections.abc import Callable
-
 import networkx as nx
 
 __all__ = ["convert_node_labels_to_integers", "relabel_nodes"]
@@ -118,10 +116,8 @@ def relabel_nodes(G, mapping, copy=True):
     """
     # you can pass any callable e.g. f(old_label) -> new_label or
     # e.g. str(old_label) -> new_label, but we'll just make a dictionary here regardless
-    if isinstance(mapping, Callable):
-        m = {n: mapping(n) for n in G}
-    else:
-        m = mapping
+    m = {n: mapping(n) for n in G} if callable(mapping) else mapping
+
     if copy:
         return _relabel_copy(G, m)
     else:

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 import networkx as nx
 
 __all__ = ["convert_node_labels_to_integers", "relabel_nodes"]
@@ -114,13 +116,9 @@ def relabel_nodes(G, mapping, copy=True):
     --------
     convert_node_labels_to_integers
     """
-    # you can pass a function f(old_label) -> new_label
-    # or a class e.g. str(old_label) -> new_label
-    # but we'll just make a dictionary here regardless
-    # To allow classes, we check if __getitem__ is a bound method using __self__
-    if not (
-        hasattr(mapping, "__getitem__") and hasattr(mapping.__getitem__, "__self__")
-    ):
+    # you can pass any callable e.g. f(old_label) -> new_label or
+    # e.g. str(old_label) -> new_label, but we'll just make a dictionary here regardless
+    if not isinstance(mapping, Mapping):
         m = {n: mapping(n) for n in G}
     else:
         m = mapping

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Callable
 
 import networkx as nx
 
@@ -118,7 +118,7 @@ def relabel_nodes(G, mapping, copy=True):
     """
     # you can pass any callable e.g. f(old_label) -> new_label or
     # e.g. str(old_label) -> new_label, but we'll just make a dictionary here regardless
-    if not isinstance(mapping, Mapping):
+    if isinstance(mapping, Callable):
         m = {n: mapping(n) for n in G}
     else:
         m = mapping

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -117,7 +117,7 @@ class TestRelabel:
         """If `mapping` is neither a Callable or a Mapping, an exception
         should be raised."""
         G = nx.path_graph(4)
-        with pytest.raises(TypeError):
+        with pytest.raises(AttributeError):
             nx.relabel_nodes(G, non_mc)
 
     def test_relabel_nodes_graph(self):

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -106,11 +106,19 @@ class TestRelabel:
         H = nx.relabel_nodes(G, mapping)
         assert nodes_equal(H.nodes(), [65, 66, 67, 68])
 
-    def test_relabel_nodes_classes(self):
+    def test_relabel_nodes_callable_type(self):
         G = nx.empty_graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3)])
         H = nx.relabel_nodes(G, str)
         assert nodes_equal(H.nodes, ["0", "1", "2", "3"])
+
+    @pytest.mark.parametrize("non_mc", ("0123", ["0", "1", "2", "3"]))
+    def test_relabel_nodes_non_mapping_or_callable(self, non_mc):
+        """If `mapping` is neither a Callable or a Mapping, an exception
+        should be raised."""
+        G = nx.path_graph(4)
+        with pytest.raises(TypeError):
+            nx.relabel_nodes(G, non_mc)
 
     def test_relabel_nodes_graph(self):
         G = nx.Graph([("A", "B"), ("A", "C"), ("B", "C"), ("C", "D")])

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -107,8 +107,7 @@ class TestRelabel:
         assert nodes_equal(H.nodes(), [65, 66, 67, 68])
 
     def test_relabel_nodes_callable_type(self):
-        G = nx.empty_graph()
-        G.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3)])
+        G = nx.path_graph(4)
         H = nx.relabel_nodes(G, str)
         assert nodes_equal(H.nodes, ["0", "1", "2", "3"])
 


### PR DESCRIPTION
Related to #5903 and #5896.

#5903 was a very nice solution to the problem identified in #5896 - i.e. the input-munging logic for the `mapping` parameter used a `hasattr("__getitem__")` check which was fragile in the case of the built-in `str`. The trick here was that `str` is a Python *type*, which both has a `__getitem__` attr, *and* is a Callable.

The logic has been updated to fix this specific case in #5903, but I'd like to propose using `isinstance` checks against ABC's if for no other reason that I personally find them slightly easier to reason about.

One major difference with this change is how the code fails. Note that previously if a user passed in an object that was neither a `Mapping` nor `Callable`, then they would eventually get an `AttributeError` when the `.get` method was called. For example

#### On main (after #5903)

```python
>>> G = nx.path_graph(4)
>>> s = "0123"
>>> l = ["0", "1", "2", "3"]
>>> nx.relabel_nodes(G, s)
Traceback (most recent call last)
   ...
AttributeError: 'str' object has no attribute 'get'
>>> nx.relabel_nodes(G, l)
Traceback (most recent call last)
   ...
AttributeError: 'list' object has no attribute 'get'
```

#### This PR

```python
>>> G = nx.path_graph(4)
>>> s = "0123"
>>> l = ["0", "1", "2", "3"]
>>> nx.relabel_nodes(G, s)
Traceback (most recent call last)
   ...
TypeError: 'str' object is not callable
>>> nx.relabel_nodes(G, l)
Traceback (most recent call last)
   ...
TypeError: 'list' object is not callable
```

Note the exception changes from an `AttributeError` to a `TypeError` with this proposed change. In principle, the check could be made more specific to improve the exception message, e.g. something like:

```python
if not isinstance(mapping, Mapping):
    if not isinstance(mapping, Callable):
        raise TypeError("mapping must either be a mapping or callable")  # or NetworkXError, if preferred
    m = {n: mapping(n) for n in G}
```

Of course, the change in exception type is a breaking change, so it could well be that this churn isn't worth it. Nevertheless I wanted to submit my two cents on the topic (since I missed the review in #5903!)