### PR TITLE
Expire random_triad deprecation.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -44,7 +44,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 Version 3.5
 ~~~~~~~~~~~
 * Remove ``all_triplets`` from ``algorithms/triads.py``
-* Remove ``random_triad`` from ``algorithms/triad.py``.
 * Remove ``d_separated`` from ``algorithms/d_separation.py``.
 * Remove ``minimal_d_separator`` from ``algorithms/d_separation.py``.
 * Add `not_implemented_for("multigraph”)` decorator to ``k_core``, ``k_shell``, ``k_crust`` and ``k_corona`` functions.

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -43,6 +43,7 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
 Version 3.5
 ~~~~~~~~~~~
+* Add `not_implemented_for("multigraph”)` decorator to ``k_core``, ``k_shell``, ``k_crust`` and ``k_corona`` functions.
 * Remove ``total_spanning_tree_weight`` from ``linalg/laplacianmatrix.py``
 * Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 
   ``generators/nonisomorphic_trees``.

--- a/doc/reference/algorithms/triads.rst
+++ b/doc/reference/algorithms/triads.rst
@@ -7,7 +7,6 @@ Triads
    :toctree: generated/
 
    triadic_census
-   random_triad
    triads_by_type
    triad_type
    is_triad

--- a/networkx/algorithms/tests/test_triads.py
+++ b/networkx/algorithms/tests/test_triads.py
@@ -15,12 +15,6 @@ def test_all_triplets_deprecated():
         nx.all_triplets(G)
 
 
-def test_random_triad_deprecated():
-    G = nx.path_graph(3, create_using=nx.DiGraph)
-    with pytest.deprecated_call():
-        nx.random_triad(G)
-
-
 def test_triadic_census():
     """Tests the triadic_census function."""
     G = nx.DiGraph()
@@ -145,19 +139,6 @@ def test_triads_by_type():
         expected_Gs = expected[tri_type]
         for a in actual_Gs:
             assert any(nx.is_isomorphic(a, e) for e in expected_Gs)
-
-
-def test_random_triad():
-    """Tests the random_triad function"""
-    G = nx.karate_club_graph()
-    G = G.to_directed()
-    for i in range(100):
-        assert nx.is_triad(nx.random_triad(G))
-
-    G = nx.DiGraph()
-    msg = "at least 3 nodes to form a triad"
-    with pytest.raises(nx.NetworkXError, match=msg):
-        nx.random_triad(G)
 
 
 def test_triadic_census_short_path_nodelist():

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -17,7 +17,6 @@ __all__ = [
     "all_triads",
     "triads_by_type",
     "triad_type",
-    "random_triad",
 ]
 
 #: The integer codes representing each type of triad.
@@ -543,62 +542,3 @@ def triad_type(G):
         return "210"
     elif num_edges == 6:
         return "300"
-
-
-@not_implemented_for("undirected")
-@py_random_state(1)
-@nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
-def random_triad(G, seed=None):
-    """Returns a random triad from a directed graph.
-
-    .. deprecated:: 3.3
-
-       random_triad is deprecated and will be removed in version 3.5.
-       Use random sampling directly instead::
-
-          G.subgraph(random.sample(list(G), 3))
-
-    Parameters
-    ----------
-    G : digraph
-       A NetworkX DiGraph
-    seed : integer, random_state, or None (default)
-        Indicator of random number generation state.
-        See :ref:`Randomness<randomness>`.
-
-    Returns
-    -------
-    G2 : subgraph
-       A randomly selected triad (order-3 NetworkX DiGraph)
-
-    Raises
-    ------
-    NetworkXError
-        If the input Graph has less than 3 nodes.
-
-    Examples
-    --------
-    >>> G = nx.DiGraph([(1, 2), (1, 3), (2, 3), (3, 1), (5, 6), (5, 4), (6, 7)])
-    >>> triad = nx.random_triad(G, seed=1)
-    >>> triad.edges
-    OutEdgeView([(1, 2)])
-
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\nrandom_triad is deprecated and will be removed in NetworkX v3.5.\n"
-            "Use random.sample instead, e.g.::\n\n"
-            "\tG.subgraph(random.sample(list(G), 3))\n"
-        ),
-        category=DeprecationWarning,
-        stacklevel=5,
-    )
-    if len(G) < 3:
-        raise nx.NetworkXError(
-            f"G needs at least 3 nodes to form a triad; (it has {len(G)} nodes)"
-        )
-    nodes = seed.sample(list(G.nodes()), 3)
-    G2 = G.subgraph(nodes)
-    return G2

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -115,9 +115,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nall_triplets"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\nrandom_triad"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="minimal_d_separator"
     )
     warnings.filterwarnings(

--- a/networkx/tests/test_all_random_functions.py
+++ b/networkx/tests/test_all_random_functions.py
@@ -137,7 +137,6 @@ def run_all_random_functions(seed):
     t(nx.random_clustered_graph, joint_degree_sequence, seed=seed)
     constructor = [(3, 3, 0.5), (10, 10, 0.7)]
     t(nx.random_shell_graph, constructor, seed=seed)
-    t(nx.random_triad, G.to_directed(), seed=seed)
     mapping = {1: 0.4, 2: 0.3, 3: 0.3}
     t(nx.utils.random_weighted_sample, mapping, k, seed=seed)
     t(nx.utils.weighted_choice, mapping, seed=seed)


### PR DESCRIPTION
Expires the `random_triad` deprecation, which is scheduled for removal in version 3.5