### PR TITLE
Delete warning in approximation documentation

### DIFF
--- a/networkx/algorithms/approximation/__init__.py
+++ b/networkx/algorithms/approximation/__init__.py
@@ -1,12 +1,12 @@
 """Approximations of graph properties and Heuristic methods for optimization.
+    
+    The functions in this class are not imported into the top-level
+    :mod:`networkx` namespace so the easiest way to use them is with:
 
-    .. warning:: These functions are not imported in the top-level of ``networkx``
+    >>> from networkx.algorithms import approximation
 
-    These functions can be accessed using
-    ``networkx.approximation.function_name``
-
-    They can be imported using ``from networkx.algorithms import approximation``
-    or ``from networkx.algorithms.approximation import function_name``
+    Another option is to import the specific function with 
+    :mod:`from networkx.algorithms.approximation import function_name`.
 
 """
 from networkx.algorithms.approximation.clustering_coefficient import *

--- a/networkx/algorithms/approximation/__init__.py
+++ b/networkx/algorithms/approximation/__init__.py
@@ -1,12 +1,12 @@
 """Approximations of graph properties and Heuristic methods for optimization.
-    
-    The functions in this class are not imported into the top-level
-    :mod:`networkx` namespace so the easiest way to use them is with:
+
+The functions in this class are not imported into the top-level ``networkx``
+namespace so the easiest way to use them is with::
 
     >>> from networkx.algorithms import approximation
 
-    Another option is to import the specific function with 
-    :mod:`from networkx.algorithms.approximation import function_name`.
+Another option is to import the specific function with
+``from networkx.algorithms.approximation import function_name``.
 
 """
 from networkx.algorithms.approximation.clustering_coefficient import *

--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -1,10 +1,9 @@
 """Functions for computing and measuring community structure.
 
-.. warning:: The functions in this class are not imported into the top-level
-:mod:`networkx` namespace. 
-
-They can be imported using the :mod:`networkx.algorithms.community` module,
-then accessing the functions as attributes of ``community``. For example::
+The functions in this class are not imported into the top-level
+:mod:`networkx` namespace. You can access these functions by importing
+the :mod:`networkx.algorithms.community` module, then accessing the
+functions as attributes of ``community``. For example::
 
     >>> from networkx.algorithms import community
     >>> G = nx.barbell_graph(5, 1)

--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -1,9 +1,10 @@
 """Functions for computing and measuring community structure.
 
-The functions in this class are not imported into the top-level
-:mod:`networkx` namespace. You can access these functions by importing
-the :mod:`networkx.algorithms.community` module, then accessing the
-functions as attributes of ``community``. For example::
+.. warning:: The functions in this class are not imported into the top-level
+:mod:`networkx` namespace. 
+
+They can be imported using the :mod:`networkx.algorithms.community` module,
+then accessing the functions as attributes of ``community``. For example::
 
     >>> from networkx.algorithms import community
     >>> G = nx.barbell_graph(5, 1)


### PR DESCRIPTION
On the approximation main page, there was a warning about how to import the functions because they are not part of the `networkx` base namespace. As discussed in another PR, warnings are unsuitable for this purpose. So I change it to delete the warning. 