### PR TITLE
Handle edge cases for greedy_modularity_communities

### DIFF
--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -309,6 +309,9 @@ def greedy_modularity_communities(
     .. [4] Newman, M. E. J."Analysis of weighted networks"
        Physical Review E 70(5 Pt 2):056131, 2004.
     """
+    if not G.size():
+        return [{n} for n in G]
+
     if (cutoff < 1) or (cutoff > G.number_of_nodes()):
         raise ValueError(f"cutoff must be between 1 and {len(G)}. Got {cutoff}.")
     if best_n is not None:

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -331,3 +331,10 @@ def test_best_n():
     best_n = 1
     expected = [frozenset(range(13))]
     assert greedy_modularity_communities(G, best_n=best_n) == expected
+
+
+def test_greedy_modularity_communities_corner_cases():
+    G = nx.empty_graph()
+    assert nx.community.greedy_modularity_communities(G) == []
+    G.add_nodes_from(range(3))
+    assert nx.community.greedy_modularity_communities(G) == [{0}, {1}, {2}]


### PR DESCRIPTION
Hi, This fork addresses issue https://github.com/networkx/networkx/issues/5562 using the solution proposed by [dschult](https://github.com/dschult) in the issue discussion. But like [j-hap](https://github.com/j-hap) mentions the error still gets thrown by any downstream functions like `networkx.algorithms.community.quality.modularity` that the result gets passed to.

If there are any changes that need to be made, I'd be happy to add those to my PR

Closes #5562 