### PR TITLE
Improve test coverage for bipartite matrix.py

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -39,6 +39,11 @@ class TestBiadjacencyMatrix:
         M = bipartite.biadjacency_matrix(G, X, Y, weight="weight")
         assert M[1, 2] == 2
 
+    def test_biadjacency_matrix_empty_graph(self):
+        G = nx.empty_graph(2)
+        M = nx.bipartite.biadjacency_matrix(G, [0])
+        assert M == sp.sparse.coo_matrix(([], ([], [])), shape=(1, 1))
+
     def test_null_graph(self):
         with pytest.raises(nx.NetworkXError):
             bipartite.biadjacency_matrix(nx.Graph(), [])

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -42,7 +42,7 @@ class TestBiadjacencyMatrix:
     def test_biadjacency_matrix_empty_graph(self):
         G = nx.empty_graph(2)
         M = nx.bipartite.biadjacency_matrix(G, [0])
-        assert M == sp.sparse.coo_matrix(([], ([], [])), shape=(1, 1))
+        assert np.array_equal(M.toarray(), np.array([[0]]))
 
     def test_null_graph(self):
         with pytest.raises(nx.NetworkXError):


### PR DESCRIPTION
I have increased test coverage for matrix.py according to here at 95.12% :-
https://app.codecov.io/gh/networkx/networkx/blob/main/networkx%2Falgorithms%2Fbipartite%2Fmatrix.py
The test coverage is now at a 100% as seen below :-
![after](https://github.com/networkx/networkx/assets/74042272/6df7d9c6-c913-4c4c-8e76-db58bcb49484)
I would love a review on this and do any changes if required!