### PR TITLE
Fix typo in contributing page

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -282,7 +282,7 @@ Guidelines
    import pandas as pd
    import networkx as nx
 
-  After importing `sp`` for ``scipy``::
+  After importing ``sp`` for ``scipy``::
 
    import scipy as sp
 


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
There was a missing backtick causing an extra one to appear after `sp` in the contributing page.