### PR TITLE
fix: Include singleton/trivial paths in all_simple_paths & other functions

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -278,6 +278,10 @@ class TestGenericPath:
         assert nx.has_path(G, 0, 2)
         assert not nx.has_path(G, 0, 4)
 
+    def test_has_path_singleton(self):
+        G = nx.empty_graph(1)
+        assert nx.has_path(G, 0, 0)
+
     def test_all_shortest_paths(self):
         G = nx.Graph()
         nx.add_path(G, [0, 1, 2, 3])

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -169,7 +169,7 @@ def all_simple_paths(G, source, target, cutoff=None):
         [0, 3, 1, 2]
         [0, 3, 2]
 
-    The singleton path from `source` to itself is considered a simple path and is
+    The singleton path from ``source`` to itself is considered a simple path and is
     included in the results:
 
         >>> G = nx.empty_graph(5)
@@ -310,6 +310,19 @@ def all_simple_edge_paths(G, source, target, cutoff=None):
         ...     print(path)
         [(1, 2, 'k0'), (2, 3, 'k0')]
         [(1, 2, 'k1'), (2, 3, 'k0')]
+
+    When ``source`` is one of the targets, the empty path starting and ending at
+    ``source`` without traversing any edge is considered a valid simple edge path
+    and is included in the results:
+
+        >>> G = nx.Graph()
+        >>> G.add_node(0)
+        >>> paths = list(nx.all_simple_edge_paths(G, 0, 0))
+        >>> for path in paths:
+        ...     print (path)
+        []
+        >>> len(paths)
+        1
 
 
     Notes

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -1,4 +1,3 @@
-import typing
 from heapq import heappop, heappush
 from itertools import count
 
@@ -347,7 +346,7 @@ def all_simple_edge_paths(G, source, target, cutoff=None):
         yield from _all_simple_edge_paths(G, source, targets, cutoff)
 
 
-def _all_simple_edge_paths(G: nx.Graph, source, targets: set, cutoff: int):
+def _all_simple_edge_paths(G, source, targets, cutoff):
     # We simulate recursion with a stack, keeping the current path being explored
     # and the outgoing edge iterators at each point in the stack.
     # To avoid unnecessary checks, the loop is structured in a way such that a path
@@ -364,8 +363,8 @@ def _all_simple_edge_paths(G: nx.Graph, source, targets: set, cutoff: int):
     # The current_path is a dictionary that maps nodes in the path to the edge that was
     # used to enter that node (instead of a list of edges) because we want both a fast
     # membership test for nodes in the path and the preservation of insertion order.
-    current_path: dict = {None: None}
-    stack: list[typing.Iterator] = [iter([(None, source)])]
+    current_path = {None: None}
+    stack = [iter([(None, source)])]
 
     while stack:
         # 1. Try to extend the current path.

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -364,26 +364,27 @@ def _all_simple_edge_paths(G: nx.Graph, source, targets: set, cutoff: int):
     # The current_path is a dictionary that maps nodes in the path to the edge that was
     # used to enter that node (instead of a list of edges) because we want both a fast
     # membership test for nodes in the path and the preservation of insertion order.
-    current_path: dict = {}
+    current_path: dict = {None: None}
     stack: list[typing.Iterator] = [iter([(None, source)])]
 
     while stack:
         # 1. Try to extend the current path.
         next_edge = next((e for e in stack[-1] if e[1] not in current_path), None)
         if next_edge is None:
-            # All children of the last node in the current path have been explored.
+            # All edges of the last node in the current path have been explored.
             stack.pop()
-            if current_path:
-                current_path.popitem()
+            current_path.popitem()
             continue
         previous_node, next_node, *_ = next_edge
 
         # 2. Check if we've reached a target.
         if next_node in targets:
-            yield (list(current_path.values()) + [next_edge])[1:]  # remove dummy edge
+            yield (list(current_path.values()) + [next_edge])[2:]  # remove dummy edge
 
         # 3. Only expand the search through the next node if it makes sense.
-        if len(current_path) < cutoff and (targets - current_path.keys() - {next_node}):
+        if len(current_path) - 1 < cutoff and (
+            targets - current_path.keys() - {next_node}
+        ):
             current_path[next_node] = next_edge
             stack.append(iter(get_edges(next_node)))
 

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -256,6 +256,7 @@ def all_simple_paths(G, source, target, cutoff=None):
     """
     if source not in G:
         raise nx.NodeNotFound(f"source node {source} not in graph")
+
     if target in G:
         targets = {target}
     else:
@@ -263,17 +264,11 @@ def all_simple_paths(G, source, target, cutoff=None):
             targets = set(target)
         except TypeError as err:
             raise nx.NodeNotFound(f"target node {target} not in graph") from err
-    if not targets:
-        return _empty_generator()
-    if cutoff is None:
-        cutoff = len(G) - 1
-    if cutoff < 0:
-        return _empty_generator()
-    return _all_simple_paths(G, source, targets, cutoff)
 
+    cutoff = cutoff if cutoff is not None else len(G) - 1
 
-def _empty_generator():
-    yield from ()
+    if cutoff >= 0 and targets:
+        yield from _all_simple_paths(G, source, targets, cutoff)
 
 
 def _all_simple_paths(G: nx.Graph, source, targets: set, cutoff: int):

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -170,6 +170,17 @@ def all_simple_paths(G, source, target, cutoff=None):
         [0, 3, 1, 2]
         [0, 3, 2]
 
+    The singleton path from `source` to itself is considered a simple path and is
+    included in the results:
+
+        >>> G = nx.empty_graph(5)
+        >>> list(nx.all_simple_paths(G, source=0, target=0))
+        [[0]]
+
+        >>> G = nx.path_graph(3)
+        >>> list(nx.all_simple_paths(G, source=0, target={0, 1, 2}))
+        [[0], [0, 1], [0, 1, 2]]
+
     Iterate over each path from the root nodes to the leaf nodes in a
     directed acyclic graph using a functional programming approach::
 
@@ -270,11 +281,13 @@ def _all_simple_paths(G: nx.Graph, source, targets: set, cutoff: int):
     # and the child iterators at each point in the stack.
     # To avoid unnecessary checks, the loop is structured in a way such that a path
     # is considered for yielding only after adding a new node.
+    # We bootstrap the search by adding a dummy iterator to the stack that only yields
+    # the source (so that the singleton path has a chance of being included).
 
     # The current_path is a dictionary (instead of a list or a set) because we want
     # both a fast membership test and the preservation of order.
-    current_path: dict = {source: True}
-    stack: list[typing.Iterator] = [(v for u, v in G.edges(source))]
+    current_path: dict = {}
+    stack: list[typing.Iterator] = [iter([source])]
 
     while stack:
         # 1. Try to extend the current path.

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -97,6 +97,10 @@ class TestCycles:
         for c in cc:
             assert any(self.is_cyclic_permutation(c, rc) for rc in ca)
 
+    def test_simple_cycles_singleton(self):
+        G = nx.Graph([(0, 0)])  # self-loop
+        assert list(nx.simple_cycles(G)) == [[0]]
+
     def test_unsortable(self):
         # this test ensures that graphs whose nodes without an intrinsic
         # ordering do not cause issues

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -276,6 +276,11 @@ def test_all_simple_edge_paths():
     assert {tuple(p) for p in paths} == {((0, 1), (1, 2), (2, 3))}
 
 
+def test_all_simple_edge_paths_empty_path():
+    G = nx.empty_graph(1)
+    assert list(nx.all_simple_edge_paths(G, 0, 0)) == [[]]
+
+
 def test_all_simple_edge_paths_with_two_targets_emits_two_paths():
     G = nx.path_graph(4)
     G.add_edge(2, 4)
@@ -339,7 +344,7 @@ def test_all_simple_edge_paths_with_two_targets_inside_cycle_emits_two_paths():
 def test_all_simple_edge_paths_source_target():
     G = nx.path_graph(4)
     paths = nx.all_simple_edge_paths(G, 1, 1)
-    assert list(paths) == []
+    assert list(paths) == [[]]
 
 
 def test_all_simple_edge_paths_cutoff():
@@ -380,7 +385,7 @@ def test_all_simple_edge_paths_on_non_trivial_graph():
 def test_all_simple_edge_paths_multigraph():
     G = nx.MultiGraph([(1, 2), (1, 2)])
     paths = nx.all_simple_edge_paths(G, 1, 1)
-    assert list(paths) == []
+    assert list(paths) == [[]]
     nx.add_path(G, [3, 1, 10, 2])
     paths = list(nx.all_simple_edge_paths(G, 1, 2))
     assert len(paths) == 3
@@ -413,7 +418,7 @@ def test_all_simple_edge_paths_empty():
 
 
 def test_all_simple_edge_paths_corner_cases():
-    assert list(nx.all_simple_edge_paths(nx.empty_graph(2), 0, 0)) == []
+    assert list(nx.all_simple_edge_paths(nx.empty_graph(2), 0, 0)) == [[]]
     assert list(nx.all_simple_edge_paths(nx.empty_graph(2), 0, 1)) == []
     assert list(nx.all_simple_edge_paths(nx.path_graph(9), 0, 8, 0)) == []
 
@@ -468,6 +473,11 @@ def test_shortest_simple_paths():
     assert [len(path) for path in nx.shortest_simple_paths(G, 1, 12)] == sorted(
         len(path) for path in nx.all_simple_paths(G, 1, 12)
     )
+
+
+def test_shortest_simple_paths_singleton_path():
+    G = nx.empty_graph(3)
+    assert list(nx.shortest_simple_paths(G, 0, 0)) == [[0]]
 
 
 def test_shortest_simple_paths_directed():

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -195,6 +195,11 @@ def test_all_simple_paths_multigraph_with_cutoff():
     assert len(paths) == 2
     assert {tuple(p) for p in paths} == {(1, 2), (1, 2)}
 
+    # See GitHub issue #6732.
+    assert list(
+        nx.all_simple_paths(nx.MultiGraph([(0, 1), (0, 2)]), 0, {1, 2}, cutoff=1)
+    ) == [[0, 1], [0, 2]]
+
 
 def test_all_simple_paths_directed():
     G = nx.DiGraph()

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -140,8 +140,7 @@ def test_all_simple_paths_with_two_targets_inside_cycle_emits_two_paths():
 
 def test_all_simple_paths_source_target():
     G = nx.path_graph(4)
-    paths = nx.all_simple_paths(G, 1, 1)
-    assert list(paths) == []
+    assert list(nx.all_simple_paths(G, 1, 1)) == [[1]]
 
 
 def test_all_simple_paths_cutoff():
@@ -181,8 +180,7 @@ def test_all_simple_paths_on_non_trivial_graph():
 
 def test_all_simple_paths_multigraph():
     G = nx.MultiGraph([(1, 2), (1, 2)])
-    paths = nx.all_simple_paths(G, 1, 1)
-    assert list(paths) == []
+    assert list(nx.all_simple_paths(G, 1, 1)) == [[1]]
     nx.add_path(G, [3, 1, 10, 2])
     paths = list(nx.all_simple_paths(G, 1, 2))
     assert len(paths) == 3
@@ -216,9 +214,18 @@ def test_all_simple_paths_empty():
 
 
 def test_all_simple_paths_corner_cases():
-    assert list(nx.all_simple_paths(nx.empty_graph(2), 0, 0)) == []
+    assert list(nx.all_simple_paths(nx.empty_graph(2), 0, 0)) == [[0]]
     assert list(nx.all_simple_paths(nx.empty_graph(2), 0, 1)) == []
     assert list(nx.all_simple_paths(nx.path_graph(9), 0, 8, 0)) == []
+
+
+def test_all_simple_paths_source_in_targets():
+    # See GitHub issue #6690.
+    assert list(nx.all_simple_paths(nx.path_graph(3), 0, {0, 1, 2})) == [
+        [0],
+        [0, 1],
+        [0, 1, 2],
+    ]
 
 
 def hamiltonian_path(G, source):

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -423,6 +423,11 @@ def test_all_simple_edge_paths_corner_cases():
     assert list(nx.all_simple_edge_paths(nx.path_graph(9), 0, 8, 0)) == []
 
 
+def test_all_simple_edge_paths_ignores_self_loop():
+    G = nx.Graph([(0, 0), (0, 1), (1, 1), (1, 2)])
+    assert list(nx.all_simple_edge_paths(G, 0, 2)) == [[(0, 1), (1, 2)]]
+
+
 def hamiltonian_edge_path(G, source):
     source = arbitrary_element(G)
     neighbors = set(G[source]) - {source}

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -194,9 +194,8 @@ def test_all_simple_paths_multigraph_with_cutoff():
     assert {tuple(p) for p in paths} == {(1, 2), (1, 2)}
 
     # See GitHub issue #6732.
-    assert list(
-        nx.all_simple_paths(nx.MultiGraph([(0, 1), (0, 2)]), 0, {1, 2}, cutoff=1)
-    ) == [[0, 1], [0, 2]]
+    G = nx.MultiGraph([(0, 1), (0, 2)])
+    assert list(nx.all_simple_paths(G, 0, {1, 2}, cutoff=1)) == [[0, 1], [0, 2]]
 
 
 def test_all_simple_paths_directed():
@@ -221,11 +220,8 @@ def test_all_simple_paths_corner_cases():
 
 def test_all_simple_paths_source_in_targets():
     # See GitHub issue #6690.
-    assert list(nx.all_simple_paths(nx.path_graph(3), 0, {0, 1, 2})) == [
-        [0],
-        [0, 1],
-        [0, 1, 2],
-    ]
+    G = nx.path_graph(3)
+    assert list(nx.all_simple_paths(G, 0, {0, 1, 2})) == [[0], [0, 1], [0, 1, 2]]
 
 
 def hamiltonian_path(G, source):


### PR DESCRIPTION
The source being one of the targets shouldn't automatically exclude all other solutions.

Closes #6690, closes #6732

- [x] Waiting on a response to https://github.com/networkx/networkx/issues/6690#issuecomment-1550373302 before marking as ready for review.
- [x] Report the single node paths (and show this in doc_string examples).
- [x] Add a test that these functions report single node paths.
- [x] Add tests to the other functions mentioned above to ensure that they treat single node paths as paths. Those tests may already exist. But if they don't it'd be good to add them.
- [x] For consistency, report empty edge paths in `all_simple_edge_paths` (pending discussion, see https://github.com/networkx/networkx/issues/6690#issuecomment-1575578041) 

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
