### PR TITLE
Avoid directed_laplacian_matrix causing nans in some cases.

### DIFF
--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -257,7 +257,8 @@ def directed_laplacian_matrix(
     evals, evecs = sp.sparse.linalg.eigs(P.T, k=1)
     v = evecs.flatten().real
     p = v / v.sum()
-    sqrtp = np.sqrt(p)
+    # p>=0 by Perron-Frobenius Thm. Use abs() to fix roundoff across zero gh-6865
+    sqrtp = np.sqrt(np.abs(p))
     Q = (
         # TODO: rm csr_array wrapper when spdiags creates arrays
         sp.sparse.csr_array(sp.sparse.spdiags(sqrtp, 0, n, n))


### PR DESCRIPTION
Fixes #6865 
Uses `np.abs` before `np.sqrt` to force round-off that switches sign to stay positive.
That avoids creating nans via sqrt.

I'd like to add tests for this -- but the example from the OP is 407 lines long. So I'm still looking for a test.