### PR TITLE
tweak _dispatch to allow G keyword. Add test.

### DIFF
--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -128,7 +128,10 @@ def _dispatch(func=None, *, name=None):
 
     @functools.wraps(func)
     def wrapper(*args, **kwds):
-        graph = args[0]
+        if args:
+            graph = args[0]
+        else:
+            graph = kwds["G"]  # raise KeyError if not present
         if hasattr(graph, "__networkx_plugin__") and plugins:
             plugin_name = graph.__networkx_plugin__
             if plugin_name in plugins:

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -131,7 +131,10 @@ def _dispatch(func=None, *, name=None):
         if args:
             graph = args[0]
         else:
-            graph = kwds["G"]  # raise KeyError if not present
+            try:
+                graph = kwds["G"]
+            except KeyError:
+                raise TypeError(f"{name}() missing positional argument: 'G'")
         if hasattr(graph, "__networkx_plugin__") and plugins:
             plugin_name = graph.__networkx_plugin__
             if plugin_name in plugins:

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -134,7 +134,7 @@ def _dispatch(func=None, *, name=None):
             try:
                 graph = kwds["G"]
             except KeyError:
-                raise TypeError(f"{name}() missing positional argument: 'G'")
+                raise TypeError(f"{name}() missing positional argument: 'G'") from None
         if hasattr(graph, "__networkx_plugin__") and plugins:
             plugin_name = graph.__networkx_plugin__
             if plugin_name in plugins:

--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -1,0 +1,11 @@
+import pytest
+
+import networkx as nx
+
+
+def test_dispatch_kwds_vs_args():
+    G = nx.path_graph(4)
+    nx.pagerank(G)
+    nx.pagerank(G=G)
+    with pytest.raises(KeyError):
+        nx.pagerank()

--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -10,5 +10,5 @@ def test_dispatch_kwds_vs_args():
     G = nx.path_graph(4)
     nx.pagerank(G)
     nx.pagerank(G=G)
-    with pytest.raises(KeyError):
+    with pytest.raises(TypeError):
         nx.pagerank()

--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -2,6 +2,9 @@ import pytest
 
 import networkx as nx
 
+pytest.importorskip("scipy")
+pytest.importorskip("numpy")
+
 
 def test_dispatch_kwds_vs_args():
     G = nx.path_graph(4)


### PR DESCRIPTION
The `_dispatch` decorator assumes that the first argument is a positional argument.
This PR allows `G` to be provided as a keyword. Note that `G` is still expected to be
the first positional argument. This only affects how people can call it: 
`nx.pagerank(G=G)` and `nx.pagerank(G)` should be the same.

Fixes #6458