### PR TITLE
`effective_size` of nodes with only self-loop edges is undefined

### DIFF
--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -104,6 +104,14 @@ def effective_size(G, nodes=None, weight=None):
 
     Notes
     -----
+    Isolated nodes, including nodes which only have self-loop edges, do not
+    have a well-defined effective size::
+
+        >>> G = nx.path_graph(3)
+        >>> G.add_edge(4, 4)
+        >>> nx.effective_size(G)
+        {0: 1.0, 1: 2.0, 2: 1.0, 4: nan}
+
     Burt also defined the related concept of *efficiency* of a node's ego
     network, which is its effective size divided by the degree of that
     node [1]_. So you can easily compute efficiency:

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -144,16 +144,18 @@ def effective_size(G, nodes=None, weight=None):
     # Use Borgatti's simplified formula for unweighted and undirected graphs
     if not G.is_directed() and weight is None:
         for v in nodes:
-            # Effective size is not defined for isolated nodes
-            if len(G[v]) == 0:
+            # Effective size is not defined for isolated nodes, including nodes
+            # with only self-edges
+            if (len(G[v]) == 0) or (set(G[v]) == {v}):
                 effective_size[v] = float("nan")
                 continue
             E = nx.ego_graph(G, v, center=False, undirected=True)
             effective_size[v] = len(E) - (2 * E.size()) / len(E)
     else:
         for v in nodes:
-            # Effective size is not defined for isolated nodes
-            if len(G[v]) == 0:
+            # Effective size is not defined for isolated nodes, including nodes
+            # with only self-edges
+            if (len(G[v]) == 0) or (set(G[v]) == {v}):
                 effective_size[v] = float("nan")
                 continue
             effective_size[v] = sum(

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -154,7 +154,7 @@ def effective_size(G, nodes=None, weight=None):
         for v in nodes:
             # Effective size is not defined for isolated nodes, including nodes
             # with only self-edges
-            if (len(G[v]) == 0) or (set(G[v]) == {v}):
+            if all(u == v for u in G[v]):
                 effective_size[v] = float("nan")
                 continue
             E = nx.ego_graph(G, v, center=False, undirected=True)
@@ -163,7 +163,7 @@ def effective_size(G, nodes=None, weight=None):
         for v in nodes:
             # Effective size is not defined for isolated nodes, including nodes
             # with only self-edges
-            if (len(G[v]) == 0) or (set(G[v]) == {v}):
+            if all(u == v for u in G[v]):
                 effective_size[v] = float("nan")
                 continue
             effective_size[v] = sum(

--- a/networkx/algorithms/tests/test_structuralholes.py
+++ b/networkx/algorithms/tests/test_structuralholes.py
@@ -135,3 +135,18 @@ class TestStructuralHoles:
         G.add_node(1)
         effective_size = nx.effective_size(G)
         assert math.isnan(effective_size[1])
+
+
+@pytest.mark.parametrize("graph", (nx.Graph, nx.DiGraph))
+def test_effective_size_isolated_node_with_selfloop(graph):
+    """Behavior consistent with isolated node without self-loop. See gh-6916"""
+    G = graph([(0, 0)])  # Single node with one self-edge
+    assert math.isnan(nx.effective_size(G)[0])
+
+
+@pytest.mark.parametrize("graph", (nx.Graph, nx.DiGraph))
+def test_effective_size_isolated_node_with_selfloop_weighted(graph):
+    """Weighted self-loop. See gh-6916"""
+    G = graph()
+    G.add_weighted_edges_from([(0, 0, 10)])
+    assert math.isnan(nx.effective_size(G)[0])


### PR DESCRIPTION
Handles the corner-case of isolated nodes that contain self-edges. Currently, isolated nodes are treated as having undefined `effective_size`:

```python
>>> G = nx.Graph()
>>> G.add_node(0)
>>> nx.effective_size(G)
{0: nan}
```

However, the current behavior for isolated nodes with self-loops is inconsistent, resulting in `ZeroDivisionError` for the undirected case and `0.0` for directed graphs::

```python
>>> G = nx.Graph([(0, 0)])
>>> nx.effective_size(G)
Traceback (most recent call last)
   ...
ZeroDivisionError: division by zero
>>> G = nx.DiGraph([(0, 0)])
>>> nx.effective_size(G)
{0: 0.0}
```

This discrepancy is due to the ambiguity of the direction of a self-edge.

Based on the current behavior and Borgatti's formula, I think the thing that makes the most sense is to have `effective_size` be undefined for *all* of these cases, making the behavior consistent across the board.

Closes #6916 