### PR TITLE
Make is_minimal_d_separator check both d_separator and minimal

### DIFF
--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -393,6 +393,9 @@ def is_minimal_d_separator(G, u, v, z):
     if any(node not in marks for node in z):
         return False
 
+    if not d_separated(G, {u}, {v}, z):
+        return False
+
     return True
 
 


### PR DESCRIPTION
Basically, what I did is that to check for non-separating set also so that it does not return true for such cases. 
Fixes #6216 