### PR TITLE
Correcting the example given under subgraph_is_monomorphic.py

### DIFF
--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -407,7 +407,7 @@ class GraphMatcher:
         >>> isomatcher.subgraph_is_monomorphic()
         False
 
-        Check whether a subgraph of H is isomorphic to G:
+        Check whether a subgraph of H is monomorphic to G:
 
         >>> isomatcher = nx.isomorphism.GraphMatcher(H, G)
         >>> isomatcher.subgraph_is_monomorphic()


### PR DESCRIPTION
This pull request resolves a documentation issue in the NetworkX isomorphism module, where the functionality of `subgraph_is_monomorphic` was incorrectly described as checking for subgraph isomorphism.

Current Documentation :
The current example incorrectly implies that `subgraph_is_monomorphic` is used to check for isomorphism:

```python
Check whether a subgraph of H is isomorphic to G:

        >>> isomatcher = nx.isomorphism.GraphMatcher(H, G)
        >>> isomatcher.subgraph_is_monomorphic()
        True
```

Expected Documentation Update :
The example should describe the functionality accurately as checking for monomorphism:

``` python
Check whether a subgraph of H is monomorphic to G:

        >>> isomatcher = nx.isomorphism.GraphMatcher(H, G)
        >>> isomatcher.subgraph_is_monomorphic()
        True
```