### PR TITLE
Refactoring assortativity by issue 4936

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -1,16 +1,16 @@
 """Node assortativity coefficients and correlation measures.
 """
-from networkx.algorithms.assortativity.mixing import (
-    attribute_mixing_matrix,
-    degree_mixing_matrix,
+from networkx.algorithms.assortativity.mixing import attribute_mixing_matrix
+from networkx.algorithms.assortativity.pairs import (
+    node_degree_xy,
+    node_attribute_xy,
 )
-from networkx.algorithms.assortativity.pairs import node_degree_xy
+import numpy as np
 
 __all__ = [
-    "degree_pearson_correlation_coefficient",
     "degree_assortativity_coefficient",
-    "attribute_assortativity_coefficient",
-    "numeric_assortativity_coefficient",
+    "discrete_assortativity_coefficient",
+    "scalar_assortativity_coefficient",
 ]
 
 
@@ -70,95 +70,15 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     .. [1] M. E. J. Newman, Mixing patterns in networks,
        Physical Review E, 67 026126, 2003
     .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
-       Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
+       Edge direction and the structure of networks, PNAS 107, 10815-20 (2010)
     """
-    if nodes is None:
-        nodes = G.nodes
-
-    degrees = None
-
-    if G.is_directed():
-        indeg = (
-            {d for _, d in G.in_degree(nodes, weight=weight)}
-            if "in" in (x, y)
-            else set()
-        )
-        outdeg = (
-            {d for _, d in G.out_degree(nodes, weight=weight)}
-            if "out" in (x, y)
-            else set()
-        )
-        degrees = set.union(indeg, outdeg)
-    else:
-        degrees = {d for _, d in G.degree(nodes, weight=weight)}
-
-    mapping = {d: i for i, d, in enumerate(degrees)}
-    M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight, mapping=mapping)
-
-    return _numeric_ac(M, mapping=mapping)
-
-
-def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, nodes=None):
-    """Compute degree assortativity of graph.
-
-    Assortativity measures the similarity of connections
-    in the graph with respect to the node degree.
-
-    This is the same as degree_assortativity_coefficient but uses the
-    potentially faster scipy.stats.pearsonr function.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-
-    x: string ('in','out')
-       The degree type for source node (directed graphs only).
-
-    y: string ('in','out')
-       The degree type for target node (directed graphs only).
-
-    weight: string or None, optional (default=None)
-       The edge attribute that holds the numerical value used
-       as a weight.  If None, then each edge has weight 1.
-       The degree is the sum of the edge weights adjacent to the node.
-
-    nodes: list or iterable (optional)
-        Compute pearson correlation of degrees only for specified nodes.
-        The default is all nodes.
-
-    Returns
-    -------
-    r : float
-       Assortativity of graph by degree.
-
-    Examples
-    --------
-    >>> G = nx.path_graph(4)
-    >>> r = nx.degree_pearson_correlation_coefficient(G)
-    >>> print(f"{r:3.1f}")
-    -0.5
-
-    Notes
-    -----
-    This calls scipy.stats.pearsonr.
-
-    References
-    ----------
-    .. [1] M. E. J. Newman, Mixing patterns in networks
-           Physical Review E, 67 026126, 2003
-    .. [2] Foster, J.G., Foster, D.V., Grassberger, P. & Paczuski, M.
-       Edge direction and the structure of networks, PNAS 107, 10815-20 (2010).
-    """
-    import scipy as sp
-    import scipy.stats  # call as sp.stats
-
     xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
     x, y = zip(*xy)
-    return sp.stats.pearsonr(x, y)[0]
+    return np.corrcoef(x, y)[0, 1]
 
 
-def attribute_assortativity_coefficient(G, attribute, nodes=None):
-    """Compute assortativity for node attributes.
+def discrete_assortativity_coefficient(G, attribute, nodes=None):
+    """Compute assortativity for discrete node attributes.
 
     Assortativity measures the similarity of connections
     in the graph with respect to the given attribute.
@@ -185,7 +105,7 @@ def attribute_assortativity_coefficient(G, attribute, nodes=None):
     >>> G.add_nodes_from([0, 1], color="red")
     >>> G.add_nodes_from([2, 3], color="blue")
     >>> G.add_edges_from([(0, 1), (2, 3)])
-    >>> print(nx.attribute_assortativity_coefficient(G, "color"))
+    >>> print(nx.discrete_assortativity_coefficient(G, "color"))
     1.0
 
     Notes
@@ -199,15 +119,18 @@ def attribute_assortativity_coefficient(G, attribute, nodes=None):
     .. [1] M. E. J. Newman, Mixing patterns in networks,
        Physical Review E, 67 026126, 2003
     """
-    M = attribute_mixing_matrix(G, attribute, nodes)
-    return attribute_ac(M)
+    M = attribute_mixing_matrix(G, attribute, nodes, normalized=True)
+    s = (M @ M).sum()
+    t = M.trace()
+    r = (t - s) / (1 - s)
+    return r
 
 
-def numeric_assortativity_coefficient(G, attribute, nodes=None):
-    """Compute assortativity for numerical node attributes.
+def scalar_assortativity_coefficient(G, attribute, nodes=None):
+    """Compute assortativity for scalar node attributes.
 
     Assortativity measures the similarity of connections
-    in the graph with respect to the given numeric attribute.
+    in the graph with respect to the given scalar attribute.
 
     Parameters
     ----------
@@ -217,7 +140,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
         Node attribute key.
 
     nodes: list or iterable (optional)
-        Compute numeric assortativity only for attributes of nodes in
+        Compute scalar assortativity only for attributes of nodes in
         container. The default is all nodes.
 
     Returns
@@ -231,7 +154,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     >>> G.add_nodes_from([0, 1], size=2)
     >>> G.add_nodes_from([2, 3], size=3)
     >>> G.add_edges_from([(0, 1), (2, 3)])
-    >>> print(nx.numeric_assortativity_coefficient(G, "size"))
+    >>> print(nx.scalar_assortativity_coefficient(G, "size"))
     1.0
 
     Notes
@@ -244,55 +167,6 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     .. [1] M. E. J. Newman, Mixing patterns in networks
            Physical Review E, 67 026126, 2003
     """
-    if nodes is None:
-        nodes = G.nodes
-    vals = {G.nodes[n][attribute] for n in nodes}
-    mapping = {d: i for i, d, in enumerate(vals)}
-    M = attribute_mixing_matrix(G, attribute, nodes, mapping)
-    return _numeric_ac(M, mapping)
-
-
-def attribute_ac(M):
-    """Compute assortativity for attribute matrix M.
-
-    Parameters
-    ----------
-    M : numpy.ndarray
-        2D ndarray representing the attribute mixing matrix.
-
-    Notes
-    -----
-    This computes Eq. (2) in Ref. [1]_ , (trace(e)-sum(e^2))/(1-sum(e^2)),
-    where e is the joint probability distribution (mixing matrix)
-    of the specified attribute.
-
-    References
-    ----------
-    .. [1] M. E. J. Newman, Mixing patterns in networks,
-       Physical Review E, 67 026126, 2003
-    """
-    if M.sum() != 1.0:
-        M = M / M.sum()
-    s = (M @ M).sum()
-    t = M.trace()
-    r = (t - s) / (1 - s)
-    return r
-
-
-def _numeric_ac(M, mapping):
-    # M is a 2D numpy array
-    # numeric assortativity coefficient, pearsonr
-    import numpy as np
-
-    if M.sum() != 1.0:
-        M = M / M.sum()
-    x = np.array(list(mapping.keys()))
-    y = x  # x and y have the same support
-    idx = list(mapping.values())
-    a = M.sum(axis=0)
-    b = M.sum(axis=1)
-    vara = (a[idx] * x**2).sum() - ((a[idx] * x).sum()) ** 2
-    varb = (b[idx] * y**2).sum() - ((b[idx] * y).sum()) ** 2
-    xy = np.outer(x, y)
-    ab = np.outer(a[idx], b[idx])
-    return (xy * (M - ab)).sum() / np.sqrt(vara * varb)
+    xy = node_attribute_xy(G, attribute, nodes=nodes)
+    x, y = zip(*xy)
+    return np.corrcoef(x, y)[0, 1]

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -14,7 +14,10 @@ __all__ = [
 
 
 def attribute_mixing_dict(G, attribute, nodes=None, normalized=False):
-    """Returns dictionary representation of mixing matrix for attribute.
+    """Returns dictionary representation of mixing patterns for attribute.
+
+    Dictionary representation of mixing patterns allows to read mixing
+    value by attribute pair.
 
     Parameters
     ----------
@@ -52,7 +55,7 @@ def attribute_mixing_dict(G, attribute, nodes=None, normalized=False):
 
 
 def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=True):
-    """Returns mixing matrix for attribute.
+    """Returns matrix representation of mixing patterns for attribute.
 
     Parameters
     ----------
@@ -80,6 +83,10 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
 
     Notes
     -----
+    Matrix representation of mixing patterns allows to compute mixing
+    properties, e.g. the marginal distribution over the joint distribution
+    of attribute pairs. Mixing values can be read by given mapping.
+
     If each node has a unique attribute value, the unnormalized mixing matrix
     will be equal to the adjacency matrix. To get a denser mixing matrix,
     the rounding can be performed to form groups of nodes with equal values.
@@ -99,9 +106,16 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
     >>> nx.set_node_attributes(G, gender, 'gender')
     >>> mapping = {'male': 0, 'female': 1}
     >>> mix_mat = nx.attribute_mixing_matrix(G, 'gender', mapping=mapping)
+    >>> # mixing matrix
+    >>> print(mix_mat)
+    [[0.   0.25]
+    [0.25 0.5 ]]
     >>> # mixing from male nodes to female nodes
     >>> mix_mat[mapping['male'], mapping['female']]
     0.25
+    >>> # marginal distribution of income attribute values
+    >>> print(mix_mat.sum(axis=0))
+    [0.25 0.75]
     """
     d = attribute_mixing_dict(G, attribute, nodes)
     a = dict_to_numpy_array(d, mapping=mapping)
@@ -111,7 +125,10 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
 
 
 def degree_mixing_dict(G, x="out", y="in", weight=None, nodes=None, normalized=False):
-    """Returns dictionary representation of mixing matrix for degree.
+    """Returns dictionary representation of mixing patterns for degree.
+
+    Dictionary representation of degree mixing patterns allows to
+    read mixing value by degree pair.
 
     Parameters
     ----------
@@ -180,6 +197,11 @@ def degree_mixing_matrix(
 
     Notes
     -----
+    Matrix representation of mixing patterns allows to compute
+    mixing properties, e.g. the marginal distribution over
+    the joint distribution of degree pairs. Mixing values can
+    be read by given mapping.
+
     Definitions of degree mixing matrix vary on whether the matrix
     should include rows for degree values that don't arise. Here we
     do not include such empty-rows. But you can force them to appear

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -1,11 +1,8 @@
 import pytest
 
 np = pytest.importorskip("numpy")
-pytest.importorskip("scipy")
-
 
 import networkx as nx
-from networkx.algorithms.assortativity.correlation import attribute_ac
 
 from .base_test import BaseTestAttributeMixing, BaseTestDegreeMixing
 
@@ -29,24 +26,6 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         r = nx.degree_assortativity_coefficient(self.M)
         np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
 
-    def test_degree_pearson_assortativity_undirected(self):
-        r = nx.degree_pearson_correlation_coefficient(self.P4)
-        np.testing.assert_almost_equal(r, -1.0 / 2, decimal=4)
-
-    def test_degree_pearson_assortativity_directed(self):
-        r = nx.degree_pearson_correlation_coefficient(self.D)
-        np.testing.assert_almost_equal(r, -0.57735, decimal=4)
-
-    def test_degree_pearson_assortativity_directed2(self):
-        """Test degree assortativity with Pearson for a directed graph where
-        the set of in/out degree does not equal the total degree."""
-        r = nx.degree_pearson_correlation_coefficient(self.D2)
-        np.testing.assert_almost_equal(r, 0.14852, decimal=4)
-
-    def test_degree_pearson_assortativity_multigraph(self):
-        r = nx.degree_pearson_correlation_coefficient(self.M)
-        np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
-
     def test_degree_assortativity_weighted(self):
         r = nx.degree_assortativity_coefficient(self.W, weight="weight")
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)
@@ -58,51 +37,25 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
     def test_attribute_assortativity_undirected(self):
-        r = nx.attribute_assortativity_coefficient(self.G, "fish")
+        r = nx.discrete_assortativity_coefficient(self.G, "fish")
         assert r == 6.0 / 22.0
 
     def test_attribute_assortativity_directed(self):
-        r = nx.attribute_assortativity_coefficient(self.D, "fish")
+        r = nx.discrete_assortativity_coefficient(self.D, "fish")
         assert r == 1.0 / 3.0
 
     def test_attribute_assortativity_multigraph(self):
-        r = nx.attribute_assortativity_coefficient(self.M, "fish")
+        r = nx.discrete_assortativity_coefficient(self.M, "fish")
         assert r == 1.0
 
-    def test_attribute_assortativity_coefficient(self):
-        # from "Mixing patterns in networks"
-        # fmt: off
-        a = np.array([[0.258, 0.016, 0.035, 0.013],
-                      [0.012, 0.157, 0.058, 0.019],
-                      [0.013, 0.023, 0.306, 0.035],
-                      [0.005, 0.007, 0.024, 0.016]])
-        # fmt: on
-        r = attribute_ac(a)
-        np.testing.assert_almost_equal(r, 0.623, decimal=3)
-
-    def test_attribute_assortativity_coefficient2(self):
-        # fmt: off
-        a = np.array([[0.18, 0.02, 0.01, 0.03],
-                      [0.02, 0.20, 0.03, 0.02],
-                      [0.01, 0.03, 0.16, 0.01],
-                      [0.03, 0.02, 0.01, 0.22]])
-        # fmt: on
-        r = attribute_ac(a)
-        np.testing.assert_almost_equal(r, 0.68, decimal=2)
-
-    def test_attribute_assortativity(self):
-        a = np.array([[50, 50, 0], [50, 50, 0], [0, 0, 2]])
-        r = attribute_ac(a)
-        np.testing.assert_almost_equal(r, 0.029, decimal=3)
-
     def test_attribute_assortativity_negative(self):
-        r = nx.numeric_assortativity_coefficient(self.N, "margin")
+        r = nx.scalar_assortativity_coefficient(self.N, "margin")
         np.testing.assert_almost_equal(r, -0.2903, decimal=4)
 
     def test_attribute_assortativity_float(self):
-        r = nx.numeric_assortativity_coefficient(self.F, "margin")
+        r = nx.scalar_assortativity_coefficient(self.F, "margin")
         np.testing.assert_almost_equal(r, -0.1429, decimal=4)
 
     def test_attribute_assortativity_mixed(self):
-        r = nx.numeric_assortativity_coefficient(self.K, "margin")
+        r = nx.scalar_assortativity_coefficient(self.K, "margin")
         np.testing.assert_almost_equal(r, 0.4340, decimal=4)


### PR DESCRIPTION
Here is my explanation of changes related to #4936.

1. Change names of functions `attribute_assortativity_coefficient` -> `discrete_assortativity_coefficient` and `numeric_assortativity_coefficient` -> `scalar_assortativity_coefficient`

"Attribute" and "numeric" are unclear names since there are numeric and non-numeric attributes. New names follow Newman's article https://arxiv.org/pdf/cond-mat/0209450.pdf. "Discrete" means attributes that can be represented by the discrete distribution, e.g. language or race, while "scalar" by the continuous distribution, e.g. age or height. The key difference between discrete and scalar is that scalar values have some ordering, that is we can compute correlation over pairs. Degree is also a scalar attribute.

2. Delete `degree_pearson_correlation_coefficient`

`degree_pearson_correlation_coefficient` has made the same things as `degree_assortativity_coefficient` by scipy that has no much sense. Source code in scipy is based on simple numpy operations like averaging, normalization and dot product, but it requires to install scipy. The docs say it is "potentially faster" but my experiments on Erdos-Renyi graphs show there is no significant difference between them. I describe it below. I think it will be better to reduce the interface to make it clear and simple.

3. Calculate `scalar_assortativity_coefficient` and `degree_assortativity_coefficient` using numpy

Discrete assortativity coefficient is exactly the Pearson correlation coefficient and it can be computed by numpy in a single line. It reduces complexity of the code, while there is no significant difference in computation time. I have computed degree assortativity coefficient of Erdos-Renyi graphs on 1000, 1500, 2000, 2500, 3000 nodes.  I have repeated it 100 times and taken the median of computation time, see the figure below.

![image](https://user-images.githubusercontent.com/12996098/189709140-29e839df-7179-45df-b339-20c1d526a0de.png)

The results on Barabasi-Albert graphs:

![image](https://user-images.githubusercontent.com/12996098/189714628-b9198a6d-e0b5-40b5-bb43-6b803bdad3b5.png)

It also allows to remove `numeric_ac`.

4. Remove `attribute_ac` from the interface and move the code to `discrete_assortativity_coefficient`

`attribute_ac` is non-network method and I don't see any meaningful ways to use it. I think it will be better to reduce the interface to make it clear and simple.

5. Keep dict and matrix representation of mixing patterns, but update the docs.

Dict representation has some pros and cons, as well as matrix representation. I think it will be better to keep both, but give more explanation in docs and examples.

6. Update tests