### PR TITLE
add **kwargs to traveling_salesman_problem

### DIFF
--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -1,4 +1,5 @@
 """Unit tests for the traveling_salesman module."""
+
 import random
 
 import pytest
@@ -300,13 +301,15 @@ def test_TSP_method():
     G = nx.cycle_graph(9)
     G[4][5]["weight"] = 10
 
+    # Test using the old currying method
+    sa_tsp = lambda G, weight: nx_app.simulated_annealing_tsp(
+        G, "greedy", weight, source=4, seed=1
+    )
+
     path = nx_app.traveling_salesman_problem(
         G,
-        method=nx_app.simulated_annealing_tsp,
+        method=sa_tsp,
         cycle=False,
-        init_cycle="greedy",
-        source=4,
-        seed=1,
     )
     print(path)
     assert path == [4, 3, 2, 1, 0, 8, 7, 6, 5]

--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -300,10 +300,14 @@ def test_TSP_method():
     G = nx.cycle_graph(9)
     G[4][5]["weight"] = 10
 
-    def my_tsp_method(G, weight):
-        return nx_app.simulated_annealing_tsp(G, "greedy", weight, source=4, seed=1)
-
-    path = nx_app.traveling_salesman_problem(G, method=my_tsp_method, cycle=False)
+    path = nx_app.traveling_salesman_problem(
+        G,
+        method=nx_app.simulated_annealing_tsp,
+        cycle=False,
+        init_cycle="greedy",
+        source=4,
+        seed=1,
+    )
     print(path)
     assert path == [4, 3, 2, 1, 0, 8, 7, 6, 5]
 
@@ -352,19 +356,27 @@ def test_TSP_weighted():
 
     # Check all methods
     methods = [
-        nx_app.christofides,
-        nx_app.greedy_tsp,
-        lambda G, wt: nx_app.simulated_annealing_tsp(G, "greedy", weight=wt),
-        lambda G, wt: nx_app.threshold_accepting_tsp(G, "greedy", weight=wt),
+        (nx_app.christofides, {}),
+        (nx_app.greedy_tsp, {}),
+        (
+            nx_app.simulated_annealing_tsp,
+            {"init_cycle": "greedy"},
+        ),
+        (
+            nx_app.threshold_accepting_tsp,
+            {"init_cycle": "greedy"},
+        ),
     ]
     for method in methods:
-        cycle = tsp(G, nodes=[3, 6], weight="weight", method=method)
+        cycle = tsp(G, nodes=[3, 6], weight="weight", method=method[0], **method[1])
         assert cycle in expected_cycles
 
-        path = tsp(G, nodes=[3, 6], weight="weight", method=method, cycle=False)
+        path = tsp(
+            G, nodes=[3, 6], weight="weight", method=method[0], cycle=False, **method[1]
+        )
         assert path in expected_paths
 
-        tourpath = tsp(G, weight="weight", method=method, cycle=False)
+        tourpath = tsp(G, weight="weight", method=method[0], cycle=False, **method[1])
         assert tourpath in expected_tourpaths
 
 
@@ -738,10 +750,9 @@ def test_asadpour_tsp():
     G = nx.DiGraph()
     G.add_weighted_edges_from(edge_list)
 
-    def fixed_asadpour(G, weight):
-        return nx_app.asadpour_atsp(G, weight, 19)
-
-    tour = nx_app.traveling_salesman_problem(G, weight="weight", method=fixed_asadpour)
+    tour = nx_app.traveling_salesman_problem(
+        G, weight="weight", method=nx_app.asadpour_atsp, seed=19
+    )
 
     # Check that the returned list is a valid tour. Because this is an
     # incomplete graph, the conditions are not as strict. We need the tour to
@@ -811,10 +822,9 @@ def test_asadpour_real_world():
     G = nx.from_numpy_array(G_array, create_using=nx.DiGraph)
     nx.relabel_nodes(G, node_map, copy=False)
 
-    def fixed_asadpour(G, weight):
-        return nx_app.asadpour_atsp(G, weight, 37, source="JFK")
-
-    tour = nx_app.traveling_salesman_problem(G, weight="weight", method=fixed_asadpour)
+    tour = nx_app.traveling_salesman_problem(
+        G, weight="weight", method=nx_app.asadpour_atsp, seed=37, source="JFK"
+    )
 
     assert tour in expected_tours
 
@@ -859,11 +869,8 @@ def test_asadpour_real_world_path():
     G = nx.from_numpy_array(G_array, create_using=nx.DiGraph)
     nx.relabel_nodes(G, node_map, copy=False)
 
-    def fixed_asadpour(G, weight):
-        return nx_app.asadpour_atsp(G, weight, 56)
-
     path = nx_app.traveling_salesman_problem(
-        G, weight="weight", cycle=False, method=fixed_asadpour
+        G, weight="weight", cycle=False, method=nx_app.asadpour_atsp, seed=56
     )
 
     assert path in expected_paths

--- a/networkx/algorithms/approximation/tests/test_traveling_salesman.py
+++ b/networkx/algorithms/approximation/tests/test_traveling_salesman.py
@@ -370,16 +370,16 @@ def test_TSP_weighted():
             {"init_cycle": "greedy"},
         ),
     ]
-    for method in methods:
-        cycle = tsp(G, nodes=[3, 6], weight="weight", method=method[0], **method[1])
+    for method, kwargs in methods:
+        cycle = tsp(G, nodes=[3, 6], weight="weight", method=method, **kwargs)
         assert cycle in expected_cycles
 
         path = tsp(
-            G, nodes=[3, 6], weight="weight", method=method[0], cycle=False, **method[1]
+            G, nodes=[3, 6], weight="weight", method=method, cycle=False, **kwargs
         )
         assert path in expected_paths
 
-        tourpath = tsp(G, weight="weight", method=method[0], cycle=False, **method[1])
+        tourpath = tsp(G, weight="weight", method=method, cycle=False, **kwargs)
         assert tourpath in expected_tourpaths
 
 

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -198,7 +198,9 @@ def _shortcutting(circuit):
 
 
 @nx._dispatchable(edge_attrs="weight")
-def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, method=None):
+def traveling_salesman_problem(
+    G, weight="weight", nodes=None, cycle=True, method=None, **kwargs
+):
     """Find the shortest path in `G` connecting specified nodes
 
     This function allows approximate solution to the traveling salesman
@@ -259,9 +261,8 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
         If `method is None`: use :func:`christofides` for undirected `G` and
         :func:`threshold_accepting_tsp` for directed `G`.
 
-        To specify parameters for these provided functions, construct lambda
-        functions that state the specific value. `method` must have 2 inputs.
-        (See examples).
+    **kwargs : dict
+        Other keyword arguments to be passed to the `method` function passed in.
 
     Returns
     -------
@@ -321,7 +322,15 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
             if u == v:
                 continue
             GG.add_edge(u, v, weight=dist[u][v])
-    best_GG = method(GG, weight)
+    print(f"Calling method(GG={GG}, {weight=}, {kwargs=})")
+
+    # Several methods using init_cycle is a positional argument.
+    # To avoid chaning the API for those methods, we use this check.
+    if "init_cycle" in kwargs:
+        init_cycle = kwargs.pop("init_cycle")
+        best_GG = method(GG, init_cycle, **kwargs)
+    else:
+        best_GG = method(GG, weight, **kwargs)
 
     if not cycle:
         # find and remove the biggest edge

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -322,7 +322,6 @@ def traveling_salesman_problem(
             if u == v:
                 continue
             GG.add_edge(u, v, weight=dist[u][v])
-    print(f"Calling method(GG={GG}, {weight=}, {kwargs=})")
 
     # Several methods using init_cycle is a positional argument.
     # To avoid chaning the API for those methods, we use this check.

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -298,7 +298,13 @@ def traveling_salesman_problem(
 
     Otherwise, pass other keyword arguments directly into the tsp function.
 
-    >>> path = tsp(G, cycle=False, method=nx.approximation.simulated_annealing_tsp, init_cycle="greedy", temp=500)
+    >>> path = tsp(
+    ...     G,
+    ...     cycle=False,
+    ...     method=nx.approximation.simulated_annealing_tsp,
+    ...     init_cycle="greedy",
+    ...     temp=500,
+    ... )
     >>> path in ([4, 3, 2, 1, 0, 8, 7, 6, 5], [5, 6, 7, 8, 0, 1, 2, 3, 4])
     True
     """

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -287,14 +287,20 @@ def traveling_salesman_problem(
     >>> path in ([4, 3, 2, 1, 0, 8, 7, 6, 5], [5, 6, 7, 8, 0, 1, 2, 3, 4])
     True
 
-    Build (curry) your own function to provide parameter values to the methods.
+    While no longer required, you can still build (curry) your own function
+    to provide parameter values to the methods.
 
     >>> SA_tsp = nx.approximation.simulated_annealing_tsp
-    >>> method = lambda G, wt: SA_tsp(G, "greedy", weight=wt, temp=500)
+    >>> method = lambda G, weight: SA_tsp(G, "greedy", weight=weight, temp=500)
     >>> path = tsp(G, cycle=False, method=method)
     >>> path in ([4, 3, 2, 1, 0, 8, 7, 6, 5], [5, 6, 7, 8, 0, 1, 2, 3, 4])
     True
 
+    Otherwise, pass other keyword arguments directly into the tsp function.
+
+    >>> path = tsp(G, cycle=False, method=nx.approximation.simulated_annealing_tsp, init_cycle="greedy", temp=500)
+    >>> path in ([4, 3, 2, 1, 0, 8, 7, 6, 5], [5, 6, 7, 8, 0, 1, 2, 3, 4])
+    True
     """
     if method is None:
         if G.is_directed():

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -259,7 +259,7 @@ def traveling_salesman_problem(
         :func:`simulated_annealing_tsp` and :func:`threshold_accepting_tsp`.
 
         If `method is None`: use :func:`christofides` for undirected `G` and
-        :func:`threshold_accepting_tsp` for directed `G`.
+        :func:`asadpour_atsp` for directed `G`.
 
     **kwargs : dict
         Other keyword arguments to be passed to the `method` function passed in.

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -323,13 +323,7 @@ def traveling_salesman_problem(
                 continue
             GG.add_edge(u, v, weight=dist[u][v])
 
-    # Several methods using init_cycle is a positional argument.
-    # To avoid chaning the API for those methods, we use this check.
-    if "init_cycle" in kwargs:
-        init_cycle = kwargs.pop("init_cycle")
-        best_GG = method(GG, init_cycle, **kwargs)
-    else:
-        best_GG = method(GG, weight, **kwargs)
+    best_GG = method(GG, weight=weight, **kwargs)
 
     if not cycle:
         # find and remove the biggest edge

--- a/networkx/tests/test_all_random_functions.py
+++ b/networkx/tests/test_all_random_functions.py
@@ -76,12 +76,16 @@ def run_all_random_functions(seed):
     t(
         approx.traveling_salesman_problem,
         H,
-        method=lambda G, wt: approx.simulated_annealing_tsp(G, "greedy", wt, seed=seed),
+        method=lambda G, weight: approx.simulated_annealing_tsp(
+            G, "greedy", weight, seed=seed
+        ),
     )
     t(
         approx.traveling_salesman_problem,
         H,
-        method=lambda G, wt: approx.threshold_accepting_tsp(G, "greedy", wt, seed=seed),
+        method=lambda G, weight: approx.threshold_accepting_tsp(
+            G, "greedy", weight, seed=seed
+        ),
     )
     t(nx.betweenness_centrality, G, seed=seed)
     t(nx.edge_betweenness_centrality, G, seed=seed)


### PR DESCRIPTION
The current interface for `traveling_salesman_problem` requires currying, creating a lambda to create a partial application of the fixed arguments for the method. This by itself is totally fine, and very commonly seen in functional programming, but as far as I know this is the only time that behavior appears in NetworkX. 

This PR adds a `**kwargs` to `traveling_salesman_problem` to remove the currying requirement. I've designed it so that existing code shouldn't break, although this does require the extra check for `init_cycle` to remain compatible with the threshold accepting and simulated annealing TSP methods. I thought about changing those methods to have a default argument, which has been considered numerous times, but decided against changing the API. The points raised in the doc string continue to be relevant. 