### PR TITLE
Fix weighted MultiDiGraphs in DAG longest path algorithms + add additional tests

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1006,7 +1006,15 @@ def dag_longest_path(G, weight="weight", default_weight=1, topo_order=None):
     dist = {}  # stores {v : (length, u)}
     for v in topo_order:
         us = [
-            (dist[u][0] + data.get(weight, default_weight), u)
+            (
+                dist[u][0]
+                + (
+                    max(data.values(), key=lambda x: x.get(weight, default_weight))
+                    if G.is_multigraph()
+                    else data
+                ).get(weight, default_weight),
+                u,
+            )
             for u, data in G.pred[v].items()
         ]
 
@@ -1068,8 +1076,13 @@ def dag_longest_path_length(G, weight="weight", default_weight=1):
     """
     path = nx.dag_longest_path(G, weight, default_weight)
     path_length = 0
-    for (u, v) in pairwise(path):
-        path_length += G[u][v].get(weight, default_weight)
+    if G.is_multigraph():
+        for u, v in pairwise(path):
+            i = max(G[u][v], key=lambda x: G[u][v][x].get(weight, default_weight))
+            path_length += G[u][v][i].get(weight, default_weight)
+    else:
+        for (u, v) in pairwise(path):
+            path_length += G[u][v].get(weight, default_weight)
 
     return path_length
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -76,11 +76,11 @@ class TestDagLongestPath:
         ]
         G.add_weighted_edges_from(edges)
         assert nx.dag_longest_path(G) == [1, 3]
-        
+
     def test_multigraph_weighted_default_weight(self):
         G = nx.MultiDiGraph([(1, 2), (2, 3)])  # Unweighted edges
         G.add_weighted_edges_from([(1, 3, 1), (1, 3, 5), (1, 3, 2)])
-        
+
         # Default value for default weight is 1
         assert nx.dag_longest_path(G) == [1, 3]
         assert nx.dag_longest_path(G, default_weight=3) == [1, 2, 3]

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -81,7 +81,7 @@ class TestDagLongestPath:
         G = nx.MultiDiGraph([(1, 2), (2, 3)])  # Unweighted edges
         G.add_weighted_edges_from([(1, 3, 1), (1, 3, 5), (1, 3, 2)])
         
-        # Default value for default weight is 0
+        # Default value for default weight is 1
         assert nx.dag_longest_path(G) == [1, 3]
         assert nx.dag_longest_path(G, default_weight=3) == [1, 2, 3]
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -60,6 +60,23 @@ class TestDagLongestPath:
         # this will raise NotImplementedError when nodes need to be ordered
         nx.dag_longest_path(G)
 
+    def test_multigraph_unweighted(self):
+        edges = [(1, 2), (2, 3), (2, 3), (3, 4), (4, 5), (1, 3), (1, 5), (3, 5)]
+        G = nx.MultiDiGraph(edges)
+        assert nx.dag_longest_path(G) == [1, 2, 3, 4, 5]
+
+    def test_multigraph_weighted(self):
+        G = nx.MultiDiGraph()
+        edges = [
+            (1, 2, 2),
+            (2, 3, 2),
+            (1, 3, 1),
+            (1, 3, 5),
+            (1, 3, 2),
+        ]
+        G.add_weighted_edges_from(edges)
+        assert nx.dag_longest_path(G) == [1, 3]
+
 
 class TestDagLongestPathLength:
     """Unit tests for computing the length of a longest path in a
@@ -88,6 +105,23 @@ class TestDagLongestPathLength:
     def test_weighted(self):
         edges = [(1, 2, -5), (2, 3, 1), (3, 4, 1), (4, 5, 0), (3, 5, 4), (1, 6, 2)]
         G = nx.DiGraph()
+        G.add_weighted_edges_from(edges)
+        assert nx.dag_longest_path_length(G) == 5
+
+    def test_multigraph_unweighted(self):
+        edges = [(1, 2), (2, 3), (2, 3), (3, 4), (4, 5), (1, 3), (1, 5), (3, 5)]
+        G = nx.MultiDiGraph(edges)
+        assert nx.dag_longest_path_length(G) == 4
+
+    def test_multigraph_weighted(self):
+        G = nx.MultiDiGraph()
+        edges = [
+            (1, 2, 2),
+            (2, 3, 2),
+            (1, 3, 1),
+            (1, 3, 5),
+            (1, 3, 2),
+        ]
         G.add_weighted_edges_from(edges)
         assert nx.dag_longest_path_length(G) == 5
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -76,6 +76,14 @@ class TestDagLongestPath:
         ]
         G.add_weighted_edges_from(edges)
         assert nx.dag_longest_path(G) == [1, 3]
+        
+    def test_multigraph_weighted_default_weight(self):
+        G = nx.MultiDiGraph([(1, 2), (2, 3)])  # Unweighted edges
+        G.add_weighted_edges_from([(1, 3, 1), (1, 3, 5), (1, 3, 2)])
+        
+        # Default value for default weight is 0
+        assert nx.dag_longest_path(G) == [1, 3]
+        assert nx.dag_longest_path(G, default_weight=3) == [1, 2, 3]
 
 
 class TestDagLongestPathLength:


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

Fixes #5987 

Personally, I would find it useful to return the edge that was calculated to be the best in addition to the node to avoid having to recalculate it again whenever traversing the path, but that would break backwards compatibility with code that is using MultiDiGraphs for unweighted longest pathing by changing the return type, so I have not included it in my fix. A potential other fix would be to create separate functions for MultiDiGraphs and add a warning to dag_longest_path and dag_longest_path_length when a MultiDiGraph is supplied—preserving backwards compatibility while notifying developers about the function's inability to compute with weights.