### PR TITLE
Fix len operation of UnionAtlas

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -134,7 +134,7 @@ class UnionAtlas(Mapping):
         self._pred = pred
 
     def __len__(self):
-        return len(self._succ) + len(self._pred)
+        return len(self._succ.keys() | self._pred.keys())
 
     def __iter__(self):
         return iter(set(self._succ.keys()) | set(self._pred.keys()))

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -155,7 +155,7 @@ class TestUnionAtlas:
         assert view.__slots__ == pview.__slots__
 
     def test_len(self):
-        assert len(self.av) == len(self.s) + len(self.p)
+        assert len(self.av) == len(self.s.keys() | self.p.keys()) == 5
 
     def test_iter(self):
         assert set(self.av) == set(self.s) | set(self.p)
@@ -257,7 +257,7 @@ class TestUnionMultiInner(TestUnionAdjacency):
         self.adjview = nx.classes.coreviews.UnionMultiInner(self.s, self.p)
 
     def test_len(self):
-        assert len(self.adjview) == len(self.s) + len(self.p)
+        assert len(self.adjview) == len(self.s.keys() | self.p.keys()) == 4
 
     def test_getitem(self):
         assert self.adjview[1] is not self.s[1]


### PR DESCRIPTION
The UnionAtlas class was computing `__len__` assuming that the two dicts being unioned have distinct keys. That is not true in general, and certainly not in the case of directed graphs with bidirectional edges.  At the UnionAdjacency level the keys must be the same (one for each node). But inside the UnionAdjacency is a UnionAtlas and for directed graphs it is a union of `_pred[node]` and `_succ[node]` which can have different keys, but it doesn't have to have different keys.

This fix corrects the computation of `__len__` to use the union of the two sets of keys, rather than the sum of the lengths. 

Fixes #6336 

