### PR TITLE
Improve testing of backends: let tests get setup up, and fallback

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -18,6 +18,18 @@ import pytest
 
 import networkx
 
+_is_pytest_running = False
+
+
+def is_pytest_running():
+    return _is_pytest_running
+
+
+@pytest.fixture(autouse=True)
+def set_is_pytest_running():
+    global _is_pytest_running
+    _is_pytest_running = True
+
 
 def pytest_addoption(parser):
     parser.addoption(


### PR DESCRIPTION
We add `is_pytest_running()` that is True once tests begin running to allow NetworkX to set up it's own tests. Otherwise, some functions go through dispatching before tests are run, which requires backends to implement them, and then the resulting graphs are the backend graph and not networkx graphs.

Also, allow algorithms to raise `NotImplementedError` to allow incremental implementation by backends. When testing, this will fallback to running the original networkx algorithm if `NETWORKX_BACKEND_TEST_EXHAUSTIVE` environment variable is set, or else the test will xfail.

This is to help with both `graphblas_algorithms` and `cugraph_nx` backends.