### PR TITLE
DOC: Fix typo in the code snippet provided in the docstring of nx_pydot.pydot_layout().

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -366,7 +366,7 @@ def pydot_layout(G, prog="neato", root=None):
     for the layout computation using something similar to::
 
         H = nx.convert_node_labels_to_integers(G, label_attribute="node_label")
-        H_layout = nx.nx_pydot.pydot_layout(G, prog="dot")
+        H_layout = nx.nx_pydot.pydot_layout(H, prog="dot")
         G_layout = {H.nodes[n]["node_label"]: p for n, p in H_layout.items()}
 
     """


### PR DESCRIPTION
Hi. Tiny PR to fix in the docstring of nx_pydot.pydot_layout().

Given Pydot recent breaking changes wrt to node names (https://github.com/pydot/pydot/pull/363), the provided code snippet to convert node name to integers was super useful. Thanks.