### PR TITLE
Fix for issue 6300 - Add common_neighbors support for directed graphs

### DIFF
--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -95,7 +95,6 @@ def resource_allocation_index(G, ebunch=None):
 
 
 @nx._dispatch
-@not_implemented_for("directed")
 @not_implemented_for("multigraph")
 def jaccard_coefficient(G, ebunch=None):
     r"""Compute the Jaccard coefficient of all node pairs in ebunch.
@@ -110,8 +109,7 @@ def jaccard_coefficient(G, ebunch=None):
 
     Parameters
     ----------
-    G : graph
-        A NetworkX undirected graph.
+    G : A NetworkX undirected or directed graph.
 
     ebunch : iterable of node pairs, optional (default = None)
         Jaccard coefficient will be computed for each pair of nodes
@@ -124,7 +122,8 @@ def jaccard_coefficient(G, ebunch=None):
     -------
     piter : iterator
         An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their Jaccard coefficient.
+        pair of nodes and p is their Jaccard coefficient. For directed graphs,
+        this refers to out-degree neighbor nodes.
 
     Examples
     --------

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -82,9 +82,6 @@ class TestJaccardCoefficient:
 
     def test_notimplemented(self):
         assert pytest.raises(
-            nx.NetworkXNotImplemented, self.func, nx.DiGraph([(0, 1), (1, 2)]), [(0, 2)]
-        )
-        assert pytest.raises(
             nx.NetworkXNotImplemented,
             self.func,
             nx.MultiGraph([(0, 1), (1, 2)]),

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -915,14 +915,13 @@ def non_edges(graph):
                 yield (u, v)
 
 
-@not_implemented_for("directed")
 def common_neighbors(G, u, v):
-    """Returns the common neighbors of two nodes in a graph.
+    """Returns the common neighbors of two nodes in a graph. In directed graphs,
+    common neighbors refer to out-degree neighbor nodes.
 
     Parameters
     ----------
-    G : graph
-        A NetworkX undirected graph.
+    G : NetworkX graph
 
     u, v : nodes
         Nodes in the graph.

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -441,12 +441,6 @@ class TestCommonNeighbors:
         G = nx.star_graph(4)
         self.test(G, 1, 2, [0])
 
-    def test_digraph(self):
-        with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.DiGraph()
-            G.add_edges_from([(0, 1), (1, 2)])
-            self.func(G, 0, 2)
-
     def test_nonexistent_nodes(self):
         G = nx.complete_graph(5)
         pytest.raises(nx.NetworkXError, nx.common_neighbors, G, 5, 4)


### PR DESCRIPTION
Removed DiGraph restrictions on `nx.common_neighbors`. Tested it on its own as well as `nx.jaccard_coefficient` because I originally discovered the lack of DiGraph support while trying to compute Jaccard coefficients. I'm stoked to have this fixed!

Didn't really have to make any code changes, just removed the DiGraph restriction decorators, updated the docstrings, and removed the NotImplemented tests for DiGraphs on those two functions.

RE: [Issue 6300](https://github.com/networkx/networkx/issues/6300)
