### PR TITLE
Add warning in community module documentation

### DIFF
--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -1,9 +1,10 @@
 """Functions for computing and measuring community structure.
 
-The functions in this class are not imported into the top-level
-:mod:`networkx` namespace. You can access these functions by importing
-the :mod:`networkx.algorithms.community` module, then accessing the
-functions as attributes of ``community``. For example::
+.. warning:: The functions in this class are not imported into the top-level
+:mod:`networkx` namespace. 
+
+They can be imported using the :mod:`networkx.algorithms.community` module,
+then accessing the functions as attributes of ``community``. For example::
 
     >>> from networkx.algorithms import community
     >>> G = nx.barbell_graph(5, 1)


### PR DESCRIPTION
I noticed that on the main page of the community module there's a comment about how to import the functions because they are not part of networkx base namespace. I made this a warning so it's easier for users to notice.
