### PR TITLE
Fix empty GraphML attribute is not parsed

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -1010,9 +1010,10 @@ class GraphMLReader(GraphML):
                     edge_label = data_element.find(f"{pref}EdgeLabel")
                     if edge_label is not None:
                         break
-
                 if edge_label is not None:
                     data["label"] = edge_label.text
+            elif text is None:
+                data[data_name] = ""
         return data
 
     def find_graphml_keys(self, graph_element):

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1527,5 +1527,5 @@ def test_empty_attribute():
     </graphml>"""
     fh = io.BytesIO(s.encode("UTF-8"))
     G = nx.read_graphml(fh)
-    assert G.nodes['0'] == {'foo': 'aaa', 'bar': 'bbb'}
-    assert G.nodes['1'] == {'foo': 'ccc', 'bar': ''}
+    assert G.nodes["0"] == {"foo": "aaa", "bar": "bbb"}
+    assert G.nodes["1"] == {"foo": "ccc", "bar": ""}

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1505,3 +1505,27 @@ def test_exception_for_unsupported_datatype_graph_attr():
     fh = io.BytesIO()
     with pytest.raises(TypeError, match="GraphML does not support"):
         nx.write_graphml(G, fh)
+
+
+def test_empty_attribute():
+    """Tests that a GraphML string with an empty attribute can be parsed
+    correctly."""
+    s = """<?xml version='1.0' encoding='utf-8'?>
+    <graphml>
+      <key id="d1" for="node" attr.name="foo" attr.type="string"/>
+      <key id="d2" for="node" attr.name="bar" attr.type="string"/>
+      <graph>
+        <node id="0">
+          <data key="d1">aaa</data>
+          <data key="d2">bbb</data>
+        </node>
+        <node id="1">
+          <data key="d1">ccc</data>
+          <data key="d2"></data>
+        </node>
+      </graph>
+    </graphml>"""
+    fh = io.BytesIO(s.encode("UTF-8"))
+    G = nx.read_graphml(fh)
+    assert G.nodes['0'] == {'foo': 'aaa', 'bar': 'bbb'}
+    assert G.nodes['1'] == {'foo': 'ccc', 'bar': ''}


### PR DESCRIPTION
Fixes https://github.com/networkx/networkx/issues/7291

networkx does not parse GraphML attributes that are empty.
As a result, they will not be added to the graph.
This fix will create the attribute with an empty string.