### PR TITLE
Add docstring examples to dag.py

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1224,6 +1224,17 @@ def compute_v_structures(G):
         The v structures within the graph. Each v structure is a 3-tuple with the
         parent, collider, and other parent.
 
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5)])
+    >>> list(nx.compute_v_structures(G))
+    [(0, 5, 4), (0, 5, 1), (1, 5, 4)]
+
+    >>> G = nx.gnp_random_graph(5, 0.3, seed = 100, directed = True)
+    >>> list(nx.compute_v_structures(G))
+    [(2, 0, 4), (0, 1, 4)]
+
     Notes
     -----
     https://en.wikipedia.org/wiki/Collider_(statistics)


### PR DESCRIPTION
I added examples in the docstring for the compute_v_structures method in dag.py for better understanding.