### PR TITLE
MAINT: move dispatch test workflow as an independent CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,25 @@ jobs:
         run: |
           pytest --doctest-modules --durations=10 --pyargs networkx
 
+  dispatch:
+    runs-on: ubuntu-latest
+    matrix:
+      python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/default.txt -r requirements/test.txt
+          python -m pip install .
+          python -m pip list
+
       - name: Test Dispatching
-        # Limit this to only a single combination from the matrix
-        if: ${{ (matrix.os == 'ubuntu') && (matrix.python-version == '3.11') }}
         run: |
           NETWORKX_TEST_BACKEND=nx-loopback pytest --doctest-modules --durations=10 --pyargs networkx
 


### PR DESCRIPTION
This change does make us write the same bit multiple times but it will make it much quicker to check if a test failure in the PR came from dispatching. This will change the action label from `test / base` to `test / dispatch`