### PR TITLE
Bump pyupgrade minimum Python version to 3.9.

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -14,7 +14,7 @@ select = [
     "SIM2",    # simplify boolean comparisons
 ]
 
-target-version = "py38"
+target-version = "py39"
 
 [per-file-ignores]
 "__init__.py" = ["I"]


### PR DESCRIPTION
I was curious to see if there were any language features that pyupgrade would automagically update for us now that Python 3.9 is the minimum supported version. How I tested: both `ruff .` and `pre-commit run --all-files` with this updated config.