### PR TITLE
Make label_attribute param of join_trees kwarg-only.

### DIFF
--- a/networkx/algorithms/tree/operations.py
+++ b/networkx/algorithms/tree/operations.py
@@ -31,7 +31,7 @@ def join(rooted_trees, label_attribute=None):
     return join_trees(rooted_trees, label_attribute=label_attribute)
 
 
-def join_trees(rooted_trees, label_attribute=None):
+def join_trees(rooted_trees, *, label_attribute=None):
     """Returns a new rooted tree made by joining `rooted_trees`
 
     Constructs a new tree by joining each tree in `rooted_trees`.

--- a/networkx/algorithms/tree/tests/test_operations.py
+++ b/networkx/algorithms/tree/tests/test_operations.py
@@ -34,7 +34,7 @@ def test_basic():
     """Joining multiple subtrees at a root node."""
     trees = [(nx.full_rary_tree(2, 2**2 - 1), 0) for i in range(2)]
     label_attribute = "old_values"
-    actual = nx.join_trees(trees, label_attribute)
+    actual = nx.join_trees(trees, label_attribute=label_attribute)
     expected = nx.full_rary_tree(2, 2**3 - 1)
     assert nx.is_isomorphic(actual, expected)
     assert _check_label_attribute(trees, actual, label_attribute)


### PR DESCRIPTION
Followup to #6908 . A proposal to make the `label_attribute` parameter of `join_trees` keyword-only. 