### PR TITLE
ADD: Voting-based centrality indices

### DIFF
--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -155,3 +155,12 @@ Laplacian
    :toctree: generated/
 
    laplacian_centrality
+
+Voting-Based Centrality
+---------
+.. autosummary::
+   :toctree: generated/
+
+   sav_voting
+   copeland_voting
+   spav_voting

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -17,4 +17,5 @@ from .second_order import *
 from .subgraph_alg import *
 from .trophic import *
 from .voterank_alg import *
+from .voting_based_alg import *
 from .laplacian import *

--- a/networkx/algorithms/centrality/tests/test_voting_based.py
+++ b/networkx/algorithms/centrality/tests/test_voting_based.py
@@ -1,0 +1,154 @@
+"""
+    Unit tests for voting based centrality indices.
+"""
+
+
+import networkx as nx
+
+
+class TestSPAVCentrality:
+    def test_spav_1(self):
+        G = nx.Graph()
+        G.add_edges_from(
+            [
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (1, 5),
+                (5, 6),
+                (6, 7),
+                (7, 8),
+                (7, 9),
+                (8, 10),
+                (10, 11),
+                (11, 12),
+                (11, 2),
+            ]
+        )
+        assert [1, 7, 11] == nx.spav_voting(G, number_of_nodes=3)
+
+class TestSAVCentrality:
+    def test_sav_1(self):
+        G = nx.Graph()
+        G.add_edges_from(
+            [
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (1, 5),
+                (5, 6),
+                (6, 7),
+                (7, 8),
+                (7, 9),
+                (8, 10),
+                (10, 11),
+                (11, 12),
+                (11, 2),
+            ]
+        )
+        result = nx.sav_voting(G)
+        assert result[1] == 3
+        assert result[2] == 1/3 + 1/4
+        assert result[3] == 1/4
+        assert result[7] == 2
+        assert result[10] == 1/2 + 1/3
+    
+    def test_sav_2(self):
+        # Graph from reference paper.
+        G = nx.Graph()
+        G.add_edges_from(
+            [
+                (0, 1),
+                (0, 2),
+                (0, 3),
+                (0, 4),
+                (0, 5),
+                (0, 6),
+                (0, 7),
+                (0, 8),
+                (1, 9),
+                (9, 10),
+                (10, 11),
+                (10, 12),
+                (10, 13),
+                (10, 14),
+                (10, 15),
+                (10, 16),
+                (10, 17),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 8),
+                (8, 1),
+            ]
+        )
+        result = nx.sav_voting(G)
+        assert max(result, key=result.get) == 10
+        assert result[10] == 7 + 1/2
+        assert result[0] == 7*(1/3) + 1/4
+        assert result[1] == 1/8 + 2*(1/3) + 1/2
+
+
+class TestCopelandCentrality:
+    def test_copeland_no_condorcet_winner(self):
+        # Graph from reference paper: Condorcet Paradox.
+        G = nx.Graph()
+        G.add_edges_from(
+            [
+                ('A', 1),
+                ('A', 2),
+                ('A', 3),
+                ('A', 4),
+                (2, 5),
+                (2, 6),
+                (2, 7),
+                (5, 6),
+                (5, 7),
+                (5, 'C'),
+                ('C', 'B'),
+                ('B', 8),
+                ('B', 9),
+                ('B', 10),
+                ('B', 11),
+                (8, 11),
+                (9, 11),
+                (10, 11),
+                (11, 4),
+            ]
+        )
+        result = nx.copeland_voting(G)
+        assert result['A'] < 13
+        assert result['B'] < 13
+        assert result['C'] < 13
+    
+    def test_copeland_condorcet_winner_exists(self):
+        # Graph from reference paper: Condorcet winner exists, and Copeland chooses it.
+        G = nx.Graph()
+        G.add_edges_from(
+            [
+                ('CW', 1),
+                ('CW', 2),
+                ('CW', 3),
+                ('CW', 'BW'),
+                ('BW', 2),
+                ('BW', 4),
+                (4, 5),
+                (2, 'CC'),
+                (3, 'CC'),
+                ('CC', 6),
+                ('CC', 7),
+                (7, 6),
+                (7, 8),
+                (7, 9),
+                (3, 10),
+                (6, 1),
+                (10, 9),
+                (1, 9),
+            ]
+        )
+        result = nx.copeland_voting(G)
+        assert max(result, key=result.get) == 'CW'
+        assert len([n for n in result if result[n] == result['CW']]) == 1

--- a/networkx/algorithms/centrality/tests/test_voting_based.py
+++ b/networkx/algorithms/centrality/tests/test_voting_based.py
@@ -26,6 +26,29 @@ class TestSPAVCentrality:
             ]
         )
         assert [1, 7, 11] == nx.spav_voting(G, number_of_nodes=3)
+    
+    def test_spav_2(self):
+        G = nx.Graph()
+        G.add_edges_from(
+            [
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (1, 5),
+                (1, 6),
+                (2, 6),
+                (3, 6),
+                (4, 6),
+                (5, 6),
+                (7, 6),
+                (7, 8),
+                (7, 9),
+                (10, 6),
+                (10, 1),
+            ]
+        )
+        assert [6, 1] == nx.spav_voting(G, number_of_nodes=2)
+        assert [6, 7] == nx.spav_voting(G, number_of_nodes=2, voting_ability_fn=lambda x : 1 if x==0 else 0)
 
 class TestSAVCentrality:
     def test_sav_1(self):

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -11,7 +11,7 @@ __all__ = ["sav_voting", "copeland_voting", "spav_voting"]
 @nx.utils.not_implemented_for("directed")
 @nx.utils.not_implemented_for("multigraph")
 def sav_voting(G):
-    """Rank nodes using Satisfaction Approval Voting (SAV).
+    """Rank nodes using Satisfaction Approval Voting (SAV) [1]_ .
 
     SAV centrality (introduced in [2]_ and based on the framework in [3]_ ) lets each node vote
     on the centrality of its neighbors. Thereby, each node x contributes 1/|degree(x)| points
@@ -83,7 +83,7 @@ def sav_voting(G):
 @nx.utils.not_implemented_for("directed")
 @nx.utils.not_implemented_for("multigraph")
 def copeland_voting(G):
-    """Rank nodes using the Condorcet-consistent voting rule due to Copeland.
+    """Rank nodes using the Condorcet-consistent voting rule due to Arthur Copeland.
 
     According to Condorcet, a candidate should win an election whenever it is preferred
     to each other candidate by a majority of voters in direct comparison. Although this
@@ -170,9 +170,9 @@ def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
     on the centrality of its neighbors in multiple rounds. In each round, the node with the highest
     voting score is elected where each node contributes the same points to each of its neighbors.
     Thereby, whenever a node is elected, all neighbors' voting ability is reduced so that in the
-    next round they contribute less points to their neighbors (similar to VoteRank). By how far the
-    voting ability is reduced depends on the voting_ability_fn, which maps an integer (how many nodes
-    from the neighborhood of a "voter" are already selected) to a real number (voting ability).
+    next round they contribute less points to their neighbors (similar to VoteRank [4]_). By how far
+    the voting ability is reduced depends on the voting_ability_fn, which maps an integer (how many
+    nodes from the neighborhood of a "voter" are already selected) to a real number (voting ability).
     By default, voting_ability_fn(0) = 1, voting_ability_fn(1) = 1/2, voting_ability_fn(2) = 1/3,
     etc., is used.
     
@@ -232,7 +232,7 @@ def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
         In: Proceedings of the 21st International Conference on Autonomous Agents and Multiagent Systems (AAMAS)
         Publisher: IFAAMAS
         https://www.ifaamas.org/Proceedings/aamas2022/pdfs/p1554.pdf
-       [1] Zhang, J.-X. et al. (2016).
+       [4] Zhang, J.-X. et al. (2016).
         "Identifying a set of influential spreaders in complex networks."
         In: Sci. Rep. 6, 27823.
         https://doi.org/10.1038/srep27823

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -1,5 +1,4 @@
-"""
-Algorithms to select influential nodes in a network, or to rank nodes by their
+"""Algorithms to select influential nodes in a network, or to rank nodes by their
 centrality using voting methods from Computational Social Choice.
 """
 
@@ -12,8 +11,7 @@ __all__ = ["sav_voting", "copeland_voting", "spav_voting"]
 
 @not_implemented_for("directed")
 def sav_voting(G):
-    """
-    Rank nodes using Satisfaction Approval Voting (SAV).
+    """Rank nodes using Satisfaction Approval Voting (SAV).
 
     SAV [1]_ [2]_ lets each node vote on the centrality of its neighbors. Thereby, each node x
     contributes 1/|degree(x)| points to the total score of each neighbor. In other words: node
@@ -34,9 +32,15 @@ def sav_voting(G):
     sav_voting : dict
         For each node the dict contains the SAV score.
 
+    See Also
+    --------
+    copeland_voting, spav_voting
+
     Examples
     --------
-    TODO
+    >>> G = nx.Graph([(1, 2), (1, 3), (1, 4), (1, 5), (5, 6), (6, 7), (7, 8), (7, 9)])
+    >>> nx.sav_voting(G)
+    {1: 3.5, 2: 0.25, 3: 0.25, 4: 0.25, 5: 0.75, 6: 0.833, 7: 2.5, 8: 0.33, 9: 0.33}
 
     References
     ----------
@@ -66,8 +70,7 @@ def sav_voting(G):
 
 @not_implemented_for("directed")
 def copeland_voting(G):
-    """
-    Rank nodes using the Condorcet-consistent voting rule due to Copeland.
+    """Rank nodes using the Condorcet-consistent voting rule due to Copeland.
 
     According to Condorcet, a candidate should win an election whenever it is preferred
     to each other candidate by a majority of voters in direct comparison. Although this
@@ -83,6 +86,8 @@ def copeland_voting(G):
     comparison. If A and B are tied (neither A nor B wins), both receive no points. The
     Copeland centrality index is achieved by summing up all the points from all comparisons.
     
+    Notes
+    -----
     The Copeland centrality index was introduced in [1]_ .
 
     Parameters
@@ -95,9 +100,15 @@ def copeland_voting(G):
     copeland_voting : dict
         For each node the dict contains the copeland score.
 
+    See Also
+    --------
+    sav_voting, spav_voting
+    
     Examples
     --------
-    TODO
+    >>> G = nx.Graph([(1, 2), (1, 3), (1, 4), (1, 5), (5, 6), (6, 7), (7, 8), (7, 9)])
+    >>> nx.copeland_voting(G)
+    {1: 5, 2: -1, 3: -1, 4: -1, 5: 8, 6: 5, 7: -1, 8: -7, 9: -7}
 
     References
     ----------
@@ -133,8 +144,7 @@ def copeland_voting(G):
 
 @not_implemented_for("directed")
 def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
-    """
-    Select a set of influential nodes using Sequential Proportional Approval Voting (SPAV).
+    """Select a set of influential nodes using Sequential Proportional Approval Voting (SPAV).
 
     SPAV [1]_ [2]_ lets each node vote on the centrality of its neighbors in multiple rounds. In each
     round, the node with the highest voting score is elected where each node contributes the same
@@ -163,9 +173,15 @@ def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
     spav_voting : list
         The sequence in which the number_of_nodes nodes are elected.
 
+    See Also
+    --------
+    copeland_voting, sav_voting
+    
     Examples
     --------
-    TODO
+    >>> G = nx.Graph([(1, 2), (1, 3), (1, 4), (1, 5), (5, 6), (6, 7), (7, 8), (7, 9)])
+    >>> nx.spav_voting(G, number_of_nodes=2)
+    [1, 7]
 
     References
     ----------

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -4,6 +4,8 @@ centrality using voting methods from Computational Social Choice.
 """
 
 import itertools
+import networkx as nx
+from networkx.utils import not_implemented_for
 
 __all__ = ["sav_voting", "copeland_voting", "spav_voting"]
 
@@ -53,7 +55,7 @@ def sav_voting(G):
     # Compute Scores
     scores = {candidate : 0 for candidate in G.nodes}
     for voter in G.nodes:
-        neighbors = G.neighbors(voter)
+        neighbors = list(G.neighbors(voter))
         voting_capability = 1/len(neighbors)
         for candidate in neighbors:
             scores[candidate] += voting_capability
@@ -106,7 +108,7 @@ def copeland_voting(G):
     """
 
     shortest_paths_len = dict()
-    for start, distances in nx.shortest_path_length(graph, source=None, target=None):
+    for start, distances in nx.shortest_path_length(G, source=None, target=None):
         shortest_paths_len[start] = distances
 
     def pairwise_comparison(A, B):
@@ -195,7 +197,7 @@ def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
             for voter in G.neighbors(candidate):
                 candidate_score += voting_ability_fn(neighbors_already_selected[voter])
             scores[candidate] = candidate_score
-        best = max(G.nodes, key=scores.get)
+        best = max(candidates, key=scores.get)
         selected_nodes.append(best)
         candidates.remove(best)
         for voter in G.neighbors(best):

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -1,9 +1,11 @@
 """
-Algorithms to select influential nodes in a network using voting methods from Computational
-Social Choice.
+Algorithms to select influential nodes in a network, or to rank nodes by their
+centrality using voting methods from Computational Social Choice.
 """
 
-__all__ = ["sav_voting"]
+import itertools
+
+__all__ = ["sav_voting", "copeland_voting"]
 
 
 @not_implemented_for("directed")
@@ -64,3 +66,70 @@ def sav_voting(G, number_of_nodes):
         selected_nodes.add(best)
         scores[best] = -1
     return selected_nodes
+
+
+
+@not_implemented_for("directed")
+def copeland_voting(G):
+    """Rank nodes using the Condorcet-consistent voting rule due to Copeland.
+
+    According to Condorcet, a candidate should win an election whenever it is preferred
+    to each other candidate by a majority of voters in direct comparison. Although this
+    is a very reasonable criterion, it doesn't tell us what to do when such a candidate
+    doesn't exist (which happens most of the time). Arthur Copeland described a method
+    which selects the Condorcet-winner whenever it exists, but chooses a winner which
+    is close to being a Condorcet winner otherwise.
+
+    This centrality index is based on Copelands method. Each node is compared with every
+    other node in direct comparison. Say nodes A and B are compared. If there are more
+    nodes strictly closer to A than to B, A receives one point (wins the pairwise
+    comparison), and B loses one point. The same holds vice versa when B wins the pairwise
+    comparison. If A and B are tied (neither A nor B wins), both receive no points. The
+    Copeland centrality index is achieved by summing up all the points from all comparisons.
+    
+    The Copeland centrality index was introduced in [1]_ .
+
+    Parameters
+    ----------
+    G : graph
+        A NetworkX graph.
+
+    Returns
+    -------
+    copeland_voting : dict
+        For each node the dict contains the copeland score.
+
+    Examples
+    --------
+    TODO
+
+    References
+    ----------
+    .. [1] Brandes, U. and Laussmann, C. and Rothe, J. (2022).
+        Voting for Centrality (Extended Abstract).
+        Proceedings of the 21st International Conference on Autonomous Agents and Multiagent Systems (AAMAS)
+        Publisher: IFAAMAS
+    """
+
+    shortest_paths_len = dict()
+    for start, distances in nx.shortest_path_length(graph, source=None, target=None):
+        shortest_paths_len[start] = distances
+
+    def pairwise_comparison(A, B):
+        other_nodes = G.nodes - {A,B}
+        prefers_A = [n for n in other_nodes if shortest_paths_len[n][A] < shortest_paths_len[n][B]]
+        prefers_B = [n for n in other_nodes if shortest_paths_len[n][A] > shortest_paths_len[n][B]]
+        if len(prefers_A) > len(prefers_B):
+            return 1
+        elif len(prefers_A) < len(prefers_B):
+            return -1
+        return 0
+
+    # Compute Scores
+    scores = {candidate : 0 for candidate in G.nodes}
+    for X,Y in itertools.combinations(G.nodes, 2):
+        comparison = pairwise_comparison(X,Y)
+        scores[X] += comparison
+        scores[Y] -= comparison
+
+    return scores

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -1,0 +1,66 @@
+"""
+Algorithms to select influential nodes in a network using voting methods from Computational
+Social Choice.
+"""
+
+__all__ = ["sav_voting"]
+
+
+@not_implemented_for("directed")
+def sav_voting(G, number_of_nodes):
+    """Select a set of influential nodes using Satisfaction Approval Voting (SAV).
+
+    SAV [1]_ [2]_ lets each node vote on the centrality of its neighbors. Thereby, each node x
+    contributes 1/|degree(x)| points to the total score of each neighbor. In other words: node
+    x distributes a total of 1 point equally to all neighbors.
+
+    Eventually, the nodes with the highest total score are selected.
+
+    SAV only works with undirected networks. Weights are ignored.
+
+    Parameters
+    ----------
+    G : graph
+        A NetworkX graph.
+
+    number_of_nodes : integer
+        Number of nodes to select.
+
+    Returns
+    -------
+    sav_voting : set
+        The number_of_nodes nodes with highest SAV score.
+
+    Examples
+    --------
+    TODO
+
+    References
+    ----------
+    .. [1] Brams, S. and Kilgour, D. (2014).
+        Satisfaction Approval Voting.
+        In: Voting Power and Procedures.
+        Publisher: Springer
+        Pages 323-346.
+       [2] Laussmann, C. (2023).
+        Network Centrality Through Voting Rules.
+        In: COMSOC Methods in Real-World Applications (Dissertation).
+        Publisher: Universitaets- und Landesbibliothek der Heinrich-Heine-Universitaet Duesseldorf
+        Pages 27-45.
+    """
+
+    # Compute Scores
+    scores = {candidate : 0 for candidate in G.nodes}
+    for voter in G.nodes:
+        neighbors = G.neighbors(voter)
+        voting_capability = 1/len(neighbors)
+        for candidate in neighbors:
+            scores[candidate] += voting_capability
+    
+    # Select best nodes
+    selected nodes = set()
+    for i in range(number_of_nodes):
+        best = max(G.nodes, key=scores.get)
+        selected_nodes.add(best)
+        scores[best] = -1
+    return selected_nodes

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -9,14 +9,16 @@ __all__ = ["sav_voting", "copeland_voting", "spav_voting"]
 
 
 @not_implemented_for("directed")
-def sav_voting(G, number_of_nodes):
-    """Select a set of influential nodes using Satisfaction Approval Voting (SAV).
+def sav_voting(G):
+    """
+    Rank nodes using Satisfaction Approval Voting (SAV).
 
     SAV [1]_ [2]_ lets each node vote on the centrality of its neighbors. Thereby, each node x
     contributes 1/|degree(x)| points to the total score of each neighbor. In other words: node
     x distributes a total of 1 point equally to all neighbors.
-
-    Eventually, the nodes with the highest total score are selected.
+    
+    One interpretation is that a node is more central according to SAV if it has many neighbors
+    which highly rely on the connection to this node (they have no, or only a few, other neighbors).
 
     SAV only works with undirected networks. Weights are ignored.
 
@@ -25,13 +27,10 @@ def sav_voting(G, number_of_nodes):
     G : graph
         A NetworkX graph.
 
-    number_of_nodes : integer
-        Number of nodes to select.
-
     Returns
     -------
-    sav_voting : set
-        The number_of_nodes nodes with highest SAV score.
+    sav_voting : dict
+        For each node the dict contains the SAV score.
 
     Examples
     --------
@@ -59,19 +58,14 @@ def sav_voting(G, number_of_nodes):
         for candidate in neighbors:
             scores[candidate] += voting_capability
     
-    # Select best nodes
-    selected_nodes = set()
-    for i in range(number_of_nodes):
-        best = max(G.nodes, key=scores.get)
-        selected_nodes.add(best)
-        scores[best] = -1
-    return selected_nodes
+    return scores
 
 
 
 @not_implemented_for("directed")
 def copeland_voting(G):
-    """Rank nodes using the Condorcet-consistent voting rule due to Copeland.
+    """
+    Rank nodes using the Condorcet-consistent voting rule due to Copeland.
 
     According to Condorcet, a candidate should win an election whenever it is preferred
     to each other candidate by a majority of voters in direct comparison. Although this

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -4,23 +4,29 @@ centrality using voting methods from Computational Social Choice.
 
 import itertools
 import networkx as nx
-from networkx.utils import not_implemented_for
 
 __all__ = ["sav_voting", "copeland_voting", "spav_voting"]
 
 
-@not_implemented_for("directed")
+@nx.not_implemented_for("directed")
+@nx.not_implemented_for("multigraph")
 def sav_voting(G):
     """Rank nodes using Satisfaction Approval Voting (SAV).
 
-    SAV [1]_ [2]_ lets each node vote on the centrality of its neighbors. Thereby, each node x
-    contributes 1/|degree(x)| points to the total score of each neighbor. In other words: node
-    x distributes a total of 1 point equally to all neighbors.
-    
-    One interpretation is that a node is more central according to SAV if it has many neighbors
-    which highly rely on the connection to this node (they have no, or only a few, other neighbors).
+    SAV centrality (introduced in [2]_ and based on the framework in [3]_ ) lets each node vote
+    on the centrality of its neighbors. Thereby, each node x contributes 1/|degree(x)| points
+    to the total score of each neighbor. In other words: node x distributes a total of 1 point
+    equally to all neighbors. One interpretation is that a node is more central according to
+    SAV centrality if it has many neighbors which highly rely on the connection to this node
+    (they have no, or only a few, other neighbors).
 
-    SAV only works with undirected networks. Weights are ignored.
+    For a detailed description of the SAV voting system which is the base of this centrality
+    method, and a study on its properties, see [1]_ and
+    https://en.wikipedia.org/wiki/Satisfaction_approval_voting
+
+    Notes
+    -----
+    SAV centrality only works with undirected networks (no multigraph). Weights are ignored.
 
     Parameters
     ----------
@@ -44,16 +50,22 @@ def sav_voting(G):
 
     References
     ----------
-    .. [1] Brams, S. and Kilgour, D. (2014).
-        Satisfaction Approval Voting.
+    .. [1] Brams, S. J. and Kilgour, D. M. (2014).
+        "Satisfaction Approval Voting"
         In: Voting Power and Procedures.
         Publisher: Springer
         Pages 323-346.
+        https://link.springer.com/chapter/10.1007/978-3-319-05158-1_18
        [2] Laussmann, C. (2023).
-        Network Centrality Through Voting Rules.
+        "Network Centrality Through Voting Rules"
         In: COMSOC Methods in Real-World Applications (Dissertation).
         Publisher: Universitaets- und Landesbibliothek der Heinrich-Heine-Universitaet Duesseldorf
         Pages 27-45.
+       [3] Brandes, U. and Laussmann, C. and Rothe, J. (2022).
+        "Voting for Centrality (Extended Abstract)"
+        In: Proceedings of the 21st International Conference on Autonomous Agents and Multiagent Systems (AAMAS)
+        Publisher: IFAAMAS
+        https://www.ifaamas.org/Proceedings/aamas2022/pdfs/p1554.pdf
     """
 
     # Compute Scores
@@ -68,27 +80,33 @@ def sav_voting(G):
 
 
 
-@not_implemented_for("directed")
+@nx.not_implemented_for("directed")
+@nx.not_implemented_for("multigraph")
 def copeland_voting(G):
     """Rank nodes using the Condorcet-consistent voting rule due to Copeland.
 
     According to Condorcet, a candidate should win an election whenever it is preferred
     to each other candidate by a majority of voters in direct comparison. Although this
     is a very reasonable criterion, it doesn't tell us what to do when such a candidate
-    doesn't exist (which happens most of the time). Arthur Copeland described a method
-    which selects the Condorcet-winner whenever it exists, but chooses a winner which
-    is close to being a Condorcet winner otherwise.
+    doesn't exist (which happens most of the time). Arthur Copeland (1951) described a
+    method which selects the Condorcet-winner whenever it exists, but chooses a candidate
+    which is close to being a Condorcet winner otherwise.
 
-    This centrality index is based on Copelands method. Each node is compared with every
+    This centrality index is based on Copeland's method. Each node is compared with every
     other node in direct comparison. Say nodes A and B are compared. If there are more
     nodes strictly closer to A than to B, A receives one point (wins the pairwise
     comparison), and B loses one point. The same holds vice versa when B wins the pairwise
     comparison. If A and B are tied (neither A nor B wins), both receive no points. The
     Copeland centrality index is achieved by summing up all the points from all comparisons.
     
+    The Copeland centrality index was introduced in [1]_ . Although the Copeland voting
+    method is mostly known under Copeland's name, it dates back at least to Llull (1299).
+    See also https://en.wikipedia.org/wiki/Copeland%27s_method
+
     Notes
     -----
-    The Copeland centrality index was introduced in [1]_ .
+    Copeland centrality only works with undirected networks (no multigraph).
+    Weights are ignored.
 
     Parameters
     ----------
@@ -113,9 +131,10 @@ def copeland_voting(G):
     References
     ----------
     .. [1] Brandes, U. and Laussmann, C. and Rothe, J. (2022).
-        Voting for Centrality (Extended Abstract).
-        Proceedings of the 21st International Conference on Autonomous Agents and Multiagent Systems (AAMAS)
+        "Voting for Centrality (Extended Abstract)"
+        In: Proceedings of the 21st International Conference on Autonomous Agents and Multiagent Systems (AAMAS)
         Publisher: IFAAMAS
+        https://www.ifaamas.org/Proceedings/aamas2022/pdfs/p1554.pdf
     """
 
     shortest_paths_len = dict()
@@ -142,19 +161,29 @@ def copeland_voting(G):
     return scores
 
 
-@not_implemented_for("directed")
+@nx.not_implemented_for("directed")
+@nx.not_implemented_for("multigraph")
 def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
     """Select a set of influential nodes using Sequential Proportional Approval Voting (SPAV).
 
-    SPAV [1]_ [2]_ lets each node vote on the centrality of its neighbors in multiple rounds. In each
-    round, the node with the highest voting score is elected where each node contributes the same
-    points to each of its neighbors. Thereby, whenever a node is elected, all neighbors' voting ability
-    is reduced so that in the next round they contribute less points to their neighbors (similar to VoteRank).
-    By how far the voting ability is reduced depends on the voting_ability_fn, which maps an integer
-    (how many nodes from the neighborhood of a "voter" are already selected) to a real number (voting ability).
-    By default, voting_ability_fn(0) = 1, voting_ability_fn(1) = 1/2, voting_ability_fn(2) = 1/3, etc., is
-    used, as it war originally proposed by Thiele in 1895.
+    SPAV centrality (introduced in [2]_ and based on the framework in [3]_ ) lets each node vote
+    on the centrality of its neighbors in multiple rounds. In each round, the node with the highest
+    voting score is elected where each node contributes the same points to each of its neighbors.
+    Thereby, whenever a node is elected, all neighbors' voting ability is reduced so that in the
+    next round they contribute less points to their neighbors (similar to VoteRank). By how far the
+    voting ability is reduced depends on the voting_ability_fn, which maps an integer (how many nodes
+    from the neighborhood of a "voter" are already selected) to a real number (voting ability).
+    By default, voting_ability_fn(0) = 1, voting_ability_fn(1) = 1/2, voting_ability_fn(2) = 1/3,
+    etc., is used.
+    
+    The original voting method SPAV was first proposed by Thorvald Thiele around 1900. For an
+    introduction, and astudy on SPAV's properties, see e.g. [1]_ as well as
+    https://en.wikipedia.org/wiki/Sequential_proportional_approval_voting
 
+    Notes
+    -----
+    SPAV centrality only works with undirected networks (no multigraph).
+    Weights are ignored.
 
     Parameters
     ----------
@@ -183,17 +212,30 @@ def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
     >>> nx.spav_voting(G, number_of_nodes=2)
     [1, 7]
 
+    >>> G = nx.Graph([(1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (2, 6), (3, 6), (4, 6), (5, 6), (7, 6), (7, 8), (7, 9), (10, 6), (10, 1),])
+    >>> nx.spav_voting(G, number_of_nodes=2, voting_ability_fn=lambda x : 1 if x==0 else 0)
+    [6, 7]
+
     References
     ----------
     .. [1] Aziz, H. et al. (2017).
-        Justified representation in approval-based committee voting.
+        "Justified Representation in Approval-based Committee Voting"
         In: Social Choice and Welfare 48
         Pages 461-485.
        [2] Laussmann, C. (2023).
-        Network Centrality Through Voting Rules.
+        "Network Centrality Through Voting Rules"
         In: COMSOC Methods in Real-World Applications (Dissertation).
         Publisher: Universitaets- und Landesbibliothek der Heinrich-Heine-Universitaet Duesseldorf
         Pages 27-45.
+       [3] Brandes, U. and Laussmann, C. and Rothe, J. (2022).
+        "Voting for Centrality (Extended Abstract)"
+        In: Proceedings of the 21st International Conference on Autonomous Agents and Multiagent Systems (AAMAS)
+        Publisher: IFAAMAS
+        https://www.ifaamas.org/Proceedings/aamas2022/pdfs/p1554.pdf
+       [1] Zhang, J.-X. et al. (2016).
+        "Identifying a set of influential spreaders in complex networks."
+        In: Sci. Rep. 6, 27823.
+        https://doi.org/10.1038/srep27823
     """
 
     # Set default values

--- a/networkx/algorithms/centrality/voting_based_alg.py
+++ b/networkx/algorithms/centrality/voting_based_alg.py
@@ -8,8 +8,8 @@ import networkx as nx
 __all__ = ["sav_voting", "copeland_voting", "spav_voting"]
 
 
-@nx.not_implemented_for("directed")
-@nx.not_implemented_for("multigraph")
+@nx.utils.not_implemented_for("directed")
+@nx.utils.not_implemented_for("multigraph")
 def sav_voting(G):
     """Rank nodes using Satisfaction Approval Voting (SAV).
 
@@ -80,8 +80,8 @@ def sav_voting(G):
 
 
 
-@nx.not_implemented_for("directed")
-@nx.not_implemented_for("multigraph")
+@nx.utils.not_implemented_for("directed")
+@nx.utils.not_implemented_for("multigraph")
 def copeland_voting(G):
     """Rank nodes using the Condorcet-consistent voting rule due to Copeland.
 
@@ -161,8 +161,8 @@ def copeland_voting(G):
     return scores
 
 
-@nx.not_implemented_for("directed")
-@nx.not_implemented_for("multigraph")
+@nx.utils.not_implemented_for("directed")
+@nx.utils.not_implemented_for("multigraph")
 def spav_voting(G, number_of_nodes=None, voting_ability_fn=None):
     """Select a set of influential nodes using Sequential Proportional Approval Voting (SPAV).
 


### PR DESCRIPTION
This PR adds some voting-based centrality methods (Copeland index, SAV index, and SPAV group selector). The idea to use voting rules to let the nodes in a network vote for the other nodes' centrality was introduced by Brandes et al. "Voting for Centrality (extended abstract)" in 2022.

Nodes (in the role of voters) use network relations such as neighbourhood and distances to construct a preference (ballot) which nodes (in the role of candidates) are most important in the network. This gives us the individual nodes' local perspective on centrality in the network. Voting rules are then used to aggregate the local views into a global view.
