### PR TITLE
add simple cycle enumerator for undirected class

### DIFF
--- a/doc/reference/algorithms/cycles.rst
+++ b/doc/reference/algorithms/cycles.rst
@@ -11,3 +11,4 @@ Cycles
    recursive_simple_cycles
    find_cycle
    minimum_cycle_basis
+   chordless_cycles

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -16,6 +16,7 @@ __all__ = [
     "recursive_simple_cycles",
     "find_cycle",
     "minimum_cycle_basis",
+    "chordless_cycles",
 ]
 
 
@@ -96,7 +97,7 @@ def cycle_basis(G, root=None):
     return cycles
 
 
-def simple_cycles(G, length_bound=None, chordless=False):
+def simple_cycles(G, length_bound=None):
     """Find simple cycles (elementary circuits) of a graph.
 
     A `simple cycle`, or `elementary circuit`, is a closed path where
@@ -119,6 +120,11 @@ def simple_cycles(G, length_bound=None, chordless=False):
     containing a particular edge, remove that edge, and further decompose the
     remainder into biconnected components.
 
+    Note that multigraphs are supported by this function -- and in undirected
+    multigraphs, a pair of parallel edges is considered a cycle of length 2.
+    Likewise, self-loops are considered to be cycles of length 1.  We define
+    cycles as sequences of nodes; so the presence of loops and parallel edges
+    does not change the number of simple cycles in a graph.
 
     Parameters
     ----------
@@ -178,9 +184,6 @@ def simple_cycles(G, length_bound=None, chordless=False):
     cycle_basis
     chordless_cycles
     """
-    if chordless:
-        yield from chordless_cycles(G, length_bound=length_bound)
-        return
 
     if length_bound is not None:
         if length_bound == 0:
@@ -469,7 +472,7 @@ def _bounded_cycle_search(G, path, length_bound):
                     B[w].add(v)
 
 
-def chordless_cycles(G, length_bound):
+def chordless_cycles(G, length_bound=None):
     """Find simple chordless cycles of a graph.
 
     A `simple cycle`, is a closed path where no node appears twice.  In a simple
@@ -544,6 +547,9 @@ def chordless_cycles(G, length_bound):
        E. Dias and D. Castonguay and H. Longo and W.A.R. Jradi
        https://arxiv.org/abs/1309.1051
 
+    See Also
+    --------
+    simple_cycles
     """
 
     if length_bound is not None:

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -533,6 +533,11 @@ def chordless_cycles(G, length_bound=None):
     list of nodes
        Each cycle is represented by a list of nodes along the cycle.
 
+    Examples
+    --------
+    >>> sorted(list(nx.chordless_cycles(nx.complete_graph(4))))
+    [[1, 0, 2], [1, 0, 3], [2, 0, 3], [2, 1, 3]]
+
     Notes
     -----
     When length_bound is None, and the graph is simple, the time complexity is

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -163,6 +163,11 @@ def simple_cycles(G, length_bound=None):
     the time complexity is $O((c+n)(k-1)d^k)$ where $d$ is the average degree of
     the nodes of G and $k$ = length_bound.
 
+    Raises
+    ------
+    ValueError
+        when length_bound < 0.
+
     References
     ----------
     .. [1] Finding all the elementary circuits of a directed graph.
@@ -256,10 +261,6 @@ def _directed_cycle_search(G, length_bound):
        If length_bound is an int, generate all simple cycles of G with length at most length_bound.
        Otherwise, generate all simple cycles of G.
 
-    chordless : bool
-       If chordless is True, limit search to chordless simple cycles of G.
-       Otherwise, generate simple cycles with or without chords.
-
     Yields
     ------
     list of nodes
@@ -309,10 +310,6 @@ def _undirected_cycle_search(G, length_bound):
     length_bound : int or None
        If length_bound is an int, generate all simple cycles of G with length at most length_bound.
        Otherwise, generate all simple cycles of G.
-
-    chordless : bool
-       If chordless is True, limit search to chordless simple cycles of G.
-       Otherwise, generate simple cycles with or without chords.
 
     Yields
     ------
@@ -475,7 +472,7 @@ def _bounded_cycle_search(G, path, length_bound):
 def chordless_cycles(G, length_bound=None):
     """Find simple chordless cycles of a graph.
 
-    A `simple cycle`, is a closed path where no node appears twice.  In a simple
+    A `simple cycle` is a closed path where no node appears twice.  In a simple
     cycle, a `chord` is an additional edge between two nodes in the cycle.  A
     `chordless cycle` is a simple cycle without chords.  Said differently, a
     chordless cycle is a cycle C in a graph G where the number of edges in the
@@ -505,7 +502,7 @@ def chordless_cycles(G, length_bound=None):
 
     Optionally, the cycles are bounded in length.
 
-    We use an algorithm  strongly inspired by that of Dias et al [1]_.  It has
+    We use an algorithm strongly inspired by that of Dias et al [1]_.  It has
     been modified in the following ways:
 
         1. Recursion is avoided, per Python's limitations
@@ -540,6 +537,11 @@ def chordless_cycles(G, length_bound=None):
     -----
     When length_bound is None, and the graph is simple, the time complexity is
     $O((n+e)(c+1))$ for $n$ nodes, $e$ edges and $c$ chordless cycles.
+
+    Raises
+    ------
+    ValueError
+        when length_bound < 0.
 
     References
     ----------

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -395,6 +395,11 @@ class TestCycleEnumeration:
 
         self.check_cycle_algorithm(g, expected_cycles, length_bound=1)
 
+        g = nx.MultiDiGraph(g)
+        g.add_edges_from((i, i) for i in range(0, 10, 2))
+        expected_cycles = [(i,) for i in range(1, 10, 2)]
+        self.check_cycle_algorithm(g, expected_cycles, chordless=True)
+
     def test_simple_cycles_notable_clique_sequences(self):
         # A000292: Number of labeled graphs on n+3 nodes that are triangles.
         g_family = [self.K(n) for n in range(2, 12)]

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -634,6 +634,14 @@ class TestCycleEnumeration:
             for k, e in enumerate(expected):
                 self.check_cycle_algorithm(g, e, length_bound=k)
 
+    def test_simple_cycles_bound_corner_cases(self):
+        G = nx.cycle_graph(4)
+        DG = nx.cycle_graph(4, create_using=nx.DiGraph)
+        assert list(nx.simple_cycles(G, length_bound=0)) == []
+        assert list(nx.simple_cycles(DG, length_bound=0)) == []
+        assert list(nx.chordless_cycles(G, length_bound=0)) == []
+        assert list(nx.chordless_cycles(DG, length_bound=0)) == []
+
     def test_simple_cycles_bound_error(self):
         with pytest.raises(ValueError):
             G = nx.DiGraph()
@@ -643,6 +651,16 @@ class TestCycleEnumeration:
         with pytest.raises(ValueError):
             G = nx.Graph()
             for c in nx.simple_cycles(G, -1):
+                assert False
+
+        with pytest.raises(ValueError):
+            G = nx.Graph()
+            for c in nx.chordless_cycles(G, -1):
+                assert False
+
+        with pytest.raises(ValueError):
+            G = nx.DiGraph()
+            for c in nx.chordless_cycles(G, -1):
                 assert False
 
     def test_chordless_cycles_clique(self):

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -237,9 +237,12 @@ class TestCycleEnumeration:
         g,
         expected_cycles,
         length_bound=None,
-        chordless=None,
-        algorithm=nx.simple_cycles,
+        chordless=False,
+        algorithm=None,
     ):
+        if algorithm is None:
+            algorithm = nx.chordless_cycles if chordless else nx.simple_cycles
+
         # note: we shuffle the labels of g to rule out accidentally-correct
         # behavior which occurred during the development of chordless cycle
         # enumeration algorithms
@@ -255,10 +258,6 @@ class TestCycleEnumeration:
         params = {}
         if length_bound is not None:
             params["length_bound"] = length_bound
-        if chordless is not None:
-            params["chordless"] = chordless
-        else:
-            chordless = False
 
         cycle_cache = {}
         for c in algorithm(h, **params):
@@ -293,7 +292,7 @@ class TestCycleEnumeration:
         cycle_counts,
         length_bound=None,
         chordless=False,
-        algorithm=nx.simple_cycles,
+        algorithm=None,
     ):
         for g, num_cycles in zip(g_family, cycle_counts):
             self.check_cycle_algorithm(


### PR DESCRIPTION
The need to enumerate simple cycles in a graph has come up frequently in my life and it's a common question that people have.  There are two ways of accomplishing this:

1. enumerate all connected sums of cycles in a cycle basis
2. exhaustive search

The first is probably the most efficient way to get all cycles, but filtering down to certain cycle lengths would not be efficient at all.  The code here is reasonably fast given the problem it is solving, but leaves some performance improvements on the table.  The biggest one is that I should probably iterate over 2-edge-connected components to avoid brute-forcing large trees.

This is a work in progress; I have not yet added tests.  And, of course, I'm open to discussion on how best to handle this -- I was unsure whether or not to dispatch this algorithm with `all_simple_cycles` in the directed case.  Also, there is a question of credit:  this was the obvious brute-force algorithm when I naively sat down with the problem, and I've found a few occurrences of this or related algorithms in literature and code snippets online; [a 2006 paper claims its novelty](https://ieeexplore.ieee.org/document/1602189) but that paper does not appear to handle equivalence by reversal.  The only point of novelty that I see is that other algorithms (including an ancient implementation of mine) assume sortability of node labels, which is not strictly necessary.  I've included a flag to enumerate chordless cycles, which is effectively a free addition to the algorithm -- again, there are several variations of this in the literature / internet.