### PR TITLE
MAINT: Add subgraph_view and reverse_view to nx namespace directly through graphviews

### DIFF
--- a/doc/reference/functions.rst
+++ b/doc/reference/functions.rst
@@ -21,10 +21,8 @@ Graph
    add_path
    add_cycle
    subgraph
-   subgraph_view
    induced_subgraph
    restricted_view
-   reverse_view
    edge_subgraph
 
 

--- a/networkx/classes/__init__.py
+++ b/networkx/classes/__init__.py
@@ -5,6 +5,7 @@ from .multidigraph import MultiDiGraph
 from .backends import _dispatch
 
 from .function import *
+from .graphviews import subgraph_view, reverse_view
 
 from networkx.classes import filters
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1320,4 +1320,4 @@ class DiGraph(Graph):
             H.add_nodes_from((n, deepcopy(d)) for n, d in self.nodes.items())
             H.add_edges_from((v, u, deepcopy(d)) for u, v, d in self.edges(data=True))
             return H
-        return nx.graphviews.reverse_view(self)
+        return nx.reverse_view(self)

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -5,7 +5,6 @@ from collections import Counter
 from itertools import chain
 
 import networkx as nx
-from networkx.classes.graphviews import reverse_view, subgraph_view
 from networkx.utils import not_implemented_for, pairwise
 
 __all__ = [
@@ -21,9 +20,7 @@ __all__ = [
     "freeze",
     "is_frozen",
     "subgraph",
-    "subgraph_view",
     "induced_subgraph",
-    "reverse_view",
     "edge_subgraph",
     "restricted_view",
     "to_directed",
@@ -391,7 +388,7 @@ def induced_subgraph(G, nbunch):
     [0, 1, 3]
     """
     induced_nodes = nx.filters.show_nodes(G.nbunch_iter(nbunch))
-    return nx.graphviews.subgraph_view(G, induced_nodes)
+    return nx.subgraph_view(G, induced_nodes)
 
 
 def edge_subgraph(G, edges):
@@ -450,7 +447,7 @@ def edge_subgraph(G, edges):
             induced_edges = nxf.show_diedges(edges)
         else:
             induced_edges = nxf.show_edges(edges)
-    return nx.graphviews.subgraph_view(G, induced_nodes, induced_edges)
+    return nx.subgraph_view(G, induced_nodes, induced_edges)
 
 
 def restricted_view(G, nodes, edges):
@@ -506,7 +503,7 @@ def restricted_view(G, nodes, edges):
             hide_edges = nxf.hide_diedges(edges)
         else:
             hide_edges = nxf.hide_edges(edges)
-    return nx.graphviews.subgraph_view(G, hide_nodes, hide_edges)
+    return nx.subgraph_view(G, hide_nodes, hide_edges)
 
 
 def to_directed(graph):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1819,7 +1819,7 @@ class Graph:
         """
         induced_nodes = nx.filters.show_nodes(self.nbunch_iter(nodes))
         # if already a subgraph, don't make a chain
-        subgraph = nx.graphviews.subgraph_view
+        subgraph = nx.subgraph_view
         if hasattr(self, "_NODE_OK"):
             return subgraph(self._graph, induced_nodes, self._EDGE_OK)
         return subgraph(self, induced_nodes)

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -960,4 +960,4 @@ class MultiDiGraph(MultiGraph, DiGraph):
                 for u, v, k, d in self.edges(keys=True, data=True)
             )
             return H
-        return nx.graphviews.reverse_view(self)
+        return nx.reverse_view(self)

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -318,7 +318,7 @@ class TestFilteredGraphs:
         self.Graphs = [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 
     def test_hide_show_nodes(self):
-        SubGraph = nx.graphviews.subgraph_view
+        SubGraph = nx.subgraph_view
         for Graph in self.Graphs:
             G = nx.path_graph(4, Graph)
             SG = G.subgraph([2, 3])
@@ -331,7 +331,7 @@ class TestFilteredGraphs:
             assert SGC.edges == RGC.edges
 
     def test_str_repr(self):
-        SubGraph = nx.graphviews.subgraph_view
+        SubGraph = nx.subgraph_view
         for Graph in self.Graphs:
             G = nx.path_graph(4, Graph)
             SG = G.subgraph([2, 3])
@@ -346,7 +346,7 @@ class TestFilteredGraphs:
             repr(RG.adj[2])
 
     def test_copy(self):
-        SubGraph = nx.graphviews.subgraph_view
+        SubGraph = nx.subgraph_view
         for Graph in self.Graphs:
             G = nx.path_graph(4, Graph)
             SG = G.subgraph([2, 3])

--- a/networkx/classes/tests/test_graphviews.py
+++ b/networkx/classes/tests/test_graphviews.py
@@ -31,9 +31,8 @@ class TestReverseView:
         assert sorted(self.rv.edges) == expected
 
     def test_exceptions(self):
-        nxg = nx.graphviews
         G = nx.Graph()
-        pytest.raises(nx.NetworkXNotImplemented, nxg.reverse_view, G)
+        pytest.raises(nx.NetworkXNotImplemented, nx.reverse_view, G)
 
     def test_subclass(self):
         class MyGraph(nx.DiGraph):
@@ -82,9 +81,8 @@ class TestMultiReverseView:
         assert sorted(self.rv.edges) == expected
 
     def test_exceptions(self):
-        nxg = nx.graphviews
         MG = nx.MultiGraph(self.G)
-        pytest.raises(nx.NetworkXNotImplemented, nxg.reverse_view, MG)
+        pytest.raises(nx.NetworkXNotImplemented, nx.reverse_view, MG)
 
 
 def test_generic_multitype():

--- a/networkx/classes/tests/test_subgraphviews.py
+++ b/networkx/classes/tests/test_subgraphviews.py
@@ -5,7 +5,7 @@ from networkx.utils import edges_equal
 
 
 class TestSubGraphView:
-    gview = staticmethod(nx.graphviews.subgraph_view)
+    gview = staticmethod(nx.subgraph_view)
     graph = nx.Graph
     hide_edges_filter = staticmethod(nx.filters.hide_edges)
     show_edges_filter = staticmethod(nx.filters.show_edges)
@@ -95,7 +95,7 @@ class TestSubGraphView:
 
 
 class TestSubDiGraphView(TestSubGraphView):
-    gview = staticmethod(nx.graphviews.subgraph_view)
+    gview = staticmethod(nx.subgraph_view)
     graph = nx.DiGraph
     hide_edges_filter = staticmethod(nx.filters.hide_diedges)
     show_edges_filter = staticmethod(nx.filters.show_diedges)
@@ -134,7 +134,7 @@ class TestSubDiGraphView(TestSubGraphView):
 
 # multigraph
 class TestMultiGraphView(TestSubGraphView):
-    gview = staticmethod(nx.graphviews.subgraph_view)
+    gview = staticmethod(nx.subgraph_view)
     graph = nx.MultiGraph
     hide_edges_filter = staticmethod(nx.filters.hide_multiedges)
     show_edges_filter = staticmethod(nx.filters.show_multiedges)
@@ -190,7 +190,7 @@ class TestMultiGraphView(TestSubGraphView):
 
 # multidigraph
 class TestMultiDiGraphView(TestMultiGraphView, TestSubDiGraphView):
-    gview = staticmethod(nx.graphviews.subgraph_view)
+    gview = staticmethod(nx.subgraph_view)
     graph = nx.MultiDiGraph
     hide_edges_filter = staticmethod(nx.filters.hide_multidiedges)
     show_edges_filter = staticmethod(nx.filters.show_multidiedges)


### PR DESCRIPTION
Currently `subgraph_view` and `reverse_view` are available in the global `nx` namespace but they are exposed via a redirect in `functions.py`. This was added in https://github.com/networkx/networkx/pull/3627 and I'm not a 100% sure why it is done this way.
Also made changes to some other places where `subgraph_view` and `reverse_view` where being imported via `networkx.graphviews` and not via the `nx` namespace.
