### PR TITLE
single_source_all_shortest_paths: don't loop over all nodes

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -559,7 +559,7 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
     >>> G = nx.Graph()
     >>> nx.add_path(G, [0, 1, 2, 3, 0])
     >>> dict(nx.single_source_all_shortest_paths(G, source=0))
-    {0: [[0]], 1: [[0, 1]], 2: [[0, 1, 2], [0, 3, 2]], 3: [[0, 3]]}
+    {0: [[0]], 1: [[0, 1]], 3: [[0, 3]], 2: [[0, 1, 2], [0, 3, 2]]}
 
     Notes
     -----
@@ -585,11 +585,8 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
         pred, dist = nx.bellman_ford_predecessor_and_distance(G, source, weight=weight)
     else:
         raise ValueError(f"method not supported: {method}")
-    for n in G:
-        try:
-            yield n, list(_build_paths_from_predecessors({source}, n, pred))
-        except nx.NetworkXNoPath:
-            pass
+    for n in pred:
+        yield n, list(_build_paths_from_predecessors({source}, n, pred))
 
 
 @nx._dispatchable(edge_attrs="weight")


### PR DESCRIPTION
### Current Behavior
Currently, the function `single_source_all_shortest_paths` contains this line:
```python
for n in G:
```
Which might be a significant waste of time if most nodes aren't reachable from the given source.

### Expected Behavior
Merely looping on the keys of `pred` could lead to a significant improvement for large very sparse graphs.
```python
for n in pred:
```

And I guess the `try`-`except` in the loop is then no longer necessary.

### Steps to Reproduce
Here's an example that shows the performance issue. The more nodes in the graph, the slower, even if they are unreachable. Even though it might not be an issue for a single call to that function, when calling it on several sources, it quickly adds up. (See **Additional context** below.)
```python
>>> import networkx as nx
>>> g = nx.DiGraph()
>>> g.add_edges_from((n, n+1) for n in range(1000000))
>>> nx.add_path(g, "ABZ")
>>> nx.add_path(g, "ACZ")
>>> nx.add_path(g, "ADZ")
>>> dict(nx.single_source_all_shortest_paths(g, "A"))
{'A': [['A']], 'B': [['A', 'B']], 'Z': [['A', 'B', 'Z'], ['A', 'C', 'Z'], ['A', 'D', 'Z']], 'C': [['A', 'C']], 'D': [['A', 'D']]}
```

### Environment
Python version: 3.12.8
NetworkX version: 3.2.1

### Additional context
Day 10 part 2 of Advent of Code has a graph with many small connected components and asks to find the number of paths from all the nodes marked `0` to all the nodes marked `9`.
https://adventofcode.com/2024/day/10
As it turns out, calling `single_source_all_shortest_paths` for all source nodes is pretty slow and takes 1.5 seconds for me. With the proposed change, it only takes 50ms.