### PR TITLE
remove usage of 'tempfile.mkstemp' in favour of a 'NamedTemporaryFile'

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -108,12 +108,10 @@ class TestEdgelist:
         G.add_edge(name1, "Radiohead", **{name2: 3})
         G.add_node(name1, bipartite=0)
         G.add_node("Radiohead", bipartite=1)
-        fd, fname = tempfile.mkstemp()
-        bipartite.write_edgelist(G, fname)
-        H = bipartite.read_edgelist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            bipartite.write_edgelist(G, f.name)
+            H = bipartite.read_edgelist(f.name)
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_latin1_issue(self):
         G = nx.Graph()
@@ -122,12 +120,14 @@ class TestEdgelist:
         G.add_edge(name1, "Radiohead", **{name2: 3})
         G.add_node(name1, bipartite=0)
         G.add_node("Radiohead", bipartite=1)
-        fd, fname = tempfile.mkstemp()
-        pytest.raises(
-            UnicodeEncodeError, bipartite.write_edgelist, G, fname, encoding="latin-1"
-        )
-        os.close(fd)
-        os.unlink(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            pytest.raises(
+                UnicodeEncodeError,
+                bipartite.write_edgelist,
+                G,
+                f.name,
+                encoding="latin-1",
+            )
 
     def test_latin1(self):
         G = nx.Graph()
@@ -136,49 +136,45 @@ class TestEdgelist:
         G.add_edge(name1, "Radiohead", **{name2: 3})
         G.add_node(name1, bipartite=0)
         G.add_node("Radiohead", bipartite=1)
-        fd, fname = tempfile.mkstemp()
-        bipartite.write_edgelist(G, fname, encoding="latin-1")
-        H = bipartite.read_edgelist(fname, encoding="latin-1")
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            bipartite.write_edgelist(G, f.name, encoding="latin-1")
+            H = bipartite.read_edgelist(f.name, encoding="latin-1")
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_graph(self):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
-        bipartite.write_edgelist(G, fname)
-        H = bipartite.read_edgelist(fname)
-        H2 = bipartite.read_edgelist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            bipartite.write_edgelist(G, f.name)
+            H = bipartite.read_edgelist(f.name)
+            H2 = bipartite.read_edgelist(f.name)
         assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_integers(self):
         G = nx.convert_node_labels_to_integers(self.G)
-        (fd, fname) = tempfile.mkstemp()
-        bipartite.write_edgelist(G, fname)
-        H = bipartite.read_edgelist(fname, nodetype=int)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            bipartite.write_edgelist(G, f.name)
+            H = bipartite.read_edgelist(f.name, nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_multigraph(self):
         G = self.MG
-        (fd, fname) = tempfile.mkstemp()
-        bipartite.write_edgelist(G, fname)
-        H = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
-        H2 = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            bipartite.write_edgelist(G, f.name)
+            H = bipartite.read_edgelist(
+                f.name, nodetype=int, create_using=nx.MultiGraph()
+            )
+            H2 = bipartite.read_edgelist(
+                f.name, nodetype=int, create_using=nx.MultiGraph()
+            )
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_empty_digraph(self):
         with pytest.raises(nx.NetworkXNotImplemented):

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -30,21 +30,9 @@ class TestAGraph:
         H = nx.nx_agraph.from_agraph(A)
         self.assert_equal(G, H)
 
-        fd, fname = tempfile.mkstemp()
-        nx.drawing.nx_agraph.write_dot(H, fname)
-        Hin = nx.nx_agraph.read_dot(fname)
-        self.assert_equal(H, Hin)
-        os.close(fd)
-        os.unlink(fname)
-
-        (fd, fname) = tempfile.mkstemp()
-        with open(fname, "w") as fh:
-            nx.drawing.nx_agraph.write_dot(H, fh)
-
-        with open(fname) as fh:
-            Hin = nx.nx_agraph.read_dot(fh)
-        os.close(fd)
-        os.unlink(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.drawing.nx_agraph.write_dot(H, f.name)
+            Hin = nx.nx_agraph.read_dot(f.name)
         self.assert_equal(H, Hin)
 
     def test_from_agraph_name(self):

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -41,36 +41,34 @@ class TestAdjlist:
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name)
+            H = nx.read_multiline_adjlist(f.name)
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_latin1_err(self):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        pytest.raises(
-            UnicodeEncodeError, nx.write_multiline_adjlist, G, fname, encoding="latin-1"
-        )
-        os.close(fd)
-        os.unlink(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            pytest.raises(
+                UnicodeEncodeError,
+                nx.write_multiline_adjlist,
+                G,
+                f.name,
+                encoding="latin-1",
+            )
 
     def test_latin1(self):
         G = nx.Graph()
         name1 = "Bj" + chr(246) + "rk"
         name2 = chr(220) + "ber"
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname, encoding="latin-1")
-        H = nx.read_multiline_adjlist(fname, encoding="latin-1")
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name, encoding="latin-1")
+            H = nx.read_multiline_adjlist(f.name, encoding="latin-1")
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_parse_adjlist(self):
         lines = ["1 2 5", "2 3 4", "3 5", "4", "5"]
@@ -83,63 +81,53 @@ class TestAdjlist:
 
     def test_adjlist_graph(self):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_adjlist(G, fname)
-        H = nx.read_adjlist(fname)
-        H2 = nx.read_adjlist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_adjlist(G, f.name)
+            H = nx.read_adjlist(f.name)
+            H2 = nx.read_adjlist(f.name)
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_adjlist_digraph(self):
         G = self.DG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_adjlist(G, fname)
-        H = nx.read_adjlist(fname, create_using=nx.DiGraph())
-        H2 = nx.read_adjlist(fname, create_using=nx.DiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_adjlist(G, f.name)
+            H = nx.read_adjlist(f.name, create_using=nx.DiGraph())
+            H2 = nx.read_adjlist(f.name, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_adjlist_integers(self):
-        (fd, fname) = tempfile.mkstemp()
         G = nx.convert_node_labels_to_integers(self.G)
-        nx.write_adjlist(G, fname)
-        H = nx.read_adjlist(fname, nodetype=int)
-        H2 = nx.read_adjlist(fname, nodetype=int)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_adjlist(G, f.name)
+            H = nx.read_adjlist(f.name, nodetype=int)
+            H2 = nx.read_adjlist(f.name, nodetype=int)
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_adjlist_multigraph(self):
         G = self.XG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_adjlist(G, fname)
-        H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
-        H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_adjlist(G, f.name)
+            H = nx.read_adjlist(f.name, nodetype=int, create_using=nx.MultiGraph())
+            H2 = nx.read_adjlist(f.name, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_adjlist_multidigraph(self):
         G = self.XDG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_adjlist(G, fname)
-        H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
-        H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_adjlist(G, f.name)
+            H = nx.read_adjlist(f.name, nodetype=int, create_using=nx.MultiDiGraph())
+            H2 = nx.read_adjlist(f.name, nodetype=int, create_using=nx.MultiDiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_adjlist_delimiter(self):
         fh = io.BytesIO()
@@ -194,69 +182,61 @@ class TestMultilineAdjlist:
 
     def test_multiline_adjlist_graph(self):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(fname)
-        H2 = nx.read_multiline_adjlist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name)
+            H = nx.read_multiline_adjlist(f.name)
+            H2 = nx.read_multiline_adjlist(f.name)
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_multiline_adjlist_digraph(self):
         G = self.DG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
-        H2 = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name)
+            H = nx.read_multiline_adjlist(f.name, create_using=nx.DiGraph())
+            H2 = nx.read_multiline_adjlist(f.name, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_multiline_adjlist_integers(self):
-        (fd, fname) = tempfile.mkstemp()
         G = nx.convert_node_labels_to_integers(self.G)
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(fname, nodetype=int)
-        H2 = nx.read_multiline_adjlist(fname, nodetype=int)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name)
+            H = nx.read_multiline_adjlist(f.name, nodetype=int)
+            H2 = nx.read_multiline_adjlist(f.name, nodetype=int)
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_multiline_adjlist_multigraph(self):
         G = self.XG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
-        H2 = nx.read_multiline_adjlist(
-            fname, nodetype=int, create_using=nx.MultiGraph()
-        )
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name)
+            H = nx.read_multiline_adjlist(
+                f.name, nodetype=int, create_using=nx.MultiGraph()
+            )
+            H2 = nx.read_multiline_adjlist(
+                f.name, nodetype=int, create_using=nx.MultiGraph()
+            )
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_multiline_adjlist_multidigraph(self):
         G = self.XDG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_multiline_adjlist(G, fname)
-        H = nx.read_multiline_adjlist(
-            fname, nodetype=int, create_using=nx.MultiDiGraph()
-        )
-        H2 = nx.read_multiline_adjlist(
-            fname, nodetype=int, create_using=nx.MultiDiGraph()
-        )
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_multiline_adjlist(G, f.name)
+            H = nx.read_multiline_adjlist(
+                f.name, nodetype=int, create_using=nx.MultiDiGraph()
+            )
+            H2 = nx.read_multiline_adjlist(
+                f.name, nodetype=int, create_using=nx.MultiDiGraph()
+            )
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_multiline_adjlist_delimiter(self):
         fh = io.BytesIO()

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -220,95 +220,79 @@ class TestEdgelist:
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        nx.write_edgelist(G, fname)
-        H = nx.read_edgelist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name)
+            H = nx.read_edgelist(f.name)
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_latin1_issue(self):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        pytest.raises(
-            UnicodeEncodeError, nx.write_edgelist, G, fname, encoding="latin-1"
-        )
-        os.close(fd)
-        os.unlink(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            pytest.raises(
+                UnicodeEncodeError, nx.write_edgelist, G, f.name, encoding="latin-1"
+            )
 
     def test_latin1(self):
         G = nx.Graph()
         name1 = "Bj" + chr(246) + "rk"
         name2 = chr(220) + "ber"
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        nx.write_edgelist(G, fname, encoding="latin-1")
-        H = nx.read_edgelist(fname, encoding="latin-1")
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name, encoding="latin-1")
+            H = nx.read_edgelist(f.name, encoding="latin-1")
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_graph(self):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_edgelist(G, fname)
-        H = nx.read_edgelist(fname)
-        H2 = nx.read_edgelist(fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name)
+            H = nx.read_edgelist(f.name)
+            H2 = nx.read_edgelist(f.name)
         assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_digraph(self):
         G = self.DG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_edgelist(G, fname)
-        H = nx.read_edgelist(fname, create_using=nx.DiGraph())
-        H2 = nx.read_edgelist(fname, create_using=nx.DiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name)
+            H = nx.read_edgelist(f.name, create_using=nx.DiGraph())
+            H2 = nx.read_edgelist(f.name, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_integers(self):
         G = nx.convert_node_labels_to_integers(self.G)
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_edgelist(G, fname)
-        H = nx.read_edgelist(fname, nodetype=int)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name)
+            H = nx.read_edgelist(f.name, nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_multigraph(self):
         G = self.XG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_edgelist(G, fname)
-        H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
-        H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name)
+            H = nx.read_edgelist(f.name, nodetype=int, create_using=nx.MultiGraph())
+            H2 = nx.read_edgelist(f.name, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_edgelist_multidigraph(self):
         G = self.XDG
-        (fd, fname) = tempfile.mkstemp()
-        nx.write_edgelist(G, fname)
-        H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
-        H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_edgelist(G, f.name)
+            H = nx.read_edgelist(f.name, nodetype=int, create_using=nx.MultiDiGraph())
+            H2 = nx.read_edgelist(f.name, nodetype=int, create_using=nx.MultiDiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -166,16 +166,13 @@ graph   [
         ]
 
     def test_read_gml(self):
-        (fd, fname) = tempfile.mkstemp()
-        fh = open(fname, "w")
-        fh.write(self.simple_data)
-        fh.close()
-        Gin = nx.read_gml(fname, label="label")
+        with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
+            f.write(self.simple_data)
+            f.close()
+            Gin = nx.read_gml(f.name, label="label")
         G = nx.parse_gml(self.simple_data, label="label")
         assert sorted(G.nodes(data=True)) == sorted(Gin.nodes(data=True))
         assert sorted(G.edges(data=True)) == sorted(Gin.edges(data=True))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_labels_are_strings(self):
         # GML requires labels to be strings (i.e., in quotes)
@@ -600,19 +597,15 @@ graph
         }
         G.add_node("Node", **numbers)
 
-        fd, fname = tempfile.mkstemp()
-        try:
-            nx.write_gml(G, fname)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            nx.write_gml(G, f.name)
             # Check that the export wrote the nonfitting numbers as strings
-            G2 = nx.read_gml(fname)
+            G2 = nx.read_gml(f.name)
             for attr, value in G2.nodes["Node"].items():
                 if attr == "toosmall" or attr == "toobig":
                     assert type(value) == str
                 else:
                     assert type(value) == int
-        finally:
-            os.close(fd)
-            os.unlink(fname)
 
 
 @contextmanager


### PR DESCRIPTION
replaces a low-level API with a context manager