### PR TITLE
ci: Add distribution verification checks to nightly wheel upload

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,10 +14,20 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - run: |
+      - name: Install Python requirements
+        run: |
           python -m pip install -r requirements/release.txt
-          python -m build --sdist --wheel
-      - uses: scientific-python/upload-nightly-action@main
+      - name: Build a wheel and a sdist
+        run: |
+          python -m build .
+      - name: Verify the distribution
+        run: twine check --strict dist/*
+      - name: List contents of sdist
+        run: python -m tarfile --list dist/networkx-*.tar.gz
+      - name: List contents of wheel
+        run: python -m zipfile --list dist/networkx-*.whl
+      - name: Upload nighlty wheel
+        uses: scientific-python/upload-nightly-action@main
         with:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_NIGHTLY }}
           artifacts_path: dist/


### PR DESCRIPTION
Following discussion in https://github.com/scientific-python/upload-nightly-action/pull/27#pullrequestreview-1557811090 this PR adds the mentioned checks to the nightly wheel upload CI.

Use 'twine check' to verify distribution and list the contents of the dist and wheel for visual inspection of distribution content in the logs.
