### PR TITLE
Fix links in eigenvector.py and katz_centrality.py 

### DIFF
--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -72,8 +72,8 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None, weight=None
     See Also
     --------
     eigenvector_centrality_numpy
-    pagerank
-    hits
+    :func:`~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+    :func:`~networkx.algorithms.link_analysis.hits_alg.hits`
 
     Notes
     -----
@@ -184,8 +184,8 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     See Also
     --------
     eigenvector_centrality
-    pagerank
-    hits
+    :func:`~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+    :func:`~networkx.algorithms.link_analysis.hits_alg.hits`
 
     Notes
     -----

--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -112,8 +112,8 @@ def katz_centrality(
     katz_centrality_numpy
     eigenvector_centrality
     eigenvector_centrality_numpy
-    pagerank
-    hits
+    :func:`~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+    :func:`~networkx.algorithms.link_analysis.hits_alg.hits`
 
     Notes
     -----
@@ -275,8 +275,8 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
     katz_centrality
     eigenvector_centrality_numpy
     eigenvector_centrality
-    pagerank
-    hits
+    :func:`~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+    :func:`~networkx.algorithms.link_analysis.hits_alg.hits`
 
     Notes
     -----


### PR DESCRIPTION
Fixed the <b>pagerank, hits</b> links in the <b><i> See Also</i></b> section that weren't working for these:- 
1. [eigenvector_centrality](https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.centrality.eigenvector_centrality.html#networkx.algorithms.centrality.eigenvector_centrality) 
2. [eigenvector_centrality_numpy](https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.centrality.eigenvector_centrality_numpy.html)
3. [katz_centrality](https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.centrality.katz_centrality.html#networkx.algorithms.centrality.katz_centrality)
4.  [katz_centrality_numpy](https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.centrality.katz_centrality_numpy.html)
