### PR TITLE
Add a toggle to API docs backend section

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
+    "sphinx_togglebutton",
     "nb2plots",
     "texext",
     "numpydoc",
@@ -272,7 +273,10 @@ def new_setitem(self, key, val):
         return
     # Update how we show backend information in the online docs.
     # Start by creating an "admonition" section to make it stand out.
-    newval = [".. admonition:: Additional backends implement this function", ""]
+    newval = [
+        ".. admonition:: Additional backends implement this function\n:class: dropdown",
+        "",
+    ]
     for line in val:
         if line and not line.startswith(" "):
             # This line must identify a backend; let's try to add a link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ doc = [
     'sphinx>=7',
     'pydata-sphinx-theme>=0.14',
     'sphinx-gallery>=0.14',
+    'sphinx_togglebutton>=0.3.2',
     'numpydoc>=1.6',
     'pillow>=9.4',
     'nb2plots>=0.7',

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -3,6 +3,7 @@
 sphinx>=7
 pydata-sphinx-theme>=0.14
 sphinx-gallery>=0.14
+sphinx_togglebutton>=0.3.2
 numpydoc>=1.6
 pillow>=9.4
 nb2plots>=0.7


### PR DESCRIPTION
Let's try this out. Need to move the backend section to the top if this looks nice.