### PR TITLE
Minor docstring touchups and test refactor for `is_path`

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -57,6 +57,10 @@ Improvements
 - [`#5898 <https://github.com/networkx/networkx/pull/5898>`_]
   Implements computing and checking for minimal d-separators between two nodes.
   Also adds functionality to DAGs for computing v-structures.
+- [`#5943 <https://github.com/networkx/networkx/pull/5943>`_]
+  ``is_path`` used to raise a `KeyError` when the ``path`` argument contained
+  a node that was not in the Graph. The behavior has been updated so that
+  ``is_path`` returns `False` in this case rather than raising the exception.
 
 API Changes
 -----------

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1253,9 +1253,7 @@ def is_path(G, path):
 
     """
     for node, nbr in nx.utils.pairwise(path):
-        if node not in G:
-            return False
-        if nbr not in G[node]:
+        if (node not in G) or (nbr not in G[node]):
             return False
     return True
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1244,7 +1244,7 @@ def is_path(G, path):
         A NetworkX graph.
 
     path : list
-        A list of node which defines the path to traverse
+        A list of nodes which defines the path to traverse
 
     Returns
     -------

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1243,13 +1243,13 @@ def is_path(G, path):
     G : graph
         A NetworkX graph.
 
-    path: list
-        A list of node labels which defines the path to traverse
+    path : list
+        A list of node which defines the path to traverse
 
     Returns
     -------
-    isPath: bool
-        A boolean representing whether or not the path exists
+    bool
+        True if `path` is a valid path in `G`
 
     """
     for node, nbr in nx.utils.pairwise(path):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -736,19 +736,17 @@ def test_pathweight():
         pytest.raises(nx.NetworkXNoPath, nx.path_weight, graph, invalid_path, "cost")
 
 
-def test_ispath():
+@pytest.mark.parametrize(
+    "G", (nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph())
+)
+def test_ispath(G):
+    G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4)])
     valid_path = [1, 2, 3, 4]
-    invalid_path = [1, 2, 4, 3]
-    another_invalid_path = [1, 2, 3, 4, 5]
-    yet_another_invalid_path = [1, 2, 5, 3, 4]
-    graphs = [nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()]
-    edges = [(1, 2), (2, 3), (1, 2), (3, 4)]
-    for graph in graphs:
-        graph.add_edges_from(edges)
-        assert nx.is_path(graph, valid_path)
-        assert not nx.is_path(graph, invalid_path)
-        assert not nx.is_path(graph, another_invalid_path)
-        assert not nx.is_path(graph, yet_another_invalid_path)
+    invalid_path = [1, 2, 4, 3]  # wrong node order
+    another_invalid_path = [1, 2, 3, 4, 5]  # contains node not in G
+    assert nx.is_path(G, valid_path)
+    assert not nx.is_path(G, invalid_path)
+    assert not nx.is_path(G, another_invalid_path)
 
 
 @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))


### PR DESCRIPTION
Just a few minor changes I'd like to propose to follow-up on #5943:
 - A few docstring/formatting touchups
 - Condense conditionals using `or`
 - parametrize test and remove redundant case

Nothing critically important, feel free to ignore!