### PR TITLE
Add linting to contributor guide.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -108,6 +108,20 @@ Development Workflow
      problems early and reduces the load on the continuous integration
      system.
 
+4. Ensure your contribution is properly formatted.
+
+   * If you installed ``pre-commit`` as recommended in step 1, all necessary
+     linting should run automatically at commit time. If there are any
+     formatting issues, the commit will not be successful and linting
+     suggestions will be applied to the patch automatically.
+     Simply ``git add`` and ``git commit`` a second time to accept the proposed
+     formatting changes.
+
+   * If the above fails for whatever reason, you can also run the linter over
+     the entire codebase with::
+
+         pre-commit run --all-files
+
 4. Submit your contribution:
 
    * Push your changes back to your fork on GitHub::


### PR DESCRIPTION
Closes #6691 

The contributor guide was a little sparse on info wrt addressing issues in CI with linting. The recommendation is still "use pre-commit", but situations can arise where things are not properly installed/configured in local dev envs, leading to annoying red x's in CI.

The best way (that I know of at least) to deal with this situation is to use `pre-commit` to run all the lint hooks over the entire codebase.