### PR TITLE
set nx-arangodb link to github

### DIFF
--- a/doc/backends.md
+++ b/doc/backends.md
@@ -39,6 +39,6 @@ backend-specific configurations it supports.
    - Parallelized implementations of various NetworkX functions using joblib
 *  - [nx-cugraph](https://rapids.ai/nx-cugraph)
    - GPU acceleration using RAPIDS cuGraph and NVIDIA GPUs
-*  - [nx-arangodb](https://nx-arangodb.readthedocs.io/en/latest/)
+*  - [nx-arangodb](https://github.com/arangodb/nx-arangodb)
    - Seamlessly adds ArangoDB as a persistence layer to NetworkX graphs
 ```


### PR DESCRIPTION
Updates the `nx-arangodb` link in Backends Gallery

Github Page has a video, which IMO is nicer to have vs. the RTD page