### PR TITLE
Fix draw_networkx_nodes return type

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -485,8 +485,7 @@ def draw_networkx_nodes(
             ax.margins(margins)
 
     node_collection.set_zorder(2)
-    # return node_collection
-    return ax
+    return node_collection
 
 
 class FancyArrowFactory:

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -362,6 +362,35 @@ def test_directed_edges_linestyle_sequence(style_seq):
         assert fap.get_linestyle() == style
 
 
+def test_return_types():
+    from matplotlib.collections import PathCollection, LineCollection
+    from matplotlib.patches import FancyArrowPatch
+    
+    G = nx.cubical_graph(nx.Graph)
+    dG = nx.cubical_graph(nx.DiGraph)
+    
+    # nodes
+    nodes = nx.draw_networkx_nodes(G)
+    assert(isinstance(nodes, PathCollection))
+    
+    # edges
+    edges = nx.draw_networkx_edges(dG, arrows=True)
+    assert(isinstance(edges, list))
+    if len(edges) > 0:
+        assert(isinstance(edges[0], FancyArrowPatch))
+            
+    edges = nx.draw_networkx_edges(dG, arrows=False)
+    assert(isinstance(edges, LineCollection))
+    
+    edges = nx.draw_networkx_edges(dG, arrows=None)
+    assert(isinstance(edges, LineCollection))
+    
+    edges = nx.draw_networkx_edges(G, arrows=True)
+    assert(isinstance(edges, list))
+    if len(edges) > 0:
+        assert(isinstance(edges[0], FancyArrowPatch))
+    
+
 def test_labels_and_colors():
     G = nx.cubical_graph()
     pos = nx.spring_layout(G)  # positions for all nodes

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -363,33 +363,28 @@ def test_directed_edges_linestyle_sequence(style_seq):
 
 
 def test_return_types():
-    from matplotlib.collections import PathCollection, LineCollection
+    from matplotlib.collections import LineCollection, PathCollection
     from matplotlib.patches import FancyArrowPatch
-    
+
     G = nx.cubical_graph(nx.Graph)
     dG = nx.cubical_graph(nx.DiGraph)
-    
     # nodes
     nodes = nx.draw_networkx_nodes(G)
-    assert(isinstance(nodes, PathCollection))
-    
+    assert isinstance(nodes, PathCollection)
     # edges
     edges = nx.draw_networkx_edges(dG, arrows=True)
-    assert(isinstance(edges, list))
+    assert isinstance(edges, list)
     if len(edges) > 0:
-        assert(isinstance(edges[0], FancyArrowPatch))
-            
+        assert isinstance(edges[0], FancyArrowPatch)
     edges = nx.draw_networkx_edges(dG, arrows=False)
-    assert(isinstance(edges, LineCollection))
-    
+    assert isinstance(edges, LineCollection)
     edges = nx.draw_networkx_edges(dG, arrows=None)
-    assert(isinstance(edges, LineCollection))
-    
+    assert isinstance(edges, LineCollection)
     edges = nx.draw_networkx_edges(G, arrows=True)
-    assert(isinstance(edges, list))
+    assert isinstance(edges, list)
     if len(edges) > 0:
-        assert(isinstance(edges[0], FancyArrowPatch))
-    
+        assert isinstance(edges[0], FancyArrowPatch)
+
 
 def test_labels_and_colors():
     G = nx.cubical_graph()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -368,19 +368,21 @@ def test_return_types():
 
     G = nx.cubical_graph(nx.Graph)
     dG = nx.cubical_graph(nx.DiGraph)
+    pos = nx.spring_layout(G)
+    dpos = nx.spring_layout(dG)
     # nodes
-    nodes = nx.draw_networkx_nodes(G)
+    nodes = nx.draw_networkx_nodes(G, pos)
     assert isinstance(nodes, PathCollection)
     # edges
-    edges = nx.draw_networkx_edges(dG, arrows=True)
+    edges = nx.draw_networkx_edges(dG,dpos, arrows=True)
     assert isinstance(edges, list)
     if len(edges) > 0:
         assert isinstance(edges[0], FancyArrowPatch)
-    edges = nx.draw_networkx_edges(dG, arrows=False)
+    edges = nx.draw_networkx_edges(dG, dpos, arrows=False)
     assert isinstance(edges, LineCollection)
-    edges = nx.draw_networkx_edges(dG, arrows=None)
+    edges = nx.draw_networkx_edges(dG, dpos, arrows=None)
     assert isinstance(edges, LineCollection)
-    edges = nx.draw_networkx_edges(G, arrows=True)
+    edges = nx.draw_networkx_edges(G, pos, arrows=True)
     assert isinstance(edges, list)
     if len(edges) > 0:
         assert isinstance(edges[0], FancyArrowPatch)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -374,7 +374,7 @@ def test_return_types():
     nodes = nx.draw_networkx_nodes(G, pos)
     assert isinstance(nodes, PathCollection)
     # edges
-    edges = nx.draw_networkx_edges(dG,dpos, arrows=True)
+    edges = nx.draw_networkx_edges(dG, dpos, arrows=True)
     assert isinstance(edges, list)
     if len(edges) > 0:
         assert isinstance(edges[0], FancyArrowPatch)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -380,9 +380,9 @@ def test_return_types():
         assert isinstance(edges[0], FancyArrowPatch)
     edges = nx.draw_networkx_edges(dG, dpos, arrows=False)
     assert isinstance(edges, LineCollection)
-    edges = nx.draw_networkx_edges(dG, dpos, arrows=None)
+    edges = nx.draw_networkx_edges(G, dpos, arrows=None)
     assert isinstance(edges, LineCollection)
-    edges = nx.draw_networkx_edges(G, pos, arrows=True)
+    edges = nx.draw_networkx_edges(dG, pos, arrows=None)
     assert isinstance(edges, list)
     if len(edges) > 0:
         assert isinstance(edges[0], FancyArrowPatch)


### PR DESCRIPTION
This PR addresses #7684 by returning the collection object rather than axis object in `draw_networkx_nodes`. Additional tests are added to check that the return types of `draw_networkx_nodes` and `draw_networkx_edges` return expected types.
