### PR TITLE
DOC: build with nx-parallel extra documentation information

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
             pip install git+https://github.com/rapidsai/cugraph.git#subdirectory=python/nx-cugraph --no-deps
             # Development version of GraphBLAS backend
             pip install git+https://github.com/python-graphblas/graphblas-algorithms.git@main --no-deps
+            # Development version of nx-parallel backend
+            pip install git+https://github.com/networkx/nx-parallel.git@main --no-deps
             pip list
 
       - save_cache:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,6 +38,8 @@ jobs:
           pip install git+https://github.com/rapidsai/cugraph.git#subdirectory=python/nx-cugraph --no-deps
           # Development version of GraphBLAS backend
           pip install git+https://github.com/python-graphblas/graphblas-algorithms.git@main --no-deps
+          # Development version of nx-parallel backend
+          pip install git+https://github.com/networkx/nx-parallel.git@main --no-deps
           pip list
 
       # To set up a cross-repository deploy key:


### PR DESCRIPTION
This should let us add information about nx-parallel implementation in the main networkx.org doc website. https://github.com/networkx/nx-parallel/pull/27 adds the `backend_info` entry point for nx-parallel.