### PR TITLE
Minor updates to colliders v_structures tests

### DIFF
--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -813,15 +813,17 @@ def test_colliders_raise():
         nx.dag.colliders(G)
 
 
-def test_colliders():
-    edges = [(0, 1), (0, 2), (3, 2)]
-    G = nx.DiGraph(edges)
-
+@pytest.mark.parametrize(
+    ("edgelist", "expected"),
+    (
+        ([(0, 1), (0, 2), (3, 2)], {(0, 2, 3)}),
+        (
+            [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")],
+            {("A", "B", "C"), ("D", "E", "G")},
+        ),
+    ),
+)
+def test_colliders(edgelist, expected):
+    G = nx.DiGraph(edgelist)
     colliders = set(nx.dag.colliders(G))
-    assert len(colliders) == 1
-    assert (0, 2, 3) in colliders
-
-    edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
-    G = nx.DiGraph(edges)
-    colliders = set(nx.dag.colliders(G))
-    assert colliders == {("A", "B", "C"), ("D", "E", "G")}
+    assert colliders == expected

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -790,22 +790,21 @@ def test_v_structures_raise():
         nx.dag.v_structures(G)
 
 
-def test_v_structures():
-    edges = [(0, 1), (0, 2), (3, 2)]
-    G = nx.DiGraph(edges)
-
+@pytest.mark.parametrize(
+    ("edgelist", "expected"),
+    (
+        ([(0, 1), (0, 2), (3, 2)], {(0, 2, 3)}),
+        (
+            [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")],
+            {("A", "B", "C")},
+        ),
+        ([(0, 1), (2, 1), (0, 2)], set()),
+    ),
+)
+def test_v_structures(edgelist, expected):
+    G = nx.DiGraph(edgelist)
     v_structs = set(nx.dag.v_structures(G))
-    assert len(v_structs) == 1
-    assert (0, 2, 3) in v_structs
-
-    edges = [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")]
-    G = nx.DiGraph(edges)
-    v_structs = set(nx.dag.v_structures(G))
-    assert v_structs == {("A", "B", "C")}
-
-    edges = [(0, 1), (2, 1), (0, 2)]  # adjacent parents case: issues#7385
-    G = nx.DiGraph(edges)
-    assert set(nx.dag.v_structures(G)) == set()
+    assert v_structs == expected
 
 
 def test_colliders_raise():

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -798,7 +798,7 @@ def test_v_structures_raise():
             [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")],
             {("A", "B", "C")},
         ),
-        ([(0, 1), (2, 1), (0, 2)], set()),
+        ([(0, 1), (2, 1), (0, 2)], set()),  # adjacent parents case: see gh-7385
     ),
 )
 def test_v_structures(edgelist, expected):

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -793,7 +793,10 @@ def test_v_structures_raise():
 @pytest.mark.parametrize(
     ("edgelist", "expected"),
     (
-        ([(0, 1), (0, 2), (3, 2)], {(0, 2, 3)}),
+        (
+            [(0, 1), (0, 2), (3, 2)],
+            {(0, 2, 3)},
+        ),
         (
             [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")],
             {("A", "B", "C")},
@@ -816,7 +819,10 @@ def test_colliders_raise():
 @pytest.mark.parametrize(
     ("edgelist", "expected"),
     (
-        ([(0, 1), (0, 2), (3, 2)], {(0, 2, 3)}),
+        (
+            [(0, 1), (0, 2), (3, 2)],
+            {(0, 2, 3)},
+        ),
         (
             [("A", "B"), ("C", "B"), ("D", "G"), ("D", "E"), ("G", "E")],
             {("A", "B", "C"), ("D", "E", "G")},

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -152,7 +152,7 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message=r"\n\nThe 'create=matrix'"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\ncompute_v_structures"
+        "ignore", category=DeprecationWarning, message="\n\n\`compute_v_structures"
     )
 
 


### PR DESCRIPTION
A very minor update to the warnings filter for `compute_v_structures` to prevent it showing up in test logs.

I also took the liberty to parametrize the colliders/v_structures tests. These refactors are very subjective - IMO they make the test body more readable, but the test setup less so :shrug: . WDYT @Schefflera-Arboricola ? NBD either way - I'm happy to back those last two commits out!