### PR TITLE
Add concurrency hook to cancel jobs on new push.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   report:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: style
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,6 +2,10 @@ name: Mypy
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   type-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   base:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
This addition to the workflow is intended to cancel running jobs within a workflow when new changes are pushed up. This should help in situations where there are a lot of rapid pushes to a PR, which can trigger a long queue of CI jobs to build up. 
See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

See also: scipy/scipy#15634 and numpy/numpy#21110. And thanks to @HarshCasper for calling attention to this improvement.