### PR TITLE
Clarify that basis generates simple cycles only

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -29,11 +29,11 @@ def cycle_basis(G, root=None):
     """Returns a list of cycles which form a basis for cycles of G.
 
     A basis for cycles of a network is a minimal collection of
-    cycles such that any cycle in the network can be written
-    as a sum of cycles in the basis.  Here summation of cycles
-    is defined as "exclusive or" of the edges. Cycle bases are
-    useful, e.g. when deriving equations for electric circuits
-    using Kirchhoff's Laws.
+    cycles  such that any  simple cycle in  the network can be
+    written as a sum of cycles in the basis. Here summation of
+    cycles  is defined as "exclusive or" of  the edges.  Cycle
+    bases   are  useful,  e.g.  when  deriving  equations  for
+    electric circuits using Kirchhoff's Laws.
 
     Parameters
     ----------


### PR DESCRIPTION
I added the **bold** part in

> A basis for cycles of a network is a minimal collection of cycles such that any **simple** cycle in the network can be written as a sum of cycles in the basis. Here summation of cycles is defined as "exclusive or" of the edges. Cycle bases are useful, e.g. when deriving equations for electric circuits using Kirchhoff's Laws.

because in the graph below, the cycle basis is `[[L1, L2, L3], [R1, R2, R3]]`, but neither of the (non-simple) cycles `[L1, L2, L3, L1, C, L1]` and `[L1, L2, L3, L1, C, R1, R2, R3, R1, C, L1]` is a sum of the basis cycles.

![`G = nx.Graph({"C": ["L1", "R1"], "L1": ["L2", "L3"], "L2": ["L3"], "R1": ["R2", "R3"], "R2": ["R3"]})`](https://github.com/networkx/networkx/assets/13442533/ccf6f1e2-36bb-456c-aa3d-ae2b29d73198)

---

It appears that text in docstrings is justified. I read the contributing guidelines and installed the pre-commit hooks, but those did not automatically justify the docstring, so I added whitespace manually.