### PR TITLE
Refix minimum_cycle_basis and scipy.sparse conversions and add tests

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -1097,7 +1097,7 @@ def _min_cycle_basis(G, weight):
                 {e for e in orth if e not in base if e[::-1] not in base}
                 | {e for e in base if e not in orth if e[::-1] not in orth}
             )
-            if any((e in orth or e[::-1] in orth) for e in cycle_edges)
+            if sum((e in orth or e[::-1] in orth) for e in cycle_edges) % 2
             else orth
             for orth in set_orth
         ]

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -917,7 +917,7 @@ class TestMinimumCycleBasis:
         cg = nx.complete_graph(N)
         cg.add_weighted_edges_from([(u, v, 9) for u, v in cg.edges])
         cg.add_weighted_edges_from([(u, v, 1) for u, v in nx.cycle_graph(N).edges])
-        mcb = nx.minimum_cycle_basis(cg, weight='weight')
+        mcb = nx.minimum_cycle_basis(cg, weight="weight")
         check_independent(mcb)
 
     def test_gh6787_and_edge_attribute_names(self):

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -8,6 +8,22 @@ import networkx as nx
 from networkx.algorithms.traversal.edgedfs import FORWARD, REVERSE
 
 
+def check_independent(basis):
+    if len(basis) == 0:
+        return
+    try:
+        import numpy as np
+    except ImportError:
+        return
+
+    H = nx.Graph()
+    for b in basis:
+        nx.add_cycle(H, b)
+    inc = nx.incidence_matrix(H, oriented=True)
+    rank = np.linalg.matrix_rank(inc.toarray(), tol=None, hermitian=False)
+    assert inc.shape[1] - rank == len(basis)
+
+
 class TestCycles:
     @classmethod
     def setup_class(cls):
@@ -837,7 +853,7 @@ def assert_basis_equal(a, b):
     assert sorted(a) == sorted(b)
 
 
-class TestMinimumCycles:
+class TestMinimumCycleBasis:
     @classmethod
     def setup_class(cls):
         T = nx.Graph()
@@ -856,19 +872,21 @@ class TestMinimumCycles:
     def test_dimensionality(self):
         # checks |MCB|=|E|-|V|+|NC|
         ntrial = 10
-        for _ in range(ntrial):
-            rg = nx.erdos_renyi_graph(10, 0.3)
+        for seed in range(1234, 1234 + ntrial):
+            rg = nx.erdos_renyi_graph(10, 0.3, seed=seed)
             nnodes = rg.number_of_nodes()
             nedges = rg.number_of_edges()
             ncomp = nx.number_connected_components(rg)
 
-            dim_mcb = len(nx.minimum_cycle_basis(rg))
-            assert dim_mcb == nedges - nnodes + ncomp
+            mcb = nx.minimum_cycle_basis(rg)
+            assert len(mcb) == nedges - nnodes + ncomp
+            check_independent(mcb)
 
     def test_complete_graph(self):
         cg = nx.complete_graph(5)
         mcb = nx.minimum_cycle_basis(cg)
         assert all(len(cycle) == 3 for cycle in mcb)
+        check_independent(mcb)
 
     def test_tree_graph(self):
         tg = nx.balanced_tree(3, 3)
@@ -891,6 +909,16 @@ class TestMinimumCycles:
         # check that order of the nodes is a path
         for c in mcb:
             assert all(G.has_edge(u, v) for u, v in nx.utils.pairwise(c, cyclic=True))
+        # check independence of the basis
+        check_independent(mcb)
+
+    def test_gh6787_variable_weighted_complete_graph(self):
+        N = 8
+        cg = nx.complete_graph(N)
+        cg.add_weighted_edges_from([(u, v, 9) for u, v in cg.edges])
+        cg.add_weighted_edges_from([(u, v, 1) for u, v in nx.cycle_graph(N).edges])
+        mcb = nx.minimum_cycle_basis(cg, weight='weight')
+        check_independent(mcb)
 
     def test_gh6787_and_edge_attribute_names(self):
         G = nx.cycle_graph(4)

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -605,7 +605,7 @@ def _csr_gen_triples(A):
     data, indices, indptr = A.data, A.indices, A.indptr
     for i in range(nrows):
         for j in range(indptr[i], indptr[i + 1]):
-            yield i, indices[j], data[j]
+            yield i, int(indices[j]), data[j]
 
 
 def _csc_gen_triples(A):
@@ -617,7 +617,7 @@ def _csc_gen_triples(A):
     data, indices, indptr = A.data, A.indices, A.indptr
     for i in range(ncols):
         for j in range(indptr[i], indptr[i + 1]):
-            yield indices[j], i, data[j]
+            yield int(indices[j]), i, data[j]
 
 
 def _coo_gen_triples(A):
@@ -625,8 +625,7 @@ def _coo_gen_triples(A):
     of weighted edge triples.
 
     """
-    row, col, data = A.row, A.col, A.data
-    return zip(row, col, data)
+    return ((int(i), int(j), d) for i, j, d in zip(A.row, A.col, A.data))
 
 
 def _dok_gen_triples(A):


### PR DESCRIPTION
Follow-up testing from #6788 showed a number of interesting bugs and deficiencies.
- My error using `any` instead of `sum` followed by `% 2` in one line. This led to the returned "basis" being not independent in some cases.
- The tests don't check non-uniformly weighted graphs sufficiently to catch the above error. So add tests.
- One reported example from @mbr085 raised a ValueError which was caused because an edge was added as `np.int32` instead of python `int`. I chased this down to `convert_matrix.py` and the handling of conversion from sparse matrices. More below if you are interested.

This PR makes 3 commits to fix these issues. The first adds tests to show the errors reported in #6788. The second adds the sum/modulo term to enable passing those tests. The third corrects the sparse matrix treatment to match that of conversion from numpy arrays. 


TL;DR:
We have to be careful not to mix nodes that are `np.int32` and nodes that are python `int` in the same graph because they equate to each other (and thus are the same node) but they compare to other nodes differently. For example `int(5)` and `np.int32(5)` are equal so you can work with both on a graph as if they are the same node. But the `np.int` value raises a ValueError when compared to, say, a tuple `(5, 1)` because it treats the tuple as an array and the sizes don't match. The python in returns `False` when you check equality of an integer to a tuple. Either storage of nodes is fine, but if you use `np.int` and then **also** add nodes to your graph that are tuples, you can get ValueErrors raised when comparing the tuple-node with the np.int-node.

NetworkX handles numpy.array conversion by making nodes python int.  It handles scipy.sparse conversion by making nodes int -- but crucially, failing to convert the np.int32 indices to python in when adding edges. So inside `G.adj` the keys are python ints and but the keys to the inner nbrdict `G.adj[5]` are `np.int32` with the same value. Amazingly, this works fine almost all the time. But if you add another node that is a tuple, you can run into a raised ValueError when our algorithms check whether two nodes are equal.

I fixed the conversion functions to convert `indices` values to python int so thy match the nodes in the graph.