### PR TITLE
Remove deprecated `find_cores`

### DIFF
--- a/doc/release/report_functions_without_rst_generated.py
+++ b/doc/release/report_functions_without_rst_generated.py
@@ -13,7 +13,6 @@ for n, f in funcs:
     # print(result)
 
     old_names = (
-        "find_cores",
         "test",
         "write_graphml_lxml",
         "write_graphml_xml",

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -34,7 +34,6 @@ from networkx.utils import not_implemented_for
 
 __all__ = [
     "core_number",
-    "find_cores",
     "k_core",
     "k_shell",
     "k_crust",
@@ -113,18 +112,6 @@ def core_number(G):
                 bin_boundaries[core[u]] += 1
                 core[u] -= 1
     return core
-
-
-def find_cores(G):
-    import warnings
-
-    msg = (
-        "\nfind_cores is deprecated as of version 2.7 and will be removed "
-        "in version 3.0.\n"
-        "The find_cores function is renamed core_number\n"
-    )
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    return nx.core_number(G)
 
 
 def _core_subgraph(G, k_filter, k=None, core=None):


### PR DESCRIPTION
It looks like we missed the `find_cores` function when removing deprecated code for NetworkX 3.0. The likely reason it was missed is that we (I) *also* forgot to add the deprecation to the NX 2.7 release notes.

Fortunately, the deprecation warning was being raised, so hopefully any users who were relying on it at least got some notification when running their code. There are a couple things we could do here:
 1) Just go ahead an remove it (as proposed here) even though we missed it in the release notes
 2) Add the deprecation to the release notes for 3.0 and push back the actual deprecation to 3.2
 3) Remove it now, but update the module `__getattr__` for the top-level `__init__.py` to advise users to use `core_number` instead.

1 is the least work, but I'm happy to update the module `__getattr__` if anyone thinks it's necessary. Let me know what you think!