### PR TITLE
Steinertree kou enhancement in response to issue 5889 type:Enhancements

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -85,7 +85,6 @@ def _mehlhorn_steiner_tree(G, terminal_nodes, weight):
     return G_4.edges()
 
 
-@nx._dispatchable(edge_attrs="weight", returns_graph=True)
 def _kou_steiner_tree(G, terminal_nodes, weight):
     # Check if the graph is connected
     if not nx.is_connected(G):

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -102,7 +102,7 @@ def _kou_steiner_tree(G, terminal_nodes, weight):
                 continue
             H.add_edge(u, v, distance=distances[v], path=path)
 
-    # Use the 'distance' attribute of each edge provided by M.
+    # Use the 'distance' attribute of each edge provided by H.
     mst_edges = nx.minimum_spanning_edges(H, weight="distance", data=True)
 
     # Create an iterator over each edge in each shortest path; repeats are okay

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -89,7 +89,7 @@ def _kou_steiner_tree(G, terminal_nodes, weight):
     # Compute the metric closure only for terminal nodes
     # Create a complete graph H from the metric edges
     H = nx.Graph()
-    unvisited_terminals = set(terminal_nodes).copy()
+    unvisited_terminals = set(terminal_nodes)
 
     # check for connected graph while processing first node
     u = unvisited_terminals.pop()

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -86,21 +86,26 @@ def _mehlhorn_steiner_tree(G, terminal_nodes, weight):
 
 
 def _kou_steiner_tree(G, terminal_nodes, weight):
-    # Check if the graph is connected
-    if not nx.is_connected(G):
-        msg = "G is not a connected graph."
-        raise nx.NetworkXError(msg)
     # Compute the metric closure only for terminal nodes
     # Create a complete graph H from the metric edges
     H = nx.Graph()
-    for u in terminal_nodes:
+    unvisited_terminals = set(terminal_nodes).copy()
+
+    # check for connected graph while processing first node
+    u = unvisited_terminals.pop()
+    distances, paths = nx.single_source_dijkstra(G, source=u, weight=weight)
+    if len(G) != len(distances):
+        msg = "G is not a connected graph."
+        raise nx.NetworkXError(msg)
+    for v in unvisited_terminals:
+        H.add_edge(u, v, distance=distances[v], path=paths[v])
+
+    # first node done -- now process the rest
+    for u in unvisited_terminals.copy():
         distances, paths = nx.single_source_dijkstra(G, source=u, weight=weight)
-        for v, path in paths.items():
-            if v == u:
-                continue
-            if v not in terminal_nodes:
-                continue
-            H.add_edge(u, v, distance=distances[v], path=path)
+        unvisited_terminals.remove(u)
+        for v in unvisited_terminals:
+            H.add_edge(u, v, distance=distances[v], path=paths[v])
 
     # Use the 'distance' attribute of each edge provided by H.
     mst_edges = nx.minimum_spanning_edges(H, weight="distance", data=True)

--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -31,7 +31,7 @@ def metric_closure(G, weight="weight"):
     # check for connected graph while processing first node
     all_paths_iter = nx.all_pairs_dijkstra(G, weight=weight)
     u, (distance, path) = next(all_paths_iter)
-    if Gnodes - set(distance):
+    if len(G) != len(distance):
         msg = "G is not a connected graph. metric_closure is not defined."
         raise nx.NetworkXError(msg)
     Gnodes.remove(u)


### PR DESCRIPTION
In follow up to issue #5889  I implemented a backward compatible enhancement by only changing the _kou_steiner_tree function in  steinertree.py. So far it passed all tests and shows significant speed up. 

This is my first ever time using GitHub, I am not sure if I am contributing correctly.

There is also a possibe improvement in the for loop on line 98, where it currently adds edges (u, v) and (v, u), although one may argue that it adds a generalization to directed graphs.

PS: It may also be considered to change the documentation of steinertree to reflect that time complexity of Kou algorithm is O(|S|(|E|+|V|log|V|)), the reason why in original paper the time complexity was shown as O(|S||V|^2) is because back when Kou's paper was published the more efficient Dijkstra implementation was not known.
