### PR TITLE
Add vf2pp_helpers subpackage to wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ dd = os.path.join(docdirbase, "examples", "javascript/force")
 pp = os.path.join("examples", "javascript/force")
 data.append((dd, glob(os.path.join(pp, "*"))))
 
-# add the tests
+# add the tests and helper subpackage(s)
 package_data = {
     "networkx": ["tests/*.py"],
     "networkx.algorithms": ["tests/*.py"],
@@ -134,7 +134,11 @@ package_data = {
     "networkx.algorithms.coloring": ["tests/*.py"],
     "networkx.algorithms.minors": ["tests/*.py"],
     "networkx.algorithms.flow": ["tests/*.py", "tests/*.bz2"],
-    "networkx.algorithms.isomorphism": ["tests/*.py", "tests/*.*99"],
+    "networkx.algorithms.isomorphism": [
+        "tests/*.py",
+        "tests/*.*99",
+        "vf2pp_helpers/*.py",
+    ],
     "networkx.algorithms.link_analysis": ["tests/*.py"],
     "networkx.algorithms.approximation": ["tests/*.py"],
     "networkx.algorithms.operators": ["tests/*.py"],


### PR DESCRIPTION
Follow up to #5973, which didn't actually fix the problem with the doc build.

After more debugging, I determined that the problem was the `vf2pp_helpers` subpackage wasn't actually included in the wheel. I missed this in my first round of debugging that led to my mis-diagnosis in #5973 likely from accidentally using `pip -e` and still building the docs from the source directory. We should probably add/update at least one CI job to not use editable installs to catch this problem in the future, though it's worth noting that the `vf2pp_helpers` subpackage appears to be unique - i.e. there are no other "helper" subpackages that are *not* included in an __init__.py somewhere.

In the slightly longer term, it might be better to refactor the `vf2pp_helpers` subpackage into a submodule instead (e.g. `_vf2pp_helpers.py`) which should remove the need to explicitly list the extra directory in the `setup.py`. That should be straightforward, but will touch a lot of import lines, so I will leave it to a different PR.