### PR TITLE
Rename and move total_spanning_tree_weight

### DIFF
--- a/doc/reference/algorithms/tree.rst
+++ b/doc/reference/algorithms/tree.rst
@@ -64,6 +64,7 @@ Spanning Trees
    minimum_spanning_edges
    maximum_spanning_edges
    SpanningTreeIterator
+   number_of_spanning_trees
 
 Decomposition
 -------------

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -1167,7 +1167,7 @@ def number_of_spanning_trees(G, root=None):
     Examples
     --------
     >>> G = nx.complete_graph(5)
-    >>> round(nx.number_of_spanning_trees(G), 10)
+    >>> round(nx.number_of_spanning_trees(G))
     125
 
     Notes

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -1134,7 +1134,6 @@ class SpanningTreeIterator:
                 del d[self.partition_key]
 
 
-#@nx.utils.not_implemented_for("directed")
 def number_of_spanning_trees(G, root=None):
     """Returns the number of spanning trees in `G`.
 
@@ -1168,7 +1167,7 @@ def number_of_spanning_trees(G, root=None):
     Examples
     --------
     >>> G = nx.complete_graph(5)
-    >>> nx.number_of_spanning_trees(G)
+    >>> round(nx.number_of_spanning_trees(G), 10)
     125
 
     Notes
@@ -1208,7 +1207,7 @@ def number_of_spanning_trees(G, root=None):
         L = nx.laplacian_matrix(G, weight=None)
     else:
         A = nx.adjacency_matrix(G, weight=None)
-        out_deg = list(d for a, d in G.out_degree())
+        out_deg = [d for a, d in G.out_degree()]
         n, m = A.shape
         # TODO: rm csr_array wrapper when spdiags can produce arrays
         D = sp.sparse.csr_array(sp.sparse.spdiags(out_deg, 0, m, n, format="csr"))

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -1162,7 +1162,7 @@ def number_of_spanning_trees(G, root=None):
     ------
     NetworkXError
         If the graph `G` is not (weakly) connected, or contains no nodes
-        or if `G` is directed and the root node is not specified.
+        or if `G` is directed and the root node is not specified or not in G.
 
     Examples
     --------
@@ -1199,6 +1199,8 @@ def number_of_spanning_trees(G, root=None):
         raise nx.NetworkXError("Graph G must be connected.")
     if graph_is_directed and root == None:
         raise nx.NetworkXError("Spanning trees in directed graphs require a root node.")
+    if graph_is_directed and root not in G:
+        raise nx.NetworkXError("The node root is not in the graph G.")
     if graph_is_directed and not nx.is_weakly_connected(G):
         raise nx.NetworkXError("Graph G must be weakly connected.")
 

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -776,6 +776,11 @@ class TestNumberOfSpanningTrees:
         with pytest.raises(nx.NetworkXError):
             nx.number_of_spanning_trees(G)
 
+    def test_nst_directed_root_not_exist(self):
+        G = nx.MultiDiGraph()
+        with pytest.raises(nx.NetworkXError):
+            nx.number_of_spanning_trees(G, 0)
+
     def test_nst_directed_not_weak_connected(self):
         G = nx.MultiDiGraph()
         G.add_edge(1, 2)

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -706,3 +706,117 @@ def test_random_spanning_tree_additive_large():
     # Assert that p is greater than the significance level so that we do not
     # reject the null hypothesis
     assert not p < 0.05
+
+
+class TestNumberOfSpanningTrees:
+    @classmethod
+    def setup_class(cls):
+        global np
+        np = pytest.importorskip("numpy")
+
+    def test_nst_disconnected(self):
+        G = nx.empty_graph(2)
+        with pytest.raises(nx.NetworkXError):
+            nx.number_of_spanning_trees(G)
+
+    def test_nst_no_nodes(self):
+        G = nx.Graph()
+        with pytest.raises(nx.NetworkXError):
+            nx.number_of_spanning_trees(G)
+
+    def test_nst_weight(self):
+        # weights are ignored
+        G = nx.Graph()
+        G.add_edge(1, 2, weight=2)
+        G.add_edge(1, 3, weight=3)
+        G.add_edge(2, 3, weight=-10)
+        assert np.isclose(nx.number_of_spanning_trees(G), 3)
+
+    def test_nst_selfloop(self):
+        # self-loops are ignored
+        G = nx.complete_graph(3)
+        G.add_edge(1, 1)
+        Nst = nx.number_of_spanning_trees(G)
+        test_data = 3
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_multigraph(self):
+        G = nx.MultiGraph()
+        G.add_edge(1, 2)
+        G.add_edge(1, 2)
+        G.add_edge(1, 3)
+        G.add_edge(2, 3)
+        Nst = nx.number_of_spanning_trees(G)
+        test_data = 5
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_complete_graph(self):
+        N = 5
+        G = nx.complete_graph(N)
+        Nst = nx.number_of_spanning_trees(G)
+        test_data = N**(N-2)
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_path_graph(self):
+        N = 5
+        G = nx.path_graph(N)
+        Nst = nx.number_of_spanning_trees(G)
+        test_data = 1
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_cycle_graph(self):
+        N = 5
+        G = nx.cycle_graph(N)
+        Nst = nx.number_of_spanning_trees(G)
+        test_data = N
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_directed_noroot(self):
+        G = nx.MultiDiGraph()
+        with pytest.raises(nx.NetworkXError):
+            nx.number_of_spanning_trees(G)
+
+    def test_nst_directed_not_weak_connected(self):
+        G = nx.MultiDiGraph()
+        G.add_edge(1, 2)
+        G.add_edge(3, 4)
+        with pytest.raises(nx.NetworkXError):
+            nx.number_of_spanning_trees(G)
+
+    def test_nst_directed_cycle_graph(self):
+        G = nx.DiGraph()
+        G = nx.cycle_graph(7, G)
+        Nst = nx.number_of_spanning_trees(G, 0)
+        test_data = 1
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_directed_complete_graph(self):
+        G = nx.DiGraph()
+        G = nx.complete_graph(7, G)
+        Nst = nx.number_of_spanning_trees(G, 0)
+        test_data = 7**5
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_directed_multi(self):
+        G = nx.MultiDiGraph()
+        G = nx.cycle_graph(3, G)
+        G.add_edge(1, 2)
+        Nst = nx.number_of_spanning_trees(G, 0)
+        test_data = 2
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_directed_selfloop(self):
+        G = nx.MultiDiGraph()
+        G = nx.cycle_graph(3, G)
+        G.add_edge(1, 1)
+        Nst = nx.number_of_spanning_trees(G, 0)
+        test_data = 1
+        assert np.isclose(Nst, test_data)
+
+    def test_nst_directed_weak_connected(self):
+        G = nx.MultiDiGraph()
+        G = nx.cycle_graph(3, G)
+        G.remove_edge(1, 2)
+        Nst = nx.number_of_spanning_trees(G, 0)
+        test_data = 0
+        assert np.isclose(Nst, test_data)

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -754,7 +754,7 @@ class TestNumberOfSpanningTrees:
         N = 5
         G = nx.complete_graph(N)
         Nst = nx.number_of_spanning_trees(G)
-        test_data = N ** (N-2)
+        test_data = N ** (N - 2)
         assert np.isclose(Nst, test_data)
 
     def test_nst_path_graph(self):

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -754,7 +754,7 @@ class TestNumberOfSpanningTrees:
         N = 5
         G = nx.complete_graph(N)
         Nst = nx.number_of_spanning_trees(G)
-        test_data = N**(N-2)
+        test_data = N ** (N-2)
         assert np.isclose(Nst, test_data)
 
     def test_nst_path_graph(self):


### PR DESCRIPTION
**Old suggestion:**

Implements a formula for computation the number of spanning trees of a graph (https://en.wikipedia.org/wiki/Kirchhoff%27s_theorem)

**Update:**

The function already existed under the name `total_spanning_tree_weight`. Instead, I updated that function with additional functionality, see #7098 and #7100.

**Further suggestions in this PR (or perhaps a new PR is better):**

- Rename from `total_spanning_tree_weight` to `number_of_spanning_trees`
- Move from `Laplacian` subfolder to `Tree` subfolder


