### PR TITLE
Faster computation of energy in Laplacian centrality

### DIFF
--- a/networkx/algorithms/centrality/laplacian.py
+++ b/networkx/algorithms/centrality/laplacian.py
@@ -122,7 +122,7 @@ def laplacian_centrality(
     else:
         lap_matrix = nx.laplacian_matrix(G, nodes, weight).toarray()
 
-    full_energy = np.power(sp.linalg.eigh(lap_matrix, eigvals_only=True), 2).sum()
+    full_energy = np.sum(lap_matrix**2)
 
     # calculate laplacian centrality
     laplace_centralities_dict = {}
@@ -137,7 +137,7 @@ def laplacian_centrality(
         np.fill_diagonal(A_2, new_diag[all_but_i])
 
         if len(all_but_i) > 0:  # catches degenerate case of single node
-            new_energy = np.power(sp.linalg.eigh(A_2, eigvals_only=True), 2).sum()
+            new_energy = np.sum(A_2**2)
         else:
             new_energy = 0.0
 


### PR DESCRIPTION
Major performance improvement when computing Laplacian centrality. Simply followed theorem 1 of the original paper (the one cited in the documentation: https://math.wvu.edu/~cqzhang/Publication-files/my-paper/INS-2012-Laplacian-W.pdf) which implies simply summing the squares of the entries of the matrix instead of computing a ton of eigenvalues.

The change is very simple (just two lines). Should give exactly the same result now due to the theorem mentioned. Preliminary testing showed it did work.

Note: it should be possible to make this even faster by only summing over the values that change when going from the big to the small matrix (the whole diagonal and respective row and column). I don't have time to do the computations for this now, though.