### PR TITLE
comments on how to save animations locally plot_greedy_coloring.py

### DIFF
--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -94,4 +94,21 @@ ani = animation.FuncAnimation(
     frames=100,
 )
 
+## To save the animation to a local file, comment in the following for GIF:
+# ani.save(
+#     "greedy_coloring.gif",
+#     writer="imagemagick",
+#     savefig_kwargs={"facecolor": "white"},
+#     fps=20,
+# )
+## Or/end the following for MP4 in AV1 coding:
+# Writer = animation.writers["ffmpeg"]
+# writer = Writer(
+#     fps=20,
+#     metadata=dict(artist="NetworkX"),
+#     bitrate=1800,
+#     extra_args=["-vcodec", "av1", "-strict", "experimental"],
+# )
+# ani.save("greedy_coloring.mp4", writer=writer)
+
 plt.show()


### PR DESCRIPTION
Added comments on how to save animations locally in plot_greedy_coloring.py. 

Originally tried to display GIF and MP4 files with animation in Sphinx auto-generated documentation for plot_greedy_coloring.py in https://github.com/networkx/networkx/pull/7142, but I do not know how to make Sphinx to show animated gif and mp4 in example's auto-generated documentation. And it takes a very long time to make the mp4. So I have closed that PR and make this new one, with just a comment how to create animated gif and mp4 rather than actually running it in Sphinx.