### PR TITLE
DOC: Specifically branch off main, instead of current branch

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,7 +94,7 @@ Development Workflow
      branch name will appear in the merge message, use a sensible name
      such as 'bugfix-for-issue-1480'::
 
-      git checkout -b bugfix-for-issue-1480
+      git checkout -b bugfix-for-issue-1480 main
 
    * Commit locally as you progress (``git add`` and ``git commit``)
 


### PR DESCRIPTION
Update the new contributor documentation to branch off from main. This will make sure people are creating branches from their local copy of main instead of the current working branch.
