### PR TITLE
Add single node with self loop check to local and global reaching centrality

### DIFF
--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -91,7 +91,9 @@ def global_reaching_centrality(G, weight=None, normalized=True):
         raise nx.NetworkXError("Size of G must be positive")
     # self loops
     if total_weight > 0 and len(G) == 1:
-        raise nx.NetworkXPointlessConcept("G is a single node with self loop")
+        raise nx.NetworkXError(
+            "global_reaching_centrality of a single node with self-loop not well-defined"
+        )
     # If provided, weights must be interpreted as connection strength
     # (so higher weights are more likely to be chosen). However, the
     # shortest path algorithms in NetworkX assume the provided "weight"
@@ -188,7 +190,9 @@ def local_reaching_centrality(G, v, paths=None, weight=None, normalized=True):
             raise nx.NetworkXError("Size of G must be positive")
         # self loops
         if total_weight > 0 and len(G) == 1:
-            raise nx.NetworkXPointlessConcept("G is a single node with self loop")
+            raise nx.NetworkXError(
+                "local_reaching_centrality of a single node with self-loop not well-defined"
+            )
         if weight is not None:
             # Interpret weights as lengths.
             def as_distance(u, v, d):

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -89,7 +89,9 @@ def global_reaching_centrality(G, weight=None, normalized=True):
     total_weight = G.size(weight=weight)
     if total_weight <= 0:
         raise nx.NetworkXError("Size of G must be positive")
-
+    # self loops
+    if total_weight > 0 and len(G) == 1:
+        raise nx.NetworkXPointlessConcept("G is a single node with self loop")
     # If provided, weights must be interpreted as connection strength
     # (so higher weights are more likely to be chosen). However, the
     # shortest path algorithms in NetworkX assume the provided "weight"
@@ -184,6 +186,9 @@ def local_reaching_centrality(G, v, paths=None, weight=None, normalized=True):
         total_weight = G.size(weight=weight)
         if total_weight <= 0:
             raise nx.NetworkXError("Size of G must be positive")
+        # self loops
+        if total_weight > 0 and len(G) == 1:
+            raise nx.NetworkXPointlessConcept("G is a single node with self loop")
         if weight is not None:
             # Interpret weights as lengths.
             def as_distance(u, v, d):

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -89,11 +89,6 @@ def global_reaching_centrality(G, weight=None, normalized=True):
     total_weight = G.size(weight=weight)
     if total_weight <= 0:
         raise nx.NetworkXError("Size of G must be positive")
-    # self loops
-    if total_weight > 0 and len(G) == 1:
-        raise nx.NetworkXError(
-            "global_reaching_centrality of a single node with self-loop not well-defined"
-        )
     # If provided, weights must be interpreted as connection strength
     # (so higher weights are more likely to be chosen). However, the
     # shortest path algorithms in NetworkX assume the provided "weight"
@@ -182,17 +177,16 @@ def local_reaching_centrality(G, v, paths=None, weight=None, normalized=True):
            *PLoS ONE* 7.3 (2012): e33799.
            https://doi.org/10.1371/journal.pone.0033799
     """
+    # Corner case: graph with single node containing a self-loop
+    if (total_weight := G.size(weight=weight)) > 0 and len(G) == 1:
+        raise nx.NetworkXError(
+            "local_reaching_centrality of a single node with self-loop not well-defined"
+        )
     if paths is None:
         if nx.is_negatively_weighted(G, weight=weight):
             raise nx.NetworkXError("edge weights must be positive")
-        total_weight = G.size(weight=weight)
         if total_weight <= 0:
             raise nx.NetworkXError("Size of G must be positive")
-        # self loops
-        if total_weight > 0 and len(G) == 1:
-            raise nx.NetworkXError(
-                "local_reaching_centrality of a single node with self-loop not well-defined"
-            )
         if weight is not None:
             # Interpret weights as lengths.
             def as_distance(u, v, d):

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -79,6 +79,18 @@ class TestGlobalReachingCentrality:
         actual = grc(G, normalized=False, weight="weight")
         assert expected == pytest.approx(actual, abs=1e-7)
 
+    def test_single_node_with_cycle(self):
+        with pytest.raises(nx.NetworkXPointlessConcept):
+            G = nx.DiGraph()
+            G.add_edge(1, 1)
+            nx.global_reaching_centrality(G)
+
+    def test_single_node_with_weighted_cycle(self):
+        with pytest.raises(nx.NetworkXPointlessConcept):
+            G = nx.DiGraph()
+            G.add_weighted_edges_from([(1, 1, 2)])
+            nx.global_reaching_centrality(G, weight="weight")
+
 
 class TestLocalReachingCentrality:
     """Unit tests for the local reaching centrality function."""
@@ -115,3 +127,15 @@ class TestLocalReachingCentrality:
             G, 1, normalized=True, weight="weight"
         )
         assert centrality == 1.0
+
+    def test_single_node_with_cycle(self):
+        with pytest.raises(nx.NetworkXPointlessConcept):
+            G = nx.DiGraph()
+            G.add_edge(1, 1)
+            nx.local_reaching_centrality(G, 1)
+
+    def test_single_node_with_weighted_cycle(self):
+        with pytest.raises(nx.NetworkXPointlessConcept):
+            G = nx.DiGraph()
+            G.add_weighted_edges_from([(1, 1, 2)])
+            nx.local_reaching_centrality(G, 1, weight="weight")

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -80,13 +80,13 @@ class TestGlobalReachingCentrality:
         assert expected == pytest.approx(actual, abs=1e-7)
 
     def test_single_node_with_cycle(self):
-        with pytest.raises(nx.NetworkXPointlessConcept):
+        with pytest.raises(nx.NetworkXError):
             G = nx.DiGraph()
             G.add_edge(1, 1)
             nx.global_reaching_centrality(G)
 
     def test_single_node_with_weighted_cycle(self):
-        with pytest.raises(nx.NetworkXPointlessConcept):
+        with pytest.raises(nx.NetworkXError):
             G = nx.DiGraph()
             G.add_weighted_edges_from([(1, 1, 2)])
             nx.global_reaching_centrality(G, weight="weight")
@@ -129,13 +129,13 @@ class TestLocalReachingCentrality:
         assert centrality == 1.0
 
     def test_single_node_with_cycle(self):
-        with pytest.raises(nx.NetworkXPointlessConcept):
+        with pytest.raises(nx.NetworkXError):
             G = nx.DiGraph()
             G.add_edge(1, 1)
             nx.local_reaching_centrality(G, 1)
 
     def test_single_node_with_weighted_cycle(self):
-        with pytest.raises(nx.NetworkXPointlessConcept):
+        with pytest.raises(nx.NetworkXError):
             G = nx.DiGraph()
             G.add_weighted_edges_from([(1, 1, 2)])
             nx.local_reaching_centrality(G, 1, weight="weight")

--- a/networkx/algorithms/centrality/tests/test_reaching.py
+++ b/networkx/algorithms/centrality/tests/test_reaching.py
@@ -80,15 +80,14 @@ class TestGlobalReachingCentrality:
         assert expected == pytest.approx(actual, abs=1e-7)
 
     def test_single_node_with_cycle(self):
-        with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
-            G.add_edge(1, 1)
+        G = nx.DiGraph([(1, 1)])
+        with pytest.raises(nx.NetworkXError, match="local_reaching_centrality"):
             nx.global_reaching_centrality(G)
 
     def test_single_node_with_weighted_cycle(self):
-        with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
-            G.add_weighted_edges_from([(1, 1, 2)])
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(1, 1, 2)])
+        with pytest.raises(nx.NetworkXError, match="local_reaching_centrality"):
             nx.global_reaching_centrality(G, weight="weight")
 
 
@@ -129,13 +128,12 @@ class TestLocalReachingCentrality:
         assert centrality == 1.0
 
     def test_single_node_with_cycle(self):
-        with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
-            G.add_edge(1, 1)
+        G = nx.DiGraph([(1, 1)])
+        with pytest.raises(nx.NetworkXError, match="local_reaching_centrality"):
             nx.local_reaching_centrality(G, 1)
 
     def test_single_node_with_weighted_cycle(self):
-        with pytest.raises(nx.NetworkXError):
-            G = nx.DiGraph()
-            G.add_weighted_edges_from([(1, 1, 2)])
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(1, 1, 2)])
+        with pytest.raises(nx.NetworkXError, match="local_reaching_centrality"):
             nx.local_reaching_centrality(G, 1, weight="weight")


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
This PR partially solves #6914

I have just added a check for single node with self loops, this behavior is meaningless and should raise ``NetworkXPointlessConcept``.
Also, I have added the corresponding test cases.