### PR TITLE
Use node_color for bbox nodes

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -315,9 +315,9 @@ def draw_networkx_nodes(
     node_color="#1f78b4",
     node_shape="o",
     alpha=None,
-    node_cmap=None,
-    node_vmin=None,
-    node_vmax=None,
+    cmap=None,
+    vmin=None,
+    vmax=None,
     ax=None,
     linewidths=None,
     edgecolors=None,
@@ -427,12 +427,10 @@ def draw_networkx_nodes(
         raise nx.NetworkXError(f"Node {err} has no position.") from err
 
     if isinstance(alpha, Iterable):
-        node_color = apply_alpha(
-            node_color, alpha, nodelist, node_cmap, node_vmin, node_vmax
-        )
+        node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)
         alpha = None
 
-    node_color = get_colormapped_value(node_color, pos, node_cmap, node_vmin, node_vmax)
+    node_color = get_colormapped_value(node_color, pos, cmap, vmin, vmax)
 
     node_collection = ax.scatter(
         xy[:, 0],
@@ -440,9 +438,9 @@ def draw_networkx_nodes(
         s=node_size,
         c=node_color,
         marker=node_shape,
-        cmap=node_cmap,
-        vmin=node_vmin,
-        vmax=node_vmax,
+        cmap=cmap,
+        vmin=vmin,
+        vmax=vmax,
         alpha=alpha,
         linewidths=linewidths,
         edgecolors=edgecolors,
@@ -951,9 +949,9 @@ def draw_networkx_labels(
     font_weight="normal",
     alpha=None,
     node_color=None,
-    node_cmap=None,
-    node_vmin=None,
-    node_vmax=None,
+    cmap=None,
+    vmin=None,
+    vmax=None,
     bbox=None,
     horizontalalignment="center",
     verticalalignment="center",
@@ -1056,7 +1054,7 @@ def draw_networkx_labels(
             label = str(label)  # this makes "1" and 1 labeled the same
         if node_color is not None and bbox is not None:
             bbox["facecolor"] = get_colormapped_value(
-                node_color, pos, node_cmap, node_vmin, node_vmax
+                node_color, pos, cmap, vmin, vmax
             )[idx]
         t = ax.text(
             x,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -934,6 +934,7 @@ def draw_networkx_labels(
     font_family="sans-serif",
     font_weight="normal",
     alpha=None,
+    node_color=None,
     bbox=None,
     horizontalalignment="center",
     verticalalignment="center",
@@ -970,6 +971,13 @@ def draw_networkx_labels(
 
     alpha : float or None (default=None)
         The text transparency
+
+    node_color : color or array of colors (default='#1f78b4')
+        Node color. Can be a single color or a sequence of colors with the same
+        length as nodelist. Color can be string or rgb (or rgba) tuple of
+        floats from 0-1. If numeric values are specified they will be
+        mapped to colors using the cmap and vmin,vmax parameters. See
+        matplotlib.scatter for more details.
 
     bbox : Matplotlib bbox, (default is Matplotlib's ax.text default)
         Specify text box properties (e.g. shape, color etc.) for node labels.
@@ -1020,6 +1028,11 @@ def draw_networkx_labels(
         (x, y) = pos[n]
         if not isinstance(label, str):
             label = str(label)  # this makes "1" and 1 labeled the same
+        if node_color is not None and bbox is not None:
+            color = node_color[idx]
+            if isinstance(color, Number):
+                color = [color, color, color]
+            bbox["facecolor"] = color
         t = ax.text(
             x,
             y,


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

Demo code:

```python
from pprint import pprint

import matplotlib.pyplot as plt
import networkx as nx
from networkx.drawing.nx_pydot import graphviz_layout

G = nx.Graph()
G.add_node((1, 4), weight=10/255)
G.add_node((7, 2), weight=130/255)
G.add_node((9, 7), weight=250/255)
node_labels = dict()
node_colors = []
for node, node_data in G.nodes.items():
    node_labels[node] = node
    node_colors.append(node_data['weight'])
pprint(node_labels)
pprint(node_colors)
fig, axs = plt.subplots(ncols=4)
plt.margins(0.0)
pos = graphviz_layout(G, prog='dot')
nx.draw(G, pos=pos, with_labels=True, labels=node_labels, node_color=node_colors, cmap=plt.cm.gray, ax=axs[0])
nx.draw(G, pos=pos, with_labels=True, labels=node_labels, node_color=node_colors, cmap=plt.cm.gray, ax=axs[1], bbox=dict(edgecolor='black', boxstyle='round,pad=0.2'), vmin=-0.8)
nx.draw(G, pos=pos, with_labels=True, labels=node_labels, node_color=node_colors, cmap=plt.cm.jet, ax=axs[2], bbox=dict(edgecolor='black', boxstyle='round,pad=0.2'))
nx.draw(G, pos=pos, with_labels=True, labels=node_labels, ax=axs[3], bbox=dict(edgecolor='black', boxstyle='round,pad=0.2'))
fig.tight_layout()

plt.show()
```

Should draw_networkx_labels()'s  cmap, vmax and vmin parameters be renamed to label_cmap, label_vmin and label_vmax, analogue to draw_networkx_edges()'s parameters?

![image](https://user-images.githubusercontent.com/3226457/209901949-38b4baca-8549-423a-b9f9-a969ed8b6da1.png)

![image](https://user-images.githubusercontent.com/3226457/209903869-17d2acbe-fbf0-4a95-835f-fa8b0f97445d.png)
