### PR TITLE
Stop searching the graph when reaching the target node

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -506,7 +506,7 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
     """
     method = "unweighted" if weight is None else method
     if method == "unweighted":
-        pred = nx.predecessor(G, source, target=target)
+        pred = nx.predecessor(G, source)
     elif method == "dijkstra":
         pred, dist = nx.dijkstra_predecessor_and_distance(G, source, target=target, weight=weight)
     elif method == "bellman-ford":

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -506,11 +506,11 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
     """
     method = "unweighted" if weight is None else method
     if method == "unweighted":
-        pred = nx.predecessor(G, source)
+        pred = nx.predecessor(G, source, target=target)
     elif method == "dijkstra":
-        pred, dist = nx.dijkstra_predecessor_and_distance(G, source, weight=weight)
+        pred, dist = nx.dijkstra_predecessor_and_distance(G, source, target=target, weight=weight)
     elif method == "bellman-ford":
-        pred, dist = nx.bellman_ford_predecessor_and_distance(G, source, weight=weight)
+        pred, dist = nx.bellman_ford_predecessor_and_distance(G, source, target=target, weight=weight)
     else:
         raise ValueError(f"method not supported: {method}")
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -882,7 +882,7 @@ def _dijkstra_multisource(
 
 
 @nx._dispatch(edge_attrs="weight")
-def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight="weight"):
+def dijkstra_predecessor_and_distance(G, source, target=None, cutoff=None, weight="weight"):
     """Compute weighted shortest path length and predecessors.
 
     Uses Dijkstra's Method to obtain the shortest weighted paths
@@ -895,6 +895,9 @@ def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight="weight"):
 
     source : node label
         Starting node for path
+
+    target: node label, optional
+        Ending node for path
 
     cutoff : integer or float, optional
         Length (sum of edge weights) at which the search is stopped.
@@ -951,7 +954,7 @@ def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight="weight"):
         raise nx.NodeNotFound(f"Node {source} is not found in the graph")
     weight = _weight_function(G, weight)
     pred = {source: []}  # dictionary of predecessors
-    return (pred, _dijkstra(G, source, weight, pred=pred, cutoff=cutoff))
+    return (pred, _dijkstra(G, source, weight, pred=pred, cutoff=cutoff, target=target))
 
 
 @nx._dispatch(edge_attrs="weight")

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -882,7 +882,7 @@ def _dijkstra_multisource(
 
 
 @nx._dispatch(edge_attrs="weight")
-def dijkstra_predecessor_and_distance(G, source, target=None, cutoff=None, weight="weight"):
+def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight="weight", target=None):
     """Compute weighted shortest path length and predecessors.
 
     Uses Dijkstra's Method to obtain the shortest weighted paths


### PR DESCRIPTION
Hi NetworkX developers,

while using the function all_shortest paths, I noticed, that the parameter 'target' is not passed through to the inner functions. This means, that the query v == target in the inner-most function is never True and the whole graph is being searched every time (without breaking when the target is reached). 
I fixed it only for weighted graphs and tested it on my computer, where the fix seems to improve computation time, especially for strongly connected graphs. 

This is my first pull request, so please let me know, if I need to change or add anything!
