### PR TITLE
Hierarchical clustering layout gallery example

### DIFF
--- a/examples/drawing/plot_clusters.py
+++ b/examples/drawing/plot_clusters.py
@@ -1,0 +1,35 @@
+"""
+==============
+Cluster Layout
+==============
+
+This example illustrates how to combine multiple layouts to visualize node
+clusters.
+
+The approach used here can be generalized to visualize hierarchical clustering
+e.g. clusters-of-clusters of nodes by combining layouts with varying scale
+factors.
+"""
+import networkx as nx
+import matplotlib.pyplot as plt
+
+G = nx.davis_southern_women_graph()  # Example graph
+communities = nx.community.greedy_modularity_communities(G)
+
+# Compute positions for the node clusters as if they were themselves nodes in a
+# supergraph using a larger scale factor
+supergraph = nx.cycle_graph(len(communities))
+superpos = nx.spring_layout(G, scale=50, seed=429)
+
+# Use the "supernode" positions as the center of each node cluster
+centers = list(superpos.values())
+pos = {}
+for center, comm in zip(centers, communities):
+    pos.update(nx.spring_layout(nx.subgraph(G, comm), center=center))
+
+# Nodes colored by cluster
+for nodes, clr in zip(communities, ("tab:blue", "tab:orange", "tab:green")):
+    nx.draw_networkx_nodes(G, pos=pos, nodelist=nodes, node_color=clr)
+nx.draw_networkx_edges(G, pos=pos)
+
+plt.show()

--- a/examples/drawing/plot_clusters.py
+++ b/examples/drawing/plot_clusters.py
@@ -25,11 +25,12 @@ superpos = nx.spring_layout(G, scale=50, seed=429)
 centers = list(superpos.values())
 pos = {}
 for center, comm in zip(centers, communities):
-    pos.update(nx.spring_layout(nx.subgraph(G, comm), center=center))
+    pos.update(nx.spring_layout(nx.subgraph(G, comm), center=center, seed=1430))
 
 # Nodes colored by cluster
 for nodes, clr in zip(communities, ("tab:blue", "tab:orange", "tab:green")):
-    nx.draw_networkx_nodes(G, pos=pos, nodelist=nodes, node_color=clr)
+    nx.draw_networkx_nodes(G, pos=pos, nodelist=nodes, node_color=clr, node_size=100)
 nx.draw_networkx_edges(G, pos=pos)
 
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
An alternative to #6923 - adds an example to the gallery with a recipe for visualizing node clusters. This is just a slightly more polished version of [the example I left in #6923](https://github.com/networkx/networkx/pull/6923#issuecomment-1716292391).

The advantage of this approach is that it generalizes to multiple layers of clustering. The example only shows one layer, but if it's preferred I can make sub-clusters within the three communities instead (at the expense of a bit more complexity in the example).

Also, if anyone has suggestions for a better example graph for finding communities, let me know!