### PR TITLE
Improved running time for harmonic centrality

### DIFF
--- a/benchmarks/benchmarks/benchmark_harmonic_centrality.py
+++ b/benchmarks/benchmarks/benchmark_harmonic_centrality.py
@@ -1,0 +1,24 @@
+"""Benchmarks for a certain set of algorithms"""
+
+import networkx as nx
+
+
+class HarmonicCentralityBenchmarks:
+    timeout = 120
+    nodes = [10, 100, 1000]
+    _graphs = [nx.wheel_graph(n) for n in nodes]
+    params = [f"wheel_graph({i})" for i in nodes]
+
+    param_names = ["graph"]
+
+    def setup(self, graph):
+        self.graphs_dict = dict(zip(self.params, self._graphs))
+
+    def time_harmonic_centrality(self, graph):
+        _ = nx.harmonic_centrality(self.graphs_dict[graph])
+
+    def time_harmonic_centrality_single_node(self, graph):
+        _ = nx.harmonic_centrality(self.graphs_dict[graph], nbunch=[0])
+
+    def time_harmonic_centrality_node_subset(self, graph):
+        _ = nx.harmonic_centrality(self.graphs_dict[graph], nbunch=[0, 1, 2, 3])

--- a/benchmarks/benchmarks/benchmark_harmonic_centrality.py
+++ b/benchmarks/benchmarks/benchmark_harmonic_centrality.py
@@ -6,13 +6,23 @@ import networkx as nx
 class HarmonicCentralityBenchmarks:
     timeout = 120
     nodes = [10, 100, 1000]
-    _graphs = [nx.wheel_graph(n) for n in nodes]
-    params = [f"wheel_graph({i})" for i in nodes]
-
+    params = [f"wheel_graph({i})" for i in nodes] + [
+        f"directed_wheel({i})" for i in nodes
+    ]
     param_names = ["graph"]
 
     def setup(self, graph):
-        self.graphs_dict = dict(zip(self.params, self._graphs))
+        def directed_wheel(n):
+            # bidirectional edges on the rim with directed edges to the central node
+            G = nx.DiGraph(nx.cycle_graph(range(1, n)))
+            G.add_node(0)
+            G.add_edges_from((0, i) for i in range(1, n))
+            return G
+
+        self.graphs_dict = {}
+        for n in self.nodes:
+            self.graphs_dict[f"wheel_graph({n})"] = nx.wheel_graph(n)
+            self.graphs_dict[f"directed_wheel({n})"] = directed_wheel(n)
 
     def time_harmonic_centrality(self, graph):
         _ = nx.harmonic_centrality(self.graphs_dict[graph])

--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -75,7 +75,7 @@ def harmonic_centrality(G, nbunch=None, distance=None, sources=None):
         transposed = True
         nbunch, sources = sources, nbunch
         if nx.is_directed(G):
-            G = nx.reverse(G)
+            G = nx.reverse(G, copy=False)
 
     spl = partial(nx.shortest_path_length, G, weight=distance)
     for v in sources:

--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -65,17 +65,25 @@ def harmonic_centrality(G, nbunch=None, distance=None, sources=None):
            Internet Mathematics 10.3-4 (2014): 222-262.
     """
 
-    nbunch = set(G.nbunch_iter(nbunch)) if nbunch is not None else set(G.nodes)
-    sources = set(G.nbunch_iter(sources)) if sources is not None else G.nodes
+    nbunch = set(G.nbunch_iter(nbunch) if nbunch is not None else G.nodes)
+    sources = set(G.nbunch_iter(sources) if sources is not None else G.nodes)
+
+    centrality = {u: 0 for u in nbunch}
+
+    transposed = False
+    if len(nbunch) < len(sources):
+        transposed = True
+        nbunch, sources = sources, nbunch
+        if nx.is_directed(G):
+            G = nx.reverse(G)
 
     spl = partial(nx.shortest_path_length, G, weight=distance)
-    centrality = {u: 0 for u in nbunch}
     for v in sources:
         dist = spl(v)
         for u in nbunch.intersection(dist):
             d = dist[u]
             if d == 0:  # handle u == v and edges with 0 weight
                 continue
-            centrality[u] += 1 / d
+            centrality[v if transposed else u] += 1 / d
 
     return centrality

--- a/networkx/algorithms/centrality/tests/test_harmonic_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_harmonic_centrality.py
@@ -103,6 +103,12 @@ class TestClosenessCentrality:
         for n in [0, 1]:
             assert c[n] == pytest.approx(d[n], abs=1e-3)
 
+    def test_cycle_c4_directed_subset(self):
+        c = harmonic_centrality(self.C4_directed, nbunch=[0, 1])
+        d = 1.833
+        for n in [0, 1]:
+            assert c[n] == pytest.approx(d, abs=1e-3)
+
     def test_p3_harmonic_subset(self):
         c = harmonic_centrality(self.P3, sources=[0, 1])
         d = {0: 1, 1: 1, 2: 1.5}


### PR DESCRIPTION
Computing the harmonic centrality was unnecessarily slow in many cases, for instance when computing the harmonic centrality for just a single vertex and all vertices as sources. This was due to a shortest path search starting from each vertex in `sources`. If `sources` is larger than `nbunch`, it is faster to do a shortest path search on the reversed graph starting from each vertex in `nbunch`. I implemented the graph reversal for this case, and a test case.