### PR TITLE
Expire deprecated nx.join in favor of join_trees.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -45,8 +45,6 @@ Version 3.4
 ~~~~~~~~~~~
 * Remove ``MultiDiGraph_EdgeKey`` class from ``algorithms/tree/branchings.py``. 
 * Remove ``Edmonds`` class from ``algorithms/tree/branchings.py``.
-* Remove renamed function ``join()`` in ``algorithms/tree/operations.py`` and
-  in ``doc/reference/algorithms/trees.rst``
 
 Version 3.5
 ~~~~~~~~~~~

--- a/doc/reference/algorithms/tree.rst
+++ b/doc/reference/algorithms/tree.rst
@@ -50,7 +50,6 @@ Operations
    :toctree: generated/
 
    join_trees
-   join
 
 Spanning Trees
 --------------

--- a/networkx/algorithms/tree/operations.py
+++ b/networkx/algorithms/tree/operations.py
@@ -4,31 +4,7 @@ from itertools import accumulate, chain
 
 import networkx as nx
 
-__all__ = ["join", "join_trees"]
-
-
-def join(rooted_trees, label_attribute=None):
-    """A deprecated name for `join_trees`
-
-    Returns a new rooted tree with a root node joined with the roots
-    of each of the given rooted trees.
-
-    .. deprecated:: 3.2
-
-       `join` is deprecated in NetworkX v3.2 and will be removed in v3.4.
-       It has been renamed join_trees with the same syntax/interface.
-
-    """
-    import warnings
-
-    warnings.warn(
-        "The function `join` is deprecated and is renamed `join_trees`.\n"
-        "The ``join`` function itself will be removed in v3.4",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    return join_trees(rooted_trees, label_attribute=label_attribute)
+__all__ = ["join_trees"]
 
 
 # Argument types don't match dispatching, but allow manual selection of backend
@@ -86,7 +62,7 @@ def join_trees(rooted_trees, *, label_attribute=None, first_label=0):
         >>> h = 4
         >>> left = nx.balanced_tree(2, h)
         >>> right = nx.balanced_tree(2, h)
-        >>> joined_tree = nx.join([(left, 0), (right, 0)])
+        >>> joined_tree = nx.join_trees([(left, 0), (right, 0)])
         >>> nx.is_isomorphic(joined_tree, nx.balanced_tree(2, h + 1))
         True
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -111,11 +111,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
-        message="The function `join` is deprecated",
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nall_triplets"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
Completes removal of `join` in favor of `join_trees`.