### PR TITLE
Improve test coverage for Steiner Tree & Docs

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -178,7 +178,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
     Raises
     ------
     NetworkXNotImplemented
-        If G is directed.
+        If `G` is directed.
 
     ValueError
         If the specified method is not supported.

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -164,7 +164,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
         Use the edge attribute specified by this string as the edge weight.
         Any edge attribute not present defaults to 1.
 
-    method : string, optional (default = 'kou')
+    method : string, optional (default = 'mehlhorn')
         The algorithm to use to approximate the Steiner tree.
         Supported options: 'kou', 'mehlhorn'.
         Other inputs produce a ValueError.
@@ -174,6 +174,14 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
     NetworkX graph
         Approximation to the minimum steiner tree of `G` induced by
         `terminal_nodes` .
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If G is directed.
+
+    ValueError
+        If the specified method is not supported.
 
     Notes
     -----

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -126,7 +126,7 @@ ALGORITHMS = {
 
 
 @not_implemented_for("directed")
-@nx._dispatchable(edge_attrs="weight", returns_graph=True)
+@nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
 def steiner_tree(G, terminal_nodes, weight="weight", method=None):
     r"""Return an approximation to the minimum Steiner tree of a graph.
 

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -181,7 +181,7 @@ def steiner_tree(G, terminal_nodes, weight="weight", method=None):
         If `G` is directed.
 
     ValueError
-        If the specified method is not supported.
+        If the specified `method` is not supported.
 
     Notes
     -----

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -214,7 +214,7 @@ def test_steiner_tree_multigraph_weight_attribute(method):
 def test_steiner_tree_methods(method):
     G = nx.star_graph(4)
     expected = nx.Graph([(0, 1), (0, 3)])
-    st = nx.approximation.steinter_tree(G, [1, 3], method=method)
+    st = nx.approximation.steiner_tree(G, [1, 3], method=method)
     assert nx.utils.edges_equal(H.edges, expected.edges)
 
 

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -215,7 +215,7 @@ def test_steiner_tree_methods(method):
     G = nx.star_graph(4)
     expected = nx.Graph([(0, 1), (0, 3)])
     st = nx.approximation.steiner_tree(G, [1, 3], method=method)
-    assert nx.utils.edges_equal(H.edges, expected.edges)
+    assert nx.utils.edges_equal(st.edges, expected.edges)
 
 
 def test_steiner_tree_method_invalid():

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -208,3 +208,18 @@ def test_steiner_tree_multigraph_weight_attribute(method):
     H = nx.approximation.steiner_tree(G, list(G), method=method, weight="distance")
     assert len(H.edges) == 2 and H.has_edge(2, 0, key=1)
     assert sum(dist for *_, dist in H.edges(data="distance")) == 15
+
+
+def test_steiner_tree_method_None():
+    G = nx.star_graph(4)
+    a = nx.approximation.steiner_tree(G, [1, 3], method=None)
+    b = nx.approximation.steiner_tree(G, [1, 3], method="mehlhorn")
+    assert list(a) == list(b)
+
+
+def test_steiner_tree_method_invalid():
+    G = nx.star_graph(4)
+    with pytest.raises(
+        ValueError, match="invalid_method is not a valid choice for an algorithm."
+    ):
+        nx.approximation.steiner_tree(G, terminal_nodes=[1, 3], method="invalid_method")

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -210,11 +210,12 @@ def test_steiner_tree_multigraph_weight_attribute(method):
     assert sum(dist for *_, dist in H.edges(data="distance")) == 15
 
 
-def test_steiner_tree_method_None():
+@pytest.mark.parametrize("method", (None, "mehlhorn", "kou"))
+def test_steiner_tree_methods(method):
     G = nx.star_graph(4)
-    a = nx.approximation.steiner_tree(G, [1, 3], method=None)
-    b = nx.approximation.steiner_tree(G, [1, 3], method="mehlhorn")
-    assert list(a) == list(b)
+    expected = nx.Graph([(0, 1), (0, 3)])
+    st = nx.approximation.steinter_tree(G, [1, 3], method=method)
+    assert nx.utils.edges_equal(H.edges, expected.edges)
 
 
 def test_steiner_tree_method_invalid():


### PR DESCRIPTION
I have increased test coverage for  Steinertree.py according to here :-
https://app.codecov.io/gh/networkx/networkx/blob/main/networkx%2Falgorithms%2Fapproximation%2Fsteinertree.py
It is now at 100% as seen below:- 
![after](https://github.com/networkx/networkx/assets/74042272/4fe202ae-80b2-4829-9826-d3cb346e8039)
I have also added Raises to docstrings and changed the default from kou to mehlhorn according to recent changes.