### PR TITLE
Expires the `forest_str` deprecation

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -41,11 +41,6 @@ Todo
 
 Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
-Version 3.3
-~~~~~~~~~~~
-* Remove the ``forest_str`` function from ``readwrite/text.py``. Replace
-  existing usages with ``write_network_text``.
-
 Version 3.4
 ~~~~~~~~~~~
 * Remove the ``random_tree`` function from ``generators/trees.py``. Replace

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -100,9 +100,6 @@ def set_warnings():
         message="\n\nshortest_path",
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\nforest_str is deprecated"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nrandom_tree"
     )
     warnings.filterwarnings(

--- a/networkx/readwrite/tests/test_text.py
+++ b/networkx/readwrite/tests/test_text.py
@@ -7,7 +7,7 @@ import pytest
 import networkx as nx
 
 
-def test_forest_str_directed():
+def test_generate_network_text_forest_directed():
     # Create a directed forest with labels
     graph = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
     for node in graph.nodes:
@@ -38,26 +38,12 @@ def test_forest_str_directed():
     ).strip()
 
     # Basic node case
-    ret = nx.forest_str(graph, with_labels=False)
-    print(ret)
-    assert ret == node_target
+    ret = nx.generate_network_text(graph, with_labels=False)
+    assert "\n".join(ret) == node_target
 
     # Basic label case
-    ret = nx.forest_str(graph, with_labels=True)
-    print(ret)
-    assert ret == label_target
-
-    # Custom write function case
-    lines = []
-    ret = nx.forest_str(graph, write=lines.append, with_labels=False)
-    assert ret is None
-    assert lines == node_target.split("\n")
-
-    # Smoke test to ensure passing the print function works. To properly test
-    # this case we would need to capture stdout. (for potential reference
-    # implementation see :class:`ubelt.util_stream.CaptureStdout`)
-    ret = nx.forest_str(graph, write=print)
-    assert ret is None
+    ret = nx.generate_network_text(graph, with_labels=True)
+    assert "\n".join(ret) == label_target
 
 
 def test_write_network_text_empty_graph():
@@ -97,12 +83,11 @@ def test_write_network_text_within_forest_glyph():
     assert text == target
 
 
-def test_forest_str_directed_multi_tree():
+def test_generate_network_text_directed_multi_tree():
     tree1 = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
     tree2 = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
     forest = nx.disjoint_union_all([tree1, tree2])
-    ret = nx.forest_str(forest)
-    print(ret)
+    ret = "\n".join(nx.generate_network_text(forest))
 
     target = dedent(
         """
@@ -126,8 +111,7 @@ def test_forest_str_directed_multi_tree():
 
     tree3 = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
     forest = nx.disjoint_union_all([tree1, tree2, tree3])
-    ret = nx.forest_str(forest, sources=[0, 14, 7])
-    print(ret)
+    ret = "\n".join(nx.generate_network_text(forest, sources=[0, 14, 7]))
 
     target = dedent(
         """
@@ -156,8 +140,9 @@ def test_forest_str_directed_multi_tree():
     ).strip()
     assert ret == target
 
-    ret = nx.forest_str(forest, sources=[0, 14, 7], ascii_only=True)
-    print(ret)
+    ret = "\n".join(
+        nx.generate_network_text(forest, sources=[0, 14, 7], ascii_only=True)
+    )
 
     target = dedent(
         """
@@ -187,13 +172,12 @@ def test_forest_str_directed_multi_tree():
     assert ret == target
 
 
-def test_forest_str_undirected_multi_tree():
+def test_generate_network_text_undirected_multi_tree():
     tree1 = nx.balanced_tree(r=2, h=2, create_using=nx.Graph)
     tree2 = nx.balanced_tree(r=2, h=2, create_using=nx.Graph)
     tree2 = nx.relabel_nodes(tree2, {n: n + len(tree1) for n in tree2.nodes})
     forest = nx.union(tree1, tree2)
-    ret = nx.forest_str(forest, sources=[0, 7])
-    print(ret)
+    ret = "\n".join(nx.generate_network_text(forest, sources=[0, 7]))
 
     target = dedent(
         """
@@ -215,8 +199,7 @@ def test_forest_str_undirected_multi_tree():
     ).strip()
     assert ret == target
 
-    ret = nx.forest_str(forest, sources=[0, 7], ascii_only=True)
-    print(ret)
+    ret = "\n".join(nx.generate_network_text(forest, sources=[0, 7], ascii_only=True))
 
     target = dedent(
         """
@@ -239,12 +222,9 @@ def test_forest_str_undirected_multi_tree():
     assert ret == target
 
 
-def test_forest_str_undirected():
+def test_generate_network_text_forest_undirected():
     # Create a directed forest
     graph = nx.balanced_tree(r=2, h=2, create_using=nx.Graph)
-
-    # arbitrary starting point
-    nx.forest_str(graph)
 
     node_target0 = dedent(
         """
@@ -259,8 +239,7 @@ def test_forest_str_undirected():
     ).strip()
 
     # defined starting point
-    ret = nx.forest_str(graph, sources=[0])
-    print(ret)
+    ret = "\n".join(nx.generate_network_text(graph, sources=[0]))
     assert ret == node_target0
 
     # defined starting point
@@ -275,24 +254,11 @@ def test_forest_str_undirected():
             └── 6
         """
     ).strip()
-    ret = nx.forest_str(graph, sources=[2])
-    print(ret)
+    ret = "\n".join(nx.generate_network_text(graph, sources=[2]))
     assert ret == node_target2
 
 
-def test_forest_str_errors():
-    ugraph = nx.complete_graph(3, create_using=nx.Graph)
-
-    with pytest.raises(nx.NetworkXNotImplemented):
-        nx.forest_str(ugraph)
-
-    dgraph = nx.complete_graph(3, create_using=nx.DiGraph)
-
-    with pytest.raises(nx.NetworkXNotImplemented):
-        nx.forest_str(dgraph)
-
-
-def test_forest_str_overspecified_sources():
+def test_generate_network_text_overspecified_sources():
     """
     When sources are directly specified, we won't be able to determine when we
     are in the last component, so there will always be a trailing, leftmost
@@ -335,18 +301,8 @@ def test_forest_str_overspecified_sources():
         """
     ).strip()
 
-    lines = []
-    nx.forest_str(graph, write=lines.append, sources=graph.nodes)
-    got1 = "\n".join(lines)
-    print("got1: ")
-    print(got1)
-
-    lines = []
-    nx.forest_str(graph, write=lines.append)
-    got2 = "\n".join(lines)
-    print("got2: ")
-    print(got2)
-
+    got1 = "\n".join(nx.generate_network_text(graph, sources=graph.nodes))
+    got2 = "\n".join(nx.generate_network_text(graph))
     assert got1 == target1
     assert got2 == target2
 

--- a/networkx/readwrite/tests/test_text.py
+++ b/networkx/readwrite/tests/test_text.py
@@ -67,7 +67,6 @@ def test_write_network_text_within_forest_glyph():
     nx.write_network_text(g, path=write, end="")
     nx.write_network_text(g, path=write, ascii_only=True, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╟── 1
@@ -322,7 +321,6 @@ def test_write_network_text_iterative_add_directed_edges():
         graph.add_edge(i, j)
         nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     # defined starting point
     target = dedent(
         """
@@ -472,7 +470,6 @@ def test_write_network_text_iterative_add_undirected_edges():
         graph.add_edge(i, j)
         nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- initial state ---
@@ -580,7 +577,6 @@ def test_write_network_text_iterative_add_random_directed_edges():
         graph.add_edge(i, j)
         nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- initial state ---
@@ -663,7 +659,6 @@ def test_write_network_text_nearly_forest():
     write("--- add (1, 8), (4, 2), (6, 3) ---")
     nx.write_network_text(g.to_undirected(), path=write, sources=[1], end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- directed case ---
@@ -721,7 +716,6 @@ def test_write_network_text_complete_graph_ascii_only():
     write("--- undirected case ---")
     nx.write_network_text(graph.to_undirected(), path=write, ascii_only=True, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- directed case ---
@@ -757,7 +751,6 @@ def test_write_network_text_with_labels():
     write = lines.append
     nx.write_network_text(graph, path=write, with_labels=True, ascii_only=False, end="")
     text = "\n".join(lines)
-    print(text)
     # Non trees with labels can get somewhat out of hand with network text
     # because we need to immediately show every non-tree edge to the right
     target = dedent(
@@ -790,7 +783,6 @@ def test_write_network_text_complete_graphs():
         write(f"--- directed k={k} ---")
         nx.write_network_text(g, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- undirected k=0 ---
@@ -880,7 +872,6 @@ def test_write_network_text_multiple_sources():
         write(f"--- source node: {n} ---")
         nx.write_network_text(g, path=write, sources=[n], end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- source node: 1 ---
@@ -944,7 +935,6 @@ def test_write_network_text_star_graph():
     write = lines.append
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╙── 1
@@ -964,7 +954,6 @@ def test_write_network_text_path_graph():
     write = lines.append
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╙── 0
@@ -981,7 +970,6 @@ def test_write_network_text_lollipop_graph():
     write = lines.append
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╙── 5
@@ -1003,7 +991,6 @@ def test_write_network_text_wheel_graph():
     write = lines.append
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╙── 1
@@ -1026,7 +1013,6 @@ def test_write_network_text_circular_ladder_graph():
     write = lines.append
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╙── 0
@@ -1052,7 +1038,6 @@ def test_write_network_text_dorogovtsev_goltsev_mendes_graph():
     write = lines.append
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         ╙── 15
@@ -1134,7 +1119,6 @@ def test_write_network_text_tree_max_depth():
     write("--- undirected case, max_depth=4 ---")
     nx.write_network_text(orig.to_undirected(), path=write, end="", max_depth=4)
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- directed case, max_depth=0 ---
@@ -1205,7 +1189,6 @@ def test_write_network_text_graph_max_depth():
     write("--- undirected case, max_depth=3 ---")
     nx.write_network_text(orig.to_undirected(), path=write, end="", max_depth=3)
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- directed case, max_depth=None ---
@@ -1312,7 +1295,6 @@ def test_write_network_text_clique_max_depth():
     write("--- undirected case, max_depth=3 ---")
     nx.write_network_text(orig.to_undirected(), path=write, end="", max_depth=3)
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- directed case, max_depth=None ---
@@ -1410,7 +1392,6 @@ def test_write_network_text_custom_label():
     nx.write_network_text(graph, path=write, with_labels="part", end="", max_depth=None)
 
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- when with_labels=True, uses the 'label' attr ---
@@ -1479,7 +1460,6 @@ def test_write_network_text_vertical_chains():
     )
 
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- Undirected UTF ---
@@ -1571,7 +1551,6 @@ def test_collapse_directed():
     graph.nodes[0]["collapse"] = True
     nx.write_network_text(graph, path=write, end="")
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- Original ---
@@ -1639,7 +1618,6 @@ def test_collapse_undirected():
     graph.nodes[0]["collapse"] = True
     nx.write_network_text(graph, path=write, end="", sources=[0])
     text = "\n".join(lines)
-    print(text)
     target = dedent(
         """
         --- Original ---
@@ -1760,6 +1738,5 @@ def test_network_text_round_trip(vertical_chains, ascii_only):
             assert new.nodes == graph.nodes
             assert new.edges == graph.edges
         except Exception:
-            print("ERROR in round trip with graph")
             nx.write_network_text(graph)
             raise

--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import networkx as nx
 from networkx.utils import open_file
 
-__all__ = ["forest_str", "generate_network_text", "write_network_text"]
+__all__ = ["generate_network_text", "write_network_text"]
 
 
 class BaseGlyphs:
@@ -642,105 +642,6 @@ def _find_sources(graph):
         ]
         sources = sorted(sources, key=lambda n: graph.degree[n])
     return sources
-
-
-def forest_str(graph, with_labels=True, sources=None, write=None, ascii_only=False):
-    """Creates a nice utf8 representation of a forest
-
-    This function has been superseded by
-    :func:`nx.readwrite.text.generate_network_text`, which should be used
-    instead.
-
-    Parameters
-    ----------
-    graph : nx.DiGraph | nx.Graph
-        Graph to represent (must be a tree, forest, or the empty graph)
-
-    with_labels : bool
-        If True will use the "label" attribute of a node to display if it
-        exists otherwise it will use the node value itself. Defaults to True.
-
-    sources : List
-        Mainly relevant for undirected forests, specifies which nodes to list
-        first. If unspecified the root nodes of each tree will be used for
-        directed forests; for undirected forests this defaults to the nodes
-        with the smallest degree.
-
-    write : callable
-        Function to use to write to, if None new lines are appended to
-        a list and returned. If set to the `print` function, lines will
-        be written to stdout as they are generated. If specified,
-        this function will return None. Defaults to None.
-
-    ascii_only : Boolean
-        If True only ASCII characters are used to construct the visualization
-
-    Returns
-    -------
-    str | None :
-        utf8 representation of the tree / forest
-
-    Examples
-    --------
-    >>> graph = nx.balanced_tree(r=2, h=3, create_using=nx.DiGraph)
-    >>> print(nx.forest_str(graph))
-    ╙── 0
-        ├─╼ 1
-        │   ├─╼ 3
-        │   │   ├─╼ 7
-        │   │   └─╼ 8
-        │   └─╼ 4
-        │       ├─╼ 9
-        │       └─╼ 10
-        └─╼ 2
-            ├─╼ 5
-            │   ├─╼ 11
-            │   └─╼ 12
-            └─╼ 6
-                ├─╼ 13
-                └─╼ 14
-
-
-    >>> graph = nx.balanced_tree(r=1, h=2, create_using=nx.Graph)
-    >>> print(nx.forest_str(graph))
-    ╙── 0
-        └── 1
-            └── 2
-
-    >>> print(nx.forest_str(graph, ascii_only=True))
-    +-- 0
-        L-- 1
-            L-- 2
-    """
-    msg = (
-        "\nforest_str is deprecated as of version 3.1 and will be removed "
-        "in version 3.3. Use generate_network_text or write_network_text "
-        "instead.\n"
-    )
-    warnings.warn(msg, DeprecationWarning)
-
-    if len(graph.nodes) > 0:
-        if not nx.is_forest(graph):
-            raise nx.NetworkXNotImplemented("input must be a forest or the empty graph")
-
-    printbuf = []
-    if write is None:
-        _write = printbuf.append
-    else:
-        _write = write
-
-    write_network_text(
-        graph,
-        _write,
-        with_labels=with_labels,
-        sources=sources,
-        ascii_only=ascii_only,
-        end="",
-    )
-
-    if write is None:
-        # Only return a string if the custom write function was not specified
-        return "\n".join(printbuf)
 
 
 def _parse_network_text(lines):


### PR DESCRIPTION
This was supposed to make it into 3.3 (oops), but better late than never! Removes `forest_str` in favor of `generate_network_text` as the deprecation message specifies.

I went ahead and updated the `forest_str` tests to use `generate_network_text` (rather than delete them) to verify that `generate_network_text` works as expected as a replacement for those use-cases. For tests that probed features/exceptions specific to `forest_str`, I went ahead and removed them. I also snuck in a commit to rm remaining extraneous print statements from the readwrite test suite.