### PR TITLE
Bug fix in swap.py

### DIFF
--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -46,7 +46,7 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     NetworkXError
         If `G` is not directed, or
         If nswap > max_tries, or
-        If there are fewer than 4 nodes in `G`
+        If there are fewer than 4 nodes or 3 edges in `G`.
     NetworkXAlgorithmError
         If the number of swap attempts exceeds `max_tries` before `nswap` swaps are made
 
@@ -70,9 +70,9 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     if nswap > max_tries:
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
     if len(G) < 4:
-        raise nx.NetworkXError("Graph has less than four nodes.")
-    if len(G.edges) == 0:
-        raise nx.NetworkXError("Graph has no edges.")
+        raise nx.NetworkXError("DiGraph has less than four nodes.")
+    elif len(G.edges) < 3:
+        raise nx.NetworkXError("DiGraph has less than 3 edges")
 
     # Instead of choosing uniformly at random from a generated edge list,
     # this algorithm chooses nonuniformly from the set of nodes with

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -71,7 +71,7 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
     if len(G) < 4:
         raise nx.NetworkXError("DiGraph has less than four nodes.")
-    elif len(G.edges) < 3:
+    if len(G.edges) < 3:
         raise nx.NetworkXError("DiGraph has less than 3 edges")
 
     # Instead of choosing uniformly at random from a generated edge list,

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -71,6 +71,8 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
         raise nx.NetworkXError("Number of swaps > number of tries allowed.")
     if len(G) < 4:
         raise nx.NetworkXError("Graph has less than four nodes.")
+    if len(G.edges) == 0:
+        raise nx.NetworkXError("Graph has no edges.")
 
     # Instead of choosing uniformly at random from a generated edge list,
     # this algorithm chooses nonuniformly from the set of nodes with

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -125,7 +125,13 @@ def test_degree_seq_c4():
     assert degrees == sorted(d for n, d in G.degree())
 
 
-def test_zero_degree():
+def test_no_edges():
     G = nx.DiGraph()
     G.add_nodes_from([0, 1, 2])
+    pytest.raises(nx.NetworkXError, nx.directed_edge_swap, G)
+
+
+def test_less_than_3_edges():
+    G = nx.DiGraph()
+    G.add_edges_from([(0, 1), (1, 2)])
     pytest.raises(nx.NetworkXError, nx.directed_edge_swap, G)

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -123,3 +123,9 @@ def test_degree_seq_c4():
     degrees = sorted(d for n, d in G.degree())
     G = nx.double_edge_swap(G, 1, 100)
     assert degrees == sorted(d for n, d in G.degree())
+
+
+def test_zero_degree():
+    G = nx.DiGraph()
+    G.add_nodes_from([0, 1, 2])
+    pytest.raises(nx.NetworkXError, nx.directed_edge_swap, G)


### PR DESCRIPTION
Closes #6144 
I changed   `directed_edge_swap`, now an exception is raised if the number of edges is less than 3. Also updated the documentation. 