### PR TITLE
Update developer deprecation todo list

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,7 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.0
 ~~~~~~~~~~~
 
-* In ``convert_matrix.py`` remove ``order`` kwarg from ``to_pandas_edgelist`` and docstring
 * In ``algorithms/operators/binary.py`` remove ``name`` kwarg from ``union`` and docstring.
 * In ``algorithms/link_analysis/pagerank_alg.py``, remove the
   ``np.asmatrix`` wrappers on the return values of ``google_matrix`` and remove

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -41,12 +41,9 @@ Todo
 
 Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
-Version 3.2
-~~~~~~~~~~~
-* Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723
-
 Version 3.3
 ~~~~~~~~~~~
+* Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723
 * Remove the ``forest_str`` function from ``readwrite/text.py``. Replace
   existing usages with ``write_network_text``.
 * Change ``single_target_shortest_path_length`` in ``algorithms/shortest_path/unweighted.py``

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,7 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.0
 ~~~~~~~~~~~
 
-* In ``algorithms/distance_measures.py`` remove ``extrema_bounding``.
 * In ``algorithms/matching.py``, remove parameter ``maxcardinality`` from ``min_weight_matching``.
 
 

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -41,12 +41,6 @@ Todo
 
 Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
-Version 3.0
-~~~~~~~~~~~
-
-* In ``algorithms/matching.py``, remove parameter ``maxcardinality`` from ``min_weight_matching``.
-
-
 Version 3.2
 ~~~~~~~~~~~
 * Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,9 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.0
 ~~~~~~~~~~~
 
-* In ``linalg/attrmatrix.py`` remove the FutureWarning, update the
-  return type by removing ``np.asmatrix``, and update the docstring to
-  reflect that the function returns a ``numpy.ndarray`` instance.
 * In ``algorithms/distance_measures.py`` remove ``extrema_bounding``.
 * In ``algorithms/matching.py``, remove parameter ``maxcardinality`` from ``min_weight_matching``.
 

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,7 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.0
 ~~~~~~~~~~~
 
-* Remove ``copy`` method in the coreview Filtered-related classes and related tests.
 * In ``convert_matrix.py`` remove ``order`` kwarg from ``to_pandas_edgelist`` and docstring
 * In ``algorithms/operators/binary.py`` remove ``name`` kwarg from ``union`` and docstring.
 * In ``algorithms/link_analysis/pagerank_alg.py``, remove the

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,9 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.0
 ~~~~~~~~~~~
 
-* In ``algorithms/link_analysis/pagerank_alg.py``, remove the
-  ``np.asmatrix`` wrappers on the return values of ``google_matrix`` and remove
-  the associated FutureWarning.
 * In ``linalg/attrmatrix.py`` remove the FutureWarning, update the
   return type by removing ``np.asmatrix``, and update the docstring to
   reflect that the function returns a ``numpy.ndarray`` instance.

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,8 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.2
 ~~~~~~~~~~~
 * Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723
-* Remove renamed function ``join()`` in ``algorithms/tree/operations.py`` and
-  in ``doc/reference/algorithms/trees.rst``
 
 Version 3.3
 ~~~~~~~~~~~
@@ -64,3 +62,5 @@ Version 3.4
 * Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
 * Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.
 * Remove ``normalized`` kwarg from ``algorithms.s_metric``
+* Remove renamed function ``join()`` in ``algorithms/tree/operations.py`` and
+  in ``doc/reference/algorithms/trees.rst``

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -45,8 +45,6 @@ Version 3.0
 ~~~~~~~~~~~
 
 * Remove ``copy`` method in the coreview Filtered-related classes and related tests.
-* In ``algorithms/link_analysis/pagerank_alg.py`` replace ``pagerank`` with ``pagerank_scipy``.
-* In ``algorithms/link_analysis/pagerank_alg.py`` rename ``pagerank_numpy`` as ``_pagerank_numpy``.
 * In ``convert_matrix.py`` remove ``order`` kwarg from ``to_pandas_edgelist`` and docstring
 * In ``algorithms/operators/binary.py`` remove ``name`` kwarg from ``union`` and docstring.
 * In ``algorithms/link_analysis/pagerank_alg.py``, remove the

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,7 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.0
 ~~~~~~~~~~~
 
-* In ``algorithms/operators/binary.py`` remove ``name`` kwarg from ``union`` and docstring.
 * In ``algorithms/link_analysis/pagerank_alg.py``, remove the
   ``np.asmatrix`` wrappers on the return values of ``google_matrix`` and remove
   the associated FutureWarning.


### PR DESCRIPTION
I added a link to the removal in the commit message for each documentation update.

The only remaining issue is what to do about pydot. For now, I just moved the note to the next release and we can discuss it later.