### PR TITLE
Allow backend graphs to be input to `nx.Graph(data)`

### DIFF
--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -50,6 +50,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
 
         Current known types are:
          any NetworkX graph
+         any NetworkX backend graph (e.g. has ``__networkx_backend__`` attribute)
          dict-of-dicts
          dict-of-lists
          container (e.g. set, list, tuple) of edges
@@ -70,6 +71,8 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
         a multigraph from a multigraph.
 
     """
+    if hasattr(data, "__networkx_backend__"):
+        data = nx.utils.backends.convert_to_nx(data)
     # NX graph
     if hasattr(data, "adj"):
         try:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -141,6 +141,12 @@ def _load_backend(backend_name):
 _registered_algorithms = {}
 
 
+def convert_to_nx(G):
+    """TODO"""
+    backend = _load_backend(G.__networkx_backend__)
+    return backend.convert_to_nx(G)
+
+
 class _dispatchable:
     # Allow any of the following decorator forms:
     #  - @_dispatchable


### PR DESCRIPTION
@rlratzel @MridulS @Schefflera-Arboricola what do you think? This allows e.g.
```python
Gnx = nx.Graph(Gcg)
```
where `Gcg` is a nx-cugraph Graph and `Gnx` is a networkx Graph.

Should I/we go ahead and update docstrings, add tests, and make this mergable?