### PR TITLE
Rm unreachable code for validating input

### DIFF
--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -357,12 +357,6 @@ def _bidirectional_shortest_path(G, source, target, exclude):
 def _bidirectional_pred_succ(G, source, target, exclude):
     # does BFS from both source and target and meets in the middle
     # excludes nodes in the container "exclude" from the search
-    if source is None or target is None:
-        raise nx.NetworkXException(
-            "Bidirectional shortest path called without source or target"
-        )
-    if target == source:
-        return ({target: None}, {source: None}, source)
 
     # handle either directed or undirected
     if G.is_directed():


### PR DESCRIPTION
Fixes #6572 

There are input validation checks in the internal `_bidirectional_shortest_path` function within the `approximation/connectivity` module that are not possible to hit without calling the private functions directly.

The internal function is called in `local_node_connectivity` which raises exceptions for `source=None` or `target=None` and `source == target`. Therefore I vote for removing these validation checks from the private function. 