### PR TITLE
Add a few more square clustering test cases.

### DIFF
--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -3,6 +3,38 @@ import pytest
 import networkx as nx
 
 
+def test_square_clustering_adjacent_squares():
+    G = nx.Graph([(1, 2), (1, 3), (2, 4), (3, 4), (3, 5), (4, 6), (5, 6)])
+    # Corner nodes: C_4 == 0.5, central face nodes: C_4 = 1 / 3
+    expected = {1: 0.5, 2: 0.5, 3: 1 / 3, 4: 1 / 3, 5: 0.5, 6: 0.5}
+    assert nx.square_clustering(G) == expected
+
+
+def test_square_clustering_2d_grid():
+    G = nx.grid_2d_graph(3, 3)
+    # Central node: 4 squares out of 20 potential
+    expected = {
+        (0, 0): 1 / 3,
+        (0, 1): 0.25,
+        (0, 2): 1 / 3,
+        (1, 0): 0.25,
+        (1, 1): 0.2,
+        (1, 2): 0.25,
+        (2, 0): 1 / 3,
+        (2, 1): 0.25,
+        (2, 2): 1 / 3,
+    }
+    assert nx.square_clustering(G) == expected
+
+
+def test_square_clustering_multiple_squares_non_complete():
+    """An example where all nodes are part of all squares, but not every node
+    is connected to every other."""
+    G = nx.Graph([(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4), (1, 5), (2, 5)])
+    expected = {n: 1 for n in G}
+    assert nx.square_clustering(G) == expected
+
+
 class TestTriangles:
     def test_empty(self):
         G = nx.Graph()


### PR DESCRIPTION
It took me longer than I'd like to admit to work out the correct value for the 2D grid example (I think the formulae in *both* cited references give the incorrect answer for the central node), but the good news is that networkx's implementation gives the correct answer!