### PR TITLE
renaming backend `func_info` dictionary's keys

### DIFF
--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -994,14 +994,14 @@ class _dispatch:
             else:
                 lines.append("")
 
-            if "backend_func_examples" in func_info:
+            if "backend_func_examples" in func_info and func_info["backend_func_examples"]:
                 lines.append("  Backend Examples:")
                 lines.append(".. code-block:: python")
                 for line in func_info["backend_func_examples"].split("\n"):
                     if line.strip():
                         lines.append(line.strip() + "\n")
 
-            if "backend_func_url" in func_info:
+            if "backend_func_url" in func_info and func_info["backend_func_url"]:
                 lines.append(f"`Learn more <{func_info['backend_func_url']}>`_")
 
         lines.pop()  # Remove last empty line

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -960,11 +960,19 @@ class _dispatch:
                 continue
 
             func_info = info["functions"][self.name]
-            if "extra_docstring" in func_info:
-                lines.extend(
-                    f"  {line}" if line else line
-                    for line in func_info["extra_docstring"].split("\n")
-                )
+
+            # Renaming extra_docstring to backend_func_docs
+            if "extra_docstring" in func_info or "backend_func_docs" in func_info:
+                if "extra_docstring" in func_info:
+                    lines.extend(
+                        f"  {line}" if line else line
+                        for line in func_info["extra_docstring"].split("\n")
+                    )
+                else:
+                    lines.extend(
+                        f"  {line}" if line else line
+                        for line in func_info["backend_func_docs"].split("\n")
+                    )
                 add_gap = True
             else:
                 add_gap = False

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -996,7 +996,7 @@ class _dispatch:
                 lines.append("  Backend Examples:")
                 lines.append(".. code-block:: python")
                 for line in func_info["backend_func_examples"].split("\n"):
-                    lines.extend(f" {line}" if line else line)
+                    if line.strip() : lines.append(line.strip()+"\n")
 
             if "backend_func_url" in func_info:
                 lines.append(f"`Learn more <{func_info['backend_func_url']}>`_")

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1003,9 +1003,11 @@ class _dispatchable:
                 for line in func_info["backend_func_examples"].split("\n"):
                     if line.strip():
                         lines.append(line.strip() + "\n")
+                lines.append("")
 
             if "backend_func_url" in func_info and func_info["backend_func_url"]:
                 lines.append(f"`Learn more <{func_info['backend_func_url']}>`_")
+                lines.append("")
 
         lines.pop()  # Remove last empty line
         to_add = "\n    ".join(lines)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -540,10 +540,7 @@ class _dispatchable:
             for backend_name in self._automatic_backends:
                 if self._can_backend_run(backend_name, *args, **kwargs):
                     return self._convert_and_call(
-                        backend_name,
-                        args,
-                        kwargs,
-                        fallback_to_nx=self._fallback_to_nx,
+                        backend_name, args, kwargs, fallback_to_nx=self._fallback_to_nx,
                     )
         # Default: run with networkx on networkx inputs
         return self.orig_func(*args, **kwargs)
@@ -978,14 +975,14 @@ class _dispatchable:
 
             # Renaming extra_parameters to additional_parameters
             if (
-                "extra_parameters" in func_info or "additional_parameters" in func_info
-            ) and (func_info["extra_parameters"] or func_info["additional_parameters"]):
+                extra_parameters := (
+                    func_info.get("extra_parameters")
+                    or func_info.get("additional_parameters")
+                )
+            ) :
                 if add_gap:
                     lines.append("")
                 lines.append("  Additional parameters:")
-                extra_parameters = func_info.get(
-                    "extra_parameters", func_info.get("additional_parameters")
-                )
                 for param in sorted(extra_parameters):
                     lines.append(f"    {param}")
                     if desc := extra_parameters[param]:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -960,7 +960,7 @@ class _dispatchable:
 
             func_info = info["functions"][self.name]
 
-            # Renaming extra_docstring to backend_func_docs
+            # Renaming extra_docstring to additional_docs
             if func_docs := (
                 func_info.get("additional_docs") or func_info.get("extra_docstring")
             ):

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -982,8 +982,10 @@ class _dispatch:
                 if add_gap:
                     lines.append("")
                 lines.append("  Additional parameters:")
-                if "extra_parameters" in func_info : extra_parameters = func_info["extra_parameters"]
-                else : extra_parameters = func_info["additional_parameters"]
+                if "extra_parameters" in func_info:
+                    extra_parameters = func_info["extra_parameters"]
+                else:
+                    extra_parameters = func_info["additional_parameters"]
                 for param in sorted(extra_parameters):
                     lines.append(f"    {param}")
                     if desc := extra_parameters[param]:
@@ -996,7 +998,8 @@ class _dispatch:
                 lines.append("  Backend Examples:")
                 lines.append(".. code-block:: python")
                 for line in func_info["backend_func_examples"].split("\n"):
-                    if line.strip() : lines.append(line.strip()+"\n")
+                    if line.strip():
+                        lines.append(line.strip() + "\n")
 
             if "backend_func_url" in func_info:
                 lines.append(f"`Learn more <{func_info['backend_func_url']}>`_")

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -962,7 +962,7 @@ class _dispatchable:
 
             # Renaming extra_docstring to backend_func_docs
             if func_docs := (
-                func_info.get("backend_func_docs") or func_info.get("extra_docstring")
+                func_info.get("additional_docs") or func_info.get("extra_docstring")
             ):
                 lines.extend(
                     f"  {line}" if line else line for line in func_docs.split("\n")
@@ -987,7 +987,7 @@ class _dispatchable:
             else:
                 lines.append("")
 
-            if func_url := func_info.get("backend_func_url"):
+            if func_url := func_info.get("url"):
                 lines.append(f"[`Source <{func_url}>`_]")
                 lines.append("")
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -958,16 +958,11 @@ class _dispatchable:
             func_info = info["functions"][self.name]
 
             # Renaming extra_docstring to backend_func_docs
-            if ("extra_docstring" in func_info and func_info["extra_docstring"]) or (
-                "backend_func_docs" in func_info and func_info["backend_func_docs"]
+            if func_docs := (
+                func_info.get("backend_func_docs") or func_info.get("extra_docstring")
             ):
-                key = (
-                    "extra_docstring"
-                    if func_info.get("extra_docstring")
-                    else "backend_func_docs"
-                )
                 lines.extend(
-                    f"  {line}" if line else line for line in func_info[key].split("\n")
+                    f"  {line}" if line else line for line in func_docs.split("\n")
                 )
                 add_gap = True
             else:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -993,6 +993,7 @@ class _dispatch:
                 lines.append("")
 
             if "backend_func_examples" in func_info:
+                lines.append("  Backend Examples:")
                 lines.append(".. code-block:: python")
                 for line in func_info["backend_func_examples"].split("\n"):
                     lines.extend(f" {line}" if line else line)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -540,7 +540,10 @@ class _dispatchable:
             for backend_name in self._automatic_backends:
                 if self._can_backend_run(backend_name, *args, **kwargs):
                     return self._convert_and_call(
-                        backend_name, args, kwargs, fallback_to_nx=self._fallback_to_nx,
+                        backend_name,
+                        args,
+                        kwargs,
+                        fallback_to_nx=self._fallback_to_nx,
                     )
         # Default: run with networkx on networkx inputs
         return self.orig_func(*args, **kwargs)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -540,7 +540,10 @@ class _dispatchable:
             for backend_name in self._automatic_backends:
                 if self._can_backend_run(backend_name, *args, **kwargs):
                     return self._convert_and_call(
-                        backend_name, args, kwargs, fallback_to_nx=self._fallback_to_nx,
+                        backend_name, 
+                        args, 
+                        kwargs, 
+                        fallback_to_nx=self._fallback_to_nx,
                     )
         # Default: run with networkx on networkx inputs
         return self.orig_func(*args, **kwargs)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -994,8 +994,8 @@ class _dispatchable:
             else:
                 lines.append("")
 
-            if "backend_func_url" in func_info and func_info["backend_func_url"]:
-                lines.append(f"[`Source <{func_info['backend_func_url']}>`_]")
+            if func_url := func_info.get("backend_func_url"):
+                lines.append(f"[`Source <{func_url}>`_]")
                 lines.append("")
 
         lines.pop()  # Remove last empty line

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -984,12 +984,13 @@ class _dispatchable:
                     lines.append("")
                 lines.append("  Additional parameters:")
                 extra_parameters = func_info.get(
-                    "extra_parameters", func_info.get("additional_parameters", {})
+                    "extra_parameters", func_info.get("additional_parameters")
                 )
-                lines.extend(
-                    [f"    {param}", f"      {desc}", ""]
-                    for param, desc in sorted(extra_parameters.items())
-                )
+                for param in sorted(extra_parameters):
+                    lines.append(f"    {param}")
+                    if desc := extra_parameters[param]:
+                        lines.append(f"      {desc}")
+                    lines.append("")
             else:
                 lines.append("")
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -979,18 +979,19 @@ class _dispatch:
 
             # Renaming extra_parameters to additional_parameters
             if "extra_parameters" in func_info or "additional_parameters" in func_info:
-                if add_gap:
-                    lines.append("")
-                lines.append("  Additional parameters:")
-                if "extra_parameters" in func_info:
-                    extra_parameters = func_info["extra_parameters"]
-                else:
-                    extra_parameters = func_info["additional_parameters"]
-                for param in sorted(extra_parameters):
-                    lines.append(f"    {param}")
-                    if desc := extra_parameters[param]:
-                        lines.append(f"      {desc}")
-                    lines.append("")
+                if func_info["extra_parameters"] or func_info["additional_parameters"]:
+                    if add_gap:
+                        lines.append("")
+                    lines.append("  Additional parameters:")
+                    if "extra_parameters" in func_info:
+                        extra_parameters = func_info["extra_parameters"]
+                    else:
+                        extra_parameters = func_info["additional_parameters"]
+                    for param in sorted(extra_parameters):
+                        lines.append(f"    {param}")
+                        if desc := extra_parameters[param]:
+                            lines.append(f"      {desc}")
+                        lines.append("")
             else:
                 lines.append("")
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -994,19 +994,8 @@ class _dispatchable:
             else:
                 lines.append("")
 
-            if (
-                "backend_func_examples" in func_info
-                and func_info["backend_func_examples"]
-            ):
-                lines.append("  Backend Examples:")
-                lines.append(".. code-block:: python")
-                for line in func_info["backend_func_examples"].split("\n"):
-                    if line.strip():
-                        lines.append(line.strip() + "\n")
-                lines.append("")
-
             if "backend_func_url" in func_info and func_info["backend_func_url"]:
-                lines.append(f"`Learn more <{func_info['backend_func_url']}>`_")
+                lines.append(f"[`Source <{func_info['backend_func_url']}>`_]")
                 lines.append("")
 
         lines.pop()  # Remove last empty line

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -974,12 +974,10 @@ class _dispatchable:
                 add_gap = False
 
             # Renaming extra_parameters to additional_parameters
-            if (
-                extra_parameters := (
-                    func_info.get("extra_parameters")
-                    or func_info.get("additional_parameters")
-                )
-            ) :
+            if extra_parameters := (
+                func_info.get("extra_parameters")
+                or func_info.get("additional_parameters")
+            ):
                 if add_gap:
                     lines.append("")
                 lines.append("  Additional parameters:")

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -995,7 +995,10 @@ class _dispatch:
             else:
                 lines.append("")
 
-            if "backend_func_examples" in func_info and func_info["backend_func_examples"]:
+            if (
+                "backend_func_examples" in func_info
+                and func_info["backend_func_examples"]
+            ):
                 lines.append("  Backend Examples:")
                 lines.append(".. code-block:: python")
                 for line in func_info["backend_func_examples"].split("\n"):

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -992,6 +992,14 @@ class _dispatch:
             else:
                 lines.append("")
 
+            if "backend_func_examples" in func_info:
+                lines.append(".. code-block:: python")
+                for line in func_info["backend_func_examples"].split("\n"):
+                    lines.extend(f" {line}" if line else line)
+
+            if "backend_func_url" in func_info:
+                lines.append(f"`Learn more <{func_info['backend_func_url']}>`_")
+
         lines.pop()  # Remove last empty line
         to_add = "\n    ".join(lines)
         return f"{self._orig_doc.rstrip()}\n\n    {to_add}"

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -968,11 +968,14 @@ class _dispatch:
                 add_gap = True
             else:
                 add_gap = False
-            if "extra_parameters" in func_info:
+
+            # Renaming extra_parameters to additional_parameters
+            if "extra_parameters" in func_info or "additional_parameters" in func_info:
                 if add_gap:
                     lines.append("")
-                lines.append("  Extra parameters:")
-                extra_parameters = func_info["extra_parameters"]
+                lines.append("  Additional parameters:")
+                if "extra_parameters" in func_info : extra_parameters = func_info["extra_parameters"]
+                else : extra_parameters = func_info["additional_parameters"]
                 for param in sorted(extra_parameters):
                     lines.append(f"    {param}")
                     if desc := extra_parameters[param]:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -540,9 +540,9 @@ class _dispatchable:
             for backend_name in self._automatic_backends:
                 if self._can_backend_run(backend_name, *args, **kwargs):
                     return self._convert_and_call(
-                        backend_name, 
-                        args, 
-                        kwargs, 
+                        backend_name,
+                        args,
+                        kwargs,
                         fallback_to_nx=self._fallback_to_nx,
                     )
         # Default: run with networkx on networkx inputs


### PR DESCRIPTION
Changes made : 
- added `url` : if we would want to link to the function's webpage page(in the future) or source code, right now in nx-parallel I've put the link to the function header(https://github.com/networkx/nx-parallel/pull/47)
-  renamed`extra_parameters` to `additional_parameters`: bcoz "extra" gives a sense that they are not necessary but "additional" gives a sense that they are an added functionality, anyways we can keep it if it's not that big of a change
- renamed `extra_docstring` to `additional_docs` for the similar reason as above
- removed an unused import