### PR TITLE
CI: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "type: Maintenance"
   - package-ecosystem: "pip"


### PR DESCRIPTION
* Group dependabot updates to reduce the number of PRs.
   - c.f. sp-repo-review GH212: Require GHA update grouping https://learn.scientific-python.org/development/guides/gha-basic/#GH212

<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
