### PR TITLE
Stabilize test of approximation.connected_components

### DIFF
--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -233,7 +233,7 @@ def test_same():
 class TestAntiGraph:
     @classmethod
     def setup_class(cls):
-        cls.Gnp = nx.gnp_random_graph(20, 0.8)
+        cls.Gnp = nx.gnp_random_graph(20, 0.8, seed=42)
         cls.Anp = _AntiGraph(nx.complement(cls.Gnp))
         cls.Gd = nx.davis_southern_women_graph()
         cls.Ad = _AntiGraph(nx.complement(cls.Gd))
@@ -256,6 +256,8 @@ class TestAntiGraph:
             assert nx.core_number(G) == nx.core_number(A)
 
     def test_connected_components(self):
+        # ccs are same unless isolated nodes or any node has degree=len(G)-1
+        # graphs in self.GA avoid this problem
         for G, A in self.GA:
             gc = [set(c) for c in nx.connected_components(G)]
             ac = [set(c) for c in nx.connected_components(A)]


### PR DESCRIPTION
There are Sporadic test failures when testing connected components of `AntiGraph` in `test_kcomponents.py`.
The tests checks whether ccs of G and AntiGraph(G) are the same.
But that is not true for graphs with isolated nodes or with nodes that connect to every other node.
One of the graphs being tested is generated using `gnp_random_graph` without a seed.
So occasionally it will construct a graph with a node connected to every other node.

Fix: Assign a seed to make sure the random graph doesn't produce such a node 
