### PR TITLE
Add conversion functions for node/edge_match to Graph based labels

### DIFF
--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -1,11 +1,15 @@
 """Functions which help end users define customize node_match and
 edge_match functions to use during isomorphism checks.
 """
+import itertools
 import math
 import types
-from itertools import permutations
+
+import networkx as nx
 
 __all__ = [
+    "node_match_to_label",
+    "edge_match_to_label",
     "categorical_node_match",
     "categorical_edge_match",
     "categorical_multiedge_match",
@@ -16,6 +20,212 @@ __all__ = [
     "generic_edge_match",
     "generic_multiedge_match",
 ]
+
+
+def node_match_to_label(node_match, Glist, attrname):
+    """Use the `node_match` function to set node labels for all graphs in `Glist`
+
+    The `node_match` function takes a pair of node datadicts and returns `True`
+    if the nodes are considered matched in the sense of isomorphism. This function
+    calls `node_match` to determine which groups of nodes all match each other.
+    Those nodes are given an integer label, unique across all graphs in Glist.
+    The node attribute `attrname` is created/updated in each graph to store the labels.
+    Node labels are equal iff the corresponding nodes match across all graphs in Glist.
+
+    The `node_match` function must be commutative and transitive across all graphs
+    (if a node matches with 2 other nodes, then the two other nodes must match).
+
+    The intent of this function is to ease transition from the match-function
+    framework of the isomorphism checkers to a match-by-label framework
+    implemented in the VF2pp tools.
+
+    This will work for multiedge_match functions as well as edge_match functions.
+
+    The labels used are integers. If other labels are desired, consider manipulating
+    the returned dict keyed by labels to cannonical datadicts for that group of nodes
+    to determine replacement labels and then get/set a node attribute in each graph.
+
+    Parameters
+    ==========
+    node_match : callable
+        A function that returns True if node n1 in G1 and n2 in G2 should
+        be considered equal during the isomorphism test.
+
+        The function will be called like
+
+           node_match(G1.nodes[n1], G2.nodes[n2]).
+
+        That is, the function will receive the node attribute dictionaries
+        for n1 and n2 as inputs.
+
+    Glist : NetworkX graph or list of NetworkX graphs
+        A single graph or list of graphs for which the labels are computed
+
+    attrname : attribute name
+        The name of the node attribute to be set to the node label.
+
+    Returns
+    =======
+    cannonical_datadicts_by_label : dict
+        A dict keyed to a single datadict that represents all nodes with that label.
+        The datadict matches all node datadicts with that label in all graphs.
+
+    Examples
+    ========
+    >>> iso = nx.isomorphism
+    >>> def node_match(d1, d2): return d1["tint"] == d2["tint"] and d1["hue"] == d2["hue"]
+
+    >>> G = nx.path_graph(4)
+    >>> H = G.copy()
+    >>> nx.set_node_attributes(G, {n: "lt" if n > 1 else "dk" for n in G}, "tint")
+    >>> nx.set_node_attributes(G, {n: "blue" if n % 2 else "red" for n in G}, "hue")
+    >>> nx.set_node_attributes(H, {n: "lt" if n < 2 else "dk" for n in H}, "tint")
+    >>> nx.set_node_attributes(H, {n: "blue" if n % 2 else "red" for n in H}, "hue")
+    >>> H.add_node(4, tint="lt", hue="purple")
+
+    >>> lbl_dds = iso.node_match_to_label(node_match, [G, H], "label")
+    >>> nx.get_node_attributes(G, "label")
+    {0: 0, 1: 1, 2: 2, 3: 3}
+    >>> nx.get_node_attributes(H, "label")
+    {0: 2, 1: 3, 2: 0, 3: 1, 4: 4}
+
+    If you want to relabel the nodes to more meaningful labels, you can use the
+    lbl_dds to construct such labels
+
+    >>> relabel = {lbl: f"{dd['tint']} {dd['hue']}" for lbl, dd in lbl_dds.items()}
+    >>> Grelabels = {n: relabel[lbl] for n, lbl in G.nodes.data("label")}
+    >>> Grelabels
+    {0: 'dk red', 1: 'dk blue', 2: 'lt red', 3: 'lt blue'}
+
+    See Also
+    ========
+    edge_match_to_label
+    """
+    if hasattr(Glist, "adj"):
+        Glist = [Glist]
+    new_label = itertools.count()
+    labels = {}
+    ddict_by_label = {}
+    for G in Glist:
+        for node in G:
+            ddn = G.nodes[node]
+            for lbl, dd in ddict_by_label.items():
+                if node_match(ddn, dd):
+                    break
+            else:
+                lbl = next(new_label)
+                ddict_by_label[lbl] = ddn
+            ddn[attrname] = lbl
+    return ddict_by_label
+
+
+def edge_match_to_label(edge_match, Glist, attrname):
+    """Use the `edge_match` function to set edge labels for all graphs in `Glist`
+
+    The `edge_match` function takes a pair of edge datadicts and returns `True`
+    if the edges are considered matched in the sense of isomorphism. This function
+    calls `edge_match` to determine which groups of edges all match each other.
+    Those edges are given an integer label, unique across all graphs in Glist.
+    The edge attribute `attrname` is created/updated in each graph to store the labels.
+    Edge labels are equal iff the corresponding edges match across all graphs in Glist.
+
+    The `edge_match` function takes a pair of edge datadicts and returns `True`
+    if the edges are match in the sense of isomorphism. This function calls
+    `edge_match` to determine which groups of edges all match each other.
+    Those edges are given an integer label, unique across all graphs in Glist.
+    The returned list of `label_dicts` correspond to each graph in Glist and
+    provide the label for each edge in that graph. Those dicts are precisely
+    what is needed for `nx.set_edge_attributes`. If the `attrname` is provided,
+    edge attributes with that name are added to each graph with the label as value.
+    Edge labels are equal iff the corresponding edges match across all graphs in Glist.
+
+    The `edge_match` function must be commutative and transitive across all graphs
+    (if a edge matches with 2 other edges, then the two other edges must match).
+
+    The intent of this function is to ease transition from the match-function
+    framework of the isomorphism checkers to a match-by-label framework
+    implemented in the VF2pp tools.
+
+    This will work for multiedge_match functions as well as edge_match functions.
+
+    The labels used are integers. If other labels are desired, consider manipulating
+    the returned dict keyed by labels to cannonical datadicts for that group of edges
+    to determine replacement labels and then get/set a edge attribute in each graph.
+
+    Parameters
+    ==========
+    edge_match : callable
+        A function that returns True if the edge attribute dictionary
+        for the pair of nodes (u1, v1) in G1 and (u2, v2) in G2 should
+        be considered equal during the isomorphism test.
+
+        The function will be called like
+
+           edge_match(G1[u1][v1], G2[u2][v2]).
+
+        That is, the function will receive the edge attribute dictionaries
+        of the edges under consideration.
+
+    Glist : NetworkX graph or list of NetworkX graphs
+        A single graph or a list of graphs for which the labels are computed
+
+    attrname : string or None (default: None)
+        The name of the edge attribute in each graph to be set.
+
+    Returns
+    =======
+    cannonical_datadicts_by_label : dict
+        A dict keyed to a single datadict that represents all edges with that label.
+        The datadict matches all edge datadicts with that label in all graphs.
+
+    Examples
+    ========
+    >>> iso = nx.isomorphism
+    >>> set_ea = nx.set_edge_attributes
+    >>> def edge_match(d1, d2): return d1["tint"] == d2["tint"] and d1["hue"] == d2["hue"]
+
+    >>> G = nx.path_graph(5)
+    >>> H = G.copy()
+    >>> set_ea(G, {e: "lt" if sum(e) > 4 else "dk" for e in G.edges}, "tint")
+    >>> set_ea(G, {e: "blue" if sum(e) in (3, 7) else "red" for e in G.edges}, "hue")
+    >>> set_ea(H, {e: "lt" if sum(e) < 4 else "dk" for e in H.edges}, "tint")
+    >>> set_ea(H, {e: "blue" if sum(e) in (3, 7) else "red" for e in H.edges}, "hue")
+    >>> H.add_edge(6, 7, tint="lt", hue="purple")
+
+    >>> lbl_dds = iso.edge_match_to_label(edge_match, [G, H], "label")
+    >>> nx.get_edge_attributes(G, "label")
+    {(0, 1): 0, (1, 2): 1, (2, 3): 2, (3, 4): 3}
+    >>> nx.get_edge_attributes(H, "label")
+    {(0, 1): 2, (1, 2): 3, (2, 3): 0, (3, 4): 1, (6, 7): 4}
+
+    If you want to relabel the edges to more meaningful labels, you can use the
+    lbl_dds to construct such labels
+
+    >>> relabel = {lbl: f"{dd['tint']} {dd['hue']}" for lbl, dd in lbl_dds.items()}
+    >>> Grelabels = {(u, v): relabel[lbl] for u, v, lbl in G.edges.data("label")}
+    >>> Grelabels
+    {(0, 1): 'dk red', (1, 2): 'dk blue', (2, 3): 'lt red', (3, 4): 'lt blue'}
+
+    See Also
+    ========
+    node_match_to_label
+    """
+    if hasattr(Glist, "adj"):
+        Glist = [Glist]
+    new_label = itertools.count()
+    labels = {}
+    ddict_by_label = {}
+    for G in Glist:
+        for edge in G.edges:
+            ddn = G.edges[edge]
+            for lbl, dd in ddict_by_label.items():
+                if edge_match(ddn, dd):
+                    break
+            else:
+                lbl = next(new_label)
+                ddict_by_label[lbl] = ddn
+            ddn[attrname] = lbl
+    return ddict_by_label
 
 
 def copyfunc(f, name=None):
@@ -335,7 +545,7 @@ def generic_multiedge_match(attr, default, op):
         for data2 in datasets2.values():
             x = tuple(data2.get(attr, d) for attr, d in attrs)
             values2.append(x)
-        for vals2 in permutations(values2):
+        for vals2 in itertools.permutations(values2):
             for xi, yi in zip(values1, vals2):
                 if not all(map(lambda x, y, z: z(x, y), xi, yi, op)):
                     # This is not an isomorphism, go to next permutation.

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -1,15 +1,102 @@
 from operator import eq
 
+import pytest
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
 
+# NODE_MATCH TESTS
+def test_node_match_to_label_uniform():
+    G = nx.path_graph(9)
+
+    def node_match(n1d, n2d):
+        return True
+
+    iso.node_match_to_label(node_match, G, "labels")
+    labels_dict = nx.get_node_attributes(G, "labels")
+    assert labels_dict == {n: 0 for n in G}
+
+
+def test_node_match_to_label_simple_attribute():
+    G = nx.path_graph(9)
+    nx.set_node_attributes(G, {n: n % 2 for n in G}, "parity")
+
+    def node_match(n1d, n2d):
+        return n1d["parity"] == n2d["parity"]
+
+    iso.node_match_to_label(node_match, G, "new_parity")
+    labels_dict = nx.get_node_attributes(G, "new_parity")
+    assert labels_dict == nx.get_node_attributes(G, "parity")
+
+
+def test_node_match_to_label_two_attributes():
+    G = nx.path_graph(9)
+    nx.set_node_attributes(G, {n: n % 2 for n in G}, "parity")
+    nx.set_node_attributes(G, {n: n < 4 for n in G}, "small")
+
+    def node_match(n1d, n2d):
+        return n1d["parity"] == n2d["parity"] and n1d["small"] == n2d["small"]
+
+    iso.node_match_to_label(node_match, G, "label")
+    labels_dict = nx.get_node_attributes(G, "label")
+    assert labels_dict == {0: 0, 1: 1, 2: 0, 3: 1, 4: 2, 5: 3, 6: 2, 7: 3, 8: 2}
+
+
+# EDGE_MATCH TESTS
+def test_edge_match_to_label_uniform():
+    G = nx.path_graph(9)
+
+    def edge_match(e1d, e2d):
+        return True
+
+    iso.edge_match_to_label(edge_match, G, "labels")
+    labels_dict = nx.get_edge_attributes(G, "labels")
+    assert labels_dict == {e: 0 for e in G.edges}
+
+
+def test_edge_match_to_label_simple_attribute():
+    G = nx.path_graph(9)
+    nx.set_edge_attributes(G, {e: 1 - (sum(e) % 2) for e in G.edges}, "parity")
+
+    def edge_match(e1d, e2d):
+        return e1d["parity"] == e2d["parity"]
+
+    iso.edge_match_to_label(edge_match, G, "new_parity")
+    labels_dict = nx.get_edge_attributes(G, "new_parity")
+    assert labels_dict == nx.get_edge_attributes(G, "parity")
+
+
+def test_edge_match_to_label_two_attributes():
+    G = nx.path_graph(9)
+    nx.set_edge_attributes(G, {e: (sum(e) % 4) // 2 for e in G.edges}, "parity")
+    nx.set_edge_attributes(G, {e: sum(e) < 9 for e in G.edges}, "small")
+
+    def edge_match(e1d, e2d):
+        return e1d["parity"] == e2d["parity"] and e1d["small"] == e2d["small"]
+
+    iso.edge_match_to_label(edge_match, G, "combined")
+    labels_dict = nx.get_edge_attributes(G, "combined")
+    assert labels_dict == {
+        (0, 1): 0,
+        (1, 2): 1,
+        (2, 3): 0,
+        (3, 4): 1,
+        (4, 5): 2,
+        (5, 6): 3,
+        (6, 7): 2,
+        (7, 8): 3,
+    }
+
+
+# TEST NODE_MATCH Creation functions
 def test_categorical_node_match():
     nm = iso.categorical_node_match(["x", "y", "z"], [None] * 3)
     assert nm(dict(x=1, y=2, z=3), dict(x=1, y=2, z=3))
     assert not nm(dict(x=1, y=2, z=2), dict(x=1, y=2, z=1))
 
 
+# TEST MULTIEDGE_MATCH Creation functions
 class TestGenericMultiEdgeMatch:
     def setup_method(self):
         self.G1 = nx.MultiDiGraph()


### PR DESCRIPTION
**Needed: a way to convert from `node_match` to label-based isomorphism checking.**
This PR provides helper functions for converting from node/edge_match to label-based matching in the isomorphism subpackage `node_match_to_label` and `edge_match_to_label`.

`nx.node_match_to_label(node_match, G, attrname)` checks the nodes in G and creates a label for each group of nodes for which node_match returns True. It update G to include the new label under the node attribute given by `attrname`. There is a similar function for edge_match.

To make sure that multiple graphs all use the same set of integer labels for nodes that match, the functions allow a list of graphs to process.

**Details**
One large API change from VF2 to VF2++ isomorphism algorithms is the way we handle matching nodes and edges. The current `is_isomorphic` uses optional `node_match/edge_match` functions which take 2 datadict inputs and return `True/False` to indicate whether those objects can be mapped to each other. The new `vf2pp_is_isomorphic` uses label names and looks up labels on the graph to determine the node labels. The nodes match when the labels match. We will be updating it to include matching of edges too.

The `node_match` functions are very flexible -- perhaps too flexible. There is no check that the matching is commutative (nodes u and v match exactly when nodes v and u match). And there is no check for transitivity (u ~ v and v ~ w means u ~ w).  There are also many special cases like checking numerical equality versus checking string or category values.  So in some ways the current interface is complicated, especially given that the only information provided to `node_match` are the datadicts for the two nodes.

Any valid matching conditions can be implemented via labels stored on the graph. But in complicated situations, that might require some work. For example, someone who currently has written a `node_match` function may find it hard to reformulate that into node labels stored in the graph. Hopefully this PR provides some help for that.

**Allowing more descriptive labels**
One difficulty with these new functions is that the labels are integers. A user might like to replace them with e.g. more meaningful strings. To help with this, the function returns a dict keyed by label to a representative datadict, from which they can relabel the nodes. An example of how to use this is provided in the doc_strings.
