### PR TITLE
DOC: fix URL econded links and doc references

### DIFF
--- a/doc/reference/algorithms/dag.rst
+++ b/doc/reference/algorithms/dag.rst
@@ -21,3 +21,4 @@ Directed Acyclic Graphs
    dag_longest_path
    dag_longest_path_length
    dag_to_branching
+   compute_v_structures

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -1202,7 +1202,7 @@ def girth(G):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Girth_(graph_theory)
+    .. [1] `Wikipedia: Girth <https://en.wikipedia.org/wiki/Girth_(graph_theory)>`_
 
     """
     girth = depth_limit = inf

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1249,7 +1249,7 @@ def compute_v_structures(G):
 
     Notes
     -----
-    https://en.wikipedia.org/wiki/Collider_(statistics)
+    `Wikipedia: Collider in causal graphs <https://en.wikipedia.org/wiki/Collider_(statistics)>`_
     """
     for collider, preds in G.pred.items():
         for common_parents in combinations(preds, r=2):


### PR DESCRIPTION
This should fix https://github.com/networkx/networkx/issues/7150 atleast in networkx docs (not the root cause in sphinx). I also found that `compute_v_structures` wasn't properly listed in the reference docs.