### PR TITLE
Add check for empty graphs in `non_randomness`

### DIFF
--- a/networkx/algorithms/non_randomness.py
+++ b/networkx/algorithms/non_randomness.py
@@ -51,7 +51,7 @@ def non_randomness(G, k=None, weight="weight"):
     NetworkXException
         if the input graph is not connected.
     NetworkXError
-        if the input graph contains self-loops.
+        if the input graph contains self-loops or if graph has no edges.
 
     Examples
     --------
@@ -74,6 +74,9 @@ def non_randomness(G, k=None, weight="weight"):
     """
     import numpy as np
 
+    # corner case: graph has no edges
+    if nx.is_empty(G):
+        raise nx.NetworkXError("non_randomness not applicable to empty graphs")
     if not nx.is_connected(G):
         raise nx.NetworkXException("Non connected graph.")
     if len(list(nx.selfloop_edges(G))) > 0:

--- a/networkx/algorithms/tests/test_non_randomness.py
+++ b/networkx/algorithms/tests/test_non_randomness.py
@@ -35,3 +35,9 @@ def test_self_loops():
     G.add_edge(1, 1)
     with pytest.raises(nx.NetworkXError):
         nx.non_randomness(G)
+
+
+def test_empty_graph():
+    G = nx.Graph()
+    G.add_node(1)
+    pytest.raises(nx.NetworkXError, nx.non_randomness, G)


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
In the light of #7393, I have adopted the same approach to solve empty graph corner case in `non_randomness` as it was also producing `ZeroDivisionError` 
```python
import networkx as nx
G = nx.Graph()
G.add_node(1)
print(nx.non_randomness(G))
```