### PR TITLE
Graph.nbunch_iter() treat single node similarly to a sequence of nodes

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -2001,10 +2001,18 @@ class Graph:
         if nbunch is None:
             return iter(self._adj)  # include all nodes via iterator
 
+        if nbunch in self:
+            return iter([nbunch])   # nbunch is a single node, found in graph;
+                                    # we do this check first to accommodate
+                                    # nodes that could coincidentally be a
+                                    # valid argument to iter()
+
         try:
-            bunch = iter(nbunch)  # nbunch is a sequence of nodes
+            bunch = iter(nbunch)    # nbunch is (likely) a sequence of nodes
         except TypeError:
-            bunch = iter([nbunch])  # nbunch is a single node
+            bunch = iter([nbunch])  # nbunch is a single node, not in graph;
+                                    # handle the same as if it was included in
+                                    # a sequence
 
         # iterator that yields nodes from nbunch if they are in the graph
         def bunch_iter(nlist, adj):


### PR DESCRIPTION
The [documentation for Graph.nbunch_iter()](https://networkx.org/documentation/latest/reference/classes/generated/networkx.Graph.nbunch_iter.html#networkx.Graph.nbunch_iter) states:

> The nodes in nbunch are checked for membership in the graph and if not are silently ignored.

Unknown nodes are indeed "silently ignored" if nbunch is a sequence, but not if nbunch is a single node. For example, using the following graph:

```pycon
>>> import networkx as nx
>>> G = nx.from_edgelist([(0,1), (1,2), (2,3)], nx.DiGraph)
```

As expected, specifying a single node "2", which exists in the graph, returns an iterator containing just that node:

```pycon
>>> list(G.nbunch_iter(2))
[2]
```

As expected, specifying a list of nodes [0, 2, 5], where only 0 and 2 exist in the graph, returns an iterator containing only 0 and 2:

```pycon
>>> list(G.nbunch_iter([0, 2, 5]))
[0, 2]
```

As expected, specifying a list containing a single node "5", which does not exist in the graph, returns an iterator that yields nothing:

```pycon
>>> list(G.nbunch_iter([5]))
[]
```

Specifying a single node "5", which does not exist in the graph, should give the same outcome as above, but instead it throws an exception:

```pycon
>>> list(G.nbunch_iter(5))
Traceback (most recent call last):
  File "/Users/mark/Dev/studbook/venv/lib/python3.9/site-packages/networkx/classes/graph.py", line 1911, in bunch_iter
    for n in nlist:
TypeError: 'int' object is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mark/Dev/studbook/venv/lib/python3.9/site-packages/networkx/classes/graph.py", line 1926, in bunch_iter
    raise exc
networkx.exception.NetworkXError: nbunch is not a node or a sequence of nodes.
```

This pull request fixes the latter case so a single node not in the graph is treated in the same way as a list containing a node not in the graph, i.e. by returning an iterator that yields nothing. I also provide clearer error messages.

I originally encountered this issue where my app's code uses `nx.edge_dfs(G, source)` and in some cases `source` was not in `G`. The resulting exceptions (as above) were very unclear and unhelpful in identifying the problem. These changes to `Graph.nbunch_iter()` will cause `edge_dfs()` to yield nothing if `source` is not in `G`, which is a sensible outcome in my particular use-case. But that may not be suitable for everyone, and consideration could be given to whether `edge_dfs()` and other similar functions should raise an exception if `source` is not in `G`.

Nonetheless, I recommend this PR because it brings `Graph.nbunch_iter()` more into line with what the documentation says it should do.

This PR somewhat implements "Option 2" proposed by @SultanOrazbayev in #6275.