### PR TITLE
Cleanup remaining usages of deprecated `random_tree` in package

### DIFF
--- a/examples/algorithms/plot_lca.py
+++ b/examples/algorithms/plot_lca.py
@@ -14,7 +14,6 @@ color scheme.
 import networkx as nx
 import matplotlib.pyplot as plt
 
-# Generate a random tree with its node positions
 G = nx.DiGraph(
     [
         (0, 2),
@@ -42,8 +41,7 @@ node_colors = ["#D5D7D8" for _ in G]
 node_edge_colors = ["None" for _ in G]
 node_seq = list(G.nodes)
 clr_pairs = (("cyan", "tab:blue"), ("moccasin", "tab:orange"), ("lime", "tab:green"))
-for (children, ancestor), clr_pair in zip(ancestors, clr_pairs):
-    child_clr, anc_clr = clr_pair
+for (children, ancestor), (child_clr, anc_clr) in zip(ancestors, clr_pairs):
     for c in children:
         node_colors[node_seq.index(c)] = child_clr
     node_colors[node_seq.index(ancestor)] = anc_clr

--- a/examples/algorithms/plot_lca.py
+++ b/examples/algorithms/plot_lca.py
@@ -15,33 +15,45 @@ import networkx as nx
 import matplotlib.pyplot as plt
 
 # Generate a random tree with its node positions
-G = nx.random_tree(14, seed=100, create_using=nx.DiGraph)
+G = nx.DiGraph(
+    [
+        (0, 2),
+        (2, 7),
+        (2, 11),
+        (5, 6),
+        (6, 9),
+        (6, 8),
+        (7, 1),
+        (7, 3),
+        (8, 12),
+        (11, 10),
+        (11, 5),
+        (12, 4),
+        (12, 13),
+    ]
+)
 pos = nx.nx_agraph.graphviz_layout(G, prog="dot")
 
 # Compute lowest-common ancestors for certain node pairs
 ancestors = list(nx.all_pairs_lowest_common_ancestor(G, ((1, 3), (4, 9), (13, 10))))
 
 # Create node color and edge color lists
-node_color_map = []
-edge_color_map = []
-for i in range(14):
-    node_color_map.append("#D5D7D8")
-    edge_color_map.append("None")
-template = ["#FFE799", "#FFD23F", "#CEB6E2", "#A77CCB", "#88DFE7", "#45CDD9"]
-x = 0
-for i in ancestors:
-    for j in i[0]:
-        node_color_map[j] = template[x]
-    x += 1
-    node_color_map[i[1]] = template[x]
-    edge_color_map[i[1]] = "black"
-    x += 1
+node_colors = ["#D5D7D8" for _ in G]
+node_edge_colors = ["None" for _ in G]
+node_seq = list(G.nodes)
+clr_pairs = (("cyan", "tab:blue"), ("moccasin", "tab:orange"), ("lime", "tab:green"))
+for (children, ancestor), clr_pair in zip(ancestors, clr_pairs):
+    child_clr, anc_clr = clr_pair
+    for c in children:
+        node_colors[node_seq.index(c)] = child_clr
+    node_colors[node_seq.index(ancestor)] = anc_clr
+    node_edge_colors[node_seq.index(ancestor)] = "black"
 
 # Plot tree
 plt.figure(figsize=(15, 15))
 plt.title("Visualize Lowest Common Ancestors of node pairs")
 nx.draw_networkx_nodes(
-    G, pos, node_color=node_color_map, node_size=2000, edgecolors=edge_color_map
+    G, pos, node_color=node_colors, node_size=2000, edgecolors=node_edge_colors
 )
 nx.draw_networkx_edges(G, pos)
 nx.draw_networkx_labels(G, pos, font_size=15)

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -947,7 +947,7 @@ class TestGirth:
             (nx.petersen_graph(), 5),
             (nx.heawood_graph(), 6),
             (nx.pappus_graph(), 6),
-            (nx.random_tree(10, seed=42), inf),
+            (nx.random_labeled_tree(10, seed=42), inf),
             (nx.empty_graph(10), inf),
             (nx.Graph(chain(cycle_edges(range(5)), cycle_edges(range(6, 10)))), 4),
             (

--- a/networkx/algorithms/tests/test_swap.py
+++ b/networkx/algorithms/tests/test_swap.py
@@ -3,7 +3,8 @@ import pytest
 import networkx as nx
 
 cycle = nx.cycle_graph(5, create_using=nx.DiGraph)
-tree = nx.random_tree(10, create_using=nx.DiGraph, seed=42)
+tree = nx.DiGraph()
+tree.add_edges_from(nx.random_labeled_tree(10, seed=42).edges)
 path = nx.path_graph(5, create_using=nx.DiGraph)
 binomial = nx.binomial_tree(3, create_using=nx.DiGraph)
 HH = nx.directed_havel_hakimi_graph([1, 2, 1, 2, 2, 2], [3, 1, 0, 1, 2, 3])

--- a/networkx/tests/test_all_random_functions.py
+++ b/networkx/tests/test_all_random_functions.py
@@ -194,7 +194,7 @@ def run_all_random_functions(seed):
     t(nx.random_lobster, n, p1, p2, seed=seed)
     t(nx.random_powerlaw_tree, n, seed=seed, tries=5000)
     t(nx.random_powerlaw_tree_sequence, 10, seed=seed, tries=5000)
-    t(nx.random_tree, n, seed=seed)
+    t(nx.random_labeled_tree, n, seed=seed)
     t(nx.utils.powerlaw_sequence, n, seed=seed)
     t(nx.utils.zipf_rv, 2.3, seed=seed)
     cdist = [0.2, 0.4, 0.5, 0.7, 0.9, 1.0]


### PR DESCRIPTION
Replaces the remaining usages of the deprecated `random_tree` with `random_labeled_tree`.