### PR TITLE
Individualize drawing attributes

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -449,7 +449,7 @@ def draw_networkx_nodes(
         alpha = None
 
     # Convert to one element np.array if needed
-    if not isinstance(node_shape, np.ndarray):
+    if not isinstance(node_shape, np.ndarray) and not isinstance(node_shape, list):
         node_shape = np.asarray([node_shape for _ in range(len(nodelist))])
 
     for shape in np.unique(node_shape):

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -448,20 +448,25 @@ def draw_networkx_nodes(
         node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)
         alpha = None
 
-    node_collection = ax.scatter(
-        xy[:, 0],
-        xy[:, 1],
-        s=node_size,
-        c=node_color,
-        marker=node_shape,
-        cmap=cmap,
-        vmin=vmin,
-        vmax=vmax,
-        alpha=alpha,
-        linewidths=linewidths,
-        edgecolors=edgecolors,
-        label=label,
-    )
+    # Convert to one element np.array if needed
+    if not isinstance(node_shape, np.array):
+        node_shape = np.array(node_shape)
+
+    for shape in np.unique(node_shape):
+        node_collection = ax.scatter(
+            xy[node_shape == shape, 0],
+            xy[:, 1],
+            s=node_size,
+            c=node_color,
+            marker=shape,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            alpha=alpha,
+            linewidths=linewidths,
+            edgecolors=edgecolors,
+            label=label,
+        )
     if hide_ticks:
         ax.tick_params(
             axis="both",
@@ -479,7 +484,8 @@ def draw_networkx_nodes(
             ax.margins(margins)
 
     node_collection.set_zorder(2)
-    return node_collection
+    # return node_collection
+    return ax
 
 
 class FancyArrowFactory:

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -448,9 +448,8 @@ def draw_networkx_nodes(
         node_color = apply_alpha(node_color, alpha, nodelist, cmap, vmin, vmax)
         alpha = None
 
-    # Convert to one element np.array if needed
     if not isinstance(node_shape, np.ndarray) and not isinstance(node_shape, list):
-        node_shape = np.asarray([node_shape for _ in range(len(nodelist))])
+        node_shape = np.array([node_shape for _ in range(len(nodelist))])
 
     for shape in np.unique(node_shape):
         node_collection = ax.scatter(

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1461,6 +1461,30 @@ def draw_networkx_edge_labels(
         ax=ax,
     )
 
+    individual_params = {}
+
+    def check_individual_params(p_value, p_name):
+        # TODO should this be list or array (as in a numpy array)?
+        if isinstance(p_value, list):
+            if len(p_value) != len(edgelist):
+                raise ValueError(f"{p_name} must have the same length as edgelist.")
+            individual_params[p_name] = p_value.iter()
+
+    # Don't need to pass in an edge because these are lists, not dicts
+    def get_param_value(p_value, p_name):
+        if p_name in individual_params:
+            return next(individual_params[p_name])
+        return p_value
+
+    check_individual_params(font_size, "font_size")
+    check_individual_params(font_color, "font_color")
+    check_individual_params(font_weight, "font_weight")
+    check_individual_params(alpha, "alpha")
+    check_individual_params(horizontalalignment, "horizontalalignment")
+    check_individual_params(verticalalignment, "verticalalignment")
+    check_individual_params(rotate, "rotate")
+    check_individual_params(label_pos, "label_pos")
+
     text_items = {}
     for i, (edge, label) in enumerate(zip(edgelist, labels)):
         if not isinstance(label, str):
@@ -1478,13 +1502,17 @@ def draw_networkx_edge_labels(
                 x,
                 y,
                 label,
-                size=font_size,
-                color=font_color,
-                family=font_family,
-                weight=font_weight,
-                alpha=alpha,
-                horizontalalignment=horizontalalignment,
-                verticalalignment=verticalalignment,
+                size=get_param_value(font_size, "font_size"),
+                color=get_param_value(font_color, "font_color"),
+                family=get_param_value(font_family, "font_family"),
+                weight=get_param_value(font_weight, "font_weight"),
+                alpha=get_param_value(alpha, "alpha"),
+                horizontalalignment=get_param_value(
+                    horizontalalignment, "horizontalalignment"
+                ),
+                verticalalignment=get_param_value(
+                    verticalalignment, "verticalalignment"
+                ),
                 rotation=0,
                 transform=ax.transData,
                 bbox=bbox,
@@ -1495,19 +1523,23 @@ def draw_networkx_edge_labels(
             text_items[edge] = CurvedArrowText(
                 arrow,
                 label,
-                size=font_size,
-                color=font_color,
-                family=font_family,
-                weight=font_weight,
-                alpha=alpha,
-                horizontalalignment=horizontalalignment,
-                verticalalignment=verticalalignment,
+                size=get_param_value(font_size, "font_size"),
+                color=get_param_value(font_color, "font_color"),
+                family=get_param_value(font_family, "font_family"),
+                weight=get_param_value(font_weight, "font_weight"),
+                alpha=get_param_value(alpha, "alpha"),
+                horizontalalignment=get_param_value(
+                    horizontalalignment, "horizontalalignment"
+                ),
+                verticalalignment=get_param_value(
+                    verticalalignment, "verticalalignment"
+                ),
                 transform=ax.transData,
                 bbox=bbox,
                 zorder=1,
                 clip_on=clip_on,
-                label_pos=label_pos,
-                labels_horizontal=not rotate,
+                label_pos=get_param_value(label_pos, "label_pos"),
+                labels_horizontal=not get_param_value(rotate, "rotate"),
                 ax=ax,
             )
 

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1078,30 +1078,32 @@ def draw_networkx_labels(
         Node-keys in labels should appear as keys in `pos`.
         If needed use: `{n:lab for n,lab in labels.items() if n in pos}`
 
-    font_size : int (default=12)
-        Font size for text labels
+    font_size : int or dictionary of nodes to ints (default=12)
+        Font size for text labels.
 
-    font_color : color (default='k' black)
+    font_color : color or dictionary of nodes to colors (default='k' black)
         Font color string. Color can be string or rgb (or rgba) tuple of
         floats from 0-1.
 
-    font_weight : string (default='normal')
-        Font weight
+    font_weight : string or dictionary of nodes to strings (default='normal')
+        Font weight.
 
-    font_family : string (default='sans-serif')
-        Font family
+    font_family : string or dictionary of nodes to strings (default='sans-serif')
+        Font family.
 
-    alpha : float or None (default=None)
-        The text transparency
+    alpha : float or None or dictionary of nodes to floats (default=None)
+        The text transparency.
 
     bbox : Matplotlib bbox, (default is Matplotlib's ax.text default)
         Specify text box properties (e.g. shape, color etc.) for node labels.
 
-    horizontalalignment : string (default='center')
-        Horizontal alignment {'center', 'right', 'left'}
+    horizontalalignment : string or array of strings (default='center')
+        Horizontal alignment {'center', 'right', 'left'}. If an array is
+        specified it must be the same length as `nodelist`.
 
     verticalalignment : string (default='center')
-        Vertical alignment {'center', 'top', 'bottom', 'baseline', 'center_baseline'}
+        Vertical alignment {'center', 'top', 'bottom', 'baseline', 'center_baseline'}.
+        If an array is specified it must be the same length as `nodelist`.
 
     ax : Matplotlib Axes object, optional
         Draw the graph in the specified Matplotlib axes.
@@ -1143,6 +1145,25 @@ def draw_networkx_labels(
     if labels is None:
         labels = {n: n for n in G.nodes()}
 
+    individual_params = set()
+
+    def check_individual_params(p_value, p_name):
+        if isinstance(p_value, dict):
+            if len(p_value) != len(labels):
+                raise ValueError(f"{p_name} must have the same length as labels.")
+            individual_params.add(p_name)
+
+    def get_param_value(node, p_value, p_name):
+        if p_name in individual_params:
+            return p_value[node]
+        return p_value
+
+    check_individual_params(font_size, "font_size")
+    check_individual_params(font_color, "font_color")
+    check_individual_params(font_weight, "font_weight")
+    check_individual_params(font_family, "font_family")
+    check_individual_params(alpha, "alpha")
+
     text_items = {}  # there is no text collection so we'll fake one
     for n, label in labels.items():
         (x, y) = pos[n]
@@ -1152,11 +1173,11 @@ def draw_networkx_labels(
             x,
             y,
             label,
-            size=font_size,
-            color=font_color,
-            family=font_family,
-            weight=font_weight,
-            alpha=alpha,
+            size=get_param_value(n, font_size, "font_size"),
+            color=get_param_value(n, font_color, "font_color"),
+            family=get_param_value(n, font_family, "font_family"),
+            weight=get_param_value(n, font_weight, "font_weight"),
+            alpha=get_param_value(n, alpha, "alpha"),
             horizontalalignment=horizontalalignment,
             verticalalignment=verticalalignment,
             transform=ax.transData,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -449,13 +449,13 @@ def draw_networkx_nodes(
         alpha = None
 
     # Convert to one element np.array if needed
-    if not isinstance(node_shape, np.array):
-        node_shape = np.array(node_shape)
+    if not isinstance(node_shape, np.ndarray):
+        node_shape = np.asarray([node_shape for _ in range(len(nodelist))])
 
     for shape in np.unique(node_shape):
         node_collection = ax.scatter(
             xy[node_shape == shape, 0],
-            xy[:, 1],
+            xy[node_shape == shape, 1],
             s=node_size,
             c=node_color,
             marker=shape,

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -791,13 +791,13 @@ def draw_networkx_edges(
 
         Note: Arrowheads will be the same color as edges.
 
-    arrowstyle : str (default='-\|>' for directed graphs)
+    arrowstyle : str or list of strs (default='-\|>' for directed graphs)
         For directed graphs and `arrows==True` defaults to '-\|>',
         For undirected graphs default to '-'.
 
         See `matplotlib.patches.ArrowStyle` for more options.
 
-    arrowsize : int (default=10)
+    arrowsize : int or list of ints(default=10)
         For directed graphs, choose the size of the arrow head's length and
         width. See `matplotlib.patches.FancyArrowPatch` for attribute
         `mutation_scale` for more info.
@@ -823,10 +823,10 @@ def draw_networkx_edges(
     label : None or string
         Label for legend
 
-    min_source_margin : int (default=0)
+    min_source_margin : int or list of ints (default=0)
         The minimum margin (gap) at the beginning of the edge at the source.
 
-    min_target_margin : int (default=0)
+    min_target_margin : int or list of ints (default=0)
         The minimum margin (gap) at the end of the edge at the target.
 
     hide_ticks : bool, optional

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -607,6 +607,24 @@ class FancyArrowFactory:
         (x1, y1), (x2, y2) = self.edge_pos[i]
         shrink_source = 0  # space from source to tail
         shrink_target = 0  # space from  head to target
+        if (
+            self.np.iterable(self.min_source_margin)
+            and not isinstance(self.min_source_margin, str)
+            and not isinstance(self.min_source_margin, tuple)
+        ):
+            min_source_margin = self.min_source_margin[i]
+        else:
+            min_source_margin = self.min_source_margin
+
+        if (
+            self.np.iterable(self.min_target_margin)
+            and not isinstance(self.min_target_margin, str)
+            and not isinstance(self.min_target_margin, tuple)
+        ):
+            min_target_margin = self.min_target_margin[i]
+        else:
+            min_target_margin = self.min_target_margin
+
         if self.np.iterable(self.node_size):  # many node sizes
             source, target = self.edgelist[i][:2]
             source_node_size = self.node_size[self.nodelist.index(source)]
@@ -616,8 +634,8 @@ class FancyArrowFactory:
         else:
             shrink_source = self.to_marker_edge(self.node_size, self.node_shape)
             shrink_target = shrink_source
-        shrink_source = max(shrink_source, self.min_source_margin)
-        shrink_target = max(shrink_target, self.min_target_margin)
+        shrink_source = max(shrink_source, min_source_margin)
+        shrink_target = max(shrink_target, min_target_margin)
 
         # scale factor of arrow head
         if isinstance(self.arrowsize, list):
@@ -658,10 +676,20 @@ class FancyArrowFactory:
             )
         else:
             connectionstyle = self.connectionstyle_factory.curved(self.edge_indices[i])
+
+        if (
+            self.np.iterable(self.arrowstyle)
+            and not isinstance(self.arrowstyle, str)
+            and not isinstance(self.arrowstyle, tuple)
+        ):
+            arrowstyle = self.arrowstyle[i]
+        else:
+            arrowstyle = self.arrowstyle
+
         return self.mpl.patches.FancyArrowPatch(
             (x1, y1),
             (x2, y2),
-            arrowstyle=self.arrowstyle,
+            arrowstyle=arrowstyle,
             shrinkA=shrink_source,
             shrinkB=shrink_target,
             mutation_scale=mutation_scale,

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -415,7 +415,9 @@ def test_labels_and_colors():
     labels[5] = r"$\beta$"
     labels[6] = r"$\gamma$"
     labels[7] = r"$\delta$"
+    colors = {n: "k" if n % 2 == 0 else "r" for n in range(8)}
     nx.draw_networkx_labels(G, pos, labels, font_size=16)
+    nx.draw_networkx_labels(G, pos, labels, font_size=16, font_color=colors)
     nx.draw_networkx_edge_labels(G, pos, edge_labels=None, rotate=False)
     nx.draw_networkx_edge_labels(G, pos, edge_labels={(4, 5): "4-5"})
     # plt.show()


### PR DESCRIPTION
A set of improvements to the existing visualization suite aimed to align the current functionality with what will be implemented after the refactor. 

Some attributes can only have one value per visualization, such as node font color or arrow style for directed graphs, but if attributes are read from the graph, we should allow individual values for all of these. 

While I haven't broken any of the existing tests, I'm not sure that I fully understand the testing infrastructure for the visualization module. Tests will need to be added, but I'm still working on it. 

Below are some examples on the karate club graph. 
```python
nx.draw_networkx(G, pos=pos, ax=ax, node_shape='o', 
    font_size={n: int(n / (34/15) + 5) for n in G.nodes()}, 
    font_color={n: 'k' if n % 2 == 0 else 'r' for n in G.nodes()})
```
![image](https://github.com/user-attachments/assets/40c60c45-3f53-4f49-a163-5d7991d9a1f6)
```python
nx.draw_networkx(G, ax=plt.axes(), 
    node_shape=np.array(['o' if n % 2 == 0 else '^' for n in G.nodes()]))
```
![image](https://github.com/user-attachments/assets/361404db-e822-44ed-a774-7bc50a9990ed)
```python
arrowstyles = ["-|>" if (u + v) % 2 == 0 else "-[" for u, v in G.edges()]
arrowsizes = [(u+v)/2 for u, v in G.edges()]
nx.draw_networkx(G, ax=plt.axes(), arrows=True, arrowstyle=arrowstyles, arrowsize=arrowsizes)
```
![image](https://github.com/user-attachments/assets/a90d2b29-ca74-43c6-8e2e-6c7f5164013b)
```python
min_source_margin = [u for u, _ in G.edges()]
min_target_margin = [v for _, v in G.edges()]
nx.draw_networkx(G, ax=plt.axes(), arrows=True, min_source_margin=min_source_margin, min_target_margin=min_target_margin)
```
![image](https://github.com/user-attachments/assets/0d0e636d-2e19-4900-856a-9b6bf8ba9119)
