### PR TITLE
Proposal: Transition-plan for NEP 51 numpy scalar reprs + NX doctests

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -94,6 +94,12 @@ def set_warnings():
 @pytest.fixture(autouse=True)
 def add_nx(doctest_namespace):
     doctest_namespace["nx"] = networkx
+    try:
+        import numpy as np
+
+        np.set_printoptions(legacy="1.21")
+    except ImportError:
+        pass
 
 
 # What dependencies are installed?


### PR DESCRIPTION
This is my proposal for how to handle the upcoming changes to NumPy scalar reprs (per [NEP 51](https://numpy.org/neps/nep-0051-scalar-representation.html)); specifically the effects on the doctests - see #6846.

This will silence doctest errors related to changes in the NumPy scalar reprs per NEP 51.
The goal is to aid in transitioning to new numpy scalars with the minimum possible churn in code/CI.

In general, the transition plan would be something like:
 - Leave this PR in place to suppress doctest failures from changes in numpy scalar reprs.
   This way, all doctests can still be run: no need to re-configure CI based on numpy version.
 - Update / modify code and/or tests as needed to limit/replace the use of numpy scalars,
   where appropriate.
 - When NumPy 2.0 becomes the minimum supported version for NetworkX, These 5 lines can
   be removed and any remaining issues related to scalar representations fixed
   (hopefully there aren't any left... see previous bullet).
