### PR TITLE
Add Greedy Coloring Example to Gallery 

### DIFF
--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -22,9 +22,6 @@ node_colors = [graph_color_to_mpl_color[graph_coloring[n]] for n in G.nodes()]
 # Define the position of each node, Specify seed for reproducibility
 pos = nx.spring_layout(G, seed=14)
 
-# Assign colors to nodes based on the greedy coloring
-node_colors = [colors[color_map.get(node) % len(colors)] for node in G.nodes()]
-
 # Draw the graph with node colors based on the greedy coloring
 nx.draw(
     G,

--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -1,0 +1,40 @@
+"""
+=====================
+Greedy Coloring Algorithm
+=====================
+We attempt to color a graph using as few colors as possible, where no neighbours of a node can have same color as the node itself.We use the function nx.greedy_color that implements the greedy coloring algorithm for a given graph.The function returns a dictionary that maps each node to its assigned color.
+"""
+import networkx as nx
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+
+# Create a dodecahedral graph
+G = nx.generators.small.dodecahedral_graph()
+
+# Apply greedy coloring
+color_map = nx.greedy_color(G)
+
+# Define warm color tones
+colors = list(mcolors.TABLEAU_COLORS.values())
+
+# Define the position of each node, Specify seed for reproducibility
+pos = nx.spring_layout(G, seed=14)
+
+# Assign colors to nodes based on the greedy coloring
+node_colors = [colors[color_map.get(node) % len(colors)] for node in G.nodes()]
+
+# Draw the graph with node colors based on the greedy coloring
+nx.draw(
+    G,
+    pos,
+    with_labels=True,
+    node_size=500,
+    node_color=node_colors,
+    edge_color="grey",
+    font_size=12,
+    font_color="#333333",
+    width=2,
+)
+
+# Show the graph
+plt.show()

--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -1,14 +1,15 @@
 """
-=========================
-Greedy Coloring Algorithm
-=========================
-We attempt to color a graph using as few colors as possible, where no neighbours of a node can have same color as the node itself.
+===============
+Greedy Coloring
+===============
+
+We attempt to color a graph using as few colors as possible, where no neighbours
+of a node can have same color as the node itself.
 """
 import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.colors as mpl
 
-# Create a dodecahedral graph
 G = nx.dodecahedral_graph()
 
 # Apply greedy coloring
@@ -19,10 +20,7 @@ unique_colors = set(graph_coloring.values())
 graph_color_to_mpl_color = dict(zip(unique_colors, mpl.TABLEAU_COLORS))
 node_colors = [graph_color_to_mpl_color[graph_coloring[n]] for n in G.nodes()]
 
-# Define the position of each node, Specify seed for reproducibility
 pos = nx.spring_layout(G, seed=14)
-
-# Draw the graph with node colors based on the greedy coloring
 nx.draw(
     G,
     pos,
@@ -34,6 +32,4 @@ nx.draw(
     font_color="#333333",
     width=2,
 )
-
-# Show the graph
 plt.show()

--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -6,7 +6,7 @@ We attempt to color a graph using as few colors as possible, where no neighbours
 """
 import networkx as nx
 import matplotlib.pyplot as plt
-import matplotlib.colors as mcolors
+import matplotlib.colors as mpl
 
 # Create a dodecahedral graph
 G = nx.dodecahedral_graph()

--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -1,21 +1,23 @@
 """
-=====================
+=========================
 Greedy Coloring Algorithm
-=====================
-We attempt to color a graph using as few colors as possible, where no neighbours of a node can have same color as the node itself.We use the function nx.greedy_color that implements the greedy coloring algorithm for a given graph.The function returns a dictionary that maps each node to its assigned color.
+=========================
+We attempt to color a graph using as few colors as possible, where no neighbours of a node can have same color as the node itself.
 """
 import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 
 # Create a dodecahedral graph
-G = nx.generators.small.dodecahedral_graph()
+G = nx.dodecahedral_graph()
 
 # Apply greedy coloring
-color_map = nx.greedy_color(G)
+graph_coloring = nx.greedy_color(G)
+unique_colors = set(graph_coloring.values())
 
-# Define warm color tones
-colors = list(mcolors.TABLEAU_COLORS.values())
+# Assign colors to nodes based on the greedy coloring
+graph_color_to_mpl_color = dict(zip(unique_colors, mpl.TABLEAU_COLORS))
+node_colors = [graph_color_to_mpl_color[graph_coloring[n]] for n in G.nodes()]
 
 # Define the position of each node, Specify seed for reproducibility
 pos = nx.spring_layout(G, seed=14)


### PR DESCRIPTION
I've written a python script to visualize greedy coloring on the given dodecahedral graph . The visualization is as follows:-
![greedy_coloring](https://user-images.githubusercontent.com/74042272/232525255-43949b25-832a-469f-91ae-c5462a461003.png)
