### PR TITLE
Fix exception for `del config[key]`

### DIFF
--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -128,11 +128,16 @@ class Config:
 
     def __setitem__(self, key, value):
         try:
-            setattr(self, key, value)
+            self.__setattr__(key, value)
         except AttributeError as err:
             raise KeyError(*err.args) from None
 
-    __delitem__ = __delattr__
+    def __delitem__(self, key):
+        try:
+            self.__delattr__(key)
+        except AttributeError as err:
+            raise KeyError(*err.args) from None
+
     _ipython_key_completions_ = __dir__  # config["<TAB>
 
     # Go ahead and make it a `collections.abc.Mapping`

--- a/networkx/utils/tests/test_config.py
+++ b/networkx/utils/tests/test_config.py
@@ -169,9 +169,9 @@ def test_not_strict():
     del cfg["y"]
     assert len(cfg) == 0
     assert list(cfg) == []
-    with pytest.raises(AttributeError, match="'y'"):
+    with pytest.raises(AttributeError, match="y"):
         del cfg.y
-    with pytest.raises(KeyError, match="'y'"):
+    with pytest.raises(KeyError, match="y"):
         del cfg["y"]
     with pytest.raises(TypeError, match="missing 1 required keyword-only"):
         FlexibleConfig()

--- a/networkx/utils/tests/test_config.py
+++ b/networkx/utils/tests/test_config.py
@@ -169,6 +169,10 @@ def test_not_strict():
     del cfg["y"]
     assert len(cfg) == 0
     assert list(cfg) == []
+    with pytest.raises(AttributeError, match="'y'"):
+        del cfg.y
+    with pytest.raises(KeyError, match="'y'"):
+        del cfg["y"]
     with pytest.raises(TypeError, match="missing 1 required keyword-only"):
         FlexibleConfig()
     # Be strict when first creating the config object


### PR DESCRIPTION
Also, make `cfg.__setitem__` (a little) faster.

I forgot to update `__delitem__` when I enabled `strict=False` option for configs.