### PR TITLE
Add label check when pull request is edited instead of push

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types:
       - opened
+      - edited
       - labeled
       - unlabeled
-  push:
 
 env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}


### PR DESCRIPTION
the push trigger occurs even if it is not a pull_request.
So we need to use a pull request action rather than push.
This PR tries to add the pull_request type `edited` instead of push.