### PR TITLE
Bump copyright year for 2024.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ NetworkX is distributed with the 3-clause BSD license.
 
 ::
 
-   Copyright (C) 2004-2023, NetworkX Developers
+   Copyright (C) 2004-2024, NetworkX Developers
    Aric Hagberg <hagberg@lanl.gov>
    Dan Schult <dschult@colgate.edu>
    Pieter Swart <swart@lanl.gov>

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ License
 
 Released under the 3-Clause BSD license (see `LICENSE.txt`)::
 
-   Copyright (C) 2004-2023 NetworkX Developers
+   Copyright (C) 2004-2024 NetworkX Developers
    Aric Hagberg <hagberg@lanl.gov>
    Dan Schult <dschult@colgate.edu>
    Pieter Swart <swart@lanl.gov>


### PR DESCRIPTION
2024 version of the basic copyright bumping chore (#6322). If anyone knows of an action or linting rule that handles this automatically LMK!