### PR TITLE
tweak `test_override_dispatch` to allow G keyword

### DIFF
--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -174,7 +174,13 @@ def test_override_dispatch(func=None, *, name=None):
             pytest.xfail(f"'{name}' not implemented by {plugin_name}")
         bound = sig.bind(*args, **kwds)
         bound.apply_defaults()
-        graph, *args = args
+        if args:
+            graph, *args = args
+        else:
+            try:
+                graph = kwds.pop("G")
+            except KeyError:
+                raise TypeError(f"{name}() missing positional argument: 'G'") from None
         # Convert graph into backend graph-like object
         #   Include the weight label, if provided to the algorithm
         weight = None


### PR DESCRIPTION
This is a simple follow-up to #6471, and, as in that PR, this fix is short term. We would like to find a more elegant, robust solution (probably after nx 3.1).

I sometimes forget there are two versions of `_dispatch`, and this PR fixes the one that gets used when `NETWORKX_GRAPH_CONVERT` environment variable is set. NetworkX does not yet test `test_override_dispatch`, so it's not easy to add a test, but it gets used by external backends such as `graphblas_algorithms`. Ideally, we should test this in NetworkX, which will require calling subprocess in a test with an environment variable set.

CC @MridulS @jim22k 