### PR TITLE
Clarify the meaning of the cutoff parameter in some path-finding functions

### DIFF
--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -565,7 +565,7 @@ def predecessor(G, source, target=None, cutoff=None, return_seen=None):
                     nextlevel.append(w)
                 elif seen[w] == level:  # add v to predecessor list if it
                     pred[w].append(v)  # is at the correct level
-        if cutoff and cutoff <= level:
+        if cutoff is not None and cutoff <= level:
             break
 
     if target is not None:

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -29,12 +29,14 @@ def single_source_shortest_path_length(G, source, cutoff=None):
        Starting node for path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search. Only target nodes where the shortest path to
+        this node from the source node contains <= cutoff edges will be
+        included in the returned results.
 
     Returns
     -------
     lengths : dict
-        Dict keyed by node to shortest path length to source.
+        Dict keyed by target node to shortest path length from source node.
 
     Examples
     --------
@@ -107,7 +109,9 @@ def single_target_shortest_path_length(G, target, cutoff=None):
        Target node for path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search. Only source nodes where the shortest path
+        from this node to the target node contains <= cutoff edges will be
+        included in the returned results.
 
     Returns
     -------
@@ -328,7 +332,9 @@ def single_source_shortest_path(G, source, cutoff=None):
        Starting node for path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search. Only target nodes where the shortest path to
+        this node from the source node contains <= cutoff edges will be
+        included in the returned results.
 
     Returns
     -------
@@ -411,12 +417,14 @@ def single_target_shortest_path(G, target, cutoff=None):
        Target node for path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search. Only source nodes where the shortest path
+        from this node to the target node contains <= cutoff edges will be
+        included in the returned results.
 
     Returns
     -------
     paths : dictionary
-        Dictionary, keyed by target, of shortest paths.
+        Dictionary, keyed by source, of shortest paths.
 
     Examples
     --------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -108,7 +108,8 @@ def all_simple_paths(G, source, target, cutoff=None):
        Single node or iterable of nodes at which to end path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search, in terms of edges. Only paths containing
+        <= cutoff edges are returned.
 
     Returns
     -------
@@ -274,7 +275,8 @@ def all_simple_edge_paths(G, source, target, cutoff=None):
        Single node or iterable of nodes at which to end path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search, in terms of edges. Only paths containing
+        <= cutoff edges are returned.
 
     Returns
     -------


### PR DESCRIPTION
## Motivation

While I was working with `all_simple_paths()`, I got confused about the `cutoff` parameter. The [current description for this parameter](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html) is

```
cutoff : integer, optional
    Depth to stop the search. Only paths of length <= cutoff are returned.
```

How "length" is defined here is ambiguous; my initial guess was that it was in terms of the number of nodes on the path, but it turns out that it's in terms of edges. (So the path `[0, 1]` has length 1, the path `[0, 1, 2]` has length 2, etc.) I imagine other people will also be confused and make the same mistake.

## Changes

- I updated the docstrings for: the following six functions:
  - `all_simple_paths()`
  - `all_simple_edge_paths()`
  - `single_source_shortest_path_length()`
  - `single_target_shortest_path_length()`
  - `single_source_shortest_path()`
  - `single_target_shortest_path()`

  to clarify the meaning of `cutoff`. I think the adjusted documentation is easier to understand.

- I fixed a small error in the documentation of `single_target_shortest_path()` -- it said `keyed by target` where it should, I think, have said `keyed by source`.

- I fixed a small bug that I noticed in `predecessor()`.
  - **Description:** The functions that have a `cutoff` parameter explicitly check if `cutoff is None` and adjust their behavior accordingly. However, `predecessor()` does not do this -- instead, it checks the truth value of `cutoff`. This will have (I think) undesirable results if `cutoff == 0`, since `cutoff == 0` will be treated the same as `cutoff == None`. (Not that I imagine a lot of people will be calling this function with a cutoff of 0, but I suppose consistency here is nice.)
  - **Fix:** I've replaced the use of `if cutoff` in this function with `if cutoff is not None` to fix this problem.

## Notes

`predecessor()` also has a `cutoff` parameter, but I haven't updated its documentation (even though it has the same issue of not explaining what the cutoff "length" means). I'm not completely sure what this function is doing, and I don't want to add incorrect documentation to it by accident.