### PR TITLE
Update graph parameter in community algorithms

### DIFF
--- a/networkx/algorithms/community/kernighan_lin.py
+++ b/networkx/algorithms/community/kernighan_lin.py
@@ -56,6 +56,7 @@ def kernighan_lin_bisection(G, partition=None, max_iter=10, weight="weight", see
     Parameters
     ----------
     G : graph
+        Graph must be undirected and not multigraph.
 
     partition : tuple
         Pair of iterables containing an initial partition. If not

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -371,6 +371,7 @@ def naive_greedy_modularity_communities(G, resolution=1, weight=None):
     Parameters
     ----------
     G : NetworkX graph
+        Graph must be undirected and not multigraph.
 
     resolution : float (default=1)
         If resolution is less than 1, modularity favors larger communities.


### PR DESCRIPTION
Task 3: Fix an issue in the NetworkX codebase

Some of the community algorithms like kernighan_lin_bisection, and
 naive_greedy_modularity_communities are only implemented for certain
 types of graphs (undirected, not multigraph). The documentation is 
updated to reflect the same.
ping; #6849
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
