### PR TITLE
Fix handling of faux_infinite values in network_simplex

### DIFF
--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -562,13 +562,9 @@ def network_simplex(G, demand="demand", capacity="capacity", weight="weight"):
     faux_inf = (
         3
         * max(
-            chain(
-                [
-                    sum(c for c in DEAF.edge_capacities if c < inf),
-                    sum(abs(w) for w in DEAF.edge_weights),
-                    sum(abs(d) for d in DEAF.node_demands),
-                ],
-            )
+            sum(c for c in DEAF.edge_capacities if c < inf),
+            sum(abs(w) for w in DEAF.edge_weights),
+            sum(abs(d) for d in DEAF.node_demands),
         )
         or 1
     )

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -560,10 +560,18 @@ def network_simplex(G, demand="demand", capacity="capacity", weight="weight"):
             DEAF.edge_sources.append(i)
             DEAF.edge_targets.append(-1)
     faux_inf = (
-        sum(capacity for capacity in DEAF.edge_capacities if capacity < inf)
-        + sum(abs(weight) for weight in DEAF.edge_weights)
-        + sum(abs(demand) for demand in DEAF.node_demands)
-    ) * 10 or 1
+        3
+        * max(
+            chain(
+                [
+                    sum(c for c in DEAF.edge_capacities if c < inf),
+                    sum(abs(w) for w in DEAF.edge_weights),
+                    sum(abs(d) for d in DEAF.node_demands),
+                ],
+            )
+        )
+        or 1
+    )
 
     n = len(DEAF.node_list)  # number of nodes
     DEAF.edge_weights.extend(repeat(faux_inf, n))

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -560,18 +560,10 @@ def network_simplex(G, demand="demand", capacity="capacity", weight="weight"):
             DEAF.edge_sources.append(i)
             DEAF.edge_targets.append(-1)
     faux_inf = (
-        3
-        * max(
-            chain(
-                [
-                    sum(c for c in DEAF.edge_capacities if c < inf),
-                    sum(abs(w) for w in DEAF.edge_weights),
-                ],
-                (abs(d) for d in DEAF.node_demands),
-            )
-        )
-        or 1
-    )
+        sum(capacity for capacity in DEAF.edge_capacities if capacity < inf)
+        + sum(abs(weight) for weight in DEAF.edge_weights)
+        + sum(abs(demand) for demand in DEAF.node_demands)
+    ) * 10 or 1
 
     n = len(DEAF.node_list)  # number of nodes
     DEAF.edge_weights.extend(repeat(faux_inf, n))

--- a/networkx/algorithms/flow/networksimplex.py
+++ b/networkx/algorithms/flow/networksimplex.py
@@ -512,34 +512,46 @@ def network_simplex(G, demand="demand", capacity="capacity", weight="weight"):
     inf = float("inf")
     for u, d in zip(DEAF.node_list, DEAF.node_demands):
         if abs(d) == inf:
-            raise nx.NetworkXError(f"node {u!r} has infinite demand")
+            raise nx.NetworkXError(
+                f"Invalid input: Node {u!r} has an infinite absolute demand, which is not allowed."
+            )
     for e, w in zip(DEAF.edge_indices, DEAF.edge_weights):
         if abs(w) == inf:
-            raise nx.NetworkXError(f"edge {e!r} has infinite weight")
+            raise nx.NetworkXError(
+                f"Invalid input: Edge {e!r} has an infinite absolute weight, making the cost computation undefined."
+            )
     if not multigraph:
         edges = nx.selfloop_edges(G, data=True)
     else:
         edges = nx.selfloop_edges(G, data=True, keys=True)
     for e in edges:
         if abs(e[-1].get(weight, 0)) == inf:
-            raise nx.NetworkXError(f"edge {e[:-1]!r} has infinite weight")
+            raise nx.NetworkXError(
+                f"Invalid input: Self-loop {e[:-1]!r} has an infinite weight, which is not allowed."
+            )
 
     ###########################################################################
     # Quick Infeasibility Detection
     ###########################################################################
 
     if sum(DEAF.node_demands) != 0:
-        raise nx.NetworkXUnfeasible("total node demand is not zero")
+        raise nx.NetworkXUnfeasible(
+            "Flow infeasible: The total supply does not match the total demand."
+        )
     for e, c in zip(DEAF.edge_indices, DEAF.edge_capacities):
         if c < 0:
-            raise nx.NetworkXUnfeasible(f"edge {e!r} has negative capacity")
+            raise nx.NetworkXUnfeasible(
+                f"Invalid input: Edge {e!r} has a negative capacity, which is not allowed."
+            )
     if not multigraph:
         edges = nx.selfloop_edges(G, data=True)
     else:
         edges = nx.selfloop_edges(G, data=True, keys=True)
     for e in edges:
         if e[-1].get(capacity, inf) < 0:
-            raise nx.NetworkXUnfeasible(f"edge {e[:-1]!r} has negative capacity")
+            raise nx.NetworkXUnfeasible(
+                f"Invalid input: Self-loop {e[:-1]!r} has a negative capacity, which is not allowed."
+            )
 
     ###########################################################################
     # Initialization
@@ -602,13 +614,17 @@ def network_simplex(G, demand="demand", capacity="capacity", weight="weight"):
     ###########################################################################
 
     if any(DEAF.edge_flow[i] != 0 for i in range(-n, 0)):
-        raise nx.NetworkXUnfeasible("no flow satisfies all node demands")
+        raise nx.NetworkXUnfeasible(
+            "Flow infeasible: The network cannot satisfy all node demands due to capacity constraints."
+        )
 
     if any(DEAF.edge_flow[i] * 2 >= faux_inf for i in range(DEAF.edge_count)) or any(
         e[-1].get(capacity, inf) == inf and e[-1].get(weight, 0) < 0
         for e in nx.selfloop_edges(G, data=True)
     ):
-        raise nx.NetworkXUnbounded("negative cycle with infinite capacity found")
+        raise nx.NetworkXUnbounded(
+            "Unbounded flow detected: A negative-weight cycle with infinite capacity allows indefinite cost reduction."
+        )
 
     ###########################################################################
     # Flow cost calculation and flow dict construction

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -6,6 +6,7 @@ import pickle
 import pytest
 
 import networkx as nx
+from networkx import NetworkXUnbounded
 
 
 @pytest.fixture
@@ -387,178 +388,79 @@ def test_graphs_type_exceptions():
     pytest.raises(nx.NetworkXError, nx.network_simplex, G)
 
 
-def test_case1_issue7562():
-    def create_graph(with_capacity):
-        G = nx.DiGraph()
+def create_graph(
+    has_large_capacity: bool = False,
+    has_large_weight: bool = False,
+    has_large_demand: bool = False,
+):
+    large_value = 1000000000
+    G = nx.DiGraph()
 
-        # Add nodes with demands
-        G.add_node("s0", demand=-89)
-        G.add_node("s1", demand=-197)
-        G.add_node("s2", demand=89)
-        G.add_node("s3", demand=212)
-        G.add_node("s4", demand=32)
-        G.add_node("s5", demand=83)
-        G.add_node("s6", demand=-159)
-        G.add_node("s7", demand=-68)
-        G.add_node("s8", demand=116)
-        G.add_node("s9", demand=120)
-        G.add_node("s10", demand=-65)
-        G.add_node("s11", demand=-74)
-
-        # Add edges
-        if with_capacity:
-            G.add_edge("s0", "s0", weight=1, capacity=10000)
-            G.add_edge("s0", "s1", weight=1, capacity=10000)
-        else:
-            G.add_edge("s0", "s0", weight=1)
-            G.add_edge("s0", "s1", weight=1)
-
-        G.add_edge("s1", "s0", weight=1)
-        G.add_edge("s1", "s2", weight=1)
-        G.add_edge("s1", "s3", weight=1)
-        G.add_edge("s1", "s4", weight=1)
-        G.add_edge("s10", "s0", weight=1)
-        G.add_edge("s10", "s10", weight=1)
-        G.add_edge("s10", "s7", weight=1)
-        G.add_edge("s11", "s0", weight=1)
-        G.add_edge("s11", "s11", weight=1)
-        G.add_edge("s11", "s5", weight=1)
-        G.add_edge("s11", "s7", weight=1)
-        G.add_edge("s11", "s9", weight=1)
-        G.add_edge("s2", "s0", weight=1)
-        G.add_edge("s2", "s1", weight=1)
-        G.add_edge("s2", "s2", weight=1)
-        G.add_edge("s2", "s5", weight=1)
-        G.add_edge("s3", "s0", weight=1)
-        G.add_edge("s3", "s1", weight=1)
-        G.add_edge("s3", "s2", weight=1)
-        G.add_edge("s3", "s3", weight=1)
-        G.add_edge("s4", "s0", weight=1)
-        G.add_edge("s4", "s6", weight=1)
-        G.add_edge("s4", "s7", weight=1)
-        G.add_edge("s5", "s0", weight=1)
-        G.add_edge("s5", "s10", weight=1)
-        G.add_edge("s5", "s11", weight=1)
-        G.add_edge("s5", "s8", weight=1)
-        G.add_edge("s5", "s9", weight=1)
-        G.add_edge("s6", "s0", weight=1)
-        G.add_edge("s6", "s10", weight=1)
-        G.add_edge("s6", "s4", weight=1)
-        G.add_edge("s6", "s6", weight=1)
-        G.add_edge("s7", "s0", weight=1)
-        G.add_edge("s7", "s10", weight=1)
-        G.add_edge("s7", "s4", weight=1)
-        G.add_edge("s7", "s6", weight=1)
-        G.add_edge("s8", "s0", weight=1)
-        G.add_edge("s8", "s11", weight=1)
-        G.add_edge("s8", "s8", weight=1)
-        G.add_edge("s8", "s9", weight=1)
-        G.add_edge("s9", "s0", weight=1)
-        G.add_edge("s9", "s11", weight=1)
-        G.add_edge("s9", "s5", weight=1)
-        G.add_edge("s9", "s7", weight=1)
-        G.add_edge("s9", "s8", weight=1)
-
-        return G
-
-    try:
-        G1 = create_graph(False)
-        flow_value, flow_dict = nx.network_simplex(G1)
-    except Exception as e:
-        pytest.fail(f"network_simplex(G1) failed with error: {e}")
-
-    try:
-        G2 = create_graph(True)
-        flow_value, flow_dict = nx.network_simplex(G2)
-    except Exception as e:
-        pytest.fail(f"network_simplex(G2) failed with error: {e}")
-
-
-def test_case2_issue7562():
-    cap = 1000000000
-
-    def create_graph(with_capacity):
-        G = nx.DiGraph()
-
-        c = {"capacity": cap} if with_capacity else {}
-
-        # Add nodes with demands
-        G.add_node("s0", demand=-89)
-        G.add_node("s1", demand=-197)
-        G.add_node("s2", demand=89)
-        G.add_node("s3", demand=212)
-        G.add_node("s4", demand=32)
-        G.add_node("s5", demand=83)
-        G.add_node("s6", demand=-159)
-        G.add_node("s7", demand=-68)
-        G.add_node("s8", demand=116)
-        G.add_node("s9", demand=120)
-        G.add_node("s10", demand=-65)
-        G.add_node("s11", demand=-74)
-
-        # Add edges
-        G.add_edge("s0", "s1", weight=1, **c)
-        G.add_edge("s1", "s2", weight=1)
-        G.add_edge("s1", "s3", weight=1)
-        G.add_edge("s1", "s4", weight=1)
-        G.add_edge("s10", "s0", weight=1)
-        G.add_edge("s11", "s9", weight=1)
-        G.add_edge("s2", "s5", weight=1)
-        G.add_edge("s5", "s11", weight=1)
-        G.add_edge("s5", "s8", weight=1)
-        G.add_edge("s6", "s10", weight=1)
-        G.add_edge("s7", "s0", weight=1)
-
-        return G
-
-    # Calculate min-cost flow
-    try:
-        G1 = create_graph(False)
-        flow_value, flow_dict = nx.network_simplex(G1)  # fails
-    except Exception as e:
-        pytest.fail(f"network_simplex(G1) failed with error: {e}")
-
-    try:
-        G2 = create_graph(True)
-        flow_value, flow_dict = nx.network_simplex(G2)
-    except Exception as e:
-        pytest.fail(f"network_simplex(G2) failed with error: {e}")
-
-
-def test_case3_issue7562():
-    cap = 1000000000
-
-    def create_graph(with_capacity):
-        G = nx.DiGraph()
-
-        c = {"capacity": cap} if with_capacity else {}
-
-        # Add nodes with demands
+    # Add nodes with demands
+    if has_large_demand:
+        G.add_node("s0", demand=-large_value)
+        G.add_node("c1", demand=large_value)
+    else:
         G.add_node("s0", demand=-4)
-        G.add_node("s1", demand=-4)
-        G.add_node("ns", demand=0)
-        G.add_node("nc", demand=0)
-        G.add_node("c0", demand=4)
         G.add_node("c1", demand=4)
 
-        # Add edges
-        G.add_edge("s0", "ns", weight=1, **c)
+    G.add_node("s1", demand=-4)
+    G.add_node("ns", demand=0)
+    G.add_node("nc", demand=0)
+    G.add_node("c0", demand=4)
+
+    # Add edges
+    if has_large_capacity:
+        G.add_edge("s0", "ns", weight=1, capacity=large_value)
+    else:
+        G.add_edge("s0", "ns")
+
+    if has_large_weight:
+        G.add_edge("s1", "ns", weight=large_value)
+    else:
         G.add_edge("s1", "ns", weight=1)
-        G.add_edge("ns", "nc", weight=1)
-        G.add_edge("nc", "c0", weight=1)
-        G.add_edge("nc", "c1", weight=1)
 
-        return G
+    G.add_edge("ns", "nc", weight=1)
+    G.add_edge("nc", "c0", weight=1)
+    G.add_edge("nc", "c1", weight=1)
 
-    # Calculate min-cost flow
-    try:
-        G1 = create_graph(False)
-        flow_value, flow_dict = nx.network_simplex(G1)  # fails
-    except Exception as e:
-        pytest.fail(f"network_simplex(G1) failed with error: {e}")
+    return G
 
-    try:
-        G2 = create_graph(True)
-        flow_value, flow_dict = nx.network_simplex(G2)
-    except Exception as e:
-        pytest.fail(f"network_simplex(G2) failed with error: {e}")
+
+@pytest.mark.parametrize(
+    "has_large_capacity, has_large_weight, has_large_demand",
+    [
+        (True, True, True),
+        (True, True, False),
+        (True, False, True),
+        (True, False, False),
+        (False, True, True),
+        (False, True, False),
+        (False, False, True),
+        (False, False, False),
+    ],
+)
+def test_network_simplex_large_capacities(
+    has_large_capacity: bool, has_large_weight: bool, has_large_demand: bool
+):
+    """Address issues raised in ticket #7562."""
+    graph = create_graph(has_large_capacity, has_large_weight, has_large_demand)
+    flow_value, flow_dict = nx.network_simplex(graph)
+
+
+def test_network_simplex_exceeding_faux_infinity():
+    G = nx.DiGraph()
+    # Add nodes
+    G.add_node("A")
+    G.add_node("B")
+    G.add_node("C")
+
+    # Add edges forming a negative cycle
+    G.add_edge("A", "B", weight=-5)
+    G.add_edge("B", "C", weight=-5)
+    G.add_edge("C", "A", weight=-5)
+
+    with pytest.raises(
+        NetworkXUnbounded, match="negative cycle with infinite capacity found"
+    ):
+        nx.network_simplex(G)

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -385,3 +385,180 @@ def test_graphs_type_exceptions():
     pytest.raises(nx.NetworkXNotImplemented, nx.network_simplex, G)
     G = nx.DiGraph()
     pytest.raises(nx.NetworkXError, nx.network_simplex, G)
+
+
+def test_case1_issue7562():
+    def create_graph(with_capacity):
+        G = nx.DiGraph()
+
+        # Add nodes with demands
+        G.add_node("s0", demand=-89)
+        G.add_node("s1", demand=-197)
+        G.add_node("s2", demand=89)
+        G.add_node("s3", demand=212)
+        G.add_node("s4", demand=32)
+        G.add_node("s5", demand=83)
+        G.add_node("s6", demand=-159)
+        G.add_node("s7", demand=-68)
+        G.add_node("s8", demand=116)
+        G.add_node("s9", demand=120)
+        G.add_node("s10", demand=-65)
+        G.add_node("s11", demand=-74)
+
+        # Add edges
+        if with_capacity:
+            G.add_edge("s0", "s0", weight=1, capacity=10000)
+            G.add_edge("s0", "s1", weight=1, capacity=10000)
+        else:
+            G.add_edge("s0", "s0", weight=1)
+            G.add_edge("s0", "s1", weight=1)
+
+        G.add_edge("s1", "s0", weight=1)
+        G.add_edge("s1", "s2", weight=1)
+        G.add_edge("s1", "s3", weight=1)
+        G.add_edge("s1", "s4", weight=1)
+        G.add_edge("s10", "s0", weight=1)
+        G.add_edge("s10", "s10", weight=1)
+        G.add_edge("s10", "s7", weight=1)
+        G.add_edge("s11", "s0", weight=1)
+        G.add_edge("s11", "s11", weight=1)
+        G.add_edge("s11", "s5", weight=1)
+        G.add_edge("s11", "s7", weight=1)
+        G.add_edge("s11", "s9", weight=1)
+        G.add_edge("s2", "s0", weight=1)
+        G.add_edge("s2", "s1", weight=1)
+        G.add_edge("s2", "s2", weight=1)
+        G.add_edge("s2", "s5", weight=1)
+        G.add_edge("s3", "s0", weight=1)
+        G.add_edge("s3", "s1", weight=1)
+        G.add_edge("s3", "s2", weight=1)
+        G.add_edge("s3", "s3", weight=1)
+        G.add_edge("s4", "s0", weight=1)
+        G.add_edge("s4", "s6", weight=1)
+        G.add_edge("s4", "s7", weight=1)
+        G.add_edge("s5", "s0", weight=1)
+        G.add_edge("s5", "s10", weight=1)
+        G.add_edge("s5", "s11", weight=1)
+        G.add_edge("s5", "s8", weight=1)
+        G.add_edge("s5", "s9", weight=1)
+        G.add_edge("s6", "s0", weight=1)
+        G.add_edge("s6", "s10", weight=1)
+        G.add_edge("s6", "s4", weight=1)
+        G.add_edge("s6", "s6", weight=1)
+        G.add_edge("s7", "s0", weight=1)
+        G.add_edge("s7", "s10", weight=1)
+        G.add_edge("s7", "s4", weight=1)
+        G.add_edge("s7", "s6", weight=1)
+        G.add_edge("s8", "s0", weight=1)
+        G.add_edge("s8", "s11", weight=1)
+        G.add_edge("s8", "s8", weight=1)
+        G.add_edge("s8", "s9", weight=1)
+        G.add_edge("s9", "s0", weight=1)
+        G.add_edge("s9", "s11", weight=1)
+        G.add_edge("s9", "s5", weight=1)
+        G.add_edge("s9", "s7", weight=1)
+        G.add_edge("s9", "s8", weight=1)
+
+        return G
+
+    try:
+        G1 = create_graph(False)
+        flow_value, flow_dict = nx.network_simplex(G1)
+    except Exception as e:
+        pytest.fail(f"network_simplex(G1) failed with error: {e}")
+
+    try:
+        G2 = create_graph(True)
+        flow_value, flow_dict = nx.network_simplex(G2)
+    except Exception as e:
+        pytest.fail(f"network_simplex(G2) failed with error: {e}")
+
+
+def test_case2_issue7562():
+    cap = 1000000000
+
+    def create_graph(with_capacity):
+        G = nx.DiGraph()
+
+        c = {"capacity": cap} if with_capacity else {}
+
+        # Add nodes with demands
+        G.add_node("s0", demand=-89)
+        G.add_node("s1", demand=-197)
+        G.add_node("s2", demand=89)
+        G.add_node("s3", demand=212)
+        G.add_node("s4", demand=32)
+        G.add_node("s5", demand=83)
+        G.add_node("s6", demand=-159)
+        G.add_node("s7", demand=-68)
+        G.add_node("s8", demand=116)
+        G.add_node("s9", demand=120)
+        G.add_node("s10", demand=-65)
+        G.add_node("s11", demand=-74)
+
+        # Add edges
+        G.add_edge("s0", "s1", weight=1, **c)
+        G.add_edge("s1", "s2", weight=1)
+        G.add_edge("s1", "s3", weight=1)
+        G.add_edge("s1", "s4", weight=1)
+        G.add_edge("s10", "s0", weight=1)
+        G.add_edge("s11", "s9", weight=1)
+        G.add_edge("s2", "s5", weight=1)
+        G.add_edge("s5", "s11", weight=1)
+        G.add_edge("s5", "s8", weight=1)
+        G.add_edge("s6", "s10", weight=1)
+        G.add_edge("s7", "s0", weight=1)
+
+        return G
+
+    # Calculate min-cost flow
+    try:
+        G1 = create_graph(False)
+        flow_value, flow_dict = nx.network_simplex(G1)  # fails
+    except Exception as e:
+        pytest.fail(f"network_simplex(G1) failed with error: {e}")
+
+    try:
+        G2 = create_graph(True)
+        flow_value, flow_dict = nx.network_simplex(G2)
+    except Exception as e:
+        pytest.fail(f"network_simplex(G2) failed with error: {e}")
+
+
+def test_case3_issue7562():
+    cap = 1000000000
+
+    def create_graph(with_capacity):
+        G = nx.DiGraph()
+
+        c = {"capacity": cap} if with_capacity else {}
+
+        # Add nodes with demands
+        G.add_node("s0", demand=-4)
+        G.add_node("s1", demand=-4)
+        G.add_node("ns", demand=0)
+        G.add_node("nc", demand=0)
+        G.add_node("c0", demand=4)
+        G.add_node("c1", demand=4)
+
+        # Add edges
+        G.add_edge("s0", "ns", weight=1, **c)
+        G.add_edge("s1", "ns", weight=1)
+        G.add_edge("ns", "nc", weight=1)
+        G.add_edge("nc", "c0", weight=1)
+        G.add_edge("nc", "c1", weight=1)
+
+        return G
+
+    # Calculate min-cost flow
+    try:
+        G1 = create_graph(False)
+        flow_value, flow_dict = nx.network_simplex(G1)  # fails
+    except Exception as e:
+        pytest.fail(f"network_simplex(G1) failed with error: {e}")
+
+    try:
+        G2 = create_graph(True)
+        flow_value, flow_dict = nx.network_simplex(G2)
+    except Exception as e:
+        pytest.fail(f"network_simplex(G2) failed with error: {e}")

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -6,7 +6,6 @@ import pickle
 import pytest
 
 import networkx as nx
-from networkx import NetworkXUnbounded
 
 
 @pytest.fixture
@@ -53,7 +52,7 @@ def test_infinite_demand_raise(simple_flow_graph):
     nx.set_node_attributes(G, {node_name: {"demand": inf}})
     with pytest.raises(
         nx.NetworkXError,
-        match=f"Invalid input: Node '{node_name}' has an infinite absolute demand, which is not allowed.",
+        match=f"node '{node_name}' has infinite demand",
     ):
         nx.network_simplex(G)
 
@@ -65,7 +64,7 @@ def test_neg_infinite_demand_raise(simple_flow_graph):
     nx.set_node_attributes(G, {node_name: {"demand": -inf}})
     with pytest.raises(
         nx.NetworkXError,
-        match=f"Invalid input: Node '{node_name}' has an infinite absolute demand, which is not allowed.",
+        match=f"node '{node_name}' has infinite demand",
     ):
         nx.network_simplex(G)
 
@@ -78,7 +77,7 @@ def test_infinite_weight_raise(simple_flow_graph):
     )
     with pytest.raises(
         nx.NetworkXError,
-        match=r"Invalid input: Edge .* has an infinite absolute weight, making the cost computation undefined.",
+        match=r"edge .* has infinite weight",
     ):
         nx.network_simplex(G)
 
@@ -88,7 +87,7 @@ def test_nonzero_net_demand_raise(simple_flow_graph):
     nx.set_node_attributes(G, {"b": {"demand": -4}})
     with pytest.raises(
         nx.NetworkXUnfeasible,
-        match="Flow infeasible: The total supply does not match the total demand.",
+        match="total node demand is not zero",
     ):
         nx.network_simplex(G)
 
@@ -98,7 +97,7 @@ def test_negative_capacity_raise(simple_flow_graph):
     nx.set_edge_attributes(G, {("a", "b"): {"weight": 1}, ("b", "d"): {"capacity": -9}})
     with pytest.raises(
         nx.NetworkXUnfeasible,
-        match=r"Invalid input: Edge .* has a negative capacity, which is not allowed.",
+        match=r"edge .* has negative capacity",
     ):
         nx.network_simplex(G)
 
@@ -107,7 +106,7 @@ def test_no_flow_satisfying_demands(simple_no_flow_graph):
     G = simple_no_flow_graph
     with pytest.raises(
         nx.NetworkXUnfeasible,
-        match="Flow infeasible: The network cannot satisfy all node demands due to capacity constraints.",
+        match="no flow satisfies all node demands",
     ):
         nx.network_simplex(G)
 
@@ -117,7 +116,7 @@ def test_sum_demands_not_zero(simple_no_flow_graph):
     nx.set_node_attributes(G, {"t": {"demand": 4}})
     with pytest.raises(
         nx.NetworkXUnfeasible,
-        match="Flow infeasible: The total supply does not match the total demand.",
+        match="total node demand is not zero",
     ):
         nx.network_simplex(G)
 
@@ -486,12 +485,10 @@ def test_network_simplex_unbounded_flow():
     G.add_node("C")
 
     # Add edges forming a negative cycle
-    G.add_edge("A", "B", weight=-5)
-    G.add_edge("B", "C", weight=-5)
-    G.add_edge("C", "A", weight=-5)
+    G.add_weighted_edges_from([("A", "B", -5), ("B", "C", -5), ("C", "A", -5)])
 
     with pytest.raises(
-        NetworkXUnbounded,
-        match="Unbounded flow detected: A negative-weight cycle with infinite capacity allows indefinite cost reduction.",
+        nx.NetworkXUnbounded,
+        match="negative cycle with infinite capacity found",
     ):
         nx.network_simplex(G)


### PR DESCRIPTION
I've looked into the issue and implemented a potential fix. While I have a general understanding of the high-level idea, I have not studied the network-simplex algorithm in full detail.

From my understanding, the purpose of the `faux_inf value` is to create dummy edges and assign them a "practical infinity" value, rather than using actual infinity. This "practical infinity" is intended to be sufficiently large compared to all other "real" weights and capacities.

Change made:

1. Implemented a new calculation for `faux_inf`: 
   `faux_inf = (sum(c for c in DEAF.edge_capacities if c < inf) +
                sum(abs(w) for w in DEAF.edge_weights) +
                sum(abs(d) for d in DEAF.node_demands)) * 10 or 1`

2. Added the three sample cases discussed in the issue as tests (for illustration):
     - Verified that these tests fail without the fix.
     - Confirmed that they pass with the fix applied.

I believe not all three test cases are necessary for permanent inclusion in the codebase. Please feel free to provide feedback or suggest changes. 

Fixes https://github.com/networkx/networkx/issues/7562 