### PR TITLE
Added an example in all_pairs_node_connectivity 

### DIFF
--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -246,8 +246,9 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
 
     Examples
     --------
-    >>> # A 3 node cycle with one extra node attached has connectivity 2 between all
-    >>> # nodes in the cycle and connectivity 1 between the extra node and the rest
+    A 3 node cycle with one extra node attached has connectivity 2 between all
+    nodes in the cycle and connectivity 1 between the extra node and the rest:
+    
     >>> G = nx.cycle_graph(3)
     >>> G.add_edge(2, 3)
     >>> nx.all_pairs_node_connectivity(G)

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -244,6 +244,18 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
     K : dictionary
         Dictionary, keyed by source and target, of pairwise node connectivity
 
+    Examples
+    --------
+    >>> # A 3 node cycle with one extra node attached has connectivity 2 between all
+    >>> # nodes in the cycle and connectivity 1 between the extra node and the rest
+    >>> G = nx.cycle_graph(3)
+    >>> G.add_edge(2, 3)
+    >>> nx.all_pairs_node_connectivity(G)
+    {0: {1: 2, 2: 2, 3: 1},
+    1: {0: 2, 2: 2, 3: 1},
+    2: {0: 2, 1: 2, 3: 1},
+    3: {0: 1, 1: 1, 2: 1}}
+
     See Also
     --------
     local_node_connectivity

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -248,15 +248,15 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
     --------
     A 3 node cycle with one extra node attached has connectivity 2 between all
     nodes in the cycle and connectivity 1 between the extra node and the rest:
-    
+
     >>> G = nx.cycle_graph(3)
     >>> G.add_edge(2, 3)
     >>> import pprint  # for nice dictionary formatting
     >>> pprint.pprint(nx.all_pairs_node_connectivity(G))
     {0: {1: 2, 2: 2, 3: 1},
-    1: {0: 2, 2: 2, 3: 1},
-    2: {0: 2, 1: 2, 3: 1},
-    3: {0: 1, 1: 1, 2: 1}}
+     1: {0: 2, 2: 2, 3: 1},
+     2: {0: 2, 1: 2, 3: 1},
+     3: {0: 1, 1: 1, 2: 1}}
 
     See Also
     --------

--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -251,7 +251,8 @@ def all_pairs_node_connectivity(G, nbunch=None, cutoff=None):
     
     >>> G = nx.cycle_graph(3)
     >>> G.add_edge(2, 3)
-    >>> nx.all_pairs_node_connectivity(G)
+    >>> import pprint  # for nice dictionary formatting
+    >>> pprint.pprint(nx.all_pairs_node_connectivity(G))
     {0: {1: 2, 2: 2, 3: 1},
     1: {0: 2, 2: 2, 3: 1},
     2: {0: 2, 1: 2, 3: 1},

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -39,9 +39,9 @@ def all_node_cuts(G, k=None, flow_func=None):
         computed. Default value: None.
 
     flow_func : function
-        Function to perform the underlying flow computations. Default value
-        edmonds_karp. This function performs better in sparse graphs with
-        right tailed degree distributions. shortest_augmenting_path will
+        Function to perform the underlying flow computations. Default value is
+        :meth:`edmonds_karp`. This function performs better in sparse graphs with
+        right tailed degree distributions. :meth:`shortest_augmenting_path` will
         perform better in denser graphs.
 
 

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -40,8 +40,9 @@ def all_node_cuts(G, k=None, flow_func=None):
 
     flow_func : function
         Function to perform the underlying flow computations. Default value is
-        :meth:`edmonds_karp`. This function performs better in sparse graphs with
-        right tailed degree distributions. :meth:`shortest_augmenting_path` will
+        :func:`~networkx.algorithms.flow.edmonds_karp`. This function performs
+        better in sparse graphs with right tailed degree distributions.
+        :func:`~networkx.algorithms.flow.shortest_augmenting_path` will
         perform better in denser graphs.
 
 


### PR DESCRIPTION
In all_pairs_node_connectivity added an example. 

Also in `all_node_cuts` added a missed link to `edmonds_karp`. 
