### PR TITLE
Solved issue #6035: Improve test coverage expanders stochastic graph generators

### DIFF
--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -42,8 +42,5 @@ def stochastic_graph(G, copy=True, weight="weight"):
     # inside the loop may be costly in computation time.
     degree = dict(G.out_degree(weight=weight))
     for u, v, d in G.edges(data=True):
-        if degree[u] == 0:
-            d[weight] = 0
-        else:
-            d[weight] = d.get(weight, 1) / degree[u]
+        d[weight] = d.get(weight, 1) / degree[u]
     return G

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -42,5 +42,8 @@ def stochastic_graph(G, copy=True, weight="weight"):
     # inside the loop may be costly in computation time.
     degree = dict(G.out_degree(weight=weight))
     for u, v, d in G.edges(data=True):
-        d[weight] = d.get(weight, 1) / degree[u]
+        if degree[u] == 0:
+            d[weight] = 0
+        else:
+            d[weight] = d.get(weight, 1) / degree[u]
     return G

--- a/networkx/generators/tests/test_stochastic.py
+++ b/networkx/generators/tests/test_stochastic.py
@@ -58,3 +58,11 @@ class TestStochasticGraph:
     def test_multigraph_disallowed(self):
         with pytest.raises(nx.NetworkXNotImplemented):
             nx.stochastic_graph(nx.MultiGraph())
+
+    def test_zero_out_degree(self):
+        D = nx.DiGraph([(1, 2, {"weight": 1}), (1, 3, {"weight": -1})])
+        S = nx.stochastic_graph(D)
+        assert sorted(S.edges(data=True)) == [
+            (1, 2, {"weight": 0}),
+            (1, 3, {"weight": 0}),
+        ]


### PR DESCRIPTION
Closes #6035
Erased an if condition that was impossible to cover by tests because the condition never occur. The condition tested if the degree of a node that has an edge is 0.