### PR TITLE
deprecate Edmonds class

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -77,5 +77,8 @@ Version 3.3
   to return a dict. See #6527
 * Change ``shortest_path`` in ``algorithms/shortest_path/generic.py``
   to return a iterator. See #6527
+
+Version 3.4
+~~~~~~~~~~~
 * Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
 * Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -77,3 +77,5 @@ Version 3.3
   to return a dict. See #6527
 * Change ``shortest_path`` in ``algorithms/shortest_path/generic.py``
   to return a iterator. See #6527
+* Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
+* Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -37,7 +37,9 @@ API Changes
 
 Deprecations
 ------------
-
+- [`#XXXX <https://github.com/networkx/pull/XXXX>`_]
+  Deprecate ``MultiDiGraph_EdgeKey`` subclass used in ``Edmonds`` class.
+  Deprecate ``Edmonds`` class for computing minimum and maximum branchings and arborescences (use ``minimum_branching``, ``minimal_branching``, ``maximum_branching``, ``minimum_arborescence`` and ``maximum_arborescence`` directly).
 
 Merged PRs
 ----------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -37,7 +37,7 @@ API Changes
 
 Deprecations
 ------------
-- [`#XXXX <https://github.com/networkx/pull/XXXX>`_]
+- [`#6785 <https://github.com/networkx/pull/6785>`_]
   Deprecate ``MultiDiGraph_EdgeKey`` subclass used in ``Edmonds`` class.
   Deprecate ``Edmonds`` class for computing minimum and maximum branchings and arborescences (use ``minimum_branching``, ``minimal_branching``, ``maximum_branching``, ``minimum_arborescence`` and ``maximum_arborescence`` directly).
 

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -211,7 +211,7 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
 
         import warnings
 
-        msg = "MultiDiGraph_EdgeKey has been deprecated and will be removed in NetworkX 3.3."
+        msg = "MultiDiGraph_EdgeKey has been deprecated and will be removed in NetworkX 3.4."
         warnings.warn(msg, DeprecationWarning)
 
     def remove_node(self, n):
@@ -322,7 +322,7 @@ class Edmonds:
 
         import warnings
 
-        msg = "Edmonds has been deprecated and will be removed in NetworkX 3.3. Please use the approiate minimum or maximum branching or arborescence function directly."
+        msg = "Edmonds has been deprecated and will be removed in NetworkX 3.4. Please use the approiate minimum or maximum branching or arborescence function directly."
         warnings.warn(msg, DeprecationWarning)
 
     def _init(self, attr, default, kind, style, preserve_attrs, seed, partition):

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -209,6 +209,11 @@ class MultiDiGraph_EdgeKey(nx.MultiDiGraph):
         self._cls = cls
         self.edge_index = {}
 
+        import warnings
+
+        msg = "MultiDiGraph_EdgeKey has been deprecated and will be removed in NetworkX 3.3."
+        warnings.warn(msg, DeprecationWarning)
+
     def remove_node(self, n):
         keys = set()
         for keydict in self.pred[n].values():
@@ -314,6 +319,11 @@ class Edmonds:
         # Since we will be creating graphs with new nodes, we need to make
         # sure that our node names do not conflict with the real node names.
         self.template = random_string(seed=seed) + "_{0}"
+
+        import warnings
+
+        msg = "Edmonds has been deprecated and will be removed in NetworkX 3.3. Please use the approiate minimum or maximum branching or arborescence function directly."
+        warnings.warn(msg, DeprecationWarning)
 
     def _init(self, attr, default, kind, style, preserve_attrs, seed, partition):
         """
@@ -821,7 +831,7 @@ def maximum_branching(
             d[partition] = data.get(partition)
 
         if preserve_attrs:
-            for d_k, d_v in d.items():
+            for d_k, d_v in data.items():
                 if d_k != attr:
                     d[d_k] = d_v
 

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -446,8 +446,7 @@ def test_edge_attribute_preservation_normal_graph():
     ]
     G.add_edges_from(edgelist)
 
-    ed = branchings.Edmonds(G)
-    B = ed.find_optimum("weight", preserve_attrs=True, seed=1)
+    B = branchings.maximum_branching(G, preserve_attrs=True)
 
     assert B[0][1]["otherattr"] == 1
     assert B[0][1]["otherattr2"] == 3
@@ -465,13 +464,13 @@ def test_edge_attribute_preservation_multigraph():
     ]
     G.add_edges_from(edgelist * 2)  # Make sure we have duplicate edge paths
 
-    ed = branchings.Edmonds(G)
-    B = ed.find_optimum("weight", preserve_attrs=True)
+    B = branchings.maximum_branching(G, preserve_attrs=True)
 
     assert B[0][1][0]["otherattr"] == 1
     assert B[0][1][0]["otherattr2"] == 3
 
 
+# TODO remove with Edmonds
 def test_Edmond_kind():
     G = nx.MultiGraph()
 
@@ -486,6 +485,7 @@ def test_Edmond_kind():
         ed.find_optimum(kind="lol", preserve_attrs=True)
 
 
+# TODO remove with MultiDiGraph_EdgeKey
 def test_MultiDiGraph_EdgeKey():
     # test if more than one edges has the same key
     G = branchings.MultiDiGraph_EdgeKey()
@@ -515,8 +515,7 @@ def test_edge_attribute_discard():
     ]
     G.add_edges_from(edgelist)
 
-    ed = branchings.Edmonds(G)
-    B = ed.find_optimum("weight", preserve_attrs=False)
+    B = branchings.maximum_branching(G, preserve_attrs=False)
 
     edge_dict = B[0][1]
     with pytest.raises(KeyError):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -81,6 +81,14 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\nforest_str is deprecated"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="Edmonds has been deprecated"
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="MultiDiGraph_EdgeKey has been deprecated",
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
As discussed in #6743, the original implementation of Edmond's algorithm for finding maximum branchings, and by extension minimum branchings as well as minimum and maximum arborescences was a class with only one method (`find_optimum`). This API structure is not common throughout NetworkX, in fact it is the only instance where a class is used to implement a network algorithm that I'm aware of. Since all of these algorithms were recently refactored and no longer depend on the class itself, it is now safe to remove the class. 

Additionally, the `MultiDiGraph` subclass `MultiDiGraph_EdgeKey` is also no longer needed. It was not used in any other algorithms in the library and doesn't extend the original class in a manner which is not easily replicated with an additional helper function. 