### PR TITLE
Preserve node order in bipartite_layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -323,10 +323,9 @@ def bipartite_layout(
     width = aspect_ratio * height
     offset = (width / 2, height / 2)
 
-    topset = set(nodes)
-    top = [n for n in G if n in topset]
-    bottom = [n for n in G if n not in topset]
-    nodes  = top + bottom
+    top = dict.fromkeys(nodes)
+    bottom = [v for v in G if v not in top]
+    nodes = list(top) + bottom
 
     left_xs = np.repeat(0, len(top))
     right_xs = np.repeat(width, len(bottom))

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -323,9 +323,10 @@ def bipartite_layout(
     width = aspect_ratio * height
     offset = (width / 2, height / 2)
 
-    top = set(nodes)
-    bottom = set(G) - top
-    nodes = list(top) + list(bottom)
+    topset = set(nodes)
+    top = [n for n in G if n in topset]
+    bottom = [n for n in G if n not in topset]
+    nodes  = top + bottom
 
     left_xs = np.repeat(0, len(top))
     right_xs = np.repeat(width, len(bottom))


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
This PR changes the code in `bipartite_layout` to preserve the specified node order.
The original code converted the nodes to sets, which are unordered in Python. This resulted in the nodes being returned in any order. But for bipartite graphs, we often want to be able to specify the order of the nodes on each side, rather than letting the layout function do it arbitrarily.

For example, code:
```
G = nx.bipartite.gnmk_random_graph(3, 5, 10, seed=123)
G_nodes = [0,1,2,5,4,3,7,6]
top = [2,0,1]
pos = nx.bipartite_layout(G_nodes, top)
nx.draw(G, pos=pos, with_labels=True)
```
before this PR:
![before](https://user-images.githubusercontent.com/7326403/232325500-684988e4-6459-4cbc-8cc0-f44f744a00a2.png)
after:
![after](https://user-images.githubusercontent.com/7326403/232325549-ca44d93a-178c-4ded-be94-54acdfbe6dd7.png)
