### PR TITLE
ENH: Speed up common/non_neighbors by using _adj dict operations

### DIFF
--- a/benchmarks/benchmarks/benchmark_neighbors.py
+++ b/benchmarks/benchmarks/benchmark_neighbors.py
@@ -1,0 +1,31 @@
+import networkx as nx
+
+
+# NOTE: explicit set construction in benchmarks is required for meaningful
+# comparisons due to change in return type from generator -> set. See gh-7244.
+class NonNeighbors:
+    param_names = ["num_nodes"]
+    params = [10, 100, 1000]
+
+    def setup(self, num_nodes):
+        self.star_graph = nx.star_graph(num_nodes)
+        self.complete_graph = nx.complete_graph(num_nodes)
+        self.path_graph = nx.path_graph(num_nodes)
+
+    def time_star_center(self, num_nodes):
+        set(nx.non_neighbors(self.star_graph, 0))
+
+    def time_star_rim(self, num_nodes):
+        set(nx.non_neighbors(self.star_graph, 5))
+
+    def time_complete(self, num_nodes):
+        set(nx.non_neighbors(self.complete_graph, 0))
+
+    def time_path_first(self, num_nodes):
+        set(nx.non_neighbors(self.path_graph, 0))
+
+    def time_path_last(self, num_nodes):
+        set(nx.non_neighbors(self.path_graph, num_nodes - 1))
+
+    def time_path_center(self, num_nodes):
+        set(nx.non_neighbors(self.path_graph, num_nodes // 2))

--- a/benchmarks/benchmarks/benchmark_neighbors.py
+++ b/benchmarks/benchmarks/benchmark_neighbors.py
@@ -29,3 +29,23 @@ class NonNeighbors:
 
     def time_path_center(self, num_nodes):
         set(nx.non_neighbors(self.path_graph, num_nodes // 2))
+
+
+# NOTE: explicit set construction in benchmarks is required for meaningful
+# comparisons due to change in return type from generator -> set. See gh-7244.
+class CommonNeighbors:
+    param_names = ["num_nodes"]
+    params = [10, 100, 1000]
+
+    def setup(self, num_nodes):
+        self.star_graph = nx.star_graph(num_nodes)
+        self.complete_graph = nx.complete_graph(num_nodes)
+
+    def time_star_center_rim(self, num_nodes):
+        set(nx.common_neighbors(self.star_graph, 0, num_nodes // 2))
+
+    def time_star_rim_rim(self, num_nodes):
+        set(nx.common_neighbors(self.star_graph, 4, 5))
+
+    def time_complete(self, num_nodes):
+        set(nx.common_neighbors(self.complete_graph, 0, num_nodes // 2))

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -169,7 +169,7 @@ def jaccard_coefficient(G, ebunch=None):
         union_size = len(set(G[u]) | set(G[v]))
         if union_size == 0:
             return 0
-        return len(list(nx.common_neighbors(G, u, v))) / union_size
+        return len(nx.common_neighbors(G, u, v)) / union_size
 
     return _apply_prediction(G, predict, ebunch)
 
@@ -329,7 +329,7 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
             if u == v:
                 raise nx.NetworkXAlgorithmError("Self loops are not supported")
 
-            return sum(1 for _ in nx.common_neighbors(G, u, v))
+            return len(nx.common_neighbors(G, u, v))
 
     else:
         spl = dict(nx.shortest_path_length(G))
@@ -340,9 +340,9 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
                 raise nx.NetworkXAlgorithmError("Self loops are not supported")
             path_len = spl[u].get(v, inf)
 
-            return alpha * sum(1 for _ in nx.common_neighbors(G, u, v)) + (
-                1 - alpha
-            ) * (G.number_of_nodes() / path_len)
+            return alpha * len(nx.common_neighbors(G, u, v)) + (1 - alpha) * (
+                G.number_of_nodes() / path_len
+            )
 
     return _apply_prediction(G, predict, ebunch)
 
@@ -486,7 +486,7 @@ def cn_soundarajan_hopcroft(G, ebunch=None, community="community"):
     def predict(u, v):
         Cu = _community(G, u, community)
         Cv = _community(G, v, community)
-        cnbors = list(nx.common_neighbors(G, u, v))
+        cnbors = nx.common_neighbors(G, u, v)
         neighbors = (
             sum(_community(G, w, community) == Cu for w in cnbors) if Cu == Cv else 0
         )
@@ -670,7 +670,7 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community="community"):
         Cv = _community(G, v, community)
         if Cu != Cv:
             return 0
-        cnbors = set(nx.common_neighbors(G, u, v))
+        cnbors = nx.common_neighbors(G, u, v)
         within = {w for w in cnbors if _community(G, w, community) == Cu}
         inter = cnbors - within
         return len(within) / (len(inter) + delta)

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -340,9 +340,8 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
                 raise nx.NetworkXAlgorithmError("Self loops are not supported")
             path_len = spl[u].get(v, inf)
 
-            return alpha * len(nx.common_neighbors(G, u, v)) + (1 - alpha) * (
-                G.number_of_nodes() / path_len
-            )
+            n_nbrs = len(nx.common_neighbors(G, u, v))
+            return alpha * n_nbrs + (1 - alpha) * len(G) / path_len
 
     return _apply_prediction(G, predict, ebunch)
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -918,11 +918,10 @@ def non_neighbors(graph, node):
 
     Returns
     -------
-    non_neighbors : iterator
-        Iterator of nodes in the graph that are not neighbors of the node.
+    non_neighbors : set
+        Set of nodes in the graph that are not neighbors of the node.
     """
-    nbors = set(neighbors(graph, node)) | {node}
-    return (nnode for nnode in graph if nnode not in nbors)
+    return graph._adj.keys() - graph._adj[node].keys() - {node}
 
 
 def non_edges(graph):
@@ -964,8 +963,8 @@ def common_neighbors(G, u, v):
 
     Returns
     -------
-    cnbors : iterator
-        Iterator of common neighbors of u and v in the graph.
+    cnbors : set
+        Set of common neighbors of u and v in the graph.
 
     Raises
     ------
@@ -982,10 +981,6 @@ def common_neighbors(G, u, v):
         raise nx.NetworkXError("u is not in the graph.")
     if v not in G:
         raise nx.NetworkXError("v is not in the graph.")
-
-    # Return a generator explicitly instead of yielding so that the above
-    # checks are executed eagerly.
-    # return (w for w in G[u] if w in G[v] and w not in (u, v))
 
     return G._adj[u].keys() & G._adj[v].keys() - {u, v}
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -985,7 +985,9 @@ def common_neighbors(G, u, v):
 
     # Return a generator explicitly instead of yielding so that the above
     # checks are executed eagerly.
-    return (w for w in G[u] if w in G[v] and w not in (u, v))
+    # return (w for w in G[u] if w in G[v] and w not in (u, v))
+
+    return G._adj[u].keys() & G._adj[v].keys() - {u, v}
 
 
 def is_weighted(G, edge=None, weight="weight"):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1288,9 +1288,10 @@ def is_path(G, path):
         True if `path` is a valid path in `G`
 
     """
-    return all(
-        (node in G and nbr in G._adj[node]) for node, nbr in nx.utils.pairwise(path)
-    )
+    try:
+        return all(nbr in G._adj[node] for node, nbr in nx.utils.pairwise(path))
+    except (KeyError, TypeError):
+        return False
 
 
 def path_weight(G, path, weight):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -297,13 +297,13 @@ class TestFunction:
     def test_non_neighbors(self):
         graph = nx.complete_graph(100)
         pop = random.sample(list(graph), 1)
-        nbors = list(nx.non_neighbors(graph, pop[0]))
+        nbors = nx.non_neighbors(graph, pop[0])
         # should be all the other vertices in the graph
         assert len(nbors) == 0
 
         graph = nx.path_graph(100)
         node = random.sample(list(graph), 1)[0]
-        nbors = list(nx.non_neighbors(graph, node))
+        nbors = nx.non_neighbors(graph, node)
         # should be all the other vertices in the graph
         if node != 0 and node != 99:
             assert len(nbors) == 97
@@ -312,13 +312,13 @@ class TestFunction:
 
         # create a star graph with 99 outer nodes
         graph = nx.star_graph(99)
-        nbors = list(nx.non_neighbors(graph, 0))
+        nbors = nx.non_neighbors(graph, 0)
         assert len(nbors) == 0
 
         # disconnected graph
         graph = nx.Graph()
         graph.add_nodes_from(range(10))
-        nbors = list(nx.non_neighbors(graph, 0))
+        nbors = nx.non_neighbors(graph, 0)
         assert len(nbors) == 9
 
     def test_non_edges(self):


### PR DESCRIPTION
I'm not sure why we should not use direct set operations on the `_adj` dictionary to find common neighbors. This will require a deprecation probably as we will change the behavior of the return type (`generator` to `set`).

This was spurred by https://github.com/networkx/networkx/discussions/7243.