### PR TITLE
Add `--doctest-modules` to base test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Test NetworkX
         run: |
-          pytest --durations=10 --pyargs networkx
+          pytest --doctest-modules --durations=10 --pyargs networkx
 
   default:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->

I came across this while reviewing (ref. https://github.com/networkx/networkx/pull/7443#issuecomment-2156054489). I'm fairly confident it's intentional, but just in case I thought I'd make a quick PR to make sure (if it is intentional, feel free to close!).
For reference, going through the git blame shows that this change happened in #5339.