### PR TITLE
Correct pydot import and export for default attribute 

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -158,18 +158,20 @@ def from_pydot(P):
             for destination_node in d:
                 N.add_edge(source_node, destination_node, **attr)
 
-    # add default attributes for graph, nodes, edges
-    pattr = P.get_attributes()
-    if pattr:
-        N.graph["graph"] = pattr
-    try:
-        N.graph["node"] = P.get_node_defaults()[0]
-    except (IndexError, TypeError):
-        pass  # N.graph['node']={}
-    try:
-        N.graph["edge"] = P.get_edge_defaults()[0]
-    except (IndexError, TypeError):
-        pass  # N.graph['edge']={}
+    # Get the graph attributes of the graph
+    for i in P.get_graph_defaults():
+        N.graph.update(i)
+
+    for i in P.get_node_defaults():
+        if "node" not in N.graph:
+            N.graph["node"] = {}
+        N.graph["node"].update(i)
+
+    for i in P.get_edge_defaults():
+        if "edge" not in N.graph:
+            N.graph["edge"] = {}
+        N.graph["edge"].update(i)
+
     return N
 
 
@@ -207,6 +209,12 @@ def to_pydot(N):
         P = pydot.Dot(
             f'"{name}"', graph_type=graph_type, strict=strict, **graph_defaults
         )
+
+    try:
+        P.set_graph_defaults(**N.graph)
+    except KeyError:
+        pass
+
     try:
         P.set_node_defaults(**N.graph["node"])
     except KeyError:

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -211,7 +211,7 @@ def to_pydot(N):
         )
 
     try:
-        P.set_graph_defaults(**N.graph)
+        P.set_graph_defaults(**{str(k): str(v) for k, v in N.graph.items()})
     except KeyError:
         pass
 


### PR DESCRIPTION
When importing the following graph:

```dot
strict graph  {
graph [test=test];
graph [test1=test2];
node [a=0]
node [b=1]
edge [c=2]
edge [d=3]
}
```

The result graph attribute will be as follows:
```python
import networkx as nx

G = nx.drawing.nx_pydot.read_dot("test.dot")
print(G.graph)

# {'name': 'G', 'node': {'a': '0'}, 'edge': {'c': '2'}}

```

This pull request corrects the behaviour to the following:
```python
import networkx as nx

G = nx.drawing.nx_pydot.read_dot("test.dot")
print(G.graph)

# {'name': 'G', 'test': 'test', 'test1': 'test2', 'node': {'a': '0', 'b': '1'}, 'edge': {'c': '2', 'd': '3'}}
```

This pull also corrects the `graph` attribute export from:
```python

import networkx as nx

G = nx.Graph(test="test")
nx.drawing.nx_pydot.write_dot(G, "test.dot")

# test.dot
# strict graph  {
# }
```

to

```python

import networkx as nx

G = nx.Graph(test="test")
nx.drawing.nx_pydot.write_dot(G, "test.dot")

# test.dot
# strict graph  {
# graph [test=test];
# }
```

