### PR TITLE
Expire deprecated `sort_neighbors` param in `generic_bfs_edges`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -43,7 +43,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
 Version 3.4
 ~~~~~~~~~~~
-* Remove the ``sort_neighbors`` input parameter from ``generic_bfs_edges``.
 * Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
 * Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.
 * Remove ``normalized`` kwarg from ``algorithms.s_metric``

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 @nx._dispatchable
-def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbors=None):
+def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
     """Iterate over edges in a breadth-first search.
 
     The breadth-first search begins at `source` and enqueues the
@@ -42,18 +42,6 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
 
     depth_limit : int, optional(default=len(G))
         Specify the maximum search depth.
-
-    sort_neighbors : Callable (default=None)
-
-        .. deprecated:: 3.2
-
-           The sort_neighbors parameter is deprecated and will be removed in
-           version 3.4. A custom (e.g. sorted) ordering of neighbors can be
-           specified with the `neighbors` parameter.
-
-        A function that takes an iterator over nodes as the input, and
-        returns an iterable of the same nodes with a custom ordering.
-        For example, `sorted` will sort the nodes in increasing order.
 
     Yields
     ------
@@ -95,19 +83,6 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None, sort_neighbor
     """
     if neighbors is None:
         neighbors = G.neighbors
-    if sort_neighbors is not None:
-        import warnings
-
-        warnings.warn(
-            (
-                "The sort_neighbors parameter is deprecated and will be removed\n"
-                "in NetworkX 3.4, use the neighbors parameter instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        _neighbors = neighbors
-        neighbors = lambda node: iter(sort_neighbors(_neighbors(node)))
     if depth_limit is None:
         depth_limit = len(G)
 

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -201,12 +201,3 @@ class TestBreadthLimitedSearch:
             assert nx.descendants_at_distance(self.G, 0, distance) == descendants
         for distance, descendants in enumerate([{2}, {3, 7}, {8}, {9}, {10}]):
             assert nx.descendants_at_distance(self.D, 2, distance) == descendants
-
-
-def test_deprecations():
-    G = nx.Graph([(1, 2)])
-    generic_bfs = nx.breadth_first_search.generic_bfs_edges
-    with pytest.deprecated_call():
-        list(generic_bfs(G, source=1, sort_neighbors=sorted))
-    with pytest.deprecated_call():
-        list(generic_bfs(G, source=1, neighbors=G.neighbors, sort_neighbors=sorted))


### PR DESCRIPTION
Removes the `sort_neighbors` param per the deprecation in #5925 .

This is ready for review, but will mark as draft until we're sure there's no need for a 3.3 patch release!