### PR TITLE
Improve is_path

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1250,6 +1250,8 @@ def is_path(G, path):
 
     """
     for node, nbr in nx.utils.pairwise(path):
+        if not G.has_node(node):
+            return False
         if nbr not in G[node]:
             return False
     return True

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1252,20 +1252,6 @@ def is_path(G, path):
         A boolean representing whether or not the path exists
 
     """
-    Parameters
-    ----------
-    G : graph
-        A NetworkX graph.
-
-    path: list
-        A list of node labels which defines the path to traverse
-
-    Returns
-    -------
-    isPath: bool
-        A boolean representing whether or not the path exists
-
-    """
     for node, nbr in nx.utils.pairwise(path):
         if node not in G:
             return False

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1233,10 +1233,7 @@ def number_of_selfloops(G):
 
 
 def is_path(G, path):
-    """Returns whether or not the specified path exists.
-    
-    For it to return True, every node on the path must exist and
-    each consecutive pair must be connected via one or more edges.
+    """Returns whether or not the specified path exists
 
     Parameters
     ----------

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1233,7 +1233,10 @@ def number_of_selfloops(G):
 
 
 def is_path(G, path):
-    """Returns whether or not the specified path exists
+    """Returns whether or not the specified path exists.
+    
+    For it to return True, every node on the path must exist and
+    each consecutive pair must be connected via one or more edges.
 
     Parameters
     ----------
@@ -1250,7 +1253,7 @@ def is_path(G, path):
 
     """
     for node, nbr in nx.utils.pairwise(path):
-        if not G.has_node(node):
+        if node not in G:
             return False
         if nbr not in G[node]:
             return False

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1233,8 +1233,25 @@ def number_of_selfloops(G):
 
 
 def is_path(G, path):
-    """Returns whether or not the specified path exists
+    """Returns whether or not the specified path exists.
 
+    For it to return True, every node on the path must exist and
+    each consecutive pair must be connected via one or more edges.
+
+    Parameters
+    ----------
+    G : graph
+        A NetworkX graph.
+
+    path: list
+        A list of node labels which defines the path to traverse
+
+    Returns
+    -------
+    isPath: bool
+        A boolean representing whether or not the path exists
+
+    """
     Parameters
     ----------
     G : graph

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -739,12 +739,16 @@ def test_pathweight():
 def test_ispath():
     valid_path = [1, 2, 3, 4]
     invalid_path = [1, 2, 4, 3]
+    another_invalid_path = [1, 2, 3, 4, 5]
+    yet_another_invalid_path = [1, 2, 5, 3, 4]
     graphs = [nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()]
     edges = [(1, 2), (2, 3), (1, 2), (3, 4)]
     for graph in graphs:
         graph.add_edges_from(edges)
         assert nx.is_path(graph, valid_path)
         assert not nx.is_path(graph, invalid_path)
+        assert not nx.is_path(graph, another_invalid_path)
+        assert not nx.is_path(graph, yet_another_invalid_path)
 
 
 @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))


### PR DESCRIPTION
## Description

is_path currently raises a KeyError if a node in the path provided does not exist.

The more appropriate outcome would be a False output, since the path provided is not, in fact, a path.

## Example to trigger the problem

import networkx as nx

G = nx.MultiDiGraph()

assert nx.is_path(G,[0,1]) == False

## Solution

To address this, I revised the is_path method to check if each element on the tentative path is a nodem namely by calling has_node on each iteration.
