### PR TITLE
Fix pygraphviz tests causing segmentation faults in backend test

### DIFF
--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1239,6 +1239,7 @@ class _dispatchable:
             "read_pajek",
             "from_pydot",
             "pydot_read_dot",
+            "agraph_read_dot",
             # graph comparison fails b/c of nan values
             "read_gexf",
         }:


### PR DESCRIPTION
Fixes #7354 

excludes `nx_agraph.read_dot` from backend equivalence checks.
algorithms that accept `TextIOWrapper` arguments ignore this check.

FYI @rossbar @MridulS @eriknw 