### PR TITLE
Fix pre-commit on Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: blacken-docs
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
The latest `isort` has a dependency bug that borks development environments with the latest 5.12 isort precommit hooks installed. I just ran into this on Python 3.10 - see pycqa/isort#2083.

Pinning isort to 5.11.5 in the pre-commit config worked for me locally.