### PR TITLE
Minor doc cleanups to remove doc build warnings

### DIFF
--- a/doc/reference/algorithms/clique.rst
+++ b/doc/reference/algorithms/clique.rst
@@ -11,9 +11,6 @@ Clique
    find_cliques_recursive
    make_max_clique_graph
    make_clique_bipartite
-   graph_clique_number
-   graph_number_of_cliques
    node_clique_number
    number_of_cliques
-   cliques_containing_node
    max_weight_clique

--- a/doc/release/index.rst
+++ b/doc/release/index.rst
@@ -14,7 +14,6 @@ period.
 .. toctree::
    :maxdepth: 2
 
-   release_dev
    release_3.2
    release_3.1
    release_3.0

--- a/networkx/algorithms/bipartite/extendability.py
+++ b/networkx/algorithms/bipartite/extendability.py
@@ -43,7 +43,7 @@ def maximal_extendability(G):
     is the graph obtained from G by directing the edges of M from V to U and the
     edges that do not belong to M from U to V.
 
-    Lemma([1]_):
+    Lemma [1]_ :
     Let M be a perfect matching of `G`. `G` is $k$-extendable if and only if its residual
     graph $G_M$ is strongly connected and there are $k$ vertex-disjoint directed
     paths between every vertex of U and every vertex of V.
@@ -59,9 +59,9 @@ def maximal_extendability(G):
 
     References
     ----------
-    ..[1] "A polynomial algorithm for the extendability problem in bipartite graphs",
+    .. [1] "A polynomial algorithm for the extendability problem in bipartite graphs",
           J. Lakhal, L. Litzler, Information Processing Letters, 1998.
-    ..[2] "On n-extendible graphs", M. D. Plummer, Discrete Mathematics, 31:201–210, 1980
+    .. [2] "On n-extendible graphs", M. D. Plummer, Discrete Mathematics, 31:201–210, 1980
           https://doi.org/10.1016/0012-365X(80)90037-0
 
     """


### PR DESCRIPTION
Similar to #7042 
 * remove the expired clique functions from the refguide to fix the doc build.
 * Fix reference formatting in maximal_extendability docstring
 * Rm `release_dev` from release notes autosummary