### PR TITLE
fix: make messages readable

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -198,7 +198,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
         import warnings
 
         msg = (
-            "steiner_tree will change default method from 'kou' to 'mehlhorn'"
+            "steiner_tree will change default method from 'kou' to 'mehlhorn' "
             "in version 3.2.\nSet the `method` kwarg to remove this warning."
         )
         warnings.warn(msg, FutureWarning, stacklevel=4)

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -404,7 +404,7 @@ def average_shortest_path_length(G, weight=None, method=None):
     # there are no paths in the null graph.
     if n == 0:
         msg = (
-            "the null graph has no paths, thus there is no average"
+            "the null graph has no paths, thus there is no average "
             "shortest path length"
         )
         raise nx.NetworkXPointlessConcept(msg)

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -42,8 +42,8 @@ def write_dot(G, path):
     Path can be a string or a file handle.
     """
     msg = (
-        "nx.nx_pydot.write_dot depends on the pydot package, which has"
-        "known issues and is not actively maintained. Consider using"
+        "nx.nx_pydot.write_dot depends on the pydot package, which has "
+        "known issues and is not actively maintained. Consider using "
         "nx.nx_agraph.write_dot instead.\n\n"
         "See https://github.com/networkx/networkx/issues/5723"
     )
@@ -79,8 +79,8 @@ def read_dot(path):
     import pydot
 
     msg = (
-        "nx.nx_pydot.read_dot depends on the pydot package, which has"
-        "known issues and is not actively maintained. Consider using"
+        "nx.nx_pydot.read_dot depends on the pydot package, which has "
+        "known issues and is not actively maintained. Consider using "
         "nx.nx_agraph.read_dot instead.\n\n"
         "See https://github.com/networkx/networkx/issues/5723"
     )
@@ -119,7 +119,7 @@ def from_pydot(P):
 
     """
     msg = (
-        "nx.nx_pydot.from_pydot depends on the pydot package, which has"
+        "nx.nx_pydot.from_pydot depends on the pydot package, which has "
         "known issues and is not actively maintained.\n\n"
         "See https://github.com/networkx/networkx/issues/5723"
     )
@@ -219,7 +219,7 @@ def to_pydot(N):
     import pydot
 
     msg = (
-        "nx.nx_pydot.to_pydot depends on the pydot package, which has"
+        "nx.nx_pydot.to_pydot depends on the pydot package, which has "
         "known issues and is not actively maintained.\n\n"
         "See https://github.com/networkx/networkx/issues/5723"
     )
@@ -347,8 +347,8 @@ def graphviz_layout(G, prog="neato", root=None):
     This is a wrapper for pydot_layout.
     """
     msg = (
-        "nx.nx_pydot.graphviz_layout depends on the pydot package, which has"
-        "known issues and is not actively maintained. Consider using"
+        "nx.nx_pydot.graphviz_layout depends on the pydot package, which has "
+        "known issues and is not actively maintained. Consider using "
         "nx.nx_agraph.graphviz_layout instead.\n\n"
         "See https://github.com/networkx/networkx/issues/5723"
     )
@@ -398,7 +398,7 @@ def pydot_layout(G, prog="neato", root=None):
     import pydot
 
     msg = (
-        "nx.nx_pydot.pydot_layout depends on the pydot package, which has"
+        "nx.nx_pydot.pydot_layout depends on the pydot package, which has "
         "known issues and is not actively maintained.\n\n"
         "See https://github.com/networkx/networkx/issues/5723"
     )

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -398,7 +398,7 @@ def _find_partition(G, starting_cell):
                 for v in new_cell:
                     if (u != v) and (v not in G_partition[u]):
                         msg = (
-                            "G is not a line graph"
+                            "G is not a line graph "
                             "(partition cell not a complete subgraph)"
                         )
                         raise nx.NetworkXError(msg)


### PR DESCRIPTION
<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->

Some messages are not properly separated by spaces.

E.g., when the following code (`main.py`) is run by `python main.py`,

```python
import networkx as nx
import matplotlib.pyplot as plt

def main():
    G = nx.complete_graph(4)
    pos = nx.nx_pydot.graphviz_layout(G)
    nx.draw(G, pos=pos)
    plt.savefig("main.png")

if __name__ == "__main__":
    main()
```

the execution result look like below.

```
/home/user/main.py:6: DeprecationWarning: nx.nx_pydot.graphviz_layout depends on the pydot package, which hasknown issues and is not actively maintained. Consider usingnx.nx_agraph.graphviz_layout instead.

See https://github.com/networkx/networkx/issues/5723
  pos = nx.nx_pydot.graphviz_layout(G)
```

However, this should look like below. Spaces are inserted between "has" and "known", and "using" and "nx.nx_agraph.graphviz".

```
/home/user/main.py:6: DeprecationWarning: nx.nx_pydot.graphviz_layout depends on the pydot package, which has known issues and is not actively maintained. Consider using nx.nx_agraph.graphviz_layout instead.

See https://github.com/networkx/networkx/issues/5723
  pos = nx.nx_pydot.graphviz_layout(G)
```