### PR TITLE
Use ruff's docstring formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,6 @@
 # pre-commit install
 
 repos:
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -407,8 +407,10 @@ def asadpour_atsp(G, weight="weight", seed=None, source=None):
     >>> import networkx as nx
     >>> import networkx.algorithms.approximation as approx
     >>> G = nx.complete_graph(3, create_using=nx.DiGraph)
-    >>> nx.set_edge_attributes(G, {(0, 1): 2, (1, 2): 2, (2, 0): 2, (0, 2): 1, (2, 1): 1, (1, 0): 1}, "weight")
-    >>> tour = approx.asadpour_atsp(G,source=0)
+    >>> nx.set_edge_attributes(
+    ...     G, {(0, 1): 2, (1, 2): 2, (2, 0): 2, (0, 2): 1, (2, 1): 1, (1, 0): 1}, "weight"
+    ... )
+    >>> tour = approx.asadpour_atsp(G, source=0)
     >>> tour
     [0, 2, 1, 0]
     """
@@ -951,11 +953,22 @@ def greedy_tsp(G, weight="weight", source=None):
     --------
     >>> from networkx.algorithms import approximation as approx
     >>> G = nx.DiGraph()
-    >>> G.add_weighted_edges_from({
-    ...     ("A", "B", 3), ("A", "C", 17), ("A", "D", 14), ("B", "A", 3),
-    ...     ("B", "C", 12), ("B", "D", 16), ("C", "A", 13),("C", "B", 12),
-    ...     ("C", "D", 4), ("D", "A", 14), ("D", "B", 15), ("D", "C", 2)
-    ... })
+    >>> G.add_weighted_edges_from(
+    ...     {
+    ...         ("A", "B", 3),
+    ...         ("A", "C", 17),
+    ...         ("A", "D", 14),
+    ...         ("B", "A", 3),
+    ...         ("B", "C", 12),
+    ...         ("B", "D", 16),
+    ...         ("C", "A", 13),
+    ...         ("C", "B", 12),
+    ...         ("C", "D", 4),
+    ...         ("D", "A", 14),
+    ...         ("D", "B", 15),
+    ...         ("D", "C", 2),
+    ...     }
+    ... )
     >>> cycle = approx.greedy_tsp(G, source="D")
     >>> cost = sum(G[n][nbr]["weight"] for n, nbr in nx.utils.pairwise(cycle))
     >>> cycle
@@ -1114,11 +1127,22 @@ def simulated_annealing_tsp(
     --------
     >>> from networkx.algorithms import approximation as approx
     >>> G = nx.DiGraph()
-    >>> G.add_weighted_edges_from({
-    ...     ("A", "B", 3), ("A", "C", 17), ("A", "D", 14), ("B", "A", 3),
-    ...     ("B", "C", 12), ("B", "D", 16), ("C", "A", 13),("C", "B", 12),
-    ...     ("C", "D", 4), ("D", "A", 14), ("D", "B", 15), ("D", "C", 2)
-    ... })
+    >>> G.add_weighted_edges_from(
+    ...     {
+    ...         ("A", "B", 3),
+    ...         ("A", "C", 17),
+    ...         ("A", "D", 14),
+    ...         ("B", "A", 3),
+    ...         ("B", "C", 12),
+    ...         ("B", "D", 16),
+    ...         ("C", "A", 13),
+    ...         ("C", "B", 12),
+    ...         ("C", "D", 4),
+    ...         ("D", "A", 14),
+    ...         ("D", "B", 15),
+    ...         ("D", "C", 2),
+    ...     }
+    ... )
     >>> cycle = approx.simulated_annealing_tsp(G, "greedy", source="D")
     >>> cost = sum(G[n][nbr]["weight"] for n, nbr in nx.utils.pairwise(cycle))
     >>> cycle
@@ -1331,11 +1355,22 @@ def threshold_accepting_tsp(
     --------
     >>> from networkx.algorithms import approximation as approx
     >>> G = nx.DiGraph()
-    >>> G.add_weighted_edges_from({
-    ...     ("A", "B", 3), ("A", "C", 17), ("A", "D", 14), ("B", "A", 3),
-    ...     ("B", "C", 12), ("B", "D", 16), ("C", "A", 13),("C", "B", 12),
-    ...     ("C", "D", 4), ("D", "A", 14), ("D", "B", 15), ("D", "C", 2)
-    ... })
+    >>> G.add_weighted_edges_from(
+    ...     {
+    ...         ("A", "B", 3),
+    ...         ("A", "C", 17),
+    ...         ("A", "D", 14),
+    ...         ("B", "A", 3),
+    ...         ("B", "C", 12),
+    ...         ("B", "D", 16),
+    ...         ("C", "A", 13),
+    ...         ("C", "B", 12),
+    ...         ("C", "D", 4),
+    ...         ("D", "A", 14),
+    ...         ("D", "B", 15),
+    ...         ("D", "C", 2),
+    ...     }
+    ... )
     >>> cycle = approx.threshold_accepting_tsp(G, "greedy", source="D")
     >>> cost = sum(G[n][nbr]["weight"] for n, nbr in nx.utils.pairwise(cycle))
     >>> cycle

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -98,12 +98,12 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
     Examples
     --------
     >>> G = nx.path_graph(3)
-    >>> gender = {0: 'male', 1: 'female', 2: 'female'}
-    >>> nx.set_node_attributes(G, gender, 'gender')
-    >>> mapping = {'male': 0, 'female': 1}
-    >>> mix_mat = nx.attribute_mixing_matrix(G, 'gender', mapping=mapping)
+    >>> gender = {0: "male", 1: "female", 2: "female"}
+    >>> nx.set_node_attributes(G, gender, "gender")
+    >>> mapping = {"male": 0, "female": 1}
+    >>> mix_mat = nx.attribute_mixing_matrix(G, "gender", mapping=mapping)
     >>> # mixing from male nodes to female nodes
-    >>> mix_mat[mapping['male'], mapping['female']]
+    >>> mix_mat[mapping["male"], mapping["female"]]
     0.25
     """
     d = attribute_mixing_dict(G, attribute, nodes)
@@ -201,7 +201,7 @@ def degree_mixing_matrix(
     have that degree, use `mapping` as follows,
 
     >>> max_degree = max(deg for n, deg in G.degree)
-    >>> mapping = {x: x for x in range(max_degree + 1)} # identity mapping
+    >>> mapping = {x: x for x in range(max_degree + 1)}  # identity mapping
     >>> mix_mat = nx.degree_mixing_matrix(G, mapping=mapping)
     >>> mix_mat[3, 1]  # mixing from node degree 3 to node degree 1
     0.5

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -263,7 +263,6 @@ def collaboration_weighted_projected_graph(B, nodes):
     [0, 2, 4, 5]
     >>> for edge in sorted(G.edges(data=True)):
     ...     print(edge)
-    ...
     (0, 2, {'weight': 0.5})
     (0, 5, {'weight': 0.5})
     (2, 4, {'weight': 1.0})
@@ -451,22 +450,18 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     ...     unbrs = set(G[u])
     ...     vnbrs = set(G[v])
     ...     return float(len(unbrs & vnbrs)) / len(unbrs | vnbrs)
-    ...
     >>> def my_weight(G, u, v, weight="weight"):
     ...     w = 0
     ...     for nbr in set(G[u]) & set(G[v]):
     ...         w += G[u][nbr].get(weight, 1) + G[v][nbr].get(weight, 1)
     ...     return w
-    ...
     >>> # A complete bipartite graph with 4 nodes and 4 edges
     >>> B = nx.complete_bipartite_graph(2, 2)
     >>> # Add some arbitrary weight to the edges
     >>> for i, (u, v) in enumerate(B.edges()):
     ...     B.edges[u, v]["weight"] = i + 1
-    ...
     >>> for edge in B.edges(data=True):
     ...     print(edge)
-    ...
     (0, 2, {'weight': 1})
     (0, 3, {'weight': 2})
     (1, 2, {'weight': 3})
@@ -476,14 +471,10 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     >>> print(list(G.edges(data=True)))
     [(0, 1, {'weight': 2})]
     >>> # To specify a custom weight function use the weight_function parameter
-    >>> G = bipartite.generic_weighted_projected_graph(
-    ...     B, [0, 1], weight_function=jaccard
-    ... )
+    >>> G = bipartite.generic_weighted_projected_graph(B, [0, 1], weight_function=jaccard)
     >>> print(list(G.edges(data=True)))
     [(0, 1, {'weight': 1.0})]
-    >>> G = bipartite.generic_weighted_projected_graph(
-    ...     B, [0, 1], weight_function=my_weight
-    ... )
+    >>> G = bipartite.generic_weighted_projected_graph(B, [0, 1], weight_function=my_weight)
     >>> print(list(G.edges(data=True)))
     [(0, 1, {'weight': 10})]
 

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -437,8 +437,9 @@ def make_max_clique_graph(G, create_using=None):
     This function behaves like the following code::
 
         import networkx as nx
+
         G = nx.make_clique_bipartite(G)
-        cliques = [v for v in G.nodes() if G.nodes[v]['bipartite'] == 0]
+        cliques = [v for v in G.nodes() if G.nodes[v]["bipartite"] == 0]
         G = nx.bipartite.projected_graph(G, cliques)
         G = nx.relabel_nodes(G, {-v: v - 1 for v in G})
 

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -39,10 +39,7 @@ def strongly_connected_components(G):
 
     >>> G = nx.cycle_graph(4, create_using=nx.DiGraph())
     >>> nx.add_cycle(G, [10, 11, 12])
-    >>> [
-    ...     len(c)
-    ...     for c in sorted(nx.strongly_connected_components(G), key=len, reverse=True)
-    ... ]
+    >>> [len(c) for c in sorted(nx.strongly_connected_components(G), key=len, reverse=True)]
     [4, 3]
 
     If you only want the largest component, it's more efficient to
@@ -277,7 +274,9 @@ def number_strongly_connected_components(G):
 
     Examples
     --------
-    >>> G = nx.DiGraph([(0, 1), (1, 2), (2, 0), (2, 3), (4, 5), (3, 4), (5, 6), (6, 3), (6, 7)])
+    >>> G = nx.DiGraph(
+    ...     [(0, 1), (1, 2), (2, 0), (2, 3), (4, 5), (3, 4), (5, 6), (6, 3), (6, 7)]
+    ... )
     >>> nx.number_strongly_connected_components(G)
     3
 
@@ -391,7 +390,7 @@ def condensation(G, scc=None):
     >>> H = nx.condensation(G)
     >>> H.nodes.data()
     NodeDataView({0: {'members': {0, 1, 2, 3}}, 1: {'members': {4, 5, 6, 7}}})
-    >>> H.graph['mapping']
+    >>> H.graph["mapping"]
     {0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1}
 
     Contracting a complete graph into one single SCC.

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -36,10 +36,7 @@ def weakly_connected_components(G):
 
     >>> G = nx.path_graph(4, create_using=nx.DiGraph())
     >>> nx.add_path(G, [10, 11, 12])
-    >>> [
-    ...     len(c)
-    ...     for c in sorted(nx.weakly_connected_components(G), key=len, reverse=True)
-    ... ]
+    >>> [len(c) for c in sorted(nx.weakly_connected_components(G), key=len, reverse=True)]
     [4, 3]
 
     If you only want the largest component, it's more efficient to

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -118,7 +118,6 @@ def local_node_connectivity(
     >>> # You also have to explicitly import the function for
     >>> # building the auxiliary digraph from the connectivity package
     >>> from networkx.algorithms.connectivity import build_auxiliary_node_connectivity
-    ...
     >>> H = build_auxiliary_node_connectivity(G)
     >>> # And the function for building the residual network from the
     >>> # flow package
@@ -131,7 +130,6 @@ def local_node_connectivity(
     >>> for u, v in itertools.combinations(G, 2):
     ...     k = local_node_connectivity(G, u, v, auxiliary=H, residual=R)
     ...     result[u][v] = k
-    ...
     >>> all(result[u][v] == 5 for u, v in itertools.combinations(G, 2))
     True
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -377,7 +377,7 @@ def lexicographical_topological_sort(G, key=None):
     The sort will fail for any graph with integer and string nodes. Comparison of integer to strings
     is not defined in python.  Is 3 greater or less than 'red'?
 
-    >>> DG = nx.DiGraph([(1, 'red'), (3, 'red'), (1, 'green'), (2, 'blue')])
+    >>> DG = nx.DiGraph([(1, "red"), (3, "red"), (1, "green"), (2, "blue")])
     >>> list(nx.lexicographical_topological_sort(DG))
     Traceback (most recent call last):
     ...
@@ -853,7 +853,7 @@ def transitive_reduction(G):
     To perform transitive reduction on a DiGraph and transfer node/edge data:
 
     >>> DG = nx.DiGraph()
-    >>> DG.add_edges_from([(1, 2), (2, 3), (1, 3)], color='red')
+    >>> DG.add_edges_from([(1, 2), (2, 3), (1, 3)], color="red")
     >>> TR = nx.transitive_reduction(DG)
     >>> TR.add_nodes_from(DG.nodes(data=True))
     >>> TR.add_edges_from((u, v, DG.edges[u, v]) for u, v in TR.edges)
@@ -988,7 +988,7 @@ def dag_longest_path(G, weight="weight", default_weight=1, topo_order=None):
 
     Examples
     --------
-    >>> DG = nx.DiGraph([(0, 1, {'cost':1}), (1, 2, {'cost':1}), (0, 2, {'cost':42})])
+    >>> DG = nx.DiGraph([(0, 1, {"cost": 1}), (1, 2, {"cost": 1}), (0, 2, {"cost": 42})])
     >>> list(nx.all_simple_paths(DG, 0, 2))
     [[0, 1, 2], [0, 2]]
     >>> nx.dag_longest_path(DG)
@@ -1078,7 +1078,7 @@ def dag_longest_path_length(G, weight="weight", default_weight=1):
 
     Examples
     --------
-    >>> DG = nx.DiGraph([(0, 1, {'cost':1}), (1, 2, {'cost':1}), (0, 2, {'cost':42})])
+    >>> DG = nx.DiGraph([(0, 1, {"cost": 1}), (1, 2, {"cost": 1}), (0, 2, {"cost": 42})])
     >>> list(nx.all_simple_paths(DG, 0, 2))
     [[0, 1, 2], [0, 2]]
     >>> nx.dag_longest_path_length(DG)

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -140,9 +140,7 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     maximum flow by using the flow_func parameter.
 
     >>> from networkx.algorithms.flow import shortest_augmenting_path
-    >>> flow_value == nx.maximum_flow(G, "x", "y", flow_func=shortest_augmenting_path)[
-    ...     0
-    ... ]
+    >>> flow_value == nx.maximum_flow(G, "x", "y", flow_func=shortest_augmenting_path)[0]
     True
 
     """
@@ -281,9 +279,7 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     maximum flow by using the flow_func parameter.
 
     >>> from networkx.algorithms.flow import shortest_augmenting_path
-    >>> flow_value == nx.maximum_flow_value(
-    ...     G, "x", "y", flow_func=shortest_augmenting_path
-    ... )
+    >>> flow_value == nx.maximum_flow_value(G, "x", "y", flow_func=shortest_augmenting_path)
     True
 
     """
@@ -582,9 +578,7 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
     minimum cut by using the flow_func parameter.
 
     >>> from networkx.algorithms.flow import shortest_augmenting_path
-    >>> cut_value == nx.minimum_cut_value(
-    ...     G, "x", "y", flow_func=shortest_augmenting_path
-    ... )
+    >>> cut_value == nx.minimum_cut_value(G, "x", "y", flow_func=shortest_augmenting_path)
     True
 
     """

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -234,13 +234,9 @@ def weisfeiler_lehman_subgraph_hashes(
     Finding similar nodes in different graphs:
 
     >>> G1 = nx.Graph()
-    >>> G1.add_edges_from([
-    ...     (1, 2), (2, 3), (2, 4), (3, 5), (4, 6), (5, 7), (6, 7)
-    ... ])
+    >>> G1.add_edges_from([(1, 2), (2, 3), (2, 4), (3, 5), (4, 6), (5, 7), (6, 7)])
     >>> G2 = nx.Graph()
-    >>> G2.add_edges_from([
-    ...     (1, 3), (2, 3), (1, 6), (1, 5), (4, 6)
-    ... ])
+    >>> G2.add_edges_from([(1, 3), (2, 3), (1, 6), (1, 5), (4, 6)])
     >>> g1_hashes = nx.weisfeiler_lehman_subgraph_hashes(G1, iterations=3, digest_size=8)
     >>> g2_hashes = nx.weisfeiler_lehman_subgraph_hashes(G2, iterations=3, digest_size=8)
 

--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -311,7 +311,6 @@ def generic_multiedge_match(attr, default, op):
     >>> nm = generic_node_match("weight", 1.0, isclose)
     >>> nm = generic_node_match("color", "red", eq)
     >>> nm = generic_node_match(["weight", "color"], [1.0, "red"], [isclose, eq])
-    ...
 
     """
 

--- a/networkx/algorithms/isomorphism/temporalisomorphvf2.py
+++ b/networkx/algorithms/isomorphism/temporalisomorphvf2.py
@@ -89,9 +89,7 @@ class TimeRespectingGraphMatcher(GraphMatcher):
 
         >>> G2 = nx.Graph(nx.path_graph(4, create_using=nx.Graph()))
 
-        >>> GM = isomorphism.TimeRespectingGraphMatcher(
-        ...     G1, G2, "date", timedelta(days=1)
-        ... )
+        >>> GM = isomorphism.TimeRespectingGraphMatcher(G1, G2, "date", timedelta(days=1))
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta
@@ -158,9 +156,7 @@ class TimeRespectingDiGraphMatcher(DiGraphMatcher):
 
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
 
-        >>> GM = isomorphism.TimeRespectingDiGraphMatcher(
-        ...     G1, G2, "date", timedelta(days=1)
-        ... )
+        >>> GM = isomorphism.TimeRespectingDiGraphMatcher(G1, G2, "date", timedelta(days=1))
         """
         self.temporal_attribute_name = temporal_attribute_name
         self.delta = delta

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -68,8 +68,9 @@ def equivalence_classes(iterable, relation):
     `X` and a function implementation of `R`.
 
     >>> X = set(range(10))
-    >>> def mod3(x, y): return (x - y) % 3 == 0
-    >>> equivalence_classes(X, mod3)    # doctest: +SKIP
+    >>> def mod3(x, y):
+    ...     return (x - y) % 3 == 0
+    >>> equivalence_classes(X, mod3)  # doctest: +SKIP
     {frozenset({1, 4, 7}), frozenset({8, 2, 5}), frozenset({0, 9, 3, 6})}
     """
     # For simplicity of implementation, we initialize the return value as a
@@ -202,9 +203,7 @@ def quotient_graph(
     are equivalent if they are not adjacent but have the same neighbor set.
 
     >>> G = nx.complete_bipartite_graph(2, 3)
-    >>> same_neighbors = lambda u, v: (
-    ...     u not in G[v] and v not in G[u] and G[u] == G[v]
-    ... )
+    >>> same_neighbors = lambda u, v: (u not in G[v] and v not in G[u] and G[u] == G[v])
     >>> Q = nx.quotient_graph(G, same_neighbors)
     >>> K2 = nx.complete_graph(2)
     >>> nx.is_isomorphic(Q, K2)

--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -57,7 +57,7 @@ def non_randomness(G, k=None, weight="weight"):
     --------
     >>> G = nx.karate_club_graph()
     >>> nr, nr_rd = nx.non_randomness(G, 2)
-    >>> nr, nr_rd = nx.non_randomness(G, 2, 'weight')
+    >>> nr, nr_rd = nx.non_randomness(G, 2, "weight")
 
     Notes
     -----

--- a/networkx/algorithms/operators/all.py
+++ b/networkx/algorithms/operators/all.py
@@ -270,8 +270,11 @@ def intersection_all(graphs):
 
     >>> gh = nx.intersection_all([g, h])
 
-    >>> new_node_attr = {n: min(*(anyG.nodes[n].get('capacity', float('inf')) for anyG in [g, h])) for n in gh}
-    >>> nx.set_node_attributes(gh, new_node_attr, 'new_capacity')
+    >>> new_node_attr = {
+    ...     n: min(*(anyG.nodes[n].get("capacity", float("inf")) for anyG in [g, h]))
+    ...     for n in gh
+    ... }
+    >>> nx.set_node_attributes(gh, new_node_attr, "new_capacity")
     >>> gh.nodes(data=True)
     NodeDataView({0: {'new_capacity': 2}, 1: {'new_capacity': 3}})
 

--- a/networkx/algorithms/operators/binary.py
+++ b/networkx/algorithms/operators/binary.py
@@ -336,30 +336,34 @@ def compose(G, H):
     By default, the attributes from `H` take precedent over attributes from `G`.
     If you prefer another way of combining attributes, you can update them after the compose operation:
 
-    >>> G = nx.Graph([(0, 1, {'weight': 2.0}), (3, 0, {'weight': 100.0})])
-    >>> H = nx.Graph([(0, 1, {'weight': 10.0}), (1, 2, {'weight': -1.0})])
-    >>> nx.set_node_attributes(G, {0: 'dark', 1: 'light', 3: 'black'}, name='color')
-    >>> nx.set_node_attributes(H, {0: 'green', 1: 'orange', 2: 'yellow'}, name='color')
+    >>> G = nx.Graph([(0, 1, {"weight": 2.0}), (3, 0, {"weight": 100.0})])
+    >>> H = nx.Graph([(0, 1, {"weight": 10.0}), (1, 2, {"weight": -1.0})])
+    >>> nx.set_node_attributes(G, {0: "dark", 1: "light", 3: "black"}, name="color")
+    >>> nx.set_node_attributes(H, {0: "green", 1: "orange", 2: "yellow"}, name="color")
     >>> GcomposeH = nx.compose(G, H)
 
     Normally, color attribute values of nodes of GcomposeH come from H. We can workaround this as follows:
 
-    >>> node_data = {n: G.nodes[n]['color'] + " " + H.nodes[n]['color'] for n in G.nodes & H.nodes}
-    >>> nx.set_node_attributes(GcomposeH, node_data, 'color')
-    >>> print(GcomposeH.nodes[0]['color'])
+    >>> node_data = {
+    ...     n: G.nodes[n]["color"] + " " + H.nodes[n]["color"] for n in G.nodes & H.nodes
+    ... }
+    >>> nx.set_node_attributes(GcomposeH, node_data, "color")
+    >>> print(GcomposeH.nodes[0]["color"])
     dark green
 
-    >>> print(GcomposeH.nodes[3]['color'])
+    >>> print(GcomposeH.nodes[3]["color"])
     black
 
     Similarly, we can update edge attributes after the compose operation in a way we prefer:
 
-    >>> edge_data = {e: G.edges[e]['weight'] * H.edges[e]['weight'] for e in G.edges & H.edges}
-    >>> nx.set_edge_attributes(GcomposeH, edge_data, 'weight')
-    >>> print(GcomposeH.edges[(0, 1)]['weight'])
+    >>> edge_data = {
+    ...     e: G.edges[e]["weight"] * H.edges[e]["weight"] for e in G.edges & H.edges
+    ... }
+    >>> nx.set_edge_attributes(GcomposeH, edge_data, "weight")
+    >>> print(GcomposeH.edges[(0, 1)]["weight"])
     20.0
 
-    >>> print(GcomposeH.edges[(3, 0)]['weight'])
+    >>> print(GcomposeH.edges[(3, 0)]["weight"])
     100.0
     """
     return nx.compose_all([G, H])

--- a/networkx/algorithms/operators/unary.py
+++ b/networkx/algorithms/operators/unary.py
@@ -28,7 +28,7 @@ def complement(G):
     --------
     >>> G = nx.Graph([(1, 2), (1, 3), (2, 3), (3, 4), (3, 5)])
     >>> G_complement = nx.complement(G)
-    >>> G_complement.edges() # This shows the edges of the complemented graph
+    >>> G_complement.edges()  # This shows the edges of the complemented graph
     EdgeView([(1, 4), (1, 5), (2, 4), (2, 5), (4, 5)])
 
     """

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -233,7 +233,7 @@ def floyd_warshall(G, weight="weight"):
     --------
     >>> G = nx.DiGraph()
     >>> G.add_weighted_edges_from([(0, 1, 5), (1, 2, 2), (2, 3, -3), (1, 3, 10), (3, 2, 8)])
-    >>> fw = nx.floyd_warshall(G, weight='weight')
+    >>> fw = nx.floyd_warshall(G, weight="weight")
     >>> results = {a: dict(b) for a, b in fw.items()}
     >>> print(results)
     {0: {0: 0, 1: 5, 2: 7, 3: 4}, 1: {1: 0, 2: 2, 3: -1, 0: inf}, 2: {2: 0, 3: -3, 0: inf, 1: inf}, 3: {3: 0, 2: 8, 0: inf, 1: inf}}

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -106,13 +106,13 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     >>> print(nx.shortest_path(G, source=0, target=4))
     [0, 1, 2, 3, 4]
     >>> p = nx.shortest_path(G, source=0)  # target not specified
-    >>> p[3] # shortest path from source=0 to target=3
+    >>> p[3]  # shortest path from source=0 to target=3
     [0, 1, 2, 3]
     >>> p = nx.shortest_path(G, target=4)  # source not specified
-    >>> p[1] # shortest path from source=1 to target=4
+    >>> p[1]  # shortest path from source=1 to target=4
     [1, 2, 3, 4]
     >>> p = dict(nx.shortest_path(G))  # source, target not specified
-    >>> p[2][4] # shortest path from source=2 to target=4
+    >>> p[2][4]  # shortest path from source=2 to target=4
     [2, 3, 4]
 
     Notes

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -133,7 +133,10 @@ def dijkstra_path(G, source, target, weight="weight"):
     >>> G.add_weighted_edges_from([(1, 2, 0.75), (1, 2, 0.5), (2, 3, 0.5), (1, 3, 1.5)])
     >>> nodes = nx.dijkstra_path(G, 1, 3)
     >>> edges = nx.utils.pairwise(nodes)
-    >>> list((u, v, min(G[u][v], key=lambda k: G[u][v][k].get('weight', 1))) for u, v in edges)
+    >>> list(
+    ...     (u, v, min(G[u][v], key=lambda k: G[u][v][k].get("weight", 1)))
+    ...     for u, v in edges
+    ... )
     [(1, 2, 1), (2, 3, 0)]
 
     Notes

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1232,9 +1232,9 @@ def simrank_similarity(
             in_neighbors_u = G.predecessors(u)
             in_neighbors_v = G.predecessors(v)
             scale = C / (len(in_neighbors_u) * len(in_neighbors_v))
-            return scale * sum(simrank(G, w, x)
-                               for w, x in product(in_neighbors_u,
-                                                   in_neighbors_v))
+            return scale * sum(
+                simrank(G, w, x) for w, x in product(in_neighbors_u, in_neighbors_v)
+            )
 
     where ``G`` is the graph, ``u`` is the source, ``v`` is the target,
     and ``C`` is a float decay or importance factor between 0 and 1.
@@ -1703,7 +1703,9 @@ def generate_random_paths(
     >>> G = nx.star_graph(3)
     >>> index_map = {}
     >>> random_path = nx.generate_random_paths(G, 3, index_map=index_map)
-    >>> paths_containing_node_0 = [random_path[path_idx] for path_idx in index_map.get(0, [])]
+    >>> paths_containing_node_0 = [
+    ...     random_path[path_idx] for path_idx in index_map.get(0, [])
+    ... ]
 
     References
     ----------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -319,7 +319,7 @@ def all_simple_edge_paths(G, source, target, cutoff=None):
         >>> G.add_node(0)
         >>> paths = list(nx.all_simple_edge_paths(G, 0, 0))
         >>> for path in paths:
-        ...     print (path)
+        ...     print(path)
         []
         >>> len(paths)
         1

--- a/networkx/algorithms/summarization.py
+++ b/networkx/algorithms/summarization.py
@@ -492,13 +492,13 @@ def snap_aggregation(
     >>> for node in nodes:
     ...     attributes = nodes[node]
     ...     G.add_node(node, **attributes)
-    ...
     >>> for source, target, type in edges:
     ...     G.add_edge(source, target, type=type)
-    ...
-    >>> node_attributes = ('color', )
-    >>> edge_attributes = ('type', )
-    >>> summary_graph = nx.snap_aggregation(G, node_attributes=node_attributes, edge_attributes=edge_attributes)
+    >>> node_attributes = ("color",)
+    >>> edge_attributes = ("type",)
+    >>> summary_graph = nx.snap_aggregation(
+    ...     G, node_attributes=node_attributes, edge_attributes=edge_attributes
+    ... )
 
     Notes
     -----

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -394,7 +394,7 @@ def find_threshold_graph(G, create_using=None):
     >>> from networkx.algorithms.threshold import find_threshold_graph
     >>> G = nx.barbell_graph(3, 3)
     >>> T = find_threshold_graph(G)
-    >>> T.nodes # may vary
+    >>> T.nodes  # may vary
     NodeView((7, 8, 5, 6))
 
     References

--- a/networkx/algorithms/time_dependent.py
+++ b/networkx/algorithms/time_dependent.py
@@ -55,10 +55,10 @@ def cd_index(G, node, time_delta, *, time="time", weight=None):
     >>> G = nx.DiGraph()
     >>> nodes = {
     ...     1: {"time": datetime(2015, 1, 1)},
-    ...     2: {"time": datetime(2012, 1, 1), 'weight': 4},
+    ...     2: {"time": datetime(2012, 1, 1), "weight": 4},
     ...     3: {"time": datetime(2010, 1, 1)},
     ...     4: {"time": datetime(2008, 1, 1)},
-    ...     5: {"time": datetime(2014, 1, 1)}
+    ...     5: {"time": datetime(2014, 1, 1)},
     ... }
     >>> G.add_nodes_from([(n, nodes[n]) for n in nodes])
     >>> edges = [(1, 3), (1, 4), (2, 3), (3, 4), (3, 5)]

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -516,7 +516,7 @@ def bfs_labeled_edges(G, sources):
 
     Examples
     --------
-    >>> G = nx.cycle_graph(4, create_using = nx.DiGraph)
+    >>> G = nx.cycle_graph(4, create_using=nx.DiGraph)
     >>> list(nx.bfs_labeled_edges(G, 0))
     [(0, 1, 'tree'), (1, 2, 'tree'), (2, 3, 'tree'), (3, 0, 'reverse')]
     >>> G = nx.complete_graph(3)

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -155,7 +155,6 @@ def triadic_census(G, nodelist=None):
     >>> triadic_census = nx.triadic_census(G)
     >>> for key, value in triadic_census.items():
     ...     print(f"{key}: {value}")
-    ...
     003: 0
     012: 0
     102: 0
@@ -427,9 +426,9 @@ def triads_by_type(G):
     --------
     >>> G = nx.DiGraph([(1, 2), (1, 3), (2, 3), (3, 1), (5, 6), (5, 4), (6, 7)])
     >>> dict = nx.triads_by_type(G)
-    >>> dict['120C'][0].edges()
+    >>> dict["120C"][0].edges()
     OutEdgeView([(1, 2), (1, 3), (2, 3), (3, 1)])
-    >>> dict['012'][0].edges()
+    >>> dict["012"][0].edges()
     OutEdgeView([(1, 2)])
 
     References

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1026,7 +1026,7 @@ class DiGraph(Graph):
         Examples
         --------
         >>> G = nx.DiGraph()
-        >>> G.add_edge(1, 2, color='blue')
+        >>> G.add_edge(1, 2, color="blue")
         >>> G.in_edges()
         InEdgeView([(1, 2)])
         >>> G.in_edges(nbunch=2)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1211,20 +1211,12 @@ class Graph:
         >>> DG = nx.DiGraph()
         >>> # dict-of-dict-of-attribute
         >>> adj = {1: {2: 1.3, 3: 0.7}, 2: {1: 1.4}, 3: {1: 0.7}}
-        >>> e = [
-        ...     (u, v, {"weight": d})
-        ...     for u, nbrs in adj.items()
-        ...     for v, d in nbrs.items()
-        ... ]
+        >>> e = [(u, v, {"weight": d}) for u, nbrs in adj.items() for v, d in nbrs.items()]
         >>> DG.update(edges=e, nodes=adj)
 
         >>> # dict-of-dict-of-dict
         >>> adj = {1: {2: {"weight": 1.3}, 3: {"color": 0.7, "weight": 1.2}}}
-        >>> e = [
-        ...     (u, v, {"weight": d})
-        ...     for u, nbrs in adj.items()
-        ...     for v, d in nbrs.items()
-        ... ]
+        >>> e = [(u, v, {"weight": d}) for u, nbrs in adj.items() for v, d in nbrs.items()]
         >>> DG.update(edges=e, nodes=adj)
 
         >>> # predecessor adjacency (dict-of-set)
@@ -1800,14 +1792,22 @@ class Graph:
             SG = G.__class__()
             SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
             if SG.is_multigraph():
-                SG.add_edges_from((n, nbr, key, d)
-                    for n, nbrs in G.adj.items() if n in largest_wcc
-                    for nbr, keydict in nbrs.items() if nbr in largest_wcc
-                    for key, d in keydict.items())
+                SG.add_edges_from(
+                    (n, nbr, key, d)
+                    for n, nbrs in G.adj.items()
+                    if n in largest_wcc
+                    for nbr, keydict in nbrs.items()
+                    if nbr in largest_wcc
+                    for key, d in keydict.items()
+                )
             else:
-                SG.add_edges_from((n, nbr, d)
-                    for n, nbrs in G.adj.items() if n in largest_wcc
-                    for nbr, d in nbrs.items() if nbr in largest_wcc)
+                SG.add_edges_from(
+                    (n, nbr, d)
+                    for n, nbrs in G.adj.items()
+                    if n in largest_wcc
+                    for nbr, d in nbrs.items()
+                    if nbr in largest_wcc
+                )
             SG.graph.update(G.graph)
 
         Examples

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -180,7 +180,6 @@ def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
 
     >>> def filter_node(n1):
     ...     return n1 != 5
-    ...
     >>> view = nx.subgraph_view(G, filter_node=filter_node)
     >>> view.nodes()
     NodeView((0, 1, 2, 3, 4))
@@ -191,12 +190,15 @@ def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
     >>> G[3][4]["cross_me"] = False
     >>> def filter_edge(n1, n2):
     ...     return G[n1][n2].get("cross_me", True)
-    ...
     >>> view = nx.subgraph_view(G, filter_edge=filter_edge)
     >>> view.edges()
     EdgeView([(0, 1), (1, 2), (2, 3), (4, 5)])
 
-    >>> view = nx.subgraph_view(G, filter_node=filter_node, filter_edge=filter_edge,)
+    >>> view = nx.subgraph_view(
+    ...     G,
+    ...     filter_node=filter_node,
+    ...     filter_edge=filter_edge,
+    ... )
     >>> view.nodes()
     NodeView((0, 1, 2, 3, 4))
     >>> view.edges()

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -639,7 +639,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
         >>> G = nx.MultiDiGraph()
         >>> nx.add_path(G, [0, 1, 2])
         >>> key = G.add_edge(2, 3, weight=5)
-        >>> key2 = G.add_edge(1, 2) # second edge between these nodes
+        >>> key2 = G.add_edge(1, 2)  # second edge between these nodes
         >>> [e for e in G.edges()]
         [(0, 1), (1, 2), (1, 2), (2, 3)]
         >>> list(G.edges(data=True))  # default data is {} (empty dict)
@@ -746,9 +746,9 @@ class MultiDiGraph(MultiGraph, DiGraph):
         1
         >>> list(G.degree([0, 1, 2]))
         [(0, 1), (1, 2), (2, 2)]
-        >>> G.add_edge(0, 1) # parallel edge
+        >>> G.add_edge(0, 1)  # parallel edge
         1
-        >>> list(G.degree([0, 1, 2])) # parallel edges are counted
+        >>> list(G.degree([0, 1, 2]))  # parallel edges are counted
         [(0, 2), (1, 3), (2, 2)]
 
         """
@@ -797,9 +797,9 @@ class MultiDiGraph(MultiGraph, DiGraph):
         0
         >>> list(G.in_degree([0, 1, 2]))
         [(0, 0), (1, 1), (2, 1)]
-        >>> G.add_edge(0, 1) # parallel edge
+        >>> G.add_edge(0, 1)  # parallel edge
         1
-        >>> list(G.in_degree([0, 1, 2])) # parallel edges counted
+        >>> list(G.in_degree([0, 1, 2]))  # parallel edges counted
         [(0, 0), (1, 2), (2, 1)]
 
         """
@@ -847,9 +847,9 @@ class MultiDiGraph(MultiGraph, DiGraph):
         1
         >>> list(G.out_degree([0, 1, 2]))
         [(0, 1), (1, 1), (2, 1)]
-        >>> G.add_edge(0, 1) # parallel edge
+        >>> G.add_edge(0, 1)  # parallel edge
         1
-        >>> list(G.out_degree([0, 1, 2])) # counts parallel edges
+        >>> list(G.out_degree([0, 1, 2]))  # counts parallel edges
         [(0, 2), (1, 1), (2, 1)]
 
         """

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -390,7 +390,7 @@ class MultiGraph(Graph):
         >>> G.edges[1, 2, 0]["weight"] = 3
         >>> result = set()
         >>> for edgekey, data in G[1][2].items():
-        ...     result.add(data.get('weight', 1))
+        ...     result.add(data.get("weight", 1))
         >>> result
         {1, 3}
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -239,11 +239,13 @@ class NodeView(Mapping, Set):
         Examples
         --------
         >>> G = nx.Graph()
-        >>> G.add_nodes_from([
-        ...     (0, {"color": "red", "weight": 10}),
-        ...     (1, {"color": "blue"}),
-        ...     (2, {"color": "yellow", "weight": 2})
-        ... ])
+        >>> G.add_nodes_from(
+        ...     [
+        ...         (0, {"color": "red", "weight": 10}),
+        ...         (1, {"color": "blue"}),
+        ...         (2, {"color": "yellow", "weight": 2}),
+        ...     ]
+        ... )
 
         Accessing node data with ``data=True`` (the default) returns a
         NodeDataView mapping each node to all of its attributes:
@@ -1129,11 +1131,13 @@ class OutEdgeView(Set, Mapping):
         Examples
         --------
         >>> G = nx.Graph()
-        >>> G.add_edges_from([
-        ...     (0, 1, {"dist": 3, "capacity": 20}),
-        ...     (1, 2, {"dist": 4}),
-        ...     (2, 0, {"dist": 5})
-        ... ])
+        >>> G.add_edges_from(
+        ...     [
+        ...         (0, 1, {"dist": 3, "capacity": 20}),
+        ...         (1, 2, {"dist": 4}),
+        ...         (2, 0, {"dist": 5}),
+        ...     ]
+        ... )
 
         Accessing edge data with ``data=True`` (the default) returns an
         edge data view object listing each edge with all of its attributes:

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -278,9 +278,7 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     For a more custom approach to handling edge data, try::
 
         dod = {
-            n: {
-                nbr: custom(n, nbr, dd) for nbr, dd in nbrdict.items()
-            }
+            n: {nbr: custom(n, nbr, dd) for nbr, dd in nbrdict.items()}
             for n, nbrdict in G.adj.items()
         }
 
@@ -300,9 +298,9 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     >>> G = nx.Graph()
     >>> G.add_edges_from(
     ...     [
-    ...         (0, 1, {'weight': 1.0}),
-    ...         (1, 2, {'weight': 2.0}),
-    ...         (2, 0, {'weight': 1.0}),
+    ...         (0, 1, {"weight": 1.0}),
+    ...         (1, 2, {"weight": 2.0}),
+    ...         (2, 0, {"weight": 1.0}),
     ...     ]
     ... )
     >>> d = nx.to_dict_of_dicts(G)
@@ -310,7 +308,7 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     {0: {1: {'weight': 1.0}, 2: {'weight': 1.0}},
      1: {0: {'weight': 1.0}, 2: {'weight': 2.0}},
      2: {1: {'weight': 2.0}, 0: {'weight': 1.0}}}
-    >>> d[1][2]['weight']
+    >>> d[1][2]["weight"]
     2.0
 
     If `edge_data` is not `None`, edge data in the original graph (if any) is
@@ -325,15 +323,15 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
     This also applies to MultiGraphs: edge data is preserved by default:
 
     >>> G = nx.MultiGraph()
-    >>> G.add_edge(0, 1, key='a', weight=1.0)
+    >>> G.add_edge(0, 1, key="a", weight=1.0)
     'a'
-    >>> G.add_edge(0, 1, key='b', weight=5.0)
+    >>> G.add_edge(0, 1, key="b", weight=5.0)
     'b'
     >>> d = nx.to_dict_of_dicts(G)
     >>> d  # doctest: +SKIP
     {0: {1: {'a': {'weight': 1.0}, 'b': {'weight': 5.0}}},
      1: {0: {'a': {'weight': 1.0}, 'b': {'weight': 5.0}}}}
-    >>> d[0][1]['b']['weight']
+    >>> d[0][1]["b"]["weight"]
     5.0
 
     But multi edge data is lost if `edge_data` is not `None`:

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -273,9 +273,9 @@ def to_pandas_edgelist(
     0      A      B     1       7
     1      C      E     9      10
 
-    >>> G = nx.MultiGraph([('A', 'B', {'cost': 1}), ('A', 'B', {'cost': 9})])
-    >>> df = nx.to_pandas_edgelist(G, nodelist=['A', 'C'], edge_key='ekey')
-    >>> df[['source', 'target', 'cost', 'ekey']]
+    >>> G = nx.MultiGraph([("A", "B", {"cost": 1}), ("A", "B", {"cost": 9})])
+    >>> df = nx.to_pandas_edgelist(G, nodelist=["A", "C"], edge_key="ekey")
+    >>> df[["source", "target", "cost", "ekey"]]
       source target  cost  ekey
     0      A      B     1     0
     1      A      B     9     1
@@ -736,9 +736,7 @@ def from_scipy_sparse_array(
     as the number of parallel edges joining those two vertices:
 
     >>> A = sp.sparse.csr_array([[1, 1], [1, 2]])
-    >>> G = nx.from_scipy_sparse_array(
-    ...     A, parallel_edges=True, create_using=nx.MultiGraph
-    ... )
+    >>> G = nx.from_scipy_sparse_array(A, parallel_edges=True, create_using=nx.MultiGraph)
     >>> G[1][1]
     AtlasView({0: {'weight': 1}, 1: {'weight': 1}})
 
@@ -934,7 +932,7 @@ def to_numpy_array(
     >>> G.add_edge(2, 0, weight=0)
     >>> G.add_edge(2, 1, weight=0)
     >>> G.add_edge(3, 0, weight=1)
-    >>> nx.to_numpy_array(G, nonedge=-1.)
+    >>> nx.to_numpy_array(G, nonedge=-1.0)
     array([[-1.,  2., -1.,  1.],
            [ 2., -1.,  0., -1.],
            [-1.,  0., -1.,  0.],

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -355,9 +355,9 @@ def pydot_layout(G, prog="neato", root=None):
     If this occurs in your case, consider relabeling the nodes just
     for the layout computation using something similar to::
 
-        H = nx.convert_node_labels_to_integers(G, label_attribute='node_label')
-        H_layout = nx.nx_pydot.pydot_layout(G, prog='dot')
-        G_layout = {H.nodes[n]['node_label']: p for n, p in H_layout.items()}
+        H = nx.convert_node_labels_to_integers(G, label_attribute="node_label")
+        H_layout = nx.nx_pydot.pydot_layout(G, prog="dot")
+        G_layout = {H.nodes[n]["node_label"]: p for n, p in H_layout.items()}
 
     """
     import pydot

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -424,7 +424,6 @@ def circulant_graph(n, offsets, create_using=None):
     ...     (7, 8),
     ...     (8, 9),
     ... ]
-    ...
     >>> sorted(edges) == sorted(G.edges())
     True
 
@@ -444,7 +443,6 @@ def circulant_graph(n, offsets, create_using=None):
     ...     (2, 4),
     ...     (3, 4),
     ... ]
-    ...
     >>> sorted(edges) == sorted(G.edges())
     True
 

--- a/networkx/generators/community.py
+++ b/networkx/generators/community.py
@@ -551,13 +551,11 @@ def stochastic_block_model(
     >>> H = nx.quotient_graph(g, g.graph["partition"], relabel=True)
     >>> for v in H.nodes(data=True):
     ...     print(round(v[1]["density"], 3))
-    ...
     0.245
     0.348
     0.405
     >>> for v in H.edges(data=True):
     ...     print(round(1.0 * v[2]["weight"] / (sizes[v[0]] * sizes[v[1]]), 3))
-    ...
     0.051
     0.022
     0.07

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -54,7 +54,7 @@ def gn_graph(n, kernel=None, create_using=None, seed=None):
 
     To specify an attachment kernel, use the `kernel` keyword argument::
 
-    >>> D = nx.gn_graph(10, kernel=lambda x: x ** 1.5)  # A_k = k^1.5
+    >>> D = nx.gn_graph(10, kernel=lambda x: x**1.5)  # A_k = k^1.5
 
     References
     ----------

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -57,11 +57,13 @@ def geometric_edges(G, radius, p=2, *, pos_name="pos"):
     coordinates.
 
     >>> G = nx.Graph()
-    >>> G.add_nodes_from([
-    ...     (0, {"pos": (0, 0)}),
-    ...     (1, {"pos": (3, 0)}),
-    ...     (2, {"pos": (8, 0)}),
-    ... ])
+    >>> G.add_nodes_from(
+    ...     [
+    ...         (0, {"pos": (0, 0)}),
+    ...         (1, {"pos": (3, 0)}),
+    ...         (2, {"pos": (8, 0)}),
+    ...     ]
+    ... )
     >>> nx.geometric_edges(G, radius=1)
     []
     >>> nx.geometric_edges(G, radius=4)

--- a/networkx/generators/line.py
+++ b/networkx/generators/line.py
@@ -48,7 +48,7 @@ def line_graph(G, create_using=None):
     attributes can be copied manually:
 
     >>> G = nx.path_graph(4)
-    >>> G.add_edges_from((u, v, {"tot": u+v}) for u, v in G.edges)
+    >>> G.add_edges_from((u, v, {"tot": u + v}) for u, v in G.edges)
     >>> G.edges(data=True)
     EdgeDataView([(0, 1, {'tot': 1}), (1, 2, {'tot': 3}), (2, 3, {'tot': 5})])
     >>> H = nx.line_graph(G)

--- a/networkx/generators/triads.py
+++ b/networkx/generators/triads.py
@@ -39,8 +39,24 @@ def triad_graph(triad_name):
 
     Each string in the following tuple is a valid triad name::
 
-        ('003', '012', '102', '021D', '021U', '021C', '111D', '111U',
-         '030T', '030C', '201', '120D', '120U', '120C', '210', '300')
+        (
+            "003",
+            "012",
+            "102",
+            "021D",
+            "021U",
+            "021C",
+            "111D",
+            "111U",
+            "030T",
+            "030C",
+            "201",
+            "120D",
+            "120U",
+            "120C",
+            "210",
+            "300",
+        )
 
     Each triad name corresponds to one of the possible valid digraph on
     three nodes.

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -26,9 +26,7 @@ def attach(module_name, submodules=None, submod_attrs=None):
     The typical way to call this function, replacing the above imports, is::
 
       __getattr__, __lazy_dir__, __all__ = lazy.attach(
-          __name__,
-          ['mysubmodule', 'anothersubmodule'],
-          {'foo': 'someattr'}
+          __name__, ["mysubmodule", "anothersubmodule"], {"foo": "someattr"}
       )
 
     This functionality requires Python 3.7 or higher.
@@ -149,8 +147,8 @@ def _lazy_import(fullname):
     fullname : str
         The full name of the package or subpackage to import.  For example::
 
-          sp = lazy.load('scipy')  # import scipy as sp
-          spla = lazy.load('scipy.linalg')  # import scipy.linalg as spla
+          sp = lazy.load("scipy")  # import scipy as sp
+          spla = lazy.load("scipy.linalg")  # import scipy.linalg as spla
 
     Returns
     -------

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -77,7 +77,13 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
      [ 0  0  0  1 -1]
      [ 0  0  0 -1  1]]
 
-    >>> edges = [(1, 2), (2, 1), (2, 4), (4, 3), (3, 4),]
+    >>> edges = [
+    ...     (1, 2),
+    ...     (2, 1),
+    ...     (2, 4),
+    ...     (4, 3),
+    ...     (3, 4),
+    ... ]
     >>> DiG = nx.DiGraph(edges)
     >>> print(nx.laplacian_matrix(DiG).toarray())
     [[ 1 -1  0  0]
@@ -156,8 +162,14 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
     --------
 
     >>> import numpy as np
-    >>> np.set_printoptions(precision=4) # To print with lower precision
-    >>> edges = [(1, 2), (2, 1), (2, 4), (4, 3), (3, 4),]
+    >>> np.set_printoptions(precision=4)  # To print with lower precision
+    >>> edges = [
+    ...     (1, 2),
+    ...     (2, 1),
+    ...     (2, 4),
+    ...     (4, 3),
+    ...     (3, 4),
+    ... ]
     >>> DiG = nx.DiGraph(edges)
     >>> print(nx.normalized_laplacian_matrix(DiG).toarray())
     [[ 1.     -0.7071  0.      0.    ]

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -119,12 +119,16 @@ def cytoscape_graph(data, name="name", ident="id"):
     Examples
     --------
     >>> data_dict = {
-    ...     'data': [],
-    ...     'directed': False,
-    ...     'multigraph': False,
-    ...     'elements': {'nodes': [{'data': {'id': '0', 'value': 0, 'name': '0'}},
-    ...       {'data': {'id': '1', 'value': 1, 'name': '1'}}],
-    ...      'edges': [{'data': {'source': 0, 'target': 1}}]}
+    ...     "data": [],
+    ...     "directed": False,
+    ...     "multigraph": False,
+    ...     "elements": {
+    ...         "nodes": [
+    ...             {"data": {"id": "0", "value": 0, "name": "0"}},
+    ...             {"data": {"id": "1", "value": 1, "name": "1"}},
+    ...         ],
+    ...         "edges": [{"data": {"source": 0, "target": 1}}],
+    ...     },
     ... }
     >>> G = nx.cytoscape_graph(data_dict)
     >>> G.name

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -179,7 +179,7 @@ def node_link_graph(
 
     Create data in node-link format by converting a graph.
 
-    >>> G = nx.Graph([('A', 'B')])
+    >>> G = nx.Graph([("A", "B")])
     >>> data = nx.node_link_data(G)
     >>> data
     {'directed': False, 'multigraph': False, 'graph': {}, 'nodes': [{'id': 'A'}, {'id': 'B'}], 'links': [{'source': 'A', 'target': 'B'}]}

--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -157,16 +157,16 @@ def generate_network_text(
     Examples
     --------
     >>> graph = nx.path_graph(10)
-    >>> graph.add_node('A')
-    >>> graph.add_node('B')
-    >>> graph.add_node('C')
-    >>> graph.add_node('D')
-    >>> graph.add_edge(9, 'A')
-    >>> graph.add_edge(9, 'B')
-    >>> graph.add_edge(9, 'C')
-    >>> graph.add_edge('C', 'D')
-    >>> graph.add_edge('C', 'E')
-    >>> graph.add_edge('C', 'F')
+    >>> graph.add_node("A")
+    >>> graph.add_node("B")
+    >>> graph.add_node("C")
+    >>> graph.add_node("D")
+    >>> graph.add_edge(9, "A")
+    >>> graph.add_edge(9, "B")
+    >>> graph.add_edge(9, "C")
+    >>> graph.add_edge("C", "D")
+    >>> graph.add_edge("C", "E")
+    >>> graph.add_edge("C", "F")
     >>> nx.write_network_text(graph)
     ╙── 0
         └── 1

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -65,7 +65,7 @@ def relabel_nodes(G, mapping, copy=True):
     A mapping can also be given as a function:
 
     >>> G = nx.path_graph(3)
-    >>> H = nx.relabel_nodes(G, lambda x: x ** 2)
+    >>> H = nx.relabel_nodes(G, lambda x: x**2)
     >>> list(H)
     [0, 1, 4]
 

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -57,10 +57,12 @@ def not_implemented_for(*graph_types):
        def sp_function(G):
            pass
 
+
        # rule out MultiDiGraph
-       @not_implemented_for("directed","multigraph")
+       @not_implemented_for("directed", "multigraph")
        def sp_np_function(G):
            pass
+
 
        # rule out all except DiGraph
        @not_implemented_for("undirected")
@@ -124,21 +126,25 @@ def open_file(path_arg, mode="r"):
     --------
     Decorate functions like this::
 
-       @open_file(0,"r")
+       @open_file(0, "r")
        def read_function(pathname):
            pass
 
-       @open_file(1,"w")
+
+       @open_file(1, "w")
        def write_function(G, pathname):
            pass
 
-       @open_file(1,"w")
+
+       @open_file(1, "w")
        def write_function(G, pathname="graph.dot"):
            pass
 
-       @open_file("pathname","w")
+
+       @open_file("pathname", "w")
        def write_function(G, pathname="graph.dot"):
            pass
+
 
        @open_file("path", "w+")
        def another_function(arg, **kwargs):
@@ -155,19 +161,19 @@ def open_file(path_arg, mode="r"):
 
       @open_file("path")
       def some_function(arg1, arg2, path=None):
-         if path is None:
-             fobj = tempfile.NamedTemporaryFile(delete=False)
-         else:
-             # `path` could have been a string or file object or something
-             # similar. In any event, the decorator has given us a file object
-             # and it will close it for us, if it should.
-             fobj = path
+          if path is None:
+              fobj = tempfile.NamedTemporaryFile(delete=False)
+          else:
+              # `path` could have been a string or file object or something
+              # similar. In any event, the decorator has given us a file object
+              # and it will close it for us, if it should.
+              fobj = path
 
-         try:
-             fobj.write("blah")
-         finally:
-             if path is None:
-                 fobj.close()
+          try:
+              fobj.write("blah")
+          finally:
+              if path is None:
+                  fobj.close()
 
     Normally, we'd want to use "with" to ensure that fobj gets closed.
     However, the decorator will make `path` a file object for us,
@@ -289,9 +295,11 @@ def np_random_state(random_state_argument):
        def random_float(seed=None):
            return seed.rand()
 
+
        @np_random_state(0)
        def random_float(rng=None):
            return rng.rand()
+
 
        @np_random_state(1)
        def random_array(dims, random_state=1):
@@ -341,9 +349,11 @@ def py_random_state(random_state_argument):
        def random_float(random_state=None):
            return random_state.rand()
 
+
        @py_random_state(0)
        def random_float(rng=None):
            return rng.rand()
+
 
        @py_random_state(1)
        def random_array(dims, seed=12345):
@@ -414,6 +424,7 @@ class argmap:
                 if amount.currency != currency:
                     amount = amount.to_currency(currency)
                 return amount
+
             return argmap(_convert, which_arg)
 
     Despite this common idiom for argmap, most of the following examples
@@ -473,9 +484,11 @@ class argmap:
         def double(a):
             return 2 * a
 
+
         @argmap(double, 3)
         def overflow(a, *args):
             return a, args
+
 
         print(overflow(1, 2, 3, 4, 5, 6))  # output is 1, (2, 3, 8, 5, 6)
 
@@ -526,6 +539,7 @@ class argmap:
                     # assume `path` handles the closing
                     fclose = lambda: None
                 return path, fclose
+
             return argmap(_opener, which_arg, try_finally=True)
 
     which can then be used as::
@@ -548,6 +562,7 @@ class argmap:
         def file_to_lines_wrapped(file):
             for line in file.readlines():
                 yield line
+
 
         def file_to_lines_wrapper(file):
             try:

--- a/networkx/utils/mapped_queue.py
+++ b/networkx/utils/mapped_queue.py
@@ -114,11 +114,11 @@ class MappedQueue:
     of initial elements and priorities.  The methods `push`, `pop`,
     `remove`, and `update` operate on the queue.
 
-    >>> colors_nm = {'red':665, 'blue': 470, 'green': 550}
+    >>> colors_nm = {"red": 665, "blue": 470, "green": 550}
     >>> q = MappedQueue(colors_nm)
-    >>> q.remove('red')
-    >>> q.update('green', 'violet', 400)
-    >>> q.push('indigo', 425)
+    >>> q.remove("red")
+    >>> q.update("green", "violet", 400)
+    >>> q.push("indigo", 425)
     True
     >>> [q.pop().element for i in range(len(q.heap))]
     ['violet', 'indigo', 'blue']
@@ -134,14 +134,14 @@ class MappedQueue:
 
     An exception is raised if the elements are not comparable.
 
-    >>> q = MappedQueue([100, 'a'])
+    >>> q = MappedQueue([100, "a"])
     Traceback (most recent call last):
     ...
     TypeError: '<' not supported between instances of 'int' and 'str'
 
     To avoid the exception, use a dictionary to assign priorities to the elements.
 
-    >>> q = MappedQueue({100: 0, 'a': 1 })
+    >>> q = MappedQueue({100: 0, "a": 1})
 
     References
     ----------

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -175,7 +175,7 @@ def arbitrary_element(iterable):
     >>> d = {k: v for k, v in zip([1, 2, 3], [3, 2, 1])}
     >>> nx.utils.arbitrary_element(d)  # dict_keys
     1
-    >>> nx.utils.arbitrary_element(d.values())   # dict values
+    >>> nx.utils.arbitrary_element(d.values())  # dict values
     3
 
     `str` is also an Iterable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,9 @@ select = [
 "tools/*.py" = ['I']
 "networkx/classes/filters.py" = ['C416']
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.mypy]
 ignore_missing_imports = true
 exclude = 'subgraphviews|reportviews'


### PR DESCRIPTION
This PR replaces blacken-docs with [ruff's docstring formatting](https://docs.astral.sh/ruff/formatter/#docstring-formatting).

As mentioned in #7270, I noticed that there were some docstrings that looked like they weren't already formatted. So the diff is pretty large.

Also we might want to tweak the configuration here depending on your preference, assuming this is a change you'd like to make.

Let me know if you'd like to tie this to an issue. I'd be happy to open one for this.