### PR TITLE
Automatically cache results from simple functions

### DIFF
--- a/networkx/algorithms/approximation/clique.py
+++ b/networkx/algorithms/approximation/clique.py
@@ -182,7 +182,7 @@ def clique_removal(G):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def large_clique_size(G):
     """Find the size of a large clique in a graph.
 

--- a/networkx/algorithms/asteroidal.py
+++ b/networkx/algorithms/asteroidal.py
@@ -91,7 +91,7 @@ def find_asteroidal_triple(G):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_at_free(G):
     """Check if a graph is AT-free.
 

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -83,7 +83,7 @@ def color(G):
     return color
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_bipartite(G):
     """Returns True if graph G is bipartite, False if not.
 

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -211,7 +211,7 @@ def average_clustering(G, nodes=None, mode="dot"):
     return sum(ccs[v] for v in nodes) / len(nodes)
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def robins_alexander_clustering(G):
     r"""Compute the bipartite clustering of G.
 

--- a/networkx/algorithms/bipartite/extendability.py
+++ b/networkx/algorithms/bipartite/extendability.py
@@ -10,6 +10,7 @@ __all__ = ["maximal_extendability"]
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
+@nx._dispatchable(auto_cache=True)
 def maximal_extendability(G):
     """Computes the extendability of a graph.
 

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -291,7 +291,7 @@ def communicability_betweenness_centrality(G):
     return cbc
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def estrada_index(G):
     r"""Returns the Estrada index of a the graph G.
 

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -28,7 +28,7 @@ class NetworkXTreewidthBoundExceeded(nx.NetworkXException):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_chordal(G):
     """Checks whether G is a chordal graph.
 
@@ -241,7 +241,7 @@ def chordal_graph_cliques(G):
             yield frozenset(clique_wanna_be)
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def chordal_graph_treewidth(G):
     """Returns the treewidth of the chordal graph G.
 

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -422,7 +422,7 @@ def clustering(G, nodes=None, weight=None):
     return clusterc
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def transitivity(G):
     r"""Compute graph transitivity, the fraction of all possible triangles
     present in G.

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -54,7 +54,7 @@ def attracting_components(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def number_attracting_components(G):
     """Returns the number of attracting components in `G`.
 
@@ -83,7 +83,7 @@ def number_attracting_components(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_attracting_component(G):
     """Returns True if `G` consists of a single attracting component.
 

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -13,7 +13,7 @@ __all__ = [
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_biconnected(G):
     """Returns True if the graph is biconnected, False otherwise.
 

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -69,7 +69,7 @@ def connected_components(G):
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def number_connected_components(G):
     """Returns the number of connected components.
 
@@ -109,7 +109,7 @@ def number_connected_components(G):
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_connected(G):
     """Returns True if the graph is connected, False otherwise.
 

--- a/networkx/algorithms/components/semiconnected.py
+++ b/networkx/algorithms/components/semiconnected.py
@@ -6,7 +6,7 @@ __all__ = ["is_semiconnected"]
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_semiconnected(G):
     r"""Returns True if the graph is semiconnected, False otherwise.
 

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -253,7 +253,7 @@ def strongly_connected_components_recursive(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def number_strongly_connected_components(G):
     """Returns number of strongly connected components in graph.
 
@@ -294,7 +294,7 @@ def number_strongly_connected_components(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_strongly_connected(G):
     """Test directed graph for strong connectivity.
 

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -63,7 +63,7 @@ def weakly_connected_components(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def number_weakly_connected_components(G):
     """Returns the number of weakly connected components in G.
 
@@ -103,7 +103,7 @@ def number_weakly_connected_components(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_weakly_connected(G):
     """Test directed graph for weak connectivity.
 

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -1166,7 +1166,7 @@ def _min_cycle(G, orth, weight):
 
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def girth(G):
     """Returns the girth of the graph.
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -110,7 +110,7 @@ def ancestors(G, source):
     return {child for parent, child in nx.bfs_edges(G, source, reverse=True)}
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def has_cycle(G):
     """Decides whether the directed graph has a cycle."""
     try:
@@ -122,7 +122,7 @@ def has_cycle(G):
         return False
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_directed_acyclic_graph(G):
     """Returns True if the graph `G` is a directed acyclic graph (DAG) or
     False if not.
@@ -572,7 +572,7 @@ def all_topological_sorts(G):
             break
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_aperiodic(G):
     """Returns True if `G` is aperiodic.
 

--- a/networkx/algorithms/distance_regular.py
+++ b/networkx/algorithms/distance_regular.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_distance_regular(G):
     """Returns True if the graph is distance regular, False otherwise.
 
@@ -184,7 +184,7 @@ def intersection_array(G):
 # TODO There is a definition for directed strongly regular graphs.
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_strongly_regular(G):
     """Returns True if and only if the given graph is strongly
     regular.

--- a/networkx/algorithms/efficiency_measures.py
+++ b/networkx/algorithms/efficiency_measures.py
@@ -60,7 +60,7 @@ def efficiency(G, u, v):
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def global_efficiency(G):
     """Returns the average global efficiency of the graph.
 
@@ -121,7 +121,7 @@ def global_efficiency(G):
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def local_efficiency(G):
     """Returns the average local efficiency of the graph.
 

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_eulerian(G):
     """Returns True if and only if `G` is Eulerian.
 
@@ -69,7 +69,7 @@ def is_eulerian(G):
     return all(d % 2 == 0 for v, d in G.degree()) and nx.is_connected(G)
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_semieulerian(G):
     """Return True iff `G` is semi-Eulerian.
 

--- a/networkx/algorithms/isolate.py
+++ b/networkx/algorithms/isolate.py
@@ -85,7 +85,7 @@ def isolates(G):
     return (n for n, d in G.degree() if d == 0)
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def number_of_isolates(G):
     """Returns the number of isolates in the graph.
 

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -5,7 +5,7 @@ import networkx as nx
 __all__ = ["check_planarity", "is_planar", "PlanarEmbedding"]
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_planar(G):
     """Returns True if and only if `G` is planar.
 

--- a/networkx/algorithms/polynomials.py
+++ b/networkx/algorithms/polynomials.py
@@ -30,7 +30,7 @@ __all__ = ["tutte_polynomial", "chromatic_polynomial"]
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def tutte_polynomial(G):
     r"""Returns the Tutte polynomial of `G`
 
@@ -180,7 +180,7 @@ def tutte_polynomial(G):
 
 
 @not_implemented_for("directed")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def chromatic_polynomial(G):
     r"""Returns the chromatic polynomial of `G`
 

--- a/networkx/algorithms/reciprocity.py
+++ b/networkx/algorithms/reciprocity.py
@@ -76,7 +76,7 @@ def _reciprocity_iter(G, nodes):
 
 
 @not_implemented_for("undirected", "multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def overall_reciprocity(G):
     """Compute the reciprocity for the whole graph.
 

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -5,7 +5,7 @@ from networkx.utils import not_implemented_for
 __all__ = ["is_regular", "is_k_regular", "k_factor"]
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_regular(G):
     """Determines whether the graph ``G`` is a regular graph.
 

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -3,7 +3,7 @@ import networkx as nx
 __all__ = ["s_metric"]
 
 
-@nx._dispatchable
+@nx._dispatchable  # (auto_cache=True) Enable auto-cache when warning is removed
 def s_metric(G, **kwargs):
     """Returns the s-metric [1]_ of graph.
 
@@ -35,7 +35,7 @@ def s_metric(G, **kwargs):
            https://arxiv.org/abs/cond-mat/0501169
     """
     # NOTE: This entire code block + the **kwargs in the signature can all be
-    # removed when the deprecation expires.
+    # removed when the deprecation expires, and auto-cache can be enabled.
     # Normalized is always False, since all `normalized=True` did was raise
     # a NotImplementedError
     if kwargs:

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -9,7 +9,7 @@ from networkx.utils import py_random_state
 __all__ = ["is_threshold_graph", "find_threshold_graph"]
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_threshold_graph(G):
     """
     Returns `True` if `G` is a threshold graph.

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -65,7 +65,7 @@ def index_satisfying(iterable, condition):
 
 @not_implemented_for("undirected")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_tournament(G):
     """Returns True if and only if `G` is a tournament.
 
@@ -349,7 +349,7 @@ def is_reachable(G, s, t):
 
 @not_implemented_for("undirected")
 @not_implemented_for("multigraph")
-@nx._dispatchable(name="tournament_is_strongly_connected")
+@nx._dispatchable(name="tournament_is_strongly_connected", auto_cache=True)
 def is_strongly_connected(G):
     """Decides whether the given tournament is strongly connected.
 

--- a/networkx/algorithms/tree/recognition.py
+++ b/networkx/algorithms/tree/recognition.py
@@ -79,7 +79,7 @@ __all__ = ["is_arborescence", "is_branching", "is_forest", "is_tree"]
 
 
 @nx.utils.not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_arborescence(G):
     """
     Returns True if `G` is an arborescence.
@@ -119,7 +119,7 @@ def is_arborescence(G):
 
 
 @nx.utils.not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_branching(G):
     """
     Returns True if `G` is a branching.
@@ -158,7 +158,7 @@ def is_branching(G):
     return is_forest(G) and max(d for n, d in G.in_degree()) <= 1
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_forest(G):
     """
     Returns True if `G` is a forest.
@@ -215,7 +215,7 @@ def is_forest(G):
     return all(len(c) - 1 == c.number_of_edges() for c in components)
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_tree(G):
     """
     Returns True if `G` is a tree.

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -280,7 +280,7 @@ def triadic_census(G, nodelist=None):
     return census
 
 
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def is_triad(G):
     """Returns True if the graph G is a triad, else False.
 
@@ -448,7 +448,7 @@ def triads_by_type(G):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(auto_cache=True)
 def triad_type(G):
     """Returns the sociological triad type for a triad.
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -360,6 +360,7 @@ class DiGraph(Graph):
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
+        self.__networkx_cache__ = {}
 
     @cached_property
     def adj(self):
@@ -465,6 +466,7 @@ class DiGraph(Graph):
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
+        self.__networkx_cache__ = {}
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -543,6 +545,7 @@ class DiGraph(Graph):
                 self._pred[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
+        self.__networkx_cache__ = {}
 
     def remove_node(self, n):
         """Remove node n.
@@ -585,6 +588,7 @@ class DiGraph(Graph):
         for u in self._pred[n]:
             del self._succ[u][n]  # remove all edges n-u in digraph
         del self._pred[n]  # remove node from pred
+        self.__networkx_cache__ = {}
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -639,6 +643,7 @@ class DiGraph(Graph):
                 del self._pred[n]  # now remove node
             except KeyError:
                 pass  # silent failure on remove
+        self.__networkx_cache__ = {}
 
     def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
@@ -709,6 +714,7 @@ class DiGraph(Graph):
         datadict.update(attr)
         self._succ[u][v] = datadict
         self._pred[v][u] = datadict
+        self.__networkx_cache__ = {}
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -791,6 +797,7 @@ class DiGraph(Graph):
             datadict.update(dd)
             self._succ[u][v] = datadict
             self._pred[v][u] = datadict
+        self.__networkx_cache__ = {}
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -824,6 +831,7 @@ class DiGraph(Graph):
             del self._pred[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} not in graph.") from err
+        self.__networkx_cache__ = {}
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -856,6 +864,7 @@ class DiGraph(Graph):
             if u in self._succ and v in self._succ[u]:
                 del self._succ[u][v]
                 del self._pred[v][u]
+        self.__networkx_cache__ = {}
 
     def has_successor(self, u, v):
         """Returns True if node u has successor v.
@@ -1195,6 +1204,7 @@ class DiGraph(Graph):
         self._pred.clear()
         self._node.clear()
         self.graph.clear()
+        self.__networkx_cache__ = {}
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1213,6 +1223,7 @@ class DiGraph(Graph):
             predecessor_dict.clear()
         for successor_dict in self._succ.values():
             successor_dict.clear()
+        self.__networkx_cache__ = {}
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -370,6 +370,7 @@ class Graph:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
         # load graph attributes (must be after convert)
         self.graph.update(attr)
+        self.__networkx_cache__ = {}
 
     @cached_property
     def adj(self):
@@ -559,6 +560,7 @@ class Graph:
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
+        self.__networkx_cache__ = {}
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -636,6 +638,7 @@ class Graph:
                 self._adj[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
+        self.__networkx_cache__ = {}
 
     def remove_node(self, n):
         """Remove node n.
@@ -676,6 +679,7 @@ class Graph:
         for u in nbrs:
             del adj[u][n]  # remove all edges n-u in graph
         del adj[n]  # now remove node
+        self.__networkx_cache__ = {}
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -728,6 +732,7 @@ class Graph:
                 del adj[n]
             except KeyError:
                 pass
+        self.__networkx_cache__ = {}
 
     @cached_property
     def nodes(self):
@@ -957,6 +962,7 @@ class Graph:
         datadict.update(attr)
         self._adj[u][v] = datadict
         self._adj[v][u] = datadict
+        self.__networkx_cache__ = {}
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -1037,6 +1043,7 @@ class Graph:
             datadict.update(dd)
             self._adj[u][v] = datadict
             self._adj[v][u] = datadict
+        self.__networkx_cache__ = {}
 
     def add_weighted_edges_from(self, ebunch_to_add, weight="weight", **attr):
         """Add weighted edges in `ebunch_to_add` with specified weight attr
@@ -1087,6 +1094,7 @@ class Graph:
         >>> G.add_weighted_edges_from(list((5, n, weight) for n in G.nodes))
         """
         self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch_to_add), **attr)
+        self.__networkx_cache__ = {}
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -1120,6 +1128,7 @@ class Graph:
                 del self._adj[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} is not in the graph") from err
+        self.__networkx_cache__ = {}
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1154,6 +1163,7 @@ class Graph:
                 del adj[u][v]
                 if u != v:  # self loop needs only one entry removed
                     del adj[v][u]
+        self.__networkx_cache__ = {}
 
     def update(self, edges=None, nodes=None):
         """Update the graph using nodes/edges/graphs as input.
@@ -1526,6 +1536,7 @@ class Graph:
         self._adj.clear()
         self._node.clear()
         self.graph.clear()
+        self.__networkx_cache__ = {}
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1541,6 +1552,7 @@ class Graph:
         """
         for nbr_dict in self._adj.values():
             nbr_dict.clear()
+        self.__networkx_cache__ = {}
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -508,6 +508,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             keydict[key] = datadict
             self._succ[u][v] = keydict
             self._pred[v][u] = keydict
+        self.__networkx_cache__ = {}
         return key
 
     def remove_edge(self, u, v, key=None):
@@ -583,6 +584,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             # remove the key entries if last edge
             del self._succ[u][v]
             del self._pred[v][u]
+        self.__networkx_cache__ = {}
 
     @cached_property
     def edges(self):

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -520,6 +520,7 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self._adj[u][v] = keydict
             self._adj[v][u] = keydict
+        self.__networkx_cache__ = {}
         return key
 
     def add_edges_from(self, ebunch_to_add, **attr):
@@ -616,6 +617,7 @@ class MultiGraph(Graph):
             key = self.add_edge(u, v, key)
             self[u][v][key].update(ddd)
             keylist.append(key)
+        self.__networkx_cache__ = {}
         return keylist
 
     def remove_edge(self, u, v, key=None):
@@ -695,6 +697,7 @@ class MultiGraph(Graph):
             del self._adj[u][v]
             if u != v:  # check for selfloop
                 del self._adj[v][u]
+        self.__networkx_cache__ = {}
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -753,6 +756,7 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
+        self.__networkx_cache__ = {}
 
     def has_edge(self, u, v, key=None):
         """Returns True if the graph has an edge between nodes u and v.


### PR DESCRIPTION
This PR introduces caching by using `G.__networkx_cache__` (which any backend graph can have). It only caches the simplest functions--a single (graph) argument that returns a scalar. One can imagine adding caching for other functions (we'd need to calculate a key from the input arguments). Also on the horizon (but probably not for this PR): automatically caching conversion to backend graphs.

I think this PR needs #7191 to know which functions mutate inputs (or maybe we can look at `mutates_input=True` in #7191 and clear the cache manually when necessary).

Config (#7225) may be useful as well to enable/disable caching.

Also related: #7233

CC @rlratzel