### PR TITLE
CI: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      attestations: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,6 +31,14 @@ jobs:
           git clean -fxd
           pip install -U build twine wheel
           python -m build --sdist --wheel
+
+      - name: Verify the distribution
+        run: twine check --strict dist/*
+
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/networkx-*"
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

This PR is related to https://github.com/scientific-python/summit-2024/issues/9 so cc @MridulS and @jarrodmillman for review.

<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
