### PR TITLE
Add `nx.config.backend` option

### DIFF
--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -633,10 +633,12 @@ class _dispatchable:
 
         if not backends:
             # Fast path if no backends are installed
+            if backend is not None:
+                raise ImportError(f"Unable to load backend: {backend}")
             return self.orig_func(*args, **kwargs)
 
         # Use `backend_name` in this function instead of `backend`
-        backend_name = backend
+        backend_name = backend if backend is not None else config.backend
         if backend_name is not None and backend_name not in backends:
             raise ImportError(f"Unable to load backend: {backend_name}")
 

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -190,6 +190,12 @@ class NetworkXConfig(Config):
 
     Parameters
     ----------
+    backend : str or None
+        If not None, the backend to use for all dispatchable functions. This is
+        equivalent to using ``backend=`` keyword argument in all dispatchable
+        functions. Input graphs will be converted to the backend if necessary.
+        Default is None.
+
     backend_priority : list of backend names
         Enable automatic conversion of graphs to backend graphs for algorithms
         implemented by the backend. Priority is given to backends listed earlier.
@@ -220,6 +226,7 @@ class NetworkXConfig(Config):
     This is a global configuration. Use with caution when using from multiple threads.
     """
 
+    backend: str | None
     backend_priority: list[str]
     backends: Config
     cache_converted_graphs: bool
@@ -227,7 +234,10 @@ class NetworkXConfig(Config):
     def _check_config(self, key, value):
         from .backends import backends
 
-        if key == "backend_priority":
+        if key == "backend":
+            if value is not None and value not in backends:
+                raise ValueError(f"Unknown backend when setting {key!r}: {value}")
+        elif key == "backend_priority":
             if not (isinstance(value, list) and all(isinstance(x, str) for x in value)):
                 raise TypeError(
                     f"{key!r} config must be a list of backend names; got {value!r}"
@@ -254,6 +264,7 @@ class NetworkXConfig(Config):
 
 # Backend configuration will be updated in backends.py
 config = NetworkXConfig(
+    backend=None,
     backend_priority=[],
     backends=Config(),
     cache_converted_graphs=bool(os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", "")),

--- a/networkx/utils/tests/test_backends.py
+++ b/networkx/utils/tests/test_backends.py
@@ -77,9 +77,13 @@ def test_graph_converter_needs_backend():
             type(nx.from_scipy_sparse_array(A, backend="nx-loopback")) is LoopbackGraph
         )
         assert side_effects == [1, 1]
+        nx.config.backend = "nx-loopback"  # This is like doing `backend="nx-loopback"`
+        assert type(nx.from_scipy_sparse_array(A)) is LoopbackGraph
+        assert side_effects == [1, 1, 1]
     finally:
         LoopbackDispatcher.convert_to_nx = staticmethod(orig_convert_to_nx)
         del LoopbackDispatcher.from_scipy_sparse_array
+        nx.config.backend = None
     with pytest.raises(ImportError, match="Unable to load"):
         nx.from_scipy_sparse_array(A, backend="bad-backend-name")
 


### PR DESCRIPTION
This is like doing `backend=...` when calling a dispatchable function.

I think this will be especially nice when combined with #7363, which will let us set it within a context:
```python
with nx.config(backend="mybackend"):
    ...  # No need to use `backend="mybackend"` when calling dispatchable networkx functions!
```

Thanks to @seberg for this idea!

CC @rlratzel