### PR TITLE
Fix steiner tree test

### DIFF
--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -136,7 +136,7 @@ class TestSteinerTree:
                 ],
                 [
                     (0, 5, {"weight": 6}),
-                    (4, 2, {"weight": 2}),
+                    (4, 2, {"weight": 4}),
                     (4, 5, {"weight": 1}),
                     (3, 5, {"weight": 5}),
                 ],


### PR DESCRIPTION
The weight in the true test result should match the weight in the graph defined on line 24.