### PR TITLE
DOC, MAINT: Deduplicate docs instructions.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -403,7 +403,7 @@ Then create a baseline image to compare against later::
 
     $ pytest -k test_barbell --mpl-generate-path=networkx/drawing/tests/baseline
 
-.. note: In order to keep the size of the repository from becoming too large, we
+.. note:: In order to keep the size of the repository from becoming too large, we
    prefer to limit the size and number of baseline images we include.
 
 And test::
@@ -413,27 +413,7 @@ And test::
 Documentation
 -------------
 
-Building the documentation locally requires that the additional dependencies
-specified in ``requirements/doc.txt`` be installed in your development
-environment.
-
-The documentation is built with ``sphinx``. To build the documentation locally,
-navigate to the ``doc/`` directory and::
-
-    make html
-
-This will generate both the reference documentation as well as the example
-gallery. If you want to build the documentation *without* building the
-gallery examples use::
-
-    make html-noplot
-
-The build products are stored in ``doc/build/`` and can be viewed directly.
-For example, to view the built html, open ``build/html/index.html``
-in your preferred web browser.
-
-.. note: ``sphinx`` supports many other output formats. Type ``make`` without
-   any arguments to see all the built-in options.
+.. include:: ../README.rst
 
 Adding examples
 ~~~~~~~~~~~~~~~

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -1,5 +1,3 @@
-# Building docs
-
 We use Sphinx for generating the API and reference documentation.
 
 Pre-built versions can be found at
@@ -8,33 +6,37 @@ Pre-built versions can be found at
 
 for both the stable and the latest (i.e., development) releases.
 
-## Instructions
+Instructions
+~~~~~~~~~~~~
 
 After installing NetworkX and its dependencies, install the Python
 packages needed to build the documentation by entering the root
-directory and executing:
+directory and executing::
 
     pip install -r requirements/doc.txt
 
 Building the example gallery additionally requires the dependencies
-listed in `requirements/extra.txt` and `requirements/example.txt`:
+listed in ``requirements/extra.txt`` and ``requirements/example.txt``::
 
     pip install -r requirements/extra.txt
     pip install -r requirements/example.txt
 
-To build the HTML documentation, enter `doc/` and execute:
+To build the HTML documentation, enter ``doc/`` and execute::
 
     make html
 
-This will generate a `build/html` subdirectory containing the built
-documentation. If the dependencies in `extra.txt` and `example.txt`
+This will generate a ``build/html`` subdirectory containing the built
+documentation. If the dependencies in ``extra.txt`` and ``example.txt``
 are **not** installed, build the HTML documentation without generating
-figures by using:
+figures by using::
 
     make html-noplot
 
-To build the PDF documentation, enter:
+To build the PDF documentation, enter::
 
     make latexpdf
 
 You will need to have LaTeX installed for this.
+
+.. note:: ``sphinx`` supports many other output formats. Type ``make`` without
+   any arguments to see all the built-in options.


### PR DESCRIPTION
Condense documentation building instructions to a single location in doc/README.rst and include that directly in the contributor guide.

This resolves some fragmentation of the contributor documentation, ensuring new contributors see the same information both in the html docs and in the source READMEs.

Closes #6770 
