### PR TITLE
Fix sphinx docs rendering of dispatched functions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,4 @@
+import os
 from datetime import date
 from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
 from warnings import filterwarnings
@@ -81,12 +82,15 @@ exclude_patterns = ["release/release_template.rst"]
 project = "NetworkX"
 copyright = f"2004-{date.today().year}, NetworkX Developers"
 
+# Used in networkx.utils.backends for cleaner rendering of functions.
+# We need to set this before we import networkx.
+os.environ["_NETWORKX_BUILDING_DOCS_"] = "True"
+import networkx
+
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 #
 # The short X.Y version.
-import networkx
-
 version = networkx.__version__
 # The full version, including dev info
 release = networkx.__version__.replace("_", "")

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -817,3 +817,19 @@ class _dispatch:
 
 def _restore_dispatch(name):
     return _registered_algorithms[name]
+
+
+if os.environ.get("_NETWORKX_BUILDING_DOCS_"):
+    # When building docs with Sphinx, use the original function with the
+    # dispatched __doc__, b/c Sphinx renders normal Python functions better.
+    # This doesn't show e.g. `*, backend=None, **backend_kwargs` in the
+    # signatures, which is probably okay. It does allow the docstring to be
+    # updated based on the installed backends.
+    _orig_dispatch = _dispatch
+
+    def _dispatch(func=None, **kwargs):
+        if func is None:
+            return partial(_dispatch, **kwargs)
+        dispatched_func = _orig_dispatch(func, **kwargs)
+        func.__doc__ = dispatched_func.__doc__
+        return func

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -827,7 +827,7 @@ if os.environ.get("_NETWORKX_BUILDING_DOCS_"):
     # updated based on the installed backends.
     _orig_dispatch = _dispatch
 
-    def _dispatch(func=None, **kwargs): # type: ignore
+    def _dispatch(func=None, **kwargs):  # type: ignore
         if func is None:
             return partial(_dispatch, **kwargs)
         dispatched_func = _orig_dispatch(func, **kwargs)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -827,7 +827,7 @@ if os.environ.get("_NETWORKX_BUILDING_DOCS_"):
     # updated based on the installed backends.
     _orig_dispatch = _dispatch
 
-    def _dispatch(func=None, **kwargs):  # type: ignore
+    def _dispatch(func=None, **kwargs):  # type: ignore[no-redef]
         if func is None:
             return partial(_dispatch, **kwargs)
         dispatched_func = _orig_dispatch(func, **kwargs)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -827,7 +827,7 @@ if os.environ.get("_NETWORKX_BUILDING_DOCS_"):
     # updated based on the installed backends.
     _orig_dispatch = _dispatch
 
-    def _dispatch(func=None, **kwargs):
+    def _dispatch(func=None, **kwargs): # type: ignore
         if func is None:
             return partial(_dispatch, **kwargs)
         dispatched_func = _orig_dispatch(func, **kwargs)


### PR DESCRIPTION
@MridulS noticed the online docs no longer render properly for dispatched functions now that `_dispatch` is a class: https://github.com/networkx/networkx/pull/6840#issuecomment-1700779731

I'm not a Sphinx expert, but here is one way to fix the problem. It also allows the dispatch machinery to update the docstring. The signature of dispatched functions is unchanged in the online docs--that is, `backend=None, **backend_kwargs` is not shown.