### PR TITLE
Fix links in laplacian_centrality and laplacian_matrix

### DIFF
--- a/networkx/algorithms/centrality/laplacian.py
+++ b/networkx/algorithms/centrality/laplacian.py
@@ -89,8 +89,8 @@ def laplacian_centrality(
 
     See Also
     --------
-    directed_laplacian_matrix
-    laplacian_matrix
+    :func:`~networkx.linalg.laplacianmatrix.directed_laplacian_matrix`
+    :func:`~networkx.linalg.laplacianmatrix.laplacian_matrix`
     """
     import numpy as np
     import scipy as sp

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -43,9 +43,9 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
 
     See Also
     --------
-    to_numpy_array
+    :func:`~networkx.convert_matrix.to_numpy_array`
     normalized_laplacian_matrix
-    laplacian_spectrum
+    :func:`~networkx.linalg.spectrum.laplacian_spectrum`
 
     Examples
     --------


### PR DESCRIPTION
Fixed the links in the `See Also` section for [laplacian_centrality](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.laplacian_centrality.html) and [laplacian_matrix](https://networkx.org/documentation/stable/reference/generated/networkx.linalg.laplacianmatrix.laplacian_matrix.html) that were not working