### PR TITLE
Error handling for invalid prufer sequence `from_prufer_sequence`: issue #6420

### DIFF
--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -331,6 +331,11 @@ def from_prufer_sequence(sequence):
     NetworkX graph
         The tree corresponding to the given Prüfer sequence.
 
+    Raises
+    ------
+    NetworkXError
+        If the Prufer sequence is not valid.
+
     Notes
     -----
     There is a bijection from labeled trees to Prüfer sequences. This

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -392,7 +392,7 @@ def from_prufer_sequence(sequence):
         # check the validity of the prufer sequence
         if v < 0 or v > n - 1:
             raise nx.NetworkXError(
-                f"Invalid Prufer sequence: Values must be between 0 and {len(sequence)-1}, got {v}"
+                f"Invalid Prufer sequence: Values must be between 0 and {n-1}, got {v}"
             )
         T.add_edge(u, v)
         not_orphaned.add(u)

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -334,7 +334,7 @@ def from_prufer_sequence(sequence):
     Raises
     ------
     NetworkXError
-        If the Prufer sequence is not valid.
+        If the Prüfer sequence is not valid.
 
     Notes
     -----

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -384,6 +384,12 @@ def from_prufer_sequence(sequence):
     not_orphaned = set()
     index = u = next(k for k in range(n) if degree[k] == 1)
     for v in sequence:
+        # check the validity of the prufer sequence
+        if v < 0 or v > n - 1:
+            msg = """ Invalid Prufer sequence: you may check that every element (sequence[i]) in the sequence
+                     does not exceed length of the sequence plus 1 ( 0 <= sequence[i] <= length(sequence)+1 )."""
+            raise nx.NetworkXException(msg)
+
         T.add_edge(u, v)
         not_orphaned.add(u)
         degree[v] -= 1

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -391,10 +391,9 @@ def from_prufer_sequence(sequence):
     for v in sequence:
         # check the validity of the prufer sequence
         if v < 0 or v > n - 1:
-            msg = """Invalid Prufer sequence: you may check that every element (sequence[i]) in the sequence
-                     does not exceed the length of the sequence plus 1 or ( 0 <= sequence[i] <= length(sequence)+1 )."""
-            raise nx.NetworkXError(msg)
-
+            raise nx.NetworkXError(
+                f"Invalid Prufer sequence: Values must be between 0 and {len(sequence)-1}, got {v}"
+            )
         T.add_edge(u, v)
         not_orphaned.add(u)
         degree[v] -= 1

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -386,9 +386,9 @@ def from_prufer_sequence(sequence):
     for v in sequence:
         # check the validity of the prufer sequence
         if v < 0 or v > n - 1:
-            msg = """ Invalid Prufer sequence: you may check that every element (sequence[i]) in the sequence
-                     does not exceed length of the sequence plus 1 ( 0 <= sequence[i] <= length(sequence)+1 )."""
-            raise nx.NetworkXException(msg)
+            msg = """Invalid Prufer sequence: you may check that every element (sequence[i]) in the sequence
+                     does not exceed the length of the sequence plus 1 or ( 0 <= sequence[i] <= length(sequence)+1 )."""
+            raise nx.NetworkXError(msg)
 
         T.add_edge(u, v)
         not_orphaned.add(u)


### PR DESCRIPTION
This pull request is meant for fixing #6420. the author of the issue passes the prufer sequence `[7,5,5,3,1]` to the function `from_prufer_sequence` and expects a valid output (tree). The conflict happens due to the difference in indexing styles; networkx uses the zero-indexing , on the other hand , mathematicians (graph theorists ) use one as the first label/index . Adopting zero-indexing style, every element in the sequence has to obey the following constraint: 
$$0 \le sequence[i] \le length(sequence) + 1   \ \ \ \  ,  \ \ \ \ such \  that  \ \ \  0 \le i < length(sequence)$$
If not the case a `NetworkXError` is raised .
Hope this is thoughtful  

Closes #6420 