### PR TITLE
Bipartite layout nodes optional

### DIFF
--- a/doc/reference/drawing.rst
+++ b/doc/reference/drawing.rst
@@ -39,6 +39,7 @@ Matplotlib
    draw_networkx_edges
    draw_networkx_labels
    draw_networkx_edge_labels
+   draw_bipartite
    draw_circular
    draw_kamada_kawai
    draw_planar

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -305,7 +305,7 @@ def shell_layout(
 
 def bipartite_layout(
     G,
-    nodes,
+    nodes=None,
     align="vertical",
     scale=1,
     center=None,
@@ -319,9 +319,9 @@ def bipartite_layout(
     G : NetworkX graph or list of nodes
         A position will be assigned to every node in G.
 
-    nodes : list or container
-        Nodes in one node set of the bipartite graph.
-        This set will be placed on left or top.
+    nodes : collection of nodes
+        Nodes in one node set of the bipartite graph. This set will be placed on
+        left or top. If `None` (the default), a node set is chosen arbitrarily.
 
     align : string (default='vertical')
         The alignment of nodes. Vertical or horizontal.
@@ -344,6 +344,11 @@ def bipartite_layout(
     -------
     pos : dict
         A dictionary of positions keyed by node.
+
+    Raises
+    ------
+    NetworkXError
+        If ``nodes=None`` and `G` is not bipartite.
 
     Examples
     --------
@@ -376,9 +381,14 @@ def bipartite_layout(
     width = aspect_ratio * height
     offset = (width / 2, height / 2)
 
-    top = dict.fromkeys(nodes)
-    bottom = [v for v in G if v not in top]
-    nodes = list(top) + bottom
+    if nodes is None:
+        top, bottom = nx.bipartite.sets(G)
+        nodes = list(G)
+    else:
+        top = set(nodes)
+        bottom = set(G) - top
+        # Preserves backward-compatible node ordering in returned pos dict
+        nodes = list(top) + list(bottom)
 
     left_xs = np.repeat(0, len(top))
     right_xs = np.repeat(width, len(bottom))

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -320,8 +320,9 @@ def bipartite_layout(
         A position will be assigned to every node in G.
 
     nodes : collection of nodes
-        Nodes in one node set of the bipartite graph. This set will be placed on
-        left or top. If `None` (the default), a node set is chosen arbitrarily.
+        Nodes in one node set of the graph. This set will be placed on
+        left or top. If `None` (the default), a node set is chosen arbitrarily
+        if the graph if bipartite.
 
     align : string (default='vertical')
         The alignment of nodes. Vertical or horizontal.
@@ -352,13 +353,28 @@ def bipartite_layout(
 
     Examples
     --------
-    >>> G = nx.bipartite.gnmk_random_graph(3, 5, 10, seed=123)
-    >>> top = nx.bipartite.sets(G)[0]
-    >>> pos = nx.bipartite_layout(G, top)
-    >>> # supress the returned dict and store on the graph directly
-    >>> _ = nx.bipartite_layout(G, top, store_pos_as="pos")
+    >>> G = nx.complete_bipartite_graph(3, 3)
+    >>> pos = nx.bipartite_layout(G)
+
+    The ordering of the layout (i.e. which nodes appear on the left/top) can
+    be specified with the `nodes` parameter:
+
+    >>> top, bottom = nx.bipartite.sets(G)
+    >>> pos = nx.bipartite_layout(G, nodes=bottom)  # "bottom" set appears on the left
+
+    `store_pos_as` can be used to store the node positions for the computed layout
+    directly on the nodes:
+
+    >>> _ = nx.bipartite_layout(G, nodes=bottom, store_pos_as="pos")
     >>> nx.get_node_attributes(G, "pos")
-    {0: array([-1. , -0.6]), 1: array([-1.,  0.]), 2: array([-1. ,  0.6]), 3: array([ 0.6, -0.6]), 4: array([ 0.6, -0.3]), 5: array([0.6, 0. ]), 6: array([0.6, 0.3]), 7: array([0.6, 0.6])}
+    {0: array([ 1.  , -0.75]), 1: array([1., 0.]), 2: array([1.  , 0.75]), 3: array([-1.  , -0.75]), 4: array([-1.,  0.]), 5: array([-1.  ,  0.75])}
+
+
+    The ``bipartite_layout`` function can be used with non-bipartite graphs
+    by explicitly specifying how the layout should be partitioned with `nodes`:
+
+    >>> G = nx.complete_graph(5)  # Non-bipartite
+    >>> pos = nx.bipartite_layout(G, nodes={0, 1, 2})
 
     Notes
     -----

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1649,6 +1649,7 @@ def draw_bipartite(G, **kwargs):
     --------
     :func:`~networkx.drawing.layout.bipartite_layout`
     """
+    draw(G, pos=nx.bipartite_layout(G), **kwargs)
 
 
 def draw_circular(G, **kwargs):

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -40,6 +40,7 @@ __all__ = [
     "draw_networkx_edges",
     "draw_networkx_labels",
     "draw_networkx_edge_labels",
+    "draw_bipartite",
     "draw_circular",
     "draw_kamada_kawai",
     "draw_random",
@@ -1605,6 +1606,49 @@ def draw_networkx_edge_labels(
         )
 
     return text_items
+
+
+def draw_bipartite(G, **kwargs):
+    """Draw the graph `G` with a bipartite layout.
+
+    This is a convenience function equivalent to::
+
+        nx.draw(G, pos=nx.bipartite_layout(G), **kwargs)
+
+    Parameters
+    ----------
+    G : graph
+        A networkx graph
+
+    kwargs : optional keywords
+        See `draw_networkx` for a description of optional keywords.
+
+    Raises
+    ------
+    NetworkXError :
+        If `G` is not bipartite.
+
+    Notes
+    -----
+    The layout is computed each time this function is called. For
+    repeated drawing it is much more efficient to call
+    `~networkx.drawing.layout.bipartite_layout` directly and reuse the result::
+
+        >>> G = nx.complete_bipartite_graph(3, 3)
+        >>> pos = nx.bipartite_layout(G)
+        >>> nx.draw(G, pos=pos)  # Draw the original graph
+        >>> # Draw a subgraph, reusing the same node positions
+        >>> nx.draw(G.subgraph([0, 1, 2]), pos=pos, node_color="red")
+
+    Examples
+    --------
+    >>> G = nx.complete_bipartite_graph(2, 5)
+    >>> nx.draw_bipartite(G)
+
+    See Also
+    --------
+    :func:`~networkx.drawing.layout.bipartite_layout`
+    """
 
 
 def draw_circular(G, **kwargs):

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -549,3 +549,20 @@ def test_bfs_layout_disconnected():
     G.add_edges_from([(10, 11), (11, 12)])
     with pytest.raises(nx.NetworkXError, match="bfs_layout didn't include all nodes"):
         nx.bfs_layout(G, start=0)
+
+
+def test_bipartite_layout_default_nodes_raises_non_bipartite_input():
+    G = nx.complete_graph(5)
+    with pytest.raises(nx.NetworkXError, match="Graph is not bipartite"):
+        nx.bipartite_layout(G)
+    # No exception if nodes are explicitly specified
+    pos = nx.bipartite_layout(G, nodes=[2, 3])
+
+
+def test_bipartite_layout_default_nodes():
+    G = nx.complete_bipartite_graph(3, 3)
+    pos = nx.bipartite_layout(G)  # no nodes specified
+    # X coords of nodes should be the same within the bipartite sets
+    for nodeset in nx.bipartite.sets(G):
+        xs = [pos[k][0] for k in nodeset]
+        assert all(x == pytest.approx(xs[0]) for x in xs)

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -54,6 +54,18 @@ def test_draw_shell_nlist():
             pass
 
 
+def test_draw_bipartite():
+    try:
+        G = nx.complete_bipartite_graph(2, 5)
+        nx.draw_bipartite(G)
+        plt.savefig("test.ps")
+    finally:
+        try:
+            os.unlink("test.ps")
+        except OSError:
+            pass
+
+
 def test_edge_colormap():
     colors = range(barbell.number_of_edges())
     nx.draw_spring(


### PR DESCRIPTION
A feature proposal to make the `nodes` parameter of `bipartite_layout` optional, with the default behavior to compute the nodesets with `nx.bipartite.sets`.

This is intended to be a minor convenience enhancement so users don't have to explicitly create partitions just to visualize the graph. This is only a proposal to add a feature and should be completely backwards compatible - including preserving the order of the nodes in the `pos` dict. I wasn't sure how important that was, but it's straightforward not to break!

I also added a `draw_bipartite` convenience function in 9196501 to match the pattern used for the other layout functions. I did so only for consistency and am completely happy to leave it out if preferred!