### PR TITLE
Disallow negative number of nodes in `complete_multipartite_graph`

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -903,6 +903,9 @@ def complete_multipartite_graph(*subset_sizes):
         subsets = [range(start, end) for start, end in extents]
     except TypeError:
         subsets = subset_sizes
+    else:
+        if any(size < 0 for size in subset_sizes):
+            raise NetworkXError(f"Negative number of nodes not valid: {subset_sizes}")
 
     # add nodes with subset attribute
     # while checking that ints are not mixed with iterables

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -618,3 +618,5 @@ class TestGeneratorClassic:
             for u, v in itertools.product(block1, block2):
                 assert v in G[u]
                 assert G.nodes[u] != G.nodes[v]
+        with pytest.raises(nx.NetworkXError, match="Negative number of nodes"):
+            nx.complete_multipartite_graph(2, -3, 4)


### PR DESCRIPTION
I doubt the current behavior with negative integer inputs to `complete_multipartite_graph` is intended or used anywhere, so let's raise instead.

Adding this check makes my life (and the job of other backend developers) easier, b/c I don't want to reproduce this behavior, nor do I want to handle this as a special case in my otherwise nice test fixture.