### PR TITLE
Move random_state decorators before `@nx._dispatch`

### DIFF
--- a/networkx/algorithms/approximation/clustering_coefficient.py
+++ b/networkx/algorithms/approximation/clustering_coefficient.py
@@ -5,8 +5,8 @@ __all__ = ["average_clustering"]
 
 
 @not_implemented_for("directed")
-@nx._dispatch(name="approximate_average_clustering")
 @py_random_state(2)
+@nx._dispatch(name="approximate_average_clustering")
 def average_clustering(G, trials=1000, seed=None):
     r"""Estimates the average clustering coefficient of G.
 

--- a/networkx/algorithms/approximation/distance_measures.py
+++ b/networkx/algorithms/approximation/distance_measures.py
@@ -6,8 +6,8 @@ from networkx.utils.decorators import py_random_state
 __all__ = ["diameter"]
 
 
-@nx._dispatch(name="approximate_diameter")
 @py_random_state(1)
+@nx._dispatch(name="approximate_diameter")
 def diameter(G, seed=None):
     """Returns a lower bound on the diameter of the graph G.
 

--- a/networkx/algorithms/approximation/maxcut.py
+++ b/networkx/algorithms/approximation/maxcut.py
@@ -5,8 +5,8 @@ __all__ = ["randomized_partitioning", "one_exchange"]
 
 
 @not_implemented_for("directed", "multigraph")
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(1)
+@nx._dispatch(edge_attrs="weight")
 def randomized_partitioning(G, seed=None, p=0.5, weight=None):
     """Compute a random partitioning of the graph nodes and its cut value.
 
@@ -50,8 +50,8 @@ def _swap_node_partition(cut, node):
 
 
 @not_implemented_for("directed", "multigraph")
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(2)
+@nx._dispatch(edge_attrs="weight")
 def one_exchange(G, initial_cut=None, seed=None, weight=None):
     """Compute a partitioning of the graphs nodes and the corresponding cut value.
 

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -336,8 +336,8 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
 
 
 @not_implemented_for("undirected")
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(2)
+@nx._dispatch(edge_attrs="weight")
 def asadpour_atsp(G, weight="weight", seed=None, source=None):
     """
     Returns an approximate solution to the traveling salesman problem.
@@ -1001,8 +1001,8 @@ def greedy_tsp(G, weight="weight", source=None):
     return cycle
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(9)
+@nx._dispatch(edge_attrs="weight")
 def simulated_annealing_tsp(
     G,
     init_cycle,
@@ -1220,8 +1220,8 @@ def simulated_annealing_tsp(
     return best_cycle
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(9)
+@nx._dispatch(edge_attrs="weight")
 def threshold_accepting_tsp(
     G,
     init_cycle,

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -11,8 +11,8 @@ from networkx.utils.decorators import not_implemented_for
 __all__ = ["betweenness_centrality", "edge_betweenness_centrality"]
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(5)
+@nx._dispatch(edge_attrs="weight")
 def betweenness_centrality(
     G, k=None, normalized=True, weight=None, endpoints=False, seed=None
 ):
@@ -148,8 +148,8 @@ def betweenness_centrality(
     return betweenness
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(4)
+@nx._dispatch(edge_attrs="weight")
 def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=None):
     r"""Compute betweenness centrality for edges.
 

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -20,8 +20,8 @@ __all__ = [
 
 
 @not_implemented_for("directed")
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(7)
+@nx._dispatch(edge_attrs="weight")
 def approximate_current_flow_betweenness_centrality(
     G,
     normalized=True,

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -31,8 +31,8 @@ def strategy_largest_first(G, colors):
     return sorted(G, key=G.degree, reverse=True)
 
 
-@nx._dispatch
 @py_random_state(2)
+@nx._dispatch
 def strategy_random_sequential(G, colors, seed=None):
     """Returns a random permutation of the nodes of ``G`` as a list.
 

--- a/networkx/algorithms/community/asyn_fluid.py
+++ b/networkx/algorithms/community/asyn_fluid.py
@@ -11,8 +11,8 @@ __all__ = ["asyn_fluidc"]
 
 
 @not_implemented_for("directed", "multigraph")
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def asyn_fluidc(G, k, max_iter=100, seed=None):
     """Returns communities in `G` as detected by Fluid Communities algorithm.
 

--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -41,8 +41,8 @@ def _kernighan_lin_sweep(edges, side):
 
 
 @not_implemented_for("directed")
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(4)
+@nx._dispatch(edge_attrs="weight")
 def kernighan_lin_bisection(G, partition=None, max_iter=10, weight="weight", seed=None):
     """Partition a graph into two blocks using the Kernighan–Lin
     algorithm.

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -9,8 +9,8 @@ from networkx.utils import groups, not_implemented_for, py_random_state
 __all__ = ["label_propagation_communities", "asyn_lpa_communities"]
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(2)
+@nx._dispatch(edge_attrs="weight")
 def asyn_lpa_communities(G, weight=None, seed=None):
     """Returns communities in `G` as detected by asynchronous label
     propagation.

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -10,8 +10,8 @@ from networkx.utils import py_random_state
 __all__ = ["louvain_communities", "louvain_partitions"]
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state("seed")
+@nx._dispatch(edge_attrs="weight")
 def louvain_communities(
     G, weight="weight", resolution=1, threshold=0.0000001, seed=None
 ):
@@ -112,8 +112,8 @@ def louvain_communities(
     return q.pop()
 
 
-@nx._dispatch(edge_attrs="weight")
 @py_random_state("seed")
+@nx._dispatch(edge_attrs="weight")
 def louvain_partitions(
     G, weight="weight", resolution=1, threshold=0.0000001, seed=None
 ):

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -253,8 +253,8 @@ def modularity(G, communities, weight="weight", resolution=1):
     return sum(map(community_contribution, communities))
 
 
-@nx._dispatch
 @require_partition
+@nx._dispatch
 def partition_quality(G, partition):
     """Returns the coverage and performance of a partition of G.
 

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -1157,8 +1157,8 @@ def _compat_shuffle(rng, input):
 
 @not_implemented_for("multigraph")
 @not_implemented_for("directed")
-@nx._dispatch
 @py_random_state(4)
+@nx._dispatch
 def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
     """Greedy algorithm for finding a k-edge-augmentation
 

--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -9,8 +9,8 @@ __all__ = ["maximal_independent_set"]
 
 
 @not_implemented_for("directed")
-@nx._dispatch
 @py_random_state(2)
+@nx._dispatch
 def maximal_independent_set(G, nodes=None, seed=None):
     """Returns a random maximal independent set guaranteed to contain
     a given set of nodes.

--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -22,8 +22,8 @@ __all__ = ["random_reference", "lattice_reference", "sigma", "omega"]
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def random_reference(G, niter=1, connectivity=True, seed=None):
     """Compute a random graph by swapping edges of a given graph.
 
@@ -120,8 +120,8 @@ def random_reference(G, niter=1, connectivity=True, seed=None):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatch
 @py_random_state(4)
+@nx._dispatch
 def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
     """Latticize the given graph by swapping edges.
 
@@ -244,8 +244,8 @@ def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def sigma(G, niter=100, nrand=10, seed=None):
     """Returns the small-world coefficient (sigma) of the given graph.
 
@@ -313,8 +313,8 @@ def sigma(G, niter=100, nrand=10, seed=None):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def omega(G, niter=5, nrand=10, seed=None):
     """Returns the small-world coefficient (omega) of a graph
 

--- a/networkx/algorithms/sparsifiers.py
+++ b/networkx/algorithms/sparsifiers.py
@@ -9,8 +9,8 @@ __all__ = ["spanner"]
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatch(edge_attrs="weight")
 @py_random_state(3)
+@nx._dispatch(edge_attrs="weight")
 def spanner(G, stretch, weight=None, seed=None):
     """Returns a spanner of the given graph with the given stretch.
 

--- a/networkx/algorithms/swap.py
+++ b/networkx/algorithms/swap.py
@@ -10,8 +10,8 @@ __all__ = ["double_edge_swap", "connected_double_edge_swap", "directed_edge_swap
 
 
 @nx.utils.not_implemented_for("undirected")
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     """Swap three edges in a directed graph while keeping the node degrees fixed.
 
@@ -130,8 +130,8 @@ def directed_edge_swap(G, *, nswap=1, max_tries=100, seed=None):
     return G
 
 
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def double_edge_swap(G, nswap=1, max_tries=100, seed=None):
     """Swap two edges in the graph while keeping the node degrees fixed.
 
@@ -228,8 +228,8 @@ def double_edge_swap(G, nswap=1, max_tries=100, seed=None):
     return G
 
 
-@nx._dispatch
 @py_random_state(3)
+@nx._dispatch
 def connected_double_edge_swap(G, nswap=1, _window_threshold=3, seed=None):
     """Attempts the specified number of double-edge swaps in the graph `G`.
 

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -107,8 +107,8 @@ def branching_weight(G, attr="weight", default=1):
     return sum(edge[2].get(attr, default) for edge in G.edges(data=True))
 
 
-@nx._dispatch(edge_attrs={"attr": "default"})
 @py_random_state(4)
+@nx._dispatch(edge_attrs={"attr": "default"})
 def greedy_branching(G, attr="weight", default=1, kind="max", seed=None):
     """
     Returns a branching obtained through a greedy algorithm.

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -742,8 +742,8 @@ def maximum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=Fa
     return T
 
 
-@nx._dispatch(preserve_edge_attrs=True)
 @py_random_state(3)
+@nx._dispatch(preserve_edge_attrs=True)
 def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
     """
     Sample a random spanning tree using the edges weights of `G`.

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -525,8 +525,8 @@ def triad_type(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatch
 @py_random_state(1)
+@nx._dispatch
 def random_triad(G, seed=None):
     """Returns a random triad from a directed graph.
 

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -7,8 +7,8 @@ from networkx.utils import np_random_state
 __all__ = ["spectral_graph_forge"]
 
 
-@nx._dispatch
 @np_random_state(3)
+@nx._dispatch
 def spectral_graph_forge(G, alpha, transformation="identity", seed=None):
     """Returns a random simple graph with spectrum resembling that of `G`
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -311,8 +311,8 @@ def _get_fiedler_func(method):
 
 
 @not_implemented_for("directed")
-@nx._dispatch(edge_attrs="weight")
 @np_random_state(5)
+@nx._dispatch(edge_attrs="weight")
 def algebraic_connectivity(
     G, weight="weight", normalized=False, tol=1e-8, method="tracemin_pcg", seed=None
 ):
@@ -407,8 +407,8 @@ def algebraic_connectivity(
 
 
 @not_implemented_for("directed")
-@nx._dispatch(edge_attrs="weight")
 @np_random_state(5)
+@nx._dispatch(edge_attrs="weight")
 def fiedler_vector(
     G, weight="weight", normalized=False, tol=1e-8, method="tracemin_pcg", seed=None
 ):
@@ -504,8 +504,8 @@ def fiedler_vector(
     return fiedler
 
 
-@nx._dispatch(edge_attrs="weight")
 @np_random_state(5)
+@nx._dispatch(edge_attrs="weight")
 def spectral_ordering(
     G, weight="weight", normalized=False, tol=1e-8, method="tracemin_pcg", seed=None
 ):


### PR DESCRIPTION
When I first tried to have `@py_random_state` and `@np_random_state` come before `@nx._dispatch` in #6688, I encountered an error. I don't recall what, but @dschult expected it to "just work" and was surprised there was an error (and it's possible I did something wrong). Anyway, I thought I would check to see if this would work now after #6840... and it does!