### PR TITLE
Multiple paths

### DIFF
--- a/networkx/algorithms/shortest_paths/__init__.py
+++ b/networkx/algorithms/shortest_paths/__init__.py
@@ -3,3 +3,4 @@ from networkx.algorithms.shortest_paths.unweighted import *
 from networkx.algorithms.shortest_paths.weighted import *
 from networkx.algorithms.shortest_paths.astar import *
 from networkx.algorithms.shortest_paths.dense import *
+from networkx.algorithms.shortest_paths.multiple_paths import *

--- a/networkx/algorithms/shortest_paths/multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/multiple_paths.py
@@ -314,6 +314,7 @@ def multiple_paths(graph, source, target, k: int, method="bhandari") -> list:
     if method not in ("suurballe", "bhandari"):
         raise ValueError(f"method not supported: {method}")
 
+    graph_nodes = list(graph.nodes)
     # copy original graph and transform to multidigraph
     if isinstance(graph, nx.MultiDiGraph):
         working_graph = copy_with_unique_keys(graph)
@@ -325,6 +326,10 @@ def multiple_paths(graph, source, target, k: int, method="bhandari") -> list:
         working_graph = copy_with_unique_keys(nx.MultiDiGraph(nx.DiGraph(graph)))
     else:
         raise ValueError("graph type not supported")
+
+    for v in graph_nodes:
+        if v not in working_graph.nodes:
+            working_graph.add_node(v)
 
     if method == "suurballe":
         for u, v, key in working_graph.edges(keys=True):

--- a/networkx/algorithms/shortest_paths/multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/multiple_paths.py
@@ -41,8 +41,7 @@ def multiple_paths(graph, source, target, k: int, method="bhandari") -> list:
     --------
     >>> G = nx.DiGraph()
     >>> edges = [ ('A', 'B', 4), ('A', 'C', 2), ('B', 'C', -3), ('B', 'D', 2),
-    >>>          ('C', 'D', 2), ('D', 'E', 1), ('C', 'E', 4)
-    >>> ]
+    >>>          ('C', 'D', 2), ('D', 'E', 1), ('C', 'E', 4) ]
     >>> G.add_weighted_edges_from(edges)
     >>>  path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2) # [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
 

--- a/networkx/algorithms/shortest_paths/multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/multiple_paths.py
@@ -1,6 +1,10 @@
+"""K minimum sum edge-disjoint paths using bhandari and suurballe algorithms."""
+
 import heapq
 
 import networkx as nx
+
+__all__ = ["multiple_paths"]
 
 
 def multiple_paths(graph, source, target, k: int, method="bhandari") -> list:
@@ -41,19 +45,11 @@ def multiple_paths(graph, source, target, k: int, method="bhandari") -> list:
     >>> ]
     >>> G.add_weighted_edges_from(edges)
     >>>  path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2) # [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
-    # graph connectivity to find out number of edge disjoint path between source and dest, similar to min-cut max-flow
-    # a theory in graph theory
-
-    # compare runtime between bhandari and suurballe on big graphs to check effectiveness of dijkstra
 
     Notes
     -----
     Edge weight attributes must be numerical.
     Distances are calculated as sums of weighted edges traversed.
-
-    See Also
-    --------
-    shortest_path, dijkstra_path
 
     """
 

--- a/networkx/algorithms/shortest_paths/multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/multiple_paths.py
@@ -1,63 +1,61 @@
-
-import networkx as nx
 import heapq
 
+import networkx as nx
 
 
-def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
+def multiple_paths(graph, source, target, k: int, method="bhandari") -> list:
     """
-        Returns a list of minimum edge-disjoint paths, each path is a list of edges, between source and target
-        using bhandari or suurballe's algorithm
+    Returns a list of minimum edge-disjoint paths, each path is a list of edges, between source and target
+    using bhandari or suurballe's algorithm
 
-        There may be less than k edge disjoint minimum sum paths. This returns all of them
+    There may be less than k edge disjoint minimum sum paths. This returns all of them
 
-        Parameters
-        ----------
-        graph : NetworkX graph (MultiDiGraph, MultiGraph, DiGraph, Graph)
+    Parameters
+    ----------
+    graph : NetworkX graph (MultiDiGraph, MultiGraph, DiGraph, Graph)
 
-        source : node
-           Starting node for path
+    source : node
+       Starting node for path
 
-        target : node
-           Ending node for path
+    target : node
+       Ending node for path
 
-        k : int
-           Number of minimum sum edge disjoint paths
+    k : int
+       Number of minimum sum edge disjoint paths
 
-        method: string
-            Name of method used, options are ('suurballe', 'bhandari')
+    method: string
+        Name of method used, options are ('suurballe', 'bhandari')
 
-        Raises
-        ------
-        NetworkXNoPath
-            If no path exists between source and target
-        NodeNotFound
-            If source or target nodes are not in graph
+    Raises
+    ------
+    NetworkXNoPath
+        If no path exists between source and target
+    NodeNotFound
+        If source or target nodes are not in graph
 
-        Examples
-        --------
-        >>> G = nx.DiGraph()
-        >>> edges = [ ('A', 'B', 4), ('A', 'C', 2), ('B', 'C', -3), ('B', 'D', 2),
-        >>>          ('C', 'D', 2), ('D', 'E', 1), ('C', 'E', 4)
-        >>> ]
-        >>> G.add_weighted_edges_from(edges)
-        >>>  path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2) # [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
-        # graph connectivity to find out number of edge disjoint path between source and dest, similar to min-cut max-flow
-        # a theory in graph theory
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> edges = [ ('A', 'B', 4), ('A', 'C', 2), ('B', 'C', -3), ('B', 'D', 2),
+    >>>          ('C', 'D', 2), ('D', 'E', 1), ('C', 'E', 4)
+    >>> ]
+    >>> G.add_weighted_edges_from(edges)
+    >>>  path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2) # [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
+    # graph connectivity to find out number of edge disjoint path between source and dest, similar to min-cut max-flow
+    # a theory in graph theory
 
-        # compare runtime between bhandari and suurballe on big graphs to check effectiveness of dijkstra
+    # compare runtime between bhandari and suurballe on big graphs to check effectiveness of dijkstra
 
-        Notes
-        -----
-        Edge weight attributes must be numerical.
-        Distances are calculated as sums of weighted edges traversed.
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
 
-        See Also
-        --------
-        shortest_path, dijkstra_path
+    See Also
+    --------
+    shortest_path, dijkstra_path
 
-        """
-
+    """
 
     def calculate_shortest_path(graph: nx.MultiDiGraph, method: str) -> dict:
         """
@@ -113,21 +111,21 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
             """
 
             # Initialize distances and predecessors
-            distances = {node: float('inf') for node in graph.nodes}
+            distances = {node: float("inf") for node in graph.nodes}
             predecessors = {node: None for node in graph.nodes}
             distances[source] = 0
 
             # Relax edges |V| - 1 times
             for _ in range(len(graph.nodes) - 1):
                 for u, v, key in graph.edges(keys=True):
-                    weight = graph[u][v][key]['weight']
+                    weight = graph[u][v][key]["weight"]
                     if distances[u] + weight < distances[v]:
                         distances[v] = distances[u] + weight
                         predecessors[v] = u
 
             # Check for negative-weight cycles
             for u, v, key in graph.edges(keys=True):
-                weight = graph[u][v][key]['weight']
+                weight = graph[u][v][key]["weight"]
                 if distances[u] + weight < distances[v]:
                     raise ValueError("Graph contains a negative-weight cycle")
 
@@ -139,7 +137,7 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
                 node = predecessors[node]
 
             if path[0] != source:
-                raise nx.NetworkXNoPath(f'{target} is not reachable from {source}')
+                raise nx.NetworkXNoPath(f"{target} is not reachable from {source}")
 
             return path
 
@@ -173,7 +171,7 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
             heapq.heappush(priority_queue, (0, source))
 
             # Distances and predecessors
-            distances = {node: float('inf') for node in graph.nodes}
+            distances = {node: float("inf") for node in graph.nodes}
             predecessors = {node: None for node in graph.nodes}
             distances[source] = 0
 
@@ -191,7 +189,7 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
 
                 # Relax edges
                 for u, v, key in graph.out_edges(current_node, keys=True):
-                    weight = graph[u][v][key]['weight']
+                    weight = graph[u][v][key]["weight"]
                     distance = current_distance + weight
 
                     if distance < distances[v]:
@@ -206,22 +204,24 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
                 node = predecessors[node]
 
             if path[0] != source:
-                raise nx.NetworkXNoPath(f'{target} is not reachable from {source}')
+                raise nx.NetworkXNoPath(f"{target} is not reachable from {source}")
 
             return distances, path
 
         path = None
         d_len = None
         try:
-            if method == 'bhandari':
+            if method == "bhandari":
                 path = bellman_ford(graph, source, target)
-            elif method == 'suurballe':
+            elif method == "suurballe":
                 d_len, path = dijkstra(graph, source, target)
         except nx.NetworkXNoPath:
-            return {'path': None}
+            return {"path": None}
 
         if path is None:
-            raise ValueError("Unknown exception occurred in method 'calculate_shortest_path'")
+            raise ValueError(
+                "Unknown exception occurred in method 'calculate_shortest_path'"
+            )
 
         # Convert into path of edges
         path = zip(path, path[1:])
@@ -230,14 +230,18 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
         path_with_keys = []
         for u, v in path:
             edge_keys = graph[u][v]  # Get all ways for edge (u, v)
-            min_key = min(edge_keys, key=lambda k: graph[u][v][k]['weight'])  # Find the key with the minimum weight
+            min_key = min(
+                edge_keys, key=lambda k: graph[u][v][k]["weight"]
+            )  # Find the key with the minimum weight
             path_with_keys.append((u, v, min_key))  # Save the edge with its key
 
-        d_out = {'path': path_with_keys}
-        if method == 'suurballe':
+        d_out = {"path": path_with_keys}
+        if method == "suurballe":
             if d_len is None:
-                raise ValueError("Unknown exception occurred in method 'calculate_shortest_path'")
-            d_out['distance'] = d_len
+                raise ValueError(
+                    "Unknown exception occurred in method 'calculate_shortest_path'"
+                )
+            d_out["distance"] = d_len
 
         return d_out
 
@@ -257,28 +261,28 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
         method: str, name of method, 'suurballe' or 'bhandari'
         """
         nonlocal source
-        path = d_path['path']
+        path = d_path["path"]
 
-        if method == 'bhandari':
+        if method == "bhandari":
             for u, v, key in path:
                 weight = graph[u][v][key]["weight"]
                 graph.remove_edge(u, v, key)
                 graph.add_edge(v, u, key=key, weight=-weight)
 
-        elif method == 'suurballe':
+        elif method == "suurballe":
             # STEP1: find distances
 
             edges_lst = list(graph.edges)
-            d_len = d_path['distance']
+            d_len = d_path["distance"]
 
             # STEP2: transform edges
             for u, v, key in edges_lst:
-                new_w = graph[u][v][key]['weight'] + d_len[u] - d_len[v]
+                new_w = graph[u][v][key]["weight"] + d_len[u] - d_len[v]
                 if (u, v, key) in path:
                     graph.remove_edge(u, v, key)
                     graph.add_edge(v, u, key=key, weight=new_w)
                 else:
-                    graph[u][v][key]['weight'] = new_w
+                    graph[u][v][key]["weight"] = new_w
 
     def copy_with_unique_keys(graph: nx.MultiDiGraph):
         """
@@ -295,8 +299,10 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
         """
         new_graph = nx.MultiDiGraph()
         counter = 0
-        for u, v, data in graph.edges(data=True,):
-            new_graph.add_edge(u, v, key = counter, **data)
+        for u, v, data in graph.edges(
+            data=True,
+        ):
+            new_graph.add_edge(u, v, key=counter, **data)
             counter += 1
         return new_graph
 
@@ -309,7 +315,7 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
         raise nx.NodeNotFound(f"Source {source} is not in G")
     if target not in graph:
         raise nx.NodeNotFound(f"Target {target} is not in G")
-    if method not in ('suurballe', 'bhandari'):
+    if method not in ("suurballe", "bhandari"):
         raise ValueError(f"method not supported: {method}")
 
     # copy original graph and transform to multidigraph
@@ -324,28 +330,28 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
     else:
         raise ValueError("graph type not supported")
 
-    if method == 'suurballe':
+    if method == "suurballe":
         for u, v, key in working_graph.edges(keys=True):
-            if working_graph[u][v][key]['weight'] < 0:
+            if working_graph[u][v][key]["weight"] < 0:
                 raise ValueError("suurballe can't run with negative weights")
-
 
     original_graph = working_graph.copy()
 
     path_list = []
 
-
     d_path = calculate_shortest_path(working_graph, method)
-    current_path = d_path['path']
+    current_path = d_path["path"]
     # check target is reachable from source
     if current_path is None:
         raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
 
     path_list.append(current_path)
     for _ in range(k - 1):
-        transform_graph(working_graph, d_path, method)  # transform working graph on last path
+        transform_graph(
+            working_graph, d_path, method
+        )  # transform working graph on last path
         d_path = calculate_shortest_path(working_graph, method)
-        current_path = d_path['path']
+        current_path = d_path["path"]
         if current_path is None:
             break
         path_list.append(current_path)
@@ -353,7 +359,7 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
     # Delete overlapping edges
     d_valid_edges = {}
     for path in path_list:
-        for (u, v, key) in path:
+        for u, v, key in path:
             edge_set = frozenset([u, v, key])
             if edge_set in d_valid_edges:
                 del d_valid_edges[edge_set]
@@ -363,7 +369,7 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
 
     # build edge-disjoint paths from set of edges that are not overlapping
     d_src_to_edges = {}  # u -> [edges in the form (u, v, key)]
-    for (u, v, key) in valid_edges:
+    for u, v, key in valid_edges:
         if u not in d_src_to_edges:
             d_src_to_edges[u] = []
         d_src_to_edges[u].append((u, v, key))
@@ -380,9 +386,11 @@ def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
             path.append(current)
         paths.append(path)
 
-
     # sort paths by weight
-    sorted_paths = sorted(paths, key=lambda path: (sum(original_graph[u][v][k]["weight"] for u, v, k in path)))
+    sorted_paths = sorted(
+        paths,
+        key=lambda path: (sum(original_graph[u][v][k]["weight"] for u, v, k in path)),
+    )
 
     # convert paths from list of edges to list of nodes
     nodes_sorted_path = []

--- a/networkx/algorithms/shortest_paths/multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/multiple_paths.py
@@ -1,0 +1,400 @@
+
+import networkx as nx
+import heapq
+
+
+
+def multiple_paths(graph, source, target, k: int, method='bhandari') -> list:
+    """
+        Returns a list of minimum edge-disjoint paths, each path is a list of edges, between source and target
+        using bhandari or suurballe's algorithm
+
+        There may be less than k edge disjoint minimum sum paths. This returns all of them
+
+        Parameters
+        ----------
+        graph : NetworkX graph (MultiDiGraph, MultiGraph, DiGraph, Graph)
+
+        source : node
+           Starting node for path
+
+        target : node
+           Ending node for path
+
+        k : int
+           Number of minimum sum edge disjoint paths
+
+        method: string
+            Name of method used, options are ('suurballe', 'bhandari')
+
+        Raises
+        ------
+        NetworkXNoPath
+            If no path exists between source and target
+        NodeNotFound
+            If source or target nodes are not in graph
+
+        Examples
+        --------
+        >>> G = nx.DiGraph()
+        >>> edges = [ ('A', 'B', 4), ('A', 'C', 2), ('B', 'C', -3), ('B', 'D', 2),
+        >>>          ('C', 'D', 2), ('D', 'E', 1), ('C', 'E', 4)
+        >>> ]
+        >>> G.add_weighted_edges_from(edges)
+        >>>  path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2) # [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
+        # graph connectivity to find out number of edge disjoint path between source and dest, similar to min-cut max-flow
+        # a theory in graph theory
+
+        # compare runtime between bhandari and suurballe on big graphs to check effectiveness of dijkstra
+
+        Notes
+        -----
+        Edge weight attributes must be numerical.
+        Distances are calculated as sums of weighted edges traversed.
+
+        See Also
+        --------
+        shortest_path, dijkstra_path
+
+        """
+
+
+    def calculate_shortest_path(graph: nx.MultiDiGraph, method: str) -> dict:
+        """
+        Computes the shortest path between source and target according method chosen,
+        method could be 'suurballe' or 'bhandari', suurballe uses dijkstra while bhandari
+        uses bellman-ford
+
+        Parameters
+        ----------
+        graph : networkx.MultiDiGraph
+
+        method: string
+            method name, 'suurballe' or 'bhandari'
+
+        Raises
+        ------
+        NetworkXNoPath
+            If no path exists between source and target
+
+        Returns
+        --------
+        d_path: dict
+            dictionary with key 'path' representing the shortest path from source to target as
+            list of nodes, if method is suurballe, key 'distance' contains dict of distances
+            from source node
+        """
+
+        nonlocal source
+        nonlocal target
+
+        def bellman_ford(graph: nx.MultiDiGraph, source, target) -> list:
+            """
+            Compute minimum path from a source node to target node in a multidigraph
+
+            Parameters
+            ----------
+            graph : networkx.MultiDiGraph
+
+            source: node
+               Starting node for path
+
+            target: node
+               Ending node for path
+
+            Raises
+            ------
+            NetworkXNoPath
+                If no path exists between source and target
+
+            Returns
+            -------
+            path: list of nodes in the shortest path from source to target
+            """
+
+            # Initialize distances and predecessors
+            distances = {node: float('inf') for node in graph.nodes}
+            predecessors = {node: None for node in graph.nodes}
+            distances[source] = 0
+
+            # Relax edges |V| - 1 times
+            for _ in range(len(graph.nodes) - 1):
+                for u, v, key in graph.edges(keys=True):
+                    weight = graph[u][v][key]['weight']
+                    if distances[u] + weight < distances[v]:
+                        distances[v] = distances[u] + weight
+                        predecessors[v] = u
+
+            # Check for negative-weight cycles
+            for u, v, key in graph.edges(keys=True):
+                weight = graph[u][v][key]['weight']
+                if distances[u] + weight < distances[v]:
+                    raise ValueError("Graph contains a negative-weight cycle")
+
+            # build path between source and target
+            path = []
+            node = target
+            while node is not None:
+                path.insert(0, node)
+                node = predecessors[node]
+
+            if path[0] != source:
+                raise nx.NetworkXNoPath(f'{target} is not reachable from {source}')
+
+            return path
+
+        def dijkstra(graph: nx.MultiDiGraph, source, target) -> (dict, list):
+            """
+            Compute distances from source to all other nodes, and minimum path from source to target in a multidigraph.
+
+            Parameters
+            ----------
+            graph : networkx.MultiDiGraph
+
+            source: node
+               Starting node for path
+
+            target: node
+               Ending node for path
+
+            Raises
+            ------
+            NetworkXNoPath
+                If no path exists between source and target
+
+            Returns
+            --------
+            distances: dict of shortest distances from the source to each node
+            path: list of nodes in the shortest path between source and target
+            """
+
+            # Priority queue (min-heap)
+            priority_queue = []
+            heapq.heappush(priority_queue, (0, source))
+
+            # Distances and predecessors
+            distances = {node: float('inf') for node in graph.nodes}
+            predecessors = {node: None for node in graph.nodes}
+            distances[source] = 0
+
+            # Visited nodes
+            visited = set()
+
+            while priority_queue:
+                # Get node with the smallest distance
+                current_distance, current_node = heapq.heappop(priority_queue)
+
+                # Skip if already visited
+                if current_node in visited:
+                    continue
+                visited.add(current_node)
+
+                # Relax edges
+                for u, v, key in graph.out_edges(current_node, keys=True):
+                    weight = graph[u][v][key]['weight']
+                    distance = current_distance + weight
+
+                    if distance < distances[v]:
+                        distances[v] = distance
+                        predecessors[v] = current_node
+                        heapq.heappush(priority_queue, (distance, v))
+            # build path
+            path = []
+            node = target
+            while node is not None:
+                path.insert(0, node)
+                node = predecessors[node]
+
+            if path[0] != source:
+                raise nx.NetworkXNoPath(f'{target} is not reachable from {source}')
+
+            return distances, path
+
+        path = None
+        d_len = None
+        try:
+            if method == 'bhandari':
+                path = bellman_ford(graph, source, target)
+            elif method == 'suurballe':
+                d_len, path = dijkstra(graph, source, target)
+        except nx.NetworkXNoPath:
+            return {'path': None}
+
+        if path is None:
+            raise ValueError("Unknown exception occurred in method 'calculate_shortest_path'")
+
+        # Convert into path of edges
+        path = zip(path, path[1:])
+
+        # Add key to edges, since it is the shortest path, the key with minimum weight
+        path_with_keys = []
+        for u, v in path:
+            edge_keys = graph[u][v]  # Get all ways for edge (u, v)
+            min_key = min(edge_keys, key=lambda k: graph[u][v][k]['weight'])  # Find the key with the minimum weight
+            path_with_keys.append((u, v, min_key))  # Save the edge with its key
+
+        d_out = {'path': path_with_keys}
+        if method == 'suurballe':
+            if d_len is None:
+                raise ValueError("Unknown exception occurred in method 'calculate_shortest_path'")
+            d_out['distance'] = d_len
+
+        return d_out
+
+    def transform_graph(graph: nx.MultiDiGraph, d_path: dict, method: str) -> None:
+        """
+        transforms graph according method and information given in d_path
+
+        Parameters
+        ----------
+        graph: networkx.MultiDiGraph
+
+        d_path: dict
+             dictionary with key 'path', storing a list of nodes of shortest path between source and target
+             and if method is 'suurballe' contains a key called 'distance' storing a dictionary of distance
+             of source to all nodes in graph
+
+        method: str, name of method, 'suurballe' or 'bhandari'
+        """
+        nonlocal source
+        path = d_path['path']
+
+        if method == 'bhandari':
+            for u, v, key in path:
+                weight = graph[u][v][key]["weight"]
+                graph.remove_edge(u, v, key)
+                graph.add_edge(v, u, key=key, weight=-weight)
+
+        elif method == 'suurballe':
+            # STEP1: find distances
+
+            edges_lst = list(graph.edges)
+            d_len = d_path['distance']
+
+            # STEP2: transform edges
+            for u, v, key in edges_lst:
+                new_w = graph[u][v][key]['weight'] + d_len[u] - d_len[v]
+                if (u, v, key) in path:
+                    graph.remove_edge(u, v, key)
+                    graph.add_edge(v, u, key=key, weight=new_w)
+                else:
+                    graph[u][v][key]['weight'] = new_w
+
+    def copy_with_unique_keys(graph: nx.MultiDiGraph):
+        """
+        copies given multidigraph with unique keys
+
+        Parameters
+        ----------
+        graph: networkx.MultiDiGraph
+
+        return
+        ------
+        graph: networkx.MultiDiGraph
+            a graph with unique keys
+        """
+        new_graph = nx.MultiDiGraph()
+        counter = 0
+        for u, v, data in graph.edges(data=True,):
+            new_graph.add_edge(u, v, key = counter, **data)
+            counter += 1
+        return new_graph
+
+    # check input is valid
+    if k <= 0:
+        raise ValueError("Number of paths must be positive.")
+    if source == target:
+        raise ValueError(f"Target {target} is Equal to Source {source}")
+    if source not in graph:
+        raise nx.NodeNotFound(f"Source {source} is not in G")
+    if target not in graph:
+        raise nx.NodeNotFound(f"Target {target} is not in G")
+    if method not in ('suurballe', 'bhandari'):
+        raise ValueError(f"method not supported: {method}")
+
+    # copy original graph and transform to multidigraph
+    if isinstance(graph, nx.MultiDiGraph):
+        working_graph = copy_with_unique_keys(graph)
+    elif isinstance(graph, nx.MultiGraph):
+        working_graph = copy_with_unique_keys(graph.to_directed())
+    elif isinstance(graph, nx.DiGraph):
+        working_graph = copy_with_unique_keys(nx.MultiDiGraph(graph))
+    elif isinstance(graph, nx.Graph):
+        working_graph = copy_with_unique_keys(nx.MultiDiGraph(nx.DiGraph(graph)))
+    else:
+        raise ValueError("graph type not supported")
+
+    if method == 'suurballe':
+        for u, v, key in working_graph.edges(keys=True):
+            if working_graph[u][v][key]['weight'] < 0:
+                raise ValueError("suurballe can't run with negative weights")
+
+
+    original_graph = working_graph.copy()
+
+    path_list = []
+
+
+    d_path = calculate_shortest_path(working_graph, method)
+    current_path = d_path['path']
+    # check target is reachable from source
+    if current_path is None:
+        raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
+
+    path_list.append(current_path)
+    for _ in range(k - 1):
+        transform_graph(working_graph, d_path, method)  # transform working graph on last path
+        d_path = calculate_shortest_path(working_graph, method)
+        current_path = d_path['path']
+        if current_path is None:
+            break
+        path_list.append(current_path)
+
+    # Delete overlapping edges
+    d_valid_edges = {}
+    for path in path_list:
+        for (u, v, key) in path:
+            edge_set = frozenset([u, v, key])
+            if edge_set in d_valid_edges:
+                del d_valid_edges[edge_set]
+            else:
+                d_valid_edges[edge_set] = (u, v, key)
+    valid_edges = set(d_valid_edges.values())
+
+    # build edge-disjoint paths from set of edges that are not overlapping
+    d_src_to_edges = {}  # u -> [edges in the form (u, v, key)]
+    for (u, v, key) in valid_edges:
+        if u not in d_src_to_edges:
+            d_src_to_edges[u] = []
+        d_src_to_edges[u].append((u, v, key))
+
+    # build paths into a list
+    paths = []
+    while len(d_src_to_edges[source]) > 0:
+        path = []
+        current = d_src_to_edges[source].pop(0)
+        path.append(current)
+        # follow the path
+        while current[1] != target:
+            current = d_src_to_edges[current[1]].pop(0)
+            path.append(current)
+        paths.append(path)
+
+
+    # sort paths by weight
+    sorted_paths = sorted(paths, key=lambda path: (sum(original_graph[u][v][k]["weight"] for u, v, k in path)))
+
+    # convert paths from list of edges to list of nodes
+    nodes_sorted_path = []
+    for p in sorted_paths:
+        n = len(p)
+        new_p = []
+        for i in range(n):
+            e = p[i]
+            new_p.append(e[0])
+            if i == n - 1:
+                new_p.append(e[1])
+
+        nodes_sorted_path.append(new_p)
+
+    return nodes_sorted_path

--- a/networkx/algorithms/shortest_paths/tests/test_multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/tests/test_multiple_paths.py
@@ -1,184 +1,268 @@
 import pytest
 
 import networkx as nx
-import multiple_paths
 
 
 class TestMultiplePaths:
-
     def test_shortest_paths_bhandari(self):
         G = nx.DiGraph()
         edges = [
-            ('s','a',1), ('s','c',4), ('a','b',1), ('b','c',1),
-            ('s','b',4), ('a','t',6), ('b','t',5), ('c','t',1)
+            ("s", "a", 1),
+            ("s", "c", 4),
+            ("a", "b", 1),
+            ("b", "c", 1),
+            ("s", "b", 4),
+            ("a", "t", 6),
+            ("b", "t", 5),
+            ("c", "t", 1),
         ]
         G.add_weighted_edges_from(edges)
-        paths_1 = multiple_paths.multiple_paths(G, 's','t', 1)
-        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2)
-        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3)
-        assert paths_1 == [['s', 'a', 'b', 'c', 't']]
-        assert paths_2 == [['s', 'c', 't'], ['s', 'a', 'b', 't']]
-        assert paths_3 == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
-        for k in range (4, 7):
-            paths_k = multiple_paths.multiple_paths(G, 's', 't', k)
-            assert paths_k == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
-
+        paths_1 = nx.multiple_paths(G, "s", "t", 1)
+        paths_2 = nx.multiple_paths(G, "s", "t", 2)
+        paths_3 = nx.multiple_paths(G, "s", "t", 3)
+        assert paths_1 == [["s", "a", "b", "c", "t"]]
+        assert paths_2 == [["s", "c", "t"], ["s", "a", "b", "t"]]
+        assert paths_3 == [["s", "c", "t"], ["s", "a", "t"], ["s", "b", "t"]]
+        for k in range(4, 7):
+            paths_k = nx.multiple_paths(G, "s", "t", k)
+            assert paths_k == [["s", "c", "t"], ["s", "a", "t"], ["s", "b", "t"]]
 
     def test_shortest_paths_suurballe(self):
         G = nx.DiGraph()
         edges = [
-            ('s', 'a', 1), ('s', 'c', 4), ('a', 'b', 1), ('b', 'c', 1),
-            ('s', 'b', 4), ('a', 't', 6), ('b', 't', 5), ('c', 't', 1)
+            ("s", "a", 1),
+            ("s", "c", 4),
+            ("a", "b", 1),
+            ("b", "c", 1),
+            ("s", "b", 4),
+            ("a", "t", 6),
+            ("b", "t", 5),
+            ("c", "t", 1),
         ]
         G.add_weighted_edges_from(edges)
-        paths_1 = multiple_paths.multiple_paths(G, 's', 't', 1, 'suurballe')
-        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
-        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3, 'suurballe')
-        assert paths_1 == [['s', 'a', 'b', 'c', 't']]
-        assert paths_2 == [['s', 'c', 't'], ['s', 'a', 'b', 't']]
-        assert paths_3 == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
+        paths_1 = nx.multiple_paths(G, "s", "t", 1, "suurballe")
+        paths_2 = nx.multiple_paths(G, "s", "t", 2, "suurballe")
+        paths_3 = nx.multiple_paths(G, "s", "t", 3, "suurballe")
+        assert paths_1 == [["s", "a", "b", "c", "t"]]
+        assert paths_2 == [["s", "c", "t"], ["s", "a", "b", "t"]]
+        assert paths_3 == [["s", "c", "t"], ["s", "a", "t"], ["s", "b", "t"]]
         for k in range(4, 7):
-            paths_k = multiple_paths.multiple_paths(G, 's', 't', k, 'suurballe')
-            assert paths_k == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
+            paths_k = nx.multiple_paths(G, "s", "t", k, "suurballe")
+            assert paths_k == [["s", "c", "t"], ["s", "a", "t"], ["s", "b", "t"]]
 
     def test_shortest_paths_2_bhandari(self):
         G = nx.DiGraph()
         edges = [
-            ('s', 'a', 3), ('s', 'b', 2), ('s', 'd', 8),
-            ('a', 'c', 1), ('a', 'd', 4), ('b', 'e', 5),
-            ('c', 't', 5), ('d', 't', 1), ('g', 't', 7),
-            ('a', 'e', 6), ('e', 'g', 2), ('g', 'b', 3)
+            ("s", "a", 3),
+            ("s", "b", 2),
+            ("s", "d", 8),
+            ("a", "c", 1),
+            ("a", "d", 4),
+            ("b", "e", 5),
+            ("c", "t", 5),
+            ("d", "t", 1),
+            ("g", "t", 7),
+            ("a", "e", 6),
+            ("e", "g", 2),
+            ("g", "b", 3),
         ]
         G.add_weighted_edges_from(edges)
-        paths_1 = multiple_paths.multiple_paths(G, 's', 't', 1)
-        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2)
-        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3)
-        assert paths_1 == [['s', 'a', 'd', 't']]
-        assert paths_2 == [['s','d', 't'], ['s', 'a', 'c', 't']] or paths_2 == [['s', 'a', 'c', 't'], ['s','d', 't']]
-        assert paths_3 == [['s','d', 't'], ['s', 'a', 'c', 't'], ['s', 'b', 'e', 'g', 't']] or paths_3 == [
-            ['s', 'a', 'c', 't'], ['s','d', 't'], ['s', 'b', 'e', 'g', 't']]
-
+        paths_1 = nx.multiple_paths(G, "s", "t", 1)
+        paths_2 = nx.multiple_paths(G, "s", "t", 2)
+        paths_3 = nx.multiple_paths(G, "s", "t", 3)
+        assert paths_1 == [["s", "a", "d", "t"]]
+        assert paths_2 == [["s", "d", "t"], ["s", "a", "c", "t"]] or paths_2 == [
+            ["s", "a", "c", "t"],
+            ["s", "d", "t"],
+        ]
+        assert paths_3 == [
+            ["s", "d", "t"],
+            ["s", "a", "c", "t"],
+            ["s", "b", "e", "g", "t"],
+        ] or paths_3 == [
+            ["s", "a", "c", "t"],
+            ["s", "d", "t"],
+            ["s", "b", "e", "g", "t"],
+        ]
 
     def test_shortest_paths_2_suurballe(self):
         G = nx.DiGraph()
         edges = [
-            ('s', 'a', 3), ('s', 'b', 2), ('s', 'd', 8),
-            ('a', 'c', 1), ('a', 'd', 4), ('b', 'e', 5),
-            ('c', 't', 5), ('d', 't', 1), ('g', 't', 7),
-            ('a', 'e', 6), ('e', 'g', 2), ('g', 'b', 3)
+            ("s", "a", 3),
+            ("s", "b", 2),
+            ("s", "d", 8),
+            ("a", "c", 1),
+            ("a", "d", 4),
+            ("b", "e", 5),
+            ("c", "t", 5),
+            ("d", "t", 1),
+            ("g", "t", 7),
+            ("a", "e", 6),
+            ("e", "g", 2),
+            ("g", "b", 3),
         ]
         G.add_weighted_edges_from(edges)
-        paths_1 = multiple_paths.multiple_paths(G, 's', 't', 1, 'suurballe')
-        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
-        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3, 'suurballe')
-        assert paths_1 == [['s', 'a', 'd', 't']]
-        assert paths_2 == [['s', 'd', 't'], ['s', 'a', 'c', 't']] or paths_2 == [['s', 'a', 'c', 't'], ['s', 'd', 't']]
-        assert paths_3 == [['s', 'd', 't'], ['s', 'a', 'c', 't'], ['s', 'b', 'e', 'g', 't']] or paths_3 == [
-            ['s', 'a', 'c', 't'], ['s', 'd', 't'], ['s', 'b', 'e', 'g', 't']]
-
+        paths_1 = nx.multiple_paths(G, "s", "t", 1, "suurballe")
+        paths_2 = nx.multiple_paths(G, "s", "t", 2, "suurballe")
+        paths_3 = nx.multiple_paths(G, "s", "t", 3, "suurballe")
+        assert paths_1 == [["s", "a", "d", "t"]]
+        assert paths_2 == [["s", "d", "t"], ["s", "a", "c", "t"]] or paths_2 == [
+            ["s", "a", "c", "t"],
+            ["s", "d", "t"],
+        ]
+        assert paths_3 == [
+            ["s", "d", "t"],
+            ["s", "a", "c", "t"],
+            ["s", "b", "e", "g", "t"],
+        ] or paths_3 == [
+            ["s", "a", "c", "t"],
+            ["s", "d", "t"],
+            ["s", "b", "e", "g", "t"],
+        ]
 
     def test_shortest_path_bhandari_3(self):
         G = nx.DiGraph()
         edges = [
-            ('a', 'd', 1), ('a', 'b', 1), ('d', 'c',  6), ('b', 'c', 1),
-            ('c', 'z', 1), ('b', 'e', 4), ('e', 'z', 1)
-
+            ("a", "d", 1),
+            ("a", "b", 1),
+            ("d", "c", 6),
+            ("b", "c", 1),
+            ("c", "z", 1),
+            ("b", "e", 4),
+            ("e", "z", 1),
         ]
         G.add_weighted_edges_from(edges)
-        paths_1 = multiple_paths.multiple_paths(G, 'a', 'z', 1)
-        paths_2 = multiple_paths.multiple_paths(G, 'a', 'z', 2)
-        assert paths_1 == [['a', 'b', 'c', 'z']]
-        assert paths_2 == [['a', 'b', 'e', 'z'], ['a', 'd', 'c', 'z']]
-
+        paths_1 = nx.multiple_paths(G, "a", "z", 1)
+        paths_2 = nx.multiple_paths(G, "a", "z", 2)
+        assert paths_1 == [["a", "b", "c", "z"]]
+        assert paths_2 == [["a", "b", "e", "z"], ["a", "d", "c", "z"]]
 
     def test_shortest_path_suurballe_3(self):
         G = nx.DiGraph()
         edges = [
-            ('a', 'd', 1), ('a', 'b', 1), ('d', 'c', 6), ('b', 'c', 1),
-            ('c', 'z', 1), ('b', 'e', 4), ('e', 'z', 1)
-
+            ("a", "d", 1),
+            ("a", "b", 1),
+            ("d", "c", 6),
+            ("b", "c", 1),
+            ("c", "z", 1),
+            ("b", "e", 4),
+            ("e", "z", 1),
         ]
         G.add_weighted_edges_from(edges)
-        paths_1 = multiple_paths.multiple_paths(G, 'a', 'z', 1, 'suurballe')
-        paths_2 = multiple_paths.multiple_paths(G, 'a', 'z', 2, 'suurballe')
-        assert paths_1 == [['a', 'b', 'c', 'z']]
-        assert paths_2 == [['a', 'b', 'e', 'z'], ['a', 'd', 'c', 'z']]
-
+        paths_1 = nx.multiple_paths(G, "a", "z", 1, "suurballe")
+        paths_2 = nx.multiple_paths(G, "a", "z", 2, "suurballe")
+        assert paths_1 == [["a", "b", "c", "z"]]
+        assert paths_2 == [["a", "b", "e", "z"], ["a", "d", "c", "z"]]
 
     def test_bhandari(self):
         G = nx.DiGraph()
         edges = [
-            ('s', 'a', 1), ('a', 's', 1), ('s', 'b', 1), ('b', 's', 1),
-            ('a', 't', 1), ('t', 'a', 1), ('b', 't', 1), ('t', 'b', 1)
-
+            ("s", "a", 1),
+            ("a", "s", 1),
+            ("s", "b", 1),
+            ("b", "s", 1),
+            ("a", "t", 1),
+            ("t", "a", 1),
+            ("b", "t", 1),
+            ("t", "b", 1),
         ]
         G.add_weighted_edges_from(edges)
-        dp_lst = multiple_paths.multiple_paths(G, 's', 't', 2)
-        assert ['s', 'a', 't'] in dp_lst
-        assert ['s', 'b', 't'] in dp_lst
-
+        dp_lst = nx.multiple_paths(G, "s", "t", 2)
+        assert ["s", "a", "t"] in dp_lst
+        assert ["s", "b", "t"] in dp_lst
 
     def test_suurballe(self):
         G = nx.DiGraph()
         edges = [
-            ('s', 'a', 1), ('a', 's', 1), ('s', 'b', 1), ('b', 's', 1),
-            ('a', 't', 1), ('t', 'a', 1), ('b', 't', 1), ('t', 'b', 1)
-
+            ("s", "a", 1),
+            ("a", "s", 1),
+            ("s", "b", 1),
+            ("b", "s", 1),
+            ("a", "t", 1),
+            ("t", "a", 1),
+            ("b", "t", 1),
+            ("t", "b", 1),
         ]
         G.add_weighted_edges_from(edges)
-        dp_lst = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
-        assert ['s', 'a', 't'] in dp_lst
-        assert ['s', 'b', 't'] in dp_lst
+        dp_lst = nx.multiple_paths(G, "s", "t", 2, "suurballe")
+        assert ["s", "a", "t"] in dp_lst
+        assert ["s", "b", "t"] in dp_lst
 
     def test_bhandari_not_directed(self):
         G = nx.Graph()
-        edges = [ ('s', 'a', 1), ('s', 'b', 1), ('a', 't', 1), ('b', 't', 1) ]
+        edges = [("s", "a", 1), ("s", "b", 1), ("a", "t", 1), ("b", "t", 1)]
         G.add_weighted_edges_from(edges)
-        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2)
-        assert paths_2 == [['s', 'a', 't'], ['s', 'b', 't']] or paths_2 == [['s', 'b', 't'], ['s', 'a', 't']]
+        paths_2 = nx.multiple_paths(G, "s", "t", 2)
+        assert paths_2 == [["s", "a", "t"], ["s", "b", "t"]] or paths_2 == [
+            ["s", "b", "t"],
+            ["s", "a", "t"],
+        ]
 
     def test_suurballe_not_directed(self):
         G = nx.Graph()
-        edges = [('s', 'a', 1), ('s', 'b', 1), ('a', 't', 1), ('b', 't', 1)]
+        edges = [("s", "a", 1), ("s", "b", 1), ("a", "t", 1), ("b", "t", 1)]
         G.add_weighted_edges_from(edges)
-        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
-        assert paths_2 == [['s', 'a', 't'], ['s', 'b', 't']] or paths_2 == [['s', 'b', 't'], ['s', 'a', 't']]
-
+        paths_2 = nx.multiple_paths(G, "s", "t", 2, "suurballe")
+        assert paths_2 == [["s", "a", "t"], ["s", "b", "t"]] or paths_2 == [
+            ["s", "b", "t"],
+            ["s", "a", "t"],
+        ]
 
     def test_bhandari_negative_weight_1(self):
         test_graph = nx.DiGraph()
-        edges = [ ('A', 'B', 4), ('A', 'C', -2), ('B', 'C', -3),
-                  ('B', 'D', 2), ('C', 'D', 2), ('D', 'E', 1),
-                  ('C', 'E', 4)
+        edges = [
+            ("A", "B", 4),
+            ("A", "C", -2),
+            ("B", "C", -3),
+            ("B", "D", 2),
+            ("C", "D", 2),
+            ("D", "E", 1),
+            ("C", "E", 4),
         ]
         test_graph.add_weighted_edges_from(edges)
-        path_1 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 1)
-        path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2)
-        assert path_1 == [['A', 'C', 'D', 'E']]
-        assert path_2 == [['A', 'C', 'E'], ['A', 'B', 'C', 'D', 'E']]
-
+        path_1 = nx.multiple_paths(test_graph, "A", "E", 1)
+        path_2 = nx.multiple_paths(test_graph, "A", "E", 2)
+        assert path_1 == [["A", "C", "D", "E"]]
+        # sum of both paths is 6, 2 valid options
+        assert path_2 == [["A", "C", "E"], ["A", "B", "C", "D", "E"]] or path_2 == [
+            ["A", "C", "D", "E"],
+            ["A", "B", "C", "E"],
+        ]
 
     def test_bhandari_negative_weight_2(self):
         test_graph = nx.DiGraph()
-        edges = [ ('A', 'B', 4), ('A', 'C', 2), ('B', 'C', -3),
-                  ('B', 'D', 2), ('C', 'D', 2), ('D', 'E', 1),
-                  ('C', 'E', 4)
+        edges = [
+            ("A", "B", 4),
+            ("A", "C", 2),
+            ("B", "C", -3),
+            ("B", "D", 2),
+            ("C", "D", 2),
+            ("D", "E", 1),
+            ("C", "E", 4),
         ]
         test_graph.add_weighted_edges_from(edges)
-        path_1 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 1)
-        path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2)
-        assert path_1 == [['A', 'B', 'C', 'D', 'E']]
-        assert path_2 == [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
-
-
+        path_1 = nx.multiple_paths(test_graph, "A", "E", 1)
+        path_2 = nx.multiple_paths(test_graph, "A", "E", 2)
+        assert path_1 == [["A", "B", "C", "D", "E"]]
+        # sum of both paths is 10, 3 valid options
+        assert (
+            path_2 == [["A", "B", "C", "D", "E"], ["A", "C", "E"]]
+            or path_2 == [["A", "B", "C", "E"], ["A", "C", "D", "E"]]
+            or path_2 == [["A", "C", "D", "E"], ["A", "B", "C", "E"]]
+        )
 
     def test_bhandari_negative_multidigraph(self):
         test_graph = nx.MultiDiGraph()
-        edges = [ ('A', 'B', 1), ('A', 'B', 2), ('B', 'D', 4),
-                  ('B', 'C', 3), ('C', 'D', 2), ('A', 'C', -1)
+        edges = [
+            ("A", "B", 1),
+            ("A", "B", 2),
+            ("B", "D", 4),
+            ("B", "C", 3),
+            ("C", "D", 2),
+            ("A", "C", -1),
         ]
         test_graph.add_weighted_edges_from(edges)
-        path_1 = multiple_paths.multiple_paths(test_graph, 'A', 'D', 1)
-        path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'D', 2)
-        assert path_1 == [['A', 'C', 'D']]
-        assert path_2 == [['A', 'C', 'D'], ['A', 'B', 'D']]
+        path_1 = nx.multiple_paths(test_graph, "A", "D", 1)
+        path_2 = nx.multiple_paths(test_graph, "A", "D", 2)
+        assert path_1 == [["A", "C", "D"]]
+        assert path_2 == [["A", "C", "D"], ["A", "B", "D"]]

--- a/networkx/algorithms/shortest_paths/tests/test_multiple_paths.py
+++ b/networkx/algorithms/shortest_paths/tests/test_multiple_paths.py
@@ -1,0 +1,184 @@
+import pytest
+
+import networkx as nx
+import multiple_paths
+
+
+class TestMultiplePaths:
+
+    def test_shortest_paths_bhandari(self):
+        G = nx.DiGraph()
+        edges = [
+            ('s','a',1), ('s','c',4), ('a','b',1), ('b','c',1),
+            ('s','b',4), ('a','t',6), ('b','t',5), ('c','t',1)
+        ]
+        G.add_weighted_edges_from(edges)
+        paths_1 = multiple_paths.multiple_paths(G, 's','t', 1)
+        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2)
+        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3)
+        assert paths_1 == [['s', 'a', 'b', 'c', 't']]
+        assert paths_2 == [['s', 'c', 't'], ['s', 'a', 'b', 't']]
+        assert paths_3 == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
+        for k in range (4, 7):
+            paths_k = multiple_paths.multiple_paths(G, 's', 't', k)
+            assert paths_k == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
+
+
+    def test_shortest_paths_suurballe(self):
+        G = nx.DiGraph()
+        edges = [
+            ('s', 'a', 1), ('s', 'c', 4), ('a', 'b', 1), ('b', 'c', 1),
+            ('s', 'b', 4), ('a', 't', 6), ('b', 't', 5), ('c', 't', 1)
+        ]
+        G.add_weighted_edges_from(edges)
+        paths_1 = multiple_paths.multiple_paths(G, 's', 't', 1, 'suurballe')
+        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
+        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3, 'suurballe')
+        assert paths_1 == [['s', 'a', 'b', 'c', 't']]
+        assert paths_2 == [['s', 'c', 't'], ['s', 'a', 'b', 't']]
+        assert paths_3 == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
+        for k in range(4, 7):
+            paths_k = multiple_paths.multiple_paths(G, 's', 't', k, 'suurballe')
+            assert paths_k == [['s', 'c', 't'], ['s', 'a', 't'], ['s', 'b', 't']]
+
+    def test_shortest_paths_2_bhandari(self):
+        G = nx.DiGraph()
+        edges = [
+            ('s', 'a', 3), ('s', 'b', 2), ('s', 'd', 8),
+            ('a', 'c', 1), ('a', 'd', 4), ('b', 'e', 5),
+            ('c', 't', 5), ('d', 't', 1), ('g', 't', 7),
+            ('a', 'e', 6), ('e', 'g', 2), ('g', 'b', 3)
+        ]
+        G.add_weighted_edges_from(edges)
+        paths_1 = multiple_paths.multiple_paths(G, 's', 't', 1)
+        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2)
+        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3)
+        assert paths_1 == [['s', 'a', 'd', 't']]
+        assert paths_2 == [['s','d', 't'], ['s', 'a', 'c', 't']] or paths_2 == [['s', 'a', 'c', 't'], ['s','d', 't']]
+        assert paths_3 == [['s','d', 't'], ['s', 'a', 'c', 't'], ['s', 'b', 'e', 'g', 't']] or paths_3 == [
+            ['s', 'a', 'c', 't'], ['s','d', 't'], ['s', 'b', 'e', 'g', 't']]
+
+
+    def test_shortest_paths_2_suurballe(self):
+        G = nx.DiGraph()
+        edges = [
+            ('s', 'a', 3), ('s', 'b', 2), ('s', 'd', 8),
+            ('a', 'c', 1), ('a', 'd', 4), ('b', 'e', 5),
+            ('c', 't', 5), ('d', 't', 1), ('g', 't', 7),
+            ('a', 'e', 6), ('e', 'g', 2), ('g', 'b', 3)
+        ]
+        G.add_weighted_edges_from(edges)
+        paths_1 = multiple_paths.multiple_paths(G, 's', 't', 1, 'suurballe')
+        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
+        paths_3 = multiple_paths.multiple_paths(G, 's', 't', 3, 'suurballe')
+        assert paths_1 == [['s', 'a', 'd', 't']]
+        assert paths_2 == [['s', 'd', 't'], ['s', 'a', 'c', 't']] or paths_2 == [['s', 'a', 'c', 't'], ['s', 'd', 't']]
+        assert paths_3 == [['s', 'd', 't'], ['s', 'a', 'c', 't'], ['s', 'b', 'e', 'g', 't']] or paths_3 == [
+            ['s', 'a', 'c', 't'], ['s', 'd', 't'], ['s', 'b', 'e', 'g', 't']]
+
+
+    def test_shortest_path_bhandari_3(self):
+        G = nx.DiGraph()
+        edges = [
+            ('a', 'd', 1), ('a', 'b', 1), ('d', 'c',  6), ('b', 'c', 1),
+            ('c', 'z', 1), ('b', 'e', 4), ('e', 'z', 1)
+
+        ]
+        G.add_weighted_edges_from(edges)
+        paths_1 = multiple_paths.multiple_paths(G, 'a', 'z', 1)
+        paths_2 = multiple_paths.multiple_paths(G, 'a', 'z', 2)
+        assert paths_1 == [['a', 'b', 'c', 'z']]
+        assert paths_2 == [['a', 'b', 'e', 'z'], ['a', 'd', 'c', 'z']]
+
+
+    def test_shortest_path_suurballe_3(self):
+        G = nx.DiGraph()
+        edges = [
+            ('a', 'd', 1), ('a', 'b', 1), ('d', 'c', 6), ('b', 'c', 1),
+            ('c', 'z', 1), ('b', 'e', 4), ('e', 'z', 1)
+
+        ]
+        G.add_weighted_edges_from(edges)
+        paths_1 = multiple_paths.multiple_paths(G, 'a', 'z', 1, 'suurballe')
+        paths_2 = multiple_paths.multiple_paths(G, 'a', 'z', 2, 'suurballe')
+        assert paths_1 == [['a', 'b', 'c', 'z']]
+        assert paths_2 == [['a', 'b', 'e', 'z'], ['a', 'd', 'c', 'z']]
+
+
+    def test_bhandari(self):
+        G = nx.DiGraph()
+        edges = [
+            ('s', 'a', 1), ('a', 's', 1), ('s', 'b', 1), ('b', 's', 1),
+            ('a', 't', 1), ('t', 'a', 1), ('b', 't', 1), ('t', 'b', 1)
+
+        ]
+        G.add_weighted_edges_from(edges)
+        dp_lst = multiple_paths.multiple_paths(G, 's', 't', 2)
+        assert ['s', 'a', 't'] in dp_lst
+        assert ['s', 'b', 't'] in dp_lst
+
+
+    def test_suurballe(self):
+        G = nx.DiGraph()
+        edges = [
+            ('s', 'a', 1), ('a', 's', 1), ('s', 'b', 1), ('b', 's', 1),
+            ('a', 't', 1), ('t', 'a', 1), ('b', 't', 1), ('t', 'b', 1)
+
+        ]
+        G.add_weighted_edges_from(edges)
+        dp_lst = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
+        assert ['s', 'a', 't'] in dp_lst
+        assert ['s', 'b', 't'] in dp_lst
+
+    def test_bhandari_not_directed(self):
+        G = nx.Graph()
+        edges = [ ('s', 'a', 1), ('s', 'b', 1), ('a', 't', 1), ('b', 't', 1) ]
+        G.add_weighted_edges_from(edges)
+        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2)
+        assert paths_2 == [['s', 'a', 't'], ['s', 'b', 't']] or paths_2 == [['s', 'b', 't'], ['s', 'a', 't']]
+
+    def test_suurballe_not_directed(self):
+        G = nx.Graph()
+        edges = [('s', 'a', 1), ('s', 'b', 1), ('a', 't', 1), ('b', 't', 1)]
+        G.add_weighted_edges_from(edges)
+        paths_2 = multiple_paths.multiple_paths(G, 's', 't', 2, 'suurballe')
+        assert paths_2 == [['s', 'a', 't'], ['s', 'b', 't']] or paths_2 == [['s', 'b', 't'], ['s', 'a', 't']]
+
+
+    def test_bhandari_negative_weight_1(self):
+        test_graph = nx.DiGraph()
+        edges = [ ('A', 'B', 4), ('A', 'C', -2), ('B', 'C', -3),
+                  ('B', 'D', 2), ('C', 'D', 2), ('D', 'E', 1),
+                  ('C', 'E', 4)
+        ]
+        test_graph.add_weighted_edges_from(edges)
+        path_1 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 1)
+        path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2)
+        assert path_1 == [['A', 'C', 'D', 'E']]
+        assert path_2 == [['A', 'C', 'E'], ['A', 'B', 'C', 'D', 'E']]
+
+
+    def test_bhandari_negative_weight_2(self):
+        test_graph = nx.DiGraph()
+        edges = [ ('A', 'B', 4), ('A', 'C', 2), ('B', 'C', -3),
+                  ('B', 'D', 2), ('C', 'D', 2), ('D', 'E', 1),
+                  ('C', 'E', 4)
+        ]
+        test_graph.add_weighted_edges_from(edges)
+        path_1 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 1)
+        path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'E', 2)
+        assert path_1 == [['A', 'B', 'C', 'D', 'E']]
+        assert path_2 == [['A', 'B', 'C', 'D', 'E'], ['A', 'C', 'E']]
+
+
+
+    def test_bhandari_negative_multidigraph(self):
+        test_graph = nx.MultiDiGraph()
+        edges = [ ('A', 'B', 1), ('A', 'B', 2), ('B', 'D', 4),
+                  ('B', 'C', 3), ('C', 'D', 2), ('A', 'C', -1)
+        ]
+        test_graph.add_weighted_edges_from(edges)
+        path_1 = multiple_paths.multiple_paths(test_graph, 'A', 'D', 1)
+        path_2 = multiple_paths.multiple_paths(test_graph, 'A', 'D', 2)
+        assert path_1 == [['A', 'C', 'D']]
+        assert path_2 == [['A', 'C', 'D'], ['A', 'B', 'D']]


### PR DESCRIPTION
algorithm for finding k edges disjoint paths s.t. sum of weights on those paths is minimum

the described algorithm has 2 implementation: 
1. Suurballe: Fast than bhandari, runs dijkstra, limited to graphs with non-negative weights
2. Bhandari: Slower than suurballe, runs bellman-ford, can run on graphs with negative weights (but no negative cycles)

- The algorithm is based on 'Survivable Networks: Algorithms for Diverse Routing' book
- The function returns list of lists of nodes representation edge disjoint path
- can be modified easily to support (by a simple transformation) minimum sum node-disjoint paths
- The algorithms involves reversing edges, so working with Multi was needed
- during the project I compared runtimes of suurballe and bhandari on big graphs with random weights, which means besides the tests I wrote, the code works on big graphs

during the run, all the tests I wrote passed, except small issue with 'DID NOT RAISE ..':
"""
============================== FAILURES ==============================
test_namespace_alias

    def test_namespace_alias():
>       with pytest.raises(ImportError):
E       Failed: DID NOT RAISE <class 'ImportError'>
networkx/tests/test_import.py:5: Failed
"""
other than that everything is fine, I'd like to hear ur feedback about this issue and how to fix it, and also your feedback in general

