### PR TITLE
DICN Algorithm Link Prediction Implementation

### DIFF
--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -621,7 +621,6 @@ def direct_indirect_common_neighbors(G, ebunch=None):
 
         \frac{\sum_{z\in{UN_{uv}}}(N_u[z] - \overline{N_u})(N_v[z] - \overline{N_v})}{\sqrt{\sum_{z\in{UN_{uv}}}(N_u[z] - \overline{N_u})^2}\sqrt{\sum_{z\in{UN_{uv}}}(N_v[z] - \overline{N_v})^2}}
 
-
     where $N_i[z]$ is the neighborhood vector, $UN_{uv}$ is the
     union neighborhood set, and $\overline{N_u}$ is the mean of
     the values in the union neighborhood set over the vector $N_u$.


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

I implemented the Direct-Indirect Common Neighbors algorithm (described here: https://www.nature.com/articles/s41598-020-76799-4#Equ14) for a class project and figured it could be added to the link_prediction.py module as it gave strong results.

I will note, however, it's computationally heavier than other link prediction algorithms offered.

This is my first open-source contribution so apologies for any errors!