### PR TITLE
MAINT : added `seed` to `gnm_random_graph` in `community/tests/test_label_propagation.py`

### DIFF
--- a/networkx/algorithms/community/tests/test_label_propagation.py
+++ b/networkx/algorithms/community/tests/test_label_propagation.py
@@ -193,7 +193,7 @@ class TestFastLabelPropagationCommunities:
         self._check_communities(G, truth)
 
     def test_random_graph(self):
-        G = nx.gnm_random_graph(self.N, self.N * self.K // 2)
+        G = nx.gnm_random_graph(self.N, self.N * self.K // 2, seed=42)
         truth = {frozenset(G)}
         self._check_communities(G, truth)
 
@@ -209,7 +209,7 @@ class TestFastLabelPropagationCommunities:
         self._check_communities(G, truth)
 
     def test_larger_graph(self):
-        G = nx.gnm_random_graph(100 * self.N, 50 * self.N * self.K)
+        G = nx.gnm_random_graph(100 * self.N, 50 * self.N * self.K, seed=42)
         nx.community.fast_label_propagation_communities(G)
 
     def test_graph_type(self):


### PR DESCRIPTION
ref. https://github.com/networkx/nx-parallel/actions/runs/7741216722/job/21107789475?pr=32
<details>
<summary>Error msg </summary>

```
=========================== short test summary info ===========================
FAILED algorithms/community/tests/test_label_propagation.py::TestFastLabelPropagationCommunities::test_random_graph - assert {frozenset({2...13, 14, ...})} == {frozenset({0..., 4, 5, ...})}
  
  Extra items in the left set:
  frozenset({2, 3, 6, 7, 8, 9, ...})
  frozenset({0, 1, 4, 5, 13, 14, ...})
  Extra items in the right set:
  frozenset({0, 1, 2, 3, 4, 5, ...})
  
  Full diff:
    {
        frozenset({
  -         0,
  -         1,
            2,
            3,
  -         4,
  -         5,
            6,
            7,
            8,
            9,
            10,
            11,
            12,
  -         13,
  -         14,
  -         15,
            16,
  -         17,
  -         18,
            19,
  -         20,
            21,
  -         22,
            23,
  -         24,
  -         25,
            26,
            27,
  -         28,
            29,
  -         30,
  -         31,
            32,
  -         33,
            34,
  -         35,
            36,
            37,
            38,
  -         39,
  -         40,
  -         41,
  -         42,
            43,
            44,
  -         45,
  -         46,
            47,
            48,
            49,
            50,
  -         51,
  -         52,
            53,
            54,
  -         55,
  -         56,
            57,
  -         58,
            59,
  -         60,
  -         61,
  -         62,
  -         63,
            64,
  -         65,
            66,
  -         67,
            68,
  -         69,
            70,
  -         71,
  -         72,
  -         73,
            74,
            75,
  -         76,
            77,
            78,
            79,
            80,
            81,
            82,
            83,
  +         86,
  +         91,
  +         95,
  +     }),
  +     frozenset({
  +         0,
  +         1,
  +         4,
  +         5,
  +         13,
  +         14,
  +         15,
  +         17,
  +         18,
  +         20,
  +         22,
  +         24,
  +         25,
  +         28,
  +         30,
  +         31,
  +         33,
  +         35,
  +         39,
  +         40,
  +         41,
  +         42,
  +         45,
  +         46,
  +         51,
  +         52,
  +         55,
  +         56,
  +         58,
  +         60,
  +         61,
  +         62,
  +         63,
  +         65,
  +         67,
  +         69,
  +         71,
  +         72,
  +         73,
  +         76,
            84,
            85,
  -         86,
            87,
            88,
            89,
            90,
  -         91,
            92,
            93,
            94,
  -         95,
            96,
            97,
            98,
            99,
        }),
    }
===== 1 failed, 5268 passed, 57 skipped, 8 warnings in 113.68s (0:01:53) ======
Error: Process completed with exit code 1.
```

</details>

PR https://github.com/networkx/nx-parallel/pull/32 in nx-parallel (windows-latest, Python 3.11)

