### PR TITLE
Clarify generation number in `dorogovtsev_goltsev_mendes_graph()`

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -489,7 +489,7 @@ def cycle_graph(n, create_using=None):
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
-    r"""Returns the hierarchically constructed Dorogovtsev--Goltsev--Mendes graph.
+    """Returns the hierarchically constructed Dorogovtsev--Goltsev--Mendes graph.
 
     The Dorogovtsev--Goltsev--Mendes [1]_ procedure deterministically produces a
     scale-free graph with ``3/2 * (3**(n-1) + 1)`` vertices
@@ -506,10 +506,10 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     Parameters
     ----------
     n : integer
-       The generation number. Must be greater than or equal to 0.
+        The generation number.
 
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
-       Graph type to create. If graph instance, then cleared before populated.
+        Graph type to create. If graph instance, then cleared before populated.
 
     Returns
     -------

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -492,7 +492,7 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     """Returns the hierarchically constructed Dorogovtsev--Goltsev--Mendes graph.
 
     The Dorogovtsev--Goltsev--Mendes [1]_ procedure deterministically produces a
-    scale-free graph with ``3/2 * (3**(n-1) + 1)`` vertices
+    scale-free graph with ``3/2 * (3**(n-1) + 1)`` nodes
     and ``3**n`` edges for a given `n`.
 
     Note that `n` denotes the number of times the state transition is applied,
@@ -546,9 +546,9 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
 
     G = empty_graph(0, create_using)
     if G.is_directed():
-        raise NetworkXError("Directed graph not supported")
+        raise NetworkXError("directed graph not supported")
     if G.is_multigraph():
-        raise NetworkXError("Multigraph not supported")
+        raise NetworkXError("multigraph not supported")
 
     G.add_edge(0, 1)
     if n == 0:

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -489,29 +489,40 @@ def cycle_graph(n, create_using=None):
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
-    """Returns the hierarchically constructed Dorogovtsev-Goltsev-Mendes graph.
+    r"""Returns the hierarchically constructed Dorogovtsev--Goltsev--Mendes graph.
 
-    The Dorogovtsev-Goltsev-Mendes [1]_ procedure produces a scale-free graph
-    deterministically with the following properties for a given `n`:
-    - Total number of nodes = ``3 * (3**n + 1) / 2``
-    - Total number of edges = ``3 ** (n + 1)``
+    The Dorogovtsev--Goltsev--Mendes [1]_ procedure deterministically produces a
+    scale-free graph with $\frac{3}{2} (3^{n-1} + 1)$ vertices
+    and $3^n$ edges for a given $n$.
+
+    Note that $n$ denotes the number of times the state transition is applied,
+    starting from the base graph with $n = 0$ (no transitions), as in [2]_.
+    This is different from the parameter $t = n - 1$ in [1]_.
 
     .. plot::
 
-        >>> nx.draw(nx.dorogovtsev_goltsev_mendes_graph(3))
+        >>> nx.draw_planar(nx.dorogovtsev_goltsev_mendes_graph(3))
 
     Parameters
     ----------
     n : integer
-       The generation number.
+       The generation number. Must be greater than or equal to 0.
 
-    create_using : NetworkX Graph, optional
-       Graph type to be returned. Directed graphs and multi graphs are not
+    create_using : NetworkX graph constructor, optional (default `nx.Graph`)
+       Graph type to be returned. Directed graphs and multigraphs are not
        supported.
+       If this is a graph instance, it gets cleared, then populated.
 
     Returns
     -------
-    G : NetworkX Graph
+    G : NetworkX `Graph`
+
+    Raises
+    ------
+    NetworkXError
+        If `n` is less than zero.
+
+        If `create_using` is a directed graph or multigraph.
 
     Examples
     --------
@@ -528,10 +539,16 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes,
         "Pseudofractal scale-free web", Physical Review E 65, 066122, 2002.
         https://arxiv.org/pdf/cond-mat/0112143.pdf
+    .. [2] Weisstein, Eric W. "Dorogovtsev--Goltsev--Mendes Graph."
+        From MathWorld--A Wolfram Web Resource.
+        https://mathworld.wolfram.com/Dorogovtsev-Goltsev-MendesGraph.html
     """
+    if n < 0:
+        raise NetworkXError("n must be greater than or equal to 0")
+
     G = empty_graph(0, create_using)
     if G.is_directed():
-        raise NetworkXError("Directed Graph not supported")
+        raise NetworkXError("Directed graph not supported")
     if G.is_multigraph():
         raise NetworkXError("Multigraph not supported")
 
@@ -539,12 +556,11 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     if n == 0:
         return G
     new_node = 2  # next node to be added
-    for i in range(1, n + 1):  # iterate over number of generations.
+    for _ in range(1, n + 1):  # iterate over number of generations.
         last_generation_edges = list(G.edges())
-        number_of_edges_in_last_generation = len(last_generation_edges)
-        for j in range(number_of_edges_in_last_generation):
-            G.add_edge(new_node, last_generation_edges[j][0])
-            G.add_edge(new_node, last_generation_edges[j][1])
+        for last_generation_edge in last_generation_edges:
+            G.add_edge(new_node, last_generation_edge[0])
+            G.add_edge(new_node, last_generation_edge[1])
             new_node += 1
     return G
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -550,16 +550,17 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     if G.is_multigraph():
         raise NetworkXError("multigraph not supported")
 
-    G.add_edge(0, 1)
-    if n == 0:
-        return G
+    edges = [(0, 1)]
     new_node = 2  # next node to be added
     for _ in range(n):  # iterate over number of generations.
-        last_generation_edges = list(G.edges())
-        for last_generation_edge in last_generation_edges:
-            G.add_edge(new_node, last_generation_edge[0])
-            G.add_edge(new_node, last_generation_edge[1])
+        this_generation_edges = []
+        for u, v in edges:
+            this_generation_edges.append((new_node, u))
+            this_generation_edges.append((new_node, v))
             new_node += 1
+        edges.extend(this_generation_edges)
+
+    G.add_edges_from(edges)
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -550,17 +550,16 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     if G.is_multigraph():
         raise NetworkXError("multigraph not supported")
 
-    edges = [(0, 1)]
+    G.add_edge(0, 1)
     new_node = 2  # next node to be added
     for _ in range(n):  # iterate over number of generations.
-        this_generation_edges = []
-        for u, v in edges:
-            this_generation_edges.append((new_node, u))
-            this_generation_edges.append((new_node, v))
+        new_edges = []
+        for u, v in G.edges():
+            new_edges.append((u, new_node))
+            new_edges.append((v, new_node))
             new_node += 1
-        edges.extend(this_generation_edges)
 
-    G.add_edges_from(edges)
+        G.add_edges_from(new_edges)
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -535,9 +535,9 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     References
     ----------
     .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes,
-        "Pseudofractal scale-free web," Physical Review E 65, 066122, 2002.
+        "Pseudofractal scale-free web", Physical Review E 65, 066122, 2002.
         https://arxiv.org/pdf/cond-mat/0112143.pdf
-    .. [2] Weisstein, Eric W. "Dorogovtsev--Goltsev--Mendes Graph."
+    .. [2] Weisstein, Eric W. "Dorogovtsev--Goltsev--Mendes Graph".
         From MathWorld--A Wolfram Web Resource.
         https://mathworld.wolfram.com/Dorogovtsev-Goltsev-MendesGraph.html
     """

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -492,12 +492,12 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     r"""Returns the hierarchically constructed Dorogovtsev--Goltsev--Mendes graph.
 
     The Dorogovtsev--Goltsev--Mendes [1]_ procedure deterministically produces a
-    scale-free graph with `3/2 * (3**(n-1) + 1)` vertices
-    and `3**n` edges for a given `n`.
+    scale-free graph with ``3/2 * (3**(n-1) + 1)`` vertices
+    and ``3**n`` edges for a given `n`.
 
     Note that `n` denotes the number of times the state transition is applied,
-    starting from the base graph with `n = 0` (no transitions), as in [2]_.
-    This is different from the parameter `t = n - 1` in [1]_.
+    starting from the base graph with ``n = 0`` (no transitions), as in [2]_.
+    This is different from the parameter ``t = n - 1`` in [1]_.
 
     .. plot::
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -492,26 +492,24 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     r"""Returns the hierarchically constructed Dorogovtsev--Goltsev--Mendes graph.
 
     The Dorogovtsev--Goltsev--Mendes [1]_ procedure deterministically produces a
-    scale-free graph with $\frac{3}{2} (3^{n-1} + 1)$ vertices
-    and $3^n$ edges for a given $n$.
+    scale-free graph with `3/2 * (3**(n-1) + 1)` vertices
+    and `3**n` edges for a given `n`.
 
-    Note that $n$ denotes the number of times the state transition is applied,
-    starting from the base graph with $n = 0$ (no transitions), as in [2]_.
-    This is different from the parameter $t = n - 1$ in [1]_.
+    Note that `n` denotes the number of times the state transition is applied,
+    starting from the base graph with `n = 0` (no transitions), as in [2]_.
+    This is different from the parameter `t = n - 1` in [1]_.
 
     .. plot::
 
-        >>> nx.draw_planar(nx.dorogovtsev_goltsev_mendes_graph(3))
+        >>> nx.draw(nx.dorogovtsev_goltsev_mendes_graph(3))
 
     Parameters
     ----------
     n : integer
        The generation number. Must be greater than or equal to 0.
 
-    create_using : NetworkX graph constructor, optional (default `nx.Graph`)
-       Graph type to be returned. Directed graphs and multigraphs are not
-       supported.
-       If this is a graph instance, it gets cleared, then populated.
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+       Graph type to create. If graph instance, then cleared before populated.
 
     Returns
     -------
@@ -537,7 +535,7 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     References
     ----------
     .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes,
-        "Pseudofractal scale-free web", Physical Review E 65, 066122, 2002.
+        "Pseudofractal scale-free web," Physical Review E 65, 066122, 2002.
         https://arxiv.org/pdf/cond-mat/0112143.pdf
     .. [2] Weisstein, Eric W. "Dorogovtsev--Goltsev--Mendes Graph."
         From MathWorld--A Wolfram Web Resource.
@@ -556,7 +554,7 @@ def dorogovtsev_goltsev_mendes_graph(n, create_using=None):
     if n == 0:
         return G
     new_node = 2  # next node to be added
-    for _ in range(1, n + 1):  # iterate over number of generations.
+    for _ in range(n):  # iterate over number of generations.
         last_generation_edges = list(G.edges())
         for last_generation_edge in last_generation_edges:
             G.add_edge(new_node, last_generation_edge[0])

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -238,7 +238,13 @@ class TestGeneratorClassic:
         G = nx.dorogovtsev_goltsev_mendes_graph(1)
         assert edges_equal(G.edges(), [(0, 1), (0, 2), (1, 2)])
         assert nx.average_clustering(G) == 1.0
+        assert nx.average_shortest_path_length(G) == 1.0
         assert sorted(nx.triangles(G).values()) == [1, 1, 1]
+        G = nx.dorogovtsev_goltsev_mendes_graph(2)
+        assert nx.number_of_nodes(G) == 6
+        assert nx.number_of_edges(G) == 9
+        assert nx.average_clustering(G) == 0.75
+        assert nx.average_shortest_path_length(G) == 1.4
         G = nx.dorogovtsev_goltsev_mendes_graph(10)
         assert nx.number_of_nodes(G) == 29526
         assert nx.number_of_edges(G) == 59049
@@ -246,6 +252,7 @@ class TestGeneratorClassic:
         assert G.degree(1) == 1024
         assert G.degree(2) == 1024
 
+        pytest.raises(nx.NetworkXError, nx.dorogovtsev_goltsev_mendes_graph, -1)
         pytest.raises(
             nx.NetworkXError,
             nx.dorogovtsev_goltsev_mendes_graph,
@@ -257,6 +264,12 @@ class TestGeneratorClassic:
             nx.dorogovtsev_goltsev_mendes_graph,
             7,
             create_using=nx.MultiGraph,
+        )
+        pytest.raises(
+            nx.NetworkXError,
+            nx.dorogovtsev_goltsev_mendes_graph,
+            7,
+            create_using=nx.MultiDiGraph,
         )
 
     def test_create_using(self):

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -240,11 +240,13 @@ class TestGeneratorClassic:
         assert nx.average_clustering(G) == 1.0
         assert nx.average_shortest_path_length(G) == 1.0
         assert sorted(nx.triangles(G).values()) == [1, 1, 1]
+        assert nx.is_planar(G)
         G = nx.dorogovtsev_goltsev_mendes_graph(2)
         assert nx.number_of_nodes(G) == 6
         assert nx.number_of_edges(G) == 9
         assert nx.average_clustering(G) == 0.75
         assert nx.average_shortest_path_length(G) == 1.4
+        assert nx.is_planar(G)
         G = nx.dorogovtsev_goltsev_mendes_graph(10)
         assert nx.number_of_nodes(G) == 29526
         assert nx.number_of_edges(G) == 59049
@@ -252,25 +254,14 @@ class TestGeneratorClassic:
         assert G.degree(1) == 1024
         assert G.degree(2) == 1024
 
-        pytest.raises(nx.NetworkXError, nx.dorogovtsev_goltsev_mendes_graph, -1)
-        pytest.raises(
-            nx.NetworkXError,
-            nx.dorogovtsev_goltsev_mendes_graph,
-            7,
-            create_using=nx.DiGraph,
-        )
-        pytest.raises(
-            nx.NetworkXError,
-            nx.dorogovtsev_goltsev_mendes_graph,
-            7,
-            create_using=nx.MultiGraph,
-        )
-        pytest.raises(
-            nx.NetworkXError,
-            nx.dorogovtsev_goltsev_mendes_graph,
-            7,
-            create_using=nx.MultiDiGraph,
-        )
+        with pytest.raises(nx.NetworkXError):
+            nx.dorogovtsev_goltsev_mendes_graph(-1)
+        with pytest.raises(nx.NetworkXError):
+            nx.dorogovtsev_goltsev_mendes_graph(7, create_using=nx.DiGraph)
+        with pytest.raises(nx.NetworkXError):
+            nx.dorogovtsev_goltsev_mendes_graph(7, create_using=nx.MultiGraph)
+        with pytest.raises(nx.NetworkXError):
+            nx.dorogovtsev_goltsev_mendes_graph(7, create_using=nx.MultiDiGraph)
 
     def test_create_using(self):
         G = nx.empty_graph()


### PR DESCRIPTION
Clarifies the meaning of the generation number in DGM graphs, as discussed in #7472.

Also contains additional tests based on average clustering and average shortest path length in the original paper, as well as minor changes to wording.

Fixes #7472.
