### PR TITLE
Fix installing nx-cugraph in deploy docs CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             # Install trusted backends, but not their dependencies.
             # We only need to use the "networkx.backend_info" entry-point.
             # This is the nightly wheel for nx-cugraph.
-            pip install nx-cugraph-cu11 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple --no-deps
+            pip install nx-cugraph-cu11 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple --no-deps --pre
             # Development version of GraphBLAS backend
             pip install git+https://github.com/python-graphblas/graphblas-algorithms.git@main --no-deps
             # Development version of nx-parallel backend

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
           # Install trusted backends, but not their dependencies.
           # We only need to use the "networkx.backend_info" entry-point.
           # This is the nightly wheel for nx-cugraph.
-          pip install nx-cugraph-cu11 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple --no-deps
+          pip install nx-cugraph-cu11 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple --no-deps --pre
           # Development version of GraphBLAS backend
           pip install git+https://github.com/python-graphblas/graphblas-algorithms.git@main --no-deps
           # Development version of nx-parallel backend


### PR DESCRIPTION
This is a follow-up to #7538 to install pre-release of `nx-cugraph` when building docs.

Failure was noticed https://github.com/networkx/networkx/pull/7498#issuecomment-2221133236.

Since this channel is for nightly wheels, we need `--pre`. It's curious that this worked before.

If connectivity to this repo is too flaky, we could increase the retries/timeout, and/or we could add the channel for regular releases `--extra-index-url https://pypi.nvidia.com nx-cugraph-cu11`.

CC @rlratzel 