### PR TITLE
number_of_walks might use a weighted edge attribute

### DIFF
--- a/networkx/algorithms/tests/test_walks.py
+++ b/networkx/algorithms/tests/test_walks.py
@@ -44,3 +44,11 @@ def test_negative_length_exception():
     G = nx.cycle_graph(3)
     with pytest.raises(ValueError):
         nx.number_of_walks(G, -1)
+
+
+def test_hidden_weight_attr():
+    G = nx.cycle_graph(3)
+    G.add_edge(1, 2, weight=5)
+    num_walks = nx.number_of_walks(G, 3)
+    expected = {0: {0: 2, 1: 3, 2: 3}, 1: {0: 3, 1: 2, 2: 3}, 2: {0: 3, 1: 3, 2: 2}}
+    assert num_walks == expected

--- a/networkx/algorithms/walks.py
+++ b/networkx/algorithms/walks.py
@@ -69,7 +69,7 @@ def number_of_walks(G, walk_length):
     if walk_length < 0:
         raise ValueError(f"`walk_length` cannot be negative: {walk_length}")
 
-    A = nx.adjacency_matrix(G)
+    A = nx.adjacency_matrix(G, weight=None)
     # TODO: Use matrix_power from scipy.sparse when available
     # power = sp.sparse.linalg.matrix_power(A, walk_length)
     power = np.linalg.matrix_power(A.toarray(), walk_length)


### PR DESCRIPTION
number_of_walks might use a weighted edge attribute if that graph has any edge attributes not equal to 1.
That will make it compute the number of walks incorrectly since it uses a power of the adjacency matrix.

This fix simply changes the call to adjacency_matrix to have `weight=None` explicitly set. Test added too.