### PR TITLE
Fix output of is_chordal for empty graphs

### DIFF
--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -73,6 +73,8 @@ def is_chordal(G):
     search. It returns False when it finds that the separator for any node
     is not a clique.  Based on the algorithms in [1]_.
 
+    Self loops are ignored.
+
     References
     ----------
     .. [1] R. E. Tarjan and M. Yannakakis, Simple linear-time algorithms
@@ -131,6 +133,8 @@ def find_induced_nodes(G, s, t, treewidth_bound=sys.maxsize):
 
     The algorithm is inspired by Algorithm 4 in [1]_.
     A formal definition of induced node can also be found on that reference.
+
+    Self Loops are ignored
 
     References
     ----------
@@ -328,9 +332,9 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
 
     If it does find one, it returns (u,v,w) where u,v,w are the three
     nodes that together with s are involved in the cycle.
+
+    It ignores any self loops.
     """
-    if nx.number_of_selfloops(G) > 0:
-        raise nx.NetworkXError("Input graph is not chordal.")
     unnumbered = set(G)
     if s is None:
         s = arbitrary_element(G)

--- a/networkx/algorithms/tests/test_chordal.py
+++ b/networkx/algorithms/tests/test_chordal.py
@@ -64,8 +64,7 @@ class TestMCS:
         assert nx.is_chordal(nx.complete_graph(3))
         assert nx.is_chordal(nx.cycle_graph(3))
         assert not nx.is_chordal(nx.cycle_graph(5))
-        # with pytest.raises(nx.NetworkXError, match="Input graph is not chordal"):
-        #     nx.is_chordal(self.self_loop_G)
+        assert nx.is_chordal(self.self_loop_G)
 
     def test_induced_nodes(self):
         G = nx.generators.classic.path_graph(10)


### PR DESCRIPTION
Closes #6562 

For graphs with number of nodes <= 3, is_chordal should return True. I have added a special condition to the code for the same.

Also added a test case that checks if True is returned when an empty graph is passed.


Though, I am confused about a particular test case - 

```python
self_loop_G = nx.Graph()
self_loop_G.add_edges_from([(1, 1)])
cls.self_loop_G = self_loop_G

with pytest.raises(nx.NetworkXError, match="Input graph is not chordal"):
       nx.is_chordal(self.self_loop_G)
```
Since the graph has only 2 nodes, shouldn't it return True?