### PR TITLE
MAINT: Use importlib.resources instead of file dunder to access files

### DIFF
--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -2,6 +2,7 @@
 """
 
 import bz2
+import importlib.resources
 import os
 import pickle
 
@@ -48,8 +49,11 @@ def gen_pyramid(N):
 
 
 def read_graph(name):
-    dirname = os.path.dirname(__file__)
-    fname = os.path.join(dirname, name + ".gpickle.bz2")
+    fname = (
+        importlib.resources.files("networkx.algorithms.flow.tests")
+        / f"{name}.gpickle.bz2"
+    )
+
     with bz2.BZ2File(fname, "rb") as f:
         G = pickle.load(f)
     return G

--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -1,4 +1,5 @@
 import bz2
+import importlib.resources
 import os
 import pickle
 
@@ -461,7 +462,10 @@ class TestMinCostFlow:
         # pytest.raises(nx.NetworkXUnfeasible, nx.capacity_scaling, G)
 
     def test_large(self):
-        fname = os.path.join(os.path.dirname(__file__), "netgen-2.gpickle.bz2")
+        fname = (
+            importlib.resources.files("networkx.algorithms.flow.tests")
+            / "netgen-2.gpickle.bz2"
+        )
         with bz2.BZ2File(fname, "rb") as f:
             G = pickle.load(f)
         flowCost, flowDict = nx.network_simplex(G)

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -1,4 +1,5 @@
 import bz2
+import importlib.resources
 import os
 import pickle
 
@@ -141,7 +142,11 @@ def test_google_or_tools_example2():
 
 
 def test_large():
-    fname = os.path.join(os.path.dirname(__file__), "netgen-2.gpickle.bz2")
+    fname = (
+        importlib.resources.files("networkx.algorithms.flow.tests")
+        / "netgen-2.gpickle.bz2"
+    )
+
     with bz2.BZ2File(fname, "rb") as f:
         G = pickle.load(f)
     flowCost, flowDict = nx.network_simplex(G)

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -2,6 +2,7 @@
     Tests for VF2 isomorphism algorithm.
 """
 
+import importlib.resources
 import os
 import random
 import struct
@@ -118,18 +119,18 @@ class TestVF2GraphDB:
         return graph
 
     def test_graph(self):
-        head, tail = os.path.split(__file__)
-        g1 = self.create_graph(os.path.join(head, "iso_r01_s80.A99"))
-        g2 = self.create_graph(os.path.join(head, "iso_r01_s80.B99"))
+        head = importlib.resources.files("networkx.algorithms.isomorphism.tests")
+        g1 = self.create_graph(head / "iso_r01_s80.A99")
+        g2 = self.create_graph(head / "iso_r01_s80.B99")
         gm = iso.GraphMatcher(g1, g2)
         assert gm.is_isomorphic()
 
     def test_subgraph(self):
         # A is the subgraph
         # B is the full graph
-        head, tail = os.path.split(__file__)
-        subgraph = self.create_graph(os.path.join(head, "si2_b06_m200.A99"))
-        graph = self.create_graph(os.path.join(head, "si2_b06_m200.B99"))
+        head = importlib.resources.files("networkx.algorithms.isomorphism.tests")
+        subgraph = self.create_graph(head / "si2_b06_m200.A99")
+        graph = self.create_graph(head / "si2_b06_m200.B99")
         gm = iso.GraphMatcher(graph, subgraph)
         assert gm.subgraph_is_isomorphic()
         # Just testing some cases

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -2,6 +2,7 @@
 Generators for the small graph atlas.
 """
 import gzip
+import importlib.resources
 import os
 import os.path
 from itertools import islice
@@ -15,9 +16,6 @@ __all__ = ["graph_atlas", "graph_atlas_g"]
 #: The graphs are labeled starting from 0 and extending to (but not
 #: including) this number.
 NUM_GRAPHS = 1253
-
-#: The absolute path representing the directory containing this file.
-THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 #: The path to the data file containing the graph edge lists.
 #:
@@ -51,7 +49,9 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 #:             f.write(bytes(f'NODES {len(G)}\n', encoding='utf-8'))
 #:             write_edgelist(G, f, data=False)
 #:
-ATLAS_FILE = os.path.join(THIS_DIR, "atlas.dat.gz")
+
+# Path to the atlas file
+ATLAS_FILE = importlib.resources.files("networkx.generators") / "atlas.dat.gz"
 
 
 def _generate_graphs():


### PR DESCRIPTION
This should fix https://github.com/networkx/networkx/issues/3929

I'm not too sure if there is a better way of doing this. I don't really like writing down the paths explicitly.