### PR TITLE
feat: docstring examples for algorithms/operators/all.py

### DIFF
--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -50,6 +50,20 @@ def union_all(graphs, rename=()):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
 
+    Example: (Note that graphs have to be disjoint)
+    >> # Initializing two graphs
+    >> G1 = nx.Graph()
+    >> G2 = nx.Graph()
+    >> 
+    >> # Adding edges
+    >> G1.add_edges_from([(1, 2), (2, 3)])
+    >> G2.add_edges_from([(4, 5), (5, 6)])
+    >> 
+    >> # Finding union of G1 and G2
+    >> result_graph = union_all([G1, G2])
+    >> print("Nodes:", result_graph.nodes())
+    >> print("Edges:", result_graph.edges())
+
     See Also
     --------
     union

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -56,7 +56,7 @@ def union_all(graphs, rename=()):
     >>> G2 = nx.Graph([(4, 5), (5, 6)])
     >>> result_graph = union_all([G1, G2])
     >>> result_graph.nodes()
-    [1, 2, 3, 4, 5, 6]
+    NodeView((1, 2, 3, 4, 5, 6))
     >>> result_graph.edges()
     EdgeView([(1, 2), (2, 3), (4, 5), (5, 6)])
 

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -138,6 +138,18 @@ def disjoint_union_all(graphs):
     NetworkXError
         In case of mixed type graphs, like MultiGraph and Graph, or directed and undirected graphs.
 
+    Example
+    -------
+    >>> G1 = nx.Graph()
+    >>> G1.add_edges_from([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph()
+    >>> G2.add_edges_from([(4, 5), (5, 6)])
+    >>> U = disjoint_union_all([G1, G2])
+    >>> list(U.nodes())
+    [0, 1, 2, 3, 4, 5]
+    >>> list(U.edges())
+    [(0, 1), (1, 2), (3, 4), (4, 5)]
+
     Notes
     -----
     For operating on mixed type graphs, they should be converted to the same type.
@@ -181,6 +193,18 @@ def compose_all(graphs):
 
     NetworkXError
         In case of mixed type graphs, like MultiGraph and Graph, or directed and undirected graphs.
+
+    Example
+    -------
+    >>> G1 = nx.Graph()
+    >>> G1.add_edges_from([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph()
+    >>> G2.add_edges_from([(3, 4), (5, 6)])
+    >>> C = compose_all([G1, G2])
+    >>> list(C.nodes())
+    [1, 2, 3, 4, 5, 6]
+    >>> list(C.edges())
+    [(1, 2), (2, 3), (3, 4), (5, 6)]
 
     Notes
     -----
@@ -258,6 +282,18 @@ def intersection_all(graphs):
     >>> nx.set_node_attributes(gh, new_node_attr, 'new_capacity')
     >>> gh.nodes(data=True)
     NodeDataView({0: {'new_capacity': 2}, 1: {'new_capacity': 3}})
+
+    Example
+    -------
+    >>> G1 = nx.Graph()
+    >>> G1.add_edges_from([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph()
+    >>> G2.add_edges_from([(2, 3), (3, 4)])
+    >>> R = intersection_all([G1, G2])
+    >>> list(R.nodes())
+    [2, 3]
+    >>> list(R.edges())
+    [(2, 3)]
 
     """
     R = None

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -54,7 +54,7 @@ def union_all(graphs, rename=()):
     --------
     >>> G1 = nx.Graph([(1, 2), (2, 3)])
     >>> G2 = nx.Graph([(4, 5), (5, 6)])
-    >>> result_graph = union_all([G1, G2])
+    >>> result_graph = nx.union_all([G1, G2])
     >>> result_graph.nodes()
     NodeView((1, 2, 3, 4, 5, 6))
     >>> result_graph.edges()
@@ -139,7 +139,7 @@ def disjoint_union_all(graphs):
     -------
     >>> G1 = nx.Graph([(1, 2), (2, 3)])
     >>> G2 = nx.Graph([(4, 5), (5, 6)])
-    >>> U = disjoint_union_all([G1, G2])
+    >>> U = nx.disjoint_union_all([G1, G2])
     >>> list(U.nodes())
     [0, 1, 2, 3, 4, 5]
     >>> list(U.edges())
@@ -193,7 +193,7 @@ def compose_all(graphs):
     -------
     >>> G1 = nx.Graph([(1, 2), (2, 3)])
     >>> G2 = nx.Graph([(3, 4), (5, 6)])
-    >>> C = compose_all([G1, G2])
+    >>> C = nx.compose_all([G1, G2])
     >>> list(C.nodes())
     [1, 2, 3, 4, 5, 6]
     >>> list(C.edges())
@@ -280,7 +280,7 @@ def intersection_all(graphs):
     -------
     >>> G1 = nx.Graph([(1, 2), (2, 3)])
     >>> G2 = nx.Graph([(2, 3), (3, 4)])
-    >>> R = intersection_all([G1, G2])
+    >>> R = nx.intersection_all([G1, G2])
     >>> list(R.nodes())
     [2, 3]
     >>> list(R.edges())

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -55,17 +55,13 @@ def union_all(graphs, rename=()):
     >> # Initializing two graphs
     >> G1 = nx.Graph()
     >> G2 = nx.Graph()
-    >> 
     >> # Adding edges
     >> G1.add_edges_from([(1, 2), (2, 3)])
     >> G2.add_edges_from([(4, 5), (5, 6)])
-    >> 
     >> # Finding union of G1 and G2
     >> result_graph = union_all([G1, G2])
     >> print("Nodes:", result_graph.nodes())
     Nodes: [1, 2, 3, 4, 5, 6]
-    >> print("Edges:", result_graph.edges())
-    Edges: [(1, 2), (2, 3), (4, 5), (5, 6)]
 
     See Also
     --------

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -50,7 +50,8 @@ def union_all(graphs, rename=()):
     If a graph attribute is present in multiple graphs, then the value
     from the last graph in the list with that attribute is used.
 
-    Example: (Note that graphs have to be disjoint)
+    Examples
+    --------
     >> # Initializing two graphs
     >> G1 = nx.Graph()
     >> G2 = nx.Graph()
@@ -62,7 +63,9 @@ def union_all(graphs, rename=()):
     >> # Finding union of G1 and G2
     >> result_graph = union_all([G1, G2])
     >> print("Nodes:", result_graph.nodes())
+    Nodes: [1, 2, 3, 4, 5, 6]
     >> print("Edges:", result_graph.edges())
+    Edges: [(1, 2), (2, 3), (4, 5), (5, 6)]
 
     See Also
     --------

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -52,16 +52,13 @@ def union_all(graphs, rename=()):
 
     Examples
     --------
-    >> # Initializing two graphs
-    >> G1 = nx.Graph()
-    >> G2 = nx.Graph()
-    >> # Adding edges
-    >> G1.add_edges_from([(1, 2), (2, 3)])
-    >> G2.add_edges_from([(4, 5), (5, 6)])
-    >> # Finding union of G1 and G2
-    >> result_graph = union_all([G1, G2])
-    >> print("Nodes:", result_graph.nodes())
-    Nodes: [1, 2, 3, 4, 5, 6]
+    >>> G1 = nx.Graph([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph([(4, 5), (5, 6)])
+    >>> result_graph = union_all([G1, G2])
+    >>> result_graph.nodes()
+    [1, 2, 3, 4, 5, 6]
+    >>> result_graph.edges()
+    EdgeView([(1, 2), (2, 3), (4, 5), (5, 6)])
 
     See Also
     --------
@@ -140,10 +137,8 @@ def disjoint_union_all(graphs):
 
     Example
     -------
-    >>> G1 = nx.Graph()
-    >>> G1.add_edges_from([(1, 2), (2, 3)])
-    >>> G2 = nx.Graph()
-    >>> G2.add_edges_from([(4, 5), (5, 6)])
+    >>> G1 = nx.Graph([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph([(4, 5), (5, 6)])
     >>> U = disjoint_union_all([G1, G2])
     >>> list(U.nodes())
     [0, 1, 2, 3, 4, 5]
@@ -196,10 +191,8 @@ def compose_all(graphs):
 
     Example
     -------
-    >>> G1 = nx.Graph()
-    >>> G1.add_edges_from([(1, 2), (2, 3)])
-    >>> G2 = nx.Graph()
-    >>> G2.add_edges_from([(3, 4), (5, 6)])
+    >>> G1 = nx.Graph([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph([(3, 4), (5, 6)])
     >>> C = compose_all([G1, G2])
     >>> list(C.nodes())
     [1, 2, 3, 4, 5, 6]
@@ -285,10 +278,8 @@ def intersection_all(graphs):
 
     Example
     -------
-    >>> G1 = nx.Graph()
-    >>> G1.add_edges_from([(1, 2), (2, 3)])
-    >>> G2 = nx.Graph()
-    >>> G2.add_edges_from([(2, 3), (3, 4)])
+    >>> G1 = nx.Graph([(1, 2), (2, 3)])
+    >>> G2 = nx.Graph([(2, 3), (3, 4)])
     >>> R = intersection_all([G1, G2])
     >>> list(R.nodes())
     [2, 3]


### PR DESCRIPTION

[DOC]:
Added docstring example for `union_all` in algorithms/operators/all.py
