### PR TITLE
Update docstring example with future-proof pandas assignment.

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -101,20 +101,22 @@ def to_pandas_adjacency(
     diagonal matrix entry value to the weight attribute of the edge
     (or the number 1 if the edge has no weight attribute).  If the
     alternate convention of doubling the edge weight is desired the
-    resulting Pandas DataFrame can be modified as follows:
+    resulting Pandas DataFrame can be modified as follows::
 
-    >>> import pandas as pd
-    >>> pd.options.display.max_columns = 20
-    >>> import numpy as np
-    >>> G = nx.Graph([(1, 1)])
-    >>> df = nx.to_pandas_adjacency(G, dtype=int)
-    >>> df
-       1
-    1  1
-    >>> df.values[np.diag_indices_from(df)] *= 2
-    >>> df
-       1
-    1  2
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> G = nx.Graph([(1, 1), (2, 2)])
+        >>> df = nx.to_pandas_adjacency(G)
+        >>> df
+             1    2
+        1  1.0  0.0
+        2  0.0  1.0
+        >>> diag_idx = list(range(len(df)))
+        >>> df.iloc[diag_idx, diag_idx] *= 2
+        >>> df
+             1    2
+        1  2.0  0.0
+        2  0.0  2.0
 
     Examples
     --------

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -103,7 +103,6 @@ def to_pandas_adjacency(
     alternate convention of doubling the edge weight is desired the
     resulting Pandas DataFrame can be modified as follows::
 
-        >>> import numpy as np
         >>> import pandas as pd
         >>> G = nx.Graph([(1, 1), (2, 2)])
         >>> df = nx.to_pandas_adjacency(G)


### PR DESCRIPTION
Fixes the test failure from the pandas-3.0 nightly wheel by replacing an assignment to `df.values` (which is becoming read-only) with index assignment via `df.iloc`. This should work both on pandas 2 and 3 - I've tested locally against the pandas-3.0dev nightly and it works as expected. I'm certainly no pandas expert so if there's a better/more idiomatic way to do this please push/suggest!

I also made minor adjustments to the example, including adding a second node with self-loop edges to make the adjacency matrix more interpretable in the repr.

Finally, I went ahead and opened pandas-dev/pandas#57687 to raise awareness about the fact that the behavior change associated with assigning to `.values` does not have an accompanying warning.