### PR TITLE
updating TSP example docs

### DIFF
--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function is used to produce the solution is christofides,
+The function used to produce the solution is christofides,
 where given a set of nodes, it calculates the route of the nodes
 that the traveler has to follow in order to minimize the total cost.
 """

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is `christofides <nx.approximation.christofides>`_,
+The function used to produce the solution is `christofides <nx.algorithms.approximation.christofides>`_,
 where given a set of nodes, it calculates the route of the nodes
 that the traveler has to follow in order to minimize the total cost.
 """

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -6,8 +6,9 @@ Traveling Salesman Problem
 This is an example of a drawing solution of the traveling salesman problem
 
 The function used to produce the solution is christofides,
-where given a set of nodes, it calculates the route of the nodes that the traveler has to follow in order to
-minimize the total cost."""
+where given a set of nodes, it calculates the route of the nodes
+that the traveler has to follow in order to minimize the total cost.
+"""
 
 import matplotlib.pyplot as plt
 import networkx as nx

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is christofides,
+The function used to produce the solution is :func:`christofides`,
 where given a set of nodes, it calculates the route of the nodes
 that the traveler has to follow in order to minimize the total cost.
 """

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is :func:`christofides`,
+The function used to produce the solution is `christofides <nx.approximation.christofides>`_,
 where given a set of nodes, it calculates the route of the nodes
 that the traveler has to follow in order to minimize the total cost.
 """

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is :func:`networkx.algorithms.approximation.traveling_salesman.christofides`,
+The function used to produce the solution is christofides,
 where given a set of nodes, it calculates the route of the nodes that the traveler has to follow in order to
 minimize the total cost."""
 

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,10 +5,9 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is `christofides <networkx.algorithms.approximation.christofides>`_,
-where given a set of nodes, it calculates the route of the nodes
-that the traveler has to follow in order to minimize the total cost.
-"""
+The function used to produce the solution is :func:`networkx.algorithms.approximation.traveling_salesman.christofides`,
+where given a set of nodes, it calculates the route of the nodes that the traveler has to follow in order to
+minimize the total cost."""
 
 import matplotlib.pyplot as plt
 import networkx as nx

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is christofides,
+The function used to produce the solution is `christofides <networkx.algorithms.approximation.traveling_salesman.christofides>`,
 where given a set of nodes, it calculates the route of the nodes
 that the traveler has to follow in order to minimize the total cost.
 """

--- a/examples/drawing/plot_tsp.py
+++ b/examples/drawing/plot_tsp.py
@@ -5,7 +5,7 @@ Traveling Salesman Problem
 
 This is an example of a drawing solution of the traveling salesman problem
 
-The function used to produce the solution is `christofides <nx.algorithms.approximation.christofides>`_,
+The function used to produce the solution is `christofides <networkx.algorithms.approximation.christofides>`_,
 where given a set of nodes, it calculates the route of the nodes
 that the traveler has to follow in order to minimize the total cost.
 """


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
Hello, I just found a small typo in the example docs for the traveling salesman problem.
I was also wondering what's the best way to add a hyperlink for christofides with this link:(https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.approximation.traveling_salesman.christofides.html#christofides), does sphinx docs support markdown in the python comments? and is there a shortcut for the link?