### PR TITLE
Bugfix /docfix for MappedQueue, issue 5681

### DIFF
--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -65,3 +65,11 @@ Cuthill-Mckee Ordering
 
    cuthill_mckee_ordering
    reverse_cuthill_mckee_ordering
+
+Mapped Queue
+------------
+.. automodule:: networkx.utils.mapped_queue
+.. autosummary::
+   :toctree: generated/
+
+   MappedQueue

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -304,7 +304,9 @@ def topological_sort(G):
 
 
 def lexicographical_topological_sort(G, key=None):
-    """Generates a unique ordering of nodes by first sorting topologically (for which there are often
+    """Generate the nodes in the unique lexicographical topological sort order.
+    
+    Generates a unique ordering of nodes by first sorting topologically (for which there are often
     multiple valid orderings) and then additionally by sorting lexicographically.
 
     A topological sort arranges the nodes of a directed graph so that the

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -376,9 +376,8 @@ def lexicographical_topological_sort(G, key=None):
     TypeError: '<' not supported between instances of 'str' and 'int'
     ...
 
-    The solution is to provide a function that returns keys that do compare.
-
-    There are many ways to write a `key` function. This one returns a tuple where the first
+    Incomparable nodes can be resolved using a `key` function. This example function 
+    allows comparison of integers and strings by returning a tuple where the first
     element is True for `str`, False otherwise. The second element is the node name.
     This groups the strings and integers separately so they can be compared only among themselves.
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -305,7 +305,7 @@ def topological_sort(G):
 
 def lexicographical_topological_sort(G, key=None):
     """Generate the nodes in the unique lexicographical topological sort order.
-    
+
     Generates a unique ordering of nodes by first sorting topologically (for which there are often
     multiple valid orderings) and then additionally by sorting lexicographically.
 
@@ -376,7 +376,7 @@ def lexicographical_topological_sort(G, key=None):
     TypeError: '<' not supported between instances of 'str' and 'int'
     ...
 
-    Incomparable nodes can be resolved using a `key` function. This example function 
+    Incomparable nodes can be resolved using a `key` function. This example function
     allows comparison of integers and strings by returning a tuple where the first
     element is True for `str`, False otherwise. The second element is the node name.
     This groups the strings and integers separately so they can be compared only among themselves.

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -333,7 +333,7 @@ def lexicographical_topological_sort(G, key=None):
 
     key : function, optional
         A function of one argument that converts a node name to a comparison key.
-        Use to resolve ambiguities in the sort order.  Defaults to the identity function.
+        It defines and resolves ambiguities in the sort order.  Defaults to the identity function.
 
     Yields
     ------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -304,12 +304,25 @@ def topological_sort(G):
 
 
 def lexicographical_topological_sort(G, key=None):
-    """Returns a generator of nodes in lexicographically topologically sorted
-    order.
+    """Generates a unique ordering of nodes by first sorting topologically (for which there are often
+    multiple valid orderings) and then additionally by sorting lexicographically.
 
-    A topological sort is a nonunique permutation of the nodes such that an
-    edge from u to v implies that u appears before v in the topological sort
-    order.
+    A topological sort arranges the nodes of a directed graph so that the
+    upstream node of each directed edge precedes the downstream node.
+    It is always possible to find a solution for directed graphs that have no cycles.
+    There may be more than one valid solution.
+
+    Lexicographical sorting is just sorting alphabetically. It is used here to break ties in the
+    topological sort and to determine a single, unique ordering.  This can be useful in comparing
+    sort results.
+
+    The lexicographical order can be customized by providing a function to the `key=` parameter.
+    The definition of the key function is the same as used in python's built-in `sort()`.
+    The function takes a single argument and returns a key to use for sorting purposes.
+
+    Lexicographical sorting can fail if the node names are un-sortable. See the example below.
+    The solution is to provide a function to the `key=` argument that returns sortable keys.
+
 
     Parameters
     ----------
@@ -317,13 +330,13 @@ def lexicographical_topological_sort(G, key=None):
         A directed acyclic graph (DAG)
 
     key : function, optional
-        This function maps nodes to keys with which to resolve ambiguities in
-        the sort order.  Defaults to the identity function.
+        A function of one argument that converts a node name to a comparison key.
+        Use to resolve ambiguities in the sort order.  Defaults to the identity function.
 
     Yields
     ------
     nodes
-        Yields the nodes in lexicographical topological sort order.
+        Yields the nodes of G in lexicographical topological sort order.
 
     Raises
     ------
@@ -339,6 +352,10 @@ def lexicographical_topological_sort(G, key=None):
     RuntimeError
         If `G` is changed while the returned iterator is being processed.
 
+    TypeError
+        Results from un-sortable node names.
+        Consider using `key=` parameter to resolve ambiguities in the sort order.
+
     Examples
     --------
     >>> DG = nx.DiGraph([(2, 1), (2, 5), (1, 3), (1, 4), (5, 4)])
@@ -346,6 +363,26 @@ def lexicographical_topological_sort(G, key=None):
     [2, 1, 3, 5, 4]
     >>> list(nx.lexicographical_topological_sort(DG, key=lambda x: -x))
     [2, 5, 1, 4, 3]
+
+    The sort will fail for this graph because the comparison of integers to strings
+    is not defined in python.  Is 3 greater or less than 'red'?
+
+    >>> DG = nx.DiGraph([(1, 'red'), (3, 'red'), (1, 'green'), (2, 'blue')])
+    >>> list(nx.lexicographical_topological_sort(DG))
+    Traceback (most recent call last):
+    ...
+    TypeError: '<' not supported between instances of 'str' and 'int'
+    ...
+
+    The solution is to provide a function that returns keys that do compare.
+
+    There are many ways to write a `key` function. This one returns a tuple where the first
+    element is True for `str`, False otherwise. The second element is the node name.
+    This groups the strings and integers separately so they can be compared only among themselves.
+
+    >>> key = lambda node: (isinstance(node, str), node)
+    >>> list(nx.lexicographical_topological_sort(DG, key=key))
+    [1, 2, 3, 'blue', 'green', 'red']
 
     Notes
     -----
@@ -391,7 +428,12 @@ def lexicographical_topological_sort(G, key=None):
             except KeyError as err:
                 raise RuntimeError("Graph changed during iteration") from err
             if indegree_map[child] == 0:
-                heapq.heappush(zero_indegree, create_tuple(child))
+                try:
+                    heapq.heappush(zero_indegree, create_tuple(child))
+                except TypeError as err:
+                    raise TypeError(
+                        f"{err}\nConsider using `key=` parameter to resolve ambiguities in the sort order."
+                    )
                 del indegree_map[child]
 
         yield node

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -366,7 +366,7 @@ def lexicographical_topological_sort(G, key=None):
     >>> list(nx.lexicographical_topological_sort(DG, key=lambda x: -x))
     [2, 5, 1, 4, 3]
 
-    The sort will fail for this graph because the comparison of integers to strings
+    The sort will fail for any graph with integer and string nodes. Comparison of integer to strings
     is not defined in python.  Is 3 greater or less than 'red'?
 
     >>> DG = nx.DiGraph([(1, 'red'), (3, 'red'), (1, 'green'), (2, 'blue')])

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -116,8 +116,8 @@ class MappedQueue:
     Examples
     --------
 
-    A `MappedQueue` can be created empty or optionally given dictionary 
-    of initial elements and priorities.  The methods `push`, `pop`, 
+    A `MappedQueue` can be created empty or optionally given dictionary
+    of initial elements and priorities.  The methods `push`, `pop`,
     `remove`, and `update` operate on the queue.
 
     >>> colors_nm = {'red':665, 'blue': 470, 'green': 550}
@@ -157,9 +157,11 @@ class MappedQueue:
        Pearson Education.
     """
 
-    def __init__(self, data=[]):
+    def __init__(self, data=None):
         """Priority queue class with updatable priorities."""
-        if isinstance(data, dict):
+        if data is None:
+            self.heap = list()
+        elif isinstance(data, dict):
             self.heap = [_HeapElement(v, k) for k, v in data.items()]
         else:
             self.heap = list(data)

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -47,7 +47,7 @@ class _HeapElement:
                 return self.element < other.element
             except TypeError as err:
                 raise TypeError(
-                    f"{err}\nConsider using a tuple for the priority to avoid such comparisons: "
+                    f"Consider using a tuple for the priority to avoid such comparisons: "
                     f"{{k: (v, i) for i, (k,v) in enumerate(data.items())}}"
                 )
         return self.priority < other_priority
@@ -63,7 +63,7 @@ class _HeapElement:
                 return self.element > other.element
             except TypeError as err:
                 raise TypeError(
-                    f"{err}\nConsider using a tuple for the priority to avoid such comparisons: "
+                    f"Consider using a tuple for the priority to avoid such comparisons: "
                     f"{{k: (v, i) for i, (k,v) in enumerate(data.items())}}"
                 )
         return self.priority > other_priority
@@ -105,12 +105,9 @@ class MappedQueue:
     library. While MappedQueue is designed for maximum compatibility with
     heapq, it adds element removal, lookup, and priority update.
 
-    Unsortable elements should be mapped to a priority via a dict.
-    Otherwise a TypeError will occur when the comparisons are made.
-
     Parameters
     ----------
-    data : dict or iterator
+    data : dict or iterable
 
     Examples
     --------
@@ -128,7 +125,7 @@ class MappedQueue:
     >>> [q.pop().element for i in range(len(q.heap))]
     ['violet', 'indigo', 'blue']
 
-    A `MappedQueue` can also be initialized with a list or other iterator. The priority is assumed
+    A `MappedQueue` can also be initialized with a list or other iterable. The priority is assumed
     to be the sort order of the items in the list.
 
     >>> q = MappedQueue([916, 50, 4609, 493, 237])

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -47,8 +47,8 @@ class _HeapElement:
                 return self.element < other.element
             except TypeError as err:
                 raise TypeError(
-                    f"Consider using a tuple for the priority to avoid such comparisons: "
-                    f"{{k: (v, i) for i, (k,v) in enumerate(data.items())}}"
+                    f"To preserve the incompatible element names, consider pairing "
+                    f"them with priority values, in a tuple, that are sortable."
                 )
         return self.priority < other_priority
 
@@ -63,8 +63,8 @@ class _HeapElement:
                 return self.element > other.element
             except TypeError as err:
                 raise TypeError(
-                    f"Consider using a tuple for the priority to avoid such comparisons: "
-                    f"{{k: (v, i) for i, (k,v) in enumerate(data.items())}}"
+                    f"To preserve the incompatible element names, consider pairing "
+                    f"them with priority values, in a tuple, that are sortable."
                 )
         return self.priority > other_priority
 

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -108,55 +108,17 @@ class MappedQueue:
     Unsortable elements should be mapped to a priority via a dict.
     Otherwise a TypeError will occur when the comparisons are made.
 
-    Attributes
+    Parameters
     ----------
     data : dict or iterator
         The dict is defined with elements as keys, priorities as values. {element: priority}
 
-    Methods
-    -------
-    push(element, priority=None)
-        Add an element to the queue.
-    pop()
-        Remove and return the smallest element in the queue.
-    update(element, new_element, priority=None)
-        Replace an element in the queue with a new one.
-    remove(element)
-        Remove an element from the queue.
-
     Examples
     --------
 
-    A `MappedQueue` can be created empty or optionally given an array of
-    initial elements. Calling `push()` will add an element and calling `pop()`
-    will remove and return the smallest element.
-
-    >>> q = MappedQueue([916, 50, 4609, 493, 237])
-    >>> q.push(1310)
-    True
-    >>> [q.pop() for i in range(len(q.heap))]
-    [50, 237, 493, 916, 1310, 4609]
-
-    Elements can also be updated or removed from anywhere in the queue.
-
-    >>> q = MappedQueue([916, 50, 4609, 493, 237])
-    >>> q.remove(493)
-    >>> q.update(237, 1117)
-    >>> [q.pop() for i in range(len(q.heap))]
-    [50, 916, 1117, 4609]
-
-    An exception is raised if the elements are not sortable.
-
-    >>> q = MappedQueue([100, 'a'])
-    Traceback (most recent call last):
-    ...
-    TypeError: '<' not supported between instances of 'int' and 'str'
-
-    To avoid the exception, use a dictionary to assign priorities to the elements.
-
-    >>> q = MappedQueue({100: 0, 'a': 1 })
-
-    The dictionary input is also useful for assigning names to values, where the values are the priorities.
+    A `MappedQueue` can be created empty or optionally given dictionary 
+    of initial elements and priorities.  The methods `push`, `pop`, 
+    `remove`, and `update` operate on the queue.
 
     >>> colors_nm = {'red':665, 'blue': 470, 'green': 550}
     >>> q = MappedQueue(colors_nm)
@@ -166,6 +128,26 @@ class MappedQueue:
     True
     >>> [q.pop().element for i in range(len(q.heap))]
     ['violet', 'indigo', 'blue']
+
+    A `MappedQueue` can also be initialized with a list or other iterator. The priority is assumed
+    to be the sort order of the items in the list.
+
+    >>> q = MappedQueue([916, 50, 4609, 493, 237])
+    >>> q.remove(493)
+    >>> q.update(237, 1117)
+    >>> [q.pop() for i in range(len(q.heap))]
+    [50, 916, 1117, 4609]
+
+    An exception is raised if the elements are not comparable.
+
+    >>> q = MappedQueue([100, 'a'])
+    Traceback (most recent call last):
+    ...
+    TypeError: '<' not supported between instances of 'int' and 'str'
+
+    To avoid the exception, use a dictionary to assign priorities to the elements.
+
+    >>> q = MappedQueue({100: 0, 'a': 1 })
 
     References
     ----------

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -47,8 +47,7 @@ class _HeapElement:
                 return self.element < other.element
             except TypeError as err:
                 raise TypeError(
-                    f"To preserve the incompatible element names, consider pairing "
-                    f"them with priority values, in a tuple, that are sortable."
+                    f"Consider using a tuple, with a priority value than can be compared."
                 )
         return self.priority < other_priority
 
@@ -63,8 +62,7 @@ class _HeapElement:
                 return self.element > other.element
             except TypeError as err:
                 raise TypeError(
-                    f"To preserve the incompatible element names, consider pairing "
-                    f"them with priority values, in a tuple, that are sortable."
+                    f"Consider using a tuple, with a priority value than can be compared."
                 )
         return self.priority > other_priority
 

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -43,7 +43,13 @@ class _HeapElement:
             return self.priority < other
         # assume comparing to another _HeapElement
         if self.priority == other_priority:
-            return self.element < other.element
+            try:
+                return self.element < other.element
+            except TypeError as err:
+                raise TypeError(
+                    f"{err}\nConsider using a tuple for the priority to avoid such comparisons: "
+                    f"{{k: (v, i) for i, (k,v) in enumerate(data.items())}}"
+                )
         return self.priority < other_priority
 
     def __gt__(self, other):
@@ -53,7 +59,13 @@ class _HeapElement:
             return self.priority > other
         # assume comparing to another _HeapElement
         if self.priority == other_priority:
-            return self.element > other.element
+            try:
+                return self.element > other.element
+            except TypeError as err:
+                raise TypeError(
+                    f"{err}\nConsider using a tuple for the priority to avoid such comparisons: "
+                    f"{{k: (v, i) for i, (k,v) in enumerate(data.items())}}"
+                )
         return self.priority > other_priority
 
     def __eq__(self, other):

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -47,7 +47,7 @@ class _HeapElement:
                 return self.element < other.element
             except TypeError as err:
                 raise TypeError(
-                    f"Consider using a tuple, with a priority value than can be compared."
+                    f"Consider using a tuple, with a priority value that can be compared."
                 )
         return self.priority < other_priority
 
@@ -62,7 +62,7 @@ class _HeapElement:
                 return self.element > other.element
             except TypeError as err:
                 raise TypeError(
-                    f"Consider using a tuple, with a priority value than can be compared."
+                    f"Consider using a tuple, with a priority value that can be compared."
                 )
         return self.priority > other_priority
 

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -53,7 +53,7 @@ class _HeapElement:
             return self.priority > other
         # assume comparing to another _HeapElement
         if self.priority == other_priority:
-            return self.element < other.element
+            return self.element > other.element
         return self.priority > other_priority
 
     def __eq__(self, other):

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -111,7 +111,6 @@ class MappedQueue:
     Parameters
     ----------
     data : dict or iterator
-        The dict is defined with elements as keys, priorities as values. {element: priority}
 
     Examples
     --------

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -47,7 +47,7 @@ class _HeapElement:
                 return self.element < other.element
             except TypeError as err:
                 raise TypeError(
-                    f"Consider using a tuple, with a priority value that can be compared."
+                    "Consider using a tuple, with a priority value that can be compared."
                 )
         return self.priority < other_priority
 
@@ -62,7 +62,7 @@ class _HeapElement:
                 return self.element > other.element
             except TypeError as err:
                 raise TypeError(
-                    f"Consider using a tuple, with a priority value that can be compared."
+                    "Consider using a tuple, with a priority value that can be compared."
                 )
         return self.priority > other_priority
 

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -126,6 +126,28 @@ class MappedQueue:
     >>> [q.pop() for i in range(len(q.heap))]
     [50, 916, 1117, 4609]
 
+    An exception is raised if the elements are not sortable.
+
+    >>> q = MappedQueue([100, 'a'])
+    Traceback (most recent call last):
+    ...
+    TypeError: '<' not supported between instances of 'int' and 'str'
+
+    To avoid the exception, use a dictionary to assign priorities to the elements.
+
+    >>> q = MappedQueue({100: 0, 'a': 1 })
+
+    The dictionary input is also useful for assigning names to values, where the values are the priorities.
+
+    >>> colors_nm = {'red':665, 'blue': 470, 'green': 550}
+    >>> q = MappedQueue(colors_nm)
+    >>> q.remove('red')
+    >>> q.update('green', 'violet', 400)
+    >>> q.push('indigo', 425)
+    True
+    >>> [q.pop().element for i in range(len(q.heap))]
+    ['violet', 'indigo', 'blue']
+
     References
     ----------
     .. [1] Cormen, T. H., Leiserson, C. E., Rivest, R. L., & Stein, C. (2001).

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -105,6 +105,25 @@ class MappedQueue:
     library. While MappedQueue is designed for maximum compatibility with
     heapq, it adds element removal, lookup, and priority update.
 
+    Unsortable elements should be mapped to a priority via a dict.
+    Otherwise a TypeError will occur when the comparisons are made.
+
+    Attributes
+    ----------
+    data : dict or iterator
+        The dict is defined with elements as keys, priorities as values. {element: priority}
+
+    Methods
+    -------
+    push(element, priority=None)
+        Add an element to the queue.
+    pop()
+        Remove and return the smallest element in the queue.
+    update(element, new_element, priority=None)
+        Replace an element in the queue with a new one.
+    remove(element)
+        Remove an element from the queue.
+
     Examples
     --------
 

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -115,7 +115,7 @@ class MappedQueue:
     Examples
     --------
 
-    A `MappedQueue` can be created empty or optionally given dictionary
+    A `MappedQueue` can be created empty, or optionally, given a dictionary
     of initial elements and priorities.  The methods `push`, `pop`,
     `remove`, and `update` operate on the queue.
 

--- a/networkx/utils/tests/test_mapped_queue.py
+++ b/networkx/utils/tests/test_mapped_queue.py
@@ -218,6 +218,16 @@ class TestMappedDict(TestMappedQueue):
         q = MappedQueue(d)
         assert q.position == {elt: pos for pos, elt in enumerate(q.heap)}
 
+    def test_pop(self):
+        d = {5: 0, 4: 1, 3: 2, 2: 3, 1: 4}
+        q = MappedQueue(d)
+        assert q.pop() == _HeapElement(0, 5)
+        assert q.position == {elt: pos for pos, elt in enumerate(q.heap)}
+
+    def test_empty_pop(self):
+        q = MappedQueue()
+        pytest.raises(IndexError, q.pop)
+
     def test_incomparable_ties(self):
         d = {5: 0, 4: 0, "a": 0, 2: 0, 1: 0}
         pytest.raises(TypeError, MappedQueue, d)

--- a/networkx/utils/tests/test_mapped_queue.py
+++ b/networkx/utils/tests/test_mapped_queue.py
@@ -12,6 +12,13 @@ def test_HeapElement_gtlt():
     assert 1 < bar
 
 
+def test_HeapElement_gtlt_tied_priority():
+    bar = _HeapElement(1, "a")
+    foo = _HeapElement(1, "b")
+    assert foo > bar
+    assert bar < foo
+
+
 def test_HeapElement_eq():
     bar = _HeapElement(1.1, "a")
     foo = _HeapElement(1, "a")
@@ -62,6 +69,10 @@ class TestMappedQueue:
         h = [5, 4, 3, 2, 1, 0]
         q = MappedQueue(h)
         self._check_map(q)
+
+    def test_incomparable(self):
+        h = [5, 4, "a", 2, 1, 0]
+        pytest.raises(TypeError, MappedQueue, h)
 
     def test_len(self):
         h = [5, 4, 3, 2, 1, 0]
@@ -196,6 +207,20 @@ class TestMappedDict(TestMappedQueue):
     def _make_mapped_queue(self, h):
         priority_dict = {elt: elt for elt in h}
         return MappedQueue(priority_dict)
+
+    def test_init(self):
+        d = {5: 0, 4: 1, "a": 2, 2: 3, 1: 4}
+        q = MappedQueue(d)
+        assert q.position == d
+
+    def test_ties(self):
+        d = {5: 0, 4: 1, 3: 2, 2: 3, 1: 4}
+        q = MappedQueue(d)
+        assert q.position == {elt: pos for pos, elt in enumerate(q.heap)}
+
+    def test_incomparable_ties(self):
+        d = {5: 0, 4: 0, "a": 0, 2: 0, 1: 0}
+        pytest.raises(TypeError, MappedQueue, d)
 
     def test_push(self):
         to_push = [6, 1, 4, 3, 2, 5, 0]


### PR DESCRIPTION


- Added Tests
        - test __gt__ in _HeapElement when priorities are tied.
        - test dictionary input in MappedQueue
        - test tied priorities
        - verify exception is raised for incomparable elements
        - tests for the `pop` method when dictionaries are the input.

- Fixed `__gt__` bug

- Added the exception for incomparable elements. Include a helpful error message.

- Added Examples
          - show that incomparable elements will fail
          - show how to fix incomparable elements by assigning priorities via a dict.

- Update the doc_string descriptions to explain assigning priorities via a dict.


- Added a reference to `MappedQueue` in the `networkx/reference/utils.rst` file.  
   I needed to check the formatting of the doc_string. This was the only way I 
   knew to get `numpydocs` to format the doc_string. I can take it back out.
- Changed the signature of the class to not use a mutable argument.

Instead of
```python
class MappedQueue(data=[])
```
I wrote,
```python
class MappedQueue(data=None)
```
and wrote a few lines to deal with `None`.
I can take this back out too.

In fact, I am not emotionally tied to any of my changes :-)
I'm looking forward to feedback.
Thanks