### PR TITLE
Allow backend graphs to be tested as compatible NetworkX graphs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Test Dispatching
         run: |
           NETWORKX_TEST_BACKEND=nx_loopback pytest --doctest-modules --durations=10 --pyargs networkx
+          pytest --backend=nx_loopback --use-backend-class networkx/classes/
 
   extra:
     runs-on: ${{ matrix.os }}

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -50,6 +50,12 @@ def convert(graph):
 
 
 class LoopbackBackendInterface:
+    Graph = LoopbackGraph
+    DiGraph = LoopbackDiGraph
+    MultiGraph = LoopbackMultiGraph
+    MultiDiGraph = LoopbackMultiDiGraph
+    PlanarEmbedding = LoopbackPlanarEmbedding
+
     def __getattr__(self, item):
         try:
             return nx.utils.backends._registered_algorithms[item].orig_func

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -50,10 +50,10 @@ class TestSparseGraph6:
     def test_from_bytes_multigraph_graph(self):
         graph_data = b":An"
         G = nx.from_sparse6_bytes(graph_data)
-        assert type(G) == nx.Graph
+        assert type(G) is type(nx.Graph())
         multigraph_data = b":Ab"
         M = nx.from_sparse6_bytes(multigraph_data)
-        assert type(M) == nx.MultiGraph
+        assert type(M) is type(nx.MultiGraph())
 
     def test_read_sparse6(self):
         data = b":Q___eDcdFcDeFcE`GaJ`IaHbKNbLM"

--- a/networkx/utils/tests/test_backends.py
+++ b/networkx/utils/tests/test_backends.py
@@ -45,6 +45,9 @@ def test_graph_converter_needs_backend():
         LoopbackGraph,
     )
 
+    if type(nx.Graph()) is LoopbackGraph:
+        pytest.xfail("This test does not work when using --use-backend-class")
+
     A = sp.sparse.coo_array([[0, 3, 2], [3, 0, 1], [2, 1, 0]])
 
     side_effects = []


### PR DESCRIPTION
Previously, running networkx tests with backends allowed backend _algorithms_ to be tested. This PR makes it so that backend graph classes can be tested directly by e.g. running tests in `networkx/classes/` or running dispatchable functions with backend graphs using the default networkx implementation.

This uses trickery with `__new__`, so there may be a few rough edges, although it seemed to work quite well overall in my experiments. Another approach could be to monkey patch e.g. `nx.Graph = backend_interface.Graph`, but I think this approach would also need to update all modules where `Graph` was imported and functions that use `Graph` as a default argument. The approach with `__new__` does not test subclassing.

For CI, I only run tests in `networkx.classes` for the sake of time. I ran all tests locally. The only failures were a couple doctests that print the repr of `type(G)`.

CC @aMahanna; you may find this useful.

CC @rlratzel; this may be useful for testing nx-cugraph graphs for networkx compatibility.