### PR TITLE
Fix `from_pandas_edgelist` for MultiGraph given edge_key

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -432,7 +432,11 @@ def from_pandas_edgelist(
     g = nx.empty_graph(0, create_using)
 
     if edge_attr is None:
-        g.add_edges_from(zip(df[source], df[target]))
+        if g.is_multigraph() and edge_key is not None:
+            for u, v, k in zip(df[source], df[target], df[edge_key]):
+                g.add_edge(u, v, k)
+        else:
+            g.add_edges_from(zip(df[source], df[target]))
         return g
 
     reserved_columns = [source, target]

--- a/networkx/tests/test_convert_pandas.py
+++ b/networkx/tests/test_convert_pandas.py
@@ -300,6 +300,16 @@ class TestConvertPandas:
                 create_using=nx.MultiGraph(),
             )
 
+    def test_multigraph_with_edgekey_no_edgeattrs(self):
+        Gtrue = nx.MultiGraph()
+        Gtrue.add_edge(0, 1, key=0)
+        Gtrue.add_edge(0, 1, key=3)
+        df = nx.to_pandas_edgelist(Gtrue, edge_key="key")
+        expected = pd.DataFrame({"source": [0, 0], "target": [1, 1], "key": [0, 3]})
+        pd.testing.assert_frame_equal(expected, df)
+        G = nx.from_pandas_edgelist(df, edge_key="key", create_using=nx.MultiGraph)
+        assert graphs_equal(Gtrue, G)
+
 
 def test_to_pandas_adjacency_with_nodelist():
     G = nx.complete_graph(5)


### PR DESCRIPTION
In `from_pandas_edgelist`, multigraphs are not correctly supported.
Previously, `edge_key=` was not used if `edge_attr` was None!
This adds code to handle the `edge_key` parameter even when no `edge_attr` are requested.