### PR TITLE
DEP: Deprecate the all_triplets one-liner.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -63,3 +63,7 @@ Version 3.4
   in ``doc/reference/algorithms/trees.rst``
 * Remove ``strongly_connected_components_recursive`` from
   ``algorithms/components/strongly_connected.py``
+
+Version 3.5
+~~~~~~~~~~~
+* Remove ``all_triplets`` from ``algorithms/triads.py``

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -9,6 +9,12 @@ import pytest
 import networkx as nx
 
 
+def test_all_triplets_deprecated():
+    G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
+    with pytest.deprecated_call():
+        nx.all_triplets(G)
+
+
 def test_triadic_census():
     """Tests the triadic_census function."""
     G = nx.DiGraph()

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -311,6 +311,13 @@ def is_triad(G):
 def all_triplets(G):
     """Returns a generator of all possible sets of 3 nodes in a DiGraph.
 
+    .. deprecated:: 3.3
+
+       all_triplets is deprecated and will be removed in NetworkX version 3.5.
+       Use `itertools.combinations` instead::
+
+          all_triplets = itertools.combinations(G, 3)
+
     Parameters
     ----------
     G : digraph
@@ -328,6 +335,16 @@ def all_triplets(G):
     [(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
 
     """
+    import warnings
+
+    warnings.warn(
+        (
+            "\n\nall_triplets is deprecated and will be rmoved in v3.5.\n"
+            "Use `itertools.combinations(G, 3)` instead."
+        ),
+        category=DeprecationWarning,
+        stacklevel=4,
+    )
     triplets = combinations(G.nodes(), 3)
     return triplets
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -117,6 +117,9 @@ def set_warnings():
         category=DeprecationWarning,
         message="\n\nstrongly_connected_components_recursive",
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\nall_triplets"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Proposal to remove the `triads.all_triplets` function, which is simply an alias for `itertools.combinations(G, 3)`.

`all_triplets` is not even used internally in the `triads` module, so AFAICT there is no special meaning attached to the term "graph triplets" - please correct me if I'm wrong!