### PR TITLE
Prioritize edgelist representations in `to_networkx_graph`

### DIFF
--- a/benchmarks/benchmarks/benchmark_to_networkx_graph.py
+++ b/benchmarks/benchmarks/benchmark_to_networkx_graph.py
@@ -1,0 +1,30 @@
+import networkx as nx
+
+
+class ToNetworkXGraphBenchmark:
+    params = [nx.Graph, nx.DiGraph]
+    param_names = ["graph_type"]
+
+    def setup(self, graph_type):
+        self.edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+
+    def time_to_networkx_graph_direct(self, graph_type):
+        _ = nx.to_networkx_graph(self.edges, create_using=graph_type)
+
+    def time_to_networkx_graph_via_constructor(self, graph_type):
+        _ = graph_type(self.edges)
+
+    ### NOTE: Multi-instance checks are explicitly included to cover the case
+    # where many graph instances are created, which is not uncommon in graph
+    # analysis. The reason why multi-instance is explicitly probed (rather than
+    # relying solely on the number of repeats/runs from `timeit` in the benchmark
+    # suite) is to capture/amplify any distinctions from potential import
+    # cacheing of the try-excepts in the *same* run
+
+    def time_to_networkx_graph_direct_multi_instance(self, graph_type):
+        for _ in range(500):  # Creating many graph instances
+            _ = nx.to_networkx_graph(self.edges, create_using=graph_type)
+
+    def time_to_networkx_graph_via_constructor_multi_instance(self, graph_type):
+        for _ in range(500):  # Creating many graph instances
+            _ = graph_type(self.edges)

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -82,6 +82,7 @@ EdgeDataView
 
     The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 """
+from abc import ABC
 from collections.abc import Mapping, Set
 
 import networkx as nx
@@ -734,8 +735,15 @@ class OutMultiDegreeView(DiDegreeView):
                 yield (n, deg)
 
 
+# A base class for all edge views. Ensures all edge view and edge data view
+# objects/classes are captured by `isinstance(obj, EdgeViewABC)` and
+# `issubclass(cls, EdgeViewABC)` respectively
+class EdgeViewABC(ABC):
+    pass
+
+
 # EdgeDataViews
-class OutEdgeDataView:
+class OutEdgeDataView(EdgeViewABC):
     """EdgeDataView for outward edges of DiGraph; See EdgeDataView"""
 
     __slots__ = (
@@ -1036,7 +1044,7 @@ class InMultiEdgeDataView(OutMultiEdgeDataView):
 
 
 # EdgeViews    have set operations and no data reported
-class OutEdgeView(Set, Mapping):
+class OutEdgeView(Set, Mapping, EdgeViewABC):
     """A EdgeView class for outward edges of a DiGraph"""
 
     __slots__ = ("_adjdict", "_graph", "_nodes_nbrs")

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -1425,3 +1425,11 @@ def test_cache_dict_get_set_state(graph):
     # Raises error if the cached properties and views do not work
     pickle.loads(pickle.dumps(G, -1))
     deepcopy(G)
+
+
+def test_edge_views_inherit_from_EdgeViewABC():
+    all_edge_view_classes = (v for v in dir(nx.reportviews) if "Edge" in v)
+    for eview_class in all_edge_view_classes:
+        assert issubclass(
+            getattr(nx.reportviews, eview_class), nx.reportviews.EdgeViewABC
+        )

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -90,13 +90,6 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
         except Exception as err:
             raise nx.NetworkXError("Input is not a correct NetworkX graph.") from err
 
-    # pygraphviz  agraph
-    if hasattr(data, "is_strict"):
-        try:
-            return nx.nx_agraph.from_agraph(data, create_using=create_using)
-        except Exception as err:
-            raise nx.NetworkXError("Input is not a correct pygraphviz graph.") from err
-
     # dict of dicts/lists
     if isinstance(data, dict):
         try:
@@ -112,6 +105,22 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
                 return from_dict_of_lists(data, create_using=create_using)
             except Exception as err2:
                 raise TypeError("Input is not known type.") from err2
+
+    # edgelist
+    if isinstance(
+        data, list | nx.reportviews.EdgeView | nx.reportviews.EdgeDataView | Iterator
+    ):
+        try:
+            return from_edgelist(data, create_using=create_using)
+        except:
+            pass
+
+    # pygraphviz  agraph
+    if hasattr(data, "is_strict"):
+        try:
+            return nx.nx_agraph.from_agraph(data, create_using=create_using)
+        except Exception as err:
+            raise nx.NetworkXError("Input is not a correct pygraphviz graph.") from err
 
     # Pandas DataFrame
     try:

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -106,10 +106,8 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
             except Exception as err2:
                 raise TypeError("Input is not known type.") from err2
 
-    # edgelist
-    if isinstance(
-        data, list | nx.reportviews.EdgeView | nx.reportviews.EdgeDataView | Iterator
-    ):
+    # edgelists
+    if isinstance(data, list | tuple | nx.reportviews.EdgeViewABC | Iterator):
         try:
             return from_edgelist(data, create_using=create_using)
         except:


### PR DESCRIPTION
This PR was originally motivated by #7401. The main issue there is the extraneous `ImportWarning` s that are raised by `to_networkx_graph` (often via the graph constructors) when creating graphs in an environment without the default dependencies (numpy, scipy, pandas). This is the case because converting from these data structures is actually attempted *before* attempting to interpret the input as an edgelist. However, creating a graph from an edge list (or edgelist-like, such as an EdgeView or generator of edges) is a very common operation - certainly much more so than from numpy/scipy/pandas objects within NetworkX itself. This latter point can be demonstrated relatively simply: see https://github.com/networkx/networkx/pull/7402#issuecomment-2048157399.

I wanted to investigate whether it'd be possible to reorganize the control-flow of `to_networkx_graph` so that the most common (at least according to the internal NX usage heuristic) data structures are handled first. This has the advantage of solving #7401 for basically all cases[^1]. I suspect it may result in a minor performance improvement too, though the use-case where that's actually meaningful may not be that common (i.e. an analysis where many graph instances are being created). I've added a benchmark to demonstrate this last point as well; results on my machine:

<details>
  <summary> ~10% improvement for this branch </summary>
<pre>
| Change   | Before [d7b61bd1] <main>         | After [a2b6d7fe] <reorder-to_networkx_graph>                              | Ratio   | Benchmark (Parameter)                                                                                                                                  |
|----------|----------------------------|------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
| -        | 5.54±0.09μs                | 4.95±0.07μs                                    | 0.89    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_direct(<class 'networkx.classes.graph.Graph'>)                             |
| -        | 3.12±0.01ms                | 2.79±0.02ms                                    | 0.89    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_direct_multi_instance(<class 'networkx.classes.digraph.DiGraph'>)          |
| -        | 2.74±0.02ms                | 2.46±0.01ms                                    | 0.90    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_direct_multi_instance(<class 'networkx.classes.graph.Graph'>)              |
| -        | 7.28±0.04μs                | 6.44±0.04μs                                    | 0.88    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_via_constructor(<class 'networkx.classes.digraph.DiGraph'>)                |
| -        | 6.34±0.03μs                | 5.70±0.03μs                                    | 0.90    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_via_constructor(<class 'networkx.classes.graph.Graph'>)                    |
|          | 3.54±0.07ms                | 3.24±0.01ms                                    | 0.91    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_via_constructor_multi_instance(<class 'networkx.classes.digraph.DiGraph'>) |
| -        | 3.18±0.02ms                | 2.85±0.05ms                                    | 0.90    | benchmark_to_networkx_graph.ToNetworkXGraphBenchmark.time_to_networkx_graph_via_constructor_multi_instance(<class 'networkx.classes.graph.Graph'>)     |
</details>

The potential downside of this approach is that there may be subtle corner cases due to the change in the order/"breadth" of the isinstance checks. I'm confident that this works for every case that the NetworkX test suite covers (using the procedure described [here](https://github.com/networkx/networkx/pull/7402#issuecomment-2048157399)), but there may be cases that are uncovered. For example, it turns out there is *a single* test in the test suite that uses a tuple of edges instead of a list of edges. That case would have been missed were it not for that single test!

[^1]: The only exceptions being branches where an exception is explicitly raised.