### PR TITLE
Rm deprecated normalized param from s_metric.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -48,7 +48,6 @@ Version 3.4
 * Remove the ``sort_neighbors`` input parameter from ``generic_bfs_edges``.
 * Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
 * Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.
-* Remove ``normalized`` kwarg from ``algorithms.s_metric``
 * Remove renamed function ``join()`` in ``algorithms/tree/operations.py`` and
   in ``doc/reference/algorithms/trees.rst``
 * Remove ``strongly_connected_components_recursive`` from

--- a/networkx/algorithms/smetric.py
+++ b/networkx/algorithms/smetric.py
@@ -4,7 +4,7 @@ __all__ = ["s_metric"]
 
 
 @nx._dispatchable
-def s_metric(G, **kwargs):
+def s_metric(G):
     """Returns the s-metric [1]_ of graph.
 
     The s-metric is defined as the sum of the products ``deg(u) * deg(v)``
@@ -14,13 +14,6 @@ def s_metric(G, **kwargs):
     ----------
     G : graph
         The graph used to compute the s-metric.
-    normalized : bool (optional)
-        Normalize the value.
-
-        .. deprecated:: 3.2
-
-           The `normalized` keyword argument is deprecated and will be removed
-           in the future
 
     Returns
     -------
@@ -34,27 +27,4 @@ def s_metric(G, **kwargs):
            Definition, Properties, and  Implications (Extended Version), 2005.
            https://arxiv.org/abs/cond-mat/0501169
     """
-    # NOTE: This entire code block + the **kwargs in the signature can all be
-    # removed when the deprecation expires.
-    # Normalized is always False, since all `normalized=True` did was raise
-    # a NotImplementedError
-    if kwargs:
-        # Warn for `normalize`, raise for any other kwarg
-        if "normalized" in kwargs:
-            import warnings
-
-            warnings.warn(
-                "\n\nThe `normalized` keyword is deprecated and will be removed\n"
-                "in the future. To silence this warning, remove `normalized`\n"
-                "when calling `s_metric`.\n\n"
-                "The value of `normalized` is ignored.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-        else:
-            # Typical raising behavior for Python when kwarg not recognized
-            raise TypeError(
-                f"s_metric got an unexpected keyword argument '{list(kwargs.keys())[0]}'"
-            )
-
     return float(sum(G.degree(u) * G.degree(v) for (u, v) in G.edges()))

--- a/networkx/algorithms/tests/test_smetric.py
+++ b/networkx/algorithms/tests/test_smetric.py
@@ -1,36 +1,8 @@
-import warnings
-
 import pytest
 
 import networkx as nx
 
 
 def test_smetric():
-    g = nx.Graph()
-    g.add_edge(1, 2)
-    g.add_edge(2, 3)
-    g.add_edge(2, 4)
-    g.add_edge(1, 4)
-    sm = nx.s_metric(g, normalized=False)
-    assert sm == 19.0
-
-
-# NOTE: Tests below to be deleted when deprecation of `normalized` kwarg expires
-
-
-def test_normalized_deprecation_warning():
-    """Test that a deprecation warning is raised when s_metric is called with
-    a `normalized` kwarg."""
-    G = nx.cycle_graph(7)
-    # No warning raised when called without kwargs (future behavior)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Fail the test if warning caught
-        assert nx.s_metric(G) == 28
-
-    # Deprecation warning
-    with pytest.deprecated_call():
-        nx.s_metric(G, normalized=True)
-
-    # Make sure you get standard Python behavior when unrecognized keyword provided
-    with pytest.raises(TypeError):
-        nx.s_metric(G, normalize=True)
+    G = nx.Graph([(1, 2), (2, 3), (2, 4), (1, 4)])
+    assert nx.s_metric(G) == 19.0


### PR DESCRIPTION
Removes the deprecated `normalized` parameter from `s_metric`. I also snuck in a cleanup of the one existing test for this function, but I'm happy to back that out if it complicates review (the test itself is unchanged, only formatting updates).

Like other dep PRs - draft for now, but this is ready for review. 