### PR TITLE
Fix docstring heading title.

### DIFF
--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -336,8 +336,8 @@ def write_network_text(
     end : string
         The line ending characater
 
-    Example
-    -------
+    Examples
+    --------
     >>> graph = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
     >>> nx.write_network_text(graph)
     ╙── 0
@@ -501,8 +501,8 @@ def forest_str(graph, with_labels=True, sources=None, write=None, ascii_only=Fal
     str | None :
         utf8 representation of the tree / forest
 
-    Example
-    -------
+    Examples
+    --------
     >>> graph = nx.balanced_tree(r=2, h=3, create_using=nx.DiGraph)
     >>> print(nx.forest_str(graph))
     ╙── 0


### PR DESCRIPTION
Very minor tweak to conform to the numpydoc standard and get rid of UserWarnings during the doc build.