### PR TITLE
Test on Python 3.13-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ["pypy-3.10"]
+        python-version: ["pypy-3.10", "3.13-dev"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.13.0-alpha1 was made available recently:
https://github.com/actions/python-versions/releases/tag/3.13.0-alpha.1-6531259803

See #7089.