### PR TITLE
Don't test numpy2 nightlies

### DIFF
--- a/.github/workflows/nightly-release-test.yml
+++ b/.github/workflows/nightly-release-test.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install packages
         run: |
           pip install --upgrade pip
+          sed -i 's/numpy>=1.22/numpy>=1.22,<2.0/g' requirements/default.txt 
           pip install -U --pre --extra-index-url https://pypi.org/simple -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r requirements/default.txt
           pip install --pre -r requirements/test.txt
           pip install .


### PR DESCRIPTION
We are failing on the nightly wheel builds b/c of numpy 2 (see #6846). This let's us test on the other wheels without the known numpy 2 failure. After merging this, I will make a PR to revert it and we can work on fixing the issue there.