### PR TITLE
Enable svg+xml or gif before png in HTML builder for Sphinx documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 import os
 from datetime import date
 from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
+from sphinx.builders.html import StandaloneHTMLBuilder
 from warnings import filterwarnings
 
 filterwarnings(
@@ -162,6 +163,16 @@ html_sidebars = {
 }
 html_logo = "_static/networkx_banner.svg"
 html_favicon = "_static/favicon.ico"
+
+# By default, the HTML builder will always prefer the png image.
+# Override the StandaloneHTMLBuilder class with the supported_image_types order
+# to pick up, e.g., an animated gif rather then a png if both are available.
+StandaloneHTMLBuilder.supported_image_types = [
+    'image/svg+xml',
+    'image/gif',
+    'image/png',
+    'image/jpeg'
+]
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,8 @@ extensions = [
     "texext",
     "numpydoc",
     "matplotlib.sphinxext.plot_directive",
+    "sphinxcontrib.images",
+    "sphinxcontrib.video",
 ]
 
 # https://github.com/sphinx-gallery/sphinx-gallery

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -171,7 +171,7 @@ StandaloneHTMLBuilder.supported_image_types = [
     "image/svg+xml",
     "image/gif",
     "image/png",
-    "image/jpeg"
+    "image/jpeg",
 ]
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,10 +168,10 @@ html_favicon = "_static/favicon.ico"
 # Override the StandaloneHTMLBuilder class with the supported_image_types order
 # to pick up, e.g., an animated gif rather then a png if both are available.
 StandaloneHTMLBuilder.supported_image_types = [
-    'image/svg+xml',
-    'image/gif',
-    'image/png',
-    'image/jpeg'
+    "image/svg+xml",
+    "image/gif",
+    "image/png",
+    "image/jpeg"
 ]
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name

--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -11,6 +11,7 @@ import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.colors as mpl
 from matplotlib import animation
+from matplotlib.animation import FuncAnimation, PillowWriter 
 
 G = nx.dodecahedral_graph()
 
@@ -95,3 +96,34 @@ ani = animation.FuncAnimation(
 )
 
 plt.show()
+
+###############################################################################
+# Rotating 3D graph animated 'gif'.
+# ---------------------------------
+#
+# Rotation of the 3D graph saved to an animated 'gif' file.
+
+# number of nodes
+size = 10
+
+# generate graph
+G=nx.complete_graph(size)
+
+frame = np.random.randint(0, 5, (size, size))
+
+pos = nx.spring_layout(G)
+nodes = nx.draw_networkx_nodes(G, pos)
+edges = nx.draw_networkx_edges(G, pos)
+plt.axis('off')
+
+def update(i):
+    nc = frame[i]
+    nodes.set_array(nc)
+    return nodes,
+
+# output animation; its important I save it
+fig = plt.gcf()
+ani = FuncAnimation(fig, update, interval=50, frames=range(size), blit=True)
+ani.save('crap.gif', writer='imagemagick',  savefig_kwargs={'facecolor':'white'}, fps=1)
+
+.. image:: crap.*

--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -10,8 +10,10 @@ import numpy as np
 import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.colors as mpl
+import matplotlib.image as mpimg
 from matplotlib import animation
-from matplotlib.animation import FuncAnimation, PillowWriter 
+from matplotlib.animation import FuncAnimation, PillowWriter
+from sphinxcontrib.images import Image
 
 G = nx.dodecahedral_graph()
 
@@ -126,4 +128,8 @@ fig = plt.gcf()
 ani = FuncAnimation(fig, update, interval=50, frames=range(size), blit=True)
 ani.save('crap.gif', writer='imagemagick',  savefig_kwargs={'facecolor':'white'}, fps=1)
 
-.. image:: crap.*
+image = Image('crap.gif', width=200, height=100, scale=50, alt='alternate text', align='right')
+
+img = mpimg.imread('crap.gif')
+plt.imshow(img)
+plt.show()

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -5,4 +5,5 @@ seaborn>=0.12
 cairocffi>=1.4
 igraph>=0.10
 scikit-learn>=1.3.1
+sphinxcontrib-images>=0.9.4
 sphinxcontrib-video>=0.2.0

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -5,4 +5,4 @@ seaborn>=0.12
 cairocffi>=1.4
 igraph>=0.10
 scikit-learn>=1.3.1
-ffmpeg>=6.1
+sphinxcontrib-video>=0.2.0

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -5,3 +5,4 @@ seaborn>=0.12
 cairocffi>=1.4
 igraph>=0.10
 scikit-learn>=1.3.1
+ffmpeg>=6.1


### PR DESCRIPTION
Add
```
StandaloneHTMLBuilder.supported_image_types = [
    'image/svg+xml',
    'image/gif',

```
to conf.py and add an example of an animated gif to the Gallery
