### PR TITLE
Bugfix for issue 5980 and 5891

### DIFF
--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 import networkx as nx
 
 __all__ = ["adjacency_data", "adjacency_graph"]

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -149,9 +149,9 @@ def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
             target = target_data.pop(id_)
             if not multigraph:
                 graph.add_edge(source, target)
-                graph[source][target].update(tdata)
+                graph[source][target].update(target_data)
             else:
                 ky = target_data.pop(key, None)
                 graph.add_edge(source, target, key=ky)
-                graph[source][target][ky].update(tdata)
+                graph[source][target][ky].update(target_data)
     return graph

--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -70,15 +70,15 @@ def adjacency_data(G, attrs=_attrs):
     data["nodes"] = []
     data["adjacency"] = []
     for n, nbrdict in G.adjacency():
-        data["nodes"].append(dict(chain(G.nodes[n].items(), [(id_, n)])))
+        data["nodes"].append({**G.nodes[n], id_: n})
         adj = []
         if multigraph:
             for nbr, keys in nbrdict.items():
                 for k, d in keys.items():
-                    adj.append(dict(chain(d.items(), [(id_, nbr), (key, k)])))
+                    adj.append({**d, id_: nbr, key: k})
         else:
             for nbr, d in nbrdict.items():
-                adj.append(dict(chain(d.items(), [(id_, nbr)])))
+                adj.append({**d, id_: nbr})
         data["adjacency"].append(adj)
     return data
 

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -50,10 +50,14 @@ def cytoscape_data(G, name="name", ident="id"):
     if name == ident:
         raise nx.NetworkXError("name and ident must be different.")
 
-    jsondata = {"data": list(G.graph.items())}
-    jsondata["directed"] = G.is_directed()
-    jsondata["multigraph"] = G.is_multigraph()
-    jsondata["elements"] = {"nodes": [], "edges": []}
+    jsondata = {
+        "data": list(
+            G.graph.items()
+        ),  # Serialise map as a list to allow non-String keys
+        "directed": G.is_directed(),
+        "multigraph": G.is_multigraph(),
+        "elements": {"nodes": [], "edges": []},
+    }
     nodes = jsondata["elements"]["nodes"]
     edges = jsondata["elements"]["edges"]
 
@@ -149,22 +153,17 @@ def cytoscape_graph(data, name="name", ident="id"):
     graph.graph = dict(data.get("data"))
     for d in data["elements"]["nodes"]:
         node_data = d["data"].copy()
-        node = d["data"]["value"]
-
-        if d["data"].get(name):
-            node_data[name] = d["data"].get(name)
-        if d["data"].get(ident):
-            node_data[ident] = d["data"].get(ident)
+        node = node_data.pop("value")
 
         graph.add_node(node)
         graph.nodes[node].update(node_data)
 
     for d in data["elements"]["edges"]:
         edge_data = d["data"].copy()
-        sour = d["data"]["source"]
-        targ = d["data"]["target"]
+        sour = edge_data.pop("source")
+        targ = edge_data.pop("target")
         if multigraph:
-            key = d["data"].get("key", 0)
+            key = edge_data.pop("key", 0)
             graph.add_edge(sour, targ, key=key)
             graph.edges[sour, targ, key].update(edge_data)
         else:

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -135,9 +135,9 @@ def cytoscape_graph(data, name="name", ident="id"):
     >>> G.nodes()
     NodeView((0, 1))
     >>> G.nodes(data=True)[0]
-    {'id': '0', 'value': 0, 'name': '0'}
+    {'id': '0', 'name': '0'}
     >>> G.edges(data=True)
-    EdgeDataView([(0, 1, {'source': 0, 'target': 1})])
+    EdgeDataView([(0, 1, {})])
     """
     if name == ident:
         raise nx.NetworkXError("name and ident must be different.")

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -1,4 +1,4 @@
-from itertools import chain, count
+from itertools import count
 
 import networkx as nx
 
@@ -162,7 +162,7 @@ def node_link_data(
     data = {
         "directed": G.is_directed(),
         "multigraph": multigraph,
-        "graph": list(G.graph.items()),
+        "graph": G.graph,
         "nodes": [{**G.nodes[n], name: n} for n in G],
     }
     if multigraph:
@@ -307,7 +307,7 @@ def node_link_graph(
 
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
     key = None if not multigraph else key
-    graph.graph = dict(data.get("graph"))
+    graph.graph = data.get("graph", {})
     c = count()
     for d in data["nodes"]:
         node_data = d.copy()

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -11,7 +11,12 @@ class TestAdjacency:
     def test_graph(self):
         G = nx.path_graph(4)
         H = adjacency_graph(adjacency_data(G))
-        nx.is_isomorphic(G, H)
+        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
+
+        H = adjacency_graph(json.loads(json.dumps(adjacency_data(G))))
+        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
@@ -37,7 +42,8 @@ class TestAdjacency:
         nx.add_path(G, [1, 2, 3])
         H = adjacency_graph(adjacency_data(G))
         assert H.is_directed()
-        nx.is_isomorphic(G, H)
+        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
 
     def test_multidigraph(self):
         G = nx.MultiDiGraph()
@@ -45,21 +51,17 @@ class TestAdjacency:
         H = adjacency_graph(adjacency_data(G))
         assert H.is_directed()
         assert H.is_multigraph()
+        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
 
     def test_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
         H = adjacency_graph(adjacency_data(G))
-        nx.is_isomorphic(G, H)
-        assert H[1][2]["second"]["color"] == "blue"
-
-    def test_deserialized_graph_equal(self):
-        G = nx.MultiGraph()
-        G.add_edge(1, 2, key="first")
-        G.add_edge(1, 2, key="second", color="blue")
-        H = adjacency_graph(adjacency_data(G))
+        assert nx.is_isomorphic(G, H)
         assert graphs_equal(G, H)
+        assert H[1][2]["second"]["color"] == "blue"
 
     def test_exception(self):
         with pytest.raises(nx.NetworkXError):

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -4,6 +4,7 @@ import pytest
 
 import networkx as nx
 from networkx.readwrite.json_graph import adjacency_data, adjacency_graph
+from networkx.utils import graphs_equal
 
 
 class TestAdjacency:
@@ -52,6 +53,13 @@ class TestAdjacency:
         H = adjacency_graph(adjacency_data(G))
         nx.is_isomorphic(G, H)
         assert H[1][2]["second"]["color"] == "blue"
+
+    def test_deserialized_graph_equal(self):
+        G = nx.MultiGraph()
+        G.add_edge(1, 2, key="first")
+        G.add_edge(1, 2, key="second", color="blue")
+        H = adjacency_graph(adjacency_data(G))
+        assert graphs_equal(G, H)
 
     def test_exception(self):
         with pytest.raises(nx.NetworkXError):

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import pytest
@@ -11,12 +12,21 @@ class TestAdjacency:
     def test_graph(self):
         G = nx.path_graph(4)
         H = adjacency_graph(adjacency_data(G))
-        assert nx.is_isomorphic(G, H)
         assert graphs_equal(G, H)
 
+    def test_dict_form_jsonisable(self):
+        G = nx.path_graph(4)
+        # Checks that the dict produced can be serialised into and deserialised from json
         H = adjacency_graph(json.loads(json.dumps(adjacency_data(G))))
-        assert nx.is_isomorphic(G, H)
         assert graphs_equal(G, H)
+
+    def test_input_data_is_not_modified_when_building_graph(self):
+        G = nx.path_graph(4)
+        input_data = adjacency_data(G)
+        orig_data = copy.deepcopy(input_data)
+        # Ensure input is unmodified by deserialisation
+        adjacency_graph(input_data)
+        assert input_data == orig_data
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
@@ -27,8 +37,10 @@ class TestAdjacency:
 
         H = adjacency_graph(adjacency_data(G))
         assert H.graph["foo"] == "bar"
+        assert H.graph[1] == "one"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
+        assert graphs_equal(G, H)
 
         d = json.dumps(adjacency_data(G))
         H = adjacency_graph(json.loads(d))
@@ -36,14 +48,15 @@ class TestAdjacency:
         assert H.graph[1] == "one"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
+        assert graphs_equal(G, H)
 
     def test_digraph(self):
         G = nx.DiGraph()
         nx.add_path(G, [1, 2, 3])
         H = adjacency_graph(adjacency_data(G))
         assert H.is_directed()
-        assert nx.is_isomorphic(G, H)
         assert graphs_equal(G, H)
+        assert isinstance(H, nx.DiGraph)
 
     def test_multidigraph(self):
         G = nx.MultiDiGraph()
@@ -51,16 +64,17 @@ class TestAdjacency:
         H = adjacency_graph(adjacency_data(G))
         assert H.is_directed()
         assert H.is_multigraph()
-        assert nx.is_isomorphic(G, H)
         assert graphs_equal(G, H)
+        assert isinstance(H, nx.MultiDiGraph)
 
     def test_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
         H = adjacency_graph(adjacency_data(G))
-        assert nx.is_isomorphic(G, H)
         assert graphs_equal(G, H)
+        assert H.is_multigraph()
+        assert isinstance(H, nx.MultiGraph)
         assert H[1][2]["second"]["color"] == "blue"
 
     def test_exception(self):

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -10,7 +10,7 @@ from networkx.readwrite.json_graph import cytoscape_data, cytoscape_graph
 def test_graph():
     G = nx.path_graph(4)
     H = cytoscape_graph(cytoscape_data(G))
-    nx.is_isomorphic(G, H)
+    assert nx.is_isomorphic(G, H)
 
 
 def test_input_data_is_not_modified_when_building_graph():
@@ -52,7 +52,7 @@ def test_digraph():
     nx.add_path(G, [1, 2, 3])
     H = cytoscape_graph(cytoscape_data(G))
     assert H.is_directed()
-    nx.is_isomorphic(G, H)
+    assert nx.is_isomorphic(G, H)
 
 
 def test_multidigraph():

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -107,7 +107,7 @@ class TestNodeLink:
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
         H = node_link_graph(node_link_data(G))
-        nx.is_isomorphic(G, H)
+        assert nx.is_isomorphic(G, H)
         assert H[1][2]["second"]["color"] == "blue"
 
     def test_graph_with_tuple_nodes(self):

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -1,9 +1,11 @@
+import copy
 import json
 
 import pytest
 
 import networkx as nx
 from networkx.readwrite.json_graph import node_link_data, node_link_graph
+from networkx.utils import graphs_equal
 
 
 # TODO: To be removed when signature change complete
@@ -46,7 +48,7 @@ class TestNodeLink:
         H = node_link_graph(
             node_link_data(G, attrs=attrs), multigraph=False, attrs=attrs
         )
-        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
@@ -76,7 +78,24 @@ class TestNodeLink:
     def test_graph(self):
         G = nx.path_graph(4)
         H = node_link_graph(node_link_data(G))
-        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
+
+    def test_non_string_keys(self):
+        G = nx.path_graph(4)
+        G.graph.update({5: 2, 3.0: 2.0, True: False})
+        H = node_link_graph(node_link_data(G))
+        assert graphs_equal(G, H)
+
+        H = node_link_graph(json.loads(json.dumps(node_link_data(G))))
+        assert graphs_equal(G, H)
+
+    def test_input_data_is_not_modified_when_building_graph(self):
+        G = nx.path_graph(4)
+        input_data = node_link_data(G)
+        orig_data = copy.deepcopy(input_data)
+        # Ensure input is unmodified by deserialisation
+        node_link_graph(input_data)
+        assert input_data == orig_data
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
@@ -89,25 +108,30 @@ class TestNodeLink:
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
+        assert graphs_equal(G, H)
 
         d = json.dumps(node_link_data(G))
         H = node_link_graph(json.loads(d))
         assert H.graph["foo"] == "bar"
-        assert H.graph["1"] == "one"
+        assert H.graph[1] == "one"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
+        assert graphs_equal(G, H)
 
     def test_digraph(self):
         G = nx.DiGraph()
         H = node_link_graph(node_link_data(G))
         assert H.is_directed()
+        assert graphs_equal(G, H)
+        assert isinstance(G, nx.DiGraph)
 
     def test_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
         H = node_link_graph(node_link_data(G))
-        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
+        assert isinstance(G, nx.MultiGraph)
         assert H[1][2]["second"]["color"] == "blue"
 
     def test_graph_with_tuple_nodes(self):
@@ -119,6 +143,7 @@ class TestNodeLink:
         H = node_link_graph(dd)
         assert H.nodes[(0, 0)] == G.nodes[(0, 0)]
         assert H[(0, 0)][(1, 0)]["color"] == [255, 255, 0]
+        assert graphs_equal(G, H)
 
     def test_unicode_keys(self):
         q = "qualité"
@@ -129,6 +154,7 @@ class TestNodeLink:
         data = json.loads(output)
         H = node_link_graph(data)
         assert H.nodes[1][q] == q
+        assert graphs_equal(G, H)
 
     def test_exception(self):
         with pytest.raises(nx.NetworkXError):
@@ -142,11 +168,8 @@ class TestNodeLink:
         G.add_node("A")
         G.add_node(q)
         G.add_edge("A", q)
-        data = node_link_data(G)
-        assert data["links"][0]["source"] == "A"
-        assert data["links"][0]["target"] == q
-        H = node_link_graph(data)
-        assert nx.is_isomorphic(G, H)
+        H = node_link_graph(node_link_data(G))
+        assert graphs_equal(G, H)
 
     def test_custom_attrs(self):
         G = nx.path_graph(4)
@@ -164,7 +187,7 @@ class TestNodeLink:
         )
 
         H = node_link_graph(node_link_data(G, **attrs), multigraph=False, **attrs)
-        assert nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -80,15 +80,6 @@ class TestNodeLink:
         H = node_link_graph(node_link_data(G))
         assert graphs_equal(G, H)
 
-    def test_non_string_keys(self):
-        G = nx.path_graph(4)
-        G.graph.update({5: 2, 3.0: 2.0, True: False})
-        H = node_link_graph(node_link_data(G))
-        assert graphs_equal(G, H)
-
-        H = node_link_graph(json.loads(json.dumps(node_link_data(G))))
-        assert graphs_equal(G, H)
-
     def test_input_data_is_not_modified_when_building_graph(self):
         G = nx.path_graph(4)
         input_data = node_link_data(G)
@@ -113,10 +104,9 @@ class TestNodeLink:
         d = json.dumps(node_link_data(G))
         H = node_link_graph(json.loads(d))
         assert H.graph["foo"] == "bar"
-        assert H.graph[1] == "one"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
-        assert graphs_equal(G, H)
+        assert nx.is_isomorphic(G, H)
 
     def test_digraph(self):
         G = nx.DiGraph()

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import pytest
@@ -28,6 +29,19 @@ def test_graph_attributes():
     d = json.dumps(tree_data(G, 1))
     H = tree_graph(json.loads(d))
     assert H.nodes[1]["color"] == "red"
+
+
+def test_input_data_is_not_modified_when_building_graph():
+    G = nx.DiGraph()
+    G.add_nodes_from([1, 2, 3], color="red")
+    G.add_edge(1, 2, foo=7)
+    G.add_edge(1, 3, foo=10)
+    G.add_edge(3, 4, foo=10)
+    input_data = tree_data(G, 1)
+    orig_data = copy.deepcopy(input_data)
+    # Ensure input is unmodified by deserialisation
+    tree_graph(input_data)
+    assert input_data == orig_data
 
 
 def test_exceptions():

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -6,43 +6,42 @@ import networkx as nx
 from networkx.readwrite.json_graph import tree_data, tree_graph
 
 
-def test_graph():
-    G = nx.DiGraph()
-    G.add_nodes_from([1, 2, 3], color="red")
-    G.add_edge(1, 2, foo=7)
-    G.add_edge(1, 3, foo=10)
-    G.add_edge(3, 4, foo=10)
-    H = tree_graph(tree_data(G, 1))
-    nx.is_isomorphic(G, H)
+class TestTree:
+    def test_graph(self):
+        G = nx.DiGraph()
+        G.add_nodes_from([1, 2, 3], color="red")
+        G.add_edge(1, 2, foo=7)
+        G.add_edge(1, 3, foo=10)
+        G.add_edge(3, 4, foo=10)
+        H = tree_graph(tree_data(G, 1))
+        assert nx.is_isomorphic(G, H)
 
+    def test_graph_attributes(self):
+        G = nx.DiGraph()
+        G.add_nodes_from([1, 2, 3], color="red")
+        G.add_edge(1, 2, foo=7)
+        G.add_edge(1, 3, foo=10)
+        G.add_edge(3, 4, foo=10)
+        H = tree_graph(tree_data(G, 1))
+        assert H.nodes[1]["color"] == "red"
 
-def test_graph_attributes():
-    G = nx.DiGraph()
-    G.add_nodes_from([1, 2, 3], color="red")
-    G.add_edge(1, 2, foo=7)
-    G.add_edge(1, 3, foo=10)
-    G.add_edge(3, 4, foo=10)
-    H = tree_graph(tree_data(G, 1))
-    assert H.nodes[1]["color"] == "red"
+        d = json.dumps(tree_data(G, 1))
+        H = tree_graph(json.loads(d))
+        assert H.nodes[1]["color"] == "red"
 
-    d = json.dumps(tree_data(G, 1))
-    H = tree_graph(json.loads(d))
-    assert H.nodes[1]["color"] == "red"
-
-
-def test_exceptions():
-    with pytest.raises(TypeError, match="is not a tree."):
-        G = nx.complete_graph(3)
-        tree_data(G, 0)
-    with pytest.raises(TypeError, match="is not directed."):
-        G = nx.path_graph(3)
-        tree_data(G, 0)
-    with pytest.raises(TypeError, match="is not weakly connected."):
-        G = nx.path_graph(3, create_using=nx.DiGraph)
-        G.add_edge(2, 0)
-        G.add_node(3)
-        tree_data(G, 0)
-    with pytest.raises(nx.NetworkXError, match="must be different."):
-        G = nx.MultiDiGraph()
-        G.add_node(0)
-        tree_data(G, 0, ident="node", children="node")
+    def test_exceptions(self):
+        with pytest.raises(TypeError, match="is not a tree."):
+            G = nx.complete_graph(3)
+            tree_data(G, 0)
+        with pytest.raises(TypeError, match="is not directed."):
+            G = nx.path_graph(3)
+            tree_data(G, 0)
+        with pytest.raises(TypeError, match="is not weakly connected."):
+            G = nx.path_graph(3, create_using=nx.DiGraph)
+            G.add_edge(2, 0)
+            G.add_node(3)
+            tree_data(G, 0)
+        with pytest.raises(nx.NetworkXError, match="must be different."):
+            G = nx.MultiDiGraph()
+            G.add_node(0)
+            tree_data(G, 0, ident="node", children="node")

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -6,42 +6,43 @@ import networkx as nx
 from networkx.readwrite.json_graph import tree_data, tree_graph
 
 
-class TestTree:
-    def test_graph(self):
-        G = nx.DiGraph()
-        G.add_nodes_from([1, 2, 3], color="red")
-        G.add_edge(1, 2, foo=7)
-        G.add_edge(1, 3, foo=10)
-        G.add_edge(3, 4, foo=10)
-        H = tree_graph(tree_data(G, 1))
-        assert nx.is_isomorphic(G, H)
+def test_graph():
+    G = nx.DiGraph()
+    G.add_nodes_from([1, 2, 3], color="red")
+    G.add_edge(1, 2, foo=7)
+    G.add_edge(1, 3, foo=10)
+    G.add_edge(3, 4, foo=10)
+    H = tree_graph(tree_data(G, 1))
+    assert nx.is_isomorphic(G, H)
 
-    def test_graph_attributes(self):
-        G = nx.DiGraph()
-        G.add_nodes_from([1, 2, 3], color="red")
-        G.add_edge(1, 2, foo=7)
-        G.add_edge(1, 3, foo=10)
-        G.add_edge(3, 4, foo=10)
-        H = tree_graph(tree_data(G, 1))
-        assert H.nodes[1]["color"] == "red"
 
-        d = json.dumps(tree_data(G, 1))
-        H = tree_graph(json.loads(d))
-        assert H.nodes[1]["color"] == "red"
+def test_graph_attributes():
+    G = nx.DiGraph()
+    G.add_nodes_from([1, 2, 3], color="red")
+    G.add_edge(1, 2, foo=7)
+    G.add_edge(1, 3, foo=10)
+    G.add_edge(3, 4, foo=10)
+    H = tree_graph(tree_data(G, 1))
+    assert H.nodes[1]["color"] == "red"
 
-    def test_exceptions(self):
-        with pytest.raises(TypeError, match="is not a tree."):
-            G = nx.complete_graph(3)
-            tree_data(G, 0)
-        with pytest.raises(TypeError, match="is not directed."):
-            G = nx.path_graph(3)
-            tree_data(G, 0)
-        with pytest.raises(TypeError, match="is not weakly connected."):
-            G = nx.path_graph(3, create_using=nx.DiGraph)
-            G.add_edge(2, 0)
-            G.add_node(3)
-            tree_data(G, 0)
-        with pytest.raises(nx.NetworkXError, match="must be different."):
-            G = nx.MultiDiGraph()
-            G.add_node(0)
-            tree_data(G, 0, ident="node", children="node")
+    d = json.dumps(tree_data(G, 1))
+    H = tree_graph(json.loads(d))
+    assert H.nodes[1]["color"] == "red"
+
+
+def test_exceptions():
+    with pytest.raises(TypeError, match="is not a tree."):
+        G = nx.complete_graph(3)
+        tree_data(G, 0)
+    with pytest.raises(TypeError, match="is not directed."):
+        G = nx.path_graph(3)
+        tree_data(G, 0)
+    with pytest.raises(TypeError, match="is not weakly connected."):
+        G = nx.path_graph(3, create_using=nx.DiGraph)
+        G.add_edge(2, 0)
+        G.add_node(3)
+        tree_data(G, 0)
+    with pytest.raises(nx.NetworkXError, match="must be different."):
+        G = nx.MultiDiGraph()
+        G.add_node(0)
+        tree_data(G, 0, ident="node", children="node")

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -187,10 +187,10 @@ class TestRelabel:
         K5 = nx.complete_graph(4)
         G = nx.complete_graph(4)
         G = nx.relabel_nodes(G, {i: i + 1 for i in range(4)}, copy=False)
-        nx.is_isomorphic(K5, G)
+        assert nx.is_isomorphic(K5, G)
         G = nx.complete_graph(4)
         G = nx.relabel_nodes(G, {i: i - 1 for i in range(4)}, copy=False)
-        nx.is_isomorphic(K5, G)
+        assert nx.is_isomorphic(K5, G)
 
     def test_relabel_selfloop(self):
         G = nx.DiGraph([(1, 1), (1, 2), (2, 3)])


### PR DESCRIPTION
removes deserialisation artifacts from adjacency_graph: fixes #5980 
ensures assert called when nx.is_isomorphic is used in tests: at least partial fix for #5981 