### PR TITLE
More accurate NodeNotFound error message.

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -91,9 +91,11 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
     shortest_path, dijkstra_path
 
     """
-    if source not in G or target not in G:
-        msg = f"Either source {source} or target {target} is not in G"
-        raise nx.NodeNotFound(msg)
+    if source not in G:
+        raise nx.NodeNotFound(f"Source {source} is not in G")
+
+    if target not in G:
+        raise nx.NodeNotFound(f"Target {target} is not in G")
 
     if heuristic is None:
         # The default heuristic is h=0 - same as Dijkstra's algorithm

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -49,7 +49,7 @@ class TestUnweightedPath:
     def test_bidirectional_shortest_path_src_tgt_not_in_graph(self, src, tgt):
         with pytest.raises(
             nx.NodeNotFound,
-            match=f"Either source {src} or target {tgt} is not in G",
+            match=f"(Source {src}|Target {tgt}) is not in G",
         ):
             nx.bidirectional_shortest_path(self.cycle, src, tgt)
 

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -239,9 +239,11 @@ def bidirectional_shortest_path(G, source, target):
     This algorithm is used by shortest_path(G, source, target).
     """
 
-    if source not in G or target not in G:
-        msg = f"Either source {source} or target {target} is not in G"
-        raise nx.NodeNotFound(msg)
+    if source not in G:
+        raise nx.NodeNotFound(f"Source {source} is not in G")
+
+    if target not in G:
+        raise nx.NodeNotFound(f"Target {target} is not in G")
 
     # call helper to do the real work
     results = _bidirectional_pred_succ(G, source, target)

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -2322,7 +2322,7 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
     Raises
     ------
     NodeNotFound
-        If either `source` or `target` is not in `G`.
+        If `source` or `target` is not in `G`.
 
     NetworkXNoPath
         If no path exists between source and target.
@@ -2364,9 +2364,11 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
     shortest_path
     shortest_path_length
     """
-    if source not in G or target not in G:
-        msg = f"Either source {source} or target {target} is not in G"
-        raise nx.NodeNotFound(msg)
+    if source not in G:
+        raise nx.NodeNotFound(f"Source {source} is not in G")
+
+    if target not in G:
+        raise nx.NodeNotFound(f"Target {target} is not in G")
 
     if source == target:
         return (0, [source])


### PR DESCRIPTION
I find the exception `Either source {source} or target {target} is not in G` to be not really helpful because the exception should really tell you which of the two it is that is not in G.

I separated the cases to raise individually on a missing source or target node. If necessary, I can also add a case when *both* are not in G.
