### PR TITLE
Fix for filtered MultiGraph views from `edge_subgraph` (#7724).

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -397,7 +397,11 @@ class FilterMultiInner(FilterAdjacency):  # muliedge_seconddict
                 yield n
 
     def __getitem__(self, nbr):
-        if nbr in self._atlas and self.NODE_OK(nbr):
+        if (
+            nbr in self._atlas
+            and self.NODE_OK(nbr)
+            and any(self.EDGE_OK(nbr, key) for key in self._atlas[nbr])
+        ):
 
             def new_node_ok(key):
                 return self.EDGE_OK(nbr, key)

--- a/networkx/classes/tests/test_subgraphviews.py
+++ b/networkx/classes/tests/test_subgraphviews.py
@@ -360,3 +360,12 @@ class TestEdgeSubGraph:
         pytest.raises(nx.NetworkXError, self.H.remove_node, 0)
         pytest.raises(nx.NetworkXError, self.H.add_edge, 5, 6)
         pytest.raises(nx.NetworkXError, self.H.remove_edge, 0, 1)
+
+    def test_consistent_edges(self):
+        # See gh-7724.
+        """Tests that the subgraph returns consistent filtered edges."""
+        G = nx.MultiDiGraph()
+        G.add_edges_from([("a", "b"), ("a", "c"), ("c", "b")])
+        H = nx.edge_subgraph(G, [("a", "b", 0), ("c", "b", 0)])
+        assert "c" not in H["a"]
+        assert not H.has_edge("a", "c")


### PR DESCRIPTION
Fixes #7724: `MultiGraph` views return inconsistent `has_edge` results.

___

Minimum working example:

```python
import networkx as nx

G = nx.MultiDiGraph()

G.add_edges_from([("a", "b"),
                  ("a", "c"),       # <-- to be filtered out
                  ("c", "b")])

H = nx.edge_subgraph(G, [("a", "b", 0), ("c", "b", 0)])

print(f"{H.edges()}\n\n"
      f"{H.has_edge('a', 'c')} \t H.has_edge('a', 'c')\n"
      f"{('a', 'c') in H.edges()} \t ('a', 'c') in H.edges()\n\n"
      f"{'c' in H['a']} \t 'c' in H['a']\n"
      f"{'c' in list(H['a'])} \t 'c' in list(H['a'])")
```

Output **before** the PR:

```
# [('a', 'b'), ('b', 'c')]
#
# True      H.has_edge('a', 'c')    # <-- inconsistent result
# False     ('a', 'c') in H.edges()
#
# True      'c' in H['a']           # <-- inconsistent result
# False     'c' in list(H['a'])
```

Output **after** the PR:

```
# [('a', 'b'), ('b', 'c')]

# False      H.has_edge('a', 'c')
# False      ('a', 'c') in H.edges()

# False      'c' in H['a']
# False      'c' in list(H['a'])
```