### PR TITLE
Rm deprecated np.row_stack in favor of vstack.

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -938,7 +938,7 @@ def planar_layout(G, scale=1, center=None, dim=2):
             raise nx.NetworkXException("G is not planar.")
     pos = nx.combinatorial_embedding_to_pos(embedding)
     node_list = list(embedding)
-    pos = np.row_stack([pos[x] for x in node_list])
+    pos = np.vstack([pos[x] for x in node_list])
     pos = pos.astype(np.float64)
     pos = rescale_layout(pos, scale=scale) + center
     return dict(zip(node_list, pos))


### PR DESCRIPTION
Handling a new deprecation from the NumPy 2.1 nightlies.

On an unrelated note, matplotlib has released v3.8.4 with support for numpy 2.0. This release (along with the latest mpl 3.9.0dev nightly wheel) fixes the test failures that had been cropping up in `test_pylab` with numpy 2.0. In other words, NX is now green across the board with numpy 2.0, scipy 1.13, and matplotlib 3.8.4!