### PR TITLE
Fix empty graph zero division error  for louvain

### DIFF
--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -163,6 +163,9 @@ def louvain_partitions(
     """
 
     partition = [{u} for u in G.nodes()]
+    if nx.is_empty(G):
+        yield partition
+        return
     mod = modularity(G, partition, resolution=resolution, weight=weight)
     is_directed = G.is_directed()
     if G.is_multigraph():

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -185,3 +185,10 @@ def test_threshold():
     mod2 = nx.community.modularity(G, partition2)
 
     assert mod1 < mod2
+
+
+def test_empty_graph():
+    G = nx.Graph()
+    G.add_nodes_from(range(5))
+    expected = [{0}, {1}, {2}, {3}, {4}]
+    assert nx.community.louvain_communities(G) == expected


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

I fixed the Zero division error for the Louvain algorithm when running it with an empty and added a test for it. 