### PR TITLE
Change `_dispatch` to a class instead of a closure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         # Limit this to only a single combination from the matrix
         if: ${{ (matrix.os == 'ubuntu') && (matrix.python-version == '3.11') }}
         run: |
-          NETWORKX_GRAPH_CONVERT=nx-loopback pytest --doctest-modules --durations=10 --pyargs networkx
+          NETWORKX_TEST_BACKEND=nx-loopback pytest --doctest-modules --durations=10 --pyargs networkx
 
   extra:
     runs-on: ${{ matrix.os }}

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -53,7 +53,7 @@ def test_intersection():
     assert set(I2.nodes()) == {1, 2, 3, 4}
     assert sorted(I2.edges()) == [(2, 3)]
     # Only test if not performing auto convert testing of backend implementations
-    if os.environ.get("NETWORKX_GRAPH_CONVERT", None) is None:
+    if nx.utils.backends._dispatch._plugin_name is None:
         with pytest.raises(TypeError):
             nx.intersection(G2, H)
         with pytest.raises(TypeError):

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -53,7 +53,7 @@ def test_intersection():
     assert set(I2.nodes()) == {1, 2, 3, 4}
     assert sorted(I2.edges()) == [(2, 3)]
     # Only test if not performing auto convert testing of backend implementations
-    if nx.utils.backends._dispatch._plugin_name is None:
+    if not nx.utils.backends._dispatch._automatic_backends:
         with pytest.raises(TypeError):
             nx.intersection(G2, H)
         with pytest.raises(TypeError):

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -67,9 +67,8 @@ class LoopbackDispatcher:
         preserve_graph_attrs=None,
         name=None,
         graph_name=None,
-        is_testing=False,
     ):
-        if is_testing and name in {
+        if name in {
             # Raise if input graph changes
             "lexicographical_topological_sort",
             "topological_generations",
@@ -185,6 +184,11 @@ class LoopbackDispatcher:
         # Verify that items can be xfailed
         for item in items:
             assert hasattr(item, "add_marker")
+
+    def can_run(self, name, args, kwargs):
+        # It is unnecessary to define this function if algorithms are fully supported.
+        # We include it for illustration purposes.
+        return hasattr(self, name)
 
 
 dispatcher = LoopbackDispatcher()

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -2,7 +2,7 @@
 
 # A full test of all dispatchable algorithms is performed by
 # modifying the pytest invocation and setting an environment variable
-# NETWORKX_GRAPH_CONVERT=nx-loopback pytest
+# NETWORKX_TEST_BACKEND=nx-loopback pytest
 # This is comprehensive, but only tests the `test_override_dispatch`
 # function in networkx.classes.backends.
 
@@ -52,7 +52,7 @@ def convert(graph):
 class LoopbackDispatcher:
     def __getattr__(self, item):
         try:
-            return nx.utils.backends._registered_algorithms[item].__wrapped__
+            return nx.utils.backends._registered_algorithms[item].orig_func
         except KeyError:
             raise AttributeError(item) from None
 
@@ -67,8 +67,9 @@ class LoopbackDispatcher:
         preserve_graph_attrs=None,
         name=None,
         graph_name=None,
+        is_testing=False,
     ):
-        if name in {
+        if is_testing and name in {
             # Raise if input graph changes
             "lexicographical_topological_sort",
             "topological_generations",

--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 import networkx as nx
@@ -12,3 +14,9 @@ def test_dispatch_kwds_vs_args():
     nx.pagerank(G=G)
     with pytest.raises(TypeError):
         nx.pagerank()
+
+
+def test_pickle():
+    for name, func in nx.utils.backends._registered_algorithms.items():
+        assert pickle.loads(pickle.dumps(func)) is func
+    assert pickle.loads(pickle.dumps(nx.inverse_line_graph)) is nx.inverse_line_graph

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -46,10 +46,10 @@ def pytest_configure(config):
     if backend is None:
         backend = os.environ.get("NETWORKX_TEST_BACKEND")
     if backend:
-        networkx.utils.backends._dispatch._plugin_name = backend
+        networkx.utils.backends._dispatch._automatic_backends = [backend]
         fallback_to_nx = config.getoption("--fallback-to-nx")
         if not fallback_to_nx:
-            fallback_to_nx = os.environ.get("NETWORKX_TEST_FALLBACK_TO_NX")
+            fallback_to_nx = os.environ.get("NETWORKX_FALLBACK_TO_NX")
         networkx.utils.backends._dispatch._fallback_to_nx = bool(fallback_to_nx)
     # nx-loopback plugin is only available when testing
     if sys.version_info < (3, 10):
@@ -65,10 +65,10 @@ def pytest_collection_modifyitems(config, items):
     # Setting this to True here allows tests to be set up before dispatching
     # any function call to a backend.
     networkx.utils.backends._dispatch._is_testing = True
-    if plugin_name := networkx.utils.backends._dispatch._plugin_name:
+    if automatic_backends := networkx.utils.backends._dispatch._automatic_backends:
         # Allow pluggable backends to add markers to tests (such as skip or xfail)
         # when running in auto-conversion test mode
-        backend = networkx.utils.backends.plugins[plugin_name].load()
+        backend = networkx.utils.backends.plugins[automatic_backends[0]].load()
         if hasattr(backend, "on_start_tests"):
             getattr(backend, "on_start_tests")(items)
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -58,7 +58,7 @@ def pytest_configure(config):
         )
     else:
         plugins = entry_points(name="nx-loopback", group="networkx.plugins")
-    [networkx.utils.backends.plugins["nx-loopback"]] = plugins
+    networkx.utils.backends.plugins["nx-loopback"] = next(iter(plugins))
 
 
 def pytest_collection_modifyitems(config, items):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -13,6 +13,7 @@ General guidelines for writing good tests:
 """
 import os
 import warnings
+from importlib.metadata import entry_points
 
 import pytest
 
@@ -44,6 +45,11 @@ def pytest_configure(config):
     if backend is None:
         backend = os.environ.get("NETWORKX_TEST_BACKEND")
     if backend:
+        if backend == "nx-loopback":
+            # nx-loopback plugin is only available when it's being tested
+            [networkx.utils.backends.plugins["nx-loopback"]] = entry_points(
+                name="nx-loopback", group="networkx.plugins"
+            )
         networkx.utils.backends._dispatch._plugin_name = backend
         fallback_to_nx = config.getoption("--fallback-to-nx")
         if not fallback_to_nx:

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -53,13 +53,12 @@ def pytest_configure(config):
         networkx.utils.backends._dispatch._fallback_to_nx = bool(fallback_to_nx)
     # nx-loopback plugin is only available when testing
     if sys.version_info < (3, 10):
-        networkx.utils.backends.plugins["nx-loopback"] = entry_points()[
-            "networkx.plugins"
-        ]["nx-loopback"]
-    else:
-        [networkx.utils.backends.plugins["nx-loopback"]] = entry_points(
-            name="nx-loopback", group="networkx.plugins"
+        plugins = (
+            ep for ep in entry_points()["networkx.plugins"] if ep.name == "nx-loopback"
         )
+    else:
+        plugins = entry_points(name="nx-loopback", group="networkx.plugins")
+    [networkx.utils.backends.plugins["nx-loopback"]] = plugins
 
 
 def pytest_collection_modifyitems(config, items):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -45,16 +45,15 @@ def pytest_configure(config):
     if backend is None:
         backend = os.environ.get("NETWORKX_TEST_BACKEND")
     if backend:
-        if backend == "nx-loopback":
-            # nx-loopback plugin is only available when it's being tested
-            [networkx.utils.backends.plugins["nx-loopback"]] = entry_points(
-                name="nx-loopback", group="networkx.plugins"
-            )
         networkx.utils.backends._dispatch._plugin_name = backend
         fallback_to_nx = config.getoption("--fallback-to-nx")
         if not fallback_to_nx:
             fallback_to_nx = os.environ.get("NETWORKX_TEST_FALLBACK_TO_NX")
         networkx.utils.backends._dispatch._fallback_to_nx = bool(fallback_to_nx)
+    # nx-loopback plugin is only available when testing
+    [networkx.utils.backends.plugins["nx-loopback"]] = entry_points(
+        name="nx-loopback", group="networkx.plugins"
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -12,6 +12,7 @@ General guidelines for writing good tests:
 
 """
 import os
+import sys
 import warnings
 from importlib.metadata import entry_points
 
@@ -51,9 +52,14 @@ def pytest_configure(config):
             fallback_to_nx = os.environ.get("NETWORKX_TEST_FALLBACK_TO_NX")
         networkx.utils.backends._dispatch._fallback_to_nx = bool(fallback_to_nx)
     # nx-loopback plugin is only available when testing
-    [networkx.utils.backends.plugins["nx-loopback"]] = entry_points(
-        name="nx-loopback", group="networkx.plugins"
-    )
+    if sys.version_info < (3, 10):
+        networkx.utils.backends.plugins["nx-loopback"] = entry_points()[
+            "networkx.plugins"
+        ]["nx-loopback"]
+    else:
+        [networkx.utils.backends.plugins["nx-loopback"]] = entry_points(
+            name="nx-loopback", group="networkx.plugins"
+        )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -193,7 +193,9 @@ class _dispatch:
         os.environ.get("NETWORKX_FALLBACK_TO_NX", "true").strip().lower() == "true"
     )
     _automatic_backends = [
-        x.strip() for x in os.environ.get("NETWORKX_AUTOMATIC_BACKENDS", "").split(",")
+        x.strip()
+        for x in os.environ.get("NETWORKX_AUTOMATIC_BACKENDS", "").split(",")
+        if x.strip()
     ]
 
     def __new__(

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -713,11 +713,10 @@ class _dispatch:
                 msg += " with the given arguments"
             raise RuntimeError(msg)
 
-        converted_args, converted_kwargs = self._convert_arguments(
-            plugin_name, args, kwargs
-        )
-
         try:
+            converted_args, converted_kwargs = self._convert_arguments(
+                plugin_name, args, kwargs
+            )
             result = getattr(backend, self.name)(*converted_args, **converted_kwargs)
         except (NotImplementedError, NetworkXNotImplemented) as exc:
             if fallback_to_nx:
@@ -742,11 +741,10 @@ class _dispatch:
                 msg += " with the given arguments"
             pytest.xfail(msg)
 
-        converted_args, converted_kwargs = self._convert_arguments(
-            plugin_name, args, kwargs
-        )
-
         try:
+            converted_args, converted_kwargs = self._convert_arguments(
+                plugin_name, args, kwargs
+            )
             result = getattr(backend, self.name)(*converted_args, **converted_kwargs)
         except (NotImplementedError, NetworkXNotImplemented) as exc:
             if fallback_to_nx:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -111,7 +111,7 @@ def _get_plugins():
             )
         else:
             rv[ep.name] = ep
-    # nx-loopback plugin is only available when it's being tested (added in conftest.py)
+    # nx-loopback plugin is only available when testing (added in conftest.py)
     del rv["nx-loopback"]
     return rv
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -257,33 +257,33 @@ class _dispatch:
         if edge_attrs is not None and not isinstance(edge_attrs, (str, dict)):
             raise TypeError(
                 f"Bad type for edge_attrs: {type(edge_attrs)}. Expected str or dict."
-            )
+            ) from None
         if node_attrs is not None and not isinstance(node_attrs, (str, dict)):
             raise TypeError(
                 f"Bad type for node_attrs: {type(node_attrs)}. Expected str or dict."
-            )
+            ) from None
         if not isinstance(self.preserve_edge_attrs, (bool, str, dict)):
             raise TypeError(
                 f"Bad type for preserve_edge_attrs: {type(self.preserve_edge_attrs)}."
                 " Expected bool, str, or dict."
-            )
+            ) from None
         if not isinstance(self.preserve_node_attrs, (bool, str, dict)):
             raise TypeError(
                 f"Bad type for preserve_node_attrs: {type(self.preserve_node_attrs)}."
                 " Expected bool, str, or dict."
-            )
+            ) from None
         if not isinstance(self.preserve_graph_attrs, (bool, set)):
             raise TypeError(
                 f"Bad type for preserve_graph_attrs: {type(self.preserve_graph_attrs)}."
                 " Expected bool or set."
-            )
+            ) from None
 
         if isinstance(graphs, str):
             graphs = {graphs: 0}
         elif not isinstance(graphs, dict):
             raise TypeError(
                 f"Bad type for graphs: {type(graphs)}. Expected str or dict."
-            )
+            ) from None
         elif len(graphs) == 0:
             raise KeyError("'graphs' must contain at least one variable name") from None
 
@@ -307,7 +307,9 @@ class _dispatch:
         self._sig = None
 
         if name in _registered_algorithms:
-            raise KeyError(f"Algorithm already exists in dispatch registry: {name}")
+            raise KeyError(
+                f"Algorithm already exists in dispatch registry: {name}"
+            ) from None
         _registered_algorithms[name] = self
         return self
 
@@ -359,23 +361,21 @@ class _dispatch:
         for gname, pos in self.graphs.items():
             if pos < len(args):
                 if gname in kwargs:
-                    raise TypeError(
-                        f"{self.name}() got multiple values for {gname!r}"
-                    ) from None
+                    raise TypeError(f"{self.name}() got multiple values for {gname!r}")
                 val = args[pos]
             elif gname in kwargs:
                 val = kwargs[gname]
             elif gname not in self.optional_graphs:
                 raise TypeError(
                     f"{self.name}() missing required graph argument: {gname}"
-                ) from None
+                )
             else:
                 continue
             if val is None:
                 if gname not in self.optional_graphs:
                     raise TypeError(
                         f"{self.name}() required graph argument {gname!r} is None; must be a graph"
-                    ) from None
+                    )
             else:
                 graphs_resolved[gname] = val
 
@@ -442,7 +442,7 @@ class _dispatch:
                 # Future work: convert between backends and run if multiple plugins found
                 raise TypeError(
                     f"{self.name}() graphs must all be from the same plugin, found {backend_names}"
-                ) from None
+                )
             [plugin_name] = backend_names
             if backend_name is not None and backend_name != plugin_name:
                 # Future work: convert between backends to `backend_name` backend
@@ -451,7 +451,7 @@ class _dispatch:
                     f"to the specified backend {backend_name!r}."
                 )
             if plugin_name not in plugins:
-                raise ImportError(f"Unable to load plugin: {plugin_name}") from None
+                raise ImportError(f"Unable to load plugin: {plugin_name}")
             if (
                 "networkx" in plugin_names
                 and plugin_name not in self._automatic_backends

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -671,3 +671,10 @@ class _dispatch:
         if is_testing:
             return backend.convert_to_nx(result, name=self.name)
         return result
+
+    def __reduce__(self):
+        return _restore_dispatch, (self.name,)
+
+
+def _restore_dispatch(name):
+    return _registered_algorithms[name]


### PR DESCRIPTION
This PR supersedes #6828 and #6829, and it implements one of the "future" items from #6804:
- change `_dispatch` to be a class instead of a closure
- fallback to original networkx function when testing if `fallback_to_nx` is set when backend raises `NotImplementedError` (also done in #6828)
- don't dispatch to backend when testing until tests are set up (also done in #6828)
- add `--backend=whatever` option to `pytest` to choose backend w/o environment variable (also done in #6829)
- add `--fallback-to-nx` option to `pytest` to run test with networkx graph is backend does not implement it
- rename `NETWORKX_GRAPH_CONVERT` environment variable to `NETWORKX_TEST_BACKEND`
- rename `NETWORKX_BACKEND_TEST_EXHAUSTIVE` environment variable to `NETWORKX_FALLBACK_TO_NX`
- add `**backend_kwargs` to signature to allow backends to have additional keyword arguments
- ~add `is_testing=` argument to `convert_from_nx`, which I would find useful for my plugins~ (removed)
- add `_dispatch._convert_and_call` method, which gets us one step closer to automatic conversions
- Newly added on 2023-08-18:
  - `NETWORKX_AUTOMATIC_BACKENDS` to enable automatic conversions to backends
  - add `backend=` keyword-only parameter to allow the backend to be explicitly chosen at call-time
  - add `_can_backend_run` and `_convert_arguments` methods to `_dispatch`; should we make these public?

The backend can still be indicated with `NETWORKX_TEST_BACKEND` environment variable, which allows us to run networkx tests with backends when networkx is installed in site-packages (b/c `pytest --backend` doesn't work in this case).

The testing environment variables are only handled when `pytest` is invoked. Previously, we checked the environment variables at import time. This is one reason I thought it appropriate to change the names of the environment variables.

Behavior of dispatching (such as changing plugin name) can be easily modified at any time by changing class attributes on `_dispatch`.

I exposed a lot of attributes of `_dispatch` objects. I would appreciate scrutiny on choice of names. We can make some/most of these private if people prefer. Keep in mind that we will likely add more attributes and methods later when we add e.g. configuration, discovering and choosing backends, etc. Having `_dispatch` as a class sets us up for more future goodness.

I have not measured performance impact of these changes. If it's significant, an easy optimization would be to compute `__signature__` on demand when needed.

Unlike #6828 and #6829, this PR has a lot more to review--sorry! I figure it would be better to make breaking changes before 3.2 is released if at all possible.

CC @jim22k @aaronzo