### PR TITLE
added note for the triangle inequality case in TSP

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -225,9 +225,9 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
     Then each edge on the new complete graph used for that analysis is
     replaced by the shortest_path between those nodes on the original graph.
     If the input graph `G` includes edges with weights that do not adhere to
-    the triangle inequality, such as when `G` is not a complete graph(i.e
+    the triangle inequality, such as when `G` is not a complete graph (i.e
     length of non-existent edges is infinity), then the returned path may
-    contain some repeating nodes(other than the starting node).
+    contain some repeating nodes (other than the starting node).
 
     Parameters
     ----------

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -223,7 +223,8 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
     accommodate the structure of the original graph. If `cycle` is ``False``,
     the biggest weight edge is removed to make a Hamiltonian path.
     Then each edge on the new complete graph used for that analysis is
-    replaced by the shortest_path between those nodes on the original graph.
+    replaced by the shortest_path between those nodes on the original graph.(Note: If the graph contains any triangle inequalities then it might return a minimal approximate cycle with repeating nodes(other than the starting node).)
+
 
     Parameters
     ----------

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -223,8 +223,7 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
     accommodate the structure of the original graph. If `cycle` is ``False``,
     the biggest weight edge is removed to make a Hamiltonian path.
     Then each edge on the new complete graph used for that analysis is
-    replaced by the shortest_path between those nodes on the original graph.(Note: If the graph contains any triangle inequalities then it might return a minimal approximate cycle with repeating nodes(other than the starting node).)
-
+    replaced by the shortest_path between those nodes on the original graph.
 
     Parameters
     ----------
@@ -266,12 +265,17 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
         List of nodes in `G` along a path with an approximation of the minimal
         path through `nodes`.
 
-
     Raises
     ------
     NetworkXError
         If `G` is a directed graph it has to be strongly connected or the
         complete version cannot be generated.
+
+    Notes
+    -----
+    If the input graph `G` contains edges whose weights do not satisfy the
+    triangle inequality, then the returned path may contain repeating nodes
+    (other than the starting node).
 
     Examples
     --------

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -224,6 +224,10 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
     the biggest weight edge is removed to make a Hamiltonian path.
     Then each edge on the new complete graph used for that analysis is
     replaced by the shortest_path between those nodes on the original graph.
+    If the input graph `G` includes edges with weights that do not adhere to
+    the triangle inequality, such as when `G` is not a complete graph(i.e
+    length of non-existent edges is infinity), then the returned path may
+    contain some repeating nodes(other than the starting node).
 
     Parameters
     ----------
@@ -270,12 +274,6 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
     NetworkXError
         If `G` is a directed graph it has to be strongly connected or the
         complete version cannot be generated.
-
-    Notes
-    -----
-    If the input graph `G` contains edges whose weights do not satisfy the
-    triangle inequality, then the returned path may contain repeating nodes
-    (other than the starting node).
 
     Examples
     --------


### PR DESCRIPTION
Closes #6748

Added the following note in the docstring of `traveling_salesman_problem()` function:
```
(Note: If the graph contains any triangle inequalities then it might return a minimal 
approximate cycle with repeating nodes(other than the starting node).)
```
should we also put a warning message here? because TSP makes sense only for valid graphs, without triangle inequalities. Please let me know what you think.

Thank you :)