### PR TITLE
Fixing typo in effective_size documentation

### DIFF
--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -56,7 +56,7 @@ def effective_size(G, nodes=None, weight=None):
     The *effective size* of a node's ego network is based on the concept
     of redundancy. A person's ego network has redundancy to the extent
     that her contacts are connected to each other as well. The
-    nonredundant part of a person's relationships it's the effective
+    nonredundant part of a person's relationships is the effective
     size of her ego network [1]_.  Formally, the effective size of a
     node $u$, denoted $e(u)$, is defined by
 


### PR DESCRIPTION
Fixing very small typo in the explanation of `effective_size`