### PR TITLE
Fix all_node_cuts output for complete graphs

### DIFF
--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -92,10 +92,11 @@ def all_node_cuts(G, k=None, flow_func=None):
 
     # Address some corner cases first.
     # For complete Graphs
+
     if nx.density(G) == 1:
-        for cut_set in combinations(G, len(G) - 1):
-            yield set(cut_set)
+        yield from ()
         return
+
     # Initialize data structures.
     # Keep track of the cuts already computed so we do not repeat them.
     seen = []

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -130,7 +130,7 @@ def all_node_cuts(G, k=None, flow_func=None):
     for x in X:
         # step 3: Compute local connectivity flow of x with all other
         # non adjacent nodes in G
-        non_adjacent = set(G) - X - set(G[x])
+        non_adjacent = set(G) - {x} - set(G[x])
         for v in non_adjacent:
             # step 4: compute maximum flow in an Even-Tarjan reduction H of G
             # and step 5: build the associated residual network R

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -259,4 +259,5 @@ def test_cycle_graph():
 
 def test_complete_graph():
     G = nx.complete_graph(5)
+    assert nx.node_connectivity(G) == 4
     assert list(nx.all_node_cuts(G)) == []

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -259,8 +259,4 @@ def test_cycle_graph():
 
 def test_complete_graph():
     G = nx.complete_graph(5)
-    solution = [{0, 1, 2, 3}, {0, 1, 2, 4}, {0, 1, 3, 4}, {0, 2, 3, 4}, {1, 2, 3, 4}]
-    cuts = list(nx.all_node_cuts(G))
-    assert len(solution) == len(cuts)
-    for cut in cuts:
-        assert cut in solution
+    assert list(nx.all_node_cuts(G)) == []

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -261,3 +261,13 @@ def test_complete_graph():
     G = nx.complete_graph(5)
     assert nx.node_connectivity(G) == 4
     assert list(nx.all_node_cuts(G)) == []
+
+
+def test_all_node_cuts_simple_case():
+    G = nx.complete_graph(5)
+    G.remove_edges_from([(0, 1), (3, 4)])
+    expected = [{0, 1, 2}, {2, 3, 4}]
+    actual = list(nx.all_node_cuts(G))
+    assert len(actual) == len(expected)
+    for cut in actual:
+        assert cut in expected


### PR DESCRIPTION
Closes #6533 

I modified the special condition for complete graphs in `all_node_cuts` to return an empty generator and also changed the test cases accordingly.