### PR TITLE
FIX: Match the doc description while copying over data

### DIFF
--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -210,7 +210,7 @@ def difference(G, H):
     # create new graph
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError("G and H must both be graphs or multigraphs.")
-    R = nx.create_empty_copy(G)
+    R = nx.create_empty_copy(G, with_data=False)
 
     if set(G) != set(H):
         raise nx.NetworkXError("Node sets of graphs not equal")
@@ -258,7 +258,7 @@ def symmetric_difference(G, H):
     # create new graph
     if not G.is_multigraph() == H.is_multigraph():
         raise nx.NetworkXError("G and H must both be graphs or multigraphs.")
-    R = nx.create_empty_copy(G)
+    R = nx.create_empty_copy(G, with_data=False)
 
     if set(G) != set(H):
         raise nx.NetworkXError("Node sets of graphs not equal")

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -199,6 +199,8 @@ def test_difference_attributes():
     assert set(gh.nodes()) == set(g.nodes())
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == []
+    # node data should not be copied over
+    assert gh.nodes.data() != g.nodes.data()
 
 
 def test_difference_multigraph_attributes():

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -199,8 +199,9 @@ def test_difference_attributes():
     assert set(gh.nodes()) == set(g.nodes())
     assert set(gh.nodes()) == set(h.nodes())
     assert sorted(gh.edges()) == []
-    # node data should not be copied over
+    # node and graph data should not be copied over
     assert gh.nodes.data() != g.nodes.data()
+    assert gh.graph != g.graph
 
 
 def test_difference_multigraph_attributes():


### PR DESCRIPTION
As pointed out by @eriknw in https://github.com/networkx/networkx/pull/7066#discussion_r1374017287, we weren't following our own docs :)
