### PR TITLE
Fix ineffective `nodes` args of graph6 writers

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -176,7 +176,10 @@ def to_graph6_bytes(G, nodes=None, header=True):
 
     """
     if nodes is not None:
-        G = G.subgraph(nodes)
+        H = G.__class__()
+        H.add_nodes_from(nodes)
+        H.add_edges_from((u, v) for (u, v) in G.edges() if u in H if v in H)
+        G = H
     H = nx.convert_node_labels_to_integers(G)
     nodes = sorted(H.nodes())
     return b"".join(_generate_graph6_bytes(H, nodes, header))
@@ -364,7 +367,10 @@ def write_graph6_file(G, f, nodes=None, header=True):
 
     """
     if nodes is not None:
-        G = G.subgraph(nodes)
+        H = G.__class__()
+        H.add_nodes_from(nodes)
+        H.add_edges_from((u, v) for (u, v) in G.edges() if u in H if v in H)
+        G = H
     H = nx.convert_node_labels_to_integers(G)
     nodes = sorted(H.nodes())
     for b in _generate_graph6_bytes(H, nodes, header):

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -118,6 +118,16 @@ class TestWriteGraph6:
         f.seek(0)
         assert f.read() == b">>graph6<<A_\n"
 
+    def test_ordering_nodes(self):
+        G = nx.Graph()
+        G.add_nodes_from(range(4))
+        G.add_edges_from([(1, 2), (1, 3)])
+        nodes = [1, 2, 3, 0]
+        f = BytesIO()
+        nx.write_graph6(G, f, nodes=nodes, header=False)
+        f.seek(0)
+        assert f.read() == b"Co\n"
+
 
 class TestToGraph6Bytes:
     def test_null_graph(self):
@@ -167,3 +177,10 @@ class TestToGraph6Bytes:
     def test_relabeling(self, edge):
         G = nx.Graph([edge])
         assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"
+
+    def test_ordering_nodes(self):
+        G = nx.Graph()
+        G.add_nodes_from(range(4))
+        G.add_edges_from([(1, 2), (1, 3)])
+        nodes = [1, 2, 3, 0]
+        assert g6.to_graph6_bytes(G, nodes=nodes, header=False) == b"Co\n"


### PR DESCRIPTION
Expecting `G.nodes()` to report in order of `G.add_nodes_from(nodes)`.