### PR TITLE
Fix code formatting of some examples

### DIFF
--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -551,7 +551,7 @@ def gnmk_random_graph(n, m, k, seed=None, directed=False):
 
     Examples
     --------
-    >>> from nx.algorithms import bipartite
+    >>> from networkx.algorithms import bipartite
     >>> G = bipartite.gnmk_random_graph(10, 20, 50)
 
     See Also

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -551,8 +551,8 @@ def gnmk_random_graph(n, m, k, seed=None, directed=False):
 
     Examples
     --------
-    from nx.algorithms import bipartite
-    G = bipartite.gnmk_random_graph(10,20,50)
+    >>> from nx.algorithms import bipartite
+    >>> G = bipartite.gnmk_random_graph(10, 20, 50)
 
     See Also
     --------

--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -551,8 +551,7 @@ def gnmk_random_graph(n, m, k, seed=None, directed=False):
 
     Examples
     --------
-    >>> from networkx.algorithms import bipartite
-    >>> G = bipartite.gnmk_random_graph(10, 20, 50)
+    >>> G = nx.bipartite.gnmk_random_graph(10, 20, 50)
 
     See Also
     --------

--- a/networkx/algorithms/centrality/subgraph_alg.py
+++ b/networkx/algorithms/centrality/subgraph_alg.py
@@ -64,6 +64,7 @@ def subgraph_centrality_exp(G):
     Examples
     --------
     (Example from [1]_)
+
     >>> G = nx.Graph(
     ...     [
     ...         (1, 2),
@@ -145,6 +146,7 @@ def subgraph_centrality(G):
     Examples
     --------
     (Example from [1]_)
+
     >>> G = nx.Graph(
     ...     [
     ...         (1, 2),

--- a/networkx/generators/geometric.py
+++ b/networkx/generators/geometric.py
@@ -272,7 +272,7 @@ def soft_random_geometric_graph(
     --------
     Default Graph:
 
-    G = nx.soft_random_geometric_graph(50, 0.2)
+    >>> G = nx.soft_random_geometric_graph(50, 0.2)
 
     Custom Graph:
 
@@ -787,7 +787,7 @@ def thresholded_random_geometric_graph(
     --------
     Default Graph:
 
-    G = nx.thresholded_random_geometric_graph(50, 0.2, 0.1)
+    >>> G = nx.thresholded_random_geometric_graph(50, 0.2, 0.1)
 
     Custom Graph:
 

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -35,7 +35,7 @@ def read_leda(path, encoding="UTF-8"):
 
     Examples
     --------
-    >>> G = nx.read_leda("file.leda")
+    >>> G = nx.read_leda("file.leda")  # doctest: +SKIP
 
     References
     ----------
@@ -61,7 +61,7 @@ def parse_leda(lines):
 
     Examples
     --------
-    >>> G = nx.parse_leda(string)
+    >>> G = nx.parse_leda(string)  # doctest: +SKIP
 
     References
     ----------

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -35,7 +35,7 @@ def read_leda(path, encoding="UTF-8"):
 
     Examples
     --------
-    G=nx.read_leda('file.leda')
+    >>> G = nx.read_leda("file.leda")
 
     References
     ----------
@@ -61,7 +61,7 @@ def parse_leda(lines):
 
     Examples
     --------
-    G=nx.parse_leda(string)
+    >>> G = nx.parse_leda(string)
 
     References
     ----------


### PR DESCRIPTION
Some `Examples` sections in the docs aren't being displayed correctly. These are the ones I was able to catch at a quick glance:
- https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.centrality.subgraph_centrality_exp.html#networkx.algorithms.centrality.subgraph_centrality_exp
- https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.centrality.subgraph_centrality.html
- https://networkx.org/documentation/latest/reference/generated/networkx.generators.geometric.thresholded_random_geometric_graph.html#networkx.generators.geometric.thresholded_random_geometric_graph
- https://networkx.org/documentation/latest/reference/generated/networkx.generators.geometric.soft_random_geometric_graph.html
- https://networkx.org/documentation/latest/reference/readwrite/generated/networkx.readwrite.leda.read_leda.html
- https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.bipartite.generators.gnmk_random_graph.html#networkx.algorithms.bipartite.generators.gnmk_random_graph