### PR TITLE
MAINT: use ruff format instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,26 +2,23 @@
 # pre-commit install
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
       - id: blacken-docs
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v3.1.0
     hooks:
       - id: prettier
         files: \.(html|md|toml|yml|yaml)
         args: [--prose-wrap=preserve]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.1.8
     hooks:
       - id: ruff
         args:
           - --fix
+      - id: ruff-format
   - repo: local
     hooks:
       - id: generate_requirements.py

--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -94,7 +94,7 @@ def degree_assortativity_coefficient(G, x="out", y="in", weight=None, nodes=None
     else:
         degrees = {d for _, d in G.degree(nodes, weight=weight)}
 
-    mapping = {d: i for i, d, in enumerate(degrees)}
+    mapping = {d: i for i, d in enumerate(degrees)}
     M = degree_mixing_matrix(G, x=x, y=y, nodes=nodes, weight=weight, mapping=mapping)
 
     return _numeric_ac(M, mapping=mapping)
@@ -251,7 +251,7 @@ def numeric_assortativity_coefficient(G, attribute, nodes=None):
     if nodes is None:
         nodes = G.nodes
     vals = {G.nodes[n][attribute] for n in nodes}
-    mapping = {d: i for i, d, in enumerate(vals)}
+    mapping = {d: i for i, d in enumerate(vals)}
     M = attribute_mixing_matrix(G, attribute, nodes, mapping)
     return _numeric_ac(M, mapping)
 

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -882,8 +882,7 @@ class ISMAGS:
 
             # The next node is the one that is unmapped and has fewest
             # candidates
-            # Pylint disables because it's a one-shot function.
-            next_sgn = min(left_to_map, key=lambda n: min(new_candidates[n], key=len))  # pylint: disable=cell-var-from-loop
+            next_sgn = min(left_to_map, key=lambda n: min(new_candidates[n], key=len))
             yield from self._map_nodes(
                 next_sgn,
                 new_candidates,
@@ -907,8 +906,7 @@ class ISMAGS:
         # "part of" the subgraph in to_be_mapped, and we make it a little
         # smaller every iteration.
 
-        # pylint disable because it's guarded against by default value
-        current_size = len(next(iter(to_be_mapped), []))  # pylint: disable=stop-iteration-return
+        current_size = len(next(iter(to_be_mapped), []))
 
         found_iso = False
         if current_size <= len(self.graph):

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -883,9 +883,7 @@ class ISMAGS:
             # The next node is the one that is unmapped and has fewest
             # candidates
             # Pylint disables because it's a one-shot function.
-            next_sgn = min(
-                left_to_map, key=lambda n: min(new_candidates[n], key=len)
-            )  # pylint: disable=cell-var-from-loop
+            next_sgn = min(left_to_map, key=lambda n: min(new_candidates[n], key=len))  # pylint: disable=cell-var-from-loop
             yield from self._map_nodes(
                 next_sgn,
                 new_candidates,
@@ -910,9 +908,7 @@ class ISMAGS:
         # smaller every iteration.
 
         # pylint disable because it's guarded against by default value
-        current_size = len(
-            next(iter(to_be_mapped), [])
-        )  # pylint: disable=stop-iteration-return
+        current_size = len(next(iter(to_be_mapped), []))  # pylint: disable=stop-iteration-return
 
         found_iso = False
         if current_size <= len(self.graph):

--- a/networkx/algorithms/isomorphism/tests/test_vf2pp_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2pp_helpers.py
@@ -57,8 +57,9 @@ class TestNodeOrdering:
             dict(zip(G2, it.cycle(labels_many))),
             "label",
         )
-        l1, l2 = nx.get_node_attributes(G1, "label"), nx.get_node_attributes(
-            G2, "label"
+        l1, l2 = (
+            nx.get_node_attributes(G1, "label"),
+            nx.get_node_attributes(G2, "label"),
         )
 
         gparams = _GraphParameters(
@@ -118,8 +119,9 @@ class TestNodeOrdering:
             dict(zip(G2, it.cycle(labels))),
             "label",
         )
-        l1, l2 = nx.get_node_attributes(G1, "label"), nx.get_node_attributes(
-            G2, "label"
+        l1, l2 = (
+            nx.get_node_attributes(G1, "label"),
+            nx.get_node_attributes(G2, "label"),
         )
         gparams = _GraphParameters(
             G1,
@@ -155,8 +157,9 @@ class TestNodeOrdering:
         G2.nodes[4]["label"] = "red"
         G2.nodes[5]["label"] = "blue"
 
-        l1, l2 = nx.get_node_attributes(G1, "label"), nx.get_node_attributes(
-            G2, "label"
+        l1, l2 = (
+            nx.get_node_attributes(G1, "label"),
+            nx.get_node_attributes(G2, "label"),
         )
         gparams = _GraphParameters(
             G1,

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -647,8 +647,9 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
     single_source_all_shortest_paths
     """
     for n in G:
-        yield n, dict(
-            single_source_all_shortest_paths(G, n, weight=weight, method=method)
+        yield (
+            n,
+            dict(single_source_all_shortest_paths(G, n, weight=weight, method=method)),
         )
 
 

--- a/networkx/algorithms/tests/test_bridges.py
+++ b/networkx/algorithms/tests/test_bridges.py
@@ -127,7 +127,7 @@ class TestLocalBridges:
         inf = float("inf")
         expected = {(3, 4, inf), (4, 3, inf)}
         assert next(nx.local_bridges(self.BB)) in expected
-        expected = {(u, v, 3) for u, v, in self.square.edges}
+        expected = {(u, v, 3) for u, v in self.square.edges}
         assert set(nx.local_bridges(self.square)) == expected
         assert list(nx.local_bridges(self.tri)) == []
 

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -247,7 +247,8 @@ def test_arbitrary_element(iterable_type, expected):
 
 
 @pytest.mark.parametrize(
-    "iterator", ((i for i in range(3)), iter([1, 2, 3]))  # generator
+    "iterator",
+    ((i for i in range(3)), iter([1, 2, 3])),  # generator
 )
 def test_arbitrary_element_raises(iterator):
     """Value error is raised when input is an iterator."""


### PR DESCRIPTION
The [ruff formatter ](https://docs.astral.sh/ruff/formatter/)is in "production-ready beta" now, and it's supposed to be a [99% drop in replacement for black](https://docs.astral.sh/ruff/formatter/#black-compatibility).

I ran our codebase with the ruff formatter and it makes minimal changes to our black formatted codebase and it's much faster than the black formatter (it still follows the black spec).

We still will depend on blacken-docs for now. They are still finialising support for formatting code inside docstrings (https://github.com/astral-sh/ruff/issues/8908).