### PR TITLE
Update `shortest_path` and `single_target_shortest_path_length` for 3.5

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -48,10 +48,6 @@ Version 3.5
 * Remove ``d_separated`` from ``algorithms/d_separation.py``.
 * Remove ``minimal_d_separator`` from ``algorithms/d_separation.py``.
 * Add `not_implemented_for("multigraph”)` decorator to ``k_core``, ``k_shell``, ``k_crust`` and ``k_corona`` functions.
-* Change ``single_target_shortest_path_length`` in ``algorithms/shortest_path/unweighted.py``
-  to return a dict. See #6527
-* Change ``shortest_path`` in ``algorithms/shortest_path/generic.py``
-  to return a iterator. See #6527
 * Remove ``total_spanning_tree_weight`` from ``linalg/laplacianmatrix.py``
 * Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 
   ``generators/nonisomorphic_trees``.

--- a/networkx/algorithms/centrality/reaching.py
+++ b/networkx/algorithms/centrality/reaching.py
@@ -103,9 +103,9 @@ def global_reaching_centrality(G, weight=None, normalized=True):
         def as_distance(u, v, d):
             return total_weight / d.get(weight, 1)
 
-        shortest_paths = nx.shortest_path(G, weight=as_distance)
+        shortest_paths = dict(nx.shortest_path(G, weight=as_distance))
     else:
-        shortest_paths = nx.shortest_path(G)
+        shortest_paths = dict(nx.shortest_path(G))
 
     centrality = local_reaching_centrality
     # TODO This can be trivially parallelized.

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -76,7 +76,7 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
 
     Returns
     -------
-    path: list or dictionary
+    path: list or dictionary or iterator
         All returned paths include both the source and target in the path.
 
         If the source and target are both specified, return a single list
@@ -90,8 +90,9 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
         sources with a list of nodes in a shortest path from one of the
         sources to the target.
 
-        If neither the source nor target are specified return a dictionary
-        of dictionaries with path[source][target]=[list of nodes in path].
+        If neither the source nor target are specified, return an iterator
+        over (source, dictionary) where dictionary is keyed by target to
+        list of nodes in a shortest path from the source to the target.
 
     Raises
     ------
@@ -136,25 +137,13 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     method = "unweighted" if weight is None else method
     if source is None:
         if target is None:
-            warnings.warn(
-                (
-                    "\n\nshortest_path will return an iterator that yields\n"
-                    "(node, path) pairs instead of a dictionary when source\n"
-                    "and target are unspecified beginning in version 3.5\n\n"
-                    "To keep the current behavior, use:\n\n"
-                    "\tdict(nx.shortest_path(G))"
-                ),
-                FutureWarning,
-                stacklevel=3,
-            )
-
-            # Find paths between all pairs.
+            # Find paths between all pairs. Iterator of dicts.
             if method == "unweighted":
-                paths = dict(nx.all_pairs_shortest_path(G))
+                paths = nx.all_pairs_shortest_path(G)
             elif method == "dijkstra":
-                paths = dict(nx.all_pairs_dijkstra_path(G, weight=weight))
+                paths = nx.all_pairs_dijkstra_path(G, weight=weight)
             else:  # method == 'bellman-ford':
-                paths = dict(nx.all_pairs_bellman_ford_path(G, weight=weight))
+                paths = nx.all_pairs_bellman_ford_path(G, weight=weight)
         else:
             # Find paths from all nodes co-accessible to the target.
             if G.is_directed():

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -212,9 +212,9 @@ class TestGenericPath:
         assert sorted(ans[4]) == [[4]]
 
     def test_all_pairs_shortest_path(self):
-        # shortest_path w/o source and target will return a generator instead of
-        # a dict beginning in version 3.5. Only the first call needs changed here.
-        p = nx.shortest_path(self.cycle)
+        # shortest_path w/o source and target returns a generator instead of
+        # a dict beginning in version 3.5. Only the first call needed changed here.
+        p = dict(nx.shortest_path(self.cycle))
         assert p[0][3] == [0, 1, 2, 3]
         assert p == dict(nx.all_pairs_shortest_path(self.cycle))
         p = dict(nx.shortest_path(self.grid))

--- a/networkx/algorithms/shortest_paths/tests/test_unweighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_unweighted.py
@@ -92,9 +92,9 @@ class TestUnweightedPath:
     def test_single_target_shortest_path_length(self):
         pl = nx.single_target_shortest_path_length
         lengths = {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert dict(pl(self.cycle, 0)) == lengths
+        assert pl(self.cycle, 0) == lengths
         lengths = {0: 0, 1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1}
-        assert dict(pl(self.directed_cycle, 0)) == lengths
+        assert pl(self.directed_cycle, 0) == lengths
         # test missing targets
         target = 8
         with pytest.raises(nx.NodeNotFound, match=f"Target {target} is not in G"):

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -112,13 +112,13 @@ def single_target_shortest_path_length(G, target, cutoff=None):
 
     Returns
     -------
-    lengths : iterator
-        (source, shortest path length) iterator
+    lengths : dictionary
+        Dictionary, keyed by source, of shortest path lengths.
 
     Examples
     --------
     >>> G = nx.path_graph(5, create_using=nx.DiGraph())
-    >>> length = dict(nx.single_target_shortest_path_length(G, 4))
+    >>> length = nx.single_target_shortest_path_length(G, 4)
     >>> length[0]
     4
     >>> for node in range(5):
@@ -135,24 +135,12 @@ def single_target_shortest_path_length(G, target, cutoff=None):
     """
     if target not in G:
         raise nx.NodeNotFound(f"Target {target} is not in G")
-
-    warnings.warn(
-        (
-            "\n\nsingle_target_shortest_path_length will return a dict instead of"
-            "\nan iterator in version 3.5"
-        ),
-        FutureWarning,
-        stacklevel=3,
-    )
-
     if cutoff is None:
         cutoff = float("inf")
     # handle either directed or undirected
     adj = G._pred if G.is_directed() else G._adj
     nextlevel = [target]
-    # for version 3.3 we will return a dict like this:
-    # return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
-    return _single_shortest_path_length(adj, nextlevel, cutoff)
+    return dict(_single_shortest_path_length(adj, nextlevel, cutoff))
 
 
 @nx._dispatchable

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -101,16 +101,6 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(autouse=True)
 def set_warnings():
     warnings.filterwarnings(
-        "ignore",
-        category=FutureWarning,
-        message="\n\nsingle_target_shortest_path_length",
-    )
-    warnings.filterwarnings(
-        "ignore",
-        category=FutureWarning,
-        message="\n\nshortest_path",
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
These have been deprecated and are slated to change in NetworkX 3.5

See: #6527