### PR TITLE
Fix ```is_k_edge_connected``` for case of k=2

### DIFF
--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -68,7 +68,7 @@ def is_k_edge_connected(G, k):
         if k == 1:
             return nx.is_connected(G)
         elif k == 2:
-            return not nx.has_bridges(G)
+            return nx.is_connected(G) and not nx.has_bridges(G)
         else:
             return nx.edge_connectivity(G, cutoff=k) >= k
 

--- a/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
+++ b/networkx/algorithms/connectivity/tests/test_edge_augmentation.py
@@ -75,6 +75,11 @@ def test_is_k_edge_connected():
     assert is_k_edge_connected(G, k=3)
     assert is_k_edge_connected(G, k=4)
 
+    G = nx.compose(nx.complete_graph([0, 1, 2]), nx.complete_graph([3, 4, 5]))
+    assert not is_k_edge_connected(G, k=1)
+    assert not is_k_edge_connected(G, k=2)
+    assert not is_k_edge_connected(G, k=3)
+
 
 def test_is_k_edge_connected_exceptions():
     pytest.raises(


### PR DESCRIPTION
Add call to ```is_connected``` in addition to ```has_bridges``` for k=2, to catch multi-component graphs without bridges, which are not not 2-edge-connected.

Fixes #7023
