### PR TITLE
Benchmarking: graph atlas

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,7 +26,7 @@ asv continuous base_commit_hash test_commit_hash
 ```
 
 The `--bench` flag can be used to limit a run to a subset of benchmarks.
-For example, the following will only run the algorith benchmarks for performance
+For example, the following will only run the algorithm benchmarks for performance
 comparison between two commits:
 
 ```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,3 +38,4 @@ The same pattern can be used to specify individual benchmarks:
 ```
 asv continuous --bench AlgorithmBenchmarks.time_pagerank <sha1> <sha2>
 ```
+To know more visit - https://asv.readthedocs.io/en/stable/commands.html

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,4 +38,5 @@ The same pattern can be used to specify individual benchmarks:
 ```
 asv continuous --bench AlgorithmBenchmarks.time_pagerank <sha1> <sha2>
 ```
+
 To know more visit - https://asv.readthedocs.io/en/stable/commands.html

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,3 +24,17 @@ Run the benchmark to compare two commits:
 ```
 asv continuous base_commit_hash test_commit_hash
 ```
+
+The `--bench` flag can be used to limit a run to a subset of benchmarks.
+For example, the following will only run the algorith benchmarks for performance
+comparison between two commits:
+
+```
+asv continuous --bench AlgorithmBenchmarks <sha1> <sha2>
+```
+
+The same pattern can be used to specify individual benchmarks:
+
+```
+asv continuous --bench AlgorithmBenchmarks.time_pagerank <sha1> <sha2>
+```

--- a/benchmarks/benchmarks/benchmark_many_components.py
+++ b/benchmarks/benchmarks/benchmark_many_components.py
@@ -1,0 +1,26 @@
+import networkx as nx
+
+
+class ManyComponentsBenchmark:
+    """Use atlas6() as a benchmarking case to probe for performance on graphs
+    with many connected components.
+
+    ``atlas6()`` is all of the graphs with at most 6 nodes and at least one edge
+    that are connected and not isomorphic to one another (142 components in total).
+    See the atlas6 gallery example for more info.
+    """
+
+    def setup(self):
+        atlas = nx.graph_atlas_g()[
+            3:209
+        ]  # 0, 1, 2 => no edges. 208 is last 6 node graph
+        U = nx.Graph()
+        for G in atlas:
+            if (nx.number_connected_components(G) == 1) and (
+                not nx.isomorphism.GraphMatcher(U, G).subgraph_is_isomorphic()
+            ):
+                U = nx.disjoint_union(U, G)
+        self.G = U
+
+    def time_single_source_all_shortest_paths(self):
+        _ = dict(nx.single_source_all_shortest_paths(self.G, 500))


### PR DESCRIPTION
Adds a benchmark that uses `atlas6` (i.e. the set of all connected graphs with at most 6 nodes and at least one edge that are not isomorphic to one another) to provide an evaluation point for algorithm performance whose variance depends on the number of components.

Inspired by #7762 - note this PR doesn't implement the suggestion from that issue, but it should be useful in evaluating the performance gains!

I also took the opportunity to add a bit more detail to the benchmarking readme - specifically, I added the recipe for running only a subset of the full benchmarking suite.