### PR TITLE
Fix rich_club_coefficient() for single node and empty graphs

### DIFF
--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -108,6 +108,9 @@ def _compute_rc(G):
     # side of the list, which would have a linear time cost.
     edge_degrees = sorted((sorted(map(G.degree, e)) for e in G.edges()), reverse=True)
     ek = G.number_of_edges()
+    if ek == 0:
+        return {}
+
     k1, k2 = edge_degrees.pop()
     rc = {}
     for d, nk in enumerate(nks):

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -75,7 +75,8 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
             "rich_club_coefficient is not implemented for graphs with self loops."
         )
     rc = _compute_rc(G)
-    if normalized:
+    # need at least 4 nodes to perform a double edge swap
+    if normalized and G.number_of_nodes() >= 4:
         # make R a copy of G, randomize with Q*|E| double edge swaps
         # and use rich_club coefficient of R to normalize
         R = G.copy()

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -47,9 +47,8 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
     Raises
     ------
     NetworkXError
-        If G has <= 3 nodes and normalized=True.
-        Raised from double_edge_swap(). A randomly sampled graph for
-        normalization cannot be generated in this case.
+        If `G` has fewer than four nodes and ``normalized=True``.
+        A randomly sampled graph for normalization cannot be generated in this case.
 
     Examples
     --------
@@ -64,13 +63,12 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
     algorithm ignores any edge weights and is not defined for directed
     graphs or graphs with parallel edges or self loops.
 
-    For graphs with <= 3 nodes, it can be proven that the graph is
-    completely determined given the degree of each vertex.
-    Normalization is done against a randomly sampled graph with the
-    same vertex degrees and different edges by repeatedly swapping the
-    endpoints of existing edges. But for <= 3 nodes, we
-    cannot generate such a random graph since there exists only one
-    graph (hence making the coefficients trivially normalized to 1).
+    Normalization is done by computing the rich club coefficient for a randomly
+    sampled graph with the same degree distribution as `G` by
+    repeatedly swapping the endpoints of existing edges. For graphs with fewer than 4
+    nodes, it is not possible to generate a random graph with a prescribed
+    degree distribution, as the degree distribution fully determines the graph
+    (hence making the coefficients trivially normalized to 1).
     This function raises an exception in this case.
 
     Estimates for appropriate values of `Q` are found in [2]_.

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -44,12 +44,6 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
     rc : dictionary
        A dictionary, keyed by degree, with rich-club coefficient values.
 
-    Raises
-    ------
-    NetworkXError
-        If G has less than 4 nodes and normalized=True.
-        Raised from within nx.double_edge_swap()
-
     Examples
     --------
     >>> G = nx.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (1, 4), (4, 5)])
@@ -62,6 +56,15 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
     The rich club definition and algorithm are found in [1]_.  This
     algorithm ignores any edge weights and is not defined for directed
     graphs or graphs with parallel edges or self loops.
+
+    For graphs with <= 3 nodes, it can be proven that the degree
+    sequence of the graph completely determines it. So the normalization
+    process which creates a random graph with the same degree sequence
+    will normalize against the same graph and set all existing rich club
+    coefficients to 1.
+    It can also be proven that the unnormalized rich club coefficients
+    for <= 3 node graphs are either {} or {0:1}. So normalization here
+    has no effect since 1/1=1.
 
     Estimates for appropriate values of `Q` are found in [2]_.
 
@@ -81,7 +84,7 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
             "rich_club_coefficient is not implemented for graphs with self loops."
         )
     rc = _compute_rc(G)
-    if normalized:
+    if normalized and G.number_of_nodes() >= 4:
         # make R a copy of G, randomize with Q*|E| double edge swaps
         # and use rich_club coefficient of R to normalize
         R = G.copy()

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -57,14 +57,11 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
     algorithm ignores any edge weights and is not defined for directed
     graphs or graphs with parallel edges or self loops.
 
-    For graphs with <= 3 nodes, it can be proven that the degree
-    sequence of the graph completely determines it. So the normalization
-    process which creates a random graph with the same degree sequence
-    will normalize against the same graph and set all existing rich club
-    coefficients to 1.
-    It can also be proven that the unnormalized rich club coefficients
-    for <= 3 node graphs are either {} or {0:1}. So normalization here
-    has no effect since 1/1=1.
+    For graphs with <= 3 nodes, it can be proven that given the degrees
+    of each vertex, we can completely determine the graph. So the
+    normalization process which creates a random graph with the same
+    degree sequence will normalize against the same graph and set all
+    existing rich club coefficients to 1.
 
     Estimates for appropriate values of `Q` are found in [2]_.
 
@@ -84,14 +81,17 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
             "rich_club_coefficient is not implemented for graphs with self loops."
         )
     rc = _compute_rc(G)
-    if normalized and G.number_of_nodes() >= 4:
-        # make R a copy of G, randomize with Q*|E| double edge swaps
-        # and use rich_club coefficient of R to normalize
-        R = G.copy()
-        E = R.number_of_edges()
-        nx.double_edge_swap(R, Q * E, max_tries=Q * E * 10, seed=seed)
-        rcran = _compute_rc(R)
-        rc = {k: v / rcran[k] for k, v in rc.items()}
+    if normalized:
+        if G.number_of_nodes() >= 4:
+            # make R a copy of G, randomize with Q*|E| double edge swaps
+            # and use rich_club coefficient of R to normalize
+            R = G.copy()
+            E = R.number_of_edges()
+            nx.double_edge_swap(R, Q * E, max_tries=Q * E * 10, seed=seed)
+            rcran = _compute_rc(R)
+            rc = {k: v / rcran[k] for k, v in rc.items()}
+        else:
+            rc = {k: 1 for k in rc}
     return rc
 
 

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -44,6 +44,12 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
     rc : dictionary
        A dictionary, keyed by degree, with rich-club coefficient values.
 
+    Raises
+    ------
+    NetworkXError
+        If G has less than 4 nodes and normalized=True.
+        Raised from within nx.double_edge_swap()
+
     Examples
     --------
     >>> G = nx.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (1, 4), (4, 5)])
@@ -75,8 +81,6 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
             "rich_club_coefficient is not implemented for graphs with self loops."
         )
     rc = _compute_rc(G)
-    # Normalized mode needs at least 4 nodes to perform a double edge swap
-    # Otherwise, an exception will be raised within nx.double_edge_swap()
     if normalized:
         # make R a copy of G, randomize with Q*|E| double edge swaps
         # and use rich_club coefficient of R to normalize

--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -75,8 +75,9 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
             "rich_club_coefficient is not implemented for graphs with self loops."
         )
     rc = _compute_rc(G)
-    # need at least 4 nodes to perform a double edge swap
-    if normalized and G.number_of_nodes() >= 4:
+    # Normalized mode needs at least 4 nodes to perform a double edge swap
+    # Otherwise, an exception will be raised within nx.double_edge_swap()
+    if normalized:
         # make R a copy of G, randomize with Q*|E| double edge swaps
         # and use rich_club coefficient of R to normalize
         R = G.copy()

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -91,6 +91,41 @@ def test_rich_club_selfloop():
         nx.rich_club_coefficient(G)
 
 
+def test_rich_club_leq_3_nodes():
+    # edgeless graphs upto 3 nodes
+    G = nx.Graph()
+    rc = nx.rich_club_coefficient(G)
+    assert rc == {}
+
+    for i in range(3):
+        G.add_node(i)
+        rc = nx.rich_club_coefficient(G)
+        assert rc == {}
+
+    # 2 nodes, single edge
+    G = nx.Graph()
+    G.add_edge(0, 1)
+    rc = nx.rich_club_coefficient(G)
+    assert rc == {0: 1}
+
+    # 3 nodes, single edge
+    G = nx.Graph()
+    G.add_nodes_from([0, 1, 2])
+    G.add_edge(0, 1)
+    rc = nx.rich_club_coefficient(G)
+    assert rc == {0: 1}
+
+    # 3 nodes, 2 edges
+    G.add_edge(1, 2)
+    rc = nx.rich_club_coefficient(G)
+    assert rc == {0: 1}
+
+    # 3 nodes, 3 edges
+    G.add_edge(0, 2)
+    rc = nx.rich_club_coefficient(G)
+    assert rc == {0: 1, 1: 1}
+
+
 # def test_richclub2_normalized():
 #    T = nx.balanced_tree(2,10)
 #    rcNorm = nx.richclub.rich_club_coefficient(T,Q=2)

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -91,38 +91,42 @@ def test_rich_club_selfloop():
         nx.rich_club_coefficient(G)
 
 
-def test_rich_club_leq_3_nodes():
+@pytest.mark.parametrize("normalized", (True, False))
+def test_rich_club_leq_3_nodes(normalized):
     # edgeless graphs upto 3 nodes
     G = nx.Graph()
-    rc = nx.rich_club_coefficient(G)
+    rc = nx.rich_club_coefficient(G, normalized)
     assert rc == {}
 
     for i in range(3):
         G.add_node(i)
-        rc = nx.rich_club_coefficient(G)
+        rc = nx.rich_club_coefficient(G, normalized)
         assert rc == {}
 
     # 2 nodes, single edge
     G = nx.Graph()
     G.add_edge(0, 1)
-    rc = nx.rich_club_coefficient(G)
+    rc = nx.rich_club_coefficient(G, normalized)
     assert rc == {0: 1}
 
     # 3 nodes, single edge
     G = nx.Graph()
     G.add_nodes_from([0, 1, 2])
     G.add_edge(0, 1)
-    rc = nx.rich_club_coefficient(G)
+    rc = nx.rich_club_coefficient(G, normalized)
     assert rc == {0: 1}
 
     # 3 nodes, 2 edges
     G.add_edge(1, 2)
-    rc = nx.rich_club_coefficient(G)
-    assert rc == {0: 1}
+    rc = nx.rich_club_coefficient(G, normalized)
+    if normalized:
+        assert rc == {0: 1}
+    else:
+        assert rc == {0: 2 / 3}
 
     # 3 nodes, 3 edges
     G.add_edge(0, 2)
-    rc = nx.rich_club_coefficient(G)
+    rc = nx.rich_club_coefficient(G, normalized)
     assert rc == {0: 1, 1: 1}
 
 

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -91,43 +91,56 @@ def test_rich_club_selfloop():
         nx.rich_club_coefficient(G)
 
 
-@pytest.mark.parametrize("normalized", (True, False))
-def test_rich_club_leq_3_nodes(normalized):
+def test_rich_club_leq_3_nodes_unnormalized():
     # edgeless graphs upto 3 nodes
     G = nx.Graph()
-    rc = nx.rich_club_coefficient(G, normalized)
+    rc = nx.rich_club_coefficient(G, normalized=False)
     assert rc == {}
 
     for i in range(3):
         G.add_node(i)
-        rc = nx.rich_club_coefficient(G, normalized)
+        rc = nx.rich_club_coefficient(G, normalized=False)
         assert rc == {}
 
     # 2 nodes, single edge
     G = nx.Graph()
     G.add_edge(0, 1)
-    rc = nx.rich_club_coefficient(G, normalized)
+    rc = nx.rich_club_coefficient(G, normalized=False)
     assert rc == {0: 1}
 
     # 3 nodes, single edge
     G = nx.Graph()
     G.add_nodes_from([0, 1, 2])
     G.add_edge(0, 1)
-    rc = nx.rich_club_coefficient(G, normalized)
+    rc = nx.rich_club_coefficient(G, normalized=False)
     assert rc == {0: 1}
 
     # 3 nodes, 2 edges
     G.add_edge(1, 2)
-    rc = nx.rich_club_coefficient(G, normalized)
-    if normalized:
-        assert rc == {0: 1}
-    else:
-        assert rc == {0: 2 / 3}
+    rc = nx.rich_club_coefficient(G, normalized=False)
+    assert rc == {0: 2 / 3}
 
     # 3 nodes, 3 edges
     G.add_edge(0, 2)
-    rc = nx.rich_club_coefficient(G, normalized)
+    rc = nx.rich_club_coefficient(G, normalized=False)
     assert rc == {0: 1, 1: 1}
+
+
+def test_rich_club_leq_3_nodes_normalized():
+    G = nx.Graph()
+    with pytest.raises(
+        nx.exception.NetworkXError,
+        match="Graph has fewer than four nodes",
+    ):
+        rc = nx.rich_club_coefficient(G, normalized=True)
+
+    for i in range(3):
+        G.add_node(i)
+        with pytest.raises(
+            nx.exception.NetworkXError,
+            match="Graph has fewer than four nodes",
+        ):
+            rc = nx.rich_club_coefficient(G, normalized=True)
 
 
 # def test_richclub2_normalized():

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -156,7 +156,10 @@ def degree_histogram(G):
     (Order(number_of_edges))
     """
     counts = Counter(d for n, d in G.degree())
-    return [counts.get(i, 0) for i in range(max(counts) + 1)]
+    if len(counts) > 0:
+        return [counts.get(i, 0) for i in range(max(counts) + 1)]
+    else:
+        return []
 
 
 def is_directed(G):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -156,10 +156,7 @@ def degree_histogram(G):
     (Order(number_of_edges))
     """
     counts = Counter(d for n, d in G.degree())
-    if len(counts) > 0:
-        return [counts.get(i, 0) for i in range(max(counts) + 1)]
-    else:
-        return []
+    return [counts.get(i, 0) for i in range(max(counts) + 1 if counts else 0)]
 
 
 def is_directed(G):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -6,6 +6,11 @@ import networkx as nx
 from networkx.utils import edges_equal, nodes_equal
 
 
+def test_degree_histogram_empty():
+    G = nx.Graph()
+    assert nx.degree_histogram(G) == []
+
+
 class TestFunction:
     def setup_method(self):
         self.G = nx.Graph({0: [1, 2, 3], 1: [1, 2, 0], 4: []}, name="Test")


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
Partial fix for issue #6920 rich_club_coefficient() bugs

For the empty graph, degree_histogram() errors out when using max() on an empty collections.Counter. This is fixed by explicitly checking the condition of non-empty counter

For the single node graph, _compute_rc() errors out where edge_degrees is popped just before the for loop. This assumes that there is at least 1 edge in the graph. For edgeless graphs, rich club coefficient dictionary should probably be empty since it is defined only for non-negative degree values d where there exist at least 2 nodes of degree > d. In an edgeless graph, there are no such nodes for any non-negative d. This is fixed by explicitly checking the edge count before the pop