### PR TITLE
Update simple_paths.py: consistent behaviour for `is_simple_path` when path contains nodes not in the graph.

### DIFF
--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -77,11 +77,11 @@ def is_simple_path(G, nodes):
     # is not in the graph, then this is not a simple path
     if not all(n in G for n in nodes):
         return False
-    
+
     # If the list is a single node, and it's in the graph, this is a simple path
     if len(nodes) == 1:
         return True
-    
+
     # Test that no node appears more than once, and that each
     # adjacent pair of nodes is adjacent.
     return len(set(nodes)) == len(nodes) and all(v in G[u] for u, v in pairwise(nodes))

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -78,13 +78,12 @@ def is_simple_path(G, nodes):
     if not all(n in G for n in nodes):
         return False
 
-    # If the list is a single node, and it's in the graph, this is a simple path
-    if len(nodes) == 1:
-        return True
+    # If the list contains repeated nodes, then it's not a simple path
+    if len(set(nodes)) != len(nodes):
+        return False
 
-    # Test that no node appears more than once, and that each
-    # adjacent pair of nodes is adjacent.
-    return len(set(nodes)) == len(nodes) and all(v in G[u] for u, v in pairwise(nodes))
+    # Test that each adjacent pair of nodes is adjacent.
+    return all(v in G[u] for u, v in pairwise(nodes))
 
 
 def all_simple_paths(G, source, target, cutoff=None):

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -72,7 +72,12 @@ def is_simple_path(G, nodes):
     # NetworkXPointlessConcept here.
     if len(nodes) == 0:
         return False
-    
+
+    # If the list is a single node, just check that the node is actually
+    # in the graph.
+    if len(nodes) == 1:
+        return nodes[0] in G
+
     # check that all nodes in the list are in the graph, if at least one
     # is not in the graph, then this is not a simple path
     if not all(n in G for n in nodes):

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -68,15 +68,9 @@ def is_simple_path(G, nodes):
     False
 
     """
-    assert isinstance(nodes, list), "Object passed as `nodes` must be a list."
-
-    # The empty list is not a valid path. Could also return
-    # NetworkXPointlessConcept here.
-    if not nodes:
-        return False
-
     # check that all nodes in the list are in the graph, if at least one
     # is not in the graph, then this is not a simple path
+    # Also, the empty list is not a valid path.
     if not all(n in G for n in nodes):
         return False
 

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -68,9 +68,13 @@ def is_simple_path(G, nodes):
     False
 
     """
+    # The empty list is not a valid path. Could also return
+    # NetworkXPointlessConcept here.
+    if len(nodes) == 0:
+        return False
+    
     # check that all nodes in the list are in the graph, if at least one
     # is not in the graph, then this is not a simple path
-    # Also, the empty list is not a valid path.
     if not all(n in G for n in nodes):
         return False
 

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -70,12 +70,18 @@ def is_simple_path(G, nodes):
     """
     # The empty list is not a valid path. Could also return
     # NetworkXPointlessConcept here.
-    if len(nodes) == 0:
+    if not nodes:
         return False
-    # If the list is a single node, just check that the node is actually
-    # in the graph.
+
+    # check that all nodes in the list are in the graph, if at least one
+    # is not in the graph, then this is not a simple path
+    if not all(n in G for n in nodes):
+        return False
+    
+    # If the list is a single node, and it's in the graph, this is a simple path
     if len(nodes) == 1:
-        return nodes[0] in G
+        return True
+    
     # Test that no node appears more than once, and that each
     # adjacent pair of nodes is adjacent.
     return len(set(nodes)) == len(nodes) and all(v in G[u] for u, v in pairwise(nodes))

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -68,6 +68,8 @@ def is_simple_path(G, nodes):
     False
 
     """
+    assert isinstance(nodes, list), "Object passed as `nodes` must be a list."
+    
     # The empty list is not a valid path. Could also return
     # NetworkXPointlessConcept here.
     if not nodes:

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -69,7 +69,7 @@ def is_simple_path(G, nodes):
 
     """
     assert isinstance(nodes, list), "Object passed as `nodes` must be a list."
-    
+
     # The empty list is not a valid path. Could also return
     # NetworkXPointlessConcept here.
     if not nodes:

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -58,6 +58,10 @@ class TestIsSimplePath:
         G = nx.path_graph(2)
         assert not nx.is_simple_path(G, [0, 2])
 
+    def test_missing_starting_node(self):
+        G = nx.path_graph(2)
+        assert not nx.is_simple_path(G, [2, 0])
+
     def test_directed_path(self):
         G = nx.DiGraph([(0, 1), (1, 2)])
         assert nx.is_simple_path(G, [0, 1, 2])


### PR DESCRIPTION
Current version of `is_simple_path` fails with `KeyError` if the first element of the node list is not in the graph.

Resolves https://github.com/networkx/networkx/issues/6271, by returning `False` if any node in the provided path is outside the graph.