### PR TITLE
Future proof xml parsing in graphml.

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -982,7 +982,7 @@ class GraphMLReader(GraphML):
                 node_label = None
                 # set GenericNode's configuration as shape type
                 gn = data_element.find(f"{{{self.NS_Y}}}GenericNode")
-                if gn:
+                if gn is not None:
                     data["shape_type"] = gn.get("configuration")
                 for node_type in ["GenericNode", "ShapeNode", "SVGNode", "ImageNode"]:
                     pref = f"{{{self.NS_Y}}}{node_type}/{{{self.NS_Y}}}"


### PR DESCRIPTION
As of Python 3.12, the lxml tree parser raises a warning about evaluating truthiness of elements directly, instead recommending an is not None or len() test. For an example of the warnings, see the warning logs on any of the Python 3.12 tests in actions, e.g. https://github.com/networkx/networkx/actions/runs/8349137374/job/22852640690
