### PR TITLE
add (alpha, beta)-core computation for bipartite graphs

### DIFF
--- a/networkx/algorithms/bipartite/__init__.py
+++ b/networkx/algorithms/bipartite/__init__.py
@@ -85,3 +85,4 @@ from networkx.algorithms.bipartite.redundancy import *
 from networkx.algorithms.bipartite.spectral import *
 from networkx.algorithms.bipartite.generators import *
 from networkx.algorithms.bipartite.extendability import *
+from networkx.algorithms.bipartite.abcore import *

--- a/networkx/algorithms/bipartite/abcore.py
+++ b/networkx/algorithms/bipartite/abcore.py
@@ -20,7 +20,8 @@ __all__ = [
 ]
 
 
-@nx._dispatchable
+@nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
+@nx.utils.not_implemented_for("directed")
 def alpha_beta_core(G, alpha, beta):
     """
     Returns the (alpha, beta)-core of a bipartite graph.

--- a/networkx/algorithms/bipartite/abcore.py
+++ b/networkx/algorithms/bipartite/abcore.py
@@ -1,0 +1,103 @@
+"""
+Find the (alpha, beta)-cores of a bipartite graph.
+
+The (alpha, beta)-core is found by recursively pruning nodes in the bipartite graph
+where the degree of a node in one set is less than alpha,
+or the degree of a node in the other set is less than beta.
+
+See the following reference for details:
+
+Efficient (alpha, beta)-core computation: An index-based approach
+B. Liu, L. Yuan, X. Lin, L. Qin, W. Zhang, & J. Zhou
+The World Wide Web Conference, 2019, pp. 1130-1141.
+https://doi.org/10.1145/3308558.3313682
+"""
+
+import networkx as nx
+
+__all__ = [
+    "alpha_beta_core",
+]
+
+
+@nx._dispatchable
+def alpha_beta_core(G, alpha, beta):
+    """
+    Returns the (alpha, beta)-core of a bipartite graph.
+
+    The (alpha, beta)-core is a maximal subgraph of a bipartite graph where
+    each node in one set has at least alpha neighbors in the other set,
+    and vice versa.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        A bipartite graph. The graph must not contain self-loops.
+    alpha : int
+        The minimum degree requirement for nodes in one partition.
+    beta : int
+        The minimum degree requirement for nodes in the other partition.
+
+    Returns
+    -------
+    G : NetworkX graph
+        The (alpha, beta)-core subgraph of G.
+
+    Raises
+    ------
+    NetworkXError
+        If the graph is not bipartite or if alpha or beta is less than 1.
+
+    Notes
+    -----
+    This implementation assumes the input graph is bipartite. It does not
+    attempt to verify the bipartite property of the graph beyond its
+    partition sets.
+
+    The function iteratively removes nodes that do not satisfy the
+    degree constraints in either partition, until the graph stabilizes.
+
+    The input graph, node, and edge attributes are copied to the subgraph.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> B = nx.Graph()
+    >>> B.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c")])
+    >>> G_ab_core = alpha_beta_core(B, alpha=1, beta=2)
+    >>> list(G_ab_core.edges)
+    [(1, 'b'), (2, 'b'), (2, 'c'), (3, 'c')]
+
+    References
+    ----------
+    .. [1] Liu, B., Yuan, L., Lin, X., Qin, L., Zhang, W., & Zhou, J. (2019, May).
+            Efficient (alpha, beta)-core computation: An index-based approach.
+            In The World Wide Web Conference (pp. 1130-1141).
+    """
+    if not nx.is_bipartite(G):
+        raise nx.NetworkXError("Graph is not bipartite")
+
+    if alpha < 1 or beta < 1:
+        raise nx.NetworkXError("alpha and beta must be greater than 0")
+
+    U, V = nx.bipartite.sets(G)
+
+    G_tmp = G.copy()
+
+    while True:
+        remove_nodes = set()
+
+        for u in U:
+            if u in G_tmp and G_tmp.degree(u) < alpha:
+                remove_nodes.add(u)
+
+        for v in V:
+            if v in G_tmp and G_tmp.degree(v) < beta:
+                remove_nodes.add(v)
+
+        if not remove_nodes:
+            break
+
+        G_tmp.remove_nodes_from(remove_nodes)
+
+    return G_tmp

--- a/networkx/algorithms/bipartite/abcore.py
+++ b/networkx/algorithms/bipartite/abcore.py
@@ -65,8 +65,8 @@ def alpha_beta_core(G, alpha, beta):
     >>> B = nx.Graph()
     >>> B.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c")])
     >>> G_ab_core = alpha_beta_core(B, alpha=1, beta=2)
-    >>> {tuple(sorted(map(str, edge))) for edge in G_ab_core.edges}
-    [(1, 'b'), (2, 'b'), (2, 'c'), (3, 'c')]
+    >>> list(G_ab_core.edges())
+    [(1, 'b'), ('b', 2), (2, 'c'), ('c', 3)]
 
     References
     ----------

--- a/networkx/algorithms/bipartite/abcore.py
+++ b/networkx/algorithms/bipartite/abcore.py
@@ -65,7 +65,7 @@ def alpha_beta_core(G, alpha, beta):
     >>> B = nx.Graph()
     >>> B.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c")])
     >>> G_ab_core = alpha_beta_core(B, alpha=1, beta=2)
-    >>> list(G_ab_core.edges)
+    >>> {tuple(sorted(map(str, edge))) for edge in G_ab_core.edges}
     [(1, 'b'), (2, 'b'), (2, 'c'), (3, 'c')]
 
     References

--- a/networkx/algorithms/bipartite/tests/test_abcore.py
+++ b/networkx/algorithms/bipartite/tests/test_abcore.py
@@ -1,0 +1,61 @@
+import pytest
+
+import networkx as nx
+from networkx.algorithms import bipartite
+
+
+class TestAlphaBetaCore:
+    @classmethod
+    def setup_class(cls):
+        cls.B1 = nx.Graph()
+        cls.B1.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c")])
+
+        cls.B2 = nx.complete_bipartite_graph(3, 3)
+
+        cls.B3 = nx.Graph()
+        cls.B3.add_edges_from(
+            [(1, "x"), (1, "y"), (2, "y"), (2, "z"), (3, "z"), (3, "x")]
+        )
+
+        cls.B4 = nx.Graph()
+        cls.B4.add_edges_from([(1, "a"), (1, "b"), ("a", "b")])
+
+    def test_alpha_beta_core_basic(self):
+        G_ab_core = bipartite.alpha_beta_core(self.B1, alpha=1, beta=2)
+        normalized_edges = {tuple(sorted(map(str, edge))) for edge in G_ab_core.edges}
+        expected_edges = {
+            tuple(sorted(map(str, edge)))
+            for edge in [(1, "b"), (2, "b"), (2, "c"), (3, "c")]
+        }
+        assert (
+            normalized_edges == expected_edges
+        ), f"Expected edges {expected_edges}, but got {normalized_edges}"
+
+    def test_alpha_beta_core_complete(self):
+        G_ab_core = bipartite.alpha_beta_core(self.B2, alpha=1, beta=1)
+        assert set(G_ab_core.edges) == set(self.B2.edges)
+
+        G_ab_core = bipartite.alpha_beta_core(self.B2, alpha=3, beta=3)
+        assert set(G_ab_core.edges) == set(self.B2.edges)
+
+    def test_alpha_beta_core_no_nodes_left(self):
+        G_ab_core = bipartite.alpha_beta_core(self.B1, alpha=4, beta=4)
+        assert set(G_ab_core.edges) == set()
+
+    def test_alpha_beta_core_invalid_input(self):
+        with pytest.raises(nx.NetworkXError, match="Graph is not bipartite"):
+            bipartite.alpha_beta_core(self.B4, alpha=2, beta=2)
+
+        with pytest.raises(
+            nx.NetworkXError, match="alpha and beta must be greater than 0"
+        ):
+            bipartite.alpha_beta_core(self.B1, alpha=0, beta=2)
+
+        with pytest.raises(
+            nx.NetworkXError, match="alpha and beta must be greater than 0"
+        ):
+            bipartite.alpha_beta_core(self.B1, alpha=1, beta=-1)
+
+    def test_alpha_beta_core_complex_structure(self):
+        G_ab_core = bipartite.alpha_beta_core(self.B3, alpha=2, beta=2)
+        assert set(G_ab_core.edges) == set(self.B3.edges)


### PR DESCRIPTION
The (alpha, beta)-core of a bipartite graph is a maximal subgraph where each vertex in the upper set has at least `alpha` neighbors and each vertex in the lower set has at least `beta` neighbors.

The idea is mentioned in the paper:
Efficient (alpha, beta)-core computation: An index-based approach
B. Liu, L. Yuan, X. Lin, L. Qin, W. Zhang, & J. Zhou
The World Wide Web Conference, 2019, pp. 1130-1141.
https://doi.org/10.1145/3308558.3313682