### PR TITLE
update triadic_census documentation for undirected graphs - issue 4386

### DIFF
--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -178,6 +178,10 @@ def triadic_census(G, nodelist=None):
     This algorithm has complexity $O(m)$ where $m$ is the number of edges in
     the graph.
 
+    For undirected graphs, the triadic census can be computed by first converting
+    the graph into a directed graph using the ``G.to_directed()`` method. Afther this conversion,
+    only the triad types 003, 102, 201 and 300 will be present in the undirected scenario.
+
     Raises
     ------
     ValueError

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -180,7 +180,7 @@ def triadic_census(G, nodelist=None):
 
     For undirected graphs, the triadic census can be computed by first converting
     the graph into a directed graph using the ``G.to_directed()`` method.
-    After this conversion, only the triad types 003, 102, 201 and 300 will be 
+    After this conversion, only the triad types 003, 102, 201 and 300 will be
     present in the undirected scenario.
 
     Raises

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -179,8 +179,9 @@ def triadic_census(G, nodelist=None):
     the graph.
 
     For undirected graphs, the triadic census can be computed by first converting
-    the graph into a directed graph using the ``G.to_directed()`` method. Afther this conversion,
-    only the triad types 003, 102, 201 and 300 will be present in the undirected scenario.
+    the graph into a directed graph using the ``G.to_directed()`` method.
+    After this conversion, only the triad types 003, 102, 201 and 300 will be 
+    present in the undirected scenario.
 
     Raises
     ------


### PR DESCRIPTION
With this contribution I have updated the documentation for triadic census to handle directed graphs. 
The update is in the Notes section of the triadic_census and the text added is as follows: 
For undirected graphs, the triadic census can be computed by first converting
the graph into a directed graph using the ``G.to_directed()`` method. Afther this conversion,
only the triad types 003, 102, 201 and 300 will be present in the undirected scenario.

Closes #4386