### PR TITLE
Make HITS raise exceptions consistent with power iterations

### DIFF
--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -77,11 +77,14 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
         return {}, {}
     A = nx.adjacency_matrix(G, nodelist=list(G), dtype=float)
 
-    if nstart is None:
-        _, _, vt = sp.sparse.linalg.svds(A, k=1, maxiter=max_iter, tol=tol)
-    else:
+    if nstart is not None:
         nstart = np.array(list(nstart.values()))
+    if max_iter <= 0:
+        raise nx.PowerIterationFailedConvergence(max_iter)
+    try:
         _, _, vt = sp.sparse.linalg.svds(A, k=1, v0=nstart, maxiter=max_iter, tol=tol)
+    except sp.sparse.linalg.ArpackNoConvergence as exc:
+        raise nx.PowerIterationFailedConvergence(max_iter) from exc
 
     a = vt.flatten().real
     h = A @ a

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -72,7 +72,7 @@ class TestHITS:
             _hits_scipy(G, max_iter=0)
         with pytest.raises(nx.PowerIterationFailedConvergence):
             _hits_python(G, max_iter=0)
-        with pytest.raises(ValueError):
+        with pytest.raises(nx.PowerIterationFailedConvergence):
             nx.hits(G, max_iter=0)
-        with pytest.raises(sp.sparse.linalg.ArpackNoConvergence):
+        with pytest.raises(nx.PowerIterationFailedConvergence):
             nx.hits(G, max_iter=1)


### PR DESCRIPTION
Specifically, instead of raising `ValueError` or `sp.sparse.linalg.ArpackNoConvergence`, change `nx.hits` to raise `nx.PowerIterationFailedConvergence` just like other algorithms that have power iterations. This makes it easier for backends to raise consistent exceptions (`ArpackNoConvergence` is particularly awkward to match).