### PR TITLE
Fix dfs_postorder_nodes function

### DIFF
--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -291,7 +291,7 @@ def dfs_postorder_nodes(G, source=None, depth_limit=None):
     bfs_tree
     """
     edges = nx.dfs_labeled_edges(G, source=source, depth_limit=depth_limit)
-    return (v for u, v, d in edges if d == "reverse")
+    return (v for u, v, d in edges if (d == "reverse" or d == "reverse-depth_limit"))
 
 
 def dfs_preorder_nodes(G, source=None, depth_limit=None):

--- a/networkx/algorithms/traversal/tests/test_dfs.py
+++ b/networkx/algorithms/traversal/tests/test_dfs.py
@@ -129,15 +129,18 @@ class TestDepthLimitedSearch:
 
     def test_dls_postorder_nodes(self):
         assert list(nx.dfs_postorder_nodes(self.G, source=3, depth_limit=3)) == [
+            0,
             1,
+            8,
             7,
             2,
+            6,
             5,
             4,
             3,
         ]
         assert list(nx.dfs_postorder_nodes(self.D, source=2, depth_limit=2)) == (
-            [3, 7, 2]
+            [3, 8, 7, 2]
         )
 
     def test_dls_successor(self):


### PR DESCRIPTION
Solves issue #6479 

I made some changes to fix `dfs_postorder_nodes` function so that it gives the correct output with `depth_limit` and also modified the test cases based on what I think should be the output.