### PR TITLE
Fix #7339. `shortest_path` inconsisitent with warning

### DIFF
--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -112,7 +112,7 @@ def global_reaching_centrality(G, weight=None, normalized=True):
     # TODO This can be trivially parallelized.
     lrc = [
         centrality(G, node, paths=paths, weight=weight, normalized=normalized)
-        for node, paths in shortest_paths
+        for node, paths in shortest_paths.items()
     ]
 
     max_lrc = max(lrc)

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -149,11 +149,11 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
 
             # Find paths between all pairs.
             if method == "unweighted":
-                paths = nx.all_pairs_shortest_path(G)
+                paths = dict(nx.all_pairs_shortest_path(G))
             elif method == "dijkstra":
-                paths = nx.all_pairs_dijkstra_path(G, weight=weight)
+                paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
             else:  # method == 'bellman-ford':
-                paths = nx.all_pairs_bellman_ford_path(G, weight=weight)
+                paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
         else:
             # Find paths from all nodes co-accessible to the target.
             if G.is_directed():

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -212,7 +212,9 @@ class TestGenericPath:
         assert sorted(ans[4]) == [[4]]
 
     def test_all_pairs_shortest_path(self):
-        p = dict(nx.shortest_path(self.cycle))
+        # shortest_path w/o source and target will return a generator instead of
+        # a dict beginning in version 3.5. Only the first call needs changed here.
+        p = nx.shortest_path(self.cycle)
         assert p[0][3] == [0, 1, 2, 3]
         assert p == dict(nx.all_pairs_shortest_path(self.cycle))
         p = dict(nx.shortest_path(self.grid))


### PR DESCRIPTION
The warning says the return type will change from dict to iterator in version 3.5. This PR changes the return type to dict, since we are not yet on version 3.5.

Please see #7339 for details. I think this will make main branch consistent and resolve the inconsistencies introduced in #6584 and #7161.