### PR TITLE
Add option to hide or show tick labels.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -243,6 +243,9 @@ def draw_networkx(G, pos=None, arrows=None, with_labels=True, **kwds):
     label : string, optional
         Label for graph legend
 
+    hide_ticks : bool
+        Hide ticks of axes.
+
     kwds : optional keywords
         See networkx.draw_networkx_nodes(), networkx.draw_networkx_edges(), and
         networkx.draw_networkx_labels() for a description of optional keywords.
@@ -326,6 +329,7 @@ def draw_networkx_nodes(
     edgecolors=None,
     label=None,
     margins=None,
+    hide_ticks=True,
 ):
     """Draw the nodes of the graph G.
 
@@ -390,6 +394,9 @@ def draw_networkx_nodes(
         be in the range ``[0, 1]``. See :meth:`matplotlib.axes.Axes.margins`
         for details. The default is `None`, which uses the Matplotlib default.
 
+    hide_ticks : bool
+        Hide ticks of axes
+
     Returns
     -------
     matplotlib.collections.PathCollection
@@ -450,14 +457,15 @@ def draw_networkx_nodes(
         edgecolors=edgecolors,
         label=label,
     )
-    ax.tick_params(
-        axis="both",
-        which="both",
-        bottom=False,
-        left=False,
-        labelbottom=False,
-        labelleft=False,
-    )
+    if hide_ticks:
+        ax.tick_params(
+            axis="both",
+            which="both",
+            bottom=False,
+            left=False,
+            labelbottom=False,
+            labelleft=False,
+        )
 
     if margins is not None:
         if isinstance(margins, Iterable):
@@ -682,6 +690,7 @@ def draw_networkx_edges(
     connectionstyle="arc3",
     min_source_margin=0,
     min_target_margin=0,
+    hide_ticks=True,
 ):
     r"""Draw the edges of the graph G.
 
@@ -780,6 +789,9 @@ def draw_networkx_edges(
 
     min_target_margin : int (default=0)
         The minimum margin (gap) at the end of the edge at the target.
+
+    hide_ticks : bool
+        Hide ticks of axes
 
     Returns
     -------
@@ -1013,14 +1025,16 @@ def draw_networkx_edges(
     corners = (minx - padx, miny - pady), (maxx + padx, maxy + pady)
     ax.update_datalim(corners)
     ax.autoscale_view()
-    ax.tick_params(
-        axis="both",
-        which="both",
-        bottom=False,
-        left=False,
-        labelbottom=False,
-        labelleft=False,
-    )
+
+    if hide_ticks:
+        ax.tick_params(
+            axis="both",
+            which="both",
+            bottom=False,
+            left=False,
+            labelbottom=False,
+            labelleft=False,
+        )
 
     return edge_viz_obj
 
@@ -1039,6 +1053,7 @@ def draw_networkx_labels(
     verticalalignment="center",
     ax=None,
     clip_on=True,
+    hide_ticks=True,
 ):
     """Draw node labels on the graph G.
 
@@ -1086,6 +1101,9 @@ def draw_networkx_labels(
 
     clip_on : bool (default=True)
         Turn on clipping of node labels at axis boundaries
+
+    hide_ticks : bool
+        Hide ticks of axes
 
     Returns
     -------
@@ -1138,14 +1156,15 @@ def draw_networkx_labels(
         )
         text_items[n] = t
 
-    ax.tick_params(
-        axis="both",
-        which="both",
-        bottom=False,
-        left=False,
-        labelbottom=False,
-        labelleft=False,
-    )
+    if hide_ticks:
+        ax.tick_params(
+            axis="both",
+            which="both",
+            bottom=False,
+            left=False,
+            labelbottom=False,
+            labelleft=False,
+        )
 
     return text_items
 
@@ -1169,6 +1188,7 @@ def draw_networkx_edge_labels(
     node_size=300,
     nodelist=None,
     connectionstyle="arc3",
+    hide_ticks=True,
 ):
     """Draw edge labels.
 
@@ -1235,6 +1255,9 @@ def draw_networkx_edge_labels(
         See `matplotlib.patches.ConnectionStyle` and
         `matplotlib.patches.FancyArrowPatch` for more info.
         If Iterable, index indicates i'th edge key of MultiGraph
+
+    hide_ticks : bool
+        Hide ticks of axes
 
     Returns
     -------
@@ -1456,14 +1479,15 @@ def draw_networkx_edge_labels(
                 ax=ax,
             )
 
-    ax.tick_params(
-        axis="both",
-        which="both",
-        bottom=False,
-        left=False,
-        labelbottom=False,
-        labelleft=False,
-    )
+    if hide_ticks:
+        ax.tick_params(
+            axis="both",
+            which="both",
+            bottom=False,
+            left=False,
+            labelbottom=False,
+            labelleft=False,
+        )
 
     return text_items
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -243,8 +243,10 @@ def draw_networkx(G, pos=None, arrows=None, with_labels=True, **kwds):
     label : string, optional
         Label for graph legend
 
-    hide_ticks : bool
-        Hide ticks of axes.
+    hide_ticks : bool, optional
+        Hide ticks of axes. When `True` (the default), ticks and ticklabels
+        are removed from the axes. To set ticks and tick labels to the pyplot default,
+        use ``hide_ticks=False``.
 
     kwds : optional keywords
         See networkx.draw_networkx_nodes(), networkx.draw_networkx_edges(), and
@@ -394,8 +396,10 @@ def draw_networkx_nodes(
         be in the range ``[0, 1]``. See :meth:`matplotlib.axes.Axes.margins`
         for details. The default is `None`, which uses the Matplotlib default.
 
-    hide_ticks : bool
-        Hide ticks of axes
+    hide_ticks : bool, optional
+        Hide ticks of axes. When `True` (the default), ticks and ticklabels
+        are removed from the axes. To set ticks and tick labels to the pyplot default,
+        use ``hide_ticks=False``.
 
     Returns
     -------
@@ -790,8 +794,10 @@ def draw_networkx_edges(
     min_target_margin : int (default=0)
         The minimum margin (gap) at the end of the edge at the target.
 
-    hide_ticks : bool
-        Hide ticks of axes
+    hide_ticks : bool, optional
+        Hide ticks of axes. When `True` (the default), ticks and ticklabels
+        are removed from the axes. To set ticks and tick labels to the pyplot default,
+        use ``hide_ticks=False``.
 
     Returns
     -------
@@ -1102,8 +1108,10 @@ def draw_networkx_labels(
     clip_on : bool (default=True)
         Turn on clipping of node labels at axis boundaries
 
-    hide_ticks : bool
-        Hide ticks of axes
+    hide_ticks : bool, optional
+        Hide ticks of axes. When `True` (the default), ticks and ticklabels
+        are removed from the axes. To set ticks and tick labels to the pyplot default,
+        use ``hide_ticks=False``.
 
     Returns
     -------
@@ -1256,8 +1264,10 @@ def draw_networkx_edge_labels(
         `matplotlib.patches.FancyArrowPatch` for more info.
         If Iterable, index indicates i'th edge key of MultiGraph
 
-    hide_ticks : bool
-        Hide ticks of axes
+    hide_ticks : bool, optional
+        Hide ticks of axes. When `True` (the default), ticks and ticklabels
+        are removed from the axes. To set ticks and tick labels to the pyplot default,
+        use ``hide_ticks=False``.
 
     Returns
     -------

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -845,3 +845,25 @@ def test_no_warning_on_default_draw_arrowstyle(draw_fn):
     assert len(w) == 0
 
     plt.delaxes(ax)
+
+
+@pytest.mark.parametrize("hide_ticks", [False, True])
+@pytest.mark.parametrize(
+    "method",
+    [
+        nx.draw_networkx,
+        nx.draw_networkx_edge_labels,
+        nx.draw_networkx_edges,
+        nx.draw_networkx_labels,
+        nx.draw_networkx_nodes,
+    ],
+)
+def test_hide_ticks(method, hide_ticks):
+    G = nx.path_graph(3)
+    pos = {n: (n, n) for n in G.nodes}
+    _, ax = plt.subplots()
+    method(G, pos=pos, ax=ax, hide_ticks=hide_ticks)
+    for axis in [ax.xaxis, ax.yaxis]:
+        assert bool(axis.get_ticklabels()) != hide_ticks
+
+    plt.delaxes(ax)


### PR DESCRIPTION
This PR adds a flag `hide_ticks` to drawing functions so tick labels can be shown. This can be useful for debugging or spatial networks, for example. The default is `hide_ticks=True` to ensure functionality does not change.

*Edit*: I'm not sure why the Circle CI test fails.
*Edit*: It seemed that Circle CI was failing because I hadn't updated my default branch from `master` to `main` yet.