### PR TITLE
Update sphinx gallery config to enable sphinx build caching

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,7 +48,7 @@ sphinx_gallery_conf = {
             "../examples/subclass",
         ]
     ),
-    "within_subsection_order": FileNameSortKey,
+    "within_subsection_order": "FileNameSortKey",
     # path where to save gallery generated examples
     "gallery_dirs": "auto_examples",
     "backreferences_dir": "modules/generated",

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -132,7 +132,7 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message=r"\n\nThe 'create=matrix'"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\n\`compute_v_structures"
+        "ignore", category=DeprecationWarning, message="\n\n`compute_v_structures"
     )
 
 


### PR DESCRIPTION
Somewhere in the Sphinx 7.3.X series, sphinx-build began emitting warnings about unpickleable values in the sphinx env:

```
pickling environment... WARNING: cannot cache unpickable configuration value: 'sphinx_gallery_conf' (because it contains a function, class, or module object)
done
```

Fortunately this has already been fixed in sphinx-gallery, cf. sphinx-gallery/sphinx-gallery#1289. These changes were part of the sphinx-gallery 0.16 release, which we're already pinned above. Due to the sphinx-gallery devs' hard work, the fix is very simple :tada: . Note to review whether this patch worked, you'd have to view the sphinx build log from circleci and verify there are no more unpickleable warnings. FWIW I've built the docs and verified this locally.

Finally, I also snuck in a tiny tweak to the warnings filters to clean up some of my own sloppiness in #7539 ( d43d177 should get rid of a SyntaxWarning I accidentally introduced).

### Additional context

In case anyone else is interested in reading a bit more about this, I found the following useful: sphinx-gallery/sphinx-gallery#1286, matplotlib/matplotlib#28103, and [the sphinx-gallery configuration docs](https://sphinx-gallery.github.io/dev/configuration.html#importing-callables).