### PR TITLE
Improve test coverage for edgelist.py

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -202,13 +202,13 @@ class TestEdgelist:
 
         # Exception raised when node is not convertible
         # to specified data type
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=".*Failed to convert nodes"):
             lines = ["a b", "b c", "c a"]
             G = bipartite.parse_edgelist(lines, nodetype=int)
 
         # Exception raised when format of data is not
         # convertible to dictionary object
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=".*Failed to convert edge data"):
             lines = ["1 2 3", "2 3 4", "3 1 2"]
             G = bipartite.parse_edgelist(lines, nodetype=int)
 
@@ -222,7 +222,7 @@ class TestEdgelist:
 
         # Exception raised when edge data is not
         # convertible to specified data type
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=".*Failed to convert key data"):
             lines = ["1 2 3 a", "2 3 4 b"]
             G = bipartite.parse_edgelist(
                 lines, nodetype=int, data=[("weight", int), ("key", int)]

--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -190,3 +190,40 @@ class TestEdgelist:
             G = nx.path_graph(4)
             bytesIO = io.BytesIO()
             bipartite.write_edgelist(G, bytesIO)
+
+    def test_parse_edgelist(self):
+        """Tests for conditions specific to
+        parse_edge_list method"""
+
+        # ignore strings of length less than 2
+        lines = ["1 2", "2 3", "3 1", "4", " "]
+        G = bipartite.parse_edgelist(lines, nodetype=int)
+        assert list(G.nodes) == [1, 2, 3]
+
+        # Exception raised when node is not convertible
+        # to specified data type
+        with pytest.raises(TypeError):
+            lines = ["a b", "b c", "c a"]
+            G = bipartite.parse_edgelist(lines, nodetype=int)
+
+        # Exception raised when format of data is not
+        # convertible to dictionary object
+        with pytest.raises(TypeError):
+            lines = ["1 2 3", "2 3 4", "3 1 2"]
+            G = bipartite.parse_edgelist(lines, nodetype=int)
+
+        # Exception raised when edge data and data
+        # keys are not of same length
+        with pytest.raises(IndexError):
+            lines = ["1 2 3 4", "2 3 4"]
+            G = bipartite.parse_edgelist(
+                lines, nodetype=int, data=[("weight", int), ("key", int)]
+            )
+
+        # Exception raised when edge data is not
+        # convertible to specified data type
+        with pytest.raises(TypeError):
+            lines = ["1 2 3 a", "2 3 4 b"]
+            G = bipartite.parse_edgelist(
+                lines, nodetype=int, data=[("weight", int), ("key", int)]
+            )


### PR DESCRIPTION
I found that the [test coverage for edgelist.py](https://app.codecov.io/gh/networkx/networkx/blob/main/networkx/algorithms/bipartite/edgelist.py) is currently 86%.

I have added test cases for the various conditions specific to the parse_edgelist() method and the coverage has now reached 100%.

![image](https://user-images.githubusercontent.com/82928853/225000103-3a95658e-069c-4ab9-baaa-bc554b84c40a.png)
