### PR TITLE
Enable edge attributes in tree format "nested_tuple"

### DIFF
--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -229,7 +229,7 @@ def from_nested_tuple(sequence, sensible_relabeling=False, edge_attribute=None):
 
     """
     
-    def _make_tree(seq, parent, graph, edge_attr_key):
+    \def _make_tree(seq, parent, graph, edge_attr_key):
         """Recursively creates a tree from the given nested tuple/list with edge attributes.
 
         Parameters

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -249,7 +249,9 @@ def from_nested_tuple(sequence, sensible_relabeling=False, edge_attribute=None):
             raise nx.NetworkXError("Each node must be a list or tuple.")
 
         if len(seq) < 2:
-            raise nx.NetworkXError("Each node must have at least a name and edge attribute.")
+            raise nx.NetworkXError(
+                "Each node must have at least a name and edge attribute."
+            )
 
         node = seq[0]
         edge_attr = seq[1] if edge_attr_key else None
@@ -268,7 +270,9 @@ def from_nested_tuple(sequence, sensible_relabeling=False, edge_attribute=None):
         return node
 
     if edge_attribute is not None and not isinstance(edge_attribute, str):
-        raise TypeError("edge_attribute must be a string representing the attribute key.")
+        raise TypeError(
+            "edge_attribute must be a string representing the attribute key."
+        )
 
     graph = nx.Graph()  # Using undirected graph; change to DiGraph if needed
 

--- a/networkx/algorithms/tree/coding.py
+++ b/networkx/algorithms/tree/coding.py
@@ -8,6 +8,7 @@ applied to unrooted trees. Furthermore, there is a bijection from Prüfer
 sequences to labeled trees.
 
 """
+
 from collections import Counter
 from itertools import chain
 
@@ -98,6 +99,7 @@ def to_nested_tuple(T, root, canonical_form=False):
         ((((),),),)
 
     """
+    
     def _make_tuple(T, root, _parent):
         """Recursively compute the nested tuple representation of the
         given rooted tree.
@@ -226,6 +228,7 @@ def from_nested_tuple(sequence, sensible_relabeling=False, edge_attribute=None):
         Faulty -> Mechanic 👎, weight: 0.9
 
     """
+    
     def _make_tree(seq, parent, graph, edge_attr_key):
         """Recursively creates a tree from the given nested tuple/list with edge attributes.
 


### PR DESCRIPTION
Changes:

Extended Nested Tuple Format:
The `from_nested_tuple` function now expects each node in the sequence to be a tuple or list
`node_name`, `edge_attributes`, 

2. New Parameter edge_attribute:
Added an optional parameter `edge_attribute` to specify the key name for the edge attributes 

3.Recursive Helper Function `_make_tree`
It extracts `node_name` and `edge_attr,` adds the node to the graph, and connects it to its parent with the specified edge attributes.

