### PR TITLE
Add `@not_implemented_for("directed")` to `number_connected_components`

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -68,6 +68,7 @@ def connected_components(G):
             yield c
 
 
+@not_implemented_for("directed")
 @nx._dispatch
 def number_connected_components(G):
     """Returns the number of connected components.
@@ -143,7 +144,7 @@ def is_connected(G):
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept(
-            "Connectivity is undefined ", "for the null graph."
+            "Connectivity is undefined for the null graph."
         )
     return sum(1 for node in _plain_bfs(G, arbitrary_element(G))) == len(G)
 


### PR DESCRIPTION
Previously, it was relying on a call to `connected_components` to check the graph type, but this doesn't work well when dispatching to a backend. Also, fix an exception message.