### PR TITLE
Remove deprecated ruff linter settings and fix string formatting warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 # Install pre-commit hooks via
 # pre-commit install
 
+# This continuous integration section enables
+# autoupdating the pre-commit configuration,
+# ensuring that the hook versions are kept up to date.
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: ffb6a759a979008c0e6dff86e39f4745a2d9eac4 # frozen: v3.1.0


### PR DESCRIPTION
Prior to this PR, running `% ruff check .` from the project root gave
```zsh
% ruff check .
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
warning: `SIM111` has been remapped to `SIM110`.
examples/algorithms/plot_dedensification.py:54:11: UP031 Use format specifiers instead of percent format
examples/algorithms/plot_dedensification.py:67:11: UP031 Use format specifiers instead of percent format
examples/algorithms/plot_snap.py:57:5: UP032 [*] Use f-string instead of `format` call
examples/algorithms/plot_snap.py:83:5: UP032 [*] Use f-string instead of `format` call
networkx/algorithms/centrality/group.py:411:21: UP031 Use format specifiers instead of percent format
networkx/algorithms/tests/test_summarization.py:258:21: UP031 Use format specifiers instead of percent format
Found 6 errors.
[*] 2 fixable with the `--fix` option (4 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

After the PR, this becomes
```zsh
% ruff check .
All checks passed!
```
