### PR TITLE
Fix performance issue in VF2 matching with unconnected graphs

### DIFF
--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -245,19 +245,16 @@ class GraphMatcher:
             for node_1 in T1_inout:
                 yield node_1, node_2
 
-        else:
-            # If T1_inout and T2_inout were both empty....
+        elif not T2_inout and (not T1_inout or self.test != "graph"):
+            # both Ts are empty or (T2_inout empty and want subgraphs). Get others!
             # P(s) = (N_1 - M_1) x {min (N_2 - M_2)}
-            # if not (T1_inout or T2_inout):  # as suggested by  [2], incorrect
-            # if 1:  # as inferred from [1], correct
-            if not T2_inout:
-                # First we determine the candidate node for G2
-                other_node = min(G2_nodes - set(self.core_2), key=min_key)
-                for node in self.G1:
-                    if node not in self.core_1:
-                        yield node, other_node
-
-        # For all other cases, we don't have any candidate pairs.
+            # First we determine the candidate node for G2
+            other_node = min(G2_nodes - set(self.core_2), key=min_key)
+            for node in self.G1:
+                if node not in self.core_1:
+                    yield node, other_node
+        else:
+            return  # no pairs available for this problem type. Can't be morphic.
 
     def initialize(self):
         """Reinitializes the state of the algorithm.
@@ -665,11 +662,8 @@ class DiGraphMatcher(GraphMatcher):
             for node_1 in T1_out:
                 yield node_1, node_2
 
-        # If T1_out and T2_out were both empty....
-        # We compute the in-terminal sets.
-
-        # elif not (T1_out or T2_out):   # as suggested by [2], incorrect
-        else:  # as suggested by [1], correct
+        elif not T2_out and (not T1_out or self.test != "graph"):
+            # both T_outs are empty or (T2_out empty and want subgraphs). Check T_in!
             T1_in = [node for node in self.in_1 if node not in self.core_1]
             T2_in = [node for node in self.in_2 if node not in self.core_2]
 
@@ -680,18 +674,17 @@ class DiGraphMatcher(GraphMatcher):
                 for node_1 in T1_in:
                     yield node_1, node_2
 
-            # If all terminal sets are empty...
-            # P(s) = (N_1 - M_1) x {min (N_2 - M_2)}
-
-            # elif not (T1_in or T2_in):   # as suggested by  [2], incorrect
-            # else:  # as inferred from [1], correct
-            elif not (T2_out or T2_in):
+            elif not T2_in and (not T1_in or self.test != "graph"):
+                # all 4 Ts are empty or (T2s are empty and want subgraph). Get others!
+                # P(s) = (N_1 - M_1) x {min (N_2 - M_2)}
                 node_2 = min(G2_nodes - set(self.core_2), key=min_key)
                 for node_1 in G1_nodes:
                     if node_1 not in self.core_1:
                         yield node_1, node_2
-
-        # For all other cases, we don't have any candidate pairs.
+            else:
+                return  # no pairs available for this problem type. Can't be morphic.
+        else:
+            return  # no pairs available for this problem type. Can't be morphic.
 
     def initialize(self):
         """Reinitializes the state of the algorithm.

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -682,8 +682,8 @@ class DiGraphMatcher(GraphMatcher):
             # If all terminal sets are empty...
             # P(s) = (N_1 - M_1) x {min (N_2 - M_2)}
 
-            # elif not (T1_in or T2_in):   # as suggested by  [2], incorrect
-            else:  # as inferred from [1], correct
+            # else:  # as inferred from [1], correct
+            elif not (T2_out or T2_in):
                 node_2 = min(G2_nodes - set(self.core_2), key=min_key)
                 for node_1 in G1_nodes:
                     if node_1 not in self.core_1:

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -249,7 +249,8 @@ class GraphMatcher:
             # If T1_inout and T2_inout were both empty....
             # P(s) = (N_1 - M_1) x {min (N_2 - M_2)}
             # if not (T1_inout or T2_inout):  # as suggested by  [2], incorrect
-            if 1:  # as inferred from [1], correct
+            # if 1:  # as inferred from [1], correct
+            if not T2_inout:
                 # First we determine the candidate node for G2
                 other_node = min(G2_nodes - set(self.core_2), key=min_key)
                 for node in self.G1:
@@ -682,6 +683,7 @@ class DiGraphMatcher(GraphMatcher):
             # If all terminal sets are empty...
             # P(s) = (N_1 - M_1) x {min (N_2 - M_2)}
 
+            # elif not (T1_in or T2_in):   # as suggested by  [2], incorrect
             # else:  # as inferred from [1], correct
             elif not (T2_out or T2_in):
                 node_2 = min(G2_nodes - set(self.core_2), key=min_key)

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -488,3 +488,26 @@ def test_three_node(e1, e2, isomorphic, subgraph_is_isomorphic):
     gm = iso.DiGraphMatcher(G1, G2)
     assert gm.is_isomorphic() == isomorphic
     assert gm.subgraph_is_isomorphic() == subgraph_is_isomorphic
+
+
+def test_monomorphism_unconnected_match():
+    G = nx.DiGraph()
+    G.add_node(1)
+    G.add_node(2)
+    G.add_node(3)
+    G.add_node(4)
+    G.add_node(5)
+    G.add_edge(1, 2, label="A")
+    G.add_edge(2, 3, label="B")
+    G.add_edge(4, 5, label="C")
+
+    SG = nx.DiGraph()
+    SG.add_node(7)
+    SG.add_node(8)
+    SG.add_node(9)
+    SG.add_node(10)
+    SG.add_edge(7, 8, label="A")
+    SG.add_edge(9, 10, label="C")
+
+    gm = iso.DiGraphMatcher(G, SG, edge_match=iso.categorical_edge_match("label", None))
+    assert gm.subgraph_is_monomorphic()

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -490,47 +490,22 @@ def test_three_node(e1, e2, isomorphic, subgraph_is_isomorphic):
     assert gm.subgraph_is_isomorphic() == subgraph_is_isomorphic
 
 
-def test_graph_monomorphism_unconnected_match():
-    G = nx.Graph()
-    G.add_node(1)
-    G.add_node(2)
-    G.add_node(3)
-    G.add_node(4)
-    G.add_node(5)
-    G.add_edge(1, 2, label="A")
-    G.add_edge(2, 3, label="B")
-    G.add_edge(4, 5, label="C")
+@pytest.mark.parametrize("nxGraph", [nx.Graph, nx.DiGraph])
+def test_graph_exactly_one_of_T1_or_T2_empty(nxGraph):
+    G = nx.empty_graph(range(1, 6), create_using=nxGraph)
+    G.add_weighted_edges_from([(1, 2, "A"), (2, 3, "B"), (4, 5, "C")], weight="label")
 
-    SG = nx.Graph()
-    SG.add_node(7)
-    SG.add_node(8)
-    SG.add_node(9)
-    SG.add_node(10)
-    SG.add_edge(7, 8, label="A")
-    SG.add_edge(9, 10, label="C")
+    SG = nx.empty_graph(range(7, 11), create_using=nxGraph)
+    SG.add_weighted_edges_from([(7, 8, "A"), (9, 10, "C")], weight="label")
 
-    gm = iso.GraphMatcher(G, SG, edge_match=iso.categorical_edge_match("label", None))
+    matcher = iso.DiGraphMatcher if G.is_directed() else iso.GraphMatcher
+    gm = matcher(G, SG, edge_match=iso.categorical_edge_match("label", None))
     assert gm.subgraph_is_monomorphic()
+    assert gm.subgraph_is_isomorphic()
+    assert not gm.is_isomorphic()
 
-
-def test_digraph_monomorphism_unconnected_match():
-    G = nx.DiGraph()
-    G.add_node(1)
-    G.add_node(2)
-    G.add_node(3)
-    G.add_node(4)
-    G.add_node(5)
-    G.add_edge(1, 2, label="A")
-    G.add_edge(2, 3, label="B")
-    G.add_edge(4, 5, label="C")
-
-    SG = nx.DiGraph()
-    SG.add_node(7)
-    SG.add_node(8)
-    SG.add_node(9)
-    SG.add_node(10)
-    SG.add_edge(7, 8, label="A")
-    SG.add_edge(9, 10, label="C")
-
-    gm = iso.DiGraphMatcher(G, SG, edge_match=iso.categorical_edge_match("label", None))
-    assert gm.subgraph_is_monomorphic()
+    # reverse G, SG to check when T1 not empty and T2 is. Should bail.
+    gm = matcher(SG, G, edge_match=iso.categorical_edge_match("label", None))
+    assert not gm.subgraph_is_monomorphic()
+    assert not gm.subgraph_is_isomorphic()
+    assert not gm.is_isomorphic()

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -490,7 +490,30 @@ def test_three_node(e1, e2, isomorphic, subgraph_is_isomorphic):
     assert gm.subgraph_is_isomorphic() == subgraph_is_isomorphic
 
 
-def test_monomorphism_unconnected_match():
+def test_graph_monomorphism_unconnected_match():
+    G = nx.Graph()
+    G.add_node(1)
+    G.add_node(2)
+    G.add_node(3)
+    G.add_node(4)
+    G.add_node(5)
+    G.add_edge(1, 2, label="A")
+    G.add_edge(2, 3, label="B")
+    G.add_edge(4, 5, label="C")
+
+    SG = nx.Graph()
+    SG.add_node(7)
+    SG.add_node(8)
+    SG.add_node(9)
+    SG.add_node(10)
+    SG.add_edge(7, 8, label="A")
+    SG.add_edge(9, 10, label="C")
+
+    gm = iso.GraphMatcher(G, SG, edge_match=iso.categorical_edge_match("label", None))
+    assert gm.subgraph_is_monomorphic()
+
+
+def test_digraph_monomorphism_unconnected_match():
     G = nx.DiGraph()
     G.add_node(1)
     G.add_node(2)


### PR DESCRIPTION
We have a use case where we need to search for small subgraph SG over a set of very large graphs G1, ..., Gk. We apply some pre-processing in order to cut down the search time by focusing on a small subgraph view of G1, ..., Gk which is guaranteed to contain all the occurrences of SG in G1, ..., Gk.

We found a scenario where a significant size reduction from close to 500k nodes to around 12k resulted in an increase in runtime instead of a reduction. The runtime with 500k nodes was around 2.13s while with the 12k nodes was 10.68s. The problem was with the scenario where both the `T1_out and T2_out` and `T1_in and T2_in` checks return `False` for unconnected graphs, in which case the `DiGraphMatcher` traverses all nodes in G1, ..., Gk.

However, this full traversal is only necessary if both `T2_out` and `T2_in` are empty. Lets assume, without loss of generality, that `T2_out` is not empty and that v is a node of G2 (SG in this case) in `T2_out`. We have that `T1_out` is also empty because otherwise the `T1_out and T2_out` check would have returned `True`. Therefore, v will never be included in the current partial mapping because no node of G1 can be mapped to v, otherwise that node would have been included in `T1_out`. Consequently, the current partial mapping isn't feasible and thus it's unnecessary to check any further candidate pairs.

This performance fix resulted in a runtime reduction from 10.68s to 0.33s for the 12k nodes subgraph views. The equivalent fix is also implemented for the `GraphMatcher`.