### PR TITLE
Correct all_simple_paths docstring #2762

### DIFF
--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -108,7 +108,7 @@ def all_simple_paths(G, source, target, cutoff=None):
        Single node or iterable of nodes at which to end path
 
     cutoff : integer, optional
-        Depth to stop the search. Only paths of length <= cutoff are returned.
+        Depth to stop the search. Only paths of length <= (cutoff + 1) are returned.
 
     Returns
     -------


### PR DESCRIPTION
As mentioned in #2762

> Please update the documentation to state explicitly that the function by default searches for paths with cutoff=(number of nodes in graph -1). You must inspect the source code in order to find that, which may lead, as in my case, to a couple of hours of debugging.

This is the behaviour in the example:

```
>>> paths = nx.all_simple_paths(G, source=0, target=3, cutoff=2)
>>> print(list(paths))
[[0, 1, 3], [0, 2, 3], [0, 3]]
```