### PR TITLE
Drop support for Python 3.8 per SPEC0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,7 +1,7 @@
 Install
 =======
 
-NetworkX requires Python 3.8, 3.9, or 3.10.  If you do not already
+NetworkX requires Python 3.9, 3.10, or 3.11.  If you do not already
 have a Python environment configured on your computer, please see the
 instructions for installing the full `scientific Python stack
 <https://scipy.org/install.html>`_.

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,6 @@
 from glob import glob
 import os
-import sys
 from setuptools import setup
-
-if sys.version_info[:2] < (3, 8):
-    error = (
-        "NetworkX 2.7+ requires Python 3.8 or later (%d.%d detected). \n"
-        "For Python 2.7, please install version 2.2 using: \n"
-        "$ pip install 'networkx==2.2'" % sys.version_info[:2]
-    )
-    sys.stderr.write(error + "\n")
-    sys.exit(1)
 
 
 name = "networkx"
@@ -45,7 +35,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -194,6 +183,6 @@ if __name__ == "__main__":
         install_requires=install_requires,
         extras_require=extras_require,
         entry_points=entry_points,
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         zip_safe=False,
     )


### PR DESCRIPTION
Follow-up to #6636  also getting ready for the move to `pyproject.toml`.  See https://scientific-python.org/specs/spec-0000/