### PR TITLE
Deprecate shortest_path functions to have consistent return values in v3.3

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -73,3 +73,5 @@ Version 3.3
 ~~~~~~~~~~~
 * Remove the ``forest_str`` function from ``readwrite/text.py``. Replace
   existing usages with ``write_network_text``.
+* Change ``single_target_shortest_path_length`` in ``algorithms/shortest_path/unweighted.py``
+  to return a dict. See #6527

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -75,3 +75,5 @@ Version 3.3
   existing usages with ``write_network_text``.
 * Change ``single_target_shortest_path_length`` in ``algorithms/shortest_path/unweighted.py``
   to return a dict. See #6527
+* Change ``shortest_path`` in ``algorithms/shortest_path/generic.py``
+  to return a iterator. See #6527

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -31,6 +31,8 @@ API Changes
 Deprecations
 ------------
 
+[`#6564 <https://github.com/networkx/networkx/pull/6564>`_]
+Deprecate ``single_target_shortest_path_length`` to change return value to a dict in v3.3.
 
 Merged PRs
 ----------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -33,6 +33,7 @@ Deprecations
 
 [`#6564 <https://github.com/networkx/networkx/pull/6564>`_]
 Deprecate ``single_target_shortest_path_length`` to change return value to a dict in v3.3.
+Deprecate ``shortest_path`` in case of all_pairs to change return value to a iterator in v3.3.
 
 Merged PRs
 ----------

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -4,6 +4,7 @@ Compute the shortest paths and path lengths between nodes in the graph.
 These algorithms work with undirected and directed graphs.
 
 """
+import warnings
 
 import networkx as nx
 
@@ -132,6 +133,9 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     method = "unweighted" if weight is None else method
     if source is None:
         if target is None:
+            msg = "shortest_path for all_pairs will return an iterator in v3.3"
+            warnings.warn(msg, DeprecationWarning)
+
             # Find paths between all pairs.
             if method == "unweighted":
                 paths = dict(nx.all_pairs_shortest_path(G))

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -1,6 +1,8 @@
 """
 Shortest path algorithms for unweighted graphs.
 """
+import warnings
+
 import networkx as nx
 
 __all__ = [
@@ -133,11 +135,16 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     if target not in G:
         raise nx.NodeNotFound(f"Target {target} is not in G")
 
+    msg = "single_target_shortest_path_length will return a dict starting in v3.3"
+    warnings.warn(msg, DeprecationWarning)
+
     if cutoff is None:
         cutoff = float("inf")
     # handle either directed or undirected
     adj = G._pred if G.is_directed() else G._adj
     nextlevel = [target]
+    # for version 3.3 we will return a dict like this:
+    # return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
     return _single_shortest_path_length(adj, nextlevel, cutoff)
 
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -68,6 +68,11 @@ def set_warnings():
         category=DeprecationWarning,
         message="\n\nThe `attrs` keyword argument of node_link",
     )
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="single_target_shortest_path_length will",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -73,6 +73,11 @@ def set_warnings():
         category=DeprecationWarning,
         message="single_target_shortest_path_length will",
     )
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="shortest_path for all_pairs",
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
See #6527 for a discussion of the changes needed for making the return values consistent. 
This deprecates the function to be changed.
`single_target_shortest_path_length`
and
`shortest_path`  in the case that `source is None and target is None`