### PR TITLE
Fix typo in Katz.py

### DIFF
--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -169,7 +169,7 @@ def katz_centrality(
     for _ in range(max_iter):
         xlast = x
         x = dict.fromkeys(xlast, 0)
-        # do the multiplication y^T = Alpha * x^T A - Beta
+        # do the multiplication y^T = Alpha * x^T A + Beta
         for n in x:
             for nbr in G[n]:
                 x[nbr] += xlast[n] * G[n][nbr].get(weight, 1)


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

The formula mentioned in this comment (`y^T = Alpha * x^T A - Beta`) is incorrect as the formula in the code has a `+` sign instead!
