### PR TITLE
Update test suite for Pytest v8

### DIFF
--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -183,8 +183,7 @@ class TestStronglyConnected:
         with pytest.raises(NetworkXNotImplemented):
             next(nx.kosaraju_strongly_connected_components(G))
         with pytest.raises(NetworkXNotImplemented):
-            with pytest.deprecated_call():
-                next(nx.strongly_connected_components_recursive(G))
+            next(nx.strongly_connected_components_recursive(G))
         pytest.raises(NetworkXNotImplemented, nx.is_strongly_connected, G)
         pytest.raises(NetworkXNotImplemented, nx.condensation, G)
 

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -1,6 +1,7 @@
 """Unit tests for PyGraphviz interface."""
 import os
 import tempfile
+import warnings
 
 import pytest
 
@@ -249,6 +250,6 @@ class TestAGraph:
         G.add_node(0, pos=(0, 0))
         G.add_node(1, pos=(1, 1))
         A = nx.nx_agraph.to_agraph(G)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             A.layout()
         assert len(record) == 0


### PR DESCRIPTION
There is a release candidate for Pytest v8 for which two of NX's tests were failing. This PR makes the necessary updates to be pytest-8 compatible:
 - f537f0b removes a `pytest.deprecated_call` check from a test which raises an exception. It turns out this never raised the warning as it hits the exception first, it's just that pytest v7 never caught this case. 
 - 7fe9c50 replaces the deprecated `pytest.warns(None)` pattern with the recommended `warnings.catch_warnings()` context manager.