### PR TITLE
added ability to check node attributes for labels

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1019,6 +1019,9 @@ def draw_networkx_labels(
 
     if labels is None:
         labels = {n: n for n in G.nodes()}
+        for n in G.nodes:
+            if 'label' in G.nodes[n]:
+                labels[n] = G.nodes[n]['label']
 
     text_items = {}  # there is no text collection so we'll fake one
     for n, label in labels.items():


### PR DESCRIPTION
This is a small feature that allows the nodes' labels to be set as attributes.
`G.add_node(mynode, label='mylabel')`
`nx.draw(G, with_labels=True)`

The only addition is to search the node attributes for the `label` key and update the default if it exists.