### PR TITLE
Katz index

### DIFF
--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -4,6 +4,7 @@ Link prediction algorithms.
 
 
 from math import log
+from scipy import sparse
 
 import networkx as nx
 from networkx.utils import not_implemented_for
@@ -17,6 +18,7 @@ __all__ = [
     "ra_index_soundarajan_hopcroft",
     "within_inter_cluster",
     "common_neighbor_centrality",
+    "katz_index"
 ]
 
 
@@ -584,6 +586,20 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community="community"):
         within = {w for w in cnbors if _community(G, w, community) == Cu}
         inter = cnbors - within
         return len(within) / (len(inter) + delta)
+
+    return _apply_prediction(G, predict, ebunch)
+
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
+def katz_index(G, ebunch=None, beta=.1):
+    def predict(u, v):
+        if not nx.has_path(G, u, v):
+            return 0
+        A = nx.adjacency_matrix(G)
+        AB = A.multiply(beta)
+        I = sparse.identity(AB.shape[0])
+        result = sparse.linalg.spsolve(I - AB, I) - I
+        return result[u, v]
 
     return _apply_prediction(G, predict, ebunch)
 

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -7,6 +7,7 @@ from math import log
 from scipy import sparse
 
 import networkx as nx
+import scipy as sp
 from networkx.utils import not_implemented_for
 
 __all__ = [
@@ -18,7 +19,7 @@ __all__ = [
     "ra_index_soundarajan_hopcroft",
     "within_inter_cluster",
     "common_neighbor_centrality",
-    "katz_index"
+    "katz_index",
 ]
 
 
@@ -589,9 +590,10 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community="community"):
 
     return _apply_prediction(G, predict, ebunch)
 
+
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-def katz_index(G, ebunch=None, beta=.1):
+def katz_index(G, ebunch=None, beta=0.1):
     r"""Compute the Katz index of all node pairs in ebunch.
 
     Katz index of nodes `u` and `v` is defined as
@@ -640,8 +642,8 @@ def katz_index(G, ebunch=None, beta=.1):
         ebunch = nx.non_edges(G)
     A = nx.adjacency_matrix(G)
     AB = A.multiply(beta)
-    I = sparse.identity(AB.shape[0])
-    indices = sparse.linalg.spsolve(I - AB, I) - I
+    I = sp.sparse.identity(AB.shape[0])
+    indices = sp.sparse.linalg.spsolve(I - AB, I) - I
     return ((u, v, indices[u, v]) for u, v in ebunch)
 
 

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -586,7 +586,7 @@ class TestWithinInterCluster:
 class Test_Katz_Index:
     @classmethod
     def setup_class(cls):
-        cls.beta = .1
+        cls.beta = 0.1
         cls.func = staticmethod(nx.katz_index)
         cls.test = partial(_test_func, predict_func=cls.func)
 
@@ -602,10 +602,14 @@ class Test_Katz_Index:
 
     def test_P4(self):
         G = nx.path_graph(4)
-        A = np.array([np.array([0, 1., 0, 0]), 
-                      np.array([1., 0, 1., 0]),
-                      np.array([0, 1., 0, 1.]), 
-                      np.array([0, 0, 1., 0])])
+        A = np.array(
+            [
+                np.array([0, 1.0, 0, 0]),
+                np.array([1.0, 0, 1.0, 0]),
+                np.array([0, 1.0, 0, 1.0]),
+                np.array([0, 0, 1.0, 0]),
+            ]
+        )
         A *= self.beta
         I = np.identity(4)
         res = np.linalg.inv(I - A) - I
@@ -640,10 +644,14 @@ class Test_Katz_Index:
 
     def test_all_nonexistent_edges(self):
         G = nx.Graph()
-        A = np.array([np.array([0, 1., 1., 0]), 
-                      np.array([1., 0, 0, 0]),
-                      np.array([1., 0, 0, 1.]), 
-                      np.array([0, 0, 1., 0])])
+        A = np.array(
+            [
+                np.array([0, 1.0, 1.0, 0]),
+                np.array([1.0, 0, 0, 0]),
+                np.array([1.0, 0, 0, 1.0]),
+                np.array([0, 0, 1.0, 0]),
+            ]
+        )
         A *= self.beta
         I = np.identity(4)
         exp = np.linalg.inv(I - A) - I

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 from functools import partial
 
 import pytest
@@ -580,3 +581,71 @@ class TestWithinInterCluster:
         G.nodes[2]["community"] = 0
         G.nodes[3]["community"] = 0
         self.test(G, None, [(0, 3, 1 / self.delta), (1, 2, 0), (1, 3, 0)])
+
+
+class Test_Katz_Index:
+    @classmethod
+    def setup_class(cls):
+        cls.beta = .1
+        cls.func = staticmethod(nx.katz_index)
+        cls.test = partial(_test_func, predict_func=cls.func)
+
+    def test_K5(self):
+        G = nx.complete_graph(5)
+        A = np.ones((5, 5))
+        I = np.identity(5)
+        # No self loops
+        A -= I
+        A *= self.beta
+        res = np.linalg.inv(I - A) - I
+        self.test(G, [(0, 1)], [(0, 1, res[0][1])])
+
+    def test_P4(self):
+        G = nx.path_graph(4)
+        A = np.array([np.array([0, 1., 0, 0]), 
+                      np.array([1., 0, 1., 0]),
+                      np.array([0, 1., 0, 1.]), 
+                      np.array([0, 0, 1., 0])])
+        A *= self.beta
+        I = np.identity(4)
+        res = np.linalg.inv(I - A) - I
+        self.test(G, [(0, 2)], [(0, 2, res[0, 2])])
+
+    def test_notimplemented(self):
+        assert pytest.raises(
+            nx.NetworkXNotImplemented, self.func, nx.DiGraph([(0, 1), (1, 2)]), [(0, 2)]
+        )
+        assert pytest.raises(
+            nx.NetworkXNotImplemented,
+            self.func,
+            nx.MultiGraph([(0, 1), (1, 2)]),
+            [(0, 2)],
+        )
+        assert pytest.raises(
+            nx.NetworkXNotImplemented,
+            self.func,
+            nx.MultiDiGraph([(0, 1), (1, 2)]),
+            [(0, 2)],
+        )
+
+    def test_no_common_neighbor(self):
+        G = nx.Graph()
+        G.add_edges_from([(0, 1), (2, 3)])
+        self.test(G, [(0, 2)], [(0, 2, 0)])
+
+    def test_isolated_nodes(self):
+        G = nx.Graph()
+        G.add_nodes_from([0, 1])
+        self.test(G, [(0, 1)], [(0, 1, 0)])
+
+    def test_all_nonexistent_edges(self):
+        G = nx.Graph()
+        A = np.array([np.array([0, 1., 1., 0]), 
+                      np.array([1., 0, 0, 0]),
+                      np.array([1., 0, 0, 1.]), 
+                      np.array([0, 0, 1., 0])])
+        A *= self.beta
+        I = np.identity(4)
+        res = np.linalg.inv(I - A) - I
+        G.add_edges_from([(0, 1), (0, 2), (2, 3)])
+        self.test(G, None, [(0, 3, res[0, 3]), (1, 2, res[1, 2]), (1, 3, res[1, 3])])

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -646,6 +646,6 @@ class Test_Katz_Index:
                       np.array([0, 0, 1., 0])])
         A *= self.beta
         I = np.identity(4)
-        res = np.linalg.inv(I - A) - I
+        exp = np.linalg.inv(I - A) - I
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        self.test(G, None, [(0, 3, res[0, 3]), (1, 2, res[1, 2]), (1, 3, res[1, 3])])
+        self.test(G, None, [(0, 3, exp[0, 3]), (1, 2, exp[1, 2]), (1, 3, exp[1, 3])])


### PR DESCRIPTION
This PR is a spiritual successor to #1163 which itself builds on #1117. I am looking to use the Katz Index in some upcoming projects and noticed that there is not an implementation for NetworkX. This is my first non-testing PR so I definitely need some feedback on documentation. Furthermore, I am not intimately familiar with using the index and do not know what a reasonable default value for beta would be. I opted to use a similar generator pattern to the existing functions, while not calling the _apply_prediction function so that the computation only has to be done one. LMK what I should fix. 