### PR TITLE
MAINT: replace numpy aliases in scipy namespace.

### DIFF
--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -138,7 +138,7 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
     # TODO: rm csr_array wrapper when spdiags can produce arrays
     D = sp.sparse.csr_array(sp.sparse.spdiags(diags, 0, m, n, format="csr"))
     L = D - A
-    with sp.errstate(divide="ignore"):
+    with np.errstate(divide="ignore"):
         diags_sqrt = 1.0 / np.sqrt(diags)
     diags_sqrt[np.isinf(diags_sqrt)] = 0
     # TODO: rm csr_array wrapper when spdiags can produce arrays

--- a/networkx/tests/test_lazy_imports.py
+++ b/networkx/tests/test_lazy_imports.py
@@ -54,7 +54,7 @@ def test_lazy_import_nonbuiltins():
     np = lazy._lazy_import("numpy")
     if isinstance(sp, lazy.DelayedImportErrorModule):
         try:
-            sp.pi
+            sp.special.erf
             assert False
         except ModuleNotFoundError:
             pass
@@ -65,7 +65,7 @@ def test_lazy_import_nonbuiltins():
         except ModuleNotFoundError:
             pass
     else:
-        assert np.sin(sp.pi) == pytest.approx(0, 1e-6)
+        assert sp.special.erf(np.pi) == pytest.approx(1, 1e-4)
 
 
 def test_lazy_attach():


### PR DESCRIPTION
Future versions of scipy are removing the symbols from scipy namespace that are simply aliases to numpy objects

This PR removes these aliases for future compatibility.

Note that the `sp.pi` was used in the testing of the lazy importing system. I went ahead and changed it to `sp.special.erf`... I *believe* this covers the same semantics, but please double-check that I'm not changing the test semantics too much!
