### PR TITLE
Add missing usebounds param descr to distance docstrings.

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -342,10 +342,10 @@ def diameter(G, e=None, usebounds=False, weight=None):
     G : NetworkX graph
        A graph
 
-    e : eccentricity dictionary, optional (default = None)
+    e : eccentricity dictionary, optional
       A precomputed dictionary of eccentricities.
 
-    usebounds : bool, optional (default = False)
+    usebounds : bool, optional
         If `True`, use the extrema bounding approach when computing the diameter
         for undirected graphs. Extrema bounding may accelerate the
         distance calculation for some graphs. `usebounds` is ignored if `G` is

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -345,7 +345,7 @@ def diameter(G, e=None, usebounds=False, weight=None):
     e : eccentricity dictionary, optional
       A precomputed dictionary of eccentricities.
 
-    usebounds : bool, optional
+    usebounds : bool, optional (default = False)
         If `True`, use the extrema bounding approach when computing the diameter
         for undirected graphs. Extrema bounding may accelerate the
         distance calculation for some graphs. `usebounds` is ignored if `G` is

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -346,7 +346,7 @@ def diameter(G, e=None, usebounds=False, weight=None):
       A precomputed dictionary of eccentricities.
 
     usebounds : bool, optional
-        If `True`, use the extrema bounding approach when computing the diameter
+        If `True`, use extrema bounding (see Notes) when computing the diameter
         for undirected graphs. Extrema bounding may accelerate the
         distance calculation for some graphs. `usebounds` is ignored if `G` is
         directed or if `e` is not `None`. Default is `False`.
@@ -375,6 +375,13 @@ def diameter(G, e=None, usebounds=False, weight=None):
     -------
     d : integer
        Diameter of graph
+
+    Notes
+    -----
+    When ``usebounds=True``, the computation makes use of smart lower
+    and upper bounds and is often linear in the number of nodes, rather than
+    quadratic (except for some border cases such as complete graphs or circle
+    shaped-graphs).
 
     Examples
     --------
@@ -483,7 +490,7 @@ def periphery(G, e=None, usebounds=False, weight=None):
       A precomputed dictionary of eccentricities.
 
     usebounds : bool, optional
-        If `True`, use the extrema bounding approach when computing the periphery
+        If `True`, use extrema bounding (see Notes) when computing the periphery
         for undirected graphs. Extrema bounding may accelerate the
         distance calculation for some graphs. `usebounds` is ignored if `G` is
         directed or if `e` is not `None`. Default is `False`.
@@ -512,6 +519,13 @@ def periphery(G, e=None, usebounds=False, weight=None):
     -------
     p : list
        List of nodes in periphery
+
+    Notes
+    -----
+    When ``usebounds=True``, the computation makes use of smart lower
+    and upper bounds and is often linear in the number of nodes, rather than
+    quadratic (except for some border cases such as complete graphs or circle
+    shaped-graphs).
 
     Examples
     --------
@@ -548,7 +562,7 @@ def radius(G, e=None, usebounds=False, weight=None):
       A precomputed dictionary of eccentricities.
 
     usebounds : bool, optional
-        If `True`, use the extrema bounding approach when computing the radius
+        If `True`, use extrema bounding (see Notes) when computing the radius
         for undirected graphs. Extrema bounding may accelerate the
         distance calculation for some graphs. `usebounds` is ignored if `G` is
         directed or if `e` is not `None`. Default is `False`.
@@ -577,6 +591,13 @@ def radius(G, e=None, usebounds=False, weight=None):
     -------
     r : integer
        Radius of graph
+
+    Notes
+    -----
+    When ``usebounds=True``, the computation makes use of smart lower
+    and upper bounds and is often linear in the number of nodes, rather than
+    quadratic (except for some border cases such as complete graphs or circle
+    shaped-graphs).
 
     Examples
     --------
@@ -607,7 +628,7 @@ def center(G, e=None, usebounds=False, weight=None):
       A precomputed dictionary of eccentricities.
 
     usebounds : bool, optional
-        If `True`, use the extrema bounding approach when computing the center
+        If `True`, use extrema bounding (see Notes) when computing the center
         for undirected graphs. Extrema bounding may accelerate the
         distance calculation for some graphs. `usebounds` is ignored if `G` is
         directed or if `e` is not `None`. Default is `False`.
@@ -636,6 +657,13 @@ def center(G, e=None, usebounds=False, weight=None):
     -------
     c : list
        List of nodes in center
+
+    Notes
+    -----
+    When ``usebounds=True``, the computation makes use of smart lower
+    and upper bounds and is often linear in the number of nodes, rather than
+    quadratic (except for some border cases such as complete graphs or circle
+    shaped-graphs).
 
     Examples
     --------

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -345,6 +345,12 @@ def diameter(G, e=None, usebounds=False, weight=None):
     e : eccentricity dictionary, optional
       A precomputed dictionary of eccentricities.
 
+    usebounds : bool, optional
+        If `True`, use the extrema bounding approach when computing the diameter
+        for undirected graphs. Extrema bounding may accelerate the
+        distance calculation for some graphs. `usebounds` is ignored if `G` is
+        directed or if `e` is not `None`. Default is `False`.
+
     weight : string, function, or None
         If this is a string, then edge weights will be accessed via the
         edge attribute with this key (that is, the weight of the edge
@@ -476,6 +482,12 @@ def periphery(G, e=None, usebounds=False, weight=None):
     e : eccentricity dictionary, optional
       A precomputed dictionary of eccentricities.
 
+    usebounds : bool, optional
+        If `True`, use the extrema bounding approach when computing the periphery
+        for undirected graphs. Extrema bounding may accelerate the
+        distance calculation for some graphs. `usebounds` is ignored if `G` is
+        directed or if `e` is not `None`. Default is `False`.
+
     weight : string, function, or None
         If this is a string, then edge weights will be accessed via the
         edge attribute with this key (that is, the weight of the edge
@@ -535,6 +547,12 @@ def radius(G, e=None, usebounds=False, weight=None):
     e : eccentricity dictionary, optional
       A precomputed dictionary of eccentricities.
 
+    usebounds : bool, optional
+        If `True`, use the extrema bounding approach when computing the radius
+        for undirected graphs. Extrema bounding may accelerate the
+        distance calculation for some graphs. `usebounds` is ignored if `G` is
+        directed or if `e` is not `None`. Default is `False`.
+
     weight : string, function, or None
         If this is a string, then edge weights will be accessed via the
         edge attribute with this key (that is, the weight of the edge
@@ -587,6 +605,12 @@ def center(G, e=None, usebounds=False, weight=None):
 
     e : eccentricity dictionary, optional
       A precomputed dictionary of eccentricities.
+
+    usebounds : bool, optional
+        If `True`, use the extrema bounding approach when computing the center
+        for undirected graphs. Extrema bounding may accelerate the
+        distance calculation for some graphs. `usebounds` is ignored if `G` is
+        directed or if `e` is not `None`. Default is `False`.
 
     weight : string, function, or None
         If this is a string, then edge weights will be accessed via the

--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -342,7 +342,7 @@ def diameter(G, e=None, usebounds=False, weight=None):
     G : NetworkX graph
        A graph
 
-    e : eccentricity dictionary, optional
+    e : eccentricity dictionary, optional (default = None)
       A precomputed dictionary of eccentricities.
 
     usebounds : bool, optional (default = False)


### PR DESCRIPTION
Adds missing `usebounds` parameter description to the docstrings for the relevant distance measures. Addresses at least the documentation part of #7687, though it may be worth keeping that open in case there's any other discussion.

Wording suggestions welcome!