### PR TITLE
Katz centrality scipy

### DIFF
--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -333,22 +333,131 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
     centrality = dict(zip(nodelist, map(float, centrality / norm)))
     return centrality
 
+
 @nx._dispatch
 @not_implemented_for("multigraph")
 def katz_centrality_scipy(G, alpha=0.1, beta=1.0, normalized=True, weight=None):
-    import scipy as sp
+    r"""Compute the Katz centrality for the graph G.
+
+    Katz centrality computes the centrality for a node based on the centrality
+    of its neighbors. It is a generalization of the eigenvector centrality. The
+    Katz centrality for node $i$ is
+
+    .. math::
+
+        x_i = \alpha \sum_{j} A_{ij} x_j + \beta,
+
+    where $A$ is the adjacency matrix of graph G with eigenvalues $\lambda$.
+
+    The parameter $\beta$ controls the initial centrality and
+
+    .. math::
+
+        \alpha < \frac{1}{\lambda_{\max}}.
+
+    Katz centrality computes the relative influence of a node within a
+    network by measuring the number of the immediate neighbors (first
+    degree nodes) and also all other nodes in the network that connect
+    to the node under consideration through these immediate neighbors.
+
+    Extra weight can be provided to immediate neighbors through the
+    parameter $\beta$.  Connections made with distant neighbors
+    are, however, penalized by an attenuation factor $\alpha$ which
+    should be strictly less than the inverse largest eigenvalue of the
+    adjacency matrix in order for the Katz centrality to be computed
+    correctly. More information is provided in [1]_.
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX graph
+
+    alpha : float
+      Attenuation factor
+
+    beta : scalar or dictionary, optional (default=1.0)
+      Weight attributed to the immediate neighborhood. If not a scalar the
+      dictionary must have an value for every node.
+
+    normalized : bool
+      If True normalize the resulting values.
+
+    weight : None or string, optional
+      If None, all edge weights are considered equal.
+      Otherwise holds the name of the edge attribute used as weight.
+      In this measure the weight is interpreted as the connection strength.
+
+    Returns
+    -------
+    nodes : dictionary
+       Dictionary of nodes with Katz centrality as the value.
+
+    Raises
+    ------
+    NetworkXError
+       If the parameter `beta` is not a scalar but lacks a value for at least
+       one node
+
+    Examples
+    --------
+    >>> import math
+    >>> G = nx.path_graph(4)
+    >>> phi = (1 + math.sqrt(5)) / 2.0  # largest eigenvalue of adj matrix
+    >>> centrality = nx.katz_centrality_scipy(G, 1 / phi)
+    >>> for n, c in sorted(centrality.items()):
+    ...     print(f"{n} {c:.2f}")
+    0 0.37
+    1 0.60
+    2 0.60
+    3 0.37
+
+    See Also
+    --------
+    katz_centrality
+    katz_centrality_numpy
+    eigenvector_centrality_numpy
+    eigenvector_centrality
+    pagerank
+    hits
+
+    Notes
+    -----
+    Katz centrality was introduced by [2]_.
+
+    This algorithm uses a direct linear solver to solve the above equation.
+    The parameter ``alpha`` should be strictly less than the inverse of largest
+    eigenvalue of the adjacency matrix for there to be a solution.
+    You can use ``max(nx.adjacency_spectrum(G))`` to get $\lambda_{\max}$ the largest
+    eigenvalue of the adjacency matrix.
+
+    When $\alpha = 1/\lambda_{\max}$ and $\beta=0$, Katz centrality is the same
+    as eigenvector centrality.
+
+    For directed graphs this finds "left" eigenvectors which corresponds
+    to the in-edges in the graph. For out-edges Katz centrality
+    first reverse the graph with ``G.reverse()``.
+
+    References
+    ----------
+    .. [1] Mark E. J. Newman:
+       Networks: An Introduction.
+       Oxford University Press, USA, 2010, p. 173.
+    .. [2] Leo Katz:
+       A New Status Index Derived from Sociometric Index.
+       Psychometrika 18(1):39–43, 1953
+       https://link.springer.com/content/pdf/10.1007/BF02289026.pdf
+    """
     import numpy as np
+    import scipy as sp
     from scipy import sparse
 
     if len(G) == 0:
-        return dict()
-    
+        return {}
+
     try:
         nodelist = beta.keys()
         if set(nodelist) != set(G):
-            raise nx.NetworkXError(
-                "beta dictionary must have a value for every node"
-            )
+            raise nx.NetworkXError("beta dictionary must have a value for every node")
         b = np.array(list(beta.values()), dtype=float)
     except AttributeError:
         nodelist = list(G)

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -345,6 +345,10 @@ class TestKatzEigenvectorVKatz:
             assert e[n] == pytest.approx(k[n], abs=1e-7)
 
 class TestKatzCentralityScipy:
+    @classmethod
+    def setup_class(cls):
+        np = pytest.importorskip("numpy")
+        sp = pytest.importorskip("scipy")
     def test_K5(self):
         """Katz centrality: K5"""
         G = nx.complete_graph(5)
@@ -442,13 +446,13 @@ class TestKatzCentralityScipy:
     def test_bad_beta_number(self):
         with pytest.raises(nx.NetworkXException):
             G = nx.Graph([(0, 1)])
-            nx.katz_centrality_numpy(G, 0.1, beta="foo")
+            nx.katz_centrality_scipy(G, 0.1, beta="foo")
 
     def test_K5_unweighted(self):
         """Katz centrality: K5"""
         G = nx.complete_graph(5)
         alpha = 0.1
-        b = nx.katz_centrality(G, alpha, weight=None)
+        b = nx.katz_centrality_scipy(G, alpha, weight=None)
         v = math.sqrt(1 / 5.0)
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
@@ -462,7 +466,7 @@ class TestKatzCentralityScipy:
         alpha = 0.1
         G = nx.path_graph(3)
         b_answer = {0: 0.5598852584152165, 1: 0.6107839182711449, 2: 0.5598852584152162}
-        b = nx.katz_centrality_numpy(G, alpha, weight=None)
+        b = nx.katz_centrality_scipy(G, alpha, weight=None)
         for n in sorted(G):
             assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
 

--- a/networkx/algorithms/centrality/tests/test_katz_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_katz_centrality.py
@@ -122,7 +122,7 @@ class TestKatzCentralityNumpy:
         """Katz centrality: K5"""
         G = nx.complete_graph(5)
         alpha = 0.1
-        b = nx.katz_centrality(G, alpha)
+        b = nx.katz_centrality_numpy(G, alpha)
         v = math.sqrt(1 / 5.0)
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
@@ -200,10 +200,10 @@ class TestKatzCentralityNumpy:
 
     def test_multigraph(self):
         with pytest.raises(nx.NetworkXException):
-            nx.katz_centrality(nx.MultiGraph(), 0.1)
+            nx.katz_centrality_numpy(nx.MultiGraph(), 0.1)
 
     def test_empty(self):
-        e = nx.katz_centrality(nx.Graph(), 0.1)
+        e = nx.katz_centrality_numpy(nx.Graph(), 0.1)
         assert e == {}
 
     def test_bad_beta(self):
@@ -221,7 +221,7 @@ class TestKatzCentralityNumpy:
         """Katz centrality: K5"""
         G = nx.complete_graph(5)
         alpha = 0.1
-        b = nx.katz_centrality(G, alpha, weight=None)
+        b = nx.katz_centrality_numpy(G, alpha, weight=None)
         v = math.sqrt(1 / 5.0)
         b_answer = dict.fromkeys(G, v)
         for n in sorted(G):
@@ -343,3 +343,126 @@ class TestKatzEigenvectorVKatz:
         k = nx.katz_centrality_numpy(G, 1.0 / l)
         for n in G:
             assert e[n] == pytest.approx(k[n], abs=1e-7)
+
+class TestKatzCentralityScipy:
+    def test_K5(self):
+        """Katz centrality: K5"""
+        G = nx.complete_graph(5)
+        alpha = 0.1
+        b = nx.katz_centrality_scipy(G, alpha)
+        v = math.sqrt(1 / 5.0)
+        b_answer = dict.fromkeys(G, v)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
+        b = nx.eigenvector_centrality_numpy(G)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-3)
+
+    def test_P3(self):
+        """Katz centrality: P3"""
+        alpha = 0.1
+        G = nx.path_graph(3)
+        b_answer = {0: 0.5598852584152165, 1: 0.6107839182711449, 2: 0.5598852584152162}
+        b = nx.katz_centrality_scipy(G, alpha)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_beta_as_scalar(self):
+        alpha = 0.1
+        beta = 0.1
+        b_answer = {0: 0.5598852584152165, 1: 0.6107839182711449, 2: 0.5598852584152162}
+        G = nx.path_graph(3)
+        b = nx.katz_centrality_scipy(G, alpha, beta)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_beta_as_dict(self):
+        alpha = 0.1
+        beta = {0: 1.0, 1: 1.0, 2: 1.0}
+        b_answer = {0: 0.5598852584152165, 1: 0.6107839182711449, 2: 0.5598852584152162}
+        G = nx.path_graph(3)
+        b = nx.katz_centrality_scipy(G, alpha, beta)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_multiple_alpha(self):
+        alpha_list = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+        for alpha in alpha_list:
+            b_answer = {
+                0.1: {
+                    0: 0.5598852584152165,
+                    1: 0.6107839182711449,
+                    2: 0.5598852584152162,
+                },
+                0.2: {
+                    0: 0.5454545454545454,
+                    1: 0.6363636363636365,
+                    2: 0.5454545454545454,
+                },
+                0.3: {
+                    0: 0.5333964609104419,
+                    1: 0.6564879518897746,
+                    2: 0.5333964609104419,
+                },
+                0.4: {
+                    0: 0.5232045649263551,
+                    1: 0.6726915834767423,
+                    2: 0.5232045649263551,
+                },
+                0.5: {
+                    0: 0.5144957746691622,
+                    1: 0.6859943117075809,
+                    2: 0.5144957746691622,
+                },
+                0.6: {
+                    0: 0.5069794004195823,
+                    1: 0.6970966755769258,
+                    2: 0.5069794004195823,
+                },
+            }
+            G = nx.path_graph(3)
+            b = nx.katz_centrality_scipy(G, alpha)
+            for n in sorted(G):
+                assert b[n] == pytest.approx(b_answer[alpha][n], abs=1e-4)
+
+    def test_multigraph(self):
+        with pytest.raises(nx.NetworkXException):
+            nx.katz_centrality_scipy(nx.MultiGraph(), 0.1)
+
+    def test_empty(self):
+        e = nx.katz_centrality_scipy(nx.Graph(), 0.1)
+        assert e == {}
+
+    def test_bad_beta(self):
+        with pytest.raises(nx.NetworkXException):
+            G = nx.Graph([(0, 1)])
+            beta = {0: 77}
+            nx.katz_centrality_scipy(G, 0.1, beta=beta)
+
+    def test_bad_beta_number(self):
+        with pytest.raises(nx.NetworkXException):
+            G = nx.Graph([(0, 1)])
+            nx.katz_centrality_numpy(G, 0.1, beta="foo")
+
+    def test_K5_unweighted(self):
+        """Katz centrality: K5"""
+        G = nx.complete_graph(5)
+        alpha = 0.1
+        b = nx.katz_centrality(G, alpha, weight=None)
+        v = math.sqrt(1 / 5.0)
+        b_answer = dict.fromkeys(G, v)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
+        b = nx.eigenvector_centrality_numpy(G, weight=None)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-3)
+
+    def test_P3_unweighted(self):
+        """Katz centrality: P3"""
+        alpha = 0.1
+        G = nx.path_graph(3)
+        b_answer = {0: 0.5598852584152165, 1: 0.6107839182711449, 2: 0.5598852584152162}
+        b = nx.katz_centrality_numpy(G, alpha, weight=None)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -4,6 +4,7 @@ Link prediction algorithms.
 
 
 from math import log
+from scipy import sparse
 
 import networkx as nx
 from networkx.utils import not_implemented_for
@@ -17,6 +18,7 @@ __all__ = [
     "ra_index_soundarajan_hopcroft",
     "within_inter_cluster",
     "common_neighbor_centrality",
+    "katz_index"
 ]
 
 
@@ -584,6 +586,20 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community="community"):
         within = {w for w in cnbors if _community(G, w, community) == Cu}
         inter = cnbors - within
         return len(within) / (len(inter) + delta)
+
+    return _apply_prediction(G, predict, ebunch)
+
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
+def katz_index(G, ebunch=None, beta=.1):
+    def predict(u, v):
+        if not nx.has_path(G, u, v):
+            return 0
+        A = nx.adjacency_matrix(G)
+        AB = A.multiply(beta)
+        I = sparse.identity(AB.shape[0])
+        result = sparse.linalg.spsolve(I - AB, I) - I
+        return result[u, v]
 
     return _apply_prediction(G, predict, ebunch)
 

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -4,9 +4,6 @@ Link prediction algorithms.
 
 from math import log
 
-import scipy as sp
-from scipy import sparse
-
 import networkx as nx
 from networkx.utils import not_implemented_for
 
@@ -636,8 +633,11 @@ def katz_index(G, ebunch=None, beta=0.1):
     ----------
     .. [1] Linyuan Lu, Tao Zhou
            Link Prediction in Complex Networks: A Survey.
-           https://arxiv.org/pdf/1010.0725v1.pdf
+           https://arxiv.org/pdf/1010.0725v1.pdf  
     """
+    import scipy as sp
+    from scipy import sparse
+    
     if ebunch is None:
         ebunch = nx.non_edges(G)
     A = nx.adjacency_matrix(G)

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -4,13 +4,11 @@ Link prediction algorithms.
 
 from math import log
 
-
 import scipy as sp
 from scipy import sparse
 
 import networkx as nx
 from networkx.utils import not_implemented_for
-
 
 __all__ = [
     "resource_allocation_index",

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -633,11 +633,11 @@ def katz_index(G, ebunch=None, beta=0.1):
     ----------
     .. [1] Linyuan Lu, Tao Zhou
            Link Prediction in Complex Networks: A Survey.
-           https://arxiv.org/pdf/1010.0725v1.pdf  
+           https://arxiv.org/pdf/1010.0725v1.pdf
     """
     import scipy as sp
     from scipy import sparse
-    
+
     if ebunch is None:
         ebunch = nx.non_edges(G)
     A = nx.adjacency_matrix(G)

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -2,13 +2,13 @@
 Link prediction algorithms.
 """
 
-
 from math import log
-from scipy import sparse
 
 import networkx as nx
 import scipy as sp
+
 from networkx.utils import not_implemented_for
+from scipy import sparse
 
 __all__ = [
     "resource_allocation_index",

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -7,6 +7,7 @@ from math import log
 from scipy import sparse
 
 import networkx as nx
+import scipy as sp
 from networkx.utils import not_implemented_for
 
 __all__ = [
@@ -18,7 +19,7 @@ __all__ = [
     "ra_index_soundarajan_hopcroft",
     "within_inter_cluster",
     "common_neighbor_centrality",
-    "katz_index"
+    "katz_index",
 ]
 
 
@@ -589,9 +590,10 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community="community"):
 
     return _apply_prediction(G, predict, ebunch)
 
+
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-def katz_index(G, ebunch=None, beta=.1):
+def katz_index(G, ebunch=None, beta=0.1):
     r"""Compute the Katz index of all node pairs in ebunch.
 
     Katz index of nodes `u` and `v` is defined as
@@ -640,8 +642,8 @@ def katz_index(G, ebunch=None, beta=.1):
         ebunch = nx.non_edges(G)
     A = nx.adjacency_matrix(G)
     AB = A.multiply(beta)
-    I = sparse.identity(AB.shape[0])
-    indices = sparse.linalg.spsolve(I - AB, I) - I
+    I = sp.sparse.identity(AB.shape[0])
+    indices = sp.sparse.linalg.spsolve(I - AB, I) - I
     return ((u, v, indices[u, v]) for u, v in ebunch)
 
 

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -4,11 +4,13 @@ Link prediction algorithms.
 
 from math import log
 
-import networkx as nx
-import scipy as sp
 
-from networkx.utils import not_implemented_for
+import scipy as sp
 from scipy import sparse
+
+import networkx as nx
+from networkx.utils import not_implemented_for
+
 
 __all__ = [
     "resource_allocation_index",

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,5 +1,4 @@
 import math
-
 from functools import partial
 
 import numpy as np

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -586,7 +586,7 @@ class TestWithinInterCluster:
 class Test_Katz_Index:
     @classmethod
     def setup_class(cls):
-        cls.beta = .1
+        cls.beta = 0.1
         cls.func = staticmethod(nx.katz_index)
         cls.test = partial(_test_func, predict_func=cls.func)
 
@@ -602,10 +602,14 @@ class Test_Katz_Index:
 
     def test_P4(self):
         G = nx.path_graph(4)
-        A = np.array([np.array([0, 1., 0, 0]), 
-                      np.array([1., 0, 1., 0]),
-                      np.array([0, 1., 0, 1.]), 
-                      np.array([0, 0, 1., 0])])
+        A = np.array(
+            [
+                np.array([0, 1.0, 0, 0]),
+                np.array([1.0, 0, 1.0, 0]),
+                np.array([0, 1.0, 0, 1.0]),
+                np.array([0, 0, 1.0, 0]),
+            ]
+        )
         A *= self.beta
         I = np.identity(4)
         res = np.linalg.inv(I - A) - I
@@ -640,10 +644,14 @@ class Test_Katz_Index:
 
     def test_all_nonexistent_edges(self):
         G = nx.Graph()
-        A = np.array([np.array([0, 1., 1., 0]), 
-                      np.array([1., 0, 0, 0]),
-                      np.array([1., 0, 0, 1.]), 
-                      np.array([0, 0, 1., 0])])
+        A = np.array(
+            [
+                np.array([0, 1.0, 1.0, 0]),
+                np.array([1.0, 0, 0, 0]),
+                np.array([1.0, 0, 0, 1.0]),
+                np.array([0, 0, 1.0, 0]),
+            ]
+        )
         A *= self.beta
         I = np.identity(4)
         exp = np.linalg.inv(I - A) - I

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,7 +1,8 @@
 import math
-import numpy as np
+
 from functools import partial
 
+import numpy as np
 import pytest
 
 import networkx as nx

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 from functools import partial
 
 import pytest
@@ -580,3 +581,71 @@ class TestWithinInterCluster:
         G.nodes[2]["community"] = 0
         G.nodes[3]["community"] = 0
         self.test(G, None, [(0, 3, 1 / self.delta), (1, 2, 0), (1, 3, 0)])
+
+
+class Test_Katz_Index:
+    @classmethod
+    def setup_class(cls):
+        cls.beta = .1
+        cls.func = staticmethod(nx.katz_index)
+        cls.test = partial(_test_func, predict_func=cls.func)
+
+    def test_K5(self):
+        G = nx.complete_graph(5)
+        A = np.ones((5, 5))
+        I = np.identity(5)
+        # No self loops
+        A -= I
+        A *= self.beta
+        res = np.linalg.inv(I - A) - I
+        self.test(G, [(0, 1)], [(0, 1, res[0][1])])
+
+    def test_P4(self):
+        G = nx.path_graph(4)
+        A = np.array([np.array([0, 1., 0, 0]), 
+                      np.array([1., 0, 1., 0]),
+                      np.array([0, 1., 0, 1.]), 
+                      np.array([0, 0, 1., 0])])
+        A *= self.beta
+        I = np.identity(4)
+        res = np.linalg.inv(I - A) - I
+        self.test(G, [(0, 2)], [(0, 2, res[0, 2])])
+
+    def test_notimplemented(self):
+        assert pytest.raises(
+            nx.NetworkXNotImplemented, self.func, nx.DiGraph([(0, 1), (1, 2)]), [(0, 2)]
+        )
+        assert pytest.raises(
+            nx.NetworkXNotImplemented,
+            self.func,
+            nx.MultiGraph([(0, 1), (1, 2)]),
+            [(0, 2)],
+        )
+        assert pytest.raises(
+            nx.NetworkXNotImplemented,
+            self.func,
+            nx.MultiDiGraph([(0, 1), (1, 2)]),
+            [(0, 2)],
+        )
+
+    def test_no_common_neighbor(self):
+        G = nx.Graph()
+        G.add_edges_from([(0, 1), (2, 3)])
+        self.test(G, [(0, 2)], [(0, 2, 0)])
+
+    def test_isolated_nodes(self):
+        G = nx.Graph()
+        G.add_nodes_from([0, 1])
+        self.test(G, [(0, 1)], [(0, 1, 0)])
+
+    def test_all_nonexistent_edges(self):
+        G = nx.Graph()
+        A = np.array([np.array([0, 1., 1., 0]), 
+                      np.array([1., 0, 0, 0]),
+                      np.array([1., 0, 0, 1.]), 
+                      np.array([0, 0, 1., 0])])
+        A *= self.beta
+        I = np.identity(4)
+        res = np.linalg.inv(I - A) - I
+        G.add_edges_from([(0, 1), (0, 2), (2, 3)])
+        self.test(G, None, [(0, 3, res[0, 3]), (1, 2, res[1, 2]), (1, 3, res[1, 3])])

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -1,8 +1,8 @@
 import math
 from functools import partial
 
-import numpy as np
 import pytest
+np = pytest.importorskip("numpy")
 
 import networkx as nx
 

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -646,6 +646,6 @@ class Test_Katz_Index:
                       np.array([0, 0, 1., 0])])
         A *= self.beta
         I = np.identity(4)
-        res = np.linalg.inv(I - A) - I
+        exp = np.linalg.inv(I - A) - I
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        self.test(G, None, [(0, 3, res[0, 3]), (1, 2, res[1, 2]), (1, 3, res[1, 3])])
+        self.test(G, None, [(0, 3, exp[0, 3]), (1, 2, exp[1, 2]), (1, 3, exp[1, 3])])

--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -2,6 +2,7 @@ import math
 from functools import partial
 
 import pytest
+
 np = pytest.importorskip("numpy")
 
 import networkx as nx


### PR DESCRIPTION
Added scipy version of the katz centrality algorithm. Followed lead of other implementations already present, including not checking if $\alpha \leq \frac{1}{\lambda}$ where $\lambda$  is the largest eigenvalue of the adjacency matrix of G. It should be noted that the closed form sum all of the implementations use is not valid if this condition is not met, but no error or warning is raised if it isn't. Should I add this to the existing implementations and my own? Also @jarrodmillman suggested in #6627 to make the new scipy version the default. I am not sure how to accomplish this. Open to suggestions on this. LMK what you guys think. 
