### PR TITLE
Rm deprecated clique helper functions

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -18,11 +18,7 @@ __all__ = [
     "find_cliques_recursive",
     "make_max_clique_graph",
     "make_clique_bipartite",
-    "graph_clique_number",
-    "graph_number_of_cliques",
     "node_clique_number",
-    "number_of_cliques",
-    "cliques_containing_node",
     "enumerate_all_cliques",
     "max_weight_clique",
 ]
@@ -511,106 +507,6 @@ def make_clique_bipartite(G, fpos=None, create_using=None, name=None):
     return B
 
 
-def graph_clique_number(G, cliques=None):
-    """Returns the clique number of the graph.
-
-    The *clique number* of a graph is the size of the largest clique in
-    the graph.
-
-    .. deprecated:: 3.0
-
-       graph_clique_number is deprecated in NetworkX 3.0 and will be removed
-       in v3.2. The graph clique number can be computed directly with::
-
-           max(len(c) for c in nx.find_cliques(G))
-
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        An undirected graph.
-
-    cliques : list
-        A list of cliques, each of which is itself a list of nodes. If
-        not specified, the list of all cliques will be computed, as by
-        :func:`find_cliques`.
-
-    Returns
-    -------
-    int
-        The size of the largest clique in `G`.
-
-    Notes
-    -----
-    You should provide `cliques` if you have already computed the list
-    of maximal cliques, in order to avoid an exponential time search for
-    maximal cliques.
-
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\ngraph_clique_number is deprecated and will be removed.\n"
-            "Use: ``max(len(c) for c in nx.find_cliques(G))`` instead."
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if len(G.nodes) < 1:
-        return 0
-    if cliques is None:
-        cliques = find_cliques(G)
-    return max([len(c) for c in cliques] or [1])
-
-
-def graph_number_of_cliques(G, cliques=None):
-    """Returns the number of maximal cliques in the graph.
-
-    .. deprecated:: 3.0
-
-       graph_number_of_cliques is deprecated and will be removed in v3.2.
-       The number of maximal cliques can be computed directly with::
-
-           sum(1 for _ in nx.find_cliques(G))
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        An undirected graph.
-
-    cliques : list
-        A list of cliques, each of which is itself a list of nodes. If
-        not specified, the list of all cliques will be computed, as by
-        :func:`find_cliques`.
-
-    Returns
-    -------
-    int
-        The number of maximal cliques in `G`.
-
-    Notes
-    -----
-    You should provide `cliques` if you have already computed the list
-    of maximal cliques, in order to avoid an exponential time search for
-    maximal cliques.
-
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\ngraph_number_of_cliques is deprecated and will be removed.\n"
-            "Use: ``sum(1 for _ in nx.find_cliques(G))`` instead."
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if cliques is None:
-        cliques = list(find_cliques(G))
-    return len(cliques)
-
-
 @nx._dispatch
 def node_clique_number(G, nodes=None, cliques=None, separate_nodes=False):
     """Returns the size of the largest maximal clique containing each given node.
@@ -673,92 +569,6 @@ def node_clique_number(G, nodes=None, cliques=None, separate_nodes=False):
     if nodes is None:
         return size_for_n
     return {n: size_for_n[n] for n in nodes}
-
-
-def number_of_cliques(G, nodes=None, cliques=None):
-    """Returns the number of maximal cliques for each node.
-
-    .. deprecated:: 3.0
-
-       number_of_cliques is deprecated and will be removed in v3.2.
-       Use the result of `find_cliques` directly to compute the number of
-       cliques containing each node::
-
-           {n: sum(1 for c in nx.find_cliques(G) if n in c) for n in G}
-
-    Returns a single or list depending on input nodes.
-    Optional list of cliques can be input if already computed.
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\nnumber_of_cliques is deprecated and will be removed.\n"
-            "Use the result of find_cliques directly to compute the number\n"
-            "of cliques containing each node:\n\n"
-            "    {n: sum(1 for c in nx.find_cliques(G) if n in c) for n in G}\n\n"
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if cliques is None:
-        cliques = list(find_cliques(G))
-
-    if nodes is None:
-        nodes = list(G.nodes())  # none, get entire graph
-
-    if not isinstance(nodes, list):  # check for a list
-        v = nodes
-        # assume it is a single value
-        numcliq = len([1 for c in cliques if v in c])
-    else:
-        numcliq = {}
-        for v in nodes:
-            numcliq[v] = len([1 for c in cliques if v in c])
-    return numcliq
-
-
-def cliques_containing_node(G, nodes=None, cliques=None):
-    """Returns a list of cliques containing the given node.
-
-    .. deprecated:: 3.0
-
-       cliques_containing_node is deprecated and will be removed in 3.2.
-       Use the result of `find_cliques` directly to compute the cliques that
-       contain each node::
-
-           {n: [c for c in nx.find_cliques(G) if n in c] for n in G}
-
-    Returns a single list or list of lists depending on input nodes.
-    Optional list of cliques can be input if already computed.
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\ncliques_containing_node is deprecated and will be removed.\n"
-            "Use the result of find_cliques directly to compute maximal cliques\n"
-            "containing each node:\n\n"
-            "    {n: [c for c in nx.find_cliques(G) if n in c] for n in G}\n\n"
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if cliques is None:
-        cliques = list(find_cliques(G))
-
-    if nodes is None:
-        nodes = list(G.nodes())  # none, get entire graph
-
-    if not isinstance(nodes, list):  # check for a list
-        v = nodes
-        # assume it is a single value
-        vcliques = [c for c in cliques if v in c]
-    else:
-        vcliques = {}
-        for v in nodes:
-            vcliques[v] = [c for c in cliques if v in c]
-    return vcliques
 
 
 class MaxWeightClique:

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -19,6 +19,7 @@ __all__ = [
     "make_max_clique_graph",
     "make_clique_bipartite",
     "node_clique_number",
+    "number_of_cliques",
     "enumerate_all_cliques",
     "max_weight_clique",
 ]
@@ -569,6 +570,29 @@ def node_clique_number(G, nodes=None, cliques=None, separate_nodes=False):
     if nodes is None:
         return size_for_n
     return {n: size_for_n[n] for n in nodes}
+
+
+def number_of_cliques(G, nodes=None, cliques=None):
+    """Returns the number of maximal cliques for each node.
+
+    Returns a single or list depending on input nodes.
+    Optional list of cliques can be input if already computed.
+    """
+    if cliques is None:
+        cliques = list(find_cliques(G))
+
+    if nodes is None:
+        nodes = list(G.nodes())  # none, get entire graph
+
+    if not isinstance(nodes, list):  # check for a list
+        v = nodes
+        # assume it is a single value
+        numcliq = len([1 for c in cliques if v in c])
+    else:
+        numcliq = {}
+        for v in nodes:
+            numcliq[v] = len([1 for c in cliques if v in c])
+    return numcliq
 
 
 class MaxWeightClique:

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -67,6 +67,67 @@ class TestCliques:
         with pytest.raises(ValueError):
             list(nx.find_cliques_recursive(self.G, [2, 6, 4, 1]))
 
+    def test_number_of_cliques(self):
+        G = self.G
+        assert nx.number_of_cliques(G, 1) == 1
+        assert list(nx.number_of_cliques(G, [1]).values()) == [1]
+        assert list(nx.number_of_cliques(G, [1, 2]).values()) == [1, 2]
+        assert nx.number_of_cliques(G, [1, 2]) == {1: 1, 2: 2}
+        assert nx.number_of_cliques(G, 2) == 2
+        assert nx.number_of_cliques(G) == {
+            1: 1,
+            2: 2,
+            3: 1,
+            4: 2,
+            5: 1,
+            6: 2,
+            7: 1,
+            8: 1,
+            9: 1,
+            10: 1,
+            11: 1,
+        }
+        assert nx.number_of_cliques(G, nodes=list(G)) == {
+            1: 1,
+            2: 2,
+            3: 1,
+            4: 2,
+            5: 1,
+            6: 2,
+            7: 1,
+            8: 1,
+            9: 1,
+            10: 1,
+            11: 1,
+        }
+        assert nx.number_of_cliques(G, nodes=[2, 3, 4]) == {2: 2, 3: 1, 4: 2}
+        assert nx.number_of_cliques(G, cliques=self.cl) == {
+            1: 1,
+            2: 2,
+            3: 1,
+            4: 2,
+            5: 1,
+            6: 2,
+            7: 1,
+            8: 1,
+            9: 1,
+            10: 1,
+            11: 1,
+        }
+        assert nx.number_of_cliques(G, list(G), cliques=self.cl) == {
+            1: 1,
+            2: 2,
+            3: 1,
+            4: 2,
+            5: 1,
+            6: 2,
+            7: 1,
+            8: 1,
+            9: 1,
+            10: 1,
+            11: 1,
+        }
+
     def test_node_clique_number(self):
         G = self.G
         assert nx.node_clique_number(G, 1) == 4

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -67,99 +67,6 @@ class TestCliques:
         with pytest.raises(ValueError):
             list(nx.find_cliques_recursive(self.G, [2, 6, 4, 1]))
 
-    def test_clique_number(self):
-        G = self.G
-        with pytest.deprecated_call():
-            assert nx.graph_clique_number(G) == 4
-        with pytest.deprecated_call():
-            assert nx.graph_clique_number(G, cliques=self.cl) == 4
-
-    def test_clique_number2(self):
-        G = nx.Graph()
-        G.add_nodes_from([1, 2, 3])
-        with pytest.deprecated_call():
-            assert nx.graph_clique_number(G) == 1
-
-    def test_clique_number3(self):
-        G = nx.Graph()
-        with pytest.deprecated_call():
-            assert nx.graph_clique_number(G) == 0
-
-    def test_number_of_cliques(self):
-        G = self.G
-        with pytest.deprecated_call():
-            assert nx.graph_number_of_cliques(G) == 5
-        with pytest.deprecated_call():
-            assert nx.graph_number_of_cliques(G, cliques=self.cl) == 5
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, 1) == 1
-        with pytest.deprecated_call():
-            assert list(nx.number_of_cliques(G, [1]).values()) == [1]
-        with pytest.deprecated_call():
-            assert list(nx.number_of_cliques(G, [1, 2]).values()) == [1, 2]
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, [1, 2]) == {1: 1, 2: 2}
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, 2) == 2
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G) == {
-                1: 1,
-                2: 2,
-                3: 1,
-                4: 2,
-                5: 1,
-                6: 2,
-                7: 1,
-                8: 1,
-                9: 1,
-                10: 1,
-                11: 1,
-            }
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, nodes=list(G)) == {
-                1: 1,
-                2: 2,
-                3: 1,
-                4: 2,
-                5: 1,
-                6: 2,
-                7: 1,
-                8: 1,
-                9: 1,
-                10: 1,
-                11: 1,
-            }
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, nodes=[2, 3, 4]) == {2: 2, 3: 1, 4: 2}
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, cliques=self.cl) == {
-                1: 1,
-                2: 2,
-                3: 1,
-                4: 2,
-                5: 1,
-                6: 2,
-                7: 1,
-                8: 1,
-                9: 1,
-                10: 1,
-                11: 1,
-            }
-        with pytest.deprecated_call():
-            assert nx.number_of_cliques(G, list(G), cliques=self.cl) == {
-                1: 1,
-                2: 2,
-                3: 1,
-                4: 2,
-                5: 1,
-                6: 2,
-                7: 1,
-                8: 1,
-                9: 1,
-                10: 1,
-                11: 1,
-            }
-
     def test_node_clique_number(self):
         G = self.G
         assert nx.node_clique_number(G, 1) == 4
@@ -195,34 +102,6 @@ class TestCliques:
         }
         assert nx.node_clique_number(G, [1, 2], cliques=self.cl) == {1: 4, 2: 4}
         assert nx.node_clique_number(G, 1, cliques=self.cl) == 4
-
-    def test_cliques_containing_node(self):
-        G = self.G
-        with pytest.deprecated_call():
-            assert nx.cliques_containing_node(G, 1) == [[2, 6, 1, 3]]
-        with pytest.deprecated_call():
-            assert list(nx.cliques_containing_node(G, [1]).values()) == [[[2, 6, 1, 3]]]
-        with pytest.deprecated_call():
-            assert [
-                sorted(c) for c in list(nx.cliques_containing_node(G, [1, 2]).values())
-            ] == [[[2, 6, 1, 3]], [[2, 6, 1, 3], [2, 6, 4]]]
-        with pytest.deprecated_call():
-            result = nx.cliques_containing_node(G, [1, 2])
-        for k, v in result.items():
-            result[k] = sorted(v)
-        assert result == {1: [[2, 6, 1, 3]], 2: [[2, 6, 1, 3], [2, 6, 4]]}
-        with pytest.deprecated_call():
-            assert nx.cliques_containing_node(G, 1) == [[2, 6, 1, 3]]
-        expected = [{2, 6, 1, 3}, {2, 6, 4}]
-        with pytest.deprecated_call():
-            answer = [set(c) for c in nx.cliques_containing_node(G, 2)]
-        assert answer in (expected, list(reversed(expected)))
-
-        with pytest.deprecated_call():
-            answer = [set(c) for c in nx.cliques_containing_node(G, 2, cliques=self.cl)]
-        assert answer in (expected, list(reversed(expected)))
-        with pytest.deprecated_call():
-            assert len(nx.cliques_containing_node(G)) == 11
 
     def test_make_clique_bipartite(self):
         G = self.G


### PR DESCRIPTION
Removes the 4 deprecated functions from the clique module: `graph_clique_number`, `graph_number_of_cliques`, `number_of_cliques` and `cliques_containing_node`.

@MridulS I know you have a preference for *not* removing helper functions, so just one final check with you :).

One thing I was thinking we could do: in each of these cases, the helper function is replaced by a one-liner[^1]. In order to further reduce the disruption of removing these functions, we could add the four names to the package `__getattr__` and have it raise an exception which includes the recommended one-liner in the message. This seems like the best of both worlds IMO: the confusing function names are removed (and we don't add them to `__dir__` so they are not discoverable), but any code that was relying on them and missed the deprecation cycle would still get an explicit message on how to update their code. WDYT?

[^1]: ... which also happens to be more efficient in some cases, since the one-liners make use of the generator returned by `find_cliques` whereas the helper implementations often create lists!