### PR TITLE
Updated docstring for generators/karate_club_graph()

### DIFF
--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -21,12 +21,13 @@ def karate_club_graph():
     belongs, either 'Mr. Hi' or 'Officer'. Each edge has a weight based on the
     number of contexts in which that edge's incident node members interacted.
 
-    The dataset is derived from the 'Club After Split From Data' column of Table 3 in the source paper.
-    This was in turn derived from the 'Club After Fission' column of Table 1 in the same paper.
-    Note that the nodes are 0-indexed in NetworkX, but 1-indexed in the paper
-    (the 'Individual Number in Matrix C' column of Table 3 starts at 1).
-    This means, for example, that ``G.nodes[9]["club"]`` returns 'Officer',
-    which corresponds to row 10 of Table 3 in the paper.
+    The dataset is derived from the 'Club After Split From Data' column of Table 3 
+    in the source paper.
+    This was in turn derived from the 'Club After Fission' column of Table 1 in the
+    same paper. Note that the nodes are 0-indexed in NetworkX, but 1-indexed in the
+    paper (the 'Individual Number in Matrix C' column of Table 3 starts at 1). This
+    means, for example, that ``G.nodes[9]["club"]`` returns 'Officer', which
+    corresponds to row 10 of Table 3 in the paper.
 
     Examples
     --------

--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -25,7 +25,7 @@ def karate_club_graph():
     This was in turn derived from the 'Club After Fission' column of Table 1 in the same paper.
     Note that the nodes are 0-indexed in NetworkX, but 1-indexed in the paper
     (the 'Individual Number in Matrix C' column of Table 3 starts at 1).
-    This means, for example, that G.nodes[9]["club"] returns 'Officer',
+    This means, for example, that ``G.nodes[9]["club"]`` returns 'Officer',
     which corresponds to row 10 of Table 3 in the paper.
 
     Examples

--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -21,8 +21,7 @@ def karate_club_graph():
     belongs, either 'Mr. Hi' or 'Officer'. Each edge has a weight based on the
     number of contexts in which that edge's incident node members interacted.
 
-    The dataset is derived from the 'Club After Split From Data' column of Table 3 
-    in the source paper.
+    The dataset is derived from the 'Club After Split From Data' column of Table 3 in [1]_.
     This was in turn derived from the 'Club After Fission' column of Table 1 in the
     same paper. Note that the nodes are 0-indexed in NetworkX, but 1-indexed in the
     paper (the 'Individual Number in Matrix C' column of Table 3 starts at 1). This

--- a/networkx/generators/social.py
+++ b/networkx/generators/social.py
@@ -21,6 +21,13 @@ def karate_club_graph():
     belongs, either 'Mr. Hi' or 'Officer'. Each edge has a weight based on the
     number of contexts in which that edge's incident node members interacted.
 
+    The dataset is derived from the 'Club After Split From Data' column of Table 3 in the source paper.
+    This was in turn derived from the 'Club After Fission' column of Table 1 in the same paper.
+    Note that the nodes are 0-indexed in NetworkX, but 1-indexed in the paper
+    (the 'Individual Number in Matrix C' column of Table 3 starts at 1).
+    This means, for example, that G.nodes[9]["club"] returns 'Officer',
+    which corresponds to row 10 of Table 3 in the paper.
+
     Examples
     --------
     To get the name of the club to which a node belongs::


### PR DESCRIPTION
Added the following lines to the `karate_club_graph()` docstring in `networkx/generators/social.py`:

```
    The dataset is derived from the 'Club After Split From Data' column of Table 3 in the source paper.
    This was in turn derived from the 'Club After Fission' column of Table 1 in the same paper.
    Note that the nodes are 0-indexed in NetworkX, but 1-indexed in the paper
    (the 'Individual Number in Matrix C' column of Table 3 starts at 1).
    This means, for example, that G.nodes[9]["club"] returns 'Officer',
    which corresponds to row 10 of Table 3 in the paper.
```

Closes #7519 #7515