### PR TITLE
Be forgiving of iteration order in `test_write_network_text_circular_ladder_graph`

### DIFF
--- a/networkx/readwrite/tests/test_text.py
+++ b/networkx/readwrite/tests/test_text.py
@@ -1071,7 +1071,8 @@ def test_write_network_text_circular_ladder_graph():
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
     print(text)
-    target = dedent(
+    # Be forgiving of iteration order
+    target1 = dedent(
         """
         ╙── 0
             ├── 1
@@ -1087,7 +1088,23 @@ def test_write_network_text_circular_ladder_graph():
             └──  ...
         """
     ).strip()
-    assert target == text
+    target2 = dedent(
+        """
+        ╙── 0
+            ├── 1
+            │   ├── 2
+            │   │   ├── 3 ─ 0
+            │   │   │   └── 7
+            │   │   │       ├── 4 ─ 0
+            │   │   │       │   └── 5 ─ 1
+            │   │   │       │       └── 6 ─ 2, 7
+            │   │   │       └──  ...
+            │   │   └──  ...
+            │   └──  ...
+            └──  ...
+        """
+    ).strip()
+    assert text in (target1, target2)
 
 
 def test_write_network_text_dorogovtsev_goltsev_mendes_graph():


### PR DESCRIPTION
This is helpful for backends that implement `circular_ladder_graph`. Currently, the backend testing infrastructure in NetworkX can call backend graph generators such as `circular_ladder_graph`, and it converts the backend Graph to a networkx Graph. This is a great way to test backend generators, but sometimes iteration order is different.

Alternatively, the testing infrastructure could call *both* the original generator and the backend generator, check that the graphs are equal, then use the original graph. This approach would avoid other test failures that result from difference in iteration order.