### PR TITLE
Optimize _plain_bfs functions

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -188,7 +188,7 @@ def node_connected_component(G, n):
 
 def _plain_bfs(G, source):
     """A fast BFS node generator"""
-    adj = G.adj
+    adj = G._adj
     n = len(adj)
     seen = {source}
     nextlevel = [source]

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -192,7 +192,6 @@ def _plain_bfs(G, source):
     n = len(adj)
     seen = {source}
     nextlevel = [source]
-    yield source
     while nextlevel:
         thislevel = nextlevel
         nextlevel = []

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -188,14 +188,19 @@ def node_connected_component(G, n):
 
 def _plain_bfs(G, source):
     """A fast BFS node generator"""
-    G_adj = G.adj
-    seen = set()
-    nextlevel = {source}
+    adj = G.adj
+    n = len(adj)
+    seen = {source}
+    nextlevel = [source]
+    yield source
     while nextlevel:
         thislevel = nextlevel
-        nextlevel = set()
+        nextlevel = []
         for v in thislevel:
-            if v not in seen:
-                seen.add(v)
-                nextlevel.update(G_adj[v])
+            for w in adj[v]:
+                if w not in seen:
+                    seen.add(w)
+                    nextlevel.append(w)
+            if len(seen) == n:
+                return seen
     return seen

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -172,7 +172,7 @@ def _plain_bfs(G, source):
     n = len(G)
     Gsucc = G.succ
     Gpred = G.pred
-    seen = set()
+    seen = {source}
     nextlevel = [source]
 
     yield source

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -170,8 +170,8 @@ def _plain_bfs(G, source):
 
     """
     n = len(G)
-    Gsucc = G.succ
-    Gpred = G.pred
+    Gsucc = G._succ
+    Gpred = G._pred
     seen = {source}
     nextlevel = [source]
 

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -169,17 +169,26 @@ def _plain_bfs(G, source):
     For directed graphs only.
 
     """
+    n = len(G)
     Gsucc = G.succ
     Gpred = G.pred
-
     seen = set()
-    nextlevel = {source}
+    nextlevel = [source]
+
+    yield source
     while nextlevel:
         thislevel = nextlevel
-        nextlevel = set()
+        nextlevel = []
         for v in thislevel:
-            if v not in seen:
-                seen.add(v)
-                nextlevel.update(Gsucc[v])
-                nextlevel.update(Gpred[v])
-                yield v
+            for w in Gsucc[v]:
+                if w not in seen:
+                    seen.add(w)
+                    nextlevel.append(w)
+                    yield w
+            for w in Gpred[v]:
+                if w not in seen:
+                    seen.add(w)
+                    nextlevel.append(w)
+                    yield w
+            if len(seen) == n:
+                return


### PR DESCRIPTION
Optimization of _plain_bfs for undirected graphs through the same principles described in #6299 and #6337.

This is a table which summarizes the new times in relation to the old ones for some graphs, as you can see there are some huge improvements in performance :-)

```
+--------------------------------------------------------+--------------------+---------------+--------------+
|                         graph                          | time: current main | time: this pr | times faster |
+--------------------------------------------------------+--------------------+---------------+--------------+
|     nx.random_regular_graph(d=1, n=10, seed=4241)      |        0.0         |      0.0      |     2.91     |
|     nx.random_regular_graph(d=9, n=10, seed=4241)      |        0.03        |      0.0      |     12.3     |
|    nx.random_regular_graph(d=10, n=100, seed=4241)     |        0.29        |      0.03     |     9.94     |
|    nx.random_regular_graph(d=99, n=100, seed=4241)     |        1.67        |      0.02     |    109.89    |
|    nx.random_regular_graph(d=1, n=1000, seed=4241)     |        0.0         |      0.0      |     2.7      |
|    nx.random_regular_graph(d=3, n=1000, seed=4241)     |        1.75        |      0.31     |     5.7      |
|    nx.random_regular_graph(d=10, n=1000, seed=4241)    |        2.91        |      0.28     |    10.58     |
|    nx.random_regular_graph(d=50, n=1000, seed=4241)    |        6.94        |      0.27     |    25.98     |
|   nx.random_regular_graph(d=100, n=1000, seed=4241)    |       13.59        |      0.26     |    52.84     |
|   nx.random_regular_graph(d=200, n=1000, seed=4241)    |       29.19        |      0.25     |    118.5     |
|   nx.random_regular_graph(d=500, n=1000, seed=4241)    |        85.0        |      0.21     |    405.64    |
|   nx.random_regular_graph(d=700, n=1000, seed=4241)    |       121.13       |      0.18     |    667.0     |
|     nx.erdos_renyi_graph(n=100, p=0.9, seed=4241)      |        1.09        |      0.01     |    95.36     |
|     nx.erdos_renyi_graph(n=1000, p=0.8, seed=4241)     |       107.46       |      0.17     |    624.35    |
| nx.watts_strogatz_graph(n=100, k=10, p=0.3, seed=4241) |        0.2         |      0.02     |     8.34     |
|           nx.connected_caveman_graph(100,10)           |        1.92        |      0.43     |     4.52     |
|                nx.caveman_graph(100,10)                |        0.02        |      0.01     |     3.99     |
|               nx.windmill_graph(10, 10)                |        0.18        |      0.01     |    18.01     |
|               nx.full_rary_tree(3, 1000)               |        1.09        |      0.14     |     7.86     |
|                 nx.complete_graph(100)                 |        1.2         |      0.01     |    110.49    |
|                 nx.complete_graph(10)                  |        0.02        |      0.0      |    11.63     |
|                  nx.cycle_graph(100)                   |        0.11        |      0.02     |     6.25     |
|                   nx.cycle_graph(10)                   |        0.01        |      0.0      |     5.44     |
+--------------------------------------------------------+--------------------+---------------+--------------+
```


<details> <summary> Code to recreate the benchmark table</summary>


```python
import timeit, prettytable

def _plain_bfs(G, source):
    """A fast BFS node generator

    The direction of the edge between nodes is ignored.

    For directed graphs only.

    """
    Gsucc = G.succ
    Gpred = G.pred
    seen = set()
    nextlevel = {source}
    while nextlevel:
        thislevel = nextlevel
        nextlevel = {}
        for v in thislevel:
            if v not in seen:
                seen.add(v)
                nextlevel.update(Gsucc[v])
                nextlevel.update(Gpred[v])
                yield v

def _plain_bfs_2(G, source):
    """A fast BFS node generator

    The direction of the edge between nodes is ignored.

    For directed graphs only.
    """
    Gsucc = G._succ
    Gpred = G._pred
    n = len(G)
    seen = set()
    nextlevel = [source]
    yield source
    while nextlevel:
        thislevel = nextlevel
        nextlevel = []
        for v in thislevel:
            for w in Gsucc[v]:
                if w not in seen:
                    seen.add(w)
                    nextlevel.append(w)
                    yield w
            for w in Gpred[v]:
                if w not in seen:
                    seen.add(w)
                    nextlevel.append(w)
                    yield w
            if len(seen) == n:
                return

graphs = [  "nx.random_regular_graph(d=1, n=10, seed=4241)", "nx.random_regular_graph(d=9, n=10, seed=4241)",
            "nx.random_regular_graph(d=10, n=100, seed=4241)", "nx.random_regular_graph(d=99, n=100, seed=4241)",
            "nx.random_regular_graph(d=1, n=1000, seed=4241)", "nx.random_regular_graph(d=3, n=1000, seed=4241)",
            "nx.random_regular_graph(d=10, n=1000, seed=4241)", "nx.random_regular_graph(d=50, n=1000, seed=4241)",
            "nx.random_regular_graph(d=100, n=1000, seed=4241)", "nx.random_regular_graph(d=200, n=1000, seed=4241)",
            "nx.random_regular_graph(d=500, n=1000, seed=4241)", "nx.random_regular_graph(d=700, n=1000, seed=4241)",
            "nx.erdos_renyi_graph(n=100, p=0.9, seed=4241)", "nx.erdos_renyi_graph(n=1000, p=0.8, seed=4241)",
            "nx.watts_strogatz_graph(n=100, k=10, p=0.3, seed=4241)", "nx.connected_caveman_graph(100,10)",  
            "nx.caveman_graph(100,10)",  "nx.windmill_graph(10, 10)", "nx.full_rary_tree(3, 1000)",  
            "nx.complete_graph(100)", "nx.complete_graph(10)",  "nx.cycle_graph(100)", "nx.cycle_graph(10)" ]

stmt_1 = "a = list(_plain_bfs(G, random.randrange(len(G)-1)))"
stmt_2 = "b = list(_plain_bfs_2(G, random.randrange(len(G)-1)))"
table = prettytable.PrettyTable()
table.field_names = ["graph", "time: current main", "time: this pr", "times faster"]

for graph in graphs:
    setup_1 = "import networkx as nx; import collections, random; from __main__ import _plain_bfs; random.seed(4241); G = {}".format("nx.DiGraph(" +graph+")")
    setup_2 = "import networkx as nx; import collections, random; from __main__ import _plain_bfs_2; random.seed(4241); G = {}".format("nx.DiGraph(" +graph+")")
    main_time = timeit.timeit(stmt_1, setup_1, number=500)
    pr_time = timeit.timeit(stmt_2, setup_2, number=500)
    a, b, c, d = graph, round(main_time,2), round(pr_time,2), round(main_time/pr_time, 2)
    table.add_row([a, b, c, d])
    print(d)
print(table)
```

</details>
