### PR TITLE
 API: Add a decorator to deprecate positional args 

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -388,7 +388,7 @@ def induced_subgraph(G, nbunch):
     [0, 1, 3]
     """
     induced_nodes = nx.filters.show_nodes(G.nbunch_iter(nbunch))
-    return nx.subgraph_view(G, induced_nodes)
+    return nx.subgraph_view(G, filter_node=induced_nodes)
 
 
 def edge_subgraph(G, edges):
@@ -447,7 +447,7 @@ def edge_subgraph(G, edges):
             induced_edges = nxf.show_diedges(edges)
         else:
             induced_edges = nxf.show_edges(edges)
-    return nx.subgraph_view(G, induced_nodes, induced_edges)
+    return nx.subgraph_view(G, filter_node=induced_nodes, filter_edge=induced_edges)
 
 
 def restricted_view(G, nodes, edges):
@@ -503,7 +503,7 @@ def restricted_view(G, nodes, edges):
             hide_edges = nxf.hide_diedges(edges)
         else:
             hide_edges = nxf.hide_edges(edges)
-    return nx.subgraph_view(G, hide_nodes, hide_edges)
+    return nx.subgraph_view(G, filter_node=hide_nodes, filter_edge=hide_edges)
 
 
 def to_directed(graph):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1821,8 +1821,10 @@ class Graph:
         # if already a subgraph, don't make a chain
         subgraph = nx.subgraph_view
         if hasattr(self, "_NODE_OK"):
-            return subgraph(self._graph, induced_nodes, self._EDGE_OK)
-        return subgraph(self, induced_nodes)
+            return subgraph(
+                self._graph, filter_node=induced_nodes, filter_edge=self._EDGE_OK
+            )
+        return subgraph(self, filter_node=induced_nodes)
 
     def edge_subgraph(self, edges):
         """Returns the subgraph induced by the specified edges.

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -33,7 +33,7 @@ from networkx.classes.coreviews import (
 )
 from networkx.classes.filters import no_filter
 from networkx.exception import NetworkXError
-from networkx.utils import not_implemented_for
+from networkx.utils import deprecate_positional_args, not_implemented_for
 
 __all__ = ["generic_graph_view", "subgraph_view", "reverse_view"]
 
@@ -132,7 +132,8 @@ def generic_graph_view(G, create_using=None):
     return newG
 
 
-def subgraph_view(G, filter_node=no_filter, filter_edge=no_filter):
+@deprecate_positional_args(version="3.4")
+def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
     """View of `G` applying a filter on nodes and edges.
 
     `subgraph_view` provides a read-only view of the input graph that excludes

--- a/networkx/classes/tests/test_coreviews.py
+++ b/networkx/classes/tests/test_coreviews.py
@@ -322,7 +322,7 @@ class TestFilteredGraphs:
         for Graph in self.Graphs:
             G = nx.path_graph(4, Graph)
             SG = G.subgraph([2, 3])
-            RG = SubGraph(G, nx.filters.hide_nodes([0, 1]))
+            RG = SubGraph(G, filter_node=nx.filters.hide_nodes([0, 1]))
             assert SG.nodes == RG.nodes
             assert SG.edges == RG.edges
             SGC = SG.copy()
@@ -335,7 +335,7 @@ class TestFilteredGraphs:
         for Graph in self.Graphs:
             G = nx.path_graph(4, Graph)
             SG = G.subgraph([2, 3])
-            RG = SubGraph(G, nx.filters.hide_nodes([0, 1]))
+            RG = SubGraph(G, filter_node=nx.filters.hide_nodes([0, 1]))
             str(SG.adj)
             str(RG.adj)
             repr(SG.adj)
@@ -350,8 +350,8 @@ class TestFilteredGraphs:
         for Graph in self.Graphs:
             G = nx.path_graph(4, Graph)
             SG = G.subgraph([2, 3])
-            RG = SubGraph(G, nx.filters.hide_nodes([0, 1]))
-            RsG = SubGraph(G, nx.filters.show_nodes([2, 3]))
+            RG = SubGraph(G, filter_node=nx.filters.hide_nodes([0, 1]))
+            RsG = SubGraph(G, filter_node=nx.filters.show_nodes([2, 3]))
             assert G.adj.copy() == G.adj
             assert G.adj[2].copy() == G.adj[2]
             assert SG.adj.copy() == SG.adj

--- a/networkx/classes/tests/test_subgraphviews.py
+++ b/networkx/classes/tests/test_subgraphviews.py
@@ -19,7 +19,6 @@ class TestSubGraphView:
         hide_nodes = [4, 5, 111]
         nodes_gone = nx.filters.hide_nodes(hide_nodes)
         gview = self.gview
-        print(gview)
         G = gview(self.G, filter_node=nodes_gone)
         assert self.G.nodes - G.nodes == {4, 5}
         assert self.G.edges - G.edges == self.hide_edges_w_hide_nodes
@@ -106,7 +105,7 @@ class TestSubDiGraphView(TestSubGraphView):
         edges_gone = self.hide_edges_filter(self.hide_edges)
         hide_nodes = [4, 5, 111]
         nodes_gone = nx.filters.hide_nodes(hide_nodes)
-        G = self.gview(self.G, nodes_gone, edges_gone)
+        G = self.gview(self.G, filter_node=nodes_gone, filter_edge=edges_gone)
 
         assert self.G.in_edges - G.in_edges == self.excluded
         assert self.G.out_edges - G.out_edges == self.excluded
@@ -115,7 +114,7 @@ class TestSubDiGraphView(TestSubGraphView):
         edges_gone = self.hide_edges_filter(self.hide_edges)
         hide_nodes = [4, 5, 111]
         nodes_gone = nx.filters.hide_nodes(hide_nodes)
-        G = self.gview(self.G, nodes_gone, edges_gone)
+        G = self.gview(self.G, filter_node=nodes_gone, filter_edge=edges_gone)
 
         assert list(G.pred[2]) == [1]
         assert list(G.pred[6]) == []
@@ -124,7 +123,7 @@ class TestSubDiGraphView(TestSubGraphView):
         edges_gone = self.hide_edges_filter(self.hide_edges)
         hide_nodes = [4, 5, 111]
         nodes_gone = nx.filters.hide_nodes(hide_nodes)
-        G = self.gview(self.G, nodes_gone, edges_gone)
+        G = self.gview(self.G, filter_node=nodes_gone, filter_edge=edges_gone)
 
         assert G.degree(2) == 1
         assert G.out_degree(2) == 0
@@ -201,7 +200,7 @@ class TestMultiDiGraphView(TestMultiGraphView, TestSubDiGraphView):
         edges_gone = self.hide_edges_filter(self.hide_edges)
         hide_nodes = [4, 5, 111]
         nodes_gone = nx.filters.hide_nodes(hide_nodes)
-        G = self.gview(self.G, nodes_gone, edges_gone)
+        G = self.gview(self.G, filter_node=nodes_gone, filter_edge=edges_gone)
 
         assert G.degree(2) == 3
         assert G.out_degree(2) == 2


### PR DESCRIPTION
[Scikit-learn has a decorator](https://github.com/scikit-learn/scikit-learn/blob/8ed0270b99344cee9bb253cbfa1d986561ea6cd7/sklearn/utils/validation.py#L37C1-L90C44) which took care of the deprecation cycle for moving to keyword args from positional args. I have vendored that in as a networkx decorator.

This should resolve https://github.com/networkx/networkx/issues/4845.
