### PR TITLE
Ensure standard import conventions are used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: check-import-conventions
         name: Check import conventions; see CONTRIBUTING.rst#guidelines
         language: pygrep
-        entry: "import (networkx(,|$| (?!as nx))|numpy(?! as np)|scipy(?! as sp)|pandas(?! as pd)|matplotlib(,|$)|matplotlib.pyplot(?! as plt)|matplotlib (?!as mpl))"
+        entry: "^ *import (networkx(,|$| (?!as nx))|numpy(?! as np)|scipy(?! as sp)|pandas(?! as pd)|matplotlib(,|$)|matplotlib.pyplot(?! as plt)|matplotlib (?!as mpl))"
         exclude: |
           (?x)^(
             CONTRIBUTING.rst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,14 @@ repos:
   - repo: local
     hooks:
       - id: check-import-conventions
-        name: Check import conventions; see CONTRIBUTING.rst or https://networkx.org/documentation/stable/developer/contribute.html#guidelines
+        name: Check import conventions; see CONTRIBUTING.rst#guidelines
         language: pygrep
-        entry: "import (networkx|numpy|scipy|pandas|matplotlib)(,|$)"
-        exclude: ^networkx/tests/test_import.py|^doc/release/old_release_log.rst
+        entry: "import (networkx(,|$| (?!as nx))|numpy(?! as np)|scipy(?! as sp)|pandas(?! as pd)|matplotlib(,|$)|matplotlib.pyplot(?! as plt)|matplotlib (?!as mpl))"
+        exclude: |
+          (?x)^(
+            CONTRIBUTING.rst
+            |doc/release/api_0.99.rst
+            |doc/release/old_release_log.rst
+            |networkx/lazy_imports.py
+            |networkx/tests/test_import.py
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,11 @@ repos:
         language: system
         entry: python tools/generate_requirements.py
         files: "pyproject.toml|requirements/.*\\.txt|tools/generate_requirements.py"
+
+  - repo: local
+    hooks:
+      - id: check-import-conventions
+        name: Check import conventions; see CONTRIBUTING.rst or https://networkx.org/documentation/stable/developer/contribute.html#guidelines
+        language: pygrep
+        entry: "import (networkx|numpy|scipy|pandas|matplotlib)(,|$)"
+        exclude: ^networkx/tests/test_import.py|^doc/release/old_release_log.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -90,7 +90,7 @@ copyright = f"2004-{date.today().year}, NetworkX Developers"
 # Used in networkx.utils.backends for cleaner rendering of functions.
 # We need to set this before we import networkx.
 os.environ["_NETWORKX_BUILDING_DOCS_"] = "True"
-import networkx
+import networkx as nx
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,9 +96,9 @@ import networkx as nx
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = networkx.__version__
+version = nx.__version__
 # The full version, including dev info
-release = networkx.__version__.replace("_", "")
+release = nx.__version__.replace("_", "")
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -291,7 +291,7 @@ def new_setitem(self, key, val):
         if line and not line.startswith(" "):
             # This line must identify a backend; let's try to add a link
             backend, *rest = line.split(" ")
-            url = networkx.utils.backends.backend_info.get(backend, {}).get("url")
+            url = nx.utils.backends.backend_info.get(backend, {}).get("url")
             if url:
                 line = f"`{backend} <{url}>`_ " + " ".join(rest)
         newval.append(f"   {line}")

--- a/doc/reference/randomness.rst
+++ b/doc/reference/randomness.rst
@@ -31,8 +31,8 @@ seed of each RNG to an arbitrary integer:
 
    >>> import random
    >>> random.seed(246)        # or any integer
-   >>> import numpy
-   >>> numpy.random.seed(4812)
+   >>> import numpy as np
+   >>> np.random.seed(4812)
 
 Many users will be satisfied with this level of control.
 

--- a/examples/algorithms/plot_blockmodel.py
+++ b/examples/algorithms/plot_blockmodel.py
@@ -26,8 +26,7 @@ from collections import defaultdict
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
-from scipy.cluster import hierarchy
-from scipy.spatial import distance
+import scipy as sp
 
 
 def create_hc(G):
@@ -38,10 +37,10 @@ def create_hc(G):
         for v, d in p.items():
             distances[u][v] = d
     # Create hierarchical cluster
-    Y = distance.squareform(distances)
-    Z = hierarchy.complete(Y)  # Creates HC using farthest point linkage
+    Y = sp.spatial.distance.squareform(distances)
+    Z = sp.cluster.hierarchy.complete(Y)  # Creates HC using farthest point linkage
     # This partition selection is arbitrary, for illustrative purposes
-    membership = list(hierarchy.fcluster(Z, t=1.15))
+    membership = list(sp.cluster.hierarchy.fcluster(Z, t=1.15))
     # Create collection of lists for blockmodel
     partition = defaultdict(list)
     for n, p in zip(list(range(len(G))), membership):

--- a/examples/drawing/plot_eigenvalues.py
+++ b/examples/drawing/plot_eigenvalues.py
@@ -8,14 +8,14 @@ Create an G{n,m} random graph and compute the eigenvalues.
 
 import matplotlib.pyplot as plt
 import networkx as nx
-import numpy.linalg
+import numpy as np
 
 n = 1000  # 1000 nodes
 m = 5000  # 5000 edges
 G = nx.gnm_random_graph(n, m, seed=5040)  # Seed for reproducibility
 
 L = nx.normalized_laplacian_matrix(G)
-e = numpy.linalg.eigvals(L.toarray())
+e = np.linalg.eigvals(L.toarray())
 print("Largest eigenvalue:", max(e))
 print("Smallest eigenvalue:", min(e))
 plt.hist(e, bins=100)  # histogram with 100 bins

--- a/examples/graph/plot_visibility_graph.py
+++ b/examples/graph/plot_visibility_graph.py
@@ -6,7 +6,7 @@ Visibility Graph
 Visibility Graph constructed from a time series
 """
 
-from matplotlib import pyplot as plt
+import matplotlib.pyplot as plt
 
 import networkx as nx
 

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -563,7 +563,7 @@ def held_karp_ascent(G, weight="weight"):
            pp.1138-1162
     """
     import numpy as np
-    from scipy import optimize
+    import scipy as sp
 
     def k_pi():
         """
@@ -707,7 +707,7 @@ def held_karp_ascent(G, weight="weight"):
                     a_eq[n_count][arb_count] = deg - 2
                     n_count -= 1
                 a_eq[len(G)][arb_count] = 1
-            program_result = optimize.linprog(
+            program_result = sp.optimize.linprog(
                 c, A_eq=a_eq, b_eq=b_eq, method="highs-ipm"
             )
             # If the constants exist, then the direction of ascent doesn't

--- a/networkx/algorithms/tests/test_regular.py
+++ b/networkx/algorithms/tests/test_regular.py
@@ -1,6 +1,5 @@
 import pytest
 
-import networkx
 import networkx as nx
 import networkx.algorithms.regular as reg
 import networkx.generators as gen

--- a/networkx/classes/tests/test_digraph_historical.py
+++ b/networkx/classes/tests/test_digraph_historical.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import networkx
 import networkx as nx
 
 from .historical_tests import HistoricalTests

--- a/networkx/classes/tests/test_graph_historical.py
+++ b/networkx/classes/tests/test_graph_historical.py
@@ -1,6 +1,5 @@
 """Original NetworkX graph tests"""
 
-import networkx
 import networkx as nx
 
 from .historical_tests import HistoricalTests

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -19,7 +19,7 @@ from importlib.metadata import entry_points
 
 import pytest
 
-import networkx
+import networkx as nx
 
 
 def pytest_addoption(parser):
@@ -61,18 +61,18 @@ def pytest_configure(config):
     if backend:
         # We will update `networkx.config.backend_priority` below in `*_modify_items`
         # to allow tests to get set up with normal networkx graphs.
-        networkx.utils.backends.backends["nx_loopback"] = loopback_ep["nx_loopback"]
-        networkx.utils.backends.backend_info["nx_loopback"] = {}
-        networkx.config.backends = networkx.utils.Config(
-            nx_loopback=networkx.utils.Config(),
-            **networkx.config.backends,
+        nx.utils.backends.backends["nx_loopback"] = loopback_ep["nx_loopback"]
+        nx.utils.backends.backend_info["nx_loopback"] = {}
+        nx.config.backends = nx.utils.Config(
+            nx_loopback=nx.utils.Config(),
+            **nx.config.backends,
         )
         fallback_to_nx = config.getoption("--fallback-to-nx")
         if not fallback_to_nx:
             fallback_to_nx = os.environ.get("NETWORKX_FALLBACK_TO_NX")
-        networkx.config.fallback_to_nx = bool(fallback_to_nx)
-        networkx.utils.backends._dispatchable.__call__ = (
-            networkx.utils.backends._dispatchable._call_if_any_backends_installed
+        nx.config.fallback_to_nx = bool(fallback_to_nx)
+        nx.utils.backends._dispatchable.__call__ = (
+            nx.utils.backends._dispatchable._call_if_any_backends_installed
         )
 
 
@@ -84,10 +84,10 @@ def pytest_collection_modifyitems(config, items):
         # when running in auto-conversion test mode
         backend_name = config.backend
         if backend_name != "networkx":
-            networkx.utils.backends._dispatchable._is_testing = True
-            networkx.config.backend_priority.algos = [backend_name]
-            networkx.config.backend_priority.generators = [backend_name]
-            backend = networkx.utils.backends.backends[backend_name].load()
+            nx.utils.backends._dispatchable._is_testing = True
+            nx.config.backend_priority.algos = [backend_name]
+            nx.config.backend_priority.generators = [backend_name]
+            backend = nx.utils.backends.backends[backend_name].load()
             if hasattr(backend, "on_start_tests"):
                 getattr(backend, "on_start_tests")(items)
 
@@ -149,34 +149,34 @@ def set_warnings():
 
 @pytest.fixture(autouse=True)
 def add_nx(doctest_namespace):
-    doctest_namespace["nx"] = networkx
+    doctest_namespace["nx"] = nx
 
 
 # What dependencies are installed?
 
 try:
-    import numpy
+    import numpy as np
 
     has_numpy = True
 except ImportError:
     has_numpy = False
 
 try:
-    import scipy
+    import scipy as sp
 
     has_scipy = True
 except ImportError:
     has_scipy = False
 
 try:
-    import matplotlib
+    import matplotlib as mpl
 
     has_matplotlib = True
 except ImportError:
     has_matplotlib = False
 
 try:
-    import pandas
+    import pandas as pd
 
     has_pandas = True
 except ImportError:

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -159,7 +159,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
 
     # scipy sparse array - any format
     try:
-        import scipy
+        import scipy as sp
 
         if hasattr(data, "format"):
             try:

--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -379,7 +379,7 @@ def is_regular_expander(G, *, epsilon=0):
     """
 
     import numpy as np
-    from scipy.sparse.linalg import eigsh
+    import scipy as sp
 
     if epsilon < 0:
         raise nx.NetworkXError("epsilon must be non negative")
@@ -390,7 +390,7 @@ def is_regular_expander(G, *, epsilon=0):
     _, d = nx.utils.arbitrary_element(G.degree)
 
     A = nx.adjacency_matrix(G, dtype=float)
-    lams = eigsh(A, which="LM", k=2, return_eigenvectors=False)
+    lams = sp.sparse.linalg.eigsh(A, which="LM", k=2, return_eigenvectors=False)
 
     # lambda2 is the second biggest eigenvalue
     lambda2 = min(lams)

--- a/networkx/generators/tests/test_directed.py
+++ b/networkx/generators/tests/test_directed.py
@@ -18,7 +18,7 @@ from networkx.generators.directed import (
 )
 
 try:
-    import numpy
+    import numpy as np
 
     has_numpy = True
 except ImportError:

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -4,10 +4,10 @@ Miscellaneous Helpers for NetworkX.
 These are not imported into the base networkx namespace but
 can be accessed, for example, as
 
->>> import networkx
->>> networkx.utils.make_list_of_ints({1, 2, 3})
+>>> import networkx as nx
+>>> nx.utils.make_list_of_ints({1, 2, 3})
 [1, 2, 3]
->>> networkx.utils.arbitrary_element({5, 1, 7})  # doctest: +SKIP
+>>> nx.utils.arbitrary_element({5, 1, 7})  # doctest: +SKIP
 1
 """
 


### PR DESCRIPTION
I was poking around open issues and saw #4426, which referenced #4401. So, I took a minute to explore whether these conventions are actually used. Linting tools such as flake8-import-conventions can also do something similar to the simple pre-commit pygrep hook I added.