### PR TITLE
fix extendability function name in bipartite.rst

### DIFF
--- a/doc/reference/algorithms/bipartite.rst
+++ b/doc/reference/algorithms/bipartite.rst
@@ -138,5 +138,5 @@ Extendability
 .. autosummary::
    :toctree: generated/
 
-   find_extendability
+   maximal_extendability
 


### PR DESCRIPTION
fix extendability function name in bipartite.rst

The name of the function maximal_extendability in the bipartite docs was not updated from `find_extendability` during PR review. So, the function doesn't show in current docs and creates quiet failures for documentation builds when looking for `find_extendbability`.

This might help e.g. #7040 successfully build the docs, but I am not sure. It should be fixed in any case.