### PR TITLE
CI: Add timeout limit to coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   report:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
The [actions log](https://github.com/networkx/networkx/actions/workflows/coverage.yml) shows we recently had a coverage workflow hang until it was killed at the maximum timeout limit, which defaults to 360 minutes. I propose to add a more stringent timeout limit so that if a coverage job goes awry, it will be terminated sooner and free up the GH runners for other jobs.

I also bumped the coverage workflow Python version from 3.10 -> 3.12, though if there is a preference for keeping it pinned to the minimum-supported Python version, please go ahead and ignore!