### PR TITLE
docstring update to lexicographical_topological_sort issue 5681

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -304,7 +304,9 @@ def topological_sort(G):
 
 
 def lexicographical_topological_sort(G, key=None):
-    """Generates a unique ordering of nodes by first sorting topologically (for which there are often
+    """Generate the nodes in the unique lexicographical topological sort order.
+    
+    Generates a unique ordering of nodes by first sorting topologically (for which there are often
     multiple valid orderings) and then additionally by sorting lexicographically.
 
     A topological sort arranges the nodes of a directed graph so that the

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -376,9 +376,8 @@ def lexicographical_topological_sort(G, key=None):
     TypeError: '<' not supported between instances of 'str' and 'int'
     ...
 
-    The solution is to provide a function that returns keys that do compare.
-
-    There are many ways to write a `key` function. This one returns a tuple where the first
+    Incomparable nodes can be resolved using a `key` function. This example function 
+    allows comparison of integers and strings by returning a tuple where the first
     element is True for `str`, False otherwise. The second element is the node name.
     This groups the strings and integers separately so they can be compared only among themselves.
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -305,7 +305,7 @@ def topological_sort(G):
 
 def lexicographical_topological_sort(G, key=None):
     """Generate the nodes in the unique lexicographical topological sort order.
-    
+
     Generates a unique ordering of nodes by first sorting topologically (for which there are often
     multiple valid orderings) and then additionally by sorting lexicographically.
 
@@ -376,7 +376,7 @@ def lexicographical_topological_sort(G, key=None):
     TypeError: '<' not supported between instances of 'str' and 'int'
     ...
 
-    Incomparable nodes can be resolved using a `key` function. This example function 
+    Incomparable nodes can be resolved using a `key` function. This example function
     allows comparison of integers and strings by returning a tuple where the first
     element is True for `str`, False otherwise. The second element is the node name.
     This groups the strings and integers separately so they can be compared only among themselves.

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -333,7 +333,7 @@ def lexicographical_topological_sort(G, key=None):
 
     key : function, optional
         A function of one argument that converts a node name to a comparison key.
-        Use to resolve ambiguities in the sort order.  Defaults to the identity function.
+        It defines and resolves ambiguities in the sort order.  Defaults to the identity function.
 
     Yields
     ------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -304,12 +304,25 @@ def topological_sort(G):
 
 
 def lexicographical_topological_sort(G, key=None):
-    """Returns a generator of nodes in lexicographically topologically sorted
-    order.
+    """Generates a unique ordering of nodes by first sorting topologically (for which there are often
+    multiple valid orderings) and then additionally by sorting lexicographically.
 
-    A topological sort is a nonunique permutation of the nodes such that an
-    edge from u to v implies that u appears before v in the topological sort
-    order.
+    A topological sort arranges the nodes of a directed graph so that the
+    upstream node of each directed edge precedes the downstream node.
+    It is always possible to find a solution for directed graphs that have no cycles.
+    There may be more than one valid solution.
+
+    Lexicographical sorting is just sorting alphabetically. It is used here to break ties in the
+    topological sort and to determine a single, unique ordering.  This can be useful in comparing
+    sort results.
+
+    The lexicographical order can be customized by providing a function to the `key=` parameter.
+    The definition of the key function is the same as used in python's built-in `sort()`.
+    The function takes a single argument and returns a key to use for sorting purposes.
+
+    Lexicographical sorting can fail if the node names are un-sortable. See the example below.
+    The solution is to provide a function to the `key=` argument that returns sortable keys.
+
 
     Parameters
     ----------
@@ -317,13 +330,13 @@ def lexicographical_topological_sort(G, key=None):
         A directed acyclic graph (DAG)
 
     key : function, optional
-        This function maps nodes to keys with which to resolve ambiguities in
-        the sort order.  Defaults to the identity function.
+        A function of one argument that converts a node name to a comparison key.
+        Use to resolve ambiguities in the sort order.  Defaults to the identity function.
 
     Yields
     ------
     nodes
-        Yields the nodes in lexicographical topological sort order.
+        Yields the nodes of G in lexicographical topological sort order.
 
     Raises
     ------
@@ -339,6 +352,10 @@ def lexicographical_topological_sort(G, key=None):
     RuntimeError
         If `G` is changed while the returned iterator is being processed.
 
+    TypeError
+        Results from un-sortable node names.
+        Consider using `key=` parameter to resolve ambiguities in the sort order.
+
     Examples
     --------
     >>> DG = nx.DiGraph([(2, 1), (2, 5), (1, 3), (1, 4), (5, 4)])
@@ -346,6 +363,26 @@ def lexicographical_topological_sort(G, key=None):
     [2, 1, 3, 5, 4]
     >>> list(nx.lexicographical_topological_sort(DG, key=lambda x: -x))
     [2, 5, 1, 4, 3]
+
+    The sort will fail for this graph because the comparison of integers to strings
+    is not defined in python.  Is 3 greater or less than 'red'?
+
+    >>> DG = nx.DiGraph([(1, 'red'), (3, 'red'), (1, 'green'), (2, 'blue')])
+    >>> list(nx.lexicographical_topological_sort(DG))
+    Traceback (most recent call last):
+    ...
+    TypeError: '<' not supported between instances of 'str' and 'int'
+    ...
+
+    The solution is to provide a function that returns keys that do compare.
+
+    There are many ways to write a `key` function. This one returns a tuple where the first
+    element is True for `str`, False otherwise. The second element is the node name.
+    This groups the strings and integers separately so they can be compared only among themselves.
+
+    >>> key = lambda node: (isinstance(node, str), node)
+    >>> list(nx.lexicographical_topological_sort(DG, key=key))
+    [1, 2, 3, 'blue', 'green', 'red']
 
     Notes
     -----
@@ -391,7 +428,12 @@ def lexicographical_topological_sort(G, key=None):
             except KeyError as err:
                 raise RuntimeError("Graph changed during iteration") from err
             if indegree_map[child] == 0:
-                heapq.heappush(zero_indegree, create_tuple(child))
+                try:
+                    heapq.heappush(zero_indegree, create_tuple(child))
+                except TypeError as err:
+                    raise TypeError(
+                        f"{err}\nConsider using `key=` parameter to resolve ambiguities in the sort order."
+                    )
                 del indegree_map[child]
 
         yield node

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -366,7 +366,7 @@ def lexicographical_topological_sort(G, key=None):
     >>> list(nx.lexicographical_topological_sort(DG, key=lambda x: -x))
     [2, 5, 1, 4, 3]
 
-    The sort will fail for this graph because the comparison of integers to strings
+    The sort will fail for any graph with integer and string nodes. Comparison of integer to strings
     is not defined in python.  Is 3 greater or less than 'red'?
 
     >>> DG = nx.DiGraph([(1, 'red'), (3, 'red'), (1, 'green'), (2, 'blue')])


### PR DESCRIPTION
Added docstring improvements to lexicographical_topological_sort as discussed in issue 5681. Partially resolves #5681 

- explains effect and purpose for lexi sort in the short and long descriptions.
- add hints for fixing un-sortable nodes
- adds hint to exception msg
- Adds example to demonstrate fixing un-sortable nodes with key function
