### PR TITLE
Add documentation building to contributor guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -405,6 +405,12 @@ navigate to the ``doc/`` directory and::
 
     make html
 
+This will generate both the reference documentation as well as the example
+gallery. If you want to build the documentation *without* building the
+gallery examples use::
+
+    make html-noplot
+
 The build products are stored in ``doc/build/`` and can be viewed directly.
 For example, to view the built html, open ``build/html/index.html``
 in your preferred web browser.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -355,7 +355,7 @@ detailing the test coverage::
   ...
 
 Adding tests
-------------
+~~~~~~~~~~~~
 
 If you're **new to testing**, see existing test files for examples of things to do.
 **Don't let the tests keep you from submitting your contribution!**
@@ -364,7 +364,7 @@ anyway.
 We will help you create the tests and sort out any kind of problem during code review.
 
 Adding examples
----------------
+~~~~~~~~~~~~~~~
 
 The gallery examples are managed by
 `sphinx-gallery <https://sphinx-gallery.readthedocs.io/>`_.
@@ -387,37 +387,8 @@ General guidelines for making a good gallery plot:
 * Describe the feature that you're showcasing and link to other relevant parts of the
   documentation.
 
-Adding References
------------------
-
-If you are contributing a new algorithm (or an improvement to a current algorithm),
-a reference paper or resource should also be provided in the function docstring.
-For references to published papers, we try to follow the
-`Chicago Citation Style <https://en.wikipedia.org/wiki/The_Chicago_Manual_of_Style>`__.
-The quickest way of generating citation in this style is
-by searching for the paper on `Google Scholar <https://scholar.google.com/>`_ and clicking on
-the ``cite`` button. It will pop up the citation of the paper in multiple formats, and copy the
-``Chicago`` style.
-
-We prefer adding DOI links for URLs. If the DOI link resolves to a paywalled version of
-the article, we prefer adding a link to the arXiv version (if available) or any other
-publicly accessible copy of the paper.
-
-An example of a reference::
-
-    .. [1] Cheong, Se-Hang, and Yain-Whar Si. "Force-directed algorithms for schematic drawings and
-    placement: A survey." Information Visualization 19, no. 1 (2020): 65-91.
-    https://doi.org/10.1177%2F1473871618821740
-
-
-If the resource is uploaded as a PDF/DOCX/PPT on the web (lecture notes, presentations) it is better
-to use the `wayback machine <https://web.archive.org/>`_ to create a snapshot of the resource
-and link the internet archive link. The URL of the resource can change, and it creates unreachable
-links from the documentation.
-
-
 Image comparison
-----------------
+~~~~~~~~~~~~~~~~
 
 To run image comparisons::
 
@@ -449,6 +420,49 @@ Then create a baseline image to compare against later::
 And test::
 
     $ pytest -k test_barbell --mpl
+
+Documentation
+-------------
+
+The documentation is built with ``sphinx``. To build the documentation locally,
+navigate to the ``doc/`` directory and::
+
+    make html
+
+The build products are stored in ``doc/build/`` and can be viewed directly.
+For example, to view the built html, open ``build/html/index.html``
+in your preferred web browser.
+
+.. note: ``sphinx`` supports many other output formats. Type ``make`` without
+   any arguments to see all the built-in options.
+
+Adding References
+~~~~~~~~~~~~~~~~~
+
+If you are contributing a new algorithm (or an improvement to a current algorithm),
+a reference paper or resource should also be provided in the function docstring.
+For references to published papers, we try to follow the
+`Chicago Citation Style <https://en.wikipedia.org/wiki/The_Chicago_Manual_of_Style>`__.
+The quickest way of generating citation in this style is
+by searching for the paper on `Google Scholar <https://scholar.google.com/>`_ and clicking on
+the ``cite`` button. It will pop up the citation of the paper in multiple formats, and copy the
+``Chicago`` style.
+
+We prefer adding DOI links for URLs. If the DOI link resolves to a paywalled version of
+the article, we prefer adding a link to the arXiv version (if available) or any other
+publicly accessible copy of the paper.
+
+An example of a reference::
+
+    .. [1] Cheong, Se-Hang, and Yain-Whar Si. "Force-directed algorithms for schematic drawings and
+    placement: A survey." Information Visualization 19, no. 1 (2020): 65-91.
+    https://doi.org/10.1177%2F1473871618821740
+
+
+If the resource is uploaded as a PDF/DOCX/PPT on the web (lecture notes, presentations) it is better
+to use the `wayback machine <https://web.archive.org/>`_ to create a snapshot of the resource
+and link the internet archive link. The URL of the resource can change, and it creates unreachable
+links from the documentation.
 
 Bugs
 ----

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -400,6 +400,10 @@ And test::
 Documentation
 -------------
 
+Building the documentation locally requires that the additional dependencies
+specified in ``requirements/doc.txt`` be installed in your development
+environment.
+
 The documentation is built with ``sphinx``. To build the documentation locally,
 navigate to the ``doc/`` directory and::
 
@@ -426,6 +430,9 @@ The gallery examples are managed by
 The source files for the example gallery are ``.py`` scripts in ``examples/`` that
 generate one or more figures. They are executed automatically by sphinx-gallery when the
 documentation is built. The output is gathered and assembled into the gallery.
+
+Building the example gallery locally requires that the additional dependencies
+in ``requirements/example.txt`` be installed in your development environment.
 
 You can **add a new** plot by placing a new ``.py`` file in one of the directories inside the
 ``examples`` directory of the repository. See the other examples to get an idea for the

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -363,30 +363,6 @@ If you're not sure how to do this or are having trouble, submit your pull reques
 anyway.
 We will help you create the tests and sort out any kind of problem during code review.
 
-Adding examples
-~~~~~~~~~~~~~~~
-
-The gallery examples are managed by
-`sphinx-gallery <https://sphinx-gallery.readthedocs.io/>`_.
-The source files for the example gallery are ``.py`` scripts in ``examples/`` that
-generate one or more figures. They are executed automatically by sphinx-gallery when the
-documentation is built. The output is gathered and assembled into the gallery.
-
-You can **add a new** plot by placing a new ``.py`` file in one of the directories inside the
-``examples`` directory of the repository. See the other examples to get an idea for the
-format.
-
-.. note:: Gallery examples should start with ``plot_``, e.g. ``plot_new_example.py``
-
-General guidelines for making a good gallery plot:
-
-* Examples should highlight a single feature/command.
-* Try to make the example as simple as possible.
-* Data needed by examples should be included in the same directory and the example script.
-* Add comments to explain things are aren't obvious from reading the code.
-* Describe the feature that you're showcasing and link to other relevant parts of the
-  documentation.
-
 Image comparison
 ~~~~~~~~~~~~~~~~
 
@@ -435,6 +411,30 @@ in your preferred web browser.
 
 .. note: ``sphinx`` supports many other output formats. Type ``make`` without
    any arguments to see all the built-in options.
+
+Adding examples
+~~~~~~~~~~~~~~~
+
+The gallery examples are managed by
+`sphinx-gallery <https://sphinx-gallery.readthedocs.io/>`_.
+The source files for the example gallery are ``.py`` scripts in ``examples/`` that
+generate one or more figures. They are executed automatically by sphinx-gallery when the
+documentation is built. The output is gathered and assembled into the gallery.
+
+You can **add a new** plot by placing a new ``.py`` file in one of the directories inside the
+``examples`` directory of the repository. See the other examples to get an idea for the
+format.
+
+.. note:: Gallery examples should start with ``plot_``, e.g. ``plot_new_example.py``
+
+General guidelines for making a good gallery plot:
+
+* Examples should highlight a single feature/command.
+* Try to make the example as simple as possible.
+* Data needed by examples should be included in the same directory and the example script.
+* Add comments to explain things are aren't obvious from reading the code.
+* Describe the feature that you're showcasing and link to other relevant parts of the
+  documentation.
 
 Adding References
 ~~~~~~~~~~~~~~~~~

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,17 +15,18 @@ ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html      to make standalone HTML files"
-	@echo "  dirhtml   to make HTML files named index.html in directories"
-	@echo "  pickle    to make pickle files"
-	@echo "  epub       to make an epub"
-	@echo "  json      to make JSON files"
-	@echo "  htmlhelp  to make HTML files and a HTML help project"
-	@echo "  qthelp    to make HTML files and a qthelp project"
-	@echo "  latex     to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  changes   to make an overview of all changed/added/deprecated items"
-	@echo "  linkcheck to check all external links for integrity"
-	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
+	@echo "  html         to make standalone HTML files"
+	@echo "  html-noplot  to make standalone HTML files without building the examples"
+	@echo "  dirhtml      to make HTML files named index.html in directories"
+	@echo "  pickle       to make pickle files"
+	@echo "  epub         to make an epub"
+	@echo "  json         to make JSON files"
+	@echo "  htmlhelp     to make HTML files and a HTML help project"
+	@echo "  qthelp       to make HTML files and a qthelp project"
+	@echo "  latex        to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  changes      to make an overview of all changed/added/deprecated items"
+	@echo "  linkcheck    to check all external links for integrity"
+	@echo "  doctest      to run all doctests embedded in the documentation (if enabled)"
 
 
 clean:
@@ -45,6 +46,11 @@ html:
 	mkdir -p auto_examples/geospatial/
 	cp ../examples/geospatial/extended_description.rst auto_examples/geospatial/
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
+	@echo
+	@echo "Build finished. The HTML pages are in build/html."
+
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery="False" -b html $(ALLSPHINXOPTS) build/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,6 +50,7 @@ sphinx_gallery_conf = {
     "gallery_dirs": "auto_examples",
     "backreferences_dir": "modules/generated",
     "image_scrapers": ("matplotlib",),
+    "plot_gallery": "True",
 }
 # Add pygraphviz png scraper, if available
 try:


### PR DESCRIPTION
There's currently no info in the contributor guide about how to build/view the documentation locally. This PR adds the minimal instructions to do so.

This also necessitated a minor reorganization of the headings for the contributor guide, which makes the diff look scarier than it actually is. I've regrouped the `Adding tests` and `Image comparison` sections as subsections under `Testing`; and grouped `Adding References` and `Adding Examples` as subsections of the newly added `Documentation` section.