### PR TITLE
bugfix-for-issue-6881

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -113,10 +113,17 @@ def _kou_steiner_tree(G, terminal_nodes, weight):
 
 
 def _remove_nonterminal_leaves(G, terminals):
+    """Remove non-terminal leaves iteratively."""
     terminals_set = set(terminals)
-    for n in list(G.nodes):
-        if n not in terminals_set and G.degree(n) == 1:
-            G.remove_node(n)
+    while True:
+        non_terminal_leaves = [
+            n for n in G.nodes if n not in terminals_set and G.degree(n) == 1
+        ]
+        if not non_terminal_leaves:
+            break
+        G.remove_nodes_from(non_terminal_leaves)
+        if len(G.nodes) == 1:  # If only one node left, exit loop
+            break
 
 
 ALGORITHMS = {
@@ -217,4 +224,8 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
             (u, v, min(G[u][v], key=lambda k: G[u][v][k][weight])) for u, v in edges
         )
     T = G.edge_subgraph(edges)
+
+    # Remove non-terminal leaves from the generated tree
+    _remove_nonterminal_leaves(T, terminal_nodes)
+
     return T


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
This updated function now checks if there is only one node left in the graph after removing non-terminal leaves. If there's only one node left, it exits the loop, preventing further removal of non-terminal leaves. This should produce the desired behavior as outlined in the provided code snippet.
```
def _remove_nonterminal_leaves(G, terminals):
    """Remove non-terminal leaves iteratively."""
    terminals_set = set(terminals)
    while True:
        non_terminal_leaves = [n for n in G.nodes if n not in terminals_set and G.degree(n) == 1]
        if not non_terminal_leaves:
            break
        G.remove_nodes_from(non_terminal_leaves)
        if len(G.nodes) == 1:  # If only one node left, exit loop
            break
```