### PR TITLE
Makes is_path return False for single node paths

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1271,8 +1271,9 @@ def number_of_selfloops(G):
 def is_path(G, path):
     """Returns whether or not the specified path exists.
 
-    For it to return True, every node on the path must exist and
-    each consecutive pair must be connected via one or more edges.
+    For it to return True, every node on the path must exist,
+    each consecutive pair must be connected via one or more edges,
+    and at least two nodes must be specified.
 
     Parameters
     ----------
@@ -1288,7 +1289,7 @@ def is_path(G, path):
         True if `path` is a valid path in `G`
 
     """
-    return all((node in G and nbr in G[node]) for node, nbr in nx.utils.pairwise(path))
+    return all((node in G and nbr in G[node]) for node, nbr in nx.utils.pairwise(path)) if len(path) >= 2 else False
 
 
 def path_weight(G, path, weight):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1289,7 +1289,11 @@ def is_path(G, path):
         True if `path` is a valid path in `G`
 
     """
-    return all((node in G and nbr in G[node]) for node, nbr in nx.utils.pairwise(path)) if len(path) >= 2 else False
+    return (
+        all((node in G and nbr in G[node]) for node, nbr in nx.utils.pairwise(path))
+        if len(path) >= 2
+        else False
+    )
 
 
 def path_weight(G, path, weight):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -757,7 +757,7 @@ def test_ispath(G):
     valid_path = [1, 2, 3, 4]
     invalid_path = [1, 2, 4, 3]  # wrong node order
     another_invalid_path = [1, 2, 3, 4, 5]  # contains node not in G
-    yet_another_invalid_path = [2] # a single node is not a path
+    yet_another_invalid_path = [2]  # a single node is not a path
     assert nx.is_path(G, valid_path)
     assert not nx.is_path(G, invalid_path)
     assert not nx.is_path(G, another_invalid_path)

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -753,13 +753,15 @@ def test_pathweight():
     "G", (nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph())
 )
 def test_ispath(G):
-    G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4)])
+    G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4), (3, 6)])
     valid_path = [1, 2, 3, 4]
     invalid_path = [1, 2, 4, 3]  # wrong node order
     another_invalid_path = [1, 2, 3, 4, 5]  # contains node not in G
+    yet_another_invalid_path = [2] # a single node is not a path
     assert nx.is_path(G, valid_path)
     assert not nx.is_path(G, invalid_path)
     assert not nx.is_path(G, another_invalid_path)
+    assert not nx.is_path(G, yet_another_invalid_path)
 
 
 @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -753,7 +753,7 @@ def test_pathweight():
     "G", (nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph())
 )
 def test_ispath(G):
-    G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4), (3, 6)])
+    G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4)])
     valid_path = [1, 2, 3, 4]
     invalid_path = [1, 2, 4, 3]  # wrong node order
     another_invalid_path = [1, 2, 3, 4, 5]  # contains node not in G


### PR DESCRIPTION
# description

The is_path method currently returns True for single-node paths. In my mind, a single node cannot be said to constitute a path. Consequently, the method should return False. I therefore corrected the aforementioned method and added a test case to verify it works correctly.

# changes introduced

The is_path method now checks the length of the path and returns False if it is shorter than two.

# before PR

import networkx as nx
G = nx.MultiDiGraph()
G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4)])
yet_another_invalid_path = [2] # a single node is not a path
assert nx.is_path(G, yet_another_invalid_path) # apparently it is

# after PR

import networkx as nx
G = nx.MultiDiGraph()
G.add_edges_from([(1, 2), (2, 3), (1, 2), (3, 4)])
yet_another_invalid_path = [2] # a single node is not a path
assert not nx.is_path(G, yet_another_invalid_path) # indeed, a single node is not a path