### PR TITLE
Add Dulmage-Mendelsohn decomposition to `algorithms.bipartite.matching`

### DIFF
--- a/doc/reference/algorithms/bipartite.rst
+++ b/doc/reference/algorithms/bipartite.rst
@@ -41,6 +41,7 @@ Matching
    to_vertex_cover
    maximum_matching
    minimum_weight_full_matching
+   dulmage_mendelsohn_decomposition
 
 
 Matrix

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -49,6 +49,7 @@ __all__ = [
     "eppstein_matching",
     "to_vertex_cover",
     "minimum_weight_full_matching",
+    "dulmage_mendelsohn_decomposition",
 ]
 
 INFINITY = float("inf")
@@ -588,10 +589,11 @@ def dulmage_mendelsohn_decomposition(G, top_nodes, matching=None):
     """Return a partition of the nodes of ``G`` into the subsets defined by
     the Dulmage-Mendelsohn decomposition
 
-    The Dulmage-Mendelsohn decomposition [1] partitions nodes of a bipartite
+    The Dulmage-Mendelsohn decomposition [1]_ partitions nodes of a bipartite
     graph into unique subsets that determine all nodes that can possibly be
     unmatched in some maximum matching. The subsets are defined in terms of
     the bipartite sets of the graph. They are:
+
     - The unmatched nodes in one set, and all nodes reachable via an alternating
       path from them
     - The unmatched nodes in the other set, and all nodes reachable via an
@@ -603,8 +605,10 @@ def dulmage_mendelsohn_decomposition(G, top_nodes, matching=None):
     particular maximum matching. However, the subsets are independent of the
     matching used to compute them.
 
-    [1] Dulmage and Mendelsohn. "Coverings of Bipartite Graphs". Can. J. Math.,
-        1958.
+    In contrast to the other functions in this module, ``top_nodes`` is a
+    required argument, even if there is only one possible bipartition. This
+    is so there is never ambiguity about which set of nodes each "reachable"
+    subset is reachable from.
 
     Parameters
     ----------
@@ -627,6 +631,11 @@ def dulmage_mendelsohn_decomposition(G, top_nodes, matching=None):
 
         List of nodes that are not reachable by an alternating path from
         unmatched nodes.
+
+    References
+    ----------
+    .. [1] Dulmage and Mendelsohn. "Coverings of Bipartite Graphs". Can. J. Math.,
+        1958.
 
     """
     if matching is None:

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -588,6 +588,24 @@ def dulmage_mendelsohn_decomposition(G, top_nodes, matching=None):
     """Return a partition of the nodes of ``G`` into the subsets defined by
     the Dulmage-Mendelsohn decomposition
 
+    The Dulmage-Mendelsohn decomposition [1] partitions nodes of a bipartite
+    graph into unique subsets that determine all nodes that can possibly be
+    unmatched in some maximum matching. The subsets are defined in terms of
+    the bipartite sets of the graph. They are:
+    - The unmatched nodes in one set, and all nodes reachable via an alternating
+      path from them
+    - The unmatched nodes in the other set, and all nodes reachable via an
+      alternating path from them
+    - The nodes that are unreachable via alternating path from any unmatched
+      node
+
+    Unmatched nodes and alternating paths are defined with respect to a
+    particular maximum matching. However, the subsets are independent of the
+    matching used to compute them.
+
+    [1] Dulmage and Mendelsohn. "Coverings of Bipartite Graphs". Can. J. Math.,
+        1958.
+
     Parameters
     ----------
     G : NetworkX graph

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -582,3 +582,73 @@ def minimum_weight_full_matching(G, top_nodes=None, weight="weight"):
     # add the ones from right to left as well.
     d.update({v: u for u, v in d.items()})
     return d
+
+
+def dulmage_mendelsohn_decomposition(G, top_nodes):
+    """Return a partition of the nodes of ``G`` into the subsets defined by
+    the Dulmage-Mendelsohn decomposition
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    top_nodes : container
+
+    Returns
+    -------
+    top_partition : tuple
+
+        Tuple of three elements: the top nodes that are possibly unmatched in a
+        maximum matching, the top nodes that are never unmatched in a maximum
+        matching, and the top nodes that are matched with possibly unmatched
+        bottom nodes
+
+    bot_partition : tuple
+
+        Tuple of three elements: the bottom nodes that are matched with possibly
+        unmatched top nodes, the bottom nodes that are never unmatched in a
+        maximum matching, and the bottom nodes that are possibly unmatched
+        in a maximum matching
+
+    """
+    top_node_set = set(top_nodes)
+    bot_nodes = [node for node in G if node not in top_node_set]
+    matching = maximum_matching(G, top_nodes=top_nodes)
+    unmatched_top = [node for node in top_nodes if node not in matching]
+    unmatched_bot = [node for node in bot_nodes if node not in matching]
+    reachable_from_top = _connected_by_alternating_paths(G, matching, unmatched_top)
+    reachable_from_bot = _connected_by_alternating_paths(G, matching, unmatched_bot)
+
+    always_matched_top = [
+        node for node in top_nodes
+        if node not in reachable_from_top and node not in reachable_from_bot
+    ]
+    always_matched_bot = [
+        node for node in bot_nodes
+        if node not in reachable_from_top and node not in reachable_from_bot
+    ]
+
+    top_reachable_from_unmatched_bot = [
+        node for node in top_nodes if node in reachable_from_bot
+    ]
+    bot_reachable_from_unmatched_bot = [
+        node for node in bot_nodes if node in reachable_from_bot
+    ]
+    bot_reachable_from_unmatched_top = [
+        node for node in bot_nodes if node in reachable_from_top
+    ]
+    top_reachable_from_unmatched_top = [
+        node for node in top_nodes if node in reachable_from_top
+    ]
+    return (
+        (
+            top_reachable_from_unmatched_top,
+            always_matched_top,
+            top_reachable_from_unmatched_bot,
+        ),
+        (
+            bot_reachable_from_unmatched_top,
+            always_matched_bot,
+            bot_reachable_from_unmatched_bot,
+        ),
+    )

--- a/networkx/algorithms/bipartite/tests/test_matching.py
+++ b/networkx/algorithms/bipartite/tests/test_matching.py
@@ -10,6 +10,7 @@ from networkx.algorithms.bipartite.matching import (
     maximum_matching,
     minimum_weight_full_matching,
     to_vertex_cover,
+    dulmage_mendelsohn_decomposition,
 )
 
 
@@ -324,3 +325,68 @@ class TestMinimumWeightFullMatching:
         G.add_edge(1, 3, mass=2)
         matching = minimum_weight_full_matching(G, weight="mass")
         assert matching == {0: 3, 1: 2, 2: 1, 3: 0}
+
+
+class TestDulmageMendelsohnDecomposition:
+    def test_pothen_fan_example(self):
+        """Example from Pothen and Fan, 1990"""
+        G = nx.Graph()
+        NL = 12
+        NR = 11
+        left_nodes = list(range(NL))
+        right_nodes = list(range(NL, NL + NR))
+
+        G.add_nodes_from(left_nodes, bipartite=0)
+        G.add_nodes_from(right_nodes, bipartite=1)
+
+        edges = [ 
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 4),
+            (0, 5),
+            (1, 3),
+            (1, 4),
+            (1, 6),
+            (1, 7),
+            (1, 9),
+            (2, 0),
+            (2, 2),
+            (2, 4),
+            (3, 5),
+            (3, 6),
+            (3, 10),
+            (4, 5),
+            (4, 6),
+            (4, 8),
+            (5, 7),
+            (5, 8),
+            (6, 7),
+            (6, 8),
+            (6, 9),
+            (7, 9),
+            (7, 10),
+            (8, 10),
+            (9, 9),
+            (10, 9),
+            (10, 10),
+            (11, 10),
+        ]
+        # Edges above are labeled as in Pothen & Fan paper. Need to
+        # convert into our space of nodes
+        edges = [(i, j + NL) for i, j in edges]
+        G.add_edges_from(edges)
+
+        top_partition, bot_partition = dulmage_mendelsohn_decomposition(
+            G, left_nodes
+        )
+        assert len(top_partition) == 3
+        assert len(bot_partition) == 3
+
+        assert top_partition[0] == [7, 8, 9, 10, 11]
+        assert top_partition[1] == [3, 4, 5, 6]
+        assert top_partition[2] == [0, 1, 2]
+        assert bot_partition[0] == [21, 22]
+        assert bot_partition[1] == [17, 18, 19, 20]
+        assert bot_partition[2] == [12, 13, 14, 15, 16]


### PR DESCRIPTION
## Motivation
The Dulmage-Mendelsohn decomposition is a useful partition for bipartite graphs that I use frequently. I thought it would be nice to have it in NetworkX.

The Dulmage-Mendelsohn decomposition is a partition that defines all nodes that can possibly be unmatched in some maximum matching of a bipartite graph. It partitions nodes into the following subsets:
- Nodes reachable via alternating path from unmatched nodes in one bipartite set
- Nodes reachable via alternating path from unmatched nodes in the other bipartite set
- Nodes not reachable via alternating path from any unmatched nodes

## Design decisions
In most descriptions of the partition (e.g. [Pothen and Fan, 1990](https://dl.acm.org/doi/pdf/10.1145/98267.98287) and Chapter 7 of [Davis, 2006](https://epubs.siam.org/doi/book/10.1137/1.9780898718881)), the subsets for the two bipartite sets are kept separate, for a total of six unique subsets. However, my current implementation only returns three subsets, as if "top nodes" are known, it is easy to partition these three subsets into "top" and "bottom".

I have also made `top_nodes` a required argument so there is no ambiguity about which of the two bipartite sets each "reachable" subset corresponds to.

I'm opening as a draft for feedback on the design and implementation. This PR still needs:
- [ ] More tests