### PR TITLE
Added Docstring Example for Bidirectional Shortest Path

### DIFF
--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -216,6 +216,13 @@ def bidirectional_shortest_path(G, source, target):
     NetworkXNoPath
        If no path exists between source and target.
 
+    Examples
+    --------
+    >>> G = nx.Graph()
+    >>> G.add_edges_from([(0, 1), (0, 8), (1, 2), (1, 5), (2, 3), (2, 4), (5, 6), (5, 7), (8, 9), (8, 12), (9, 10), (9, 11), (12, 13), (12, 14)])
+    >>> nx.bidirectional_shortest_path(G, 3, 13)
+    [3, 2, 1, 0, 8, 9, 10]
+
     See Also
     --------
     shortest_path


### PR DESCRIPTION
I have added example to the docstring of Bidirectional Shortest Path in unweighted.py. This is part of issue #6553 . I have used an example that uses the simplest possible input graph yet illustrates the demonstrated functionality well. I have referred GFG for this.
The graph used for this example looks like this :-
![bidirectional](https://user-images.githubusercontent.com/74042272/228349818-63e2ae7a-f416-47ea-a296-1289326adae3.png)
