### PR TITLE
Revert breaking change to `node_link_*` link defaults

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -60,4 +60,5 @@ Version 3.6
 ~~~~~~~~~~~
 * Remove ``compute_v_structures`` from ``algorithms/dag.py``.
 * Remove ``link`` kwarg from ``readwrite/json_graph/node_link.py``;
-  Change ``edges`` default value to ``edges``.
+  Remove the ``FutureWarning`` re: the default value of ``edges`` and change the
+  default value to ``"edges"``.

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -129,6 +129,7 @@ def node_link_data(
         warnings.warn(
             "Keyword argument 'link' is deprecated; use 'edges' instead",
             DeprecationWarning,
+            stacklevel=2,
         )
         if edges is not None:
             raise ValueError(
@@ -273,6 +274,7 @@ def node_link_graph(
         warnings.warn(
             "Keyword argument 'link' is deprecated; use 'edges' instead",
             DeprecationWarning,
+            stacklevel=2,
         )
         if edges is not None:
             raise ValueError(

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -74,7 +74,7 @@ def node_link_data(
     --------
     >>> from pprint import pprint
     >>> G = nx.Graph([("A", "B")])
-    >>> data1 = nx.node_link_data(G)
+    >>> data1 = nx.node_link_data(G, edges="edges")
     >>> pprint(data1)
     {'directed': False,
      'edges': [{'source': 'A', 'target': 'B'}],
@@ -89,11 +89,11 @@ def node_link_data(
     >>> s1
     '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "edges": [{"source": "A", "target": "B"}]}'
 
-    A graph can also be serialized by passing `node_link_data` as an encoder function. The two methods are equivalent.
+    A graph can also be serialized by passing `node_link_data` as an encoder function.
 
     >>> s1 = json.dumps(G, default=nx.node_link_data)
     >>> s1
-    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "edges": [{"source": "A", "target": "B"}]}'
+    '{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, {"id": "B"}], "links": [{"source": "A", "target": "B"}]}'
 
     The attribute names for storing NetworkX-internal graph data can
     be specified as keyword options.
@@ -118,7 +118,6 @@ def node_link_data(
 
     To use `node_link_data` in conjunction with `node_link_graph`,
     the keyword names for the attributes must match.
-
 
     See Also
     --------
@@ -234,7 +233,7 @@ def node_link_graph(
 
     >>> from pprint import pprint
     >>> G = nx.Graph([("A", "B")])
-    >>> data = nx.node_link_data(G)
+    >>> data = nx.node_link_data(G, edges="edges")
     >>> pprint(data)
     {'directed': False,
      'edges': [{'source': 'A', 'target': 'B'}],
@@ -244,15 +243,15 @@ def node_link_graph(
 
     Revert data in node-link format to a graph.
 
-    >>> H = nx.node_link_graph(data)
+    >>> H = nx.node_link_graph(data, edges="edges")
     >>> print(H.edges)
     [('A', 'B')]
 
     To serialize and deserialize a graph with JSON,
 
     >>> import json
-    >>> d = json.dumps(nx.node_link_data(G))
-    >>> H = nx.node_link_graph(json.loads(d))
+    >>> d = json.dumps(nx.node_link_data(G, edges="edges"))
+    >>> H = nx.node_link_graph(json.loads(d), edges="edges")
     >>> print(G.edges, H.edges)
     [('A', 'B')] [('A', 'B')]
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -139,7 +139,16 @@ def node_link_data(
             edges = link
     else:
         if edges is None:
-            edges = "edges"
+            warnings.warn(
+                (
+                    '\nThe default value will be `edges="edges" in NetworkX 3.6.\n\n'
+                    "To make this warning go away, explicitly set the edges kwarg, e.g.:\n\n"
+                    '  nx.node_link_data(G, edges="links") to preserve current behavior, or\n'
+                    '  nx.node_link_data(G, edges="edges") for forward compatibility.'
+                ),
+                FutureWarning,
+            )
+            edges = "links"
     # ------------------------------------------------------------
 
     multigraph = G.is_multigraph()
@@ -274,7 +283,16 @@ def node_link_graph(
             edges = link
     else:
         if edges is None:
-            edges = "edges"
+            warnings.warn(
+                (
+                    '\nThe default value will be changed to `edges="edges" in NetworkX 3.6.\n\n'
+                    "To make this warning go away, explicitly set the edges kwarg, e.g.:\n\n"
+                    '  nx.node_link_graph(data, edges="links") to preserve current behavior, or\n'
+                    '  nx.node_link_graph(data, edges="edges") for forward compatibility.'
+                ),
+                FutureWarning,
+            )
+            edges = "links"
     # -------------------------------------------------------------
 
     multigraph = data.get("multigraph", multigraph)

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -15,6 +15,14 @@ def test_node_link_edges_default_future_warning():
         H = nx.node_link_graph(data)  # edges=None, the default
 
 
+def test_node_link_deprecated_link_param():
+    G = nx.Graph([(1, 2)])
+    with pytest.warns(DeprecationWarning, match="Keyword argument 'link'"):
+        data = nx.node_link_data(G, link="links")
+    with pytest.warns(DeprecationWarning, match="Keyword argument 'link'"):
+        H = nx.node_link_graph(data, link="links")
+
+
 class TestNodeLink:
     # TODO: To be removed when signature change complete
     def test_custom_attrs_dep(self):

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -116,10 +116,12 @@ class TestNodeLink:
         G.add_node("A")
         G.add_node(q)
         G.add_edge("A", q)
-        data = node_link_data(G)
-        assert data["edges"][0]["source"] == "A"
-        assert data["edges"][0]["target"] == q
-        H = node_link_graph(data)
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            data = node_link_data(G)
+        assert data["links"][0]["source"] == "A"
+        assert data["links"][0]["target"] == q
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(data)
         assert nx.is_isomorphic(G, H)
 
     def test_custom_attrs(self):

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -52,13 +52,15 @@ class TestNodeLink:
         assert H[1][2]["width"] == 7
 
     def test_exception_dep(self):
+        G = nx.MultiDiGraph()
         with pytest.raises(nx.NetworkXError):
-            G = nx.MultiDiGraph()
-            node_link_data(G, name="node", source="node", target="node", key="node")
+            with pytest.warns(FutureWarning, match="\nThe default value will be"):
+                node_link_data(G, name="node", source="node", target="node", key="node")
 
     def test_graph(self):
         G = nx.path_graph(4)
-        H = node_link_graph(node_link_data(G))
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(node_link_data(G))
         assert nx.is_isomorphic(G, H)
 
     def test_graph_attributes(self):
@@ -68,13 +70,16 @@ class TestNodeLink:
         G.graph[1] = "one"
         G.graph["foo"] = "bar"
 
-        H = node_link_graph(node_link_data(G))
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(node_link_data(G))
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
 
-        d = json.dumps(node_link_data(G))
-        H = node_link_graph(json.loads(d))
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            d = json.dumps(node_link_data(G))
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(json.loads(d))
         assert H.graph["foo"] == "bar"
         assert H.graph["1"] == "one"
         assert H.nodes[1]["color"] == "red"
@@ -82,24 +87,28 @@ class TestNodeLink:
 
     def test_digraph(self):
         G = nx.DiGraph()
-        H = node_link_graph(node_link_data(G))
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(node_link_data(G))
         assert H.is_directed()
 
     def test_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
-        H = node_link_graph(node_link_data(G))
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(node_link_data(G))
         assert nx.is_isomorphic(G, H)
         assert H[1][2]["second"]["color"] == "blue"
 
     def test_graph_with_tuple_nodes(self):
         G = nx.Graph()
         G.add_edge((0, 0), (1, 0), color=[255, 255, 0])
-        d = node_link_data(G)
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            d = node_link_data(G)
         dumped_d = json.dumps(d)
         dd = json.loads(dumped_d)
-        H = node_link_graph(dd)
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(dd)
         assert H.nodes[(0, 0)] == G.nodes[(0, 0)]
         assert H[(0, 0)][(1, 0)]["color"] == [255, 255, 0]
 
@@ -107,17 +116,20 @@ class TestNodeLink:
         q = "qualité"
         G = nx.Graph()
         G.add_node(1, **{q: q})
-        s = node_link_data(G)
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            s = node_link_data(G)
         output = json.dumps(s, ensure_ascii=False)
         data = json.loads(output)
-        H = node_link_graph(data)
+        with pytest.warns(FutureWarning, match="\nThe default value will be"):
+            H = node_link_graph(data)
         assert H.nodes[1][q] == q
 
     def test_exception(self):
+        G = nx.MultiDiGraph()
+        attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
         with pytest.raises(nx.NetworkXError):
-            G = nx.MultiDiGraph()
-            attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
-            node_link_data(G, **attrs)
+            with pytest.warns(FutureWarning, match="\nThe default value will be"):
+                node_link_data(G, **attrs)
 
     def test_string_ids(self):
         q = "qualité"

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -6,6 +6,15 @@ import networkx as nx
 from networkx.readwrite.json_graph import node_link_data, node_link_graph
 
 
+def test_node_link_edges_default_future_warning():
+    "Test FutureWarning is raised when `edges=None` in node_link_data and node_link_graph"
+    G = nx.Graph([(1, 2)])
+    with pytest.warns(FutureWarning, match="\nThe default value will be"):
+        data = nx.node_link_data(G)  # edges=None, the default
+    with pytest.warns(FutureWarning, match="\nThe default value will be"):
+        H = nx.node_link_graph(data)  # edges=None, the default
+
+
 class TestNodeLink:
     # TODO: To be removed when signature change complete
     def test_custom_attrs_dep(self):


### PR DESCRIPTION
Follow-up to #7565 

One of the changes in #7565 was to change the default value for the `edges` (cf. `link`) parameter from `"links"` to the more networkx-y `"edges"`. At the time of the discussion, this was recognized as a breaking change, but the consensus (including my own opinion) was that it was better to get all of the changes in now rather than have multiple deprecation cycles.

However, this change did lead to a break downstream in `nx-guides`, which can be interpreted as a proxy for how disruptive any change might be in user-code. Essentially, changing the default without warning will affect any user attempting to read saved graphs saved in `node_link` format with the default edge values. Given this, I *do* now think a deprecation cycle is a good idea - not only does it avoid breakage in all existing code that relies on default values, but there's also a way to provide users with a "fixable" warning; i.e. a recommended change that will make the code more explicit and be forward-compatible. Here's a quick example of what this proposal looks like:

```python
>>> G = nx.Graph([(1, 2)])
>>> data = nx.node_link_data(G)  # Relying on default value for `link` raises a FutureWarning
The default value will be `edges="edges" in NetworkX 3.6.

To make this warning go away, explicitly set the edges kwarg, e.g.:

  nx.node_link_data(G, edges="links") to preserve current behavior, or
  nx.node_link_data(G, edges="edges") for forward compatibility.

>>> data = nx.node_link_data(G, edges="edges")  # Explicitly specifying `edges` silences the warning 
```

The downside here is that this warning is *a lot* more noisy than the DeprecationWarning, as it is emitted whenever the function is called with the default value for `link`. However, I think this noisiness is just a consequence of changing a default in the API - in other words I don't see a good way around it. We can either raise a noisy warning (with a proposed fix that will make the warning go away) or we just break user code.

The only other alternative I could think of was to continue with the current plan (i.e. don't warn) and add special-casing logic for certain values of `edges`/`links` to raise specific exceptions that clearly state what the issue is (right now, users get a generic KeyError). IMO though, if you're going to raise special exceptions for the same special cases, you might as well warn instead and give users an opportunity to avoid the exception. 