### PR TITLE
`write_graphml`: Small fix for object type description on `TypeError` exception

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -455,7 +455,7 @@ class GraphML:
             return self.xml_type[key]
         except KeyError as err:
             raise TypeError(
-                f"GraphML does not support type {type(key)} as data values."
+                f"GraphML does not support type {key} as data values."
             ) from err
 
 


### PR DESCRIPTION
Fixes a small issue when calling `networkx.write_graphml` on a graph with invalid attribute types (e.g., a `list`).

The exception message raised by networkx currently displays an unhelpful error message, which reads:

```
TypeError: GraphML does not support type <class 'type'> as data values.
```

This PR simply fixes it to display the object type that is causing the exception, such as in:

```
TypeError: GraphML does not support type <class 'list'> as data values.
```

