### PR TITLE
Remove serialisation artifacts on adjacency_graph

### DIFF
--- a/networkx/readwrite/json_graph/adjacency.py
+++ b/networkx/readwrite/json_graph/adjacency.py
@@ -149,9 +149,9 @@ def adjacency_graph(data, directed=False, multigraph=True, attrs=_attrs):
             target = target_data.pop(id_)
             if not multigraph:
                 graph.add_edge(source, target)
-                graph[source][target].update(tdata)
+                graph[source][target].update(target_data)
             else:
                 ky = target_data.pop(key, None)
                 graph.add_edge(source, target, key=ky)
-                graph[source][target][ky].update(tdata)
+                graph[source][target][ky].update(target_data)
     return graph

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -42,7 +42,6 @@ class TestAdjacency:
         assert H.is_directed()
         assert graphs_equal(G, H)
 
-
     def test_multidigraph(self):
         G = nx.MultiDiGraph()
         nx.add_path(G, [1, 2, 3])

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -1,16 +1,18 @@
+import copy
 import json
 
 import pytest
 
 import networkx as nx
 from networkx.readwrite.json_graph import adjacency_data, adjacency_graph
+from networkx.utils import graphs_equal
 
 
 class TestAdjacency:
     def test_graph(self):
         G = nx.path_graph(4)
         H = adjacency_graph(adjacency_data(G))
-        nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
 
     def test_graph_attributes(self):
         G = nx.path_graph(4)
@@ -20,12 +22,14 @@ class TestAdjacency:
         G.graph[1] = "one"
 
         H = adjacency_graph(adjacency_data(G))
+        assert graphs_equal(G, H)
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
 
         d = json.dumps(adjacency_data(G))
         H = adjacency_graph(json.loads(d))
+        assert graphs_equal(G, H)
         assert H.graph["foo"] == "bar"
         assert H.graph[1] == "one"
         assert H.nodes[1]["color"] == "red"
@@ -36,7 +40,7 @@ class TestAdjacency:
         nx.add_path(G, [1, 2, 3])
         H = adjacency_graph(adjacency_data(G))
         assert H.is_directed()
-        nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
 
     def test_multidigraph(self):
         G = nx.MultiDiGraph()
@@ -44,14 +48,28 @@ class TestAdjacency:
         H = adjacency_graph(adjacency_data(G))
         assert H.is_directed()
         assert H.is_multigraph()
+        assert graphs_equal(G, H)
 
     def test_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
         H = adjacency_graph(adjacency_data(G))
-        nx.is_isomorphic(G, H)
+        assert graphs_equal(G, H)
         assert H[1][2]["second"]["color"] == "blue"
+
+    def test_input_data_is_not_modified_when_building_graph(self):
+        G = nx.path_graph(4)
+        input_data = adjacency_data(G)
+        orig_data = copy.deepcopy(input_data)
+        # Ensure input is unmodified by deserialisation
+        assert graphs_equal(G, adjacency_graph(input_data))
+        assert input_data == orig_data
+
+    def test_adjacency_form_json_serialisable(self):
+        G = nx.path_graph(4)
+        H = adjacency_graph(json.loads(json.dumps(adjacency_data(G))))
+        assert graphs_equal(G, H)
 
     def test_exception(self):
         with pytest.raises(nx.NetworkXError):


### PR DESCRIPTION
- Deserialised Serialised Graph should be equal to Graph
- Deserialisation should not modify serialised object

Fixes #5980