### PR TITLE
Add remove attribute functions

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -30,8 +30,10 @@ __all__ = [
     "create_empty_copy",
     "set_node_attributes",
     "get_node_attributes",
+    "remove_node_attributes",
     "set_edge_attributes",
     "get_edge_attributes",
+    "remove_edge_attributes",
     "all_neighbors",
     "non_neighbors",
     "non_edges",
@@ -701,6 +703,34 @@ def get_node_attributes(G, name, default=None):
     return {n: d[name] for n, d in G.nodes.items() if name in d}
 
 
+def remove_node_attributes(G, *attr_names):
+    """Remove node attributes from all nodes in the graph.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+
+    *attr_names : List of Strings
+        The attribute names to remove from the graph.
+
+    Examples
+    --------
+    >>> G = nx.Graph()
+    >>> G.add_nodes_from([1, 2, 3], color="blue")
+    >>> nx.get_node_attributes(G, "color")
+    {1: 'blue', 2: 'blue', 3: 'blue'}
+    >>> nx.remove_node_attributes(G, "color")
+    >>> nx.get_node_attributes(G, "color")
+    {}
+    """
+    for attr in attr_names:
+        for _, d in G.nodes(data=True):
+            try:
+                del d[attr]
+            except KeyError:
+                pass
+
+
 def set_edge_attributes(G, values, name=None):
     """Sets edge attributes from a given value or dictionary of values.
 
@@ -879,6 +909,37 @@ def get_edge_attributes(G, name, default=None):
     if default is not None:
         return {x[:-1]: x[-1].get(name, default) for x in edges}
     return {x[:-1]: x[-1][name] for x in edges if name in x[-1]}
+
+
+def remove_edge_attributes(G, *attr_names):
+    """Remove edge attributes from all edges in the graph.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+
+    *attr_names : List of Strings
+        The attribute names to remove from the graph.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(3)
+    >>> nx.set_edge_attributes(G, {(u, v): u + v for u, v in G.edges()}, name="weight")
+    >>> nx.get_edge_attributes(G, "weight")
+    {(0, 1): 1, (1, 2): 3}
+    >>> remove_edge_attributes(G, "weight")
+    >>> nx.get_edge_attributes(G, "weight")
+    {}
+    """
+    for attr in attr_names:
+        edges = (
+            G.edges(keys=True, data=True) if G.is_multigraph() else G.edges(data=True)
+        )
+        for *e, d in edges:
+            try:
+                del d[attr]
+            except KeyError:
+                pass
 
 
 def all_neighbors(graph, node):

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -703,7 +703,7 @@ def get_node_attributes(G, name, default=None):
     return {n: d[name] for n, d in G.nodes.items() if name in d}
 
 
-def remove_node_attributes(G, *attr_names):
+def remove_node_attributes(G, *attr_names, nbunch=None):
     """Remove node attributes from all nodes in the graph.
 
     Parameters
@@ -712,6 +712,9 @@ def remove_node_attributes(G, *attr_names):
 
     *attr_names : List of Strings
         The attribute names to remove from the graph.
+
+    nbunch : List of Nodes
+        Remove the node attributes only from the nodes in this list.
 
     Examples
     --------
@@ -723,12 +726,17 @@ def remove_node_attributes(G, *attr_names):
     >>> nx.get_node_attributes(G, "color")
     {}
     """
+
+    if nbunch is None:
+        nbunch = G.nodes()
+
     for attr in attr_names:
-        for _, d in G.nodes(data=True):
-            try:
-                del d[attr]
-            except KeyError:
-                pass
+        for n, d in G.nodes(data=True):
+            if n in nbunch:
+                try:
+                    del d[attr]
+                except KeyError:
+                    pass
 
 
 def set_edge_attributes(G, values, name=None):
@@ -911,7 +919,7 @@ def get_edge_attributes(G, name, default=None):
     return {x[:-1]: x[-1][name] for x in edges if name in x[-1]}
 
 
-def remove_edge_attributes(G, *attr_names):
+def remove_edge_attributes(G, *attr_names, ebunch=None):
     """Remove edge attributes from all edges in the graph.
 
     Parameters
@@ -931,15 +939,19 @@ def remove_edge_attributes(G, *attr_names):
     >>> nx.get_edge_attributes(G, "weight")
     {}
     """
+    if ebunch is None:
+        ebunch = G.edges(keys=True) if G.is_multigraph() else G.edges()
+
     for attr in attr_names:
         edges = (
             G.edges(keys=True, data=True) if G.is_multigraph() else G.edges(data=True)
         )
         for *e, d in edges:
-            try:
-                del d[attr]
-            except KeyError:
-                pass
+            if tuple(e) in ebunch:
+                try:
+                    del d[attr]
+                except KeyError:
+                    pass
 
 
 def all_neighbors(graph, node):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -656,6 +656,209 @@ def test_get_edge_attributes():
             assert deafult_attrs[edge] == vals
 
 
+@pytest.mark.parametrize(
+    "graph_type", (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)
+)
+def test_remove_node_attributes(graph_type):
+    # Test removing single attribute
+    G = nx.path_graph(3, create_using=graph_type)
+    vals = 100
+    attr = "hello"
+    nx.set_node_attributes(G, vals, attr)
+    nx.remove_node_attributes(G, attr)
+    assert attr not in G.nodes[0]
+    assert attr not in G.nodes[1]
+    assert attr not in G.nodes[2]
+
+    # Test removing single attribute when multiple present
+    G = nx.path_graph(3, create_using=graph_type)
+    other_vals = 200
+    other_attr = "other"
+    nx.set_node_attributes(G, vals, attr)
+    nx.set_node_attributes(G, other_vals, other_attr)
+    nx.remove_node_attributes(G, attr)
+    assert attr not in G.nodes[0]
+    assert G.nodes[0][other_attr] == other_vals
+    assert attr not in G.nodes[1]
+    assert G.nodes[1][other_attr] == other_vals
+    assert attr not in G.nodes[2]
+    assert G.nodes[2][other_attr] == other_vals
+
+    # Test removing multiple attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    nx.set_node_attributes(G, vals, attr)
+    nx.set_node_attributes(G, other_vals, other_attr)
+    nx.remove_node_attributes(G, attr, other_attr)
+    assert attr not in G.nodes[0] and other_attr not in G.nodes[0]
+    assert attr not in G.nodes[1] and other_attr not in G.nodes[1]
+    assert attr not in G.nodes[2] and other_attr not in G.nodes[2]
+
+    # Test removing multiple (but not all) attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    third_vals = 300
+    third_attr = "three"
+    nx.set_node_attributes(
+        G,
+        {
+            n: {attr: vals, other_attr: other_vals, third_attr: third_vals}
+            for n in G.nodes()
+        },
+    )
+    nx.remove_node_attributes(G, other_attr, third_attr)
+    assert other_attr not in G.nodes[0] and third_attr not in G.nodes[0]
+    assert other_attr not in G.nodes[1] and third_attr not in G.nodes[1]
+    assert other_attr not in G.nodes[2] and third_attr not in G.nodes[2]
+    assert G.nodes[0][attr] == vals
+    assert G.nodes[1][attr] == vals
+    assert G.nodes[2][attr] == vals
+
+    # Test incomplete node attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    nx.set_node_attributes(
+        G,
+        {
+            1: {attr: vals, other_attr: other_vals},
+            2: {attr: vals, other_attr: other_vals},
+        },
+    )
+    nx.remove_node_attributes(G, attr)
+    assert attr not in G.nodes[0]
+    assert attr not in G.nodes[1]
+    assert attr not in G.nodes[2]
+    assert G.nodes[1][other_attr] == other_vals
+    assert G.nodes[2][other_attr] == other_vals
+
+
+@pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
+def test_remove_edge_attributes(graph_type):
+    # Test removing single attribute
+    G = nx.path_graph(3, create_using=graph_type)
+    attr = "hello"
+    vals = 100
+    nx.set_edge_attributes(G, vals, attr)
+    nx.remove_edge_attributes(G, attr)
+    assert len(nx.get_edge_attributes(G, attr)) == 0
+
+    # Test removing only some attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    other_attr = "other"
+    other_vals = 200
+    nx.set_edge_attributes(G, vals, attr)
+    nx.set_edge_attributes(G, other_vals, other_attr)
+    nx.remove_edge_attributes(G, attr)
+
+    assert attr not in G[0][1]
+    assert attr not in G[1][2]
+    assert G[0][1][other_attr] == 200
+    assert G[1][2][other_attr] == 200
+
+    # Test removing multiple attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    nx.set_edge_attributes(G, vals, attr)
+    nx.set_edge_attributes(G, other_vals, other_attr)
+    nx.remove_edge_attributes(G, attr, other_attr)
+    assert attr not in G[0][1] and other_attr not in G[0][1]
+    assert attr not in G[1][2] and other_attr not in G[1][2]
+
+    # Test removing multiple (not all) attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    third_attr = "third"
+    third_vals = 300
+    nx.set_edge_attributes(
+        G,
+        {
+            (u, v): {attr: vals, other_attr: other_vals, third_attr: third_vals}
+            for u, v in G.edges()
+        },
+    )
+    nx.remove_edge_attributes(G, other_attr, third_attr)
+    assert other_attr not in G[0][1] and third_attr not in G[0][1]
+    assert other_attr not in G[1][2] and third_attr not in G[1][2]
+    assert G[0][1][attr] == vals
+    assert G[1][2][attr] == vals
+
+    # Test removing incomplete edge attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    nx.set_edge_attributes(G, {(0, 1): {attr: vals, other_attr: other_vals}})
+    nx.remove_edge_attributes(G, other_attr)
+    assert other_attr not in G[0][1] and G[0][1][attr] == vals
+    assert other_attr not in G[1][2]
+
+
+@pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
+def test_remove_multi_edge_attributes(graph_type):
+    # Test removing single attribute
+    G = nx.path_graph(3, create_using=graph_type)
+    G.add_edge(1, 2)
+    attr = "hello"
+    vals = 100
+    nx.set_edge_attributes(G, vals, attr)
+    nx.remove_edge_attributes(G, attr)
+    assert attr not in G[0][1][0]
+    assert attr not in G[1][2][0]
+    assert attr not in G[1][2][1]
+
+    # Test removing only some attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    G.add_edge(1, 2)
+    other_attr = "other"
+    other_vals = 200
+    nx.set_edge_attributes(G, vals, attr)
+    nx.set_edge_attributes(G, other_vals, other_attr)
+    nx.remove_edge_attributes(G, attr)
+    assert attr not in G[0][1][0]
+    assert attr not in G[1][2][0]
+    assert attr not in G[1][2][1]
+    assert G[0][1][0][other_attr] == other_vals
+    assert G[1][2][0][other_attr] == other_vals
+    assert G[1][2][1][other_attr] == other_vals
+
+    # Test removing multiple attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    G.add_edge(1, 2)
+    nx.set_edge_attributes(G, vals, attr)
+    nx.set_edge_attributes(G, other_vals, other_attr)
+    nx.remove_edge_attributes(G, attr, other_attr)
+    assert attr not in G[0][1][0] and other_attr not in G[0][1][0]
+    assert attr not in G[1][2][0] and other_attr not in G[1][2][0]
+    assert attr not in G[1][2][1] and other_attr not in G[1][2][1]
+
+    # Test removing multiple (not all) attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    G.add_edge(1, 2)
+    third_attr = "third"
+    third_vals = 300
+    nx.set_edge_attributes(
+        G,
+        {
+            (u, v, k): {attr: vals, other_attr: other_vals, third_attr: third_vals}
+            for u, v, k in G.edges(keys=True)
+        },
+    )
+    nx.remove_edge_attributes(G, other_attr, third_attr)
+    assert other_attr not in G[0][1][0] and third_attr not in G[0][1][0]
+    assert other_attr not in G[1][2][0] and other_attr not in G[1][2][0]
+    assert other_attr not in G[1][2][1] and other_attr not in G[1][2][1]
+    assert G[0][1][0][attr] == vals
+    assert G[1][2][0][attr] == vals
+    assert G[1][2][1][attr] == vals
+
+    # Test removing incomplete edge attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    G.add_edge(1, 2)
+    nx.set_edge_attributes(
+        G,
+        {
+            (0, 1, 0): {attr: vals, other_attr: other_vals},
+            (1, 2, 1): {attr: vals, other_attr: other_vals},
+        },
+    )
+    nx.remove_edge_attributes(G, other_attr)
+    assert other_attr not in G[0][1][0] and G[0][1][0][attr] == vals
+    assert other_attr not in G[1][2][0]
+    assert other_attr not in G[1][2][1]
+
+
 def test_is_empty():
     graphs = [nx.Graph(), nx.DiGraph(), nx.MultiGraph(), nx.MultiDiGraph()]
     for G in graphs:

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -728,6 +728,22 @@ def test_remove_node_attributes(graph_type):
     assert G.nodes[1][other_attr] == other_vals
     assert G.nodes[2][other_attr] == other_vals
 
+    # Test removing on a subset of nodes
+    G = nx.path_graph(3, create_using=graph_type)
+    nx.set_node_attributes(
+        G,
+        {
+            n: {attr: vals, other_attr: other_vals, third_attr: third_vals}
+            for n in G.nodes()
+        },
+    )
+    nx.remove_node_attributes(G, attr, other_attr, nbunch=[0, 1])
+    assert attr not in G.nodes[0] and other_attr not in G.nodes[0]
+    assert attr not in G.nodes[1] and other_attr not in G.nodes[1]
+    assert attr in G.nodes[2] and other_attr in G.nodes[2]
+    assert third_attr in G.nodes[0] and G.nodes[0][third_attr] == third_vals
+    assert third_attr in G.nodes[1] and G.nodes[1][third_attr] == third_vals
+
 
 @pytest.mark.parametrize("graph_type", (nx.Graph, nx.DiGraph))
 def test_remove_edge_attributes(graph_type):
@@ -783,6 +799,19 @@ def test_remove_edge_attributes(graph_type):
     nx.remove_edge_attributes(G, other_attr)
     assert other_attr not in G[0][1] and G[0][1][attr] == vals
     assert other_attr not in G[1][2]
+
+    # Test removing subset of edge attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    nx.set_edge_attributes(
+        G,
+        {
+            (u, v): {attr: vals, other_attr: other_vals, third_attr: third_vals}
+            for u, v in G.edges()
+        },
+    )
+    nx.remove_edge_attributes(G, other_attr, third_attr, ebunch=[(0, 1)])
+    assert other_attr not in G[0][1] and third_attr not in G[0][1]
+    assert other_attr in G[1][2] and third_attr in G[1][2]
 
 
 @pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
@@ -857,6 +886,22 @@ def test_remove_multi_edge_attributes(graph_type):
     assert other_attr not in G[0][1][0] and G[0][1][0][attr] == vals
     assert other_attr not in G[1][2][0]
     assert other_attr not in G[1][2][1]
+
+    # Test removing subset of edge attributes
+    G = nx.path_graph(3, create_using=graph_type)
+    G.add_edge(1, 2)
+    nx.set_edge_attributes(
+        G,
+        {
+            (0, 1, 0): {attr: vals, other_attr: other_vals},
+            (1, 2, 0): {attr: vals, other_attr: other_vals},
+            (1, 2, 1): {attr: vals, other_attr: other_vals},
+        },
+    )
+    nx.remove_edge_attributes(G, attr, ebunch=[(0, 1, 0), (1, 2, 0)])
+    assert attr not in G[0][1][0] and other_attr in G[0][1][0]
+    assert attr not in G[1][2][0] and other_attr in G[1][2][0]
+    assert attr in G[1][2][1] and other_attr in G[1][2][1]
 
 
 def test_is_empty():


### PR DESCRIPTION
With the addition of attribute based visualization, users may want to be able to remove visualization related attributes. I was a bit surprised that this functionality didn't already exist, but these are a pair of convenience functions to help with that. 