### PR TITLE
CI: Update scientific-python/upload-nightly-action from 0.3.0 to 0.4.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: List contents of wheel
         run: python -m zipfile --list dist/networkx-*.whl
       - name: Upload nighlty wheel
-        uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
+        uses: scientific-python/upload-nightly-action@95f7bf6a22281b8072fae929429dd0408f09ea63 # 0.4.0
         with:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_NIGHTLY }}
           artifacts_path: dist/


### PR DESCRIPTION
* Update the scientific-python/upload-nightly-action to v0.4.0 to avoid issues with uploading wheels of the same name to Anaconda Cloud where the project being uploaded to only contains one wheel (the one being replaced).
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.4.0

I know that Dependabot maanges the GitHub Actions updates, but this release was made specifically to try to fix the issues that `networkx` has been having

<img width="1649" alt="Screenshot 2024-02-21 at 10 27 39 PM" src="https://github.com/networkx/networkx/assets/5142394/bc9ca745-9f2e-40f9-af26-efe5956f2026">

so I wanted to try to fix this rather than waiting a month.

 
