### PR TITLE
MAINT: delay loading of backend_info to after imports

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -50,5 +50,6 @@ from networkx.drawing import *
 
 
 # load_and_call entry_points, set configs
-config = utils.config = utils.backends._set_configs_from_environment()
+config = utils.backends._set_configs_from_environment()
+utils.config = utils.configs.config = config  # type: ignore[attr-defined]
 type(config.backends).__doc__ = "All installed NetworkX backends and their configs."

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -17,7 +17,7 @@ from networkx.lazy_imports import _lazy_import
 from networkx.exception import *
 
 from networkx import utils
-from networkx.utils import _clear_cache, _dispatchable, config
+from networkx.utils import _clear_cache, _dispatchable
 
 from networkx import classes
 from networkx.classes import filters
@@ -47,3 +47,8 @@ from networkx.linalg import *
 
 from networkx import drawing
 from networkx.drawing import *
+
+
+# load_and_call entry_points, set configs
+config = utils.config = utils.backends._set_configs_from_environment()
+type(config.backends).__doc__ = "All installed NetworkX backends and their configs."

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -52,4 +52,3 @@ from networkx.drawing import *
 # load_and_call entry_points, set configs
 config = utils.backends._set_configs_from_environment()
 utils.config = utils.configs.config = config  # type: ignore[attr-defined]
-type(config.backends).__doc__ = "All installed NetworkX backends and their configs."

--- a/networkx/utils/__init__.py
+++ b/networkx/utils/__init__.py
@@ -4,5 +4,5 @@ from networkx.utils.random_sequence import *
 from networkx.utils.union_find import *
 from networkx.utils.rcm import *
 from networkx.utils.heaps import *
-from networkx.utils.backends import *
 from networkx.utils.configs import *
+from networkx.utils.backends import *

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -594,6 +594,7 @@ def _set_configs_from_environment():
         },
     )
     backend_info["networkx"] = {}
+    type(config.backends).__doc__ = "All installed NetworkX backends and their configs."
 
     # NETWORKX_BACKEND_PRIORITY is the same as NETWORKX_BACKEND_PRIORITY_ALGOS
     priorities = {
@@ -1772,7 +1773,7 @@ class _dispatchable:
             )
             compat_key, rv = _get_from_cache(cache, key, mutations=mutations)
             if rv is not None:
-                if "cache" not in config.warnings_to_ignore:
+                if "cache" not in nx.config.warnings_to_ignore:
                     warnings.warn(
                         "Note: conversions to backend graphs are saved to cache "
                         "(`G.__networkx_cache__` on the original graph) by default."

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -4,7 +4,7 @@ import typing
 import warnings
 from dataclasses import dataclass
 
-__all__ = ["Config", "config"]
+__all__ = ["Config"]
 
 
 @dataclass(init=False, eq=False, slots=True, kw_only=True, match_args=False)
@@ -385,22 +385,3 @@ class NetworkXConfig(Config):
                     + ", ".join(sorted(known_warnings))
                 )
         return value
-
-
-# Backend configuration will be updated in backends.py
-config = NetworkXConfig(
-    backend_priority=BackendPriorities(
-        algos=[],
-        generators=[],
-    ),
-    backends=Config(),
-    cache_converted_graphs=bool(
-        os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", True)
-    ),
-    fallback_to_nx=bool(os.environ.get("NETWORKX_FALLBACK_TO_NX", False)),
-    warnings_to_ignore={
-        x.strip()
-        for x in os.environ.get("NETWORKX_WARNINGS_TO_IGNORE", "").split(",")
-        if x.strip()
-    },
-)


### PR DESCRIPTION
Fixes #7671 

Delays updating backend_info and setting up configs until the end of the import process so that backends which import networkx inside their backend_info function don't run into a circular import issue.

We should test this locally with nx-cugraph installed just to make sure nothing strange occurs.