### PR TITLE
Add support for tuple-nodes to default gml parser

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -749,6 +749,8 @@ def generate_gml(G, stringizer=None):
                 for key, value in value.items():
                     yield from stringize(key, value, (), next_indent)
                 yield indent + "]"
+            elif isinstance(value, tuple) and key == "label":
+                yield indent + key + f" \"({','.join(repr(v) for v in value)})\""
             elif isinstance(value, (list, tuple)) and key != "label" and not in_list:
                 if len(value) == 0:
                     yield indent + key + " " + f'"{value!r}"'

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -212,12 +212,13 @@ graph
         fh.seek(0)
         pytest.raises(nx.NetworkXError, nx.read_gml, fh, label="label")
 
-    def test_tuplelabels(self):
+    @pytest.mark.parametrize("stringizer", (None, literal_stringizer))
+    def test_tuplelabels(self, stringizer):
         # https://github.com/networkx/networkx/pull/1048
         # Writing tuple labels to GML failed.
         G = nx.Graph()
         G.add_edge((0, 1), (1, 0))
-        data = "\n".join(nx.generate_gml(G, stringizer=literal_stringizer))
+        data = "\n".join(nx.generate_gml(G, stringizer=stringizer))
         answer = """graph [
   node [
     id 0


### PR DESCRIPTION
Minor followup to #6943 - while `literal_(de)stringizer` is still necessary for the nested-sequence corner case, this PR adds support to the default stringizer for nodes which are tuples.