### PR TITLE
Rm deprecated `create_using` kwarg from scale_free_graph

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -63,8 +63,6 @@ Version 3.0
 
 Version 3.2
 ~~~~~~~~~~~
-* In ``generators/directed.py`` remove the ``create_using`` keyword argument
-  for the ``scale_free_graph`` function.
 * Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723
 * In ``readwrite/json_graph/node_link.py`` remove the ``attrs` keyword code 
   and docstring in ``node_link_data`` and ``node_link_graph``. Also the associated tests.

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -94,10 +94,6 @@ def set_warnings():
         category=DeprecationWarning,
         message="literal_destringizer is deprecated",
     )
-    # create_using for scale_free_graph
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="The create_using argument"
-    )
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="nx.nx_pydot"
     )

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -249,6 +249,8 @@ def scale_free_graph(
         return seed.choice(candidates)
 
     if initial_graph is not None and hasattr(initial_graph, "_adj"):
+        if not isinstance(initial_graph, nx.MultiDiGraph):
+            raise nx.NetworkXError("initial_graph must be a MultiDiGraph.")
         G = initial_graph
     else:
         # Start with 3-cycle

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -179,7 +179,7 @@ def gnc_graph(n, create_using=None, seed=None):
     return G
 
 
-@py_random_state(7)
+@py_random_state(6)
 def scale_free_graph(
     n,
     alpha=0.41,
@@ -187,7 +187,6 @@ def scale_free_graph(
     gamma=0.05,
     delta_in=0.2,
     delta_out=0,
-    create_using=None,
     seed=None,
     initial_graph=None,
 ):
@@ -212,22 +211,12 @@ def scale_free_graph(
         Bias for choosing nodes from in-degree distribution.
     delta_out : float
         Bias for choosing nodes from out-degree distribution.
-    create_using : NetworkX graph constructor, optional
-        The default is a MultiDiGraph 3-cycle.
-        If a graph instance, use it without clearing first.
-        If a graph constructor, call it to construct an empty graph.
-
-        .. deprecated:: 3.0
-
-           create_using is deprecated, use `initial_graph` instead.
-
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
     initial_graph : MultiDiGraph instance, optional
         Build the scale-free graph starting from this initial MultiDiGraph,
         if provided.
-
 
     Returns
     -------
@@ -259,37 +248,11 @@ def scale_free_graph(
                 return seed.choice(node_list)
         return seed.choice(candidates)
 
-    if create_using is not None:
-        import warnings
-
-        warnings.warn(
-            "The create_using argument is deprecated and will be removed in the future.\n\n"
-            "To create a scale free graph from an existing MultiDiGraph, use\n"
-            "initial_graph instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    # TODO: Rm all this complicated logic when deprecation expires and replace
-    # with commented code:
-    #    if initial_graph is not None and hasattr(initial_graph, "_adj"):
-    #        G = initial_graph
-    #    else:
-    #        # Start with 3-cycle
-    #        G = nx.MultiDiGraph([(0, 1), (1, 2), (2, 0)])
-    if create_using is not None and hasattr(create_using, "_adj"):
-        if initial_graph is not None:
-            raise ValueError(
-                "Cannot set both create_using and initial_graph. Set create_using=None."
-            )
-        G = create_using
+    if initial_graph is not None and hasattr(initial_graph, "_adj"):
+        G = initial_graph
     else:
-        if initial_graph is not None and hasattr(initial_graph, "_adj"):
-            G = initial_graph
-        else:
-            G = nx.MultiDiGraph([(0, 1), (1, 2), (2, 0)])
-    if not (G.is_directed() and G.is_multigraph()):
-        raise nx.NetworkXError("MultiDiGraph required in initial_graph")
+        # Start with 3-cycle
+        G = nx.MultiDiGraph([(0, 1), (1, 2), (2, 0)])
 
     if alpha <= 0:
         raise ValueError("alpha must be > 0.")

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -31,7 +31,6 @@ class TestGeneratorsDirected:
         pytest.raises(nx.NetworkXError, gn_graph, 100, create_using=Graph())
         pytest.raises(nx.NetworkXError, gnr_graph, 100, 0.5, create_using=Graph())
         pytest.raises(nx.NetworkXError, gnc_graph, 100, create_using=Graph())
-        pytest.raises(nx.NetworkXError, scale_free_graph, 100, create_using=Graph())
         G = gn_graph(100, seed=1)
         MG = gn_graph(100, create_using=MultiDiGraph(), seed=1)
         assert sorted(G.edges()) == sorted(MG.edges())
@@ -70,20 +69,11 @@ class TestGeneratorsDirected:
         assert nx.is_isomorphic(gnr_graph(1, 0.5), G)
 
 
-def test_scale_free_graph_create_using_with_initial_graph():
-    G = nx.MultiGraph()
-    with pytest.raises(
-        ValueError,
-        match="Cannot set both create_using and initial_graph. Set create_using=None.",
-    ):
-        scale_free_graph(10, create_using=nx.Graph, initial_graph=G)
-
-
 def test_scale_free_graph_negative_delta():
     with pytest.raises(ValueError, match="delta_in must be >= 0."):
-        scale_free_graph(10, create_using=None, delta_in=-1)
+        scale_free_graph(10, delta_in=-1)
     with pytest.raises(ValueError, match="delta_out must be >= 0."):
-        scale_free_graph(10, create_using=None, delta_out=-1)
+        scale_free_graph(10, delta_out=-1)
 
 
 def test_non_numeric_ordering():


### PR DESCRIPTION
Expires the deprecation of create_using (replaced by initial_graph) in `scale_free_graph` in preparation for v3.2.