### PR TITLE
Remove `topo_order` kwarg from `is_semiconnected` without deprecation.

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -29,6 +29,10 @@ Improvements
 
 API Changes
 -----------
+- [`#6651 <https://github.com/networkx/networkx/pull/6651>`_]
+  In `is_semiconnected`, the keyword argument `topo_order` has been removed.
+  That argument resulted in silently incorrect results more often than not.
+
 
 
 Deprecations

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -6,7 +6,7 @@ __all__ = ["is_semiconnected"]
 
 
 @not_implemented_for("undirected")
-def is_semiconnected(G, topo_order=None):
+def is_semiconnected(G):
     """Returns True if the graph is semiconnected, False otherwise.
 
     A graph is semiconnected if, and only if, for any pair of nodes, either one
@@ -16,9 +16,6 @@ def is_semiconnected(G, topo_order=None):
     ----------
     G : NetworkX graph
         A directed graph.
-
-    topo_order: list or tuple, optional
-        A topological order for G (if None, the function will compute one)
 
     Returns
     -------
@@ -57,8 +54,6 @@ def is_semiconnected(G, topo_order=None):
     if not nx.is_weakly_connected(G):
         return False
 
-    G = nx.condensation(G)
-    if topo_order is None:
-        topo_order = nx.topological_sort(G)
+    H = nx.condensation(G)
 
-    return all(G.has_edge(u, v) for u, v in pairwise(topo_order))
+    return all(H.has_edge(u, v) for u, v in pairwise(nx.topological_sort(H)))

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -9,8 +9,18 @@ __all__ = ["is_semiconnected"]
 def is_semiconnected(G):
     """Returns True if the graph is semiconnected, False otherwise.
 
-    A graph is semiconnected if, and only if, for any pair of nodes, either one
+    A graph is semiconnected if and only if for any pair of nodes, either one
     is reachable from the other, or they are mutually reachable.
+
+    This function uses a theorem that states that a DAG is semiconnected
+    if for any topological sort, for node $v_n$ in that sort, there is an
+    edge $(v_i, v_{i+1})$. That allows us to check if a non-DAG `G` is
+    semiconnected by condensing the graph: i.e. constructing a new graph `H`
+    with nodes being the strongly connected components of `G`, and edges
+    (scc_1, scc_2) if there is a edge $(v_1, v_2)$ in `G` for some
+    $v_1 \in scc_1$ and $v_2 \in scc_2$. That results in a DAG, so we compute
+    the topological sort of `H` and check if for every $n$ there is an edge
+    $(scc_n, scc_{n+1})$.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR proposes to remove the `topo_order` kwarg from `is_semiconnected` *without* a deprecation period. This represents the most aggressive potential solution to the problem identified in #6645 .

The rationale for removing without a deprecation period is that using the `topo_order` kwarg results in silently incorrect results more often than not. A quick example:

```python
>>> G = nx.DiGraph([(0, 1), (1, 2)])  # directed path graph
>>> nx.is_semiconnected(G)  # correct
True
>>> nx.is_semiconnected(G, topo_order=[0, 1, 2])  # Wrong result, even though topo_order is valid!
False
```

Therefore, the `topo_order` kwarg itself can be considered a bug rather than a feature, and should be fixed without a deprecation. The main downside of this approach is that any users who are currently using the `topo_order` kwarg will get an uniformative error message:

```python
>>> nx.is_semiconnected(G, topo_order=[0, 1, 2])
Traceback (most recent call last)
   ...
TypeError: is_semiconnected() got an unexpected keyword argument 'topo_order'
```

An alternative would be to raise a more informative exception whenever `topo_order` is passed in with a non-default value. The downside of *that* approach is that `topo_order` will remain in the signature. This could potentially be resolved by adding `**kwargs` sentinel instead.