### PR TITLE
Use trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Build Wheel and Release
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: "3.11"
+
+      - name: Build wheels
+        run: |
+          git clean -fxd
+          pip install -U build twine wheel
+          python -m build --sdist --wheel
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,12 @@ name: Build Wheel and Release
 on:
   push:
     tags:
-      - v*
+      - networkx-*
 
 jobs:
   pypi-publish:
     name: upload release to PyPI
+    if: github.repository_owner == 'networkx' && startsWith(github.ref, 'refs/tags/networkx-') && github.actor == 'jarrodmillman' && always()
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release

--- a/doc/developer/release.rst
+++ b/doc/developer/release.rst
@@ -50,22 +50,6 @@ Release Process
 
    https://github.com/networkx/networkx/tags
 
-- Pin badges in ``README.rst``::
-
-  - https://github.com/networkx/networkx/workflows/test/badge.svg?tag=networkx-<major>.<minor>
-  - https://github.com/networkx/networkx/actions?query=branch%3Anetworkx-<major>.<minor>
-
-- Publish on PyPi::
-
-   git clean -fxd
-   pip install -r requirements/release.txt
-   python -m build --sdist --wheel
-   twine upload -s dist/*
-
-- Unpin badges in ``README.rst``::
-
-   git restore README.rst 
-
 - Update documentation on the web:
   The documentation is kept in a separate repo: networkx/documentation
 


### PR DESCRIPTION
I enabled GH as a trusted publisher for PyPI:
![2023-10-05T08:13:43,311731019-07:00](https://github.com/networkx/networkx/assets/123428/09cde9ba-1d46-44c6-80c5-afb199e3e746)
