### PR TITLE
Add minimum_cycle_basis to cycle_basis See Also.

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -66,6 +66,7 @@ def cycle_basis(G, root=None):
     See Also
     --------
     simple_cycles
+    minimum_cycle_basis
     """
     gnodes = dict.fromkeys(G)  # set-like object that maintains node order
     cycles = []


### PR DESCRIPTION
Minor doc improvement related to #7272 - adds `minimum_cycle_basis` to the `See Also` section of `cycle_basis` (thanks @boothby !)