### PR TITLE
Make `is_negatively_weighted` dispatchable

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1038,6 +1038,7 @@ def is_weighted(G, edge=None, weight="weight"):
     return all(weight in data for u, v, data in G.edges(data=True))
 
 
+@nx._dispatchable(edge_attrs="weight")
 def is_negatively_weighted(G, edge=None, weight="weight"):
     """Returns True if `G` has negatively weighted edges.
 


### PR DESCRIPTION
This function may be useful for backends (and _is_ useful for `nx-cugraph`).

We may want to dispatch more functions in `nx.classes.function` after version 3.3 is released. `is_negatively_weighted` and other functions in this file are often plenty fast with the NetworkX implementation, but I think making these dispatchable becomes much more feasible and desirable once we have `should_run` (already in) and caching (coming soon 🤞).

CC @rlratzel