### PR TITLE
DOC: Add example for self loop multidigraph in contraction

### DIFF
--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -503,10 +503,10 @@ def contracted_nodes(G, u, v, self_loops=True, copy=True):
 
     >>> G = nx.MultiDiGraph([(1, 2), (2, 2)])
     >>> H = nx.contracted_nodes(G, 1, 2)
-    >>> list(H.edges()) # edge 1->2, 2->2, 2->2 from the original Graph G
+    >>> list(H.edges())  # edge 1->2, 2->2, 2<-2 from the original Graph G
     [(1, 1), (1, 1), (1, 1)]
     >>> H = nx.contracted_nodes(G, 1, 2, self_loops=False)
-    >>> list(H.edges()) # edge 2->2, 2->2 from the original Graph G
+    >>> list(H.edges())  # edge 2->2, 2<-2 from the original Graph G
     [(1, 1), (1, 1)]
 
     See Also

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -497,6 +497,18 @@ def contracted_nodes(G, u, v, self_loops=True, copy=True):
     >>> list(H.edges())
     [(1, 1)]
 
+    In a ``MultiDiGraph`` with a self loop, the in and out edges will
+    be treated separately as edges, so while contracting a node which
+    has a self loop the contraction will add multiple edges:
+
+    >>> G = nx.MultiDiGraph([(1, 2), (2, 2)])
+    >>> H = nx.contracted_nodes(G, 1, 2)
+    >>> list(H.edges()) # edge 1->2, 2->2, 2->2 from the original Graph G
+    [(1, 1), (1, 1), (1, 1)]
+    >>> H = nx.contracted_nodes(G, 1, 2, self_loops=False)
+    >>> list(H.edges()) # edge 2->2, 2->2 from the original Graph G
+    [(1, 1), (1, 1)]
+
     See Also
     --------
     contracted_edge


### PR DESCRIPTION
Add an example to explain for multidigraphs while contracting nodes with self loops in the original graph.

An example to resolve https://github.com/networkx/networkx/issues/6739

@Diarmuid-ODonoghue do you think this accurately covers the case?