### PR TITLE
Fix definition of $m$ parameter in docstring of `modularity` function

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -152,9 +152,10 @@ def modularity(G, communities, weight="weight", resolution=1):
         Q = \frac{1}{2m} \sum_{ij} \left( A_{ij} - \gamma\frac{k_ik_j}{2m}\right)
             \delta(c_i,c_j)
 
-    where $m$ is the number of edges, $A$ is the adjacency matrix of `G`,
-    $k_i$ is the degree of $i$, $\gamma$ is the resolution parameter,
-    and $\delta(c_i, c_j)$ is 1 if $i$ and $j$ are in the same community else 0.
+    where $m$ is the sum of the weights of the links in the network, $A$ is the
+    adjacency matrix of `G`, $k_i$ is the degree of $i$, $\gamma$ is the
+    resolution parameter, and $\delta(c_i, c_j)$ is 1 if $i$ and $j$ are in the
+    same community else 0.
 
     According to [2]_ (and verified by some algebra) this can be reduced to
 

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -152,8 +152,8 @@ def modularity(G, communities, weight="weight", resolution=1):
         Q = \frac{1}{2m} \sum_{ij} \left( A_{ij} - \gamma\frac{k_ik_j}{2m}\right)
             \delta(c_i,c_j)
 
-    where $m$ is the sum of the weights of the links in the network (as defined
-    in [5]_), $A$ is the adjacency matrix of `G`, $k_i$ is the degree of $i$,
+    where $m$ is the number of edges (or sum of all edge weights as in [5]_),
+    $A$ is the adjacency matrix of `G`, $k_i$ is the (weighted) degree of $i$,
     $\gamma$ is the resolution parameter, and $\delta(c_i, c_j)$ is 1 if $i$ and
     $j$ are in the same community else 0.
 

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -223,7 +223,10 @@ def modularity(G, communities, weight="weight", resolution=1):
     .. [4] M. E. J. Newman, "Equivalence between modularity optimization and
        maximum likelihood methods for community detection"
        Phys. Rev. E 94, 052315, 2016. https://doi.org/10.1103/PhysRevE.94.052315
-
+    .. [5] Blondel, V.D. et al. "Fast unfolding of communities in large
+       networks" J. Stat. Mech 10008, 1-12 (2008).
+       https://doi.org/10.1088/1742-5468/2008/10/P10008
+       
     """
     if not isinstance(communities, list):
         communities = list(communities)

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -226,7 +226,6 @@ def modularity(G, communities, weight="weight", resolution=1):
     .. [5] Blondel, V.D. et al. "Fast unfolding of communities in large
        networks" J. Stat. Mech 10008, 1-12 (2008).
        https://doi.org/10.1088/1742-5468/2008/10/P10008
-       
     """
     if not isinstance(communities, list):
         communities = list(communities)

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -152,10 +152,10 @@ def modularity(G, communities, weight="weight", resolution=1):
         Q = \frac{1}{2m} \sum_{ij} \left( A_{ij} - \gamma\frac{k_ik_j}{2m}\right)
             \delta(c_i,c_j)
 
-    where $m$ is the sum of the weights of the links in the network, $A$ is the
-    adjacency matrix of `G`, $k_i$ is the degree of $i$, $\gamma$ is the
-    resolution parameter, and $\delta(c_i, c_j)$ is 1 if $i$ and $j$ are in the
-    same community else 0.
+    where $m$ is the sum of the weights of the links in the network (as defined
+    in [5]_), $A$ is the adjacency matrix of `G`, $k_i$ is the degree of $i$,
+    $\gamma$ is the resolution parameter, and $\delta(c_i, c_j)$ is 1 if $i$ and
+    $j$ are in the same community else 0.
 
     According to [2]_ (and verified by some algebra) this can be reduced to
 


### PR DESCRIPTION
Hello!

The docstring for the `modularity` function (`networkx/algorithms/community/quality.py`) states that:

>  $m$ is the number of edges

This is incorrect, as the function itself defines `m` as:

```python
out_degree = in_degree = dict(G.degree(weight=weight))
deg_sum = sum(out_degree.values()) # Sum of all weights in G!
m = deg_sum / 2 # Divide by two to account for mirrors
```

in the undirected case (same goes for the directed case, except because it uses `G.in_degrees`/`G.out_degrees`).

I therefore corrected the docstring and cited [this paper](https://arxiv.org/abs/cond-mat/0408187) exactly as it appears in `networkx/algorithms/community/louvain.py`.