### PR TITLE
Added test cases for join operation and fixed join operation to handle label_attributes

### DIFF
--- a/networkx/algorithms/tree/operations.py
+++ b/networkx/algorithms/tree/operations.py
@@ -78,25 +78,13 @@ def join(rooted_trees, label_attribute=None):
 
     # Get the relabeled roots.
     roots = [
-        next(v for v, d in tree.nodes(data=True) if d.get("_old") == root)
+        next(v for v, d in tree.nodes(data=True) if d.get(label_attribute) == root)
         for tree, root in zip(trees, roots)
     ]
 
-    # Remove the old node labels.
+    # Add all sets of nodes and edges, attributes
     for tree in trees:
-        for v in tree:
-            tree.nodes[v].pop("_old")
-
-    # Add all sets of nodes and edges, with data.
-    nodes = (tree.nodes(data=True) for tree in trees)
-    edges = (tree.edges(data=True) for tree in trees)
-    R.add_nodes_from(chain.from_iterable(nodes))
-    R.add_edges_from(chain.from_iterable(edges))
-
-    # Add graph attributes; later attributes take precedent over earlier
-    # attributes.
-    for tree in trees:
-        R.graph.update(tree.graph)
+        R.update(tree)
 
     # Finally, join the subtrees at the root. We know 0 is unused by the
     # way we relabeled the subtrees.

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -2,8 +2,20 @@
 
 """
 
+from itertools import chain
+
 import networkx as nx
 from networkx.utils import edges_equal, nodes_equal
+
+
+def _check_label_attribute(input_trees, res_tree, label_attribute="_old"):
+    """Tests to check if label_attribute is storing"""
+
+    res_attr_dict = nx.get_node_attributes(res_tree, label_attribute)
+    res_attr_list = list(res_attr_dict.values())
+    input_label = (list(tree[0].nodes()) for tree in input_trees)
+    input_label_list = list(chain.from_iterable(input_label))
+    return res_attr_list == input_label_list
 
 
 class TestJoin:
@@ -24,14 +36,18 @@ class TestJoin:
 
         """
         T = nx.empty_graph(1)
-        actual = nx.join([(T, 0)])
+        trees = [(T, 0)]
+        actual = nx.join(trees)
         expected = nx.path_graph(2)
         assert nodes_equal(list(expected), list(actual))
         assert edges_equal(list(expected.edges()), list(actual.edges()))
+        assert _check_label_attribute(trees, actual)
 
     def test_basic(self):
         """Tests for joining multiple subtrees at a root node."""
         trees = [(nx.full_rary_tree(2, 2**2 - 1), 0) for i in range(2)]
-        actual = nx.join(trees)
+        label_attribute = "old_values"
+        actual = nx.join(trees, label_attribute)
         expected = nx.full_rary_tree(2, 2**3 - 1)
         assert nx.is_isomorphic(actual, expected)
+        assert _check_label_attribute(trees, actual, label_attribute)

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -9,12 +9,10 @@ from networkx.utils import edges_equal, nodes_equal
 
 
 def _check_label_attribute(input_trees, res_tree, label_attribute="_old"):
-    """Tests to check if label_attribute is storing"""
-
     res_attr_dict = nx.get_node_attributes(res_tree, label_attribute)
-    res_attr_list = list(res_attr_dict.values())
+    res_attr_list = set(res_attr_dict.values())
     input_label = (list(tree[0].nodes()) for tree in input_trees)
-    input_label_list = list(chain.from_iterable(input_label))
+    input_label_list = set(chain.from_iterable(input_label))
     return res_attr_list == input_label_list
 
 

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -10,10 +10,10 @@ from networkx.utils import edges_equal, nodes_equal
 
 def _check_label_attribute(input_trees, res_tree, label_attribute="_old"):
     res_attr_dict = nx.get_node_attributes(res_tree, label_attribute)
-    res_attr_list = set(res_attr_dict.values())
+    res_attr_set = set(res_attr_dict.values())
     input_label = (list(tree[0].nodes()) for tree in input_trees)
-    input_label_list = set(chain.from_iterable(input_label))
-    return res_attr_list == input_label_list
+    input_label_set = set(chain.from_iterable(input_label))
+    return res_attr_set == input_label_set
 
 
 class TestJoin:


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
Fixes #6488 and fixes #6490 
@MridulS 
Modified join operation to store label_attributes and handled the case when label_attribute argument is provided.
Added test cases for join operation to check label_attributes.
Could you please check the PR and suggest any changes if needed to be done.

https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.tree.operations.join.html
In the documentation its written that Input has to be list of trees but this function works for graphs as well. Should I change the documentation by replacing trees with graphs or modify the join function to not accept list of graphs as input?