### PR TITLE
See matplotlb 3.6rc1 failure

### DIFF
--- a/examples/drawing/plot_directed.py
+++ b/examples/drawing/plot_directed.py
@@ -39,8 +39,8 @@ for i in range(M):
 
 pc = mpl.collections.PatchCollection(edges, cmap=cmap)
 pc.set_array(edge_colors)
-plt.colorbar(pc)
 
 ax = plt.gca()
 ax.set_axis_off()
+plt.colorbar(pc)
 plt.show()

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -110,10 +110,10 @@ def draw(G, pos=None, ax=None, **kwds):
         cf = ax.get_figure()
     cf.set_facecolor("w")
     if ax is None:
-        if cf._axstack() is None:
-            ax = cf.add_axes((0, 0, 1, 1))
-        else:
+        if cf.axes:
             ax = cf.gca()
+        else:
+            ax = cf.add_axes((0, 0, 1, 1))
 
     if "with_labels" not in kwds:
         kwds["with_labels"] = "labels" in kwds

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.20
 scipy>=1.8
-matplotlib==3.6.0rc1
+matplotlib>=3.4
 pandas>=1.3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.20
 scipy>=1.8
-matplotlib>=3.4
+matplotlib==3.6.0rc1
 pandas>=1.3


### PR DESCRIPTION
Matplotlib 3.6rc1 just came out:
https://pypi.org/project/matplotlib/3.6.0rc1/

While preparing NX 2.8.6, I noticed we are getting errors with this prerelease. I don't have time to look at it right now, but wanted to create this PR to see if anyone else could look into it before I have a chance.

```
if ax is None:
>           if cf._axstack() is None:
E           TypeError: '_AxesStack' object is not callable

networkx/drawing/nx_pylab.py:113: TypeError
=============================== warnings summary ===============================
networkx/drawing/tests/test_pylab.py::test_alpha_iter
  /home/circleci/project/networkx/drawing/tests/test_pylab.py:489:
  MatplotlibDeprecationWarning: Auto-removal of overlapping axes is deprecated since 3.6 and
  will be removed two minor releases later; explicitly call ax.remove() as needed.
    plt.subplot(131)
```