### PR TITLE
Fix typos

### DIFF
--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -69,7 +69,7 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None, weight=None
     -------
     nodes : dictionary
        Dictionary of nodes with eigenvector centrality as the value. The
-       associated vector has unit Euclidian norm and the values are
+       associated vector has unit Euclidean norm and the values are
        nonegative.
 
     Examples
@@ -248,7 +248,7 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     -------
     nodes : dictionary
        Dictionary of nodes with eigenvector centrality as the value. The
-       associated vector has unit Euclidian norm and the values are
+       associated vector has unit Euclidean norm and the values are
        nonegative.
 
     Examples

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -65,7 +65,7 @@ def test_undirected_selfloops():
     partition = nx.community.louvain_communities(G, seed=2, weight="weight")
     assert part != partition
 
-    # small self-loop weights arent enough to impact partition in this graph
+    # small self-loop weights aren't enough to impact partition in this graph
     partition = nx.community.louvain_communities(G, seed=2, weight=None)
     assert part == partition
 
@@ -94,7 +94,7 @@ def test_directed_selfloops():
     G_partition = nx.community.louvain_communities(G, seed=123, weight="weight")
     assert G_partition != G_expected_partition
 
-    # small self-loop weights arent enough to impact partition in this graph
+    # small self-loop weights aren't enough to impact partition in this graph
     G_partition = nx.community.louvain_communities(G, seed=123, weight=None)
     assert G_partition == G_expected_partition
 

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -671,7 +671,7 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
 
     # Expand the given top-level blossom.
     def expandBlossom(b, endstage):
-        # This is an obnoxiously complicated recusive function for the sake of
+        # This is an obnoxiously complicated recursive function for the sake of
         # a stack-transformation.  So, we hack around the complexity by using
         # a trampoline pattern.  By yielding the arguments to each recursive
         # call, we keep the actual callstack flat.
@@ -787,7 +787,7 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
     # between vertex v and the base vertex. Keep blossom bookkeeping
     # consistent.
     def augmentBlossom(b, v):
-        # This is an obnoxiously complicated recusive function for the sake of
+        # This is an obnoxiously complicated recursive function for the sake of
         # a stack-transformation.  So, we hack around the complexity by using
         # a trampoline pattern.  By yielding the arguments to each recursive
         # call, we keep the actual callstack flat.

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -612,7 +612,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
     def test_zero_cycle(self):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         G.add_edge(2, 3, weight=-4)
-        # check that zero cycle doesnt raise
+        # check that zero cycle doesn't raise
         nx.goldberg_radzik(G, 1)
         nx.bellman_ford_predecessor_and_distance(G, 1)
 

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -324,7 +324,7 @@ class Edmonds:
 
         import warnings
 
-        msg = "Edmonds has been deprecated and will be removed in NetworkX 3.4. Please use the approiate minimum or maximum branching or arborescence function directly."
+        msg = "Edmonds has been deprecated and will be removed in NetworkX 3.4. Please use the appropriate minimum or maximum branching or arborescence function directly."
         warnings.warn(msg, DeprecationWarning)
 
     def _init(self, attr, default, kind, style, preserve_attrs, seed, partition):
@@ -847,7 +847,7 @@ def maximum_branching(
 
     # These are the buckets from the paper.
     #
-    # In the paper, G^i are modifed versions of the original graph.
+    # In the paper, G^i are modified versions of the original graph.
     # D^i and E^i are the nodes and edges of the maximal edges that are
     # consistent with G^i. In this implementation, D^i and E^i are stored
     # together as the graph B^i. We will have strictly more B^i then the
@@ -930,7 +930,7 @@ def maximum_branching(
 
     def edmonds_step_I2(v, desired_edge, level):
         """
-        Perfrom step I2 from Edmonds' paper
+        Perform step I2 from Edmonds' paper
 
         First, check if the last step I1 created a cycle. If it did not, do nothing.
         If it did, store the cycle for later reference and contract it.
@@ -1117,8 +1117,8 @@ def maximum_branching(
 
         # The current level is i, and we start counting from 0.
         #
-        # We need the node at level i+1 that resuilts from merging a circuit
-        # at level i. basename_0 is the first merged node and this happends
+        # We need the node at level i+1 that results from merging a circuit
+        # at level i. basename_0 is the first merged node and this happens
         # at level 1. That is basename_0 is a node at level 1 that results
         # from merging a circuit at level 0.
 

--- a/networkx/generators/time_series.py
+++ b/networkx/generators/time_series.py
@@ -27,7 +27,7 @@ def visibility_graph(series):
     Parameters
     ----------
     series : Sequence[Number]
-       A Time Series sequence (iterable and slicable) of numeric values
+       A Time Series sequence (iterable and sliceable) of numeric values
        representing times.
 
     Returns

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -179,7 +179,7 @@ class _dispatch:
         If a string, ``edge_attrs`` holds the function argument name that
         indicates a single edge attribute to include in the converted graph.
         The default value for this attribute is 1. To indicate that an argument
-        is a list of attributes (all with deafult value 1), use e.g. ``"[attrs]"``.
+        is a list of attributes (all with default value 1), use e.g. ``"[attrs]"``.
         If a dict, ``edge_attrs`` holds a dict keyed by argument names, with
         values that are either the default value or, if a string, the argument
         name that indicates the default value.


### PR DESCRIPTION
Found via `codespell -L
ans,wth,nd,ist,dout,coo,childs,nin,ded,ons,nam,perfor,malins,stoer,mis,abritrary,commun,ser,te,equil,numer,thi,clos,infor,hax,pich,inout,alledges`

<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
