### PR TITLE
MAINT: Make GEXF and graphml writer work with numpy 2.0

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -229,7 +229,6 @@ class GEXF:
                 (np.float64, "float"),
                 (np.float32, "float"),
                 (np.float16, "float"),
-                (np.float_, "float"),
                 (np.int_, "int"),
                 (np.int8, "int"),
                 (np.int16, "int"),

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -413,7 +413,6 @@ class GraphML:
                 (np.float64, "float"),
                 (np.float32, "float"),
                 (np.float16, "float"),
-                (np.float_, "float"),
                 (np.int_, "int"),
                 (np.int8, "int"),
                 (np.int16, "int"),

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1288,17 +1288,6 @@ class TestWriteGraphML(BaseGraphML):
         assert H.edges["n0", "n1", 0]["special"] == 2
         assert H.edges["n0", "n1", 1]["special"] == 3
 
-    def test_numpy_float(self):
-        np = pytest.importorskip("numpy")
-        wt = np.float_(3.4)
-        G = nx.Graph([(1, 2, {"weight": wt})])
-        fd, fname = tempfile.mkstemp()
-        self.writer(G, fname)
-        H = nx.read_graphml(fname, node_type=int)
-        assert G._adj == H._adj
-        os.close(fd)
-        os.unlink(fname)
-
     def test_multigraph_to_graph(self):
         # test converting multigraph to graph if no parallel edges found
         G = nx.MultiGraph()


### PR DESCRIPTION
Nightly tests are failing with numpy 2.0 as numpy has removed `np.float_` https://github.com/networkx/networkx/actions/runs/6061305343/job/16446362472

I think this change should be backward compatible (?) as GEXF and graphml the format don't have a concept of numpy floats (?).