### PR TITLE
doc: clarify allowed `alpha` when using nx.draw_networkx_edges

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -522,8 +522,11 @@ def draw_networkx_edges(
         Also, `(offset, onoffseq)` tuples can be used as style instead of a strings.
         (See `matplotlib.patches.FancyArrowPatch`: `linestyle`)
 
-    alpha : float or None (default=None)
-        The edge transparency
+    alpha : float or array of floats (default=None)
+        The edge transparency.  This can be a single alpha value,
+        in which case it will be applied to all the nodes of color. Otherwise,
+        if it is an array, the elements of alpha will be applied to the colors
+        in order (cycling through alpha multiple times if necessary).
 
     edge_cmap : Matplotlib colormap, optional
         Colormap for mapping intensities of edges

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -524,7 +524,7 @@ def draw_networkx_edges(
 
     alpha : float or array of floats (default=None)
         The edge transparency.  This can be a single alpha value,
-        in which case it will be applied to all the nodes of color. Otherwise,
+        in which case it will be applied to all specified edges. Otherwise,
         if it is an array, the elements of alpha will be applied to the colors
         in order (cycling through alpha multiple times if necessary).
 


### PR DESCRIPTION
This inconsistency between the docs and actual behaviour came up in two StackOverflow questions:

https://stackoverflow.com/a/74106862/20148180
https://stackoverflow.com/q/74622898/10693596

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
