### PR TITLE
MAINT: Move stub func in the correct scope for pickle test

### DIFF
--- a/networkx/utils/tests/test_backends.py
+++ b/networkx/utils/tests/test_backends.py
@@ -8,6 +8,11 @@ sp = pytest.importorskip("scipy")
 pytest.importorskip("numpy")
 
 
+@nx._dispatchable(implemented_by_nx=False)
+def _stub_func(G):
+    raise NotImplementedError("_stub_func is a stub")
+
+
 def test_dispatch_kwds_vs_args():
     G = nx.path_graph(4)
     nx.pagerank(G)
@@ -171,10 +176,6 @@ def test_fallback_to_nx():
 
 
 def test_not_implemented_by_nx():
-    @nx._dispatchable(implemented_by_nx=False)
-    def _stub_func(G):
-        raise NotImplementedError("_stub_func is a stub")
-
     assert "networkx" in nx.pagerank.backends
     assert "networkx" not in _stub_func.backends
 


### PR DESCRIPTION
pytest-randomly seems to be tripping up on this https://github.com/networkx/networkx/actions/workflows/pytest-randomly.yml

Closes #7808 