### PR TITLE
When drawing directed edges account for node boundary width

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -482,6 +482,7 @@ def draw_networkx_edges(
     node_size=300,
     nodelist=None,
     node_shape="o",
+    linewidths=None,
     connectionstyle="arc3",
     min_source_margin=0,
     min_target_margin=0,
@@ -573,6 +574,10 @@ def draw_networkx_edges(
     node_shape :  string (default='o')
         The marker used for nodes, used in determining edge positioning.
         Specification is as a `matplotlib.markers` marker, e.g. one of 'so^>v<dph8'.
+
+    linewidths : scalar or array, optional
+        The linewidth of the node marker edges. Defaults to
+        `matplotlib.rcParams["lines.linewidth"]`.
 
     label : None or string
         Label for legend
@@ -756,11 +761,11 @@ def draw_networkx_edges(
         # marker.  Meanwhile, this works well for polygons with more than 4
         # sides and circle.
 
-        def to_marker_edge(marker_size, marker):
+        def to_marker_edge(marker_size, marker, boundary_width):
             if marker in "s^>v<d":  # `large` markers need extra space
-                return np.sqrt(2 * marker_size) / 2
+                return (np.sqrt(2 * marker_size) + boundary_width) / 2
             else:
-                return np.sqrt(marker_size) / 2
+                return (np.sqrt(marker_size) + boundary_width) / 2
 
         # Draw arrows with `matplotlib.patches.FancyarrowPatch`
         arrow_collection = []
@@ -822,14 +827,34 @@ def draw_networkx_edges(
                 # Scale each factor of each arrow based on arrowsize list
                 mutation_scale = arrowsize[i]
 
+            if np.iterable(linewidths):
+                source, target = edgelist[i][:2]
+                source_node_linewidth = linewidths[nodelist.index(source)]
+                target_node_linewidth = linewidths[nodelist.index(target)]
+            elif linewidths is None:
+                source_node_linewidth = target_node_linewidth = mpl.rcParams[
+                    "lines.linewidth"
+                ]
+            else:
+                source_node_linewidth = target_node_linewidth = linewidths
+
             if np.iterable(node_size):  # many node sizes
                 source, target = edgelist[i][:2]
                 source_node_size = node_size[nodelist.index(source)]
                 target_node_size = node_size[nodelist.index(target)]
-                shrink_source = to_marker_edge(source_node_size, node_shape)
-                shrink_target = to_marker_edge(target_node_size, node_shape)
+                shrink_source = to_marker_edge(
+                    source_node_size, node_shape, source_node_linewidth
+                )
+                shrink_target = to_marker_edge(
+                    target_node_size, node_shape, target_node_linewidth
+                )
             else:
-                shrink_source = shrink_target = to_marker_edge(node_size, node_shape)
+                shrink_source = to_marker_edge(
+                    node_size, node_shape, source_node_linewidth
+                )
+                shrink_target = to_marker_edge(
+                    node_size, node_shape, target_node_linewidth
+                )
 
             if shrink_source < min_source_margin:
                 shrink_source = min_source_margin

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -589,6 +589,35 @@ def test_draw_edges_min_source_target_margins(node_shape):
     assert padded_extent[1] < default_extent[1]
 
 
+def test_draw_edges_account_for_node_boundaries():
+    """Test that the calculation of shrinkA and shrinkB for an FancyArrowPatch
+    accounts for the node boundary with (additional to the node size).
+    """
+    fig, ax = plt.subplots()
+    G = nx.DiGraph([(0, 1)])
+    pos = {0: (0, 0), 1: (1, 0)}  # horizontal layout
+    node_size = 300
+    linewidths = [10, 1]
+
+    # Draw an edge assuming no node boundaries
+    edge_ignore = nx.draw_networkx_edges(
+        G, pos, ax=ax, node_size=node_size, linewidths=0
+    )[0]
+    # Draw an edge assuming node boundaries of a certain width. This should be
+    # accounted for through some extra padding between edge and source and
+    # target node.
+    edge = nx.draw_networkx_edges(
+        G, pos, ax=ax, node_size=node_size, linewidths=linewidths
+    )[0]
+
+    # Get the extents of the FancyArrowPatch objects in display coordinates
+    edge_ignore_extent = edge_ignore.get_extents().corners()[::2, 0]
+    edge_extent = edge.get_extents().corners()[::2, 0]
+    # Ensure that there is extra padding
+    assert edge_extent[0] >= edge_ignore_extent[0]
+    assert edge_extent[1] <= edge_ignore_extent[1]
+
+
 def test_nonzero_selfloop_with_single_node():
     """Ensure that selfloop extent is non-zero when there is only one node."""
     # Create explicit axis object for test


### PR DESCRIPTION
This PR adds the `linewidths` kwarg to `nx.draw_networkx_edges`. It's the same parameter as in `nx.draw_networkx_nodes` which specifies the boundary width(s) of the node marker(s). When drawing edges as FancyArrowPatches, the length of the drawn edges is adjusted such that the nodes don't cover the arrows.

The main change is a `+ linewidths / 2` in the calculation of the `shrinkA` and `shrinkB` parameter of the FancyArrowPatch.

Closes #4601 
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
