### PR TITLE
DOC: Misc typos.

### DIFF
--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -43,6 +43,7 @@ Algebraic Connectivity
    algebraic_connectivity
    fiedler_vector
    spectral_ordering
+   spectral_bisection
 
 Attribute Matrices
 ------------------

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -383,7 +383,7 @@ def power(G, k):
     >>> list(nx.power(G, 3).edges)
     [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
 
-    The `k`th power of a cycle graph on *n* nodes is the complete graph
+    The `k`\ th power of a cycle graph on *n* nodes is the complete graph
     on *n* nodes, if `k` is at least ``n // 2``:
 
     >>> G = nx.cycle_graph(5)

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -632,7 +632,7 @@ def spectral_bisection(
         See :ref:`Randomness<randomness>`.
 
     Returns
-    --------
+    -------
     bisection : tuple of sets
         Sets with the bisection of nodes
 


### PR DESCRIPTION
Interpreted text don't like trailing text (unless it is some limited set of character. It renders incorrectly in docs.

Also a too long underline that triggers a Numpydoc warning

And `spectral_bisection` to `doc/reference/linalg.rst`
