### PR TITLE
remove unused code

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -631,20 +631,6 @@ def barycenter(G, weight=None, attr=None, sp=None):
     return barycenter_vertices
 
 
-def _count_lu_permutations(perm_array):
-    """Counts the number of permutations in SuperLU perm_c or perm_r"""
-    perm_cnt = 0
-    arr = perm_array.tolist()
-    for i in range(len(arr)):
-        if i != arr[i]:
-            perm_cnt += 1
-            n = arr.index(i)
-            arr[n] = arr[i]
-            arr[i] = i
-
-    return perm_cnt
-
-
 @not_implemented_for("directed")
 @nx._dispatch(edge_attrs="weight")
 def resistance_distance(G, nodeA=None, nodeB=None, weight=None, invert_weight=True):


### PR DESCRIPTION
#6925 improved the `resistance_distance`.
I already removed some old code in #7053, but this PR removes a no-longer-used auxiliary function.