### PR TITLE
modified product.py to raise NodeNotFound when 'root is not in H'

### DIFF
--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -5,8 +5,8 @@ Graph products.
 from itertools import product
 
 import networkx as nx
-from networkx.utils import not_implemented_for
 from networkx import NodeNotFound
+from networkx.utils import not_implemented_for
 
 __all__ = [
     "tensor_product",

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -5,7 +5,6 @@ Graph products.
 from itertools import product
 
 import networkx as nx
-from networkx import NodeNotFound
 from networkx.utils import not_implemented_for
 
 __all__ = [
@@ -463,7 +462,7 @@ def rooted_product(G, H, root):
     The nodes of G and H are not relabeled.
     """
     if root not in H:
-        raise NodeNotFound("root must be a vertex in H")
+        raise nx.NodeNotFound("root must be a vertex in H")
 
     R = nx.Graph()
     R.add_nodes_from(product(G, H))

--- a/networkx/algorithms/operators/product.py
+++ b/networkx/algorithms/operators/product.py
@@ -6,6 +6,7 @@ from itertools import product
 
 import networkx as nx
 from networkx.utils import not_implemented_for
+from networkx import NodeNotFound
 
 __all__ = [
     "tensor_product",
@@ -462,7 +463,7 @@ def rooted_product(G, H, root):
     The nodes of G and H are not relabeled.
     """
     if root not in H:
-        raise nx.NetworkXError("root must be a vertex in H")
+        raise NodeNotFound("root must be a vertex in H")
 
     R = nx.Graph()
     R.add_nodes_from(product(G, H))

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -2,6 +2,7 @@ import pytest
 
 import networkx as nx
 from networkx.utils import edges_equal
+from networkx import NodeNotFound
 
 
 def test_tensor_product_raises():
@@ -414,7 +415,7 @@ def test_graph_power_negative():
 
 
 def test_rooted_product_raises():
-    with pytest.raises(nx.NetworkXError):
+    with pytest.raises(NodeNotFound):
         nx.rooted_product(nx.Graph(), nx.path_graph(2), 10)
 
 

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -1,7 +1,6 @@
 import pytest
 
 import networkx as nx
-from networkx import NodeNotFound
 from networkx.utils import edges_equal
 
 
@@ -415,7 +414,7 @@ def test_graph_power_negative():
 
 
 def test_rooted_product_raises():
-    with pytest.raises(NodeNotFound):
+    with pytest.raises(nx.NodeNotFound):
         nx.rooted_product(nx.Graph(), nx.path_graph(2), 10)
 
 

--- a/networkx/algorithms/operators/tests/test_product.py
+++ b/networkx/algorithms/operators/tests/test_product.py
@@ -1,8 +1,8 @@
 import pytest
 
 import networkx as nx
-from networkx.utils import edges_equal
 from networkx import NodeNotFound
+from networkx.utils import edges_equal
 
 
 def test_tensor_product_raises():


### PR DESCRIPTION
Addressing #7486 , I have modified the product.py file and test_product.py file to raise the NodeNotFound Exception instead of 
NetworkXError when root is not in H.