### PR TITLE
Add missing metadata to v3.3 release notes

### DIFF
--- a/doc/release/release_3.3.rst
+++ b/doc/release/release_3.3.rst
@@ -3,6 +3,18 @@ networkx 3.3
 
 We're happy to announce the release of networkx 3.3!
 
+Release date: 6 April 2024
+
+Supports Python 3.10, 3.11, and 3.12.
+
+NetworkX is a Python package for the creation, manipulation, and study of the
+structure, dynamics, and functions of complex networks.
+
+For more information, please visit our `website <https://networkx.org/>`_
+and our :ref:`gallery of examples <examples_gallery>`.
+Please send comments and questions to the `networkx-discuss mailing list
+<http://groups.google.com/group/networkx-discuss>`_.
+
 API Changes
 -----------
 


### PR DESCRIPTION
Compared to recent releases, v3.3 was missing

- release date (taken from PyPI)
- supported python versions (taken from pyproject.toml)
- high level project description (taken from previous release)

<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
