### PR TITLE
Add test about zero weight cycles and fix goldberg-radzik

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -32,6 +32,10 @@ Improvements
   which, if true, reduces horizontal space by rendering chains of nodes
   vertically.
 
+- [`#6892 <https://github.com/networkx/networkx/pull/6892>`_]
+  The shortest path function `goldberg_radzik` handles a zero-weight-cycle
+  correctly instead of raising an exception as a negative weight cycle.
+
 API Changes
 -----------
 - [`#6651 <https://github.com/networkx/networkx/pull/6651>`_]

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -596,6 +596,20 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         )
         pytest.raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, 1)
 
+    def test_zero_cycle(self):
+        G = nx.cycle_graph(5, create_using=nx.DiGraph())
+        G.add_edge(2, 3, weight=-4)
+        # check that zero cycle doesnt raise
+        nx.goldberg_radzik(G, 1)
+        nx.bellman_ford_predecessor_and_distance(G, 1)
+
+        G.add_edge(2, 3, weight=-4.0001)
+        # check that negative cycle does raise
+        pytest.raises(
+            nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, G, 1
+        )
+        pytest.raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, 1)
+
     def test_find_negative_cycle_longer_cycle(self):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         nx.add_cycle(G, [3, 5, 6, 7, 8, 9])

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -2057,7 +2057,7 @@ def goldberg_radzik(G, source, weight="weight"):
                     continue
                 t = d[u] + weight(u, v, e)
                 d_v = d[v]
-                if t <= d_v:
+                if t < d_v:
                     is_neg = t < d_v
                     d[v] = t
                     pred[v] = u

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1973,6 +1973,10 @@ def goldberg_radzik(G, source, weight="weight"):
         negative (di)cycle.  Note: any negative weight edge in an
         undirected graph is a negative cycle.
 
+        As of NetworkX v3.2, a zero weight cycle is no longer
+        incorrectly reported as a negative weight cycle.
+
+
     Examples
     --------
     >>> G = nx.path_graph(5, create_using=nx.DiGraph())


### PR DESCRIPTION
Fixes #6874 

The NetworkX shortest path algorithm Goldberg-Radzik handles negative edge weights. It finds negative weight cycles and raises in this case. But it incorrectly identifies zero-weight cycles as negative cycles.  But zero weight cycles do not make the shortest path unbounded. The path found is not unique, but it exists and has a finite length. (Bellman-Ford in NX correctly reports these paths.) 

This PR corrects Goldberg-Radzik to report shortest paths in the presence of zero-weight cycles. It adds a test of g-r and b-f algorithms. And it adds a short note in the doc_string of goldberg-radzik that the behavior has changed as of NX v3.2.

I don't think we need to deprecate since it was an incorrect result. But I thought a note in the doc_string would help people who find that their code now behaves differently.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
