### PR TITLE
Minor Python 2 cleanup

### DIFF
--- a/networkx/algorithms/bipartite/redundancy.py
+++ b/networkx/algorithms/bipartite/redundancy.py
@@ -103,9 +103,7 @@ def _node_redundancy(G, v):
 
     """
     n = len(G[v])
-    # TODO On Python 3, we could just use `G[u].keys() & G[w].keys()` instead
-    # of instantiating the entire sets.
     overlap = sum(
-        1 for (u, w) in combinations(G[v], 2) if (set(G[u]) & set(G[w])) - {v}
+        1 for (u, w) in combinations(G[v], 2) if (G[u].keys() & G[w].keys()) - {v}
     )
     return (2 * overlap) / (n * (n - 1))


### PR DESCRIPTION
Use dict.keys() for set operations rather than explicitly creating sets, as recommended in the comment.