### PR TITLE
ENH: Cache graphs objects when converting to a backend

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -17,7 +17,7 @@ from networkx.lazy_imports import _lazy_import
 from networkx.exception import *
 
 from networkx import utils
-from networkx.utils.backends import _dispatchable, config
+from networkx.utils import _clear_cache, _dispatchable, config
 
 from networkx import classes
 from networkx.classes import filters

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -767,8 +767,7 @@ def held_karp_ascent(G, weight="weight"):
         for u, v, d in G.edges(data=True):
             d[weight] = original_edge_weights[(u, v)] + pi_dict[u]
         dir_ascent, k_d = direction_of_ascent()
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
     # k_d is no longer an individual 1-arborescence but rather a set of
     # minimal 1-arborescences at the maximum point of the polytope and should
     # be reflected as such

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -340,7 +340,7 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
 
 @not_implemented_for("undirected")
 @py_random_state(2)
-@nx._dispatchable(edge_attrs="weight")
+@nx._dispatchable(edge_attrs="weight", mutates_input=True)
 def asadpour_atsp(G, weight="weight", seed=None, source=None):
     """
     Returns an approximate solution to the traveling salesman problem.
@@ -492,7 +492,7 @@ def asadpour_atsp(G, weight="weight", seed=None, source=None):
     return _shortcutting(circuit)
 
 
-@nx._dispatchable(edge_attrs="weight", returns_graph=True)
+@nx._dispatchable(edge_attrs="weight", mutates_input=True, returns_graph=True)
 def held_karp_ascent(G, weight="weight"):
     """
     Minimizes the Held-Karp relaxation of the TSP for `G`
@@ -767,6 +767,8 @@ def held_karp_ascent(G, weight="weight"):
         for u, v, d in G.edges(data=True):
             d[weight] = original_edge_weights[(u, v)] + pi_dict[u]
         dir_ascent, k_d = direction_of_ascent()
+    if cache := getattr(G, "__networkx_cache__", None):
+        cache.clear()
     # k_d is no longer an individual 1-arborescence but rather a set of
     # minimal 1-arborescences at the maximum point of the polytope and should
     # be reflected as such
@@ -777,6 +779,7 @@ def held_karp_ascent(G, weight="weight"):
     for k in k_max:
         if len([n for n in k if k.degree(n) == 2]) == G.order():
             # Tour found
+            # TODO: this branch does not restore original_edge_weights of G!
             return k.size(weight), k
 
     # Write the original edge weights back to G and every member of k_max at

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -350,6 +350,7 @@ def prominent_group(
     else:
         nodes = list(G.nodes)
     DF_tree = nx.Graph()
+    DF_tree.__networkx_cache__ = None  # Disable caching
     PB, sigma, D = _group_preprocessing(G, nodes, weight)
     betweenness = pd.DataFrame.from_dict(PB)
     if C is not None:

--- a/networkx/algorithms/community/lukes.py
+++ b/networkx/algorithms/community/lukes.py
@@ -175,6 +175,8 @@ def lukes_partitioning(G, max_size, node_weight=None, edge_weight=None):
         t_G.nodes[inner][PKEY] = {}
         slot = safe_G.nodes[inner][node_weight]
         t_G.nodes[inner][PKEY][slot] = [{inner}]
+    if cache := getattr(t_G, "__networkx_cache__", None):
+        cache.clear()
 
     # CORE ALGORITHM -----------------------
     while True:

--- a/networkx/algorithms/community/lukes.py
+++ b/networkx/algorithms/community/lukes.py
@@ -175,8 +175,7 @@ def lukes_partitioning(G, max_size, node_weight=None, edge_weight=None):
         t_G.nodes[inner][PKEY] = {}
         slot = safe_G.nodes[inner][node_weight]
         t_G.nodes[inner][PKEY][slot] = [{inner}]
-    if cache := getattr(t_G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(t_G)
 
     # CORE ALGORITHM -----------------------
     while True:

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -146,7 +146,7 @@ def test_modularity_communities_directed_weighted():
 
     # A large weight of the edge (2, 6) causes 6 to change group, even if it shares
     # only one connection with the new group and 3 with the old one.
-    G.add_edge(2, 6, weight=20)
+    G[2][6]["weight"] = 20
     expected = [frozenset({1, 2, 3, 6}), frozenset({4, 5, 7, 8})]
     assert greedy_modularity_communities(G, weight="weight") == expected
 
@@ -214,7 +214,7 @@ def test_greedy_modularity_communities_multigraph_weighted():
     assert greedy_modularity_communities(G, weight="weight") == expected
 
     # Increasing the weight of edge (1, 4) causes node 4 to return to the former group.
-    G.add_edge(1, 4, 1, weight=3)
+    G[1][4][1]["weight"] = 3
     expected = [frozenset({1, 2, 3, 4}), frozenset({5, 6, 7, 8})]
     assert greedy_modularity_communities(G, weight="weight") == expected
 

--- a/networkx/algorithms/community/tests/test_modularity_max.py
+++ b/networkx/algorithms/community/tests/test_modularity_max.py
@@ -146,7 +146,7 @@ def test_modularity_communities_directed_weighted():
 
     # A large weight of the edge (2, 6) causes 6 to change group, even if it shares
     # only one connection with the new group and 3 with the old one.
-    G[2][6]["weight"] = 20
+    G.add_edge(2, 6, weight=20)
     expected = [frozenset({1, 2, 3, 6}), frozenset({4, 5, 7, 8})]
     assert greedy_modularity_communities(G, weight="weight") == expected
 
@@ -214,7 +214,7 @@ def test_greedy_modularity_communities_multigraph_weighted():
     assert greedy_modularity_communities(G, weight="weight") == expected
 
     # Increasing the weight of edge (1, 4) causes node 4 to return to the former group.
-    G[1][4][1]["weight"] = 3
+    G.add_edge(1, 4, 1, weight=3)
     expected = [frozenset({1, 2, 3, 4}), frozenset({5, 6, 7, 8})]
     assert greedy_modularity_communities(G, weight="weight") == expected
 

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -31,11 +31,7 @@ __all__ = [
 ]
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "auxiliary?": 4, "residual?": 5},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"auxiliary", "residual"},
-)
+@nx._dispatchable(graphs={"G": 0, "auxiliary?": 4}, preserve_graph_attrs={"auxiliary"})
 def local_node_connectivity(
     G, s, t, flow_func=None, auxiliary=None, residual=None, cutoff=None
 ):
@@ -490,11 +486,7 @@ def all_pairs_node_connectivity(G, nbunch=None, flow_func=None):
     return all_pairs
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "auxiliary?": 4, "residual?": 5},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"residual"},
-)
+@nx._dispatchable(graphs={"G": 0, "auxiliary?": 4})
 def local_edge_connectivity(
     G, s, t, flow_func=None, auxiliary=None, residual=None, cutoff=None
 ):

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -22,12 +22,9 @@ __all__ = [
 
 
 @nx._dispatchable(
-    graphs={"G": 0, "auxiliary?": 4, "residual?": 5},
-    preserve_edge_attrs={
-        "auxiliary": {"capacity": float("inf")},
-        "residual": {"capacity": float("inf")},
-    },
-    preserve_graph_attrs={"auxiliary", "residual"},
+    graphs={"G": 0, "auxiliary?": 4},
+    preserve_edge_attrs={"auxiliary": {"capacity": float("inf")}},
+    preserve_graph_attrs={"auxiliary"},
 )
 def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     """Returns the edges of the cut-set of a minimum (s, t)-cut.
@@ -162,10 +159,9 @@ def minimum_st_edge_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
 
 
 @nx._dispatchable(
-    graphs={"G": 0, "auxiliary?": 4, "residual?": 5},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
+    graphs={"G": 0, "auxiliary?": 4},
     preserve_node_attrs={"auxiliary": {"id": None}},
-    preserve_graph_attrs={"auxiliary", "residual"},
+    preserve_graph_attrs={"auxiliary"},
 )
 def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     r"""Returns a set of nodes of minimum cardinality that disconnect source

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -20,12 +20,8 @@ __all__ = ["edge_disjoint_paths", "node_disjoint_paths"]
 
 
 @nx._dispatchable(
-    graphs={"G": 0, "auxiliary?": 5, "residual?": 6},
-    preserve_edge_attrs={
-        "auxiliary": {"capacity": float("inf")},
-        "residual": {"capacity": float("inf")},
-    },
-    preserve_graph_attrs={"residual"},
+    graphs={"G": 0, "auxiliary?": 5},
+    preserve_edge_attrs={"auxiliary": {"capacity": float("inf")}},
 )
 def edge_disjoint_paths(
     G, s, t, flow_func=None, cutoff=None, auxiliary=None, residual=None
@@ -235,10 +231,9 @@ def edge_disjoint_paths(
 
 
 @nx._dispatchable(
-    graphs={"G": 0, "auxiliary?": 5, "residual?": 6},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
+    graphs={"G": 0, "auxiliary?": 5},
     preserve_node_attrs={"auxiliary": {"id": None}},
-    preserve_graph_attrs={"auxiliary", "residual"},
+    preserve_graph_attrs={"auxiliary"},
 )
 def node_disjoint_paths(
     G, s, t, flow_func=None, cutoff=None, auxiliary=None, residual=None

--- a/networkx/algorithms/connectivity/stoerwagner.py
+++ b/networkx/algorithms/connectivity/stoerwagner.py
@@ -94,6 +94,7 @@ def stoer_wagner(G, weight="weight", heap=BinaryHeap):
     G = nx.Graph(
         (u, v, {"weight": e.get(weight, 1)}) for u, v, e in G.edges(data=True) if u != v
     )
+    G.__networkx_cache__ = None  # Disable caching
 
     for u, v, e in G.edges(data=True):
         if e["weight"] < 0:

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -764,7 +764,7 @@ def _chordless_cycle_search(F, B, path, length_bound):
 
 
 @not_implemented_for("undirected")
-@nx._dispatchable
+@nx._dispatchable(mutates_input=True)
 def recursive_simple_cycles(G):
     """Find simple cycles (elementary circuits) of a directed graph.
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -629,6 +629,8 @@ def barycenter(G, weight=None, attr=None, sp=None):
             barycenter_vertices = [v]
         elif barycentricity == smallest:
             barycenter_vertices.append(v)
+    if attr is not None:
+        G.__networkx_cache__.clear()
     return barycenter_vertices
 
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -630,7 +630,8 @@ def barycenter(G, weight=None, attr=None, sp=None):
         elif barycentricity == smallest:
             barycenter_vertices.append(v)
     if attr is not None:
-        G.__networkx_cache__.clear()
+        if cache := getattr(G, "__networkx_cache__", None):
+            cache.clear()
     return barycenter_vertices
 
 

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -630,8 +630,7 @@ def barycenter(G, weight=None, attr=None, sp=None):
         elif barycentricity == smallest:
             barycenter_vertices.append(v)
     if attr is not None:
-        if cache := getattr(G, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(G)
     return barycenter_vertices
 
 

--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -156,8 +156,7 @@ def boykov_kolmogorov(
     """
     R = boykov_kolmogorov_impl(G, s, t, capacity, residual, cutoff)
     R.graph["algorithm"] = "boykov_kolmogorov"
-    if cache := getattr(R, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(R)
     return R
 
 

--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -10,13 +10,7 @@ from networkx.algorithms.flow.utils import build_residual_network
 __all__ = ["boykov_kolmogorov"]
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "residual?": 4},
-    edge_attrs={"capacity": float("inf")},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"residual"},
-    returns_graph=True,
-)
+@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
 def boykov_kolmogorov(
     G, s, t, capacity="capacity", residual=None, value_only=False, cutoff=None
 ):
@@ -162,6 +156,8 @@ def boykov_kolmogorov(
     """
     R = boykov_kolmogorov_impl(G, s, t, capacity, residual, cutoff)
     R.graph["algorithm"] = "boykov_kolmogorov"
+    if cache := getattr(R, "__networkx_cache__", None):
+        cache.clear()
     return R
 
 

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -10,13 +10,7 @@ from networkx.utils import pairwise
 __all__ = ["dinitz"]
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "residual?": 4},
-    edge_attrs={"capacity": float("inf")},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"residual"},
-    returns_graph=True,
-)
+@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
 def dinitz(G, s, t, capacity="capacity", residual=None, value_only=False, cutoff=None):
     """Find a maximum single-commodity flow using Dinitz' algorithm.
 
@@ -141,6 +135,8 @@ def dinitz(G, s, t, capacity="capacity", residual=None, value_only=False, cutoff
     """
     R = dinitz_impl(G, s, t, capacity, residual, cutoff)
     R.graph["algorithm"] = "dinitz"
+    if cache := getattr(R, "__networkx_cache__", None):
+        cache.clear()
     return R
 
 

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -135,8 +135,7 @@ def dinitz(G, s, t, capacity="capacity", residual=None, value_only=False, cutoff
     """
     R = dinitz_impl(G, s, t, capacity, residual, cutoff)
     R.graph["algorithm"] = "dinitz"
-    if cache := getattr(R, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(R)
     return R
 
 

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -94,6 +94,7 @@ def edmonds_karp_core(R, s, t, cutoff):
             path.append(u)
         flow_value += augment(path)
 
+    R.__networkx_cache__.clear()
     return flow_value
 
 

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -8,12 +8,6 @@ from networkx.algorithms.flow.utils import build_residual_network
 __all__ = ["edmonds_karp"]
 
 
-@nx._dispatchable(
-    graphs="R",
-    preserve_edge_attrs={"R": {"capacity": float("inf"), "flow": 0}},
-    preserve_graph_attrs=True,
-    mutates_input=True,
-)
 def edmonds_karp_core(R, s, t, cutoff):
     """Implementation of the Edmonds-Karp algorithm."""
     R_nodes = R.nodes
@@ -94,7 +88,6 @@ def edmonds_karp_core(R, s, t, cutoff):
             path.append(u)
         flow_value += augment(path)
 
-    R.__networkx_cache__.clear()
     return flow_value
 
 
@@ -124,13 +117,7 @@ def edmonds_karp_impl(G, s, t, capacity, residual, cutoff):
     return R
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "residual?": 4},
-    edge_attrs={"capacity": float("inf")},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"residual"},
-    returns_graph=True,
-)
+@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
 def edmonds_karp(
     G, s, t, capacity="capacity", residual=None, value_only=False, cutoff=None
 ):
@@ -250,4 +237,6 @@ def edmonds_karp(
     """
     R = edmonds_karp_impl(G, s, t, capacity, residual, cutoff)
     R.graph["algorithm"] = "edmonds_karp"
+    if cache := getattr(R, "__networkx_cache__", None):
+        cache.clear()
     return R

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -237,6 +237,5 @@ def edmonds_karp(
     """
     R = edmonds_karp_impl(G, s, t, capacity, residual, cutoff)
     R.graph["algorithm"] = "edmonds_karp"
-    if cache := getattr(R, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(R)
     return R

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -288,13 +288,7 @@ def preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq, value_on
     return R
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "residual?": 4},
-    edge_attrs={"capacity": float("inf")},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"residual"},
-    returns_graph=True,
-)
+@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
 def preflow_push(
     G, s, t, capacity="capacity", residual=None, global_relabel_freq=1, value_only=False
 ):
@@ -427,4 +421,6 @@ def preflow_push(
     """
     R = preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq, value_only)
     R.graph["algorithm"] = "preflow_push"
+    if cache := getattr(R, "__networkx_cache__", None):
+        cache.clear()
     return R

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -421,6 +421,5 @@ def preflow_push(
     """
     R = preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq, value_only)
     R.graph["algorithm"] = "preflow_push"
-    if cache := getattr(R, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(R)
     return R

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -163,13 +163,7 @@ def shortest_augmenting_path_impl(G, s, t, capacity, residual, two_phase, cutoff
     return R
 
 
-@nx._dispatchable(
-    graphs={"G": 0, "residual?": 4},
-    edge_attrs={"capacity": float("inf")},
-    preserve_edge_attrs={"residual": {"capacity": float("inf")}},
-    preserve_graph_attrs={"residual"},
-    returns_graph=True,
-)
+@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
 def shortest_augmenting_path(
     G,
     s,
@@ -302,4 +296,6 @@ def shortest_augmenting_path(
     """
     R = shortest_augmenting_path_impl(G, s, t, capacity, residual, two_phase, cutoff)
     R.graph["algorithm"] = "shortest_augmenting_path"
+    if cache := getattr(R, "__networkx_cache__", None):
+        cache.clear()
     return R

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -296,6 +296,5 @@ def shortest_augmenting_path(
     """
     R = shortest_augmenting_path_impl(G, s, t, capacity, residual, two_phase, cutoff)
     R.graph["algorithm"] = "shortest_augmenting_path"
-    if cache := getattr(R, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(R)
     return R

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -102,6 +102,7 @@ def build_residual_network(G, capacity):
         raise nx.NetworkXError("MultiGraph and MultiDiGraph not supported (yet).")
 
     R = nx.DiGraph()
+    R.__networkx_cache__ = None  # Disable caching
     R.add_nodes_from(G)
 
     inf = float("inf")

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -951,8 +951,7 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(
                 f"The node {n} is not in the planar embedding."
             ) from err
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -1235,8 +1234,7 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(
                 f"The edge {u}-{v} is not in the planar embedding."
             ) from err
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -951,7 +951,8 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(
                 f"The node {n} is not in the planar embedding."
             ) from err
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -1079,7 +1080,6 @@ class PlanarEmbedding(nx.DiGraph):
                 raise nx.NetworkXError("Invalid reference node.")
             # adding the first edge out of start_node
             super().add_edge(start_node, end_node, ccw=end_node, cw=end_node)
-        self.__networkx_cache__.clear()
 
     def check_structure(self):
         """Runs without exceptions if this object is valid.
@@ -1235,7 +1235,8 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(
                 f"The edge {u}-{v} is not in the planar embedding."
             ) from err
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -951,6 +951,7 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(
                 f"The node {n} is not in the planar embedding."
             ) from err
+        self.__networkx_cache__.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -1078,6 +1079,7 @@ class PlanarEmbedding(nx.DiGraph):
                 raise nx.NetworkXError("Invalid reference node.")
             # adding the first edge out of start_node
             super().add_edge(start_node, end_node, ccw=end_node, cw=end_node)
+        self.__networkx_cache__.clear()
 
     def check_structure(self):
         """Runs without exceptions if this object is valid.
@@ -1233,6 +1235,7 @@ class PlanarEmbedding(nx.DiGraph):
             raise nx.NetworkXError(
                 f"The edge {u}-{v} is not in the planar embedding."
             ) from err
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -390,7 +390,7 @@ class TestWeightedPath(WeightedTestBase):
         p = dict(nx.all_pairs_dijkstra_path(cycle))
         assert p[0][3] == [0, 1, 2, 3]
 
-        cycle.add_edge(1, 2, weight=10)
+        cycle[1][2]["weight"] = 10
         p = dict(nx.all_pairs_dijkstra_path(cycle))
         assert p[0][3] == [0, 6, 5, 4, 3]
 
@@ -399,7 +399,7 @@ class TestWeightedPath(WeightedTestBase):
         pl = dict(nx.all_pairs_dijkstra_path_length(cycle))
         assert pl[0] == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
 
-        cycle.add_edge(1, 2, weight=10)
+        cycle[1][2]["weight"] = 10
         pl = dict(nx.all_pairs_dijkstra_path_length(cycle))
         assert pl[0] == {0: 0, 1: 1, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
 
@@ -409,7 +409,7 @@ class TestWeightedPath(WeightedTestBase):
         assert out[0][0] == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
         assert out[0][1][3] == [0, 1, 2, 3]
 
-        cycle.add_edge(1, 2, weight=10)
+        cycle[1][2]["weight"] = 10
         out = dict(nx.all_pairs_dijkstra(cycle))
         assert out[0][0] == {0: 0, 1: 1, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
         assert out[0][1][3] == [0, 6, 5, 4, 3]
@@ -539,7 +539,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert not nx.negative_edge_cycle(G, heuristic=True)
         G.add_edge(2, 0, weight=1.999)
         assert nx.negative_edge_cycle(G, heuristic=True)
-        G.add_edge(2, 0, weight=2)
+        G.edges[2, 0]["weight"] = 2
         assert not nx.negative_edge_cycle(G, heuristic=True)
 
     def test_negative_cycle_consistency(self):

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -390,7 +390,7 @@ class TestWeightedPath(WeightedTestBase):
         p = dict(nx.all_pairs_dijkstra_path(cycle))
         assert p[0][3] == [0, 1, 2, 3]
 
-        cycle[1][2]["weight"] = 10
+        cycle.add_edge(1, 2, weight=10)
         p = dict(nx.all_pairs_dijkstra_path(cycle))
         assert p[0][3] == [0, 6, 5, 4, 3]
 
@@ -399,7 +399,7 @@ class TestWeightedPath(WeightedTestBase):
         pl = dict(nx.all_pairs_dijkstra_path_length(cycle))
         assert pl[0] == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
 
-        cycle[1][2]["weight"] = 10
+        cycle.add_edge(1, 2, weight=10)
         pl = dict(nx.all_pairs_dijkstra_path_length(cycle))
         assert pl[0] == {0: 0, 1: 1, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
 
@@ -409,7 +409,7 @@ class TestWeightedPath(WeightedTestBase):
         assert out[0][0] == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
         assert out[0][1][3] == [0, 1, 2, 3]
 
-        cycle[1][2]["weight"] = 10
+        cycle.add_edge(1, 2, weight=10)
         out = dict(nx.all_pairs_dijkstra(cycle))
         assert out[0][0] == {0: 0, 1: 1, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
         assert out[0][1][3] == [0, 6, 5, 4, 3]
@@ -539,7 +539,7 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         assert not nx.negative_edge_cycle(G, heuristic=True)
         G.add_edge(2, 0, weight=1.999)
         assert nx.negative_edge_cycle(G, heuristic=True)
-        G.edges[2, 0]["weight"] = 2
+        G.add_edge(2, 0, weight=2)
         assert not nx.negative_edge_cycle(G, heuristic=True)
 
     def test_negative_cycle_consistency(self):

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -823,6 +823,8 @@ def maximum_branching(
 
     G_original = G
     G = nx.MultiDiGraph()
+    G.__networkx_cache__ = None  # Disable caching
+
     # A dict to reliably track mutations to the edges using the key of the edge.
     G_edge_index = {}
     # Each edge is given an arbitrary numerical key
@@ -1080,7 +1082,6 @@ def maximum_branching(
 
             edmonds_add_edge(B, B_edge_index, u, v, desired_edge[2], **dd)
             G[u][v][desired_edge[2]][candidate_attr] = True
-            nx._clear_cache(G)
             uf.union(u, v)
 
             ###################

--- a/networkx/algorithms/tree/branchings.py
+++ b/networkx/algorithms/tree/branchings.py
@@ -1080,8 +1080,7 @@ def maximum_branching(
 
             edmonds_add_edge(B, B_edge_index, u, v, desired_edge[2], **dd)
             G[u][v][desired_edge[2]][candidate_attr] = True
-            if cache := getattr(G, "__networkx_cache__", None):
-                cache.clear()
+            nx._clear_cache(G)
             uf.union(u, v)
 
             ###################
@@ -1177,20 +1176,17 @@ def minimum_branching(
 ):
     for _, _, d in G.edges(data=True):
         d[attr] = -d.get(attr, default)
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
     B = maximum_branching(G, attr, default, preserve_attrs, partition)
 
     for _, _, d in G.edges(data=True):
         d[attr] = -d.get(attr, default)
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
     for _, _, d in B.edges(data=True):
         d[attr] = -d.get(attr, default)
-    if cache := getattr(B, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(B)
 
     return B
 
@@ -1243,21 +1239,18 @@ def minimal_branching(
         # in order to prevent the edge weights from becoming negative during
         # computation
         d[attr] = max_weight + 1 + (max_weight - min_weight) - d.get(attr, default)
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
     B = maximum_branching(G, attr, default, preserve_attrs, partition)
 
     # Reverse the weight transformations
     for _, _, d in G.edges(data=True):
         d[attr] = max_weight + 1 + (max_weight - min_weight) - d.get(attr, default)
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
     for _, _, d in B.edges(data=True):
         d[attr] = max_weight + 1 + (max_weight - min_weight) - d.get(attr, default)
-    if cache := getattr(B, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(B)
 
     return B
 
@@ -1286,20 +1279,17 @@ def maximum_spanning_arborescence(
 
     for _, _, d in G.edges(data=True):
         d[attr] = d.get(attr, default) - min_weight + 1 - (min_weight - max_weight)
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
     B = maximum_branching(G, attr, default, preserve_attrs, partition)
 
     for _, _, d in G.edges(data=True):
         d[attr] = d.get(attr, default) + min_weight - 1 + (min_weight - max_weight)
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
     for _, _, d in B.edges(data=True):
         d[attr] = d.get(attr, default) + min_weight - 1 + (min_weight - max_weight)
-    if cache := getattr(B, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(B)
 
     if not is_arborescence(B):
         raise nx.exception.NetworkXException("No maximum spanning arborescence in G.")
@@ -1579,8 +1569,7 @@ class ArborescenceIterator:
                 d[self.partition_key] = partition.partition_dict[(u, v)]
             else:
                 d[self.partition_key] = nx.EdgePartition.OPEN
-        if cache := getattr(self.G, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self.G)
 
         for n in self.G:
             included_count = 0
@@ -1596,8 +1585,6 @@ class ArborescenceIterator:
                 for u, v, d in self.G.in_edges(nbunch=n, data=True):
                     if d.get(self.partition_key) != nx.EdgePartition.INCLUDED:
                         d[self.partition_key] = nx.EdgePartition.EXCLUDED
-        if cache := getattr(self.G, "__networkx_cache__", None):
-            cache.clear()  # CHECK (probably keep for sanity)
 
     def _clear_partition(self, G):
         """
@@ -1606,3 +1593,4 @@ class ArborescenceIterator:
         for u, v, d in G.edges(data=True):
             if self.partition_key in d:
                 del d[self.partition_key]
+        nx._clear_cache(self.G)

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -1027,6 +1027,7 @@ class SpanningTreeIterator:
             If `ignore_nan is True` then that edge is ignored instead.
         """
         self.G = G.copy()
+        self.G.__networkx_cache__ = None  # Disable caching
         self.weight = weight
         self.minimum = minimum
         self.ignore_nan = ignore_nan

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -355,6 +355,7 @@ class DiGraph(Graph):
         self._pred = self.adjlist_outer_dict_factory()  # predecessor
         # Note: self._succ = self._adj  # successor
 
+        self.__networkx_cache__ = {}
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
@@ -465,6 +466,7 @@ class DiGraph(Graph):
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
+        self.__networkx_cache__.clear()
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -543,6 +545,7 @@ class DiGraph(Graph):
                 self._pred[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
+        self.__networkx_cache__.clear()
 
     def remove_node(self, n):
         """Remove node n.
@@ -585,6 +588,7 @@ class DiGraph(Graph):
         for u in self._pred[n]:
             del self._succ[u][n]  # remove all edges n-u in digraph
         del self._pred[n]  # remove node from pred
+        self.__networkx_cache__.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -639,6 +643,7 @@ class DiGraph(Graph):
                 del self._pred[n]  # now remove node
             except KeyError:
                 pass  # silent failure on remove
+        self.__networkx_cache__.clear()
 
     def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
@@ -709,6 +714,7 @@ class DiGraph(Graph):
         datadict.update(attr)
         self._succ[u][v] = datadict
         self._pred[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -791,6 +797,7 @@ class DiGraph(Graph):
             datadict.update(dd)
             self._succ[u][v] = datadict
             self._pred[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -824,6 +831,7 @@ class DiGraph(Graph):
             del self._pred[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} not in graph.") from err
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -856,6 +864,7 @@ class DiGraph(Graph):
             if u in self._succ and v in self._succ[u]:
                 del self._succ[u][v]
                 del self._pred[v][u]
+        self.__networkx_cache__.clear()
 
     def has_successor(self, u, v):
         """Returns True if node u has successor v.
@@ -1195,6 +1204,7 @@ class DiGraph(Graph):
         self._pred.clear()
         self._node.clear()
         self.graph.clear()
+        self.__networkx_cache__.clear()
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1213,6 +1223,7 @@ class DiGraph(Graph):
             predecessor_dict.clear()
         for successor_dict in self._succ.values():
             successor_dict.clear()
+        self.__networkx_cache__.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -466,7 +466,8 @@ class DiGraph(Graph):
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -545,7 +546,8 @@ class DiGraph(Graph):
                 self._pred[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_node(self, n):
         """Remove node n.
@@ -588,7 +590,8 @@ class DiGraph(Graph):
         for u in self._pred[n]:
             del self._succ[u][n]  # remove all edges n-u in digraph
         del self._pred[n]  # remove node from pred
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -643,7 +646,8 @@ class DiGraph(Graph):
                 del self._pred[n]  # now remove node
             except KeyError:
                 pass  # silent failure on remove
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
@@ -714,7 +718,8 @@ class DiGraph(Graph):
         datadict.update(attr)
         self._succ[u][v] = datadict
         self._pred[v][u] = datadict
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -797,7 +802,8 @@ class DiGraph(Graph):
             datadict.update(dd)
             self._succ[u][v] = datadict
             self._pred[v][u] = datadict
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -831,7 +837,8 @@ class DiGraph(Graph):
             del self._pred[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} not in graph.") from err
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -864,7 +871,8 @@ class DiGraph(Graph):
             if u in self._succ and v in self._succ[u]:
                 del self._succ[u][v]
                 del self._pred[v][u]
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def has_successor(self, u, v):
         """Returns True if node u has successor v.
@@ -1204,7 +1212,8 @@ class DiGraph(Graph):
         self._pred.clear()
         self._node.clear()
         self.graph.clear()
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1223,7 +1232,8 @@ class DiGraph(Graph):
             predecessor_dict.clear()
         for successor_dict in self._succ.values():
             successor_dict.clear()
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -466,8 +466,7 @@ class DiGraph(Graph):
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -546,8 +545,7 @@ class DiGraph(Graph):
                 self._pred[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_node(self, n):
         """Remove node n.
@@ -590,8 +588,7 @@ class DiGraph(Graph):
         for u in self._pred[n]:
             del self._succ[u][n]  # remove all edges n-u in digraph
         del self._pred[n]  # remove node from pred
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -646,8 +643,7 @@ class DiGraph(Graph):
                 del self._pred[n]  # now remove node
             except KeyError:
                 pass  # silent failure on remove
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def add_edge(self, u_of_edge, v_of_edge, **attr):
         """Add an edge between u and v.
@@ -718,8 +714,7 @@ class DiGraph(Graph):
         datadict.update(attr)
         self._succ[u][v] = datadict
         self._pred[v][u] = datadict
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -802,8 +797,7 @@ class DiGraph(Graph):
             datadict.update(dd)
             self._succ[u][v] = datadict
             self._pred[v][u] = datadict
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -837,8 +831,7 @@ class DiGraph(Graph):
             del self._pred[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} not in graph.") from err
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -871,8 +864,7 @@ class DiGraph(Graph):
             if u in self._succ and v in self._succ[u]:
                 del self._succ[u][v]
                 del self._pred[v][u]
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def has_successor(self, u, v):
         """Returns True if node u has successor v.
@@ -1212,8 +1204,7 @@ class DiGraph(Graph):
         self._pred.clear()
         self._node.clear()
         self.graph.clear()
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1232,8 +1223,7 @@ class DiGraph(Graph):
             predecessor_dict.clear()
         for successor_dict in self._succ.values():
             successor_dict.clear()
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -663,8 +663,7 @@ def set_node_attributes(G, values, name=None):
                 G.nodes[n].update(d)
             except KeyError:
                 pass
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
 
 def get_node_attributes(G, name, default=None):
@@ -838,8 +837,7 @@ def set_edge_attributes(G, values, name=None):
                     G._adj[u][v].update(d)
                 except KeyError:
                     pass
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
 
 
 def get_edge_attributes(G, name, default=None):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -663,6 +663,8 @@ def set_node_attributes(G, values, name=None):
                 G.nodes[n].update(d)
             except KeyError:
                 pass
+    if cache := getattr(G, "__networkx_cache__", None):
+        cache.clear()
 
 
 def get_node_attributes(G, name, default=None):
@@ -836,6 +838,8 @@ def set_edge_attributes(G, values, name=None):
                     G._adj[u][v].update(d)
                 except KeyError:
                     pass
+    if cache := getattr(G, "__networkx_cache__", None):
+        cache.clear()
 
 
 def get_edge_attributes(G, name, default=None):

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -404,6 +404,7 @@ class Graph:
     @name.setter
     def name(self, s):
         self.graph["name"] = s
+        self.__networkx_cache__.clear()
 
     def __str__(self):
         """Returns a short summary of the graph.

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -365,6 +365,7 @@ class Graph:
         self.graph = self.graph_attr_dict_factory()  # dictionary for graph attributes
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._adj = self.adjlist_outer_dict_factory()  # empty adjacency dict
+        self.__networkx_cache__ = {}
         # attempt to load graph with data
         if incoming_graph_data is not None:
             convert.to_networkx_graph(incoming_graph_data, create_using=self)
@@ -559,6 +560,7 @@ class Graph:
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
+        self.__networkx_cache__.clear()
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -636,6 +638,7 @@ class Graph:
                 self._adj[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
+        self.__networkx_cache__.clear()
 
     def remove_node(self, n):
         """Remove node n.
@@ -676,6 +679,7 @@ class Graph:
         for u in nbrs:
             del adj[u][n]  # remove all edges n-u in graph
         del adj[n]  # now remove node
+        self.__networkx_cache__.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -728,6 +732,7 @@ class Graph:
                 del adj[n]
             except KeyError:
                 pass
+        self.__networkx_cache__.clear()
 
     @cached_property
     def nodes(self):
@@ -957,6 +962,7 @@ class Graph:
         datadict.update(attr)
         self._adj[u][v] = datadict
         self._adj[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -1037,6 +1043,7 @@ class Graph:
             datadict.update(dd)
             self._adj[u][v] = datadict
             self._adj[v][u] = datadict
+        self.__networkx_cache__.clear()
 
     def add_weighted_edges_from(self, ebunch_to_add, weight="weight", **attr):
         """Add weighted edges in `ebunch_to_add` with specified weight attr
@@ -1087,6 +1094,7 @@ class Graph:
         >>> G.add_weighted_edges_from(list((5, n, weight) for n in G.nodes))
         """
         self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch_to_add), **attr)
+        self.__networkx_cache__.clear()
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -1120,6 +1128,7 @@ class Graph:
                 del self._adj[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} is not in the graph") from err
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1154,6 +1163,7 @@ class Graph:
                 del adj[u][v]
                 if u != v:  # self loop needs only one entry removed
                     del adj[v][u]
+        self.__networkx_cache__.clear()
 
     def update(self, edges=None, nodes=None):
         """Update the graph using nodes/edges/graphs as input.
@@ -1526,6 +1536,7 @@ class Graph:
         self._adj.clear()
         self._node.clear()
         self.graph.clear()
+        self.__networkx_cache__.clear()
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1541,6 +1552,7 @@ class Graph:
         """
         for nbr_dict in self._adj.values():
             nbr_dict.clear()
+        self.__networkx_cache__.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -404,8 +404,7 @@ class Graph:
     @name.setter
     def name(self, s):
         self.graph["name"] = s
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def __str__(self):
         """Returns a short summary of the graph.
@@ -562,8 +561,7 @@ class Graph:
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -641,8 +639,7 @@ class Graph:
                 self._adj[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_node(self, n):
         """Remove node n.
@@ -683,8 +680,7 @@ class Graph:
         for u in nbrs:
             del adj[u][n]  # remove all edges n-u in graph
         del adj[n]  # now remove node
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -737,8 +733,7 @@ class Graph:
                 del adj[n]
             except KeyError:
                 pass
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     @cached_property
     def nodes(self):
@@ -968,8 +963,7 @@ class Graph:
         datadict.update(attr)
         self._adj[u][v] = datadict
         self._adj[v][u] = datadict
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -1050,8 +1044,7 @@ class Graph:
             datadict.update(dd)
             self._adj[u][v] = datadict
             self._adj[v][u] = datadict
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def add_weighted_edges_from(self, ebunch_to_add, weight="weight", **attr):
         """Add weighted edges in `ebunch_to_add` with specified weight attr
@@ -1102,8 +1095,7 @@ class Graph:
         >>> G.add_weighted_edges_from(list((5, n, weight) for n in G.nodes))
         """
         self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch_to_add), **attr)
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -1137,8 +1129,7 @@ class Graph:
                 del self._adj[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} is not in the graph") from err
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1173,8 +1164,7 @@ class Graph:
                 del adj[u][v]
                 if u != v:  # self loop needs only one entry removed
                     del adj[v][u]
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def update(self, edges=None, nodes=None):
         """Update the graph using nodes/edges/graphs as input.
@@ -1547,8 +1537,7 @@ class Graph:
         self._adj.clear()
         self._node.clear()
         self.graph.clear()
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1564,8 +1553,7 @@ class Graph:
         """
         for nbr_dict in self._adj.values():
             nbr_dict.clear()
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -404,7 +404,8 @@ class Graph:
     @name.setter
     def name(self, s):
         self.graph["name"] = s
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def __str__(self):
         """Returns a short summary of the graph.
@@ -561,7 +562,8 @@ class Graph:
             attr_dict.update(attr)
         else:  # update attr even if node already exists
             self._node[node_for_adding].update(attr)
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.
@@ -639,7 +641,8 @@ class Graph:
                 self._adj[n] = self.adjlist_inner_dict_factory()
                 self._node[n] = self.node_attr_dict_factory()
             self._node[n].update(newdict)
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_node(self, n):
         """Remove node n.
@@ -680,7 +683,8 @@ class Graph:
         for u in nbrs:
             del adj[u][n]  # remove all edges n-u in graph
         del adj[n]  # now remove node
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_nodes_from(self, nodes):
         """Remove multiple nodes.
@@ -733,7 +737,8 @@ class Graph:
                 del adj[n]
             except KeyError:
                 pass
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     @cached_property
     def nodes(self):
@@ -963,7 +968,8 @@ class Graph:
         datadict.update(attr)
         self._adj[u][v] = datadict
         self._adj[v][u] = datadict
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def add_edges_from(self, ebunch_to_add, **attr):
         """Add all the edges in ebunch_to_add.
@@ -1044,7 +1050,8 @@ class Graph:
             datadict.update(dd)
             self._adj[u][v] = datadict
             self._adj[v][u] = datadict
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def add_weighted_edges_from(self, ebunch_to_add, weight="weight", **attr):
         """Add weighted edges in `ebunch_to_add` with specified weight attr
@@ -1095,7 +1102,8 @@ class Graph:
         >>> G.add_weighted_edges_from(list((5, n, weight) for n in G.nodes))
         """
         self.add_edges_from(((u, v, {weight: d}) for u, v, d in ebunch_to_add), **attr)
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_edge(self, u, v):
         """Remove the edge between u and v.
@@ -1129,7 +1137,8 @@ class Graph:
                 del self._adj[v][u]
         except KeyError as err:
             raise NetworkXError(f"The edge {u}-{v} is not in the graph") from err
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -1164,7 +1173,8 @@ class Graph:
                 del adj[u][v]
                 if u != v:  # self loop needs only one entry removed
                     del adj[v][u]
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def update(self, edges=None, nodes=None):
         """Update the graph using nodes/edges/graphs as input.
@@ -1537,7 +1547,8 @@ class Graph:
         self._adj.clear()
         self._node.clear()
         self.graph.clear()
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def clear_edges(self):
         """Remove all edges from the graph without altering nodes.
@@ -1553,7 +1564,8 @@ class Graph:
         """
         for nbr_dict in self._adj.values():
             nbr_dict.clear()
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def is_multigraph(self):
         """Returns True if graph is a multigraph, False otherwise."""

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -508,7 +508,8 @@ class MultiDiGraph(MultiGraph, DiGraph):
             keydict[key] = datadict
             self._succ[u][v] = keydict
             self._pred[v][u] = keydict
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
         return key
 
     def remove_edge(self, u, v, key=None):
@@ -584,7 +585,8 @@ class MultiDiGraph(MultiGraph, DiGraph):
             # remove the key entries if last edge
             del self._succ[u][v]
             del self._pred[v][u]
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     @cached_property
     def edges(self):

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -508,6 +508,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             keydict[key] = datadict
             self._succ[u][v] = keydict
             self._pred[v][u] = keydict
+        self.__networkx_cache__.clear()
         return key
 
     def remove_edge(self, u, v, key=None):
@@ -583,6 +584,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             # remove the key entries if last edge
             del self._succ[u][v]
             del self._pred[v][u]
+        self.__networkx_cache__.clear()
 
     @cached_property
     def edges(self):

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -508,8 +508,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             keydict[key] = datadict
             self._succ[u][v] = keydict
             self._pred[v][u] = keydict
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
         return key
 
     def remove_edge(self, u, v, key=None):
@@ -585,8 +584,7 @@ class MultiDiGraph(MultiGraph, DiGraph):
             # remove the key entries if last edge
             del self._succ[u][v]
             del self._pred[v][u]
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     @cached_property
     def edges(self):

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -520,6 +520,7 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self._adj[u][v] = keydict
             self._adj[v][u] = keydict
+        self.__networkx_cache__.clear()
         return key
 
     def add_edges_from(self, ebunch_to_add, **attr):
@@ -616,6 +617,7 @@ class MultiGraph(Graph):
             key = self.add_edge(u, v, key)
             self[u][v][key].update(ddd)
             keylist.append(key)
+        self.__networkx_cache__.clear()
         return keylist
 
     def remove_edge(self, u, v, key=None):
@@ -695,6 +697,7 @@ class MultiGraph(Graph):
             del self._adj[u][v]
             if u != v:  # check for selfloop
                 del self._adj[v][u]
+        self.__networkx_cache__.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -753,6 +756,7 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
+        self.__networkx_cache__.clear()
 
     def has_edge(self, u, v, key=None):
         """Returns True if the graph has an edge between nodes u and v.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -520,8 +520,7 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self._adj[u][v] = keydict
             self._adj[v][u] = keydict
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
         return key
 
     def add_edges_from(self, ebunch_to_add, **attr):
@@ -618,8 +617,7 @@ class MultiGraph(Graph):
             key = self.add_edge(u, v, key)
             self[u][v][key].update(ddd)
             keylist.append(key)
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
         return keylist
 
     def remove_edge(self, u, v, key=None):
@@ -699,8 +697,7 @@ class MultiGraph(Graph):
             del self._adj[u][v]
             if u != v:  # check for selfloop
                 del self._adj[v][u]
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -759,8 +756,7 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
-        if cache := getattr(self, "__networkx_cache__", None):
-            cache.clear()
+        nx._clear_cache(self)
 
     def has_edge(self, u, v, key=None):
         """Returns True if the graph has an edge between nodes u and v.

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -520,7 +520,8 @@ class MultiGraph(Graph):
             keydict[key] = datadict
             self._adj[u][v] = keydict
             self._adj[v][u] = keydict
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
         return key
 
     def add_edges_from(self, ebunch_to_add, **attr):
@@ -617,7 +618,8 @@ class MultiGraph(Graph):
             key = self.add_edge(u, v, key)
             self[u][v][key].update(ddd)
             keylist.append(key)
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
         return keylist
 
     def remove_edge(self, u, v, key=None):
@@ -697,7 +699,8 @@ class MultiGraph(Graph):
             del self._adj[u][v]
             if u != v:  # check for selfloop
                 del self._adj[v][u]
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def remove_edges_from(self, ebunch):
         """Remove all edges specified in ebunch.
@@ -756,7 +759,8 @@ class MultiGraph(Graph):
                 self.remove_edge(*e[:3])
             except NetworkXError:
                 pass
-        self.__networkx_cache__.clear()
+        if cache := getattr(self, "__networkx_cache__", None):
+            cache.clear()
 
     def has_edge(self, u, v, key=None):
         """Returns True if the graph has an edge between nodes u and v.

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -50,5 +50,6 @@ def stochastic_graph(G, copy=True, weight="weight"):
             d[weight] = 0
         else:
             d[weight] = d.get(weight, 1) / degree[u]
-    G.__networkx_cache__.clear()
+    if cache := getattr(G, "__networkx_cache__", None):
+        cache.clear()
     return G

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -50,4 +50,5 @@ def stochastic_graph(G, copy=True, weight="weight"):
             d[weight] = 0
         else:
             d[weight] = d.get(weight, 1) / degree[u]
+    G.__networkx_cache__.clear()
     return G

--- a/networkx/generators/stochastic.py
+++ b/networkx/generators/stochastic.py
@@ -50,6 +50,5 @@ def stochastic_graph(G, copy=True, weight="weight"):
             d[weight] = 0
         else:
             d[weight] = d.get(weight, 1) / degree[u]
-    if cache := getattr(G, "__networkx_cache__", None):
-        cache.clear()
+    nx._clear_cache(G)
     return G

--- a/networkx/utils/__init__.py
+++ b/networkx/utils/__init__.py
@@ -4,3 +4,5 @@ from networkx.utils.random_sequence import *
 from networkx.utils.union_find import *
 from networkx.utils.rcm import *
 from networkx.utils.heaps import *
+from networkx.utils.backends import *
+from networkx.utils.configs import *

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1071,7 +1071,7 @@ class _dispatchable:
         if use_cache and cache is not None:
             cache[key] = rv
             # Remove old cached items that are no longer necessary since
-            # then are dominated/subsumed by what was just calculated.
+            # they are dominated/subsumed by what was just calculated.
             # This uses the same logic as above, but with keys switched.
             for compat_key in list(cache):
                 if compat_key == key:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1024,6 +1024,24 @@ class _dispatchable:
                 preserve_graph_attrs,
             )
             if cache:
+                warning_message = (
+                    f"Using cached graph for {backend_name!r} backend in "
+                    f"call to {self.name}.\n\nFor the cache to be consistent "
+                    "(i.e., correct), the input graph must not have been "
+                    "manually mutated since the cached graph was created. "
+                    "Examples of manually mutating the graph data structures "
+                    "resulting in an inconsistent cache include:\n\n"
+                    "    >>> G[u][v][key] = val\n\n"
+                    "and\n\n"
+                    "    >>> for u, v, d in G.edges(data=True):\n"
+                    "    ...     d[key] = val\n\n"
+                    "Using methods such as `G.add_edge(u, v, weight=val)` "
+                    "will correctly clear the cache to keep it consistent. "
+                    "You may also use `G.__networkx_cache__.clear()` to "
+                    "manually clear the cache, or set `G.__networkx_cache__` "
+                    "to None to disable caching for G. Enable or disable "
+                    "caching via `nx.config.cache_converted_graphs` config."
+                )
                 # Do a simple search for a cached graph with compatible data.
                 # For example, if we need a single attribute, then it's okay
                 # to use a cached graph that preserved all attributes.
@@ -1034,24 +1052,7 @@ class _dispatchable:
                     (graph_key, True) if graph_key is not True else (True,),
                 ):
                     if (rv := cache.get(compat_key)) is not None:
-                        warnings.warn(
-                            f"Using cached graph for {backend_name!r} backend in "
-                            f"call to {self.name}.\n\nFor the cache to be consistent "
-                            "(i.e., correct), the input graph must not have been "
-                            "manually mutated since the cached graph was created. "
-                            "Examples of manually mutating the graph data structures "
-                            "resulting in an inconsistent cache include:\n\n"
-                            "    >>> G[u][v][key] = val\n\n"
-                            "and\n\n"
-                            "    >>> for u, v, d in G.edges(data=True):\n"
-                            "    ...     d[key] = val\n\n"
-                            "Using methods such as `G.add_edge(u, v, weight=val)` "
-                            "will correctly clear the cache to keep it consistent. "
-                            "You may also use `G.__networkx_cache__.clear()` to "
-                            "manually clear the cache, or set `G.__networkx_cache__` "
-                            "to None to disable caching for G. Enable or disable "
-                            "caching via `nx.config.cache_converted_graphs` config."
-                        )
+                        warnings.warn(warning_message)
                         return rv
                 if edge_key is not True and node_key is not True:
                     # Iterate over the items in `cache` to see if any are compatible.
@@ -1078,24 +1079,7 @@ class _dispatchable:
                             continue
                         if graph_key and not gkey:
                             continue
-                        warnings.warn(
-                            f"Using cached graph for {backend_name!r} backend in "
-                            f"call to {self.name}.\n\nFor the cache to be consistent "
-                            "(i.e., correct), the input graph must not have been "
-                            "manually mutated since the cached graph was created. "
-                            "Examples of manually mutating the graph data structures "
-                            "resulting in an inconsistent cache include:\n\n"
-                            "    >>> G[u][v][key] = val\n\n"
-                            "and\n\n"
-                            "    >>> for u, v, d in G.edges(data=True):\n"
-                            "    ...     d[key] = val\n\n"
-                            "Using methods such as `G.add_edge(u, v, weight=val)` "
-                            "will correctly clear the cache to keep it consistent. "
-                            "You may also use `G.__networkx_cache__.clear()` to "
-                            "manually clear the cache, or set `G.__networkx_cache__` "
-                            "to None to disable caching for G. Enable or disable "
-                            "caching via `nx.config.cache_converted_graphs` config."
-                        )
+                        warnings.warn(warning_message)
                         return val
 
         backend = _load_backend(backend_name)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1034,8 +1034,9 @@ class _dispatchable:
                         return rv
                 if edge_key is not True and node_key is not True:
                     # Iterate over the items in `cache` to see if any are compatible.
-                    # For example, if no edge attributes are needed, then a graph with
-                    # any edge attribute will suffice.
+                    # For example, if no edge attributes are needed, then a graph
+                    # with any edge attribute will suffice. We use the same logic
+                    # below (but switched) to clear unnecessary items from the cache.
                     for (ekey, nkey, gkey), val in cache.items():
                         if edge_key is False or ekey is True:
                             pass
@@ -1069,14 +1070,10 @@ class _dispatchable:
             graph_name=graph_name,
         )
         if use_cache and cache is not None:
-            cache[key] = rv
-            # Remove old cached items that are no longer necessary since
-            # they are dominated/subsumed by what was just calculated.
+            # Remove old cached items that are no longer necessary since they
+            # are dominated/subsumed/outdated by what was just calculated.
             # This uses the same logic as above, but with keys switched.
-            for compat_key in list(cache):
-                if compat_key == key:
-                    continue
-                ekey, nkey, gkey = compat_key
+            for ekey, nkey, gkey in list(cache):
                 if ekey is False or edge_key is True:
                     pass
                 elif ekey is True or edge_key is False or not ekey.issubset(edge_key):
@@ -1087,7 +1084,8 @@ class _dispatchable:
                     continue
                 if gkey and not graph_key:
                     continue
-                del cache[compat_key]
+                del cache[ekey, nkey, gkey]
+            cache[key] = rv
 
         return rv
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1031,6 +1031,20 @@ class _dispatchable:
                     (graph_key, True) if graph_key is not True else (True,),
                 ):
                     if (rv := cache.get(compat_key)) is not None:
+                        warnings.warn(
+                            f"Using cached graph for {backend_name!r} backend in "
+                            f"call to {self.name}.\n\nFor the cache to be consistent "
+                            "(i.e., correct), the input graph must not have been "
+                            "manually mutated since the cached graph was created. "
+                            "Examples of manually mutating the graph data structures "
+                            "resulting in an inconsistent cache include:\n\n"
+                            "    >>> G[u][v][key] = val\n\n"
+                            "and\n\n"
+                            "    >>> for u, v, d in G.edges(data=True):\n"
+                            "    ...     d[key] = val\n\n"
+                            "Using methods such as `G.add_edge(u, v, weight=val)` "
+                            "will correctly clear the cache to keep it consistent."
+                        )
                         return rv
                 if edge_key is not True and node_key is not True:
                     # Iterate over the items in `cache` to see if any are compatible.
@@ -1056,6 +1070,20 @@ class _dispatchable:
                             continue
                         if graph_key and not gkey:
                             continue
+                        warnings.warn(
+                            f"Using cached graph for {backend_name!r} backend in "
+                            f"call to {self.name}.\n\nFor the cache to be consistent "
+                            "(i.e., correct), the input graph must not have been "
+                            "manually mutated since the cached graph was created. "
+                            "Examples of manually mutating the graph data structures "
+                            "resulting in an inconsistent cache include:\n\n"
+                            "    >>> G[u][v][key] = val\n\n"
+                            "and\n\n"
+                            "    >>> for u, v, d in G.edges(data=True):\n"
+                            "    ...     d[key] = val\n\n"
+                            "Using methods such as `G.add_edge(u, v, weight=val)` "
+                            "will correctly clear the cache to keep it consistent."
+                        )
                         return val
 
         backend = _load_backend(backend_name)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -170,7 +170,7 @@ import networkx as nx
 
 from .decorators import argmap
 
-__all__ = ["_dispatchable", "config"]
+__all__ = ["_dispatchable"]
 
 
 def _do_nothing():
@@ -1338,7 +1338,7 @@ class _dispatchable:
                 G1 = backend.convert_to_nx(bound.arguments["G"])
                 G2 = bound2.arguments["G"]
                 G2._adj = G1._adj
-                G2.__networkx_cache__.clear()
+                nx._clear_cache(G2)
             elif self.name == "edmonds_karp":
                 R1 = backend.convert_to_nx(bound.arguments["residual"])
                 R2 = bound2.arguments["residual"]
@@ -1346,15 +1346,14 @@ class _dispatchable:
                     for k, v in R1.edges.items():
                         R2.edges[k]["flow"] = v["flow"]
                     R2.graph.update(R1.graph)
-                    if cache := getattr(R2, "__networkx_cache__", None):
-                        cache.clear()
+                    nx._clear_cache(R2)
             elif self.name == "barycenter" and bound.arguments["attr"] is not None:
                 G1 = backend.convert_to_nx(bound.arguments["G"])
                 G2 = bound2.arguments["G"]
                 attr = bound.arguments["attr"]
                 for k, v in G1.nodes.items():
                     G2.nodes[k][attr] = v[attr]
-                G2.__networkx_cache__.clear()
+                nx._clear_cache(G2)
             elif (
                 self.name in {"contracted_nodes", "contracted_edge"}
                 and not bound.arguments["copy"]
@@ -1363,13 +1362,13 @@ class _dispatchable:
                 G1 = backend.convert_to_nx(bound.arguments["G"])
                 G2 = bound2.arguments["G"]
                 G2.__dict__.update(G1.__dict__)
-                G2.__networkx_cache__.clear()
+                nx._clear_cache(G2)
             elif self.name == "stochastic_graph" and not bound.arguments["copy"]:
                 G1 = backend.convert_to_nx(bound.arguments["G"])
                 G2 = bound2.arguments["G"]
                 for k, v in G1.edges.items():
                     G2.edges[k]["weight"] = v["weight"]
-                G2.__networkx_cache__.clear()
+                nx._clear_cache(G2)
             elif (
                 self.name == "relabel_nodes"
                 and not bound.arguments["copy"]
@@ -1389,7 +1388,7 @@ class _dispatchable:
                 if hasattr(G1, "_succ") and hasattr(G2, "_succ"):
                     G2._succ.clear()
                     G2._succ.update(G1._succ)
-                G2.__networkx_cache__.clear()
+                nx._clear_cache(G2)
                 if self.name == "relabel_nodes":
                     return G2
             return backend.convert_to_nx(result)

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -154,6 +154,9 @@ Notes
     It will be called with the list of NetworkX tests discovered. Each item
     is a test object that can be marked as xfail if the backend does not support
     the test using ``item.add_marker(pytest.mark.xfail(reason=...))``.
+
+-   A backend graph instance may have a ``G.__networkx_cache__`` dict to enable
+    caching, and care should be taken to clear the cache when appropriate.
 """
 
 import inspect
@@ -1046,7 +1049,8 @@ class _dispatchable:
                             "will correctly clear the cache to keep it consistent. "
                             "You may also use `G.__networkx_cache__.clear()` to "
                             "manually clear the cache, or set `G.__networkx_cache__` "
-                            "to None to disable caching for G."
+                            "to None to disable caching for G. Enable or disable "
+                            "caching via `nx.config.cache_converted_graphs` config."
                         )
                         return rv
                 if edge_key is not True and node_key is not True:
@@ -1089,7 +1093,8 @@ class _dispatchable:
                             "will correctly clear the cache to keep it consistent. "
                             "You may also use `G.__networkx_cache__.clear()` to "
                             "manually clear the cache, or set `G.__networkx_cache__` "
-                            "to None to disable caching for G."
+                            "to None to disable caching for G. Enable or disable "
+                            "caching via `nx.config.cache_converted_graphs` config."
                         )
                         return val
 
@@ -1140,7 +1145,7 @@ class _dispatchable:
 
         try:
             converted_args, converted_kwargs = self._convert_arguments(
-                backend_name, args, kwargs, use_cache=True
+                backend_name, args, kwargs, use_cache=config.cache_converted_graphs
             )
             result = getattr(backend, self.name)(*converted_args, **converted_kwargs)
         except (NotImplementedError, nx.NetworkXNotImplemented) as exc:

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -1,4 +1,5 @@
 import collections
+import os
 import typing
 from dataclasses import dataclass
 
@@ -187,14 +188,34 @@ class NetworkXConfig(Config):
     backend_priority : list of backend names
         Enable automatic conversion of graphs to backend graphs for algorithms
         implemented by the backend. Priority is given to backends listed earlier.
+        Default is empty list.
 
     backends : Config mapping of backend names to backend Config
         The keys of the Config mapping are names of all installed NetworkX backends,
         and the values are their configurations as Config mappings.
+
+    cache_converted_graphs : bool
+        If True, then save converted graphs to the cache of the input graph. Graph
+        conversion may occur when automatically using a backend from `backend_priority`
+        or when using the `backend=` keyword argument to a function call. Caching can
+        improve performance by avoiding repeated conversions, but it uses more memory.
+        Care should be taken to not manually mutate a graph that has cached graphs; for
+        example, ``G[u][v][k] = val`` changes the graph, but does not clear the cache.
+        Using methods such as ``G.add_edge(u, v, weight=val)`` will clear the cache to
+        keep it consistent. ``G.__networkx_cache__.clear()`` manually clears the cache.
+        Default is False.
+
+    Notes
+    -----
+    Environment variables may be used to control some default configurations:
+
+    - NETWORKX_BACKEND_PRIORITY: set `backend_priority` from comma-separated names.
+    - NETWORKX_CACHE_CONVERTED_GRAPHS: set `cache_converted_graphs` to True if nonempty.
     """
 
     backend_priority: list[str]
     backends: Config
+    cache_converted_graphs: bool
 
     def _check_config(self, key, value):
         from .backends import backends
@@ -219,10 +240,14 @@ class NetworkXConfig(Config):
             if missing := {x for x in value if x not in backends}:
                 missing = ", ".join(map(repr, sorted(missing)))
                 raise ValueError(f"Unknown backend when setting {key!r}: {missing}")
+        elif key == "cache_converted_graphs":
+            if not isinstance(value, bool):
+                raise TypeError(f"{key!r} config must be True or False; got {value!r}")
 
 
 # Backend configuration will be updated in backends.py
 config = NetworkXConfig(
     backend_priority=[],
     backends=Config(),
+    cache_converted_graphs=bool(os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", "")),
 )

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -211,6 +211,8 @@ class NetworkXConfig(Config):
 
     - NETWORKX_BACKEND_PRIORITY: set `backend_priority` from comma-separated names.
     - NETWORKX_CACHE_CONVERTED_GRAPHS: set `cache_converted_graphs` to True if nonempty.
+
+    This is a global configuration. Use with caution when using from multiple threads.
     """
 
     backend_priority: list[str]

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -35,6 +35,7 @@ __all__ = [
     "nodes_equal",
     "edges_equal",
     "graphs_equal",
+    "_clear_cache",
 ]
 
 
@@ -589,3 +590,12 @@ def graphs_equal(graph1, graph2):
         and graph1.nodes == graph2.nodes
         and graph1.graph == graph2.graph
     )
+
+
+def _clear_cache(G):
+    """Clear the cache of a graph (currently stores converted graphs).
+
+    Caching is controlled via ``nx.config.cache_converted_graphs`` configuration.
+    """
+    if cache := getattr(G, "__networkx_cache__", None):
+        cache.clear()

--- a/networkx/utils/tests/test_config.py
+++ b/networkx/utils/tests/test_config.py
@@ -128,6 +128,8 @@ def test_nxconfig():
         nx.config.backends = Config(plausible_backend_name={})
     with pytest.raises(ValueError, match="Unknown backend when setting"):
         nx.config.backends = Config(this_almost_certainly_is_not_a_backend=Config())
+    with pytest.raises(TypeError, match="must be True or False"):
+        nx.config.cache_converted_graphs = "bad value"
 
 
 def test_not_strict():


### PR DESCRIPTION
This builds off of #7344.

Caching backend graph conversions can provide a huge performance (and usability) benefit to users. It comes at the cost of increased memory, so it would be nice to be able to control caching via config (#7225).

CC @rlratzel