### PR TITLE
Pin to sphinx 5.2.3

### DIFF
--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -1,2 +1,2 @@
 pre-commit>=2.20
-mypy>=0.990
+mypy>=0.991

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,4 +1,4 @@
-sphinx>=5.2
+sphinx==5.2.3
 pydata-sphinx-theme>=0.11
 sphinx-gallery>=0.11
 numpydoc>=1.5

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,3 +1,3 @@
-build>=0.8
+build>=0.9
 twine>=4.0
-wheel>=0.37
+wheel>=0.38


### PR DESCRIPTION
and update release requirements


TODO: math roles aren't rendered with sphinx 5.3

See https://github.com/sphinx-doc/sphinx/issues/10944 for example.
