### PR TITLE
Remove an instance of random.sample from a set (deprecated in Python 3.9)

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -224,7 +224,7 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
     if k is None:
         nodes = G
     else:
-        nodes = seed.sample(G.nodes(), k)
+        nodes = seed.sample(list(G.nodes()), k)
     for s in nodes:
         # single source shortest paths
         if weight is None:  # use BFS


### PR DESCRIPTION
I encountered this DeprecationWarning today. This change was missed in #4602

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
