### PR TITLE
Add an optional argument to the incidence_matrix function to provide …

### DIFF
--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -6,7 +6,9 @@ import networkx as nx
 __all__ = ["incidence_matrix", "adjacency_matrix"]
 
 
-def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=None):
+def incidence_matrix(
+    G, nodelist=None, edgelist=None, oriented=False, weight=None, dtype=None
+):
     """Returns incidence matrix of G.
 
     The incidence matrix assigns each row to a node and each column to an edge.
@@ -38,6 +40,12 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
        If None, then each edge has weight 1.  Edge weights, if used,
        should be positive so that the orientation can provide the sign.
 
+    dtype : something or None, optional (default=None)
+        The dtype of the output sparse array. This type should be a compatible
+        type of the weight argument, eg. if weight would return a float this
+        argument should also be a float.
+        If None, then the default for SciPy is used.
+
     Returns
     -------
     A : SciPy sparse array
@@ -65,7 +73,7 @@ def incidence_matrix(G, nodelist=None, edgelist=None, oriented=False, weight=Non
             edgelist = list(G.edges(keys=True))
         else:
             edgelist = list(G.edges())
-    A = sp.sparse.lil_array((len(nodelist), len(edgelist)))
+    A = sp.sparse.lil_array((len(nodelist), len(edgelist)), dtype=dtype)
     node_index = {node: i for i, node in enumerate(nodelist)}
     for ei, e in enumerate(edgelist):
         (u, v) = e[:2]

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -40,7 +40,7 @@ def incidence_matrix(
        If None, then each edge has weight 1.  Edge weights, if used,
        should be positive so that the orientation can provide the sign.
 
-    dtype : something or None, optional (default=None)
+    dtype : a NumPy dtype or None (default=None)
         The dtype of the output sparse array. This type should be a compatible
         type of the weight argument, eg. if weight would return a float this
         argument should also be a float.

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -14,7 +14,7 @@ def test_incidence_matrix_simple():
     deg = [(1, 0), (1, 0), (1, 0), (2, 0), (1, 0), (2, 1), (0, 1), (0, 1)]
     MG = nx.random_clustered_graph(deg, seed=42)
 
-    I = nx.incidence_matrix(G).todense().astype(int)
+    I = nx.incidence_matrix(G, dtype=int).todense()
     # fmt: off
     expected = np.array(
         [[1, 1, 1, 0],
@@ -26,7 +26,7 @@ def test_incidence_matrix_simple():
     # fmt: on
     np.testing.assert_equal(I, expected)
 
-    I = nx.incidence_matrix(MG).todense().astype(int)
+    I = nx.incidence_matrix(MG, dtype=int).todense()
     # fmt: off
     expected = np.array(
         [[1, 0, 0, 0, 0, 0, 0],
@@ -103,104 +103,80 @@ class TestGraphMatrix:
 
     def test_incidence_matrix(self):
         "Conversion to incidence matrix"
-        I = (
-            nx.incidence_matrix(
-                self.G,
-                nodelist=sorted(self.G),
-                edgelist=sorted(self.G.edges()),
-                oriented=True,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.G,
+            nodelist=sorted(self.G),
+            edgelist=sorted(self.G.edges()),
+            oriented=True,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, self.OI)
 
-        I = (
-            nx.incidence_matrix(
-                self.G,
-                nodelist=sorted(self.G),
-                edgelist=sorted(self.G.edges()),
-                oriented=False,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.G,
+            nodelist=sorted(self.G),
+            edgelist=sorted(self.G.edges()),
+            oriented=False,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, np.abs(self.OI))
 
-        I = (
-            nx.incidence_matrix(
-                self.MG,
-                nodelist=sorted(self.MG),
-                edgelist=sorted(self.MG.edges()),
-                oriented=True,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.MG,
+            nodelist=sorted(self.MG),
+            edgelist=sorted(self.MG.edges()),
+            oriented=True,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, self.OI)
 
-        I = (
-            nx.incidence_matrix(
-                self.MG,
-                nodelist=sorted(self.MG),
-                edgelist=sorted(self.MG.edges()),
-                oriented=False,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.MG,
+            nodelist=sorted(self.MG),
+            edgelist=sorted(self.MG.edges()),
+            oriented=False,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, np.abs(self.OI))
 
-        I = (
-            nx.incidence_matrix(
-                self.MG2,
-                nodelist=sorted(self.MG2),
-                edgelist=sorted(self.MG2.edges()),
-                oriented=True,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.MG2,
+            nodelist=sorted(self.MG2),
+            edgelist=sorted(self.MG2.edges()),
+            oriented=True,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, self.MGOI)
 
-        I = (
-            nx.incidence_matrix(
-                self.MG2,
-                nodelist=sorted(self.MG),
-                edgelist=sorted(self.MG2.edges()),
-                oriented=False,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.MG2,
+            nodelist=sorted(self.MG),
+            edgelist=sorted(self.MG2.edges()),
+            oriented=False,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, np.abs(self.MGOI))
 
         I = nx.incidence_matrix(self.G, dtype=np.uint8)
         assert I.dtype == np.uint8
 
     def test_weighted_incidence_matrix(self):
-        I = (
-            nx.incidence_matrix(
-                self.WG,
-                nodelist=sorted(self.WG),
-                edgelist=sorted(self.WG.edges()),
-                oriented=True,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.WG,
+            nodelist=sorted(self.WG),
+            edgelist=sorted(self.WG.edges()),
+            oriented=True,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, self.OI)
 
-        I = (
-            nx.incidence_matrix(
-                self.WG,
-                nodelist=sorted(self.WG),
-                edgelist=sorted(self.WG.edges()),
-                oriented=False,
-            )
-            .todense()
-            .astype(int)
-        )
+        I = nx.incidence_matrix(
+            self.WG,
+            nodelist=sorted(self.WG),
+            edgelist=sorted(self.WG.edges()),
+            oriented=False,
+            dtype=int,
+        ).todense()
         np.testing.assert_equal(I, np.abs(self.OI))
 
         # np.testing.assert_equal(nx.incidence_matrix(self.WG,oriented=True,

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -175,6 +175,9 @@ class TestGraphMatrix:
         )
         np.testing.assert_equal(I, np.abs(self.MGOI))
 
+        I = nx.incidence_matrix(self.G, dtype=np.uint8)
+        assert I.dtype == np.uint8
+
     def test_weighted_incidence_matrix(self):
         I = (
             nx.incidence_matrix(


### PR DESCRIPTION
Add an optional argument to the incidence_matrix function to provide the dtype to the scipy sparse array

This avoids extra copying of the array if you need to do `astype` after creating the array.

I've added a very basic test which can be added to. Lots of the other tests also use `astype` so I could change those as well if preferred. Thanks for the review!
