### PR TITLE
Expire deprecation for strongly_connected_components_recursive.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -51,8 +51,6 @@ Version 3.4
 * Remove ``normalized`` kwarg from ``algorithms.s_metric``
 * Remove renamed function ``join()`` in ``algorithms/tree/operations.py`` and
   in ``doc/reference/algorithms/trees.rst``
-* Remove ``strongly_connected_components_recursive`` from
-  ``algorithms/components/strongly_connected.py``
 
 Version 3.5
 ~~~~~~~~~~~

--- a/doc/reference/algorithms/component.rst
+++ b/doc/reference/algorithms/component.rst
@@ -25,7 +25,6 @@ Strong connectivity
    is_strongly_connected
    number_strongly_connected_components
    strongly_connected_components
-   strongly_connected_components_recursive
    kosaraju_strongly_connected_components
    condensation
 

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -6,7 +6,6 @@ __all__ = [
     "number_strongly_connected_components",
     "strongly_connected_components",
     "is_strongly_connected",
-    "strongly_connected_components_recursive",
     "kosaraju_strongly_connected_components",
     "condensation",
 ]
@@ -168,88 +167,6 @@ def kosaraju_strongly_connected_components(G, source=None):
         new = {v for v in c if v not in seen}
         seen.update(new)
         yield new
-
-
-@not_implemented_for("undirected")
-@nx._dispatchable
-def strongly_connected_components_recursive(G):
-    """Generate nodes in strongly connected components of graph.
-
-    .. deprecated:: 3.2
-
-       This function is deprecated and will be removed in a future version of
-       NetworkX. Use `strongly_connected_components` instead.
-
-    Recursive version of algorithm.
-
-    Parameters
-    ----------
-    G : NetworkX Graph
-        A directed graph.
-
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each strongly connected
-        component of G.
-
-    Raises
-    ------
-    NetworkXNotImplemented
-        If G is undirected.
-
-    Examples
-    --------
-    Generate a sorted list of strongly connected components, largest first.
-
-    >>> G = nx.cycle_graph(4, create_using=nx.DiGraph())
-    >>> nx.add_cycle(G, [10, 11, 12])
-    >>> [
-    ...     len(c)
-    ...     for c in sorted(
-    ...         nx.strongly_connected_components_recursive(G), key=len, reverse=True
-    ...     )
-    ... ]
-    [4, 3]
-
-    If you only want the largest component, it's more efficient to
-    use max instead of sort.
-
-    >>> largest = max(nx.strongly_connected_components_recursive(G), key=len)
-
-    To create the induced subgraph of the components use:
-    >>> S = [G.subgraph(c).copy() for c in nx.weakly_connected_components(G)]
-
-    See Also
-    --------
-    connected_components
-
-    Notes
-    -----
-    Uses Tarjan's algorithm[1]_ with Nuutila's modifications[2]_.
-
-    References
-    ----------
-    .. [1] Depth-first search and linear graph algorithms, R. Tarjan
-       SIAM Journal of Computing 1(2):146-160, (1972).
-
-    .. [2] On finding the strongly connected components in a directed graph.
-       E. Nuutila and E. Soisalon-Soinen
-       Information Processing Letters 49(1): 9-14, (1994)..
-
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\nstrongly_connected_components_recursive is deprecated and will be\n"
-            "removed in the future. Use strongly_connected_components instead."
-        ),
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-
-    yield from strongly_connected_components(G)
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/components/tests/test_strongly_connected.py
+++ b/networkx/algorithms/components/tests/test_strongly_connected.py
@@ -60,12 +60,6 @@ class TestStronglyConnected:
         for G, C in self.gc:
             assert {frozenset(g) for g in scc(G)} == C
 
-    def test_tarjan_recursive(self):
-        scc = nx.strongly_connected_components_recursive
-        for G, C in self.gc:
-            with pytest.deprecated_call():
-                assert {frozenset(g) for g in scc(G)} == C
-
     def test_kosaraju(self):
         scc = nx.kosaraju_strongly_connected_components
         for G, C in self.gc:
@@ -169,8 +163,6 @@ class TestStronglyConnected:
         G = nx.DiGraph()
         assert list(nx.strongly_connected_components(G)) == []
         assert list(nx.kosaraju_strongly_connected_components(G)) == []
-        with pytest.deprecated_call():
-            assert list(nx.strongly_connected_components_recursive(G)) == []
         assert len(nx.condensation(G)) == 0
         pytest.raises(
             nx.NetworkXPointlessConcept, nx.is_strongly_connected, nx.DiGraph()
@@ -182,8 +174,6 @@ class TestStronglyConnected:
             next(nx.strongly_connected_components(G))
         with pytest.raises(NetworkXNotImplemented):
             next(nx.kosaraju_strongly_connected_components(G))
-        with pytest.raises(NetworkXNotImplemented):
-            next(nx.strongly_connected_components_recursive(G))
         pytest.raises(NetworkXNotImplemented, nx.is_strongly_connected, G)
         pytest.raises(NetworkXNotImplemented, nx.condensation, G)
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -119,11 +119,6 @@ def set_warnings():
         message="The function `join` is deprecated",
     )
     warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
-        message="\n\nstrongly_connected_components_recursive",
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nall_triplets"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
Completes removal of `strongly_connected_components_recursive`.