### PR TITLE
Fix a reference

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -433,8 +433,8 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
 
     References
     ----------
-    .. [1] Dorogotsev S.N., Goltsev A.V., and Mendes J.F.F "Pseudofractal
-       Scale-free Web". arXiv:cond-mat/0112143
+    .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes,
+        "Pseudofractal scale-free web", Physical Review E 65, 066122, 2002.
     """
     G = empty_graph(0, create_using)
     if G.is_directed():

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -435,6 +435,7 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     ----------
     .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes,
         "Pseudofractal scale-free web", Physical Review E 65, 066122, 2002.
+        https://arxiv.org/pdf/cond-mat/0112143.pdf
     """
     G = empty_graph(0, create_using)
     if G.is_directed():


### PR DESCRIPTION
Fix a reference from `dorogovtsev_goltsev_mendes_graph`.
Fixes a spelling error in one of the author's names and now refers to published article instead of arXiv.