### PR TITLE
Use intersphinx_registry to manage intersphinx mapping.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 import os
 from datetime import date
 from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
+from intersphinx_registry import get_intersphinx_mapping
 from warnings import filterwarnings
 
 filterwarnings(
@@ -228,19 +229,22 @@ latex_documents = [
 latex_appendices = ["tutorial"]
 
 # Intersphinx mapping
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "neps": ("https://numpy.org/neps/", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "geopandas": ("https://geopandas.org/en/stable/", None),
-    "pygraphviz": ("https://pygraphviz.github.io/documentation/stable/", None),
-    "sphinx-gallery": ("https://sphinx-gallery.github.io/stable/", None),
-    "nx-guides": ("https://networkx.org/nx-guides/", None),
-    "sympy": ("https://docs.sympy.org/latest/", None),
-}
+
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={
+        "python",
+        "numpy",
+        "neps",
+        "matplotlib",
+        "scipy",
+        "pandas",
+        "geopandas",
+        "pygraphviz",
+        "sphinx-gallery",
+        "sympy",
+        "nx-guides",
+    }
+)
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ doc = [
     'pillow>=9.4',
     'texext>=0.6.7',
     'myst-nb>=1.1',
+    'intersphinx_registry',
 ]
 extra = [
     'lxml>=4.6',

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,3 +7,4 @@ numpydoc>=1.7
 pillow>=9.4
 texext>=0.6.7
 myst-nb>=1.1
+intersphinx_registry


### PR DESCRIPTION
Makes use of the centralized intersphinx db provided/maintained by [intersphinx_registry](https://pypi.org/project/intersphinx_registry/). IMO this is a nice convenience!