### PR TITLE
Fix doc warnings from recently added docs

### DIFF
--- a/doc/backends.md
+++ b/doc/backends.md
@@ -25,7 +25,7 @@ backends that NetworkX developers don't know about. You should be able to
 install the backend, enable the backend using the `backend=...` keyword arg,
 the `NETWORKX_BACKEND_PRIORITY` environment variable, or the config setting
 `nx.config.backend_priority="..."` as described in the
-[Tutorial](/tutorial.md#using-networkx-backends).
+[Tutorial](#using-networkx-backends).
 
 See the documentation for a particular backend for a description of
 the NetworkX functions it provides, how to install it, and any special

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -569,6 +569,8 @@ sp[3]
 See {doc}`/reference/algorithms/index` for details on graph algorithms
 supported.
 
+(using-networkx-backends)=
+
 ## Using NetworkX backends
 
 NetworkX can be configured to use separate thrid-party backends to improve

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -275,10 +275,10 @@ class BackendPriorities(Config, strict=False):
 class NetworkXConfig(Config):
     """Configuration for NetworkX that controls behaviors such as how to use backends.
 
-    Attribute and bracket notation are supported for getting and setting configurations:
+    Attribute and bracket notation are supported for getting and setting configurations::
 
-    >>> nx.config.backend_priority == nx.config["backend_priority"]
-    True
+        >>> nx.config.backend_priority == nx.config["backend_priority"]
+        True
 
     Parameters
     ----------
@@ -330,7 +330,7 @@ class NetworkXConfig(Config):
 
     and can be used for finer control of ``backend_priority`` such as:
 
-    - ``NETWORKX_BACKEND_PRIORITY_ALGOS``: same as ``NETWORKX_BACKEND_PRIORITY`` to set ``backend_priority.algos`.
+    - ``NETWORKX_BACKEND_PRIORITY_ALGOS``: same as ``NETWORKX_BACKEND_PRIORITY`` to set ``backend_priority.algos``.
 
     This is a global configuration. Use with caution when using from multiple threads.
     """


### PR DESCRIPTION
Minor formatting touchups to get rid of sphinx warnings in the doc build