### PR TITLE
optimize generic_bfs_edges function

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -70,7 +70,8 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
     if neighbors is None:
         neighbors = G.neighbors
     if sort_neighbors is not None:
-        neighbors = lambda node: iter(sort_neighbors(neighbors(node)))
+        _neighbors = neighbors
+        neighbors = lambda node: iter(sort_neighbors(_neighbors(node)))
     if depth_limit is None:
         depth_limit = float("inf")
 

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -37,8 +37,8 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
         that returns an iterator over some or all of the neighbors of a
         given node, in any order.
 
-    depth_limit : int
-        Specify the maximum search depth, by default it searches the all graph.
+    depth_limit : int, optional(default=len(G))
+        Specify the maximum search depth.
 
     sort_neighbors : function
         A function that takes the list of neighbors of given node as input, and
@@ -73,7 +73,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
         _neighbors = neighbors
         neighbors = lambda node: iter(sort_neighbors(_neighbors(node)))
     if depth_limit is None:
-        depth_limit = float("inf")
+        depth_limit = len(G)
 
     seen = {source}
     n = len(G)

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbors=None):
+def generic_bfs_edges(G, source, neighbors=None, depth_limit=float("inf"), sort_neighbors=None):
     """Iterate over edges in a breadth-first search.
 
     The breadth-first search begins at `source` and enqueues the
@@ -37,8 +37,8 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
         that returns an iterator over some or all of the neighbors of a
         given node, in any order.
 
-    depth_limit : int, optional(default=len(G))
-        Specify the maximum search depth
+    depth_limit : int
+        Specify the maximum search depth, it defaults to traverse the all graph.
 
     sort_neighbors : function
         A function that takes the list of neighbors of given node as input, and
@@ -67,25 +67,27 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
     .. _PADS: http://www.ics.uci.edu/~eppstein/PADS/BFS.py
     .. _Depth-limited-search: https://en.wikipedia.org/wiki/Depth-limited_search
     """
-    if callable(sort_neighbors):
-        _neighbors = neighbors
-        neighbors = lambda node: iter(sort_neighbors(_neighbors(node)))
+    if neighbors is None:
+        neighbors = G.neighbors
+    if sort_neighbors is not None:
+        neighbors = lambda node: iter(sort_neighbors(neighbors(node)))
 
-    visited = {source}
-    if depth_limit is None:
-        depth_limit = len(G)
-    queue = deque([(source, depth_limit, neighbors(source))])
-    while queue:
-        parent, depth_now, children = queue[0]
-        try:
-            child = next(children)
-            if child not in visited:
-                yield parent, child
-                visited.add(child)
-                if depth_now > 1:
-                    queue.append((child, depth_now - 1, neighbors(child)))
-        except StopIteration:
-            queue.popleft()
+    seen = {source}
+    n = len(G)
+    depth = 0
+    next_parents_children = [(source, neighbors(source))]
+    while next_parents_children and depth < depth_limit:
+        this_parents_children = next_parents_children
+        next_parents_children = []
+        for parent, children in this_parents_children:
+            for child in children:
+                if child not in seen:
+                    seen.add(child)
+                    next_parents_children.append((child, neighbors(child)))
+                    yield parent, child
+            if len(seen) == n:
+                return
+        depth += 1
 
 
 @nx._dispatch

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def generic_bfs_edges(G, source, neighbors=None, depth_limit=float("inf"), sort_neighbors=None):
+def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbors=None):
     """Iterate over edges in a breadth-first search.
 
     The breadth-first search begins at `source` and enqueues the
@@ -38,7 +38,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=float("inf"), sort_
         given node, in any order.
 
     depth_limit : int
-        Specify the maximum search depth, it defaults to traverse the all graph.
+        Specify the maximum search depth, by default it searches the all graph.
 
     sort_neighbors : function
         A function that takes the list of neighbors of given node as input, and
@@ -71,6 +71,8 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=float("inf"), sort_
         neighbors = G.neighbors
     if sort_neighbors is not None:
         neighbors = lambda node: iter(sort_neighbors(neighbors(node)))
+    if depth_limit is None:
+        depth_limit = float("inf")
 
     seen = {source}
     n = len(G)


### PR DESCRIPTION
Another bfs which could be updated. Here it is the table of comparison of performance between the current implementation vs. the new one:

```
+--------------------------------------------------------+--------------------+---------------+--------------+
|                         graph                          | time: current main | time: this pr | times faster |
+--------------------------------------------------------+--------------------+---------------+--------------+
|     nx.random_regular_graph(d=1, n=10, seed=4241)      |        0.0         |      0.0      |     1.56     |
|     nx.random_regular_graph(d=9, n=10, seed=4241)      |        0.0         |      0.0      |     3.77     |
|    nx.random_regular_graph(d=10, n=100, seed=4241)     |        0.01        |      0.0      |     3.86     |
|    nx.random_regular_graph(d=99, n=100, seed=4241)     |        0.06        |      0.0      |    27.23     |
|    nx.random_regular_graph(d=1, n=1000, seed=4241)     |        0.0         |      0.0      |     1.55     |
|    nx.random_regular_graph(d=3, n=1000, seed=4241)     |        0.08        |      0.04     |     1.89     |
|    nx.random_regular_graph(d=10, n=1000, seed=4241)    |        0.12        |      0.04     |     2.88     |
|    nx.random_regular_graph(d=50, n=1000, seed=4241)    |        0.35        |      0.04     |     8.34     |
|   nx.random_regular_graph(d=100, n=1000, seed=4241)    |        0.65        |      0.04     |    16.09     |
|   nx.random_regular_graph(d=200, n=1000, seed=4241)    |        1.22        |      0.04     |    30.69     |
|   nx.random_regular_graph(d=500, n=1000, seed=4241)    |        2.97        |      0.04     |    80.08     |
|   nx.random_regular_graph(d=700, n=1000, seed=4241)    |        4.11        |      0.04     |    116.05    |
|     nx.erdos_renyi_graph(n=100, p=0.9, seed=4241)      |        0.06        |      0.0      |    22.98     |
|     nx.erdos_renyi_graph(n=1000, p=0.8, seed=4241)     |        4.66        |      0.03     |    146.43    |
| nx.watts_strogatz_graph(n=100, k=10, p=0.3, seed=4241) |        0.01        |      0.0      |     3.12     |
|           nx.connected_caveman_graph(100,10)           |        0.11        |      0.05     |     2.22     |
|                nx.caveman_graph(100,10)                |        0.0         |      0.0      |     2.1      |
|               nx.windmill_graph(10, 10)                |        0.01        |      0.0      |     4.33     |
|               nx.full_rary_tree(3, 1000)               |        0.07        |      0.03     |     2.17     |
|                 nx.complete_graph(100)                 |        0.06        |      0.0      |     28.8     |
|                 nx.complete_graph(10)                  |        0.0         |      0.0      |     3.83     |
|                  nx.cycle_graph(100)                   |        0.01        |      0.0      |     2.17     |
|                   nx.cycle_graph(10)                   |        0.0         |      0.0      |     1.9      |
+--------------------------------------------------------+--------------------+---------------+--------------+
```

<details>
<summary> benchmark code </summary>

```python

import timeit, prettytable
import collections

def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbors=None):
    if neighbors is None:
        neighbors = G.neighbors
    if callable(sort_neighbors):
        _neighbors = neighbors
        neighbors = lambda node: iter(sort_neighbors(_neighbors(node)))

    visited = {source}
    if depth_limit is None:
        depth_limit = len(G)
    queue = collections.deque([(source, depth_limit, neighbors(source))])
    while queue:
        parent, depth_now, children = queue[0]
        try:
            child = next(children)
            if child not in visited:
                yield parent, child
                visited.add(child)
                if depth_now > 1:
                    queue.append((child, depth_now - 1, neighbors(child)))
        except StopIteration:
            queue.popleft()

def generic_bfs_edges_2(G, source, neighbors=None, depth_limit=float("inf"), sort_neighbors=None):
    if neighbors is None:
        neighbors = G.neighbors
    if sort_neighbors is not None:
        neighbors = lambda node: iter(sort_neighbors(neighbors(node)))

    seen = {source}
    n = len(G)
    depth = 0
    next_parents_children = [(source, neighbors(source))]
    while next_parents_children and depth < depth_limit:
        this_parents_children = next_parents_children
        next_parents_children = []
        for parent, children in this_parents_children:
            for child in children:
                if child not in seen:
                    seen.add(child)
                    next_parents_children.append((child, neighbors(child)))
                    yield parent, child
            if len(seen) == n:
                return
        depth += 1

graphs = [  "nx.random_regular_graph(d=1, n=10, seed=4241)", "nx.random_regular_graph(d=9, n=10, seed=4241)",
            "nx.random_regular_graph(d=10, n=100, seed=4241)", "nx.random_regular_graph(d=99, n=100, seed=4241)",
            "nx.random_regular_graph(d=1, n=1000, seed=4241)", "nx.random_regular_graph(d=3, n=1000, seed=4241)",
            "nx.random_regular_graph(d=10, n=1000, seed=4241)", "nx.random_regular_graph(d=50, n=1000, seed=4241)",
            "nx.random_regular_graph(d=100, n=1000, seed=4241)", "nx.random_regular_graph(d=200, n=1000, seed=4241)",
            "nx.random_regular_graph(d=500, n=1000, seed=4241)", "nx.random_regular_graph(d=700, n=1000, seed=4241)",
            "nx.erdos_renyi_graph(n=100, p=0.9, seed=4241)", "nx.erdos_renyi_graph(n=1000, p=0.8, seed=4241)",
            "nx.watts_strogatz_graph(n=100, k=10, p=0.3, seed=4241)", "nx.connected_caveman_graph(100,10)",  
            "nx.caveman_graph(100,10)",  "nx.windmill_graph(10, 10)", "nx.full_rary_tree(3, 1000)",  
            "nx.complete_graph(100)", "nx.complete_graph(10)",  "nx.cycle_graph(100)", "nx.cycle_graph(10)" ]

stmt_1 = "a = list(generic_bfs_edges(G, random.randrange(len(G)-1))); #print(len(a))"
stmt_2 = "b = list(generic_bfs_edges_2(G, random.randrange(len(G)-1))); #print(len(b))"
table = prettytable.PrettyTable()
table.field_names = ["graph", "time: current main", "time: this pr", "times faster"]

for graph in graphs:
    setup_1 = "import networkx as nx; import collections, random; from __main__ import generic_bfs_edges; random.seed(4241); G = {}".format(graph)
    setup_2 = "import networkx as nx; import collections, random; from __main__ import generic_bfs_edges_2; random.seed(4241); G = {}".format(graph)
    main_time = timeit.timeit(stmt_1, setup_1, number=100)
    pr_time = timeit.timeit(stmt_2, setup_2, number=100)
    a, b, c, d = graph, round(main_time,2), round(pr_time,2), round(main_time/pr_time, 2)
    table.add_row([a, b, c, d])
    print(d)
print(table)
```

</details>

I also assigned G.neighbors to neighbors if nothing is passed for the parameter (to be coherent with what was written in the docstring)