### PR TITLE
perf: optimise `random_k_out_graph`

### DIFF
--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -5,12 +5,16 @@ scale-free graphs.
 """
 
 import numbers
-
-import numpy as np
+from collections import Counter
 
 import networkx as nx
 from networkx.generators.classic import empty_graph
-from networkx.utils import discrete_sequence, np_random_state, py_random_state
+from networkx.utils import (
+    discrete_sequence,
+    np_random_state,
+    py_random_state,
+    weighted_choice,
+)
 
 __all__ = [
     "gn_graph",
@@ -415,7 +419,6 @@ def random_uniform_k_out_graph(n, k, self_loops=True, with_replacement=True, see
     return G
 
 
-@np_random_state(4)
 @nx._dispatchable(graphs=None, returns_graph=True)
 def random_k_out_graph(n, k, alpha, self_loops=True, seed=None):
     """Returns a random `k`-out graph with preferential attachment.
@@ -486,6 +489,13 @@ def random_k_out_graph(n, k, alpha, self_loops=True, seed=None):
     """
     if alpha < 0:
         raise ValueError("alpha must be positive")
+    return _random_k_out_graph_numpy(n, k, alpha, self_loops, seed)
+
+
+@np_random_state(4)
+def _random_k_out_graph_numpy(n, k, alpha, self_loops=True, seed=None):
+    import numpy as np
+
     G = nx.empty_graph(n, create_using=nx.MultiDiGraph)
     nodes = np.arange(n)
     remaining_mask = np.full(n, True)
@@ -513,4 +523,30 @@ def random_k_out_graph(n, k, alpha, self_loops=True, seed=None):
         out_strengths[u] += 1
         if out_strengths[u] == k:
             remaining_mask[u] = False
+    return G
+
+
+@py_random_state(4)
+def _random_k_out_graph_python(n, k, alpha, self_loops=True, seed=None):
+    G = nx.empty_graph(n, create_using=nx.MultiDiGraph)
+    weights = Counter({v: alpha for v in G})
+    out_strengths = Counter({v: 0 for v in G})
+
+    for i in range(k * n):
+        u = seed.choice(list(out_strengths.keys()))
+        # If self-loops are not allowed, make the source node `u` have
+        # weight zero.
+        if not self_loops:
+            uweight = weights.pop(u)
+
+        v = weighted_choice(weights, seed=seed)
+
+        if not self_loops:
+            weights[u] = uweight
+
+        G.add_edge(u, v)
+        weights[v] += 1
+        out_strengths[u] += 1
+        if out_strengths[u] == k:
+            out_strengths.pop(u)
     return G

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -506,16 +506,13 @@ def _random_k_out_graph_numpy(n, k, alpha, self_loops=True, seed=None):
     for i in range(k * n):
         u = seed.choice(nodes[remaining_mask])
 
-        if not self_loops:
-            u_weight = weights[u]
-            weights[u] = 0
-            total_weight -= u_weight
-
-        v = seed.choice(nodes, p=weights / total_weight)
-
-        if not self_loops:
+        if self_loops:                                                          
+            v = seed.choice(nodes, p=weights / total_weight)                    
+        else:  # Ignore weight of u when selecting v                            
+            u_weight = weights[u]                                               
+            weights[u] = 0                                                      
+            v = seed.choice(nodes, p=weights / (total_weight - u_weight))       
             weights[u] = u_weight
-            total_weight += u_weight
 
         G.add_edge(u, v)
         weights[v] += 1

--- a/networkx/generators/directed.py
+++ b/networkx/generators/directed.py
@@ -506,12 +506,12 @@ def _random_k_out_graph_numpy(n, k, alpha, self_loops=True, seed=None):
     for i in range(k * n):
         u = seed.choice(nodes[remaining_mask])
 
-        if self_loops:                                                          
-            v = seed.choice(nodes, p=weights / total_weight)                    
-        else:  # Ignore weight of u when selecting v                            
-            u_weight = weights[u]                                               
-            weights[u] = 0                                                      
-            v = seed.choice(nodes, p=weights / (total_weight - u_weight))       
+        if self_loops:
+            v = seed.choice(nodes, p=weights / total_weight)
+        else:  # Ignore weight of u when selecting v
+            u_weight = weights[u]
+            weights[u] = 0
+            v = seed.choice(nodes, p=weights / (total_weight - u_weight))
             weights[u] = u_weight
 
         G.add_edge(u, v)

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -105,26 +105,32 @@ class TestRandomKOutGraph:
 
     """
 
-    @pytest.mark.parametrize("use_numpy", [False] + ([True] if has_numpy else []))
-    def test_regularity(self, use_numpy):
+    @pytest.mark.parametrize(
+        "f", (_random_k_out_graph_numpy, _random_k_out_graph_python)
+    )
+    def test_regularity(self, f):
         """Tests that the generated graph is `k`-out-regular."""
-        fun = _random_k_out_graph_numpy if use_numpy else _random_k_out_graph_python
+        if (f == _random_k_out_graph_numpy) and not has_numpy:
+            pytest.skip()
         n = 10
         k = 3
         alpha = 1
-        G = fun(n, k, alpha)
+        G = f(n, k, alpha)
         assert all(d == k for v, d in G.out_degree())
-        G = fun(n, k, alpha, seed=42)
+        G = f(n, k, alpha, seed=42)
         assert all(d == k for v, d in G.out_degree())
 
-    @pytest.mark.parametrize("use_numpy", [False] + ([True] if has_numpy else []))
-    def test_no_self_loops(self, use_numpy):
+    @pytest.mark.parametrize(
+        "f", (_random_k_out_graph_numpy, _random_k_out_graph_python)
+    )
+    def test_no_self_loops(self, f):
         """Tests for forbidding self-loops."""
-        fun = _random_k_out_graph_numpy if use_numpy else _random_k_out_graph_python
+        if (f == _random_k_out_graph_numpy) and not has_numpy:
+            pytest.skip()
         n = 10
         k = 3
         alpha = 1
-        G = fun(n, k, alpha, self_loops=False)
+        G = f(n, k, alpha, self_loops=False)
         assert nx.number_of_selfloops(G) == 0
 
     def test_negative_alpha(self):

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -7,6 +7,8 @@ import pytest
 import networkx as nx
 from networkx.classes import Graph, MultiDiGraph
 from networkx.generators.directed import (
+    _random_k_out_graph_numpy,
+    _random_k_out_graph_python,
     gn_graph,
     gnc_graph,
     gnr_graph,
@@ -14,6 +16,13 @@ from networkx.generators.directed import (
     random_uniform_k_out_graph,
     scale_free_graph,
 )
+
+try:
+    import numpy
+
+    has_numpy = True
+except ImportError:
+    has_numpy = False
 
 
 class TestGeneratorsDirected:
@@ -96,22 +105,26 @@ class TestRandomKOutGraph:
 
     """
 
-    def test_regularity(self):
+    @pytest.mark.parametrize("use_numpy", [False] + ([True] if has_numpy else []))
+    def test_regularity(self, use_numpy):
         """Tests that the generated graph is `k`-out-regular."""
+        fun = _random_k_out_graph_numpy if use_numpy else _random_k_out_graph_python
         n = 10
         k = 3
         alpha = 1
-        G = random_k_out_graph(n, k, alpha)
+        G = fun(n, k, alpha)
         assert all(d == k for v, d in G.out_degree())
-        G = random_k_out_graph(n, k, alpha, seed=42)
+        G = fun(n, k, alpha, seed=42)
         assert all(d == k for v, d in G.out_degree())
 
-    def test_no_self_loops(self):
+    @pytest.mark.parametrize("use_numpy", [False] + ([True] if has_numpy else []))
+    def test_no_self_loops(self, use_numpy):
         """Tests for forbidding self-loops."""
+        fun = _random_k_out_graph_numpy if use_numpy else _random_k_out_graph_python
         n = 10
         k = 3
         alpha = 1
-        G = random_k_out_graph(n, k, alpha, self_loops=False)
+        G = fun(n, k, alpha, self_loops=False)
         assert nx.number_of_selfloops(G) == 0
 
     def test_negative_alpha(self):


### PR DESCRIPTION
I found this generator to be particularly slow, so I dug into it and made several optimizations. The main bottleneck I found was the re-computation of out-degrees at every single step. Updating their values at every step already allowed for a ~20x performance improvement for `nx.random_k_out_graph(1000, 100, 0.1)`. I then introduced numpy to optimize further to reach a ~60x improvement for this same set of parameters (from 2 minutes down to 2 seconds). There are more lines of code but not really more complexity, as most lines are for variable initialisations and updates.