### PR TITLE
[A-star] Added expansion pruning via cutoff if cutoff is provided

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -49,7 +49,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
        dictionary of edge attributes for that edge. The function must
        return a number or None to indicate a hidden edge.
 
-    cutoff : optional float
+    cutoff : float, optional
        If this is provided, the search will be bounded to this value. I.e. if
        the evaluation function surpasses this value for a node n, the node will not
        be expanded further and will be ignored. More formally, let h'(n) be the
@@ -211,7 +211,7 @@ def astar_path_length(
        dictionary of edge attributes for that edge. The function must
        return a number or None to indicate a hidden edge.
 
-    cutoff : optional float
+    cutoff : float, optional
        If this is provided, the search will be bounded to this value. I.e. if
        the evaluation function surpasses this value for a node n, the node will not
        be expanded further and will be ignored. More formally, let h'(n) be the

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -2,7 +2,6 @@
 """
 from heapq import heappop, heappush
 from itertools import count
-from typing import Any
 
 import networkx as nx
 from networkx.algorithms.shortest_paths.weighted import _weight_function

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -2,7 +2,6 @@
 """
 from heapq import heappop, heappush
 from itertools import count
-from typing import Optional
 
 import networkx as nx
 from networkx.algorithms.shortest_paths.weighted import _weight_function

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -2,6 +2,7 @@
 """
 from heapq import heappop, heappush
 from itertools import count
+from typing import Optional
 
 import networkx as nx
 from networkx.algorithms.shortest_paths.weighted import _weight_function
@@ -10,7 +11,9 @@ __all__ = ["astar_path", "astar_path_length"]
 
 
 @nx._dispatch(edge_attrs="weight", preserve_node_attrs="heuristic")
-def astar_path(G, source, target, heuristic=None, weight="weight"):
+def astar_path(
+    G, source, target, heuristic=None, weight="weight", cutoff: float | None = None
+):
     """Returns a list of nodes in a shortest path between source and target
     using the A* ("A-star") algorithm.
 
@@ -48,6 +51,15 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
        positional arguments: the two endpoints of an edge and the
        dictionary of edge attributes for that edge. The function must
        return a number or None to indicate a hidden edge.
+
+    cutoff : optional float
+       If this is provided, the search will be bounded to this value. I.e. if
+       the evaluation function surpasses this value for a node n, the node will not
+       be expanded further and will be ignored. More formally, let h'(n) be the
+       heuristic function, and g(n) be the cost of reaching n from the source node. Then,
+       if g(n) + h'(n) > cutoff, the node will not be explored further.
+       Note that if the heuristic is inadmissible, it is possible that paths
+       are ignored even though they satisfy the cutoff.
 
     Raises
     ------
@@ -152,6 +164,10 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                     continue
             else:
                 h = heuristic(neighbor, target)
+
+            if cutoff and ncost + h > cutoff:
+                continue
+
             enqueued[neighbor] = ncost, h
             push(queue, (ncost + h, next(c), neighbor, ncost, curnode))
 
@@ -159,7 +175,9 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
 
 
 @nx._dispatch(edge_attrs="weight", preserve_node_attrs="heuristic")
-def astar_path_length(G, source, target, heuristic=None, weight="weight"):
+def astar_path_length(
+    G, source, target, heuristic=None, weight="weight", cutoff: float | None = None
+):
     """Returns the length of the shortest path between source and target using
     the A* ("A-star") algorithm.
 
@@ -195,6 +213,16 @@ def astar_path_length(G, source, target, heuristic=None, weight="weight"):
        positional arguments: the two endpoints of an edge and the
        dictionary of edge attributes for that edge. The function must
        return a number or None to indicate a hidden edge.
+
+    cutoff : optional float
+       If this is provided, the search will be bounded to this value. I.e. if
+       the evaluation function surpasses this value for a node n, the node will not
+       be expanded further and will be ignored. More formally, let h'(n) be the
+       heuristic function, and g(n) be the cost of reaching n from the source node. Then,
+       if g(n) + h'(n) > cutoff, the node will not be explored further.
+       Note that if the heuristic is inadmissible, it is possible that paths
+       are ignored even though they satisfy the cutoff.
+
     Raises
     ------
     NetworkXNoPath
@@ -210,5 +238,5 @@ def astar_path_length(G, source, target, heuristic=None, weight="weight"):
         raise nx.NodeNotFound(msg)
 
     weight = _weight_function(G, weight)
-    path = astar_path(G, source, target, heuristic, weight)
+    path = astar_path(G, source, target, heuristic, weight, cutoff)
     return sum(weight(u, v, G[u][v]) for u, v in zip(path[:-1], path[1:]))

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -2,6 +2,7 @@
 """
 from heapq import heappop, heappush
 from itertools import count
+from typing import Any
 
 import networkx as nx
 from networkx.algorithms.shortest_paths.weighted import _weight_function
@@ -119,9 +120,9 @@ def astar_path(
     # Maps enqueued nodes to distance of discovered paths and the
     # computed heuristics to target. We avoid computing the heuristics
     # more than once and inserting the node into the queue too many times.
-    enqueued = {}
+    enqueued: dict[Any, Any] = {}
     # Maps explored nodes to parent closest to the source.
-    explored = {}
+    explored: dict[Any, Any] = {}
 
     while queue:
         # Pop the smallest item from queue.

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -11,9 +11,7 @@ __all__ = ["astar_path", "astar_path_length"]
 
 
 @nx._dispatch(edge_attrs="weight", preserve_node_attrs="heuristic")
-def astar_path(
-    G, source, target, heuristic=None, weight="weight", cutoff: float | None = None
-):
+def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=None):
     """Returns a list of nodes in a shortest path between source and target
     using the A* ("A-star") algorithm.
 
@@ -120,9 +118,9 @@ def astar_path(
     # Maps enqueued nodes to distance of discovered paths and the
     # computed heuristics to target. We avoid computing the heuristics
     # more than once and inserting the node into the queue too many times.
-    enqueued: dict[Any, Any] = {}
+    enqueued = {}
     # Maps explored nodes to parent closest to the source.
-    explored: dict[Any, Any] = {}
+    explored = {}
 
     while queue:
         # Pop the smallest item from queue.
@@ -176,7 +174,7 @@ def astar_path(
 
 @nx._dispatch(edge_attrs="weight", preserve_node_attrs="heuristic")
 def astar_path_length(
-    G, source, target, heuristic=None, weight="weight", cutoff: float | None = None
+    G, source, target, heuristic=None, weight="weight", *, cutoff=None
 ):
     """Returns the length of the shortest path between source and target using
     the A* ("A-star") algorithm.
@@ -238,5 +236,5 @@ def astar_path_length(
         raise nx.NodeNotFound(msg)
 
     weight = _weight_function(G, weight)
-    path = astar_path(G, source, target, heuristic, weight, cutoff)
+    path = astar_path(G, source, target, heuristic, weight, cutoff=cutoff)
     return sum(weight(u, v, G[u][v]) for u, v in zip(path[:-1], path[1:]))

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -180,6 +180,30 @@ class TestAStar:
         with pytest.raises(nx.NetworkXNoPath):
             # optimal path_length in XG is 9
             nx.astar_path(self.XG, "s", "v", cutoff=8.0)
+        with pytest.raises(nx.NetworkXNoPath):
+            nx.astar_path_length(self.XG, "s", "v", cutoff=8.0)
+
+    def test_astar_heuristic_with_cutoff(self):
+        # admissible heuristic
+        heuristic_values = {"s": 36, "y": 4, "x": 0, "u": 0, "v": 0}
+        def h(u, v):
+            return heuristic_values[u]
+        assert nx.astar_path_length(self.XG, "s", "v") == 9
+        assert nx.astar_path_length(self.XG, "s", "v", heuristic=h) == 9
+        assert nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=12) == 9
+        assert nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=9) == 9
+        with pytest.raises(nx.NetworkXNoPath):
+            nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=8)
+
+        # inadmissible heuristic
+        heuristic_values = {"s": 36, "y": 14, "x": 10, "u": 10, "v": 0}
+        # optimal path_length in XG is 9. This heuristic gives over-estimate.
+        assert nx.astar_path_length(self.XG, "s", "v", heuristic=h) == 10
+        assert nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=15) == 10
+        with pytest.raises(nx.NetworkXNoPath):
+            nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=9)
+        with pytest.raises(nx.NetworkXNoPath):
+            nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=12)
 
     def test_astar_cutoff2(self):
         assert nx.astar_path(self.XG, "s", "v", cutoff=10.0) == ["s", "x", "u", "v"]

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -182,7 +182,6 @@ class TestAStar:
             nx.astar_path(self.XG, "s", "v", cutoff=8.0)
 
     def test_astar_cutoff2(self):
-        # optimal path_length in XG is 9
         assert nx.astar_path(self.XG, "s", "v", cutoff=10.0) == ["s", "x", "u", "v"]
         assert nx.astar_path_length(self.XG, "s", "v") == 9
 

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -183,11 +183,12 @@ class TestAStar:
         with pytest.raises(nx.NetworkXNoPath):
             nx.astar_path_length(self.XG, "s", "v", cutoff=8.0)
 
-    def test_astar_heuristic_with_cutoff(self):
-        # admissible heuristic
+    def test_astar_admissible_heuristic_with_cutoff(self):
         heuristic_values = {"s": 36, "y": 4, "x": 0, "u": 0, "v": 0}
+
         def h(u, v):
             return heuristic_values[u]
+
         assert nx.astar_path_length(self.XG, "s", "v") == 9
         assert nx.astar_path_length(self.XG, "s", "v", heuristic=h) == 9
         assert nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=12) == 9
@@ -195,8 +196,12 @@ class TestAStar:
         with pytest.raises(nx.NetworkXNoPath):
             nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=8)
 
-        # inadmissible heuristic
+    def test_astar_inadmissible_heuristic_with_cutoff(self):
         heuristic_values = {"s": 36, "y": 14, "x": 10, "u": 10, "v": 0}
+
+        def h(u, v):
+            return heuristic_values[u]
+
         # optimal path_length in XG is 9. This heuristic gives over-estimate.
         assert nx.astar_path_length(self.XG, "s", "v", heuristic=h) == 10
         assert nx.astar_path_length(self.XG, "s", "v", heuristic=h, cutoff=15) == 10

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -176,6 +176,16 @@ class TestAStar:
         with pytest.raises(nx.NodeNotFound):
             nx.astar_path(self.XG, "s", "moon")
 
+    def test_astar_cutoff(self):
+        with pytest.raises(nx.NetworkXNoPath):
+            # optimal path_length in XG is 9
+            nx.astar_path(self.XG, "s", "v", cutoff=8.0)
+
+    def test_astar_cutoff2(self):
+        # optimal path_length in XG is 9
+        assert nx.astar_path(self.XG, "s", "v", cutoff=10.0) == ["s", "x", "u", "v"]
+        assert nx.astar_path_length(self.XG, "s", "v") == 9
+
     def test_cycle(self):
         C = nx.cycle_graph(7)
         assert nx.astar_path(C, 0, 3) == [0, 1, 2, 3]


### PR DESCRIPTION
Added a cutoff to limit the exploration of a large, potentially disconnected graph. The use-case is highlighted in https://github.com/networkx/networkx/discussions/7026.

Reasoning for implementing this in A-star:

It is not directly mentioned in papers that a cutoff can be added. However, since it's not an unknown concept (as also implemented in Dijkstra), I think the [original paper on A-star](https://sci-hub.se/10.1109/TSSC.1968.300136) highlights it the best. Going by the definition of the evaluation function f:

$f(n) = g(n) + h(n)$

where $g(n)$ is the actual cost from source to $n$ and $h(n)$ is the actual cost of an optimal path from $n$ to the target.

It is then given for A* to be admissible that our heuristic $h'(n)$ must be $h'(n) <= h(n)$. I.e. when $g(n) + h'(n) > cutoff$, we are guaranteed that no path exists from $n$ to the target that satisfies the cutoff. Meaning, we could essentially add the cutoff check before enqueueing a node (and simply `continue` if it fails this check), or terminate the search when the algorithm explores a node $n$ that fails the cutoff check since $n$ would have the lowest $f(n)$ in the queue.

I've opted for the former since it reduces the memory footprint by applying the cutoff early.