### PR TITLE
Fix doc inconsistencies related to cutoff in connectivity.py and disjoint_paths.py

### DIFF
--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -80,7 +80,7 @@ def local_node_connectivity(
         flow value reaches or exceeds the cutoff. This is only for the
         algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
         and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :meth:`maximum_flow` for details). Default value: None.
+        parameter (see :algorithms:`flow` for details). Default value: None.
 
     Returns
     -------
@@ -534,7 +534,7 @@ def local_edge_connectivity(
         flow value reaches or exceeds the cutoff. This is only for the
         algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
         and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :meth:`maximum_flow` for details). Default value: None.
+        parameter (see :algorithms:`flow` for details). Default value: None.
 
     Returns
     -------
@@ -684,7 +684,7 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
         flow value reaches or exceeds the cutoff. This is only for the
         algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
         and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :meth:`maximum_flow` for details). Default value: None.
+        parameter (see :algorithms:`flow` for details). Default value: None.
 
     Returns
     -------

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -78,9 +78,9 @@ def local_node_connectivity(
     cutoff : integer, float
         If specified, the maximum flow algorithm will terminate when the
         flow value reaches or exceeds the cutoff. This is only for the
-        algorithms that support the cutoff parameter: :meth:`edmonds_karp`
-        and :meth:`shortest_augmenting_path`. Other algorithms will ignore
-        this parameter. Default value: None.
+        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
+        and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
+        parameter (see :meth:`maximum_flow` for details). Default value: None.
 
     Returns
     -------
@@ -532,9 +532,9 @@ def local_edge_connectivity(
     cutoff : integer, float
         If specified, the maximum flow algorithm will terminate when the
         flow value reaches or exceeds the cutoff. This is only for the
-        algorithms that support the cutoff parameter: :meth:`edmonds_karp`
-        and :meth:`shortest_augmenting_path`. Other algorithms will ignore
-        this parameter. Default value: None.
+        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
+        and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
+        parameter (see :meth:`maximum_flow` for details). Default value: None.
 
     Returns
     -------
@@ -682,9 +682,9 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
     cutoff : integer, float
         If specified, the maximum flow algorithm will terminate when the
         flow value reaches or exceeds the cutoff. This is only for the
-        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`
-        and :meth:`shortest_augmenting_path`. Other algorithms will ignore
-        this parameter. Default value: None.
+        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
+        and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
+        parameter (see :meth:`maximum_flow` for details). Default value: None.
 
     Returns
     -------

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -75,7 +75,7 @@ def local_node_connectivity(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    integer, float, or None (default: None)
+    cutoff : integer, float, or None (default: None)
         If specified, the maximum flow algorithm will terminate when the
         flow value reaches or exceeds the cutoff. This only works for flows
         that support the cutoff parameter (most do) and is ignored otherwise.
@@ -527,7 +527,7 @@ def local_edge_connectivity(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    integer, float, or None (default: None)
+    cutoff : integer, float, or None (default: None)
         If specified, the maximum flow algorithm will terminate when the
         flow value reaches or exceeds the cutoff. This only works for flows
         that support the cutoff parameter (most do) and is ignored otherwise.
@@ -675,7 +675,7 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
         choice of the default function may change from version
         to version and should not be relied on. Default value: None.
 
-    integer, float, or None (default: None)
+    cutoff : integer, float, or None (default: None)
         If specified, the maximum flow algorithm will terminate when the
         flow value reaches or exceeds the cutoff. This only works for flows
         that support the cutoff parameter (most do) and is ignored otherwise.

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -75,12 +75,10 @@ def local_node_connectivity(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    cutoff : integer, float
+    integer, float, or None (default: None)
         If specified, the maximum flow algorithm will terminate when the
-        flow value reaches or exceeds the cutoff. This is only for the
-        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
-        and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :ref:`flow<flow>` for details). Default value: None.
+        flow value reaches or exceeds the cutoff. This only works for flows
+        that support the cutoff parameter (most do) and is ignored otherwise.
 
     Returns
     -------
@@ -529,12 +527,10 @@ def local_edge_connectivity(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    cutoff : integer, float
+    integer, float, or None (default: None)
         If specified, the maximum flow algorithm will terminate when the
-        flow value reaches or exceeds the cutoff. This is only for the
-        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
-        and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :ref:`flow<flow>` for details). Default value: None.
+        flow value reaches or exceeds the cutoff. This only works for flows
+        that support the cutoff parameter (most do) and is ignored otherwise.
 
     Returns
     -------
@@ -679,12 +675,10 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
         choice of the default function may change from version
         to version and should not be relied on. Default value: None.
 
-    cutoff : integer, float
+    integer, float, or None (default: None)
         If specified, the maximum flow algorithm will terminate when the
-        flow value reaches or exceeds the cutoff. This is only for the
-        algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
-        and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :ref:`flow<flow>` for details). Default value: None.
+        flow value reaches or exceeds the cutoff. This only works for flows
+        that support the cutoff parameter (most do) and is ignored otherwise.
 
     Returns
     -------

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -80,7 +80,7 @@ def local_node_connectivity(
         flow value reaches or exceeds the cutoff. This is only for the
         algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
         and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :algorithms:`flow` for details). Default value: None.
+        parameter (see :ref:`flow<flow>` for details). Default value: None.
 
     Returns
     -------
@@ -534,7 +534,7 @@ def local_edge_connectivity(
         flow value reaches or exceeds the cutoff. This is only for the
         algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
         and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :algorithms:`flow` for details). Default value: None.
+        parameter (see :ref:`flow<flow>` for details). Default value: None.
 
     Returns
     -------
@@ -684,7 +684,7 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
         flow value reaches or exceeds the cutoff. This is only for the
         algorithms that support the cutoff parameter: e.g., :meth:`edmonds_karp`,
         and :meth:`shortest_augmenting_path`. Other algorithms will ignore this
-        parameter (see :algorithms:`flow` for details). Default value: None.
+        parameter (see :ref:`flow<flow>` for details). Default value: None.
 
     Returns
     -------

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -54,7 +54,7 @@ def edge_disjoint_paths(
         :meth:`shortest_augmenting_path` support the cutoff parameter,
         and will terminate when the flow value reaches or exceeds the
         cutoff. Other algorithms will ignore this parameter (see
-        :algorithms:`flow` for details). Default value: None.
+        :ref:`flow<flow>` for details). Default value: None.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based edge connectivity. It has
@@ -260,7 +260,7 @@ def node_disjoint_paths(
         :meth:`shortest_augmenting_path` support the cutoff parameter,
         and will terminate when the flow value reaches or exceeds the
         cutoff. Other algorithms will ignore this parameter (see
-        :algorithms:`flow` for details). Default value: None.
+        :ref:`flow<flow>` for details). Default value: None.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based node connectivity. It has

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -53,8 +53,8 @@ def edge_disjoint_paths(
         algorithms, such as :meth:`edmonds_karp` (the default) and
         :meth:`shortest_augmenting_path` support the cutoff parameter,
         and will terminate when the flow value reaches or exceeds the
-        cutoff. Other algorithms will ignore this parameter.
-        Default value: None.
+        cutoff. Other algorithms will ignore this parameter (see :meth:
+        `maximum_flow` for details). Default value: None.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based edge connectivity. It has
@@ -259,8 +259,8 @@ def node_disjoint_paths(
         algorithms, such as :meth:`edmonds_karp` (the default) and
         :meth:`shortest_augmenting_path` support the cutoff parameter,
         and will terminate when the flow value reaches or exceeds the
-        cutoff. Other algorithms will ignore this parameter.
-        Default value: None.
+        cutoff. Other algorithms will ignore this parameter (see :meth:
+        `maximum_flow` for details). Default value: None.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based node connectivity. It has

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -53,8 +53,8 @@ def edge_disjoint_paths(
         algorithms, such as :meth:`edmonds_karp` (the default) and
         :meth:`shortest_augmenting_path` support the cutoff parameter,
         and will terminate when the flow value reaches or exceeds the
-        cutoff. Other algorithms will ignore this parameter (see :meth:
-        `maximum_flow` for details). Default value: None.
+        cutoff. Other algorithms will ignore this parameter (see
+        :algorithms:`flow` for details). Default value: None.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based edge connectivity. It has
@@ -259,8 +259,8 @@ def node_disjoint_paths(
         algorithms, such as :meth:`edmonds_karp` (the default) and
         :meth:`shortest_augmenting_path` support the cutoff parameter,
         and will terminate when the flow value reaches or exceeds the
-        cutoff. Other algorithms will ignore this parameter (see :meth:
-        `maximum_flow` for details). Default value: None.
+        cutoff. Other algorithms will ignore this parameter (see
+        :algorithms:`flow` for details). Default value: None.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based node connectivity. It has

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -48,13 +48,11 @@ def edge_disjoint_paths(
         may change from version to version and should not be relied on.
         Default value: None.
 
-    cutoff : int
-        Maximum number of paths to yield. Some of the maximum flow
-        algorithms, such as :meth:`edmonds_karp` (the default) and
-        :meth:`shortest_augmenting_path` support the cutoff parameter,
-        and will terminate when the flow value reaches or exceeds the
-        cutoff. Other algorithms will ignore this parameter (see
-        :ref:`flow<flow>` for details). Default value: None.
+    cutoff : integer or None (default: None)
+        Maximum number of paths to yield. If specified, the maximum flow
+        algorithm will terminate when the flow value reaches or exceeds the
+        cutoff. This only works for flows that support the cutoff parameter
+        (most do) and is ignored otherwise.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based edge connectivity. It has
@@ -254,13 +252,11 @@ def node_disjoint_paths(
         of the default function may change from version to version and
         should not be relied on. Default value: None.
 
-    cutoff : int
-        Maximum number of paths to yield. Some of the maximum flow
-        algorithms, such as :meth:`edmonds_karp` (the default) and
-        :meth:`shortest_augmenting_path` support the cutoff parameter,
-        and will terminate when the flow value reaches or exceeds the
-        cutoff. Other algorithms will ignore this parameter (see
-        :ref:`flow<flow>` for details). Default value: None.
+    cutoff : integer or None (default: None)
+        Maximum number of paths to yield. If specified, the maximum flow
+        algorithm will terminate when the flow value reaches or exceeds the
+        cutoff. This only works for flows that support the cutoff parameter
+        (most do) and is ignored otherwise.
 
     auxiliary : NetworkX DiGraph
         Auxiliary digraph to compute flow based node connectivity. It has


### PR DESCRIPTION
In `local_edge_connectivity` and `local_node_connectivity` from **connectivity.py** the cutoff description implies that only `edmonds_karp()` and `shortest_augmenting_path()` support cutoff. That is not true. Now those algorithms are given as examples of flow functions that allow cutoff. I tried to keep the description as general as possible and reference to [Flow](https://networkx.org/documentation/stable/reference/algorithms/flow.html) as the source of truth so in the future, if new flow algorithms are added there's no need to change this. 
Also changed the cutoff description in `edge_connectivity` from **connectivity.py** to match `local_edge_connectivity` and `local_node_connectivity` cutoff description. 
Finally in **disjoint_paths.py** added a reference to [Flow](https://networkx.org/documentation/stable/reference/algorithms/flow.html) in the cutoff description of `node_disjoint_paths `and `edge_disjoint_paths`.
