### PR TITLE
Allow backend kwargs to be passed via special keywords `*_kwargs=`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Test Dispatching
         run: |
-          NETWORKX_TEST_BACKEND=nx-loopback pytest --doctest-modules --durations=10 --pyargs networkx
+          NETWORKX_TEST_BACKEND=nx_loopback pytest --doctest-modules --durations=10 --pyargs networkx
 
   extra:
     runs-on: ${{ matrix.os }}

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -2,7 +2,7 @@
 
 # A full test of all dispatchable algorithms is performed by
 # modifying the pytest invocation and setting an environment variable
-# NETWORKX_TEST_BACKEND=nx-loopback pytest
+# NETWORKX_TEST_BACKEND=nx_loopback pytest
 # This is comprehensive, but only tests the `test_override_dispatch`
 # function in networkx.classes.backends.
 
@@ -16,23 +16,23 @@ from networkx.classes.reportviews import NodeView
 
 
 class LoopbackGraph(Graph):
-    __networkx_backend__ = "nx-loopback"
+    __networkx_backend__ = "nx_loopback"
 
 
 class LoopbackDiGraph(DiGraph):
-    __networkx_backend__ = "nx-loopback"
+    __networkx_backend__ = "nx_loopback"
 
 
 class LoopbackMultiGraph(MultiGraph):
-    __networkx_backend__ = "nx-loopback"
+    __networkx_backend__ = "nx_loopback"
 
 
 class LoopbackMultiDiGraph(MultiDiGraph):
-    __networkx_backend__ = "nx-loopback"
+    __networkx_backend__ = "nx_loopback"
 
 
 class LoopbackPlanarEmbedding(PlanarEmbedding):
-    __networkx_backend__ = "nx-loopback"
+    __networkx_backend__ = "nx_loopback"
 
 
 def convert(graph):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -51,15 +51,15 @@ def pytest_configure(config):
         if not fallback_to_nx:
             fallback_to_nx = os.environ.get("NETWORKX_FALLBACK_TO_NX")
         networkx.utils.backends._dispatchable._fallback_to_nx = bool(fallback_to_nx)
-    # nx-loopback backend is only available when testing
-    backends = entry_points(name="nx-loopback", group="networkx.backends")
+    # nx_loopback backend is only available when testing
+    backends = entry_points(name="nx_loopback", group="networkx.backends")
     if backends:
-        networkx.utils.backends.backends["nx-loopback"] = next(iter(backends))
+        networkx.utils.backends.backends["nx_loopback"] = next(iter(backends))
     else:
         warnings.warn(
             "\n\n             WARNING: Mixed NetworkX configuration! \n\n"
             "        This environment has mixed configuration for networkx.\n"
-            "        The test object nx-loopback is not configured correctly.\n"
+            "        The test object nx_loopback is not configured correctly.\n"
             "        You should not be seeing this message.\n"
             "        Try `pip install -e .`, or change your PYTHONPATH\n"
             "        Make sure python finds the networkx repo you are testing\n\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Documentation = 'https://networkx.org/documentation/stable/'
 "Source Code" = 'https://github.com/networkx/networkx'
 
 [project.entry-points."networkx.backends"]
-nx-loopback = 'networkx.classes.tests.dispatch_interface:dispatcher'
+nx_loopback = 'networkx.classes.tests.dispatch_interface:dispatcher'
 
 [project.optional-dependencies]
 default = [


### PR DESCRIPTION
For example, add `my_backend_kwargs={"be_awesome": True}` to a dispatchable function call, which will add `be_awesome=True` when using `my_backend` and will ignore it otherwise. This should only be used for backend-specific keyword arguments.

CC @rlratzel