### PR TITLE
DEP: Deprecate random_triad

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -67,3 +67,4 @@ Version 3.4
 Version 3.5
 ~~~~~~~~~~~
 * Remove ``all_triplets`` from ``algorithms/triads.py``
+* Remove ``random_triad`` from ``algorithms/triad.py``.

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -15,6 +15,12 @@ def test_all_triplets_deprecated():
         nx.all_triplets(G)
 
 
+def test_random_triad_deprecated():
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    with pytest.deprecated_call():
+        nx.random_triad(G)
+
+
 def test_triadic_census():
     """Tests the triadic_census function."""
     G = nx.DiGraph()

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -547,6 +547,13 @@ def triad_type(G):
 def random_triad(G, seed=None):
     """Returns a random triad from a directed graph.
 
+    .. deprecated:: 3.3
+
+       random_triad is deprecated and will be removed in version 3.5.
+       Use random sampling directly instead::
+
+          G.subgraph(random.sample(list(G), 3))
+
     Parameters
     ----------
     G : digraph
@@ -573,6 +580,17 @@ def random_triad(G, seed=None):
     OutEdgeView([(1, 2)])
 
     """
+    import warnings
+
+    warnings.warn(
+        (
+            "\n\nrandom_triad is deprecated and will be removed in NetworkX v3.5.\n"
+            "Use random.sample instead, e.g.::\n\n"
+            "\tG.subgraph(random.sample(list(G), 3))\n"
+        ),
+        category=DeprecationWarning,
+        stacklevel=5,
+    )
     if len(G) < 3:
         raise nx.NetworkXError(
             f"G needs at least 3 nodes to form a triad; (it has {len(G)} nodes)"

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -130,6 +130,9 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nall_triplets"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\nrandom_triad"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Another proposal for deprecation in the `triads` module. This is another one-liner "helper function". It doesn't appear to have any special meaning w.r.t triadic analysis and isn't used at all internally. The one caveat here though is that unlike "triplets" (see #7060), triads are only defined for directed graphs. In other words, if a user did `nx.subgraph(G, random.sample(list(G), 3))` and `G` *wasn't* a directed graph, then this would technically not be a triad (at least given the current definitions - see #4386 for related discussion).