### PR TITLE
Improve test coverage for redundancy.py

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_redundancy.py
+++ b/networkx/algorithms/bipartite/tests/test_redundancy.py
@@ -10,8 +10,14 @@ from networkx.algorithms.bipartite import complete_bipartite_graph, node_redunda
 
 def test_no_redundant_nodes():
     G = complete_bipartite_graph(2, 2)
+
+    # when nodes is None
     rc = node_redundancy(G)
     assert all(redundancy == 1 for redundancy in rc.values())
+
+    # when set of nodes is specified
+    rc = node_redundancy(G, (2, 3))
+    assert rc == {2: 1.0, 3: 1.0}
 
 
 def test_redundant_nodes():


### PR DESCRIPTION
I found that the [test coverage for redundancy.py](https://app.codecov.io/gh/networkx/networkx/blob/main/networkx/algorithms/bipartite/redundancy.py) is currently 92.31%.

I have added some code that tests an _if_ condition that was previously not covered.

The test coverage has now reached 100%.

![image](https://user-images.githubusercontent.com/82928853/227724810-f844b1cd-b4ce-46fd-9f0b-53f8d3af0f64.png)
