### PR TITLE
More numpy scalars cleanup for numpy 2.0

### DIFF
--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -103,8 +103,9 @@ def attribute_mixing_matrix(G, attribute, nodes=None, mapping=None, normalized=T
     >>> mapping = {"male": 0, "female": 1}
     >>> mix_mat = nx.attribute_mixing_matrix(G, "gender", mapping=mapping)
     >>> # mixing from male nodes to female nodes
-    >>> mix_mat[mapping["male"], mapping["female"]]
-    0.25
+    >>> mix_mat
+    array([[0.  , 0.25],
+           [0.25, 0.5 ]])
     """
     d = attribute_mixing_dict(G, attribute, nodes)
     a = dict_to_numpy_array(d, mapping=mapping)
@@ -194,8 +195,9 @@ def degree_mixing_matrix(
     --------
     >>> G = nx.star_graph(3)
     >>> mix_mat = nx.degree_mixing_matrix(G)
-    >>> mix_mat[0, 1]  # mixing from node degree 1 to node degree 3
-    0.5
+    >>> mix_mat  # mixing from node degree 1 to node degree 3
+    array([[0. , 0.5],
+           [0.5, 0. ]])
 
     If you want every possible degree to appear as a row, even if no nodes
     have that degree, use `mapping` as follows,
@@ -203,8 +205,11 @@ def degree_mixing_matrix(
     >>> max_degree = max(deg for n, deg in G.degree)
     >>> mapping = {x: x for x in range(max_degree + 1)}  # identity mapping
     >>> mix_mat = nx.degree_mixing_matrix(G, mapping=mapping)
-    >>> mix_mat[3, 1]  # mixing from node degree 3 to node degree 1
-    0.5
+    >>> mix_mat  # mixing from node degree 3 to node degree 1
+    array([[0. , 0. , 0. , 0. ],
+           [0. , 0. , 0. , 0.5],
+           [0. , 0. , 0. , 0. ],
+           [0. , 0.5, 0. , 0. ]])
     """
     d = degree_mixing_dict(G, x=x, y=y, nodes=nodes, weight=weight)
     a = dict_to_numpy_array(d, mapping=mapping)

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1520,7 +1520,7 @@ def _simrank_similarity_numpy(
         )
 
     if source is not None and target is not None:
-        return newsim[source, target]
+        return float(newsim[source, target])
     if source is not None:
         return newsim[source]
     return newsim

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -396,7 +396,8 @@ def is_regular_expander(G, *, epsilon=0):
     # lambda2 is the second biggest eigenvalue
     lambda2 = min(lams)
 
-    return abs(lambda2) < 2 ** np.sqrt(d - 1) + epsilon
+    # Use bool() to convert numpy scalar to Python Boolean
+    return bool(abs(lambda2) < 2 ** np.sqrt(d - 1) + epsilon)
 
 
 @nx.utils.decorators.np_random_state("seed")


### PR DESCRIPTION
Follow up to #7282 

The latest [nightly wheels tests](https://github.com/rossbar/networkx/actions/runs/8405408971/job/23018090094) turned up a few more failures related to numpy 2.0 scalar repr changes.

This PR fixes the linked failures that are related to NetworkX itself. Unfortunately, it seems there are some real behavior changes to the drawing related to numpy 2.0. I haven't had the time to chase down exactly what's happening, but there are 4 nx_pylab test failures that are indeed real and seem to stem from behavior changes in matplotlib w/ numpy 2.0. I plan to dig further and report upstream.