### PR TITLE
issue #6081: allow cutoff functionality for flow functions

### DIFF
--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -446,7 +446,7 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    if kwargs.get("cutoff") is not None and flow_func in flow_funcs_without_cutoff:
+    if kwargs.get("cutoff") is not None and flow_func is preflow_push:
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -13,9 +13,7 @@ from .utils import build_flow_dict
 # Define the default flow function for computing maximum flow.
 default_flow_func = preflow_push
 # Functions that don't support cutoff for minimum cut computations.
-flow_funcs_without_cutoff = [
-    preflow_push,
-]
+flow_funcs_without_cutoff = [preflow_push]
 
 __all__ = ["maximum_flow", "maximum_flow_value", "minimum_cut", "minimum_cut_value"]
 

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -14,7 +14,6 @@ from .utils import build_flow_dict
 default_flow_func = preflow_push
 # Functions that don't support cutoff for minimum cut computations.
 flow_funcs_without_cutoff = [
-    boykov_kolmogorov,
     dinitz,
     edmonds_karp,
     preflow_push,

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -12,8 +12,6 @@ from .utils import build_flow_dict
 
 # Define the default flow function for computing maximum flow.
 default_flow_func = preflow_push
-# Functions that don't support cutoff for minimum cut computations.
-flow_funcs_without_cutoff = [preflow_push]
 
 __all__ = ["maximum_flow", "maximum_flow_value", "minimum_cut", "minimum_cut_value"]
 
@@ -597,7 +595,7 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    if kwargs.get("cutoff") is not None and flow_func in flow_funcs_without_cutoff:
+    if kwargs.get("cutoff") is not None and flow_func is preflow_push:
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -14,8 +14,6 @@ from .utils import build_flow_dict
 default_flow_func = preflow_push
 # Functions that don't support cutoff for minimum cut computations.
 flow_funcs_without_cutoff = [
-    dinitz,
-    edmonds_karp,
     preflow_push,
 ]
 

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -13,12 +13,11 @@ from .utils import build_flow_dict
 # Define the default flow function for computing maximum flow.
 default_flow_func = preflow_push
 # Functions that don't support cutoff for minimum cut computations.
-flow_funcs = [
+flow_funcs_without_cutoff = [
     boykov_kolmogorov,
     dinitz,
     edmonds_karp,
     preflow_push,
-    shortest_augmenting_path,
 ]
 
 __all__ = ["maximum_flow", "maximum_flow_value", "minimum_cut", "minimum_cut_value"]
@@ -452,7 +451,7 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    if kwargs.get("cutoff") is not None and flow_func in flow_funcs:
+    if kwargs.get("cutoff") is not None and flow_func in flow_funcs_without_cutoff:
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
@@ -603,7 +602,7 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
-    if kwargs.get("cutoff") is not None and flow_func in flow_funcs:
+    if kwargs.get("cutoff") is not None and flow_func in flow_funcs_without_cutoff:
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -14,7 +14,6 @@ from networkx.algorithms.flow import (
 )
 
 flow_funcs_without_cutoff = {
-    boykov_kolmogorov,
     dinitz,
     edmonds_karp,
     preflow_push,

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -20,6 +20,7 @@ flow_funcs = {
     preflow_push,
     shortest_augmenting_path,
 }
+
 max_min_funcs = {nx.maximum_flow, nx.minimum_cut}
 flow_value_funcs = {nx.maximum_flow_value, nx.minimum_cut_value}
 interface_funcs = max_min_funcs & flow_value_funcs
@@ -425,7 +426,7 @@ class TestMaxFlowMinCutInterface:
                     result = result[0]
                 assert fv == result, errmsg
 
-    def test_minimum_cut_no_cutoff(self):
+    """ def test_minimum_cut_no_cutoff(self):
         G = self.G
         for flow_func in flow_funcs:
             pytest.raises(
@@ -445,7 +446,7 @@ class TestMaxFlowMinCutInterface:
                 "y",
                 flow_func=flow_func,
                 cutoff=1.0,
-            )
+            ) """
 
     def test_kwargs(self):
         G = self.H

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -14,8 +14,6 @@ from networkx.algorithms.flow import (
 )
 
 flow_funcs_without_cutoff = {
-    dinitz,
-    edmonds_karp,
     preflow_push,
 }
 

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -13,6 +13,13 @@ from networkx.algorithms.flow import (
     shortest_augmenting_path,
 )
 
+flow_funcs_without_cutoff = {
+    boykov_kolmogorov,
+    dinitz,
+    edmonds_karp,
+    preflow_push,
+}
+
 flow_funcs = {
     boykov_kolmogorov,
     dinitz,
@@ -426,9 +433,9 @@ class TestMaxFlowMinCutInterface:
                     result = result[0]
                 assert fv == result, errmsg
 
-    """ def test_minimum_cut_no_cutoff(self):
+    def test_minimum_cut_no_cutoff(self):
         G = self.G
-        for flow_func in flow_funcs:
+        for flow_func in flow_funcs_without_cutoff:
             pytest.raises(
                 nx.NetworkXError,
                 nx.minimum_cut,
@@ -446,7 +453,7 @@ class TestMaxFlowMinCutInterface:
                 "y",
                 flow_func=flow_func,
                 cutoff=1.0,
-            ) """
+            )
 
     def test_kwargs(self):
         G = self.H

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -12,10 +12,7 @@ from networkx.algorithms.flow import (
     preflow_push,
     shortest_augmenting_path,
 )
-
-flow_funcs_without_cutoff = {
-    preflow_push,
-}
+from networkx.algorithms.flow.maxflow import flow_funcs_without_cutoff
 
 flow_funcs = {
     boykov_kolmogorov,

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -12,7 +12,6 @@ from networkx.algorithms.flow import (
     preflow_push,
     shortest_augmenting_path,
 )
-from networkx.algorithms.flow.maxflow import flow_funcs_without_cutoff
 
 flow_funcs = {
     boykov_kolmogorov,
@@ -429,25 +428,24 @@ class TestMaxFlowMinCutInterface:
 
     def test_minimum_cut_no_cutoff(self):
         G = self.G
-        for flow_func in flow_funcs_without_cutoff:
-            pytest.raises(
-                nx.NetworkXError,
-                nx.minimum_cut,
-                G,
-                "x",
-                "y",
-                flow_func=flow_func,
-                cutoff=1.0,
-            )
-            pytest.raises(
-                nx.NetworkXError,
-                nx.minimum_cut_value,
-                G,
-                "x",
-                "y",
-                flow_func=flow_func,
-                cutoff=1.0,
-            )
+        pytest.raises(
+            nx.NetworkXError,
+            nx.minimum_cut,
+            G,
+            "x",
+            "y",
+            flow_func=preflow_push,
+            cutoff=1.0,
+        )
+        pytest.raises(
+            nx.NetworkXError,
+            nx.minimum_cut_value,
+            G,
+            "x",
+            "y",
+            flow_func=preflow_push,
+            cutoff=1.0,
+        )
 
     def test_kwargs(self):
         G = self.H


### PR DESCRIPTION
In maxflow.py, I changed ``` flow_funcs ``` to ``` flow_funcs_without_cutoff  ``` and also updated the flow functions that support *cutoff*. In text_maxflow.py, I added  ``` flow_funcs_without_cutoff  ```. 
This was discussed in https://github.com/networkx/networkx/issues/6081. 
Closes #6081