### PR TITLE
Fix triangles to avoid using `is` to compare nodes

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -72,7 +72,7 @@ def triangles(G, nodes=None):
     # iterate over the nodes in a graph
     for node, neighbors in G.adjacency():
         later_neighbors[node] = {
-            n for n in neighbors if n not in later_neighbors and n is not node
+            n for n in neighbors if n not in later_neighbors and n != node
         }
 
     # instantiate Counter for each node to include isolated nodes

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1363,7 +1363,7 @@ def _simrank_similarity_python(
 
     for its in range(max_iterations):
         oldsim = newsim
-        newsim = {u: {v: sim(u, v) if u is not v else 1 for v in G} for u in G}
+        newsim = {u: {v: sim(u, v) if u != v else 1 for v in G} for u in G}
         is_close = all(
             all(
                 abs(newsim[u][v] - old) <= tolerance * (1 + abs(old))


### PR DESCRIPTION
Fixes #7038 

Using `n is not node` compares whether n and node are the same object, not whether they are equal.
Thanks to a bug report in #7038 we discovered that the string "46" can sometimes be created twice and not [interned](http://guilload.com/python-string-interning/)so that `n is not node` returns True even though both are equal to "46".

The error occurs in `triangles` when ensuring that a node in not included in its list of neighbors (ruling out self-loops).
`n` is the neighbor in question and `node` is the node being checked.  This only goes to prove that "46" is not always the same object as "46". They are the same object if they are interned.

Unfortunately figuring out when interning occurs is quite complicated and it may change. So I could not think of a good test to write for this error.  So, this PR just replaces the idiom `n is not node` with `n != node` which is really how node comparisons should be written always.

I don't think we usually do backports but if we release a 3.2.1 for any reason, we should include this fix. It does not occur in v3.1.