### PR TITLE
Update usage of "Yields" section

### DIFF
--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -7,7 +7,7 @@ __all__ = ["node_attribute_xy", "node_degree_xy"]
 
 @nx._dispatchable(node_attrs="attribute")
 def node_attribute_xy(G, attribute, nodes=None):
-    """Yields 2-tuples of node attribute values for all edges in `G`.
+    """Yield 2-tuples of node attribute values for all edges in `G`.
 
     This generator yields, for each edge in `G` incident to a node in `nodes`,
     a 2-tuple of form ``(attribute value,  attribute value)`` for the parameter
@@ -27,7 +27,7 @@ def node_attribute_xy(G, attribute, nodes=None):
     Yields
     ------
     (x, y): 2-tuple
-        Generates 2-tuple of (attribute, attribute) values.
+        2-tuple of (attribute, attribute) values.
 
     Examples
     --------
@@ -67,7 +67,7 @@ def node_attribute_xy(G, attribute, nodes=None):
 
 @nx._dispatchable(edge_attrs="weight")
 def node_degree_xy(G, x="out", y="in", weight=None, nodes=None):
-    """Yields 2-tuples of ``(degree, degree)`` values for edges in `G`.
+    """Yield 2-tuples of ``(degree, degree)`` values for edges in `G`.
 
     This generator yields, for each edge in `G` incident to a node in `nodes`,
     a 2-tuple of form ``(degree, degree)``. The node degrees are weighted
@@ -95,7 +95,7 @@ def node_degree_xy(G, x="out", y="in", weight=None, nodes=None):
     Yields
     ------
     (x, y): 2-tuple
-        Generates 2-tuple of (degree, degree) values.
+        2-tuple of (degree, degree) values.
 
     Examples
     --------

--- a/networkx/algorithms/boundary.py
+++ b/networkx/algorithms/boundary.py
@@ -18,7 +18,7 @@ __all__ = ["edge_boundary", "node_boundary"]
 
 @nx._dispatchable(edge_attrs={"data": "default"}, preserve_edge_attrs="data")
 def edge_boundary(G, nbunch1, nbunch2=None, data=False, keys=False, default=None):
-    """Returns the edge boundary of `nbunch1`.
+    """Yield the edge boundary of `nbunch1`.
 
     The *edge boundary* of a set *S* with respect to a set *T* is the
     set of edges (*u*, *v*) such that *u* is in *S* and *v* is in *T*.
@@ -52,13 +52,12 @@ def edge_boundary(G, nbunch1, nbunch2=None, data=False, keys=False, default=None
         This parameter has the same meaning as in
         :meth:`MultiGraph.edges`.
 
-    Returns
-    -------
-    iterator
-        An iterator over the edges in the boundary of `nbunch1` with
-        respect to `nbunch2`. If `keys`, `data`, or `default`
-        are specified and `G` is a multigraph, then edges are returned
-        with keys and/or data, as in :meth:`MultiGraph.edges`.
+    Yields
+    ------
+    edge : tuple
+        The edges in the boundary of `nbunch1` with respect to `nbunch2`.
+        If `keys`, `data`, or `default` are specified and `G` is a multigraph,
+        then edges are yielded with keys and/or data as in :meth:`MultiGraph.edges`.
 
     Examples
     --------

--- a/networkx/algorithms/bridges.py
+++ b/networkx/algorithms/bridges.py
@@ -11,7 +11,7 @@ __all__ = ["bridges", "has_bridges", "local_bridges"]
 @not_implemented_for("directed")
 @nx._dispatchable
 def bridges(G, root=None):
-    """Generate all bridges in a graph.
+    """Yield all bridges in a graph.
 
     A *bridge* in a graph is an edge whose removal causes the number of
     connected components of the graph to increase.  Equivalently, a bridge is an
@@ -28,7 +28,7 @@ def bridges(G, root=None):
 
     Yields
     ------
-    e : edge
+    edge : 2-tuple
        An edge in the graph whose removal disconnects the graph (or
        causes the number of connected components to increase).
 
@@ -144,7 +144,7 @@ def has_bridges(G, root=None):
 @not_implemented_for("directed")
 @nx._dispatchable(edge_attrs="weight")
 def local_bridges(G, with_span=True, weight=None):
-    """Iterate over local bridges of `G` optionally computing the span
+    """Yield local bridges of `G` optionally computing the span.
 
     A *local bridge* is an edge whose endpoints have no common neighbors.
     That is, the edge is not part of a triangle in the graph.
@@ -166,7 +166,7 @@ def local_bridges(G, with_span=True, weight=None):
 
     Yields
     ------
-    e : edge
+    edge : tuple
         The local bridges as an edge 2-tuple of nodes `(u, v)` or
         as a 3-tuple `(u, v, span)` when `with_span is True`.
 

--- a/networkx/algorithms/chains.py
+++ b/networkx/algorithms/chains.py
@@ -10,7 +10,7 @@ __all__ = ["chain_decomposition"]
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def chain_decomposition(G, root=None):
-    """Returns the chain decomposition of a graph.
+    """Yield the chain decomposition of a graph.
 
     The *chain decomposition* of a graph with respect a depth-first
     search tree is a set of cycles or paths derived from the set of
@@ -34,10 +34,10 @@ def chain_decomposition(G, root=None):
 
     Yields
     ------
-    chain : list
-       A list of edges representing a chain. There is no guarantee on
-       the orientation of the edges in each chain (for example, if a
-       chain includes the edge joining nodes 1 and 2, the chain may
+    edge : 2-tuple
+       A sequence of edges representing a chain. There is no guarantee
+       on the orientation of the edges in each chain (for example, if
+       a chain includes the edge joining nodes 1 and 2, the chain may
        include either (1, 2) or (2, 1)).
 
     Raises

--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -171,7 +171,7 @@ def find_induced_nodes(G, s, t, treewidth_bound=sys.maxsize):
 
 @nx._dispatchable
 def chordal_graph_cliques(G):
-    """Returns all maximal cliques of a chordal graph.
+    """Yield all maximal cliques of a chordal graph.
 
     The algorithm breaks the graph in connected components and performs a
     maximum cardinality search in each component to get the cliques.

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -29,7 +29,7 @@ __all__ = [
 @not_implemented_for("directed")
 @nx._dispatchable
 def enumerate_all_cliques(G):
-    """Returns all cliques in an undirected graph.
+    """Yield all cliques in an undirected graph.
 
     This function returns an iterator over cliques, each of which is a
     list of nodes. The iteration is ordered by cardinality of the
@@ -41,11 +41,11 @@ def enumerate_all_cliques(G):
     G : NetworkX graph
         An undirected graph.
 
-    Returns
-    -------
-    iterator
-        An iterator over cliques, each of which is a list of nodes in
-        `G`. The cliques are ordered according to size.
+    Yields
+    ------
+    clique : list
+        List of nodes in a clique of `G`. The cliques are ordered by size,
+        smallest to largest.
 
     Notes
     -----
@@ -101,7 +101,7 @@ def enumerate_all_cliques(G):
 @not_implemented_for("directed")
 @nx._dispatchable
 def find_cliques(G, nodes=None):
-    """Returns all maximal cliques in an undirected graph.
+    """Yield all maximal cliques in an undirected graph.
 
     For each node *n*, a *maximal clique for n* is a largest complete
     subgraph containing *n*. The largest maximal clique is sometimes
@@ -124,13 +124,12 @@ def find_cliques(G, nodes=None):
         If provided, only yield *maximal cliques* containing all nodes in `nodes`.
         If `nodes` isn't a clique itself, a ValueError is raised.
 
-    Returns
-    -------
-    iterator
-        An iterator over maximal cliques, each of which is a list of
-        nodes in `G`. If `nodes` is provided, only the maximal cliques
-        containing all the nodes in `nodes` are returned. The order of
-        cliques is arbitrary.
+    Yields
+    ------
+    clique : list
+        List of nodes of a maximal clique of `G`. If `nodes` is provided,
+        only the maximal cliques containing all the nodes in `nodes` are
+        returned. The order of cliques is arbitrary.
 
     Raises
     ------
@@ -297,7 +296,7 @@ def find_cliques(G, nodes=None):
 # TODO Should this also be not implemented for directed graphs?
 @nx._dispatchable
 def find_cliques_recursive(G, nodes=None):
-    """Returns all maximal cliques in a graph.
+    """Yield all maximal cliques in a graph.
 
     For each node *v*, a *maximal clique for v* is a largest complete
     subgraph containing *v*. The largest maximal clique is sometimes
@@ -320,13 +319,12 @@ def find_cliques_recursive(G, nodes=None):
         If provided, only yield *maximal cliques* containing all nodes in `nodes`.
         If `nodes` isn't a clique itself, a ValueError is raised.
 
-    Returns
-    -------
-    iterator
-        An iterator over maximal cliques, each of which is a list of
-        nodes in `G`. If `nodes` is provided, only the maximal cliques
-        containing all the nodes in `nodes` are yielded. The order of
-        cliques is arbitrary.
+    Yields
+    ------
+    clique : list
+        List of nodes of a maximal clique of `G`. If `nodes` is provided,
+        only the maximal cliques containing all the nodes in `nodes` are
+        returned. The order of cliques is arbitrary.
 
     Raises
     ------

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -202,8 +202,7 @@ def strategy_connected_sequential(G, colors, traversal="bfs"):
 
 
 def strategy_saturation_largest_first(G, colors):
-    """Iterates over all the nodes of ``G`` in "saturation order" (also
-    known as "DSATUR").
+    """Yield all the nodes of ``G`` in "saturation order" (also known as "DSATUR").
 
     ``G`` is a NetworkX graph. ``colors`` is a dictionary mapping nodes of
     ``G`` to colors, for those nodes that have already been colored.

--- a/networkx/algorithms/community/asyn_fluid.py
+++ b/networkx/algorithms/community/asyn_fluid.py
@@ -15,7 +15,7 @@ __all__ = ["asyn_fluidc"]
 @py_random_state(3)
 @nx._dispatchable
 def asyn_fluidc(G, k, max_iter=100, seed=None):
-    """Returns communities in `G` as detected by Fluid Communities algorithm.
+    """Yield communities in `G` as detected by Fluid Communities algorithm.
 
     The asynchronous fluid communities algorithm is described in
     [1]_. The algorithm is based on the simple idea of fluids interacting
@@ -52,10 +52,10 @@ def asyn_fluidc(G, k, max_iter=100, seed=None):
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    communities : iterable
-        Iterable of communities given as sets of nodes.
+    Yields
+    ------
+    community : set
+        Set of nodes of a community.
 
     Notes
     -----
@@ -147,5 +147,5 @@ def asyn_fluidc(G, k, max_iter=100, seed=None):
         # If maximum iterations reached --> output actual results
         if iter_count > max_iter:
             break
-    # Return results by grouping communities as list of vertices
+    # Yield results by grouping communities as list of vertices
     return iter(groups(communities).values())

--- a/networkx/algorithms/community/centrality.py
+++ b/networkx/algorithms/community/centrality.py
@@ -7,7 +7,7 @@ __all__ = ["girvan_newman"]
 
 @nx._dispatchable(preserve_edge_attrs="most_valuable_edge")
 def girvan_newman(G, most_valuable_edge=None):
-    """Finds communities in a graph using the Girvan–Newman method.
+    """Yield communities in a graph using the Girvan–Newman method.
 
     Parameters
     ----------
@@ -21,12 +21,12 @@ def girvan_newman(G, most_valuable_edge=None):
         If not specified, the edge with the highest
         :func:`networkx.edge_betweenness_centrality` will be used.
 
-    Returns
-    -------
-    iterator
-        Iterator over tuples of sets of nodes in `G`. Each set of node
-        is a community, each tuple is a sequence of communities at a
-        particular level of the algorithm.
+    Yields
+    ------
+    communities : tuple of sets
+        Tuples of sets of nodes in `G`. Each set of nodes is a community,
+        and each tuple is a sequence of communities at a particular
+        level of the algorithm.
 
     Examples
     --------

--- a/networkx/algorithms/community/kclique.py
+++ b/networkx/algorithms/community/kclique.py
@@ -7,7 +7,7 @@ __all__ = ["k_clique_communities"]
 
 @nx._dispatchable
 def k_clique_communities(G, k, cliques=None):
-    """Find k-clique communities in graph using the percolation method.
+    """Yield k-clique communities in graph using the percolation method.
 
     A k-clique community is the union of all cliques of size k that
     can be reached through adjacent (sharing k-1 nodes) k-cliques.
@@ -22,9 +22,10 @@ def k_clique_communities(G, k, cliques=None):
     cliques: list or generator
        Precomputed cliques (use networkx.find_cliques(G))
 
-    Returns
-    -------
-    Yields sets of nodes, one for each k-clique community.
+    Yields
+    ------
+    community : frozenset
+        A frozenset of nodes of a k-clique community.
 
     Examples
     --------
@@ -67,7 +68,7 @@ def k_clique_communities(G, k, cliques=None):
     # Connected components of clique graph with perc edges
     # are the percolated cliques
     for component in nx.connected_components(perc_graph):
-        yield (frozenset.union(*component))
+        yield frozenset.union(*component)
 
 
 def _get_adjacent_cliques(clique, membership_dict):

--- a/networkx/algorithms/community/label_propagation.py
+++ b/networkx/algorithms/community/label_propagation.py
@@ -17,7 +17,7 @@ __all__ = [
 @py_random_state("seed")
 @nx._dispatchable(edge_attrs="weight")
 def fast_label_propagation_communities(G, *, weight=None, seed=None):
-    """Returns communities in `G` as detected by fast label propagation.
+    """Yield communities in `G` as detected by fast label propagation.
 
     The fast label propagation algorithm is described in [1]_. The algorithm is
     probabilistic and the found communities may vary in different executions.
@@ -47,10 +47,10 @@ def fast_label_propagation_communities(G, *, weight=None, seed=None):
     seed : integer, random_state, or None (default)
         Indicator of random number generation state. See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    communities : iterable
-        Iterable of communities given as sets of nodes.
+    Yields
+    ------
+    community : set
+        Set of nodes of a community.
 
     Notes
     -----
@@ -140,7 +140,7 @@ def _fast_label_count(G, comms, node, weight=None):
 @py_random_state(2)
 @nx._dispatchable(edge_attrs="weight")
 def asyn_lpa_communities(G, weight=None, seed=None):
-    """Returns communities in `G` as detected by asynchronous label
+    """Yield communities in `G` as detected by asynchronous label
     propagation.
 
     The asynchronous label propagation algorithm is described in
@@ -173,10 +173,10 @@ def asyn_lpa_communities(G, weight=None, seed=None):
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    communities : iterable
-        Iterable of communities given as sets of nodes.
+    Yields
+    ------
+    community : set
+        Set of nodes of a community.
 
     Notes
     -----
@@ -236,7 +236,7 @@ def asyn_lpa_communities(G, weight=None, seed=None):
 @not_implemented_for("directed")
 @nx._dispatchable
 def label_propagation_communities(G):
-    """Generates community sets determined by label propagation
+    """Return community sets determined by label propagation.
 
     Finds communities in `G` using a semi-synchronous label propagation
     method [1]_. This method combines the advantages of both the synchronous
@@ -249,7 +249,7 @@ def label_propagation_communities(G):
 
     Returns
     -------
-    communities : iterable
+    community : dict_values
         A dict_values object that contains a set of nodes for each community.
 
     Raises

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -176,7 +176,7 @@ def louvain_partitions(
 
     Yields
     ------
-    list
+    communities : list of sets
         A list of sets (partition of `G`). Each set represents one community and contains
         all the nodes that constitute it.
 

--- a/networkx/algorithms/components/attracting.py
+++ b/networkx/algorithms/components/attracting.py
@@ -13,7 +13,7 @@ __all__ = [
 @not_implemented_for("undirected")
 @nx._dispatchable
 def attracting_components(G):
-    """Generates the attracting components in `G`.
+    """Yield the attracting components in `G`.
 
     An attracting component in a directed graph `G` is a strongly connected
     component with the property that a random walker on the graph will never
@@ -31,10 +31,10 @@ def attracting_components(G):
     G : DiGraph, MultiDiGraph
         The graph to be analyzed.
 
-    Returns
-    -------
-    attractors : generator of sets
-        A generator of sets of nodes, one for each attracting component of G.
+    Yields
+    ------
+    attractors : set
+        Set of nodes of attracting component of `G`.
 
     Raises
     ------

--- a/networkx/algorithms/components/biconnected.py
+++ b/networkx/algorithms/components/biconnected.py
@@ -97,8 +97,8 @@ def is_biconnected(G):
 @not_implemented_for("directed")
 @nx._dispatchable
 def biconnected_component_edges(G):
-    """Returns a generator of lists of edges, one list for each biconnected
-    component of the input graph.
+    """Yield lists of edges, one list for each biconnected component
+    of the input graph.
 
     Biconnected components are maximal subgraphs such that the removal of a
     node (and all edges incident on that node) will not disconnect the
@@ -113,10 +113,10 @@ def biconnected_component_edges(G):
     G : NetworkX Graph
         An undirected graph.
 
-    Returns
-    -------
-    edges : generator of lists
-        Generator of lists of edges, one list for each bicomponent.
+    Yields
+    ------
+    edges : list
+        List of edges of a bicomponent.
 
     Raises
     ------
@@ -170,8 +170,7 @@ def biconnected_component_edges(G):
 @not_implemented_for("directed")
 @nx._dispatchable
 def biconnected_components(G):
-    """Returns a generator of sets of nodes, one set for each biconnected
-    component of the graph
+    """Yield sets of nodes, one set for each biconnected component of the graph.
 
     Biconnected components are maximal subgraphs such that the removal of a
     node (and all edges incident on that node) will not disconnect the
@@ -187,10 +186,10 @@ def biconnected_components(G):
     G : NetworkX Graph
         An undirected graph.
 
-    Returns
-    -------
-    nodes : generator
-        Generator of sets of nodes, one set for each biconnected component.
+    Yields
+    ------
+    nodes : set
+        Set of nodes of a biconnected component.
 
     Raises
     ------

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -16,17 +16,17 @@ __all__ = [
 @not_implemented_for("directed")
 @nx._dispatchable
 def connected_components(G):
-    """Generate connected components.
+    """Yield connected components.
 
     Parameters
     ----------
     G : NetworkX graph
        An undirected graph
 
-    Returns
-    -------
-    comp : generator of sets
-       A generator of sets of nodes, one for each component of G.
+    Yields
+    ------
+    comp : set
+       Set of nodes of a connected component of G.
 
     Raises
     ------

--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -15,18 +15,17 @@ __all__ = [
 @not_implemented_for("undirected")
 @nx._dispatchable
 def strongly_connected_components(G):
-    """Generate nodes in strongly connected components of graph.
+    """Yield nodes of strongly connected components of graph.
 
     Parameters
     ----------
     G : NetworkX Graph
         A directed graph.
 
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each strongly connected
-        component of G.
+    Yields
+    ------
+    comp : set
+       Set of nodes of a strongly connected component of G.
 
     Raises
     ------
@@ -114,18 +113,17 @@ def strongly_connected_components(G):
 @not_implemented_for("undirected")
 @nx._dispatchable
 def kosaraju_strongly_connected_components(G, source=None):
-    """Generate nodes in strongly connected components of graph.
+    """Yield nodes of strongly connected components of graph.
 
     Parameters
     ----------
     G : NetworkX Graph
         A directed graph.
 
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each strongly connected
-        component of G.
+    Yields
+    ------
+    comp : set
+       Set of nodes of a strongly connected component of G.
 
     Raises
     ------

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -13,18 +13,17 @@ __all__ = [
 @not_implemented_for("undirected")
 @nx._dispatchable
 def weakly_connected_components(G):
-    """Generate weakly connected components of G.
+    """Yield nodes of weakly connected components of G.
 
     Parameters
     ----------
     G : NetworkX graph
         A directed graph
 
-    Returns
-    -------
-    comp : generator of sets
-        A generator of sets of nodes, one for each weakly connected
-        component of G.
+    Yields
+    ------
+    comp : set
+       Set of nodes of a weakly connected component of G.
 
     Raises
     ------

--- a/networkx/algorithms/connectivity/disjoint_paths.py
+++ b/networkx/algorithms/connectivity/disjoint_paths.py
@@ -27,7 +27,7 @@ __all__ = ["edge_disjoint_paths", "node_disjoint_paths"]
 def edge_disjoint_paths(
     G, s, t, flow_func=None, cutoff=None, auxiliary=None, residual=None
 ):
-    """Returns the edges disjoint paths between source and target.
+    """Yield the edge disjoint paths between source and target.
 
     Edge disjoint paths are paths that do not share any edge. The
     number of edge disjoint paths between source and target is equal
@@ -69,10 +69,10 @@ def edge_disjoint_paths(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    Returns
-    -------
-    paths : generator
-        A generator of edge independent paths.
+    Yields
+    ------
+    path : list
+        List of nodes of an edge independent path.
 
     Raises
     ------
@@ -239,7 +239,7 @@ def edge_disjoint_paths(
 def node_disjoint_paths(
     G, s, t, flow_func=None, cutoff=None, auxiliary=None, residual=None
 ):
-    r"""Computes node disjoint paths between source and target.
+    r"""Yield node disjoint paths between source and target.
 
     Node disjoint paths are paths that only share their first and last
     nodes. The number of node independent paths between two nodes is
@@ -281,10 +281,10 @@ def node_disjoint_paths(
         Residual network to compute maximum flow. If provided it will be
         reused instead of recreated. Default value: None.
 
-    Returns
-    -------
-    paths : generator
-        Generator of node disjoint paths.
+    Yields
+    ------
+    path : list
+        Node disjoint path.
 
     Raises
     ------

--- a/networkx/algorithms/connectivity/edge_augmentation.py
+++ b/networkx/algorithms/connectivity/edge_augmentation.py
@@ -27,7 +27,7 @@ __all__ = ["k_edge_augmentation", "is_k_edge_connected", "is_locally_k_edge_conn
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def is_k_edge_connected(G, k):
-    """Tests to see if a graph is k-edge-connected.
+    """Test to see if a graph is k-edge-connected.
 
     Is it impossible to disconnect the graph by removing fewer than k edges?
     If so, then G is k-edge-connected.
@@ -136,7 +136,7 @@ def is_locally_k_edge_connected(G, s, t, k):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
-    """Finds set of edges to k-edge-connect G.
+    """Yield set of edges to k-edge-connect G.
 
     Adding edges from the augmentation to G make it impossible to disconnect G
     unless k or more edges are removed. This function uses the most efficient
@@ -287,7 +287,7 @@ def k_edge_augmentation(G, k, avail=None, weight=None, partial=False):
 
 @nx._dispatchable
 def partial_k_edge_augmentation(G, k, avail, weight=None):
-    """Finds augmentation that k-edge-connects as much of the graph as possible.
+    """Find augmentation that k-edge-connects as much of the graph as possible.
 
     When a k-edge-augmentation is not possible, we can still try to find a
     small set of edges that partially k-edge-connects as much of the graph as
@@ -390,7 +390,7 @@ def partial_k_edge_augmentation(G, k, avail, weight=None):
 @not_implemented_for("directed")
 @nx._dispatchable
 def one_edge_augmentation(G, avail=None, weight=None, partial=False):
-    """Finds minimum weight set of edges to connect G.
+    """Find minimum weight set of edges to connect G.
 
     Equivalent to :func:`k_edge_augmentation` when k=1. Adding the resulting
     edges to G will make it 1-edge-connected. The solution is optimal for both
@@ -445,7 +445,7 @@ def one_edge_augmentation(G, avail=None, weight=None, partial=False):
 @not_implemented_for("directed")
 @nx._dispatchable
 def bridge_augmentation(G, avail=None, weight=None):
-    """Finds the a set of edges that bridge connects G.
+    """Find the a set of edges that bridge connects G.
 
     Equivalent to :func:`k_edge_augmentation` when k=2, and partial=False.
     Adding the resulting edges to G will make it 2-edge-connected.  If no
@@ -581,7 +581,7 @@ def _lightest_meta_edges(mapping, avail_uv, avail_w):
 
 @nx._dispatchable
 def unconstrained_one_edge_augmentation(G):
-    """Finds the smallest set of edges to connect G.
+    """Find the smallest set of edges to connect G.
 
     This is a variant of the unweighted MST problem.
     If G is not empty, a feasible solution always exists.
@@ -624,7 +624,7 @@ def unconstrained_one_edge_augmentation(G):
 
 @nx._dispatchable
 def weighted_one_edge_augmentation(G, avail, weight=None, partial=False):
-    """Finds the minimum weight set of edges to connect G if one exists.
+    """Find the minimum weight set of edges to connect G if one exists.
 
     This is a variant of the weighted MST problem.
 
@@ -693,7 +693,7 @@ def weighted_one_edge_augmentation(G, avail, weight=None, partial=False):
 
 @nx._dispatchable
 def unconstrained_bridge_augmentation(G):
-    """Finds an optimal 2-edge-augmentation of G using the fewest edges.
+    """Find an optimal 2-edge-augmentation of G using the fewest edges.
 
     This is an implementation of the algorithm detailed in [1]_.
     The basic idea is to construct a meta-graph of bridge-ccs, connect leaf
@@ -848,7 +848,7 @@ def unconstrained_bridge_augmentation(G):
 
 @nx._dispatchable
 def weighted_bridge_augmentation(G, avail, weight=None):
-    """Finds an approximate min-weight 2-edge-augmentation of G.
+    """Find an approximate min-weight 2-edge-augmentation of G.
 
     This is an implementation of the approximation algorithm detailed in [1]_.
     It chooses a set of edges from avail to add to G that renders it
@@ -1115,7 +1115,7 @@ def collapse(G, grouped_nodes):
 
 @nx._dispatchable
 def complement_edges(G):
-    """Returns only the edges in the complement of G
+    """Yield only the edges in the complement of G
 
     Parameters
     ----------

--- a/networkx/algorithms/connectivity/edge_kcomponents.py
+++ b/networkx/algorithms/connectivity/edge_kcomponents.py
@@ -26,7 +26,7 @@ __all__ = [
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def k_edge_components(G, k):
-    """Generates nodes in each maximal k-edge-connected component in G.
+    """Yield nodes in each maximal k-edge-connected component in G.
 
     Parameters
     ----------
@@ -35,10 +35,10 @@ def k_edge_components(G, k):
     k : Integer
         Desired edge connectivity
 
-    Returns
-    -------
-    k_edge_components : a generator of k-edge-ccs. Each set of returned nodes
-       will have k-edge-connectivity in the graph G.
+    Yields
+    ------
+    k_edge_components : set of nodes
+        Each set of returned nodes with k-edge-connectivity in the graph G.
 
     See Also
     --------
@@ -110,7 +110,7 @@ def k_edge_components(G, k):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def k_edge_subgraphs(G, k):
-    """Generates nodes in each maximal k-edge-connected subgraph in G.
+    """Yield nodes in each maximal k-edge-connected subgraph in G.
 
     Parameters
     ----------
@@ -119,10 +119,10 @@ def k_edge_subgraphs(G, k):
     k : Integer
         Desired edge connectivity
 
-    Returns
-    -------
-    k_edge_subgraphs : a generator of k-edge-subgraphs
-        Each k-edge-subgraph is a maximal set of nodes that defines a subgraph
+    Yields
+    ------
+    k_edge_subgraphs : set of nodes
+        Each k-edge-subgraph as a maximal set of nodes that defines a subgraph
         of G that is k-edge-connected.
 
     See Also
@@ -199,16 +199,16 @@ def _k_edge_subgraphs_nodes(G, k):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def bridge_components(G):
-    """Finds all bridge-connected components G.
+    """Yield all bridge-connected components G.
 
     Parameters
     ----------
     G : NetworkX undirected graph
 
-    Returns
-    -------
-    bridge_components : a generator of 2-edge-connected components
-
+    Yields
+    ------
+    bridge_components : set of nodes
+        2-edge-connected components.
 
     See Also
     --------

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -24,7 +24,7 @@ __all__ = ["all_node_cuts"]
 
 @nx._dispatchable
 def all_node_cuts(G, k=None, flow_func=None):
-    r"""Returns all minimum k cutsets of an undirected graph G.
+    r"""Yield all minimum k cutsets of an undirected graph G.
 
     This implementation is based on Kanevsky's algorithm [1]_ for finding all
     minimum-size node cut-sets of an undirected graph G; ie the set (or sets)
@@ -48,10 +48,10 @@ def all_node_cuts(G, k=None, flow_func=None):
         perform better in denser graphs.
 
 
-    Returns
-    -------
-    cuts : a generator of node cutsets
-        Each node cutset has cardinality equal to the node connectivity of
+    Yields
+    ------
+    cuts : set of nodes
+        Each node cutset with cardinality equal to the node connectivity of
         the input graph.
 
     Examples

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -26,7 +26,7 @@ __all__ = [
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def cycle_basis(G, root=None):
-    """Returns a list of cycles which form a basis for cycles of G.
+    """Return a list of cycles which form a basis for cycles of G.
 
     A basis for cycles of a network is a minimal collection of
     cycles such that any cycle in the network can be written
@@ -104,7 +104,7 @@ def cycle_basis(G, root=None):
 
 @nx._dispatchable
 def simple_cycles(G, length_bound=None):
-    """Find simple cycles (elementary circuits) of a graph.
+    """Yield simple cycles (elementary circuits) of a graph.
 
     A "simple cycle", or "elementary circuit", is a closed path where
     no node appears twice.  In a directed graph, two simple cycles are distinct
@@ -144,7 +144,7 @@ def simple_cycles(G, length_bound=None):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
 
     Examples
     --------
@@ -269,7 +269,7 @@ def _directed_cycle_search(G, length_bound):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
     """
 
     scc = nx.strongly_connected_components
@@ -319,7 +319,7 @@ def _undirected_cycle_search(G, length_bound):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
     """
 
     bcc = nx.biconnected_components
@@ -367,7 +367,7 @@ def _johnson_cycle_search(G, path):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
 
     References
     ----------
@@ -430,7 +430,7 @@ def _bounded_cycle_search(G, path, length_bound):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
 
     References
     ----------
@@ -476,7 +476,7 @@ def _bounded_cycle_search(G, path, length_bound):
 
 @nx._dispatchable
 def chordless_cycles(G, length_bound=None):
-    """Find simple chordless cycles of a graph.
+    """Yield simple chordless cycles of a graph.
 
     A `simple cycle` is a closed path where no node appears twice.  In a simple
     cycle, a `chord` is an additional edge between two nodes in the cycle.  A
@@ -537,7 +537,7 @@ def chordless_cycles(G, length_bound=None):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
 
     Examples
     --------
@@ -723,7 +723,7 @@ def _chordless_cycle_search(F, B, path, length_bound):
     Yields
     ------
     list of nodes
-       Each cycle is represented by a list of nodes along the cycle.
+       Each cycle represented by a list of nodes along the cycle.
 
     References
     ----------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -165,7 +165,7 @@ def is_directed_acyclic_graph(G):
 
 @nx._dispatchable
 def topological_generations(G):
-    """Stratifies a DAG into generations.
+    """Stratify a DAG into generations and yield each generation.
 
     A topological generation is node collection in which ancestors of a node in each
     generation are guaranteed to be in a previous generation, and any descendants of
@@ -179,8 +179,8 @@ def topological_generations(G):
 
     Yields
     ------
-    sets of nodes
-        Yields sets of nodes representing each generation.
+    generation : set of nodes
+        Set of nodes for each generation.
 
     Raises
     ------
@@ -243,7 +243,7 @@ def topological_generations(G):
 
 @nx._dispatchable
 def topological_sort(G):
-    """Returns a generator of nodes in topologically sorted order.
+    """Yield nodes in topologically sorted order.
 
     A topological sort is a nonunique permutation of the nodes of a
     directed graph such that an edge from u to v implies that u
@@ -257,8 +257,8 @@ def topological_sort(G):
 
     Yields
     ------
-    nodes
-        Yields the nodes in topological sorted order.
+    node
+        Each node in topologically sorted order.
 
     Raises
     ------
@@ -312,7 +312,7 @@ def topological_sort(G):
 
 @nx._dispatchable
 def lexicographical_topological_sort(G, key=None):
-    """Generate the nodes in the unique lexicographical topological sort order.
+    """Yield nodes in the unique lexicographical topological sort order.
 
     Generates a unique ordering of nodes by first sorting topologically (for which there are often
     multiple valid orderings) and then additionally by sorting lexicographically.
@@ -345,8 +345,8 @@ def lexicographical_topological_sort(G, key=None):
 
     Yields
     ------
-    nodes
-        Yields the nodes of G in lexicographical topological sort order.
+    node
+        Each node of G in lexicographical topological sort order.
 
     Raises
     ------
@@ -455,7 +455,7 @@ def lexicographical_topological_sort(G, key=None):
 @not_implemented_for("undirected")
 @nx._dispatchable
 def all_topological_sorts(G):
-    """Returns a generator of _all_ topological sorts of the directed graph G.
+    """Yield _all_ topological sorts of the directed graph G.
 
     A topological sort is a nonunique permutation of the nodes such that an
     edge from u to v implies that u appears before v in the topological sort
@@ -469,7 +469,7 @@ def all_topological_sorts(G):
     Yields
     ------
     topological_sort_order : list
-        a list of nodes in `G`, representing one of the topological sort orders
+        A list of nodes in `G`, representing one of the topological sort orders
 
     Raises
     ------
@@ -890,7 +890,7 @@ def transitive_reduction(G):
 @not_implemented_for("undirected")
 @nx._dispatchable
 def antichains(G, topo_order=None):
-    """Generates antichains from a directed acyclic graph (DAG).
+    """Yield antichains from a directed acyclic graph (DAG).
 
     An antichain is a subset of a partially ordered set such that any
     two elements in the subset are incomparable.
@@ -906,7 +906,7 @@ def antichains(G, topo_order=None):
     Yields
     ------
     antichain : list
-        a list of nodes in `G` representing an antichain
+        A list of nodes in `G` representing an antichain
 
     Raises
     ------
@@ -1109,7 +1109,7 @@ def dag_longest_path_length(G, weight="weight", default_weight=1):
 
 @nx._dispatchable
 def root_to_leaf_paths(G):
-    """Yields root-to-leaf paths in a directed acyclic graph.
+    """Yield root-to-leaf paths in a directed acyclic graph.
 
     `G` must be a directed acyclic graph. If not, the behavior of this
     function is undefined. A "root" in this graph is a node of in-degree
@@ -1228,7 +1228,7 @@ def dag_to_branching(G):
 @not_implemented_for("undirected")
 @nx._dispatchable
 def compute_v_structures(G):
-    """Yields 3-node tuples that represent the v-structures in `G`.
+    """Yield 3-node tuples that represent the v-structures in `G`.
 
     .. deprecated:: 3.4
 
@@ -1303,7 +1303,7 @@ def compute_v_structures(G):
 @not_implemented_for("undirected")
 @nx._dispatchable
 def v_structures(G):
-    """Yields 3-node tuples that represent the v-structures in `G`.
+    """Yield 3-node tuples that represent the v-structures in `G`.
 
     Colliders are triples in the directed acyclic graph (DAG) where two parent nodes
     point to the same child node. V-structures are colliders where the two parent
@@ -1362,7 +1362,7 @@ def v_structures(G):
 @not_implemented_for("undirected")
 @nx._dispatchable
 def colliders(G):
-    """Yields 3-node tuples that represent the colliders in `G`.
+    """Yield 3-node tuples that represent the colliders in `G`.
 
     In a Directed Acyclic Graph (DAG), if you have three nodes A, B, and C, and
     there are edges from A to C and from B to C, then C is a collider [1]_ . In

--- a/networkx/algorithms/euler.py
+++ b/networkx/algorithms/euler.py
@@ -20,7 +20,7 @@ __all__ = [
 
 @nx._dispatchable
 def is_eulerian(G):
-    """Returns True if and only if `G` is Eulerian.
+    """Return True if and only if `G` is Eulerian.
 
     A graph is *Eulerian* if it has an Eulerian circuit. An *Eulerian
     circuit* is a closed walk that includes each edge of a graph exactly
@@ -157,7 +157,7 @@ def _multigraph_eulerian_circuit(G, source):
 
 @nx._dispatchable
 def eulerian_circuit(G, source=None, keys=False):
-    """Returns an iterator over the edges of an Eulerian circuit in `G`.
+    """Yield edges of an Eulerian circuit in `G`.
 
     An *Eulerian circuit* is a closed walk that includes each edge of a
     graph exactly once.
@@ -175,10 +175,10 @@ def eulerian_circuit(G, source=None, keys=False):
        ``(u, v)``. Otherwise, edges will be of the form ``(u, v, k)``.
        This option is ignored unless `G` is a multigraph.
 
-    Returns
-    -------
-    edges : iterator
-       An iterator over edges in the Eulerian circuit.
+    Yields
+    ------
+    edge : tuple
+       Each edge in the Eulerian circuit.
 
     Raises
     ------
@@ -333,7 +333,7 @@ def has_eulerian_path(G, source=None):
 
 @nx._dispatchable
 def eulerian_path(G, source=None, keys=False):
-    """Return an iterator over the edges of an Eulerian path in `G`.
+    """Yield edges of an Eulerian path in `G`.
 
     Parameters
     ----------
@@ -348,7 +348,8 @@ def eulerian_path(G, source=None, keys=False):
 
     Yields
     ------
-    Edge tuples along the eulerian path.
+    edge : tuple
+        Each edge along the Eulerian path.
 
     Warning: If `source` provided is not the start node of an Euler path
     will raise error even if an Euler Path exists.

--- a/networkx/algorithms/isolate.py
+++ b/networkx/algorithms/isolate.py
@@ -42,7 +42,7 @@ def is_isolate(G, n):
 
 @nx._dispatchable
 def isolates(G):
-    """Iterator over isolates in the graph.
+    """Yield isolate nodes of the graph.
 
     An *isolate* is a node with no neighbors (that is, with degree
     zero). For directed graphs, this means no in-neighbors and no
@@ -52,10 +52,10 @@ def isolates(G):
     ----------
     G : NetworkX graph
 
-    Returns
-    -------
-    iterator
-        An iterator over the isolates of `G`.
+    Yields
+    ------
+    isolate : node
+        An isolate node of `G`.
 
     Examples
     --------

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -440,7 +440,7 @@ class ISMAGS:
         return comparer
 
     def find_isomorphisms(self, symmetry=True):
-        """Find all subgraph isomorphisms between subgraph and graph
+        """Yield all subgraph isomorphisms between subgraph and graph.
 
         Finds isomorphisms where :attr:`subgraph` <= :attr:`graph`.
 
@@ -538,7 +538,7 @@ class ISMAGS:
 
     def largest_common_subgraph(self, symmetry=True):
         """
-        Find the largest common induced subgraphs between :attr:`subgraph` and
+        Yield the largest common induced subgraphs between :attr:`subgraph` and
         :attr:`graph`.
 
         Parameters

--- a/networkx/algorithms/isomorphism/vf2pp.py
+++ b/networkx/algorithms/isomorphism/vf2pp.py
@@ -166,7 +166,7 @@ def vf2pp_is_isomorphic(G1, G2, node_label=None, default_label=None):
 
 @nx._dispatchable(graphs={"G1": 0, "G2": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_all_isomorphisms(G1, G2, node_label=None, default_label=None):
-    """Yields all the possible mappings between G1 and G2.
+    """Yield all the possible mappings between G1 and G2.
 
     Parameters
     ----------

--- a/networkx/algorithms/link_prediction.py
+++ b/networkx/algorithms/link_prediction.py
@@ -49,7 +49,7 @@ def _apply_prediction(G, func, ebunch=None):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def resource_allocation_index(G, ebunch=None):
-    r"""Compute the resource allocation index of all node pairs in ebunch.
+    r"""Yield the resource allocation index of all node pairs in ebunch.
 
     Resource allocation index of `u` and `v` is defined as
 
@@ -71,11 +71,11 @@ def resource_allocation_index(G, ebunch=None):
         is None then all nonexistent edges in the graph will be used.
         Default value: None.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their resource allocation index.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their resource allocation index.
 
     Raises
     ------
@@ -112,7 +112,7 @@ def resource_allocation_index(G, ebunch=None):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def jaccard_coefficient(G, ebunch=None):
-    r"""Compute the Jaccard coefficient of all node pairs in ebunch.
+    r"""Yield the Jaccard coefficient of all node pairs in ebunch.
 
     Jaccard coefficient of nodes `u` and `v` is defined as
 
@@ -134,11 +134,11 @@ def jaccard_coefficient(G, ebunch=None):
         then all nonexistent edges in the graph will be used.
         Default value: None.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their Jaccard coefficient.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their Jaccard coefficient.
 
     Raises
     ------
@@ -177,7 +177,7 @@ def jaccard_coefficient(G, ebunch=None):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def adamic_adar_index(G, ebunch=None):
-    r"""Compute the Adamic-Adar index of all node pairs in ebunch.
+    r"""Yield the Adamic-Adar index of all node pairs in ebunch.
 
     Adamic-Adar index of `u` and `v` is defined as
 
@@ -201,11 +201,11 @@ def adamic_adar_index(G, ebunch=None):
         nonexistent edges in the graph will be used.
         Default value: None.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their Adamic-Adar index.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their Adamic-Adar index.
 
     Raises
     ------
@@ -241,7 +241,7 @@ def adamic_adar_index(G, ebunch=None):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
-    r"""Return the CCPA score for each pair of nodes.
+    r"""Yield the CCPA score for each pair of nodes.
 
     Compute the Common Neighbor and Centrality based Parameterized Algorithm(CCPA)
     score of all node pairs in ebunch.
@@ -285,12 +285,11 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
             dataset.
             Default value: 0.8
 
-
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their Common Neighbor and Centrality based
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their Common Neighbor and Centrality based
         Parameterized Algorithm(CCPA) score.
 
     Raises
@@ -349,7 +348,7 @@ def common_neighbor_centrality(G, ebunch=None, alpha=0.8):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def preferential_attachment(G, ebunch=None):
-    r"""Compute the preferential attachment score of all node pairs in ebunch.
+    r"""Yield the preferential attachment score of all node pairs in ebunch.
 
     Preferential attachment score of `u` and `v` is defined as
 
@@ -371,11 +370,11 @@ def preferential_attachment(G, ebunch=None):
         is None then all nonexistent edges in the graph will be used.
         Default value: None.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their preferential attachment score.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their preferential attachment score.
 
     Raises
     ------
@@ -443,11 +442,11 @@ def cn_soundarajan_hopcroft(G, ebunch=None, community="community"):
         G[u][community] identifies which community u belongs to. Each
         node belongs to at most one community. Default value: 'community'.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their score.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their score.
 
     Raises
     ------
@@ -529,11 +528,11 @@ def ra_index_soundarajan_hopcroft(G, ebunch=None, community="community"):
         G[u][community] identifies which community u belongs to. Each
         node belongs to at most one community. Default value: 'community'.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their score.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their score.
 
     Raises
     ------
@@ -616,11 +615,11 @@ def within_inter_cluster(G, ebunch=None, delta=0.001, community="community"):
         G[u][community] identifies which community u belongs to. Each
         node belongs to at most one community. Default value: 'community'.
 
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their WIC measure.
+    Yields
+    ------
+    (u, v, p) : 3-tuple
+        3-tuple in the form (u, v, p) where (u, v) is a pair of nodes
+        and p is their WIC measure.
 
     Raises
     ------

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -17,7 +17,7 @@ __all__ = [
 @not_implemented_for("undirected")
 @nx._dispatchable
 def all_pairs_lowest_common_ancestor(G, pairs=None):
-    """Return the lowest common ancestor of all pairs or the provided pairs
+    """Yield the lowest common ancestor of all pairs or the provided pairs
 
     Parameters
     ----------
@@ -167,10 +167,11 @@ def tree_all_pairs_lowest_common_ancestor(G, root=None, pairs=None):
         The pairs of interest. If None, Defaults to all pairs of nodes
         under `root` that have a lowest common ancestor.
 
-    Returns
-    -------
-    lcas : generator of tuples `((u, v), lca)` where `u` and `v` are nodes
-        in `pairs` and `lca` is their lowest common ancestor.
+    Yields
+    ------
+    ((u, v), lca) : tuple
+        `((u, v), lca)` where `u` and `v` are nodes in `pairs` and `lca`
+        is their lowest common ancestor.
 
     Examples
     --------

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -984,7 +984,7 @@ class PlanarEmbedding(nx.DiGraph):
             # silently skip non-existing nodes
 
     def neighbors_cw_order(self, v):
-        """Generator for the neighbors of v in clockwise order.
+        """Yield the neighbors of v in clockwise order.
 
         Parameters
         ----------

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -439,7 +439,7 @@ def average_shortest_path_length(G, weight=None, method=None):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
-    """Compute all shortest simple paths in the graph.
+    """Yield all shortest simple paths in the graph.
 
     Parameters
     ----------
@@ -468,10 +468,10 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
 
-    Returns
-    -------
-    paths : generator of lists
-        A generator of all paths between source and target.
+    Yields
+    ------
+    path : list
+        Eath path between source and target.
 
     Raises
     ------
@@ -517,7 +517,7 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
 
 @nx._dispatchable(edge_attrs="weight")
 def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
-    """Compute all shortest simple paths from the given source in the graph.
+    """Yield all shortest simple paths from the given source in the graph.
 
     Parameters
     ----------
@@ -543,10 +543,10 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
 
-    Returns
-    -------
-    paths : generator of dictionary
-        A generator of all paths between source and all nodes in the graph.
+    Yields
+    ------
+    (target, paths) : 2-tuple
+        All paths between source and target in the graph.
 
     Raises
     ------
@@ -590,7 +590,7 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
-    """Compute all shortest paths between all nodes.
+    """Yield all shortest paths between all nodes.
 
     Parameters
     ----------
@@ -613,10 +613,11 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
 
-    Returns
-    -------
-    paths : generator of dictionary
-        Dictionary of arrays, keyed by source and target, of all shortest paths.
+    Yields
+    ------
+    (source, paths_dict) : 2-tuple
+        (source, paths_dict) tuple with dictionary keyed by target and
+        shortest path as the key value.
 
     Raises
     ------
@@ -649,7 +650,7 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
 
 
 def _build_paths_from_predecessors(sources, target, pred):
-    """Compute all simple paths to target, given the predecessors found in
+    """Yield all simple paths to target, given the predecessors found in
     pred, terminating when any source in sources is found.
 
     Parameters
@@ -663,10 +664,10 @@ def _build_paths_from_predecessors(sources, target, pred):
     pred : dict
        A dictionary of predecessor lists, keyed by node
 
-    Returns
-    -------
-    paths : generator of lists
-        A generator of all paths between source and target.
+    Yields
+    ------
+    path : list
+        A path between source and target. All paths will be generated.
 
     Raises
     ------

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -61,7 +61,7 @@ def single_source_shortest_path_length(G, source, cutoff=None):
 
 
 def _single_shortest_path_length(adj, firstlevel, cutoff):
-    """Yields (node, level) in a breadth first search
+    """Yield (node, level) in a breadth first search
 
     Shortest Path Length helper function
     Parameters
@@ -142,7 +142,7 @@ def single_target_shortest_path_length(G, target, cutoff=None):
 
 @nx._dispatchable
 def all_pairs_shortest_path_length(G, cutoff=None):
-    """Computes the shortest path lengths between all nodes in `G`.
+    """Yield shortest path lengths between all nodes in `G`.
 
     Parameters
     ----------
@@ -152,10 +152,10 @@ def all_pairs_shortest_path_length(G, cutoff=None):
         Depth at which to stop the search. Only paths of length at most
         `cutoff` are returned.
 
-    Returns
-    -------
-    lengths : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
+    Yields
+    ------
+    (source, length_dict) : 2-tuple
+        (source, length_dict) tuple with dictionary keyed by target and
         shortest path length as the key value.
 
     Notes
@@ -441,7 +441,7 @@ def single_target_shortest_path(G, target, cutoff=None):
 
 @nx._dispatchable
 def all_pairs_shortest_path(G, cutoff=None):
-    """Compute shortest paths between all nodes.
+    """Yield shortest paths between all nodes.
 
     Parameters
     ----------
@@ -451,10 +451,11 @@ def all_pairs_shortest_path(G, cutoff=None):
         Depth at which to stop the search. Only paths of length at most
         `cutoff` are returned.
 
-    Returns
-    -------
-    paths : iterator
-        Dictionary, keyed by source and target, of shortest paths.
+    Yields
+    ------
+    (source, paths_dict) : 2-tuple
+        (source, paths_dict) tuple with dictionary keyed by target and
+        shortest path as the key value.
 
     Examples
     --------

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -959,7 +959,7 @@ def dijkstra_predecessor_and_distance(G, source, cutoff=None, weight="weight"):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_pairs_dijkstra(G, cutoff=None, weight="weight"):
-    """Find shortest weighted paths and lengths between all nodes.
+    """Yield shortest weighted paths and lengths between all nodes.
 
     Parameters
     ----------
@@ -1028,7 +1028,7 @@ def all_pairs_dijkstra(G, cutoff=None, weight="weight"):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_pairs_dijkstra_path_length(G, cutoff=None, weight="weight"):
-    """Compute shortest path lengths between all nodes in a weighted graph.
+    """Yield shortest path lengths between all nodes in a weighted graph.
 
     Parameters
     ----------
@@ -1051,10 +1051,10 @@ def all_pairs_dijkstra_path_length(G, cutoff=None, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number or None to indicate a hidden edge.
 
-    Returns
-    -------
-    distance : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
+    Yields
+    ------
+    (source, length_dict) : 2-tuple
+        (source, length_dict) tuple with dictionary keyed by target and
         shortest path length as the key value.
 
     Examples
@@ -1087,7 +1087,7 @@ def all_pairs_dijkstra_path_length(G, cutoff=None, weight="weight"):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_pairs_dijkstra_path(G, cutoff=None, weight="weight"):
-    """Compute shortest paths between all nodes in a weighted graph.
+    """Yield shortest paths between all nodes in a weighted graph.
 
     Parameters
     ----------
@@ -1110,10 +1110,10 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number or None to indicate a hidden edge.
 
-    Returns
-    -------
-    paths : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
+    Yields
+    ------
+    (source, paths_dict) : 2-tuple
+        (source, paths_dict) tuple with dictionary keyed by target and
         shortest path as the key value.
 
     Examples
@@ -1832,7 +1832,7 @@ def single_source_bellman_ford(G, source, target=None, weight="weight"):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_pairs_bellman_ford_path_length(G, weight="weight"):
-    """Compute shortest path lengths between all nodes in a weighted graph.
+    """Yield shortest path lengths between all nodes in a weighted graph.
 
     Parameters
     ----------
@@ -1851,10 +1851,10 @@ def all_pairs_bellman_ford_path_length(G, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number.
 
-    Returns
-    -------
-    distance : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
+    Yields
+    ------
+    (source, length_dict) : 2-tuple
+        (source, length_dict) tuple with dictionary keyed by target and
         shortest path length as the key value.
 
     Examples
@@ -1887,7 +1887,7 @@ def all_pairs_bellman_ford_path_length(G, weight="weight"):
 
 @nx._dispatchable(edge_attrs="weight")
 def all_pairs_bellman_ford_path(G, weight="weight"):
-    """Compute shortest paths between all nodes in a weighted graph.
+    """Yield shortest paths between all nodes in a weighted graph.
 
     Parameters
     ----------
@@ -1906,10 +1906,10 @@ def all_pairs_bellman_ford_path(G, weight="weight"):
         dictionary of edge attributes for that edge. The function must
         return a number.
 
-    Returns
-    -------
-    paths : iterator
-        (source, dictionary) iterator with dictionary keyed by target and
+    Yields
+    ------
+    (source, paths_dict) : 2-tuple
+        (source, paths_dict) tuple with dictionary keyed by target and
         shortest path as the key value.
 
     Examples

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -401,7 +401,7 @@ def optimize_graph_edit_distance(
     edge_ins_cost=None,
     upper_bound=None,
 ):
-    """Returns consecutive approximations of GED (graph edit distance)
+    """Yield consecutive approximations of GED (graph edit distance)
     between graphs G1 and G2.
 
     Graph edit distance is a graph similarity measure analogous to
@@ -494,9 +494,10 @@ def optimize_graph_edit_distance(
     upper_bound : numeric
         Maximum edit distance to consider.
 
-    Returns
-    -------
-    Generator of consecutive approximations of graph edit distance.
+    Yields
+    ------
+    dist : float
+        Consecutive approximations of graph edit distance.
 
     Examples
     --------
@@ -665,9 +666,9 @@ def optimize_edit_paths(
         Maximum number of seconds to execute.
         After timeout is met, the current best GED is returned.
 
-    Returns
-    -------
-    Generator of tuples (node_edit_path, edge_edit_path, cost)
+    Yields
+    ------
+    (node_edit_path, edge_edit_path, cost) : 3-tuple
         node_edit_path : list of tuples (u, v)
         edge_edit_path : list of tuples ((u1, v1), (u2, v2))
         cost : numeric
@@ -1694,10 +1695,10 @@ def generate_random_paths(
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
 
-    Returns
-    -------
-    paths : generator of lists
-        Generator of `sample_size` paths each with length `path_length`.
+    Yields
+    ------
+    path : list
+        Path with length `path_length`. There are `sample_size` paths in total.
 
     Examples
     --------

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -93,7 +93,7 @@ def is_simple_path(G, nodes):
 
 @nx._dispatchable
 def all_simple_paths(G, source, target, cutoff=None):
-    """Generate all simple paths in the graph G from source to target.
+    """Yield all simple paths in the graph G from source to target.
 
     A simple path is a path with no repeated nodes.
 
@@ -110,14 +110,14 @@ def all_simple_paths(G, source, target, cutoff=None):
     cutoff : integer, optional
         Depth to stop the search. Only paths of length <= cutoff are returned.
 
-    Returns
-    -------
-    path_generator: generator
-       A generator that produces lists of simple paths.  If there are no paths
-       between the source and target within the given cutoff the generator
-       produces no output. If it is possible to traverse the same sequence of
-       nodes in multiple ways, namely through parallel edges, then it will be
-       returned multiple times (once for each viable edge combination).
+    Yields
+    ------
+    path : list of nodes
+        Simple path as a list. If there are no paths between the source
+        and target within the given cutoff the generator produces no output.
+        If it is possible to traverse the same sequence of nodes in multiple
+        ways, namely through parallel edges, then it will be returned multiple
+        times (once for each viable edge combination).
 
     Examples
     --------
@@ -259,7 +259,7 @@ def all_simple_paths(G, source, target, cutoff=None):
 
 @nx._dispatchable
 def all_simple_edge_paths(G, source, target, cutoff=None):
-    """Generate lists of edges for all simple paths in G from source to target.
+    """Yield lists of edges for all simple paths in G from source to target.
 
     A simple path is a path with no repeated nodes.
 
@@ -276,14 +276,13 @@ def all_simple_edge_paths(G, source, target, cutoff=None):
     cutoff : integer, optional
         Depth to stop the search. Only paths of length <= cutoff are returned.
 
-    Returns
-    -------
-    path_generator: generator
-       A generator that produces lists of simple paths.  If there are no paths
-       between the source and target within the given cutoff the generator
-       produces no output.
-       For multigraphs, the list of edges have elements of the form `(u,v,k)`.
-       Where `k` corresponds to the edge key.
+    Yields
+    ------
+    path : list of edges
+        Simple path as a list. If there are no paths between the source and
+        target within the given cutoff the generator produces no output.
+        For multigraphs, the list of edges have elements of the form `(u,v,k)`
+        where `k` corresponds to the edge key.
 
     Examples
     --------
@@ -404,8 +403,8 @@ def _all_simple_edge_paths(G, source, targets, cutoff):
 @not_implemented_for("multigraph")
 @nx._dispatchable(edge_attrs="weight")
 def shortest_simple_paths(G, source, target, weight=None):
-    """Generate all simple paths in the graph G from source to target,
-       starting from shortest ones.
+    """Yield all simple paths in the graph G from source to target,
+    starting from shortest ones.
 
     A simple path is a path with no repeated nodes.
 
@@ -437,11 +436,10 @@ def shortest_simple_paths(G, source, target, weight=None):
         If None all edges are considered to have unit weight. Default
         value None.
 
-    Returns
-    -------
-    path_generator: generator
-       A generator that produces lists of simple paths, in order from
-       shortest to longest.
+    Yields
+    ------
+    path : list of nodes
+        Simple path as a list, in order from shortest to longest.
 
     Raises
     ------

--- a/networkx/algorithms/tests/test_chains.py
+++ b/networkx/algorithms/tests/test_chains.py
@@ -8,7 +8,7 @@ import networkx as nx
 
 
 def cycles(seq):
-    """Yields cyclic permutations of the given sequence.
+    """Yield cyclic permutations of the given sequence.
 
     For example::
 

--- a/networkx/algorithms/traversal/beamsearch.py
+++ b/networkx/algorithms/traversal/beamsearch.py
@@ -7,7 +7,7 @@ __all__ = ["bfs_beam_edges"]
 
 @nx._dispatchable
 def bfs_beam_edges(G, source, value, width=None):
-    """Iterates over edges in a beam search.
+    """Yield edges in a beam search.
 
     The beam search is a generalized breadth-first search in which only
     the "best" *w* neighbors of the current node are enqueued, where *w*
@@ -46,7 +46,7 @@ def bfs_beam_edges(G, source, value, width=None):
 
     Yields
     ------
-    edge
+    edge : 2-tuple
         Edges in the beam search starting from `source`, given as a pair
         of nodes.
 

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -18,7 +18,7 @@ __all__ = [
 
 @nx._dispatchable
 def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
-    """Iterate over edges in a breadth-first search.
+    """Yield edges in a breadth-first search.
 
     The breadth-first search begins at `source` and enqueues the
     neighbors of newly visited nodes specified by the `neighbors`
@@ -47,7 +47,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
     Yields
     ------
     edge
-        Edges in the breadth-first search starting from `source`.
+        Edge in the breadth-first search starting from `source`.
 
     Examples
     --------
@@ -107,7 +107,7 @@ def generic_bfs_edges(G, source, neighbors=None, depth_limit=None):
 
 @nx._dispatchable
 def bfs_edges(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
-    """Iterate over edges in a breadth-first-search starting at source.
+    """Yield edges in a breadth-first-search starting at source.
 
     Parameters
     ----------
@@ -131,8 +131,8 @@ def bfs_edges(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
 
     Yields
     ------
-    edge: 2-tuple of nodes
-       Yields edges resulting from the breadth-first search.
+    edge : 2-tuple of nodes
+       Each edge resulting from the breadth-first search.
 
     Examples
     --------
@@ -264,7 +264,7 @@ def bfs_tree(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
 
 @nx._dispatchable
 def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
-    """Returns an iterator of predecessors in breadth-first-search from source.
+    """Yield predecessors in breadth-first-search from source.
 
     Parameters
     ----------
@@ -281,11 +281,11 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    pred: iterator
-        (node, predecessor) iterator where `predecessor` is the predecessor of
-        `node` in a breadth first search starting from `source`.
+    Yields
+    ------
+    (node, predecessor) : tuple
+        `predecessor` is the predecessor of `node` in a breadth first search
+        starting from `source`.
 
     Examples
     --------
@@ -330,7 +330,7 @@ def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
 
 @nx._dispatchable
 def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
-    """Returns an iterator of successors in breadth-first-search from source.
+    """Yield successors in breadth-first-search from source.
 
     Parameters
     ----------
@@ -347,12 +347,11 @@ def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    succ: iterator
-       (node, successors) iterator where `successors` is the non-empty list of
-       successors of `node` in a breadth first search from `source`.
-       To appear in the iterator, `node` must have successors.
+    Yields
+    ------
+    (node, successors) : tuple
+       `successors` is the non-empty list of successors of `node` in a breadth first
+        search from `source`. To appear in the iterator, `node` must have successors.
 
     Examples
     --------
@@ -404,7 +403,7 @@ def bfs_successors(G, source, depth_limit=None, sort_neighbors=None):
 
 @nx._dispatchable
 def bfs_layers(G, sources):
-    """Returns an iterator of all the layers in breadth-first search traversal.
+    """Yield all the layers in breadth-first search traversal.
 
     Parameters
     ----------
@@ -416,8 +415,8 @@ def bfs_layers(G, sources):
 
     Yields
     ------
-    layer: list of nodes
-        Yields list of nodes at the same distance from sources
+    layer : list of nodes
+        List of nodes at the same distance from sources
 
     Examples
     --------
@@ -462,7 +461,7 @@ LEVEL_EDGE = "level"
 
 @nx._dispatchable
 def bfs_labeled_edges(G, sources):
-    """Iterate over edges in a breadth-first search (BFS) labeled by type.
+    """Yield edges in a breadth-first search (BFS) labeled by type.
 
     We generate triple of the form (*u*, *v*, *d*), where (*u*, *v*) is the
     edge being explored in the breadth-first search and *d* is one of the
@@ -486,8 +485,8 @@ def bfs_labeled_edges(G, sources):
 
     Yields
     ------
-    edges: generator
-       A generator of triples (*u*, *v*, *d*) where (*u*, *v*) is the edge being
+    edge : tuple
+       Edge as a triple (*u*, *v*, *d*) where (*u*, *v*) is the edge being
        explored and *d* is described above.
 
     Examples

--- a/networkx/algorithms/traversal/depth_first_search.py
+++ b/networkx/algorithms/traversal/depth_first_search.py
@@ -17,7 +17,7 @@ __all__ = [
 
 @nx._dispatchable
 def dfs_edges(G, source=None, depth_limit=None, *, sort_neighbors=None):
-    """Iterate over edges in a depth-first-search (DFS).
+    """Yield edges in a depth-first-search (DFS).
 
     Perform a depth-first-search over the nodes of `G` and yield
     the edges in order. This may not generate all edges in `G`
@@ -41,8 +41,8 @@ def dfs_edges(G, source=None, depth_limit=None, *, sort_neighbors=None):
 
     Yields
     ------
-    edge: 2-tuple of nodes
-       Yields edges resulting from the depth-first-search.
+    edge : 2-tuple of nodes
+       Edge resulting from the depth-first-search.
 
     Examples
     --------
@@ -294,7 +294,7 @@ def dfs_successors(G, source=None, depth_limit=None, *, sort_neighbors=None):
 
 @nx._dispatchable
 def dfs_postorder_nodes(G, source=None, depth_limit=None, *, sort_neighbors=None):
-    """Generate nodes in a depth-first-search post-ordering starting at source.
+    """Yield nodes in a depth-first-search post-ordering starting at source.
 
     Parameters
     ----------
@@ -311,10 +311,10 @@ def dfs_postorder_nodes(G, source=None, depth_limit=None, *, sort_neighbors=None
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    nodes: generator
-       A generator of nodes in a depth-first-search post-ordering.
+    Yields
+    ------
+    node
+       Each node in a depth-first-search post-ordering.
 
     Examples
     --------
@@ -353,7 +353,7 @@ def dfs_postorder_nodes(G, source=None, depth_limit=None, *, sort_neighbors=None
 
 @nx._dispatchable
 def dfs_preorder_nodes(G, source=None, depth_limit=None, *, sort_neighbors=None):
-    """Generate nodes in a depth-first-search pre-ordering starting at source.
+    """Yield nodes in a depth-first-search pre-ordering starting at source.
 
     Parameters
     ----------
@@ -371,10 +371,10 @@ def dfs_preorder_nodes(G, source=None, depth_limit=None, *, sort_neighbors=None)
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    nodes: generator
-       A generator of nodes in a depth-first-search pre-ordering.
+    Yields
+    ------
+    node
+       Each node in a depth-first-search pre-ordering.
 
     Examples
     --------
@@ -412,7 +412,7 @@ def dfs_preorder_nodes(G, source=None, depth_limit=None, *, sort_neighbors=None)
 
 @nx._dispatchable
 def dfs_labeled_edges(G, source=None, depth_limit=None, *, sort_neighbors=None):
-    """Iterate over edges in a depth-first-search (DFS) labeled by type.
+    """Yield edges in a depth-first-search (DFS) labeled by type.
 
     Parameters
     ----------
@@ -430,12 +430,12 @@ def dfs_labeled_edges(G, source=None, depth_limit=None, *, sort_neighbors=None):
         returns an iterable of the same nodes with a custom ordering.
         For example, `sorted` will sort the nodes in increasing order.
 
-    Returns
-    -------
-    edges: generator
-       A generator of triples of the form (*u*, *v*, *d*), where (*u*,
-       *v*) is the edge being explored in the depth-first search and *d*
-       is one of the strings 'forward', 'nontree', 'reverse', or 'reverse-depth_limit'.
+    Yields
+    ------
+    edge : 3-tuple
+       An edge as a triple of the form (*u*, *v*, *d*), where (*u*, *v*) is
+       the edge being explored in the depth-first search and *d* is one of
+       the strings 'forward', 'nontree', 'reverse', or 'reverse-depth_limit'.
        A 'forward' edge is one in which *u* has been visited but *v* has
        not. A 'nontree' edge is one in which both *u* and *v* have been
        visited but the edge is not in the DFS tree. A 'reverse' edge is

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -146,8 +146,7 @@ def boruvka_mst_edges(
 def kruskal_mst_edges(
     G, minimum, weight="weight", keys=True, data=True, ignore_nan=False, partition=None
 ):
-    """
-    Iterate over edge of a Kruskal's algorithm min/max spanning tree.
+    """Yield edges of a Kruskal's algorithm min/max spanning tree.
 
     Parameters
     ----------
@@ -181,7 +180,7 @@ def kruskal_mst_edges(
 
     Yields
     ------
-    edge tuple
+    edge : tuple
         The edges as discovered by Kruskal's method. Each edge can
         take the following forms: `(u, v)`, `(u, v, d)` or `(u, v, k, d)`
         depending on the `key` and `data` parameters
@@ -373,8 +372,7 @@ ALGORITHMS = {
 def minimum_spanning_edges(
     G, algorithm="kruskal", weight="weight", keys=True, data=True, ignore_nan=False
 ):
-    """Generate edges in a minimum spanning forest of an undirected
-    weighted graph.
+    """Yield edges in a minimum spanning forest of an undirected weighted graph.
 
     A minimum spanning tree is a subgraph of the graph (a tree)
     with the minimum sum of edge weights.  A spanning forest is a
@@ -404,10 +402,10 @@ def minimum_spanning_edges(
         If a NaN is found as an edge weight normally an exception is raised.
         If `ignore_nan is True` then that edge is ignored instead.
 
-    Returns
-    -------
-    edges : iterator
-       An iterator over edges in a maximum spanning tree of `G`.
+    Yields
+    ------
+    edge : tuple
+       Edge in a maximum spanning tree of `G`.
        Edges connecting nodes `u` and `v` are represented as tuples:
        `(u, v, k, d)` or `(u, v, k)` or `(u, v, d)` or `(u, v)`
 
@@ -468,8 +466,7 @@ def minimum_spanning_edges(
 def maximum_spanning_edges(
     G, algorithm="kruskal", weight="weight", keys=True, data=True, ignore_nan=False
 ):
-    """Generate edges in a maximum spanning forest of an undirected
-    weighted graph.
+    """Yield edges in a maximum spanning forest of an undirected weighted graph.
 
     A maximum spanning tree is a subgraph of the graph (a tree)
     with the maximum possible sum of edge weights.  A spanning forest is a
@@ -499,10 +496,10 @@ def maximum_spanning_edges(
         If a NaN is found as an edge weight normally an exception is raised.
         If `ignore_nan is True` then that edge is ignored instead.
 
-    Returns
-    -------
-    edges : iterator
-       An iterator over edges in a maximum spanning tree of `G`.
+    Yields
+    ------
+    edge : tuple
+       Edge in a maximum spanning tree of `G`.
        Edges connecting nodes `u` and `v` are represented as tuples:
        `(u, v, k, d)` or `(u, v, k)` or `(u, v, d)` or `(u, v)`
 

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -327,8 +327,8 @@ def all_triplets(G):
     G : digraph
        A NetworkX DiGraph
 
-    Returns
-    -------
+    Yields
+    ------
     triplets : generator of 3-tuples
        Generator of tuples of 3 nodes
 
@@ -356,17 +356,17 @@ def all_triplets(G):
 @not_implemented_for("undirected")
 @nx._dispatchable(returns_graph=True)
 def all_triads(G):
-    """A generator of all possible triads in G.
+    """Yield all possible triads in G.
 
     Parameters
     ----------
     G : digraph
        A NetworkX DiGraph
 
-    Returns
-    -------
-    all_triads : generator of DiGraphs
-       Generator of triads (order-3 DiGraphs)
+    Yields
+    ------
+    triads : DiGraphs
+       A triad from G (order-3 DiGraph)
 
     Examples
     --------

--- a/networkx/generators/internet_as_graphs.py
+++ b/networkx/generators/internet_as_graphs.py
@@ -399,7 +399,7 @@ class AS_graph_generator:
 @py_random_state(1)
 @nx._dispatchable(graphs=None, returns_graph=True)
 def random_internet_as_graph(n, seed=None):
-    """Generates a random undirected graph resembling the Internet AS network
+    """Create a random undirected graph resembling the Internet AS network
 
     Parameters
     ----------

--- a/networkx/generators/interval_graph.py
+++ b/networkx/generators/interval_graph.py
@@ -11,7 +11,7 @@ __all__ = ["interval_graph"]
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def interval_graph(intervals):
-    """Generates an interval graph for a list of intervals given.
+    """Create an interval graph for a list of intervals given.
 
     In graph theory, an interval graph is an undirected graph formed from a set
     of closed intervals on the real line, with a vertex for each interval

--- a/networkx/generators/joint_degree_seq.py
+++ b/networkx/generators/joint_degree_seq.py
@@ -144,7 +144,7 @@ def _neighbor_switch(G, w, unsat, h_node_residual, avoid_node_id=None):
 @py_random_state(1)
 @nx._dispatchable(graphs=None, returns_graph=True)
 def joint_degree_graph(joint_degrees, seed=None):
-    """Generates a random simple graph with the given joint degree dictionary.
+    """Create a random simple graph with the given joint degree dictionary.
 
     Parameters
     ----------
@@ -471,7 +471,7 @@ def _directed_neighbor_switch_rev(
 @py_random_state(3)
 @nx._dispatchable(graphs=None, returns_graph=True)
 def directed_joint_degree_graph(in_degrees, out_degrees, nkk, seed=None):
-    """Generates a random simple directed graph with the joint degree.
+    """Create a random simple directed graph with the joint degree.
 
     Parameters
     ----------

--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -14,7 +14,7 @@ import networkx as nx
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def nonisomorphic_trees(order, create="graph"):
-    """Generates lists of nonisomorphic trees
+    """Yield nonisomorphic trees.
 
     Parameters
     ----------
@@ -36,8 +36,8 @@ def nonisomorphic_trees(order, create="graph"):
 
     Yields
     ------
-    list
-       A list of nonisomorphic trees, in one of two formats depending on the
+    tree : Graph or list-of-lists
+       Nonisomorphic trees, in one of two formats depending on the
        value of the `create` parameter:
        - ``create="graph"``: yields a list of `networkx.Graph` instances
        - ``create="matrix"``: yields a list of list-of-lists representing adjacency matrices

--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -79,7 +79,7 @@ def generate_network_text(
     ascii_only=False,
     vertical_chains=False,
 ):
-    """Generate lines in the "network text" format
+    """Yield lines in the "network text" format.
 
     This works via a depth-first traversal of the graph and writing a line for
     each unique node encountered. Non-tree edges are written to the right of

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -1168,7 +1168,7 @@ class argmap:
 
     @staticmethod
     def _flatten(nestlist, visited):
-        """flattens a recursive list of lists that doesn't have cyclic references
+        """Flatten a recursive list of lists that doesn't have cyclic references.
 
         Parameters
         ----------


### PR DESCRIPTION
This continues (and uses) #7258 to update usage of "Yields" section in docstrings, because several functions incorrectly use "Returns".

As we discussed last year, the docstrings were updated to not distinguish between _being_ a generator function (a function with `yield` or `yield from`) or a function that _returns_ an iterator, because they are functionally used the same. This PR only changes docstrings.

Using `yield from iterator` has the advantage of better tracebacks from exceptions within the generator. Using `return iterator` has the advantage that it will execute code upon first being called, so some exceptions are raised earlier (otherwise, they would raise on the first invocation of `next(...)`). As a general rule, I _slightly_ prefer using `yield from`.

I did a first-pass update of docstrings. I updated many of them to use imperative tone (such as "Return x" instead of "Returns x"). Please make suggestions for updating (or reverting) docstrings as you feel best.