### PR TITLE
Enhance biconnected components to avoid indexing

### DIFF
--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -369,7 +369,7 @@ def _biconnected_dfs(G, components=True):
                 if len(stack) > 1:
                     if low[parent] >= discovery[grandparent]:
                         if components:
-                            ind = edge_index(grandparent, child)
+                            ind = edge_index[grandparent, parent]
                             yield edge_stack[ind:]
                             del edge_stack[ind:]
 
@@ -379,7 +379,7 @@ def _biconnected_dfs(G, components=True):
                 elif stack:  # length 1 so grandparent is root
                     root_children += 1
                     if components:
-                        ind = edge_index(grandparent, child)
+                        ind = edge_index[grandparent, parent]
                         yield edge_stack[ind:]
                         del edge_stack[ind:]
         if not components:

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -365,17 +365,23 @@ def _biconnected_dfs(G, components=True):
                 if len(stack) > 1:
                     if low[parent] >= discovery[grandparent]:
                         if components:
-                            ind = edge_stack.index((grandparent, parent))
-                            yield edge_stack[ind:]
-                            edge_stack = edge_stack[:ind]
+                            scc_edges = []
+                            while edge_stack[-1] != (grandparent, parent):
+                                scc_edges.append(edge_stack.pop())
+                            scc_edges.append(edge_stack.pop())
+
+                            yield scc_edges
                         else:
                             yield grandparent
                     low[grandparent] = min(low[parent], low[grandparent])
                 elif stack:  # length 1 so grandparent is root
                     root_children += 1
                     if components:
-                        ind = edge_stack.index((grandparent, parent))
-                        yield edge_stack[ind:]
+                        scc_edges = []
+                        while edge_stack[-1] != (grandparent, parent):
+                            scc_edges.append(edge_stack.pop())
+                        scc_edges.append(edge_stack.pop())
+                        yield scc_edges
         if not components:
             # root node is articulation point if it has more than 1 child
             if root_children > 1:

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -343,6 +343,7 @@ def _biconnected_dfs(G, components=True):
         visited.add(start)
         edge_stack = []
         stack = [(start, start, iter(G[start]))]
+        edge_index = {}
         while stack:
             grandparent, parent, children = stack[-1]
             try:
@@ -353,35 +354,34 @@ def _biconnected_dfs(G, components=True):
                     if discovery[child] <= discovery[parent]:  # back edge
                         low[parent] = min(low[parent], discovery[child])
                         if components:
+                            edge_index[parent, child] = len(edge_stack)
                             edge_stack.append((parent, child))
                 else:
                     low[child] = discovery[child] = len(discovery)
                     visited.add(child)
                     stack.append((parent, child, iter(G[child])))
                     if components:
+                        edge_index[parent, child] = len(edge_stack)
                         edge_stack.append((parent, child))
+
             except StopIteration:
                 stack.pop()
                 if len(stack) > 1:
                     if low[parent] >= discovery[grandparent]:
                         if components:
-                            scc_edges = []
-                            while edge_stack[-1] != (grandparent, parent):
-                                scc_edges.append(edge_stack.pop())
-                            scc_edges.append(edge_stack.pop())
+                            ind = edge_index(grandparent, child)
+                            yield edge_stack[ind:]
+                            del edge_stack[ind:]
 
-                            yield scc_edges
                         else:
                             yield grandparent
                     low[grandparent] = min(low[parent], low[grandparent])
                 elif stack:  # length 1 so grandparent is root
                     root_children += 1
                     if components:
-                        scc_edges = []
-                        while edge_stack[-1] != (grandparent, parent):
-                            scc_edges.append(edge_stack.pop())
-                        scc_edges.append(edge_stack.pop())
-                        yield scc_edges
+                        ind = edge_index(grandparent, child)
+                        yield edge_stack[ind:]
+                        del edge_stack[ind:]
         if not components:
             # root node is articulation point if it has more than 1 child
             if root_children > 1:


### PR DESCRIPTION
Index costs the size of the stack, which is always greater than or equal to the size of the newly discovered biconnnected component, and in general much larger. Updated to use edge stack as a stack instead of indexing, which has a cost of the size of the newly discovered biconnencted component as opposed to the size of the entire stack .
