### PR TITLE
add docs for source input of dfs_predecessor and dfs_successor

### DIFF
--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -156,6 +156,9 @@ def dfs_predecessors(G, source=None, depth_limit=None):
 
     source : node, optional
        Specify starting node for depth-first search.
+       Note that you will get predecessors for all nodes in the
+       component containing `source`. This input only specifies
+       where the DFS starts.
 
     depth_limit : int, optional (default=len(G))
        Specify the maximum search depth.
@@ -207,6 +210,9 @@ def dfs_successors(G, source=None, depth_limit=None):
 
     source : node, optional
        Specify starting node for depth-first search.
+       Note that you will get successors for all nodes in the
+       component containing `source`. This input only specifies
+       where the DFS starts.
 
     depth_limit : int, optional (default=len(G))
        Specify the maximum search depth.


### PR DESCRIPTION
Add to the doc_strings for `source` input argument of `dfs_predecessors` and `dfs_successors`.
Fixes #6795