### PR TITLE
Error message improvement for nbunch_iter ( NetworkXError raised with specific message on TypeError with "iter" in msg )

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -2011,7 +2011,6 @@ class Graph:
         ------
         NetworkXError
             If nbunch is not a node or sequence of nodes.
-            If nbunch is not a valid node in the graph.
             If a node in nbunch is not hashable.
 
         See Also
@@ -2045,6 +2044,11 @@ class Graph:
                     exc, message = err, err.args[0]
                     # capture error for non-sequence/iterator nbunch.
                     if "iter" in message:
+                        exc = NetworkXError(
+                            "nbunch is not a node or a sequence of nodes."
+                        )
+                    # capture single nodes that are not in the graph.
+                    if "object is not iterable" in message:
                         exc = NetworkXError(f"Node {nbunch} is not in the graph.")
                     # capture error for unhashable node.
                     if "hashable" in message:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -2011,6 +2011,7 @@ class Graph:
         ------
         NetworkXError
             If nbunch is not a node or sequence of nodes.
+            If nbunch is not a valid node in the graph.
             If a node in nbunch is not hashable.
 
         See Also
@@ -2046,6 +2047,10 @@ class Graph:
                     if "iter" in message:
                         exc = NetworkXError(
                             "nbunch is not a node or a sequence of nodes."
+                        )
+                    if "int" in message:
+                        exc = NetworkXError(
+                            f"Node {nbunch} is not a valid node in the graph."
                         )
                     # capture error for unhashable node.
                     if "hashable" in message:

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1993,7 +1993,7 @@ class Graph:
         """Returns an iterator over nodes contained in nbunch that are
         also in the graph.
 
-        The nodes in iterable nbunch are checked for membership in the graph
+        The nodes in an iterable nbunch are checked for membership in the graph
         and if not are silently ignored.
 
         Parameters

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -2049,7 +2049,9 @@ class Graph:
                         )
                     # capture single nodes that are not in the graph.
                     if "object is not iterable" in message:
-                        exc = NetworkXError(f"Node {nbunch} is not in the graph.")
+                        exc = NetworkXError(
+                            f"Node {nbunch} is not in the graph."
+                        )
                     # capture error for unhashable node.
                     if "hashable" in message:
                         exc = NetworkXError(

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -2049,9 +2049,7 @@ class Graph:
                         )
                     # capture single nodes that are not in the graph.
                     if "object is not iterable" in message:
-                        exc = NetworkXError(
-                            f"Node {nbunch} is not in the graph."
-                        )
+                        exc = NetworkXError(f"Node {nbunch} is not in the graph.")
                     # capture error for unhashable node.
                     if "hashable" in message:
                         exc = NetworkXError(

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1993,7 +1993,7 @@ class Graph:
         """Returns an iterator over nodes contained in nbunch that are
         also in the graph.
 
-        The nodes in nbunch are checked for membership in the graph
+        The nodes in iterable nbunch are checked for membership in the graph
         and if not are silently ignored.
 
         Parameters
@@ -2045,13 +2045,7 @@ class Graph:
                     exc, message = err, err.args[0]
                     # capture error for non-sequence/iterator nbunch.
                     if "iter" in message:
-                        exc = NetworkXError(
-                            "nbunch is not a node or a sequence of nodes."
-                        )
-                    if "int" in message:
-                        exc = NetworkXError(
-                            f"Node {nbunch} is not a valid node in the graph."
-                        )
+                        exc = NetworkXError(f"Node {nbunch} is not in the graph.")
                     # capture error for unhashable node.
                     if "hashable" in message:
                         exc = NetworkXError(

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -9,6 +9,13 @@ import networkx as nx
 from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
+def test_degree_node_not_found_exception_message():
+    """See gh-7740"""
+    G = nx.path_graph(5)
+    with pytest.raises(nx.NetworkXError, match="Node.*is not in the graph"):
+        G.degree(100)
+
+
 class BaseGraphTester:
     """Tests for data-structure independent graph class features."""
 

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -139,7 +139,7 @@ class BaseGraphTester:
         # node not in graph doesn't get caught upon creation of iterator
         bunch = G.nbunch_iter(-1)
         # but gets caught when iterator used
-        with pytest.raises(nx.NetworkXError, match="is not a node or a sequence"):
+        with pytest.raises(nx.NetworkXError, match="is not in the graph"):
             list(bunch)
         # unhashable doesn't get caught upon creation of iterator
         bunch = G.nbunch_iter([0, 1, 2, {}])


### PR DESCRIPTION
This closes https://github.com/networkx/networkx/issues/7740

Changes :

    Error message changed to include what nbunch is instead of just 'nbunch'

    Tests changed accordingly to look for new error message.

    Small improvement in documentation && documentation changed accordingly.
