### PR TITLE
Start using ruff for pyupgrade and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,22 +6,10 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.13.0
     hooks:
       - id: blacken-docs
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["--profile", "black", "--filter-files", "--skip", "__init__.py"]
-        files: ^networkx/
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -1,5 +1,7 @@
 """Betweenness centrality measures for subsets of nodes."""
-from networkx.algorithms.centrality.betweenness import _add_edge_keys
+from networkx.algorithms.centrality.betweenness import (
+    _add_edge_keys,
+)
 from networkx.algorithms.centrality.betweenness import (
     _single_source_dijkstra_path_basic as dijkstra,
 )

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,6 @@
 select = [
+    "I",       # isort
+    "UP",      # pyupgrade
     "C4",      # flake8-comprehensions
     "E713",    # use 'key not in list'
     "PIE",     # flake8-pie
@@ -11,3 +13,12 @@ select = [
     "SIM118",  # use 'key in dict'
     "SIM2",    # simplify boolean comparisons
 ]
+
+target-version = "py38"
+
+[per-file-ignores]
+"__init__.py" = ["I"]
+"setup.py" = ["I"]
+"examples/*.py" = ["I"]
+"doc/*.py" = ["I"]
+"tools/*.py" = ["I"]


### PR DESCRIPTION
Use ruff's isort and pyupgrade in the pre-commit pipeline.

All works except there is a ruff-isort change in `networkx/algorithms/centrality/betweenness_subset.py`, not a 100% sure if this is an issue or not. I'm fine either way.