### PR TITLE
Improve handling of create_using to allow Mixins of type Protocol

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -481,7 +481,7 @@ def empty_graph(n=0, create_using=None, default=Graph):
     """
     if create_using is None:
         G = default()
-    elif type(create_using) is type:
+    elif isinstance(create_using, type):
         G = create_using()
     elif not hasattr(create_using, "adj"):
         raise TypeError("create_using is not a valid NetworkX graph type or instance")

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -6,6 +6,7 @@ Generators - Classic
 Unit tests for various classic graph generators in generators/classic.py
 """
 import itertools
+import typing
 
 import pytest
 
@@ -287,6 +288,15 @@ class TestGeneratorClassic:
         assert H.is_multigraph()
         assert not H.is_directed()
         assert G is not H
+
+        # test for subclasses that also use typing.Protocol. See gh-6243
+        class Mixin(typing.Protocol):
+            pass
+
+        class MyGraph(Mixin, nx.DiGraph):
+            pass
+
+        G = nx.empty_graph(create_using=MyGraph)
 
     def test_empty_graph(self):
         G = nx.empty_graph()


### PR DESCRIPTION
 switch create_using handling to `isinstance(_, type)` instead of `type(_) is type`

Fixes: #6243
