### PR TITLE
Remove deprecated maxcardinality parameter from min_weight_matching

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -178,7 +178,7 @@ def christofides(G, weight="weight", tree=None):
     L.remove_nodes_from([v for v, degree in tree.degree if not (degree % 2)])
     MG = nx.MultiGraph()
     MG.add_edges_from(tree.edges)
-    edges = nx.min_weight_matching(L, maxcardinality=True, weight=weight)
+    edges = nx.min_weight_matching(L, weight=weight)
     MG.add_edges_from(edges)
     return _shortcutting(nx.eulerian_circuit(MG))
 

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -255,7 +255,7 @@ def is_perfect_matching(G, matching):
 
 @not_implemented_for("multigraph")
 @not_implemented_for("directed")
-def min_weight_matching(G, maxcardinality=None, weight="weight"):
+def min_weight_matching(G, weight="weight"):
     """Computing a minimum-weight maximal matching of G.
 
     Use the maximum-weight algorithm with edge weights subtracted
@@ -290,15 +290,6 @@ def min_weight_matching(G, maxcardinality=None, weight="weight"):
     G : NetworkX graph
       Undirected graph
 
-    maxcardinality: bool
-        .. deprecated:: 2.8
-            The `maxcardinality` parameter will be removed in v3.0.
-            It doesn't make sense to set it to False when looking for
-            a min weight matching because then we just return no edges.
-
-        If maxcardinality is True, compute the maximum-cardinality matching
-        with minimum weight among all maximum-cardinality matchings.
-
     weight: string, optional (default='weight')
        Edge data key corresponding to the edge weight.
        If key not found, uses 1 as weight.
@@ -312,12 +303,6 @@ def min_weight_matching(G, maxcardinality=None, weight="weight"):
     --------
     max_weight_matching
     """
-    if maxcardinality not in (True, None):
-        raise nx.NetworkXError(
-            "The argument maxcardinality does not make sense "
-            "in the context of minimum weight matchings."
-            "It is deprecated and will be removed in v3.0."
-        )
     if len(G.edges) == 0:
         return max_weight_matching(G, maxcardinality=True, weight=weight)
     G_edges = G.edges(data=weight, default=1)

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -117,7 +117,8 @@ class TestMaxWeightMatching:
             nx.max_weight_matching(G), matching_dict_to_set({1: 2, 2: 1})
         )
         assert edges_equal(
-            nx.max_weight_matching(G, 1), matching_dict_to_set({1: 3, 2: 4, 3: 1, 4: 2})
+            nx.max_weight_matching(G, maxcardinality=True),
+            matching_dict_to_set({1: 3, 2: 4, 3: 1, 4: 2}),
         )
         assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 2, 3: 4})

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -122,9 +122,6 @@ class TestMaxWeightMatching:
         assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 2, 3: 4})
         )
-        assert edges_equal(
-            nx.min_weight_matching(G, 1), matching_dict_to_set({1: 2, 3: 4})
-        )
 
     def test_s_blossom(self):
         """Create S-blossom and use it for augmentation:"""


### PR DESCRIPTION
Another deprecation removal for 3.0 - the `maxcardinality` parameter of `min_weight_matching` in this case.