### PR TITLE
DOC: Add plots to classic graph generators docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -254,6 +254,7 @@ np.random.seed(42)
 
 plot_formats = [("png", 100)]
 
+
 def setup(app):
     app.add_css_file("custom.css")
     app.add_js_file("copybutton.js")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -248,9 +248,9 @@ numpydoc_show_class_members = False
 
 plot_pre_code = """
 import networkx as nx
+import numpy as np
+np.random.seed(42)
 """
-
-plot_formats = [("png", 100), "pdf"]
 
 
 def setup(app):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -252,6 +252,7 @@ import numpy as np
 np.random.seed(42)
 """
 
+plot_formats = [("png", 100)]
 
 def setup(app):
     app.add_css_file("custom.css")

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -75,6 +75,10 @@ def full_rary_tree(r, n, create_using=None):
     (if a leaf at the bottom level is missing, then so are all of the
     leaves to its right." [1]_
 
+    .. plot::
+
+        >>> nx.draw(nx.full_rary_tree(2, 10))
+
     Parameters
     ----------
     r : int
@@ -102,6 +106,10 @@ def full_rary_tree(r, n, create_using=None):
 @nx._dispatch(graphs=None)
 def balanced_tree(r, h, create_using=None):
     """Returns the perfectly balanced `r`-ary tree of height `h`.
+
+    .. plot::
+
+        >>> nx.draw(nx.balanced_tree(2, 3))
 
     Parameters
     ----------
@@ -148,6 +156,10 @@ def balanced_tree(r, h, create_using=None):
 @nx._dispatch(graphs=None)
 def barbell_graph(m1, m2, create_using=None):
     """Returns the Barbell Graph: two complete graphs connected by a path.
+
+    .. plot::
+
+        >>> nx.draw(nx.barbell_graph(4, 2))
 
     Parameters
     ----------
@@ -221,6 +233,10 @@ def binomial_tree(n, create_using=None):
     The binomial tree of order 0 consists of a single node. A binomial tree of order k
     is defined recursively by linking two binomial trees of order k-1: the root of one is
     the leftmost child of the root of the other.
+
+    .. plot::
+
+        >>> nx.draw(nx.binomial_tree(3))
 
     Parameters
     ----------
@@ -305,6 +321,10 @@ def circular_ladder_graph(n, create_using=None):
 
     Node labels are the integers 0 to n-1
 
+    .. plot::
+
+        >>> nx.draw(nx.circular_ladder_graph(5))
+
     """
     G = ladder_graph(n, create_using)
     G.add_edge(0, n - 1)
@@ -319,6 +339,10 @@ def circulant_graph(n, offsets, create_using=None):
     The circulant graph $Ci_n(x_1, ..., x_m)$ consists of $n$ nodes $0, ..., n-1$
     such that node $i$ is connected to nodes $(i + x) \mod n$ and $(i - x) \mod n$
     for all $x$ in $x_1, ..., x_m$. Thus $Ci_n(1)$ is a cycle graph.
+
+    .. plot::
+
+        >>> nx.draw(nx.circulant_graph(10, [1]))
 
     Parameters
     ----------
@@ -392,6 +416,10 @@ def cycle_graph(n, create_using=None):
 
     $C_n$ is a path with its two end-nodes connected.
 
+    .. plot::
+
+        >>> nx.draw(nx.cycle_graph(5))
+
     Parameters
     ----------
     n : int or iterable container of nodes
@@ -421,6 +449,10 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     deterministically with the following properties for a given `n`:
     - Total number of nodes = ``3 * (3**n + 1) / 2``
     - Total number of edges = ``3 ** (n + 1)``
+
+    .. plot::
+
+        >>> nx.draw(nx.dorogovtsev_goltsev_mendes_graph(3))
 
     Parameters
     ----------
@@ -475,6 +507,10 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
 @nx._dispatch(graphs=None)
 def empty_graph(n=0, create_using=None, default=Graph):
     """Returns the empty graph with n nodes and zero edges.
+
+    .. plot::
+
+        >>> nx.draw(nx.empty_graph(5))
 
     Parameters
     ----------
@@ -575,6 +611,10 @@ def ladder_graph(n, create_using=None):
 
     Node labels are the integers 0 to 2*n - 1.
 
+    .. plot::
+
+        >>> nx.draw(nx.ladder_graph(5))
+
     """
     G = empty_graph(2 * n, create_using)
     if G.is_directed():
@@ -591,6 +631,10 @@ def lollipop_graph(m, n, create_using=None):
     """Returns the Lollipop Graph; ``K_m`` connected to ``P_n``.
 
     This is the Barbell Graph without the right barbell.
+
+    .. plot::
+
+        >>> nx.draw(nx.lollipop_graph(3, 4))
 
     Parameters
     ----------
@@ -664,6 +708,10 @@ def null_graph(create_using=None):
 def path_graph(n, create_using=None):
     """Returns the Path graph `P_n` of linearly connected nodes.
 
+    .. plot::
+
+        >>> nx.draw(nx.path_graph(5))
+
     Parameters
     ----------
     n : int or iterable
@@ -687,6 +735,10 @@ def star_graph(n, create_using=None):
     """Return the star graph
 
     The star graph consists of one center node connected to n outer nodes.
+
+    .. plot::
+
+        >>> nx.draw(nx.star_graph(6))
 
     Parameters
     ----------
@@ -723,6 +775,10 @@ def tadpole_graph(m, n, create_using=None):
 
     This graph on m+n nodes connects a cycle of size `m` to a path of length `n`.
     It looks like a tadpole. It is also called a kite graph or a dragon graph.
+
+    .. plot::
+
+        >>> nx.draw(nx.tadpole_graph(3, 5))
 
     Parameters
     ----------
@@ -776,7 +832,13 @@ def tadpole_graph(m, n, create_using=None):
 
 @nx._dispatch(graphs=None)
 def trivial_graph(create_using=None):
-    """Return the Trivial graph with one node (with label 0) and no edges."""
+    """Return the Trivial graph with one node (with label 0) and no edges.
+
+    .. plot::
+
+        >>> nx.draw(nx.trivial_graph(), with_labels=True)
+
+    """
     G = empty_graph(1, create_using)
     return G
 
@@ -792,6 +854,10 @@ def turan_graph(n, r):
     Given $n$ and $r$, we create a complete multipartite graph with
     $r-(n \mod r)$ partitions of size $n/r$, rounded down, and
     $n \mod r$ partitions of size $n/r+1$, rounded down.
+
+    .. plot::
+
+        >>> nx.draw(nx.turan_graph(6, 2))
 
     Parameters
     ----------
@@ -822,6 +888,10 @@ def wheel_graph(n, create_using=None):
 
     The wheel graph consists of a hub node connected to a cycle of (n-1) nodes.
 
+    .. plot::
+
+        >>> nx.draw(nx.wheel_graph(5))
+
     Parameters
     ----------
     n : int or iterable
@@ -850,6 +920,10 @@ def wheel_graph(n, create_using=None):
 @nx._dispatch(graphs=None)
 def complete_multipartite_graph(*subset_sizes):
     """Returns the complete multipartite graph with the specified subset sizes.
+
+    .. plot::
+
+        >>> nx.draw(nx.complete_multipartite_graph(1, 2, 3))
 
     Parameters
     ----------


### PR DESCRIPTION
Builds on top of https://github.com/networkx/networkx/pull/6401

I have added a seed and removed the links to download script/png/pdf from the doc build. IMO we should be using this to just quickly show how the graph looks like, we don't need to worry about making this reproducible on a pixel level.