### PR TITLE
Propose to make new node_link arguments keyword only.

### DIFF
--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -26,7 +26,14 @@ def _to_tuple(x):
 
 
 def node_link_data(
-    G, attrs=None, source="source", target="target", name="id", key="key", link="links"
+    G,
+    attrs=None,
+    *,
+    source="source",
+    target="target",
+    name="id",
+    key="key",
+    link="links",
 ):
     """Returns data in node-link format that is suitable for JSON serialization
     and use in Javascript documents.
@@ -176,6 +183,7 @@ def node_link_graph(
     directed=False,
     multigraph=True,
     attrs=None,
+    *,
     source="source",
     target="target",
     name="id",


### PR DESCRIPTION
Just an idea I had while following up on #5787 

Since we're adding these new arguments to replace the strange `attrs` munging (an obvious improvement, thanks @brocla ) I thought it might make sense to set the new args to keyword only.

Note - if we decide to do this, it should go in before the next release!