### PR TITLE
Warn on unused visualization kwargs that only apply to FancyArrowPatch edges

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -650,16 +650,48 @@ def draw_networkx_edges(
     # undirected graphs (for performance reasons) and use FancyArrowPatches
     # for directed graphs.
     # The `arrows` keyword can be used to override the default behavior
+    use_linecollection = not G.is_directed()
+    if arrows in (True, False):
+        use_linecollection = not arrows
+
+    # Some kwargs only apply to FancyArrowPatches. Warn users when they use
+    # non-default values for these kwargs when LineCollection is being used
+    # instead of silently ignoring the specified option
+    if use_linecollection and any(
+        [
+            arrowstyle is not None,
+            arrowsize != 10,
+            connectionstyle != "arc3",
+            min_source_margin != 0,
+            min_target_margin != 0,
+        ]
+    ):
+        import warnings
+
+        msg = (
+            "\n\nThe {0} keyword argument is not applicable when drawing edges\n"
+            "with LineCollection.\n\n"
+            "To make this warning go away, either specify `arrows=True` to\n"
+            "force FancyArrowPatches or use the default value for {0}.\n"
+            "Note that using FancyArrowPatches may be slow for large graphs.\n"
+        )
+        if arrowstyle is not None:
+            msg = msg.format("arrowstyle")
+        if arrowsize != 10:
+            msg = msg.format("arrowsize")
+        if connectionstyle != "arc3":
+            msg = msg.format("connectionstyle")
+        if min_source_margin != 0:
+            msg = msg.format("min_source_margin")
+        if min_target_margin != 0:
+            msg = msg.format("min_target_margin")
+        warnings.warn(msg, category=UserWarning, stacklevel=2)
 
     if arrowstyle == None:
         if G.is_directed():
             arrowstyle = "-|>"
         else:
             arrowstyle = "-"
-
-    use_linecollection = not G.is_directed()
-    if arrows in (True, False):
-        use_linecollection = not arrows
 
     if ax is None:
         ax = plt.gca()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -396,6 +396,7 @@ def test_labels_and_colors():
         G,
         pos,
         edgelist=[(4, 5), (5, 6), (6, 7), (7, 4)],
+        arrows=True,
         min_source_margin=0.5,
         min_target_margin=0.75,
         width=8,

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -752,3 +752,31 @@ def test_draw_networkx_edges_undirected_selfloop_colors():
     for fap, clr, slp in zip(ax.patches, edge_colors[-3:], sl_points):
         assert fap.get_path().contains_point(slp)
         assert mpl.colors.same_color(fap.get_edgecolor(), clr)
+    plt.delaxes(ax)
+
+
+@pytest.mark.parametrize(
+    "fap_only_kwarg",  # Non-default values for kwargs that only apply to FAPs
+    (
+        {"arrowstyle": "-"},
+        {"arrowsize": 20},
+        {"connectionstyle": "arc3,rad=0.2"},
+        {"min_source_margin": 10},
+        {"min_target_margin": 10},
+    ),
+)
+def test_user_warnings_for_unused_edge_drawing_kwargs(fap_only_kwarg):
+    """Users should get a warning when they specify a non-default value for
+    one of the kwargs that applies only to edges drawn with FancyArrowPatches,
+    but FancyArrowPatches aren't being used under the hood."""
+    G = nx.path_graph(3)
+    pos = {n: (n, n) for n in G}
+    fig, ax = plt.subplots()
+    # By default, an undirected graph will use LineCollection to represent
+    # the edges
+    kwarg_name = list(fap_only_kwarg.keys())[0]
+    with pytest.warns(
+        UserWarning, match=f"\n\nThe {kwarg_name} keyword argument is not applicable"
+    ):
+        nx.draw_networkx_edges(G, pos, ax=ax, **fap_only_kwarg)
+    plt.delaxes(ax)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -1,6 +1,7 @@
 """Unit tests for matplotlib drawing functions."""
 import itertools
 import os
+import warnings
 
 import pytest
 
@@ -780,4 +781,11 @@ def test_user_warnings_for_unused_edge_drawing_kwargs(fap_only_kwarg):
         UserWarning, match=f"\n\nThe {kwarg_name} keyword argument is not applicable"
     ):
         nx.draw_networkx_edges(G, pos, ax=ax, **fap_only_kwarg)
+    # FancyArrowPatches are always used when `arrows=True` is specified.
+    # Check that warnings are *not* raised in this case
+    with warnings.catch_warnings():
+        # Escalate warnings -> errors so tests fail if warnings are raised
+        warnings.simplefilter("error")
+        nx.draw_networkx_edges(G, pos, ax=ax, arrows=True, **fap_only_kwarg)
+
     plt.delaxes(ax)


### PR DESCRIPTION
Closes #5857 and #5694

`draw_networkx_edges` has a few keyword arguments that only apply when FancyArrowPatch (FAP) objects are used to represent the edges (as opposed to a LineCollection (LC)). The tricky part is that the logic for determining which object is used is not immediately clear to the user. By default, LCs are used when the input graph `G` is undirected, and FAPs are used when `G` is directed. The reason for this is that LC are *much* faster to draw than FAPs, so using LCs where possible greatly enhances the ability to visualize graphs with many edges. The default behavior can be overridden with the `arrows` kwarg: `arrows=True` will force `draw_networkx_edges` to use FAPs even if `G` is undirected. This may make the visualization much slower, especially if there are a lot of edges, but the tradeoff is that the user can then take advantage of FAP-specific features, like the ability to draw curved edges.

This PR introduces UserWarnings whenever a user calls `draw_networkx_edges` with a FAP-specific kwarg when LC is being used to draw the edges. The current behavior is to silently ignore the FAP-specific kwarg which leads to confusion - see e.g. #5857 and #5694. The warning message specifies how to fix the situation, either by using `arrows=True` to force FAPs (which may be slow) or by deleting the unused kwarg option if it is not needed.

The hope is that the warning is useful without being noisy - note that adding it in caught one instance in the NX test suite where kwargs were silently ignored. The other concern is that the warnings are *not* raised when they shouldn't be - I double checked the output of the gallery examples to ensure that there were no new, unexpected warnings from this change.