### PR TITLE
Add examples to bipartite centrality.py

### DIFF
--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -25,7 +25,8 @@ def degree_centrality(G, nodes):
     Examples
     --------
     >>> G = nx.wheel_graph(5)
-    >>> nx.bipartite.degree_centrality(G, [0, 1, 2])
+    >>> top_nodes = {0, 1, 2}
+    >>> nx.bipartite.degree_centrality(G, nodes=top_nodes)
     {0: 2.0, 1: 1.5, 2: 1.5, 3: 1.0, 4: 1.0}
 
     See Also
@@ -129,7 +130,8 @@ def betweenness_centrality(G, nodes):
     Examples
     --------
     >>> G = nx.cycle_graph(4)
-    >>> nx.bipartite.betweenness_centrality(G, [1, 2])
+    >>> top_nodes = {1, 2}
+    >>> nx.bipartite.betweenness_centrality(G, nodes=top_nodes)
     {0: 0.25, 1: 0.25, 2: 0.25, 3: 0.25}
 
     See Also
@@ -205,7 +207,8 @@ def closeness_centrality(G, nodes, normalized=True):
     Examples
     --------
     >>> G = nx.wheel_graph(5)
-    >>> nx.bipartite.closeness_centrality(G, [0, 1, 2])
+    >>> top_nodes = {0, 1, 2}
+    >>> nx.bipartite.closeness_centrality(G, nodes=top_nodes)
     {0: 1.5, 1: 1.2, 2: 1.2, 3: 1.0, 4: 1.0}
 
     See Also


### PR DESCRIPTION
I added examples in the docstring for the degree_centrality, betweenness_centrality and closeness_centrality methods in  centrality.py