### PR TITLE
Fix weakly_connected docstring

### DIFF
--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -112,8 +112,8 @@ def number_weakly_connected_components(G):
 def is_weakly_connected(G):
     """Test directed graph for weak connectivity.
 
-    A directed graph is weakly connected if and only if the graph
-    is connected when the direction of the edge between nodes is ignored.
+    A directed graph is weakly connected if the graph is connected when the
+    direction of the edge between nodes is ignored.
 
     Note that if a graph is strongly connected (i.e. the graph is connected
     even when we account for directionality), it is by definition weakly


### PR DESCRIPTION
Fixed incorrect usage of "if and only if". IFF would imply that a graph is not weakly connected if it strongly connected, which is not true and contradicted by the following sentence in the docstring. Changed to "if" for clarity.