### PR TITLE
Future-proofing and improve tests

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -498,15 +498,15 @@ def _heuristic(k, root, DF_tree, D, nodes, greedy):
                         / root_node["sigma"][added_node][y]
                     )
             DF_tree.nodes[node_p]["sigma"][x][y] = root_node["sigma"][x][y] * (1 - dxvy)
-            DF_tree.nodes[node_p]["betweenness"][x][y] = (
+            DF_tree.nodes[node_p]["betweenness"].loc[y, x] = (
                 root_node["betweenness"][x][y] - root_node["betweenness"][x][y] * dxvy
             )
             if y != added_node:
-                DF_tree.nodes[node_p]["betweenness"][x][y] -= (
+                DF_tree.nodes[node_p]["betweenness"].loc[y, x] -= (
                     root_node["betweenness"][x][added_node] * dxyv
                 )
             if x != added_node:
-                DF_tree.nodes[node_p]["betweenness"][x][y] -= (
+                DF_tree.nodes[node_p]["betweenness"].loc[y, x] -= (
                     root_node["betweenness"][added_node][y] * dvxy
                 )
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -117,7 +117,9 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="function `join` is deprecated"
+        "ignore",
+        category=DeprecationWarning,
+        message="The function `join` is deprecated",
     )
     warnings.filterwarnings(
         "ignore",

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -248,7 +248,7 @@ def maybe_regular_expander(n, d, *, create_using=None, max_tries=100, seed=None)
 
     Examples
     --------
-    >>> G = nx.maybe_regular_expander(n=200, d=6)
+    >>> G = nx.maybe_regular_expander(n=200, d=6, seed=8020)
 
     Returns
     -------

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -387,8 +387,8 @@ def is_regular_expander(G, *, epsilon=0):
 
     _, d = nx.utils.arbitrary_element(G.degree)
 
-    A = nx.adjacency_matrix(G)
-    lams = eigsh(A.asfptype(), which="LM", k=2, return_eigenvectors=False)
+    A = nx.adjacency_matrix(G, dtype=float)
+    lams = eigsh(A, which="LM", k=2, return_eigenvectors=False)
 
     # lambda2 is the second biggest eigenvalue
     lambda2 = min(lams)


### PR DESCRIPTION
This PR fixes the warnings seen in the test suite from the nightly wheels of the default dependencies. Other improvements include:
 - A fix to one of the warning filters in the test config
 - Seeding a doctest to avoid intermittent failures