### PR TITLE
add missing `join` deprecation stuff to release_dev and conftest

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -46,6 +46,8 @@ API Changes
   ``get_edge_attributes``. The ``default`` keyword can be used to set
   a default value if the attribute is missing from a node/edge.
 
+- [`#6908 <https://github.com/networkx/networkx/pull/6908>`_]
+  Rename `join` as `join_trees` in `algorithms.tree.operations.py`.
 
 Deprecations
 ------------

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -130,6 +130,9 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="function `join` is deprecated"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
I forgot to update `conftest.py` and `release_dev.rst` for the renaming `join` deprecation in #6908 
This adds them.