### PR TITLE
Ignore weakrefs when testing for memory leak

### DIFF
--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -72,6 +72,14 @@ class BaseGraphTester:
         G = self.Graph()
 
         def count_objects_of_type(_type):
+            # Iterating over all objects tracked by gc can include weak references
+            # whose weakly-referenced objects may no longer exist. Calling `isinstance`
+            # on such a weak reference will raise ReferenceError. There are two common
+            # workarounds for this: one is to compare type names instead of `isinstance`
+            # such as `type(obj).__name__ == typename`, and the other is to explicitly
+            # ignore ProxyTypes as we do below.
+            # NOTE: even if this safeguard is deemed unnecessary to pass NetworkX tests,
+            # we should still keep it for maximum safety for other NetworkX backends.
             return sum(
                 1
                 for obj in gc.get_objects()

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -1,6 +1,7 @@
 import gc
 import pickle
 import platform
+import weakref
 
 import pytest
 
@@ -71,7 +72,11 @@ class BaseGraphTester:
         G = self.Graph()
 
         def count_objects_of_type(_type):
-            return sum(1 for obj in gc.get_objects() if isinstance(obj, _type))
+            return sum(
+                1
+                for obj in gc.get_objects()
+                if not isinstance(obj, weakref.ProxyTypes) and isinstance(obj, _type)
+            )
 
         gc.collect()
         before = count_objects_of_type(self.Graph)

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -74,10 +74,10 @@ class BaseGraphTester:
         def count_objects_of_type(_type):
             # Iterating over all objects tracked by gc can include weak references
             # whose weakly-referenced objects may no longer exist. Calling `isinstance`
-            # on such a weak reference will raise ReferenceError. There are two common
-            # workarounds for this: one is to compare type names instead of `isinstance`
-            # such as `type(obj).__name__ == typename`, and the other is to explicitly
-            # ignore ProxyTypes as we do below.
+            # on such a weak reference will raise ReferenceError. There are at least
+            # three workarounds for this: one is to compare type names instead of using
+            # `isinstance` such as `type(obj).__name__ == typename`, another is to use
+            # `type(obj) == _type`, and the last is to ignore ProxyTypes as we do below.
             # NOTE: even if this safeguard is deemed unnecessary to pass NetworkX tests,
             # we should still keep it for maximum safety for other NetworkX backends.
             return sum(


### PR DESCRIPTION
I started to encounter an error with this when testing `graphblas_algorithms`, b/c it was trying to operate on weakly-reference objects that no longer exist. I have no other context about this, but this change seems "safe" to me.