### PR TITLE
Fix minimum_spanning_arborescence regression

### DIFF
--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -1181,22 +1181,22 @@ def minimum_branching(
     G, attr="weight", default=1, preserve_attrs=False, partition=None
 ):
     for _, _, d in G.edges(data=True):
-        d[attr] = -d[attr]
+        d[attr] = -d.get(attr, default)
 
     B = maximum_branching(G, attr, default, preserve_attrs, partition)
 
     for _, _, d in G.edges(data=True):
-        d[attr] = -d[attr]
+        d[attr] = -d.get(attr, default)
 
     for _, _, d in B.edges(data=True):
-        d[attr] = -d[attr]
+        d[attr] = -d.get(attr, default)
 
     return B
 
 
 @nx._dispatchable(
     edge_attrs={"attr": "default", "partition": None},
-    preserve_edge_attrs="preserve_attrs",
+    preserve_edge_attrs="preserve_edge_attrsserve_attrs",
 )
 def minimal_branching(
     G, /, *, attr="weight", default=1, preserve_attrs=False, partition=None

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -28,7 +28,6 @@ This implementation is based on:
 # }
 import string
 from dataclasses import dataclass, field
-from enum import Enum
 from operator import itemgetter
 from queue import PriorityQueue
 
@@ -470,7 +469,6 @@ class Edmonds:
         D = set()
         nodes = iter(list(G.nodes()))
         attr = self._attr
-        G_pred = G.pred
 
         def desired_edge(v):
             """

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -1196,7 +1196,7 @@ def minimum_branching(
 
 @nx._dispatchable(
     edge_attrs={"attr": "default", "partition": None},
-    preserve_edge_attrs="preserve_edge_attrsserve_attrs",
+    preserve_edge_attrs="preserve_attrs",
 )
 def minimal_branching(
     G, /, *, attr="weight", default=1, preserve_attrs=False, partition=None

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -1233,7 +1233,7 @@ def minimal_branching(
     """
     max_weight = -INF
     min_weight = INF
-    for _, _, w in G.edges(data=attr):
+    for _, _, w in G.edges(data=attr, default=default):
         if w > max_weight:
             max_weight = w
         if w < min_weight:
@@ -1244,16 +1244,16 @@ def minimal_branching(
         # the difference between the max and min weights. This is important
         # in order to prevent the edge weights from becoming negative during
         # computation
-        d[attr] = max_weight + 1 + (max_weight - min_weight) - d[attr]
+        d[attr] = max_weight + 1 + (max_weight - min_weight) - d.get(attr, default)
 
     B = maximum_branching(G, attr, default, preserve_attrs, partition)
 
     # Reverse the weight transformations
     for _, _, d in G.edges(data=True):
-        d[attr] = max_weight + 1 + (max_weight - min_weight) - d[attr]
+        d[attr] = max_weight + 1 + (max_weight - min_weight) - d.get(attr, default)
 
     for _, _, d in B.edges(data=True):
-        d[attr] = max_weight + 1 + (max_weight - min_weight) - d[attr]
+        d[attr] = max_weight + 1 + (max_weight - min_weight) - d.get(attr, default)
 
     return B
 
@@ -1277,22 +1277,22 @@ def maximum_spanning_arborescence(
 
     min_weight = INF
     max_weight = -INF
-    for _, _, w in G.edges(data=attr):
+    for _, _, w in G.edges(data=attr, default=default):
         if w < min_weight:
             min_weight = w
         if w > max_weight:
             max_weight = w
 
     for _, _, d in G.edges(data=True):
-        d[attr] = d[attr] - min_weight + 1 - (min_weight - max_weight)
+        d[attr] = d.get(attr, default) - min_weight + 1 - (min_weight - max_weight)
 
     B = maximum_branching(G, attr, default, preserve_attrs, partition)
 
     for _, _, d in G.edges(data=True):
-        d[attr] = d[attr] + min_weight - 1 + (min_weight - max_weight)
+        d[attr] = d.get(attr, default) + min_weight - 1 + (min_weight - max_weight)
 
     for _, _, d in B.edges(data=True):
-        d[attr] = d[attr] + min_weight - 1 + (min_weight - max_weight)
+        d[attr] = d.get(attr, default) + min_weight - 1 + (min_weight - max_weight)
 
     if not is_arborescence(B):
         raise nx.exception.NetworkXException("No maximum spanning arborescence in G.")
@@ -1365,8 +1365,8 @@ maximum_branching.__doc__ = docstring_branching.format(
 minimum_branching.__doc__ = (
     docstring_branching.format(kind="minimum", style="branching")
     + """
-See Also 
--------- 
+See Also
+--------
     minimal_branching
 """
 )

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -630,3 +630,27 @@ def test_arborescence_iterator_initial_partition():
         for e in excluded_edges:
             assert e not in B.edges
     assert arborescence_count == 16
+
+
+def test_minimum_spanning_arborescence_with_default_weights():
+    """
+    Tests building a minimum spanning arborescence uses default weights.
+    For more information, see issue #7279.
+    """
+    graph = nx.erdos_renyi_graph(10, p=0.2, directed=True, seed=123)
+    assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
+        'test is for graphs without a weight attribute')
+    tree = nx.minimum_spanning_arborescence(graph)
+    assert tree.number_of_edges() == 9
+
+
+def test_maximum_spanning_arborescence_with_default_weights():
+    """
+    Tests building a maximum spanning arborescence uses default weights.
+    For more information, see issue #7279.
+    """
+    graph = nx.erdos_renyi_graph(10, p=0.2, directed=True, seed=123)
+    assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
+        'test is for graphs without a weight attribute')
+    tree = nx.maximum_spanning_arborescence(graph)
+    assert tree.number_of_edges() == 9

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -648,6 +648,9 @@ def test_branchings_with_default_weights():
     nx.maximum_spanning_arborescence(graph.copy())
     nx.minimum_branching(graph.copy())
     nx.maximum_branching(graph.copy())
+    nx.algorithms.tree.minimal_branching(graph.copy())
+    nx.algorithms.tree.branching_weight(graph.copy())
+    nx.algorithms.tree.greedy_branching(graph.copy())
 
     assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
         'The above calls should not modify the initial graph in-place')

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -639,8 +639,9 @@ def test_branchings_with_default_weights():
     """
     graph = nx.erdos_renyi_graph(10, p=0.2, directed=True, seed=123)
 
-    assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
-        'test is for graphs without a weight attribute')
+    assert all(
+        "weight" not in d for (u, v, d) in graph.edges(data=True)
+    ), "test is for graphs without a weight attribute"
 
     # Calling these functions will modify graph inplace to add weights
     # copy the graph to avoid this.
@@ -652,5 +653,6 @@ def test_branchings_with_default_weights():
     nx.algorithms.tree.branching_weight(graph.copy())
     nx.algorithms.tree.greedy_branching(graph.copy())
 
-    assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
-        'The above calls should not modify the initial graph in-place')
+    assert all(
+        "weight" not in d for (u, v, d) in graph.edges(data=True)
+    ), "The above calls should not modify the initial graph in-place"

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -632,25 +632,22 @@ def test_arborescence_iterator_initial_partition():
     assert arborescence_count == 16
 
 
-def test_minimum_spanning_arborescence_with_default_weights():
+def test_branchings_with_default_weights():
     """
-    Tests building a minimum spanning arborescence uses default weights.
+    Tests that various brancing algorithms work on graphs without weights.
     For more information, see issue #7279.
     """
     graph = nx.erdos_renyi_graph(10, p=0.2, directed=True, seed=123)
+
     assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
         'test is for graphs without a weight attribute')
-    tree = nx.minimum_spanning_arborescence(graph)
-    assert tree.number_of_edges() == 9
 
+    # Calling these functions will modify graph inplace to add weights
+    # copy the graph to avoid this.
+    nx.minimum_spanning_arborescence(graph.copy())
+    nx.maximum_spanning_arborescence(graph.copy())
+    nx.minimum_branching(graph.copy())
+    nx.maximum_branching(graph.copy())
 
-def test_maximum_spanning_arborescence_with_default_weights():
-    """
-    Tests building a maximum spanning arborescence uses default weights.
-    For more information, see issue #7279.
-    """
-    graph = nx.erdos_renyi_graph(10, p=0.2, directed=True, seed=123)
     assert all('weight' not in d for (u, v, d) in graph.edges(data=True)), (
-        'test is for graphs without a weight attribute')
-    tree = nx.maximum_spanning_arborescence(graph)
-    assert tree.number_of_edges() == 9
+        'The above calls should not modify the initial graph in-place')


### PR DESCRIPTION
Attempts to fix https://github.com/networkx/networkx/issues/7279

It looks like the code for `minimal_branching` and a bunch of other algorithms access the weight attribute `attr` directrly from node or edge data `d` via `d[attr]` and does not respect the specified `default` value provided in the signature.

This PR does fix the issue by replacing these with `d.get(attr, default)`, but I'm not sure it does it correctly. Looking at the code, I'm not sure the algorithm structures ever used something like `d.get(attr, default)`, instead it looks like the "dispatch" decorator is ensuring the graph structure is ammenable to this sort of direct lookup (perhaps for efficiency?). I don't understand the dispatch structure well enough to say for sure. Advice and / or pointers to docs would be appreciated. I'm hoping this is a simple fix and not some new policy that forces the user to specify weights in a graph when there is a clear default of 1.