### PR TITLE
ENH -- Replaced for-loops in :function:`rescale_layout` with numpy vectorized methods.

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1252,7 +1252,7 @@ def rescale_layout(pos, scale=1):
 
     # Find max length over all dimensions
     pos -= pos.mean(axis=0)
-    lim = max(np.abs(pos).max(), 0)  # max coordinate for all axes
+    lim = np.abs(pos).max()  # max coordinate for all axes
     # rescale to (-scale, scale) in all directions, preserves aspect
     if lim > 0:
         pos *= scale / lim

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1248,15 +1248,14 @@ def rescale_layout(pos, scale=1):
     --------
     rescale_layout_dict
     """
+    import numpy as np
+
     # Find max length over all dimensions
-    lim = 0  # max coordinate for all axes
-    for i in range(pos.shape[1]):
-        pos[:, i] -= pos[:, i].mean()
-        lim = max(abs(pos[:, i]).max(), lim)
+    pos -= pos.mean(axis=0)
+    lim = max(np.abs(pos).max(), 0)  # max coordinate for all axes
     # rescale to (-scale, scale) in all directions, preserves aspect
     if lim > 0:
-        for i in range(pos.shape[1]):
-            pos[:, i] *= scale / lim
+        pos *= scale / lim
     return pos
 
 


### PR DESCRIPTION
modified:   networkx/drawing/layout.py
- Replaced for-loops in :function:`rescale_layout` with numpy vectorized methods.
- No new tests as output should not have changed and no new features were introduced.
- Tested specifically with :method:`TestLayout.test_rescale_layout_dict` in drawing/tests/test_layout.py.
- All other tests ran per contributor guide.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
