### PR TITLE
Improve test coverage for bipartite extendability

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_extendability.py
+++ b/networkx/algorithms/bipartite/tests/test_extendability.py
@@ -29,7 +29,7 @@ def test_no_perfect_matching_raises():
         nx.bipartite.maximal_extendability(G)
 
 
-def test_not_connected_raises():
+def test_not_strongly_connected_raises():
     G = nx.Graph([(1, 2), (2, 3), (3, 4)])
     with pytest.raises(
         nx.NetworkXError, match="The residual graph of G is not strongly connected"

--- a/networkx/algorithms/bipartite/tests/test_extendability.py
+++ b/networkx/algorithms/bipartite/tests/test_extendability.py
@@ -29,7 +29,7 @@ def test_no_perfect_matching_raises():
         nx.bipartite.maximal_extendability(G)
 
 
-def test_not_strongly_connected_raises():
+def test_residual_graph_not_strongly_connected_raises():
     G = nx.Graph([(1, 2), (2, 3), (3, 4)])
     with pytest.raises(
         nx.NetworkXError, match="The residual graph of G is not strongly connected"

--- a/networkx/algorithms/bipartite/tests/test_extendability.py
+++ b/networkx/algorithms/bipartite/tests/test_extendability.py
@@ -29,6 +29,14 @@ def test_no_perfect_matching_raises():
         nx.bipartite.maximal_extendability(G)
 
 
+def test_not_connected_raises():
+    G = nx.Graph([(1, 2), (2, 3), (3, 4)])
+    with pytest.raises(
+        nx.NetworkXError, match="The residual graph of G is not strongly connected"
+    ):
+        nx.bipartite.maximal_extendability(G)
+
+
 def test_ladder_graph_is_1():
     G = nx.ladder_graph(3)
     assert nx.bipartite.maximal_extendability(G) == 1


### PR DESCRIPTION
I have increased test coverage for extendability.py according to here at 92.59% :-
https://app.codecov.io/gh/networkx/networkx/blob/main/networkx%2Falgorithms%2Fbipartite%2Fextendability.py
The test coverage is now at a 100% as seen below :-
![after](https://github.com/networkx/networkx/assets/74042272/d2b8b56d-ba58-4802-801a-8dcaff702bed)
I would love a review on this and do any changes if required!
