### PR TITLE
Changed arguments list of GraphMLWriterLxml.dump()

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -825,7 +825,7 @@ class GraphMLWriterLxml(GraphMLWriter):
     def __str__(self):
         return object.__str__(self)
 
-    def dump(self):
+    def dump(self, stream=None):
         self._graphml.__exit__(None, None, None)
         self._xml_base.__exit__(None, None, None)
 


### PR DESCRIPTION
Changed arguments list of GraphMLWriterLxml.dump to be consistent with the type of GraphMLWriter.dump. Otherwise, if we have some GraphMLWriterLxml A, and some user calls A.dump(stream) (maybe in the context of a function which takes a GraphMLWriter) then it will throw an error.
This also makes static analysis tools happier, which reduces the amount of things to look at when debugging.
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
