### PR TITLE
DOC: Add example to generic_bfs_edges to demonstrate the `neighbors` param

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -37,7 +37,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
         A function that takes a newly visited node of the graph as input
         and returns an *iterator* (not just a list) of nodes that are
         neighbors of that node with custom ordering. If not specified, this is
-        just the``G.neighbors`` method, but in general it can be any function
+        just the ``G.neighbors`` method, but in general it can be any function
         that returns an iterator over some or all of the neighbors of a
         given node, in any order.
 
@@ -63,11 +63,29 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
 
     Examples
     --------
-    >>> G = nx.path_graph(3)
-    >>> list(nx.bfs_edges(G, 0))
-    [(0, 1), (1, 2)]
-    >>> list(nx.bfs_edges(G, source=0, depth_limit=1))
-    [(0, 1)]
+    >>> G = nx.path_graph(7)
+    >>> list(nx.generic_bfs_edges(G, source=0))
+    [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+    >>> list(nx.generic_bfs_edges(G, source=2))
+    [(2, 1), (2, 3), (1, 0), (3, 4), (4, 5), (5, 6)]
+    >>> list(nx.generic_bfs_edges(G, source=2, depth_limit=2))
+    [(2, 1), (2, 3), (1, 0), (3, 4)]
+
+    The `neighbors` param can be used to specify the visitation order of each
+    node's neighbors generically. In the following example, we modify the default
+    neighbor to return *odd* nodes first:
+
+    >>> def odd_first(n):
+    ...     nbrs = set(G.neighbors(n))
+    ...     evens = {n for n in nbrs if n % 2 == 0}
+    ...     odds = nbrs - evens
+    ...     return list(odds) + list(evens)
+
+    >>> G = nx.star_graph(5)
+    >>> list(nx.generic_bfs_edges(G, source=0))  # Default neighbor ordering
+    [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)]
+    >>> list(nx.generic_bfs_edges(G, source=0, neighbors=odd_first))
+    [(0, 1), (0, 3), (0, 5), (0, 2), (0, 4)]
 
     Notes
     -----

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -76,10 +76,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
     neighbor to return *odd* nodes first:
 
     >>> def odd_first(n):
-    ...     nbrs = set(G.neighbors(n))
-    ...     evens = {n for n in nbrs if n % 2 == 0}
-    ...     odds = nbrs - evens
-    ...     return list(odds) + list(evens)
+    ...     return sorted(G.neighbors(n), key=lambda x: x % 2, reverse=True)
 
     >>> G = nx.star_graph(5)
     >>> list(nx.generic_bfs_edges(G, source=0))  # Default neighbor ordering


### PR DESCRIPTION
Updates the `generic_bfs_edges` docstring examples to better demonstrate the parameters.