### PR TITLE
Run test suite without any dependencies in CI with CPython versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ["pypy-3.10"]
+        python-version: ["3.10", "3.11", "3.12", "pypy-3.10"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I noticed this the other day - we're currently not testing against the CPython versions without any dependencies installed. It may be that this was intentional, but I figured I'd raise it on the off chance it's not - @jarrodmillman 

The only thing this is likely to catch is when developers forget `pytest.importorskip` for functions that depend on numpy/scipy etc. Perhaps that's not worth the tradeoff of adding back 9 more testing jobs!