### PR TITLE
Update `_raise_on_directed` to work with `create_using` pos arg

### DIFF
--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -366,8 +366,8 @@ def test_return_types():
     from matplotlib.collections import LineCollection, PathCollection
     from matplotlib.patches import FancyArrowPatch
 
-    G = nx.cubical_graph(nx.Graph)
-    dG = nx.cubical_graph(nx.DiGraph)
+    G = nx.frucht_graph(create_using=nx.Graph)
+    dG = nx.frucht_graph(create_using=nx.DiGraph)
     pos = nx.spring_layout(G)
     dpos = nx.spring_layout(dG)
     # nodes

--- a/networkx/generators/small.py
+++ b/networkx/generators/small.py
@@ -46,12 +46,15 @@ def _raise_on_directed(func):
     A decorator which inspects the `create_using` argument and raises a
     NetworkX exception when `create_using` is a DiGraph (class or instance) for
     graph generators that do not support directed outputs.
+
+    `create_using` may be a keyword argument or the first positional argument.
     """
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if kwargs.get("create_using") is not None:
-            G = nx.empty_graph(create_using=kwargs["create_using"])
+        create_using = args[0] if args else kwargs.get("create_using")
+        if create_using is not None:
+            G = nx.empty_graph(create_using=create_using)
             if G.is_directed():
                 raise NetworkXError("Directed Graph not supported")
         return func(*args, **kwargs)

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -206,3 +206,6 @@ class TestGeneratorsSmall:
 def tests_raises_with_directed_create_using(fn, create_using):
     with pytest.raises(nx.NetworkXError, match="Directed Graph not supported"):
         fn(create_using=create_using)
+    # All these functions have `create_using` as the first positional argument too
+    with pytest.raises(nx.NetworkXError, match="Directed Graph not supported"):
+        fn(create_using)


### PR DESCRIPTION
This decorator is only used by the "small" graph generators. We could update this to use `argmap`, but probably not worth the effort since all functions have create_using as the first positional argument.

If we were creating these functions today, we might make create_using keyword-only, but that would be a breaking change.

I came across this when running networkx tests with nx-cugraph with networkx 3.4.2. The test added in #7685 was failing for nx-cugraph, because `cubical_graph` isn't supposed to work with directed graphs and we were raising.