### PR TITLE
Add warning in documentation: import modules

### DIFF
--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -1,9 +1,10 @@
 """Functions for computing and measuring community structure.
 
-The functions in this class are not imported into the top-level
-:mod:`networkx` namespace. You can access these functions by importing
-the :mod:`networkx.algorithms.community` module, then accessing the
-functions as attributes of ``community``. For example::
+.. warning:: The functions in this class are not imported into the top-level
+:mod:`networkx` namespace. 
+
+They can be imported using the :mod:`networkx.algorithms.community` module,
+then accessing the functions as attributes of ``community``. For example::
 
     >>> from networkx.algorithms import community
     >>> G = nx.barbell_graph(5, 1)

--- a/networkx/algorithms/node_classification.py
+++ b/networkx/algorithms/node_classification.py
@@ -1,9 +1,9 @@
 """ This module provides the functions for node classification problem.
 
-The functions in this module are not imported
-into the top level `networkx` namespace.
-You can access these functions by importing
-the `networkx.algorithms.node_classification` modules,
+.. warning:: The functions in this module are not imported into the top level 
+:mod:`networkx` namespace.
+
+They can be imported using the `networkx.algorithms.node_classification` modules,
 then accessing the functions as attributes of `node_classification`.
 For example:
 

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -7,8 +7,11 @@ accepts a graph as input, you must provide a tournament graph. The
 responsibility is on the caller to ensure that the graph is a tournament
 graph.
 
-To access the functions in this module, you must access them through the
-:mod:`networkx.algorithms.tournament` module::
+.. warning:: The functions in this module are not imported into the top level 
+:mod:`networkx` namespace.
+
+They can be imported using :mod:`networkx.algorithms.tournament`. 
+For example:
 
     >>> from networkx.algorithms import tournament
     >>> G = nx.DiGraph([(0, 1), (1, 2), (2, 0)])


### PR DESCRIPTION
 I noticed that on the main page of some modules there's a comment about how to import the functions because they are not part of the `networkx` base namespace. I checked all the documentation and made this a warning so it's easier for users to notice.
I added this in `node_classification` and  `tournament`. 
