### PR TITLE
Make new dtype param for incidence_matrix kwarg-only.

### DIFF
--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -8,7 +8,7 @@ __all__ = ["incidence_matrix", "adjacency_matrix"]
 
 @nx._dispatch(edge_attrs="weight")
 def incidence_matrix(
-    G, nodelist=None, edgelist=None, oriented=False, weight=None, dtype=None
+    G, nodelist=None, edgelist=None, oriented=False, weight=None, *, dtype=None
 ):
     """Returns incidence matrix of G.
 


### PR DESCRIPTION
Followup to #6725 . Proposal to make the newly added (in v3.2) `dtype` parameter to `incidence_matrix` keyword-only.