### PR TITLE
MAINT: Close mpl figures in tests to clear up test env

### DIFF
--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -479,6 +479,7 @@ def test_axes():
     fig, ax = plt.subplots()
     nx.draw(barbell, ax=ax)
     nx.draw_networkx_edge_labels(barbell, nx.circular_layout(barbell), ax=ax)
+    plt.close(fig)
 
 
 def test_empty_graph():
@@ -1031,6 +1032,7 @@ def test_hide_ticks(method, hide_ticks):
 def test_edge_label_bar_connectionstyle():
     """Check that FancyArrowPatches with `bar` connectionstyle are also supported
     in edge label rendering. See gh-7735."""
+    fig = plt.figure()
     edge = (0, 1)
     G = nx.DiGraph([edge])
     pos = {n: (n, 0) for n in G}  # Edge is horizontal line between (0, 0) and (1, 0)
@@ -1050,3 +1052,4 @@ def test_edge_label_bar_connectionstyle():
     assert arc_lbl[edge].x, arc_lbl[edge].y == pytest.approx((0.5, 0))
     # The label should be below the x-axis for the "bar" style
     assert bar_lbl[edge].y < arc_lbl[edge].y
+    plt.close(fig)


### PR DESCRIPTION
The test in https://github.com/networkx/networkx/pull/7739 added some flakiness to our [pytest-randomly runs](https://github.com/networkx/networkx/actions/workflows/pytest-randomly.yml). This should hopefully clean it up :)