### PR TITLE
fix: make `PlanarEmbedding.copy()` use `add_edges_from()` from parent (closes #7223)

### DIFF
--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -1385,3 +1385,16 @@ class PlanarEmbedding(nx.DiGraph):
         contained.
         """
         return False
+
+    def copy(self, as_view=False):
+        if as_view is True:
+            return nx.graphviews.generic_graph_view(self)
+        G = self.__class__()
+        G.graph.update(self.graph)
+        G.add_nodes_from((n, d.copy()) for n, d in self._node.items())
+        super(self.__class__, G).add_edges_from(
+            (u, v, datadict.copy())
+            for u, nbrs in self._adj.items()
+            for v, datadict in nbrs.items()
+        )
+        return G


### PR DESCRIPTION
closes #7223

`PlanarEmbedding` inherits the method `copy()` from `nx.Graph`. However, the current implementation uses the method `add_edges_from()` which was made forbidden by PR #6798.

### Current Behavior

```python
embedding = nx.PlanarEmbedding({1: {2: {"cw": 2, "ccw": 2}},
                                2: {1: {"cw": 1, "ccw": 1}}})
emb2 = embedding.copy()
```
```
NotImplementedError: Use `add_half_edge` method to add edges to a PlanarEmbedding.
```