### PR TITLE
Replacing codecov Python CLI with gh action.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,4 +39,6 @@ jobs:
       - name: Test NetworkX
         run: |
           pytest --cov=networkx --runslow --doctest-modules --durations=20 --pyargs networkx
-          codecov
+
+      - name: Updload to codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,5 +40,5 @@ jobs:
         run: |
           pytest --cov=networkx --runslow --doctest-modules --durations=20 --pyargs networkx
 
-      - name: Updload to codecov
+      - name: Upload to codecov
         uses: codecov/codecov-action@v3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,2 @@
 pytest>=7.2
 pytest-cov>=4.0
-codecov>=2.1


### PR DESCRIPTION
The `codecov` CLI has been yanked from PyPI, so we need to update how we upload the coverage results to codecov.io.

See: https://github.com/networkx/networkx/pull/6634#issuecomment-1507376906