### PR TITLE
Improve Test Coverage for reaching.py

### DIFF
--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -107,3 +107,13 @@ class TestLocalReachingCentrality:
             G, 1, normalized=False, weight="weight"
         )
         assert centrality == 1.5
+        
+    def test_local_reaching_centrality_normalized_weight(self):
+        # Test with a directed graph with normalized weights
+        G = nx.Graph()
+        G.add_weighted_edges_from([(1, 2, 1), (1, 3, 2)])
+        centrality = nx.local_reaching_centrality(
+            G, 1, normalized=True, weight="weight"
+        )
+        assert centrality == 1.0
+

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -107,7 +107,7 @@ class TestLocalReachingCentrality:
             G, 1, normalized=False, weight="weight"
         )
         assert centrality == 1.5
-        
+
     def test_local_reaching_centrality_normalized_weight(self):
         # Test with a directed graph with normalized weights
         G = nx.Graph()
@@ -116,4 +116,3 @@ class TestLocalReachingCentrality:
             G, 1, normalized=True, weight="weight"
         )
         assert centrality == 1.0
-

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -109,7 +109,6 @@ class TestLocalReachingCentrality:
         assert centrality == 1.5
 
     def test_local_reaching_centrality_normalized_weight(self):
-        # Test with a directed graph with normalized weights
         G = nx.Graph()
         G.add_weighted_edges_from([(1, 2, 1), (1, 3, 2)])
         centrality = nx.local_reaching_centrality(


### PR DESCRIPTION
Improve test coverage for reaching.py according to this :- https://app.codecov.io/gh/networkx/networkx/blob/main/networkx/algorithms/centrality/reaching.py
Now the Coverage is at 100% as below:- 

![reaching_after](https://user-images.githubusercontent.com/74042272/235462297-edad7e51-68de-4598-a679-63ad6f71ceeb.png)
