### PR TITLE
GML: added support for reading multi-line values

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -311,7 +311,7 @@ def parse_gml_lines(lines, label, destringizer):
         ]
         tokens = re.compile("|".join(f"({pattern})" for pattern in patterns))
         lineno = 0
-        multilines = []# entries spread across multiple lines
+        multilines = []  # entries spread across multiple lines
         for line in lines:
             pos = 0
 
@@ -320,16 +320,16 @@ def parse_gml_lines(lines, label, destringizer):
             # should we actually have to deal with escaped "s then do it here
             if multilines:
                 multilines.append(line.strip())
-                if line[-1] == '"':# closing multiline entry
+                if line[-1] == '"':  # closing multiline entry
                     # multiline entries will be joined by space. cannot
                     # reintroduce newlines as this will break the tokenizer
                     line = " ".join(multilines)
                     multilines = []
-                else:# continued multiline entry
+                else:  # continued multiline entry
                     lineno += 1
                     continue
             else:
-                if line.count('"') == 1: # opening multiline entry
+                if line.count('"') == 1:  # opening multiline entry
                     if line.strip()[0] != '"' and line.strip()[-1] != '"':
                         # since we expect something like key "value", the " should not be found at ends
                         # otherwise tokenizer will pick up the formatting mistake.

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -311,9 +311,34 @@ def parse_gml_lines(lines, label, destringizer):
         ]
         tokens = re.compile("|".join(f"({pattern})" for pattern in patterns))
         lineno = 0
+        multilines = []# entries spread across multiple lines
         for line in lines:
-            length = len(line)
             pos = 0
+
+            # deal with entries spread across multiple lines
+            #
+            # should we actually have to deal with escaped "s then do it here
+            if multilines:
+                multilines.append(line.strip())
+                if line[-1] == '"':# closing multiline entry
+                    # multiline entries will be joined by space. cannot
+                    # reintroduce newlines as this will break the tokenizer
+                    line = " ".join(multilines)
+                    multilines = []
+                else:# continued multiline entry
+                    lineno += 1
+                    continue
+            else:
+                if line.count('"') == 1: # opening multiline entry
+                    if line.strip()[0] != '"' and line.strip()[-1] != '"':
+                        # since we expect something like key "value", the " should not be found at ends
+                        # otherwise tokenizer will pick up the formatting mistake.
+                        multilines = [line.rstrip()]
+                        lineno += 1
+                        continue
+
+            length = len(line)
+
             while pos < length:
                 match = tokens.match(line, pos)
                 if match is None:

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -631,7 +631,11 @@ graph
 ]
 """
         G = nx.parse_gml(multiline_example)
-        assert G.nodes["multiline node"] == {"label2": "multiline1 multiline2 multiline3", "alt_name": "id 0"}
+        assert G.nodes["multiline node"] == {
+            "label2": "multiline1 multiline2 multiline3",
+            "alt_name": "id 0",
+        }
+
 
 @contextmanager
 def byte_file():

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -630,8 +630,8 @@ graph
     ]
 ]
 """
-        nx.parse_gml(multiline_example)
-
+        G = nx.parse_gml(multiline_example)
+        assert G.nodes["multiline node"] == {"label2": "multiline1 multiline2 multiline3", "alt_name": "id 0"}
 
 @contextmanager
 def byte_file():

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -614,6 +614,24 @@ graph
             os.close(fd)
             os.unlink(fname)
 
+    def test_multiline(self):
+        # example from issue #6836
+        multiline_example = """
+graph
+[
+    node
+    [
+	    id 0
+	    label "multiline node"
+	    label2 "multiline1
+    multiline2
+    multiline3"
+	    alt_name "id 0"
+    ]
+]
+"""
+        nx.parse_gml(multiline_example)
+
 
 @contextmanager
 def byte_file():


### PR DESCRIPTION
This PR adds support for reading GML files with multiline entries. Currently NetworkX fails reading those files. The multiple lines are concatenated by space. This is achieved by introducing a buffer called `multilines`.

Fixes #6836 