### PR TITLE
Improve test coverage for astar.py

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -194,3 +194,17 @@ class TestAStar:
         G.add_edges_from(pairwise(nodes, cyclic=True))
         path = nx.astar_path(G, nodes[0], nodes[2])
         assert len(path) == 3
+
+    def test_astar_NetworkXNoPath(self):
+        """Tests that exception is raised when there exists no
+        path between source and target"""
+        G = nx.gnp_random_graph(10, 0.2, seed=10)
+        with pytest.raises(nx.NetworkXNoPath):
+            nx.astar_path(G, 4, 9)
+
+    def test_astar_NodeNotFound(self):
+        """Tests that exception is raised when either
+        source or target is not in graph"""
+        G = nx.gnp_random_graph(10, 0.2, seed=10)
+        with pytest.raises(nx.NodeNotFound):
+            nx.astar_path_length(G, 11, 9)


### PR DESCRIPTION
I found that the [test coverage for astar.py](https://app.codecov.io/gh/networkx/networkx/blob/main/networkx/algorithms/shortest_paths/astar.py) is currently 91%.

I have added test cases for the two exceptions that can possibly be raised by the astar_path and astar_path_length methods.

The test coverage has now reached 100%.

![image](https://user-images.githubusercontent.com/82928853/224756817-81ca5a05-5c60-4d7c-bc69-20f487d0f28f.png)
