### PR TITLE
Fix all sphinx warnings during doc build.

### DIFF
--- a/examples/3d_drawing/plot_3d_rotation_animation.py
+++ b/examples/3d_drawing/plot_3d_rotation_animation.py
@@ -1,6 +1,6 @@
 """
 =========================================
-Animations of 3D rotation and random walk.
+Animations of 3D rotation and random walk
 =========================================
 Examples of 3D plots of a graph in the 3D spectral layout with animation. 
 Following 

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -546,11 +546,11 @@ def modular_product(G, H):
     - if u is adjacent to x in `G` and v is adjacent to y in `H`, or
     - if u is not adjacent to x in `G` and v is not adjacent to y in `H`.
 
-    More formally
-    ::
+    More formally::
 
         E(M) = {((u, v), (x, y)) | ((u, x) in E(G) and (v, y) in E(H)) or
                                    ((u, x) not in E(G) and (v, y) not in E(H))}
+
     Parameters
     ----------
     G, H: NetworkX graphs
@@ -559,12 +559,12 @@ def modular_product(G, H):
     Returns
     -------
     M: NetworkX graph
-        The Modular product of G and H.
+        The Modular product of `G` and `H`.
 
     Raises
     ------
     NetworkXNotImplemented
-        If G is not a simple graph.
+        If `G` is not a simple graph.
 
     Examples
     --------

--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -14,7 +14,7 @@ import networkx as nx
 
 @nx._dispatchable(graphs=None)
 def nonisomorphic_trees(order, create="graph"):
-    """Returns a list of nonisomorphic trees
+    """Generates lists of nonisomorphic trees
 
     Parameters
     ----------
@@ -31,8 +31,7 @@ def nonisomorphic_trees(order, create="graph"):
        A list of nonisomorphic trees, in one of two formats depending on the
        value of the `create` parameter:
        - ``create="graph"``: yields a list of `networkx.Graph` instances
-       - ``create="matrix"``: yields a list of list-of-lists representing
-         adjacency matrices
+       - ``create="matrix"``: yields a list of list-of-lists representing adjacency matrices
     """
 
     if order < 2:


### PR DESCRIPTION
Fix all sphinx warnings related specifically to formatting issues in docstrings. There are still a lot of extraneous warnings from plotting, but those are covered in issue #7284 and should be handled separately.