### PR TITLE
Update dispatchable for `forceatlas2_layout`...

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1426,7 +1426,7 @@ def arf_layout(
 
 
 @np_random_state("seed")
-@nx._dispatchable
+@nx._dispatchable(mutates_input={"store_pos_as": 15})
 def forceatlas2_layout(
     G,
     pos=None,


### PR DESCRIPTION
to handle new `store_pos_as=` parameter introduced in #7571, which mutates the input graph when used.

#7571 and #7794 (which just added `@nx._dispatchable` to FA2) were merged virtually simultaneously, so there was no chance to update one with the other.