### PR TITLE
Clean up pygrep pre-commit for import convention checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,3 @@ repos:
         name: Check import conventions; see CONTRIBUTING.rst#guidelines
         language: pygrep
         entry: "^ *import (networkx(,|$| (?!as nx))|numpy(?! as np)|scipy(?! as sp)|pandas(?! as pd)|matplotlib(,|$)|matplotlib.pyplot(?! as plt)|matplotlib (?!as mpl))"
-        exclude: |
-          (?x)^(
-            CONTRIBUTING.rst
-            |doc/release/api_0.99.rst
-            |doc/release/old_release_log.rst
-            |networkx/lazy_imports.py
-            |networkx/tests/test_import.py
-          )$


### PR DESCRIPTION
This is a quick follow-up to #7821.

The last commit in #7821 added `"^ *"` to the regex string to avoid false-positives by only matching lines that begin with spaces (optional) and "import". Without this regex, we would get the following:
```
Check import conventions; see CONTRIBUTING.rst#guidelines.......................Failed
- hook id: check-import-conventions
- exit code: 1

CONTRIBUTING.rst:288:  ``import scipy.sparse.linalg as spla``.
doc/release/api_0.99.rst:290:>>> import networkx # e.g. centrality functions available as networkx.fcn()
doc/release/old_release_log.rst:730:     >>> import networkx
doc/release/old_release_log.rst:1036: - import networkx
doc/release/old_release_log.rst:1037: - import networkx as NX
networkx/lazy_imports.py:117:    The workaround is to import numpy before importing from the subpackage.
networkx/lazy_imports.py:151:          spla = lazy.load("scipy.linalg")  # import scipy.linalg as spla
networkx/tests/test_import.py:11:        from networkx import networkx
```
In a way it's nice to have `exclude: |` section so it's clear how to use it and add to it--and there's no particular need to check these files--but excluding these files is no longer necessary.