### PR TITLE
CI: Pin scientific-python/upload-nightly-action to 0.2.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: List contents of wheel
         run: python -m zipfile --list dist/networkx-*.whl
       - name: Upload nighlty wheel
-        uses: scientific-python/upload-nightly-action@main
+        uses: scientific-python/upload-nightly-action@5fb764c5bce1ac2297084c0f7161b1919f17c74f # 0.2.0
         with:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_NIGHTLY }}
           artifacts_path: dist/


### PR DESCRIPTION
## PR Summary

The [`scientific-python/upload-nightly-action`](https://github.com/scientific-python/upload-nightly-action/) action has received stability updates in [`0.2.0`](https://github.com/scientific-python/upload-nightly-action/releases/tag/0.2.0) that provide a reproducible runtime environment for the action, which should mitigate issues with stability.

Using stable known releases provides additional protection from service disruption incidents (like https://github.com/scientific-python/upload-nightly-action/issues/43). Future releases will get picked up automatically by Dependabot

https://github.com/networkx/networkx/blob/364e20eca8f270b9d364fab7f73ea63338790d98/.github/dependabot.yml#L2-L8
