### PR TITLE
Fix docstrings for generators

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -247,6 +247,8 @@ intersphinx_mapping = {
 default_role = "obj"
 
 numpydoc_show_class_members = False
+numpydoc_validation_checks = {"YD01"}
+numpydoc_validation_exclude = [r".coreviews."]
 
 plot_pre_code = """
 import networkx as nx

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -248,7 +248,7 @@ default_role = "obj"
 
 numpydoc_show_class_members = False
 numpydoc_validation_checks = {"YD01"}
-numpydoc_validation_exclude = [r".coreviews."]
+numpydoc_validation_exclude = {r".coreviews.", r".coloring.strategy."}
 
 plot_pre_code = """
 import networkx as nx

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -6,7 +6,7 @@ __all__ = ["node_attribute_xy", "node_degree_xy"]
 
 @nx._dispatchable(node_attrs="attribute")
 def node_attribute_xy(G, attribute, nodes=None):
-    """Returns iterator of node-attribute pairs for all edges in G.
+    """Yields node-attribute pairs for all edges in `G`.
 
     Parameters
     ----------
@@ -16,13 +16,12 @@ def node_attribute_xy(G, attribute, nodes=None):
        The node attribute key.
 
     nodes: list or iterable (optional)
-        Use only edges that are incident to specified nodes.
-        The default is all nodes.
+       Use only edges that are incident to specified nodes. The default is all nodes.
 
-    Returns
-    -------
+    Yields
+    ------
     (x, y): 2-tuple
-        Generates 2-tuple of (attribute, attribute) values.
+        2-tuples of ``(attribute, attribute)`` values.
 
     Examples
     --------
@@ -61,7 +60,7 @@ def node_attribute_xy(G, attribute, nodes=None):
 
 @nx._dispatchable(edge_attrs="weight")
 def node_degree_xy(G, x="out", y="in", weight=None, nodes=None):
-    """Generate node degree-degree pairs for edges in G.
+    """Generate node degree-degree pairs for edges in `G`.
 
     Parameters
     ----------
@@ -82,10 +81,10 @@ def node_degree_xy(G, x="out", y="in", weight=None, nodes=None):
         Use only edges that are adjacency to specified nodes.
         The default is all nodes.
 
-    Returns
-    -------
+    Yields
+    ------
     (x, y): 2-tuple
-        Generates 2-tuple of (degree, degree) values.
+        2-tuples of ``(degree, degree)`` values.
 
 
     Examples

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -96,8 +96,8 @@ def generate_edgelist(G, delimiter=" ", data=True):
        representation of edge data.  If a list of keys use a list of data
        values corresponding to the keys.
 
-    Returns
-    -------
+    Yields
+    ------
     lines : string
         Lines of data in adjlist format.
 

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -40,11 +40,11 @@ def enumerate_all_cliques(G):
     G : NetworkX graph
         An undirected graph.
 
-    Returns
-    -------
-    iterator
-        An iterator over cliques, each of which is a list of nodes in
-        `G`. The cliques are ordered according to size.
+    Yields
+    ------
+    list
+        Lists of nodes representing the cliques in `G`. The cliques are ordered
+        according to size.
 
     Notes
     -----
@@ -123,13 +123,12 @@ def find_cliques(G, nodes=None):
         If provided, only yield *maximal cliques* containing all nodes in `nodes`.
         If `nodes` isn't a clique itself, a ValueError is raised.
 
-    Returns
-    -------
-    iterator
-        An iterator over maximal cliques, each of which is a list of
-        nodes in `G`. If `nodes` is provided, only the maximal cliques
-        containing all the nodes in `nodes` are returned. The order of
-        cliques is arbitrary.
+    Yields
+    ------
+    list
+        Lists of nodes representing the maximal cliques in `G`. If `nodes` is
+        provided, only the maximal cliques containing all the nodes in `nodes`
+        are returned. The order of cliques is arbitrary.
 
     Raises
     ------

--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -7,7 +7,7 @@ __all__ = ["girvan_newman"]
 
 @nx._dispatchable(preserve_edge_attrs="most_valuable_edge")
 def girvan_newman(G, most_valuable_edge=None):
-    """Finds communities in a graph using the Girvan–Newman method.
+    """Finds communities in graph `G` using the Girvan–Newman method.
 
     Parameters
     ----------
@@ -21,12 +21,11 @@ def girvan_newman(G, most_valuable_edge=None):
         If not specified, the edge with the highest
         :func:`networkx.edge_betweenness_centrality` will be used.
 
-    Returns
-    -------
-    iterator
-        Iterator over tuples of sets of nodes in `G`. Each set of node
-        is a community, each tuple is a sequence of communities at a
-        particular level of the algorithm.
+    Yields
+    ------
+    tuple
+        Tuples of sets of nodes in `G`. Each set of nodes is a community, each
+        tuple is a sequence of communities at a particular level of the algorithm.
 
     Examples
     --------
@@ -93,7 +92,7 @@ def girvan_newman(G, most_valuable_edge=None):
         ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9])
 
     To specify a different ranking algorithm for edges, use the
-    `most_valuable_edge` keyword argument::
+    `most_valuable_edge` keyword argument:
 
         >>> from networkx import edge_betweenness_centrality
         >>> from random import random
@@ -106,7 +105,6 @@ def girvan_newman(G, most_valuable_edge=None):
         ...     # Add some random noise.
         ...     centrality = {e: c + random() for e, c in centrality.items()}
         ...     return max(centrality, key=centrality.get)
-        ...
         >>> G = nx.path_graph(10)
         >>> comp = nx.community.girvan_newman(G, most_valuable_edge=most_central_edge)
 

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -7,10 +7,10 @@ __all__ = ["k_clique_communities"]
 
 @nx._dispatchable
 def k_clique_communities(G, k, cliques=None):
-    """Find k-clique communities in graph using the percolation method.
+    """Find k-clique communities in `G` using the percolation method [1]_.
 
-    A k-clique community is the union of all cliques of size k that
-    can be reached through adjacent (sharing k-1 nodes) k-cliques.
+    A k-clique community is the union of all cliques of size `k` that
+    can be reached through adjacent (sharing ``k-1`` nodes) k-cliques.
 
     Parameters
     ----------
@@ -22,9 +22,9 @@ def k_clique_communities(G, k, cliques=None):
     cliques: list or generator
        Precomputed cliques (use networkx.find_cliques(G))
 
-    Returns
-    -------
-    Yields sets of nodes, one for each k-clique community.
+    Yields
+    ------
+    Sets of nodes as `frozenset` s, one for each k-clique community.
 
     Examples
     --------

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -24,7 +24,8 @@ def k_clique_communities(G, k, cliques=None):
 
     Yields
     ------
-    Sets of nodes as `frozenset` s, one for each k-clique community.
+    frozenset
+       Sets of nodes as `frozenset` s, one for each k-clique community.
 
     Examples
     --------

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -46,10 +46,10 @@ def fast_label_propagation_communities(G, *, weight=None, seed=None):
     seed : integer, random_state, or None (default)
         Indicator of random number generation state. See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    communities : iterable
-        Iterable of communities given as sets of nodes.
+    Yields
+    ------
+    communities : set
+        Sets of nodes representing the communities in `G`
 
     Notes
     -----
@@ -172,10 +172,10 @@ def asyn_lpa_communities(G, weight=None, seed=None):
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    communities : iterable
-        Iterable of communities given as sets of nodes.
+    Yields
+    ------
+    communities : set
+        Sets of nodes representing communities in `G`
 
     Notes
     -----

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -30,10 +30,10 @@ def attracting_components(G):
     G : DiGraph, MultiDiGraph
         The graph to be analyzed.
 
-    Returns
-    -------
-    attractors : generator of sets
-        A generator of sets of nodes, one for each attracting component of G.
+    Yields
+    ------
+    attractors : set
+        Sets of nodes, one for each attracting component of `G`.
 
     Raises
     ------

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -112,10 +112,10 @@ def biconnected_component_edges(G):
     G : NetworkX Graph
         An undirected graph.
 
-    Returns
-    -------
-    edges : generator of lists
-        Generator of lists of edges, one list for each bicomponent.
+    Yields
+    ------
+    list
+        Lists of edges, one for each bicomponent of `G`.
 
     Raises
     ------
@@ -169,8 +169,7 @@ def biconnected_component_edges(G):
 @not_implemented_for("directed")
 @nx._dispatchable
 def biconnected_components(G):
-    """Returns a generator of sets of nodes, one set for each biconnected
-    component of the graph
+    """Yield all biconnected components of `G`
 
     Biconnected components are maximal subgraphs such that the removal of a
     node (and all edges incident on that node) will not disconnect the
@@ -186,10 +185,10 @@ def biconnected_components(G):
     G : NetworkX Graph
         An undirected graph.
 
-    Returns
-    -------
-    nodes : generator
-        Generator of sets of nodes, one set for each biconnected component.
+    Yields
+    ------
+    set
+        Sets of nodes, one set for each biconnected component.
 
     Raises
     ------

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -22,10 +22,10 @@ def connected_components(G):
     G : NetworkX graph
        An undirected graph
 
-    Returns
-    -------
-    comp : generator of sets
-       A generator of sets of nodes, one for each component of G.
+    Yields
+    ------
+    set
+       Sets of nodes representing the components of `G`.
 
     Raises
     ------

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -117,11 +117,10 @@ def kosaraju_strongly_connected_components(G, source=None):
     G : NetworkX Graph
         A directed graph.
 
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each strongly connected
-        component of G.
+    Yields
+    ------
+    set
+        A set of nodes representing a strongly connected component of `G`.
 
     Raises
     ------

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -22,11 +22,10 @@ def strongly_connected_components(G):
     G : NetworkX Graph
         A directed graph.
 
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each strongly connected
-        component of G.
+    Yields
+    ------
+    set
+        A set of nodes representing a strongly connected component of `G`.
 
     Raises
     ------

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -19,11 +19,10 @@ def weakly_connected_components(G):
     G : NetworkX graph
         A directed graph
 
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each weakly connected
-        component of G.
+    Yields
+    ------
+    set
+        A set of nodes comprising a weakly-connected component of `G`.
 
     Raises
     ------

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -26,9 +26,9 @@ __all__ = ["edge_disjoint_paths", "node_disjoint_paths"]
 def edge_disjoint_paths(
     G, s, t, flow_func=None, cutoff=None, auxiliary=None, residual=None
 ):
-    """Returns the edges disjoint paths between source and target.
+    """Yields edge-disjoint paths between source `s` and target `t`.
 
-    Edge disjoint paths are paths that do not share any edge. The
+    Edge-disjoint paths are paths that do not share any edge. The
     number of edge disjoint paths between source and target is equal
     to their edge connectivity.
 
@@ -68,10 +68,10 @@ def edge_disjoint_paths(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    Returns
-    -------
-    paths : generator
-        A generator of edge independent paths.
+    Yields
+    ------
+    path : list of nodes
+        A list of nodes representing an edge independent path between `s` and `t`.
 
     Raises
     ------
@@ -238,7 +238,7 @@ def edge_disjoint_paths(
 def node_disjoint_paths(
     G, s, t, flow_func=None, cutoff=None, auxiliary=None, residual=None
 ):
-    r"""Computes node disjoint paths between source and target.
+    r"""Yields node-disjoint paths between source `s` and target `t`.
 
     Node disjoint paths are paths that only share their first and last
     nodes. The number of node independent paths between two nodes is
@@ -280,10 +280,10 @@ def node_disjoint_paths(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    Returns
-    -------
-    paths : generator
-        Generator of node disjoint paths.
+    Yields
+    ------
+    path : list of nodes
+        A list of nodes representing a node-disjoint path between `s` and `t`.
 
     Raises
     ------

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -25,19 +25,19 @@ __all__ = [
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def k_edge_components(G, k):
-    """Generates nodes in each maximal k-edge-connected component in G.
+    """Yields nodes in each maximal `k`-edge-connected component in `G`.
 
     Parameters
     ----------
     G : NetworkX graph
 
-    k : Integer
+    k : int
         Desired edge connectivity
 
-    Returns
-    -------
-    k_edge_components : a generator of k-edge-ccs. Each set of returned nodes
-       will have k-edge-connectivity in the graph G.
+    Yields
+    ------
+    k_edge_components : sets of nodes
+       Each set of returned nodes will have `k`-edge-connectivity in the graph `G`.
 
     See Also
     --------
@@ -60,9 +60,9 @@ def k_edge_components(G, k):
     Attempts to use the most efficient implementation available based on k.
     If k=1, this is simply connected components for directed graphs and
     connected components for undirected graphs.
-    If k=2 on an efficient bridge connected component algorithm from _[1] is
+    If k=2 on an efficient bridge connected component algorithm from [1]_ is
     run based on the chain decomposition.
-    Otherwise, the algorithm from _[2] is used.
+    Otherwise, the algorithm from [2]_ is used.
 
     Examples
     --------
@@ -109,20 +109,20 @@ def k_edge_components(G, k):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def k_edge_subgraphs(G, k):
-    """Generates nodes in each maximal k-edge-connected subgraph in G.
+    """Yields nodes in each maximal `k`-edge-connected subgraph in `G`.
 
     Parameters
     ----------
     G : NetworkX graph
 
-    k : Integer
+    k : int
         Desired edge connectivity
 
-    Returns
-    -------
-    k_edge_subgraphs : a generator of k-edge-subgraphs
+    Yields
+    ------
+    k_edge_subgraph : set of nodes
         Each k-edge-subgraph is a maximal set of nodes that defines a subgraph
-        of G that is k-edge-connected.
+        of `G` that is `k`-edge-connected.
 
     See Also
     --------
@@ -143,7 +143,7 @@ def k_edge_subgraphs(G, k):
     -----
     Attempts to use the most efficient implementation available based on k.
     If k=1, or k=2 and the graph is undirected, then this simply calls
-    `k_edge_components`.  Otherwise the algorithm from _[1] is used.
+    `k_edge_components`.  Otherwise the algorithm from [1]_ is used.
 
     Examples
     --------
@@ -198,15 +198,16 @@ def _k_edge_subgraphs_nodes(G, k):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def bridge_components(G):
-    """Finds all bridge-connected components G.
+    """Yields all bridge-connected components `G`.
 
     Parameters
     ----------
     G : NetworkX undirected graph
 
-    Returns
-    -------
-    bridge_components : a generator of 2-edge-connected components
+    Yields
+    ------
+    bridge_component : sets of nodes
+       Sets of nodes comprising 2-edge-connected components
 
 
     See Also
@@ -387,9 +388,10 @@ class EdgeComponentAuxGraph:
         k : Integer
             Desired edge connectivity
 
-        Returns
-        -------
-        k_edge_components : a generator of k-edge-ccs
+        Yields
+        ------
+        k_edge_components : set of nodes
+            Sets of nodes representing k-edge-connected components
 
         Notes
         -----
@@ -420,9 +422,10 @@ class EdgeComponentAuxGraph:
         k : Integer
             Desired edge connectivity
 
-        Returns
-        -------
-        k_edge_subgraphs : a generator of k-edge-subgraphs
+        Yields
+        ------
+        k_edge_subgraphs : sets of nodes
+            Sets of nodes representing k-edge-subgraphs.
 
         Notes
         -----

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -23,21 +23,21 @@ __all__ = ["all_node_cuts"]
 
 @nx._dispatchable
 def all_node_cuts(G, k=None, flow_func=None):
-    r"""Returns all minimum k cutsets of an undirected graph G.
+    r"""Returns all minimum `k` cutsets of an undirected graph `G`.
 
     This implementation is based on Kanevsky's algorithm [1]_ for finding all
-    minimum-size node cut-sets of an undirected graph G; ie the set (or sets)
-    of nodes of cardinality equal to the node connectivity of G. Thus if
-    removed, would break G into two or more connected components.
+    minimum-size node cut-sets of an undirected graph `G`; i.e. the set (or sets)
+    of nodes of cardinality equal to the node connectivity of `G`. Thus removal
+    of a cut-set would break `G` into two or more connected components.
 
     Parameters
     ----------
     G : NetworkX graph
         Undirected graph
 
-    k : Integer
-        Node connectivity of the input graph. If k is None, then it is
-        computed. Default value: None.
+    k : int, optional
+        Node connectivity of the input graph. If `k` is `None`, then it is
+        computed. Default value: `None`.
 
     flow_func : function
         Function to perform the underlying flow computations. Default value is
@@ -47,9 +47,9 @@ def all_node_cuts(G, k=None, flow_func=None):
         perform better in denser graphs.
 
 
-    Returns
-    -------
-    cuts : a generator of node cutsets
+    Yields
+    ------
+    cuts : set
         Each node cutset has cardinality equal to the node connectivity of
         the input graph.
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1235,11 +1235,11 @@ def compute_v_structures(G):
     G : graph
         A networkx DiGraph.
 
-    Returns
-    -------
-    vstructs : iterator of tuples
-        The v structures within the graph. Each v structure is a 3-tuple with the
-        parent, collider, and other parent.
+    Yields
+    ------
+    tuple
+        The v structures in `G`, where each v structure is a 3-tuple of the form
+        ``(parent1, collider, parent2)``
 
     Examples
     --------

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -156,7 +156,7 @@ def _multigraph_eulerian_circuit(G, source):
 
 @nx._dispatchable
 def eulerian_circuit(G, source=None, keys=False):
-    """Returns an iterator over the edges of an Eulerian circuit in `G`.
+    """Yields the edges of an Eulerian circuit in `G`.
 
     An *Eulerian circuit* is a closed walk that includes each edge of a
     graph exactly once.
@@ -174,10 +174,10 @@ def eulerian_circuit(G, source=None, keys=False):
        ``(u, v)``. Otherwise, edges will be of the form ``(u, v, k)``.
        This option is ignored unless `G` is a multigraph.
 
-    Returns
-    -------
-    edges : iterator
-       An iterator over edges in the Eulerian circuit.
+    Yields
+    ------
+    edges : tuple
+       Edges in the Eulerian circuit.
 
     Raises
     ------

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -662,12 +662,23 @@ class ISMAGS:
         """
         Does the same as :meth:`find_isomorphisms` if :attr:`graph` and
         :attr:`subgraph` have the same number of nodes.
+
+        Yields
+        ------
+        dict
+            The found isomorphism mappings of {graph_node: subgraph_node}.
         """
         if len(self.graph) == len(self.subgraph):
             yield from self.subgraph_isomorphisms_iter(symmetry=symmetry)
 
     def subgraph_isomorphisms_iter(self, symmetry=True):
-        """Alternative name for :meth:`find_isomorphisms`."""
+        """Alternative name for :meth:`find_isomorphisms`.
+
+        Yields
+        ------
+        dict
+            The found isomorphism mappings of {graph_node: subgraph_node}.
+        """
         return self.find_isomorphisms(symmetry)
 
     def _find_nodecolor_candidates(self):

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -205,7 +205,13 @@ class GraphMatcher:
         sys.setrecursionlimit(self.old_recursion_limit)
 
     def candidate_pairs_iter(self):
-        """Iterator over candidate pairs of nodes in G1 and G2."""
+        """Iterator over candidate pairs of nodes in G1 and G2.
+
+        Yields
+        ------
+        tuple
+            Candidate pairs of nodes
+        """
 
         # All computations are done using the current state!
 
@@ -292,7 +298,13 @@ class GraphMatcher:
             return False
 
     def isomorphisms_iter(self):
-        """Generator over isomorphisms between G1 and G2."""
+        """Generator over isomorphisms between G1 and G2.
+
+        Yields
+        ------
+        dict
+           Isomorphic mapping between G1 and G2
+        """
         # Declare that we are looking for a graph-graph isomorphism.
         self.test = "graph"
         self.initialize()
@@ -306,6 +318,10 @@ class GraphMatcher:
         variables after each recursive call. If an isomorphism is found,
         we yield the mapping.
 
+        Yields
+        ------
+        dict
+           Isomorphic mapping between G1 and G2
         """
         if len(self.core_1) == len(self.G2):
             # Save the final mapping, otherwise garbage collection deletes it.
@@ -382,14 +398,26 @@ class GraphMatcher:
     #    subgraph_is_isomorphic.__doc__ += "\n" + subgraph.replace('\n','\n'+indent)
 
     def subgraph_isomorphisms_iter(self):
-        """Generator over isomorphisms between a subgraph of G1 and G2."""
+        """Generator over isomorphisms between a subgraph of G1 and G2.
+
+        Yields
+        ------
+        dict
+           Isomorphic mapping between G1 and G2
+        """
         # Declare that we are looking for graph-subgraph isomorphism.
         self.test = "subgraph"
         self.initialize()
         yield from self.match()
 
     def subgraph_monomorphisms_iter(self):
-        """Generator over monomorphisms between a subgraph of G1 and G2."""
+        """Generator over monomorphisms between a subgraph of G1 and G2.
+
+        Yields
+        ------
+        dict
+           Monomorphic mapping between G1 and G2
+        """
         # Declare that we are looking for graph-subgraph monomorphism.
         self.test = "mono"
         self.initialize()
@@ -544,7 +572,13 @@ class DiGraphMatcher(GraphMatcher):
         super().__init__(G1, G2)
 
     def candidate_pairs_iter(self):
-        """Iterator over candidate pairs of nodes in G1 and G2."""
+        """Iterator over candidate pairs of nodes in G1 and G2.
+
+        Yields
+        ------
+        tuple
+            Candidate pairs of nodes
+        """
 
         # All computations are done using the current state!
 

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -166,10 +166,11 @@ def tree_all_pairs_lowest_common_ancestor(G, root=None, pairs=None):
         The pairs of interest. If None, Defaults to all pairs of nodes
         under `root` that have a lowest common ancestor.
 
-    Returns
-    -------
-    lcas : generator of tuples `((u, v), lca)` where `u` and `v` are nodes
-        in `pairs` and `lca` is their lowest common ancestor.
+    Yields
+    ------
+    tuple
+       2-tuples of the form ``((u, v), lca)`` where ``u`` and ``v`` are nodes
+       in `pairs` and ``lca`` is their lowest common ancestor.
 
     Examples
     --------

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -554,10 +554,11 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
 
-    Returns
-    -------
-    paths : generator of dictionary
-        A generator of all paths between source and all nodes in the graph.
+    Yields
+    ------
+    (node, shortest_path) pairs
+       2-tuples where the first element is the target node and the second element
+       is a list representing the shortest path from `source` to that node.
 
     Raises
     ------
@@ -627,10 +628,12 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
 
-    Returns
-    -------
-    paths : generator of dictionary
-        Dictionary of arrays, keyed by source and target, of all shortest paths.
+    Yields
+    ------
+    (node, path_dict) pairs
+        2-tuple where the first element is a node in `G` and the second element
+        is a dict keyed by node where the values are lists representing the shortest
+        path between the two nodes.
 
     Raises
     ------

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -166,15 +166,15 @@ def all_pairs_shortest_path_length(G, cutoff=None):
         Depth at which to stop the search. Only paths of length at most
         `cutoff` are returned.
 
-    Returns
-    -------
-    lengths : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
-        shortest path length as the key value.
+    Yields
+    ------
+    (source, dict) tuple
+        A 2-tuple where the first element is the source node and the second is a
+        dictionary keyed by target node with shortest path length as the value.
 
     Notes
     -----
-    The iterator returned only has reachable node pairs.
+    Only generates path lengths for reachable node pairs.
 
     Examples
     --------
@@ -453,7 +453,7 @@ def single_target_shortest_path(G, target, cutoff=None):
 
 @nx._dispatchable
 def all_pairs_shortest_path(G, cutoff=None):
-    """Compute shortest paths between all nodes.
+    """Yields shortest paths between all nodes.
 
     Parameters
     ----------
@@ -463,10 +463,12 @@ def all_pairs_shortest_path(G, cutoff=None):
         Depth at which to stop the search. Only paths of length at most
         `cutoff` are returned.
 
-    Returns
-    -------
-    paths : iterator
-        Dictionary, keyed by source and target, of shortest paths.
+    Yields
+    ------
+    (source, dict) tuple
+        2-tuples where the first element is the source node and the second is
+        a dictionary keyed by target node with lists of nodes representing the shortest
+        path between the source and target as values.
 
     Examples
     --------

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1051,11 +1051,11 @@ def all_pairs_dijkstra_path_length(G, cutoff=None, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number or None to indicate a hidden edge.
 
-    Returns
-    -------
-    distance : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
-        shortest path length as the key value.
+    Yields
+    ------
+    (source, dictionary) tuple
+        2-tuple where the first element is the source node and the second element
+        is a dictionary keyed by target node and the shortest path length as the value.
 
     Examples
     --------
@@ -1110,11 +1110,12 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number or None to indicate a hidden edge.
 
-    Returns
-    -------
-    paths : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
-        shortest path as the key value.
+    Yields
+    ------
+    (source, dict) tuple
+        A 2-tuple where the first element is the source node and the second is
+        a dictionary keyed by target node containing node lists representing a shortest path
+        betwen the source and target.
 
     Examples
     --------
@@ -1851,11 +1852,11 @@ def all_pairs_bellman_ford_path_length(G, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number.
 
-    Returns
-    -------
-    distance : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
-        shortest path length as the key value.
+    Yields
+    ------
+    (source, dict) tuple
+        A 2-tuple where the first element is the source node and the second is
+        a dictionary keyed by target node with the shortest path length as the value.
 
     Examples
     --------
@@ -1906,11 +1907,12 @@ def all_pairs_bellman_ford_path(G, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number.
 
-    Returns
-    -------
-    paths : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
-        shortest path as the key value.
+    Yields
+    ------
+    (source, dict) tuple
+        A 2-tuple where the first element is the source node and the second is
+        a dictionary keyed by target node containing node lists representing a shortest path
+        betwen the source and target.
 
     Examples
     --------

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -401,10 +401,9 @@ def optimize_graph_edit_distance(
     edge_ins_cost=None,
     upper_bound=None,
 ):
-    """Returns consecutive approximations of GED (graph edit distance)
-    between graphs G1 and G2.
+    """Yields consecutive approximations of graph edit distance between `G1` and `G2`.
 
-    Graph edit distance is a graph similarity measure analogous to
+    Graph edit distance (GED) is a graph similarity measure analogous to
     Levenshtein distance for strings.  It is defined as minimum cost
     of edit path (sequence of node and edge edit operations)
     transforming graph G1 to graph isomorphic to G2.
@@ -412,7 +411,7 @@ def optimize_graph_edit_distance(
     Parameters
     ----------
     G1, G2: graphs
-        The two graphs G1 and G2 must be of the same type.
+        The two graphs `G1` and `G2` must be of the same type.
 
     node_match : callable
         A function that returns True if node n1 in G1 and n2 in G2
@@ -494,17 +493,16 @@ def optimize_graph_edit_distance(
     upper_bound : numeric
         Maximum edit distance to consider.
 
-    Returns
-    -------
-    Generator of consecutive approximations of graph edit distance.
+    Yields
+    ------
+    scalar
+       Scalar value representing sequential approximations of graph edit distance.
 
     Examples
     --------
     >>> G1 = nx.cycle_graph(6)
     >>> G2 = nx.wheel_graph(7)
-    >>> for v in nx.optimize_graph_edit_distance(G1, G2):
-    ...     minv = v
-    >>> minv
+    >>> min(nx.optimize_graph_edit_distance(G1, G2))
     7.0
 
     See Also
@@ -557,7 +555,7 @@ def optimize_edit_paths(
     roots=None,
     timeout=None,
 ):
-    """GED (graph edit distance) calculation: advanced interface.
+    """Compute graph edit paths and cost.
 
     Graph edit path is a sequence of node and edge edit operations
     transforming graph G1 to graph isomorphic to G2.  Edit operations
@@ -665,12 +663,13 @@ def optimize_edit_paths(
         Maximum number of seconds to execute.
         After timeout is met, the current best GED is returned.
 
-    Returns
-    -------
-    Generator of tuples (node_edit_path, edge_edit_path, cost)
-        node_edit_path : list of tuples (u, v)
-        edge_edit_path : list of tuples ((u1, v1), (u2, v2))
-        cost : numeric
+    Yields
+    ------
+    tuple
+        3-tuple of the form ``(node_edit_path, edge_edit_path, cost)`` where
+        ``node_edit_path`` : list of tuples ``(u, v)``
+        ``edge_edit_path`` : list of tuples ``((u1, v1), (u2, v2))``, and
+        ``cost : scalar value``
 
     See Also
     --------
@@ -1695,17 +1694,17 @@ def generate_random_paths(
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    paths : generator of lists
-        Generator of `sample_size` paths each with length `path_length`.
+    Yields
+    ------
+    path : list of nodes
+        Generate `sample_size` paths each with length `path_length`.
 
     Examples
     --------
-    Note that the return value is the list of paths:
-
     >>> G = nx.star_graph(3)
-    >>> random_path = nx.generate_random_paths(G, 2)
+    >>> list(nx.generate_random_paths(G, 2))  # doctest: +SKIP
+    [[3, 0, 1, 0, 3, 0], [2, 0, 3, 0, 1, 0]]
+
 
     By passing a dictionary into `index_map`, it will build an
     inverted index mapping of nodes to the paths in which that node is present:

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -403,8 +403,7 @@ def _all_simple_edge_paths(G, source, targets, cutoff):
 @not_implemented_for("multigraph")
 @nx._dispatchable(edge_attrs="weight")
 def shortest_simple_paths(G, source, target, weight=None):
-    """Generate all simple paths in the graph G from source to target,
-       starting from shortest ones.
+    """All simple paths in `G` from `source` to `target`, starting from the shortest ones.
 
     A simple path is a path with no repeated nodes.
 
@@ -433,11 +432,11 @@ def shortest_simple_paths(G, source, target, weight=None):
         If None all edges are considered to have unit weight. Default
         value None.
 
-    Returns
-    -------
-    path_generator: generator
-       A generator that produces lists of simple paths, in order from
-       shortest to longest.
+    Yields
+    ------
+    list
+       A list of nodes representing a simple path. Paths are yielded in order
+       according to path length, from shortest to longest.
 
     Raises
     ------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -93,7 +93,7 @@ def is_simple_path(G, nodes):
 
 @nx._dispatchable
 def all_simple_paths(G, source, target, cutoff=None):
-    """Generate all simple paths in the graph G from source to target.
+    """Generate all simple paths in the graph `G` from `source` to `target`.
 
     A simple path is a path with no repeated nodes.
 
@@ -110,11 +110,11 @@ def all_simple_paths(G, source, target, cutoff=None):
     cutoff : integer, optional
         Depth to stop the search. Only paths of length <= cutoff are returned.
 
-    Returns
-    -------
-    path_generator: generator
-       A generator that produces lists of simple paths.  If there are no paths
-       between the source and target within the given cutoff the generator
+    Yields
+    ------
+    path : list of nodes
+       A list of nodes representing a simple path. If there are no paths
+       between `source` and `target` within the given `cutoff` the generator
        produces no output. If it is possible to traverse the same sequence of
        nodes in multiple ways, namely through parallel edges, then it will be
        returned multiple times (once for each viable edge combination).
@@ -259,7 +259,7 @@ def all_simple_paths(G, source, target, cutoff=None):
 
 @nx._dispatchable
 def all_simple_edge_paths(G, source, target, cutoff=None):
-    """Generate lists of edges for all simple paths in G from source to target.
+    """Generate lists of edges for all simple paths in `G` from `source` to `target`.
 
     A simple path is a path with no repeated nodes.
 
@@ -276,18 +276,17 @@ def all_simple_edge_paths(G, source, target, cutoff=None):
     cutoff : integer, optional
         Depth to stop the search. Only paths of length <= cutoff are returned.
 
-    Returns
-    -------
-    path_generator: generator
-       A generator that produces lists of simple paths.  If there are no paths
-       between the source and target within the given cutoff the generator
+    Yields
+    ------
+    path : list of nodes
+       A list of nodes representing a simple path. If there are no paths
+       between `source` and `target` within the given `cutoff` the generator
        produces no output.
-       For multigraphs, the list of edges have elements of the form `(u,v,k)`.
-       Where `k` corresponds to the edge key.
+       For multigraphs, the list of edges have elements of the form ``(u, v, k)``
+       where ``k`` corresponds to the edge key.
 
     Examples
     --------
-
     Print the simple path edges of a Graph::
 
         >>> g = nx.Graph([(1, 2), (2, 4), (1, 3), (3, 4)])

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -288,7 +288,7 @@ def bfs_tree(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
 
 @nx._dispatchable
 def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
-    """Returns an iterator of predecessors in breadth-first-search from source.
+    """Yields predecessors of `source` via breadth-first-search.
 
     Parameters
     ----------
@@ -305,11 +305,12 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    pred: iterator
-        (node, predecessor) iterator where `predecessor` is the predecessor of
-        `node` in a breadth first search starting from `source`.
+    Yields
+    ------
+    tuple
+        2-tuple of nodes  ``(node, predecessor)`` where the first element is the
+        node and the second is its predecessor, yielded according to the order
+        seen via breadth-first-search from `source`.
 
     Examples
     --------
@@ -354,7 +355,7 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
 
 @nx._dispatchable
 def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
-    """Returns an iterator of successors in breadth-first-search from source.
+    """Yields ``(node, successor)`` pairs as encountered via BFS from `source`
 
     Parameters
     ----------
@@ -371,12 +372,13 @@ def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    succ: iterator
-       (node, successors) iterator where `successors` is the non-empty list of
-       successors of `node` in a breadth first search from `source`.
-       To appear in the iterator, `node` must have successors.
+    Yields
+    ------
+    tuple
+        2-tuple of nodes  ``(node, successors)`` where the first element is the
+        node and the second is a list of nodes representing the successors of the
+        node as encountered in a breadth-first-search from `source`. To appear in
+        the iterator, ``node`` must have successors.
 
     Examples
     --------

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -429,20 +429,20 @@ def dfs_labeled_edges(G, source=None, depth_limit=None, *, sort_neighbors=None):
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    edges: generator
-       A generator of triples of the form (*u*, *v*, *d*), where (*u*,
-       *v*) is the edge being explored in the depth-first search and *d*
-       is one of the strings 'forward', 'nontree', 'reverse', or 'reverse-depth_limit'.
-       A 'forward' edge is one in which *u* has been visited but *v* has
-       not. A 'nontree' edge is one in which both *u* and *v* have been
-       visited but the edge is not in the DFS tree. A 'reverse' edge is
-       one in which both *u* and *v* have been visited and the edge is in
-       the DFS tree. When the `depth_limit` is reached via a 'forward' edge,
-       a 'reverse' edge is immediately generated rather than the subtree
-       being explored. To indicate this flavor of 'reverse' edge, the string
-       yielded is 'reverse-depth_limit'.
+    Yields
+    ------
+    tuple
+       3-tuples of the form ``(u, v, d)``, where ``(u, v)`` is the edge being
+       explored in the depth-first search and ``d`` is a string indicating the
+       edge type: ``"forward"``, ``"nontree"``, ``"reverse"``, or ``"reverse-depth_limit"``.
+       A ``"forward"`` edge is one in which ``u`` has been visited but ``v`` has
+       not. A ``"nontree"`` edge is one in which both ``u`` and ``v`` have been
+       visited but the edge is not in the DFS tree. A ``"reverse"`` edge is
+       one in which both ``u`` and ``v`` have been visited and the edge is in
+       the DFS tree. When the `depth_limit` is reached via a ``"forward"`` edge,
+       a ``"reverse"`` edge is immediately generated rather than the subtree
+       being explored. To indicate this flavor of ``"reverse"`` edge, the string
+       yielded is ``"reverse-depth_limit"``.
 
     Examples
     --------

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -356,17 +356,17 @@ def all_triplets(G):
 @not_implemented_for("undirected")
 @nx._dispatchable(returns_graph=True)
 def all_triads(G):
-    """A generator of all possible triads in G.
+    """A generator of all possible triads in `G`.
 
     Parameters
     ----------
     G : digraph
        A NetworkX DiGraph
 
-    Returns
-    -------
-    all_triads : generator of DiGraphs
-       Generator of triads (order-3 DiGraphs)
+    Yields
+    ------
+    nx.DiGraph
+       A triad (order-3 DiGraph) in `G`
 
     Examples
     --------

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -927,17 +927,17 @@ def non_neighbors(graph, node):
 
 
 def non_edges(graph):
-    """Returns the nonexistent edges in the graph.
+    """Yields the nonexistent edges in the `graph`.
 
     Parameters
     ----------
     graph : NetworkX graph.
         Graph to find nonexistent edges.
 
-    Returns
-    -------
-    non_edges : iterator
-        Iterator of edges that are not in the graph.
+    Yields
+    ------
+    non_edges : tuple
+        Edges that are not in `graph`
     """
     if graph.is_directed():
         for u in graph:

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -29,7 +29,7 @@ from networkx.utils import open_file
 
 
 def generate_adjlist(G, delimiter=" "):
-    """Generate a single line of the graph G in adjacency list format.
+    """Generate a single line of the graph `G` in adjacency list format.
 
     Parameters
     ----------
@@ -38,10 +38,10 @@ def generate_adjlist(G, delimiter=" "):
     delimiter : string, optional
        Separator for node labels
 
-    Returns
-    -------
-    lines : string
-        Lines of data in adjlist format.
+    Yields
+    ------
+    line : string
+        Line of data in adjlist format.
 
     Examples
     --------
@@ -62,7 +62,7 @@ def generate_adjlist(G, delimiter=" "):
 
     Notes
     -----
-    The default `delimiter=" "` will result in unexpected results if node names contain
+    The default ``delimiter=" "`` will result in unexpected results if node names contain
     whitespace characters. To avoid this problem, specify an alternate delimiter when spaces are
     valid in node names.
 

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -41,7 +41,7 @@ from networkx.utils import open_file
 
 
 def generate_edgelist(G, delimiter=" ", data=True):
-    """Generate a single line of the graph G in edge list format.
+    """Generate a single line of the graph `G` in edge list format.
 
     Parameters
     ----------
@@ -51,14 +51,14 @@ def generate_edgelist(G, delimiter=" ", data=True):
        Separator for node labels
 
     data : bool or list of keys
-       If False generate no edge data.  If True use a dictionary
+       If `False` generate no edge data.  If `True` use a dictionary
        representation of edge data.  If a list of keys use a list of data
        values corresponding to the keys.
 
-    Returns
-    -------
-    lines : string
-        Lines of data in adjlist format.
+    Yields
+    ------
+    line : string
+        Line of data in edge list format.
 
     Examples
     --------

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -88,7 +88,7 @@ def write_gexf(G, path, encoding="utf-8", prettyprint=True, version="1.2draft"):
 
 
 def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
-    """Generate lines of GEXF format representation of G.
+    """Generate lines of GEXF format representation of `G`.
 
     "GEXF (Graph Exchange XML Format) is a language for describing
     complex networks structures, their associated data and dynamics" [1]_.
@@ -96,15 +96,19 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
     Parameters
     ----------
     G : graph
-    A NetworkX graph
+       A NetworkX graph
     encoding : string (optional, default: 'utf-8')
-    Encoding for text data.
+       Encoding for text data.
     prettyprint : bool (optional, default: True)
-    If True use line breaks and indenting in output XML.
+       If `True` use line breaks and indenting in output XML.
     version : string (default: 1.2draft)
-    Version of GEFX File Format (see http://gexf.net/schema.html)
-    Supported values: "1.1draft", "1.2draft"
+       Version of GEFX File Format (see <https://gexf.net/schema.html>_)
+       Supported values: "1.1draft", "1.2draft"
 
+    Yields
+    ------
+    line : string
+       Line of a file representing the graph `G` in GEXF format
 
     Examples
     --------

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -635,9 +635,9 @@ def generate_gml(G, stringizer=None):
         strings. If it cannot convert a value into a string, it should raise a
         `ValueError` to indicate that. Default value: None.
 
-    Returns
-    -------
-    lines: generator of strings
+    Yields
+    ------
+    line : string
         Lines of GML data. Newlines are not appended.
 
     Raises

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -192,7 +192,7 @@ def generate_graphml(
     named_key_ids=False,
     edge_id_from_attribute=None,
 ):
-    """Generate GraphML lines for G
+    """Generate GraphML lines for `G`
 
     Parameters
     ----------
@@ -205,9 +205,14 @@ def generate_graphml(
     named_key_ids : bool (optional)
        If True use attr.name as value for key elements' id attribute.
     edge_id_from_attribute : dict key (optional)
-        If provided, the graphml edge id is set by looking up the corresponding
-        edge data attribute keyed by this parameter. If `None` or the key does not exist in edge data,
-        the edge id is set by the edge key if `G` is a MultiGraph, else the edge id is left unset.
+       If provided, the graphml edge id is set by looking up the corresponding
+       edge data attribute keyed by this parameter. If `None` or the key does not exist in edge data,
+       the edge id is set by the edge key if `G` is a MultiGraph, else the edge id is left unset.
+
+    Yields
+    ------
+    line : str
+       Line of a file representing `G` in GraphML format.
 
     Examples
     --------

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -46,10 +46,10 @@ def generate_multiline_adjlist(G, delimiter=" "):
     delimiter : string, optional
        Separator for node labels
 
-    Returns
-    -------
-    lines : string
-        Lines of data in multiline adjlist format.
+    Yields
+    ------
+    line : string
+        Lines of data representing `G` in multiline adjlist format.
 
     Examples
     --------

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -30,6 +30,11 @@ def generate_pajek(G):
     G : graph
        A Networkx graph
 
+    Yields
+    ------
+    line : string
+       A line of a file representing `G` in Pajek format.
+
     References
     ----------
     See http://vlado.fmf.uni-lj.si/pub/networks/pajek/doc/draweps.htm

--- a/networkx/utils/rcm.py
+++ b/networkx/utils/rcm.py
@@ -27,24 +27,26 @@ def cuthill_mckee_ordering(G, heuristic=None):
       a node from a pseudo-peripheral pair is used.  A user-defined function
       can be supplied that takes a graph object and returns a single node.
 
-    Returns
-    -------
-    nodes : generator
-       Generator of nodes in Cuthill-McKee ordering.
+    Yields
+    ------
+    node
+       Yields nodes in Cuthill-McKee ordering.
 
     Examples
     --------
     >>> from networkx.utils import cuthill_mckee_ordering
     >>> G = nx.path_graph(4)
     >>> rcm = list(cuthill_mckee_ordering(G))
+    >>> rcm
+    [3, 2, 1, 0]
     >>> A = nx.adjacency_matrix(G, nodelist=rcm)
 
     Smallest degree node as heuristic function:
 
     >>> def smallest_degree(G):
     ...     return min(G, key=G.degree)
-    >>> rcm = list(cuthill_mckee_ordering(G, heuristic=smallest_degree))
-
+    >>> list(cuthill_mckee_ordering(G, heuristic=smallest_degree))
+    [0, 1, 2, 3]
 
     See Also
     --------


### PR DESCRIPTION
Fixes #7258 and adds a regression test for all of the generators in NetworkX which had incorrect `Returns` sections in the docstrings.

These are just the ones caught by numpydoc (and ignores inherited methods), so there may be others!