### PR TITLE
Replace .A call with .toarray for sparse array in example.

### DIFF
--- a/examples/drawing/plot_eigenvalues.py
+++ b/examples/drawing/plot_eigenvalues.py
@@ -14,7 +14,7 @@ m = 5000  # 5000 edges
 G = nx.gnm_random_graph(n, m, seed=5040)  # Seed for reproducibility
 
 L = nx.normalized_laplacian_matrix(G)
-e = numpy.linalg.eigvals(L.A)
+e = numpy.linalg.eigvals(L.toarray())
 print("Largest eigenvalue:", max(e))
 print("Smallest eigenvalue:", min(e))
 plt.hist(e, bins=100)  # histogram with 100 bins


### PR DESCRIPTION
Fixes up the `plot_eigenvalues` example to use best-practices when creating a dense array from a sparse array.