### PR TITLE
Add check for empty graphs in `flow_hierarchy`

### DIFF
--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -42,6 +42,9 @@ def flow_hierarchy(G, weight=None):
        DOI: 10.1002/cplx.20368
        http://web.mit.edu/~cmagee/www/documents/28-DetectingEvolvingPatterns_FlowHierarchy.pdf
     """
+    # corner case: G has no edges
+    if G.size() == 0:
+        raise nx.NetworkXError("G must have edges in flow_hierarchy")
     if not G.is_directed():
         raise nx.NetworkXError("G must be a digraph in flow_hierarchy")
     scc = nx.strongly_connected_components(G)

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -30,6 +30,7 @@ def flow_hierarchy(G, weight=None):
     ------
     NetworkXError
        If `G` is not a directed graph or if `G` has no edges.
+
     Notes
     -----
     The algorithm described in [1]_ computes the flow hierarchy through

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -28,11 +28,8 @@ def flow_hierarchy(G, weight=None):
 
     Raises
     ------
-    NetworkXPointlessConcept
-       If `G` is empty.
-
     NetworkXError
-       If `G` is not a directed graph.
+       If `G` is not a directed graph or if `G` has no edges.
     Notes
     -----
     The algorithm described in [1]_ computes the flow hierarchy through
@@ -51,7 +48,7 @@ def flow_hierarchy(G, weight=None):
     """
     # corner case: G has no edges
     if nx.is_empty(G):
-        raise nx.NetworkXPointlessConcept("G must have edges in flow_hierarchy")
+        raise nx.NetworkXError("flow_hierarchy not applicable to empty graphs")
     if not G.is_directed():
         raise nx.NetworkXError("G must be a digraph in flow_hierarchy")
     scc = nx.strongly_connected_components(G)

--- a/networkx/algorithms/hierarchy.py
+++ b/networkx/algorithms/hierarchy.py
@@ -26,6 +26,13 @@ def flow_hierarchy(G, weight=None):
     h : float
        Flow hierarchy value
 
+    Raises
+    ------
+    NetworkXPointlessConcept
+       If `G` is empty.
+
+    NetworkXError
+       If `G` is not a directed graph.
     Notes
     -----
     The algorithm described in [1]_ computes the flow hierarchy through
@@ -43,8 +50,8 @@ def flow_hierarchy(G, weight=None):
        http://web.mit.edu/~cmagee/www/documents/28-DetectingEvolvingPatterns_FlowHierarchy.pdf
     """
     # corner case: G has no edges
-    if G.size() == 0:
-        raise nx.NetworkXError("G must have edges in flow_hierarchy")
+    if nx.is_empty(G):
+        raise nx.NetworkXPointlessConcept("G must have edges in flow_hierarchy")
     if not G.is_directed():
         raise nx.NetworkXError("G must be a digraph in flow_hierarchy")
     scc = nx.strongly_connected_components(G)

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -37,3 +37,9 @@ def test_hierarchy_weight():
         ]
     )
     assert nx.flow_hierarchy(G, weight="weight") == 0.75
+
+
+def test_hierarchy_null_graph():
+    G = nx.DiGraph()
+    G.add_node(1)
+    pytest.raises(nx.NetworkXError, nx.flow_hierarchy, G)

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -3,7 +3,7 @@ import pytest
 import networkx as nx
 
 
-def test_hierarchy_exception():
+def test_hierarchy_undirected():
     G = nx.cycle_graph(5)
     pytest.raises(nx.NetworkXError, nx.flow_hierarchy, G)
 
@@ -42,4 +42,4 @@ def test_hierarchy_weight():
 def test_hierarchy_null_graph():
     G = nx.DiGraph()
     G.add_node(1)
-    pytest.raises(nx.NetworkXError, nx.flow_hierarchy, G)
+    pytest.raises(nx.NetworkXPointlessConcept, nx.flow_hierarchy, G)

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -42,4 +42,4 @@ def test_hierarchy_weight():
 def test_hierarchy_null_graph():
     G = nx.DiGraph()
     G.add_node(1)
-    pytest.raises(nx.NetworkXPointlessConcept, nx.flow_hierarchy, G)
+    pytest.raises(nx.NetworkXError, nx.flow_hierarchy, G)

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -39,7 +39,7 @@ def test_hierarchy_weight():
     assert nx.flow_hierarchy(G, weight="weight") == 0.75
 
 
-def test_hierarchy_null_graph():
+def test_hierarchy_empty_graph():
     G = nx.DiGraph()
     G.add_node(1)
     pytest.raises(nx.NetworkXError, nx.flow_hierarchy, G)

--- a/networkx/algorithms/tests/test_hierarchy.py
+++ b/networkx/algorithms/tests/test_hierarchy.py
@@ -39,7 +39,8 @@ def test_hierarchy_weight():
     assert nx.flow_hierarchy(G, weight="weight") == 0.75
 
 
-def test_hierarchy_empty_graph():
-    G = nx.DiGraph()
-    G.add_node(1)
-    pytest.raises(nx.NetworkXError, nx.flow_hierarchy, G)
+@pytest.mark.parametrize("n", (0, 1, 3))
+def test_hierarchy_empty_graph(n):
+    G = nx.empty_graph(n, create_using=nx.DiGraph)
+    with pytest.raises(nx.NetworkXError, match=".*not applicable to empty graphs"):
+        nx.flow_hierarchy(G)


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
The following snippet produces a division by zero error due to the lack of null graph catching condition, I just added it and updated the tests :) 
```py
import networkx as nx
G = nx.DiGraph()
G.add_node(1)
print(nx.flow_hierarchy(G))
```