### PR TITLE
Add Plausible Analytics to our docs

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,9 +1,8 @@
-{% extends "!layout.html" %} 
-
-{% block extrahead %}
-    <script defer data-domain="networkx.org" src="https://views.scientific-python.org/js/script.js"></script>
-    {{ super() }}
-{% endblock %}
-
-{% block content %} {% include "dev_banner.html" %}
+{% extends "!layout.html" %} {% block extrahead %}
+<script
+  defer
+  data-domain="networkx.org"
+  src="https://views.scientific-python.org/js/script.js"
+></script>
+{{ super() }} {% endblock %} {% block content %} {% include "dev_banner.html" %}
 {{ super() }} {% endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,2 +1,9 @@
-{% extends "!layout.html" %} {% block content %} {% include "dev_banner.html" %}
+{% extends "!layout.html" %} 
+
+{% block extrahead %}
+    <script defer data-domain="networkx.org" src="https://views.scientific-python.org/js/script.js"></script>
+    {{ super() }}
+{% endblock %}
+
+{% block content %} {% include "dev_banner.html" %}
 {{ super() }} {% endblock %}


### PR DESCRIPTION
This gives us an anonymous way of tracking usage of our documentation website. By this PR we will only be able to track usage of the latest dev website, which I think is a good start.

This uses the instances hosted by the Scientific Python project.

Should we also put up some disclaimer or note in our README that we are using this?
