### PR TITLE
Undo change in return type of `single_target_shortest_path_length`

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -92,9 +92,9 @@ class TestUnweightedPath:
     def test_single_target_shortest_path_length(self):
         pl = nx.single_target_shortest_path_length
         lengths = {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert pl(self.cycle, 0) == lengths
+        assert dict(pl(self.cycle, 0)) == lengths
         lengths = {0: 0, 1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
-        assert pl(self.directed_cycle, 0) == lengths
+        assert dict(pl(self.directed_cycle, 0)) == lengths
         # test missing targets
         target = 8
         with pytest.raises(nx.NodeNotFound, match=f"Target {target} is not in G"):

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -117,7 +117,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     Examples
     --------
     >>> G = nx.path_graph(5, create_using=nx.DiGraph())
-    >>> length = nx.single_target_shortest_path_length(G, 4)
+    >>> length = dict(nx.single_target_shortest_path_length(G, 4))
     >>> length[0]
     4
     >>> for node in range(5):
@@ -151,7 +151,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     nextlevel = [target]
     # for version 3.3 we will return a dict like this:
     # return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
-    return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
+    return _single_shortest_path_length(adj, nextlevel, cutoff)
 
 
 @nx._dispatchable


### PR DESCRIPTION
Fixes #7315 by reverting the change in return type until the FutureWarning has expired (scheduled for 3.5).

The other possible solution would be to remove the FutureWarning and implement the change now. I don't recall from previous discussions which was the desired course of action, so if I got this wrong please LMK! Either way - the behavior needs to be consistent with the warning (or lack thereof).