### PR TITLE
Fixes #7575: Inconsistent `nx.subgraph` node types.

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -296,7 +296,7 @@ class FilterAtlas(Mapping):  # nodedict, nbrdict, keydict
         except AttributeError:
             node_ok_shorter = False
         if node_ok_shorter:
-            return (n for n in self.NODE_OK.nodes if n in self._atlas)
+            return (n for n in self._atlas if n in self.NODE_OK.nodes)
         return (n for n in self._atlas if self.NODE_OK(n))
 
     def __getitem__(self, key):


### PR DESCRIPTION
Subgraphs now return node types as defined in the graph object, independent of the input to the `subgraph` function.

See corresponding issue ticket for details (#7575) and the example below for a quick rundown running `numpy==2.0.1`.

___

#### Input:

```python
import networkx as nx
import numpy as np

graphs = [
      nx.dense_gnm_random_graph(3, 3*(3-1)/2),
      nx.dense_gnm_random_graph(5, 4*(4-1)/2),
      nx.karate_club_graph(),
]

nodes_int = [0, 1]
nodes_npy = [np.int64(0), np.int64(1)]
nodes_mix = [0, np.int64(1)]

edges_int = [(0, 1)]
edges_npy = [(np.int64(0), np.int64(1))]
edges_mix = [(0, np.int64(1))]

for G in graphs:
    print(f"{G}\n"
          f"G_subgraph_int: {G.subgraph(nodes_int).nodes()}\n"
          f"G_subgraph_npy: {G.subgraph(nodes_npy).nodes()}\n"
          f"G_subgraph_mix: {G.subgraph(nodes_mix).nodes()}\n"
          f"G_edge_subgraph_int: {G.edge_subgraph(edges_int).nodes()}\n"
          f"G_edge_subgraph_npy: {G.edge_subgraph(edges_npy).nodes()}\n"
          f"G_edge_subgraph_mix: {G.edge_subgraph(edges_mix).nodes()}\n")
```

#### Output (after change):

```none
Graph with 3 nodes and 3 edges
G_subgraph_int: [0, 1]
G_subgraph_npy: [0, 1]
G_subgraph_mix: [0, 1]
G_edge_subgraph_int: [0, 1]
G_edge_subgraph_npy: [0, 1]
G_edge_subgraph_mix: [0, 1]

Graph with 5 nodes and 6 edges
G_subgraph_int: [0, 1]
G_subgraph_npy: [0, 1]
G_subgraph_mix: [0, 1]
G_edge_subgraph_int: [0, 1]
G_edge_subgraph_npy: [0, 1]
G_edge_subgraph_mix: [0, 1]

Graph named "Zachary's Karate Club" with 34 nodes and 78 edges
G_subgraph_int: [0, 1]
G_subgraph_npy: [0, 1]
G_subgraph_mix: [0, 1]
G_edge_subgraph_int: [0, 1]
G_edge_subgraph_npy: [0, 1]
G_edge_subgraph_mix: [0, 1]
```

#### Output (before change):

```none
Graph with 3 nodes and 3 edges
G_subgraph_int: [0, 1]
G_subgraph_npy: [0, 1]
G_subgraph_mix: [0, 1]
G_edge_subgraph_int: [0, 1]
G_edge_subgraph_npy: [0, 1]
G_edge_subgraph_mix: [0, 1]

Graph with 5 nodes and 6 edges
G_subgraph_int: [0, 1]
G_subgraph_npy: [np.int64(0), np.int64(1)]
G_subgraph_mix: [0, np.int64(1)]
G_edge_subgraph_int: [0, 1]
G_edge_subgraph_npy: [np.int64(0), np.int64(1)]
G_edge_subgraph_mix: [0, np.int64(1)]

Graph named "Zachary's Karate Club" with 34 nodes and 78 edges
G_subgraph_int: [0, 1]
G_subgraph_npy: [np.int64(0), np.int64(1)]
G_subgraph_mix: [0, np.int64(1)]
G_edge_subgraph_int: [0, 1]
G_edge_subgraph_npy: [np.int64(0), np.int64(1)]
G_edge_subgraph_mix: [0, np.int64(1)]
```