### PR TITLE
add missing `seed` to function called by `connected_double_edge_swap`

### DIFF
--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -350,7 +350,7 @@ def connected_double_edge_swap(G, nswap=1, _window_threshold=3, seed=None):
             while wcount < window and n < nswap:
                 # Pick two random edges without creating the edge list. Choose
                 # source nodes from the discrete degree distribution.
-                (ui, xi) = nx.utils.discrete_sequence(2, cdistribution=cdf)
+                (ui, xi) = discrete_sequence(2, cdistribution=cdf, seed=seed)
                 # If the source nodes are the same, skip this pair.
                 if ui == xi:
                     continue


### PR DESCRIPTION
Inside `connected_double_edge_swap`, one call to `nx.utils.discrete_sequence` does not give the `seed` as input which will mess up trying to make it deterministic by providing a seed.  

This PR adds `seed` to that function call. 

I haven't been able to make this into a test -- and I spotted it while going through the code... not due to a behavior I didn't expect.