### PR TITLE
Minor updates to expanders generator tests

### DIFF
--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -64,6 +64,9 @@ def test_paley_graph(p):
             assert (v, u) in G.edges
 
 
-def test_margulis_gabber_galil_graph_badinput():
-    pytest.raises(nx.NetworkXError, nx.margulis_gabber_galil_graph, 3, nx.DiGraph())
-    pytest.raises(nx.NetworkXError, nx.margulis_gabber_galil_graph, 3, nx.Graph())
+@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+def test_margulis_gabber_galil_graph_badinput(graph_type):
+    with pytest.raises(
+        nx.NetworkXError, match="`create_using` must be an undirected multigraph"
+    ):
+        nx.margulis_gabber_galil_graph(3, create_using=graph_type)

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -5,18 +5,12 @@
 import pytest
 
 import networkx as nx
-from networkx import adjacency_matrix, number_of_nodes
-from networkx.generators.expanders import (
-    chordal_cycle_graph,
-    margulis_gabber_galil_graph,
-    paley_graph,
-)
 
 
 @pytest.mark.parametrize("n", (2, 3, 5, 6, 10))
 def test_margulis_gabber_galil_graph_properties(n):
-    g = margulis_gabber_galil_graph(n)
-    assert number_of_nodes(g) == n * n
+    g = nx.margulis_gabber_galil_graph(n)
+    assert g.number_of_nodes() == n * n
     for node in g:
         assert g.degree(node) == 8
         assert len(node) == 2
@@ -31,22 +25,22 @@ def test_margulis_gabber_galil_graph_eigvals(n):
     sp = pytest.importorskip("scipy")
     import scipy.linalg
 
-    g = margulis_gabber_galil_graph(n)
+    g = nx.margulis_gabber_galil_graph(n)
     # Eigenvalues are already sorted using the scipy eigvalsh,
     # but the implementation in numpy does not guarantee order.
-    w = sorted(sp.linalg.eigvalsh(adjacency_matrix(g).toarray()))
+    w = sorted(sp.linalg.eigvalsh(nx.adjacency_matrix(g).toarray()))
     assert w[-2] < 5 * np.sqrt(2)
 
 
 @pytest.mark.parametrize("p", (3, 5, 7, 11))  # Primes
 def test_chordal_cycle_graph(p):
     """Test for the :func:`networkx.chordal_cycle_graph` function."""
-    G = chordal_cycle_graph(p)
+    G = nx.chordal_cycle_graph(p)
     assert len(G) == p
     # TODO The second largest eigenvalue should be smaller than a constant,
     # independent of the number of nodes in the graph:
     #
-    #     eigs = sorted(sp.linalg.eigvalsh(adjacency_matrix(G).A))
+    #     eigs = sorted(sp.linalg.eigvalsh(nx.adjacency_matrix(G).toarray()))
     #     assert_less(eigs[-2], ...)
     #
 
@@ -54,7 +48,7 @@ def test_chordal_cycle_graph(p):
 @pytest.mark.parametrize("p", (3, 5, 7, 11, 13))  # Primes
 def test_paley_graph(p):
     """Test for the :func:`networkx.paley_graph` function."""
-    G = paley_graph(p)
+    G = nx.paley_graph(p)
     # G has p nodes
     assert len(G) == p
     # G is (p-1)/2-regular
@@ -71,5 +65,5 @@ def test_paley_graph(p):
 
 
 def test_margulis_gabber_galil_graph_badinput():
-    pytest.raises(nx.NetworkXError, margulis_gabber_galil_graph, 3, nx.DiGraph())
-    pytest.raises(nx.NetworkXError, margulis_gabber_galil_graph, 3, nx.Graph())
+    pytest.raises(nx.NetworkXError, nx.margulis_gabber_galil_graph, 3, nx.DiGraph())
+    pytest.raises(nx.NetworkXError, nx.margulis_gabber_galil_graph, 3, nx.Graph())

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -13,21 +13,25 @@ from networkx.generators.expanders import (
 )
 
 
-def test_margulis_gabber_galil_graph():
-    for n in 2, 3, 5, 6, 10:
-        g = margulis_gabber_galil_graph(n)
-        assert number_of_nodes(g) == n * n
-        for node in g:
-            assert g.degree(node) == 8
-            assert len(node) == 2
-            for i in node:
-                assert int(i) == i
-                assert 0 <= i < n
+@pytest.mark.parametrize("n", (2, 3, 5, 6, 10))
+def test_margulis_gabber_galil_graph_properties(n):
+    g = margulis_gabber_galil_graph(n)
+    assert number_of_nodes(g) == n * n
+    for node in g:
+        assert g.degree(node) == 8
+        assert len(node) == 2
+        for i in node:
+            assert int(i) == i
+            assert 0 <= i < n
 
+
+@pytest.mark.parametrize("n", (2, 3, 5, 6, 10))
+def test_margulis_gabber_galil_graph_eigvals(n):
     np = pytest.importorskip("numpy")
     sp = pytest.importorskip("scipy")
     import scipy.linalg
 
+    g = margulis_gabber_galil_graph(n)
     # Eigenvalues are already sorted using the scipy eigvalsh,
     # but the implementation in numpy does not guarantee order.
     w = sorted(sp.linalg.eigvalsh(adjacency_matrix(g).toarray()))

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -38,38 +38,36 @@ def test_margulis_gabber_galil_graph_eigvals(n):
     assert w[-2] < 5 * np.sqrt(2)
 
 
-def test_chordal_cycle_graph():
+@pytest.mark.parametrize("p", (3, 5, 7, 11))  # Primes
+def test_chordal_cycle_graph(p):
     """Test for the :func:`networkx.chordal_cycle_graph` function."""
-    primes = [3, 5, 7, 11]
-    for p in primes:
-        G = chordal_cycle_graph(p)
-        assert len(G) == p
-        # TODO The second largest eigenvalue should be smaller than a constant,
-        # independent of the number of nodes in the graph:
-        #
-        #     eigs = sorted(sp.linalg.eigvalsh(adjacency_matrix(G).A))
-        #     assert_less(eigs[-2], ...)
-        #
+    G = chordal_cycle_graph(p)
+    assert len(G) == p
+    # TODO The second largest eigenvalue should be smaller than a constant,
+    # independent of the number of nodes in the graph:
+    #
+    #     eigs = sorted(sp.linalg.eigvalsh(adjacency_matrix(G).A))
+    #     assert_less(eigs[-2], ...)
+    #
 
 
-def test_paley_graph():
+@pytest.mark.parametrize("p", (3, 5, 7, 11, 13))  # Primes
+def test_paley_graph(p):
     """Test for the :func:`networkx.paley_graph` function."""
-    primes = [3, 5, 7, 11, 13]
-    for p in primes:
-        G = paley_graph(p)
-        # G has p nodes
-        assert len(G) == p
-        # G is (p-1)/2-regular
-        in_degrees = {G.in_degree(node) for node in G.nodes}
-        out_degrees = {G.out_degree(node) for node in G.nodes}
-        assert len(in_degrees) == 1 and in_degrees.pop() == (p - 1) // 2
-        assert len(out_degrees) == 1 and out_degrees.pop() == (p - 1) // 2
+    G = paley_graph(p)
+    # G has p nodes
+    assert len(G) == p
+    # G is (p-1)/2-regular
+    in_degrees = {G.in_degree(node) for node in G.nodes}
+    out_degrees = {G.out_degree(node) for node in G.nodes}
+    assert len(in_degrees) == 1 and in_degrees.pop() == (p - 1) // 2
+    assert len(out_degrees) == 1 and out_degrees.pop() == (p - 1) // 2
 
-        # If p = 1 mod 4, -1 is a square mod 4 and therefore the
-        # edge in the Paley graph are symmetric.
-        if p % 4 == 1:
-            for (u, v) in G.edges:
-                assert (v, u) in G.edges
+    # If p = 1 mod 4, -1 is a square mod 4 and therefore the
+    # edge in the Paley graph are symmetric.
+    if p % 4 == 1:
+        for (u, v) in G.edges:
+            assert (v, u) in G.edges
 
 
 def test_margulis_gabber_galil_graph_badinput():


### PR DESCRIPTION
The main update is splitting the margulis_galil_gabber test into two: one that doesn't depend on numpy/scipy and one that does. In principle this is a minor improvement as previously the entire test was skipped if the dependencies were not installed.

There are some other minor tweaks, like using functions from the `nx` namespace (so this now doubles as a test of the public API); and parametrizing the tests.

IMO this (along with some other testing, see [here](https://github.com/networkx/networkx/issues/6026#issuecomment-1273627062)) is sufficient to close #6026 