### PR TITLE
Fixed return type inconsistencies in shortest path methods documentation

### DIFF
--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -445,7 +445,7 @@ def all_pairs_shortest_path(G, cutoff=None):
 
     Returns
     -------
-    paths : dictionary
+    paths : iterator
         Dictionary, keyed by source and target, of shortest paths.
 
     Examples


### PR DESCRIPTION
Minor edits to correct the return type of path-related methods from `lengths` to `paths` in the documentation.