### PR TITLE
FilterAdjacency: __len__ is recalculated unnecessarily #7377

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -286,14 +286,12 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
             return self.NODE_OK.length
         if hasattr(self.NODE_OK, "nodes"):
             return len(self.NODE_OK.nodes)
-        return sum(1 for _ in self)
+        return sum(1 for n in self._atlas if self.NODE_OK(n))
 
     def __iter__(self):
-        try:  # check that NODE_OK has attr 'nodes'
-            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
-        except AttributeError:
-            node_ok_shorter = False
-        if node_ok_shorter:
+        if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
+            self._atlas
+        ):
             return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 
@@ -333,14 +331,12 @@ class FilterAdjacency(Mapping):  # edgedict
             return self.NODE_OK.length
         if hasattr(self.NODE_OK, "nodes"):
             return len(self.NODE_OK.nodes)
-        return sum(1 for _ in self)
+        return sum(1 for n in self._atlas if self.NODE_OK(n))
 
     def __iter__(self):
-        try:  # check that NODE_OK has attr 'nodes'
-            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
-        except AttributeError:
-            node_ok_shorter = False
-        if node_ok_shorter:
+        if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
+            self._atlas
+        ):
             return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -281,6 +281,8 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         self.NODE_OK = NODE_OK
 
     def __len__(self):
+        # check whether NODE_OK stores the number of nodes as `length`
+        # or the nodes themselves as a set `nodes`. If not, count the nodes.
         if hasattr(self.NODE_OK, "length"):
             return self.NODE_OK.length
         if hasattr(self.NODE_OK, "nodes"):
@@ -328,6 +330,8 @@ class FilterAdjacency(Mapping):  # edgedict
         self.EDGE_OK = EDGE_OK
 
     def __len__(self):
+        # check whether NODE_OK stores the number of nodes as `length`
+        # or the nodes themselves as a set `nodes`. If not, count the nodes.
         if hasattr(self.NODE_OK, "length"):
             return self.NODE_OK.length
         if hasattr(self.NODE_OK, "nodes"):

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -277,16 +277,16 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     FilterMultiAdjacency
     """
 
-    def __init__(self, d, NODE_OK, cache_length: bool = False):
+    def __init__(self, d, NODE_OK):
         self._atlas = d
         self.NODE_OK = NODE_OK
-        self.cache_length = cache_length
-        self.__len = None
 
     def __len__(self):
-        if self.__len is None or not self.cache_length:
-            self.__len = sum(1 for _ in self)
-        return self.__len
+        if hasattr(self.NODE_OK, "length"):
+            return self.NODE_OK.length
+        if hasattr(self.NODE_OK, "nodes"):
+            return len(self.NODE_OK.nodes)
+        return sum(1 for _ in self)
 
     def __iter__(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -323,17 +323,17 @@ class FilterAdjacency(Mapping):  # edgedict
     FilterMultiAdjacency
     """
 
-    def __init__(self, d, NODE_OK, EDGE_OK, cache_length: bool = False):
+    def __init__(self, d, NODE_OK, EDGE_OK):
         self._atlas = d
         self.NODE_OK = NODE_OK
         self.EDGE_OK = EDGE_OK
-        self.cache_length = cache_length
-        self.__len = None
 
     def __len__(self):
-        if self.__len is None or not self.cache_length:
-            self.__len = sum(1 for _ in self)
-        return self.__len
+        if hasattr(self.NODE_OK, "length"):
+            return self.NODE_OK.length
+        if hasattr(self.NODE_OK, "nodes"):
+            return len(self.NODE_OK.nodes)
+        return sum(1 for _ in self)
 
     def __iter__(self):
         try:  # check that NODE_OK has attr 'nodes'

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -2,6 +2,7 @@
 These ``Views`` often restrict element access, with either the entire view or
 layers of nested mappings being read-only.
 """
+
 from collections.abc import Mapping
 
 __all__ = [
@@ -263,6 +264,35 @@ class UnionMultiAdjacency(UnionAdjacency):
         return UnionMultiInner(self._succ[node], self._pred[node])
 
 
+class FilterMixin(Mapping):
+    """A Mixin to avoid code duplication.
+
+    It is possible to avoid recalculation of __len__ by
+    setting the length attribute of NODE_OK.
+
+    See Also
+    ========
+    FilterAtlas
+    FilterAdjacency
+    """
+
+    def __init__(self, d, NODE_OK):
+        self._atlas = d
+        self.NODE_OK = NODE_OK
+
+    def __len__(self):
+        if hasattr(self.NODE_OK, "length"):
+            return self.NODE_OK.length
+        if hasattr(self.NODE_OK, "nodes"):
+            return len(self.NODE_OK.nodes & self._atlas.keys())
+        return sum(1 for n in self._atlas if self.NODE_OK(n))
+
+    def __iter__(self):
+        if hasattr(self.NODE_OK, "nodes"):
+            return (n for n in self.NODE_OK.nodes & self._atlas.keys())
+        return (n for n in self._atlas if self.NODE_OK(n))
+
+
 class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     """A read-only Mapping of Mappings with filtering criteria for nodes.
 
@@ -277,33 +307,16 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     """
 
     def __init__(self, d, NODE_OK):
-        self._atlas = d
-        self.NODE_OK = NODE_OK
-
-    def __len__(self):
-        if hasattr(self.NODE_OK, "length"):
-            return self.NODE_OK.length
-        if hasattr(self.NODE_OK, "nodes"):
-            return len(self.NODE_OK.nodes)
-        return sum(1 for n in self._atlas if self.NODE_OK(n))
-
-    def __iter__(self):
-        if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
-            self._atlas
-        ):
-            return (n for n in self.NODE_OK.nodes if n in self._atlas)
-        return (n for n in self._atlas if self.NODE_OK(n))
+        super().__init__(d, NODE_OK)
 
     def __getitem__(self, key):
         if key in self._atlas and self.NODE_OK(key):
             return self._atlas[key]
         raise KeyError(f"Key {key} not found")
 
-    def __str__(self):
-        return str({nbr: self[nbr] for nbr in self})
-
     def __repr__(self):
-        return f"{self.__class__.__name__}({self._atlas!r}, {self.NODE_OK!r})"
+        name = self.__class__.__name__
+        return f"{name}({self._atlas!r}, {self.NODE_OK!r})"
 
 
 class FilterAdjacency(Mapping):  # edgedict
@@ -321,23 +334,8 @@ class FilterAdjacency(Mapping):  # edgedict
     """
 
     def __init__(self, d, NODE_OK, EDGE_OK):
-        self._atlas = d
-        self.NODE_OK = NODE_OK
+        super().__init__(d, NODE_OK)
         self.EDGE_OK = EDGE_OK
-
-    def __len__(self):
-        if hasattr(self.NODE_OK, "length"):
-            return self.NODE_OK.length
-        if hasattr(self.NODE_OK, "nodes"):
-            return len(self.NODE_OK.nodes)
-        return sum(1 for n in self._atlas if self.NODE_OK(n))
-
-    def __iter__(self):
-        if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
-            self._atlas
-        ):
-            return (n for n in self.NODE_OK.nodes if n in self._atlas)
-        return (n for n in self._atlas if self.NODE_OK(n))
 
     def __getitem__(self, node):
         if node in self._atlas and self.NODE_OK(node):
@@ -347,9 +345,6 @@ class FilterAdjacency(Mapping):  # edgedict
 
             return FilterAtlas(self._atlas[node], new_node_ok)
         raise KeyError(f"Key {node} not found")
-
-    def __str__(self):
-        return str({nbr: self[nbr] for nbr in self})
 
     def __repr__(self):
         name = self.__class__.__name__
@@ -370,12 +365,8 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
     """
 
     def __iter__(self):
-        try:  # check that NODE_OK has attr 'nodes'
-            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
-        except AttributeError:
-            node_ok_shorter = False
-        if node_ok_shorter:
-            my_nodes = (n for n in self.NODE_OK.nodes if n in self._atlas)
+        if hasattr(self.NODE_OK, "nodes"):
+            my_nodes = (n for n in self.NODE_OK.nodes & self._atlas.keys())
         else:
             my_nodes = (n for n in self._atlas if self.NODE_OK(n))
         for n in my_nodes:

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -292,7 +292,7 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
             self._atlas
         ):
-            return (n for n in self.NODE_OK.nodes & self._atlas.keys())
+            return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 
     def __getitem__(self, key):
@@ -337,7 +337,7 @@ class FilterAdjacency(Mapping):  # edgedict
         if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
             self._atlas
         ):
-            return (n for n in self.NODE_OK.nodes & self._atlas.keys())
+            return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 
     def __getitem__(self, node):

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -2,6 +2,7 @@
 These ``Views`` often restrict element access, with either the entire view or
 layers of nested mappings being read-only.
 """
+
 from collections.abc import Mapping
 
 __all__ = [
@@ -279,9 +280,12 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     def __init__(self, d, NODE_OK):
         self._atlas = d
         self.NODE_OK = NODE_OK
+        self.__len = None
 
     def __len__(self):
-        return sum(1 for n in self)
+        if self.__len is None:
+            self.__len = sum(1 for _ in self)
+        return self.__len
 
     def __iter__(self):
         try:  # check that NODE_OK has attr 'nodes'
@@ -322,9 +326,12 @@ class FilterAdjacency(Mapping):  # edgedict
         self._atlas = d
         self.NODE_OK = NODE_OK
         self.EDGE_OK = EDGE_OK
+        self.__len = None
 
     def __len__(self):
-        return sum(1 for n in self)
+        if self.__len is None:
+            self.__len = sum(1 for _ in self)
+        return self.__len
 
     def __iter__(self):
         try:  # check that NODE_OK has attr 'nodes'

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -289,9 +289,11 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         return sum(1 for n in self._atlas if self.NODE_OK(n))
 
     def __iter__(self):
-        if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
-            self._atlas
-        ):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 
@@ -334,9 +336,11 @@ class FilterAdjacency(Mapping):  # edgedict
         return sum(1 for n in self._atlas if self.NODE_OK(n))
 
     def __iter__(self):
-        if hasattr(self.NODE_OK, "nodes") and 2 * len(self.NODE_OK.nodes) < len(
-            self._atlas
-        ):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
             return (n for n in self.NODE_OK.nodes if n in self._atlas)
         return (n for n in self._atlas if self.NODE_OK(n))
 

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -2,6 +2,7 @@
 These ``Views`` often restrict element access, with either the entire view or
 layers of nested mappings being read-only.
 """
+
 from collections.abc import Mapping
 
 __all__ = [
@@ -374,7 +375,12 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
     """
 
     def __iter__(self):
-        if hasattr(self.NODE_OK, "nodes"):
+        try:  # check that NODE_OK has attr 'nodes'
+            node_ok_shorter = 2 * len(self.NODE_OK.nodes) < len(self._atlas)
+        except AttributeError:
+            node_ok_shorter = False
+        if node_ok_shorter:
+            my_nodes = (n for n in self.NODE_OK.nodes if n in self._atlas)
             my_nodes = (n for n in self.NODE_OK.nodes & self._atlas.keys())
         else:
             my_nodes = (n for n in self._atlas if self.NODE_OK(n))

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -2,7 +2,6 @@
 These ``Views`` often restrict element access, with either the entire view or
 layers of nested mappings being read-only.
 """
-
 from collections.abc import Mapping
 
 __all__ = [

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -293,7 +293,7 @@ class FilterMixin(Mapping):
         return (n for n in self._atlas if self.NODE_OK(n))
 
 
-class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
+class FilterAtlas(FilterMixin):  # nodedict, nbrdict, keydict
     """A read-only Mapping of Mappings with filtering criteria for nodes.
 
     It is a view into a dict-of-dict data structure, and it selects only

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -277,13 +277,14 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
     FilterMultiAdjacency
     """
 
-    def __init__(self, d, NODE_OK):
+    def __init__(self, d, NODE_OK, cache_length: bool = False):
         self._atlas = d
         self.NODE_OK = NODE_OK
+        self.cache_length = cache_length
         self.__len = None
 
     def __len__(self):
-        if self.__len is None:
+        if self.__len is None or not self.cache_length:
             self.__len = sum(1 for _ in self)
         return self.__len
 
@@ -322,14 +323,15 @@ class FilterAdjacency(Mapping):  # edgedict
     FilterMultiAdjacency
     """
 
-    def __init__(self, d, NODE_OK, EDGE_OK):
+    def __init__(self, d, NODE_OK, EDGE_OK, cache_length: bool = False):
         self._atlas = d
         self.NODE_OK = NODE_OK
         self.EDGE_OK = EDGE_OK
+        self.cache_length = cache_length
         self.__len = None
 
     def __len__(self):
-        if self.__len is None:
+        if self.__len is None or not self.cache_length:
             self.__len = sum(1 for _ in self)
         return self.__len
 

--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -381,7 +381,6 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
             node_ok_shorter = False
         if node_ok_shorter:
             my_nodes = (n for n in self.NODE_OK.nodes if n in self._atlas)
-            my_nodes = (n for n in self.NODE_OK.nodes & self._atlas.keys())
         else:
             my_nodes = (n for n in self._atlas if self.NODE_OK(n))
         for n in my_nodes:

--- a/networkx/classes/filters.py
+++ b/networkx/classes/filters.py
@@ -54,7 +54,14 @@ def hide_multiedges(edges):
 
 # write show_nodes as a class to make SubGraph pickleable
 class show_nodes:
-    """Filter class to show specific nodes."""
+    """Filter class to show specific nodes.
+
+    Attach the set of nodes as an attribute to speed up this commonly used filter
+
+    Note that another allowed attribute for filters is to store the number of nodes
+    on the filter as attribute `length` (used in `__len__`). It is a user
+    responsibility to ensure this attribute is accurate if present.
+    """
 
     def __init__(self, nodes):
         self.nodes = set(nodes)

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -23,6 +23,7 @@ the chain is tricky and much harder with restricted_views than
 with induced subgraphs.
 Often it is easiest to use .copy() to avoid chains.
 """
+
 import networkx as nx
 from networkx.classes.coreviews import (
     FilterAdjacency,
@@ -133,7 +134,9 @@ def generic_graph_view(G, create_using=None):
 
 
 @deprecate_positional_args(version="3.4")
-def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
+def subgraph_view(
+    G, *, filter_node=no_filter, filter_edge=no_filter, cache_length: bool = False
+):
     """View of `G` applying a filter on nodes and edges.
 
     `subgraph_view` provides a read-only view of the input graph that excludes
@@ -165,6 +168,11 @@ def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
         A function taking as input the two nodes describing an edge (plus the
         edge-key if `G` is a multi-graph), which returns `True` if the edge
         should appear in the view.
+
+    cache_length : bool, optional
+        If 'True' the length of the filtered nodes is cached for performance
+        improvement. Setting cache_length 'True' assumes that the length
+        is not change by another function.
 
     Returns
     -------
@@ -212,7 +220,7 @@ def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
     newG._graph = G
     newG.graph = G.graph
 
-    newG._node = FilterAtlas(G._node, filter_node)
+    newG._node = FilterAtlas(G._node, filter_node, cache_length)
     if G.is_multigraph():
         Adj = FilterMultiAdjacency
 
@@ -226,8 +234,8 @@ def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
             return filter_edge(v, u)
 
     if G.is_directed():
-        newG._succ = Adj(G._succ, filter_node, filter_edge)
-        newG._pred = Adj(G._pred, filter_node, reverse_edge)
+        newG._succ = Adj(G._succ, filter_node, filter_edge, cache_length)
+        newG._pred = Adj(G._pred, filter_node, reverse_edge, cache_length)
         # newG._adj is synced with _succ
     else:
         newG._adj = Adj(G._adj, filter_node, filter_edge)

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -134,9 +134,7 @@ def generic_graph_view(G, create_using=None):
 
 
 @deprecate_positional_args(version="3.4")
-def subgraph_view(
-    G, *, filter_node=no_filter, filter_edge=no_filter, cache_length: bool = False
-):
+def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
     """View of `G` applying a filter on nodes and edges.
 
     `subgraph_view` provides a read-only view of the input graph that excludes
@@ -220,7 +218,7 @@ def subgraph_view(
     newG._graph = G
     newG.graph = G.graph
 
-    newG._node = FilterAtlas(G._node, filter_node, cache_length)
+    newG._node = FilterAtlas(G._node, filter_node)
     if G.is_multigraph():
         Adj = FilterMultiAdjacency
 
@@ -234,8 +232,8 @@ def subgraph_view(
             return filter_edge(v, u)
 
     if G.is_directed():
-        newG._succ = Adj(G._succ, filter_node, filter_edge, cache_length)
-        newG._pred = Adj(G._pred, filter_node, reverse_edge, cache_length)
+        newG._succ = Adj(G._succ, filter_node, filter_edge)
+        newG._pred = Adj(G._pred, filter_node, reverse_edge)
         # newG._adj is synced with _succ
     else:
         newG._adj = Adj(G._adj, filter_node, filter_edge)

--- a/networkx/classes/graphviews.py
+++ b/networkx/classes/graphviews.py
@@ -167,11 +167,6 @@ def subgraph_view(G, *, filter_node=no_filter, filter_edge=no_filter):
         edge-key if `G` is a multi-graph), which returns `True` if the edge
         should appear in the view.
 
-    cache_length : bool, optional
-        If 'True' the length of the filtered nodes is cached for performance
-        improvement. Setting cache_length 'True' assumes that the length
-        is not change by another function.
-
     Returns
     -------
     graph : networkx.Graph


### PR DESCRIPTION
__len__ result is being stored for FilterAdjacency and FilterAtlas

Fixes #7377 

Impacts of dynamic computation of len
---
The class FilterAdjacency is only used in views and therefore only works on frozen sets of edges and nodes. Despite that its __len__ function is recalculated each time it is called instead of it being calculated and stored once upon its first call.

### Current Behavior

__len__ of FilterAdjacency is recalculated unnecessarily upon each call using up 80% of runtime for my application.

### Expected Behavior

__len__ of FilterAdjacency should calculated and stored once upon its first call. For all other calls the stored value is returned.

### Steps to Reproduce

Any use of nx.subgraph_view shows this behaviour. Very poor performance shows in my case for number of nodes > 100.000.

### Environment

Should be completely independent of env.

Python version: 3.11.8 
NetworkX version: 3.2.1