### PR TITLE
add laplacian_spectrum example

### DIFF
--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -32,7 +32,7 @@ def laplacian_spectrum(G, weight="weight"):
     Notes
     -----
     For MultiGraph/MultiDiGraph, the edges weights are summed.
-    See to_numpy_array for other options.
+    See :func:`~networkx.convert_matrix.to_numpy_array` for other options.
 
     See Also
     --------

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -43,7 +43,6 @@ def laplacian_spectrum(G, weight="weight"):
     The multiplicity of 0 as an eigenvalue of the laplacian matrix is equal
     to the number of connected components of G.
 
-    >>> import numpy as np
     >>> G = nx.Graph()  # Create a graph with 5 nodes and 3 connected components
     >>> G.add_nodes_from(range(5))
     >>> G.add_edges_from([(0, 2), (3, 4)])

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -40,7 +40,7 @@ def laplacian_spectrum(G, weight="weight"):
 
     Examples
     --------
-    The multiplicity of O as an eigenvalue of the laplacian matrix is equal
+    The multiplicity of 0 as an eigenvalue of the laplacian matrix is equal
     to the number of connected components of G.
 
     >>> import numpy as np

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -37,6 +37,18 @@ def laplacian_spectrum(G, weight="weight"):
     See Also
     --------
     laplacian_matrix
+
+    Examples
+    --------
+    The multiplicity of O as an eigenvalue of the laplacian matrix is equal
+    to the number of connected components of G.
+
+    >>> import numpy as np
+    >>> G = nx.graph_atlas(22) #This graph from the Graph Atlas has 3 connected components.
+    >>> eigvals = nx.laplacian_spectrum(G).round(10)
+    >>> print(len(eigvals) - np.count_nonzero(eigvals)) #Count zero eigvalues
+    3
+
     """
     import scipy as sp
     import scipy.linalg  # call as sp.linalg

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -44,7 +44,9 @@ def laplacian_spectrum(G, weight="weight"):
     to the number of connected components of G.
 
     >>> import numpy as np
-    >>> G = nx.graph_atlas(22) #This graph from the Graph Atlas has 3 connected components.
+    >>> G = nx.Graph()  # Create a graph with 5 nodes and 3 connected components
+    >>> G.add_nodes_from(range(5))
+    >>> G.add_edges_from([(0, 2), (3, 4)])
     >>> eigvals = nx.laplacian_spectrum(G).round(10)
     >>> print(len(eigvals) - np.count_nonzero(eigvals)) #Count zero eigvalues
     3

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -47,9 +47,8 @@ def laplacian_spectrum(G, weight="weight"):
     >>> G = nx.Graph()  # Create a graph with 5 nodes and 3 connected components
     >>> G.add_nodes_from(range(5))
     >>> G.add_edges_from([(0, 2), (3, 4)])
-    >>> eigvals = nx.laplacian_spectrum(G).round(10)
-    >>> print(len(eigvals) - np.count_nonzero(eigvals)) #Count zero eigvalues
-    3
+    >>> nx.laplacian_spectrum(G)
+    array([0., 0., 0., 2., 2.])
 
     """
     import scipy as sp


### PR DESCRIPTION
Added an example where the laplacian_spectrum is used to get the number of eigenvalues of the Laplacian matrix that are zero to count the number of connected components of a graph. 

Also added a missed link to to_numpy_array