### PR TITLE
Improve Test Coverage for current_flow_closeness.py

### DIFF
--- a/networkx/algorithms/centrality/tests/test_current_flow_closeness.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_closeness.py
@@ -32,6 +32,12 @@ class TestFlowClosenessCentrality:
         for n in sorted(G):
             assert b[n] == pytest.approx(b_answer[n], abs=1e-7)
 
+    def test_current_flow_closeness_centrality_not_connected(self):
+        G = nx.Graph()
+        G.add_nodes_from([1, 2, 3])
+        with pytest.raises(nx.NetworkXError):
+            nx.current_flow_closeness_centrality(G)
+
 
 class TestWeightedFlowClosenessCentrality:
     pass


### PR DESCRIPTION
I have increased test coverage for current_flow_closeness.py according to here :- https://app.codecov.io/gh/networkx/networkx/blob/main/networkx/algorithms/centrality/current_flow_closeness.py
The coverage is now at a 100% as seen below:- 
![cfcafter](https://user-images.githubusercontent.com/74042272/235638451-a64a66e1-e63d-439b-ac26-d58cfd8a415f.png)

