### PR TITLE
Make weight part of the API for functions which had default assumptions

### DIFF
--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -39,7 +39,7 @@ __all__ = ["second_order_centrality"]
 
 
 @not_implemented_for("directed")
-@nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
+@nx._dispatch(edge_attrs="weight")
 def second_order_centrality(G, weight="weight"):
     """Compute the second order centrality for nodes of G.
 

--- a/networkx/algorithms/centrality/second_order.py
+++ b/networkx/algorithms/centrality/second_order.py
@@ -40,7 +40,7 @@ __all__ = ["second_order_centrality"]
 
 @not_implemented_for("directed")
 @nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
-def second_order_centrality(G):
+def second_order_centrality(G, weight="weight"):
     """Compute the second order centrality for nodes of G.
 
     The second order centrality of a given node is the standard deviation of
@@ -50,6 +50,10 @@ def second_order_centrality(G):
     ----------
     G : graph
       A NetworkX connected and undirected graph.
+
+    weight : string or None, optional (default="weight")
+        The name of an edge attribute that holds the numerical value
+        used as a weight. If None then each edge has weight 1.
 
     Returns
     -------
@@ -103,12 +107,12 @@ def second_order_centrality(G):
         raise nx.NetworkXException("Empty graph.")
     if not nx.is_connected(G):
         raise nx.NetworkXException("Non connected graph.")
-    if any(d.get("weight", 0) < 0 for u, v, d in G.edges(data=True)):
+    if any(d.get(weight, 0) < 0 for u, v, d in G.edges(data=True)):
         raise nx.NetworkXException("Graph has negative edge weights.")
 
     # balancing G for Metropolis-Hastings random walks
     G = nx.DiGraph(G)
-    in_deg = dict(G.in_degree(weight="weight"))
+    in_deg = dict(G.in_degree(weight=weight))
     d_max = max(in_deg.values())
     for i, deg in in_deg.items():
         if deg < d_max:

--- a/networkx/algorithms/centrality/tests/test_second_order_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_second_order_centrality.py
@@ -10,58 +10,73 @@ pytest.importorskip("scipy")
 import networkx as nx
 
 
-class TestSecondOrderCentrality:
-    def test_empty(self):
-        with pytest.raises(nx.NetworkXException):
-            G = nx.empty_graph()
-            nx.second_order_centrality(G)
+def test_empty():
+    with pytest.raises(nx.NetworkXException):
+        G = nx.empty_graph()
+        nx.second_order_centrality(G)
 
-    def test_non_connected(self):
-        with pytest.raises(nx.NetworkXException):
-            G = nx.Graph()
-            G.add_node(0)
-            G.add_node(1)
-            nx.second_order_centrality(G)
 
-    def test_non_negative_edge_weights(self):
-        with pytest.raises(nx.NetworkXException):
-            G = nx.path_graph(2)
-            G.add_edge(0, 1, weight=-1)
-            nx.second_order_centrality(G)
-
-    def test_one_node_graph(self):
-        """Second order centrality: single node"""
+def test_non_connected():
+    with pytest.raises(nx.NetworkXException):
         G = nx.Graph()
         G.add_node(0)
-        G.add_edge(0, 0)
-        assert nx.second_order_centrality(G)[0] == 0
+        G.add_node(1)
+        nx.second_order_centrality(G)
 
-    def test_P3(self):
-        """Second order centrality: line graph, as defined in paper"""
-        G = nx.path_graph(3)
-        b_answer = {0: 3.741, 1: 1.414, 2: 3.741}
 
-        b = nx.second_order_centrality(G)
+def test_non_negative_edge_weights():
+    with pytest.raises(nx.NetworkXException):
+        G = nx.path_graph(2)
+        G.add_edge(0, 1, weight=-1)
+        nx.second_order_centrality(G)
 
-        for n in sorted(G):
-            assert b[n] == pytest.approx(b_answer[n], abs=1e-2)
 
-    def test_K3(self):
-        """Second order centrality: complete graph, as defined in paper"""
-        G = nx.complete_graph(3)
-        b_answer = {0: 1.414, 1: 1.414, 2: 1.414}
+def test_weight_attribute():
+    G = nx.Graph()
+    G.add_weighted_edges_from([(0, 1, 1.0), (1, 2, 3.5)], weight="w")
+    expected = {0: 3.431, 1: 3.082, 2: 5.612}
+    b = nx.second_order_centrality(G, weight="w")
 
-        b = nx.second_order_centrality(G)
+    for n in sorted(G):
+        assert b[n] == pytest.approx(expected[n], abs=1e-2)
 
-        for n in sorted(G):
-            assert b[n] == pytest.approx(b_answer[n], abs=1e-2)
 
-    def test_ring_graph(self):
-        """Second order centrality: ring graph, as defined in paper"""
-        G = nx.cycle_graph(5)
-        b_answer = {0: 4.472, 1: 4.472, 2: 4.472, 3: 4.472, 4: 4.472}
+def test_one_node_graph():
+    """Second order centrality: single node"""
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_edge(0, 0)
+    assert nx.second_order_centrality(G)[0] == 0
 
-        b = nx.second_order_centrality(G)
 
-        for n in sorted(G):
-            assert b[n] == pytest.approx(b_answer[n], abs=1e-2)
+def test_P3():
+    """Second order centrality: line graph, as defined in paper"""
+    G = nx.path_graph(3)
+    b_answer = {0: 3.741, 1: 1.414, 2: 3.741}
+
+    b = nx.second_order_centrality(G)
+
+    for n in sorted(G):
+        assert b[n] == pytest.approx(b_answer[n], abs=1e-2)
+
+
+def test_K3():
+    """Second order centrality: complete graph, as defined in paper"""
+    G = nx.complete_graph(3)
+    b_answer = {0: 1.414, 1: 1.414, 2: 1.414}
+
+    b = nx.second_order_centrality(G)
+
+    for n in sorted(G):
+        assert b[n] == pytest.approx(b_answer[n], abs=1e-2)
+
+
+def test_ring_graph():
+    """Second order centrality: ring graph, as defined in paper"""
+    G = nx.cycle_graph(5)
+    b_answer = {0: 4.472, 1: 4.472, 2: 4.472, 3: 4.472, 4: 4.472}
+
+    b = nx.second_order_centrality(G)
+
+    for n in sorted(G):
+        assert b[n] == pytest.approx(b_answer[n], abs=1e-2)

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -94,7 +94,7 @@ def equivalence_classes(iterable, relation):
     return {frozenset(block) for block in blocks}
 
 
-@nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
+@nx._dispatch(edge_attrs="weight")
 def quotient_graph(
     G,
     partition,

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -101,6 +101,7 @@ def quotient_graph(
     edge_relation=None,
     node_data=None,
     edge_data=None,
+    weight="weight",
     relabel=False,
     create_using=None,
 ):
@@ -141,18 +142,6 @@ def quotient_graph(
         only if some node in *B* is adjacent to some node in *C*,
         according to the edge set of `G`.
 
-    edge_data : function
-        This function takes two arguments, *B* and *C*, each one a set
-        of nodes, and must return a dictionary representing the edge
-        data attributes to set on the edge joining *B* and *C*, should
-        there be an edge joining *B* and *C* in the quotient graph (if
-        no such edge occurs in the quotient graph as determined by
-        `edge_relation`, then the output of this function is ignored).
-
-        If the quotient graph would be a multigraph, this function is
-        not applied, since the edge data from each edge in the graph
-        `G` appears in the edges of the quotient graph.
-
     node_data : function
         This function takes one argument, *B*, a set of nodes in `G`,
         and must return a dictionary representing the node data
@@ -165,6 +154,22 @@ def quotient_graph(
         * 'nedges', the number of edges within this block,
         * 'density', the density of the subgraph of `G` that this
           block represents.
+
+    edge_data : function
+        This function takes two arguments, *B* and *C*, each one a set
+        of nodes, and must return a dictionary representing the edge
+        data attributes to set on the edge joining *B* and *C*, should
+        there be an edge joining *B* and *C* in the quotient graph (if
+        no such edge occurs in the quotient graph as determined by
+        `edge_relation`, then the output of this function is ignored).
+
+        If the quotient graph would be a multigraph, this function is
+        not applied, since the edge data from each edge in the graph
+        `G` appears in the edges of the quotient graph.
+
+    weight : string or None, optional (default="weight")
+        The name of an edge attribute that holds the numerical value
+        used as a weight. If None then each edge has weight 1.
 
     relabel : bool
         If True, relabel the nodes of the quotient graph to be
@@ -303,7 +308,14 @@ def quotient_graph(
                 "Input `partition` is not an equivalence relation for nodes of G"
             )
         return _quotient_graph(
-            G, partition, edge_relation, node_data, edge_data, relabel, create_using
+            G,
+            partition,
+            edge_relation,
+            node_data,
+            edge_data,
+            weight,
+            relabel,
+            create_using,
         )
 
     # If the partition is a dict, it is assumed to be one where the keys are
@@ -321,18 +333,19 @@ def quotient_graph(
     if not nx.community.is_partition(G, partition):
         raise NetworkXException("each node must be in exactly one part of `partition`")
     return _quotient_graph(
-        G, partition, edge_relation, node_data, edge_data, relabel, create_using
+        G,
+        partition,
+        edge_relation,
+        node_data,
+        edge_data,
+        weight,
+        relabel,
+        create_using,
     )
 
 
 def _quotient_graph(
-    G,
-    partition,
-    edge_relation=None,
-    node_data=None,
-    edge_data=None,
-    relabel=False,
-    create_using=None,
+    G, partition, edge_relation, node_data, edge_data, weight, relabel, create_using
 ):
     """Construct the quotient graph assuming input has been checked"""
     if create_using is None:
@@ -377,7 +390,7 @@ def _quotient_graph(
                 for u, v, d in G.edges(b | c, data=True)
                 if (u in b and v in c) or (u in c and v in b)
             )
-            return {"weight": sum(d.get("weight", 1) for d in edgedata)}
+            return {"weight": sum(d.get(weight, 1) for d in edgedata)}
 
     block_pairs = permutations(H, 2) if H.is_directed() else combinations(H, 2)
     # In a multigraph, add one edge in the quotient graph for each edge

--- a/networkx/algorithms/minors/tests/test_contraction.py
+++ b/networkx/algorithms/minors/tests/test_contraction.py
@@ -5,418 +5,441 @@ import networkx as nx
 from networkx.utils import arbitrary_element, edges_equal, nodes_equal
 
 
-class TestQuotient:
-    """Unit tests for computing quotient graphs."""
+def test_quotient_graph_complete_multipartite():
+    """Tests that the quotient graph of the complete *n*-partite graph
+    under the "same neighbors" node relation is the complete graph on *n*
+    nodes.
 
-    def test_quotient_graph_complete_multipartite(self):
-        """Tests that the quotient graph of the complete *n*-partite graph
-        under the "same neighbors" node relation is the complete graph on *n*
-        nodes.
+    """
+    G = nx.complete_multipartite_graph(2, 3, 4)
+    # Two nodes are equivalent if they are not adjacent but have the same
+    # neighbor set.
 
-        """
-        G = nx.complete_multipartite_graph(2, 3, 4)
-        # Two nodes are equivalent if they are not adjacent but have the same
-        # neighbor set.
+    def same_neighbors(u, v):
+        return u not in G[v] and v not in G[u] and G[u] == G[v]
 
-        def same_neighbors(u, v):
-            return u not in G[v] and v not in G[u] and G[u] == G[v]
+    expected = nx.complete_graph(3)
+    actual = nx.quotient_graph(G, same_neighbors)
+    # It won't take too long to run a graph isomorphism algorithm on such
+    # small graphs.
+    assert nx.is_isomorphic(expected, actual)
 
-        expected = nx.complete_graph(3)
-        actual = nx.quotient_graph(G, same_neighbors)
-        # It won't take too long to run a graph isomorphism algorithm on such
-        # small graphs.
-        assert nx.is_isomorphic(expected, actual)
 
-    def test_quotient_graph_complete_bipartite(self):
-        """Tests that the quotient graph of the complete bipartite graph under
-        the "same neighbors" node relation is `K_2`.
+def test_quotient_graph_complete_bipartite():
+    """Tests that the quotient graph of the complete bipartite graph under
+    the "same neighbors" node relation is `K_2`.
 
-        """
-        G = nx.complete_bipartite_graph(2, 3)
-        # Two nodes are equivalent if they are not adjacent but have the same
-        # neighbor set.
+    """
+    G = nx.complete_bipartite_graph(2, 3)
+    # Two nodes are equivalent if they are not adjacent but have the same
+    # neighbor set.
 
-        def same_neighbors(u, v):
-            return u not in G[v] and v not in G[u] and G[u] == G[v]
+    def same_neighbors(u, v):
+        return u not in G[v] and v not in G[u] and G[u] == G[v]
 
-        expected = nx.complete_graph(2)
-        actual = nx.quotient_graph(G, same_neighbors)
-        # It won't take too long to run a graph isomorphism algorithm on such
-        # small graphs.
-        assert nx.is_isomorphic(expected, actual)
+    expected = nx.complete_graph(2)
+    actual = nx.quotient_graph(G, same_neighbors)
+    # It won't take too long to run a graph isomorphism algorithm on such
+    # small graphs.
+    assert nx.is_isomorphic(expected, actual)
 
-    def test_quotient_graph_edge_relation(self):
-        """Tests for specifying an alternate edge relation for the quotient
-        graph.
 
-        """
-        G = nx.path_graph(5)
+def test_quotient_graph_edge_relation():
+    """Tests for specifying an alternate edge relation for the quotient
+    graph.
 
-        def identity(u, v):
-            return u == v
+    """
+    G = nx.path_graph(5)
 
-        def same_parity(b, c):
-            return arbitrary_element(b) % 2 == arbitrary_element(c) % 2
+    def identity(u, v):
+        return u == v
 
-        actual = nx.quotient_graph(G, identity, same_parity)
-        expected = nx.Graph()
-        expected.add_edges_from([(0, 2), (0, 4), (2, 4)])
-        expected.add_edge(1, 3)
-        assert nx.is_isomorphic(actual, expected)
+    def same_parity(b, c):
+        return arbitrary_element(b) % 2 == arbitrary_element(c) % 2
 
-    def test_condensation_as_quotient(self):
-        """This tests that the condensation of a graph can be viewed as the
-        quotient graph under the "in the same connected component" equivalence
-        relation.
+    actual = nx.quotient_graph(G, identity, same_parity)
+    expected = nx.Graph()
+    expected.add_edges_from([(0, 2), (0, 4), (2, 4)])
+    expected.add_edge(1, 3)
+    assert nx.is_isomorphic(actual, expected)
 
-        """
-        # This example graph comes from the file `test_strongly_connected.py`.
-        G = nx.DiGraph()
-        G.add_edges_from(
-            [
-                (1, 2),
-                (2, 3),
-                (2, 11),
-                (2, 12),
-                (3, 4),
-                (4, 3),
-                (4, 5),
-                (5, 6),
-                (6, 5),
-                (6, 7),
-                (7, 8),
-                (7, 9),
-                (7, 10),
-                (8, 9),
-                (9, 7),
-                (10, 6),
-                (11, 2),
-                (11, 4),
-                (11, 6),
-                (12, 6),
-                (12, 11),
-            ]
-        )
-        scc = list(nx.strongly_connected_components(G))
-        C = nx.condensation(G, scc)
-        component_of = C.graph["mapping"]
-        # Two nodes are equivalent if they are in the same connected component.
 
-        def same_component(u, v):
-            return component_of[u] == component_of[v]
+def test_condensation_as_quotient():
+    """This tests that the condensation of a graph can be viewed as the
+    quotient graph under the "in the same connected component" equivalence
+    relation.
 
-        Q = nx.quotient_graph(G, same_component)
-        assert nx.is_isomorphic(C, Q)
+    """
+    # This example graph comes from the file `test_strongly_connected.py`.
+    G = nx.DiGraph()
+    G.add_edges_from(
+        [
+            (1, 2),
+            (2, 3),
+            (2, 11),
+            (2, 12),
+            (3, 4),
+            (4, 3),
+            (4, 5),
+            (5, 6),
+            (6, 5),
+            (6, 7),
+            (7, 8),
+            (7, 9),
+            (7, 10),
+            (8, 9),
+            (9, 7),
+            (10, 6),
+            (11, 2),
+            (11, 4),
+            (11, 6),
+            (12, 6),
+            (12, 11),
+        ]
+    )
+    scc = list(nx.strongly_connected_components(G))
+    C = nx.condensation(G, scc)
+    component_of = C.graph["mapping"]
+    # Two nodes are equivalent if they are in the same connected component.
 
-    def test_path(self):
+    def same_component(u, v):
+        return component_of[u] == component_of[v]
+
+    Q = nx.quotient_graph(G, same_component)
+    assert nx.is_isomorphic(C, Q)
+
+
+def test_path():
+    G = nx.path_graph(6)
+    partition = [{0, 1}, {2, 3}, {4, 5}]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1
+
+
+def test_path__partition_provided_as_dict_of_lists():
+    G = nx.path_graph(6)
+    partition = {0: [0, 1], 2: [2, 3], 4: [4, 5]}
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1
+
+
+def test_path__partition_provided_as_dict_of_tuples():
+    G = nx.path_graph(6)
+    partition = {0: (0, 1), 2: (2, 3), 4: (4, 5)}
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1
+
+
+def test_path__partition_provided_as_dict_of_sets():
+    G = nx.path_graph(6)
+    partition = {0: {0, 1}, 2: {2, 3}, 4: {4, 5}}
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1
+
+
+def test_multigraph_path():
+    G = nx.MultiGraph(nx.path_graph(6))
+    partition = [{0, 1}, {2, 3}, {4, 5}]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1
+
+
+def test_directed_path():
+    G = nx.DiGraph()
+    nx.add_path(G, range(6))
+    partition = [{0, 1}, {2, 3}, {4, 5}]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 0.5
+
+
+def test_directed_multigraph_path():
+    G = nx.MultiDiGraph()
+    nx.add_path(G, range(6))
+    partition = [{0, 1}, {2, 3}, {4, 5}]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 0.5
+
+
+def test_overlapping_blocks():
+    with pytest.raises(nx.NetworkXException):
         G = nx.path_graph(6)
-        partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1
-
-    def test_path__partition_provided_as_dict_of_lists(self):
-        G = nx.path_graph(6)
-        partition = {0: [0, 1], 2: [2, 3], 4: [4, 5]}
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1
-
-    def test_path__partition_provided_as_dict_of_tuples(self):
-        G = nx.path_graph(6)
-        partition = {0: (0, 1), 2: (2, 3), 4: (4, 5)}
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1
-
-    def test_path__partition_provided_as_dict_of_sets(self):
-        G = nx.path_graph(6)
-        partition = {0: {0, 1}, 2: {2, 3}, 4: {4, 5}}
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1
-
-    def test_multigraph_path(self):
-        G = nx.MultiGraph(nx.path_graph(6))
-        partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1
-
-    def test_directed_path(self):
-        G = nx.DiGraph()
-        nx.add_path(G, range(6))
-        partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 0.5
-
-    def test_directed_multigraph_path(self):
-        G = nx.MultiDiGraph()
-        nx.add_path(G, range(6))
-        partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 0.5
-
-    def test_overlapping_blocks(self):
-        with pytest.raises(nx.NetworkXException):
-            G = nx.path_graph(6)
-            partition = [{0, 1, 2}, {2, 3}, {4, 5}]
-            nx.quotient_graph(G, partition)
-
-    def test_weighted_path(self):
-        G = nx.path_graph(6)
-        for i in range(5):
-            G[i][i + 1]["weight"] = i + 1
-        partition = [{0, 1}, {2, 3}, {4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        assert M[0][1]["weight"] == 2
-        assert M[1][2]["weight"] == 4
-        for n in M:
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1
-
-    def test_barbell(self):
-        G = nx.barbell_graph(3, 0)
-        partition = [{0, 1, 2}, {3, 4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1])
-        assert edges_equal(M.edges(), [(0, 1)])
-        for n in M:
-            assert M.nodes[n]["nedges"] == 3
-            assert M.nodes[n]["nnodes"] == 3
-            assert M.nodes[n]["density"] == 1
-
-    def test_barbell_plus(self):
-        G = nx.barbell_graph(3, 0)
-        # Add an extra edge joining the bells.
-        G.add_edge(0, 5)
-        partition = [{0, 1, 2}, {3, 4, 5}]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M, [0, 1])
-        assert edges_equal(M.edges(), [(0, 1)])
-        assert M[0][1]["weight"] == 2
-        for n in M:
-            assert M.nodes[n]["nedges"] == 3
-            assert M.nodes[n]["nnodes"] == 3
-            assert M.nodes[n]["density"] == 1
-
-    def test_blockmodel(self):
-        G = nx.path_graph(6)
-        partition = [[0, 1], [2, 3], [4, 5]]
-        M = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(M.nodes(), [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M.nodes():
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1.0
-
-    def test_multigraph_blockmodel(self):
-        G = nx.MultiGraph(nx.path_graph(6))
-        partition = [[0, 1], [2, 3], [4, 5]]
-        M = nx.quotient_graph(G, partition, create_using=nx.MultiGraph(), relabel=True)
-        assert nodes_equal(M.nodes(), [0, 1, 2])
-        assert edges_equal(M.edges(), [(0, 1), (1, 2)])
-        for n in M.nodes():
-            assert M.nodes[n]["nedges"] == 1
-            assert M.nodes[n]["nnodes"] == 2
-            assert M.nodes[n]["density"] == 1.0
-
-    def test_quotient_graph_incomplete_partition(self):
-        G = nx.path_graph(6)
-        partition = []
-        H = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(H.nodes(), [])
-        assert edges_equal(H.edges(), [])
-
-        partition = [[0, 1], [2, 3], [5]]
-        H = nx.quotient_graph(G, partition, relabel=True)
-        assert nodes_equal(H.nodes(), [0, 1, 2])
-        assert edges_equal(H.edges(), [(0, 1)])
+        partition = [{0, 1, 2}, {2, 3}, {4, 5}]
+        nx.quotient_graph(G, partition)
 
 
-class TestContraction:
-    """Unit tests for node and edge contraction functions."""
+def test_weighted_path():
+    G = nx.path_graph(6)
+    for i in range(5):
+        G[i][i + 1]["w"] = i + 1
+    partition = [{0, 1}, {2, 3}, {4, 5}]
+    M = nx.quotient_graph(G, partition, weight="w", relabel=True)
+    assert nodes_equal(M, [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    assert M[0][1]["weight"] == 2
+    assert M[1][2]["weight"] == 4
+    for n in M:
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1
 
-    def test_undirected_node_contraction(self):
-        """Tests for node contraction in an undirected graph."""
+
+def test_barbell():
+    G = nx.barbell_graph(3, 0)
+    partition = [{0, 1, 2}, {3, 4, 5}]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1])
+    assert edges_equal(M.edges(), [(0, 1)])
+    for n in M:
+        assert M.nodes[n]["nedges"] == 3
+        assert M.nodes[n]["nnodes"] == 3
+        assert M.nodes[n]["density"] == 1
+
+
+def test_barbell_plus():
+    G = nx.barbell_graph(3, 0)
+    # Add an extra edge joining the bells.
+    G.add_edge(0, 5)
+    partition = [{0, 1, 2}, {3, 4, 5}]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M, [0, 1])
+    assert edges_equal(M.edges(), [(0, 1)])
+    assert M[0][1]["weight"] == 2
+    for n in M:
+        assert M.nodes[n]["nedges"] == 3
+        assert M.nodes[n]["nnodes"] == 3
+        assert M.nodes[n]["density"] == 1
+
+
+def test_blockmodel():
+    G = nx.path_graph(6)
+    partition = [[0, 1], [2, 3], [4, 5]]
+    M = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(M.nodes(), [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M.nodes():
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1.0
+
+
+def test_multigraph_blockmodel():
+    G = nx.MultiGraph(nx.path_graph(6))
+    partition = [[0, 1], [2, 3], [4, 5]]
+    M = nx.quotient_graph(G, partition, create_using=nx.MultiGraph(), relabel=True)
+    assert nodes_equal(M.nodes(), [0, 1, 2])
+    assert edges_equal(M.edges(), [(0, 1), (1, 2)])
+    for n in M.nodes():
+        assert M.nodes[n]["nedges"] == 1
+        assert M.nodes[n]["nnodes"] == 2
+        assert M.nodes[n]["density"] == 1.0
+
+
+def test_quotient_graph_incomplete_partition():
+    G = nx.path_graph(6)
+    partition = []
+    H = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(H.nodes(), [])
+    assert edges_equal(H.edges(), [])
+
+    partition = [[0, 1], [2, 3], [5]]
+    H = nx.quotient_graph(G, partition, relabel=True)
+    assert nodes_equal(H.nodes(), [0, 1, 2])
+    assert edges_equal(H.edges(), [(0, 1)])
+
+
+def test_undirected_node_contraction():
+    """Tests for node contraction in an undirected graph."""
+    G = nx.cycle_graph(4)
+    actual = nx.contracted_nodes(G, 0, 1)
+    expected = nx.cycle_graph(3)
+    expected.add_edge(0, 0)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_directed_node_contraction():
+    """Tests for node contraction in a directed graph."""
+    G = nx.DiGraph(nx.cycle_graph(4))
+    actual = nx.contracted_nodes(G, 0, 1)
+    expected = nx.DiGraph(nx.cycle_graph(3))
+    expected.add_edge(0, 0)
+    expected.add_edge(0, 0)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_undirected_node_contraction_no_copy():
+    """Tests for node contraction in an undirected graph
+    by making changes in place."""
+    G = nx.cycle_graph(4)
+    actual = nx.contracted_nodes(G, 0, 1, copy=False)
+    expected = nx.cycle_graph(3)
+    expected.add_edge(0, 0)
+    assert nx.is_isomorphic(actual, G)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_directed_node_contraction_no_copy():
+    """Tests for node contraction in a directed graph
+    by making changes in place."""
+    G = nx.DiGraph(nx.cycle_graph(4))
+    actual = nx.contracted_nodes(G, 0, 1, copy=False)
+    expected = nx.DiGraph(nx.cycle_graph(3))
+    expected.add_edge(0, 0)
+    expected.add_edge(0, 0)
+    assert nx.is_isomorphic(actual, G)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_create_multigraph():
+    """Tests that using a MultiGraph creates multiple edges."""
+    G = nx.path_graph(3, create_using=nx.MultiGraph())
+    G.add_edge(0, 1)
+    G.add_edge(0, 0)
+    G.add_edge(0, 2)
+    actual = nx.contracted_nodes(G, 0, 2)
+    expected = nx.MultiGraph()
+    expected.add_edge(0, 1)
+    expected.add_edge(0, 1)
+    expected.add_edge(0, 1)
+    expected.add_edge(0, 0)
+    expected.add_edge(0, 0)
+    assert edges_equal(actual.edges, expected.edges)
+
+
+def test_multigraph_keys():
+    """Tests that multiedge keys are reset in new graph."""
+    G = nx.path_graph(3, create_using=nx.MultiGraph())
+    G.add_edge(0, 1, 5)
+    G.add_edge(0, 0, 0)
+    G.add_edge(0, 2, 5)
+    actual = nx.contracted_nodes(G, 0, 2)
+    expected = nx.MultiGraph()
+    expected.add_edge(0, 1, 0)
+    expected.add_edge(0, 1, 5)
+    expected.add_edge(0, 1, 2)  # keyed as 2 b/c 2 edges already in G
+    expected.add_edge(0, 0, 0)
+    expected.add_edge(0, 0, 1)  # this comes from (0, 2, 5)
+    assert edges_equal(actual.edges, expected.edges)
+
+
+def test_node_attributes():
+    """Tests that node contraction preserves node attributes."""
+    G = nx.cycle_graph(4)
+    # Add some data to the two nodes being contracted.
+    G.nodes[0]["foo"] = "bar"
+    G.nodes[1]["baz"] = "xyzzy"
+    actual = nx.contracted_nodes(G, 0, 1)
+    # We expect that contracting the nodes 0 and 1 in C_4 yields K_3, but
+    # with nodes labeled 0, 2, and 3, and with a -loop on 0.
+    expected = nx.complete_graph(3)
+    expected = nx.relabel_nodes(expected, {1: 2, 2: 3})
+    expected.add_edge(0, 0)
+    cdict = {1: {"baz": "xyzzy"}}
+    expected.nodes[0].update({"foo": "bar", "contraction": cdict})
+    assert nx.is_isomorphic(actual, expected)
+    assert actual.nodes == expected.nodes
+
+
+def test_edge_attributes():
+    """Tests that node contraction preserves edge attributes."""
+    # Shape: src1 --> dest <-- src2
+    G = nx.DiGraph([("src1", "dest"), ("src2", "dest")])
+    G["src1"]["dest"]["value"] = "src1-->dest"
+    G["src2"]["dest"]["value"] = "src2-->dest"
+    H = nx.MultiDiGraph(G)
+
+    G = nx.contracted_nodes(G, "src1", "src2")  # New Shape: src1 --> dest
+    assert G.edges[("src1", "dest")]["value"] == "src1-->dest"
+    assert (
+        G.edges[("src1", "dest")]["contraction"][("src2", "dest")]["value"]
+        == "src2-->dest"
+    )
+
+    H = nx.contracted_nodes(H, "src1", "src2")  # New Shape: src1 -(x2)-> dest
+    assert len(H.edges(("src1", "dest"))) == 2
+
+
+def test_without_self_loops():
+    """Tests for node contraction without preserving -loops."""
+    G = nx.cycle_graph(4)
+    actual = nx.contracted_nodes(G, 0, 1, self_loops=False)
+    expected = nx.complete_graph(3)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_contract_loop_graph():
+    """Tests for node contraction when nodes have loops."""
+    G = nx.cycle_graph(4)
+    G.add_edge(0, 0)
+    actual = nx.contracted_nodes(G, 0, 1)
+    expected = nx.complete_graph([0, 2, 3])
+    expected.add_edge(0, 0)
+    expected.add_edge(0, 0)
+    assert edges_equal(actual.edges, expected.edges)
+    actual = nx.contracted_nodes(G, 1, 0)
+    expected = nx.complete_graph([1, 2, 3])
+    expected.add_edge(1, 1)
+    expected.add_edge(1, 1)
+    assert edges_equal(actual.edges, expected.edges)
+
+
+def test_undirected_edge_contraction():
+    """Tests for edge contraction in an undirected graph."""
+    G = nx.cycle_graph(4)
+    actual = nx.contracted_edge(G, (0, 1))
+    expected = nx.complete_graph(3)
+    expected.add_edge(0, 0)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_multigraph_edge_contraction():
+    """Tests for edge contraction in a multigraph"""
+    G = nx.cycle_graph(4)
+    actual = nx.contracted_edge(G, (0, 1, 0))
+    expected = nx.complete_graph(3)
+    expected.add_edge(0, 0)
+    assert nx.is_isomorphic(actual, expected)
+
+
+def test_nonexistent_edge():
+    """Tests that attempting to contract a non-existent edge raises an
+    exception.
+
+    """
+    with pytest.raises(ValueError):
         G = nx.cycle_graph(4)
-        actual = nx.contracted_nodes(G, 0, 1)
-        expected = nx.cycle_graph(3)
-        expected.add_edge(0, 0)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_directed_node_contraction(self):
-        """Tests for node contraction in a directed graph."""
-        G = nx.DiGraph(nx.cycle_graph(4))
-        actual = nx.contracted_nodes(G, 0, 1)
-        expected = nx.DiGraph(nx.cycle_graph(3))
-        expected.add_edge(0, 0)
-        expected.add_edge(0, 0)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_undirected_node_contraction_no_copy(self):
-        """Tests for node contraction in an undirected graph
-        by making changes in place."""
-        G = nx.cycle_graph(4)
-        actual = nx.contracted_nodes(G, 0, 1, copy=False)
-        expected = nx.cycle_graph(3)
-        expected.add_edge(0, 0)
-        assert nx.is_isomorphic(actual, G)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_directed_node_contraction_no_copy(self):
-        """Tests for node contraction in a directed graph
-        by making changes in place."""
-        G = nx.DiGraph(nx.cycle_graph(4))
-        actual = nx.contracted_nodes(G, 0, 1, copy=False)
-        expected = nx.DiGraph(nx.cycle_graph(3))
-        expected.add_edge(0, 0)
-        expected.add_edge(0, 0)
-        assert nx.is_isomorphic(actual, G)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_create_multigraph(self):
-        """Tests that using a MultiGraph creates multiple edges."""
-        G = nx.path_graph(3, create_using=nx.MultiGraph())
-        G.add_edge(0, 1)
-        G.add_edge(0, 0)
-        G.add_edge(0, 2)
-        actual = nx.contracted_nodes(G, 0, 2)
-        expected = nx.MultiGraph()
-        expected.add_edge(0, 1)
-        expected.add_edge(0, 1)
-        expected.add_edge(0, 1)
-        expected.add_edge(0, 0)
-        expected.add_edge(0, 0)
-        assert edges_equal(actual.edges, expected.edges)
-
-    def test_multigraph_keys(self):
-        """Tests that multiedge keys are reset in new graph."""
-        G = nx.path_graph(3, create_using=nx.MultiGraph())
-        G.add_edge(0, 1, 5)
-        G.add_edge(0, 0, 0)
-        G.add_edge(0, 2, 5)
-        actual = nx.contracted_nodes(G, 0, 2)
-        expected = nx.MultiGraph()
-        expected.add_edge(0, 1, 0)
-        expected.add_edge(0, 1, 5)
-        expected.add_edge(0, 1, 2)  # keyed as 2 b/c 2 edges already in G
-        expected.add_edge(0, 0, 0)
-        expected.add_edge(0, 0, 1)  # this comes from (0, 2, 5)
-        assert edges_equal(actual.edges, expected.edges)
-
-    def test_node_attributes(self):
-        """Tests that node contraction preserves node attributes."""
-        G = nx.cycle_graph(4)
-        # Add some data to the two nodes being contracted.
-        G.nodes[0]["foo"] = "bar"
-        G.nodes[1]["baz"] = "xyzzy"
-        actual = nx.contracted_nodes(G, 0, 1)
-        # We expect that contracting the nodes 0 and 1 in C_4 yields K_3, but
-        # with nodes labeled 0, 2, and 3, and with a self-loop on 0.
-        expected = nx.complete_graph(3)
-        expected = nx.relabel_nodes(expected, {1: 2, 2: 3})
-        expected.add_edge(0, 0)
-        cdict = {1: {"baz": "xyzzy"}}
-        expected.nodes[0].update({"foo": "bar", "contraction": cdict})
-        assert nx.is_isomorphic(actual, expected)
-        assert actual.nodes == expected.nodes
-
-    def test_edge_attributes(self):
-        """Tests that node contraction preserves edge attributes."""
-        # Shape: src1 --> dest <-- src2
-        G = nx.DiGraph([("src1", "dest"), ("src2", "dest")])
-        G["src1"]["dest"]["value"] = "src1-->dest"
-        G["src2"]["dest"]["value"] = "src2-->dest"
-        H = nx.MultiDiGraph(G)
-
-        G = nx.contracted_nodes(G, "src1", "src2")  # New Shape: src1 --> dest
-        assert G.edges[("src1", "dest")]["value"] == "src1-->dest"
-        assert (
-            G.edges[("src1", "dest")]["contraction"][("src2", "dest")]["value"]
-            == "src2-->dest"
-        )
-
-        H = nx.contracted_nodes(H, "src1", "src2")  # New Shape: src1 -(x2)-> dest
-        assert len(H.edges(("src1", "dest"))) == 2
-
-    def test_without_self_loops(self):
-        """Tests for node contraction without preserving self-loops."""
-        G = nx.cycle_graph(4)
-        actual = nx.contracted_nodes(G, 0, 1, self_loops=False)
-        expected = nx.complete_graph(3)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_contract_selfloop_graph(self):
-        """Tests for node contraction when nodes have selfloops."""
-        G = nx.cycle_graph(4)
-        G.add_edge(0, 0)
-        actual = nx.contracted_nodes(G, 0, 1)
-        expected = nx.complete_graph([0, 2, 3])
-        expected.add_edge(0, 0)
-        expected.add_edge(0, 0)
-        assert edges_equal(actual.edges, expected.edges)
-        actual = nx.contracted_nodes(G, 1, 0)
-        expected = nx.complete_graph([1, 2, 3])
-        expected.add_edge(1, 1)
-        expected.add_edge(1, 1)
-        assert edges_equal(actual.edges, expected.edges)
-
-    def test_undirected_edge_contraction(self):
-        """Tests for edge contraction in an undirected graph."""
-        G = nx.cycle_graph(4)
-        actual = nx.contracted_edge(G, (0, 1))
-        expected = nx.complete_graph(3)
-        expected.add_edge(0, 0)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_multigraph_edge_contraction(self):
-        """Tests for edge contraction in a multigraph"""
-        G = nx.cycle_graph(4)
-        actual = nx.contracted_edge(G, (0, 1, 0))
-        expected = nx.complete_graph(3)
-        expected.add_edge(0, 0)
-        assert nx.is_isomorphic(actual, expected)
-
-    def test_nonexistent_edge(self):
-        """Tests that attempting to contract a non-existent edge raises an
-        exception.
-
-        """
-        with pytest.raises(ValueError):
-            G = nx.cycle_graph(4)
-            nx.contracted_edge(G, (0, 2))
+        nx.contracted_edge(G, (0, 2))

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1495,8 +1495,10 @@ def _simrank_similarity_numpy(
     return newsim
 
 
-@nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
-def panther_similarity(G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None):
+@nx._dispatch(edge_attrs="weight")
+def panther_similarity(
+    G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None, weight="weight"
+):
     r"""Returns the Panther similarity of nodes in the graph `G` to node ``v``.
 
     Panther is a similarity metric that says "two objects are considered
@@ -1522,6 +1524,9 @@ def panther_similarity(G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None
     eps : float or None (default = None)
         The error bound. Per [1]_, a good value is ``sqrt(1/|E|)``. Therefore,
         if no value is provided, the recommended computed value will be used.
+    weight : string or None, optional (default="weight")
+        The name of an edge attribute that holds the numerical value
+        used as a weight. If None then each edge has weight 1.
 
     Returns
     -------
@@ -1567,7 +1572,7 @@ def panther_similarity(G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None
     index_map = {}
     _ = list(
         generate_random_paths(
-            G, sample_size, path_length=path_length, index_map=index_map
+            G, sample_size, path_length=path_length, index_map=index_map, weight=weight
         )
     )
     S = np.zeros(num_nodes)
@@ -1601,8 +1606,10 @@ def panther_similarity(G, source, k=5, path_length=5, c=0.5, delta=0.1, eps=None
     return top_k_with_val
 
 
-@nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
-def generate_random_paths(G, sample_size, path_length=5, index_map=None):
+@nx._dispatch(edge_attrs="weight")
+def generate_random_paths(
+    G, sample_size, path_length=5, index_map=None, weight="weight"
+):
     """Randomly generate `sample_size` paths of length `path_length`.
 
     Parameters
@@ -1619,6 +1626,9 @@ def generate_random_paths(G, sample_size, path_length=5, index_map=None):
         If provided, this will be populated with the inverted
         index of nodes mapped to the set of generated random path
         indices within ``paths``.
+    weight : string or None, optional (default="weight")
+        The name of an edge attribute that holds the numerical value
+        used as a weight. If None then each edge has weight 1.
 
     Returns
     -------
@@ -1652,7 +1662,7 @@ def generate_random_paths(G, sample_size, path_length=5, index_map=None):
 
     # Calculate transition probabilities between
     # every pair of vertices according to Eq. (3)
-    adj_mat = nx.to_numpy_array(G)
+    adj_mat = nx.to_numpy_array(G, weight=weight)
     inv_row_sums = np.reciprocal(adj_mat.sum(axis=1)).reshape(-1, 1)
     transition_probabilities = adj_mat * inv_row_sums
 

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -810,13 +810,13 @@ class TestSimilarity:
         np.random.seed(42)
 
         G = nx.Graph()
-        G.add_edge("v1", "v2", weight=5)
-        G.add_edge("v1", "v3", weight=1)
-        G.add_edge("v1", "v4", weight=2)
-        G.add_edge("v2", "v3", weight=0.1)
-        G.add_edge("v3", "v5", weight=1)
+        G.add_edge("v1", "v2", w=5)
+        G.add_edge("v1", "v3", w=1)
+        G.add_edge("v1", "v4", w=2)
+        G.add_edge("v2", "v3", w=0.1)
+        G.add_edge("v3", "v5", w=1)
         expected = {"v3": 0.75, "v4": 0.5, "v2": 0.5, "v5": 0.25}
-        sim = nx.panther_similarity(G, "v1", path_length=2)
+        sim = nx.panther_similarity(G, "v1", path_length=2, weight="w")
         assert sim == expected
 
     def test_generate_random_paths_unweighted(self):

--- a/networkx/algorithms/walks.py
+++ b/networkx/algorithms/walks.py
@@ -6,7 +6,7 @@ import networkx as nx
 __all__ = ["number_of_walks"]
 
 
-@nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
+@nx._dispatch
 def number_of_walks(G, walk_length):
     """Returns the number of walks connecting each pair of nodes in `G`
 


### PR DESCRIPTION
As part of https://github.com/networkx/networkx/pull/6688, we found some functions were making assumptions about the `weight` parameter. It was not user programmable and it was defaulting to `weight` the string.

This implements https://github.com/networkx/networkx/issues/6753 and exposes `weight` as part of the API.