### PR TITLE
label check on push and change check name

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -6,13 +6,14 @@ on:
       - opened
       - labeled
       - unlabeled
+  push:
 
 env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
 
 jobs:
   check-type-label:
-    name: ensure type label
+    name: revr gave label?
     runs-on: ubuntu-latest
     steps:
       - if: "contains( env.LABELS, 'type: ' ) == false"

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check-type-label:
-    name: revr gave label?
+    name: reviewer label?
     runs-on: ubuntu-latest
     steps:
       - if: "contains( env.LABELS, 'type: ' ) == false"


### PR DESCRIPTION
Make label check activate on each push
(currently red x disappears after first run because not rerun on push)

I also renamed the label check so it hopefully makes it clear that a reviewer gives the label.
Other name suggestions welcome. I tried to keep it under 20 chars.