### PR TITLE
Changed return types of shortest path methods to improve consistency

### DIFF
--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -103,9 +103,9 @@ def global_reaching_centrality(G, weight=None, normalized=True):
         def as_distance(u, v, d):
             return total_weight / d.get(weight, 1)
 
-        shortest_paths = nx.shortest_path(G, weight=as_distance)
+        shortest_paths = dict(nx.shortest_path(G, weight=as_distance))
     else:
-        shortest_paths = nx.shortest_path(G)
+        shortest_paths = dict(nx.shortest_path(G))
 
     centrality = local_reaching_centrality
     # TODO This can be trivially parallelized.

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -103,15 +103,15 @@ def global_reaching_centrality(G, weight=None, normalized=True):
         def as_distance(u, v, d):
             return total_weight / d.get(weight, 1)
 
-        shortest_paths = dict(nx.shortest_path(G, weight=as_distance))
+        shortest_paths = nx.shortest_path(G, weight=as_distance)
     else:
-        shortest_paths = dict(nx.shortest_path(G))
+        shortest_paths = nx.shortest_path(G)
 
     centrality = local_reaching_centrality
     # TODO This can be trivially parallelized.
     lrc = [
         centrality(G, node, paths=paths, weight=weight, normalized=normalized)
-        for node, paths in shortest_paths.items()
+        for node, paths in shortest_paths
     ]
 
     max_lrc = max(lrc)

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -109,7 +109,7 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     >>> p = nx.shortest_path(G, target=4)  # source not specified
     >>> p[1] # shortest path from source=1 to target=4
     [1, 2, 3, 4]
-    >>> p = nx.shortest_path(G)  # source, target not specified
+    >>> p = dict(nx.shortest_path(G))  # source, target not specified
     >>> p[2][4] # shortest path from source=2 to target=4
     [2, 3, 4]
 

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -138,11 +138,11 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
 
             # Find paths between all pairs.
             if method == "unweighted":
-                paths = dict(nx.all_pairs_shortest_path(G))
+                paths = nx.all_pairs_shortest_path(G)
             elif method == "dijkstra":
-                paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
+                paths = nx.all_pairs_dijkstra_path(G, weight=weight)
             else:  # method == 'bellman-ford':
-                paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
+                paths = nx.all_pairs_bellman_ford_path(G, weight=weight)
         else:
             # Find paths from all nodes co-accessible to the target.
             if G.is_directed():

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -173,22 +173,22 @@ class TestGenericPath:
         assert ans == dict(nx.single_source_bellman_ford_path_length(self.cycle, 0))
 
     def test_all_pairs_shortest_path(self):
-        p = nx.shortest_path(self.cycle)
+        p = dict(nx.shortest_path(self.cycle))
         assert p[0][3] == [0, 1, 2, 3]
         assert p == dict(nx.all_pairs_shortest_path(self.cycle))
-        p = nx.shortest_path(self.grid)
+        p = dict(nx.shortest_path(self.grid))
         validate_grid_path(4, 4, 1, 12, p[1][12])
         # now with weights
-        p = nx.shortest_path(self.cycle, weight="weight")
+        p = dict(nx.shortest_path(self.cycle, weight="weight"))
         assert p[0][3] == [0, 1, 2, 3]
         assert p == dict(nx.all_pairs_dijkstra_path(self.cycle))
-        p = nx.shortest_path(self.grid, weight="weight")
+        p = dict(nx.shortest_path(self.grid, weight="weight"))
         validate_grid_path(4, 4, 1, 12, p[1][12])
         # weights and method specified
-        p = nx.shortest_path(self.cycle, weight="weight", method="dijkstra")
+        p = dict(nx.shortest_path(self.cycle, weight="weight", method="dijkstra"))
         assert p[0][3] == [0, 1, 2, 3]
         assert p == dict(nx.all_pairs_dijkstra_path(self.cycle))
-        p = nx.shortest_path(self.cycle, weight="weight", method="bellman-ford")
+        p = dict(nx.shortest_path(self.cycle, weight="weight", method="bellman-ford"))
         assert p[0][3] == [0, 1, 2, 3]
         assert p == dict(nx.all_pairs_bellman_ford_path(self.cycle))
 

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -92,9 +92,9 @@ class TestUnweightedPath:
     def test_single_target_shortest_path_length(self):
         pl = nx.single_target_shortest_path_length
         lengths = {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert dict(pl(self.cycle, 0)) == lengths
+        assert pl(self.cycle, 0) == lengths
         lengths = {0: 0, 1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
-        assert dict(pl(self.directed_cycle, 0)) == lengths
+        assert pl(self.directed_cycle, 0) == lengths
         # test missing targets
         target = 8
         with pytest.raises(nx.NodeNotFound, match=f"Target {target} is not in G"):

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -117,7 +117,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     Examples
     --------
     >>> G = nx.path_graph(5, create_using=nx.DiGraph())
-    >>> length = dict(nx.single_target_shortest_path_length(G, 4))
+    >>> length = nx.single_target_shortest_path_length(G, 4)
     >>> length[0]
     4
     >>> for node in range(5):

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -145,7 +145,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     nextlevel = [target]
     # for version 3.3 we will return a dict like this:
     # return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
-    return _single_shortest_path_length(adj, nextlevel, cutoff)
+    return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
 
 
 @nx._dispatch


### PR DESCRIPTION
Fixes: #6527 
Deprecation warnings for this added in #6567   This should be merged in v3.3

Changed the output of `single_target_shortest_path_length` to dictionary, and of `shortest_path` to iterator. The test cases have also been modified accordingly.

This makes the shortest path methods more consistent.