### PR TITLE
DOC: Link methods in functions to base Graph methods/properties

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -51,7 +51,7 @@ __all__ = [
 def nodes(G):
     """Returns a NodeView over the graph nodes.
 
-    This function wraps the :func:`networkx.Graph.nodes` property.
+    This function wraps the :func:`G.nodes <networkx.Graph.nodes>` property.
     """
     return G.nodes()
 
@@ -63,7 +63,7 @@ def edges(G, nbunch=None):
 
     For digraphs, edges=out_edges
 
-    This function wraps the :func:`networkx.Graph.edges` property.
+    This function wraps the :func:`G.edges <networkx.Graph.edges>` property.
     """
     return G.edges(nbunch)
 
@@ -72,7 +72,7 @@ def degree(G, nbunch=None, weight=None):
     """Returns a degree view of single node or of nbunch of nodes.
     If nbunch is omitted, then return degrees of *all* nodes.
 
-    This function wraps the :func:`networkx.Graph.degree` property.
+    This function wraps the :func:`G.degree <networkx.Graph.degree>` property.
     """
     return G.degree(nbunch, weight)
 
@@ -80,7 +80,7 @@ def degree(G, nbunch=None, weight=None):
 def neighbors(G, n):
     """Returns an iterator over all neighbors of node n.
 
-    This function wraps the :func:`networkx.Graph.neighbors` function.
+    This function wraps the :func:``G.neighbors <networkx.Graph.neighbors>` function.
     """
     return G.neighbors(n)
 
@@ -88,7 +88,7 @@ def neighbors(G, n):
 def number_of_nodes(G):
     """Returns the number of nodes in the graph.
 
-    This function wraps the :func:`networkx.Graph.number_of_nodes` function.
+    This function wraps the :func:`G.number_of_nodes <networkx.Graph.number_of_nodes>` function.
     """
     return G.number_of_nodes()
 
@@ -96,7 +96,7 @@ def number_of_nodes(G):
 def number_of_edges(G):
     """Returns the number of edges in the graph.
 
-    This function wraps the :func:`networkx.Graph.number_of_edges` function.
+    This function wraps the :func:`G.number_of_edges <networkx.Graph.number_of_edges>` function.
     """
     return G.number_of_edges()
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -49,7 +49,10 @@ __all__ = [
 
 
 def nodes(G):
-    """Returns an iterator over the graph nodes."""
+    """Returns a NodeView over the graph nodes.
+
+    This function wraps the :func:`networkx.Graph.nodes` property.
+    """
     return G.nodes()
 
 
@@ -59,6 +62,8 @@ def edges(G, nbunch=None):
     Return all edges if nbunch is unspecified or nbunch=None.
 
     For digraphs, edges=out_edges
+
+    This function wraps the :func:`networkx.Graph.edges` property.
     """
     return G.edges(nbunch)
 
@@ -66,22 +71,33 @@ def edges(G, nbunch=None):
 def degree(G, nbunch=None, weight=None):
     """Returns a degree view of single node or of nbunch of nodes.
     If nbunch is omitted, then return degrees of *all* nodes.
+
+    This function wraps the :func:`networkx.Graph.degree` property.
     """
     return G.degree(nbunch, weight)
 
 
 def neighbors(G, n):
-    """Returns a list of nodes connected to node n."""
+    """Returns an iterator over all neighbors of node n.
+
+    This function wraps the :func:`networkx.Graph.neighbors` function.
+    """
     return G.neighbors(n)
 
 
 def number_of_nodes(G):
-    """Returns the number of nodes in the graph."""
+    """Returns the number of nodes in the graph.
+
+    This function wraps the :func:`networkx.Graph.number_of_nodes` function.
+    """
     return G.number_of_nodes()
 
 
 def number_of_edges(G):
-    """Returns the number of edges in the graph."""
+    """Returns the number of edges in the graph.
+
+    This function wraps the :func:`networkx.Graph.number_of_edges` function.
+    """
     return G.number_of_edges()
 
 


### PR DESCRIPTION
This links the functions.py docstrings to the base Graph class, should resolve https://github.com/networkx/networkx/issues/7124