### PR TITLE
Review and update `@nx._dispatchable` usage since 3.2.1

### DIFF
--- a/examples/algorithms/plot_greedy_coloring.py
+++ b/examples/algorithms/plot_greedy_coloring.py
@@ -3,7 +3,7 @@
 Greedy Coloring
 ===============
 
-We attempt to color a graph using as few colors as possible, where no neighbours
+We attempt to color a graph using as few colors as possible, where no neighbors
 of a node can have same color as the node itself.
 """
 import numpy as np

--- a/networkx/algorithms/community/divisive.py
+++ b/networkx/algorithms/community/divisive.py
@@ -8,6 +8,7 @@ __all__ = [
 ]
 
 
+@nx._dispatchable(edge_attrs="weight")
 def edge_betweenness_partition(G, number_of_sets, *, weight=None):
     """Partition created by iteratively removing the highest edge betweenness edge.
 
@@ -83,6 +84,7 @@ def edge_betweenness_partition(G, number_of_sets, *, weight=None):
     return partition
 
 
+@nx._dispatchable(edge_attrs="weight")
 def edge_current_flow_betweenness_partition(G, number_of_sets, *, weight=None):
     """Partition created by removing the highest edge current flow betweenness edge.
 

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -535,7 +535,7 @@ def corona_product(G, H):
     return GH
 
 
-@nx._dispatchable(graphs=_G_H)
+@nx._dispatchable(graphs=_G_H, preserve_edge_attrs=True, preserve_node_attrs=True)
 def modular_product(G, H):
     r"""Returns the Modular product of G and H.
 

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -217,7 +217,7 @@ def score_sequence(G):
 
 @not_implemented_for("undirected")
 @not_implemented_for("multigraph")
-@nx._dispatchable
+@nx._dispatchable(preserve_edge_attrs={"G": {"weight": 1}})
 def tournament_matrix(G):
     r"""Returns the tournament matrix for the given tournament graph.
 

--- a/networkx/algorithms/wiener.py
+++ b/networkx/algorithms/wiener.py
@@ -94,6 +94,7 @@ def wiener_index(G, weight=None):
 
 @nx.utils.not_implemented_for("directed")
 @nx.utils.not_implemented_for("multigraph")
+@nx._dispatchable(edge_attrs="weight")
 def schultz_index(G, weight=None):
     r"""Returns the Schultz Index (of the first kind) of `G`
 
@@ -161,6 +162,7 @@ def schultz_index(G, weight=None):
 
 @nx.utils.not_implemented_for("directed")
 @nx.utils.not_implemented_for("multigraph")
+@nx._dispatchable(edge_attrs="weight")
 def gutman_index(G, weight=None):
     r"""Returns the Gutman Index for the graph `G`.
 

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -214,6 +214,7 @@ def paley_graph(p, create_using=None):
 
 
 @nx.utils.decorators.np_random_state("seed")
+@nx._dispatchable(graphs=None)
 def maybe_regular_expander(n, d, *, create_using=None, max_tries=100, seed=None):
     r"""Utility for creating a random regular expander.
 
@@ -330,6 +331,7 @@ def maybe_regular_expander(n, d, *, create_using=None, max_tries=100, seed=None)
 
 @nx.utils.not_implemented_for("directed")
 @nx.utils.not_implemented_for("multigraph")
+@nx._dispatchable(preserve_edge_attrs={"G": {"weight": 1}})
 def is_regular_expander(G, *, epsilon=0):
     r"""Determines whether the graph G is a regular expander. [1]_
 
@@ -396,7 +398,11 @@ def is_regular_expander(G, *, epsilon=0):
     return abs(lambda2) < 2 ** np.sqrt(d - 1) + epsilon
 
 
-def random_regular_expander_graph(n, d, *, epsilon=0, create_using=None, max_tries=100):
+@nx.utils.decorators.np_random_state("seed")
+@nx._dispatchable(graphs=None)
+def random_regular_expander_graph(
+    n, d, *, epsilon=0, create_using=None, max_tries=100, seed=None
+):
     r"""Returns a random regular expander graph on $n$ nodes with degree $d$.
 
     An expander graph is a sparse graph with strong connectivity properties. [1]_
@@ -417,6 +423,8 @@ def random_regular_expander_graph(n, d, *, epsilon=0, create_using=None, max_tri
     epsilon : int, float, default=0
     max_tries : int, (default: 100)
       The number of allowed loops, also used in the maybe_regular_expander utility
+    seed : (default: None)
+      Seed used to set random number generation state. See :ref`Randomness<randomness>`.
 
     Raises
     ------
@@ -446,13 +454,15 @@ def random_regular_expander_graph(n, d, *, epsilon=0, create_using=None, max_tri
     .. [3] Ramanujan graphs, https://en.wikipedia.org/wiki/Ramanujan_graph
 
     """
-    G = maybe_regular_expander(n, d, create_using=create_using, max_tries=max_tries)
+    G = maybe_regular_expander(
+        n, d, create_using=create_using, max_tries=max_tries, seed=seed
+    )
     iterations = max_tries
 
     while not is_regular_expander(G, epsilon=epsilon):
         iterations -= 1
         G = maybe_regular_expander(
-            n=n, d=d, create_using=create_using, max_tries=max_tries
+            n=n, d=d, create_using=create_using, max_tries=max_tries, seed=seed
         )
 
         if iterations == 0:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -806,6 +806,8 @@ class _dispatchable:
         from itertools import tee
         from random import Random
 
+        from numpy.random import RandomState
+
         # We sometimes compare the backend result to the original result,
         # so we need two sets of arguments. We tee iterators and copy
         # random state so that they may be used twice.
@@ -815,7 +817,7 @@ class _dispatchable:
             args1, args2 = zip(
                 *(
                     (arg, copy(arg))
-                    if isinstance(arg, Random | BytesIO)
+                    if isinstance(arg, BytesIO | Random | RandomState)
                     else tee(arg)
                     if isinstance(arg, Iterator) and not isinstance(arg, BufferedReader)
                     else (arg, arg)
@@ -828,7 +830,7 @@ class _dispatchable:
             kwargs1, kwargs2 = zip(
                 *(
                     ((k, v), (k, copy(v)))
-                    if isinstance(v, Random | BytesIO)
+                    if isinstance(v, BytesIO | Random | RandomState)
                     else ((k, (teed := tee(v))[0]), (k, teed[1]))
                     if isinstance(v, Iterator) and not isinstance(v, BufferedReader)
                     else ((k, v), (k, v))


### PR DESCRIPTION
This adds (and updates) `@nx._dispatchable` decorator to some new functions. I reviewed the diff since version 3.2.1.

There are now three algorithms I know that implicitly use `"weight"` weight (no `weight` argument): `hits`, `tournament_matrix`, and `is_regular_expander`.

The only other functional change I made in this PR is to add `seed` to `random_regular_expander_graph`.