### PR TITLE
Fix the recursive version of strongly_connected_components

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -237,7 +237,7 @@ def strongly_connected_components_recursive(G):
 
     """
 
-   def visit(v, cnt):
+    def visit(v, cnt):
         root[v] = cnt[0]
         visited[v] = cnt[0]
         cnt[0] += 1

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -237,16 +237,17 @@ def strongly_connected_components_recursive(G):
 
     """
 
-    def visit(v, cnt):
-        root[v] = cnt
-        visited[v] = cnt
-        cnt += 1
+   def visit(v, cnt):
+        root[v] = cnt[0]
+        visited[v] = cnt[0]
+        cnt[0] += 1
         stack.append(v)
         for w in G[v]:
             if w not in visited:
                 yield from visit(w, cnt)
-            if w not in component:
                 root[v] = min(root[v], root[w])
+            elif w not in component:
+                root[v] = min(root[v], visited[w])
         if root[v] == visited[v]:
             component[v] = root[v]
             tmpc = {v}  # hold nodes in this component
@@ -260,7 +261,7 @@ def strongly_connected_components_recursive(G):
     visited = {}
     component = {}
     root = {}
-    cnt = 0
+    cnt = [0]
     stack = []
     for source in G:
         if source not in visited:


### PR DESCRIPTION
Hello! Sorry for bothering you. 
I have investigated the issue of the Tarjan algorithm for `strongly_connected_components_recursive` in #6897 and tried to fix it.
I believe that the root cause of the issue is that we let `cnt` be independent for different visiting in the following code:
```Python
    for source in G:
        if source not in visited:
            yield from visit(source, cnt)
```
In addition, the updating of the `root` array also had some problems and I corrected it.
Please kindly review my code for fixing, it would be highly appreciated.

Best regards,
Joye
