### PR TITLE
Only allow connected graphs in `eigenvector_centrality_numpy`

### DIFF
--- a/benchmarks/benchmarks/benchmark_algorithms.py
+++ b/benchmarks/benchmarks/benchmark_algorithms.py
@@ -31,11 +31,6 @@ class AlgorithmBenchmarks:
         # underlying shortest path methods
         _ = nx.betweenness_centrality(self.graphs_dict[graph])
 
-    def time_eigenvector_centrality_numpy(self, graph):
-        # Added to ensure the connectivity check doesn't affect
-        # performance too much (see gh-6888, gh-7549).
-        _ = nx.eigenvector_centrality_numpy(self.graphs_dict[graph])
-
     def time_greedy_modularity_communities(self, graph):
         _ = community.greedy_modularity_communities(self.graphs_dict[graph])
 
@@ -53,3 +48,28 @@ class AlgorithmBenchmarks:
 
     def time_average_clustering(self, graph):
         _ = nx.average_clustering(self.graphs_dict[graph])
+
+
+class AlgorithmBenchmarksConnectedGraphsOnly:
+    timeout = 120
+    nodes = 100
+    _graphs = [
+        nx.erdos_renyi_graph(nodes, 0.1),
+        nx.erdos_renyi_graph(nodes, 0.5),
+        nx.erdos_renyi_graph(nodes, 0.9),
+    ]
+    params = [
+        "Erdos Renyi (100, 0.1)",
+        "Erdos Renyi (100, 0.5)",
+        "Erdos Renyi (100, 0.9)",
+    ]
+
+    param_names = ["graph"]
+
+    def setup(self, graph):
+        self.graphs_dict = dict(zip(self.params, self._graphs))
+
+    def time_eigenvector_centrality_numpy(self, graph):
+        # Added to ensure the connectivity check doesn't affect
+        # performance too much (see gh-6888, gh-7549).
+        _ = nx.eigenvector_centrality_numpy(self.graphs_dict[graph])

--- a/benchmarks/benchmarks/benchmark_algorithms.py
+++ b/benchmarks/benchmarks/benchmark_algorithms.py
@@ -31,6 +31,11 @@ class AlgorithmBenchmarks:
         # underlying shortest path methods
         _ = nx.betweenness_centrality(self.graphs_dict[graph])
 
+    def time_eigenvector_centrality_numpy(self, graph):
+        # Added to ensure the connectivity check doesn't affect
+        # performance too much (see gh-6888, gh-7549).
+        _ = nx.eigenvector_centrality_numpy(self.graphs_dict[graph])
+
     def time_greedy_modularity_communities(self, graph):
         _ = community.greedy_modularity_communities(self.graphs_dict[graph])
 

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -343,10 +343,11 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
         raise nx.NetworkXPointlessConcept(
             "cannot compute centrality for the null graph"
         )
-    connectivity_func = nx.is_strongly_connected if G.is_directed() else nx.is_connected
-    if not connectivity_func(G):  # See gh-6888.
-        msg = "`eigenvector_centrality_numpy` does not give consistent results for disconnected graphs"
-        raise nx.AmbiguousSolution(msg)
+    connected = nx.is_strongly_connected if G.is_directed() else nx.is_connected
+    if not connected(G):  # See gh-6888.
+        raise nx.AmbiguousSolution(
+            "`eigenvector_centrality_numpy` does not give consistent results for disconnected graphs"
+        )
     M = nx.to_scipy_sparse_array(G, nodelist=list(G), weight=weight, dtype=float)
     _, eigenvector = sp.sparse.linalg.eigs(
         M.T, k=1, which="LR", maxiter=max_iter, tol=tol

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -343,8 +343,8 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
         raise nx.NetworkXPointlessConcept(
             "cannot compute centrality for the null graph"
         )
-    connected = nx.is_strongly_connected if G.is_directed() else nx.is_connected
-    if not connected(G):  # See gh-6888.
+    connected = nx.is_strongly_connected(G) if G.is_directed() else nx.is_connected(G)
+    if not connected:  # See gh-6888.
         raise nx.AmbiguousSolution(
             "`eigenvector_centrality_numpy` does not give consistent results for disconnected graphs"
         )

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -196,7 +196,7 @@ def eigenvector_centrality(G, max_iter=100, tol=1.0e-6, nstart=None, weight=None
 
 @nx._dispatchable(edge_attrs="weight")
 def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
-    r"""Compute the eigenvector centrality for the graph G.
+    r"""Compute the eigenvector centrality for the graph `G`.
 
     Eigenvector centrality computes the centrality for a node by adding
     the centrality of its predecessors. The centrality for node $i$ is the
@@ -208,7 +208,7 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
 
          \lambda x^T = x^T A,
 
-    where $A$ is the adjacency matrix of the graph G. By definition of
+    where $A$ is the adjacency matrix of the graph `G`. By definition of
     row-column product, the equation above is equivalent to
 
     .. math::
@@ -220,37 +220,42 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     $\lambda$. In the case of undirected graphs, $x$ also solves the familiar
     right-eigenvector equation $Ax = \lambda x$.
 
-    By virtue of the Perron–Frobenius theorem [1]_, if G is strongly
-    connected there is a unique eigenvector $x$, and all its entries
+    By virtue of the Perron--Frobenius theorem [1]_, if `G` is (strongly)
+    connected, there is a unique eigenvector $x$, and all its entries
     are strictly positive.
 
-    If G is not strongly connected there might be several left
+    However, if `G` is not (strongly) connected, there might be several left
     eigenvectors associated with $\lambda$, and some of their elements
     might be zero.
+    Depending on the method used to choose eigenvectors, round-off error can affect
+    which of the infinitely many eigenvectors is reported.
+    This can lead to inconsistent results for the same graph,
+    which the underlying implementation is not robust to.
+    For this reason, only (strongly) connected graphs are accepted.
 
     Parameters
     ----------
     G : graph
         A connected NetworkX graph.
 
+    weight : None or string, optional (default=None)
+        If ``None``, all edge weights are considered equal. Otherwise holds the
+        name of the edge attribute used as weight. In this measure the
+        weight is interpreted as the connection strength.
+
     max_iter : integer, optional (default=50)
-      Maximum number of Arnoldi update iterations allowed.
+        Maximum number of Arnoldi update iterations allowed.
 
     tol : float, optional (default=0)
-      Relative accuracy for eigenvalues (stopping criterion).
-      The default value of 0 implies machine precision.
-
-    weight : None or string, optional (default=None)
-      If None, all edge weights are considered equal. Otherwise holds the
-      name of the edge attribute used as weight. In this measure the
-      weight is interpreted as the connection strength.
+        Relative accuracy for eigenvalues (stopping criterion).
+        The default value of 0 implies machine precision.
 
     Returns
     -------
-    nodes : dictionary
-       Dictionary of nodes with eigenvector centrality as the value. The
-       associated vector has unit Euclidean norm and the values are
-       nonegative.
+    nodes : dict of nodes
+        Dictionary of nodes with eigenvector centrality as the value. The
+        associated vector has unit Euclidean norm and the values are
+        nonnegative.
 
     Examples
     --------
@@ -262,7 +267,7 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     Raises
     ------
     NetworkXPointlessConcept
-        If the graph G is the null graph.
+        If the graph `G` is the null graph.
 
     ArpackNoConvergence
         When the requested convergence is not obtained. The currently
@@ -298,58 +303,38 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     to find the largest eigenvalue/eigenvector pair using Arnoldi iterations
     [7]_.
 
-    Normally, the Perron--Frobenius theorem [8]_ [9]_ ensures
-    that there is only a line of eigenvectors for the largest eigenvalue.
-    This makes uniquely selecting the eigenvector straightforward.
-    However, the Perron-Frobenius theorem does not hold
-    when the network is disconnected (or equivalently, when the adjacency matrix is reducible).
-    In that case, there is an entire plane (or more) of eigenvectors for the largest eigenvalue,
-    and the computed eigenvectors reflect one of many correct eigenvector choices.
-    Depending on the method used, round-off error can affect
-    which of the infinitely many choices of eigenvector may be reported.
-    This can lead to inconsistent results for the same disconnected graph.
-    For this reason, disconnected graphs are not accepted by this function.
-    For directed graphs, the equivalent condition is strong connectivity.
-
     References
     ----------
     .. [1] Abraham Berman and Robert J. Plemmons.
-       "Nonnegative Matrices in the Mathematical Sciences."
-       Classics in Applied Mathematics. SIAM, 1994.
+        "Nonnegative Matrices in the Mathematical Sciences".
+        Classics in Applied Mathematics. SIAM, 1994.
 
     .. [2] Edmund Landau.
-       "Zur relativen Wertbemessung der Turnierresultate."
-       Deutsches Wochenschach, 11:366–369, 1895.
+        "Zur relativen Wertbemessung der Turnierresultate".
+        Deutsches Wochenschach, 11:366--369, 1895.
 
     .. [3] Teh-Hsing Wei.
-       "The Algebraic Foundations of Ranking Theory."
-       PhD thesis, University of Cambridge, 1952.
+        "The Algebraic Foundations of Ranking Theory".
+        PhD thesis, University of Cambridge, 1952.
 
     .. [4] Maurice G. Kendall.
-       "Further contributions to the theory of paired comparisons."
-       Biometrics, 11(1):43–62, 1955.
-       https://www.jstor.org/stable/3001479
+        "Further contributions to the theory of paired comparisons".
+        Biometrics, 11(1):43--62, 1955.
+        https://www.jstor.org/stable/3001479
 
-    .. [5] Claude Berge
-       "Théorie des graphes et ses applications."
-       Dunod, Paris, France, 1958.
+    .. [5] Claude Berge.
+        "Théorie des graphes et ses applications".
+        Dunod, Paris, France, 1958.
 
     .. [6] Phillip Bonacich.
-       "Technique for analyzing overlapping memberships."
-       Sociological Methodology, 4:176–185, 1972.
-       https://www.jstor.org/stable/270732
+        "Technique for analyzing overlapping memberships".
+        Sociological Methodology, 4:176--185, 1972.
+        https://www.jstor.org/stable/270732
 
-    .. [7] Arnoldi iteration:: https://en.wikipedia.org/wiki/Arnoldi_iteration
-
-    .. [8] Perron, Oskar.
-        "Zur Theorie der Matrices".
-        Mathematische Annalen 64 (1907): 248--263.
-        https://eudml.org/doc/158317
-
-    .. [9] Frobenius, Georg.
-        "Über Matrizen aus nicht negativen Elementen".
-        Sitzungsberichte der Königlich Preussischen Akademie der Wissenschaften (1912): 456--477.
-        https://www.e-rara.ch/doi/10.3931/e-rara-18865
+    .. [7] Arnoldi, W. E. (1951).
+        "The principle of minimized iterations in the solution of the matrix eigenvalue problem".
+        Quarterly of Applied Mathematics. 9 (1): 17--29.
+        https://doi.org/10.1090/qam/42792
     """
     import numpy as np
     import scipy as sp
@@ -359,7 +344,7 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
             "cannot compute centrality for the null graph"
         )
     connectivity_func = nx.is_strongly_connected if G.is_directed() else nx.is_connected
-    if not connectivity_func(G):
+    if not connectivity_func(G):  # See gh-6888.
         msg = "`eigenvector_centrality_numpy` does not give consistent results for disconnected graphs"
         raise nx.AmbiguousSolution(msg)
     M = nx.to_scipy_sparse_array(G, nodelist=list(G), weight=weight, dtype=float)

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -306,35 +306,35 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     References
     ----------
     .. [1] Abraham Berman and Robert J. Plemmons.
-        "Nonnegative Matrices in the Mathematical Sciences".
-        Classics in Applied Mathematics. SIAM, 1994.
+       "Nonnegative Matrices in the Mathematical Sciences".
+       Classics in Applied Mathematics. SIAM, 1994.
 
     .. [2] Edmund Landau.
-        "Zur relativen Wertbemessung der Turnierresultate".
-        Deutsches Wochenschach, 11:366--369, 1895.
+       "Zur relativen Wertbemessung der Turnierresultate".
+       Deutsches Wochenschach, 11:366--369, 1895.
 
     .. [3] Teh-Hsing Wei.
-        "The Algebraic Foundations of Ranking Theory".
-        PhD thesis, University of Cambridge, 1952.
+       "The Algebraic Foundations of Ranking Theory".
+       PhD thesis, University of Cambridge, 1952.
 
     .. [4] Maurice G. Kendall.
-        "Further contributions to the theory of paired comparisons".
-        Biometrics, 11(1):43--62, 1955.
-        https://www.jstor.org/stable/3001479
+       "Further contributions to the theory of paired comparisons".
+       Biometrics, 11(1):43--62, 1955.
+       https://www.jstor.org/stable/3001479
 
     .. [5] Claude Berge.
-        "Théorie des graphes et ses applications".
-        Dunod, Paris, France, 1958.
+       "Théorie des graphes et ses applications".
+       Dunod, Paris, France, 1958.
 
     .. [6] Phillip Bonacich.
-        "Technique for analyzing overlapping memberships".
-        Sociological Methodology, 4:176--185, 1972.
-        https://www.jstor.org/stable/270732
+       "Technique for analyzing overlapping memberships".
+       Sociological Methodology, 4:176--185, 1972.
+       https://www.jstor.org/stable/270732
 
     .. [7] Arnoldi, W. E. (1951).
-        "The principle of minimized iterations in the solution of the matrix eigenvalue problem".
-        Quarterly of Applied Mathematics. 9 (1): 17--29.
-        https://doi.org/10.1090/qam/42792
+       "The principle of minimized iterations in the solution of the matrix eigenvalue problem".
+       Quarterly of Applied Mathematics. 9 (1): 17--29.
+       https://doi.org/10.1090/qam/42792
     """
     import numpy as np
     import scipy as sp

--- a/networkx/algorithms/centrality/eigenvector.py
+++ b/networkx/algorithms/centrality/eigenvector.py
@@ -231,7 +231,7 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     Parameters
     ----------
     G : graph
-      A networkx graph.
+        A connected NetworkX graph.
 
     max_iter : integer, optional (default=50)
       Maximum number of Arnoldi update iterations allowed.
@@ -299,20 +299,17 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
     [7]_.
 
     Normally, the Perron--Frobenius theorem [8]_ [9]_ ensures
-    that there is only a line of eigenvectors for the largest eigenvalue
-    (it cannot be less than a line because
-    any multiple of an eigenvector is also an eigenvector).
-    We usually select a unique eigenvector by choosing
-    a unit vector with first nonzero element positive.
+    that there is only a line of eigenvectors for the largest eigenvalue.
+    This makes uniquely selecting the eigenvector straightforward.
     However, the Perron-Frobenius theorem does not hold
-    when the network is disconnected
-    (or equivalently, when the adjacency matrix is reducible),
-    in which case there is an entire plane (or more) of eigenvectors for the largest eigenvalue
-    and the computed eigenvectors reflect one of many correct eigenvectors.
+    when the network is disconnected (or equivalently, when the adjacency matrix is reducible).
+    In that case, there is an entire plane (or more) of eigenvectors for the largest eigenvalue,
+    and the computed eigenvectors reflect one of many correct eigenvector choices.
     Depending on the method used, round-off error can affect
     which of the infinitely many choices of eigenvector may be reported.
     This can lead to inconsistent results for the same disconnected graph.
     For this reason, disconnected graphs are not accepted by this function.
+    For directed graphs, the equivalent condition is strong connectivity.
 
     References
     ----------
@@ -361,7 +358,8 @@ def eigenvector_centrality_numpy(G, weight=None, max_iter=50, tol=0):
         raise nx.NetworkXPointlessConcept(
             "cannot compute centrality for the null graph"
         )
-    if not nx.is_connected(G):
+    connectivity_func = nx.is_strongly_connected if G.is_directed() else nx.is_connected
+    if not connectivity_func(G):
         msg = "`eigenvector_centrality_numpy` does not give consistent results for disconnected graphs"
         raise nx.AmbiguousSolution(msg)
     M = nx.to_scipy_sparse_array(G, nodelist=list(G), weight=weight, dtype=float)

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -167,7 +167,6 @@ class TestEigenvectorCentralityExceptions:
         with pytest.raises(nx.NetworkXException):
             nx.eigenvector_centrality_numpy(nx.Graph())
 
-    # `eigenvector_centrality` raises `AmbiguousSolution` for disconnected graphs; gh-6888.
     @pytest.mark.parametrize(
         "G",
         [

--- a/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py
@@ -159,13 +159,26 @@ class TestEigenvectorCentralityExceptions:
         with pytest.raises(nx.NetworkXException):
             nx.eigenvector_centrality_numpy(nx.MultiGraph())
 
-    def test_empty(self):
+    def test_null(self):
         with pytest.raises(nx.NetworkXException):
             nx.eigenvector_centrality(nx.Graph())
 
-    def test_empty_numpy(self):
+    def test_null_numpy(self):
         with pytest.raises(nx.NetworkXException):
             nx.eigenvector_centrality_numpy(nx.Graph())
+
+    # `eigenvector_centrality` raises `AmbiguousSolution` for disconnected graphs; gh-6888.
+    @pytest.mark.parametrize(
+        "G",
+        [
+            nx.empty_graph(3),
+            nx.DiGraph([(0, 1), (1, 2)]),
+        ],
+    )
+    def test_disconnected_numpy(self, G):
+        msg = "does not give consistent results for disconnected"
+        with pytest.raises(nx.AmbiguousSolution, match=msg):
+            nx.eigenvector_centrality_numpy(G)
 
     def test_zero_nstart(self):
         G = nx.Graph([(1, 2), (1, 3), (2, 3)])


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
Fixes #6888.

As discussed in #6888, the SciPy solver does not handle disconnected graphs well, leading to inconsistent results. The proposed solution was to add a check that `G` is connected, as long as that didn't make the algorithm much slower (for reference, the execution time was usually around 1-2% longer with the check).

This PR:
  - Changes `eigenvector_centrality_numpy` to only accept connected graphs (strongly connected for directed graphs)
  - Updates the docstring to clearly mention the reason for this choice (i.e. the inconsistency, and its explanation by @dschult)
  - Adds two tests to verify that the function properly raises when given a disconnected graph as input
  - Reorganises the arguments in the docstring to match the arguments of the function
  - Has other very minor changes (improvements?) to the docstring.

