### PR TITLE
 Move arrowstyle input munging after intput validation. 

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -858,9 +858,6 @@ def draw_networkx_edges(
             raise TypeError("Argument `arrows` must be of type bool or None")
         use_linecollection = not arrows
 
-    if arrowstyle is None:
-        arrowstyle = "-|>" if G.is_directed() else "-"
-
     if isinstance(connectionstyle, str):
         connectionstyle = [connectionstyle]
     elif np.iterable(connectionstyle):
@@ -896,6 +893,10 @@ def draw_networkx_edges(
             warnings.warn(
                 msg.format("connectionstyle"), category=UserWarning, stacklevel=2
             )
+
+    # NOTE: Arrowstyle modification must occur after the warnings section
+    if arrowstyle is None:
+        arrowstyle = "-|>" if G.is_directed() else "-"
 
     if ax is None:
         ax = plt.gca()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -833,3 +833,15 @@ def test_user_warnings_for_unused_edge_drawing_kwargs(fap_only_kwarg):
         nx.draw_networkx_edges(G, pos, ax=ax, arrows=True, **fap_only_kwarg)
 
     plt.delaxes(ax)
+
+
+@pytest.mark.parametrize("draw_fn", (nx.draw, nx.draw_circular))
+def test_no_warning_on_default_draw_arrowstyle(draw_fn):
+    # See gh-7284
+    fig, ax = plt.subplots()
+    G = nx.cycle_graph(5)
+    with warnings.catch_warnings(record=True, category=UserWarning) as w:
+        draw_fn(G, ax=ax)
+    assert len(w) == 0
+
+    plt.delaxes(ax)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -840,7 +840,7 @@ def test_no_warning_on_default_draw_arrowstyle(draw_fn):
     # See gh-7284
     fig, ax = plt.subplots()
     G = nx.cycle_graph(5)
-    with warnings.catch_warnings(record=True, category=UserWarning) as w:
+    with warnings.catch_warnings(record=True) as w:
         draw_fn(G, ax=ax)
     assert len(w) == 0
 


### PR DESCRIPTION
Fixes #7284 

A UserWarning is raised on the value of arrowstyle, but the value
is modified internally before this validation is performed.

Move the modification *after* the validation step to suppress the
spurious warnings.