### PR TITLE
add implementation to re-dispatch all functions for easier testing

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -11,7 +11,6 @@ General guidelines for writing good tests:
   and add the module to the relevant entries below.
 
 """
-import sys
 import warnings
 
 import pytest
@@ -23,10 +22,21 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
+    parser.addoption(
+        "--backend",
+        action="store",
+        default="",
+        help="set plugin name for auto-converting nx graphs",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    if backend := config.getoption("--backend"):
+        import networkx.utils.backends as nxb
+
+        nxb.plugin_name = backend
+        nxb.reregister_all_algos(nxb.test_override_dispatch)
 
 
 def pytest_collection_modifyitems(config, items):

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -136,7 +136,7 @@ def reregister_all_algos(dispatch_override=None):
     global _registered_algorithms
 
     dispatch_fn = _dispatch if dispatch_override is None else dispatch_override
-    algos, _registered_algorithms = _registered_algorithms.copy(), {}
+    algos = _registered_algorithms.copy()
     _registered_algorithms = {}
 
     for wrapped_func in algos.values():


### PR DESCRIPTION
the `--backend=nx-loopback` option reregisters all algorithms before the tests execute.
the ability to reregister all (or some) functions I can see being useful in other situations, e.g. if a function is monkey-patched.
additionally, all dispatched functions keep a `dispatchargs` attribute which can be queried to see which aspects are kept when dispatching, which I think is also useful.

Came from discussion on #6819 