### PR TITLE
Correctly point towards 2.8.8 in release notes

### DIFF
--- a/doc/release/release_2.8.8.rst
+++ b/doc/release/release_2.8.8.rst
@@ -1,4 +1,4 @@
-NetworkX 2.8.7
+NetworkX 2.8.8
 ==============
 
 Release date: 1 November 2022


### PR DESCRIPTION
Fixes https://github.com/networkx/networkx/issues/6297