### PR TITLE
type: Generating paley graphs more efficiently

### DIFF
--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -204,7 +204,7 @@ def paley_graph(p, create_using=None):
     # Compute the squares in Z/pZ.
     # Make it a set to uniquify (there are exactly (p-1)/2 squares in Z/pZ
     # when is prime).
-    square_set = {(x**2) % p for x in range(1, p) if (x**2) % p != 0}
+    square_set = {(x**2) % p for x in range(1, p)}
 
     for x in range(p):
         for x2 in square_set:


### PR DESCRIPTION
There is no need checking that (x**2)%p == 0 when p is prime and x is not zero, as it would means that x is a zero divisor, contradicting the fact that  z/zp is a field.