### PR TITLE
Add filters for LOBPCG convergence warnings

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -101,6 +101,11 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(autouse=True)
 def set_warnings():
     warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        message=r"Exited (at iteration \d+|postprocessing) with accuracies.*",
+    )
+    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->

There are four LOBPCG convergence warnings in current test suite so add warnings filters to filter them. Details are seen in issue [7755](https://github.com/networkx/networkx/issues/7755). Please add a reviewer label for this PR otherwise the checks are not successful. Thanks.
