### PR TITLE
Implements Bonacich power centrality (networkx#7078)

### DIFF
--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -22,6 +22,7 @@ Eigenvector
    eigenvector_centrality_numpy
    katz_centrality
    katz_centrality_numpy
+   power_centrality
 
 Closeness
 ---------

--- a/networkx/algorithms/centrality/__init__.py
+++ b/networkx/algorithms/centrality/__init__.py
@@ -12,6 +12,7 @@ from .harmonic import *
 from .katz import *
 from .load import *
 from .percolation import *
+from .power import *
 from .reaching import *
 from .second_order import *
 from .subgraph_alg import *

--- a/networkx/algorithms/centrality/power.py
+++ b/networkx/algorithms/centrality/power.py
@@ -1,0 +1,127 @@
+"""Bonacich power centrality."""
+
+import numpy as np
+
+import networkx as nx
+from networkx.utils import not_implemented_for
+
+__all__ = ["power_centrality"]
+
+
+@not_implemented_for("multigraph")
+@nx._dispatch(edge_attrs="weight")
+def power_centrality(G, beta=0.1, normalized=False, weight=None):
+    r"""Compute the Bonacich power centrality for the graph G.
+
+    Bonacich power centrality computes the centrality of a node based on the
+    centrality of its neighbors. It is a generalization of eigenvector centrality,
+    motivated by the observation that power does not equal centrality in exchange
+    networks - power comes from being connected to those who are powerless [1]_.
+    The Bonacich power centrality for node $i$ is:
+
+    .. math::
+
+        c_i(\alpha, \beta) = \alpha (\mathbf{I} - \beta \mathbf{A})^{-1} \mathbf{A}
+            \mathbf{1},
+
+    where $\mathbf{A}$ is the graph adjacency matrix, $\alpha$ is a scaling parameter,
+    $\beta$ is a decay rate, and $\mathbf{1}$ is a column vector of ones.
+
+    Following [1]_, if `normalized = False`, this algorithm sets $\alpha$ such that
+    $\sum_i c_i(\alpha, \beta)^2$ equals to the number of nodes in the network. This
+    allows $c_i(\alpha, \beta) = 1$ to be used as a reference value for the "middle"
+    of the centrality range.
+
+    $\beta$ reflects the degree to which $i$'s power is a function of those to whom
+    $i$ is connected. The magnitude of $\beta$ controls the influence of distant nodes
+    on $i$'s power, with larger magnitudes indicating slower rates of decay. When
+    $\beta > 0$, a node becomes more powerful as its neighbors becomes more powerful
+    (as occurs in cooperative relations). When $\beta < 0$, a node becomes powerful
+    only when their neighbors become weaker (as occurs in competitive or antagonistic
+    relations).
+
+    Parameters
+    ----------
+    G : graph
+      A NetworkX graph
+
+    beta : scalar, optional (default=0.1)
+      The decay rate $\beta$, can be negative.
+
+    normalized : bool, optional (default=False)
+      If True, the centrality scores are normalized such that they sum to 1.
+
+    weight : None or string, optional (default=None)
+      If None, all edge weights are considered equal.
+      Otherwise holds the name of the edge attribute used as weight.
+      In this measure the weight is interpreted as the connection strength.
+
+    Returns
+    -------
+    nodes : dictionary
+       Dictionary of nodes with Bonacich power centrality as the value.
+
+    Raises
+    ------
+    numpy.linalg.LinAlgError :
+       If $\mathbf{I} - \beta \mathbf{A}$ is singular
+
+    Examples
+    --------
+    >>> G = nx.star_graph(3)
+    >>> centrality = nx.power_centrality(G)
+    >>> for n, c in sorted(centrality.items()):
+    ...     print(f"{n} {c:.2f}")
+    0 1.65
+    1 0.65
+    2 0.65
+    3 0.65
+
+    See Also
+    --------
+    katz_centrality
+    katz_centrality_numpy
+    eigenvector_centrality_numpy
+    eigenvector_centrality
+    :func:`~networkx.algorithms.link_analysis.pagerank_alg.pagerank`
+    :func:`~networkx.algorithms.link_analysis.hits_alg.hits`
+
+    Notes
+    -----
+    This algorithm is implemented with reference to the R igraph implementation [2]_.
+
+    One interesting feature of this centrality measure is its relative instability to
+    changes in the magnitude of $\beta$ (particularly in the negative case). If your
+    theory motivates use of this measure, you should be very careful to choose $\beta$
+    on a non-ad-hoc basis. For more information, see [3]_.
+
+    This algorithm may fail if $\mathbf{I} - \beta \mathbf{A}$ is singular.
+
+    References
+    ----------
+    .. [1] Phillip Bonacich:
+       "Power and Centrality: A Family of Measures."
+       American Journal of Sociology, 92, 1170-1182.
+       https://www.jstor.org/stable/pdf/2780000.pdf
+    .. [2] "Find Bonacich Power Centrality Scores of Network Positions."
+       https://igraph.org/r/html/1.2.6/power_centrality.html
+    .. [3] Simon Rodan:
+       "Choosing the ‘β’ parameter when using the Bonacich power measure."
+       Journal of Social Structure 12.1 (2011): 1-23.
+       https://intapi.sciendo.com/pdf/10.21307/joss-2019-032
+    """
+    if len(G) == 0:
+        return {}
+
+    A = nx.adjacency_matrix(G, weight=weight).todense()
+    n = A.shape[0]
+    I = np.identity(n)
+
+    centrality = np.linalg.solve(I - beta * A, np.matmul(A, np.ones(n)))
+
+    if normalized:
+        centrality = centrality / sum(centrality)
+    else:
+        centrality = centrality * np.sqrt(n / sum(centrality**2))
+
+    return dict(zip(G.nodes, centrality))

--- a/networkx/algorithms/centrality/tests/test_power_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_power_centrality.py
@@ -1,0 +1,241 @@
+import numpy as np
+import pytest
+
+import networkx as nx
+
+
+class TestPowerCentrality:
+    def test_K5(self):
+        G = nx.complete_graph(5)
+        b = nx.power_centrality(G)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(1, abs=1e-4)
+
+    def test_P3(self):
+        G = nx.path_graph(3)
+        b = nx.power_centrality(G)
+        b_answer = {0: 0.7480544714310444, 1: 1.3714331976235816, 2: 0.7480544714310444}
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_S3(self):
+        G = nx.star_graph(3)
+        b = nx.power_centrality(G)
+        b_answer = {
+            0: 1.6520663752618043,
+            1: 0.6508140266182866,
+            2: 0.6508140266182866,
+            3: 0.6508140266182866,
+        }
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_directed_P3(self):
+        G = nx.path_graph(3, nx.DiGraph)
+        b = nx.power_centrality(G)
+        b_answer = {0: 1.2816138016780187, 1: 1.1651034560709261, 2: 0.0}
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_directed_S3(self):
+        G = nx.DiGraph([(0, 1), (0, 2), (0, 3)])
+        b = nx.power_centrality(G)
+        b_answer = {0: 2, 1: 0, 2: 0, 3: 0}
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_directed_C3(self):
+        G = nx.cycle_graph(3, nx.DiGraph)
+        b = nx.power_centrality(G)
+        for n in sorted(G):
+            assert b[n] == pytest.approx(1, abs=1e-4)
+
+    def test_weighted(self):
+        edges = [
+            (0, 1, {"weight": 24}),
+            (0, 2, {"weight": 24}),
+            (0, 3, {"weight": 24}),
+            (1, 2, {"weight": 24}),
+            (1, 3, {"weight": 20}),
+            (2, 3, {"weight": 20}),
+        ]
+        G = nx.Graph(edges)
+        b = nx.power_centrality(G, beta=0.01, weight="weight")
+        b_answer = {
+            0: 1.0460403421078126,
+            1: 1.0002278950842434,
+            2: 1.0002278950842434,
+            3: 0.9512559689556005,
+        }
+        for n in sorted(G):
+            assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_cook_1c(self):
+        """Fig. 2 network 1c in Bonacich (1987). Results identical to Tab. 3"""
+        G = nx.Graph([(0, 1), (0, 2), (1, 3), (2, 4)])
+        b_answers = {
+            -0.3: {
+                0: 0.9730085108210397,
+                1: 1.3378867023789296,
+                2: 1.3378867023789296,
+                3: 0.48650425541051995,
+                4: 0.48650425541051995,
+            },
+            -0.2: {
+                0: 1.0882143751650173,
+                1: 1.2695834376925206,
+                2: 1.2695834376925204,
+                3: 0.5441071875825086,
+                4: 0.5441071875825086,
+            },
+            -0.1: {
+                0: 1.1534996014569447,
+                1: 1.225593326548004,
+                2: 1.2255933265480041,
+                3: 0.5767498007284724,
+                4: 0.5767498007284724,
+            },
+            0: {
+                0: 1.1952286093343936,
+                1: 1.1952286093343936,
+                2: 1.1952286093343936,
+                3: 0.5976143046671968,
+                4: 0.5976143046671968,
+            },
+            0.1: {
+                0: 1.2241074813555017,
+                1: 1.173103002965689,
+                2: 1.173103002965689,
+                3: 0.6120537406777509,
+                4: 0.6120537406777509,
+            },
+            0.2: {
+                0: 1.245244117188435,
+                1: 1.1562981088178326,
+                2: 1.1562981088178326,
+                3: 0.6226220585942176,
+                4: 0.6226220585942176,
+            },
+            0.3: {
+                0: 1.2613684401582361,
+                1: 1.1431151488934015,
+                2: 1.1431151488934015,
+                3: 0.630684220079118,
+                4: 0.6306842200791181,
+            },
+        }
+        for beta, b_answer in b_answers.items():
+            b = nx.power_centrality(G, beta=beta)
+            for n in sorted(G):
+                assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_cook_1d(self):
+        """Fig. 2 network 1d in Bonacich (1987). Results identical to Tab. 3"""
+        G = nx.Graph([(0, 1), (0, 2), (0, 3), (1, 4), (2, 5), (3, 6)])
+        b_answer = {
+            0: 1.6201851746019653,
+            1: 1.0801234497346432,
+            2: 1.0801234497346432,
+            3: 1.0801234497346432,
+            4: 0.5400617248673216,
+            5: 0.5400617248673216,
+            6: 0.5400617248673216,
+        }
+        for beta in [-0.3, -0.2, -0.1, 0, 0.1, 0.2, 0.3]:
+            b = nx.power_centrality(G, beta=beta)
+            for n in sorted(G):
+                assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_cook_1d_directed(self):
+        """Fig. 2 network 1d in Bonacich (1987). Results identical to Tab. 4"""
+        G = nx.DiGraph(
+            [(0, 1), (0, 2), (0, 3), (1, 0), (2, 0), (3, 0), (1, 4), (2, 5), (3, 6)]
+        )
+        b_answers = {
+            -0.3: {
+                0: 1.410023290755643,
+                1: 1.2925213498593398,
+                2: 1.2925213498593398,
+                3: 1.2925213498593395,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+            -0.2: {
+                0: 1.5769724491135402,
+                1: 1.2265341270883094,
+                2: 1.2265341270883092,
+                3: 1.2265341270883092,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+            -0.1: {
+                0: 1.671579730129196,
+                1: 1.1840356421748466,
+                2: 1.1840356421748468,
+                3: 1.1840356421748466,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+            0: {
+                0: 1.7320508075688772,
+                1: 1.1547005383792515,
+                2: 1.1547005383792515,
+                3: 1.1547005383792515,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+            0.1: {
+                0: 1.773900269015164,
+                1: 1.133325171870799,
+                2: 1.1333251718707993,
+                3: 1.133325171870799,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+            0.2: {
+                0: 1.8045301643153684,
+                1: 1.1170901017190376,
+                2: 1.1170901017190376,
+                3: 1.1170901017190376,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+            0.3: {
+                0: 1.8278965282086308,
+                1: 1.104354152459381,
+                2: 1.104354152459381,
+                3: 1.104354152459381,
+                4: 0.0,
+                5: 0.0,
+                6: 0.0,
+            },
+        }
+        for beta, b_answer in b_answers.items():
+            b = nx.power_centrality(G, beta=beta)
+            for n in sorted(G):
+                assert b[n] == pytest.approx(b_answer[n], abs=1e-4)
+
+    def test_multigraph(self):
+        with pytest.raises(nx.NetworkXException):
+            nx.power_centrality(nx.MultiGraph())
+
+    def test_empty(self):
+        e = nx.power_centrality(nx.Graph())
+        assert e == {}
+
+    def test_singular_matrix(self):
+        with pytest.raises(np.linalg.LinAlgError):
+            edges = [
+                (0, 1, {"weight": -1}),
+                (0, 2, {"weight": -1}),
+                (0, 0, {"weight": 1}),
+                (1, 1, {"weight": 1}),
+                (2, 2, {"weight": 1}),
+            ]
+            nx.power_centrality(nx.Graph(edges), beta=1, weight="weight")


### PR DESCRIPTION
This PR is a fairly straightforward implementation of Bonacich power centrality (networkx#7078), following what is implemented in R `igraph`, but additionally considers edge weights (this is really straightforward, didn't understand why the R implementation does not consider this). I have checked that the R `igraph` implementation will return the same or very similar results in all the tests on non-weighted graphs. 

This is my first time submitting a PR to `networkx` so please let me know if I need to change or add anything in this PR.
