### PR TITLE
Improve Test Coverage for Semiconnected.py

### DIFF
--- a/networkx/algorithms/components/tests/test_semiconnected.py
+++ b/networkx/algorithms/components/tests/test_semiconnected.py
@@ -53,3 +53,10 @@ class TestIsSemiconnected:
             chain.from_iterable([(i, i - 1), (i, i + 1)] for i in range(0, 100, 2))
         )
         assert not nx.is_semiconnected(G)
+
+    def test_topo_order(self):
+        G = nx.path_graph(100, create_using=nx.DiGraph())
+        topo_order = list(nx.topological_sort(G))
+        assert not nx.is_semiconnected(G, topo_order=topo_order)
+        rev_topo_order = list(reversed(topo_order))
+        assert nx.is_semiconnected(G, topo_order=rev_topo_order)


### PR DESCRIPTION
I have added a test case at [test_semiconnected.py](https://github.com/networkx/networkx/blob/main/networkx/algorithms/components/tests/test_semiconnected.py) to improve test coverage of [semiconnected.py](https://github.com/networkx/networkx/blob/main/networkx/algorithms/components/semiconnected.py).  The test coverage is now at a 100%.
Before :- 
![before](https://user-images.githubusercontent.com/74042272/232328264-7371736f-0b95-4546-97a0-53c7b3d59e18.png)
After :- 
![after](https://user-images.githubusercontent.com/74042272/232328269-883ed752-8d14-419e-8836-a04e11247f3e.png)

