### PR TITLE
Transmogrify `_dispatchable` objects into functions

### DIFF
--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -17,8 +17,16 @@ def test_dispatch_kwds_vs_args():
 
 
 def test_pickle():
+    count = 0
     for name, func in nx.utils.backends._registered_algorithms.items():
-        assert pickle.loads(pickle.dumps(func)) is func
+        try:
+            # Some functions can't be pickled, but it's not b/c of _dispatchable
+            pickled = pickle.dumps(func)
+        except pickle.PicklingError:
+            continue
+        assert pickle.loads(pickled) is func
+        count += 1
+    assert count > 0
     assert pickle.loads(pickle.dumps(nx.inverse_line_graph)) is nx.inverse_line_graph
 
 

--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -74,3 +74,7 @@ def test_graph_converter_needs_backend():
         del LoopbackDispatcher.from_scipy_sparse_array
     with pytest.raises(ImportError, match="Unable to load"):
         nx.from_scipy_sparse_array(A, backend="bad-backend-name")
+
+
+def test_dispatchable_are_functions():
+    assert type(nx.pagerank) is type(nx.pagerank.orig_func)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -94,8 +94,13 @@ from importlib.metadata import entry_points
 import networkx as nx
 
 from ..exception import NetworkXNotImplemented
+from .decorators import argmap
 
 __all__ = ["_dispatchable"]
+
+
+def _do_nothing():
+    """This does nothing at all, yet it helps turn `_dispatchable` into functions."""
 
 
 def _get_backends(group, *, load_and_call=False):
@@ -348,6 +353,11 @@ class _dispatchable:
             raise KeyError(
                 f"Algorithm already exists in dispatch registry: {name}"
             ) from None
+        # Use the magic of `argmap` to turn `self` into a function. This does result
+        # in small additional overhead compared to calling `_dispatchable` directly,
+        # but `argmap` has the magical property that it can stack with other `argmap`
+        # decorators "for free". Being a function is better for REPRs and type-checkers.
+        self = argmap(_do_nothing)(self)
         _registered_algorithms[name] = self
         return self
 

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -1107,7 +1107,13 @@ class argmap:
             if prev == param.POSITIONAL_ONLY != kind:
                 # the last token was position-only, but this one isn't
                 def_sig.append("/")
-            if prev != param.KEYWORD_ONLY == kind != param.VAR_POSITIONAL:
+            if (
+                param.VAR_POSITIONAL
+                != prev
+                != param.KEYWORD_ONLY
+                == kind
+                != param.VAR_POSITIONAL
+            ):
                 # param is the first keyword-only arg and isn't starred
                 def_sig.append("*")
 


### PR DESCRIPTION
`_dispatchable` objects don't look good in REPRs and they make it really awkward for type checkers. This PR uses `argmap` to transmogrify `_dispatchable` objects into functions. I hope to someday understand `argmap`.

@rossbar, this is as discussed in #7185 and the meeting today. Everything looks good in REPRs to me. This PR supercedes #7185.

CC @rlratzel