### PR TITLE
Update GML parsing/writing to allow empty lists/tuples as node attributes

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -363,6 +363,11 @@ def parse_gml_lines(lines, label, destringizer):
                         value = destringizer(value)
                     except ValueError:
                         pass
+                # Special handling for empty lists and tuples
+                if value == "()":
+                    value = tuple()
+                if value == "[]":
+                    value = list()
                 curr_token = next(tokens)
             elif category == Pattern.DICT_START:
                 curr_token, value = parse_dict(curr_token)
@@ -728,12 +733,9 @@ def generate_gml(G, stringizer=None):
                 for key, value in value.items():
                     yield from stringize(key, value, (), next_indent)
                 yield indent + "]"
-            elif (
-                isinstance(value, (list, tuple))
-                and key != "label"
-                and value
-                and not in_list
-            ):
+            elif isinstance(value, (list, tuple)) and key != "label" and not in_list:
+                if len(value) == 0:
+                    yield indent + key + " " + f'"{value!r}"'
                 if len(value) == 1:
                     yield indent + key + " " + f'"{LIST_START_VALUE}"'
                 for val in value:

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -710,14 +710,15 @@ class TestPropertyLists:
         assert graph.nodes(data=True)["n1"] == {"properties": ["element"]}
 
 
-def test_stringize_empty_list():
+@pytest.mark.parametrize("coll", (list(), tuple()))
+def test_stringize_empty_list_tuple(coll):
     G = nx.path_graph(2)
-    G.nodes[0]["test"] = []  # test serializing an empty list
+    G.nodes[0]["test"] = coll  # test serializing an empty collection
     f = io.BytesIO()
     nx.write_gml(G, f)  # Smoke test - should not raise
     f.seek(0)
     H = nx.read_gml(f)
-    assert H.nodes["0"]["test"] == []  # Check empty list round-trips properly
+    assert H.nodes["0"]["test"] == coll  # Check empty list round-trips properly
     # Check full round-tripping. Note that nodes are loaded as strings by
     # default, so there needs to be some remapping prior to comparison
     H = nx.relabel_nodes(H, {"0": 0, "1": 1})

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -715,3 +715,15 @@ def test_stringize_empty_list():
     G.nodes[0]["test"] = []  # test serializing an empty list
     f = io.BytesIO()
     nx.write_gml(G, f)  # Smoke test - should not raise
+    f.seek(0)
+    H = nx.read_gml(f)
+    assert H.nodes["0"]["test"] == []  # Check empty list round-trips properly
+    # Check full round-tripping. Note that nodes are loaded as strings by
+    # default, so there needs to be some remapping prior to comparison
+    H = nx.relabel_nodes(H, {"0": 0, "1": 1})
+    assert nx.utils.graphs_equal(G, H)
+    # Same as above, but use destringizer for node remapping. Should have no
+    # effect on node attr
+    f.seek(0)
+    H = nx.read_gml(f, destringizer=int)
+    assert nx.utils.graphs_equal(G, H)

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -712,3 +712,10 @@ class TestPropertyLists:
             f.seek(0)
             graph = nx.read_gml(f)
         assert graph.nodes(data=True)["n1"] == {"properties": ["element"]}
+
+
+def test_stringize_empty_list():
+    G = nx.path_graph(2)
+    G.nodes[0]["test"] = []  # test serializing an empty list
+    f = io.BytesIO()
+    nx.write_gml(G, f)  # Smoke test - should not raise

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -571,10 +571,6 @@ graph
         G = nx.Graph()
         G.graph["data"] = frozenset([1, 2, 3])
         assert_generate_error(G, stringizer=literal_stringizer)
-        G = nx.Graph()
-        G.graph["data"] = []
-        assert_generate_error(G)
-        assert_generate_error(G, stringizer=len)
 
     def test_label_kwarg(self):
         G = nx.parse_gml(self.simple_data, label="id")


### PR DESCRIPTION
Updates the "stringization" functionality in `gml.py` to allow storing empty lists or tuples as node attributes.

This was formerly disallowed, but AFAICT there's nothing in the GML standard (pdf only) that prohibits empty lists/tuples from being used. This would fix the issue raised in #4953 directly, without having to use the deprecated `literal_stringizer` function.