### PR TITLE
Fix `nx_pydot.graphviz_layout` for nodes with quoted/escaped chars

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -409,8 +409,7 @@ def pydot_layout(G, prog="neato", root=None):
                 For example the string \'attribute:data1\' should be written as \'"attribute:data1"\'.\
                 Please refer https://github.com/pydot/pydot/issues/258'
             )
-        pydot_node = pydot.Node(str_n).get_name()
-        node = Q.get_node(pydot_node)
+        node = Q.get_node(pydot.quote_id_if_necessary(str_n))
 
         if isinstance(node, list):
             node = node[0]

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -90,6 +90,25 @@ class TestPydot:
         assert graphs_equal(G, H)
 
 
+def test_pydot_issue_7581(tmp_path):
+    """Validate that `nx_pydot.pydot_layout` handles nodes
+    with characters like "\n", " ".
+
+    Those characters cause `pydot` to escape and quote them on output,
+    which caused #7581.
+    """
+    G = nx.Graph()
+    G.add_edges_from([("A\nbig test", "B"), ("A\nbig test", "C"), ("B", "C")])
+
+    graph_layout = nx.nx_pydot.pydot_layout(G, prog="dot")
+    assert isinstance(graph_layout, dict)
+
+    # Convert the graph to pydot and back into a graph. There should be no difference.
+    P = nx.nx_pydot.to_pydot(G)
+    G2 = nx.Graph(nx.nx_pydot.from_pydot(P))
+    assert graphs_equal(G, G2)
+
+
 def test_pydot_issue_258():
     G = nx.Graph([("Example:A", 1)])
     with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes https://github.com/networkx/networkx/issues/7581 and https://github.com/pydot/pydot/issues/396

Explanation of the problem:

1. In new versions of Pydot, node names are stored unchanged. They are NOT quoted/escaped on creation.
2. They are quoted/escaped if necessary when output to a `.dot` file. This is to follow the DOT grammar. Example: `Node("a\nb")` must be saved in the .dot file as `"a\nb"` (quoted and escaped), not `a(actual new line)b`.
3. Combining 1. and 2. means that saving a node in `.dot` and reading it back may result in a node with a different name. Example: `Node("a\nb")` -> saved to `.dot` as `"a\nb"` -> read back into a `Node("a\\nb")`.
4. `nx.drawing.nx_pydot.graphviz_layout` doesn't expect this.

This PR fixes the issue by explicitly using `pydot.quote_id_if_necessary` in the place which didn't expect the unquoted value to appear.

An additional test was added. It is easier than modifying the existing old test which is quite long.