### PR TITLE
Inconsistent behavior for simple and multi undirected graph when using from_adj_mx

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1848,7 +1848,7 @@ class Graph:
         induced_nodes = nx.filters.show_nodes(self.nbunch_iter(nodes))
         # if already a subgraph, don't make a chain
         subgraph = nx.subgraph_view
-        if hasattr(self, "_NODE_OK"):
+        if hasattr(self, "_EDGE_OK"):
             return subgraph(
                 self._graph, filter_node=induced_nodes, filter_edge=self._EDGE_OK
             )

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -813,7 +813,7 @@ def from_scipy_sparse_array(
     multigraph (constructed from `create_using`) with parallel edges.
     In this case, `edge_attribute` will be ignored.
 
-    If `create_using` indicates an undirected multigraph, then only the edges
+    If `create_using` indicates an undirected graph, then only the edges
     indicated by the upper triangle of the matrix `A` will be added to the
     graph.
 
@@ -875,7 +875,7 @@ def from_scipy_sparse_array(
     #
     # Without this check, we run into a problem where each edge is added twice
     # when `G.add_weighted_edges_from()` is invoked below.
-    if G.is_multigraph() and not G.is_directed():
+    if not G.is_directed():
         triples = ((u, v, d) for u, v, d in triples if u <= v)
     G.add_weighted_edges_from(triples, weight=edge_attribute)
     return G
@@ -1162,7 +1162,7 @@ def from_numpy_array(
     entries of `A` are of type :class:`int`, then this function returns a
     multigraph (of the same type as `create_using`) with parallel edges.
 
-    If `create_using` indicates an undirected multigraph, then only the edges
+    If `create_using` indicates an undirected graph, then only the edges
     indicated by the upper triangle of the array `A` will be added to the
     graph.
 
@@ -1190,7 +1190,7 @@ def from_numpy_array(
     >>> A = np.array([[1, 1], [2, 1]])
     >>> G = nx.from_numpy_array(A)
     >>> G.edges(data=True)
-    EdgeDataView([(0, 0, {'weight': 1}), (0, 1, {'weight': 2}), (1, 1, {'weight': 1})])
+    EdgeDataView([(0, 0, {'weight': 1}), (0, 1, {'weight': 1}), (1, 1, {'weight': 1})])
 
     If `create_using` indicates a multigraph and the array has only integer
     entries and `parallel_edges` is False, then the entries will be treated
@@ -1307,7 +1307,7 @@ def from_numpy_array(
     #
     # Without this check, we run into a problem where each edge is added twice
     # when `G.add_edges_from()` is invoked below.
-    if G.is_multigraph() and not G.is_directed():
+    if not G.is_directed():
         triples = ((u, v, d) for u, v, d in triples if u <= v)
     # Remap nodes if user provided custom `nodelist`
     if not _default_nodes:

--- a/networkx/tests/test_convert_numpy.py
+++ b/networkx/tests/test_convert_numpy.py
@@ -192,7 +192,7 @@ class TestConvertNumpyArray:
         A = np.array([[0, 2], [3, 0]])
         G = nx.from_numpy_array(A, edge_attr="cost")
         assert "weight" not in G.edges[0, 1]
-        assert G.edges[0, 1]["cost"] == 3
+        assert G.edges[0, 1]["cost"] == 2
 
     def test_symmetric(self):
         """Tests that a symmetric array has edges added only once to an


### PR DESCRIPTION
We should focus on the upper triangular part of the adjacency matrix for both simple and multi undirected graph.

Using the original code and example in the documentation, we would have the following outcome:
```py
>>> A = np.array([[1, 1], [2, 1]])
>>> from_adj_mx(A).edges(data=True)
EdgeDataView([(0, 0, {'weight': 1}), (0, 1, {'weight': 2}), (1, 1, {'weight': 1})])
```
But it seems strange to have simple and multigraph behave differently, where the former focuses on the lower triangular and the latter on the upper triangular part of the adjacency matrix.