### PR TITLE
Modify `s_metric` `normalized` default so function doesn't raise

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -83,3 +83,4 @@ Version 3.4
 * Remove the ``sort_neighbors`` input parameter from ``generic_bfs_edges``.
 * Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
 * Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.
+* Remove ``normalized`` kwarg from ``algorithms.s_metric``

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -48,7 +48,13 @@ Deprecations
   and will be removed in v3.4.  Use ``neighbors`` to sort the nodes if desired.
 - [`#6785 <https://github.com/networkx/pull/6785>`_]
   Deprecate ``MultiDiGraph_EdgeKey`` subclass used in ``Edmonds`` class.
-  Deprecate ``Edmonds`` class for computing minimum and maximum branchings and arborescences (use ``minimum_branching``, ``minimal_branching``, ``maximum_branching``, ``minimum_arborescence`` and ``maximum_arborescence`` directly).
+  Deprecate ``Edmonds`` class for computing minimum and maximum branchings and
+  arborescences (use ``minimum_branching``, ``minimal_branching``,
+  ``maximum_branching``, ``minimum_arborescence`` and ``maximum_arborescence``
+  directly).
+- [`#6841 <https://github.com/networkx/pull/6841>`_]
+  Deprecate the ``normalized`` keyword of the ``s_metric`` function. Ignore
+  value of ``normalized`` for future compatibility.
 
 Merged PRs
 ----------

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -4,20 +4,18 @@ __all__ = ["s_metric"]
 
 
 @nx._dispatch
-def s_metric(G, normalized=True):
-    """Returns the s-metric of graph.
+def s_metric(G, normalized=False):
+    """Returns the s-metric [1]_ of graph.
 
-    The s-metric is defined as the sum of the products deg(u)*deg(v)
-    for every edge (u,v) in G. If norm is provided construct the
-    s-max graph and compute it's s_metric, and return the normalized
-    s value
+    The s-metric is defined as the sum of the products ``deg(u) * deg(v)``
+    for every edge ``(u, v)`` in `G`.
 
     Parameters
     ----------
-    G    : graph
-           The graph used to compute the s-metric.
+    G : graph
+        The graph used to compute the s-metric.
     normalized : bool (optional)
-           Normalize the value.
+        Normalize the value.
 
     Returns
     -------

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -4,7 +4,7 @@ __all__ = ["s_metric"]
 
 
 @nx._dispatch
-def s_metric(G, normalized=False):
+def s_metric(G, **kwargs):
     """Returns the s-metric [1]_ of graph.
 
     The s-metric is defined as the sum of the products ``deg(u) * deg(v)``
@@ -15,6 +15,10 @@ def s_metric(G, normalized=False):
     G : graph
         The graph used to compute the s-metric.
     normalized : bool (optional)
+        .. deprecated:: 3.2
+
+           The `normalized` keyword argument is deprecated and will be removed
+           in the future
         Normalize the value.
 
     Returns
@@ -29,9 +33,28 @@ def s_metric(G, normalized=False):
            Definition, Properties, and  Implications (Extended Version), 2005.
            https://arxiv.org/abs/cond-mat/0501169
     """
-    if normalized:
-        raise nx.NetworkXError("Normalization not implemented")
-    #        Gmax = li_smax_graph(list(G.degree().values()))
-    #        return s_metric(G,normalized=False)/s_metric(Gmax,normalized=False)
-    #    else:
+    # NOTE: This entire code block + the **kwargs in the signature can all be
+    # removed when the deprecation expires.
+    # Normalized is always False, since all `normalized=True` did was raise
+    # a NotImplementedError
+    normalized = False
+    if kwargs:
+        # Warn for `normalize`, raise for any other kwarg
+        if "normalized" in kwargs:
+            import warnings
+
+            warnings.warn(
+                "\n\nThe `normalized` keyword is deprecated and will be removed\n"
+                "in the future. To silence this warning, remove `normalized`\n"
+                "when calling `s_metric`.\n\n"
+                "The value of `normalized` is ignored.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        else:
+            # Typical raising behavior for Python when kwarg not recognized
+            raise TypeError(
+                f"s_metric got an unexpected keyword argument '{list(kwargs.keys())[0]}'"
+            )
+
     return float(sum(G.degree(u) * G.degree(v) for (u, v) in G.edges()))

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -37,7 +37,6 @@ def s_metric(G, **kwargs):
     # removed when the deprecation expires.
     # Normalized is always False, since all `normalized=True` did was raise
     # a NotImplementedError
-    normalized = False
     if kwargs:
         # Warn for `normalize`, raise for any other kwarg
         if "normalized" in kwargs:

--- a/networkx/algorithms/tests/test_smetric.py
+++ b/networkx/algorithms/tests/test_smetric.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 import networkx as nx
@@ -13,10 +15,22 @@ def test_smetric():
     assert sm == 19.0
 
 
-#    smNorm = nx.s_metric(g,normalized=True)
-#    assert_equal(smNorm, 0.95)
+# NOTE: Tests below to be deleted when deprecation of `normalized` kwarg expires
 
 
-def test_normalized():
-    with pytest.raises(nx.NetworkXError):
-        sm = nx.s_metric(nx.Graph(), normalized=True)
+def test_normalized_deprecation_warning():
+    """Test that a deprecation warning is raised when s_metric is called with
+    a `normalized` kwarg."""
+    G = nx.cycle_graph(7)
+    # No warning raised when called without kwargs (future behavior)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Fail the test if warning caught
+        assert nx.s_metric(G) == 28
+
+    # Deprecation warning
+    with pytest.deprecated_call():
+        nx.s_metric(G, normalized=True)
+
+    # Make sure you get standard Python behavior when unrecognized keyword provided
+    with pytest.raises(TypeError):
+        nx.s_metric(G, normalize=True)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -89,6 +89,9 @@ def set_warnings():
         category=DeprecationWarning,
         message="MultiDiGraph_EdgeKey has been deprecated",
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Currently, the `nx.s_metric` function raises a `NetworkXException` when called with the default keyword argument values because normalization is not implmented:

```python
>>> G = nx.cycle_graph(4)
>>> nx.s_metric(G)
Traceback (most recent call last)
   ...
NetworkXError: Normalization not implemented
```

I think it's safe to say this function is not frequently used :upside_down_face: Nevertheless, I propose to change the default to `normalization=False`. I don't think the deprecation/futurewarning policy really applies in this case since the default is broken; however, if there are other suggestions for how to handle this (e.g. remove the kwarg outright) LMK!

fixes https://github.com/networkx/networkx/issues/5906