### PR TITLE
MAINT: Renaming `LoopbackDispatcher` to `LoopbackBackendInterface` and `dispatcher` to `backend_interface`

### DIFF
--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -49,7 +49,7 @@ def convert(graph):
     raise TypeError(f"Unsupported type of graph: {type(graph)}")
 
 
-class LoopbackDispatcher:
+class LoopbackBackendInterface:
     def __getattr__(self, item):
         try:
             return nx.utils.backends._registered_algorithms[item].orig_func
@@ -191,4 +191,4 @@ class LoopbackDispatcher:
         return hasattr(self, name)
 
 
-dispatcher = LoopbackDispatcher()
+backend_interface = LoopbackBackendInterface()

--- a/networkx/utils/tests/test_backends.py
+++ b/networkx/utils/tests/test_backends.py
@@ -41,7 +41,7 @@ def test_graph_converter_needs_backend():
     # If not testing, then calling `nx.from_scipy_sparse_array` w/o `backend=` will
     # always call the original version. `backend=` is *required* to call the backend.
     from networkx.classes.tests.dispatch_interface import (
-        LoopbackDispatcher,
+        LoopbackBackendInterface,
         LoopbackGraph,
     )
 
@@ -64,10 +64,10 @@ def test_graph_converter_needs_backend():
             return obj
         return nx.Graph(obj)
 
-    # *This mutates LoopbackDispatcher!*
-    orig_convert_to_nx = LoopbackDispatcher.convert_to_nx
-    LoopbackDispatcher.convert_to_nx = convert_to_nx
-    LoopbackDispatcher.from_scipy_sparse_array = from_scipy_sparse_array
+    # *This mutates LoopbackBackendInterface!*
+    orig_convert_to_nx = LoopbackBackendInterface.convert_to_nx
+    LoopbackBackendInterface.convert_to_nx = convert_to_nx
+    LoopbackBackendInterface.from_scipy_sparse_array = from_scipy_sparse_array
 
     try:
         assert side_effects == []
@@ -78,8 +78,8 @@ def test_graph_converter_needs_backend():
         )
         assert side_effects == [1, 1]
     finally:
-        LoopbackDispatcher.convert_to_nx = staticmethod(orig_convert_to_nx)
-        del LoopbackDispatcher.from_scipy_sparse_array
+        LoopbackBackendInterface.convert_to_nx = staticmethod(orig_convert_to_nx)
+        del LoopbackBackendInterface.from_scipy_sparse_array
     with pytest.raises(ImportError, match="Unable to load"):
         nx.from_scipy_sparse_array(A, backend="bad-backend-name")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Documentation = 'https://networkx.org/documentation/stable/'
 "Source Code" = 'https://github.com/networkx/networkx'
 
 [project.entry-points."networkx.backends"]
-nx-loopback = 'networkx.classes.tests.dispatch_interface:dispatcher'
+nx-loopback = 'networkx.classes.tests.dispatch_interface:backend_interface'
 
 [project.optional-dependencies]
 default = [


### PR DESCRIPTION
from PR https://github.com/networkx/networkx/pull/7404

(ref. [review comment](https://github.com/networkx/networkx/pull/7404#discussion_r1610816636))