### PR TITLE
Fixed an error in the documentation of the katz centrality

### DIFF
--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -59,7 +59,7 @@ def katz_centrality(
 
     beta : scalar or dictionary, optional (default=1.0)
       Weight attributed to the immediate neighborhood. If not a scalar, the
-      dictionary must have an value for every node.
+      dictionary must have a value for every node.
 
     max_iter : integer, optional (default=1000)
       Maximum number of iterations in power method.
@@ -128,7 +128,7 @@ def katz_centrality(
     The iteration will stop after ``max_iter`` iterations or an error tolerance of
     ``number_of_nodes(G) * tol`` has been reached.
 
-    When $\alpha = 1/\lambda_{\max}$ and $\beta=0$, Katz centrality is the same
+    When $\alpha = 1/\lambda_{\max}$ and $\beta=1$, Katz centrality is the same
     as eigenvector centrality.
 
     For directed graphs this finds "left" eigenvectors which corresponds

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -128,11 +128,11 @@ def katz_centrality(
     The iteration will stop after ``max_iter`` iterations or an error tolerance of
     ``number_of_nodes(G) * tol`` has been reached.
 
-    When $\alpha = 1/\lambda_{\max}$ and $\beta=1$, Katz centrality is the same
-    as eigenvector centrality.
+    For strongly connected graphs, as $\alpha \to 1/\lambda_{\max}$, and $\beta > 0$,
+    Katz centrality approaches the results for eigenvector centrality.
 
     For directed graphs this finds "left" eigenvectors which corresponds
-    to the in-edges in the graph. For out-edges Katz centrality
+    to the in-edges in the graph. For out-edges Katz centrality,
     first reverse the graph with ``G.reverse()``.
 
     References
@@ -183,7 +183,6 @@ def katz_centrality(
                 # normalize vector
                 try:
                     s = 1.0 / math.hypot(*x.values())
-                # this should never be zero?
                 except ZeroDivisionError:
                     s = 1.0
             else:
@@ -289,11 +288,11 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
     You can use ``max(nx.adjacency_spectrum(G))`` to get $\lambda_{\max}$ the largest
     eigenvalue of the adjacency matrix.
 
-    When $\alpha = 1/\lambda_{\max}$ and $\beta=0$, Katz centrality is the same
-    as eigenvector centrality.
+    For strongly connected graphs, as $\alpha \to 1/\lambda_{\max}$, and $\beta > 0$,
+    Katz centrality approaches the results for eigenvector centrality.
 
     For directed graphs this finds "left" eigenvectors which corresponds
-    to the in-edges in the graph. For out-edges Katz centrality
+    to the in-edges in the graph. For out-edges Katz centrality,
     first reverse the graph with ``G.reverse()``.
 
     References


### PR DESCRIPTION
Issue  #6279 reported a sentence in the documentation of the method stating

>  When $\alpha = 1/\lambda_{\max}$ and $\beta=0$, Katz centrality is the same 
>      as eigenvector centrality. 

I replaced $\beta=0$ with $\beta=1$, according to the issue's suggestion (and fixed a small typo along the way). 