### PR TITLE
Bump nodelink args deprecation expiration to v3.2

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -88,13 +88,11 @@ Version 3.0
 * In ``utils/misc.py`` remove ``to_tuple``.
 * In ``algorithms/matching.py``, remove parameter ``maxcardinality`` from ``min_weight_matching``.
 
-Version 3.1
-~~~~~~~~~~~
-* In ``readwrite/json_graph/node_link.py`` remove the ``attrs` keyword code 
-  and docstring in ``node_link_data`` and ``node_link_graph``. Also the associated tests.
 
 Version 3.2
 ~~~~~~~~~~~
 * In ``generators/directed.py`` remove the ``create_using`` keyword argument
   for the ``scale_free_graph`` function.
 * Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723
+* In ``readwrite/json_graph/node_link.py`` remove the ``attrs` keyword code 
+  and docstring in ``node_link_data`` and ``node_link_graph``. Also the associated tests.

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -145,7 +145,7 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore",
         category=DeprecationWarning,
-        message="signature change for node_link functions",
+        message="\n\nThe `attrs` keyword argument of node_link",
     )
 
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -50,7 +50,7 @@ def node_link_data(
         .. deprecated:: 2.8.6
 
            The `attrs` keyword argument will be replaced with `source`, `target`, `name`,
-           `key` and `link`. in networkx 3.1
+           `key` and `link`. in networkx 3.2
 
            If the `attrs` keyword and the new keywords are both used in a single function call (not recommended)
            the `attrs` keyword argument will take precedence.
@@ -127,7 +127,7 @@ def node_link_data(
 
         msg = (
             "\n\nThe `attrs` keyword argument of node_link_data is deprecated\n"
-            "and will be removed in networkx 3.1. It is replaced with explicit\n"
+            "and will be removed in networkx 3.2. It is replaced with explicit\n"
             "keyword arguments: `source`, `target`, `name`, `key` and `link`.\n"
             "To make this warning go away, and ensure usage is forward\n"
             "compatible, replace `attrs` with the keywords. "
@@ -135,7 +135,7 @@ def node_link_data(
             "   >>> node_link_data(G, attrs={'target': 'foo', 'name': 'bar'})\n\n"
             "should instead be written as\n\n"
             "   >>> node_link_data(G, target='foo', name='bar')\n\n"
-            "in networkx 3.1.\n"
+            "in networkx 3.2.\n"
             "The default values of the keywords will not change.\n"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
@@ -207,7 +207,7 @@ def node_link_graph(
         .. deprecated:: 2.8.6
 
            The `attrs` keyword argument will be replaced with the individual keywords: `source`, `target`, `name`,
-           `key` and `link`. in networkx 3.1.
+           `key` and `link`. in networkx 3.2.
 
            If the `attrs` keyword and the new keywords are both used in a single function call (not recommended)
            the `attrs` keyword argument will take precedence.
@@ -272,7 +272,7 @@ def node_link_graph(
 
         msg = (
             "\n\nThe `attrs` keyword argument of node_link_graph is deprecated\n"
-            "and will be removed in networkx 3.1. It is replaced with explicit\n"
+            "and will be removed in networkx 3.2. It is replaced with explicit\n"
             "keyword arguments: `source`, `target`, `name`, `key` and `link`.\n"
             "To make this warning go away, and ensure usage is forward\n"
             "compatible, replace `attrs` with the keywords. "
@@ -280,7 +280,7 @@ def node_link_graph(
             "   >>> node_link_graph(data, attrs={'target': 'foo', 'name': 'bar'})\n\n"
             "should instead be written as\n\n"
             "   >>> node_link_graph(data, target='foo', name='bar')\n\n"
-            "in networkx 3.1.\n"
+            "in networkx 3.2.\n"
             "The default values of the keywords will not change.\n"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
I propose to bump the deprecation expiration for the arguments of the `node_link_` functions from v3.1 to v3.2. See https://github.com/networkx/networkx/pull/5928#issuecomment-1213017715 and https://github.com/networkx/networkx/pull/5899#issuecomment-1212910911 for further discussion.

Also includes minor fixup to the warnings filter.