### PR TITLE
Direct use of `spdiags`'s argument for matrix types in PageRank computation

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -457,8 +457,8 @@ def _pagerank_scipy(
     A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)
     S = A.sum(axis=1)
     S[S != 0] = 1.0 / S[S != 0]
-    # TODO: csr_array
-    Q = sp.sparse.csr_array(sp.sparse.spdiags(S.T, 0, *A.shape))
+
+    Q = sp.sparse.spdiags(S.T, 0, *A.shape, format="csr")
     A = Q @ A
 
     # initial vector


### PR DESCRIPTION
The `spdiags` supports "format" argument specifying wanted matrix type - specifying it to `csr` simplifies the cast.
