### PR TITLE
Use generator to limit memory footprint of read_graph6.

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -121,7 +121,7 @@ def from_graph6_bytes(bytes_in):
 
     G = nx.Graph()
     G.add_nodes_from(range(n))
-    for (i, j), b in zip([(i, j) for j in range(1, n) for i in range(j)], bits()):
+    for (i, j), b in zip(((i, j) for j in range(1, n) for i in range(j)), bits()):
         if b:
             G.add_edge(i, j)
 


### PR DESCRIPTION
Switching from a list to a generator prevents the allocation of a `num_nodes**2 / 2` list of 2-tuples, which is a blocker for graphs with many nodes (see #6510).

Closes #6510