### PR TITLE
Update dispatch decorator for `hits` to use `"weight"` edge weight

### DIFF
--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -5,7 +5,7 @@ import networkx as nx
 __all__ = ["hits"]
 
 
-@nx._dispatch
+@nx._dispatch(preserve_edge_attrs={"G": {"weight": 1}})
 def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
     """Returns HITS hubs and authorities values for nodes.
 


### PR DESCRIPTION
`"weight"` edge weight is currently fixed.