### PR TITLE
Improve test coverage for mst.py and bug fix in prim_mst_edges()

### DIFF
--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -334,12 +334,22 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
                         continue
                     for k2, d2 in keydict.items():
                         new_weight = d2.get(weight, 1) * sign
+                        if isnan(new_weight):
+                            if ignore_nan:
+                                continue
+                            msg = f"NaN found as an edge weight. Edge {(v, w, k2, d2)}"
+                            raise ValueError(msg)
                         push(frontier, (new_weight, next(c), v, w, k2, d2))
             else:
                 for w, d2 in G.adj[v].items():
                     if w in visited:
                         continue
                     new_weight = d2.get(weight, 1) * sign
+                    if isnan(new_weight):
+                        if ignore_nan:
+                            continue
+                        msg = f"NaN found as an edge weight. Edge {(v, w, d2)}"
+                        raise ValueError(msg)
                     push(frontier, (new_weight, next(c), v, w, d2))
 
 

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -307,9 +307,8 @@ class TestPrim(MultigraphMSTTestBase):
         )
 
         # NaN weight edges raise Error when ignore_nan=False
-        edges = nx.minimum_spanning_edges(H, algorithm=self.algo, ignore_nan=False)
         with pytest.raises(ValueError):
-            list(edges)
+            list(nx.minimum_spanning_edges(H, algorithm=self.algo, ignore_nan=False))
 
     def test_multigraph_keys_tree(self):
         G = nx.MultiGraph()

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -1,6 +1,5 @@
 """Unit tests for the :mod:`networkx.algorithms.tree.mst` module."""
 
-import numpy as np
 import pytest
 
 import networkx as nx
@@ -296,7 +295,7 @@ class TestPrim(MultigraphMSTTestBase):
         """Tests that the edges with NaN weights are ignored or
         raise an Error based on ignore_nan is true or false"""
         H = nx.MultiGraph()
-        H.add_edge(1, 2, key=1, weight=np.NaN)
+        H.add_edge(1, 2, key=1, weight=float("nan"))
         H.add_edge(1, 2, key=2, weight=3)
         H.add_edge(3, 2, key=1, weight=2)
         H.add_edge(3, 1, key=1, weight=4)

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -1,5 +1,6 @@
 """Unit tests for the :mod:`networkx.algorithms.tree.mst` module."""
 
+import numpy as np
 import pytest
 
 import networkx as nx
@@ -253,6 +254,36 @@ class TestKruskal(MultigraphMSTTestBase):
 
     algorithm = "kruskal"
 
+    def test_key_data_bool(self):
+        """Tests that the keys and data values are included in
+        MST edges based on whether keys and data parameters are
+        true or false"""
+        G = nx.MultiGraph()
+        G.add_edge(1, 2, key=1, weight=2)
+        G.add_edge(1, 2, key=2, weight=3)
+        G.add_edge(3, 2, key=1, weight=2)
+        G.add_edge(3, 1, key=1, weight=4)
+
+        # keys are included and data is not included
+        mst_edges = nx.minimum_spanning_edges(
+            G, algorithm=self.algo, keys=True, data=False
+        )
+        assert edges_equal([(1, 2, 1), (2, 3, 1)], list(mst_edges))
+
+        # keys are not included and data is included
+        mst_edges = nx.minimum_spanning_edges(
+            G, algorithm=self.algo, keys=False, data=True
+        )
+        assert edges_equal(
+            [(1, 2, {"weight": 2}), (2, 3, {"weight": 2})], list(mst_edges)
+        )
+
+        # both keys and data are not included
+        mst_edges = nx.minimum_spanning_edges(
+            G, algorithm=self.algo, keys=False, data=False
+        )
+        assert edges_equal([(1, 2), (2, 3)], list(mst_edges))
+
 
 class TestPrim(MultigraphMSTTestBase):
     """Unit tests for computing a minimum (or maximum) spanning tree
@@ -260,6 +291,26 @@ class TestPrim(MultigraphMSTTestBase):
     """
 
     algorithm = "prim"
+
+    def test_ignore_nan(self):
+        """Tests that the edges with NaN weights are ignored or
+        raise an Error based on ignore_nan is true or false"""
+        H = nx.MultiGraph()
+        H.add_edge(1, 2, key=1, weight=np.NaN)
+        H.add_edge(1, 2, key=2, weight=3)
+        H.add_edge(3, 2, key=1, weight=2)
+        H.add_edge(3, 1, key=1, weight=4)
+
+        # NaN weight edges are ignored when ignore_nan=True
+        mst_edges = nx.minimum_spanning_edges(H, algorithm=self.algo, ignore_nan=True)
+        assert edges_equal(
+            [(1, 2, 2, {"weight": 3}), (2, 3, 1, {"weight": 2})], list(mst_edges)
+        )
+
+        # NaN weight edges raise Error when ignore_nan=False
+        edges = nx.minimum_spanning_edges(H, algorithm=self.algo, ignore_nan=False)
+        with pytest.raises(ValueError):
+            list(edges)
 
     def test_multigraph_keys_tree(self):
         G = nx.MultiGraph()


### PR DESCRIPTION
Closes #6477 

I have added test cases for Kruskal and Prims algorithms. The test coverage for mst.py has now increased to 98%.

![image](https://user-images.githubusercontent.com/82928853/224429707-4cc0fcd8-ebf8-4dd5-8c63-b9de5fc59c43.png)

This is my first time writing tests, so I apologize in advance if there are any errors in the code. I am specifically doubtful of the Prims test when ignore_nan = False and an Error is raised.

Edit - This PR also fixes some bugs based on [this discussion](https://github.com/networkx/networkx/pull/6486#discussion_r1136069166). The bug fix introduces new branches to the code, so the test coverage is now 96%.