### PR TITLE
retain adjacency order in nx-loopback copy of networkx graph

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -25,6 +25,9 @@ class _CachedPropertyResetterAdjAndSucc:
     are set to new objects. In addition, the attributes `_succ` and `_adj`
     are synced so these two names point to the same object.
 
+    Warning: most of the time, when ``G._adj`` is set, ``G._pred`` should also
+    be set to maintain a valid data structure. They share datadicts.
+
     This object sits on a class and ensures that any instance of that
     class clears its cached properties "succ" and "adj" whenever the
     underlying instance attributes "_succ" or "_adj" are set to a new object.
@@ -43,6 +46,9 @@ class _CachedPropertyResetterAdjAndSucc:
             del od["adj"]
         if "succ" in od:
             del od["succ"]
+        for prop in ["edges", "out_edges", "degree", "out_degree", "in_degree"]:
+            if prop in od:
+                del od[prop]
 
 
 class _CachedPropertyResetterPred:
@@ -50,6 +56,9 @@ class _CachedPropertyResetterPred:
 
     This assumes that the ``cached_property`` ``G.pred`` should be reset whenever
     ``G._pred`` is set to a new value.
+
+    Warning: most of the time, when ``G._pred`` is set, ``G._adj`` should also
+    be set to maintain a valid data structure. They share datadicts.
 
     This object sits on a class and ensures that any instance of that
     class clears its cached property "pred" whenever the underlying
@@ -65,6 +74,9 @@ class _CachedPropertyResetterPred:
         od["_pred"] = value
         if "pred" in od:
             del od["pred"]
+        for prop in ["in_edges", "degree", "out_degree", "in_degree"]:
+            if prop in od:
+                del od[prop]
 
 
 class DiGraph(Graph):

--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -42,11 +42,16 @@ class _CachedPropertyResetterAdjAndSucc:
         od["_adj"] = value
         od["_succ"] = value
         # reset cached properties
-        if "adj" in od:
-            del od["adj"]
-        if "succ" in od:
-            del od["succ"]
-        for prop in ["edges", "out_edges", "degree", "out_degree", "in_degree"]:
+        props = [
+            "adj",
+            "succ",
+            "edges",
+            "out_edges",
+            "degree",
+            "out_degree",
+            "in_degree",
+        ]
+        for prop in props:
             if prop in od:
                 del od[prop]
 
@@ -72,9 +77,9 @@ class _CachedPropertyResetterPred:
     def __set__(self, obj, value):
         od = obj.__dict__
         od["_pred"] = value
-        if "pred" in od:
-            del od["pred"]
-        for prop in ["in_edges", "degree", "out_degree", "in_degree"]:
+        # reset cached properties
+        props = ["pred", "in_edges", "degree", "out_degree", "in_degree"]
+        for prop in props:
             if prop in od:
                 del od[prop]
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -39,6 +39,10 @@ class _CachedPropertyResetterAdj:
         od["_adj"] = value
         if "adj" in od:
             del od["adj"]
+        if "edges" in od:
+            del od["edges"]
+        if "degree" in od:
+            del od["degree"]
 
 
 class _CachedPropertyResetterNode:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -37,12 +37,11 @@ class _CachedPropertyResetterAdj:
     def __set__(self, obj, value):
         od = obj.__dict__
         od["_adj"] = value
-        if "adj" in od:
-            del od["adj"]
-        if "edges" in od:
-            del od["edges"]
-        if "degree" in od:
-            del od["degree"]
+        # reset cached properties
+        props = ["adj", "edges", "degree"]
+        for prop in props:
+            if prop in od:
+                del od[prop]
 
 
 class _CachedPropertyResetterNode:
@@ -63,6 +62,7 @@ class _CachedPropertyResetterNode:
     def __set__(self, obj, value):
         od = obj.__dict__
         od["_node"] = value
+        # reset cached properties
         if "nodes" in od:
             del od["nodes"]
 

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -164,6 +164,8 @@ class LoopbackDispatcher:
                     (nbr, G_adj[nbr][n] if n in G_adj[nbr] else G_new_inner(dd))
                     for nbr, dd in nbrs.items()
                 )
+
+        assert False
         return G
 
     @staticmethod

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -165,7 +165,6 @@ class LoopbackDispatcher:
                     for nbr, dd in nbrs.items()
                 )
 
-        assert False
         return G
 
     @staticmethod

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1368,6 +1368,8 @@ class _dispatchable:
                 G1 = backend.convert_to_nx(bound.arguments["G"])
                 G2 = bound2.arguments["G"]
                 G2._adj = G1._adj
+                if G2.is_directed():
+                    G2._pred = G1._pred
                 nx._clear_cache(G2)
             elif self.name == "edmonds_karp":
                 R1 = backend.convert_to_nx(bound.arguments["residual"])


### PR DESCRIPTION
This rewrites the copy functionality within nx-loopback to ensure that the neighbor order is the same in the copy. Instead of copying edges, this copies adjacencies (careful to ensure opposite representations of an edge point to the same datadict).

The result is that the incoming PR for fixing colliders and v-structures passes its tests.
Also, dfs_labeled_edges test passes. In fact all the topological sort functions that were excluded pass the tests as well, though I'm not sure whether we should still exclude them from the nx-loopback tests because I don't know what the issue was regarding the function changing the original graph. E.g. maybe we shouldn't be copying the graph at all since it needs to be changed.

~~This also seems to fix the long time for the nx-loopback tests. It is still about 8 secs (~10-15%) longer to run, but not multiple minutes.  Almost all of that is due to using `G._adj` directly instead of `add_edges_from` and `G.edges`.~~ [Edit: error on my part caused mistaken speed results. With the change it is the same speed as it was.]

@eriknw can you look at my comments near the top of the diff:
1) should any of these functions marked as being skipped be included? (~~I think the topo sort maybe~~) [A: Only the dfs_labeled_edges is fixed by the order of edges in loopback. The rest stay in place.]
2) the conversion of an AntiGraph to a normal graph class is just `G = nx.complement(A)`. But I'm not sure how that helps the code near the comment about AntiGraph.  [A: Removing comment about AntiGraph]