### PR TITLE
Adding the definition of `nx.effective_size` for isolated nodes, and solve the division error in #6916

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -237,7 +237,7 @@ def strongly_connected_components_recursive(G):
 
     """
 
-   def visit(v, cnt):
+    def visit(v, cnt):
         root[v] = cnt[0]
         visited[v] = cnt[0]
         cnt[0] += 1

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -237,16 +237,17 @@ def strongly_connected_components_recursive(G):
 
     """
 
-    def visit(v, cnt):
-        root[v] = cnt
-        visited[v] = cnt
-        cnt += 1
+   def visit(v, cnt):
+        root[v] = cnt[0]
+        visited[v] = cnt[0]
+        cnt[0] += 1
         stack.append(v)
         for w in G[v]:
             if w not in visited:
                 yield from visit(w, cnt)
-            if w not in component:
                 root[v] = min(root[v], root[w])
+            elif w not in component:
+                root[v] = min(root[v], visited[w])
         if root[v] == visited[v]:
             component[v] = root[v]
             tmpc = {v}  # hold nodes in this component
@@ -260,7 +261,7 @@ def strongly_connected_components_recursive(G):
     visited = {}
     component = {}
     root = {}
-    cnt = 0
+    cnt = [0]
     stack = []
     for source in G:
         if source not in visited:

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -5,7 +5,7 @@ import networkx as nx
 __all__ = ["constraint", "local_constraint", "effective_size"]
 
 
-@nx._dispatch
+@nx._dispatch(edge_attrs="weight")
 def mutual_weight(G, u, v, weight=None):
     """Returns the sum of the weights of the edge from `u` to `v` and
     the edge from `v` to `u` in `G`.

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -5,7 +5,7 @@ import networkx as nx
 __all__ = ["constraint", "local_constraint", "effective_size"]
 
 
-@nx._dispatch(edge_attrs="weight")
+@nx._dispatch
 def mutual_weight(G, u, v, weight=None):
     """Returns the sum of the weights of the edge from `u` to `v` and
     the edge from `v` to `u` in `G`.
@@ -28,7 +28,6 @@ def mutual_weight(G, u, v, weight=None):
     return a_uv + a_vu
 
 
-@nx._dispatch(edge_attrs="weight")
 def normalized_mutual_weight(G, u, v, norm=sum, weight=None):
     """Returns normalized mutual weight of the edges from `u` to `v`
     with respect to the mutual weights of the neighbors of `u` in `G`.
@@ -49,7 +48,6 @@ def normalized_mutual_weight(G, u, v, norm=sum, weight=None):
     return 0 if scale == 0 else mutual_weight(G, u, v, weight) / scale
 
 
-@nx._dispatch(edge_attrs="weight")
 def effective_size(G, nodes=None, weight=None):
     r"""Returns the effective size of all nodes in the graph ``G``.
 
@@ -144,17 +142,15 @@ def effective_size(G, nodes=None, weight=None):
     # Use Borgatti's simplified formula for unweighted and undirected graphs
     if not G.is_directed() and weight is None:
         for v in nodes:
-            # Effective size is not defined for isolated nodes
-            if len(G[v]) == 0:
-                effective_size[v] = float("nan")
+            if len(G[v]) - list(G[v]).count(v) == 0:
+                effective_size[v] = 0
                 continue
             E = nx.ego_graph(G, v, center=False, undirected=True)
             effective_size[v] = len(E) - (2 * E.size()) / len(E)
     else:
         for v in nodes:
-            # Effective size is not defined for isolated nodes
-            if len(G[v]) == 0:
-                effective_size[v] = float("nan")
+            if len(G[v]) - list(G[v]).count(v) == 0:
+                effective_size[v] = 0
                 continue
             effective_size[v] = sum(
                 redundancy(G, v, u, weight) for u in set(nx.all_neighbors(G, v))
@@ -162,7 +158,6 @@ def effective_size(G, nodes=None, weight=None):
     return effective_size
 
 
-@nx._dispatch(edge_attrs="weight")
 def constraint(G, nodes=None, weight=None):
     r"""Returns the constraint on all nodes in the graph ``G``.
 
@@ -223,7 +218,6 @@ def constraint(G, nodes=None, weight=None):
     return constraint
 
 
-@nx._dispatch(edge_attrs="weight")
 def local_constraint(G, u, v, weight=None):
     r"""Returns the local constraint on the node ``u`` with respect to
     the node ``v`` in the graph ``G``.

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -28,6 +28,7 @@ def mutual_weight(G, u, v, weight=None):
     return a_uv + a_vu
 
 
+@nx._dispatch(edge_attrs="weight")
 def normalized_mutual_weight(G, u, v, norm=sum, weight=None):
     """Returns normalized mutual weight of the edges from `u` to `v`
     with respect to the mutual weights of the neighbors of `u` in `G`.
@@ -48,6 +49,7 @@ def normalized_mutual_weight(G, u, v, norm=sum, weight=None):
     return 0 if scale == 0 else mutual_weight(G, u, v, weight) / scale
 
 
+@nx._dispatch(edge_attrs="weight")
 def effective_size(G, nodes=None, weight=None):
     r"""Returns the effective size of all nodes in the graph ``G``.
 
@@ -158,6 +160,7 @@ def effective_size(G, nodes=None, weight=None):
     return effective_size
 
 
+@nx._dispatch(edge_attrs="weight")
 def constraint(G, nodes=None, weight=None):
     r"""Returns the constraint on all nodes in the graph ``G``.
 
@@ -218,6 +221,7 @@ def constraint(G, nodes=None, weight=None):
     return constraint
 
 
+@nx._dispatch(edge_attrs="weight")
 def local_constraint(G, u, v, weight=None):
     r"""Returns the local constraint on the node ``u`` with respect to
     the node ``v`` in the graph ``G``.


### PR DESCRIPTION
Hi all! Sorry for being late to investigate my bug reports~ Based on our discussion, I try to fix #6916 and define `effective size` for isolated nodes by giving the value `0` as the original formula.

Please feel free to tell me if my implementation needs to improve.

Best regards,
Joye
