### PR TITLE
Expire all_triplets deprecation.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -43,7 +43,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
 Version 3.5
 ~~~~~~~~~~~
-* Remove ``all_triplets`` from ``algorithms/triads.py``
 * Remove ``random_triad`` from ``algorithms/triad.py``.
 * Remove ``d_separated`` from ``algorithms/d_separation.py``.
 * Remove ``minimal_d_separator`` from ``algorithms/d_separation.py``.

--- a/doc/reference/algorithms/triads.rst
+++ b/doc/reference/algorithms/triads.rst
@@ -12,4 +12,3 @@ Triads
    triad_type
    is_triad
    all_triads
-   all_triplets

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -9,12 +9,6 @@ import pytest
 import networkx as nx
 
 
-def test_all_triplets_deprecated():
-    G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
-    with pytest.deprecated_call():
-        nx.all_triplets(G)
-
-
 def test_random_triad_deprecated():
     G = nx.path_graph(3, create_using=nx.DiGraph)
     with pytest.deprecated_call():
@@ -57,23 +51,8 @@ def test_is_triad():
         assert nx.is_triad(G2)
 
 
-def test_all_triplets():
-    """Tests the all_triplets function."""
-    G = nx.DiGraph()
-    G.add_edges_from(["01", "02", "03", "04", "05", "12", "16", "51", "56", "65"])
-    expected = [
-        f"{i},{j},{k}"
-        for i in range(7)
-        for j in range(i + 1, 7)
-        for k in range(j + 1, 7)
-    ]
-    expected = [set(x.split(",")) for x in expected]
-    actual = [set(x) for x in nx.all_triplets(G)]
-    assert all(any(s1 == s2 for s1 in expected) for s2 in actual)
-
-
 def test_all_triads():
-    """Tests the all_triplets function."""
+    """Tests the all_triads function."""
     G = nx.DiGraph()
     G.add_edges_from(["01", "02", "03", "04", "05", "12", "16", "51", "56", "65"])
     expected = [
@@ -131,7 +110,6 @@ def test_triad_type():
 
 
 def test_triads_by_type():
-    """Tests the all_triplets function."""
     G = nx.DiGraph()
     G.add_edges_from(["01", "02", "03", "04", "05", "12", "16", "51", "56", "65"])
     all_triads = nx.all_triads(G)

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -13,7 +13,6 @@ from networkx.utils import not_implemented_for, py_random_state
 __all__ = [
     "triadic_census",
     "is_triad",
-    "all_triplets",
     "all_triads",
     "triads_by_type",
     "triad_type",
@@ -308,49 +307,6 @@ def is_triad(G):
             if not any((n, n) in G.edges() for n in G.nodes()):
                 return True
     return False
-
-
-@not_implemented_for("undirected")
-@nx._dispatchable
-def all_triplets(G):
-    """Returns a generator of all possible sets of 3 nodes in a DiGraph.
-
-    .. deprecated:: 3.3
-
-       all_triplets is deprecated and will be removed in NetworkX version 3.5.
-       Use `itertools.combinations` instead::
-
-          all_triplets = itertools.combinations(G, 3)
-
-    Parameters
-    ----------
-    G : digraph
-       A NetworkX DiGraph
-
-    Returns
-    -------
-    triplets : generator of 3-tuples
-       Generator of tuples of 3 nodes
-
-    Examples
-    --------
-    >>> G = nx.DiGraph([(1, 2), (2, 3), (3, 4)])
-    >>> list(nx.all_triplets(G))
-    [(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
-
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\nall_triplets is deprecated and will be removed in v3.5.\n"
-            "Use `itertools.combinations(G, 3)` instead."
-        ),
-        category=DeprecationWarning,
-        stacklevel=4,
-    )
-    triplets = combinations(G.nodes(), 3)
-    return triplets
 
 
 @not_implemented_for("undirected")

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -112,9 +112,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\nall_triplets"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nrandom_triad"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
Expires the `all_triplets` deprecation, which is scheduled to be removed in 3.5