### PR TITLE
Enable caching by default

### DIFF
--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -256,5 +256,7 @@ class NetworkXConfig(Config):
 config = NetworkXConfig(
     backend_priority=[],
     backends=Config(),
-    cache_converted_graphs=bool(os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", True)),
+    cache_converted_graphs=bool(
+        os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", True)
+    ),
 )

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -208,7 +208,7 @@ class NetworkXConfig(Config):
         example, ``G[u][v][k] = val`` changes the graph, but does not clear the cache.
         Using methods such as ``G.add_edge(u, v, weight=val)`` will clear the cache to
         keep it consistent. ``G.__networkx_cache__.clear()`` manually clears the cache.
-        Default is False.
+        Default is True.
 
     Notes
     -----
@@ -256,5 +256,5 @@ class NetworkXConfig(Config):
 config = NetworkXConfig(
     backend_priority=[],
     backends=Config(),
-    cache_converted_graphs=bool(os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", "")),
+    cache_converted_graphs=bool(os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", True)),
 )


### PR DESCRIPTION
Enable cache by default as discussed during the dispatch meeting yesterday.

#7497 is a companion PR that will make caching UX even nicer.

CC @rlratzel 