### PR TITLE
MAINT: Ignore SciPy v1.11 in requirements

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.22
-scipy>=1.9
+scipy>=1.9,!=1.11
 matplotlib>=3.5
 pandas>=1.4

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.22
-scipy>=1.9,!=1.11
+scipy>=1.9,!=1.11.0
 matplotlib>=3.5
 pandas>=1.4


### PR DESCRIPTION
Should we just keep this pin till scipy 1.11+ becomes the min supported scipy version for networkx?