### PR TITLE
[ENH, BUG]: added `colliders` and `v_structures` and deprecated `compute_v_structures` in `dag.py`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -68,3 +68,7 @@ Version 3.5
 * Remove ``total_spanning_tree_weight`` from ``linalg/laplacianmatrix.py``
 * Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 
   ``generators/nonisomorphic_trees``.
+
+Version 3.6
+~~~~~~~~~~~
+* Remove ``compute_v_structures`` from ``algorithms/dag.py``.

--- a/doc/reference/algorithms/dag.rst
+++ b/doc/reference/algorithms/dag.rst
@@ -21,5 +21,5 @@ Directed Acyclic Graphs
    dag_longest_path
    dag_longest_path_length
    dag_to_branching
-   compute_colliders
-   compute_v_structures
+   colliders
+   v_structures

--- a/doc/reference/algorithms/dag.rst
+++ b/doc/reference/algorithms/dag.rst
@@ -21,4 +21,5 @@ Directed Acyclic Graphs
    dag_longest_path
    dag_longest_path_length
    dag_to_branching
+   compute_colliders
    compute_v_structures

--- a/doc/reference/algorithms/dag.rst
+++ b/doc/reference/algorithms/dag.rst
@@ -21,5 +21,6 @@ Directed Acyclic Graphs
    dag_longest_path
    dag_longest_path_length
    dag_to_branching
+   compute_v_structures
    colliders
    v_structures

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -16,7 +16,24 @@ from networkx.algorithms.covering import *
 from networkx.algorithms.cycles import *
 from networkx.algorithms.cuts import *
 from networkx.algorithms.d_separation import *
-from networkx.algorithms.dag import *
+from networkx.algorithms.dag import (
+    descendants,
+    ancestors,
+    topological_sort,
+    lexicographical_topological_sort,
+    all_topological_sorts,
+    topological_generations,
+    is_directed_acyclic_graph,
+    is_aperiodic,
+    transitive_closure,
+    transitive_closure_dag,
+    transitive_reduction,
+    antichains,
+    dag_longest_path,
+    dag_longest_path_length,
+    dag_to_branching,
+    compute_v_structures,
+)
 from networkx.algorithms.distance_measures import *
 from networkx.algorithms.distance_regular import *
 from networkx.algorithms.dominance import *
@@ -74,6 +91,7 @@ from networkx.algorithms import components
 from networkx.algorithms import connectivity
 from networkx.algorithms import community
 from networkx.algorithms import coloring
+from networkx.algorithms import dag
 from networkx.algorithms import flow
 from networkx.algorithms import isomorphism
 from networkx.algorithms import link_analysis

--- a/networkx/algorithms/__init__.py
+++ b/networkx/algorithms/__init__.py
@@ -16,24 +16,7 @@ from networkx.algorithms.covering import *
 from networkx.algorithms.cycles import *
 from networkx.algorithms.cuts import *
 from networkx.algorithms.d_separation import *
-from networkx.algorithms.dag import (
-    descendants,
-    ancestors,
-    topological_sort,
-    lexicographical_topological_sort,
-    all_topological_sorts,
-    topological_generations,
-    is_directed_acyclic_graph,
-    is_aperiodic,
-    transitive_closure,
-    transitive_closure_dag,
-    transitive_reduction,
-    antichains,
-    dag_longest_path,
-    dag_longest_path_length,
-    dag_to_branching,
-    compute_v_structures,
-)
+from networkx.algorithms.dag import *
 from networkx.algorithms.distance_measures import *
 from networkx.algorithms.distance_regular import *
 from networkx.algorithms.dominance import *
@@ -91,7 +74,6 @@ from networkx.algorithms import components
 from networkx.algorithms import connectivity
 from networkx.algorithms import community
 from networkx.algorithms import coloring
-from networkx.algorithms import dag
 from networkx.algorithms import flow
 from networkx.algorithms import isomorphism
 from networkx.algorithms import link_analysis

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -30,6 +30,7 @@ __all__ = [
     "dag_longest_path",
     "dag_longest_path_length",
     "dag_to_branching",
+    "compute_colliders",
     "compute_v_structures",
 ]
 
@@ -1223,37 +1224,85 @@ def dag_to_branching(G):
 
 @not_implemented_for("undirected")
 @nx._dispatchable
-def compute_v_structures(G):
-    """Iterate through the graph to compute all v-structures.
-
-    V-structures are triples in the directed graph where
-    two parent nodes point to the same child and the two parent nodes
-    are not adjacent.
+def compute_colliders(G):
+    """In a DAG, if you have three nodes A, B, and C, and there are edges from A to C
+    and from B to C, then C is a collider. This means that both A and B are "causing" C
+    in the graph, and conditioning on C would open up an association between A and B.
 
     Parameters
     ----------
     G : graph
-        A networkx DiGraph.
+        A networkx `DiGraph`.
 
     Returns
     -------
-    vstructs : iterator of tuples
-        The v structures within the graph. Each v structure is a 3-tuple with the
-        parent, collider, and other parent.
+    collider : iterator of tuples
+        Each collider is a 3-tuple with the parent, collider, and other parent.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is an undirected graph.
 
     Examples
     --------
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5)])
-    >>> sorted(nx.compute_v_structures(G))
-    [(0, 5, 1), (0, 5, 4), (1, 5, 4)]
+    >>> sorted(nx.compute_colliders(G))
+    [(0, 5, 1), (0, 5, 4), (4, 5, 1)]
+
+    See Also
+    --------
+    compute_v_structures
 
     Notes
     -----
     `Wikipedia: Collider in causal graphs <https://en.wikipedia.org/wiki/Collider_(statistics)>`_
     """
-    for collider, preds in G.pred.items():
-        for common_parents in combinations(preds, r=2):
-            # ensure that the colliders are the same
-            common_parents = sorted(common_parents)
-            yield (common_parents[0], collider, common_parents[1])
+    for node in G.nodes:
+        for p1, p2 in combinations(G.predecessors(node), 2):
+            yield ((p1, node, p2))
+
+
+@not_implemented_for("undirected")
+@nx._dispatchable
+def compute_v_structures(G):
+    """Colliders are triples in the directed graph where two parent nodes point to the
+    same child node. V-structures are colliders where the two parent nodes are not
+    adjacent.
+
+    Parameters
+    ----------
+    G : graph
+        A networkx `DiGraph`.
+
+    Returns
+    -------
+    vstructs : iterator of tuples
+        Each v-structure is a 3-tuple with the parent, collider, and other parent.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is an undirected graph.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5), (5, 2)])
+    >>> sorted(nx.compute_v_structures(G))
+    [(0, 5, 1), (0, 5, 4), (4, 5, 1)]
+
+    See Also
+    --------
+    compute_colliders
+
+    Notes
+    -----
+    `Pearl's PRIMER, Ch-2 page 50: v-structures def. <http://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
+    """
+    for collider in compute_colliders(G):
+        if not (
+            G.has_edge(collider[0], collider[2]) or G.has_edge(collider[2], collider[0])
+        ):
+            yield collider

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1250,9 +1250,9 @@ def colliders(G):
     --------
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
-    >>> colliders = [(p1, v, p2) for p1, v, p2 in colliders(G)]
-    >>> colliders
-    [(1, 2, 4), (0, 4, 3), (0, 4, 1), (3, 4, 1)]
+    >>> collidrs = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in colliders(G)]
+    >>> sorted(collidrs)
+    [(0, 4, 1), (0, 4, 3), (1, 2, 4), (1, 4, 3)]
 
     See Also
     --------
@@ -1295,9 +1295,9 @@ def v_structures(G):
     --------
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
-    >>> vstrct = [(p1, v, p2) for p1, v, p2 in v_structures(G)]
-    >>> vstrct
-    [(0, 4, 3), (0, 4, 1), (3, 4, 1)]
+    >>> vstrct = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in v_structures(G)]
+    >>> sorted(vstrct)
+    [(0, 4, 1), (0, 4, 3), (1, 4, 3)]
 
     See Also
     --------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1251,7 +1251,7 @@ def colliders(G):
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
     >>> colliders = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in nx.colliders(G)]
-    >>> colliders
+    >>> sorted(colliders)
     [(0, 4, 1), (0, 4, 3), (1, 2, 4), (1, 4, 3)]
 
     See Also
@@ -1296,7 +1296,7 @@ def v_structures(G):
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
     >>> vstructures = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in nx.v_structures(G)]
-    >>> vstructures
+    >>> sorted(vstructures)
     [(0, 4, 1), (0, 4, 3), (1, 4, 3)]
 
     See Also

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1249,7 +1249,7 @@ def compute_colliders(G):
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5)])
     >>> sorted(nx.compute_colliders(G))
-    [(0, 5, 1), (0, 5, 4), (4, 5, 1)]
+    [(0, 5, 1), (0, 5, 4), (1, 5, 4)]
 
     See Also
     --------
@@ -1261,6 +1261,7 @@ def compute_colliders(G):
     """
     for node in G.nodes:
         for p1, p2 in combinations(G.predecessors(node), 2):
+            p1, p2 = sorted([p1, p2])  # sorting parents for consistent output
             yield ((p1, node, p2))
 
 
@@ -1291,7 +1292,7 @@ def compute_v_structures(G):
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5), (5, 2)])
     >>> sorted(nx.compute_v_structures(G))
-    [(0, 5, 1), (0, 5, 4), (4, 5, 1)]
+    [(0, 5, 1), (0, 5, 4), (1, 5, 4)]
 
     See Also
     --------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1250,8 +1250,8 @@ def colliders(G):
     --------
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
-    >>> collidrs = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in colliders(G)]
-    >>> sorted(collidrs)
+    >>> colliders = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in nx.colliders(G)]
+    >>> sorted(colliders)
     [(0, 4, 1), (0, 4, 3), (1, 2, 4), (1, 4, 3)]
 
     See Also

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1249,10 +1249,10 @@ def colliders(G):
     Examples
     --------
     >>> G = nx.DiGraph()
-    >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5), (5, 2)])
+    >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
     >>> colliders = [(p1, v, p2) for p1, v, p2 in colliders(G)]
     >>> colliders
-    [(1, 2, 5), (0, 5, 4), (0, 5, 1), (4, 5, 1)]
+    [(1, 2, 4), (0, 4, 3), (0, 4, 1), (3, 4, 1)]
 
     See Also
     --------
@@ -1294,10 +1294,10 @@ def v_structures(G):
     Examples
     --------
     >>> G = nx.DiGraph()
-    >>> G.add_edges_from([(1, 2), (0, 5), (3, 1), (2, 4), (3, 1), (4, 5), (1, 5), (5, 2)])
+    >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
     >>> vstrct = [(p1, v, p2) for p1, v, p2 in v_structures(G)]
     >>> vstrct
-    [(0, 5, 4), (0, 5, 1), (4, 5, 1)]
+    [(0, 4, 3), (0, 4, 1), (3, 4, 1)]
 
     See Also
     --------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1238,7 +1238,7 @@ def colliders(G):
 
     Yields
     ------
-    An iterator of tuples
+    A 3-tuple representation of a collider
         Each collider is a 3-tuple with the parent, collider, and other parent.
 
     Raises
@@ -1251,7 +1251,7 @@ def colliders(G):
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
     >>> colliders = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in nx.colliders(G)]
-    >>> sorted(colliders)
+    >>> colliders
     [(0, 4, 1), (0, 4, 3), (1, 2, 4), (1, 4, 3)]
 
     See Also
@@ -1283,7 +1283,7 @@ def v_structures(G):
 
     Yields
     ------
-    An iterator of tuples
+    A 3-tuple representation of a v-structure
         Each v-structure is a 3-tuple with the parent, collider, and other parent.
 
     Raises
@@ -1296,7 +1296,7 @@ def v_structures(G):
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
     >>> vstructures = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in nx.v_structures(G)]
-    >>> sorted(vstructures)
+    >>> vstructures
     [(0, 4, 1), (0, 4, 3), (1, 4, 3)]
 
     See Also

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1264,7 +1264,7 @@ def colliders(G):
     """
     for node in G.nodes:
         for p1, p2 in combinations(G.predecessors(node), 2):
-            yield ((p1, node, p2))
+            yield (p1, node, p2)
 
 
 @not_implemented_for("undirected")
@@ -1308,7 +1308,5 @@ def v_structures(G):
     `Pearl's PRIMER, Ch-2 page 50: v-structures def. <http://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
     """
     for p1, c, p2 in colliders(G):
-        if not (
-            G.has_edge(p1, p2) or G.has_edge(p2, p1)
-        ):
-            yield ((p1, c, p2))
+        if not (G.has_edge(p1, p2) or G.has_edge(p2, p1)):
+            yield (p1, c, p2)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1295,8 +1295,8 @@ def v_structures(G):
     --------
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (0, 4), (2, 3), (3, 4), (1, 4), (4, 2)])
-    >>> vstrct = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in v_structures(G)]
-    >>> sorted(vstrct)
+    >>> vstructures = [(min(p1, p2), v, max(p1, p2)) for p1, v, p2 in nx.v_structures(G)]
+    >>> sorted(vstructures)
     [(0, 4, 1), (0, 4, 3), (1, 4, 3)]
 
     See Also

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1273,7 +1273,7 @@ def compute_v_structures(G):
 
     References
     ----------
-    .. [1]  `Pearl's PRIMER,<http://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
+    .. [1]  `Pearl's PRIMER <https://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
             Ch-2 page 50: v-structures def.
     .. [2] A Hyttinen, P.O. Hoyer, F. Eberhardt, M J ̈arvisalo, (2013)
            "Discovering cyclic causal models with latent variables:
@@ -1342,7 +1342,7 @@ def v_structures(G):
 
     References
     ----------
-    .. [1]  `Pearl's PRIMER,<http://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
+    .. [1]  `Pearl's PRIMER <https://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
             Ch-2 page 50: v-structures def.
     .. [2] A Hyttinen, P.O. Hoyer, F. Eberhardt, M J ̈arvisalo, (2013)
            "Discovering cyclic causal models with latent variables:

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1322,7 +1322,8 @@ def v_structures(G):
     Examples
     --------
     >>> G = nx.DiGraph([(1, 2), (0, 4), (3, 1), (2, 4), (0, 5), (4, 5), (1, 5)])
-    >>> assert nx.is_directed_acyclic_graph(G)
+    >>> nx.is_directed_acyclic_graph(G)
+    True
     >>> list(nx.dag.v_structures(G))
     [(0, 4, 2), (0, 5, 1), (4, 5, 1)]
 
@@ -1381,7 +1382,8 @@ def colliders(G):
     Examples
     --------
     >>> G = nx.DiGraph([(1, 2), (0, 4), (3, 1), (2, 4), (0, 5), (4, 5), (1, 5)])
-    >>> assert nx.is_directed_acyclic_graph(G)
+    >>> nx.is_directed_acyclic_graph(G)
+    True
     >>> list(nx.dag.colliders(G))
     [(0, 4, 2), (0, 5, 4), (0, 5, 1), (4, 5, 1)]
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -31,8 +31,6 @@ __all__ = [
     "dag_longest_path_length",
     "dag_to_branching",
     "compute_v_structures",
-    "v_structures",
-    "colliders",
 ]
 
 chaini = chain.from_iterable
@@ -1290,7 +1288,7 @@ def compute_v_structures(G):
             "removed in version 3.6. Use `nx.dag.v_structures` instead.\n"
         ),
         category=DeprecationWarning,
-        stacklevel=2,
+        stacklevel=5,
     )
 
     return colliders(G)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1266,8 +1266,8 @@ def compute_v_structures(G):
 
     Notes
     -----
-    This function was written to be used on DAGs. But it works on cyclic graphs
-    too and since colliders are referred to in the cyclic causal graph literature
+    This function was written to be used on DAGs, however it works on cyclic graphs
+    too. Since colliders are referred to in the cyclic causal graph literature
     [2]_ we allow cyclic graphs in this function. It is suggested that you test if
     your input graph is acyclic as in the example if you want that property.
 
@@ -1309,7 +1309,7 @@ def v_structures(G):
     Parameters
     ----------
     G : graph
-        A networkx `DiGraph`.
+        A networkx `~networkx.DiGraph`.
 
     Yields
     ------
@@ -1335,8 +1335,8 @@ def v_structures(G):
 
     Notes
     -----
-    This function was written to be used on DAGs. But it works on cyclic graphs
-    too and since colliders are referred to in the cyclic causal graph literature
+    This function was written to be used on DAGs, however it works on cyclic graphs
+    too. Since colliders are referred to in the cyclic causal graph literature
     [2]_ we allow cyclic graphs in this function. It is suggested that you test if
     your input graph is acyclic as in the example if you want that property.
 
@@ -1369,7 +1369,7 @@ def colliders(G):
     Parameters
     ----------
     G : graph
-        A networkx `DiGraph`.
+        A networkx `~networkx.DiGraph`.
 
     Yields
     ------
@@ -1395,8 +1395,8 @@ def colliders(G):
 
     Notes
     -----
-    This function was written to be used on DAGs. But it works on cyclic graphs
-    too and since colliders are referred to in the cyclic causal graph literature
+    This function was written to be used on DAGs, however it works on cyclic graphs
+    too. Since colliders are referred to in the cyclic causal graph literature
     [2]_ we allow cyclic graphs in this function. It is suggested that you test if
     your input graph is acyclic as in the example if you want that property.
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1233,7 +1233,7 @@ def compute_v_structures(G):
 
     .. deprecated:: 3.4
        `compute_v_structures` actually yields colliders. It will be removed in
-       version 3.6. Use `nx.dag.v_structures` instead.
+       version 3.6. Use `nx.dag.v_structures` or `nx.dag.colliders` instead.
 
     Parameters
     ----------
@@ -1285,7 +1285,8 @@ def compute_v_structures(G):
     warnings.warn(
         (
             "\n\n`compute_v_structures` actually yields colliders. It will be\n"
-            "removed in version 3.6. Use `nx.dag.v_structures` instead.\n"
+            "removed in version 3.6. Use `nx.dag.v_structures` or `nx.dag.colliders`\n"
+            "instead.\n"
         ),
         category=DeprecationWarning,
         stacklevel=5,

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -30,8 +30,9 @@ __all__ = [
     "dag_longest_path",
     "dag_longest_path_length",
     "dag_to_branching",
-    "colliders",
+    "compute_v_structures",
     "v_structures",
+    "colliders",
 ]
 
 chaini = chain.from_iterable
@@ -1224,14 +1225,17 @@ def dag_to_branching(G):
 
 @not_implemented_for("undirected")
 @nx._dispatchable
-def colliders(G):
-    """Yields 3-node tuples that represent the colliders in `G`.
+def compute_v_structures(G):
+    """Yields 3-node tuples that represent the v-structures in `G`.
 
-    In a Directed Acyclic Graph (DAG), if you have three nodes A, B, and C, and
-    there are edges from A to C and from B to C, then C is a collider [1]_ . In
-    a causal graph setting, this means that both events A and B are "causing" C,
-    and conditioning on C provide an association between A and B even if
-    no direct causal relationship exists between A and B.
+    Colliders are triples in the directed acyclic graph (DAG) where two parent nodes
+    point to the same child node. V-structures are colliders where the two parent
+    nodes are not adjacent. In a causal graph setting, the parents do not directly
+    depend on each other, but conditioning on the child node provides an association.
+
+    .. deprecated:: 3.4
+       `compute_v_structures` actually yields colliders. It will be removed in
+       version 3.6. Use `nx.dag.v_structures` instead.
 
     Parameters
     ----------
@@ -1240,8 +1244,8 @@ def colliders(G):
 
     Yields
     ------
-    A 3-tuple representation of a collider
-        Each collider is a 3-tuple with the parent, collider, and other parent.
+    A 3-tuple representation of a v-structure
+        Each v-structure is a 3-tuple with the parent, collider, and other parent.
 
     Raises
     ------
@@ -1251,13 +1255,15 @@ def colliders(G):
     Examples
     --------
     >>> G = nx.DiGraph([(1, 2), (0, 4), (3, 1), (2, 4), (0, 5), (4, 5), (1, 5)])
-    >>> assert nx.is_directed_acyclic_graph(G)
-    >>> list(nx.colliders(G))
+    >>> nx.is_directed_acyclic_graph(G)
+    True
+    >>> list(nx.compute_v_structures(G))
     [(0, 4, 2), (0, 5, 4), (0, 5, 1), (4, 5, 1)]
 
     See Also
     --------
     v_structures
+    colliders
 
     Notes
     -----
@@ -1268,16 +1274,26 @@ def colliders(G):
 
     References
     ----------
-    .. [1] `Wikipedia: Collider in causal graphs <https://en.wikipedia.org/wiki/Collider_(statistics)>`_
+    .. [1]  `Pearl's PRIMER,<http://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
+            Ch-2 page 50: v-structures def.
     .. [2] A Hyttinen, P.O. Hoyer, F. Eberhardt, M J ̈arvisalo, (2013)
            "Discovering cyclic causal models with latent variables:
            a general SAT-based procedure", UAI'13: Proceedings of the Twenty-Ninth
            Conference on Uncertainty in Artificial Intelligence, pg 301–310,
            `doi:10.5555/3023638.3023669 <https://dl.acm.org/doi/10.5555/3023638.3023669>`_
     """
-    for node in G.nodes:
-        for p1, p2 in combinations(G.predecessors(node), 2):
-            yield (p1, node, p2)
+    import warnings
+
+    warnings.warn(
+        (
+            "\n\n`compute_v_structures` actually yields colliders. It will be\n"
+            "removed in version 3.6. Use `nx.dag.v_structures` instead.\n"
+        ),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return colliders(G)
 
 
 @not_implemented_for("undirected")
@@ -1309,7 +1325,7 @@ def v_structures(G):
     --------
     >>> G = nx.DiGraph([(1, 2), (0, 4), (3, 1), (2, 4), (0, 5), (4, 5), (1, 5)])
     >>> assert nx.is_directed_acyclic_graph(G)
-    >>> list(nx.v_structures(G))
+    >>> list(nx.dag.v_structures(G))
     [(0, 4, 2), (0, 5, 1), (4, 5, 1)]
 
     See Also
@@ -1327,7 +1343,70 @@ def v_structures(G):
     ----------
     .. [1]  `Pearl's PRIMER,<http://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
             Ch-2 page 50: v-structures def.
+    .. [2] A Hyttinen, P.O. Hoyer, F. Eberhardt, M J ̈arvisalo, (2013)
+           "Discovering cyclic causal models with latent variables:
+           a general SAT-based procedure", UAI'13: Proceedings of the Twenty-Ninth
+           Conference on Uncertainty in Artificial Intelligence, pg 301–310,
+           `doi:10.5555/3023638.3023669 <https://dl.acm.org/doi/10.5555/3023638.3023669>`_
     """
     for p1, c, p2 in colliders(G):
         if not (G.has_edge(p1, p2) or G.has_edge(p2, p1)):
             yield (p1, c, p2)
+
+
+@not_implemented_for("undirected")
+@nx._dispatchable
+def colliders(G):
+    """Yields 3-node tuples that represent the colliders in `G`.
+
+    In a Directed Acyclic Graph (DAG), if you have three nodes A, B, and C, and
+    there are edges from A to C and from B to C, then C is a collider [1]_ . In
+    a causal graph setting, this means that both events A and B are "causing" C,
+    and conditioning on C provide an association between A and B even if
+    no direct causal relationship exists between A and B.
+
+    Parameters
+    ----------
+    G : graph
+        A networkx `DiGraph`.
+
+    Yields
+    ------
+    A 3-tuple representation of a collider
+        Each collider is a 3-tuple with the parent, collider, and other parent.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is an undirected graph.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph([(1, 2), (0, 4), (3, 1), (2, 4), (0, 5), (4, 5), (1, 5)])
+    >>> assert nx.is_directed_acyclic_graph(G)
+    >>> list(nx.dag.colliders(G))
+    [(0, 4, 2), (0, 5, 4), (0, 5, 1), (4, 5, 1)]
+
+    See Also
+    --------
+    v_structures
+
+    Notes
+    -----
+    This function was written to be used on DAGs. But it works on cyclic graphs
+    too and since colliders are referred to in the cyclic causal graph literature
+    [2]_ we allow cyclic graphs in this function. It is suggested that you test if
+    your input graph is acyclic as in the example if you want that property.
+
+    References
+    ----------
+    .. [1] `Wikipedia: Collider in causal graphs <https://en.wikipedia.org/wiki/Collider_(statistics)>`_
+    .. [2] A Hyttinen, P.O. Hoyer, F. Eberhardt, M J ̈arvisalo, (2013)
+           "Discovering cyclic causal models with latent variables:
+           a general SAT-based procedure", UAI'13: Proceedings of the Twenty-Ninth
+           Conference on Uncertainty in Artificial Intelligence, pg 301–310,
+           `doi:10.5555/3023638.3023669 <https://dl.acm.org/doi/10.5555/3023638.3023669>`_
+    """
+    for node in G.nodes:
+        for p1, p2 in combinations(G.predecessors(node), 2):
+            yield (p1, node, p2)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1226,19 +1226,20 @@ def dag_to_branching(G):
 def compute_v_structures(G):
     """Yields 3-node tuples that represent the v-structures in `G`.
 
+    .. deprecated:: 3.4
+
+       `compute_v_structures` actually yields colliders. It will be removed in
+       version 3.6. Use `nx.dag.v_structures` or `nx.dag.colliders` instead.
+
     Colliders are triples in the directed acyclic graph (DAG) where two parent nodes
     point to the same child node. V-structures are colliders where the two parent
     nodes are not adjacent. In a causal graph setting, the parents do not directly
     depend on each other, but conditioning on the child node provides an association.
 
-    .. deprecated:: 3.4
-       `compute_v_structures` actually yields colliders. It will be removed in
-       version 3.6. Use `nx.dag.v_structures` or `nx.dag.colliders` instead.
-
     Parameters
     ----------
     G : graph
-        A networkx `DiGraph`.
+        A networkx `~networkx.DiGraph`.
 
     Yields
     ------

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -758,43 +758,43 @@ def test_ancestors_descendants_undirected():
     nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}
 
 
-def test_compute_colliders_raise():
+def test_colliders_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.compute_colliders, G)
+    pytest.raises(nx.NetworkXNotImplemented, nx.colliders, G)
 
 
-def test_compute_colliders():
+def test_colliders():
     edges = [(0, 1), (0, 2), (3, 2)]
     G = nx.DiGraph(edges)
 
-    colliders = set(nx.compute_colliders(G))
+    colliders = set(nx.colliders(G))
     assert len(colliders) == 1
     assert (0, 2, 3) in colliders
 
     edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
     G = nx.DiGraph(edges)
-    colliders = set(nx.compute_colliders(G))
+    colliders = set(nx.colliders(G))
     assert len(colliders) == 2
 
 
-def test_compute_v_structures_raise():
+def test_v_structures_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.compute_v_structures, G)
+    pytest.raises(nx.NetworkXNotImplemented, nx.v_structures, G)
 
 
-def test_compute_v_structures():
+def test_v_structures():
     edges = [(0, 1), (0, 2), (3, 2)]
     G = nx.DiGraph(edges)
 
-    v_structs = set(nx.compute_v_structures(G))
+    v_structs = set(nx.v_structures(G))
     assert len(v_structs) == 1
     assert (0, 2, 3) in v_structs
 
     edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
     G = nx.DiGraph(edges)
-    v_structs = set(nx.compute_v_structures(G))
+    v_structs = set(nx.v_structures(G))
     assert len(v_structs) == 2
 
     edges = [(0, 1), (2, 1), (0, 2)]  # adjacent parents case: issues#7385
     G = nx.DiGraph(edges)
-    assert set(nx.compute_v_structures(G)) == set()
+    assert set(nx.v_structures(G)) == set()

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -771,10 +771,10 @@ def test_colliders():
     assert len(colliders) == 1
     assert (0, 2, 3) in colliders
 
-    edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
+    edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
     G = nx.DiGraph(edges)
     colliders = set(nx.colliders(G))
-    assert len(colliders) == 2
+    assert colliders == {("A", "B", "C"), ("D", "E", "G")}
 
 
 def test_v_structures_raise():
@@ -790,10 +790,10 @@ def test_v_structures():
     assert len(v_structs) == 1
     assert (0, 2, 3) in v_structs
 
-    edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
+    edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
     G = nx.DiGraph(edges)
     v_structs = set(nx.v_structures(G))
-    assert len(v_structs) == 2
+    assert v_structs == {("A", "B", "C")}
 
     edges = [(0, 1), (2, 1), (0, 2)]  # adjacent parents case: issues#7385
     G = nx.DiGraph(edges)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -758,6 +758,25 @@ def test_ancestors_descendants_undirected():
     nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}
 
 
+def test_compute_colliders_raise():
+    G = nx.Graph()
+    pytest.raises(nx.NetworkXNotImplemented, nx.compute_colliders, G)
+
+
+def test_compute_colliders():
+    edges = [(0, 1), (0, 2), (3, 2)]
+    G = nx.DiGraph(edges)
+
+    colliders = set(nx.compute_colliders(G))
+    assert len(colliders) == 1
+    assert (0, 2, 3) in colliders
+
+    edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
+    G = nx.DiGraph(edges)
+    colliders = set(nx.compute_colliders(G))
+    assert len(colliders) == 2
+
+
 def test_compute_v_structures_raise():
     G = nx.Graph()
     pytest.raises(nx.NetworkXNotImplemented, nx.compute_v_structures, G)
@@ -775,3 +794,7 @@ def test_compute_v_structures():
     G = nx.DiGraph(edges)
     v_structs = set(nx.compute_v_structures(G))
     assert len(v_structs) == 2
+
+    edges = [(0, 1), (2, 1), (0, 2)]  # adjacent parents case: issues#7385
+    G = nx.DiGraph(edges)
+    assert set(nx.compute_v_structures(G)) == set()

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -758,43 +758,68 @@ def test_ancestors_descendants_undirected():
     nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}
 
 
-def test_colliders_raise():
+def test_compute_v_structures_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.colliders, G)
+    pytest.raises(nx.NetworkXNotImplemented, nx.compute_v_structures, G)
 
 
-def test_colliders():
+def test_compute_v_structures():
     edges = [(0, 1), (0, 2), (3, 2)]
     G = nx.DiGraph(edges)
 
-    colliders = set(nx.colliders(G))
-    assert len(colliders) == 1
-    assert (0, 2, 3) in colliders
+    v_structs = set(nx.compute_v_structures(G))
+    assert len(v_structs) == 1
+    assert (0, 2, 3) in v_structs
 
-    edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
+    edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
     G = nx.DiGraph(edges)
-    colliders = set(nx.colliders(G))
-    assert colliders == {("A", "B", "C"), ("D", "E", "G")}
+    v_structs = set(nx.compute_v_structures(G))
+    assert len(v_structs) == 2
+
+
+def test_compute_v_structures_deprecated():
+    G = nx.DiGraph()
+    with pytest.deprecated_call():
+        nx.compute_v_structures(G)
 
 
 def test_v_structures_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.v_structures, G)
+    pytest.raises(nx.NetworkXNotImplemented, nx.dag.v_structures, G)
 
 
 def test_v_structures():
     edges = [(0, 1), (0, 2), (3, 2)]
     G = nx.DiGraph(edges)
 
-    v_structs = set(nx.v_structures(G))
+    v_structs = set(nx.dag.v_structures(G))
     assert len(v_structs) == 1
     assert (0, 2, 3) in v_structs
 
     edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
     G = nx.DiGraph(edges)
-    v_structs = set(nx.v_structures(G))
+    v_structs = set(nx.dag.v_structures(G))
     assert v_structs == {("A", "B", "C")}
 
     edges = [(0, 1), (2, 1), (0, 2)]  # adjacent parents case: issues#7385
     G = nx.DiGraph(edges)
-    assert set(nx.v_structures(G)) == set()
+    assert set(nx.dag.v_structures(G)) == set()
+
+
+def test_colliders_raise():
+    G = nx.Graph()
+    pytest.raises(nx.NetworkXNotImplemented, nx.dag.colliders, G)
+
+
+def test_colliders():
+    edges = [(0, 1), (0, 2), (3, 2)]
+    G = nx.DiGraph(edges)
+
+    colliders = set(nx.dag.colliders(G))
+    assert len(colliders) == 1
+    assert (0, 2, 3) in colliders
+
+    edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
+    G = nx.DiGraph(edges)
+    colliders = set(nx.dag.colliders(G))
+    assert colliders == {("A", "B", "C"), ("D", "E", "G")}

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -760,7 +760,8 @@ def test_ancestors_descendants_undirected():
 
 def test_compute_v_structures_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.compute_v_structures, G)
+    with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):
+        nx.compute_v_structures(G)
 
 
 def test_compute_v_structures():
@@ -785,7 +786,8 @@ def test_compute_v_structures_deprecated():
 
 def test_v_structures_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.dag.v_structures, G)
+    with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):
+        nx.dag.v_structures(G)
 
 
 def test_v_structures():
@@ -808,7 +810,8 @@ def test_v_structures():
 
 def test_colliders_raise():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXNotImplemented, nx.dag.colliders, G)
+    with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):
+        nx.dag.colliders(G)
 
 
 def test_colliders():

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -151,6 +151,9 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message=r"\n\nThe 'create=matrix'"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\ncompute_v_structures"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
closes https://github.com/networkx/networkx/issues/7385

<strike>
previously `compute_v_structures` was computing colliders. Now, I've renamed `compute_v_structures` to `compute_colliders`(and updated its implementation too) and added the correct implementation for `compute_v_structures`. Also, updated and added the relevant docs and tests.
</strike>

Thank you :)