### PR TITLE
Add doc total_spanning_tree_weight

### DIFF
--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -25,6 +25,7 @@ Laplacian Matrix
    normalized_laplacian_matrix
    directed_laplacian_matrix
    directed_combinatorial_laplacian_matrix
+   total_spanning_tree_weight
 
 Bethe Hessian Matrix
 --------------------


### PR DESCRIPTION
Following #7065
Add missing link in documentation to `total_spanning_tree_weight`.