### PR TITLE
MAINT: use nx.layout instead of importing layouts.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -22,16 +22,6 @@ import itertools
 from numbers import Number
 
 import networkx as nx
-from networkx.drawing.layout import (
-    circular_layout,
-    forceatlas2_layout,
-    kamada_kawai_layout,
-    planar_layout,
-    random_layout,
-    shell_layout,
-    spectral_layout,
-    spring_layout,
-)
 
 __all__ = [
     "draw",
@@ -1643,7 +1633,7 @@ def draw_circular(G, **kwargs):
     --------
     :func:`~networkx.drawing.layout.circular_layout`
     """
-    draw(G, circular_layout(G), **kwargs)
+    draw(G, pos=nx.circular_layout(G), **kwargs)
 
 
 def draw_kamada_kawai(G, **kwargs):
@@ -1683,7 +1673,7 @@ def draw_kamada_kawai(G, **kwargs):
     --------
     :func:`~networkx.drawing.layout.kamada_kawai_layout`
     """
-    draw(G, kamada_kawai_layout(G), **kwargs)
+    draw(G, pos=nx.kamada_kawai_layout(G), **kwargs)
 
 
 def draw_random(G, **kwargs):
@@ -1722,7 +1712,7 @@ def draw_random(G, **kwargs):
     --------
     :func:`~networkx.drawing.layout.random_layout`
     """
-    draw(G, random_layout(G), **kwargs)
+    draw(G, pos=nx.random_layout(G), **kwargs)
 
 
 def draw_spectral(G, **kwargs):
@@ -1764,7 +1754,7 @@ def draw_spectral(G, **kwargs):
     --------
     :func:`~networkx.drawing.layout.spectral_layout`
     """
-    draw(G, spectral_layout(G), **kwargs)
+    draw(G, pos=nx.spectral_layout(G), **kwargs)
 
 
 def draw_spring(G, **kwargs):
@@ -1807,7 +1797,7 @@ def draw_spring(G, **kwargs):
     draw
     :func:`~networkx.drawing.layout.spring_layout`
     """
-    draw(G, spring_layout(G), **kwargs)
+    draw(G, pos=nx.spring_layout(G), **kwargs)
 
 
 def draw_shell(G, nlist=None, **kwargs):
@@ -1852,7 +1842,7 @@ def draw_shell(G, nlist=None, **kwargs):
     --------
     :func:`~networkx.drawing.layout.shell_layout`
     """
-    draw(G, shell_layout(G, nlist=nlist), **kwargs)
+    draw(G, pos=nx.shell_layout(G, nlist=nlist), **kwargs)
 
 
 def draw_planar(G, **kwargs):
@@ -1896,7 +1886,7 @@ def draw_planar(G, **kwargs):
     --------
     :func:`~networkx.drawing.layout.planar_layout`
     """
-    draw(G, planar_layout(G), **kwargs)
+    draw(G, pos=nx.planar_layout(G), **kwargs)
 
 
 def draw_forceatlas2(G, **kwargs):
@@ -1916,7 +1906,7 @@ def draw_forceatlas2(G, **kwargs):
        with the exception of the pos parameter which is not used by this
        function.
     """
-    draw(G, forceatlas2_layout(G), **kwargs)
+    draw(G, pos=nx.forceatlas2_layout(G), **kwargs)
 
 
 def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):


### PR DESCRIPTION
A purely cosmetic change: removes the importation of specific layout functions in `nx_pylab` and instead calls them from the `nx.` namespace. Essentially just an (opinionated) lint - the main motivation is getting rid of the big import statement.