### PR TITLE
DEV: Add files generated by benchmarking to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ networkx.egg-info/
 
 # Virtual environment directory
 networkx-dev/
+
+# Benchmark products
+benchmarks/env
+benchmarks/results


### PR DESCRIPTION
Very minor improvements to the development workflow related to benchmarking.

Running `asv` locally to do comparison benchmarks ends up generating files/dirs in the `benchmarks/` folder. This PR adds those generated files to `.gitignore`. I've only captured the files generated from local workflows (e.g. `asv run`, `asv continuous` and `asv compare`). There may be others for other workflows, in which case please feel free to add them here (@MridulS ).