### PR TITLE
FIX: Better default behaviour for percolation centrality with no node attrs

### DIFF
--- a/networkx/algorithms/centrality/percolation.py
+++ b/networkx/algorithms/centrality/percolation.py
@@ -38,7 +38,10 @@ def percolation_centrality(G, attribute="percolation", states=None, weight=None)
 
     attribute : None or string, optional (default='percolation')
       Name of the node attribute to use for percolation state, used
-      if `states` is None.
+      if `states` is None. If a node does not set the attribute the
+      state of that node will be set to the default value of 1.
+      If all nodes do not have the attribute all nodes will be set to
+      1 and the centrality measure will be equivalent to betweenness centrality.
 
     states : None or dict, optional (default=None)
       Specify percolation states for the nodes, nodes as keys states
@@ -85,7 +88,7 @@ def percolation_centrality(G, attribute="percolation", states=None, weight=None)
     nodes = G
 
     if states is None:
-        states = nx.get_node_attributes(nodes, attribute)
+        states = nx.get_node_attributes(nodes, attribute, default=1)
 
     # sum of all percolation states
     p_sigma_x_t = 0.0

--- a/networkx/algorithms/centrality/tests/test_percolation_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_percolation_centrality.py
@@ -80,3 +80,8 @@ class TestPercolationCentrality:
         p_answer = nx.percolation_centrality(G, states=p_states)
         for n in sorted(G):
             assert p_answer[n] == pytest.approx(b_answer[n], abs=1e-3)
+
+
+def test_default_percolation():
+    G = nx.erdos_renyi_graph(42, 0.42, seed=42)
+    assert nx.percolation_centrality(G) == pytest.approx(nx.betweenness_centrality(G))

--- a/networkx/algorithms/centrality/tests/test_percolation_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_percolation_centrality.py
@@ -31,55 +31,55 @@ def example1b_G():
     return G
 
 
-class TestPercolationCentrality:
-    def test_percolation_example1a(self):
-        """percolation centrality: example 1a"""
-        G = example1a_G()
-        p = nx.percolation_centrality(G)
-        p_answer = {4: 0.625, 6: 0.667}
-        for n, k in p_answer.items():
-            assert p[n] == pytest.approx(k, abs=1e-3)
+def test_percolation_example1a():
+    """percolation centrality: example 1a"""
+    G = example1a_G()
+    p = nx.percolation_centrality(G)
+    p_answer = {4: 0.625, 6: 0.667}
+    for n, k in p_answer.items():
+        assert p[n] == pytest.approx(k, abs=1e-3)
 
-    def test_percolation_example1b(self):
-        """percolation centrality: example 1a"""
-        G = example1b_G()
-        p = nx.percolation_centrality(G)
-        p_answer = {4: 0.825, 6: 0.4}
-        for n, k in p_answer.items():
-            assert p[n] == pytest.approx(k, abs=1e-3)
 
-    def test_converge_to_betweenness(self):
-        """percolation centrality: should converge to betweenness
-        centrality when all nodes are percolated the same"""
-        # taken from betweenness test test_florentine_families_graph
-        G = nx.florentine_families_graph()
-        b_answer = {
-            "Acciaiuoli": 0.000,
-            "Albizzi": 0.212,
-            "Barbadori": 0.093,
-            "Bischeri": 0.104,
-            "Castellani": 0.055,
-            "Ginori": 0.000,
-            "Guadagni": 0.255,
-            "Lamberteschi": 0.000,
-            "Medici": 0.522,
-            "Pazzi": 0.000,
-            "Peruzzi": 0.022,
-            "Ridolfi": 0.114,
-            "Salviati": 0.143,
-            "Strozzi": 0.103,
-            "Tornabuoni": 0.092,
-        }
+def test_percolation_example1b():
+    """percolation centrality: example 1a"""
+    G = example1b_G()
+    p = nx.percolation_centrality(G)
+    p_answer = {4: 0.825, 6: 0.4}
+    for n, k in p_answer.items():
+        assert p[n] == pytest.approx(k, abs=1e-3)
 
-        p_states = {k: 1.0 for k, v in b_answer.items()}
-        p_answer = nx.percolation_centrality(G, states=p_states)
-        for n in sorted(G):
-            assert p_answer[n] == pytest.approx(b_answer[n], abs=1e-3)
 
-        p_states = {k: 0.3 for k, v in b_answer.items()}
-        p_answer = nx.percolation_centrality(G, states=p_states)
-        for n in sorted(G):
-            assert p_answer[n] == pytest.approx(b_answer[n], abs=1e-3)
+def test_converge_to_betweenness():
+    """percolation centrality: should converge to betweenness
+    centrality when all nodes are percolated the same"""
+    # taken from betweenness test test_florentine_families_graph
+    G = nx.florentine_families_graph()
+    b_answer = {
+        "Acciaiuoli": 0.000,
+        "Albizzi": 0.212,
+        "Barbadori": 0.093,
+        "Bischeri": 0.104,
+        "Castellani": 0.055,
+        "Ginori": 0.000,
+        "Guadagni": 0.255,
+        "Lamberteschi": 0.000,
+        "Medici": 0.522,
+        "Pazzi": 0.000,
+        "Peruzzi": 0.022,
+        "Ridolfi": 0.114,
+        "Salviati": 0.143,
+        "Strozzi": 0.103,
+        "Tornabuoni": 0.092,
+    }
+
+    # If no initial state is provided, state for
+    # every node defaults to 1
+    p_answer = nx.percolation_centrality(G)
+    assert p_answer == pytest.approx(b_answer, abs=1e-3)
+
+    p_states = {k: 0.3 for k, v in b_answer.items()}
+    p_answer = nx.percolation_centrality(G, states=p_states)
+    assert p_answer == pytest.approx(b_answer, abs=1e-3)
 
 
 def test_default_percolation():


### PR DESCRIPTION
Closes #6886 (we could raise an error instead)
If the default attribute (`percolation`) is not present for every node it will default to 1. This will also add defaults to nodes if the node attribute is only present for a subset of nodes. This shouldn't break any old code as anyone using this with the node attribute not set for every node would have been getting a `KeyError`.


~This depends on https://github.com/networkx/networkx/pull/6887~