### PR TITLE
Attach milestone to merged PRs

### DIFF
--- a/.github/workflows/milestone-merged-prs.yaml
+++ b/.github/workflows/milestone-merged-prs.yaml
@@ -1,0 +1,18 @@
+name: Milestone
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - "main"
+
+jobs:
+  milestone_pr:
+    name: attach to PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: scientific-python/attach-next-milestone-action@f94a5235518d4d34911c41e19d780b8e79d42238
+        with:
+          token: ${{ secrets.MILESTONE_LABELER_TOKEN }}
+          force: true


### PR DESCRIPTION
This will attach the next milestone to PRs when they are merged into main. I've created the TOKEN, so this should work.

I also enabled `Fine-grained personal access tokens` in the process:
https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/

We are already using them for scientific-python and scikit-image.