### PR TITLE
 MAINT: Point the PR template to pre-commit 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,4 @@
 Please use pre-commit to lint your code.
 For more details check out https://networkx.org/documentation/latest/developer/contribute.html#development-workflow
 step 2 and step 4.
-
-(optional) You can also assign an appropriate label from the dropdown menu on the right, use the labels "type: XXXXXXXXX"
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
 <!--
-Please run black to format your code.
-See https://networkx.org/documentation/latest/developer/contribute.html for details.
+Please use pre-commit to lint your code.
+For more details check out https://networkx.org/documentation/latest/developer/contribute.html#development-workflow
+step 2 and step 4.
+
+(optional) You can also assign an appropriate label from the dropdown menu on the right, use the labels "type: XXXXXXXXX"
 -->


### PR DESCRIPTION
The PR template was asking users to install black and use it manually to fix linting. We should be asking contributors to run pre-commit.