### PR TITLE
Make all.py generator friendly

### DIFF
--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -14,8 +14,8 @@ def union_all(graphs, rename=(None,)):
 
     Parameters
     ----------
-    graphs : list of graphs
-       List of NetworkX graphs
+    graphs : iterable
+       Iterable of NetworkX graphs
 
     rename : bool , default=(None, None)
        Node names of G and H can be changed by specifying the tuple
@@ -45,16 +45,8 @@ def union_all(graphs, rename=(None,)):
     union
     disjoint_union_all
     """
-    # collect the graphs in case an iterator was passed
-    graphs = list(graphs)
-
-    if not graphs:
-        raise ValueError("cannot apply union_all to an empty list")
-
-    U = graphs[0]
-
-    if any(G.is_multigraph() != U.is_multigraph() for G in graphs):
-        raise nx.NetworkXError("All graphs must be graphs or multigraphs.")
+    R = None
+    seen_nodes = set()
 
     # rename graph to obtain disjoint node labels
     def add_prefix(graph, prefix):
@@ -70,33 +62,32 @@ def union_all(graphs, rename=(None,)):
 
         return nx.relabel_nodes(graph, label)
 
-    graphs = [add_prefix(G, name) for G, name in zip_longest(graphs, rename)]
+    graphs = (add_prefix(G, name) for G, name in zip_longest(graphs, rename))
 
-    if sum(len(G) for G in graphs) != len(set().union(*graphs)):
-        raise nx.NetworkXError(
-            "The node sets of the graphs are not disjoint.",
-            "Use appropriate rename"
-            "=(G1prefix,G2prefix,...,GNprefix)"
-            "or use disjoint_union(G1,G2,...,GN).",
+    for i, G in enumerate(graphs):
+        G_nodes_set = set(G)
+        if i == 0:
+            # Union is the same type as first graph
+            R = G.__class__()
+        elif G.is_multigraph() != R.is_multigraph():
+            raise nx.NetworkXError("All graphs must be graphs or multigraphs.")
+        elif not seen_nodes.isdisjoint(G_nodes_set):
+            raise nx.NetworkXError(
+                "The node sets of the graphs are not disjoint.",
+                "Use appropriate rename"
+                "=(G1prefix,G2prefix,...,GNprefix)"
+                "or use disjoint_union(G1,G2,...,GN).",
+            )
+
+        seen_nodes |= G_nodes_set
+        R.graph.update(G.graph)
+        R.add_nodes_from(G.nodes(data=True))
+        R.add_edges_from(
+            G.edges(keys=True, data=True) if G.is_multigraph() else G.edges(data=True)
         )
 
-    # Union is the same type as first graph
-    R = U.__class__()
-
-    # add graph attributes, later attributes take precedent over earlier ones
-    for G in graphs:
-        R.graph.update(G.graph)
-
-    # add nodes and attributes
-    for G in graphs:
-        R.add_nodes_from(G.nodes(data=True))
-
-    if U.is_multigraph():
-        for G in graphs:
-            R.add_edges_from(G.edges(keys=True, data=True))
-    else:
-        for G in graphs:
-            R.add_edges_from(G.edges(data=True))
+    if R is None:
+        raise ValueError("cannot apply union_all to an empty list")
 
     return R
 
@@ -230,8 +221,8 @@ def intersection_all(graphs):
         elif G.is_multigraph() != R.is_multigraph():
             raise nx.NetworkXError("All graphs must be graphs or multigraphs.")
 
-        node_intersection &= G.nodes
-        edge_intersection &= G.edges(keys=True) if G.is_multigraph() else G.edges()
+        node_intersection &= set(G.nodes)
+        edge_intersection &= set(G.edges(keys=True) if G.is_multigraph() else G.edges())
 
     if R is None:
         raise ValueError("cannot apply intersection_all to an empty list")

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -118,18 +118,13 @@ def disjoint_union_all(graphs):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
     """
-    graph_info = []
-
-    def yield_relabeled():
+    def yield_relabeled(graphs):
         first_label = 0
         for G in graphs:
             yield nx.convert_node_labels_to_integers(G, first_label=first_label)
             first_label += len(G)
-            graph_info.append(G.graph)
 
-    R = union_all(yield_relabeled())
-    for info in graph_info:
-        R.graph.update(info)
+    R = union_all(yield_relabeled(graphs))
 
     return R
 

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -130,18 +130,16 @@ def disjoint_union_all(graphs):
     from the last graph in the list with that attribute is used.
     """
     first_labels = [0]
-    relabeled, graph_info = [], []
+    graph_info = []
 
-    for G in graphs:
-        first_label = first_labels[-1]
-        first_labels.append(len(G) + first_label)
-        relabeled.append(nx.convert_node_labels_to_integers(G, first_label=first_label))
-        graph_info.append(G.graph)
+    def yield_relabeled():
+        for G in graphs:
+            first_label = first_labels[-1]
+            first_labels.append(len(G) + first_label)
+            graph_info.append(G.graph)
+            yield nx.convert_node_labels_to_integers(G, first_label=first_label)
 
-    if not relabeled:
-        raise ValueError("cannot apply disjoint_union_all to an empty list")
-
-    R = union_all(relabeled)
+    R = union_all(yield_relabeled())
     for info in graph_info:
         R.graph.update(info)
 
@@ -182,6 +180,7 @@ def compose_all(graphs):
     # add graph attributes, H attributes take precedent over G attributes
     for i, G in enumerate(graphs):
         if i == 0:
+            # create new graph
             R = G.__class__()
         elif G.is_multigraph() != R.is_multigraph():
             raise nx.NetworkXError("All graphs must be graphs or multigraphs.")

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -7,7 +7,7 @@ import networkx as nx
 __all__ = ["union_all", "compose_all", "disjoint_union_all", "intersection_all"]
 
 
-def union_all(graphs, rename=(None,)):
+def union_all(graphs, rename=()):
     """Returns the union of all graphs.
 
     The graphs must be disjoint, otherwise an exception is raised.
@@ -17,8 +17,8 @@ def union_all(graphs, rename=(None,)):
     graphs : iterable
        Iterable of NetworkX graphs
 
-    rename : bool , default=(None, None)
-       Node names of G and H can be changed by specifying the tuple
+    rename : tuple , optional
+       Node names of graphs can be changed by specifying the tuple
        rename=('G-','H-') (for example).  Node "u" in G is then renamed
        "G-u" and "v" in H is renamed "H-v".
 
@@ -54,11 +54,7 @@ def union_all(graphs, rename=(None,)):
             return graph
 
         def label(x):
-            if isinstance(x, str):
-                name = prefix + x
-            else:
-                name = prefix + repr(x)
-            return name
+            return f"{prefix}{x}"
 
         return nx.relabel_nodes(graph, label)
 

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -1,6 +1,6 @@
 """Operations on many graphs.
 """
-from itertools import zip_longest
+from itertools import chain, repeat
 
 import networkx as nx
 
@@ -17,10 +17,11 @@ def union_all(graphs, rename=()):
     graphs : iterable
        Iterable of NetworkX graphs
 
-    rename : tuple , optional
+    rename : iterable , optional
        Node names of graphs can be changed by specifying the tuple
        rename=('G-','H-') (for example).  Node "u" in G is then renamed
-       "G-u" and "v" in H is renamed "H-v".
+       "G-u" and "v" in H is renamed "H-v". Infinite generators (like itertools.count)
+       are also supported.
 
     Returns
     -------
@@ -58,7 +59,9 @@ def union_all(graphs, rename=()):
 
         return nx.relabel_nodes(graph, label)
 
-    graphs = (add_prefix(G, name) for G, name in zip_longest(graphs, rename))
+    graphs = (
+        add_prefix(G, name) for G, name in zip(graphs, chain(rename, repeat(None)))
+    )
 
     for i, G in enumerate(graphs):
         G_nodes_set = set(G.nodes)

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -65,7 +65,7 @@ def union_all(graphs, rename=(None,)):
     graphs = (add_prefix(G, name) for G, name in zip_longest(graphs, rename))
 
     for i, G in enumerate(graphs):
-        G_nodes_set = set(G)
+        G_nodes_set = set(G.nodes)
         if i == 0:
             # Union is the same type as first graph
             R = G.__class__()
@@ -212,17 +212,20 @@ def intersection_all(graphs):
     graph.
     """
     R = None
-    node_intersection, edge_intersection = set(), set()
 
     for i, G in enumerate(graphs):
+        G_nodes_set = set(G.nodes)
+        G_edges_set = set(G.edges(keys=True) if G.is_multigraph() else G.edges())
         if i == 0:
             # create new graph
             R = G.__class__()
+            node_intersection = G_nodes_set
+            edge_intersection = G_edges_set
         elif G.is_multigraph() != R.is_multigraph():
             raise nx.NetworkXError("All graphs must be graphs or multigraphs.")
-
-        node_intersection &= set(G.nodes)
-        edge_intersection &= set(G.edges(keys=True) if G.is_multigraph() else G.edges())
+        else:
+            node_intersection &= G_nodes_set
+            edge_intersection &= G_edges_set
 
     if R is None:
         raise ValueError("cannot apply intersection_all to an empty list")

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -59,9 +59,8 @@ def union_all(graphs, rename=()):
 
         return nx.relabel_nodes(graph, label)
 
-    graphs = (
-        add_prefix(G, name) for G, name in zip(graphs, chain(rename, repeat(None)))
-    )
+    rename = chain(rename, repeat(None))
+    graphs = (add_prefix(G, name) for G, name in zip(graphs, rename))
 
     for i, G in enumerate(graphs):
         G_nodes_set = set(G.nodes)

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -118,6 +118,7 @@ def disjoint_union_all(graphs):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
     """
+
     def yield_relabeled(graphs):
         first_label = 0
         for G in graphs:
@@ -218,6 +219,8 @@ def intersection_all(graphs):
         else:
             node_intersection &= G_nodes_set
             edge_intersection &= G_edges_set
+
+        R.graph.update(G.graph)
 
     if R is None:
         raise ValueError("cannot apply intersection_all to an empty list")

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -118,15 +118,14 @@ def disjoint_union_all(graphs):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
     """
-    first_labels = [0]
     graph_info = []
 
     def yield_relabeled():
+        first_label = 0
         for G in graphs:
-            first_label = first_labels[-1]
-            first_labels.append(len(G) + first_label)
-            graph_info.append(G.graph)
             yield nx.convert_node_labels_to_integers(G, first_label=first_label)
+            first_label += len(G)
+            graph_info.append(G.graph)
 
     R = union_all(yield_relabeled())
     for info in graph_info:

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def union(G, H, rename=(None, None)):
+def union(G, H, rename=()):
     """Combine graphs G and H. The names of nodes must be unique.
 
     A name collision between the graphs will raise an exception.
@@ -27,7 +27,7 @@ def union(G, H, rename=(None, None)):
     G, H : graph
        A NetworkX graph
 
-    rename : tuple , default=(None, None)
+    rename : iterable , optional
        Node names of G and H can be changed by specifying the tuple
        rename=('G-','H-') (for example).  Node "u" in G is then renamed
        "G-u" and "v" in H is renamed "H-v".
@@ -418,11 +418,7 @@ def full_join(G, H, rename=(None, None)):
             return graph
 
         def label(x):
-            if isinstance(x, str):
-                name = prefix + x
-            else:
-                name = prefix + repr(x)
-            return name
+            return f"{prefix}{x}"
 
         return nx.relabel_nodes(graph, label)
 

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -34,7 +34,7 @@ def test_union_all_attributes():
 def test_intersection_all():
     G = nx.Graph()
     H = nx.Graph()
-    R = nx.Graph()
+    R = nx.Graph(awesome=True)
     G.add_nodes_from([1, 2, 3, 4])
     G.add_edge(1, 2)
     G.add_edge(2, 3)
@@ -47,6 +47,7 @@ def test_intersection_all():
     I = nx.intersection_all([G, H, R])
     assert set(I.nodes()) == {1, 2, 3, 4}
     assert sorted(I.edges()) == [(2, 3)]
+    assert I.graph["awesome"]
 
 
 def test_intersection_all_different_node_sets():
@@ -241,7 +242,7 @@ def test_input_output():
     l = [nx.Graph([(1, 2)]), nx.Graph([(3, 4)], awesome=True)]
     U = nx.disjoint_union_all(l)
     assert len(l) == 2
-    assert U.graph['awesome']
+    assert U.graph["awesome"]
     C = nx.compose_all(l)
     assert len(l) == 2
     l = [nx.Graph([(1, 2)]), nx.Graph([(1, 2)])]

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -238,9 +238,10 @@ def test_union_all_multigraph():
 
 
 def test_input_output():
-    l = [nx.Graph([(1, 2)]), nx.Graph([(3, 4)])]
+    l = [nx.Graph([(1, 2)]), nx.Graph([(3, 4)], awesome=True)]
     U = nx.disjoint_union_all(l)
     assert len(l) == 2
+    assert U.graph['awesome']
     C = nx.compose_all(l)
     assert len(l) == 2
     l = [nx.Graph([(1, 2)]), nx.Graph([(1, 2)])]


### PR DESCRIPTION
Hi 👋 

This PR makes `union_all`, `disjoint_union_all`, `compose_all`, `intersection_all` generator friendly, allowing for a much smaller memory footprint when dealing with many graphs.

We have a bunch of large, dense, and overlapping graphs on disk. To create a composition, they would all have to be loaded into memory at the same time. Then, `G.nodes` and `G.edges` are called on all of them without intermediate garbage collect, further increasing memory footprint (this is where we hit a `MemoryError` on a 64GB machine after some iterations in the `compose_all` loops).

This rewrite:
- still allows the user to pass a list of graphs
- now also allows a generator that loads graphs into memory just-in-time (what we use to avoid `MemoryError`)
  - allows garbage collector to deallocate and therefore in-memory overwrite of the `G` variable with each iteration
- throws the same errors as before (though some errors are postponed to avoid having to load all graphs into memory at the same point in time)
- reduces the function's cognitive and computational complexity (specifically: reduces amount of loops over the graphs to 1)

~the same can be done for other functions in this module, if you're interested!~ done 😄 