### PR TITLE
Fix pygraphviz install on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,8 +158,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements/default.txt -r requirements/test.txt
           python -m pip install --config-settings="--global-option=build_ext" `
-              --config-settings="--global-option="-IC:\Program Files\Graphviz\include" `
-              --config-settings="--global-option="-LC:\Program Files\Graphviz\lib" `
+              --config-settings="--global-option=-IC:\Program Files\Graphviz\include" `
+              --config-settings="--global-option=-LC:\Program Files\Graphviz\lib" `
               pygraphviz
       - name: Install packages (windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
           pip install -r requirements/extra.txt
           pip install .
           pip list
-      - name: Install packages (windows)
+      - name: Install Pygraphviz packages  (windows)
         if: runner.os == 'Windows'
         run: |
           echo "C:\Program Files\Graphviz\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -161,6 +161,10 @@ jobs:
                                 --global-option="-IC:\Program Files\Graphviz\include" `
                                 --global-option="-LC:\Program Files\Graphviz\lib" `
                                 pygraphviz
+      - name: Install packages (windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "C:\Program Files\Graphviz\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           python -m pip install -r requirements/extra.txt
           python -m pip install .
           python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,10 +157,10 @@ jobs:
           echo "C:\Program Files\Graphviz\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           python -m pip install --upgrade pip
           python -m pip install -r requirements/default.txt -r requirements/test.txt
-          python -m pip install --global-option=build_ext `
-                                --global-option="-IC:\Program Files\Graphviz\include" `
-                                --global-option="-LC:\Program Files\Graphviz\lib" `
-                                pygraphviz
+          python -m pip install --config-settings="--global-option=build_ext" `
+              --config-settings="--global-option="-IC:\Program Files\Graphviz\include" `
+              --config-settings="--global-option="-LC:\Program Files\Graphviz\lib" `
+              pygraphviz
       - name: Install packages (windows)
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
See discussion in https://github.com/networkx/networkx/pull/7495,

This is failing on main, but the error is just swallowed. Split int two step to see if we can actually see the failure in CI

See for example https://github.com/networkx/networkx/actions/runs/9584451708/job/26428116613 (current main), which is green but says:

ERROR: Could not build wheels for pygraphviz, which is required to install pyproject.toml-based projects
Failed to build pygraphviz