### PR TITLE
Fix `with nx.config(backend_priority=backends):`

### DIFF
--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -346,8 +346,11 @@ class NetworkXConfig(Config):
 
         if key == "backend_priority":
             if isinstance(value, list):
-                getattr(self, key).algos = value
-                value = getattr(self, key)
+                # `config.backend_priority = [backend]` sets `backend_priority.algos`
+                value = dict(
+                    self.backend_priority,
+                    algos=self.backend_priority._on_setattr("algos", value),
+                )
             elif isinstance(value, dict):
                 kwargs = value
                 value = BackendPriorities(algos=[], generators=[])

--- a/networkx/utils/tests/test_config.py
+++ b/networkx/utils/tests/test_config.py
@@ -138,6 +138,30 @@ def test_nxconfig():
         nx.config.warnings_to_ignore = {"bad value"}
 
 
+def test_nxconfig_context():
+    # We do some special handling so that `nx.config.backend_priority = val`
+    # actually does `nx.config.backend_priority.algos = val`.
+    orig = nx.config.backend_priority.algos
+    val = [] if orig else ["networkx"]
+    assert orig != val
+    assert nx.config.backend_priority.algos != val
+    with nx.config(backend_priority=val):
+        assert nx.config.backend_priority.algos == val
+    assert nx.config.backend_priority.algos == orig
+    with nx.config.backend_priority(algos=val):
+        assert nx.config.backend_priority.algos == val
+    assert nx.config.backend_priority.algos == orig
+    bad = ["bad-backend"]
+    with pytest.raises(ValueError, match="Unknown backend"):
+        nx.config.backend_priority = bad
+    with pytest.raises(ValueError, match="Unknown backend"):
+        with nx.config(backend_priority=bad):
+            pass
+    with pytest.raises(ValueError, match="Unknown backend"):
+        with nx.config.backend_priority(algos=bad):
+            pass
+
+
 def test_not_strict():
     class FlexibleConfig(Config, strict=False):
         x: int


### PR DESCRIPTION
Previously, it didn't restore the original values

Thanks @rlratzel who discovered this.