### PR TITLE
FEAT: adding a PoC of creating an internal cache

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -457,14 +457,7 @@ def _pagerank_scipy(
         return {}
 
     nodelist = list(G)
-
-    # Check if the cache exists
-    if "networkx-sparse" in G._cache_it_all:
-        # Get the cached sparse array
-        A = G._cache_it_all["networkx-sparse"]
-    else:
-        A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)
-        G._cache_it_all["networkx-sparse"] = A
+    A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)
 
     S = A.sum(axis=1)
     S[S != 0] = 1.0 / S[S != 0]

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -457,7 +457,15 @@ def _pagerank_scipy(
         return {}
 
     nodelist = list(G)
-    A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)
+
+    # Check if the cache exists
+    if "networkx-sparse" in G._cache_it_all:
+        # Get the cached sparse array
+        A = G._cache_it_all["networkx-sparse"]
+    else:
+        A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)
+        G._cache_it_all["networkx-sparse"] = A
+
     S = A.sum(axis=1)
     S[S != 0] = 1.0 / S[S != 0]
     # TODO: csr_array

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -305,7 +305,7 @@ class Graph:
 
     _adj = _CachedPropertyResetterAdj()
     _node = _CachedPropertyResetterNode()
-    _cache_it_all = {}
+    _cache = {}
 
     node_dict_factory = dict
     node_attr_dict_factory = dict
@@ -552,8 +552,8 @@ class Graph:
         NetworkX Graphs, though one should be careful that the hash
         doesn't change on mutables.
         """
-        if len(self._cache_it_all) > 0:
-            self._cache_it_all = {}
+        if len(self._cache) > 0:
+            self._cache = {}
         if node_for_adding not in self._node:
             if node_for_adding is None:
                 raise ValueError("None cannot be a node")
@@ -624,8 +624,8 @@ class Graph:
         >>> # correct way
         >>> G.add_nodes_from(list(n + 1 for n in G.nodes))
         """
-        if len(self._cache_it_all) > 0:
-            self._cache_it_all = {}
+        if len(self._cache) > 0:
+            self._cache = {}
         for n in nodes_for_adding:
             try:
                 newnode = n not in self._node
@@ -672,8 +672,8 @@ class Graph:
         []
 
         """
-        if len(self._cache_it_all) > 0:
-            self._cache_it_all = {}
+        if len(self._cache) > 0:
+            self._cache = {}
         adj = self._adj
         try:
             nbrs = list(adj[n])  # list handles self-loops (allows mutation)
@@ -726,8 +726,8 @@ class Graph:
         >>> # this command will work, since the dictionary underlying graph is not modified
         >>> G.remove_nodes_from(list(n for n in G.nodes if n < 2))
         """
-        if len(self._cache_it_all) > 0:
-            self._cache_it_all = {}
+        if len(self._cache) > 0:
+            self._cache = {}
         adj = self._adj
         for n in nodes:
             try:
@@ -2037,3 +2037,6 @@ class Graph:
 
             bunch = bunch_iter(nbunch, self._adj)
         return bunch
+
+    def _clear_cache(self):
+        self._cache = {}

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -305,6 +305,7 @@ class Graph:
 
     _adj = _CachedPropertyResetterAdj()
     _node = _CachedPropertyResetterNode()
+    _cache_it_all = {}
 
     node_dict_factory = dict
     node_attr_dict_factory = dict
@@ -551,6 +552,8 @@ class Graph:
         NetworkX Graphs, though one should be careful that the hash
         doesn't change on mutables.
         """
+        if len(self._cache_it_all) > 0:
+            self._cache_it_all = {}
         if node_for_adding not in self._node:
             if node_for_adding is None:
                 raise ValueError("None cannot be a node")
@@ -621,6 +624,8 @@ class Graph:
         >>> # correct way
         >>> G.add_nodes_from(list(n + 1 for n in G.nodes))
         """
+        if len(self._cache_it_all) > 0:
+            self._cache_it_all = {}
         for n in nodes_for_adding:
             try:
                 newnode = n not in self._node
@@ -667,6 +672,8 @@ class Graph:
         []
 
         """
+        if len(self._cache_it_all) > 0:
+            self._cache_it_all = {}
         adj = self._adj
         try:
             nbrs = list(adj[n])  # list handles self-loops (allows mutation)
@@ -719,6 +726,8 @@ class Graph:
         >>> # this command will work, since the dictionary underlying graph is not modified
         >>> G.remove_nodes_from(list(n for n in G.nodes if n < 2))
         """
+        if len(self._cache_it_all) > 0:
+            self._cache_it_all = {}
         adj = self._adj
         for n in nodes:
             try:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -564,9 +564,12 @@ def to_scipy_sparse_array(G, nodelist=None, dtype=None, weight="weight", format=
     .. [1] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
-    cache_key = f"sparse-{hash(tuple(nodelist)) if nodelist is not None else '-'}-{dtype}-{weight}-{format}"
-    if cache_key in G._cache and not G.is_directed() and not G.is_multigraph():
-        return G._cache[cache_key]
+    if nodelist is None:
+        cache_key = f"sparse-{dtype}-{weight}-{format}"
+        if cache_key in G._cache:
+            return G._cache[cache_key]
+    else:
+        cache_key = None
 
     import scipy as sp
 
@@ -617,7 +620,8 @@ def to_scipy_sparse_array(G, nodelist=None, dtype=None, weight="weight", format=
         A = sp.sparse.coo_array((d, (r, c)), shape=(nlen, nlen), dtype=dtype)
     try:
         A = A.asformat(format)
-        G._cache[cache_key] = A
+        if cache_key:
+            G._cache[cache_key] = A
         return A
     except ValueError as err:
         raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from err

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -564,6 +564,10 @@ def to_scipy_sparse_array(G, nodelist=None, dtype=None, weight="weight", format=
     .. [1] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
+    cache_key = f"sparse-{hash(tuple(nodelist))}-{dtype}-{weight}-{format}"
+    if cache_key in G._cache:
+        return G._cache[cache_key]
+
     import scipy as sp
 
     if len(G) == 0:
@@ -612,7 +616,9 @@ def to_scipy_sparse_array(G, nodelist=None, dtype=None, weight="weight", format=
             c += diag_index
         A = sp.sparse.coo_array((d, (r, c)), shape=(nlen, nlen), dtype=dtype)
     try:
-        return A.asformat(format)
+        A = A.asformat(format)
+        G._cache[cache_key] = A
+        return A
     except ValueError as err:
         raise nx.NetworkXError(f"Unknown sparse matrix format: {format}") from err
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -564,8 +564,8 @@ def to_scipy_sparse_array(G, nodelist=None, dtype=None, weight="weight", format=
     .. [1] Scipy Dev. References, "Sparse Matrices",
        https://docs.scipy.org/doc/scipy/reference/sparse.html
     """
-    cache_key = f"sparse-{hash(tuple(nodelist))}-{dtype}-{weight}-{format}"
-    if cache_key in G._cache:
+    cache_key = f"sparse-{hash(tuple(nodelist)) if nodelist is not None else '-'}-{dtype}-{weight}-{format}"
+    if cache_key in G._cache and not G.is_directed() and not G.is_multigraph():
         return G._cache[cache_key]
 
     import scipy as sp


### PR DESCRIPTION
We had a nice discussion in the networkx developer meeting today about cache-ing intermediate scipy sparse states and also providing this cache dictionary to backends so they can store their objects once converted.

This is just a PoC to show how it could look like, we should probably create a NXEP or a doc to cover the cacheing policy.

There is considerable speedups on the second call as this caches the sparse array, even without a "backend" there is considerable speedup and we should look at this in a bit more detail.

``` python
In [1]: import networkx as nx

In [2]: G = nx.erdos_renyi_graph(10_000, 0.1)

In [3]: %time _ = nx.pagerank(G)
CPU times: user 7.85 s, sys: 1.53 s, total: 9.38 s
Wall time: 7.68 s

In [4]: %time _ = nx.pagerank(G)
CPU times: user 73.6 ms, sys: 11.4 ms, total: 85 ms
Wall time: 85.7 ms

In [5]: G.remove_node(0)

In [6]: %time _ = nx.pagerank(G)
CPU times: user 5.45 s, sys: 254 ms, total: 5.7 s
Wall time: 5.76 s

In [7]: %time _ = nx.pagerank(G)
CPU times: user 72.2 ms, sys: 12.2 ms, total: 84.4 ms
Wall time: 85.3 ms
```