### PR TITLE
Fix weakly_connected_components() performance on graph view

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -62,9 +62,10 @@ def connected_components(G):
 
     """
     seen = set()
+    n = len(G)
     for v in G:
         if v not in seen:
-            c = _plain_bfs(G, v)
+            c = _plain_bfs(G, n, v)
             seen.update(c)
             yield c
 
@@ -148,11 +149,12 @@ def is_connected(G):
     For undirected graphs only.
 
     """
-    if len(G) == 0:
+    n = len(G)
+    if n == 0:
         raise nx.NetworkXPointlessConcept(
             "Connectivity is undefined for the null graph."
         )
-    return sum(1 for node in _plain_bfs(G, arbitrary_element(G))) == len(G)
+    return sum(1 for node in _plain_bfs(G, n, arbitrary_element(G))) == len(G)
 
 
 @not_implemented_for("directed")
@@ -193,13 +195,12 @@ def node_connected_component(G, n):
     For undirected graphs only.
 
     """
-    return _plain_bfs(G, n)
+    return _plain_bfs(G, len(G), n)
 
 
-def _plain_bfs(G, source):
+def _plain_bfs(G, n, source):
     """A fast BFS node generator"""
     adj = G._adj
-    n = len(adj)
     seen = {source}
     nextlevel = [source]
     while nextlevel:

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -59,9 +59,10 @@ def weakly_connected_components(G):
 
     """
     seen = set()
+    n = len(G)  # must be outside the loop to avoid performance hit with graph views
     for v in G:
         if v not in seen:
-            c = set(_plain_bfs(G, v))
+            c = set(_plain_bfs(G, n, v))
             seen.update(c)
             yield c
 
@@ -164,7 +165,7 @@ def is_weakly_connected(G):
     return len(next(weakly_connected_components(G))) == len(G)
 
 
-def _plain_bfs(G, source):
+def _plain_bfs(G, n, source):
     """A fast BFS node generator
 
     The direction of the edge between nodes is ignored.
@@ -172,7 +173,6 @@ def _plain_bfs(G, source):
     For directed graphs only.
 
     """
-    n = len(G)
     Gsucc = G._succ
     Gpred = G._pred
     seen = {source}


### PR DESCRIPTION
Description
========
weakly_connected_components() calls len(G) inside a loop, resulting in poor performance on graph views.
suggested pull request moves len(G) to outside the loop.

Reproduction:
=========

```
import datetime
import os.path
import sys

sys.path.insert(0, os.path.dirname(__file__))
from networkx import DiGraph, weakly_connected_components, subgraph_view

g = DiGraph()
for i in range(10_000):
    g.add_node(i)

view = subgraph_view(g, filter_node=lambda n: True, filter_edge=lambda u, v: True)

for i in range(10):
    start = datetime.datetime.now()
    for c in weakly_connected_components(view):
        pass
    end = datetime.datetime.now()
    tmp = None
    print(f'{(end - start).total_seconds():.9f}')
```

Evaluation results:
===========
* before fix: ~15.4sec per iteration
* after fix: 0.064sec per iteration
