### PR TITLE
Fix random_spanning_tree() for single node and empty graphs

### DIFF
--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -905,6 +905,8 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
             #    multiplicative total spanning tree weight if the weight of each edge
             #    is assumed to be 1, which is conveniently built into networkx already,
             #    by calling total_spanning_tree_weight with weight=None
+            #
+            # 3. There are no edges in the graph. Then the weight of the MST is zero
             else:
                 total = 0
                 for u, v, w in G.edges(data=weight):
@@ -913,6 +915,20 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
                     )
                 return total
 
+    # Spanning tree for an empty graph is an empty graph
+    if G.number_of_nodes() == 0:
+        spanning_tree = nx.Graph()
+        return spanning_tree
+
+    # Spanning tree for a single node graph is that single node.
+    # A new graph is returned instead of returning G or its copy,
+    # in case G had a self loop
+    if G.number_of_nodes() == 1:
+        spanning_tree = nx.Graph()
+        spanning_tree.add_node(list(G.nodes)[0])
+        return G
+
+    # General case: For graphs of 2 or more nodes
     U = set()
     st_cached_value = 0
     V = set(G.edges())

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -897,16 +897,15 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
             #    itself.
             if G.number_of_edges() == 1:
                 return G.edges(data=weight).__iter__().__next__()[2]
-            # 2. There are more than two edges in the graph. Then, we can find the
+            # 2. There are no edges or two or more edges in the graph. Then, we find the
             #    total weight of the spanning trees using the formula in the
-            #    reference paper: take the weight of that edge and multiple it by
-            #    the number of spanning trees which have to include that edge. This
+            #    reference paper: take the weight of each edge and multiply it by
+            #    the number of spanning trees which include that edge. This
             #    can be accomplished by contracting the edge and finding the
             #    multiplicative total spanning tree weight if the weight of each edge
             #    is assumed to be 1, which is conveniently built into networkx already,
-            #    by calling total_spanning_tree_weight with weight=None
-            #
-            # 3. There are no edges in the graph. Then the weight of the MST is zero
+            #    by calling total_spanning_tree_weight with weight=None.
+            #    Note that with no edges the returned value is just zero.
             else:
                 total = 0
                 for u, v, w in G.edges(data=weight):
@@ -915,20 +914,10 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
                     )
                 return total
 
-    # Spanning tree for an empty graph is an empty graph
-    if G.number_of_nodes() == 0:
-        spanning_tree = nx.Graph()
-        return spanning_tree
+    if G.number_of_nodes() < 2:
+        # no edges in the spanning tree
+        return nx.empty_graph(G.nodes)
 
-    # Spanning tree for a single node graph is that single node.
-    # A new graph is returned instead of returning G or its copy,
-    # in case G had a self loop
-    if G.number_of_nodes() == 1:
-        spanning_tree = nx.Graph()
-        spanning_tree.add_node(list(G.nodes)[0])
-        return spanning_tree
-
-    # General case: For graphs of 2 or more nodes
     U = set()
     st_cached_value = 0
     V = set(G.edges())

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -926,7 +926,7 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
     if G.number_of_nodes() == 1:
         spanning_tree = nx.Graph()
         spanning_tree.add_node(list(G.nodes)[0])
-        return G
+        return spanning_tree
 
     # General case: For graphs of 2 or more nodes
     U = set()

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -706,3 +706,26 @@ def test_random_spanning_tree_additive_large():
     # Assert that p is greater than the significance level so that we do not
     # reject the null hypothesis
     assert not p < 0.05
+
+
+def test_random_spanning_tree_empty_graph():
+    """
+    Test on empty graph, should return an empty spanning tree
+    """
+
+    G = nx.Graph()
+    rst = nx.tree.random_spanning_tree(G)
+    assert len(rst.nodes) == 0
+    assert len(rst.edges) == 0
+
+
+def test_random_spanning_tree_single_node_graph():
+    """
+    Test on single node graph, should return a spanning tree with that node
+    """
+
+    G = nx.Graph()
+    G.add_node(0)
+    rst = nx.tree.random_spanning_tree(G)
+    assert len(rst.nodes) == 1
+    assert len(rst.edges) == 0

--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -709,10 +709,6 @@ def test_random_spanning_tree_additive_large():
 
 
 def test_random_spanning_tree_empty_graph():
-    """
-    Test on empty graph, should return an empty spanning tree
-    """
-
     G = nx.Graph()
     rst = nx.tree.random_spanning_tree(G)
     assert len(rst.nodes) == 0
@@ -720,12 +716,17 @@ def test_random_spanning_tree_empty_graph():
 
 
 def test_random_spanning_tree_single_node_graph():
-    """
-    Test on single node graph, should return a spanning tree with that node
-    """
-
     G = nx.Graph()
     G.add_node(0)
+    rst = nx.tree.random_spanning_tree(G)
+    assert len(rst.nodes) == 1
+    assert len(rst.edges) == 0
+
+
+def test_random_spanning_tree_single_node_loop():
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_edge(0, 0)
     rst = nx.tree.random_spanning_tree(G)
     assert len(rst.nodes) == 1
     assert len(rst.edges) == 0


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
Partial fix for issue #6920 for random_spanning_tree() by checking explicitly for empty and single node graphs. Earlier, the main for loop was the only return path, and these edge cases would cause an Exception meant for trees with less edges.