### PR TITLE
Hide edges with a weight of None in simple_paths

### DIFF
--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -915,8 +915,11 @@ def _bidirectional_dijkstra(
 
         for w in neighs[dir](v):
             # wt(v, w, d) for forward and wt(w, v, d) for back direction
-            cost = (wt(v, w, G.get_edge_data(v, w)) if dir == 0 else
-                    wt(w, v, G.get_edge_data(w, v)))
+            cost = (
+                wt(v, w, G.get_edge_data(v, w))
+                if dir == 0
+                else wt(w, v, G.get_edge_data(w, v))
+            )
             if cost is None:
                 continue
             vwLength = dists[dir][v] + cost

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -429,7 +429,10 @@ def shortest_simple_paths(G, source, target, weight=None):
         If it is a function, the weight of an edge is the value returned
         by the function. The function must accept exactly three positional
         arguments: the two endpoints of an edge and the dictionary of edge
-        attributes for that edge. The function must return a number.
+        attributes for that edge. The function must return a number or None.
+        The weight function can be used to hide edges by returning None.
+        So ``weight = lambda u, v, d: 1 if d['color']=="red" else None``
+        will find the shortest red path.
 
         If None all edges are considered to have unit weight. Default
         value None.
@@ -756,19 +759,24 @@ def _bidirectional_dijkstra(
     G : NetworkX graph
 
     source : node
-       Starting node.
+        Starting node.
 
     target : node
-       Ending node.
+        Ending node.
 
     weight: string, function, optional (default='weight')
-       Edge data key or weight function corresponding to the edge weight
+        Edge data key or weight function corresponding to the edge weight
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     ignore_nodes : container of nodes
-       nodes to ignore, optional
+        nodes to ignore, optional
 
     ignore_edges : container of edges
-       edges to ignore, optional
+        edges to ignore, optional
 
     Returns
     -------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -914,15 +914,14 @@ def _bidirectional_dijkstra(
             return (finaldist, finalpath)
 
         for w in neighs[dir](v):
-            # wt(v, w, d) for forward and wt(w, v, d) for back direction
-            cost = (
-                wt(v, w, G.get_edge_data(v, w))
-                if dir == 0
-                else wt(w, v, G.get_edge_data(w, v))
-            )
-            if cost is None:
+            if dir == 0:  # forward
+                minweight = wt(v, w, G.get_edge_data(v, w))
+            else:  # back, must remember to change v,w->w,v
+                minweight = wt(w, v, G.get_edge_data(w, v))
+            if minweight is None:
                 continue
-            vwLength = dists[dir][v] + cost
+            vwLength = dists[dir][v] + minweight
+
             if w in dists[dir]:
                 if vwLength < dists[dir][w]:
                     raise ValueError("Contradictory paths found: negative weights?")

--- a/networkx/algorithms/tests/test_simple_paths.py
+++ b/networkx/algorithms/tests/test_simple_paths.py
@@ -509,6 +509,17 @@ def test_shortest_simple_paths_with_weight_function():
     assert list(paths) == [[0, 1, 2, 3]]
 
 
+def test_shortest_simple_paths_with_none_weight_function():
+    def cost(u, v, x):
+        delta = abs(u - v)
+        # ignore interior edges
+        return 1 if (delta == 1 or delta == 4) else None
+
+    G = nx.complete_graph(5)
+    paths = nx.shortest_simple_paths(G, 0, 2, weight=cost)
+    assert list(paths) == [[0, 1, 2], [0, 4, 3, 2]]
+
+
 def test_Greg_Bernstein():
     g1 = nx.Graph()
     g1.add_nodes_from(["N0", "N1", "N2", "N3", "N4"])


### PR DESCRIPTION
Commit d82815dba6 for issue #5945 added the ability for A* weight functions to return None, in which case that edge is ignored. This was done for consistency with Dijkstra.

The simple_paths() algorithms would benefit from the same ability.
