### PR TITLE
Dispatch classes such as `nx.Graph(backend=...)`

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -331,6 +331,11 @@ class DiGraph(Graph):
     _succ = _adj  # type: ignore[has-type]
     _pred = _CachedPropertyResetterPred()
 
+    @nx._dispatchable(name="digraph__new__", graphs=None, returns_graph=True)
+    def __new__(cls, incoming_graph_data=None, **attr):
+        return object.__new__(cls)
+
+    @nx._dispatchable(name="digraph__init__", graphs="self", mutates_input=True)
     def __init__(self, incoming_graph_data=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -336,6 +336,11 @@ class Graph:
         """
         return Graph
 
+    @nx._dispatchable(name="graph__new__", graphs=None, returns_graph=True)
+    def __new__(cls, incoming_graph_data=None, **attr):
+        return object.__new__(cls)
+
+    @nx._dispatchable(name="graph__init__", graphs="self", mutates_input=True)
     def __init__(self, incoming_graph_data=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -299,6 +299,11 @@ class MultiDiGraph(MultiGraph, DiGraph):
     edge_key_dict_factory = dict
     # edge_attr_dict_factory = dict
 
+    @nx._dispatchable(name="multidigraph__new__", graphs=None, returns_graph=True)
+    def __init__(cls, incoming_graph_data=None, multigraph_input=None, **attr):
+        return object.__new__(cls)
+
+    @nx._dispatchable(name="multidigraph__init__", graphs="self", mutates_input=True)
     def __init__(self, incoming_graph_data=None, multigraph_input=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -307,6 +307,11 @@ class MultiGraph(Graph):
         """
         return MultiGraph
 
+    @nx._dispatchable(name="multigraph__new__", graphs=None, returns_graph=True)
+    def __init__(cls, incoming_graph_data=None, multigraph_input=None, **attr):
+        return object.__new__(cls)
+
+    @nx._dispatchable(name="multigraph__init__", graphs="self", mutates_input=True)
     def __init__(self, incoming_graph_data=None, multigraph_input=None, **attr):
         """Initialize a graph with edges, name, or graph attributes.
 

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -238,6 +238,8 @@ class BackendPriorities(Config, strict=False):
         This controls "algorithms" such as ``nx.pagerank`` that don't return a graph.
     generators : list of backend names
         This controls "generators" such as ``nx.from_pandas_edgelist`` that return a graph.
+    classes : list of backend names
+        This controls graph classes such as ``nx.Graph()``.
     kwargs : variadic keyword arguments of function name to list of backend names
         This allows each function to be configured separately and will override the config
         in ``algos`` or ``generators`` if present. The dispatchable function name may be
@@ -247,16 +249,18 @@ class BackendPriorities(Config, strict=False):
 
     algos: list[str]
     generators: list[str]
+    classes: list[str]
 
     def _on_setattr(self, key, value):
         from .backends import _registered_algorithms, backend_info
 
-        if key in {"algos", "generators"}:
+        if key in {"algos", "generators", "classes"}:
             pass
         elif key not in _registered_algorithms:
             raise AttributeError(
-                f"Invalid config name: {key!r}. Expected 'algos', 'generators', or a name "
-                "of a dispatchable function (e.g. `.name` attribute of the function)."
+                f"Invalid config name: {key!r}. Expected 'algos', 'generators', "
+                "'classes', or a name of a dispatchable function "
+                "(e.g. `.name` attribute of the function)."
             )
         if not (isinstance(value, list) and all(isinstance(x, str) for x in value)):
             raise TypeError(
@@ -268,7 +272,7 @@ class BackendPriorities(Config, strict=False):
         return value
 
     def _on_delattr(self, key):
-        if key in {"algos", "generators"}:
+        if key in {"algos", "generators", "classes"}:
             raise TypeError(f"{key!r} configuration item can't be deleted.")
 
 
@@ -285,10 +289,11 @@ class NetworkXConfig(Config):
     backend_priority : list of backend names or dict or BackendPriorities
         Enable automatic conversion of graphs to backend graphs for functions
         implemented by the backend. Priority is given to backends listed earlier.
-        This is a nested configuration with keys ``algos``, ``generators``, and,
-        optionally, function names. Setting this value to a list of backend names
-        will set ``nx.config.backend_priority.algos``. For more information, see
-        ``help(nx.config.backend_priority)``. Default is empty list.
+        This is a nested configuration with keys ``algos``, ``generators``,
+        ``classes``, and, optionally, function names. Setting this value to a
+        list of backend names will set ``nx.config.backend_priority.algos``.
+        For more information, see ``help(nx.config.backend_priority)``.
+        Default is empty list.
 
     backends : Config mapping of backend names to backend Config
         The keys of the Config mapping are names of all installed NetworkX backends,
@@ -350,7 +355,7 @@ class NetworkXConfig(Config):
                 value = getattr(self, key)
             elif isinstance(value, dict):
                 kwargs = value
-                value = BackendPriorities(algos=[], generators=[])
+                value = BackendPriorities(algos=[], generators=[], classes=[])
                 for key, val in kwargs.items():
                     setattr(value, key, val)
             elif not isinstance(value, BackendPriorities):


### PR DESCRIPTION
I was experimenting running libraries that depend on networkx, and I wanted to also dispatch classes to backends just to see. This PR dispatches e.g. `nx.Graph(...)`. When we previously discussed possibly doing this, we agreed "not yet", so let's discuss again. I think the changes to enable this are actually pretty minimal; as ever, testing would be nice to have.

CC @rlratzel. Also, @aMahanna, you may find this interesting; you could do e.g. `nx.Graph(backend="arangodb", db=db)`.