### PR TITLE
Replace tempfile with tmp_path fixture in test suite.

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_edgelist.py
+++ b/networkx/algorithms/bipartite/tests/test_edgelist.py
@@ -2,8 +2,6 @@
     Unit tests for bipartite edgelists.
 """
 import io
-import os
-import tempfile
 
 import pytest
 
@@ -101,51 +99,47 @@ class TestEdgelist:
         fh.seek(0)
         assert fh.read() == b"1 2 2.0\n3 2 3.0\n"
 
-    def test_unicode(self):
+    def test_unicode(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
         G.add_node(name1, bipartite=0)
         G.add_node("Radiohead", bipartite=1)
-        fd, fname = tempfile.mkstemp()
+
+        fname = tmp_path / "edgelist.txt"
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname)
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_latin1_issue(self):
+    def test_latin1_issue(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
         G.add_node(name1, bipartite=0)
         G.add_node("Radiohead", bipartite=1)
-        fd, fname = tempfile.mkstemp()
-        pytest.raises(
-            UnicodeEncodeError, bipartite.write_edgelist, G, fname, encoding="latin-1"
-        )
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_latin1(self):
+        fname = tmp_path / "edgelist.txt"
+        with pytest.raises(UnicodeEncodeError):
+            bipartite.write_edgelist(G, fname, encoding="latin-1")
+
+    def test_latin1(self, tmp_path):
         G = nx.Graph()
         name1 = "Bj" + chr(246) + "rk"
         name2 = chr(220) + "ber"
         G.add_edge(name1, "Radiohead", **{name2: 3})
         G.add_node(name1, bipartite=0)
         G.add_node("Radiohead", bipartite=1)
-        fd, fname = tempfile.mkstemp()
+
+        fname = tmp_path / "edgelist.txt"
         bipartite.write_edgelist(G, fname, encoding="latin-1")
         H = bipartite.read_edgelist(fname, encoding="latin-1")
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_graph(self):
+    def test_edgelist_graph(self, tmp_path):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "edgelist.txt"
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname)
         H2 = bipartite.read_edgelist(fname)
@@ -153,32 +147,26 @@ class TestEdgelist:
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_integers(self):
+    def test_edgelist_integers(self, tmp_path):
         G = nx.convert_node_labels_to_integers(self.G)
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "edgelist.txt"
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname, nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_multigraph(self):
+    def test_edgelist_multigraph(self, tmp_path):
         G = self.MG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "edgelist.txt"
         bipartite.write_edgelist(G, fname)
         H = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = bipartite.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_empty_digraph(self):
         with pytest.raises(nx.NetworkXNotImplemented):

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -1,6 +1,4 @@
 """Unit tests for PyGraphviz interface."""
-import os
-import tempfile
 import warnings
 
 import pytest
@@ -25,27 +23,26 @@ class TestAGraph:
         assert edges_equal(G1.edges(), G2.edges())
         assert G1.graph["metal"] == G2.graph["metal"]
 
-    def agraph_checks(self, G):
+    @pytest.mark.parametrize(
+        "G", (nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph())
+    )
+    def test_agraph_roundtripping(self, G, tmp_path):
         G = self.build_graph(G)
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A)
         self.assert_equal(G, H)
 
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.dot"
         nx.drawing.nx_agraph.write_dot(H, fname)
         Hin = nx.nx_agraph.read_dot(fname)
         self.assert_equal(H, Hin)
-        os.close(fd)
-        os.unlink(fname)
 
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "fh_test.dot"
         with open(fname, "w") as fh:
             nx.drawing.nx_agraph.write_dot(H, fh)
 
         with open(fname) as fh:
             Hin = nx.nx_agraph.read_dot(fh)
-        os.close(fd)
-        os.unlink(fname)
         self.assert_equal(H, Hin)
 
     def test_from_agraph_name(self):
@@ -74,18 +71,6 @@ class TestAGraph:
         H = nx.nx_agraph.from_agraph(A)
         assert isinstance(H, nx.Graph)
         assert ("0", "1", {"key": "foo"}) in H.edges(data=True)
-
-    def test_undirected(self):
-        self.agraph_checks(nx.Graph())
-
-    def test_directed(self):
-        self.agraph_checks(nx.DiGraph())
-
-    def test_multi_undirected(self):
-        self.agraph_checks(nx.MultiGraph())
-
-    def test_multi_directed(self):
-        self.agraph_checks(nx.MultiDiGraph())
 
     def test_to_agraph_with_nodedata(self):
         G = nx.Graph()

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,5 +1,4 @@
 """Unit tests for pydot drawing functions."""
-import tempfile
 from io import StringIO
 
 import pytest

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,5 +1,4 @@
 """Unit tests for pydot drawing functions."""
-import os
 import tempfile
 from io import StringIO
 
@@ -12,7 +11,9 @@ pydot = pytest.importorskip("pydot")
 
 
 class TestPydot:
-    def pydot_checks(self, G, prog):
+    @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
+    @pytest.mark.parametrize("prog", ("neato", "dot"))
+    def test_pydot(self, G, prog, tmp_path):
         """
         Validate :mod:`pydot`-based usage of the passed NetworkX graph with the
         passed basename of an external GraphViz command (e.g., `dot`, `neato`).
@@ -39,7 +40,7 @@ class TestPydot:
         # Validate the original and resulting graphs to be the same.
         assert graphs_equal(G, G2)
 
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "out.dot"
 
         # Serialize this "pydot.Dot" instance to a temporary file in dot format
         P.write_raw(fname)
@@ -77,15 +78,6 @@ class TestPydot:
 
         # Validate the original and resulting graphs to be the same.
         assert graphs_equal(G, Hin)
-
-        os.close(fd)
-        os.unlink(fname)
-
-    def test_undirected(self):
-        self.pydot_checks(nx.Graph(), prog="neato")
-
-    def test_directed(self):
-        self.pydot_checks(nx.DiGraph(), prog="dot")
 
     def test_read_write(self):
         G = nx.MultiGraph()

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -2,8 +2,6 @@
     Unit tests for adjlist.
 """
 import io
-import os
-import tempfile
 
 import pytest
 
@@ -36,41 +34,35 @@ class TestAdjlist:
         adj = {"1": {"3": {}, "2": {}}, "3": {"1": {}}, "2": {"1": {}}}
         assert graphs_equal(G, nx.Graph(adj))
 
-    def test_unicode(self):
+    def test_unicode(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
+
+        fname = tmp_path / "adjlist.txt"
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname)
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_latin1_err(self):
+    def test_latin1_err(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        pytest.raises(
-            UnicodeEncodeError, nx.write_multiline_adjlist, G, fname, encoding="latin-1"
-        )
-        os.close(fd)
-        os.unlink(fname)
+        fname = tmp_path / "adjlist.txt"
+        with pytest.raises(UnicodeEncodeError):
+            nx.write_multiline_adjlist(G, fname, encoding="latin-1")
 
-    def test_latin1(self):
+    def test_latin1(self, tmp_path):
         G = nx.Graph()
         name1 = "Bj" + chr(246) + "rk"
         name2 = chr(220) + "ber"
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_multiline_adjlist(G, fname, encoding="latin-1")
         H = nx.read_multiline_adjlist(fname, encoding="latin-1")
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
     def test_parse_adjlist(self):
         lines = ["1 2 5", "2 3 4", "3 5", "4", "5"]
@@ -81,32 +73,28 @@ class TestAdjlist:
         with pytest.raises(TypeError):
             nx.parse_adjlist(lines, nodetype=int)
 
-    def test_adjlist_graph(self):
+    def test_adjlist_graph(self, tmp_path):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname)
         H2 = nx.read_adjlist(fname)
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_adjlist_digraph(self):
+    def test_adjlist_digraph(self, tmp_path):
         G = self.DG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, create_using=nx.DiGraph())
         H2 = nx.read_adjlist(fname, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_adjlist_integers(self):
-        (fd, fname) = tempfile.mkstemp()
+    def test_adjlist_integers(self, tmp_path):
+        fname = tmp_path / "adjlist.txt"
         G = nx.convert_node_labels_to_integers(self.G)
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, nodetype=int)
@@ -114,32 +102,26 @@ class TestAdjlist:
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_adjlist_multigraph(self):
+    def test_adjlist_multigraph(self, tmp_path):
         G = self.XG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_adjlist_multidigraph(self):
+    def test_adjlist_multidigraph(self, tmp_path):
         G = self.XDG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_adjlist(G, fname)
         H = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         H2 = nx.read_adjlist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_adjlist_delimiter(self):
         fh = io.BytesIO()
@@ -192,32 +174,28 @@ class TestMultilineAdjlist:
         with pytest.raises(TypeError):
             nx.parse_multiline_adjlist(iter(lines))
 
-    def test_multiline_adjlist_graph(self):
+    def test_multiline_adjlist_graph(self, tmp_path):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname)
         H2 = nx.read_multiline_adjlist(fname)
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_multiline_adjlist_digraph(self):
+    def test_multiline_adjlist_digraph(self, tmp_path):
         G = self.DG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
         H2 = nx.read_multiline_adjlist(fname, create_using=nx.DiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_multiline_adjlist_integers(self):
-        (fd, fname) = tempfile.mkstemp()
+    def test_multiline_adjlist_integers(self, tmp_path):
+        fname = tmp_path / "adjlist.txt"
         G = nx.convert_node_labels_to_integers(self.G)
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname, nodetype=int)
@@ -225,12 +203,10 @@ class TestMultilineAdjlist:
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_multiline_adjlist_multigraph(self):
+    def test_multiline_adjlist_multigraph(self, tmp_path):
         G = self.XG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_multiline_adjlist(
@@ -239,12 +215,10 @@ class TestMultilineAdjlist:
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_multiline_adjlist_multidigraph(self):
+    def test_multiline_adjlist_multidigraph(self, tmp_path):
         G = self.XDG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "adjlist.txt"
         nx.write_multiline_adjlist(G, fname)
         H = nx.read_multiline_adjlist(
             fname, nodetype=int, create_using=nx.MultiDiGraph()
@@ -255,8 +229,6 @@ class TestMultilineAdjlist:
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_multiline_adjlist_delimiter(self):
         fh = io.BytesIO()

--- a/networkx/readwrite/tests/test_edgelist.py
+++ b/networkx/readwrite/tests/test_edgelist.py
@@ -2,8 +2,6 @@
     Unit tests for edgelists.
 """
 import io
-import os
-import tempfile
 import textwrap
 
 import pytest
@@ -215,45 +213,39 @@ class TestEdgelist:
         fh.seek(0)
         assert fh.read() == b"1 2 2.0\n2 3 3.0\n"
 
-    def test_unicode(self):
+    def test_unicode(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname)
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_latin1_issue(self):
+    def test_latin1_issue(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
-        pytest.raises(
-            UnicodeEncodeError, nx.write_edgelist, G, fname, encoding="latin-1"
-        )
-        os.close(fd)
-        os.unlink(fname)
+        fname = tmp_path / "el.txt"
+        with pytest.raises(UnicodeEncodeError):
+            nx.write_edgelist(G, fname, encoding="latin-1")
 
-    def test_latin1(self):
+    def test_latin1(self, tmp_path):
         G = nx.Graph()
         name1 = "Bj" + chr(246) + "rk"
         name2 = chr(220) + "ber"
         G.add_edge(name1, "Radiohead", **{name2: 3})
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
+
         nx.write_edgelist(G, fname, encoding="latin-1")
         H = nx.read_edgelist(fname, encoding="latin-1")
         assert graphs_equal(G, H)
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_graph(self):
+    def test_edgelist_graph(self, tmp_path):
         G = self.G
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname)
         H2 = nx.read_edgelist(fname)
@@ -261,12 +253,10 @@ class TestEdgelist:
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_digraph(self):
+    def test_edgelist_digraph(self, tmp_path):
         G = self.DG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, create_using=nx.DiGraph())
         H2 = nx.read_edgelist(fname, create_using=nx.DiGraph())
@@ -274,41 +264,33 @@ class TestEdgelist:
         G.remove_node("g")  # isolated nodes are not written in edgelist
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_integers(self):
+    def test_edgelist_integers(self, tmp_path):
         G = nx.convert_node_labels_to_integers(self.G)
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, nodetype=int)
         # isolated nodes are not written in edgelist
         G.remove_nodes_from(list(nx.isolates(G)))
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_multigraph(self):
+    def test_edgelist_multigraph(self, tmp_path):
         G = self.XG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_edgelist_multidigraph(self):
+    def test_edgelist_multidigraph(self, tmp_path):
         G = self.XDG
-        (fd, fname) = tempfile.mkstemp()
+        fname = tmp_path / "el.txt"
         nx.write_edgelist(G, fname)
         H = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         H2 = nx.read_edgelist(fname, nodetype=int, create_using=nx.MultiDiGraph())
         assert H is not H2  # they should be different graphs
         assert nodes_equal(list(H), list(G))
         assert edges_equal(list(H.edges()), list(G.edges()))
-        os.close(fd)
-        os.unlink(fname)

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -1,8 +1,6 @@
 import codecs
 import io
 import math
-import os
-import tempfile
 from ast import literal_eval
 from contextlib import contextmanager
 from textwrap import dedent
@@ -165,17 +163,14 @@ graph   [
             ("Node 3", "Node 1", {"label": "Edge from node 3 to node 1"}),
         ]
 
-    def test_read_gml(self):
-        (fd, fname) = tempfile.mkstemp()
-        fh = open(fname, "w")
-        fh.write(self.simple_data)
-        fh.close()
+    def test_read_gml(self, tmp_path):
+        fname = tmp_path / "test.gml"
+        with open(fname, "w") as fh:
+            fh.write(self.simple_data)
         Gin = nx.read_gml(fname, label="label")
         G = nx.parse_gml(self.simple_data, label="label")
         assert sorted(G.nodes(data=True)) == sorted(Gin.nodes(data=True))
         assert sorted(G.edges(data=True)) == sorted(Gin.edges(data=True))
-        os.close(fd)
-        os.unlink(fname)
 
     def test_labels_are_strings(self):
         # GML requires labels to be strings (i.e., in quotes)
@@ -235,18 +230,18 @@ graph
 ]"""
         assert data == answer
 
-    def test_quotes(self):
+    def test_quotes(self, tmp_path):
         # https://github.com/networkx/networkx/issues/1061
         # Encoding quotes as HTML entities.
         G = nx.path_graph(1)
         G.name = "path_graph(1)"
         attr = 'This is "quoted" and this is a copyright: ' + chr(169)
         G.nodes[0]["demo"] = attr
-        fobj = tempfile.NamedTemporaryFile()
-        nx.write_gml(G, fobj)
-        fobj.seek(0)
-        # Should be bytes in 2.x and 3.x
-        data = fobj.read().strip().decode("ascii")
+        with open(tmp_path / "test.gml", "w+b") as fobj:
+            nx.write_gml(G, fobj)
+            fobj.seek(0)
+            # Should be bytes in 2.x and 3.x
+            data = fobj.read().strip().decode("ascii")
         answer = """graph [
   name "path_graph(1)"
   node [
@@ -257,15 +252,15 @@ graph
 ]"""
         assert data == answer
 
-    def test_unicode_node(self):
+    def test_unicode_node(self, tmp_path):
         node = "node" + chr(169)
         G = nx.Graph()
         G.add_node(node)
-        fobj = tempfile.NamedTemporaryFile()
-        nx.write_gml(G, fobj)
-        fobj.seek(0)
-        # Should be bytes in 2.x and 3.x
-        data = fobj.read().strip().decode("ascii")
+        with open(tmp_path / "test.gml", "w+b") as fobj:
+            nx.write_gml(G, fobj)
+            fobj.seek(0)
+            # Should be bytes in 2.x and 3.x
+            data = fobj.read().strip().decode("ascii")
         answer = """graph [
   node [
     id 0
@@ -274,15 +269,15 @@ graph
 ]"""
         assert data == answer
 
-    def test_float_label(self):
+    def test_float_label(self, tmp_path):
         node = 1.0
         G = nx.Graph()
         G.add_node(node)
-        fobj = tempfile.NamedTemporaryFile()
-        nx.write_gml(G, fobj)
-        fobj.seek(0)
-        # Should be bytes in 2.x and 3.x
-        data = fobj.read().strip().decode("ascii")
+        with open(tmp_path / "test.gml", "w+b") as fobj:
+            nx.write_gml(G, fobj)
+            fobj.seek(0)
+            # Should be bytes in 2.x and 3.x
+            data = fobj.read().strip().decode("ascii")
         answer = """graph [
   node [
     id 0
@@ -291,7 +286,7 @@ graph
 ]"""
         assert data == answer
 
-    def test_special_float_label(self):
+    def test_special_float_label(self, tmp_path):
         special_floats = [float("nan"), float("+inf"), float("-inf")]
         try:
             import numpy as np
@@ -307,12 +302,12 @@ graph
         attrs = {edges[i]: value for i, value in enumerate(special_floats)}
         nx.set_edge_attributes(G, attrs, "edgefloat")
 
-        fobj = tempfile.NamedTemporaryFile()
-        nx.write_gml(G, fobj)
-        fobj.seek(0)
-        # Should be bytes in 2.x and 3.x
-        data = fobj.read().strip().decode("ascii")
-        answer = """graph [
+        with open(tmp_path / "test.gml", "w+b") as fobj:
+            nx.write_gml(G, fobj)
+            fobj.seek(0)
+            # Should be bytes in 2.x and 3.x
+            data = fobj.read().strip().decode("ascii")
+            answer = """graph [
   node [
     id 0
     label "0"
@@ -374,24 +369,24 @@ graph
     edgefloat -INF
   ]
 ]"""
-        assert data == answer
+            assert data == answer
 
-        fobj.seek(0)
-        graph = nx.read_gml(fobj)
-        for indx, value in enumerate(special_floats):
-            node_value = graph.nodes[str(indx)]["nodefloat"]
-            if math.isnan(value):
-                assert math.isnan(node_value)
-            else:
-                assert node_value == value
+            fobj.seek(0)
+            graph = nx.read_gml(fobj)
+            for indx, value in enumerate(special_floats):
+                node_value = graph.nodes[str(indx)]["nodefloat"]
+                if math.isnan(value):
+                    assert math.isnan(node_value)
+                else:
+                    assert node_value == value
 
-            edge = edges[indx]
-            string_edge = (str(edge[0]), str(edge[1]))
-            edge_value = graph.edges[string_edge]["edgefloat"]
-            if math.isnan(value):
-                assert math.isnan(edge_value)
-            else:
-                assert edge_value == value
+                edge = edges[indx]
+                string_edge = (str(edge[0]), str(edge[1]))
+                edge_value = graph.edges[string_edge]["edgefloat"]
+                if math.isnan(value):
+                    assert math.isnan(edge_value)
+                else:
+                    assert edge_value == value
 
     def test_name(self):
         G = nx.parse_gml('graph [ name "x" node [ id 0 label "x" ] ]')
@@ -480,13 +475,13 @@ graph
         )
         assert answer == gml
 
-    def test_exceptions(self):
+    def test_exceptions(self, tmp_path):
         pytest.raises(ValueError, literal_destringizer, "(")
         pytest.raises(ValueError, literal_destringizer, "frozenset([1, 2, 3])")
         pytest.raises(ValueError, literal_destringizer, literal_destringizer)
         pytest.raises(ValueError, literal_stringizer, frozenset([1, 2, 3]))
         pytest.raises(ValueError, literal_stringizer, literal_stringizer)
-        with tempfile.TemporaryFile() as f:
+        with open(tmp_path / "test.gml", "w+b") as f:
             f.write(codecs.BOM_UTF8 + b"graph[]")
             f.seek(0)
             pytest.raises(nx.NetworkXError, nx.read_gml, f)
@@ -584,7 +579,7 @@ graph
         labels = [G.nodes[n]["label"] for n in sorted(G.nodes)]
         assert labels == ["Node 1", "Node 2", "Node 3"]
 
-    def test_outofrange_integers(self):
+    def test_outofrange_integers(self, tmp_path):
         # GML restricts integers to 32 signed bits.
         # Check that we honor this restriction on export
         G = nx.Graph()
@@ -601,19 +596,15 @@ graph
         }
         G.add_node("Node", **numbers)
 
-        fd, fname = tempfile.mkstemp()
-        try:
-            nx.write_gml(G, fname)
-            # Check that the export wrote the nonfitting numbers as strings
-            G2 = nx.read_gml(fname)
-            for attr, value in G2.nodes["Node"].items():
-                if attr == "toosmall" or attr == "toobig":
-                    assert type(value) == str
-                else:
-                    assert type(value) == int
-        finally:
-            os.close(fd)
-            os.unlink(fname)
+        fname = tmp_path / "test.gml"
+        nx.write_gml(G, fname)
+        # Check that the export wrote the nonfitting numbers as strings
+        G2 = nx.read_gml(fname)
+        for attr, value in G2.nodes["Node"].items():
+            if attr == "toosmall" or attr == "toobig":
+                assert type(value) == str
+            else:
+                assert type(value) == int
 
     def test_multiline(self):
         # example from issue #6836

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -1,4 +1,3 @@
-import tempfile
 from io import BytesIO
 
 import pytest
@@ -104,8 +103,8 @@ class TestWriteGraph6:
             assert nodes_equal(G.nodes(), H.nodes())
             assert edges_equal(G.edges(), H.edges())
 
-    def test_write_path(self):
-        with tempfile.NamedTemporaryFile() as f:
+    def test_write_path(self, tmp_path):
+        with open(tmp_path / "test.g6", "w+b") as f:
             g6.write_graph6_file(nx.null_graph(), f)
             f.seek(0)
             assert f.read() == b">>graph6<<?\n"

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1,6 +1,4 @@
 import io
-import os
-import tempfile
 
 import pytest
 
@@ -1210,7 +1208,7 @@ class TestWriteGraphML(BaseGraphML):
         assert ("attr.type", "double") in keys[0]
         assert ("attr.type", "double") in keys[1]
 
-    def test_more_multigraph_keys(self):
+    def test_more_multigraph_keys(self, tmp_path):
         """Writing keys as edge id attributes means keys become strings.
         The original keys are stored as data, so read them back in
         if `str(key) == edge_id`
@@ -1218,14 +1216,12 @@ class TestWriteGraphML(BaseGraphML):
         """
         G = nx.MultiGraph()
         G.add_edges_from([("a", "b", 2), ("a", "b", 3)])
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname)
         H = nx.read_graphml(fname)
         assert H.is_multigraph()
         assert edges_equal(G.edges(keys=True), H.edges(keys=True))
         assert G._adj == H._adj
-        os.close(fd)
-        os.unlink(fname)
 
     def test_default_attribute(self):
         G = nx.Graph(name="Fred")
@@ -1288,38 +1284,34 @@ class TestWriteGraphML(BaseGraphML):
         assert H.edges["n0", "n1", 0]["special"] == 2
         assert H.edges["n0", "n1", 1]["special"] == 3
 
-    def test_multigraph_to_graph(self):
+    def test_multigraph_to_graph(self, tmp_path):
         # test converting multigraph to graph if no parallel edges found
         G = nx.MultiGraph()
         G.add_edges_from([("a", "b", 2), ("b", "c", 3)])  # no multiedges
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname)
         H = nx.read_graphml(fname)
         assert not H.is_multigraph()
         H = nx.read_graphml(fname, force_multigraph=True)
         assert H.is_multigraph()
-        os.close(fd)
-        os.unlink(fname)
 
         # add a multiedge
         G.add_edge("a", "b", "e-id")
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname)
         H = nx.read_graphml(fname)
         assert H.is_multigraph()
         H = nx.read_graphml(fname, force_multigraph=True)
         assert H.is_multigraph()
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_write_generate_edge_id_from_attribute(self):
+    def test_write_generate_edge_id_from_attribute(self, tmp_path):
         from xml.etree.ElementTree import parse
 
         G = nx.Graph()
         G.add_edges_from([("a", "b"), ("b", "c"), ("a", "c")])
         edge_attributes = {e: str(e) for e in G.edges}
         nx.set_edge_attributes(G, edge_attributes, "eid")
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         # set edge_id_from_attribute e.g. "eid" for write_graphml()
         self.writer(G, fname, edge_id_from_attribute="eid")
         # set edge_id_from_attribute e.g. "eid" for generate_graphml()
@@ -1353,17 +1345,14 @@ class TestWriteGraphML(BaseGraphML):
         nx.set_edge_attributes(G, edge_attributes, "id")
         assert edges_equal(G.edges(data=True), J.edges(data=True))
 
-        os.close(fd)
-        os.unlink(fname)
-
-    def test_multigraph_write_generate_edge_id_from_attribute(self):
+    def test_multigraph_write_generate_edge_id_from_attribute(self, tmp_path):
         from xml.etree.ElementTree import parse
 
         G = nx.MultiGraph()
         G.add_edges_from([("a", "b"), ("b", "c"), ("a", "c"), ("a", "b")])
         edge_attributes = {e: str(e) for e in G.edges}
         nx.set_edge_attributes(G, edge_attributes, "eid")
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         # set edge_id_from_attribute e.g. "eid" for write_graphml()
         self.writer(G, fname, edge_id_from_attribute="eid")
         # set edge_id_from_attribute e.g. "eid" for generate_graphml()
@@ -1411,14 +1400,11 @@ class TestWriteGraphML(BaseGraphML):
             edge_attributes.values()
         )
 
-        os.close(fd)
-        os.unlink(fname)
-
-    def test_numpy_float64(self):
+    def test_numpy_float64(self, tmp_path):
         np = pytest.importorskip("numpy")
         wt = np.float64(3.4)
         G = nx.Graph([(1, 2, {"weight": wt})])
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname)
         H = nx.read_graphml(fname, node_type=int)
         assert G.edges == H.edges
@@ -1427,14 +1413,12 @@ class TestWriteGraphML(BaseGraphML):
         assert wtG == pytest.approx(wtH, abs=1e-6)
         assert type(wtG) == np.float64
         assert type(wtH) == float
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_numpy_float32(self):
+    def test_numpy_float32(self, tmp_path):
         np = pytest.importorskip("numpy")
         wt = np.float32(3.4)
         G = nx.Graph([(1, 2, {"weight": wt})])
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname)
         H = nx.read_graphml(fname, node_type=int)
         assert G.edges == H.edges
@@ -1443,32 +1427,26 @@ class TestWriteGraphML(BaseGraphML):
         assert wtG == pytest.approx(wtH, abs=1e-6)
         assert type(wtG) == np.float32
         assert type(wtH) == float
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_numpy_float64_inference(self):
+    def test_numpy_float64_inference(self, tmp_path):
         np = pytest.importorskip("numpy")
         G = self.attribute_numeric_type_graph
         G.edges[("n1", "n1")]["weight"] = np.float64(1.1)
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname, infer_numeric_types=True)
         H = nx.read_graphml(fname)
         assert G._adj == H._adj
-        os.close(fd)
-        os.unlink(fname)
 
-    def test_unicode_attributes(self):
+    def test_unicode_attributes(self, tmp_path):
         G = nx.Graph()
         name1 = chr(2344) + chr(123) + chr(6543)
         name2 = chr(5543) + chr(1543) + chr(324)
         node_type = str
         G.add_edge(name1, "Radiohead", foo=name2)
-        fd, fname = tempfile.mkstemp()
+        fname = tmp_path / "test.graphml"
         self.writer(G, fname)
         H = nx.read_graphml(fname, node_type=node_type)
         assert G._adj == H._adj
-        os.close(fd)
-        os.unlink(fname)
 
     def test_unicode_escape(self):
         # test for handling json escaped strings in python 2 Issue #1880

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -1,9 +1,6 @@
 """
 Pajek tests
 """
-import os
-import tempfile
-
 import networkx as nx
 from networkx.utils import edges_equal, nodes_equal
 
@@ -27,13 +24,6 @@ class TestPajek:
         )
 
         cls.G.graph["name"] = "Tralala"
-        (fd, cls.fname) = tempfile.mkstemp()
-        with os.fdopen(fd, "wb") as fh:
-            fh.write(cls.data.encode("UTF-8"))
-
-    @classmethod
-    def teardown_class(cls):
-        os.unlink(cls.fname)
 
     def test_parse_pajek_simple(self):
         # Example without node positions or shape
@@ -68,9 +58,14 @@ class TestPajek:
             {("one", "one"), ("two", "one"), ("two", "two"), ("two", "three")},
         )
 
-    def test_read_pajek(self):
+    def test_read_pajek(self, tmp_path):
         G = nx.parse_pajek(self.data)
-        Gin = nx.read_pajek(self.fname)
+        # Read data from file
+        fname = tmp_path / "test.pjk"
+        with open(fname, "wb") as fh:
+            fh.write(self.data.encode("UTF-8"))
+
+        Gin = nx.read_pajek(fname)
         assert sorted(G.nodes()) == sorted(Gin.nodes())
         assert edges_equal(G.edges(), Gin.edges())
         assert self.G.graph == Gin.graph

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -1,4 +1,3 @@
-import tempfile
 from io import BytesIO
 
 import pytest
@@ -158,16 +157,10 @@ class TestWriteSparse6:
         with pytest.raises(nx.NetworkXNotImplemented):
             nx.write_sparse6(nx.DiGraph(), BytesIO())
 
-    def test_write_path(self):
-        # On Windows, we can't reopen a file that is open
-        # So, for test we get a valid name from tempfile but close it.
-        with tempfile.NamedTemporaryFile() as f:
-            fullfilename = f.name
+    def test_write_path(self, tmp_path):
+        # Get a valid temporary file name
+        fullfilename = str(tmp_path / "test.s6")
         # file should be closed now, so write_sparse6 can open it
         nx.write_sparse6(nx.null_graph(), fullfilename)
-        fh = open(fullfilename, mode="rb")
-        assert fh.read() == b">>sparse6<<:?\n"
-        fh.close()
-        import os
-
-        os.remove(fullfilename)
+        with open(fullfilename, mode="rb") as fh:
+            assert fh.read() == b">>sparse6<<:?\n"


### PR DESCRIPTION
An alternative to #6554 which removes `tempfile` entirely in favor of the [`tmp_path` fixture](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmp-path-fixture) in the test suite.