### PR TITLE
Add pytest-mpl to requirements/test

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest>=7.1
 pytest-cov>=3.0
+pytest-mpl>=0.16
 codecov>=2.1


### PR DESCRIPTION
I just tried a clean install using our documentation and it didn't install pytest-mpl