### PR TITLE
Deprecate graph_could_be_isomorphic

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -58,3 +58,9 @@ Version 3.6
 * Remove ``link`` kwarg from ``readwrite/json_graph/node_link.py``;
   Remove the ``FutureWarning`` re: the default value of ``edges`` and change the
   default value to ``"edges"``.
+
+Version 3.7
+~~~~~~~~~~~
+* Remove ``graph_could_be_isomorphic``, ``fast_graph_could_be_isomorphic``, and
+  ``faster_graph_could_be_isomorphic``, from
+  ``networkx.algorithms.isomorphism.isomorph``.

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -160,7 +160,21 @@ def faster_could_be_isomorphic(G1, G2):
     return True
 
 
-faster_graph_could_be_isomorphic = faster_could_be_isomorphic
+def faster_graph_could_be_isomorphic(G1, G2):
+    """
+    .. deprecated:: 3.5
+
+       `faster_graph_could_be_isomorphic` is a deprecated alias for
+       `faster_could_be_isomorphic`. Use `faster_could_be_isomorphic` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "faster_graph_could_be_isomorphic is deprecated, use faster_could_be_isomorphic instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return faster_could_be_isomorphic(G1, G2)
 
 
 @nx._dispatchable(

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -58,7 +58,21 @@ def could_be_isomorphic(G1, G2):
     return True
 
 
-graph_could_be_isomorphic = could_be_isomorphic
+def graph_could_be_isomorphic(G1, G2):
+    """
+    .. deprecated:: 3.5
+
+       `graph_could_be_isomorphic` is a deprecated alias for `could_be_isomorphic`.
+       Use `could_be_isomorphic` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "graph_could_be_isomorphic is deprecated, use `could_be_isomorphic` instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return could_be_isomorphic(G1, G2)
 
 
 @nx._dispatchable(graphs={"G1": 0, "G2": 1})

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -113,7 +113,21 @@ def fast_could_be_isomorphic(G1, G2):
     return True
 
 
-fast_graph_could_be_isomorphic = fast_could_be_isomorphic
+def fast_graph_could_be_isomorphic(G1, G2):
+    """
+    .. deprecated:: 3.5
+
+       `fast_graph_could_be_isomorphic` is a deprecated alias for
+       `fast_could_be_isomorphic`. Use `fast_could_be_isomorphic` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "fast_graph_could_be_isomorphic is deprecated, use fast_could_be_isomorphic instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return fast_could_be_isomorphic(G1, G2)
 
 
 @nx._dispatchable(graphs={"G1": 0, "G2": 1})

--- a/networkx/algorithms/isomorphism/tests/test_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphism.py
@@ -4,6 +4,20 @@ import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
 
+def test_graph_could_be_isomorphic_variants_deprecated():
+    G1 = nx.Graph([(1, 2), (1, 3), (1, 5), (2, 3)])
+    G2 = nx.Graph([(10, 20), (20, 30), (10, 30), (10, 50)])
+    with pytest.deprecated_call():  # graph_could_be_isomorphic
+        result = nx.isomorphism.isomorph.graph_could_be_isomorphic(G1, G2)
+    assert nx.could_be_isomorphic(G1, G2) == result
+    with pytest.deprecated_call():  # fast_graph_could_be_isomorphic
+        result = nx.isomorphism.isomorph.fast_graph_could_be_isomorphic(G1, G2)
+    assert nx.fast_could_be_isomorphic(G1, G2) == result
+    with pytest.deprecated_call():
+        result = nx.isomorphism.isomorph.faster_graph_could_be_isomorphic(G1, G2)
+    assert nx.faster_could_be_isomorphic(G1, G2) == result
+
+
 class TestIsomorph:
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/tests/test_threshold.py
+++ b/networkx/algorithms/tests/test_threshold.py
@@ -7,7 +7,6 @@ import pytest
 
 import networkx as nx
 import networkx.algorithms.threshold as nxt
-from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
 
 cnlti = nx.convert_node_labels_to_integers
 
@@ -50,9 +49,9 @@ class TestGeneratorThreshold:
         H2 = nxt.threshold_graph(cs2)
         assert cs2 == [2, 1, 1]
         assert "".join(nxt.uncompact(cs2)) == "ddid"
-        assert graph_could_be_isomorphic(H0, G)
-        assert graph_could_be_isomorphic(H0, H1)
-        assert graph_could_be_isomorphic(H0, H2)
+        assert nx.could_be_isomorphic(H0, G)
+        assert nx.could_be_isomorphic(H0, H1)
+        assert nx.could_be_isomorphic(H0, H2)
 
     def test_make_compact(self):
         assert nxt.make_compact(["d", "d", "d", "i", "d", "d"]) == [3, 1, 2]

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -12,10 +12,7 @@ import typing
 import pytest
 
 import networkx as nx
-from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
 from networkx.utils import edges_equal, nodes_equal
-
-is_isomorphic = graph_could_be_isomorphic
 
 
 class TestGeneratorClassic:
@@ -37,11 +34,11 @@ class TestGeneratorClassic:
     def test_balanced_tree_star(self):
         # balanced_tree(r,1) is the r-star
         t = nx.balanced_tree(r=2, h=1)
-        assert is_isomorphic(t, nx.star_graph(2))
+        assert nx.could_be_isomorphic(t, nx.star_graph(2))
         t = nx.balanced_tree(r=5, h=1)
-        assert is_isomorphic(t, nx.star_graph(5))
+        assert nx.could_be_isomorphic(t, nx.star_graph(5))
         t = nx.balanced_tree(r=10, h=1)
-        assert is_isomorphic(t, nx.star_graph(10))
+        assert nx.could_be_isomorphic(t, nx.star_graph(10))
 
     def test_balanced_tree_path(self):
         """Tests that the balanced tree with branching factor one is the
@@ -51,7 +48,7 @@ class TestGeneratorClassic:
         # A tree of height four has five levels.
         T = nx.balanced_tree(1, 4)
         P = nx.path_graph(5)
-        assert is_isomorphic(T, P)
+        assert nx.could_be_isomorphic(T, P)
 
     def test_full_rary_tree(self):
         r = 2
@@ -69,17 +66,17 @@ class TestGeneratorClassic:
     def test_full_rary_tree_balanced(self):
         t = nx.full_rary_tree(2, 15)
         th = nx.balanced_tree(2, 3)
-        assert is_isomorphic(t, th)
+        assert nx.could_be_isomorphic(t, th)
 
     def test_full_rary_tree_path(self):
         t = nx.full_rary_tree(1, 10)
-        assert is_isomorphic(t, nx.path_graph(10))
+        assert nx.could_be_isomorphic(t, nx.path_graph(10))
 
     def test_full_rary_tree_empty(self):
         t = nx.full_rary_tree(0, 10)
-        assert is_isomorphic(t, nx.empty_graph(10))
+        assert nx.could_be_isomorphic(t, nx.empty_graph(10))
         t = nx.full_rary_tree(3, 0)
-        assert is_isomorphic(t, nx.empty_graph(0))
+        assert nx.could_be_isomorphic(t, nx.empty_graph(0))
 
     def test_full_rary_tree_3_20(self):
         t = nx.full_rary_tree(3, 20)
@@ -120,17 +117,17 @@ class TestGeneratorClassic:
         m1 = 2
         m2 = 5
         b = nx.barbell_graph(m1, m2)
-        assert is_isomorphic(b, nx.path_graph(m2 + 4))
+        assert nx.could_be_isomorphic(b, nx.path_graph(m2 + 4))
 
         m1 = 2
         m2 = 10
         b = nx.barbell_graph(m1, m2)
-        assert is_isomorphic(b, nx.path_graph(m2 + 4))
+        assert nx.could_be_isomorphic(b, nx.path_graph(m2 + 4))
 
         m1 = 2
         m2 = 20
         b = nx.barbell_graph(m1, m2)
-        assert is_isomorphic(b, nx.path_graph(m2 + 4))
+        assert nx.could_be_isomorphic(b, nx.path_graph(m2 + 4))
 
         pytest.raises(
             nx.NetworkXError, nx.barbell_graph, m1, m2, create_using=nx.DiGraph()
@@ -206,7 +203,7 @@ class TestGeneratorClassic:
         # Ci_6(1, 3) is K_3,3 i.e. the utility graph
         Ci6_1_3 = nx.circulant_graph(6, [1, 3])
         K3_3 = nx.complete_bipartite_graph(3, 3)
-        assert is_isomorphic(Ci6_1_3, K3_3)
+        assert nx.could_be_isomorphic(Ci6_1_3, K3_3)
 
     def test_cycle_graph(self):
         G = nx.cycle_graph(4)
@@ -340,7 +337,7 @@ class TestGeneratorClassic:
             (2, nx.hypercube_graph(2)),
             (10, nx.grid_graph([2, 10])),
         ]:
-            assert is_isomorphic(nx.ladder_graph(i), G)
+            assert nx.could_be_isomorphic(nx.ladder_graph(i), G)
 
         pytest.raises(nx.NetworkXError, nx.ladder_graph, 2, create_using=nx.DiGraph)
 
@@ -379,7 +376,7 @@ class TestGeneratorClassic:
     @pytest.mark.parametrize(("m", "n"), [(2, 0), (2, 5), (2, 10), ("ab", 20)])
     def test_lollipop_graph_same_as_path_when_m1_is_2(self, m, n):
         G = nx.lollipop_graph(m, n)
-        assert is_isomorphic(G, nx.path_graph(n + 2))
+        assert nx.could_be_isomorphic(G, nx.path_graph(n + 2))
 
     def test_lollipop_graph_for_multigraph(self):
         G = nx.lollipop_graph(5, 20)
@@ -393,24 +390,24 @@ class TestGeneratorClassic:
     def test_lollipop_graph_mixing_input_types(self, m, n):
         expected = nx.compose(nx.complete_graph(4), nx.path_graph(range(100, 103)))
         expected.add_edge(0, 100)  # Connect complete graph and path graph
-        assert is_isomorphic(nx.lollipop_graph(m, n), expected)
+        assert nx.could_be_isomorphic(nx.lollipop_graph(m, n), expected)
 
     def test_lollipop_graph_non_builtin_ints(self):
         np = pytest.importorskip("numpy")
         G = nx.lollipop_graph(np.int32(4), np.int64(3))
         expected = nx.compose(nx.complete_graph(4), nx.path_graph(range(100, 103)))
         expected.add_edge(0, 100)  # Connect complete graph and path graph
-        assert is_isomorphic(G, expected)
+        assert nx.could_be_isomorphic(G, expected)
 
     def test_null_graph(self):
         assert nx.number_of_nodes(nx.null_graph()) == 0
 
     def test_path_graph(self):
         p = nx.path_graph(0)
-        assert is_isomorphic(p, nx.null_graph())
+        assert nx.could_be_isomorphic(p, nx.null_graph())
 
         p = nx.path_graph(1)
-        assert is_isomorphic(p, nx.empty_graph(1))
+        assert nx.could_be_isomorphic(p, nx.empty_graph(1))
 
         p = nx.path_graph(10)
         assert nx.is_connected(p)
@@ -442,12 +439,14 @@ class TestGeneratorClassic:
         assert G.has_edge(2, 4)
 
     def test_star_graph(self):
-        assert is_isomorphic(nx.star_graph(""), nx.empty_graph(0))
-        assert is_isomorphic(nx.star_graph([]), nx.empty_graph(0))
-        assert is_isomorphic(nx.star_graph(0), nx.empty_graph(1))
-        assert is_isomorphic(nx.star_graph(1), nx.path_graph(2))
-        assert is_isomorphic(nx.star_graph(2), nx.path_graph(3))
-        assert is_isomorphic(nx.star_graph(5), nx.complete_bipartite_graph(1, 5))
+        assert nx.could_be_isomorphic(nx.star_graph(""), nx.empty_graph(0))
+        assert nx.could_be_isomorphic(nx.star_graph([]), nx.empty_graph(0))
+        assert nx.could_be_isomorphic(nx.star_graph(0), nx.empty_graph(1))
+        assert nx.could_be_isomorphic(nx.star_graph(1), nx.path_graph(2))
+        assert nx.could_be_isomorphic(nx.star_graph(2), nx.path_graph(3))
+        assert nx.could_be_isomorphic(
+            nx.star_graph(5), nx.complete_bipartite_graph(1, 5)
+        )
 
         s = nx.star_graph(10)
         assert sorted(d for n, d in s.degree()) == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 10]
@@ -508,12 +507,12 @@ class TestGeneratorClassic:
     @pytest.mark.parametrize(("m", "n"), [(2, 0), (2, 5), (2, 10), ("ab", 20)])
     def test_tadpole_graph_same_as_path_when_m_is_2(self, m, n):
         G = nx.tadpole_graph(m, n)
-        assert is_isomorphic(G, nx.path_graph(n + 2))
+        assert nx.could_be_isomorphic(G, nx.path_graph(n + 2))
 
     @pytest.mark.parametrize("m", [4, 7])
     def test_tadpole_graph_same_as_cycle_when_m2_is_0(self, m):
         G = nx.tadpole_graph(m, 0)
-        assert is_isomorphic(G, nx.cycle_graph(m))
+        assert nx.could_be_isomorphic(G, nx.cycle_graph(m))
 
     def test_tadpole_graph_for_multigraph(self):
         G = nx.tadpole_graph(5, 20)
@@ -527,21 +526,21 @@ class TestGeneratorClassic:
     def test_tadpole_graph_mixing_input_types(self, m, n):
         expected = nx.compose(nx.cycle_graph(4), nx.path_graph(range(100, 103)))
         expected.add_edge(0, 100)  # Connect cycle and path
-        assert is_isomorphic(nx.tadpole_graph(m, n), expected)
+        assert nx.could_be_isomorphic(nx.tadpole_graph(m, n), expected)
 
     def test_tadpole_graph_non_builtin_integers(self):
         np = pytest.importorskip("numpy")
         G = nx.tadpole_graph(np.int32(4), np.int64(3))
         expected = nx.compose(nx.cycle_graph(4), nx.path_graph(range(100, 103)))
         expected.add_edge(0, 100)  # Connect cycle and path
-        assert is_isomorphic(G, expected)
+        assert nx.could_be_isomorphic(G, expected)
 
     def test_trivial_graph(self):
         assert nx.number_of_nodes(nx.trivial_graph()) == 1
 
     def test_turan_graph(self):
         assert nx.number_of_edges(nx.turan_graph(13, 4)) == 63
-        assert is_isomorphic(
+        assert nx.could_be_isomorphic(
             nx.turan_graph(13, 4), nx.complete_multipartite_graph(3, 4, 3, 3)
         )
 
@@ -555,7 +554,7 @@ class TestGeneratorClassic:
             (4, nx.complete_graph(4)),
         ]:
             g = nx.wheel_graph(n)
-            assert is_isomorphic(g, G)
+            assert nx.could_be_isomorphic(g, G)
 
         g = nx.wheel_graph(10)
         assert sorted(d for n, d in g.degree()) == [3, 3, 3, 3, 3, 3, 3, 3, 3, 9]
@@ -625,15 +624,15 @@ class TestGeneratorClassic:
 
     def test_kneser_graph(self):
         # the petersen graph is a special case of the kneser graph when n=5 and k=2
-        assert is_isomorphic(nx.kneser_graph(5, 2), nx.petersen_graph())
+        assert nx.could_be_isomorphic(nx.kneser_graph(5, 2), nx.petersen_graph())
 
         # when k is 1, the kneser graph returns a complete graph with n vertices
         for i in range(1, 7):
-            assert is_isomorphic(nx.kneser_graph(i, 1), nx.complete_graph(i))
+            assert nx.could_be_isomorphic(nx.kneser_graph(i, 1), nx.complete_graph(i))
 
         # the kneser graph of n and n-1 is the empty graph with n vertices
         for j in range(3, 7):
-            assert is_isomorphic(nx.kneser_graph(j, j - 1), nx.empty_graph(j))
+            assert nx.could_be_isomorphic(nx.kneser_graph(j, j - 1), nx.empty_graph(j))
 
         # in general the number of edges of the kneser graph is equal to
         # (n choose k) times (n-k choose k) divided by 2

--- a/networkx/generators/tests/test_small.py
+++ b/networkx/generators/tests/test_small.py
@@ -1,15 +1,6 @@
 import pytest
 
 import networkx as nx
-from networkx.algorithms.isomorphism.isomorph import graph_could_be_isomorphic
-
-is_isomorphic = graph_could_be_isomorphic
-
-"""Generators - Small
-=====================
-
-Some small graphs
-"""
 
 null = nx.null_graph()
 
@@ -18,21 +9,21 @@ class TestGeneratorsSmall:
     def test__LCF_graph(self):
         # If n<=0, then return the null_graph
         G = nx.LCF_graph(-10, [1, 2], 100)
-        assert is_isomorphic(G, null)
+        assert nx.could_be_isomorphic(G, null)
         G = nx.LCF_graph(0, [1, 2], 3)
-        assert is_isomorphic(G, null)
+        assert nx.could_be_isomorphic(G, null)
         G = nx.LCF_graph(0, [1, 2], 10)
-        assert is_isomorphic(G, null)
+        assert nx.could_be_isomorphic(G, null)
 
         # Test that LCF(n,[],0) == cycle_graph(n)
         for a, b, c in [(5, [], 0), (10, [], 0), (5, [], 1), (10, [], 10)]:
             G = nx.LCF_graph(a, b, c)
-            assert is_isomorphic(G, nx.cycle_graph(a))
+            assert nx.could_be_isomorphic(G, nx.cycle_graph(a))
 
         # Generate the utility graph K_{3,3}
         G = nx.LCF_graph(6, [3, -3], 3)
         utility_graph = nx.complete_bipartite_graph(3, 3)
-        assert is_isomorphic(G, utility_graph)
+        assert nx.could_be_isomorphic(G, utility_graph)
 
         with pytest.raises(nx.NetworkXError, match="Directed Graph not supported"):
             G = nx.LCF_graph(6, [3, -3], 3, create_using=nx.DiGraph)


### PR DESCRIPTION
`graph_could_be_isomorphic` (and friends `fast_` and `faster_`) are aliases for `could_be_isomorphic` that is not exported outside of the `isomorph` module, so this should be a relatively undisruptive deprecation (the only way to access the alias is to import from `nx.algorithms.isomorphism.isomorph` - see e.g. the removed examples in the test suite).

There were some internal usages in the test suite which are easily replaced with the (newly) recommended function.