### PR TITLE
Edge cases Laplacian centrality

### DIFF
--- a/networkx/algorithms/centrality/laplacian.py
+++ b/networkx/algorithms/centrality/laplacian.py
@@ -126,9 +126,13 @@ def laplacian_centrality(
         new_diag = lap_matrix.diagonal() - abs(lap_matrix[:, i])
         np.fill_diagonal(A_2, new_diag[all_but_i])
 
-        new_energy = np.power(sp.linalg.eigh(A_2, eigvals_only=True), 2).sum()
+        if len(all_but_i) > 0:  # catches degenerate case of single node
+            new_energy = np.power(sp.linalg.eigh(A_2, eigvals_only=True), 2).sum()
+        else:
+            new_energy = 0.0
+
         lapl_cent = full_energy - new_energy
-        if normalized:
+        if normalized and full_energy != 0.0:
             lapl_cent = lapl_cent / full_energy
 
         laplace_centralities_dict[node] = lapl_cent

--- a/networkx/algorithms/centrality/laplacian.py
+++ b/networkx/algorithms/centrality/laplacian.py
@@ -99,7 +99,7 @@ def laplacian_centrality(
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("null graph has no centrality defined")
 
-    if nodelist != None:
+    if nodelist is not None:
         nodeset = set(G.nbunch_iter(nodelist))
         if len(nodeset) != len(nodelist):
             raise nx.NetworkXError("nodelist has duplicate nodes or nodes not in G")
@@ -113,6 +113,11 @@ def laplacian_centrality(
         lap_matrix = nx.laplacian_matrix(G, nodes, weight).toarray()
 
     full_energy = np.power(sp.linalg.eigh(lap_matrix, eigvals_only=True), 2).sum()
+
+    if full_energy == 0.0 and normalized:
+        raise nx.NetworkXPointlessConcept(
+            "graph without edges has centrality undefined or 0 and can not be be normalized"
+        )
 
     # calculate laplacian centrality
     laplace_centralities_dict = {}
@@ -132,7 +137,7 @@ def laplacian_centrality(
             new_energy = 0.0
 
         lapl_cent = full_energy - new_energy
-        if normalized and full_energy != 0.0:
+        if normalized:
             lapl_cent = lapl_cent / full_energy
 
         laplace_centralities_dict[node] = lapl_cent

--- a/networkx/algorithms/centrality/tests/test_laplacian_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_laplacian_centrality.py
@@ -1,9 +1,16 @@
 import pytest
 
 import networkx as nx
+from networkx import NetworkXPointlessConcept
 
 np = pytest.importorskip("numpy")
 sp = pytest.importorskip("scipy")
+
+
+def test_laplacian_centrality_empty_graph_raises_pointless_concept():
+    G = nx.Graph()
+    with pytest.raises(NetworkXPointlessConcept):
+        d = nx.laplacian_centrality(G, normalized=False)
 
 
 def test_laplacian_centrality_single_node():
@@ -18,7 +25,7 @@ def test_laplacian_centrality_single_node():
 
     G = nx.Graph()
     G.add_node(0)
-    d = nx.laplacian_centrality(G)
+    d = nx.laplacian_centrality(G, normalized=False)
     exact = {
         0: 0.0,
     }
@@ -47,10 +54,8 @@ def test_laplacian_centrality_unconnected_nodes():
     """
 
     G = nx.Graph()
-    G.add_node(0)
-    G.add_node(1)
-    G.add_node(2)
-    d = nx.laplacian_centrality(G)
+    G.add_nodes_from([0, 1, 2])
+    d = nx.laplacian_centrality(G, normalized=False)
 
     exact = {
         0: 0.0,
@@ -60,6 +65,14 @@ def test_laplacian_centrality_unconnected_nodes():
 
     for n, dc in d.items():
         assert exact[n] == pytest.approx(dc, abs=1e-7)
+
+
+def test_laplacian_centrality_unconnected_nodes_normalized():
+    """Normalizing the Laplacian centrality of a graph without edges raises a NetworkXPointlessConcept."""
+    G = nx.Graph()
+    G.add_nodes_from([0, 1, 2])
+    with pytest.raises(NetworkXPointlessConcept):
+        d = nx.laplacian_centrality(G, normalized=True)
 
 
 def test_laplacian_centrality_E():

--- a/networkx/algorithms/centrality/tests/test_laplacian_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_laplacian_centrality.py
@@ -6,6 +6,62 @@ np = pytest.importorskip("numpy")
 sp = pytest.importorskip("scipy")
 
 
+def test_laplacian_centrality_single_node():
+    """This test checks if issue #6571 is fixed - laplacian_centrality on a single node graph returned an error.
+    In a graph with a single node, the concept of Laplacian centrality becomes trivial, as there are no other nodes
+    or edges to consider. However, we can still calculate the Laplacian centrality for the sake of completeness.
+    For a single node graph, the adjacency matrix (A) will be a 1x1 matrix with a single entry of 0, as there are no
+    connections between nodes. The degree matrix (D) will also be a 1x1 matrix with a single entry of 0, as the single
+    node has a degree of 0.
+    As a result, the Laplacian matrix (L) will be a 1x1 matrix with a single entry of 0:
+    """
+
+    G = nx.Graph()
+    G.add_node(0)
+    d = nx.laplacian_centrality(G)
+    exact = {
+        0: 0.0,
+    }
+
+    assert d[0] == exact[0]
+
+
+def test_laplacian_centrality_unconnected_nodes():
+    """Checks for an issue similar to #6571 - laplacian_centrality on a unconnected node graph should return 0
+    In a graph with two unconnected nodes, the Laplacian centrality can still be calculated, but it may not be
+    as informative as in a connected graph. This is because the lack of connections means that the removal of a node
+    will not significantly change the graph structure.
+    For unconnected nodes, the adjacency matrix (A) will have all zero entries since there are no connections between
+    the nodes. The degree matrix (D) will also have all zero entries because both nodes have a degree of zero.
+    Consequently, the Laplacian matrix (L) will be a zero matrix, and the Laplacian energy (LE) of the graph will be
+    zero as well.
+    When you remove either node from the graph, the remaining graph will still have zero Laplacian energy since it is
+    essentially the same structure with one node removed. So the Laplacian centrality (LC) for each unconnected node
+    will be:
+
+        LC(v) = LE(G) - LE(G - v) = 0 - 0 = 0
+
+    In this case, the Laplacian centrality for both unconnected nodes is 0, indicating that their removal will not
+    affect the graph's structure. However, this measure is not as meaningful in this scenario, as the graph itself
+    is not connected, and there is no information about the nodes' influence or contribution to the overall network.
+    """
+
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_node(1)
+    G.add_node(2)
+    d = nx.laplacian_centrality(G)
+
+    exact = {
+        0: 0.0,
+        1: 0.0,
+        2: 0.0,
+    }
+
+    for n, dc in d.items():
+        assert exact[n] == pytest.approx(dc, abs=1e-7)
+
+
 def test_laplacian_centrality_E():
     E = nx.Graph()
     E.add_weighted_edges_from(


### PR DESCRIPTION
This code handles a few edge cases of the Laplacian centrality with empty, single-node, and unconnected (edgeless) graphs.
Following changes have been made to the laplacian_centrality calculation

1. NetworkXPointlessConcept is raised for empty and single node graphs
2. NetworkXPointlessConcept is raised for graphs without edges and normalized=True (we can't normalize to 0.0)

Test cases are provided. The code has been reviewed, and review comments have been processed.

fixes https://github.com/networkx/networkx/issues/6571, fixes https://github.com/networkx/networkx/issues/6626