### PR TITLE
Fix warnings from running tests in randomized order

### DIFF
--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -485,18 +485,19 @@ def test_multigraph_edgelist_tuples():
 
 def test_alpha_iter():
     pos = nx.random_layout(barbell)
+    fig = plt.figure()
     # with fewer alpha elements than nodes
-    plt.subplot(131)
+    fig.add_subplot(131)  # Each test in a new axis object
     nx.draw_networkx_nodes(barbell, pos, alpha=[0.1, 0.2])
     # with equal alpha elements and nodes
     num_nodes = len(barbell.nodes)
     alpha = [x / num_nodes for x in range(num_nodes)]
     colors = range(num_nodes)
-    plt.subplot(132)
+    fig.add_subplot(132)
     nx.draw_networkx_nodes(barbell, pos, node_color=colors, alpha=alpha)
     # with more alpha elements than nodes
     alpha.append(1)
-    plt.subplot(133)
+    fig.add_subplot(133)
     nx.draw_networkx_nodes(barbell, pos, alpha=alpha)
 
 

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -30,7 +30,7 @@ def test_margulis_gabber_galil_graph():
 
     # Eigenvalues are already sorted using the scipy eigvalsh,
     # but the implementation in numpy does not guarantee order.
-    w = sorted(sp.linalg.eigvalsh(adjacency_matrix(g).A))
+    w = sorted(sp.linalg.eigvalsh(adjacency_matrix(g).toarray()))
     assert w[-2] < 5 * np.sqrt(2)
 
 


### PR DESCRIPTION
A few minor fixups to the test suite. I noticed these from a few warnings that were popping up when running the test suite in random order.

- 68144a9 cleans up a `.A` call on a sparse array that was missed during the general sparse cleanup (though the fact that this warning is only raised when the test suite is run in random order means we probably need to take a closer look and ensure the tests in this file are all being run!)
- 7978bad fixes crosstalk between pylab tests from the fact that a axis object created when using the `pyplot` interface for matplotlib persists across tests, since the default axis object for most of the nx drawing commands is `plt.gca`. Many of these had been fixed previously.