### PR TITLE
add seed to graph creation

### DIFF
--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -5,7 +5,7 @@ import networkx as nx
 cycle = nx.cycle_graph(5, create_using=nx.DiGraph)
 tree = nx.random_tree(10, create_using=nx.DiGraph, seed=42)
 path = nx.path_graph(5, create_using=nx.DiGraph)
-binomial = nx.binomial_tree(3, create_using=nx.DiGraph, seed=43)
+binomial = nx.binomial_tree(3, create_using=nx.DiGraph)
 HH = nx.directed_havel_hakimi_graph([1, 2, 1, 2, 2, 2], [3, 1, 0, 1, 2, 3])
 balanced_tree = nx.balanced_tree(2, 3, create_using=nx.DiGraph)
 

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -3,9 +3,9 @@ import pytest
 import networkx as nx
 
 cycle = nx.cycle_graph(5, create_using=nx.DiGraph)
-tree = nx.random_tree(10, create_using=nx.DiGraph)
+tree = nx.random_tree(10, create_using=nx.DiGraph, seed=42)
 path = nx.path_graph(5, create_using=nx.DiGraph)
-binomial = nx.binomial_tree(3, create_using=nx.DiGraph)
+binomial = nx.binomial_tree(3, create_using=nx.DiGraph, seed=43)
 HH = nx.directed_havel_hakimi_graph([1, 2, 1, 2, 2, 2], [3, 1, 0, 1, 2, 3])
 balanced_tree = nx.balanced_tree(2, 3, create_using=nx.DiGraph)
 


### PR DESCRIPTION
Fixes #7236 

One of the test graphs is currently random graphs and that sometimes affects the `max_tries` count needed for the `directed_edge_swap` to be successful.  I added seed to the graph creation call so the tests become deterministic.
[Edited -- only one graph creation routine needed seed added: `random_tree`]