### PR TITLE
Avoid exception when converting from pandas adjacency with integer column names

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -216,7 +216,7 @@ def from_pandas_adjacency(df, create_using=None):
     A = df.values
     G = from_numpy_array(A, create_using=create_using)
 
-    nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=False)
+    nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=True)
     return G
 
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -215,8 +215,10 @@ def from_pandas_adjacency(df, create_using=None):
 
     A = df.values
     G = from_numpy_array(A, create_using=create_using)
-
-    nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=True)
+    try:
+        nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=False)
+    except nx.NetworkXUnfeasible as err:
+        nx.relabel_nodes(G, dict(enumerate(df.columns)), copy=True)
     return G
 
 


### PR DESCRIPTION
Fixes #7407 