### PR TITLE
Use the correct namespace for girvan_newman examples

### DIFF
--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -32,7 +32,7 @@ def girvan_newman(G, most_valuable_edge=None):
     To get the first pair of communities::
 
         >>> G = nx.path_graph(10)
-        >>> comp = girvan_newman(G)
+        >>> comp = nx.community.girvan_newman(G)
         >>> tuple(sorted(c) for c in next(comp))
         ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9])
 
@@ -42,7 +42,7 @@ def girvan_newman(G, most_valuable_edge=None):
         >>> import itertools
         >>> G = nx.path_graph(8)
         >>> k = 2
-        >>> comp = girvan_newman(G)
+        >>> comp = nx.community.girvan_newman(G)
         >>> for communities in itertools.islice(comp, k):
         ...     print(tuple(sorted(c) for c in communities))
         ...
@@ -55,7 +55,7 @@ def girvan_newman(G, most_valuable_edge=None):
         >>> import itertools
         >>> G = nx.path_graph(8)
         >>> k = 4
-        >>> comp = girvan_newman(G)
+        >>> comp = nx.community.girvan_newman(G)
         >>> limited = itertools.takewhile(lambda c: len(c) <= k, comp)
         >>> for communities in limited:
         ...     print(tuple(sorted(c) for c in communities))
@@ -74,7 +74,7 @@ def girvan_newman(G, most_valuable_edge=None):
         ...     u, v, w = max(G.edges(data="weight"), key=itemgetter(2))
         ...     return (u, v)
         ...
-        >>> comp = girvan_newman(G, most_valuable_edge=heaviest)
+        >>> comp = nx.community.girvan_newman(G, most_valuable_edge=heaviest)
         >>> tuple(sorted(c) for c in next(comp))
         ([0, 1, 2, 3, 4, 5, 6, 7, 8], [9])
 
@@ -87,7 +87,7 @@ def girvan_newman(G, most_valuable_edge=None):
         ...     return max(centrality, key=centrality.get)
         ...
         >>> G = nx.path_graph(10)
-        >>> comp = girvan_newman(G, most_valuable_edge=most_central_edge)
+        >>> comp = nx.community.girvan_newman(G, most_valuable_edge=most_central_edge)
         >>> tuple(sorted(c) for c in next(comp))
         ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9])
 
@@ -107,7 +107,7 @@ def girvan_newman(G, most_valuable_edge=None):
         ...     return max(centrality, key=centrality.get)
         ...
         >>> G = nx.path_graph(10)
-        >>> comp = girvan_newman(G, most_valuable_edge=most_central_edge)
+        >>> comp = nx.community.girvan_newman(G, most_valuable_edge=most_central_edge)
 
     Notes
     -----


### PR DESCRIPTION
Users won't be able to run the example code just by doing copy and paste with the current examples. And the first guess of doing `nx.girvan_newman` will also be wrong. We should try to be explicit about the namespaces (something I got from the user survey).