### PR TITLE
Fix docstrings of dispatchable functions

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -19,6 +19,10 @@ from networkx.exception import *
 from networkx import utils
 from networkx.utils import _clear_cache, _dispatchable
 
+# load_and_call entry_points, set configs
+config = utils.backends._set_configs_from_environment()
+utils.config = utils.configs.config = config  # type: ignore[attr-defined]
+
 from networkx import classes
 from networkx.classes import filters
 from networkx.classes import *
@@ -47,8 +51,3 @@ from networkx.linalg import *
 
 from networkx import drawing
 from networkx.drawing import *
-
-
-# load_and_call entry_points, set configs
-config = utils.backends._set_configs_from_environment()
-utils.config = utils.configs.config = config  # type: ignore[attr-defined]

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -2310,6 +2310,8 @@ class _dispatchable:
 
         lines.pop()  # Remove last empty line
         to_add = "\n    ".join(lines)
+        if not self._orig_doc:
+            return f"The original docstring for {self.name} was empty.\n\n    {to_add}"
         return f"{self._orig_doc.rstrip()}\n\n    {to_add}"
 
     def __reduce__(self):


### PR DESCRIPTION
This may not fix when building the docs; let's experiment!

For backends to show up in docs, we need to load `backend_info` before we decorate functions with `_dispatchable`.

This fixes #7675 and attempts to fix #7677, and is a follow-up to #7672. Let's see if #7671 remains fixed with this PR.

@Schefflera-Arboricola will this work for nx-parallel?