### PR TITLE
Improve test coverage for reaching.py

### DIFF
--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -107,3 +107,11 @@ class TestLocalReachingCentrality:
             G, 1, normalized=False, weight="weight"
         )
         assert centrality == 1.5
+
+    def test_undirected_weighted_normalized(self):
+        G = nx.Graph()
+        G.add_weighted_edges_from([(1, 2, 1), (1, 3, 2)])
+        centrality = nx.local_reaching_centrality(
+            G, 1, normalized=True, weight="weight"
+        )
+        assert centrality == 1.0


### PR DESCRIPTION
I have increased test coverage for reaching.py according to here :- https://app.codecov.io/gh/networkx/networkx/blob/main/networkx/algorithms/centrality/reaching.py
The test coverage is now at a 100% as seen below :- 
![reaching_after](https://user-images.githubusercontent.com/74042272/235658055-2bacb143-02da-41f4-8df2-e906ce807e35.png)
