### PR TITLE
Add `edges` keyword/deprecate `link` keyword arguments in `JSON` input-output

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -59,3 +59,5 @@ Version 3.5
 Version 3.6
 ~~~~~~~~~~~
 * Remove ``compute_v_structures`` from ``algorithms/dag.py``.
+* Remove ``link`` kwarg from ``readwrite/json_graph/node_link.py``;
+  Change ``edges`` default value to ``links``.

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -60,4 +60,4 @@ Version 3.6
 ~~~~~~~~~~~
 * Remove ``compute_v_structures`` from ``algorithms/dag.py``.
 * Remove ``link`` kwarg from ``readwrite/json_graph/node_link.py``;
-  Change ``edges`` default value to ``links``.
+  Change ``edges`` default value to ``edges``.

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -134,6 +134,9 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\n`compute_v_structures"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="Keyword argument 'link'"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -49,11 +49,11 @@ def node_link_data(
     key : string
         A string that provides the 'key' attribute name for storing NetworkX-internal graph data.
     edges : string
-        A string that provides the 'link' attribute name for storing NetworkX-internal graph data.
+        A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
     nodes : string
         A string that provides the 'nodes' attribute name for storing NetworkX-internal graph data.
     link : string
-        (Deprecated, use 'edges') A string that provides the 'link' attribute name for storing NetworkX-internal graph data.
+        (Deprecated, use 'edges') A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------
@@ -73,7 +73,7 @@ def node_link_data(
     >>> pprint(data1)
     {'directed': False,
      'graph': {},
-     'links': [{'source': 'A', 'target': 'B'}],
+     'edges': [{'source': 'A', 'target': 'B'}],
      'multigraph': False,
      'nodes': [{'id': 'A'}, {'id': 'B'}]}
 
@@ -82,24 +82,24 @@ def node_link_data(
     >>> import json
     >>> s1 = json.dumps(data1)
     >>> s1
-    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
+    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "edges": [{"source": "A", "target": "B"}]}'
 
     A graph can also be serialized by passing `node_link_data` as an encoder function. The two methods are equivalent.
 
     >>> s1 = json.dumps(G, default=nx.node_link_data)
     >>> s1
-    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
+    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "edges": [{"source": "A", "target": "B"}]}'
 
     The attribute names for storing NetworkX-internal graph data can
     be specified as keyword options.
 
     >>> H = nx.gn_graph(2)
     >>> data2 = nx.node_link_data(
-    ...     H, edges="edges", source="from", target="to", nodes="vertices"
+    ...     H, edges="links", source="from", target="to", nodes="vertices"
     ... )
     >>> pprint(data2)
     {'directed': True,
-     'edges': [{'from': 1, 'to': 0}],
+     'links': [{'from': 1, 'to': 0}],
      'graph': {},
      'multigraph': False,
      'vertices': [{'id': 0}, {'id': 1}]}
@@ -131,7 +131,7 @@ def node_link_data(
             edges = link
     else:
         if edges is None:
-            edges = "links"
+            edges = "edges"
     multigraph = G.is_multigraph()
 
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
@@ -191,11 +191,11 @@ def node_link_graph(
     key : string
         A string that provides the 'key' attribute name for storing NetworkX-internal graph data.
     edges : string
-        A string that provides the 'link' attribute name for storing NetworkX-internal graph data.
+        A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
     nodes : string
         A string that provides the 'nodes' attribute name for storing NetworkX-internal graph data.
     link : string
-        (Deprecated, use 'edges') A string that provides the 'link' attribute name for storing NetworkX-internal graph data.
+        (Deprecated, use 'edges') A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------
@@ -213,7 +213,7 @@ def node_link_graph(
     >>> pprint(data)
     {'directed': False,
      'graph': {},
-     'links': [{'source': 'A', 'target': 'B'}],
+     'edges': [{'source': 'A', 'target': 'B'}],
      'multigraph': False,
      'nodes': [{'id': 'A'}, {'id': 'B'}]}
 
@@ -255,7 +255,7 @@ def node_link_graph(
             edges = link
     else:
         if edges is None:
-            edges = "links"
+            edges = "edges"
     multigraph = data.get("multigraph", multigraph)
     directed = data.get("directed", directed)
     if multigraph:

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -53,7 +53,12 @@ def node_link_data(
     nodes : string
         A string that provides the 'nodes' attribute name for storing NetworkX-internal graph data.
     link : string
-        (Deprecated, use 'edges') A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
+        .. deprecated:: 3.4
+
+           The `link` argument is deprecated and will be removed in version `3.6`.
+           Use the `edges` keyword instead.
+
+        A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------
@@ -169,6 +174,7 @@ def node_link_graph(
     link=None,
 ):
     """Returns graph from node-link data format.
+
     Useful for de-serialization from JSON.
 
     Parameters
@@ -195,7 +201,12 @@ def node_link_graph(
     nodes : string
         A string that provides the 'nodes' attribute name for storing NetworkX-internal graph data.
     link : string
-        (Deprecated, use 'edges') A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
+        .. deprecated:: 3.4
+
+           The `link` argument is deprecated and will be removed in version `3.6`.
+           Use the `edges` keyword instead.
+
+        A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -77,8 +77,8 @@ def node_link_data(
     >>> data1 = nx.node_link_data(G)
     >>> pprint(data1)
     {'directed': False,
-     'graph': {},
      'edges': [{'source': 'A', 'target': 'B'}],
+     'graph': {},
      'multigraph': False,
      'nodes': [{'id': 'A'}, {'id': 'B'}]}
 
@@ -104,8 +104,8 @@ def node_link_data(
     ... )
     >>> pprint(data2)
     {'directed': True,
-     'links': [{'from': 1, 'to': 0}],
      'graph': {},
+     'links': [{'from': 1, 'to': 0}],
      'multigraph': False,
      'vertices': [{'id': 0}, {'id': 1}]}
 
@@ -223,8 +223,8 @@ def node_link_graph(
     >>> data = nx.node_link_data(G)
     >>> pprint(data)
     {'directed': False,
-     'graph': {},
      'edges': [{'source': 'A', 'target': 'B'}],
+     'graph': {},
      'multigraph': False,
      'nodes': [{'id': 'A'}, {'id': 'B'}]}
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -124,19 +124,24 @@ def node_link_data(
     --------
     node_link_graph, adjacency_data, tree_data
     """
+    # TODO: Remove between the lines when `link` deprecation expires
+    # -------------------------------------------------------------
     if link is not None:
+        warnings.warn(
+            "Keyword argument 'link' is deprecated; use 'edges' instead",
+            DeprecationWarning,
+        )
         if edges is not None:
             raise ValueError(
                 "Both 'edges' and 'link' are specified. Use 'edges', 'link' will be remove in a future release"
             )
         else:
-            warnings.warn(
-                "Keyword argument 'link' is deprecated; use 'edges", DeprecationWarning
-            )
             edges = link
     else:
         if edges is None:
             edges = "edges"
+    # ------------------------------------------------------------
+
     multigraph = G.is_multigraph()
 
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
@@ -254,19 +259,24 @@ def node_link_graph(
     --------
     node_link_data, adjacency_data, tree_data
     """
+    # TODO: Remove between the lines when `link` deprecation expires
+    # -------------------------------------------------------------
     if link is not None:
+        warnings.warn(
+            "Keyword argument 'link' is deprecated; use 'edges' instead",
+            DeprecationWarning,
+        )
         if edges is not None:
             raise ValueError(
                 "Both 'edges' and 'link' are specified. Use 'edges', 'link' will be remove in a future release"
             )
         else:
-            warnings.warn(
-                "Keyword argument 'link' is deprecated; use 'edges", DeprecationWarning
-            )
             edges = link
     else:
         if edges is None:
             edges = "edges"
+    # -------------------------------------------------------------
+
     multigraph = data.get("multigraph", multigraph)
     directed = data.get("directed", directed)
     if multigraph:

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -117,8 +117,8 @@ class TestNodeLink:
         G.add_node(q)
         G.add_edge("A", q)
         data = node_link_data(G)
-        assert data["links"][0]["source"] == "A"
-        assert data["links"][0]["target"] == q
+        assert data["edges"][0]["source"] == "A"
+        assert data["edges"][0]["target"] == q
         H = node_link_graph(data)
         assert nx.is_isomorphic(G, H)
 


### PR DESCRIPTION
Following the discussion in #7532, this PR does the following:

- New keyword argument `edges` is introduced to JSON reading/writing functions
- Previous keyword argument `link` is deprecated
- Functions raise `ValueError` if both are provided
- Functions raise `DeprecationWarning` if `link` is provided

In the second commit, the actual default value for `edges` is set to `"edges"` instead of `"links"`.
I am not sure if the idea was to chage it now or maintain backwards compatibility of scripts that might use default values.
