### PR TITLE
CI: Include Python 3.13 in nightly wheel tests

### DIFF
--- a/.github/workflows/nightly-release-test.yml
+++ b/.github/workflows/nightly-release-test.yml
@@ -10,13 +10,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install packages
         run: |


### PR DESCRIPTION
Add Python 3.13 to the nightly wheel test matrix, to get an overview of the state of the ecosystem and find any remaining missing dependencies.

Python 3.13 is now in release candidate phase and is ABI stable.
