### PR TITLE
DOC: Minor formatting fixups to get rid of doc build warnings.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -464,4 +464,4 @@ All interactions with the project are subject to the
 We also follow these policies:
 
 * :doc:`NetworkX deprecation policy <deprecations>`
-* :doc:`Python version support <nep-0029-deprecation_policy>`
+* :external+neps:doc:`Python version support <nep-0029-deprecation_policy>`

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,7 @@ html_theme_options = {
     ],
     "external_links": [{"name": "Guides", "url": "https://networkx.org/nx-guides/"}],
     "navbar_end": ["theme-switcher", "navbar-icon-links", "version"],
-    "page_sidebar_items": ["search-field", "page-toc", "edit-this-page"],
+    "secondary_sidebar_items": ["search-field", "page-toc", "edit-this-page"],
     "header_links_before_dropdown": 7,
 }
 html_sidebars = {

--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -110,7 +110,7 @@ For example, let's say you are interested in making a change to the
 where it is defined. In an IPython terminal, you can use ``?`` --- the source file is
 listed in the ``File:`` field:
 
-.. code-block:: ipython
+.. code-block:: ipython3
 
    In [1]: import networkx as nx
    In [2]: nx.kamada_kawai_layout?

--- a/doc/developer/nxeps/nxep-0004.rst
+++ b/doc/developer/nxeps/nxep-0004.rst
@@ -21,12 +21,12 @@ that includes support for `numpy.random` and the Python built-in `random` module
 preferred package for random number generation.
 NumPy introduced a new interface in the `numpy.random` package in NumPy version
 1.17.
-According to :doc:`NEP19 <nep-0019-rng-policy>`, the new interface based on
+According to :external+neps:doc:`NEP19 <nep-0019-rng-policy>`, the new interface based on
 `numpy.random.Generator`
 is recommended over the legacy `numpy.random.RandomState` as the former has
 `better statistical properties <https://www.pcg-random.org/index.html>`_,
-:doc:`more features <reference/random/new-or-different>`,
-and :doc:`improved performance <reference/random/performance>`.
+:external+numpy:doc:`more features <reference/random/new-or-different>`,
+and :external+numpy:doc:`improved performance <reference/random/performance>`.
 This NXEP proposes a strategy for adopting `numpy.random.Generator` as the
 **default** interface for random number generation within NetworkX.
 

--- a/doc/developer/projects.rst
+++ b/doc/developer/projects.rst
@@ -47,7 +47,7 @@ Completed Projects
 - `VF2++ algorithm for graph isomorphism`_
     - Program: Google Summer of Code 2022
     - Contributor: `@kpetridis24 <https://github.com/kpetridis24/>`__
-    - Link to Proposal: `GSoC 2022: VF2++ Algorithm <https://github.com/networkx/archive/blob/main/proposals-gsoc/GSoC-2022-VF2plusplus-isomorphism.pdf`_
+    - Link to Proposal: `GSoC 2022: VF2++ Algorithm <https://github.com/networkx/archive/blob/main/proposals-gsoc/GSoC-2022-VF2plusplus-isomorphism.pdf>`_
 
 - `Louvain community detection algorithm`_ 
     - Program: Google Summer of Code 2021

--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -150,7 +150,7 @@ VoteRank
    voterank
 
 Laplacian
---------
+---------
 .. autosummary::
    :toctree: generated/
 

--- a/examples/algorithms/plot_betweenness_centrality.py
+++ b/examples/algorithms/plot_betweenness_centrality.py
@@ -1,7 +1,7 @@
 """
-=====================
+======================
 Betweenness Centrality
-=====================
+======================
 
 Betweenness centrality measures of positive gene functional associations
 using WormNet v.3-GS.

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -134,21 +134,21 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
 
     The approximation algorithm is specified with the `method` keyword
     argument. All three available algorithms produce a tree whose weight is
-    within a (2 - (2 / l)) factor of the weight of the optimal Steiner tree,
-    where *l* is the minimum number of leaf nodes across all possible Steiner
+    within a ``(2 - (2 / l))`` factor of the weight of the optimal Steiner tree,
+    where ``l`` is the minimum number of leaf nodes across all possible Steiner
     trees.
 
-    * `kou` [2]_ (runtime $O(|S| |V|^2)$) computes the minimum spanning tree of
-    the subgraph of the metric closure of *G* induced by the terminal nodes,
-    where the metric closure of *G* is the complete graph in which each edge is
-    weighted by the shortest path distance between the nodes in *G*.
+    * ``"kou"`` [2]_ (runtime $O(|S| |V|^2)$) computes the minimum spanning tree of
+      the subgraph of the metric closure of *G* induced by the terminal nodes,
+      where the metric closure of *G* is the complete graph in which each edge is
+      weighted by the shortest path distance between the nodes in *G*.
 
-    * `mehlhorn` [3]_ (runtime $O(|E|+|V|\log|V|)$) modifies Kou et al.'s
-    algorithm, beginning by finding the closest terminal node for each
-    non-terminal. This data is used to create a complete graph containing only
-    the terminal nodes, in which edge is weighted with the shortest path
-    distance between them. The algorithm then proceeds in the same way as Kou
-    et al..
+    * ``"mehlhorn"`` [3]_ (runtime $O(|E|+|V|\log|V|)$) modifies Kou et al.'s
+      algorithm, beginning by finding the closest terminal node for each
+      non-terminal. This data is used to create a complete graph containing only
+      the terminal nodes, in which edge is weighted with the shortest path
+      distance between them. The algorithm then proceeds in the same way as Kou
+      et al..
 
     Parameters
     ----------

--- a/networkx/algorithms/centrality/laplacian.py
+++ b/networkx/algorithms/centrality/laplacian.py
@@ -11,8 +11,8 @@ def laplacian_centrality(
 ):
     r"""Compute the Laplacian centrality for nodes in the graph `G`.
 
-    The Laplacian Centrality of a node `i` is measured by the drop in the
-    Laplacian Energy after deleting node `i` from the graph. The Laplacian Energy
+    The Laplacian Centrality of a node ``i`` is measured by the drop in the
+    Laplacian Energy after deleting node ``i`` from the graph. The Laplacian Energy
     is the sum of the squared eigenvalues of a graph's Laplacian matrix.
 
     .. math::
@@ -22,14 +22,13 @@ def laplacian_centrality(
         E_L (G) = \sum_{i=0}^n \lambda_i^2
 
     Where $E_L (G)$ is the Laplacian energy of graph `G`,
-    E_L (G_i) is the Laplacian energy of graph `G` after deleting node `i`
+    E_L (G_i) is the Laplacian energy of graph `G` after deleting node ``i``
     and $\lambda_i$ are the eigenvalues of `G`'s Laplacian matrix.
     This formula shows the normalized value. Without normalization,
     the numerator on the right side is returned.
 
     Parameters
     ----------
-
     G : graph
         A networkx graph
 
@@ -73,8 +72,8 @@ def laplacian_centrality(
 
     Notes
     -----
-    The algorithm is implemented based on [1] with an extension to directed graphs
-    using the `nx.directed_laplacian_matrix` function.
+    The algorithm is implemented based on [1]_ with an extension to directed graphs
+    using the ``directed_laplacian_matrix`` function.
 
     Raises
     ------
@@ -84,12 +83,12 @@ def laplacian_centrality(
     References
     ----------
     .. [1] Qi, X., Fuller, E., Wu, Q., Wu, Y., and Zhang, C.-Q. (2012).
-    Laplacian centrality: A new centrality measure for weighted networks.
-    Information Sciences, 194:240-253.
-    https://math.wvu.edu/~cqzhang/Publication-files/my-paper/INS-2012-Laplacian-W.pdf
+       Laplacian centrality: A new centrality measure for weighted networks.
+       Information Sciences, 194:240-253.
+       https://math.wvu.edu/~cqzhang/Publication-files/my-paper/INS-2012-Laplacian-W.pdf
 
     See Also
-    ========
+    --------
     directed_laplacian_matrix
     laplacian_matrix
     """

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -384,7 +384,7 @@ def triads_by_type(G):
     - 210: 1 -> 2 <-> 3, 1 <-> 3
     - 300: 1 <-> 2 <-> 3, 1 <-> 3
 
-    Refer to the :doc:`example gallery <auto_examples/graph/plot_triad_types>`
+    Refer to the :doc:`example gallery </auto_examples/graph/plot_triad_types>`
     for visual examples of the triad types.
 
     Parameters

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -7,56 +7,53 @@ Create a Dispatcher
 To be a valid plugin, a package must register an entry_point
 of `networkx.plugins` with a key pointing to the handler.
 
-For example:
+For example::
 
-```
-entry_points={'networkx.plugins': 'sparse = networkx_plugin_sparse'}
-```
+    entry_points={'networkx.plugins': 'sparse = networkx_plugin_sparse'}
 
 The plugin must create a Graph-like object which contains an attribute
-`__networkx_plugin__` with a value of the entry point name.
+``__networkx_plugin__`` with a value of the entry point name.
 
-Continuing the example above:
+Continuing the example above::
 
-```
-class WrappedSparse:
-    __networkx_plugin__ = "sparse"
-    ...
-```
+    class WrappedSparse:
+        __networkx_plugin__ = "sparse"
+        ...
 
 When a dispatchable NetworkX algorithm encounters a Graph-like object
-with a `__networkx_plugin__` attribute, it will look for the associated
+with a ``__networkx_plugin__`` attribute, it will look for the associated
 dispatch object in the entry_points, load it, and dispatch the work to it.
 
 
 Testing
 -------
 To assist in validating the backend algorithm implementations, if an
-environment variable `NETWORKX_GRAPH_CONVERT` is set to a registered
+environment variable ``NETWORKX_GRAPH_CONVERT`` is set to a registered
 plugin keys, the dispatch machinery will automatically convert regular
 networkx Graphs and DiGraphs to the backend equivalent by calling
-`<backend dispatcher>.convert_from_nx(G, weight=weight, name=name)`.
+``<backend dispatcher>.convert_from_nx(G, weight=weight, name=name)``.
 
 The converted object is then passed to the backend implementation of
 the algorithm. The result is then passed to
-`<backend dispatcher>.convert_to_nx(result, name=name)` to convert back
+``<backend dispatcher>.convert_to_nx(result, name=name)`` to convert back
 to a form expected by the NetworkX tests.
 
-By defining `convert_from_nx` and `convert_to_nx` methods and setting
+By defining ``convert_from_nx`` and ``convert_to_nx`` methods and setting
 the environment variable, NetworkX will automatically route tests on
 dispatchable algorithms to the backend, allowing the full networkx test
 suite to be run against the backend implementation.
 
-Example pytest invocation:
-NETWORKX_GRAPH_CONVERT=sparse pytest --pyargs networkx
+Example pytest invocation::
+
+    NETWORKX_GRAPH_CONVERT=sparse pytest --pyargs networkx
 
 Dispatchable algorithms which are not implemented by the backend
-will cause a `pytest.xfail()`, giving some indication that not all
+will cause a ``pytest.xfail()``, giving some indication that not all
 tests are working, while avoiding causing an explicit failure.
 
-A special `on_start_tests(items)` function may be defined by the backend.
+A special ``on_start_tests(items)`` function may be defined by the backend.
 It will be called with the list of NetworkX tests discovered. Each item
-is a pytest.Node object. If the backend does not support the test, that
+is a `pytest.Node` object. If the backend does not support the test, that
 test can be marked as xfail.
 """
 import functools

--- a/networkx/drawing/nx_latex.py
+++ b/networkx/drawing/nx_latex.py
@@ -485,7 +485,7 @@ def write_latex(Gbunch, path, **options):
 
     This convenience function creates the latex drawing code as a string
     and writes that to a file ready to be compiled when `as_document` is True
-    or ready to be ``\\import``ed or `\\include``ed into your main LaTeX document.
+    or ready to be ``import`` ed or ``include`` ed into your main LaTeX document.
 
     The `path` argument can be a string filename or a file handle to write to.
 
@@ -498,71 +498,71 @@ def write_latex(Gbunch, path, **options):
     path : filename
         Filename or file handle to write to
     options : dict
-        By default, TikZ is used with options: (others are ignored):
+        By default, TikZ is used with options: (others are ignored)::
 
-        pos : string or dict or list
-            The name of the node attribute on `G` that holds the position of each node.
-            Positions can be sequences of length 2 with numbers for (x,y) coordinates.
-            They can also be strings to denote positions in TikZ style, such as (x, y)
-            or (angle:radius).
-            If a dict, it should be keyed by node to a position.
-            If an empty dict, a circular layout is computed by TikZ.
-            If you are drawing many graphs in subfigures, use a list of position dicts.
-        tikz_options : string
-            The tikzpicture options description defining the options for the picture.
-            Often large scale options like `[scale=2]`.
-        default_node_options : string
-            The draw options for a path of nodes. Individual node options override these.
-        node_options : string or dict
-            The name of the node attribute on `G` that holds the options for each node.
-            Or a dict keyed by node to a string holding the options for that node.
-        node_label : string or dict
-            The name of the node attribute on `G` that holds the node label (text)
-            displayed for each node. If the attribute is "" or not present, the node
-            itself is drawn as a string. LaTeX processing such as ``"$A_1$"`` is allowed.
-            Or a dict keyed by node to a string holding the label for that node.
-        default_edge_options : string
-            The options for the scope drawing all edges. The default is "[-]" for
-            undirected graphs and "[->]" for directed graphs.
-        edge_options : string or dict
-            The name of the edge attribute on `G` that holds the options for each edge.
-            If the edge is a self-loop and ``"loop" not in edge_options`` the option
-            "loop," is added to the options for the self-loop edge. Hence you can
-            use "[loop above]" explicitly, but the default is "[loop]".
-            Or a dict keyed by edge to a string holding the options for that edge.
-        edge_label : string or dict
-            The name of the edge attribute on `G` that holds the edge label (text)
-            displayed for each edge. If the attribute is "" or not present, no edge
-            label is drawn.
-            Or a dict keyed by edge to a string holding the label for that edge.
-        edge_label_options : string or dict
-            The name of the edge attribute on `G` that holds the label options for
-            each edge. For example, "[sloped,above,blue]". The default is no options.
-            Or a dict keyed by edge to a string holding the label options for that edge.
-        caption : string
-            The caption string for the figure environment
-        latex_label : string
-            The latex label used for the figure for easy referral from the main text
-        sub_captions : list of strings
-            The sub_caption string for each subfigure in the figure
-        sub_latex_labels : list of strings
-            The latex label for each subfigure in the figure
-        n_rows : int
-            The number of rows of subfigures to arrange for multiple graphs
-        as_document : bool
-            Whether to wrap the latex code in a document envionment for compiling
-        document_wrapper : formatted text string with variable ``content``.
-            This text is called to evaluate the content embedded in a document
-            environment with a preamble setting up the TikZ syntax.
-        figure_wrapper : formatted text string
-            This text is evaluated with variables ``content``, ``caption`` and ``label``.
-            It wraps the content and if a caption is provided, adds the latex code for
-            that caption, and if a label is provided, adds the latex code for a label.
-        subfigure_wrapper : formatted text string
-            This text evaluate variables ``size``, ``content``, ``caption`` and ``label``.
-            It wraps the content and if a caption is provided, adds the latex code for
-            that caption, and if a label is provided, adds the latex code for a label.
-            The size is the vertical size of each row of subfigures as a fraction.
+            pos : string or dict or list
+                The name of the node attribute on `G` that holds the position of each node.
+                Positions can be sequences of length 2 with numbers for (x,y) coordinates.
+                They can also be strings to denote positions in TikZ style, such as (x, y)
+                or (angle:radius).
+                If a dict, it should be keyed by node to a position.
+                If an empty dict, a circular layout is computed by TikZ.
+                If you are drawing many graphs in subfigures, use a list of position dicts.
+            tikz_options : string
+                The tikzpicture options description defining the options for the picture.
+                Often large scale options like `[scale=2]`.
+            default_node_options : string
+                The draw options for a path of nodes. Individual node options override these.
+            node_options : string or dict
+                The name of the node attribute on `G` that holds the options for each node.
+                Or a dict keyed by node to a string holding the options for that node.
+            node_label : string or dict
+                The name of the node attribute on `G` that holds the node label (text)
+                displayed for each node. If the attribute is "" or not present, the node
+                itself is drawn as a string. LaTeX processing such as ``"$A_1$"`` is allowed.
+                Or a dict keyed by node to a string holding the label for that node.
+            default_edge_options : string
+                The options for the scope drawing all edges. The default is "[-]" for
+                undirected graphs and "[->]" for directed graphs.
+            edge_options : string or dict
+                The name of the edge attribute on `G` that holds the options for each edge.
+                If the edge is a self-loop and ``"loop" not in edge_options`` the option
+                "loop," is added to the options for the self-loop edge. Hence you can
+                use "[loop above]" explicitly, but the default is "[loop]".
+                Or a dict keyed by edge to a string holding the options for that edge.
+            edge_label : string or dict
+                The name of the edge attribute on `G` that holds the edge label (text)
+                displayed for each edge. If the attribute is "" or not present, no edge
+                label is drawn.
+                Or a dict keyed by edge to a string holding the label for that edge.
+            edge_label_options : string or dict
+                The name of the edge attribute on `G` that holds the label options for
+                each edge. For example, "[sloped,above,blue]". The default is no options.
+                Or a dict keyed by edge to a string holding the label options for that edge.
+            caption : string
+                The caption string for the figure environment
+            latex_label : string
+                The latex label used for the figure for easy referral from the main text
+            sub_captions : list of strings
+                The sub_caption string for each subfigure in the figure
+            sub_latex_labels : list of strings
+                The latex label for each subfigure in the figure
+            n_rows : int
+                The number of rows of subfigures to arrange for multiple graphs
+            as_document : bool
+                Whether to wrap the latex code in a document envionment for compiling
+            document_wrapper : formatted text string with variable ``content``.
+                This text is called to evaluate the content embedded in a document
+                environment with a preamble setting up the TikZ syntax.
+            figure_wrapper : formatted text string
+                This text is evaluated with variables ``content``, ``caption`` and ``label``.
+                It wraps the content and if a caption is provided, adds the latex code for
+                that caption, and if a label is provided, adds the latex code for a label.
+            subfigure_wrapper : formatted text string
+                This text evaluate variables ``size``, ``content``, ``caption`` and ``label``.
+                It wraps the content and if a caption is provided, adds the latex code for
+                that caption, and if a label is provided, adds the latex code for a label.
+                The size is the vertical size of each row of subfigures as a fraction.
 
     See Also
     ========

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -2,7 +2,7 @@
 
 .. warning::
     This parser uses the standard xml library present in Python, which is
-    insecure - see :doc:`library/xml` for additional information.
+    insecure - see :external+python:mod:`xml` for additional information.
     Only parse GEFX files you trust.
 
 GEXF (Graph Exchange XML Format) is a language for describing complex

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -7,7 +7,7 @@ Read and write graphs in GraphML format.
 .. warning::
 
     This parser uses the standard xml library present in Python, which is
-    insecure - see :doc:`library/xml` for additional information.
+    insecure - see :external+python:mod:`xml` for additional information.
     Only parse GraphML files you trust.
 
 This implementation does not support mixed graphs (directed and unidirected


### PR DESCRIPTION
Just some minor doc formatting fixups to get rid of the 25+ sphinx warnings that had accumulated.