### PR TITLE
CI: Fix typo in nightly run pip install

### DIFF
--- a/.github/workflows/nightly-release-test.yml
+++ b/.github/workflows/nightly-release-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install packages
         run: |
           pip install --upgrade pip
-          pip install -U --pre --extra-index-url https://pypi.org/simple -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r .[test,default]
+          pip install -U --pre --extra-index-url https://pypi.org/simple -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple .[test,default]
           pip list
 
       - name: Test NetworkX


### PR DESCRIPTION
Nightly tests are broken https://github.com/networkx/networkx/actions/workflows/nightly-release-test.yml because of a typo in the pip install command.