### PR TITLE
Add clear edges method to the list of methods to be frozen by the nx.…

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -201,6 +201,7 @@ def freeze(G):
     G.remove_edge = frozen
     G.remove_edges_from = frozen
     G.clear = frozen
+    G.clear_edges = frozen
     G.frozen = True
     return G
 

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -252,6 +252,7 @@ class TestFunction:
         pytest.raises(nx.NetworkXError, G.add_edges_from, [(1, 2)])
         pytest.raises(nx.NetworkXError, G.remove_edge, 1, 2)
         pytest.raises(nx.NetworkXError, G.remove_edges_from, [(1, 2)])
+        pytest.raises(nx.NetworkXError, G.clear_edges)
         pytest.raises(nx.NetworkXError, G.clear)
 
     def test_is_frozen(self):
@@ -259,6 +260,18 @@ class TestFunction:
         G = nx.freeze(self.G)
         assert G.frozen == nx.is_frozen(self.G)
         assert G.frozen
+
+    def test_node_attributes_are_still_mutable_on_frozen_graph(self):
+        G = nx.freeze(self.G)
+        node = G.nodes[0]
+        node["node_attribute"] = True
+        assert node["node_attribute"] == True
+
+    def test_edge_attributes_are_still_mutable_on_frozen_graph(self):
+        G = nx.freeze(self.G)
+        edge = G.edges[(0, 1)]
+        edge["edge_attribute"] = True
+        assert edge["edge_attribute"] == True
 
     def test_neighbors_complete_graph(self):
         graph = nx.complete_graph(100)

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -262,13 +262,13 @@ class TestFunction:
         assert G.frozen
 
     def test_node_attributes_are_still_mutable_on_frozen_graph(self):
-        G = nx.freeze(self.G)
+        G = nx.freeze(nx.path_graph(3))
         node = G.nodes[0]
         node["node_attribute"] = True
         assert node["node_attribute"] == True
 
     def test_edge_attributes_are_still_mutable_on_frozen_graph(self):
-        G = nx.freeze(self.G)
+        G = nx.freeze(nx.path_graph(3))
         edge = G.edges[(0, 1)]
         edge["edge_attribute"] = True
         assert edge["edge_attribute"] == True


### PR DESCRIPTION
…freeze function

`nx.freeze` was freezing most of the attributes of a graph but didn't freeze the `clear_edges` method. This PR adds that method into the list of methods to be frozen.

A different design choice would be to re-implement the freeze method to call into a `__freeze__` method on the graph. This would allow subclasses to modify the freeze method based on their needs and would also make any future ommisions like this easier to fix in subclasses. However since this is my first time contributing I went for a minimal changes.

Happy to have comments and suggestions on this!
