### PR TITLE
FIX: scipy 1d indexing tripped up numpy?

### DIFF
--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -71,11 +71,7 @@ class InverseLaplacian:
         m = 0
         for i, row in enumerate(L):
             w = 0
-            # scipy.sparse indexing for 1D has changed https://github.com/scipy/scipy/pull/20120
-            try:
-                x, y = np.nonzero(row)
-            except ValueError:
-                y = np.nonzero(row)[0]
+            y = np.nonzero(row)[-1]
             if len(y) > 0:
                 v = y - i
                 w = v.max() - v.min() + 1

--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -71,7 +71,11 @@ class InverseLaplacian:
         m = 0
         for i, row in enumerate(L):
             w = 0
-            x, y = np.nonzero(row)
+            # scipy.sparse indexing for 1D has changed https://github.com/scipy/scipy/pull/20120
+            try:
+                x, y = np.nonzero(row)
+            except ValueError:
+                y = np.nonzero(row)[0]
             if len(y) > 0:
                 v = y - i
                 w = v.max() - v.min() + 1


### PR DESCRIPTION
Our nightlies are broken right now https://github.com/networkx/networkx/actions/workflows/nightly-release-test.yml and my hunch is something happened after https://github.com/scipy/scipy/pull/20120

I am not sure if this is expected behavior @dschult ?