### PR TITLE
address 'flake8-pytest-style' lints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         files: \.(html|md|yml|yaml)
         args: [--prose-wrap=preserve]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.258
+    rev: v0.0.259
     hooks:
       - id: ruff
         args:

--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -214,8 +214,8 @@ def test_example_1_detail_3_and_4():
 
 
 def test_directed():
+    G = nx.gnp_random_graph(10, 0.4, directed=True)
     with pytest.raises(nx.NetworkXNotImplemented):
-        G = nx.gnp_random_graph(10, 0.4, directed=True)
         kc = k_components(G)
 
 

--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -375,13 +375,15 @@ def test_TSP_incomplete_graph_short_path():
 
     cycle = nx_app.traveling_salesman_problem(G)
     print(cycle)
-    assert len(cycle) == 17 and len(set(cycle)) == 12
+    assert len(cycle) == 17
+    assert len(set(cycle)) == 12
 
     # make sure that cutting one edge out of complete graph formulation
     # cuts out many edges out of the path of the TSP
     path = nx_app.traveling_salesman_problem(G, cycle=False)
     print(path)
-    assert len(path) == 13 and len(set(path)) == 12
+    assert len(path) == 13
+    assert len(set(path)) == 12
 
 
 def test_held_karp_ascent():
@@ -902,7 +904,7 @@ def test_asadpour_empty_graph():
     pytest.raises(nx.NetworkXError, nx_app.asadpour_atsp, G)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_asadpour_integral_held_karp():
     """
     This test uses an integral held karp solution and the held karp function

--- a/networkx/algorithms/approximation/tests/test_treewidth.py
+++ b/networkx/algorithms/approximation/tests/test_treewidth.py
@@ -120,11 +120,7 @@ class TestTreewidthMinDegree:
                     graph[u].add(v)
 
         deg_heuristic = MinDegreeHeuristic(graph)
-        node = deg_heuristic.best_node(graph)
-        if node is None:
-            pass
-        else:
-            assert False
+        assert deg_heuristic.best_node(graph) is None
 
     def test_empty_graph(self):
         """Test empty graph"""
@@ -228,11 +224,7 @@ class TestTreewidthMinFillIn:
             for v in self.complete[u]:
                 if u != v:  # ignore self-loop
                     graph[u].add(v)
-        next_node = min_fill_in_heuristic(graph)
-        if next_node is None:
-            pass
-        else:
-            assert False
+        assert min_fill_in_heuristic(graph) is None
 
     def test_empty_graph(self):
         """Test empty graph"""

--- a/networkx/algorithms/assortativity/tests/test_connectivity.py
+++ b/networkx/algorithms/assortativity/tests/test_connectivity.py
@@ -118,13 +118,13 @@ class TestNeighborConnectivity:
             assert c == cw
 
     def test_invalid_source(self):
+        G = nx.DiGraph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
             nx.average_degree_connectivity(G, source="bogus")
 
     def test_invalid_target(self):
+        G = nx.DiGraph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
             nx.average_degree_connectivity(G, target="bogus")
 
     def test_invalid_undirected_graph(self):

--- a/networkx/algorithms/bipartite/tests/test_basic.py
+++ b/networkx/algorithms/bipartite/tests/test_basic.py
@@ -44,9 +44,9 @@ class TestBipartiteBasic:
         assert Y == {1, 3}
 
     def test_bipartite_sets_disconnected(self):
+        G = nx.path_graph(4)
+        G.add_edges_from([(5, 6), (6, 7)])
         with pytest.raises(nx.AmbiguousSolution):
-            G = nx.path_graph(4)
-            G.add_edges_from([(5, 6), (6, 7)])
             X, Y = bipartite.sets(G)
 
     def test_is_bipartite_node_set(self):

--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -181,14 +181,14 @@ class TestEdgelist:
         os.unlink(fname)
 
     def test_empty_digraph(self):
+        bytesIO = io.BytesIO()
         with pytest.raises(nx.NetworkXNotImplemented):
-            bytesIO = io.BytesIO()
             bipartite.write_edgelist(nx.DiGraph(), bytesIO)
 
     def test_raise_attribute(self):
+        G = nx.path_graph(4)
+        bytesIO = io.BytesIO()
         with pytest.raises(AttributeError):
-            G = nx.path_graph(4)
-            bytesIO = io.BytesIO()
             bipartite.write_edgelist(G, bytesIO)
 
     def test_parse_edgelist(self):
@@ -202,28 +202,28 @@ class TestEdgelist:
 
         # Exception raised when node is not convertible
         # to specified data type
+        lines = ["a b", "b c", "c a"]
         with pytest.raises(TypeError, match=".*Failed to convert nodes"):
-            lines = ["a b", "b c", "c a"]
             G = bipartite.parse_edgelist(lines, nodetype=int)
 
         # Exception raised when format of data is not
         # convertible to dictionary object
+        lines = ["1 2 3", "2 3 4", "3 1 2"]
         with pytest.raises(TypeError, match=".*Failed to convert edge data"):
-            lines = ["1 2 3", "2 3 4", "3 1 2"]
             G = bipartite.parse_edgelist(lines, nodetype=int)
 
         # Exception raised when edge data and data
         # keys are not of same length
+        lines = ["1 2 3 4", "2 3 4"]
         with pytest.raises(IndexError):
-            lines = ["1 2 3 4", "2 3 4"]
             G = bipartite.parse_edgelist(
                 lines, nodetype=int, data=[("weight", int), ("key", int)]
             )
 
         # Exception raised when edge data is not
         # convertible to specified data type
+        lines = ["1 2 3 a", "2 3 4 b"]
         with pytest.raises(TypeError, match=".*Failed to convert key data"):
-            lines = ["1 2 3 a", "2 3 4 b"]
             G = bipartite.parse_edgelist(
                 lines, nodetype=int, data=[("weight", int), ("key", int)]
             )

--- a/networkx/algorithms/bipartite/tests/test_redundancy.py
+++ b/networkx/algorithms/bipartite/tests/test_redundancy.py
@@ -26,6 +26,6 @@ def test_redundant_nodes():
 
 
 def test_not_enough_neighbors():
+    G = complete_bipartite_graph(1, 2)
     with pytest.raises(NetworkXError):
-        G = complete_bipartite_graph(1, 2)
         node_redundancy(G)

--- a/networkx/algorithms/centrality/tests/test_closeness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_closeness_centrality.py
@@ -223,31 +223,31 @@ class TestClosenessCentrality:
         return (u, v)
 
     def test_directed_raises(self):
+        dir_G = nx.gn_graph(n=5)
+        prev_cc = None
+        edge = self.pick_add_edge(dir_G)
+        insert = True
         with pytest.raises(nx.NetworkXNotImplemented):
-            dir_G = nx.gn_graph(n=5)
-            prev_cc = None
-            edge = self.pick_add_edge(dir_G)
-            insert = True
             nx.incremental_closeness_centrality(dir_G, edge, prev_cc, insert)
 
     def test_wrong_size_prev_cc_raises(self):
+        G = self.undirected_G.copy()
+        edge = self.pick_add_edge(G)
+        insert = True
+        prev_cc = self.undirected_G_cc.copy()
+        prev_cc.pop(0)
         with pytest.raises(nx.NetworkXError):
-            G = self.undirected_G.copy()
-            edge = self.pick_add_edge(G)
-            insert = True
-            prev_cc = self.undirected_G_cc.copy()
-            prev_cc.pop(0)
             nx.incremental_closeness_centrality(G, edge, prev_cc, insert)
 
     def test_wrong_nodes_prev_cc_raises(self):
+        G = self.undirected_G.copy()
+        edge = self.pick_add_edge(G)
+        insert = True
+        prev_cc = self.undirected_G_cc.copy()
+        num_nodes = len(prev_cc)
+        prev_cc.pop(0)
+        prev_cc[num_nodes] = 0.5
         with pytest.raises(nx.NetworkXError):
-            G = self.undirected_G.copy()
-            edge = self.pick_add_edge(G)
-            insert = True
-            prev_cc = self.undirected_G_cc.copy()
-            num_nodes = len(prev_cc)
-            prev_cc.pop(0)
-            prev_cc[num_nodes] = 0.5
             nx.incremental_closeness_centrality(G, edge, prev_cc, insert)
 
     def test_zero_centrality(self):

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
@@ -184,11 +184,11 @@ class TestEdgeFlowBetweennessCentrality:
 
 @pytest.mark.parametrize(
     "centrality_func",
-    (
+    [
         nx.current_flow_betweenness_centrality,
         nx.edge_current_flow_betweenness_centrality,
         nx.approximate_current_flow_betweenness_centrality,
-    ),
+    ],
 )
 def test_unconnected_graphs_betweenness_centrality(centrality_func):
     G = nx.Graph([(1, 2), (3, 4)])

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -47,8 +47,8 @@ class TestEigenvectorCentrality:
             assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
 
     def test_maxiter(self):
+        G = nx.path_graph(3)
         with pytest.raises(nx.PowerIterationFailedConvergence):
-            G = nx.path_graph(3)
             nx.eigenvector_centrality(G, max_iter=0)
 
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -114,7 +114,8 @@ class TestProminentGroup:
         k = 1
         b, g = nx.prominent_group(G, k, normalized=False, endpoints=False)
         b_answer, g_answer = 4.0, [2]
-        assert b == b_answer and g == g_answer
+        assert b == b_answer
+        assert g == g_answer
 
     def test_prominent_group_with_c(self):
         """
@@ -124,7 +125,8 @@ class TestProminentGroup:
         k = 1
         b, g = nx.prominent_group(G, k, normalized=False, C=[2])
         b_answer, g_answer = 3.0, [1]
-        assert b == b_answer and g == g_answer
+        assert b == b_answer
+        assert g == g_answer
 
     def test_prominent_group_normalized_endpoints(self):
         """
@@ -134,7 +136,8 @@ class TestProminentGroup:
         k = 2
         b, g = nx.prominent_group(G, k, normalized=True, endpoints=True)
         b_answer, g_answer = 1.7, [2, 5]
-        assert b == b_answer and g == g_answer
+        assert b == b_answer
+        assert g == g_answer
 
     def test_prominent_group_disconnected_graph(self):
         """
@@ -145,7 +148,8 @@ class TestProminentGroup:
         k = 1
         b, g = nx.prominent_group(G, k, weight=None, normalized=False)
         b_answer, g_answer = 4.0, [3]
-        assert b == b_answer and g == g_answer
+        assert b == b_answer
+        assert g == g_answer
 
     def test_prominent_group_node_not_in_graph(self):
         """
@@ -169,7 +173,8 @@ class TestProminentGroup:
         k = 2
         b, g = nx.prominent_group(G, k, weight="weight", normalized=False)
         b_answer, g_answer = 5.0, [1, 2]
-        assert b == b_answer and g == g_answer
+        assert b == b_answer
+        assert g == g_answer
 
     def test_prominent_group_greedy_algorithm(self):
         """
@@ -179,7 +184,8 @@ class TestProminentGroup:
         k = 2
         b, g = nx.prominent_group(G, k, normalized=True, endpoints=True, greedy=True)
         b_answer, g_answer = 1.7, [6, 3]
-        assert b == b_answer and g == g_answer
+        assert b == b_answer
+        assert g == g_answer
 
 
 class TestGroupClosenessCentrality:

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -100,14 +100,14 @@ class TestKatzCentrality:
         assert e == {}
 
     def test_bad_beta(self):
+        G = nx.Graph([(0, 1)])
+        beta = {0: 77}
         with pytest.raises(nx.NetworkXException):
-            G = nx.Graph([(0, 1)])
-            beta = {0: 77}
             nx.katz_centrality(G, 0.1, beta=beta)
 
     def test_bad_beta_numbe(self):
+        G = nx.Graph([(0, 1)])
         with pytest.raises(nx.NetworkXException):
-            G = nx.Graph([(0, 1)])
             nx.katz_centrality(G, 0.1, beta="foo")
 
 
@@ -207,14 +207,14 @@ class TestKatzCentralityNumpy:
         assert e == {}
 
     def test_bad_beta(self):
+        G = nx.Graph([(0, 1)])
+        beta = {0: 77}
         with pytest.raises(nx.NetworkXException):
-            G = nx.Graph([(0, 1)])
-            beta = {0: 77}
             nx.katz_centrality_numpy(G, 0.1, beta=beta)
 
     def test_bad_beta_numbe(self):
+        G = nx.Graph([(0, 1)])
         with pytest.raises(nx.NetworkXException):
-            G = nx.Graph([(0, 1)])
             nx.katz_centrality_numpy(G, 0.1, beta="foo")
 
     def test_K5_unweighted(self):

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -8,14 +8,14 @@ class TestGlobalReachingCentrality:
     """Unit tests for the global reaching centrality function."""
 
     def test_non_positive_weights(self):
+        G = nx.DiGraph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
             nx.global_reaching_centrality(G, weight="weight")
 
     def test_negatively_weighted(self):
+        G = nx.Graph()
+        G.add_weighted_edges_from([(0, 1, -2), (1, 2, +1)])
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
-            G.add_weighted_edges_from([(0, 1, -2), (1, 2, +1)])
             nx.global_reaching_centrality(G, weight="weight")
 
     def test_directed_star(self):
@@ -84,15 +84,15 @@ class TestLocalReachingCentrality:
     """Unit tests for the local reaching centrality function."""
 
     def test_non_positive_weights(self):
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, 0)])
         with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
-            G.add_weighted_edges_from([(0, 1, 0)])
             nx.local_reaching_centrality(G, 0, weight="weight")
 
     def test_negatively_weighted(self):
+        G = nx.Graph()
+        G.add_weighted_edges_from([(0, 1, -2), (1, 2, +1)])
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
-            G.add_weighted_edges_from([(0, 1, -2), (1, 2, +1)])
             nx.local_reaching_centrality(G, 0, weight="weight")
 
     def test_undirected_unweighted_star(self):

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -12,21 +12,21 @@ import networkx as nx
 
 class TestSecondOrderCentrality:
     def test_empty(self):
+        G = nx.empty_graph()
         with pytest.raises(nx.NetworkXException):
-            G = nx.empty_graph()
             nx.second_order_centrality(G)
 
     def test_non_connected(self):
+        G = nx.Graph()
+        G.add_node(0)
+        G.add_node(1)
         with pytest.raises(nx.NetworkXException):
-            G = nx.Graph()
-            G.add_node(0)
-            G.add_node(1)
             nx.second_order_centrality(G)
 
     def test_non_negative_edge_weights(self):
+        G = nx.path_graph(2)
+        G.add_edge(0, 1, weight=-1)
         with pytest.raises(nx.NetworkXException):
-            G = nx.path_graph(2)
-            G.add_edge(0, 1, weight=-1)
             nx.second_order_centrality(G)
 
     def test_one_node_graph(self):

--- a/networkx/algorithms/coloring/equitable_coloring.py
+++ b/networkx/algorithms/coloring/equitable_coloring.py
@@ -71,7 +71,8 @@ def make_H_from_C_N(C, N):
 
 def change_color(u, X, Y, N, H, F, C, L):
     """Change the color of 'u' from X to Y and update N, H, F, C."""
-    assert F[u] == X and X != Y
+    assert F[u] == X
+    assert X != Y
 
     # Change the class of 'u' from X to Y
     F[u] = Y
@@ -374,11 +375,10 @@ def procedure_P(V_minus, V_plus, N, H, F, C, L, excluded_colors=None):
                     if made_equitable:
                         break
                 else:
-                    assert False, (
+                    raise AssertionError(
                         "Must find a w which is the solo neighbor "
                         "of two vertices in B_cal_prime."
                     )
-
             if made_equitable:
                 break
 

--- a/networkx/algorithms/community/tests/test_kernighan_lin.py
+++ b/networkx/algorithms/community/tests/test_kernighan_lin.py
@@ -40,16 +40,16 @@ def test_seed_argument():
 
 
 def test_non_disjoint_partition():
+    G = nx.barbell_graph(3, 0)
+    partition = ({0, 1, 2}, {2, 3, 4, 5})
     with pytest.raises(nx.NetworkXError):
-        G = nx.barbell_graph(3, 0)
-        partition = ({0, 1, 2}, {2, 3, 4, 5})
         kernighan_lin_bisection(G, partition)
 
 
 def test_too_many_blocks():
+    G = nx.barbell_graph(3, 0)
+    partition = ({0, 1}, {2}, {3, 4, 5})
     with pytest.raises(nx.NetworkXError):
-        G = nx.barbell_graph(3, 0)
-        partition = ({0, 1}, {2}, {3, 4, 5})
         kernighan_lin_bisection(G, partition)
 
 

--- a/networkx/algorithms/community/tests/test_label_propagation.py
+++ b/networkx/algorithms/community/tests/test_label_propagation.py
@@ -6,12 +6,12 @@ import networkx as nx
 
 
 def test_directed_not_supported():
+    test = nx.DiGraph()
+    test.add_edge("a", "b")
+    test.add_edge("a", "c")
+    test.add_edge("b", "d")
     with pytest.raises(nx.NetworkXNotImplemented):
         # not supported for directed graphs
-        test = nx.DiGraph()
-        test.add_edge("a", "b")
-        test.add_edge("a", "c")
-        test.add_edge("b", "d")
         result = nx.community.label_propagation_communities(test)
 
 

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -8,7 +8,7 @@ from networkx.algorithms.community import (
 
 
 @pytest.mark.parametrize(
-    "func", (greedy_modularity_communities, naive_greedy_modularity_communities)
+    "func", [greedy_modularity_communities, naive_greedy_modularity_communities]
 )
 def test_modularity_communities(func):
     G = nx.karate_club_graph()
@@ -22,7 +22,7 @@ def test_modularity_communities(func):
 
 
 @pytest.mark.parametrize(
-    "func", (greedy_modularity_communities, naive_greedy_modularity_communities)
+    "func", [greedy_modularity_communities, naive_greedy_modularity_communities]
 )
 def test_modularity_communities_categorical_labels(func):
     # Using other than 0-starting contiguous integers as node-labels.
@@ -92,7 +92,7 @@ def test_greedy_modularity_communities_directed():
 
 
 @pytest.mark.parametrize(
-    "func", (greedy_modularity_communities, naive_greedy_modularity_communities)
+    "func", [greedy_modularity_communities, naive_greedy_modularity_communities]
 )
 def test_modularity_communities_weighted(func):
     G = nx.balanced_tree(2, 3)

--- a/networkx/algorithms/connectivity/tests/test_disjoint_paths.py
+++ b/networkx/algorithms/connectivity/tests/test_disjoint_paths.py
@@ -172,78 +172,78 @@ def test_cutoff_disjoint_paths():
 
 
 def test_missing_source_edge_paths():
+    G = nx.path_graph(4)
     with pytest.raises(nx.NetworkXError):
-        G = nx.path_graph(4)
         list(nx.edge_disjoint_paths(G, 10, 1))
 
 
 def test_missing_source_node_paths():
+    G = nx.path_graph(4)
     with pytest.raises(nx.NetworkXError):
-        G = nx.path_graph(4)
         list(nx.node_disjoint_paths(G, 10, 1))
 
 
 def test_missing_target_edge_paths():
+    G = nx.path_graph(4)
     with pytest.raises(nx.NetworkXError):
-        G = nx.path_graph(4)
         list(nx.edge_disjoint_paths(G, 1, 10))
 
 
 def test_missing_target_node_paths():
+    G = nx.path_graph(4)
     with pytest.raises(nx.NetworkXError):
-        G = nx.path_graph(4)
         list(nx.node_disjoint_paths(G, 1, 10))
 
 
 def test_not_weakly_connected_edges():
+    G = nx.DiGraph()
+    nx.add_path(G, [1, 2, 3])
+    nx.add_path(G, [4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.DiGraph()
-        nx.add_path(G, [1, 2, 3])
-        nx.add_path(G, [4, 5])
         list(nx.edge_disjoint_paths(G, 1, 5))
 
 
 def test_not_weakly_connected_nodes():
+    G = nx.DiGraph()
+    nx.add_path(G, [1, 2, 3])
+    nx.add_path(G, [4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.DiGraph()
-        nx.add_path(G, [1, 2, 3])
-        nx.add_path(G, [4, 5])
         list(nx.node_disjoint_paths(G, 1, 5))
 
 
 def test_not_connected_edges():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
+    nx.add_path(G, [4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
-        nx.add_path(G, [4, 5])
         list(nx.edge_disjoint_paths(G, 1, 5))
 
 
 def test_not_connected_nodes():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
+    nx.add_path(G, [4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
-        nx.add_path(G, [4, 5])
         list(nx.node_disjoint_paths(G, 1, 5))
 
 
 def test_isolated_edges():
+    G = nx.Graph()
+    G.add_node(1)
+    nx.add_path(G, [4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.Graph()
-        G.add_node(1)
-        nx.add_path(G, [4, 5])
         list(nx.edge_disjoint_paths(G, 1, 5))
 
 
 def test_isolated_nodes():
+    G = nx.Graph()
+    G.add_node(1)
+    nx.add_path(G, [4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.Graph()
-        G.add_node(1)
-        nx.add_path(G, [4, 5])
         list(nx.node_disjoint_paths(G, 1, 5))
 
 
 def test_invalid_auxiliary():
+    G = nx.complete_graph(5)
     with pytest.raises(nx.NetworkXError):
-        G = nx.complete_graph(5)
         list(nx.node_disjoint_paths(G, 0, 3, auxiliary=G))

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -74,8 +74,8 @@ def torrents_and_ferraro_graph():
 
 
 def test_directed():
+    G = nx.gnp_random_graph(10, 0.2, directed=True, seed=42)
     with pytest.raises(nx.NetworkXNotImplemented):
-        G = nx.gnp_random_graph(10, 0.2, directed=True, seed=42)
         nx.k_components(G)
 
 
@@ -91,7 +91,7 @@ def _check_connectivity(G, k_components):
             assert K >= k
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_torrents_and_ferraro_graph():
     G = torrents_and_ferraro_graph()
     result = nx.k_components(G)
@@ -107,14 +107,14 @@ def test_torrents_and_ferraro_graph():
     assert all(len(c) == 5 for c in result[4])
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_random_gnp():
     G = nx.gnp_random_graph(50, 0.2, seed=42)
     result = nx.k_components(G)
     _check_connectivity(G, result)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_shell():
     constructor = [(20, 80, 0.8), (80, 180, 0.6)]
     G = nx.random_shell_graph(constructor, seed=42)

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -133,7 +133,7 @@ def _check_separating_sets(G):
             assert not nx.is_connected(nx.restricted_view(G, cut, []))
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_torrents_and_ferraro_graph():
     G = torrents_and_ferraro_graph()
     _check_separating_sets(G)
@@ -207,7 +207,7 @@ def test_disconnected_graph():
     pytest.raises(nx.NetworkXError, next, cuts)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_alternative_flow_functions():
     graphs = [nx.grid_2d_graph(4, 4), nx.cycle_graph(5)]
     for G in graphs:

--- a/networkx/algorithms/flow/tests/test_gomory_hu.py
+++ b/networkx/algorithms/flow/tests/test_gomory_hu.py
@@ -73,7 +73,7 @@ class TestGomoryHuTree:
                 cut_value, edge = self.minimum_edge_weight(T, u, v)
                 assert nx.minimum_cut_value(G, u, v) == cut_value
 
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_les_miserables_graph_cutset(self):
         G = nx.les_miserables_graph()
         nx.set_edge_attributes(G, 1, "capacity")
@@ -118,11 +118,11 @@ class TestGomoryHuTree:
                 assert nx.minimum_cut_value(G, u, v, capacity="weight") == cut_value
 
     def test_directed_raises(self):
+        G = nx.DiGraph()
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.DiGraph()
             T = nx.gomory_hu_tree(G)
 
     def test_empty_raises(self):
+        G = nx.empty_graph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.empty_graph()
             T = nx.gomory_hu_tree(G)

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -121,7 +121,7 @@ class TestMaxflowLargeGraph:
     #            validate_flows(G, s, t, 156545, flow_func(G, s, t, **kwargs),
     #                           flow_func)
 
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_gw1(self):
         G = read_graph("gw1")
         s = 1

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -7,7 +7,7 @@ import pytest
 import networkx as nx
 
 
-@pytest.fixture
+@pytest.fixture()
 def simple_flow_graph():
     G = nx.DiGraph()
     G.add_node("a", demand=0)
@@ -21,7 +21,7 @@ def simple_flow_graph():
     return G
 
 
-@pytest.fixture
+@pytest.fixture()
 def simple_no_flow_graph():
     G = nx.DiGraph()
     G.add_node("s", demand=-5)

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -1045,7 +1045,8 @@ class ISMAGS:
         """
         t_partition = top_partitions[pair_idx]
         b_partition = bottom_partitions[pair_idx]
-        assert t_node in t_partition and b_node in b_partition
+        assert t_node in t_partition
+        assert b_node in b_partition
         # Couple node to node2. This means they get their own partition
         new_top_partitions = [top.copy() for top in top_partitions]
         new_bottom_partitions = [bot.copy() for bot in bottom_partitions]

--- a/networkx/algorithms/isomorphism/tests/test_vf2pp.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2pp.py
@@ -116,7 +116,7 @@ class TestPreCheck:
 
 
 class TestAllGraphTypesEdgeCases:
-    @pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph, nx.DiGraph))
+    @pytest.mark.parametrize("graph_type", [nx.Graph, nx.MultiGraph, nx.DiGraph])
     def test_both_graphs_empty(self, graph_type):
         G = graph_type()
         H = graph_type()
@@ -130,13 +130,13 @@ class TestAllGraphTypesEdgeCases:
         H.add_node(0)
         assert vf2pp_isomorphism(G, H) == {0: 0}
 
-    @pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph, nx.DiGraph))
+    @pytest.mark.parametrize("graph_type", [nx.Graph, nx.MultiGraph, nx.DiGraph])
     def test_first_graph_empty(self, graph_type):
         G = graph_type()
         H = graph_type([(0, 1)])
         assert vf2pp_isomorphism(G, H) is None
 
-    @pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph, nx.DiGraph))
+    @pytest.mark.parametrize("graph_type", [nx.Graph, nx.MultiGraph, nx.DiGraph])
     def test_second_graph_empty(self, graph_type):
         G = graph_type([(0, 1)])
         H = graph_type()

--- a/networkx/algorithms/isomorphism/tests/test_vf2pp_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2pp_helpers.py
@@ -1095,7 +1095,7 @@ class TestGraphISOFeasibility:
         G1.add_edge(u, 7)
         assert _consistent_PT(u, v, gparams, sparams)
 
-    @pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+    @pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph])
     def test_cut_inconsistent_labels(self, graph_type):
         G1 = graph_type(
             [

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -41,7 +41,7 @@ class TestHITS:
         for n in G:
             assert a[n] == pytest.approx(G.a[n], abs=1e-4)
 
-    @pytest.mark.parametrize("hits_alg", (nx.hits, _hits_python, _hits_scipy))
+    @pytest.mark.parametrize("hits_alg", [nx.hits, _hits_python, _hits_scipy])
     def test_hits(self, hits_alg):
         G = self.G
         h, a = hits_alg(G, tol=1.0e-08)

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -59,7 +59,7 @@ class TestPageRank:
             )
         )
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python])
     def test_pagerank(self, alg):
         G = self.G
         p = alg(G, alpha=0.9, tol=1.0e-08)
@@ -71,7 +71,7 @@ class TestPageRank:
         for n in G:
             assert p[n] == pytest.approx(G.pagerank[n], abs=1e-4)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python])
     def test_pagerank_max_iter(self, alg):
         with pytest.raises(nx.PowerIterationFailedConvergence):
             alg(self.G, max_iter=0)
@@ -90,7 +90,7 @@ class TestPageRank:
         for a, b in zip(p, self.G.pagerank.values()):
             assert a == pytest.approx(b, abs=1e-7)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python, _pagerank_numpy))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python, _pagerank_numpy])
     def test_personalization(self, alg):
         G = nx.complete_graph(4)
         personalize = {0: 1, 1: 1, 2: 4, 3: 4}
@@ -104,13 +104,13 @@ class TestPageRank:
         for n in G:
             assert p[n] == pytest.approx(answer[n], abs=1e-4)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python, nx.google_matrix))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python, nx.google_matrix])
     def test_zero_personalization_vector(self, alg):
         G = nx.complete_graph(4)
         personalize = {0: 0, 1: 0, 2: 0, 3: 0}
         pytest.raises(ZeroDivisionError, alg, G, personalization=personalize)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python])
     def test_one_nonzero_personalization_value(self, alg):
         G = nx.complete_graph(4)
         personalize = {0: 0, 1: 0, 2: 0, 3: 1}
@@ -124,7 +124,7 @@ class TestPageRank:
         for n in G:
             assert p[n] == pytest.approx(answer[n], abs=1e-4)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python])
     def test_incomplete_personalization(self, alg):
         G = nx.complete_graph(4)
         personalize = {3: 1}
@@ -157,7 +157,7 @@ class TestPageRank:
                 else:
                     assert M2[i, j] == pytest.approx(M1[i, j], abs=1e-4)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python, _pagerank_numpy))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python, _pagerank_numpy])
     def test_dangling_pagerank(self, alg):
         pr = alg(self.G, dangling=self.dangling_edges)
         for n in self.G:
@@ -170,7 +170,7 @@ class TestPageRank:
         assert _pagerank_numpy(G) == {}
         assert nx.google_matrix(G).shape == (0, 0)
 
-    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python))
+    @pytest.mark.parametrize("alg", [nx.pagerank, _pagerank_python])
     def test_multigraph(self, alg):
         G = nx.MultiGraph()
         G.add_edges_from([(1, 2), (1, 2), (1, 2), (2, 3), (2, 3), ("3", 3), ("3", 3)])

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -507,7 +507,8 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
     # coming through an edge from vertex v.
     def assignLabel(w, t, v):
         b = inblossom[w]
-        assert label.get(w) is None and label.get(b) is None
+        assert label.get(w) is None
+        assert label.get(b) is None
         label[w] = label[b] = t
         if v is not None:
             labeledge[w] = labeledge[b] = (v, w)
@@ -867,7 +868,8 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
                 s += 2 * blossomdual[bi]
             assert s >= 0
             if mate.get(i) == j or mate.get(j) == i:
-                assert mate[i] == j and mate[j] == i
+                assert mate[i] == j
+                assert mate[j] == i
                 assert s == 0
         # 2. all single vertices have zero dual value;
         for v in gnodes:
@@ -877,7 +879,8 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
             if blossomdual[b] > 0:
                 assert len(b.edges) % 2 == 1
                 for i, j in b.edges[1::2]:
-                    assert mate[i] == j and mate[j] == i
+                    assert mate[i] == j
+                    assert mate[j] == i
         # Ok.
 
     # Main loop: continue until no further improvement is possible.

--- a/networkx/algorithms/minors/tests/test_contraction.py
+++ b/networkx/algorithms/minors/tests/test_contraction.py
@@ -188,9 +188,9 @@ class TestQuotient:
             assert M.nodes[n]["density"] == 0.5
 
     def test_overlapping_blocks(self):
+        G = nx.path_graph(6)
+        partition = [{0, 1, 2}, {2, 3}, {4, 5}]
         with pytest.raises(nx.NetworkXException):
-            G = nx.path_graph(6)
-            partition = [{0, 1, 2}, {2, 3}, {4, 5}]
             nx.quotient_graph(G, partition)
 
     def test_weighted_path(self):
@@ -417,6 +417,6 @@ class TestContraction:
         exception.
 
         """
+        G = nx.cycle_graph(4)
         with pytest.raises(ValueError):
-            G = nx.cycle_graph(4)
             nx.contracted_edge(G, (0, 2))

--- a/networkx/algorithms/operators/tests/test_all.py
+++ b/networkx/algorithms/operators/tests/test_all.py
@@ -251,34 +251,34 @@ def test_input_output():
 
 
 def test_mixed_type_union():
+    G = nx.Graph()
+    H = nx.MultiGraph()
+    I = nx.Graph()
     with pytest.raises(nx.NetworkXError):
-        G = nx.Graph()
-        H = nx.MultiGraph()
-        I = nx.Graph()
         U = nx.union_all([G, H, I])
 
 
 def test_mixed_type_disjoint_union():
+    G = nx.Graph()
+    H = nx.MultiGraph()
+    I = nx.Graph()
     with pytest.raises(nx.NetworkXError):
-        G = nx.Graph()
-        H = nx.MultiGraph()
-        I = nx.Graph()
         U = nx.disjoint_union_all([G, H, I])
 
 
 def test_mixed_type_intersection():
+    G = nx.Graph()
+    H = nx.MultiGraph()
+    I = nx.Graph()
     with pytest.raises(nx.NetworkXError):
-        G = nx.Graph()
-        H = nx.MultiGraph()
-        I = nx.Graph()
         U = nx.intersection_all([G, H, I])
 
 
 def test_mixed_type_compose():
+    G = nx.Graph()
+    H = nx.MultiGraph()
+    I = nx.Graph()
     with pytest.raises(nx.NetworkXError):
-        G = nx.Graph()
-        H = nx.MultiGraph()
-        I = nx.Graph()
         U = nx.compose_all([G, H, I])
 
 

--- a/networkx/algorithms/shortest_paths/tests/test_dense.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense.py
@@ -90,31 +90,29 @@ class TestFloyd:
         }
 
     def test_reconstruct_path(self):
+        XG = nx.DiGraph()
+        XG.add_weighted_edges_from(
+            [
+                ("s", "u", 10),
+                ("s", "x", 5),
+                ("u", "v", 1),
+                ("u", "x", 2),
+                ("v", "y", 1),
+                ("x", "u", 3),
+                ("x", "v", 5),
+                ("x", "y", 2),
+                ("y", "s", 7),
+                ("y", "v", 6),
+            ]
+        )
+        predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
+
+        path = nx.reconstruct_path("s", "v", predecessors)
+        assert path == ["s", "x", "u", "v"]
+
+        path = nx.reconstruct_path("s", "s", predecessors)
+        assert path == []
         with pytest.raises(KeyError):
-            XG = nx.DiGraph()
-            XG.add_weighted_edges_from(
-                [
-                    ("s", "u", 10),
-                    ("s", "x", 5),
-                    ("u", "v", 1),
-                    ("u", "x", 2),
-                    ("v", "y", 1),
-                    ("x", "u", 3),
-                    ("x", "v", 5),
-                    ("x", "y", 2),
-                    ("y", "s", 7),
-                    ("y", "v", 6),
-                ]
-            )
-            predecessors, _ = nx.floyd_warshall_predecessor_and_distance(XG)
-
-            path = nx.reconstruct_path("s", "v", predecessors)
-            assert path == ["s", "x", "u", "v"]
-
-            path = nx.reconstruct_path("s", "s", predecessors)
-            assert path == []
-
-            # this part raises the keyError
             nx.reconstruct_path("1", "2", predecessors)
 
     def test_cycle(self):

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -250,14 +250,14 @@ class TestGenericPath:
         )
 
     def test_all_shortest_paths_raise(self):
+        G = nx.path_graph(4)
+        G.add_node(4)
         with pytest.raises(nx.NetworkXNoPath):
-            G = nx.path_graph(4)
-            G.add_node(4)
             list(nx.all_shortest_paths(G, 0, 4))
 
     def test_bad_method(self):
+        G = nx.path_graph(2)
         with pytest.raises(ValueError):
-            G = nx.path_graph(2)
             list(nx.all_shortest_paths(G, 0, 1, weight="weight", method="SPAM"))
 
     def test_all_shortest_paths_zero_weight_edge(self):
@@ -351,8 +351,8 @@ class TestAverageShortestPathLength:
             nx.average_shortest_path_length(nx.null_graph())
 
     def test_bad_method(self):
+        G = nx.path_graph(2)
         with pytest.raises(ValueError):
-            G = nx.path_graph(2)
             nx.average_shortest_path_length(G, weight="weight", method="SPAM")
 
 

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -39,12 +39,12 @@ class TestUnweightedPath:
 
     @pytest.mark.parametrize(
         ("src", "tgt"),
-        (
+        [
             (8, 3),  # source not in graph
             (3, 8),  # target not in graph
             (8, 10),  # neither source nor target in graph
             (8, 8),  # src == tgt, neither in graph - tests order of input checks
-        ),
+        ],
     )
     def test_bidirectional_shortest_path_src_tgt_not_in_graph(self, src, tgt):
         with pytest.raises(

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -243,22 +243,22 @@ class TestWeightedPath(WeightedTestBase):
         vlp(G, s, t, length, astar, weight)
 
     def test_bidirectional_dijkstra_no_path(self):
+        G = nx.Graph()
+        nx.add_path(G, [1, 2, 3])
+        nx.add_path(G, [4, 5, 6])
         with pytest.raises(nx.NetworkXNoPath):
-            G = nx.Graph()
-            nx.add_path(G, [1, 2, 3])
-            nx.add_path(G, [4, 5, 6])
             path = nx.bidirectional_dijkstra(G, 1, 6)
 
     @pytest.mark.parametrize(
         "fn",
-        (
+        [
             nx.dijkstra_path,
             nx.dijkstra_path_length,
             nx.single_source_dijkstra_path,
             nx.single_source_dijkstra_path_length,
             nx.single_source_dijkstra,
             nx.dijkstra_predecessor_and_distance,
-        ),
+        ],
     )
     def test_absent_source(self, fn):
         G = nx.path_graph(2)
@@ -465,11 +465,11 @@ class TestMultiSourceDijkstra:
 
     @pytest.mark.parametrize(
         "fn",
-        (
+        [
             nx.multi_source_dijkstra_path,
             nx.multi_source_dijkstra_path_length,
             nx.multi_source_dijkstra,
-        ),
+        ],
     )
     def test_absent_source(self, fn):
         G = nx.path_graph(2)
@@ -523,8 +523,8 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
             pytest.raises(nx.NodeNotFound, fn, G, 3, 3)
 
     def test_absent_source_goldberg_radzik(self):
+        G = nx.path_graph(2)
         with pytest.raises(nx.NodeNotFound):
-            G = nx.path_graph(2)
             nx.goldberg_radzik(G, 3, 0)
 
     def test_negative_cycle_heuristic(self):
@@ -865,9 +865,9 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
 
 class TestJohnsonAlgorithm(WeightedTestBase):
     def test_single_node_graph(self):
+        G = nx.DiGraph()
+        G.add_node(0)
         with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
-            G.add_node(0)
             nx.johnson(G)
 
     def test_negative_cycle(self):
@@ -915,8 +915,8 @@ class TestJohnsonAlgorithm(WeightedTestBase):
         }
 
     def test_unweighted_graph(self):
+        G = nx.path_graph(5)
         with pytest.raises(nx.NetworkXError):
-            G = nx.path_graph(5)
             nx.johnson(G)
 
     def test_graphs(self):

--- a/networkx/algorithms/tests/test_chordal.py
+++ b/networkx/algorithms/tests/test_chordal.py
@@ -51,7 +51,7 @@ class TestMCS:
         self_loop_G.add_edges_from([(1, 1)])
         cls.self_loop_G = self_loop_G
 
-    @pytest.mark.parametrize("G", (nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()))
+    @pytest.mark.parametrize("G", [nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()])
     def test_is_chordal_not_implemented(self, G):
         with pytest.raises(nx.NetworkXNotImplemented):
             nx.is_chordal(G)

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -41,13 +41,13 @@ class TestCycles:
         assert sort_cy == [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], ["A", "B", "C"]]
 
     def test_cycle_basis2(self):
+        G = nx.DiGraph()
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.DiGraph()
             cy = networkx.cycle_basis(G, 0)
 
     def test_cycle_basis3(self):
+        G = nx.MultiGraph()
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.MultiGraph()
             cy = networkx.cycle_basis(G, 0)
 
     def test_cycle_basis_self_loop(self):
@@ -69,8 +69,8 @@ class TestCycles:
             assert any(self.is_cyclic_permutation(c, rc) for rc in ca)
 
     def test_simple_cycles_graph(self):
+        G = nx.Graph()
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.Graph()
             c = sorted(nx.simple_cycles(G))
 
     def test_unsortable(self):

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -728,8 +728,8 @@ class TestDagToBranching:
 
     def test_not_acyclic(self):
         """Tests that a non-acyclic graph causes an exception."""
+        G = nx.DiGraph(pairwise("abc", cyclic=True))
         with pytest.raises(nx.HasACycle):
-            G = nx.DiGraph(pairwise("abc", cyclic=True))
             nx.dag_to_branching(G)
 
     def test_undirected(self):

--- a/networkx/algorithms/tests/test_distance_measures.py
+++ b/networkx/algorithms/tests/test_distance_measures.py
@@ -82,18 +82,18 @@ class TestDistance:
         pytest.raises(nx.NetworkXError, nx.diameter, G)
 
     def test_eccentricity_infinite(self):
+        G = nx.Graph([(1, 2), (3, 4)])
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph([(1, 2), (3, 4)])
             e = nx.eccentricity(G)
 
     def test_eccentricity_undirected_not_connected(self):
+        G = nx.Graph([(1, 2), (3, 4)])
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph([(1, 2), (3, 4)])
             e = nx.eccentricity(G, sp=1)
 
     def test_eccentricity_directed_weakly_connected(self):
+        DG = nx.DiGraph([(1, 2), (1, 3)])
         with pytest.raises(nx.NetworkXError):
-            DG = nx.DiGraph([(1, 2), (1, 3)])
             nx.eccentricity(DG)
 
 
@@ -365,13 +365,13 @@ class TestResistanceDistance:
         assert np.isclose(rd, 1 / (1 / (2 + 4) + 1 / (1 + 3)))
 
     def test_resistance_distance_div0(self):
+        self.G[1][2]["weight"] = 0
         with pytest.raises(ZeroDivisionError):
-            self.G[1][2]["weight"] = 0
             nx.resistance_distance(self.G, 1, 3, "weight")
 
     def test_resistance_distance_not_connected(self):
+        self.G.add_node(5)
         with pytest.raises(nx.NetworkXError):
-            self.G.add_node(5)
             nx.resistance_distance(self.G, 1, 5)
 
     def test_resistance_distance_same_node(self):

--- a/networkx/algorithms/tests/test_dominating.py
+++ b/networkx/algorithms/tests/test_dominating.py
@@ -22,8 +22,8 @@ def test_complete():
 
 
 def test_raise_dominating_set():
+    G = nx.path_graph(4)
     with pytest.raises(nx.NetworkXError):
-        G = nx.path_graph(4)
         D = nx.dominating_set(G, start_with=10)
 
 

--- a/networkx/algorithms/tests/test_euler.py
+++ b/networkx/algorithms/tests/test_euler.py
@@ -149,12 +149,12 @@ class TestHasEulerianPath:
         G.add_node(3)
         assert not nx.has_eulerian_path(G)
 
-    @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+    @pytest.mark.parametrize("G", [nx.Graph(), nx.DiGraph()])
     def test_has_eulerian_path_not_weakly_connected(self, G):
         G.add_edges_from([(0, 1), (2, 3), (3, 2)])
         assert not nx.has_eulerian_path(G)
 
-    @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+    @pytest.mark.parametrize("G", [nx.Graph(), nx.DiGraph()])
     def test_has_eulerian_path_unbalancedins_more_than_one(self, G):
         G.add_edges_from([(0, 1), (2, 3)])
         assert not nx.has_eulerian_path(G)
@@ -242,8 +242,8 @@ class TestEulerianPath:
 
 class TestEulerize:
     def test_disconnected(self):
+        G = nx.from_edgelist([(0, 1), (2, 3)])
         with pytest.raises(nx.NetworkXError):
-            G = nx.from_edgelist([(0, 1), (2, 3)])
             nx.eulerize(G)
 
     def test_null_graph(self):

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -184,7 +184,7 @@ class TestCommonNeighborCentrality:
         G = nx.star_graph(4)
         self.test(G, [(1, 2)], [(1, 2, 1.75)], alpha=0.5)
 
-    @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
+    @pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph])
     def test_notimplemented(self, graph_type):
         assert pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -57,7 +57,8 @@ class TestTreeLCA:
     def test_tree_all_pairs_lca_return_subset(self):
         test_pairs = [(0, 1), (0, 1), (1, 0)]
         ans = dict(tree_all_pairs_lca(self.DG, 0, test_pairs))
-        assert (0, 1) in ans and (1, 0) in ans
+        assert (0, 1) in ans
+        assert (1, 0) in ans
         assert len(ans) == 2
 
     def test_tree_all_pairs_lca(self):
@@ -108,7 +109,8 @@ class TestTreeLCA:
     def test_tree_all_pairs_lca_generator(self):
         pairs = iter([(0, 1), (0, 1), (1, 0)])
         some_pairs = dict(tree_all_pairs_lca(self.DG, 0, pairs))
-        assert (0, 1) in some_pairs and (1, 0) in some_pairs
+        assert (0, 1) in some_pairs
+        assert (1, 0) in some_pairs
         assert len(some_pairs) == 2
 
     def test_tree_all_pairs_lca_nonexisting_pairs_exception(self):

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -1,7 +1,7 @@
 import math
 from itertools import permutations
 
-from pytest import raises
+import pytest
 
 import networkx as nx
 from networkx.algorithms.matching import matching_dict_to_set
@@ -395,10 +395,10 @@ class TestMaxWeightMatching:
 
     def test_wrong_graph_type(self):
         error = nx.NetworkXNotImplemented
-        raises(error, nx.max_weight_matching, nx.MultiGraph())
-        raises(error, nx.max_weight_matching, nx.MultiDiGraph())
-        raises(error, nx.max_weight_matching, nx.DiGraph())
-        raises(error, nx.min_weight_matching, nx.DiGraph())
+        pytest.raises(error, nx.max_weight_matching, nx.MultiGraph())
+        pytest.raises(error, nx.max_weight_matching, nx.MultiDiGraph())
+        pytest.raises(error, nx.max_weight_matching, nx.DiGraph())
+        pytest.raises(error, nx.min_weight_matching, nx.DiGraph())
 
 
 class TestIsMatching:
@@ -434,16 +434,16 @@ class TestIsMatching:
         error = nx.NetworkXError
         G = nx.path_graph(4)
         # edge to node not in G
-        raises(error, nx.is_matching, G, {(0, 5), (2, 3)})
+        pytest.raises(error, nx.is_matching, G, {(0, 5), (2, 3)})
         # edge not a 2-tuple
-        raises(error, nx.is_matching, G, {(0, 1, 2), (2, 3)})
-        raises(error, nx.is_matching, G, {(0,), (2, 3)})
+        pytest.raises(error, nx.is_matching, G, {(0, 1, 2), (2, 3)})
+        pytest.raises(error, nx.is_matching, G, {(0,), (2, 3)})
 
     def test_selfloops(self):
         error = nx.NetworkXError
         G = nx.path_graph(4)
         # selfloop for node not in G
-        raises(error, nx.is_matching, G, {(5, 5), (2, 3)})
+        pytest.raises(error, nx.is_matching, G, {(5, 5), (2, 3)})
         # selfloop edge not in G
         assert not nx.is_matching(G, {(0, 0), (1, 2), (2, 3)})
         # selfloop edge in G
@@ -457,7 +457,7 @@ class TestIsMatching:
     def test_invalid_edge(self):
         G = nx.path_graph(4)
         assert not nx.is_matching(G, {(0, 3), (1, 2)})
-        raises(nx.NetworkXError, nx.is_matching, G, {(0, 55)})
+        pytest.raises(nx.NetworkXError, nx.is_matching, G, {(0, 55)})
 
         G = nx.DiGraph(G.edges)
         assert nx.is_matching(G, {(0, 1)})
@@ -478,11 +478,11 @@ class TestIsMaximalMatching:
         error = nx.NetworkXError
         G = nx.path_graph(4)
         # edge to node not in G
-        raises(error, nx.is_maximal_matching, G, {(0, 5)})
-        raises(error, nx.is_maximal_matching, G, {(5, 0)})
+        pytest.raises(error, nx.is_maximal_matching, G, {(0, 5)})
+        pytest.raises(error, nx.is_maximal_matching, G, {(5, 0)})
         # edge not a 2-tuple
-        raises(error, nx.is_maximal_matching, G, {(0, 1, 2), (2, 3)})
-        raises(error, nx.is_maximal_matching, G, {(0,), (2, 3)})
+        pytest.raises(error, nx.is_maximal_matching, G, {(0, 1, 2), (2, 3)})
+        pytest.raises(error, nx.is_maximal_matching, G, {(0,), (2, 3)})
 
     def test_valid(self):
         G = nx.path_graph(4)
@@ -526,17 +526,17 @@ class TestIsPerfectMatching:
         error = nx.NetworkXError
         G = nx.path_graph(4)
         # edge to node not in G
-        raises(error, nx.is_perfect_matching, G, {(0, 5)})
-        raises(error, nx.is_perfect_matching, G, {(5, 0)})
+        pytest.raises(error, nx.is_perfect_matching, G, {(0, 5)})
+        pytest.raises(error, nx.is_perfect_matching, G, {(5, 0)})
         # edge not a 2-tuple
-        raises(error, nx.is_perfect_matching, G, {(0, 1, 2), (2, 3)})
-        raises(error, nx.is_perfect_matching, G, {(0,), (2, 3)})
+        pytest.raises(error, nx.is_perfect_matching, G, {(0, 1, 2), (2, 3)})
+        pytest.raises(error, nx.is_perfect_matching, G, {(0,), (2, 3)})
 
     def test_selfloops(self):
         error = nx.NetworkXError
         G = nx.path_graph(4)
         # selfloop for node not in G
-        raises(error, nx.is_perfect_matching, G, {(5, 5), (2, 3)})
+        pytest.raises(error, nx.is_perfect_matching, G, {(5, 5), (2, 3)})
         # selfloop edge not in G
         assert not nx.is_perfect_matching(G, {(0, 0), (1, 2), (2, 3)})
         # selfloop edge in G
@@ -600,6 +600,6 @@ class TestMaximalMatching:
 
     def test_wrong_graph_type(self):
         error = nx.NetworkXNotImplemented
-        raises(error, nx.maximal_matching, nx.MultiGraph())
-        raises(error, nx.maximal_matching, nx.MultiDiGraph())
-        raises(error, nx.maximal_matching, nx.DiGraph())
+        pytest.raises(error, nx.maximal_matching, nx.MultiGraph())
+        pytest.raises(error, nx.maximal_matching, nx.MultiDiGraph())
+        pytest.raises(error, nx.maximal_matching, nx.DiGraph())

--- a/networkx/algorithms/tests/test_node_classification.py
+++ b/networkx/algorithms/tests/test_node_classification.py
@@ -20,31 +20,31 @@ class TestHarmonicFunction:
         assert predicted[3] == "B"
 
     def test_no_labels(self):
+        G = nx.path_graph(4)
         with pytest.raises(nx.NetworkXError):
-            G = nx.path_graph(4)
             node_classification.harmonic_function(G)
 
     def test_no_nodes(self):
+        G = nx.Graph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
             node_classification.harmonic_function(G)
 
     def test_no_edges(self):
+        G = nx.Graph()
+        G.add_node(1)
+        G.add_node(2)
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
-            G.add_node(1)
-            G.add_node(2)
             node_classification.harmonic_function(G)
 
     def test_digraph(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1)
+        G.add_edge(1, 2)
+        G.add_edge(2, 3)
+        label_name = "label"
+        G.nodes[0][label_name] = "A"
+        G.nodes[3][label_name] = "B"
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.DiGraph()
-            G.add_edge(0, 1)
-            G.add_edge(1, 2)
-            G.add_edge(2, 3)
-            label_name = "label"
-            G.nodes[0][label_name] = "A"
-            G.nodes[3][label_name] = "B"
             node_classification.harmonic_function(G)
 
     def test_one_labeled_node(self):
@@ -91,31 +91,31 @@ class TestLocalAndGlobalConsistency:
         assert predicted[3] == "B"
 
     def test_no_labels(self):
+        G = nx.path_graph(4)
         with pytest.raises(nx.NetworkXError):
-            G = nx.path_graph(4)
             node_classification.local_and_global_consistency(G)
 
     def test_no_nodes(self):
+        G = nx.Graph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
             node_classification.local_and_global_consistency(G)
 
     def test_no_edges(self):
+        G = nx.Graph()
+        G.add_node(1)
+        G.add_node(2)
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
-            G.add_node(1)
-            G.add_node(2)
             node_classification.local_and_global_consistency(G)
 
     def test_digraph(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1)
+        G.add_edge(1, 2)
+        G.add_edge(2, 3)
+        label_name = "label"
+        G.nodes[0][label_name] = "A"
+        G.nodes[3][label_name] = "B"
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.DiGraph()
-            G.add_edge(0, 1)
-            G.add_edge(1, 2)
-            G.add_edge(2, 3)
-            label_name = "label"
-            G.nodes[0][label_name] = "A"
-            G.nodes[3][label_name] = "B"
             node_classification.harmonic_function(G)
 
     def test_one_labeled_node(self):

--- a/networkx/algorithms/tests/test_non_randomness.py
+++ b/networkx/algorithms/tests/test_non_randomness.py
@@ -6,7 +6,7 @@ np = pytest.importorskip("numpy")
 
 
 @pytest.mark.parametrize(
-    "k, weight, expected",
+    ("k", "weight", "expected"),
     [
         (None, None, 7.21),  # infers 3 communities
         (2, None, 11.7),

--- a/networkx/algorithms/tests/test_planar_drawing.py
+++ b/networkx/algorithms/tests/test_planar_drawing.py
@@ -84,10 +84,10 @@ def test_multiple_component_graph2():
 
 
 def test_invalid_half_edge():
+    embedding_data = {1: [2, 3, 4], 2: [1, 3, 4], 3: [1, 2, 4], 4: [1, 2, 3]}
+    embedding = nx.PlanarEmbedding()
+    embedding.set_data(embedding_data)
     with pytest.raises(nx.NetworkXException):
-        embedding_data = {1: [2, 3, 4], 2: [1, 3, 4], 3: [1, 2, 4], 4: [1, 2, 3]}
-        embedding = nx.PlanarEmbedding()
-        embedding.set_data(embedding_data)
         nx.combinatorial_embedding_to_pos(embedding)
 
 

--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -264,17 +264,17 @@ class TestLRPlanarity:
         self.check_graph(G, is_planar=False)
 
     def test_counterexample_planar(self):
+        # Try to get a counterexample of a planar graph
+        G = nx.Graph()
+        G.add_node(1)
         with pytest.raises(nx.NetworkXException):
-            # Try to get a counterexample of a planar graph
-            G = nx.Graph()
-            G.add_node(1)
             get_counterexample(G)
 
     def test_counterexample_planar_recursive(self):
+        # Try to get a counterexample of a planar graph
+        G = nx.Graph()
+        G.add_node(1)
         with pytest.raises(nx.NetworkXException):
-            # Try to get a counterexample of a planar graph
-            G = nx.Graph()
-            G.add_node(1)
             get_counterexample_recursive(G)
 
 
@@ -379,40 +379,40 @@ class TestPlanarEmbeddingClass:
         assert data == data_cmp
 
     def test_missing_edge_orientation(self):
+        embedding = nx.PlanarEmbedding()
+        embedding.add_edge(1, 2)
+        embedding.add_edge(2, 1)
         with pytest.raises(nx.NetworkXException):
-            embedding = nx.PlanarEmbedding()
-            embedding.add_edge(1, 2)
-            embedding.add_edge(2, 1)
             # Invalid structure because the orientation of the edge was not set
             embedding.check_structure()
 
     def test_invalid_edge_orientation(self):
+        embedding = nx.PlanarEmbedding()
+        embedding.add_half_edge_first(1, 2)
+        embedding.add_half_edge_first(2, 1)
+        embedding.add_edge(1, 3)
         with pytest.raises(nx.NetworkXException):
-            embedding = nx.PlanarEmbedding()
-            embedding.add_half_edge_first(1, 2)
-            embedding.add_half_edge_first(2, 1)
-            embedding.add_edge(1, 3)
             embedding.check_structure()
 
     def test_missing_half_edge(self):
+        embedding = nx.PlanarEmbedding()
+        embedding.add_half_edge_first(1, 2)
         with pytest.raises(nx.NetworkXException):
-            embedding = nx.PlanarEmbedding()
-            embedding.add_half_edge_first(1, 2)
             # Invalid structure because other half edge is missing
             embedding.check_structure()
 
     def test_not_fulfilling_euler_formula(self):
+        embedding = nx.PlanarEmbedding()
+        for i in range(5):
+            for j in range(5):
+                if i != j:
+                    embedding.add_half_edge_first(i, j)
         with pytest.raises(nx.NetworkXException):
-            embedding = nx.PlanarEmbedding()
-            for i in range(5):
-                for j in range(5):
-                    if i != j:
-                        embedding.add_half_edge_first(i, j)
             embedding.check_structure()
 
     def test_missing_reference(self):
+        embedding = nx.PlanarEmbedding()
         with pytest.raises(nx.NetworkXException):
-            embedding = nx.PlanarEmbedding()
             embedding.add_half_edge_cw(1, 2, 3)
 
     def test_connect_components(self):
@@ -427,10 +427,10 @@ class TestPlanarEmbeddingClass:
         assert face == [1, 2]
 
     def test_unsuccessful_face_traversal(self):
+        embedding = nx.PlanarEmbedding()
+        embedding.add_edge(1, 2, ccw=2, cw=3)
+        embedding.add_edge(2, 1, ccw=1, cw=3)
         with pytest.raises(nx.NetworkXException):
-            embedding = nx.PlanarEmbedding()
-            embedding.add_edge(1, 2, ccw=2, cw=3)
-            embedding.add_edge(2, 1, ccw=1, cw=3)
             embedding.traverse_face(1, 2)
 
     @staticmethod

--- a/networkx/algorithms/tests/test_reciprocity.py
+++ b/networkx/algorithms/tests/test_reciprocity.py
@@ -12,8 +12,8 @@ class TestReciprocity:
 
     # test empty graph's overall reciprocity which will throw an error
     def test_overall_reciprocity_empty_graph(self):
+        DG = nx.DiGraph()
         with pytest.raises(nx.NetworkXError):
-            DG = nx.DiGraph()
             nx.overall_reciprocity(DG)
 
     # test for reciprocity for a list of nodes
@@ -31,7 +31,7 @@ class TestReciprocity:
 
     # test for reciprocity for an isolated node
     def test_reciprocity_graph_isolated_nodes(self):
+        DG = nx.DiGraph([(1, 2)])
+        DG.add_node(4)
         with pytest.raises(nx.NetworkXError):
-            DG = nx.DiGraph([(1, 2)])
-            DG.add_node(4)
             nx.reciprocity(DG, 4)

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -69,14 +69,14 @@ def test_richclub4():
 
 
 def test_richclub_exception():
+    G = nx.DiGraph()
     with pytest.raises(nx.NetworkXNotImplemented):
-        G = nx.DiGraph()
         nx.rich_club_coefficient(G)
 
 
 def test_rich_club_exception2():
+    G = nx.MultiGraph()
     with pytest.raises(nx.NetworkXNotImplemented):
-        G = nx.MultiGraph()
         nx.rich_club_coefficient(G)
 
 

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -244,16 +244,16 @@ def test_cutoff_zero():
 
 
 def test_source_missing():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NodeNotFound):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.all_simple_paths(nx.MultiGraph(G), 0, 3))
 
 
 def test_target_missing():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NodeNotFound):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.all_simple_paths(nx.MultiGraph(G), 1, 4))
 
 
@@ -434,16 +434,16 @@ def test_edge_cutoff_zero():
 
 
 def test_edge_source_missing():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NodeNotFound):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.all_simple_edge_paths(nx.MultiGraph(G), 0, 3))
 
 
 def test_edge_target_missing():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NodeNotFound):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.all_simple_edge_paths(nx.MultiGraph(G), 1, 4))
 
 
@@ -582,31 +582,31 @@ def test_weight_name():
 
 
 def test_ssp_source_missing():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NodeNotFound):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.shortest_simple_paths(G, 0, 3))
 
 
 def test_ssp_target_missing():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NodeNotFound):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.shortest_simple_paths(G, 1, 4))
 
 
 def test_ssp_multigraph():
+    G = nx.MultiGraph()
+    nx.add_path(G, [1, 2, 3])
     with pytest.raises(nx.NetworkXNotImplemented):
-        G = nx.MultiGraph()
-        nx.add_path(G, [1, 2, 3])
         list(nx.shortest_simple_paths(G, 1, 4))
 
 
 def test_ssp_source_missing2():
+    G = nx.Graph()
+    nx.add_path(G, [0, 1, 2])
+    nx.add_path(G, [3, 4, 5])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.Graph()
-        nx.add_path(G, [0, 1, 2])
-        nx.add_path(G, [3, 4, 5])
         list(nx.shortest_simple_paths(G, 0, 3))
 
 
@@ -751,10 +751,10 @@ def test_bidirectional_dijksta_restricted():
 
 
 def test_bidirectional_dijkstra_no_path():
+    G = nx.Graph()
+    nx.add_path(G, [1, 2, 3])
+    nx.add_path(G, [4, 5, 6])
     with pytest.raises(nx.NetworkXNoPath):
-        G = nx.Graph()
-        nx.add_path(G, [1, 2, 3])
-        nx.add_path(G, [4, 5, 6])
         _bidirectional_dijkstra(G, 1, 6)
 
 

--- a/networkx/algorithms/tests/test_smallworld.py
+++ b/networkx/algorithms/tests/test_smallworld.py
@@ -55,7 +55,8 @@ def test_omega():
     omegal = omega(Gl, niter=1, nrand=1, seed=rng)
     omegar = omega(Gr, niter=1, nrand=1, seed=rng)
     omegas = omega(Gs, niter=1, nrand=1, seed=rng)
-    assert omegal < omegas and omegas < omegar
+    assert omegal < omegas
+    assert omegas < omegar
 
     # Test that omega lies within the [-1, 1] bounds
     G_barbell = nx.barbell_graph(5, 1)
@@ -70,7 +71,7 @@ def test_omega():
         assert -1 <= o <= 1
 
 
-@pytest.mark.parametrize("f", (nx.random_reference, nx.lattice_reference))
+@pytest.mark.parametrize("f", [nx.random_reference, nx.lattice_reference])
 def test_graph_no_edges(f):
     G = nx.Graph()
     G.add_nodes_from([0, 1, 2, 3])

--- a/networkx/algorithms/tests/test_sparsifiers.py
+++ b/networkx/algorithms/tests/test_sparsifiers.py
@@ -132,6 +132,6 @@ def test_spanner_unweighted_disconnected_graph():
 
 def test_spanner_invalid_stretch():
     """Check whether an invalid stretch is caught."""
+    G = nx.empty_graph()
     with pytest.raises(ValueError):
-        G = nx.empty_graph()
         nx.spanner(G, 0)

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -124,9 +124,9 @@ def test_connected_double_edge_swap_small():
 
 
 def test_connected_double_edge_swap_not_connected():
+    G = nx.path_graph(3)
+    nx.add_path(G, [10, 11, 12])
     with pytest.raises(nx.NetworkXError):
-        G = nx.path_graph(3)
-        nx.add_path(G, [10, 11, 12])
         G = nx.connected_double_edge_swap(G)
 
 

--- a/networkx/algorithms/tree/tests/test_coding.py
+++ b/networkx/algorithms/tree/tests/test_coding.py
@@ -14,8 +14,8 @@ class TestPruferSequence:
     """
 
     def test_nontree(self):
+        G = nx.cycle_graph(3)
         with pytest.raises(nx.NotATree):
-            G = nx.cycle_graph(3)
             nx.to_prufer_sequence(G)
 
     def test_null_graph(self):
@@ -27,8 +27,8 @@ class TestPruferSequence:
             nx.to_prufer_sequence(nx.trivial_graph())
 
     def test_bad_integer_labels(self):
+        T = nx.Graph(nx.utils.pairwise("abc"))
         with pytest.raises(KeyError):
-            T = nx.Graph(nx.utils.pairwise("abc"))
             nx.to_prufer_sequence(T)
 
     def test_encoding(self):
@@ -74,13 +74,13 @@ class TestNestedTuple:
     """Unit tests for the nested tuple encoding and decoding functions."""
 
     def test_nontree(self):
+        G = nx.cycle_graph(3)
         with pytest.raises(nx.NotATree):
-            G = nx.cycle_graph(3)
             nx.to_nested_tuple(G, 0)
 
     def test_unknown_root(self):
+        G = nx.path_graph(2)
         with pytest.raises(nx.NodeNotFound):
-            G = nx.path_graph(2)
             nx.to_nested_tuple(G, "bogus")
 
     def test_encoding(self):

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -452,7 +452,7 @@ def test_random_spanning_tree_multiplicative_small():
     assert nx.utils.edges_equal(solution.edges, sampled_tree.edges)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_random_spanning_tree_multiplicative_large():
     """
     Sample many trees from the distribution created in the last test
@@ -578,7 +578,7 @@ def test_random_spanning_tree_additive_small():
     assert nx.utils.edges_equal(solution.edges, sampled_tree.edges)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_random_spanning_tree_additive_large():
     """
     Sample many spanning trees from the additive method.

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -442,9 +442,9 @@ class TestCommonNeighbors:
         self.test(G, 1, 2, [0])
 
     def test_digraph(self):
+        G = nx.DiGraph()
+        G.add_edges_from([(0, 1), (1, 2)])
         with pytest.raises(nx.NetworkXNotImplemented):
-            G = nx.DiGraph()
-            G.add_edges_from([(0, 1), (1, 2)])
             self.func(G, 0, 2)
 
     def test_nonexistent_nodes(self):
@@ -466,7 +466,7 @@ class TestCommonNeighbors:
 
 
 @pytest.mark.parametrize(
-    "graph_type", (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)
+    "graph_type", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 )
 def test_set_node_attributes(graph_type):
     # Test single value
@@ -500,10 +500,10 @@ def test_set_node_attributes(graph_type):
 
 @pytest.mark.parametrize(
     ("values", "name"),
-    (
+    [
         ({0: "red", 1: "blue"}, "color"),  # values dictionary
         ({0: {"color": "red"}, 1: {"color": "blue"}}, None),  # dict-of-dict
-    ),
+    ],
 )
 def test_set_node_attributes_ignores_extra_nodes(values, name):
     """
@@ -517,7 +517,7 @@ def test_set_node_attributes_ignores_extra_nodes(values, name):
     assert 1 not in G.nodes
 
 
-@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+@pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph])
 def test_set_edge_attributes(graph_type):
     # Test single value
     G = nx.path_graph(3, create_using=graph_type)
@@ -549,10 +549,10 @@ def test_set_edge_attributes(graph_type):
 
 @pytest.mark.parametrize(
     ("values", "name"),
-    (
+    [
         ({(0, 1): 1.0, (0, 2): 2.0}, "weight"),  # values dict
         ({(0, 1): {"weight": 1.0}, (0, 2): {"weight": 2.0}}, None),  # values dod
-    ),
+    ],
 )
 def test_set_edge_attributes_ignores_extra_edges(values, name):
     """If `values` is a dict or dict-of-dicts containing edges that are not in
@@ -564,7 +564,7 @@ def test_set_edge_attributes_ignores_extra_edges(values, name):
     assert (0, 2) not in G.edges
 
 
-@pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
+@pytest.mark.parametrize("graph_type", [nx.MultiGraph, nx.MultiDiGraph])
 def test_set_edge_attributes_multi(graph_type):
     # Test single value
     G = nx.path_graph(3, create_using=graph_type)
@@ -596,10 +596,10 @@ def test_set_edge_attributes_multi(graph_type):
 
 @pytest.mark.parametrize(
     ("values", "name"),
-    (
+    [
         ({(0, 1, 0): 1.0, (0, 2, 0): 2.0}, "weight"),  # values dict
         ({(0, 1, 0): {"weight": 1.0}, (0, 2, 0): {"weight": 2.0}}, None),  # values dod
-    ),
+    ],
 )
 def test_set_edge_attributes_multi_ignores_extra_edges(values, name):
     """If `values` is a dict or dict-of-dicts containing edges that are not in
@@ -750,7 +750,7 @@ def test_pathweight():
 
 
 @pytest.mark.parametrize(
-    "G", (nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph())
+    "G", [nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()]
 )
 def test_ispath(G):
     G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4)])
@@ -762,7 +762,7 @@ def test_ispath(G):
     assert not nx.is_path(G, another_invalid_path)
 
 
-@pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+@pytest.mark.parametrize("G", [nx.Graph(), nx.DiGraph()])
 def test_restricted_view(G):
     G.add_edges_from([(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2)])
     G.add_node(4)
@@ -771,7 +771,7 @@ def test_restricted_view(G):
     assert set(H.edges()) == {(1, 1)}
 
 
-@pytest.mark.parametrize("G", (nx.MultiGraph(), nx.MultiDiGraph()))
+@pytest.mark.parametrize("G", [nx.MultiGraph(), nx.MultiDiGraph()])
 def test_restricted_view_multi(G):
     G.add_edges_from(
         [(0, 1, 0), (0, 2, 0), (0, 3, 0), (0, 1, 1), (1, 0, 0), (1, 1, 0), (1, 2, 0)]

--- a/networkx/classes/tests/test_multigraph.py
+++ b/networkx/classes/tests/test_multigraph.py
@@ -248,7 +248,7 @@ class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
         (dol, False, single_edge),
     ]
 
-    @pytest.mark.parametrize("dod, mgi, edges", cases)
+    @pytest.mark.parametrize(("dod", "mgi", "edges"), cases)
     def test_non_multigraph_input(self, dod, mgi, edges):
         G = self.Graph(dod, multigraph_input=mgi)
         assert list(G.edges(keys=True, data=True)) == edges
@@ -261,7 +261,7 @@ class TestMultiGraph(BaseMultiGraphTester, _TestGraph):
         (dodod3, single_edge3),
     ]
 
-    @pytest.mark.parametrize("dod, edges", mgi_none_cases)
+    @pytest.mark.parametrize(("dod", "edges"), mgi_none_cases)
     def test_non_multigraph_input_mgi_none(self, dod, edges):
         # test constructor without to_networkx_graph for mgi=None
         G = self.Graph(dod)

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -348,9 +348,11 @@ class TestEdgeDataView:
         evr = self.eview(self.G)
         ev = evr()
         if self.G.is_directed():
-            assert (1, 2) in ev and (2, 1) not in ev
+            assert (1, 2) in ev
+            assert (2, 1) not in ev
         else:
-            assert (1, 2) in ev and (2, 1) in ev
+            assert (1, 2) in ev
+            assert (2, 1) in ev
         assert (1, 4) not in ev
         assert (1, 90) not in ev
         assert (90, 1) not in ev
@@ -626,11 +628,15 @@ class TestEdgeView:
         ev = self.eview(self.G)
         edv = ev()
         if self.G.is_directed():
-            assert (1, 2) in ev and (2, 1) not in ev
-            assert (1, 2) in edv and (2, 1) not in edv
+            assert (1, 2) in ev
+            assert (2, 1) not in ev
+            assert (1, 2) in edv
+            assert (2, 1) not in edv
         else:
-            assert (1, 2) in ev and (2, 1) in ev
-            assert (1, 2) in edv and (2, 1) in edv
+            assert (1, 2) in ev
+            assert (2, 1) in ev
+            assert (1, 2) in edv
+            assert (2, 1) in edv
         assert (1, 4) not in ev
         assert (1, 4) not in edv
         # edge not in graph
@@ -1370,7 +1376,7 @@ class TestInMultiDegreeView(TestDegreeView):
 
 @pytest.mark.parametrize(
     ("reportview", "err_msg_terms"),
-    (
+    [
         (rv.NodeView, "list(G.nodes"),
         (rv.NodeDataView, "list(G.nodes.data"),
         (rv.EdgeView, "list(G.edges"),
@@ -1381,7 +1387,7 @@ class TestInMultiDegreeView(TestDegreeView):
         (rv.MultiEdgeView, "list(G.edges"),
         (rv.InMultiEdgeView, "list(G.in_edges"),
         (rv.OutMultiEdgeView, "list(G.edges"),
-    ),
+    ],
 )
 def test_slicing_reportviews(reportview, err_msg_terms):
     G = nx.complete_graph(3)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -45,7 +45,7 @@ def pytest_collection_modifyitems(config, items):
 
 # TODO: The warnings below need to be dealt with, but for now we silence them.
 @pytest.fixture(autouse=True)
-def set_warnings():
+def _set_warnings():
     warnings.filterwarnings(
         "ignore",
         category=DeprecationWarning,
@@ -71,7 +71,7 @@ def set_warnings():
 
 
 @pytest.fixture(autouse=True)
-def add_nx(doctest_namespace):
+def _add_nx(doctest_namespace):
     doctest_namespace["nx"] = networkx
 
 

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -54,7 +54,7 @@ class TestAGraph:
         assert G.name == "test"
 
     @pytest.mark.parametrize(
-        "graph_class", (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)
+        "graph_class", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
     )
     def test_from_agraph_create_using(self, graph_class):
         G = nx.path_graph(3)
@@ -92,7 +92,7 @@ class TestAGraph:
         A = nx.nx_agraph.to_agraph(G)
         assert dict(A.nodes()[0].attr) == {"color": "red"}
 
-    @pytest.mark.parametrize("graph_class", (nx.Graph, nx.MultiGraph))
+    @pytest.mark.parametrize("graph_class", [nx.Graph, nx.MultiGraph])
     def test_to_agraph_with_edgedata(self, graph_class):
         G = graph_class()
         G.add_nodes_from([0, 1])

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -11,7 +11,7 @@ from networkx.utils import graphs_equal
 pydot = pytest.importorskip("pydot")
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail()
 class TestPydot:
     def pydot_checks(self, G, prog):
         """

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -67,7 +67,7 @@ def test_arrows():
 
 @pytest.mark.parametrize(
     ("edge_color", "expected"),
-    (
+    [
         (None, "black"),  # Default
         ("r", "red"),  # Non-default color string
         (["r"], "red"),  # Single non-default color in a list
@@ -77,9 +77,9 @@ def test_arrows():
         ([(0, 1, 0, 1)], "lime"),  # single color as rgba tuple in list
         ("#0000ff", "blue"),  # single color hex code
         (["#0000ff"], "blue"),  # hex code in list
-    ),
+    ],
 )
-@pytest.mark.parametrize("edgelist", (None, [(0, 1)]))
+@pytest.mark.parametrize("edgelist", [None, [(0, 1)]])
 def test_single_edge_color_undirected(edge_color, expected, edgelist):
     """Tests ways of specifying all edges have a single color for edges
     drawn with a LineCollection"""
@@ -93,7 +93,7 @@ def test_single_edge_color_undirected(edge_color, expected, edgelist):
 
 @pytest.mark.parametrize(
     ("edge_color", "expected"),
-    (
+    [
         (None, "black"),  # Default
         ("r", "red"),  # Non-default color string
         (["r"], "red"),  # Single non-default color in a list
@@ -103,9 +103,9 @@ def test_single_edge_color_undirected(edge_color, expected, edgelist):
         ([(0, 1, 0, 1)], "lime"),  # single color as rgba tuple in list
         ("#0000ff", "blue"),  # single color hex code
         (["#0000ff"], "blue"),  # hex code in list
-    ),
+    ],
 )
-@pytest.mark.parametrize("edgelist", (None, [(0, 1)]))
+@pytest.mark.parametrize("edgelist", [None, [(0, 1)]])
 def test_single_edge_color_directed(edge_color, expected, edgelist):
     """Tests ways of specifying all edges have a single color for edges drawn
     with FancyArrowPatches"""
@@ -226,7 +226,7 @@ def test_edge_color_string_with_global_alpha_directed():
         assert ec[-1] == 0.2
 
 
-@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+@pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph])
 def test_edge_width_default_value(graph_type):
     """Test the default linewidth for edges drawn either via LineCollection or
     FancyArrowPatches."""
@@ -240,10 +240,10 @@ def test_edge_width_default_value(graph_type):
 
 @pytest.mark.parametrize(
     ("edgewidth", "expected"),
-    (
+    [
         (3, 3),  # single-value, non-default
         ([3], 3),  # Single value as a list
-    ),
+    ],
 )
 def test_edge_width_single_value_undirected(edgewidth, expected):
     G = nx.path_graph(4)
@@ -255,10 +255,10 @@ def test_edge_width_single_value_undirected(edgewidth, expected):
 
 @pytest.mark.parametrize(
     ("edgewidth", "expected"),
-    (
+    [
         (3, 3),  # single-value, non-default
         ([3], 3),  # Single value as a list
-    ),
+    ],
 )
 def test_edge_width_single_value_directed(edgewidth, expected):
     G = nx.path_graph(4, create_using=nx.DiGraph)
@@ -271,11 +271,11 @@ def test_edge_width_single_value_directed(edgewidth, expected):
 
 @pytest.mark.parametrize(
     "edgelist",
-    (
+    [
         [(0, 1), (1, 2), (2, 3)],  # one width specification per edge
         None,  #  fewer widths than edges - widths cycle
         [(0, 1), (1, 2)],  # More widths than edges - unused widths ignored
-    ),
+    ],
 )
 def test_edge_width_sequence(edgelist):
     G = barbell.to_directed()
@@ -316,11 +316,11 @@ def test_directed_edges_linestyle_default():
 
 @pytest.mark.parametrize(
     "style",
-    (
+    [
         "dashed",  # edge with string style
         "--",  # edge with simplified string style
         (1, (1, 1)),  # edge with (offset, onoffseq) style
-    ),
+    ],
 )
 def test_directed_edges_linestyle_single_value(style):
     """Tests support for specifying linestyles with a single value to be applied to
@@ -338,14 +338,14 @@ def test_directed_edges_linestyle_single_value(style):
 
 @pytest.mark.parametrize(
     "style_seq",
-    (
+    [
         ["dashed"],  # edge with string style in list
         ["--"],  # edge with simplified string style in list
         [(1, (1, 1))],  # edge with (offset, onoffseq) style in list
         ["--", "-", ":"],  # edges with styles for each edge
         ["--", "-"],  # edges with fewer styles than edges (styles cycle)
         ["--", "-", ":", "-."],  # edges with more styles than edges (extra unused)
-    ),
+    ],
 )
 def test_directed_edges_linestyle_sequence(style_seq):
     """Tests support for specifying linestyles with sequences in
@@ -419,7 +419,7 @@ def test_labels_and_colors():
     # plt.show()
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare()
 def test_house_with_colors():
     G = nx.house_graph()
     # explicitly set positions
@@ -517,7 +517,7 @@ def test_draw_networkx_arrowsize_incorrect_size():
         nx.draw(G, arrowsize=arrowsize)
 
 
-@pytest.mark.parametrize("arrowsize", (30, [10, 20, 30]))
+@pytest.mark.parametrize("arrowsize", [30, [10, 20, 30]])
 def test_draw_edges_arrowsize(arrowsize):
     G = nx.DiGraph([(0, 1), (0, 2), (1, 2)])
     pos = {0: (0, 0), 1: (0, 1), 2: (1, 0)}
@@ -544,7 +544,7 @@ def test_draw_nodes_missing_node_from_position():
 
 # NOTE: parametrizing on marker to test both branches of internal
 # nx.draw_networkx_edges.to_marker_edge function
-@pytest.mark.parametrize("node_shape", ("o", "s"))
+@pytest.mark.parametrize("node_shape", ["o", "s"])
 def test_draw_edges_min_source_target_margins(node_shape):
     """Test that there is a wider gap between the node and the start of an
     incident edge when min_source_margin is specified.
@@ -601,7 +601,8 @@ def test_nonzero_selfloop_with_single_node():
     patch = nx.draw_networkx_edges(G, {0: (0, 0)})[0]
     # The resulting patch must have non-zero extent
     bbox = patch.get_extents()
-    assert bbox.width > 0 and bbox.height > 0
+    assert bbox.width > 0
+    assert bbox.height > 0
     # Cleanup
     plt.delaxes(ax)
 
@@ -620,7 +621,8 @@ def test_nonzero_selfloop_with_single_edge_in_edgelist():
     patch = nx.draw_networkx_edges(G, pos, edgelist=[(1, 1)])[0]
     # The resulting patch must have non-zero extent
     bbox = patch.get_extents()
-    assert bbox.width > 0 and bbox.height > 0
+    assert bbox.width > 0
+    assert bbox.height > 0
     # Cleanup
     plt.delaxes(ax)
 
@@ -670,7 +672,7 @@ def test_draw_edges_toggling_with_arrows_kwarg():
     assert isinstance(edges[0], mpl.patches.FancyArrowPatch)
 
 
-@pytest.mark.parametrize("drawing_func", (nx.draw, nx.draw_networkx))
+@pytest.mark.parametrize("drawing_func", [nx.draw, nx.draw_networkx])
 def test_draw_networkx_arrows_default_undirected(drawing_func):
     import matplotlib.collections
 
@@ -682,7 +684,7 @@ def test_draw_networkx_arrows_default_undirected(drawing_func):
     plt.delaxes(ax)
 
 
-@pytest.mark.parametrize("drawing_func", (nx.draw, nx.draw_networkx))
+@pytest.mark.parametrize("drawing_func", [nx.draw, nx.draw_networkx])
 def test_draw_networkx_arrows_default_directed(drawing_func):
     import matplotlib.collections
 
@@ -759,13 +761,13 @@ def test_draw_networkx_edges_undirected_selfloop_colors():
 
 @pytest.mark.parametrize(
     "fap_only_kwarg",  # Non-default values for kwargs that only apply to FAPs
-    (
+    [
         {"arrowstyle": "-"},
         {"arrowsize": 20},
         {"connectionstyle": "arc3,rad=0.2"},
         {"min_source_margin": 10},
         {"min_target_margin": 10},
-    ),
+    ],
 )
 def test_user_warnings_for_unused_edge_drawing_kwargs(fap_only_kwarg):
     """Users should get a warning when they specify a non-default value for

--- a/networkx/generators/tests/test_community.py
+++ b/networkx/generators/tests/test_community.py
@@ -234,85 +234,85 @@ def test_generator():
 
 
 def test_invalid_tau1():
+    n = 100
+    tau1 = 2
+    tau2 = 1
+    mu = 0.1
     with pytest.raises(nx.NetworkXError, match="tau2 must be greater than one"):
-        n = 100
-        tau1 = 2
-        tau2 = 1
-        mu = 0.1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 def test_invalid_tau2():
+    n = 100
+    tau1 = 1
+    tau2 = 2
+    mu = 0.1
     with pytest.raises(nx.NetworkXError, match="tau1 must be greater than one"):
-        n = 100
-        tau1 = 1
-        tau2 = 2
-        mu = 0.1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 def test_mu_too_large():
+    n = 100
+    tau1 = 2
+    tau2 = 2
+    mu = 1.1
     with pytest.raises(nx.NetworkXError, match="mu must be in the interval \\[0, 1\\]"):
-        n = 100
-        tau1 = 2
-        tau2 = 2
-        mu = 1.1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 def test_mu_too_small():
+    n = 100
+    tau1 = 2
+    tau2 = 2
+    mu = -1
     with pytest.raises(nx.NetworkXError, match="mu must be in the interval \\[0, 1\\]"):
-        n = 100
-        tau1 = 2
-        tau2 = 2
-        mu = -1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2)
 
 
 def test_both_degrees_none():
+    n = 100
+    tau1 = 2
+    tau2 = 2
+    mu = 1
     with pytest.raises(
         nx.NetworkXError,
         match="Must assign exactly one of min_degree and average_degree",
     ):
-        n = 100
-        tau1 = 2
-        tau2 = 2
-        mu = 1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu)
 
 
 def test_neither_degrees_none():
+    n = 100
+    tau1 = 2
+    tau2 = 2
+    mu = 1
     with pytest.raises(
         nx.NetworkXError,
         match="Must assign exactly one of min_degree and average_degree",
     ):
-        n = 100
-        tau1 = 2
-        tau2 = 2
-        mu = 1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2, average_degree=5)
 
 
 def test_max_iters_exeded():
+    n = 10
+    tau1 = 2
+    tau2 = 2
+    mu = 0.1
     with pytest.raises(
         nx.ExceededMaxIterations,
         match="Could not assign communities; try increasing min_community",
     ):
-        n = 10
-        tau1 = 2
-        tau2 = 2
-        mu = 0.1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2, max_iters=10, seed=1)
 
 
 def test_max_deg_out_of_range():
+    n = 10
+    tau1 = 2
+    tau2 = 2
+    mu = 0.1
     with pytest.raises(
         nx.NetworkXError, match="max_degree must be in the interval \\(0, n\\]"
     ):
-        n = 10
-        tau1 = 2
-        tau2 = 2
-        mu = 0.1
         nx.LFR_benchmark_graph(
             n, tau1, tau2, mu, max_degree=n + 1, max_iters=10, seed=1
         )
@@ -340,13 +340,13 @@ def test_max_community():
 
 
 def test_powerlaw_iterations_exceeded():
+    n = 100
+    tau1 = 2
+    tau2 = 2
+    mu = 1
     with pytest.raises(
         nx.ExceededMaxIterations, match="Could not create power law sequence"
     ):
-        n = 100
-        tau1 = 2
-        tau2 = 2
-        mu = 1
         nx.LFR_benchmark_graph(n, tau1, tau2, mu, min_degree=2, max_iters=0)
 
 

--- a/networkx/generators/tests/test_degree_seq.py
+++ b/networkx/generators/tests/test_degree_seq.py
@@ -88,9 +88,9 @@ class TestConfigurationModel:
 
 
 def test_directed_configuation_raise_unequal():
+    zin = [5, 3, 3, 3, 3, 2, 2, 2, 1, 1]
+    zout = [5, 3, 3, 3, 3, 2, 2, 2, 1, 2]
     with pytest.raises(nx.NetworkXError):
-        zin = [5, 3, 3, 3, 3, 2, 2, 2, 1, 1]
-        zout = [5, 3, 3, 3, 3, 2, 2, 2, 1, 2]
         nx.directed_configuration_model(zin, zout)
 
 

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -93,7 +93,7 @@ def test_non_numeric_ordering():
     assert len(s.edges) == 3
 
 
-@pytest.mark.parametrize("ig", (nx.Graph(), nx.DiGraph([(0, 1)])))
+@pytest.mark.parametrize("ig", [nx.Graph(), nx.DiGraph([(0, 1)])])
 def test_scale_free_graph_initial_graph_kwarg(ig):
     with pytest.raises(nx.NetworkXError):
         scale_free_graph(100, initial_graph=ig)

--- a/networkx/generators/tests/test_duplication.py
+++ b/networkx/generators/tests/test_duplication.py
@@ -58,11 +58,11 @@ class TestPartialDuplicationGraph:
         assert len(G) == n
 
     def test_invalid_initial_size(self):
+        N = 5
+        n = 10
+        p = 0.5
+        q = 0.5
         with pytest.raises(NetworkXError):
-            N = 5
-            n = 10
-            p = 0.5
-            q = 0.5
             G = partial_duplication_graph(N, n, p, q)
 
     def test_invalid_probabilities(self):

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -7,7 +7,7 @@ import pytest
 import networkx as nx
 
 
-@pytest.mark.parametrize("n", (2, 3, 5, 6, 10))
+@pytest.mark.parametrize("n", [2, 3, 5, 6, 10])
 def test_margulis_gabber_galil_graph_properties(n):
     g = nx.margulis_gabber_galil_graph(n)
     assert g.number_of_nodes() == n * n
@@ -19,7 +19,7 @@ def test_margulis_gabber_galil_graph_properties(n):
             assert 0 <= i < n
 
 
-@pytest.mark.parametrize("n", (2, 3, 5, 6, 10))
+@pytest.mark.parametrize("n", [2, 3, 5, 6, 10])
 def test_margulis_gabber_galil_graph_eigvals(n):
     np = pytest.importorskip("numpy")
     sp = pytest.importorskip("scipy")
@@ -32,7 +32,7 @@ def test_margulis_gabber_galil_graph_eigvals(n):
     assert w[-2] < 5 * np.sqrt(2)
 
 
-@pytest.mark.parametrize("p", (3, 5, 7, 11))  # Primes
+@pytest.mark.parametrize("p", [3, 5, 7, 11])  # Primes
 def test_chordal_cycle_graph(p):
     """Test for the :func:`networkx.chordal_cycle_graph` function."""
     G = nx.chordal_cycle_graph(p)
@@ -45,7 +45,7 @@ def test_chordal_cycle_graph(p):
     #
 
 
-@pytest.mark.parametrize("p", (3, 5, 7, 11, 13))  # Primes
+@pytest.mark.parametrize("p", [3, 5, 7, 11, 13])  # Primes
 def test_paley_graph(p):
     """Test for the :func:`networkx.paley_graph` function."""
     G = nx.paley_graph(p)
@@ -54,8 +54,10 @@ def test_paley_graph(p):
     # G is (p-1)/2-regular
     in_degrees = {G.in_degree(node) for node in G.nodes}
     out_degrees = {G.out_degree(node) for node in G.nodes}
-    assert len(in_degrees) == 1 and in_degrees.pop() == (p - 1) // 2
-    assert len(out_degrees) == 1 and out_degrees.pop() == (p - 1) // 2
+    assert len(in_degrees) == 1
+    assert in_degrees.pop() == (p - 1) // 2
+    assert len(out_degrees) == 1
+    assert out_degrees.pop() == (p - 1) // 2
 
     # If p = 1 mod 4, -1 is a square mod 4 and therefore the
     # edge in the Paley graph are symmetric.
@@ -64,7 +66,7 @@ def test_paley_graph(p):
             assert (v, u) in G.edges
 
 
-@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph, nx.MultiDiGraph))
+@pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph, nx.MultiDiGraph])
 def test_margulis_gabber_galil_graph_badinput(graph_type):
     with pytest.raises(
         nx.NetworkXError, match="`create_using` must be an undirected multigraph"
@@ -72,7 +74,7 @@ def test_margulis_gabber_galil_graph_badinput(graph_type):
         nx.margulis_gabber_galil_graph(3, create_using=graph_type)
 
 
-@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph, nx.MultiDiGraph))
+@pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph, nx.MultiDiGraph])
 def test_chordal_cycle_graph_badinput(graph_type):
     with pytest.raises(
         nx.NetworkXError, match="`create_using` must be an undirected multigraph"

--- a/networkx/generators/tests/test_internet_as_graphs.py
+++ b/networkx/generators/tests/test_internet_as_graphs.py
@@ -1,4 +1,4 @@
-from pytest import approx
+import pytest
 
 from networkx import is_connected, neighbors
 from networkx.generators.internet_as_graphs import random_internet_as_graph
@@ -161,16 +161,24 @@ class TestInternetASTopology:
             else:
                 raise ValueError("Unexpected data in the graph edge attributes")
 
-        assert d_m / len(self.M) == approx((2 + (2.5 * self.n) / 10000), abs=1e-0)
-        assert d_cp / len(self.CP) == approx((2 + (1.5 * self.n) / 10000), abs=1e-0)
-        assert d_c / len(self.C) == approx((1 + (5 * self.n) / 100000), abs=1e-0)
+        assert d_m / len(self.M) == pytest.approx(
+            (2 + (2.5 * self.n) / 10000), abs=1e-0
+        )
+        assert d_cp / len(self.CP) == pytest.approx(
+            (2 + (1.5 * self.n) / 10000), abs=1e-0
+        )
+        assert d_c / len(self.C) == pytest.approx((1 + (5 * self.n) / 100000), abs=1e-0)
 
-        assert p_m_m / len(self.M) == approx((1 + (2 * self.n) / 10000), abs=1e-0)
-        assert p_cp_m / len(self.CP) == approx((0.2 + (2 * self.n) / 10000), abs=1e-0)
-        assert p_cp_cp / len(self.CP) == approx(
+        assert p_m_m / len(self.M) == pytest.approx(
+            (1 + (2 * self.n) / 10000), abs=1e-0
+        )
+        assert p_cp_m / len(self.CP) == pytest.approx(
+            (0.2 + (2 * self.n) / 10000), abs=1e-0
+        )
+        assert p_cp_cp / len(self.CP) == pytest.approx(
             (0.05 + (2 * self.n) / 100000), abs=1e-0
         )
 
-        assert t_m / d_m == approx(0.375, abs=1e-1)
-        assert t_cp / d_cp == approx(0.375, abs=1e-1)
-        assert t_c / d_c == approx(0.125, abs=1e-1)
+        assert t_m / d_m == pytest.approx(0.375, abs=1e-1)
+        assert t_cp / d_cp == pytest.approx(0.375, abs=1e-1)
+        assert t_c / d_c == pytest.approx(0.125, abs=1e-1)

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -12,7 +12,7 @@ _gnp_generators = [
 
 
 @pytest.mark.parametrize("generator", _gnp_generators)
-@pytest.mark.parametrize("directed", (True, False))
+@pytest.mark.parametrize("directed", [True, False])
 def test_gnp_generators_negative_edge_probability(generator, directed):
     """If the edge probability `p` is <=0, the resulting graph should have no edges."""
     G = generator(10, -1.1, directed=directed)
@@ -37,7 +37,7 @@ def test_gnp_generators_greater_than_1_edge_probability(
 
 
 @pytest.mark.parametrize("generator", _gnp_generators)
-@pytest.mark.parametrize("directed", (True, False))
+@pytest.mark.parametrize("directed", [True, False])
 def test_gnp_generators_basic(generator, directed):
     """If the edge probability `p` is >0 and <1, test only the basic properties."""
     G = generator(10, 0.1, directed=directed)
@@ -56,8 +56,8 @@ def test_gnp_generators_for_p_close_to_1(generator):
 
 
 @pytest.mark.parametrize("generator", _gnp_generators)
-@pytest.mark.parametrize("p", (0.2, 0.8))
-@pytest.mark.parametrize("directed", (True, False))
+@pytest.mark.parametrize("p", [0.2, 0.8])
+@pytest.mark.parametrize("directed", [True, False])
 def test_gnp_generators_edge_probability(generator, p, directed):
     """Test that gnp generators generate edges according to the their probability `p`."""
     runs = 5000

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -182,7 +182,7 @@ class TestGeneratorsSmall:
 
 @pytest.mark.parametrize(
     "fn",
-    (
+    [
         nx.bull_graph,
         nx.chvatal_graph,
         nx.cubical_graph,
@@ -195,10 +195,10 @@ class TestGeneratorsSmall:
         nx.petersen_graph,
         nx.truncated_cube_graph,
         nx.tutte_graph,
-    ),
+    ],
 )
 @pytest.mark.parametrize(
-    "create_using", (nx.DiGraph, nx.MultiDiGraph, nx.DiGraph([(0, 1)]))
+    "create_using", [nx.DiGraph, nx.MultiDiGraph, nx.DiGraph([(0, 1)])]
 )
 def tests_raises_with_directed_create_using(fn, create_using):
     with pytest.raises(nx.NetworkXError, match="Directed Graph not supported"):

--- a/networkx/generators/tests/test_trees.py
+++ b/networkx/generators/tests/test_trees.py
@@ -4,7 +4,7 @@ import networkx as nx
 from networkx.utils import arbitrary_element, graphs_equal
 
 
-@pytest.mark.parametrize("prefix_tree_fn", (nx.prefix_tree, nx.prefix_tree_recursive))
+@pytest.mark.parametrize("prefix_tree_fn", [nx.prefix_tree, nx.prefix_tree_recursive])
 def test_basic_prefix_tree(prefix_tree_fn):
     # This example is from the Wikipedia article "Trie"
     # <https://en.wikipedia.org/wiki/Trie>.
@@ -70,12 +70,12 @@ def test_basic_prefix_tree(prefix_tree_fn):
 
 @pytest.mark.parametrize(
     "strings",
-    (
+    [
         ["a", "to", "tea", "ted", "ten", "i", "in", "inn"],
         ["ab", "abs", "ad"],
         ["ab", "abs", "ad", ""],
         ["distant", "disparaging", "distant", "diamond", "ruby"],
-    ),
+    ],
 )
 def test_implementations_consistent(strings):
     """Ensure results are consistent between prefix_tree implementations."""

--- a/networkx/linalg/tests/test_algebraic_connectivity.py
+++ b/networkx/linalg/tests/test_algebraic_connectivity.py
@@ -190,10 +190,10 @@ class TestAlgebraicConnectivity:
 
     @pytest.mark.parametrize(
         ("normalized", "sigma", "laplacian_fn"),
-        (
+        [
             (False, 0.2434017461399311, nx.laplacian_matrix),
             (True, 0.08113391537997749, nx.normalized_laplacian_matrix),
-        ),
+        ],
     )
     @pytest.mark.parametrize("method", methods)
     def test_buckminsterfullerene(self, normalized, sigma, laplacian_fn, method):
@@ -385,10 +385,10 @@ class TestSpectralOrdering:
 
     @pytest.mark.parametrize(
         ("normalized", "expected_order"),
-        (
+        [
             (False, [[1, 2, 0, 3, 4, 5, 6, 9, 7, 8], [8, 7, 9, 6, 5, 4, 3, 0, 2, 1]]),
             (True, [[1, 2, 3, 0, 4, 5, 9, 6, 7, 8], [8, 7, 6, 9, 5, 4, 0, 3, 2, 1]]),
-        ),
+        ],
     )
     @pytest.mark.parametrize("method", methods)
     def test_cycle(self, normalized, expected_order, method):

--- a/networkx/readwrite/json_graph/tests/test_adjacency.py
+++ b/networkx/readwrite/json_graph/tests/test_adjacency.py
@@ -54,7 +54,7 @@ class TestAdjacency:
         assert H[1][2]["second"]["color"] == "blue"
 
     def test_exception(self):
+        G = nx.MultiDiGraph()
+        attrs = {"id": "node", "key": "node"}
         with pytest.raises(nx.NetworkXError):
-            G = nx.MultiDiGraph()
-            attrs = {"id": "node", "key": "node"}
             adjacency_data(G, attrs)

--- a/networkx/readwrite/json_graph/tests/test_cytoscape.py
+++ b/networkx/readwrite/json_graph/tests/test_cytoscape.py
@@ -73,6 +73,6 @@ def test_multigraph():
 
 
 def test_exception():
+    G = nx.MultiDiGraph()
     with pytest.raises(nx.NetworkXError):
-        G = nx.MultiDiGraph()
         cytoscape_data(G, name="foo", ident="foo")

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -73,9 +73,9 @@ class TestNodeLink:
 
     # TODO: To be removed when signature change complete
     def test_exception_dep(self):
+        G = nx.MultiDiGraph()
+        attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
         with pytest.raises(nx.NetworkXError):
-            G = nx.MultiDiGraph()
-            attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
             node_link_data(G, attrs)
 
     def test_graph(self):
@@ -136,9 +136,9 @@ class TestNodeLink:
         assert H.nodes[1][q] == q
 
     def test_exception(self):
+        G = nx.MultiDiGraph()
+        attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
         with pytest.raises(nx.NetworkXError):
-            G = nx.MultiDiGraph()
-            attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
             node_link_data(G, **attrs)
 
     def test_string_ids(self):

--- a/networkx/readwrite/json_graph/tests/test_tree.py
+++ b/networkx/readwrite/json_graph/tests/test_tree.py
@@ -31,18 +31,18 @@ def test_graph_attributes():
 
 
 def test_exceptions():
+    G = nx.complete_graph(3)
     with pytest.raises(TypeError, match="is not a tree."):
-        G = nx.complete_graph(3)
         tree_data(G, 0)
+    G = nx.path_graph(3)
     with pytest.raises(TypeError, match="is not directed."):
-        G = nx.path_graph(3)
         tree_data(G, 0)
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    G.add_edge(2, 0)
+    G.add_node(3)
     with pytest.raises(TypeError, match="is not weakly connected."):
-        G = nx.path_graph(3, create_using=nx.DiGraph)
-        G.add_edge(2, 0)
-        G.add_node(3)
         tree_data(G, 0)
+    G = nx.MultiDiGraph()
+    G.add_node(0)
     with pytest.raises(nx.NetworkXError, match="must be different."):
-        G = nx.MultiDiGraph()
-        G.add_node(0)
         tree_data(G, 0, ident="node", children="node")

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -70,13 +70,13 @@ _expected_edges_multiattr = [
 
 @pytest.mark.parametrize(
     ("data", "extra_kwargs"),
-    (
+    [
         (edges_no_data, {}),
         (edges_with_values, {}),
         (edges_with_weight, {}),
         (edges_with_multiple_attrs, {}),
         (edges_with_multiple_attrs_csv, {"delimiter": ","}),
-    ),
+    ],
 )
 def test_read_edgelist_no_data(data, extra_kwargs):
     bytesIO = io.BytesIO(data.encode("utf-8"))
@@ -92,11 +92,11 @@ def test_read_weighted_edgelist():
 
 @pytest.mark.parametrize(
     ("data", "extra_kwargs", "expected"),
-    (
+    [
         (edges_with_weight, {}, _expected_edges_weights),
         (edges_with_multiple_attrs, {}, _expected_edges_multiattr),
         (edges_with_multiple_attrs_csv, {"delimiter": ","}, _expected_edges_multiattr),
-    ),
+    ],
 )
 def test_read_edgelist_with_data(data, extra_kwargs, expected):
     bytesIO = io.BytesIO(data.encode("utf-8"))
@@ -104,7 +104,7 @@ def test_read_edgelist_with_data(data, extra_kwargs, expected):
     assert edges_equal(G.edges(data=True), expected)
 
 
-@pytest.fixture
+@pytest.fixture()
 def example_graph():
     G = nx.Graph()
     G.add_weighted_edges_from([(1, 2, 3.0), (2, 3, 27.0), (3, 4, 3.0)])
@@ -142,22 +142,22 @@ def test_parse_edgelist():
     G = nx.parse_edgelist(lines, nodetype=int)
     assert list(G.edges()) == [(2, 3), (3, 4)]
     # unknown nodetype
+    lines = ["1 2", "2 3", "3 4"]
     with pytest.raises(TypeError, match="Failed to convert nodes"):
-        lines = ["1 2", "2 3", "3 4"]
         nx.parse_edgelist(lines, nodetype="nope")
     # lines have invalid edge format
+    lines = ["1 2 3", "2 3", "3 4"]
     with pytest.raises(TypeError, match="Failed to convert edge data"):
-        lines = ["1 2 3", "2 3", "3 4"]
         nx.parse_edgelist(lines, nodetype=int)
     # edge data and data_keys not the same length
+    lines = ["1 2 3", "2 3 27", "3 4 3.0"]
     with pytest.raises(IndexError, match="not the same length"):
-        lines = ["1 2 3", "2 3 27", "3 4 3.0"]
         nx.parse_edgelist(
             lines, nodetype=int, data=(("weight", float), ("capacity", int))
         )
     # edge data can't be converted to edge type
+    lines = ["1 2 't1'", "2 3 't3'", "3 4 't3'"]
     with pytest.raises(TypeError, match="Failed to convert"):
-        lines = ["1 2 't1'", "2 3 't3'", "3 4 't3'"]
         nx.parse_edgelist(lines, nodetype=int, data=(("weight", float),))
 
 

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -710,7 +710,7 @@ class TestPropertyLists:
         assert graph.nodes(data=True)["n1"] == {"properties": ["element"]}
 
 
-@pytest.mark.parametrize("coll", ([], ()))
+@pytest.mark.parametrize("coll", [[], ()])
 def test_stringize_empty_list_tuple(coll):
     G = nx.path_graph(2)
     G.nodes[0]["test"] = coll  # test serializing an empty collection

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -80,7 +80,7 @@ class TestWriteGraph6:
         # The expected encoding here was verified by Sage.
         assert result.getvalue() == b"N??F~z{~Fw^_~?~?^_?\n"
 
-    @pytest.mark.parametrize("G", (nx.MultiGraph(), nx.DiGraph()))
+    @pytest.mark.parametrize("G", [nx.MultiGraph(), nx.DiGraph()])
     def test_no_directed_or_multi_graphs(self, G):
         with pytest.raises(nx.NetworkXNotImplemented):
             nx.write_graph6(G, BytesIO())
@@ -110,7 +110,7 @@ class TestWriteGraph6:
             f.seek(0)
             assert f.read() == b">>graph6<<?\n"
 
-    @pytest.mark.parametrize("edge", ((0, 1), (1, 2), (1, 42)))
+    @pytest.mark.parametrize("edge", [(0, 1), (1, 2), (1, 42)])
     def test_relabeling(self, edge):
         G = nx.Graph([edge])
         f = BytesIO()
@@ -143,7 +143,7 @@ class TestToGraph6Bytes:
         G = nx.complete_bipartite_graph(6, 9)
         assert g6.to_graph6_bytes(G, header=False) == b"N??F~z{~Fw^_~?~?^_?\n"
 
-    @pytest.mark.parametrize("G", (nx.MultiGraph(), nx.DiGraph()))
+    @pytest.mark.parametrize("G", [nx.MultiGraph(), nx.DiGraph()])
     def test_no_directed_or_multi_graphs(self, G):
         with pytest.raises(nx.NetworkXNotImplemented):
             g6.to_graph6_bytes(G)
@@ -163,7 +163,7 @@ class TestToGraph6Bytes:
             assert nodes_equal(G.nodes(), H.nodes())
             assert edges_equal(G.edges(), H.edges())
 
-    @pytest.mark.parametrize("edge", ((0, 1), (1, 2), (1, 42)))
+    @pytest.mark.parametrize("edge", [(0, 1), (1, 2), (1, 42)])
     def test_relabeling(self, edge):
         G = nx.Graph([edge])
         assert g6.to_graph6_bytes(G) == b">>graph6<<A_\n"

--- a/networkx/tests/test_all_random_functions.py
+++ b/networkx/tests/test_all_random_functions.py
@@ -219,7 +219,7 @@ def run_all_random_functions(seed):
 # seed = 14
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 # print("NetworkX Version:", nx.__version__)
 def test_rng_interface():
     global progress

--- a/networkx/tests/test_convert.py
+++ b/networkx/tests/test_convert.py
@@ -282,12 +282,12 @@ class TestConvert:
 
 @pytest.mark.parametrize(
     "edgelist",
-    (
+    [
         # Graph with no edge data
         [(0, 1), (1, 2)],
         # Graph with edge data
         [(0, 1, {"weight": 1.0}), (1, 2, {"weight": 2.0})],
-    ),
+    ],
 )
 def test_to_dict_of_dicts_with_edgedata_param(edgelist):
     G = nx.Graph()

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -196,7 +196,7 @@ class TestConvertNumpyArray:
         assert A.dtype == int
 
 
-@pytest.fixture
+@pytest.fixture()
 def multigraph_test_graph():
     G = nx.MultiGraph()
     G.add_edge(1, 2, weight=7)
@@ -204,7 +204,7 @@ def multigraph_test_graph():
     return G
 
 
-@pytest.mark.parametrize(("operator", "expected"), ((sum, 77), (min, 7), (max, 70)))
+@pytest.mark.parametrize(("operator", "expected"), [(sum, 77), (min, 7), (max, 70)])
 def test_numpy_multigraph(multigraph_test_graph, operator, expected):
     A = nx.to_numpy_array(multigraph_test_graph, multigraph_weight=operator)
     assert A[1, 0] == expected
@@ -219,7 +219,7 @@ def test_to_numpy_array_multigraph_nodelist(multigraph_test_graph):
 
 
 @pytest.mark.parametrize(
-    "G, expected",
+    ("G", "expected"),
     [
         (nx.Graph(), np.array([[0, 1 + 2j], [1 + 2j, 0]], dtype=complex)),
         (nx.DiGraph(), np.array([[0, 1 + 2j], [0, 0]], dtype=complex)),
@@ -246,8 +246,8 @@ def test_to_numpy_array_arbitrary_weights():
 
 
 @pytest.mark.parametrize(
-    "func, expected",
-    ((min, -1), (max, 10), (sum, 11), (np.mean, 11 / 3), (np.median, 2)),
+    ("func", "expected"),
+    [(min, -1), (max, 10), (sum, 11), (np.mean, 11 / 3), (np.median, 2)],
 )
 def test_to_numpy_array_multiweight_reduction(func, expected):
     """Test various functions for reducing multiedge weights."""
@@ -264,7 +264,7 @@ def test_to_numpy_array_multiweight_reduction(func, expected):
 
 
 @pytest.mark.parametrize(
-    ("G, expected"),
+    (("G", "expected")),
     [
         (nx.Graph(), [[(0, 0), (10, 5)], [(10, 5), (0, 0)]]),
         (nx.DiGraph(), [[(0, 0), (10, 5)], [(0, 0), (0, 0)]]),
@@ -304,7 +304,7 @@ def test_to_numpy_array_structured_dtype_single_attr(field_name, expected_attr_v
     npt.assert_array_equal(A[field_name], expected)
 
 
-@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+@pytest.mark.parametrize("graph_type", [nx.Graph, nx.DiGraph])
 @pytest.mark.parametrize(
     "edge",
     [
@@ -323,7 +323,7 @@ def test_to_numpy_array_structured_dtype_multiple_fields(graph_type, edge):
         npt.assert_array_equal(A[attr], expected)
 
 
-@pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+@pytest.mark.parametrize("G", [nx.Graph(), nx.DiGraph()])
 def test_to_numpy_array_structured_dtype_scalar_nonedge(G):
     G.add_edge(0, 1, weight=10)
     dtype = np.dtype([("weight", float), ("cost", float)])
@@ -333,7 +333,7 @@ def test_to_numpy_array_structured_dtype_scalar_nonedge(G):
         npt.assert_array_equal(A[attr], expected)
 
 
-@pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+@pytest.mark.parametrize("G", [nx.Graph(), nx.DiGraph()])
 def test_to_numpy_array_structured_dtype_nonedge_ary(G):
     """Similar to the scalar case, except has a different non-edge value for
     each named field."""
@@ -359,7 +359,7 @@ def test_to_numpy_array_structured_dtype_with_weight_raises():
         nx.to_numpy_array(G, dtype=dtype, weight="cost")
 
 
-@pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
+@pytest.mark.parametrize("graph_type", [nx.MultiGraph, nx.MultiDiGraph])
 def test_to_numpy_array_structured_multigraph_raises(graph_type):
     G = nx.path_graph(3, create_using=graph_type)
     dtype = np.dtype([("weight", int), ("cost", int)])

--- a/networkx/tests/test_convert_scipy.py
+++ b/networkx/tests/test_convert_scipy.py
@@ -161,12 +161,10 @@ class TestConvertScipy:
         )
 
     def test_format_keyword_raise(self):
+        WP4 = nx.Graph()
+        WP4.add_edges_from((n, n + 1, {"weight": 0.5, "other": 0.3}) for n in range(3))
+        P4 = path_graph(4)
         with pytest.raises(nx.NetworkXError):
-            WP4 = nx.Graph()
-            WP4.add_edges_from(
-                (n, n + 1, {"weight": 0.5, "other": 0.3}) for n in range(3)
-            )
-            P4 = path_graph(4)
             nx.to_scipy_sparse_array(P4, format="any_other")
 
     def test_null_raise(self):
@@ -264,7 +262,7 @@ class TestConvertScipy:
         assert graphs_equal(G, expected)
 
 
-@pytest.mark.parametrize("sparse_format", ("csr", "csc", "dok"))
+@pytest.mark.parametrize("sparse_format", ["csr", "csc", "dok"])
 def test_from_scipy_sparse_array_formats(sparse_format):
     """Test all formats supported by _generate_weighted_edges."""
     # trinode complete graph with non-uniform edge weights

--- a/networkx/tests/test_lazy_imports.py
+++ b/networkx/tests/test_lazy_imports.py
@@ -16,14 +16,14 @@ def test_lazy_import_basics():
     # poor-mans pytest.raises for testing errors on attribute access
     try:
         anything_not_real.pi
-        assert False  # Should not get here
+        pytest.fail("Should not get here")
     except ModuleNotFoundError:
         pass
     assert isinstance(anything_not_real, lazy.DelayedImportErrorModule)
     # see if it changes for second access
     try:
         anything_not_real.pi
-        assert False  # Should not get here
+        pytest.fail("Should not get here")
     except ModuleNotFoundError:
         pass
 
@@ -55,13 +55,13 @@ def test_lazy_import_nonbuiltins():
     if isinstance(sp, lazy.DelayedImportErrorModule):
         try:
             sp.pi
-            assert False
+            pytest.fail("Should not get here")
         except ModuleNotFoundError:
             pass
     elif isinstance(np, lazy.DelayedImportErrorModule):
         try:
             np.sin(np.pi)
-            assert False
+            pytest.fail("Should not get here")
         except ModuleNotFoundError:
             pass
     else:

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -84,8 +84,8 @@ class TestRelabel:
         assert H.nodes[3]["label"] == "D"
 
     def test_convert_to_integers_raise(self):
+        G = nx.Graph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.Graph()
             H = nx.convert_node_labels_to_integers(G, ordering="increasing age")
 
     def test_relabel_nodes_copy(self):
@@ -111,7 +111,7 @@ class TestRelabel:
         H = nx.relabel_nodes(G, str)
         assert nodes_equal(H.nodes, ["0", "1", "2", "3"])
 
-    @pytest.mark.parametrize("non_mc", ("0123", ["0", "1", "2", "3"]))
+    @pytest.mark.parametrize("non_mc", ["0123", ["0", "1", "2", "3"]])
     def test_relabel_nodes_non_mapping_or_callable(self, non_mc):
         """If `mapping` is neither a Callable or a Mapping, an exception
         should be raised."""

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -82,7 +82,7 @@ def test_not_implemented_decorator():
 
 
 def test_not_implemented_decorator_key():
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError):  # noqa: PT012
 
         @not_implemented_for("foo")
         def test1(G):
@@ -92,12 +92,11 @@ def test_not_implemented_decorator_key():
 
 
 def test_not_implemented_decorator_raise():
+    @not_implemented_for("graph")
+    def test1(G):
+        pass
+
     with pytest.raises(nx.NetworkXNotImplemented):
-
-        @not_implemented_for("graph")
-        def test1(G):
-            pass
-
         test1(nx.Graph())
 
 
@@ -287,43 +286,39 @@ class TestRandomState:
 
 
 def test_random_state_string_arg_index():
+    @np_random_state("a")
+    def make_random_state(rs):
+        pass
+
     with pytest.raises(nx.NetworkXError):
-
-        @np_random_state("a")
-        def make_random_state(rs):
-            pass
-
-        rstate = make_random_state(1)
+        make_random_state(1)
 
 
 def test_py_random_state_string_arg_index():
+    @py_random_state("a")
+    def make_random_state(rs):
+        pass
+
     with pytest.raises(nx.NetworkXError):
-
-        @py_random_state("a")
-        def make_random_state(rs):
-            pass
-
-        rstate = make_random_state(1)
+        make_random_state(1)
 
 
 def test_random_state_invalid_arg_index():
+    @np_random_state(2)
+    def make_random_state(rs):
+        pass
+
     with pytest.raises(nx.NetworkXError):
-
-        @np_random_state(2)
-        def make_random_state(rs):
-            pass
-
-        rstate = make_random_state(1)
+        make_random_state(1)
 
 
 def test_py_random_state_invalid_arg_index():
+    @py_random_state(2)
+    def make_random_state(rs):
+        pass
+
     with pytest.raises(nx.NetworkXError):
-
-        @py_random_state(2)
-        def make_random_state(rs):
-            pass
-
-        rstate = make_random_state(1)
+        make_random_state(1)
 
 
 class TestArgmap:

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -239,7 +239,7 @@ def test_PythonRandomInterface_Generator():
 
 
 @pytest.mark.parametrize(
-    ("iterable_type", "expected"), ((list, 1), (tuple, 1), (str, "["), (set, 1))
+    ("iterable_type", "expected"), [(list, 1), (tuple, 1), (str, "["), (set, 1)]
 )
 def test_arbitrary_element(iterable_type, expected):
     iterable = iterable_type([1, 2, 3])
@@ -247,7 +247,7 @@ def test_arbitrary_element(iterable_type, expected):
 
 
 @pytest.mark.parametrize(
-    "iterator", ((i for i in range(3)), iter([1, 2, 3]))  # generator
+    "iterator", [(i for i in range(3)), iter([1, 2, 3])]  # generator
 )
 def test_arbitrary_element_raises(iterator):
     """Value error is raised when input is an iterator."""

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,12 +6,16 @@ select = [
     "PIE",     # flake8-pie
     "PGH003",  # forbid blanket 'type: ignore' comments
     "PLR0402", # useless import alias
+    "PT",      # flake8-pytest-style
     "SIM101",  # merge 'isinstance' calls
     "SIM109",  # use a tuple for multiple comparisons
     "SIM110",  # convert loop to 'any'
     "SIM111",  # convert loop to 'all'
     "SIM118",  # use 'key in dict'
     "SIM2",    # simplify boolean comparisons
+]
+ignore = [
+    "PT011" # use specific error in 'pytest.raises'
 ]
 
 target-version = "py38"


### PR DESCRIPTION
addresses 'flake8-pytest-style' lints.

- reduce scope of `pytest.raises`
- separate 'stacked' assertions
- consistent usage of types in `pytest.parametrize`
- remove 'assert False'