### PR TITLE
Replace deprecated numpy.alltrue method

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -721,7 +721,7 @@ def draw_networkx_edges(
     if (
         np.iterable(edge_color)
         and (len(edge_color) == len(edge_pos))
-        and np.alltrue([isinstance(c, Number) for c in edge_color])
+        and np.all([isinstance(c, Number) for c in edge_color])
     ):
         if edge_cmap is not None:
             assert isinstance(edge_cmap, mpl.colors.Colormap)


### PR DESCRIPTION
The method `numpy.alltrue` has been deprecated in 1.25 and will be removed in numpy 2.0. See https://github.com/numpy/numpy/pull/23314
