### PR TITLE
Improve error messages for misconfigured backend treatment

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -62,8 +62,7 @@ def pytest_configure(config):
             "        The test object nx-loopback is not configured correctly.\n"
             "        You should not be seeing this message.\n"
             "        Try `pip install -e .`, or change your PYTHONPATH\n"
-            "        Make sure you are testing a repo that mirrors entry_points\n"
-            "        of the networkx library found by python.\n\n"
+            "        Make sure python finds the networkx repo you are testing\n\n"
         )
 
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -53,7 +53,18 @@ def pytest_configure(config):
         networkx.utils.backends._dispatch._fallback_to_nx = bool(fallback_to_nx)
     # nx-loopback backend is only available when testing
     backends = entry_points(name="nx-loopback", group="networkx.backends")
-    networkx.utils.backends.backends["nx-loopback"] = next(iter(backends))
+    if backends:
+        networkx.utils.backends.backends["nx-loopback"] = next(iter(backends))
+    else:
+        warnings.warn(
+            "\n\n             WARNING: Mixed NetworkX configuration! \n\n"
+            "        This environment has mixed configuration for networkx.\n"
+            "        The test object nx-loopback is not configured correctly.\n"
+            "        You should not be seeing this message.\n"
+            "        Try `pip install -e .`, or change your PYTHONPATH\n"
+            "        Make sure you are testing a repo that mirrors entry_points\n"
+            "        of the networkx library found by python.\n\n"
+        )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -95,7 +95,7 @@ class DelayedImportErrorModule(types.ModuleType):
                 f"No module named '{fd['spec']}'\n\n"
                 "This error is lazily reported, having originally occurred in\n"
                 f'  File {fd["filename"]}, line {fd["lineno"]}, in {fd["function"]}\n\n'
-                f'----> {"".join(fd["code_context"]).strip()}'
+                f'----> {"".join(fd["code_context"] or "").strip()}'
             )
 
 


### PR DESCRIPTION
Fixes #7047 

Allow pytest to run even when `nx-loopback` is not available resulting in 5 failed nx-loopback tests, but other tests run OK.

I put a warning message into this version for the PR, but we could instead have no message (no one should ever be in this situation except maybe our future selves). And we could raise an exception instead of a warning.

These error s create a ModuleNotFoundError which is handled by our lazy_loading code. The error message in that code tries to provide information about the `context` of the error, but in this case the context's value is `None`. So I added a hack to handle the None allowing the error message to be created in cases where the context is None.
