### PR TITLE
Better default alpha value for viz attributes in gexf writer

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -569,7 +569,7 @@ class GEXFWriter(GEXF):
                         r=str(color.get("r")),
                         g=str(color.get("g")),
                         b=str(color.get("b")),
-                        a=str(color.get("a")),
+                        a=str(color.get("a", 1.0)),
                     )
                 element.append(e)
 

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -491,6 +491,16 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
             sorted(e) for e in H.edges()
         )
 
+        # Test missing alpha value for version >draft1.1 - set default alpha value
+        # to 1.0 instead of `None` when writing for better general compatibility
+        fh = io.BytesIO()
+        # G.nodes[0]["viz"]["color"] does not have an alpha value explicitly defined
+        # so the default is used instead
+        nx.write_gexf(G, fh, version="1.2draft")
+        fh.seek(0)
+        H = nx.read_gexf(fh, node_type=int)
+        assert H.nodes[0]["viz"]["color"]["a"] == 1.0
+
         # Second graph for the other branch
         G = nx.Graph()
         G.add_node(0, label="1", color="green")


### PR DESCRIPTION
Closes #6443 with @dschult 's fix. The added test should make clear the motivation for this change - this test fails on `main` due to `'None'` being given as the default.