### PR TITLE
Update documentation header links for latest pydata-sphinx-theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,6 +137,7 @@ html_theme_options = {
     "external_links": [{"name": "Guides", "url": "https://networkx.org/nx-guides/"}],
     "navbar_end": ["theme-switcher", "navbar-icon-links", "version"],
     "page_sidebar_items": ["search-field", "page-toc", "edit-this-page"],
+    "header_links_before_dropdown": 7,
 }
 html_sidebars = {
     "**": ["sidebar-nav-bs", "sidebar-ethical-ads"],

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -119,6 +119,6 @@ Bibliography
    install
    tutorial
    reference/index
-   release/index
-   developer/index
    auto_examples/index
+   developer/index
+   release/index


### PR DESCRIPTION
By default, the latest `pydata-sphinx-theme` only shows 5 header link items in the navbar, placing the extra in a dropdown menu under "More". In our case, this ended up hiding the `Gallery` link, which I wanted to bring back out to make sure it as always visible. Therefore I made two changes:
 1. Keep header links always visible by increasing the number allowed from 5->7
 2. Re-ordered the links so that `Gallery` is before the developer guide link and the release notes.