### PR TITLE
Remove redundant graph copy in `algorithms.bridges.bridges()`

### DIFF
--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -70,7 +70,6 @@ def bridges(G, root=None):
     H = nx.Graph(G) if multigraph else G
     chains = nx.chain_decomposition(H, root=root)
     chain_edges = set(chain.from_iterable(chains))
-    H_copy = H.copy()
     if root is not None:
         H = H.subgraph(nx.node_connected_component(H, root)).copy()
     for u, v in H.edges():


### PR DESCRIPTION
Closes #7469 
