### PR TITLE
Add explicit targets of missing modules for intersphinx

### DIFF
--- a/doc/reference/algorithms/assortativity.rst
+++ b/doc/reference/algorithms/assortativity.rst
@@ -6,6 +6,8 @@ Assortativity
 .. autosummary::
    :toctree: generated/
 
+.. _networkx.algorithms.assortativity.correlation:
+
 Assortativity
 -------------
 .. autosummary::
@@ -16,6 +18,8 @@ Assortativity
    numeric_assortativity_coefficient
    degree_pearson_correlation_coefficient
 
+.. _networkx.algorithms.assortativity.neighbor_degree:
+
 Average neighbor degree
 -----------------------
 .. autosummary::
@@ -23,6 +27,7 @@ Average neighbor degree
 
    average_neighbor_degree
 
+.. _networkx.algorithms.assortativity.connectivity:
 
 Average degree connectivity
 ---------------------------
@@ -31,6 +36,7 @@ Average degree connectivity
 
    average_degree_connectivity
 
+.. _networkx.algorithms.assortativity.mixing:
 
 Mixing
 ------
@@ -42,6 +48,8 @@ Mixing
    attribute_mixing_dict
    degree_mixing_dict
    mixing_dict
+
+.. _networkx.algorithms.assortativity.pairs:
 
 Pairs
 -----

--- a/doc/reference/algorithms/centrality.rst
+++ b/doc/reference/algorithms/centrality.rst
@@ -4,6 +4,8 @@ Centrality
 
 .. automodule:: networkx.algorithms.centrality
 
+.. _networkx.algorithms.centrality.degree_alg:
+
 Degree
 ------
 .. autosummary::
@@ -12,6 +14,9 @@ Degree
    degree_centrality
    in_degree_centrality
    out_degree_centrality
+
+.. _networkx.algorithms.centrality.eigenvector:
+.. _networkx.algorithms.centrality.katz:
 
 Eigenvector
 -----------
@@ -23,6 +28,8 @@ Eigenvector
    katz_centrality
    katz_centrality_numpy
 
+.. _networkx.algorithms.centrality.closeness:
+
 Closeness
 ---------
 .. autosummary::
@@ -31,6 +38,8 @@ Closeness
    closeness_centrality
    incremental_closeness_centrality
 
+.. _networkx.algorithms.centrality.current_flow_closeness:
+
 Current Flow Closeness
 ----------------------
 .. autosummary::
@@ -38,6 +47,9 @@ Current Flow Closeness
 
    current_flow_closeness_centrality
    information_centrality
+
+.. _networkx.algorithms.centrality.betweenness:
+.. _networkx.algorithms.centrality.betweenness_subset:
 
 (Shortest Path) Betweenness
 ---------------------------
@@ -49,6 +61,8 @@ Current Flow Closeness
    edge_betweenness_centrality
    edge_betweenness_centrality_subset
 
+.. _networkx.algorithms.centrality.current_flow_betweenness:
+.. _networkx.algorithms.centrality.current_flow_betweenness_subset:
 
 Current Flow Betweenness
 ------------------------
@@ -68,6 +82,8 @@ Communicability Betweenness
 
    communicability_betweenness_centrality
 
+.. _networkx.algorithms.centrality.group:
+
 Group Centrality
 ----------------
 .. autosummary::
@@ -80,6 +96,8 @@ Group Centrality
    group_out_degree_centrality
    prominent_group
 
+.. _networkx.algorithms.centrality.load:
+
 Load
 ----
 .. autosummary::
@@ -87,6 +105,8 @@ Load
 
    load_centrality
    edge_load_centrality
+
+.. _networkx.algorithms.centrality.subgraph_alg:
 
 Subgraph
 --------
@@ -96,6 +116,8 @@ Subgraph
    subgraph_centrality
    subgraph_centrality_exp
    estrada_index
+
+.. _networkx.algorithms.centrality.harmonic:
 
 Harmonic Centrality
 -------------------
@@ -111,6 +133,8 @@ Dispersion
 
    dispersion
 
+.. _networkx.algorithms.centrality.reaching:
+
 Reaching
 --------
 .. autosummary::
@@ -119,6 +143,8 @@ Reaching
    local_reaching_centrality
    global_reaching_centrality
 
+.. _networkx.algorithms.centrality.percolation:
+
 Percolation
 -----------
 .. autosummary::
@@ -126,12 +152,16 @@ Percolation
 
    percolation_centrality
 
+.. _networkx.algorithms.centrality.second_order:
+
 Second Order Centrality
 -----------------------
 .. autosummary::
    :toctree: generated/
 
    second_order_centrality
+
+.. _networkx.algorithms.centrality.trophic:
 
 Trophic
 -------
@@ -142,12 +172,16 @@ Trophic
    trophic_differences
    trophic_incoherence_parameter
 
+.. _networkx.algorithms.centrality.voterank_alg:
+
 VoteRank
 --------
 .. autosummary::
    :toctree: generated/
 
    voterank
+
+.. _networkx.algorithms.centrality.laplacian:
 
 Laplacian
 ---------

--- a/doc/reference/algorithms/coloring.rst
+++ b/doc/reference/algorithms/coloring.rst
@@ -1,3 +1,6 @@
+.. _networkx.algorithms.coloring.greedy_coloring:
+.. _networkx.algorithms.coloring.equitable_coloring:
+
 ********
 Coloring
 ********

--- a/doc/reference/algorithms/community.rst
+++ b/doc/reference/algorithms/community.rst
@@ -15,7 +15,7 @@ Bipartitions
    kernighan_lin_bisection
 
 Divisive Communities
----------------------
+--------------------
 .. automodule:: networkx.algorithms.community.divisive
 .. autosummary::
    :toctree: generated/

--- a/doc/reference/algorithms/component.rst
+++ b/doc/reference/algorithms/component.rst
@@ -3,6 +3,8 @@ Components
 **********
 .. automodule:: networkx.algorithms.components
 
+.. _networkx.algorithms.components.connected:
+
 Connectivity
 ------------
 .. autosummary::
@@ -12,6 +14,8 @@ Connectivity
    number_connected_components
    connected_components
    node_connected_component
+
+.. _networkx.algorithms.components.strongly_connected:
 
 Strong connectivity
 -------------------
@@ -25,6 +29,8 @@ Strong connectivity
    kosaraju_strongly_connected_components
    condensation
 
+.. _networkx.algorithms.components.weakly_connected:
+
 Weak connectivity
 -----------------
 .. autosummary::
@@ -33,6 +39,8 @@ Weak connectivity
    is_weakly_connected
    number_weakly_connected_components
    weakly_connected_components
+
+.. _networkx.algorithms.components.attracting:
 
 Attracting components
 ---------------------
@@ -43,6 +51,8 @@ Attracting components
    number_attracting_components
    attracting_components
 
+.. _networkx.algorithms.components.biconnected:
+
 Biconnected components
 ----------------------
 .. autosummary::
@@ -52,6 +62,8 @@ Biconnected components
    biconnected_components
    biconnected_component_edges
    articulation_points
+
+.. _networkx.algorithms.components.semiconnected:
 
 Semiconnectedness
 -----------------

--- a/doc/reference/algorithms/flow.rst
+++ b/doc/reference/algorithms/flow.rst
@@ -4,6 +4,7 @@ Flows
 
 .. automodule:: networkx.algorithms.flow
 
+.. _networkx.algorithms.flow.maxflow:
 
 Maximum Flow
 ------------
@@ -15,6 +16,7 @@ Maximum Flow
    minimum_cut
    minimum_cut_value
 
+.. _networkx.algorithms.flow.edmondskarp:
 
 Edmonds-Karp
 ------------
@@ -23,6 +25,7 @@ Edmonds-Karp
 
    edmonds_karp
 
+.. _networkx.algorithms.flow.shortestaugmentingpath:
 
 Shortest Augmenting Path
 ------------------------
@@ -31,6 +34,7 @@ Shortest Augmenting Path
 
    shortest_augmenting_path
 
+.. _networkx.algorithms.flow.preflowpush:
 
 Preflow-Push
 ------------
@@ -39,6 +43,7 @@ Preflow-Push
 
    preflow_push
 
+.. _networkx.algorithms.flow.dinitz_alg:
 
 Dinitz
 ------
@@ -47,6 +52,7 @@ Dinitz
 
    dinitz
 
+.. _networkx.algorithms.flow.boykovkolmogorov:
 
 Boykov-Kolmogorov
 -----------------
@@ -55,6 +61,7 @@ Boykov-Kolmogorov
 
    boykov_kolmogorov
 
+.. _networkx.algorithms.flow.gomory_hu:
 
 Gomory-Hu Tree
 --------------
@@ -63,6 +70,7 @@ Gomory-Hu Tree
 
    gomory_hu_tree
 
+.. _networkx.algorithms.flow.utils:
 
 Utils
 -----
@@ -71,6 +79,8 @@ Utils
 
    build_residual_network
 
+.. _networkx.algorithms.flow.mincost:
+.. _networkx.algorithms.flow.networksimplex:
 
 Network Simplex
 ---------------
@@ -83,6 +93,7 @@ Network Simplex
     cost_of_flow
     max_flow_min_cost
 
+.. _networkx.algorithms.flow.capacityscaling:
 
 Capacity Scaling Minimum Cost Flow
 ----------------------------------

--- a/doc/reference/algorithms/isomorphism.rst
+++ b/doc/reference/algorithms/isomorphism.rst
@@ -1,4 +1,5 @@
 .. _isomorphism:
+.. _networkx.algorithms.isomorphism.isomorph:
 
 ***********
 Isomorphism

--- a/doc/reference/algorithms/minors.rst
+++ b/doc/reference/algorithms/minors.rst
@@ -1,3 +1,5 @@
+.. _networkx.algorithms.minors.contraction:
+
 ******
 Minors
 ******

--- a/doc/reference/readwrite/json_graph.rst
+++ b/doc/reference/readwrite/json_graph.rst
@@ -1,3 +1,8 @@
+.. _networkx.readwrite.json_graph.adjacency:
+.. _networkx.readwrite.json_graph.cytoscape:
+.. _networkx.readwrite.json_graph.node_link:
+.. _networkx.readwrite.json_graph.tree:
+
 JSON
 ====
 .. automodule:: networkx.readwrite.json_graph


### PR DESCRIPTION
This covers all the missing modules that I could find. `sphinxobjinv` is a useful tool:
- https://sphobjinv.readthedocs.io/en/stable/

For starters, it can convert the binary `objects.inv` into text:
```bash
$ sphobjinv convert plain objects.inv objects.txt
```
Closes #7278. This is a simple solution, but I don't know if better solutions exist. At the very least, this PR shows what's missing. This may look like a lot of changes, but the vast majority of modules already have targets.