### PR TITLE
Handle weights as `distance=` in testing dispatch

### DIFF
--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -52,7 +52,8 @@ def test_intersection():
     I2 = nx.intersection(G2, H2)
     assert set(I2.nodes()) == {1, 2, 3, 4}
     assert sorted(I2.edges()) == [(2, 3)]
-    if os.environ.get("NETWORKX_GRAPH_CONVERT", None) != "nx-loopback":
+    # Only test if not performing auto convert testing of backend implementations
+    if os.environ.get("NETWORKX_GRAPH_CONVERT", None) is None:
         with pytest.raises(TypeError):
             nx.intersection(G2, H)
         with pytest.raises(TypeError):

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -233,6 +233,9 @@ def test_override_dispatch(func=None, *, name=None, graphs="G"):
                 weight = bound.arguments["data"]
             elif bound.arguments["data"]:
                 weight = "weight"
+        elif "distance" in bound.arguments:
+            # For ego_graph
+            weight = bound.arguments["distance"]
         for gname in graph_list:
             bound.arguments[gname] = backend.convert_from_nx(
                 bound.arguments[gname], weight=weight, name=name


### PR DESCRIPTION
This handles `ego_graph`, which I just implemented in `graphblas-algorithms` here: https://github.com/python-graphblas/graphblas-algorithms/pull/61

This `dispatch` function is only used when testing, and it automatically converts graph inputs to the backend specified in an environment variable (it also converts Graph outputs back to networkx graphs). To convert correctly, it needs to know which weight to use for each algorithm. To date, this has worked fairly well by using a small set of rules. As done in this PR, these rules will likely need to be updated as more and more algorithms support dispatch. Some thoughts:
- Perhaps we don't need to do this; instead, can we rely on every backend to properly handle networkx Graphs as inputs?
- Or, instead, perhaps we add e.g. `weight_argument="distance"` to the `@dispatch` decorator to indicate which argument should be used as the weight argument. Sooner or later, we probably ought to make `@dispatch` return an instance of a class instead of relying on closures.

CC @jim22k @MridulS 