### PR TITLE
optimize _single_shortest_path function

### DIFF
--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -361,16 +361,19 @@ def _single_shortest_path(adj, firstlevel, paths, cutoff, join):
             list inputs `p1` and `p2`, and returns a list. Usually returns
             `p1 + p2` (forward from source) or `p2 + p1` (backward from target)
     """
-    level = 0  # the current level
-    nextlevel = firstlevel
+    level = 0
+    nextlevel = list(firstlevel)
+    n = len(adj)
     while nextlevel and cutoff > level:
         thislevel = nextlevel
-        nextlevel = {}
+        nextlevel = []
         for v in thislevel:
             for w in adj[v]:
                 if w not in paths:
                     paths[w] = join(paths[v], [w])
-                    nextlevel[w] = 1
+                    nextlevel.append(w)
+            if len(paths) == n:
+                return paths
         level += 1
     return paths
 


### PR DESCRIPTION
Applied here the same optimizations in  #6299 (the ones already not included) for the function `_single_shortest_path`. Practically, just:

- Use a list instead of a dict for `nextlevel/thislevel` (verified that is slightly better independently of the othe optimization);
- Check if all the nodes were visited inside the loop: this has a very big impact for "uniformly dense" graphs, in the sense that the last level of the graph is composed by lots of edges, and so we can exit the bfs earlier);

Code for benchmark:

```
import timeit, prettytable

def join(p1, p2):
    return p1 + p2

def _single_shortest_path(adj, firstlevel, paths, cutoff, join):
    """Returns shortest paths
    Shortest Path helper function
    Parameters
    ----------
        adj : dict
            Adjacency dict or view
        firstlevel : dict
            starting nodes, e.g. {source: 1} or {target: 1}
        paths : dict
            paths for starting nodes, e.g. {source: [source]}
        cutoff : int or float
            level at which we stop the process
        join : function
            function to construct a path from two partial paths. Requires two
            list inputs `p1` and `p2`, and returns a list. Usually returns
            `p1 + p2` (forward from source) or `p2 + p1` (backward from target)
    """
    level = 0  # the current level
    nextlevel = firstlevel
    while nextlevel and cutoff > level:
        thislevel = nextlevel
        nextlevel = {}
        for v in thislevel:
            for w in adj[v]:
                if w not in paths:
                    paths[w] = join(paths[v], [w])
                    nextlevel[w] = 1
        level += 1
    return paths

def _single_shortest_path_2(adj, firstlevel, paths, cutoff, join):
    """Returns shortest paths
    Shortest Path helper function
    Parameters
    ----------
        adj : dict
            Adjacency dict or view
        firstlevel : dict
            starting nodes, e.g. {source: 1} or {target: 1}
        paths : dict
            paths for starting nodes, e.g. {source: [source]}
        cutoff : int or float
            level at which we stop the process
        join : function
            function to construct a path from two partial paths. Requires two
            list inputs `p1` and `p2`, and returns a list. Usually returns
            `p1 + p2` (forward from source) or `p2 + p1` (backward from target)
    """
    level = 0
    nextlevel = list(firstlevel)
    n = len(adj)
    while nextlevel and cutoff > level:
        thislevel = nextlevel
        nextlevel = []
        for v in thislevel:
            for w in adj[v]:
                if w not in paths:
                    paths[w] = join(paths[v], [w])
                    nextlevel.append(w)
            if len(paths) == n:
                return paths
        level += 1
    return paths

graphs = [  "nx.gaussian_random_partition_graph(100, 10, 5, 0.5, 0.05, seed=4241)",
            "nx.gaussian_random_partition_graph(100, 10, 5, 0.8, 0.3, seed=4241)",
            "nx.random_regular_graph(d=2, n=1000, seed=4241)", "nx.random_regular_graph(d=5, n=1000, seed=4241)",
            "nx.random_regular_graph(d=10, n=1000, seed=4241)", "nx.random_regular_graph(d=50, n=1000, seed=4241)",
            "nx.random_regular_graph(d=100, n=1000, seed=4241)", "nx.random_regular_graph(d=200, n=1000, seed=4241)",
            "nx.random_regular_graph(d=500, n=1000, seed=4241)", "nx.random_regular_graph(d=700, n=1000, seed=4241)",
            "nx.erdos_renyi_graph(n=100, p=0.9, seed=4241)", "nx.erdos_renyi_graph(n=1000, p=0.8, seed=4241)",
            "nx.watts_strogatz_graph(n=100, k=10, p=0.3, seed=4241)", "nx.connected_caveman_graph(100,10)",  
            "nx.caveman_graph(100,10)",  "nx.windmill_graph(10, 10)", "nx.full_rary_tree(3, 1000)",  
            "nx.complete_graph(100)", "nx.complete_graph(10)",  "nx.cycle_graph(100)", "nx.cycle_graph(10)",
            "nx.binomial_tree(10)", "nx.path_graph(10)" ]

stmt_1 = "q = random.randrange(len(G)-1); list(_single_shortest_path(G.adj, {q: 1}, {q:[q]}, float('inf'), join))"
stmt_2 = "q = random.randrange(len(G)-1); list(_single_shortest_path_2(G.adj, {q: 1}, {q:[q]}, float('inf'), join))"
table = prettytable.PrettyTable()
table.field_names = ["graph", "time: current main", "time: this pr", "times faster"]

for graph in graphs:
    setup_1 = "import networkx as nx; import collections, random; from __main__ import _single_shortest_path, join; random.seed(4241); G = {}".format(graph)
    setup_2 = "import networkx as nx; import collections, random; from __main__ import _single_shortest_path_2, join; random.seed(4241); G = {}".format(graph)
    main_time = timeit.timeit(stmt_1, setup_1, number=2000)
    pr_time = timeit.timeit(stmt_2, setup_2, number=2000)
    a, b, c, d = graph, round(main_time,2), round(pr_time,2), round(main_time/pr_time, 2)
    table.add_row([a, b, c, d])
    print(d)

print(table)
```

which produces in 3.11:

```
+----------------------------------------------------------------------+--------------------+---------------+--------------+
|                                graph                                 | time: current main | time: this pr | times faster |
+----------------------------------------------------------------------+--------------------+---------------+--------------+
| nx.gaussian_random_partition_graph(100, 10, 5, 0.5, 0.05, seed=4241) |        0.01        |      0.01     |     1.49     |
| nx.gaussian_random_partition_graph(100, 10, 5, 0.8, 0.3, seed=4241)  |        0.03        |      0.01     |     3.99     |
|           nx.random_regular_graph(d=2, n=1000, seed=4241)            |        0.26        |      0.26     |     1.01     |
|           nx.random_regular_graph(d=5, n=1000, seed=4241)            |        0.12        |      0.11     |     1.1      |
|           nx.random_regular_graph(d=10, n=1000, seed=4241)           |        0.15        |      0.1      |     1.49     |
|           nx.random_regular_graph(d=50, n=1000, seed=4241)           |        0.37        |      0.08     |     4.51     |
|          nx.random_regular_graph(d=100, n=1000, seed=4241)           |        0.63        |      0.08     |     8.09     |
|          nx.random_regular_graph(d=200, n=1000, seed=4241)           |        1.16        |      0.07     |    16.07     |
|          nx.random_regular_graph(d=500, n=1000, seed=4241)           |        2.72        |      0.06     |    43.15     |
|          nx.random_regular_graph(d=700, n=1000, seed=4241)           |        3.85        |      0.06     |    65.49     |
|            nx.erdos_renyi_graph(n=100, p=0.9, seed=4241)             |        0.06        |      0.0      |    13.11     |
|            nx.erdos_renyi_graph(n=1000, p=0.8, seed=4241)            |        4.29        |      0.05     |     79.5     |
|        nx.watts_strogatz_graph(n=100, k=10, p=0.3, seed=4241)        |        0.01        |      0.01     |     1.59     |
|                  nx.connected_caveman_graph(100,10)                  |        0.16        |      0.17     |     0.96     |
|                       nx.caveman_graph(100,10)                       |        0.0         |      0.0      |     0.94     |
|                      nx.windmill_graph(10, 10)                       |        0.01        |      0.0      |     2.91     |
|                      nx.full_rary_tree(3, 1000)                      |        0.1         |      0.08     |     1.25     |
|                        nx.complete_graph(100)                        |        0.06        |      0.0      |    15.21     |
|                        nx.complete_graph(10)                         |        0.0         |      0.0      |     2.53     |
|                         nx.cycle_graph(100)                          |        0.01        |      0.01     |     1.11     |
|                          nx.cycle_graph(10)                          |        0.0         |      0.0      |     1.12     |
|                         nx.binomial_tree(10)                         |        0.11        |      0.11     |     0.94     |
|                          nx.path_graph(10)                           |        0.0         |      0.0      |     1.03     |
+----------------------------------------------------------------------+--------------------+---------------+--------------+
```