### PR TITLE
Add a `nodelist` feature to `from_numpy_array`

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -214,7 +214,7 @@ def from_pandas_adjacency(df, create_using=None):
         raise nx.NetworkXError("Columns must match Indices.", msg) from err
 
     A = df.values
-    G = from_numpy_array(A, create_using=create_using, node_labels=df.columns)
+    G = from_numpy_array(A, create_using=create_using, nodelist=df.columns)
 
     return G
 
@@ -1022,7 +1022,7 @@ def to_numpy_array(
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def from_numpy_array(
-    A, parallel_edges=False, create_using=None, edge_attr="weight", *, node_labels=None
+    A, parallel_edges=False, create_using=None, edge_attr="weight", *, nodelist=None
 ):
     """Returns a graph from a 2D NumPy array.
 
@@ -1047,7 +1047,7 @@ def from_numpy_array(
         The attribute to which the array values are assigned on each edge. If
         it is None, edge attributes will not be assigned.
 
-    node_labels : list of nodes, optional
+    nodelist : list of nodes, optional
         A list of objects to use as the nodes in the graph. If provided, the
         list of nodes must be the same length as the dimensions of `A`. The
         default is `None`, in which case the nodes are drawn from ``range(n)``.
@@ -1145,14 +1145,14 @@ def from_numpy_array(
         python_type = kind_to_python_type[dt.kind]
     except Exception as err:
         raise TypeError(f"Unknown numpy data type: {dt}") from err
-    if _default_nodes := (node_labels is None):
-        node_labels = range(n)
+    if _default_nodes := (nodelist is None):
+        nodelist = range(n)
     else:
-        if len(node_labels) != n:
-            raise ValueError("node_labels must have the same length as A.shape[0]")
+        if len(nodelist) != n:
+            raise ValueError("nodelist must have the same length as A.shape[0]")
 
     # Make sure we get even the isolated nodes of the graph.
-    G.add_nodes_from(node_labels)
+    G.add_nodes_from(nodelist)
     # Get a list of all the entries in the array with nonzero entries. These
     # coordinates become edges in the graph. (convert to int from np.int64)
     edges = ((int(e[0]), int(e[1])) for e in zip(*A.nonzero()))
@@ -1209,9 +1209,9 @@ def from_numpy_array(
     # when `G.add_edges_from()` is invoked below.
     if G.is_multigraph() and not G.is_directed():
         triples = ((u, v, d) for u, v, d in triples if u <= v)
-    # Remap nodes if user provided custom `node_labels`
+    # Remap nodes if user provided custom `nodelist`
     if not _default_nodes:
-        idx_to_node = dict(enumerate(node_labels))
+        idx_to_node = dict(enumerate(nodelist))
         triples = ((idx_to_node[u], idx_to_node[v], d) for u, v, d in triples)
     G.add_edges_from(triples)
     return G

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1047,8 +1047,8 @@ def from_numpy_array(
         The attribute to which the array values are assigned on each edge. If
         it is None, edge attributes will not be assigned.
 
-    nodelist : list of nodes, optional
-        A list of objects to use as the nodes in the graph. If provided, the
+    nodelist : sequence of nodes, optional
+        A sequence of objects to use as the nodes in the graph. If provided, the
         list of nodes must be the same length as the dimensions of `A`. The
         default is `None`, in which case the nodes are drawn from ``range(n)``.
 

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -214,9 +214,8 @@ def from_pandas_adjacency(df, create_using=None):
         raise nx.NetworkXError("Columns must match Indices.", msg) from err
 
     A = df.values
-    G = from_numpy_array(A, create_using=create_using)
+    G = from_numpy_array(A, create_using=create_using, node_labels=df.columns)
 
-    nx.relabel.relabel_nodes(G, dict(enumerate(df.columns)), copy=False)
     return G
 
 

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -417,7 +417,7 @@ def test_from_numpy_array_nodelist_bad_size():
     # Too few node labels
     nodes = list(range(n - 1))
     with pytest.raises(ValueError, match="nodelist must have the same length as A"):
-        nx.from_numpy_array(A, nodelist=list(range(n - 1)))
+        nx.from_numpy_array(A, nodelist=nodes)
 
 
 @pytest.mark.parametrize(

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -397,8 +397,8 @@ def test_to_numpy_array_structured_multigraph_raises(graph_type):
         nx.to_numpy_array(G, dtype=dtype, weight=None)
 
 
-def test_from_numpy_array_node_labels_bad_size():
-    """An exception is raised when `len(node_labels) != A.shape[0]`."""
+def test_from_numpy_array_nodelist_bad_size():
+    """An exception is raised when `len(nodelist) != A.shape[0]`."""
     n = 5  # Number of nodes
     A = np.diag(np.ones(n - 1), k=1)  # Adj. matrix for P_n
     expected = nx.path_graph(n)
@@ -406,18 +406,18 @@ def test_from_numpy_array_node_labels_bad_size():
     assert graphs_equal(nx.from_numpy_array(A, edge_attr=None), expected)
     nodes = list(range(n))
     assert graphs_equal(
-        nx.from_numpy_array(A, edge_attr=None, node_labels=nodes), expected
+        nx.from_numpy_array(A, edge_attr=None, nodelist=nodes), expected
     )
 
     # Too many node labels
     nodes = list(range(n + 1))
     with pytest.raises(ValueError):
-        nx.from_numpy_array(A, node_labels=nodes)
+        nx.from_numpy_array(A, nodelist=nodes)
 
     # Too few node labels
     nodes = list(range(n - 1))
     with pytest.raises(ValueError):
-        nx.from_numpy_array(A, node_labels=list(range(n - 1)))
+        nx.from_numpy_array(A, nodelist=list(range(n - 1)))
 
 
 @pytest.mark.parametrize(
@@ -430,18 +430,18 @@ def test_from_numpy_array_node_labels_bad_size():
         ["A", 2, 7, "spam", (1, 3)],
     ),
 )
-def test_from_numpy_array_node_labels(nodes):
+def test_from_numpy_array_nodelist(nodes):
     A = np.diag(np.ones(4), k=1)
     # Without edge attributes
     expected = nx.relabel_nodes(
         nx.path_graph(5), mapping=dict(enumerate(nodes)), copy=True
     )
-    G = nx.from_numpy_array(A, edge_attr=None, node_labels=nodes)
+    G = nx.from_numpy_array(A, edge_attr=None, nodelist=nodes)
     assert graphs_equal(G, expected)
 
     # With edge attributes
     nx.set_edge_attributes(expected, 1.0, name="weight")
-    G = nx.from_numpy_array(A, node_labels=nodes)
+    G = nx.from_numpy_array(A, nodelist=nodes)
     assert graphs_equal(G, expected)
 
 
@@ -455,19 +455,17 @@ def test_from_numpy_array_node_labels(nodes):
         ["A", 2, 7, "spam", (1, 3)],
     ),
 )
-def test_from_numpy_array_node_labels_directed(nodes):
+def test_from_numpy_array_nodelist_directed(nodes):
     A = np.diag(np.ones(4), k=1)
     # Without edge attributes
     H = nx.DiGraph([(0, 1), (1, 2), (2, 3), (3, 4)])
     expected = nx.relabel_nodes(H, mapping=dict(enumerate(nodes)), copy=True)
-    G = nx.from_numpy_array(
-        A, create_using=nx.DiGraph, edge_attr=None, node_labels=nodes
-    )
+    G = nx.from_numpy_array(A, create_using=nx.DiGraph, edge_attr=None, nodelist=nodes)
     assert graphs_equal(G, expected)
 
     # With edge attributes
     nx.set_edge_attributes(expected, 1.0, name="weight")
-    G = nx.from_numpy_array(A, create_using=nx.DiGraph, node_labels=nodes)
+    G = nx.from_numpy_array(A, create_using=nx.DiGraph, nodelist=nodes)
     assert graphs_equal(G, expected)
 
 
@@ -481,7 +479,7 @@ def test_from_numpy_array_node_labels_directed(nodes):
         ["A", 2, 7, "spam", (1, 3)],
     ),
 )
-def test_from_numpy_array_node_labels_multigraph(nodes):
+def test_from_numpy_array_nodelist_multigraph(nodes):
     A = np.array(
         [
             [0, 1, 0, 0, 0],
@@ -502,7 +500,7 @@ def test_from_numpy_array_node_labels_multigraph(nodes):
         parallel_edges=True,
         create_using=nx.MultiGraph,
         edge_attr=None,
-        node_labels=nodes,
+        nodelist=nodes,
     )
     assert graphs_equal(G, expected)
 
@@ -518,11 +516,11 @@ def test_from_numpy_array_node_labels_multigraph(nodes):
     ),
 )
 @pytest.mark.parametrize("graph", (nx.complete_graph, nx.cycle_graph, nx.wheel_graph))
-def test_from_numpy_array_node_labels_rountrip(graph, nodes):
+def test_from_numpy_array_nodelist_rountrip(graph, nodes):
     G = graph(5)
     A = nx.to_numpy_array(G)
     expected = nx.relabel_nodes(G, mapping=dict(enumerate(nodes)), copy=True)
-    H = nx.from_numpy_array(A, edge_attr=None, node_labels=nodes)
+    H = nx.from_numpy_array(A, edge_attr=None, nodelist=nodes)
     assert graphs_equal(H, expected)
 
     # With an isolated node
@@ -530,5 +528,5 @@ def test_from_numpy_array_node_labels_rountrip(graph, nodes):
     G.add_node("foo")
     A = nx.to_numpy_array(G)
     expected = nx.relabel_nodes(G, mapping=dict(zip(G.nodes, nodes)), copy=True)
-    H = nx.from_numpy_array(A, edge_attr=None, node_labels=nodes)
+    H = nx.from_numpy_array(A, edge_attr=None, nodelist=nodes)
     assert graphs_equal(H, expected)

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -411,12 +411,12 @@ def test_from_numpy_array_nodelist_bad_size():
 
     # Too many node labels
     nodes = list(range(n + 1))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="nodelist must have the same length as A"):
         nx.from_numpy_array(A, nodelist=nodes)
 
     # Too few node labels
     nodes = list(range(n - 1))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="nodelist must have the same length as A"):
         nx.from_numpy_array(A, nodelist=list(range(n - 1)))
 
 

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -505,3 +505,30 @@ def test_from_numpy_array_node_labels_multigraph(nodes):
         node_labels=nodes,
     )
     assert graphs_equal(G, expected)
+
+
+@pytest.mark.parametrize(
+    "nodes",
+    (
+        [4, 3, 2, 1, 0],
+        [9, 7, 1, 2, 8],
+        ["a", "b", "c", "d", "e"],
+        [(0, 0), (1, 1), (2, 3), (0, 2), (3, 1)],
+        ["A", 2, 7, "spam", (1, 3)],
+    ),
+)
+@pytest.mark.parametrize("graph", (nx.complete_graph, nx.cycle_graph, nx.wheel_graph))
+def test_from_numpy_array_node_labels_rountrip(graph, nodes):
+    G = graph(5)
+    A = nx.to_numpy_array(G)
+    expected = nx.relabel_nodes(G, mapping=dict(enumerate(nodes)), copy=True)
+    H = nx.from_numpy_array(A, edge_attr=None, node_labels=nodes)
+    assert graphs_equal(H, expected)
+
+    # With an isolated node
+    G = graph(4)
+    G.add_node("foo")
+    A = nx.to_numpy_array(G)
+    expected = nx.relabel_nodes(G, mapping=dict(zip(G.nodes, nodes)), copy=True)
+    H = nx.from_numpy_array(A, edge_attr=None, node_labels=nodes)
+    assert graphs_equal(H, expected)

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -318,3 +318,21 @@ def test_to_pandas_edgelist_with_nodelist():
     df = nx.to_pandas_edgelist(G, nodelist=[1, 2])
     assert 0 not in df["source"].to_numpy()
     assert 100 not in df["weight"].to_numpy()
+
+
+def test_from_pandas_adjacency_with_index_collisions():
+    """See gh-7407"""
+    df = pd.DataFrame(
+        [
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 0, 0, 0],
+        ],
+        index=[1010001, 2, 1, 1010002],
+        columns=[1010001, 2, 1, 1010002],
+    )
+    G = nx.from_pandas_adjacency(df, create_using=nx.DiGraph)
+    expected = nx.DiGraph([(1010001, 2), (2, 1), (1, 1010002)])
+    assert nodes_equal(G.nodes, expected.nodes)
+    assert edges_equal(G.edges, expected.edges)


### PR DESCRIPTION
Adds a kwarg to allow users to specify a sequence of nodes which map to the dimensions of the adjacency matrix. The mapping implicitly relies on the ordering of the nodes in the adjacency matrix, i.e. `node_labels[0] -> row 0`, `node_labels[1] -> row 1`, etc.

I'm not sure about the name of the kwarg. One motivating factor for this proposal is it fixes #7407 in an efficient way. I've added that change in a1a17ac7, but I'm happy to break that into a separate PR in order to focus on the new feature proposal!