### PR TITLE
Pin sphinx<7 as temporary fix for doc CI failures

### DIFF
--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,4 +1,4 @@
-sphinx>=6.1
+sphinx>=6.1,<7
 pydata-sphinx-theme>=0.13
 sphinx-gallery>=0.12
 numpydoc>=1.5


### PR DESCRIPTION
It turns out the failures in the circleci job are because we're picking up sphinx 7 which was recently released.

This is a temporary fix to get the circleci job green again.