### PR TITLE
Add example for fiedler_vector

### DIFF
--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -470,9 +470,6 @@ def fiedler_vector(
     >>> nx.fiedler_vector(G, normalized=True, seed=1)
     array([-0.32864129, -0.32864129, -0.32864129, -0.32864129, -0.26072899,
             0.26072899,  0.32864129,  0.32864129,  0.32864129,  0.32864129])
-    >>> nx.fiedler_vector(G, normalized=True, seed=1)
-    array([-0.32864129, -0.32864129, -0.32864129, -0.32864129, -0.26072899,
-            0.26072899,  0.32864129,  0.32864129,  0.32864129,  0.32864129])
 
     The connected components are the two 5-node cliques of the barbell graph.
     """

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -460,6 +460,17 @@ def fiedler_vector(
     See Also
     --------
     laplacian_matrix
+
+    Examples
+    --------
+    Given a connected graph the signs of the values in the Fiedler vector can be
+    used to partition the graph into two components.
+
+    >>> G = nx.cycle_graph(4)
+    >>> print(nx.fiedler_vector(G, normalized=True, seed = 1))
+    [-0.69141345 -0.1481467   0.69141344  0.14814671]
+
+    The connected components are {0,1} and {2,3}.
     """
     import numpy as np
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -466,11 +466,15 @@ def fiedler_vector(
     Given a connected graph the signs of the values in the Fiedler vector can be
     used to partition the graph into two components.
 
-    >>> G = nx.cycle_graph(4)
-    >>> print(nx.fiedler_vector(G, normalized=True, seed = 1))
-    [-0.69141345 -0.1481467   0.69141344  0.14814671]
+    >>> G = nx.barbell_graph(5, 0)
+    >>> nx.fiedler_vector(G, normalized=True, seed=1)
+    array([-0.32864129, -0.32864129, -0.32864129, -0.32864129, -0.26072899,
+            0.26072899,  0.32864129,  0.32864129,  0.32864129,  0.32864129])
+    >>> nx.fiedler_vector(G, normalized=True, seed=1)
+    array([-0.32864129, -0.32864129, -0.32864129, -0.32864129, -0.26072899,
+            0.26072899,  0.32864129,  0.32864129,  0.32864129,  0.32864129])
 
-    The connected components are {0,1} and {2,3}.
+    The connected components are the two 5-node cliques of the barbell graph.
     """
     import numpy as np
 


### PR DESCRIPTION
I added an example for `fiedler_vector` in `algebraicconnectivity.py`. In the example, I use the Fiedler vector to partition a connected graph. 
