### PR TITLE
forbid blanket 'type: ignore' comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,11 @@ repos:
       - id: prettier
         files: \.(html|md|yml|yaml)
         args: [--prose-wrap=preserve]
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.208
+    hooks:
+      - id: ruff
+        args:
+          - --force-exclude
+          - --fix

--- a/networkx/algorithms/approximation/kcomponents.py
+++ b/networkx/algorithms/approximation/kcomponents.py
@@ -212,7 +212,7 @@ class _AntiGraph(nx.Graph):
     def single_edge_dict(self):
         return self.all_edge_dict
 
-    edge_attr_dict_factory = single_edge_dict  # type: ignore
+    edge_attr_dict_factory = single_edge_dict  # type: ignore[assignment]
 
     def __getitem__(self, n):
         """Returns a dict of neighbors of node n in the dense graph.

--- a/networkx/algorithms/planar_drawing.py
+++ b/networkx/algorithms/planar_drawing.py
@@ -223,7 +223,7 @@ def get_canonical_ordering(embedding, outer_face):
                 ready_to_pick.discard(v)
 
     # Initialize canonical_ordering
-    canonical_ordering = [None] * len(embedding.nodes())  # type: list
+    canonical_ordering = [None] * len(embedding.nodes())
     canonical_ordering[0] = (v1, [])
     canonical_ordering[1] = (v2, [])
     ready_to_pick.discard(v1)

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -309,8 +309,8 @@ class DiGraph(Graph):
     True
     """
 
-    _adj = _CachedPropertyResetterAdjAndSucc()  # type: ignore
-    _succ = _adj  # type: ignore
+    _adj = _CachedPropertyResetterAdjAndSucc()  # type: ignore[assignment]
+    _succ = _adj  # type: ignore[has-type]
     _pred = _CachedPropertyResetterPred()
 
     def __init__(self, incoming_graph_data=None, **attr):

--- a/networkx/classes/tests/test_multidigraph.py
+++ b/networkx/classes/tests/test_multidigraph.py
@@ -421,13 +421,13 @@ class CustomDictClass(UserDict):
 
 
 class MultiDiGraphSubClass(nx.MultiDiGraph):
-    node_dict_factory = CustomDictClass  # type: ignore
-    node_attr_dict_factory = CustomDictClass  # type: ignore
-    adjlist_outer_dict_factory = CustomDictClass  # type: ignore
-    adjlist_inner_dict_factory = CustomDictClass  # type: ignore
-    edge_key_dict_factory = CustomDictClass  # type: ignore
-    edge_attr_dict_factory = CustomDictClass  # type: ignore
-    graph_attr_dict_factory = CustomDictClass  # type: ignore
+    node_dict_factory = CustomDictClass  # type: ignore[assignment]
+    node_attr_dict_factory = CustomDictClass  # type: ignore[assignment]
+    adjlist_outer_dict_factory = CustomDictClass  # type: ignore[assignment]
+    adjlist_inner_dict_factory = CustomDictClass  # type: ignore[assignment]
+    edge_key_dict_factory = CustomDictClass  # type: ignore[assignment]
+    edge_attr_dict_factory = CustomDictClass  # type: ignore[assignment]
+    graph_attr_dict_factory = CustomDictClass  # type: ignore[assignment]
 
 
 class TestMultiDiGraphSubclass(TestMultiDiGraph):

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -235,7 +235,7 @@ class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
     dol = {"a": ["b"]}
 
     multiple_edge = [("a", "b", "traits", etraits), ("a", "b", "graphics", egraphics)]
-    single_edge = [("a", "b", 0, {})]  # type: ignore
+    single_edge = [("a", "b", 0, {})]  # type: ignore[var-annotated]
     single_edge1 = [("a", "b", 0, edata)]
     single_edge2 = [("a", "b", 0, etraits)]
     single_edge3 = [("a", "b", 0, {"traits": etraits, "s": "foo"})]
@@ -492,13 +492,13 @@ class CustomDictClass(UserDict):
 
 
 class MultiGraphSubClass(nx.MultiGraph):
-    node_dict_factory = CustomDictClass  # type: ignore
-    node_attr_dict_factory = CustomDictClass  # type: ignore
-    adjlist_outer_dict_factory = CustomDictClass  # type: ignore
-    adjlist_inner_dict_factory = CustomDictClass  # type: ignore
-    edge_key_dict_factory = CustomDictClass  # type: ignore
-    edge_attr_dict_factory = CustomDictClass  # type: ignore
-    graph_attr_dict_factory = CustomDictClass  # type: ignore
+    node_dict_factory = CustomDictClass  # type: ignore[assignment]
+    node_attr_dict_factory = CustomDictClass  # type: ignore[assignment]
+    adjlist_outer_dict_factory = CustomDictClass  # type: ignore[assignment]
+    adjlist_inner_dict_factory = CustomDictClass  # type: ignore[assignment]
+    edge_key_dict_factory = CustomDictClass  # type: ignore[assignment]
+    edge_attr_dict_factory = CustomDictClass  # type: ignore[assignment]
+    graph_attr_dict_factory = CustomDictClass  # type: ignore[assignment]
 
 
 class TestMultiGraphSubclass(TestMultiGraph):

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -97,7 +97,7 @@ fopeners = {
     ".gzip": gzip.open,
     ".bz2": bz2.BZ2File,
 }
-_dispatch_dict = defaultdict(lambda: open, **fopeners)  # type: ignore
+_dispatch_dict = defaultdict(lambda: open, **fopeners)
 
 
 def open_file(path_arg, mode="r"):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+select = [
+    "PGH003",  # forbid blanket 'type: ignore' comments
+]


### PR DESCRIPTION
error suppression should use the smallest possible scope. Additionally, if specific error codes are used, then mypy will return an error if that error is no longer triggered (with a blanket statement this behaviour does not occur)

This PR uses ruff to forbid blanket ignore statements and requires users to set a specific error code.