### PR TITLE
Add a step to CI to check for warnings at import time.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
           python -m pip install .
           python -m pip list
 
+      - name: Test for warnings at import time
+        run: python -Werror -c "import networkx"
+
       - name: Test NetworkX
         run: |
           pytest --doctest-modules --durations=10 --pyargs networkx


### PR DESCRIPTION
Related to #7064 and #7032.

This PR adds a minimal step to the `default` testing job to check for warnings raised at import time. I'm still not able to reproduce #7064 / #7032 locally, so I suspect that they are specific to Python config/environment management systems. Nevertheless, this is a relatively lightweight check that will hopefully help catch any user-facing import warnings prior to releases.

If anyone has ideas how this can be made more robust, please chime in!