### PR TITLE
Reset deploy-action param names for latest version.

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -63,10 +63,10 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
-          GIT_CONFIG_NAME: nx-doc-deploy-bot
-          GIT_CONFIG_EMAIL: nx-doc-deploy-bot@nomail
-          FOLDER: doc/build/html
-          REPOSITORY_NAME: networkx/documentation
-          BRANCH: gh-pages
-          TARGET_FOLDER: latest
-          SSH: true
+          git-config-name: nx-doc-deploy-bot
+          git-config-email: nx-doc-deploy-bot@nomail
+          folder: doc/build/html
+          repository-name: networkx/documentation
+          branch: gh-pages
+          target-folder: latest
+          ssh-key: true


### PR DESCRIPTION
Follow-up for #6446 .

According to the warnings in the [deploy action log](https://github.com/networkx/networkx/actions/runs/4254090726), the [parameter names for the gh-pages deploy action](https://github.com/JamesIves/github-pages-deploy-action#optional-choices) changed with the version bump. This PR should fix those and get the deploy job running again.