### PR TITLE
Add time series Visibility Graph generator

### DIFF
--- a/doc/reference/generators.rst
+++ b/doc/reference/generators.rst
@@ -360,7 +360,7 @@ Sudoku
 
    sudoku_graph
 
-Times Series
+Time Series
 ____________
 .. automodule:: networkx.generators.time_series
 .. autosummary::

--- a/doc/reference/generators.rst
+++ b/doc/reference/generators.rst
@@ -359,3 +359,11 @@ Sudoku
    :toctree: generated/
 
    sudoku_graph
+
+Times Series
+____________
+.. automodule:: networkx.generators.time_series
+.. autosummary::
+   :toctree: generated/
+
+   visibility_graph

--- a/doc/reference/generators.rst
+++ b/doc/reference/generators.rst
@@ -361,7 +361,7 @@ Sudoku
    sudoku_graph
 
 Time Series
-____________
+-----------
 .. automodule:: networkx.generators.time_series
 .. autosummary::
    :toctree: generated/

--- a/examples/graph/plot_visibility_graph.py
+++ b/examples/graph/plot_visibility_graph.py
@@ -1,0 +1,40 @@
+"""
+================
+Visibility Graph
+================
+
+Visibility Graph constructed from a time series
+"""
+from matplotlib import pyplot
+
+import networkx as nx
+
+time_series = [0, 2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3, 4, 0]
+# or
+# import random
+# time_series = [random.randint(1,10) for i in range(10)]
+
+g = nx.visibility_graph(time_series)
+
+labels = nx.get_node_attributes(g, "value")
+
+# a layout emphasizing the line-of-sight connectivity
+pos = {x: (x, 0) for x in range(len(time_series))}
+nx.draw_networkx_nodes(g, pos)
+nx.draw_networkx_labels(g, pos, labels=labels)
+nx.draw_networkx_edges(
+    g,
+    pos,
+    arrows=True,
+    arrowstyle="->",
+    arrowsize=10,
+    connectionstyle="arc3,rad=-1.57079632679",
+)
+pyplot.show()
+
+# a layout showcasing the time series values
+pos = {i: (i, v) for i, v in enumerate(time_series)}
+nx.draw_networkx_nodes(g, pos)
+nx.draw_networkx_labels(g, pos, labels=labels)
+nx.draw_networkx_edges(g, pos, arrows=True, arrowstyle="->", arrowsize=10)
+pyplot.show()

--- a/examples/graph/plot_visibility_graph.py
+++ b/examples/graph/plot_visibility_graph.py
@@ -19,42 +19,33 @@ G = nx.visibility_graph(time_series)
 labels = nx.get_node_attributes(G, "value")
 
 fig, all_axes = plt.subplots(2, 1, num="Visibility Graph", figsize=(8, 12))
-ax = all_axes.flat
+axs = all_axes.flat
 
-ax[0].title.set_text("Line-of-Sight Connectivity")
-ax[0].title.set_size(11)
+layouts_params = {
+    # a layout emphasizing the line-of-sight connectivity
+    "Line-of-Sight Connectivity": {
+        "pos": {x: (x, 0) for x in range(len(time_series))},
+        "connectionstyle": "arc3,rad=-1.57079632679",
+    },
+    # a layout showcasing the time series values
+    "Time Series values with Connectivity": {
+        "pos": {i: (i, v) for i, v in enumerate(time_series)}
+    },
+}
 
-ax[0].set_xlabel("Time", size=10)
+for i, (name, params) in enumerate(layouts_params.items()):
+    axs[i].title.set_text(name)
+    axs[i].title.set_size(11)
+    axs[i].set_xlabel("Time", size=10)
+    axs[i].margins(0.10)
+    nx.draw_networkx_nodes(G, params.get("pos"), ax=axs[i], alpha=0.5)
+    nx.draw_networkx_labels(G, params.get("pos"), ax=axs[i], labels=labels)
+    nx.draw_networkx_edges(
+        G, **params, ax=axs[i], arrows=True, arrowstyle="<->", arrowsize=10
+    )
 
-ax[1].title.set_text(
-    "Time Series values with Connectivity",
-)
-ax[1].title.set_size(11)
-ax[1].set_xlabel("Time", size=10)
-ax[1].set_ylabel("Value", size=10)
+axs[1].set_ylabel("Value", size=10)
 
-# a plot layout emphasizing the line-of-sight connectivity
-pos = {x: (x, 0) for x in range(len(time_series))}
-nx.draw_networkx_nodes(G, pos, ax=ax[0], alpha=0.5)
-nx.draw_networkx_labels(G, pos, ax=ax[0], labels=labels)
-nx.draw_networkx_edges(
-    G,
-    pos,
-    ax=ax[0],
-    arrows=True,
-    arrowstyle="<->",
-    arrowsize=10,
-    connectionstyle="arc3,rad=-1.57079632679",
-)
-
-# a plot layout showcasing the time series values
-pos = {i: (i, v) for i, v in enumerate(time_series)}
-nx.draw_networkx_nodes(G, pos, ax=ax[1], alpha=0.5)
-nx.draw_networkx_labels(G, pos, ax=ax[1], labels=labels)
-nx.draw_networkx_edges(G, pos, ax=ax[1], arrows=True, arrowstyle="<->", arrowsize=10)
-
-for a in ax:
-    a.margins(0.10)
 fig.suptitle("Visibility Graph")
 fig.tight_layout()
 plt.show()

--- a/examples/graph/plot_visibility_graph.py
+++ b/examples/graph/plot_visibility_graph.py
@@ -5,7 +5,7 @@ Visibility Graph
 
 Visibility Graph constructed from a time series
 """
-from matplotlib import pyplot
+from matplotlib import pyplot as plt
 
 import networkx as nx
 
@@ -14,27 +14,47 @@ time_series = [0, 2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3, 4, 0]
 # import random
 # time_series = [random.randint(1,10) for i in range(10)]
 
-g = nx.visibility_graph(time_series)
+G = nx.visibility_graph(time_series)
 
-labels = nx.get_node_attributes(g, "value")
+labels = nx.get_node_attributes(G, "value")
 
-# a layout emphasizing the line-of-sight connectivity
+fig, all_axes = plt.subplots(2, 1, num="Visibility Graph", figsize=(8, 12))
+ax = all_axes.flat
+
+ax[0].title.set_text("Line-of-Sight Connectivity")
+ax[0].title.set_size(11)
+
+ax[0].set_xlabel("Time", size=10)
+
+ax[1].title.set_text(
+    "Time Series values with Connectivity",
+)
+ax[1].title.set_size(11)
+ax[1].set_xlabel("Time", size=10)
+ax[1].set_ylabel("Value", size=10)
+
+# a plot layout emphasizing the line-of-sight connectivity
 pos = {x: (x, 0) for x in range(len(time_series))}
-nx.draw_networkx_nodes(g, pos)
-nx.draw_networkx_labels(g, pos, labels=labels)
+nx.draw_networkx_nodes(G, pos, ax=ax[0], alpha=0.5)
+nx.draw_networkx_labels(G, pos, ax=ax[0], labels=labels)
 nx.draw_networkx_edges(
-    g,
+    G,
     pos,
+    ax=ax[0],
     arrows=True,
-    arrowstyle="->",
+    arrowstyle="<->",
     arrowsize=10,
     connectionstyle="arc3,rad=-1.57079632679",
 )
-pyplot.show()
 
-# a layout showcasing the time series values
+# a plot layout showcasing the time series values
 pos = {i: (i, v) for i, v in enumerate(time_series)}
-nx.draw_networkx_nodes(g, pos)
-nx.draw_networkx_labels(g, pos, labels=labels)
-nx.draw_networkx_edges(g, pos, arrows=True, arrowstyle="->", arrowsize=10)
-pyplot.show()
+nx.draw_networkx_nodes(G, pos, ax=ax[1], alpha=0.5)
+nx.draw_networkx_labels(G, pos, ax=ax[1], labels=labels)
+nx.draw_networkx_edges(G, pos, ax=ax[1], arrows=True, arrowstyle="<->", arrowsize=10)
+
+for a in ax:
+    a.margins(0.10)
+fig.suptitle("Visibility Graph")
+fig.tight_layout()
+plt.show()

--- a/networkx/generators/__init__.py
+++ b/networkx/generators/__init__.py
@@ -24,8 +24,9 @@ from networkx.generators.random_clustered import *
 from networkx.generators.random_graphs import *
 from networkx.generators.small import *
 from networkx.generators.social import *
-from networkx.generators.sudoku import *
 from networkx.generators.spectral_graph_forge import *
 from networkx.generators.stochastic import *
+from networkx.generators.sudoku import *
+from networkx.generators.time_series import *
 from networkx.generators.trees import *
 from networkx.generators.triads import *

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -6,7 +6,7 @@ import networkx as nx
 
 def test_visibility_graph_static_series():
     # arrange
-    series = range(10)
+    series = [i ** 2 for i in range(10)]  # no obstructions
     expected_series_length = len(series)
 
     # act
@@ -14,12 +14,24 @@ def test_visibility_graph_static_series():
 
     # assert
     assert actual_graph.number_of_nodes() == expected_series_length
-    assert actual_graph.number_of_edges() == 9
+    assert actual_graph.number_of_edges() == 45
+
+
+def test_visibility_graph_corner_cases():
+    edge_graph = nx.visibility_graph([10, 20])
+    assert list(edge_graph.edges) == [(0, 1)]
+
+    node_graph = nx.visibility_graph([10])
+    assert node_graph.number_of_nodes() == 1
+    assert node_graph.number_of_edges() == 0
+
+    null_graph = nx.visibility_graph([])
+    assert node_graph.number_of_nodes() == 0
 
 
 def test_visibility_graph_cyclic_series():
     # arrange
-    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 12))
+    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 15))
     expected_series_length = len(series)
 
     # act
@@ -27,4 +39,4 @@ def test_visibility_graph_cyclic_series():
 
     # assert
     assert actual_graph.number_of_nodes() == expected_series_length
-    assert actual_graph.number_of_edges() == 18
+    assert actual_graph.number_of_edges() == 23

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -14,7 +14,6 @@ class TestVisibilityGraph:
         actual_graph = networkx.generators.time_series.visibility_graph(series)
 
         # assert
-
         assert actual_graph.number_of_nodes() == expected_series_length
         assert actual_graph.number_of_edges() == 9
 
@@ -22,10 +21,10 @@ class TestVisibilityGraph:
         # arrange
         series = [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3]
         expected_series_length = len(series)
+
         # act
         actual_graph = networkx.generators.time_series.visibility_graph(series)
 
         # assert
-
         assert actual_graph.number_of_nodes() == expected_series_length
         assert actual_graph.number_of_edges() == 18

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -1,0 +1,31 @@
+"""Unit tests for the :mod:`networkx.generators.time_series` module."""
+import networkx
+
+
+class TestVisibilityGraph:
+    """Unit tests for :func:`networkx.generators.time_series.visibility_graph`"""
+
+    def test_static_series(self):
+        # arrange
+        series = range(10)
+        expected_series_length = len(series)
+
+        # act
+        actual_graph = networkx.generators.time_series.visibility_graph(series)
+
+        # assert
+
+        assert actual_graph.number_of_nodes() == expected_series_length
+        assert actual_graph.number_of_edges() == 9
+
+    def test_cyclic_series(self):
+        # arrange
+        series = [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3]
+        expected_series_length = len(series)
+        # act
+        actual_graph = networkx.generators.time_series.visibility_graph(series)
+
+        # assert
+
+        assert actual_graph.number_of_nodes() == expected_series_length
+        assert actual_graph.number_of_edges() == 18

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -4,9 +4,9 @@ import itertools
 import networkx as nx
 
 
-def test_visibility_graph__empty_ts__empty_graph():
+def test_visibility_graph__empty_series__empty_graph():
     null_graph = nx.visibility_graph([])
-    assert null_graph.number_of_nodes() == 0
+    assert nx.is_empty(null_graph)
 
 
 def test_visibility_graph__single_value_ts__single_node_graph():
@@ -20,7 +20,7 @@ def test_visibility_graph__two_values_ts__single_edge_graph():
     assert list(edge_graph.edges) == [(0, 1)]
 
 
-def test_visibility_graph_convex_series():
+def test_visibility_graph__convex_series__complete_graph():
     # arrange
     series = [i**2 for i in range(10)]  # no obstructions
     expected_series_length = len(series)
@@ -31,16 +31,45 @@ def test_visibility_graph_convex_series():
     # assert
     assert actual_graph.number_of_nodes() == expected_series_length
     assert actual_graph.number_of_edges() == 45
+    assert nx.is_isomorphic(actual_graph, nx.complete_graph(expected_series_length))
 
 
-def test_visibility_graph_cyclic_series():
+def test_visibility_graph__concave_series__path_graph():
     # arrange
-    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 15))
-    expected_series_length = len(series)
+    series = [-(i**2) for i in range(10)]  # living in 1D flatland
+    expected_node_count = len(series)
 
     # act
     actual_graph = nx.visibility_graph(series)
 
     # assert
-    assert actual_graph.number_of_nodes() == expected_series_length
-    assert actual_graph.number_of_edges() == 23
+    assert actual_graph.number_of_nodes() == expected_node_count
+    assert actual_graph.number_of_edges() == expected_node_count - 1
+    assert nx.is_isomorphic(actual_graph, nx.path_graph(expected_node_count))
+
+
+def test_visibility_graph__flat_series__path_graph():
+    # arrange
+    series = [0] * 10  # living in 1D flatland
+    expected_node_count = len(series)
+
+    # act
+    actual_graph = nx.visibility_graph(series)
+
+    # assert
+    assert actual_graph.number_of_nodes() == expected_node_count
+    assert actual_graph.number_of_edges() == expected_node_count - 1
+    assert nx.is_isomorphic(actual_graph, nx.path_graph(expected_node_count))
+
+
+def test_visibility_graph_cyclic_series():
+    # arrange
+    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 17))
+    expected_node_count = len(series)
+
+    # act
+    actual_graph = nx.visibility_graph(series)
+
+    # assert
+    assert actual_graph.number_of_nodes() == expected_node_count
+    assert actual_graph.number_of_edges() == 25

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -5,71 +5,59 @@ import networkx as nx
 
 
 def test_visibility_graph__empty_series__empty_graph():
-    null_graph = nx.visibility_graph([])
+    null_graph = nx.visibility_graph([])  # move along nothing to see here
     assert nx.is_empty(null_graph)
 
 
 def test_visibility_graph__single_value_ts__single_node_graph():
-    node_graph = nx.visibility_graph([10])
+    node_graph = nx.visibility_graph([10])  # So Lonely
     assert node_graph.number_of_nodes() == 1
     assert node_graph.number_of_edges() == 0
 
 
 def test_visibility_graph__two_values_ts__single_edge_graph():
-    edge_graph = nx.visibility_graph([10, 20])
+    edge_graph = nx.visibility_graph([10, 20])  # Two of Us
     assert list(edge_graph.edges) == [(0, 1)]
 
 
 def test_visibility_graph__convex_series__complete_graph():
-    # arrange
     series = [i**2 for i in range(10)]  # no obstructions
     expected_series_length = len(series)
 
-    # act
     actual_graph = nx.visibility_graph(series)
 
-    # assert
     assert actual_graph.number_of_nodes() == expected_series_length
     assert actual_graph.number_of_edges() == 45
     assert nx.is_isomorphic(actual_graph, nx.complete_graph(expected_series_length))
 
 
 def test_visibility_graph__concave_series__path_graph():
-    # arrange
-    series = [-(i**2) for i in range(10)]  # living in 1D flatland
+    series = [-(i**2) for i in range(10)]  # Slip Slidin' Away
     expected_node_count = len(series)
 
-    # act
     actual_graph = nx.visibility_graph(series)
 
-    # assert
     assert actual_graph.number_of_nodes() == expected_node_count
     assert actual_graph.number_of_edges() == expected_node_count - 1
     assert nx.is_isomorphic(actual_graph, nx.path_graph(expected_node_count))
 
 
 def test_visibility_graph__flat_series__path_graph():
-    # arrange
     series = [0] * 10  # living in 1D flatland
     expected_node_count = len(series)
 
-    # act
     actual_graph = nx.visibility_graph(series)
 
-    # assert
     assert actual_graph.number_of_nodes() == expected_node_count
     assert actual_graph.number_of_edges() == expected_node_count - 1
     assert nx.is_isomorphic(actual_graph, nx.path_graph(expected_node_count))
 
 
 def test_visibility_graph_cyclic_series():
-    # arrange
-    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 17))
+    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 17))  # It's so bumpy!
     expected_node_count = len(series)
 
-    # act
     actual_graph = nx.visibility_graph(series)
 
-    # assert
     assert actual_graph.number_of_nodes() == expected_node_count
     assert actual_graph.number_of_edges() == 25

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -1,30 +1,30 @@
 """Unit tests for the :mod:`networkx.generators.time_series` module."""
-import networkx
+import itertools
+
+import networkx as nx
 
 
-class TestVisibilityGraph:
-    """Unit tests for :func:`networkx.generators.time_series.visibility_graph`"""
+def test_visibility_graph_static_series():
+    # arrange
+    series = range(10)
+    expected_series_length = len(series)
 
-    def test_static_series(self):
-        # arrange
-        series = range(10)
-        expected_series_length = len(series)
+    # act
+    actual_graph = nx.visibility_graph(series)
 
-        # act
-        actual_graph = networkx.generators.time_series.visibility_graph(series)
+    # assert
+    assert actual_graph.number_of_nodes() == expected_series_length
+    assert actual_graph.number_of_edges() == 9
 
-        # assert
-        assert actual_graph.number_of_nodes() == expected_series_length
-        assert actual_graph.number_of_edges() == 9
 
-    def test_cyclic_series(self):
-        # arrange
-        series = [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3]
-        expected_series_length = len(series)
+def test_visibility_graph_cyclic_series():
+    # arrange
+    series = list(itertools.islice(itertools.cycle((2, 1, 3)), 12))
+    expected_series_length = len(series)
 
-        # act
-        actual_graph = networkx.generators.time_series.visibility_graph(series)
+    # act
+    actual_graph = nx.visibility_graph(series)
 
-        # assert
-        assert actual_graph.number_of_nodes() == expected_series_length
-        assert actual_graph.number_of_edges() == 18
+    # assert
+    assert actual_graph.number_of_nodes() == expected_series_length
+    assert actual_graph.number_of_edges() == 18

--- a/networkx/generators/tests/test_time_series.py
+++ b/networkx/generators/tests/test_time_series.py
@@ -4,9 +4,25 @@ import itertools
 import networkx as nx
 
 
-def test_visibility_graph_static_series():
+def test_visibility_graph__empty_ts__empty_graph():
+    null_graph = nx.visibility_graph([])
+    assert null_graph.number_of_nodes() == 0
+
+
+def test_visibility_graph__single_value_ts__single_node_graph():
+    node_graph = nx.visibility_graph([10])
+    assert node_graph.number_of_nodes() == 1
+    assert node_graph.number_of_edges() == 0
+
+
+def test_visibility_graph__two_values_ts__single_edge_graph():
+    edge_graph = nx.visibility_graph([10, 20])
+    assert list(edge_graph.edges) == [(0, 1)]
+
+
+def test_visibility_graph_convex_series():
     # arrange
-    series = [i ** 2 for i in range(10)]  # no obstructions
+    series = [i**2 for i in range(10)]  # no obstructions
     expected_series_length = len(series)
 
     # act
@@ -15,18 +31,6 @@ def test_visibility_graph_static_series():
     # assert
     assert actual_graph.number_of_nodes() == expected_series_length
     assert actual_graph.number_of_edges() == 45
-
-
-def test_visibility_graph_corner_cases():
-    edge_graph = nx.visibility_graph([10, 20])
-    assert list(edge_graph.edges) == [(0, 1)]
-
-    node_graph = nx.visibility_graph([10])
-    assert node_graph.number_of_nodes() == 1
-    assert node_graph.number_of_edges() == 0
-
-    null_graph = nx.visibility_graph([])
-    assert node_graph.number_of_nodes() == 0
 
 
 def test_visibility_graph_cyclic_series():

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -36,20 +36,20 @@ def visibility_graph(series: Iterable[float]) -> nx.Graph:
     >>> import networkx as nx
     >>> from matplotlib import pyplot
     >>>
-    >>> series_list = [range(10), [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3], random.sample(range(100), 100)]
+    >>> series_list = [range(10), [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3]]
     >>>
     >>> for s in series_list:
     ...     g = nx.visibility_graph(s)
     ...     print(g)
-    ...     pos = [[x, 0] for x in range(len(s))]
-    ...     labels = nx.get_node_attributes(g, 'value')
-    ...     nx.draw_networkx_nodes(g, pos)
-    ...     nx.draw_networkx_labels(g, pos, labels=labels)
-    ...     nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
-    ...     pyplot.show()
+    ...     # Uncomment to following lines to plot the Graph.
+    ...     # pos = [[x, 0] for x in range(len(s))]
+    ...     # labels = nx.get_node_attributes(g, 'value')
+    ...     # nx.draw_networkx_nodes(g, pos)
+    ...     # nx.draw_networkx_labels(g, pos, labels=labels)
+    ...     # nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
+    ...     # pyplot.show()
     Graph with 10 nodes and 9 edges
     Graph with 12 nodes and 18 edges
-    Graph with 100 nodes and {xxx} edges
 
     References
     ----------

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -12,14 +12,22 @@ def visibility_graph(series):
     """
     Return a Visibility Graph of an input Time Series.
 
-    It converts a time series into a graph. The constructed graph inherits several properties of the series in its
-    structure. Thereby, periodic series convert into regular graphs, and random series do so into random graphs.
-    Moreover, fractal series convert into scale-free networks [1]_.
+    A visibility graph converts a time series into a graph. The constructed graph
+    uses integer nodes to indicate which event in the series the node represents. 
+    Edges are formed as follows: consider a bar plot of the series and view that
+    as a side view of a landscape with a node at the top of each bar. An edge
+    means that the nodes can be connected by a straight "line-of-sight" without
+    being obscured by any bars between the nodes. 
+    
+    The resulting graph inherits several properties of the series in its structure.
+    Thereby, periodic series convert into regular graphs, random series convert
+    into random graphs, and fractal series convert into scale-free networks [1]_.
 
     Parameters
     ----------
-    series: list[float] | tuple[float] | list[int] | tuple[int]
-       Time Series iterable of float or int values
+    series : Sequence[Number]
+       A Time Series sequence (iterable and slicable) of numeric values
+       representing times.
 
     Returns
     -------
@@ -28,7 +36,6 @@ def visibility_graph(series):
 
     Examples
     --------
-    >>> import networkx as nx
     >>> series_list = [range(10), [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3]]
     >>> for s in series_list:
     ...     g = nx.visibility_graph(s)
@@ -44,21 +51,12 @@ def visibility_graph(series):
            https://www.pnas.org/doi/10.1073/pnas.0709247105
     """
 
-    # TODO: Consider adding support for generator, numpy array, pandas series etc.
-    if not isinstance(series, (list, tuple, range)):
-        raise nx.NetworkXError(
-            "Input series must be a sliceable Iterable, "
-            "i.e. of one the following types: list, tuple or range"
-        )
-
     # Sequential values are always connected
     G = nx.path_graph(len(series))
     nx.set_node_attributes(G, dict(enumerate(series)), "value")
 
     # Check all combinations of nodes n series
-    for s1, s2 in itertools.combinations(enumerate(series), 2):
-        n1, t1 = s1
-        n2, t2 = s2
+    for (n1, t1), (n2, t2) in itertools.combinations(enumerate(series), 2):
         # check if any value between obstructs line of sight
         slope = (t2 - t1) / (n2 - n1)
         constant = t2 - slope * n2

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -39,19 +39,17 @@ def visibility_graph(series: Iterable[float]) -> nx.Graph:
     >>> series_list = [range(10), [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3], random.sample(range(100), 100)]
     >>>
     >>> for s in series_list:
-    >>>     g = nx.visibility_graph(s)
-    >>>     print(g)
-    >>>
-    >>>     pos = [[x, 0] for x in range(len(s))]
-    >>>     labels = nx.get_node_attributes(g, 'value')
-    >>>     nx.draw_networkx_nodes(g, pos)
-    >>>     nx.draw_networkx_labels(g, pos, labels=labels)
-    >>>     nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
-    >>>     pyplot.show()
+    ...     g = nx.visibility_graph(s)
+    ...     print(g)
+    ...     pos = [[x, 0] for x in range(len(s))]
+    ...     labels = nx.get_node_attributes(g, 'value')
+    ...     nx.draw_networkx_nodes(g, pos)
+    ...     nx.draw_networkx_labels(g, pos, labels=labels)
+    ...     nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
+    ...     pyplot.show()
     Graph with 10 nodes and 9 edges
     Graph with 12 nodes and 18 edges
     Graph with 100 nodes and {xxx} edges
-
 
     References
     ----------

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -82,10 +82,12 @@ def visibility_graph(series: Iterable[float]) -> nx.Graph:
         n2, t2 = s2
 
         if n2 == n1 + 1:
+            # Sequential values are always connected
             G.add_node(n1, value=t1)
             G.add_node(n2, value=t2)
             G.add_edge(n1, n2)
         else:
+            # Otherwise check if any value between obstructs line of sight
             is_obstruction = obstruction_predicate(n1, t1, n2, t2)
             obstructed = any(
                 is_obstruction(n, t) for n, t in enumerate(series) if n1 < n < n2

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -59,10 +59,10 @@ def visibility_graph(series):
     for (n1, t1), (n2, t2) in itertools.combinations(enumerate(series), 2):
         # check if any value between obstructs line of sight
         slope = (t2 - t1) / (n2 - n1)
-        constant = t2 - slope * n2
+        offset = t2 - slope * n2
 
         obstructed = any(
-            t >= constant + slope * n
+            t >= slope * n + offset
             for n, t in enumerate(series[n1 + 1 : n2], start=n1 + 1)
         )
 

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -36,11 +36,7 @@ def visibility_graph(series: Iterable[float]) -> nx.Graph:
     >>> import networkx as nx
     >>> from matplotlib import pyplot
     >>>
-    >>> series_list = [
-    >>>     range(10),
-    >>>     [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3],
-    >>>     random.sample(range(100), 100)
-    >>> ]
+    >>> series_list = [range(10), [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3], random.sample(range(100), 100)]
     >>>
     >>> for s in series_list:
     >>>     g = nx.visibility_graph(s)
@@ -52,6 +48,10 @@ def visibility_graph(series: Iterable[float]) -> nx.Graph:
     >>>     nx.draw_networkx_labels(g, pos, labels=labels)
     >>>     nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
     >>>     pyplot.show()
+    Graph with 10 nodes and 9 edges
+    Graph with 12 nodes and 18 edges
+    Graph with 100 nodes and {xxx} edges
+
 
     References
     ----------

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -3,6 +3,7 @@ Time Series Graphs
 """
 import itertools
 from collections.abc import Iterable
+from typing import Callable
 
 import networkx as nx
 
@@ -63,11 +64,13 @@ def visibility_graph(series: Iterable[float]) -> nx.Graph:
        https://www.pnas.org/doi/10.1073/pnas.0709247105
     """
 
-    def obstruction_predicate(n1, t1, n2, t2):
+    def obstruction_predicate(
+        n1: int, t1: float, n2: int, t2: float
+    ) -> Callable[[int, float], bool]:
         slope = (t2 - t1) / (n2 - n1)
         constant = t2 - slope * n2
 
-        def is_obstruction(n, t):
+        def is_obstruction(n: int, t: float) -> bool:
             return t >= constant + slope * n
 
         return is_obstruction

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -1,0 +1,93 @@
+"""
+Time Series Graphs
+"""
+import itertools
+from collections.abc import Iterable
+
+import networkx as nx
+
+__all__ = ["visibility_graph"]
+
+
+def visibility_graph(series: Iterable[float]) -> nx.Graph:
+    """
+    Return a Visibility Graph of an input Time Series.
+
+    It converts a time series into a graph. The constructed graph inherits several properties of the series in its
+    structure. Thereby, periodic series convert into regular graphs, and random series do so into random graphs.
+    Moreover, fractal series convert into scale-free networks.
+    -- https://www.pnas.org/doi/10.1073/pnas.0709247105
+
+    Parameters
+    ----------
+    series: Iterable[float]
+       Time Series iterable of float values
+
+    Returns
+    -------
+    NetworkX graph
+        The Visibility Graph of series
+
+    Examples
+    --------
+    >>> import random
+    >>>
+    >>> import networkx as nx
+    >>> from matplotlib import pyplot
+    >>>
+    >>> series_list = [
+    >>>     range(10),
+    >>>     [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3],
+    >>>     random.sample(range(100), 100)
+    >>> ]
+    >>>
+    >>> for s in series_list:
+    >>>     g = nx.visibility_graph(s)
+    >>>     print(g)
+    >>>
+    >>>     pos = [[x, 0] for x in range(len(s))]
+    >>>     labels = nx.get_node_attributes(g, 'value')
+    >>>     nx.draw_networkx_nodes(g, pos)
+    >>>     nx.draw_networkx_labels(g, pos, labels=labels)
+    >>>     nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
+    >>>     pyplot.show()
+
+    References
+    ----------
+    .. [1] Lucas Lacasa lucas@dmae.upm.es, Bartolo Luque, Fernando Ballesteros, Jordi Luque, and Juan Carlos Nuño,
+       "From time series to complex networks: The visibility graph"
+       Proceedings of the National Academy of Sciences,
+       Vol. 105 | No. 1
+       April 1, 2008
+       PubMed: 18362361
+       https://www.pnas.org/doi/10.1073/pnas.0709247105
+    """
+
+    def obstruction_predicate(n1, t1, n2, t2):
+        slope = (t2 - t1) / (n2 - n1)
+        constant = t2 - slope * n2
+
+        def is_obstruction(n, t):
+            return t >= constant + slope * n
+
+        return is_obstruction
+
+    G = nx.Graph()
+    # Check all combinations of nodes n series
+    for s1, s2 in itertools.combinations(enumerate(series), 2):
+        n1, t1 = s1
+        n2, t2 = s2
+
+        if n2 == n1 + 1:
+            G.add_node(n1, value=t1)
+            G.add_node(n2, value=t2)
+            G.add_edge(n1, n2)
+        else:
+            is_obstruction = obstruction_predicate(n1, t1, n2, t2)
+            obstructed = any(
+                is_obstruction(n, t) for n, t in enumerate(series) if n1 < n < n2
+            )
+            if not obstructed:
+                G.add_edge(n1, n2)
+
+    return G

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -13,12 +13,12 @@ def visibility_graph(series):
     Return a Visibility Graph of an input Time Series.
 
     A visibility graph converts a time series into a graph. The constructed graph
-    uses integer nodes to indicate which event in the series the node represents. 
+    uses integer nodes to indicate which event in the series the node represents.
     Edges are formed as follows: consider a bar plot of the series and view that
     as a side view of a landscape with a node at the top of each bar. An edge
     means that the nodes can be connected by a straight "line-of-sight" without
-    being obscured by any bars between the nodes. 
-    
+    being obscured by any bars between the nodes.
+
     The resulting graph inherits several properties of the series in its structure.
     Thereby, periodic series convert into regular graphs, random series convert
     into random graphs, and fractal series convert into scale-free networks [1]_.

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -59,6 +59,7 @@ def visibility_graph(series):
        https://www.pnas.org/doi/10.1073/pnas.0709247105
     """
 
+    # TO-DO: Consider adding support for generator, numpy array, pandas series etc.
     if not isinstance(series, (list, tuple, range)):
         raise nx.NetworkXError(
             "Input series must be a sliceable Iterable, "
@@ -66,6 +67,7 @@ def visibility_graph(series):
         )
 
     G = nx.Graph()
+
     # Check all combinations of nodes n series
     for s1, s2 in itertools.combinations(enumerate(series), 2):
         n1, t1 = s1


### PR DESCRIPTION
    Return a Visibility Graph of an input Time Series.

    It converts a time series into a graph. The constructed graph inherits several properties of the series in its
    structure. Thereby, periodic series convert into regular graphs, and random series do so into random graphs.
    Moreover, fractal series convert into scale-free networks.
    -- https://www.pnas.org/doi/10.1073/pnas.0709247105

    Parameters
    ----------
    series: Iterable[float]
       Time Series iterable of float values

    Returns
    -------
    NetworkX graph
        The Visibility Graph of series

    Examples
    --------
    >>> import networkx as nx
    >>> from matplotlib import pyplot
    >>>
    >>> series_list = [range(10), [2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3]]
    >>>
    >>> for s in series_list:
    ...     g = nx.visibility_graph(s)
    ...     print(g)
    ...     # Uncomment the following lines to plot the graph
    ...     # pos = [[x, 0] for x in range(len(s))]
    ...     # labels = nx.get_node_attributes(g, 'value')
    ...     # nx.draw_networkx_nodes(g, pos)
    ...     # nx.draw_networkx_labels(g, pos, labels=labels)
    ...     # nx.draw_networkx_edges(g, pos, arrows=True, connectionstyle='arc3,rad=-1.57079632679')
    ...     # pyplot.show()
    Graph with 10 nodes and 9 edges
    Graph with 12 nodes and 18 edges

    References
    ----------
    .. [1] Lucas Lacasa lucas@dmae.upm.es, Bartolo Luque, Fernando Ballesteros, Jordi Luque, and Juan Carlos Nuño,
       "From time series to complex networks: The visibility graph"
       Proceedings of the National Academy of Sciences,
       Vol. 105 | No. 1
       April 1, 2008
       PubMed: 18362361
       https://www.pnas.org/doi/10.1073/pnas.0709247105