### PR TITLE
Minimal PR to add cache dict to graphs and clear them

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -629,6 +629,8 @@ def barycenter(G, weight=None, attr=None, sp=None):
             barycenter_vertices = [v]
         elif barycentricity == smallest:
             barycenter_vertices.append(v)
+    if attr is not None:
+        G.__networkx_cache__.clear()
     return barycenter_vertices
 
 

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -94,6 +94,7 @@ def edmonds_karp_core(R, s, t, cutoff):
             path.append(u)
         flow_value += augment(path)
 
+    R.__networkx_cache__.clear()
     return flow_value
 
 

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -355,6 +355,7 @@ class DiGraph(Graph):
         self._pred = self.adjlist_outer_dict_factory()  # predecessor
         # Note: self._succ = self._adj  # successor
 
+        self.__networkx_cache__ = {}
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
@@ -465,6 +466,7 @@ class DiGraph(Graph):
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
+        self.__networkx_cache__.clear()
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -543,6 +545,7 @@ class DiGraph(Graph):
                 self._pred[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
+        self.__networkx_cache__.clear()
 
     def remove_node(self, n):
         """Remove node n.
@@ -585,6 +588,7 @@ class DiGraph(Graph):
         for u in self._pred[n]:
             del self._succ[u][n]  # remove all edges n-u in digraph
         del self._pred[n]  # remove node from pred
+        self.__networkx_cache__.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -639,6 +643,7 @@ class DiGraph(Graph):
                 del self._pred[n]  # now remove node
             except KeyError:
                 pass  # silent failure on remove
+        self.__networkx_cache__.clear()
 
     def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
@@ -709,6 +714,7 @@ class DiGraph(Graph):
         datadict.update(attr)
         self._succ[u][v] = datadict
         self._pred[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -791,6 +797,7 @@ class DiGraph(Graph):
             datadict.update(dd)
             self._succ[u][v] = datadict
             self._pred[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -824,6 +831,7 @@ class DiGraph(Graph):
             del self._pred[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} not in graph.") from err
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -856,6 +864,7 @@ class DiGraph(Graph):
             if u in self._succ and v in self._succ[u]:
                 del self._succ[u][v]
                 del self._pred[v][u]
+        self.__networkx_cache__.clear()
 
     def has_successor(self, u, v):
         """Returns True if node u has successor v.
@@ -1195,6 +1204,7 @@ class DiGraph(Graph):
         self._pred.clear()
         self._node.clear()
         self.graph.clear()
+        self.__networkx_cache__.clear()
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1213,6 +1223,7 @@ class DiGraph(Graph):
             predecessor_dict.clear()
         for successor_dict in self._succ.values():
             successor_dict.clear()
+        self.__networkx_cache__.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -365,6 +365,7 @@ class Graph:
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
+        self.__networkx_cache__ = {}
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
@@ -559,6 +560,7 @@ class Graph:
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
+        self.__networkx_cache__.clear()
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -636,6 +638,7 @@ class Graph:
                 self._adj[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
+        self.__networkx_cache__.clear()
 
     def remove_node(self, n):
         """Remove node n.
@@ -676,6 +679,7 @@ class Graph:
         for u in nbrs:
             del adj[u][n]  # remove all edges n-u in graph
         del adj[n]  # now remove node
+        self.__networkx_cache__.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -728,6 +732,7 @@ class Graph:
                 del adj[n]
             except KeyError:
                 pass
+        self.__networkx_cache__.clear()
 
     @cached_property
     def nodes(self):
@@ -957,6 +962,7 @@ class Graph:
         datadict.update(attr)
         self._adj[u][v] = datadict
         self._adj[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -1037,6 +1043,7 @@ class Graph:
             datadict.update(dd)
             self._adj[u][v] = datadict
             self._adj[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def add_weighted_edges_from(self, ebunch_to_add, weight="weight", **attr):
         """Add weighted edges in `ebunch_to_add` with specified weight attr
@@ -1087,6 +1094,7 @@ class Graph:
         >>> G.add_weighted_edges_from(list((5, n, weight) for n in G.nodes))
         """
         self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch_to_add), **attr)
+        self.__networkx_cache__.clear()
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -1120,6 +1128,7 @@ class Graph:
                 del self._adj[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} is not in the graph") from err
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1154,6 +1163,7 @@ class Graph:
                 del adj[u][v]
                 if u != v:  # self loop needs only one entry removed
                     del adj[v][u]
+        self.__networkx_cache__.clear()
 
     def update(self, edges=None, nodes=None):
         """Update the graph using nodes/edges/graphs as input.
@@ -1526,6 +1536,7 @@ class Graph:
         self._adj.clear()
         self._node.clear()
         self.graph.clear()
+        self.__networkx_cache__.clear()
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1541,6 +1552,7 @@ class Graph:
         """
         for nbr_dict in self._adj.values():
             nbr_dict.clear()
+        self.__networkx_cache__.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -508,6 +508,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             keydict[key] = datadict
             self._succ[u][v] = keydict
             self._pred[v][u] = keydict
+        self.__networkx_cache__.clear()
         return key
 
     def remove_edge(self, u, v, key=None):
@@ -583,6 +584,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             # remove the key entries if last edge
             del self._succ[u][v]
             del self._pred[v][u]
+        self.__networkx_cache__.clear()
 
     @cached_property
     def edges(self):

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -520,6 +520,7 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self._adj[u][v] = keydict
             self._adj[v][u] = keydict
+        self.__networkx_cache__.clear()
         return key
 
     def add_edges_from(self, ebunch_to_add, **attr):
@@ -616,6 +617,7 @@ class MultiGraph(Graph):
             key = self.add_edge(u, v, key)
             self[u][v][key].update(ddd)
             keylist.append(key)
+        self.__networkx_cache__.clear()
         return keylist
 
     def remove_edge(self, u, v, key=None):
@@ -695,6 +697,7 @@ class MultiGraph(Graph):
             del self._adj[u][v]
             if u != v:  # check for selfloop
                 del self._adj[v][u]
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -753,6 +756,7 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
+        self.__networkx_cache__.clear()
 
     def has_edge(self, u, v, key=None):
         """Returns True if the graph has an edge between nodes u and v.

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -50,4 +50,5 @@ def stochastic_graph(G, copy=True, weight="weight"):
             d[weight] = 0
         else:
             d[weight] = d.get(weight, 1) / degree[u]
+    G.__networkx_cache__.clear()
     return G


### PR DESCRIPTION
An even simpler start to caching than #7283, this PR creates a `__networkx_cache__` dict on graph objects and clears them when appropriate.

This takes a conservative approach to clear the cache in functions and methods whenever any graph data changes.

I'm pretty confident that all graph methods and dispatched functions clear the cache appropriately. There may be some non-dispatched functions that mutate the graph that aren't captured here.

This PR is minimal in that it doesn't do anything with the cache. By creating the cache, though, backends, users, and specific functions may begin experimenting with using the cache.