### PR TITLE
keep out scipy 1.11.1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.22
-scipy>=1.9,!=1.11.0
+scipy>=1.9,!=1.11.0,!=1.11.1
 matplotlib>=3.5
 pandas>=1.4


### PR DESCRIPTION
Scipy released 1.11.1 without waiting for the fix we need to be able to use superLU.

