### PR TITLE
Expire d_separated and minimum_d_separator functions.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -45,8 +45,6 @@ Version 3.5
 ~~~~~~~~~~~
 * Remove ``all_triplets`` from ``algorithms/triads.py``
 * Remove ``random_triad`` from ``algorithms/triad.py``.
-* Remove ``d_separated`` from ``algorithms/d_separation.py``.
-* Remove ``minimal_d_separator`` from ``algorithms/d_separation.py``.
 * Add `not_implemented_for("multigraph”)` decorator to ``k_core``, ``k_shell``, ``k_crust`` and ``k_corona`` functions.
 * Remove ``total_spanning_tree_weight`` from ``linalg/laplacianmatrix.py``
 * Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -223,8 +223,6 @@ __all__ = [
     "is_d_separator",
     "is_minimal_d_separator",
     "find_minimal_d_separator",
-    "d_separated",
-    "minimal_d_separator",
 ]
 
 
@@ -677,46 +675,3 @@ def _reachable(G, x, a, z):
                 processed.append((f, n))
 
     return {w for (_, w) in processed}
-
-
-# Deprecated functions:
-def d_separated(G, x, y, z):
-    """Return whether nodes sets ``x`` and ``y`` are d-separated by ``z``.
-
-    .. deprecated:: 3.3
-
-        This function is deprecated and will be removed in NetworkX v3.5.
-        Please use `is_d_separator(G, x, y, z)`.
-
-    """
-    import warnings
-
-    warnings.warn(
-        "d_separated is deprecated and will be removed in NetworkX v3.5."
-        "Please use `is_d_separator(G, x, y, z)`.",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return nx.is_d_separator(G, x, y, z)
-
-
-def minimal_d_separator(G, u, v):
-    """Returns a minimal_d-separating set between `x` and `y` if possible
-
-    .. deprecated:: 3.3
-
-        minimal_d_separator is deprecated and will be removed in NetworkX v3.5.
-        Please use `find_minimal_d_separator(G, x, y)`.
-
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "This function is deprecated and will be removed in NetworkX v3.5."
-            "Please use `is_d_separator(G, x, y)`."
-        ),
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return nx.find_minimal_d_separator(G, u, v)

--- a/networkx/algorithms/tests/test_d_separation.py
+++ b/networkx/algorithms/tests/test_d_separation.py
@@ -338,11 +338,3 @@ def test__reachable(large_collider_graph):
     ancestors = {"A", "B", "C", "D", "F"}
     assert reachable(g, x, ancestors, {"B"}) == {"B", "F", "D"}
     assert reachable(g, x, ancestors, set()) == ancestors
-
-
-def test_deprecations():
-    G = nx.DiGraph([(0, 1), (1, 2)])
-    with pytest.deprecated_call():
-        nx.d_separated(G, 0, 2, {1})
-    with pytest.deprecated_call():
-        z = nx.minimal_d_separator(G, 0, 2)

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -117,12 +117,6 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nrandom_triad"
     )
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="minimal_d_separator"
-    )
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="d_separated"
-    )
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="\n\nk_core")
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nk_shell"


### PR DESCRIPTION
Expire deprecations of `d_separated` and `minimum_d_separator`, which are scheduled for removal in 3.5