### PR TITLE
Fixed test for average shortest path in the case of directed graphs

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -61,6 +61,10 @@ Improvements
   ``is_path`` used to raise a `KeyError` when the ``path`` argument contained
   a node that was not in the Graph. The behavior has been updated so that
   ``is_path`` returns `False` in this case rather than raising the exception.
+- [`#6003 <https://github.com/networkx/networkx/pull/6003>`_]
+  ``avg_shortest_path_length`` now raises an exception if the provided
+  graph is directed but not strongly connected. The previous test (weak
+  connecting) was wrong; in that case, the returned value was nonsensical.
 
 API Changes
 -----------

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -354,7 +354,7 @@ def average_shortest_path_length(G, weight=None, method=None):
         If `G` is the null graph (that is, the graph on zero nodes).
 
     NetworkXError
-        If `G` is not connected (or not weakly connected, in the case
+        If `G` is not connected (or not strongly connected, in the case
         of a directed graph).
 
     ValueError
@@ -397,9 +397,10 @@ def average_shortest_path_length(G, weight=None, method=None):
     # For the special case of the trivial graph, return zero immediately.
     if n == 1:
         return 0
-    # Shortest path length is undefined if the graph is disconnected.
-    if G.is_directed() and not nx.is_weakly_connected(G):
-        raise nx.NetworkXError("Graph is not weakly connected.")
+    # Shortest path length is undefined if the graph is not strongly connected.
+    if G.is_directed() and not nx.is_strongly_connected(G):
+        raise nx.NetworkXError("Graph is not strongly connected.")
+    # Shortest path length is undefined if the graph is not connected.
     if not G.is_directed() and not nx.is_connected(G):
         raise nx.NetworkXError("Graph is not connected.")
 

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -326,6 +326,8 @@ def average_shortest_path_length(G, weight=None, method=None):
     `d(s, t)` is the shortest path from `s` to `t`,
     and `n` is the number of nodes in `G`.
 
+    .. versionchanged:: 3.0
+
     Parameters
     ----------
     G : NetworkX graph

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -320,7 +320,7 @@ def average_shortest_path_length(G, weight=None, method=None):
 
     .. math::
 
-       a =\sum_{s,t \in V, s\neq t} \frac{d(s, t)}{n(n-1)}
+       a =\sum_{\substack{s,t \in V \\ s\neq t}} \frac{d(s, t)}{n(n-1)}
 
     where `V` is the set of nodes in `G`,
     `d(s, t)` is the shortest path from `s` to `t`,

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -327,6 +327,8 @@ def average_shortest_path_length(G, weight=None, method=None):
     and `n` is the number of nodes in `G`.
 
     .. versionchanged:: 3.0
+       An exception is raised for directed graphs that are not strongly
+       connected.
 
     Parameters
     ----------

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -320,7 +320,7 @@ def average_shortest_path_length(G, weight=None, method=None):
 
     .. math::
 
-       a =\sum_{s,t \in V} \frac{d(s, t)}{n(n-1)}
+       a =\sum_{s,t \in V, s\neq t} \frac{d(s, t)}{n(n-1)}
 
     where `V` is the set of nodes in `G`,
     `d(s, t)` is the shortest path from `s` to `t`,

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -325,10 +325,9 @@ class TestAverageShortestPathLength:
         assert ans == pytest.approx(4, abs=1e-7)
 
     def test_directed_not_strongly_connected(self):
-        g = nx.DiGraph()
-        g.add_nodes_from(range(2))
-        g.add_edge(0, 1)
-        pytest.raises(nx.NetworkXError, nx.average_shortest_path_length, g)
+        G = nx.DiGraph([(0, 1)])
+        with pytest.raises(nx.NetworkXError, match="Graph is not strongly connected"):
+            nx.average_shortest_path_length(G)
 
     def test_undirected_not_connected(self):
         g = nx.Graph()

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -324,12 +324,16 @@ class TestAverageShortestPathLength:
         )
         assert ans == pytest.approx(4, abs=1e-7)
 
-    def test_disconnected(self):
+    def test_undirected_not_connected(self):
         g = nx.Graph()
         g.add_nodes_from(range(3))
         g.add_edge(0, 1)
         pytest.raises(nx.NetworkXError, nx.average_shortest_path_length, g)
-        g = g.to_directed()
+
+    def test_directed_not_strongly_connected(self):
+        g = nx.DiGraph()
+        g.add_nodes_from(range(2))
+        g.add_edge(0, 1)
         pytest.raises(nx.NetworkXError, nx.average_shortest_path_length, g)
 
     def test_trivial_graph(self):

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -324,15 +324,15 @@ class TestAverageShortestPathLength:
         )
         assert ans == pytest.approx(4, abs=1e-7)
 
-    def test_undirected_not_connected(self):
-        g = nx.Graph()
-        g.add_nodes_from(range(3))
-        g.add_edge(0, 1)
-        pytest.raises(nx.NetworkXError, nx.average_shortest_path_length, g)
-
     def test_directed_not_strongly_connected(self):
         g = nx.DiGraph()
         g.add_nodes_from(range(2))
+        g.add_edge(0, 1)
+        pytest.raises(nx.NetworkXError, nx.average_shortest_path_length, g)
+
+    def test_undirected_not_connected(self):
+        g = nx.Graph()
+        g.add_nodes_from(range(3))
         g.add_edge(0, 1)
         pytest.raises(nx.NetworkXError, nx.average_shortest_path_length, g)
 


### PR DESCRIPTION
The code for `average_shortest_path_length()` contains a mathematical error: it computes a value for directed graphs that are just weakly connected instead of strongly connected. This approach has no mathematical sense: for example, the current code in the case of the directed graph 0 → 1 returns 1/2, because it adds a single distance $d(0,1)=1$ but then divides by the number of possible distances (2).

In other words, the current code adds $k$ lengths (where $k$ is the number of reachable pairs) and then divides by $n(n-1)$. It is not an average in any possible mathematical sense when $k\neq n(n-1)$.

This fix simply change the wrong test for weak connectivity to a test for strong connectivity, updating the documentation.

A sensible notion of diameter for directed graphs that are not strongly connected (or undirected graphs that are not connected) is the harmonic diameter (#5251).