### PR TITLE
Bump gh-pages deploy bot version.

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Deploy docs
         if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
           GIT_CONFIG_NAME: nx-doc-deploy-bot
           GIT_CONFIG_EMAIL: nx-doc-deploy-bot@nomail


### PR DESCRIPTION
Very minor CI maintenance. Should get rid of a [deprecation warning in the actions log](https://github.com/networkx/networkx/actions/runs/4211756548) due to GH bumping software versions in the actions infrastructure.

See also: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Unfortunately this is one of those changes that we won't know whether it worked until after merging as the `deploy-docs` job only runs post-merge!