### PR TITLE
Update louvain test modularity comparison to leq.

### DIFF
--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -236,7 +236,7 @@ def test_threshold():
     mod1 = nx.community.modularity(G, partition1)
     mod2 = nx.community.modularity(G, partition2)
 
-    assert mod1 < mod2
+    assert mod1 <= mod2
 
 
 def test_empty_graph():


### PR DESCRIPTION
Closes #6823 

I'm no expert in community detection, but from reading through the Louvain description (and thinking about the various floating-point issues associated with the modularity calculation) I think using `<=` for this comparison is correct, since equivalence is also "not increasing".