### PR TITLE
FIX: consistently ignore self loops in chordal graphs

### DIFF
--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -297,12 +297,10 @@ def chordal_graph_treewidth(G):
 
 def _is_complete_graph(G):
     """Returns True if G is a complete graph."""
-    if nx.number_of_selfloops(G) > 0:
-        raise nx.NetworkXError("Self loop found in _is_complete_graph()")
     n = G.number_of_nodes()
     if n < 2:
         return True
-    e = G.number_of_edges()
+    e = G.number_of_edges() - nx.number_of_selfloops(G)
     max_edges = (n * (n - 1)) / 2
     return e == max_edges
 

--- a/networkx/algorithms/tests/test_chordal.py
+++ b/networkx/algorithms/tests/test_chordal.py
@@ -47,7 +47,7 @@ class TestMCS:
         non_chordal_G.add_edges_from([(1, 2), (1, 3), (2, 4), (2, 5), (3, 4), (3, 5)])
         cls.non_chordal_G = non_chordal_G
 
-        self_loop_G = nx.Graph()
+        self_loop_G = chordal_G.copy()
         self_loop_G.add_edges_from([(1, 1)])
         cls.self_loop_G = self_loop_G
 
@@ -92,8 +92,6 @@ class TestMCS:
         assert set(nx.chordal_graph_cliques(self.chordal_G)) == cliques
         with pytest.raises(nx.NetworkXError, match="Input graph is not chordal"):
             set(nx.chordal_graph_cliques(self.non_chordal_G))
-        with pytest.raises(nx.NetworkXError, match="Input graph is not chordal"):
-            set(nx.chordal_graph_cliques(self.self_loop_G))
 
     def test_chordal_find_cliques_path(self):
         G = nx.path_graph(10)


### PR DESCRIPTION
In https://github.com/networkx/networkx/pull/6563 we decided to ignore self loops in chordal graphs but we weren't really testing for the implementation. The `self_loop_G` was both a chordal and not a chordal graph.

I've updated the test which checks that we ignore self loops which checking for chordality.

