### PR TITLE
Refactor geometric_soft_configuration_model tests for performance

### DIFF
--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -387,19 +387,15 @@ def test_set_attributes_S1():
     assert len(radii) == 100
 
 
-def test_mean_kappas_S1():
+def test_mean_kappas_mean_degree_S1():
     G = nx.geometric_soft_configuration_graph(
-        beta=2.5, n=5000, gamma=2.7, mean_degree=10, seed=42
+        beta=2.5, n=50, gamma=2.7, mean_degree=10, seed=8023
     )
+
     kappas = nx.get_node_attributes(G, "kappa")
     mean_kappas = sum(kappas.values()) / len(kappas)
     assert math.fabs(mean_kappas - 10) < 0.5
 
-
-def test_mean_degree_S1():
-    G = nx.geometric_soft_configuration_graph(
-        beta=2.5, n=5000, gamma=2.7, mean_degree=10, seed=42
-    )
     degrees = dict(G.degree())
     mean_degree = sum(degrees.values()) / len(degrees)
     assert math.fabs(mean_degree - 10) < 1

--- a/networkx/generators/tests/test_geometric.py
+++ b/networkx/generators/tests/test_geometric.py
@@ -476,10 +476,10 @@ def test_mean_degree_influence_on_connectivity_S1():
 
 def test_compare_mean_kappas_different_gammas_S1():
     G1 = nx.geometric_soft_configuration_graph(
-        beta=1.5, n=2000, gamma=2.7, mean_degree=20, seed=42
+        beta=1.5, n=20, gamma=2.7, mean_degree=5, seed=42
     )
     G2 = nx.geometric_soft_configuration_graph(
-        beta=1.5, n=2000, gamma=3.5, mean_degree=20, seed=42
+        beta=1.5, n=20, gamma=3.5, mean_degree=5, seed=42
     )
     kappas1 = nx.get_node_attributes(G1, "kappa")
     mean_kappas1 = sum(kappas1.values()) / len(kappas1)


### PR DESCRIPTION
#6858 added the `geometric_soft_configuration_model` generator, which included several tests that generated graphs with >1k nodes. These tests were quite slow:

```bash
$ pytest --durations 4 networkx/generators/tests/test_geometric.py

...

4.07s call     networkx/generators/tests/test_geometric.py::test_mean_degree_S1
4.06s call     networkx/generators/tests/test_geometric.py::test_mean_kappas_S1
1.34s call     networkx/generators/tests/test_geometric.py::test_compare_mean_kappas_different_gammas_S1
0.18s call     networkx/generators/tests/test_geometric.py::test_dict_kappas_S1
```

These could be decorated with `pytest.mark.slow`, but then they'd still be running in the coverage job in CI. Since the tests are pseudo-stochastic anyways (i.e. they test average properties of graphs created with a seed) I figured there was no harm in refactoring them instead to improve performance. The main thing was to drop the total number of nodes from 1000's to 10's (reducing the `mean_degree` as well, where necessary). I also consolidated two of the tests into one so that the input graph is only created once. These changes result in:

```bash
$ pytest --durations 4 networkx/generators/tests/test_geometric.py

...

0.18s call     networkx/generators/tests/test_geometric.py::test_dict_kappas_S1
0.03s call     networkx/generators/tests/test_geometric.py::TestRandomGeometricGraph::test_number_of_nodes
0.03s call     networkx/generators/tests/test_geometric.py::TestNavigableSmallWorldGraph::test_navigable_small_world
0.01s call     networkx/generators/tests/test_geometric.py::test_beta_clustering_S1
```

... removing the bottlenecks and dropping the total test runtime for the module from ~10s -> 0.4s (on my machine).