### PR TITLE
Ensure warnings related to changes in shortest_path returns are visible to users

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -46,10 +46,6 @@ Version 3.3
 * Remove pydot functionality ``drawing/nx_pydot.py``, if pydot is still not being maintained. See #5723
 * Remove the ``forest_str`` function from ``readwrite/text.py``. Replace
   existing usages with ``write_network_text``.
-* Change ``single_target_shortest_path_length`` in ``algorithms/shortest_path/unweighted.py``
-  to return a dict. See #6527
-* Change ``shortest_path`` in ``algorithms/shortest_path/generic.py``
-  to return a iterator. See #6527
 
 Version 3.4
 ~~~~~~~~~~~
@@ -69,3 +65,7 @@ Version 3.5
 * Remove ``all_triplets`` from ``algorithms/triads.py``
 * Remove ``random_triad`` from ``algorithms/triad.py``.
 * Add `not_implemented_for("multigraph”)` decorator to ``k_core``, ``k_shell``, ``k_crust`` and ``k_corona`` functions.
+* Change ``single_target_shortest_path_length`` in ``algorithms/shortest_path/unweighted.py``
+  to return a dict. See #6527
+* Change ``shortest_path`` in ``algorithms/shortest_path/generic.py``
+  to return a iterator. See #6527

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -135,8 +135,17 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     method = "unweighted" if weight is None else method
     if source is None:
         if target is None:
-            msg = "shortest_path for all_pairs will return an iterator in v3.3"
-            warnings.warn(msg, DeprecationWarning)
+            warnings.warn(
+                (
+                    "\n\nshortest_path will return an iterator that yields\n"
+                    "(node, path) pairs instead of a dictionary when source\n"
+                    "and target are unspecified beginning in version 3.5\n\n"
+                    "To keep the current behavior, use:\n\n"
+                    "\tdict(nx.shortest_path(G))"
+                ),
+                FutureWarning,
+                stacklevel=3,
+            )
 
             # Find paths between all pairs.
             if method == "unweighted":

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -135,8 +135,14 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     if target not in G:
         raise nx.NodeNotFound(f"Target {target} is not in G")
 
-    msg = "single_target_shortest_path_length will return a dict starting in v3.3"
-    warnings.warn(msg, DeprecationWarning)
+    warnings.warn(
+        (
+            "\n\nsingle_target_shortest_path_length will return a dict instead of"
+            "\nan iterator in version 3.5"
+        ),
+        FutureWarning,
+        stacklevel=3,
+    )
 
     if cutoff is None:
         cutoff = float("inf")

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -94,13 +94,13 @@ def set_warnings():
     )
     warnings.filterwarnings(
         "ignore",
-        category=DeprecationWarning,
-        message="single_target_shortest_path_length will",
+        category=FutureWarning,
+        message="\n\nsingle_target_shortest_path_length",
     )
     warnings.filterwarnings(
         "ignore",
-        category=DeprecationWarning,
-        message="shortest_path for all_pairs",
+        category=FutureWarning,
+        message="\n\nshortest_path",
     )
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\nforest_str is deprecated"


### PR DESCRIPTION
As discussed in the community meeting, this PR ensures[^1] that visible warnings will be raised notifying users of proposed changes to the return type of `shortest_path` and `single_target_shortest_path_length`.

I also went ahead and made a couple additional changes to the warning:
 - I changed the type from `DeprecationWarning` -> `FutureWarning` since the only thing changing is the return type rather than something being removed from the API
 - I reset the deprecation cycle to the current release; i.e. the warning will be raised for 2 cycles (3.3 and 3.4) then the behavior change implemented in 3.5
 - Finally, I beefed up the text for the `shortest_path` warning. I wanted to illustrate that it's possible to future proof your code now by wrapping `shortest_path` in `dict` (since `dict(<dictionary_instance>)` is a no-op). I'm happy to hack the text back down to a single sentence if that's what others prefer - just LMK!

As noted [here](https://github.com/networkx/networkx/pull/7156#issuecomment-1854560919), if the visible warnings are added then at least some of the changes in #6584 should be reverted until the reset-deprecation expires.

[^1]: or at least makes more likely