### PR TITLE
Bugfixes and performace improvement in community.LFR_benchmark_graph

### DIFF
--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -1065,6 +1065,7 @@ def LFR_benchmark_graph(
             while G.degree(u) < s:
                 v = seed.choice(available_in)
                 G.add_edge(u, v)
+                available_in = list(set(available_in).difference({v}))
 
             # Filter non-neighbor nodes outside community
             available_out = list((all_nodes.difference(c)).difference(neigh))
@@ -1076,5 +1077,6 @@ def LFR_benchmark_graph(
             while G.degree(u) < deg_seq[u]:
                 v = seed.choice(available_out)
                 G.add_edge(u, v)
+                available_out = list(set(available_out).difference({v}))
             G.nodes[u]["community"] = c
     return G

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -777,18 +777,19 @@ def _generate_communities(degree_seq, community_sizes, mu, max_iters, seed):
     result = [set() for _ in community_sizes]
     n = len(degree_seq)
     free = list(range(n))
+    all_c = range(len(community_sizes))
     for i in range(max_iters):
         v = free.pop()
-        c = seed.choice(range(len(community_sizes)))
-        # s = int(degree_seq[v] * (1 - mu) + 0.5)
         s = round(degree_seq[v] * (1 - mu))
-        # If the community is large enough, add the node to the chosen
-        # community. Otherwise, return it to the list of unaffiliated
-        # nodes.
-        if s < community_sizes[c]:
-            result[c].add(v)
-        else:
-            free.append(v)
+        # Choose a community from communities which are large enough
+        available_c = list(filter(lambda x: community_sizes[x] > s, all_c))
+        if len(available_c) == 0:
+            msg = "Could not assign communities; try increasing min_community"
+            raise nx.ExceededMaxIterations(msg)
+        c = seed.choice(available_c)
+        # Add the node to the chosen community
+        result[c].add(v)
+
         # If the community is too big, remove a node from it.
         if len(result[c]) > community_sizes[c]:
             free.append(result[c].pop())


### PR DESCRIPTION
Fixes infinite while loops in main `LFR_benchmark_graph` function during adding edge. Add `available_in` and `available_out` variables which contain the available nodes for connecting inside and outside community. Checks, if the number of available nodes suffices to meet the number of in- and out-community edges.

Improve performance during adding edges -- add edges from a list of possible nodes and update the list.

Improve performance during generating communities -- check if there are communities big enough to hold the node. Choose the node community from the list of available enough-sized communities.