### PR TITLE
Fixing DOT format for to_agraph()

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -139,9 +139,10 @@ def to_agraph(N):
     strict = nx.number_of_selfloops(N) == 0 and not N.is_multigraph()
 
     for node in N:
-        N.nodes[node]["pos"] = "{},{}!".format(
-            N.nodes[node]["pos"][0], N.nodes[node]["pos"][1]
-        )
+        if "pos" in N.nodes[node]:
+            N.nodes[node]["pos"] = "{},{}!".format(
+                N.nodes[node]["pos"][0], N.nodes[node]["pos"][1]
+            )
 
     A = pygraphviz.AGraph(name=N.name, strict=strict, directed=directed)
 

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -137,6 +137,12 @@ def to_agraph(N):
         ) from err
     directed = N.is_directed()
     strict = nx.number_of_selfloops(N) == 0 and not N.is_multigraph()
+
+    for node in N:
+        N.nodes[node]["pos"] = "{},{}!".format(
+            N.nodes[node]["pos"][0], N.nodes[node]["pos"][1]
+        )
+
     A = pygraphviz.AGraph(name=N.name, strict=strict, directed=directed)
 
     # default graph attributes

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -241,7 +241,10 @@ class TestAGraph:
         assert len(pos) == 5
         assert len(pos[0]) == 3
 
-    def test_warnings(self):
+    def test_no_warnings_raised(self):
+        # Test that no warnings are raised when Networkx graph
+        # is converted to Pygraphviz graph and 'pos'
+        # attribute is given
         G = nx.Graph()
         G.add_node(0, pos=(0, 0))
         G.add_node(1, pos=(1, 1))

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -240,3 +240,12 @@ class TestAGraph:
         pos = list(pos.values())
         assert len(pos) == 5
         assert len(pos[0]) == 3
+
+    def test_warnings(self):
+        G = nx.Graph()
+        G.add_node(0, pos=(0, 0))
+        G.add_node(1, pos=(1, 1))
+        A = nx.nx_agraph.to_agraph(G)
+        with pytest.warns(None) as record:
+            A.layout()
+        assert len(record) == 0


### PR DESCRIPTION
Fixes: #6049 

First, I replicated the issue discussed in #6049 and found that it still persists.

<img width="566" alt="image" src="https://user-images.githubusercontent.com/82928853/223691011-25ed6908-d842-471e-8fed-da58ce1c2413.png">

The output of the out.dot file is given below which is in the format pos="(0,0)"

<img width="170" alt="image" src="https://user-images.githubusercontent.com/82928853/223691185-e362d361-d47c-48cc-a7ac-8b4c56b45054.png">

As discussed in the issue, I made changes to the to_agraph() method so that the DOT format is pos="0,0". Now the code executes without any warnings as expected.

<img width="565" alt="image" src="https://user-images.githubusercontent.com/82928853/223691422-2bff0a12-f78a-4c75-b058-b2df4f3c4cd3.png">

The contents of the file out.dot are also as expected.

<img width="157" alt="image" src="https://user-images.githubusercontent.com/82928853/223691785-01127d4c-7a62-4f5a-b9d0-9ec46f1e46cb.png">