### PR TITLE
Raise an exception for k_core functions with multigraphs.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -47,7 +47,6 @@ Version 3.5
 * Remove ``random_triad`` from ``algorithms/triad.py``.
 * Remove ``d_separated`` from ``algorithms/d_separation.py``.
 * Remove ``minimal_d_separator`` from ``algorithms/d_separation.py``.
-* Add `not_implemented_for("multigraph”)` decorator to ``k_core``, ``k_shell``, ``k_crust`` and ``k_corona`` functions.
 * Remove ``total_spanning_tree_weight`` from ``linalg/laplacianmatrix.py``
 * Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 
   ``generators/nonisomorphic_trees``.

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -149,14 +149,12 @@ def _core_subgraph(G, k_filter, k=None, core=None):
     return G.subgraph(nodes).copy()
 
 
+@nx.utils.not_implemented_for("multigraph")
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
 def k_core(G, k=None, core_number=None):
     """Returns the k-core of G.
 
     A k-core is a maximal subgraph that contains nodes of degree `k` or more.
-
-    .. deprecated:: 3.3
-       `k_core` will not accept `MultiGraph` objects in version 3.5.
 
     Parameters
     ----------
@@ -206,34 +204,19 @@ def k_core(G, k=None, core_number=None):
        https://arxiv.org/abs/cs.DS/0310049
     """
 
-    import warnings
-
-    if G.is_multigraph():
-        warnings.warn(
-            (
-                "\n\n`k_core` will not accept `MultiGraph` objects in version 3.5.\n"
-                "Convert it to an undirected graph instead, using::\n\n"
-                "\tG = nx.Graph(G)\n"
-            ),
-            category=DeprecationWarning,
-            stacklevel=5,
-        )
-
     def k_filter(v, k, c):
         return c[v] >= k
 
     return _core_subgraph(G, k_filter, k, core_number)
 
 
+@nx.utils.not_implemented_for("multigraph")
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
 def k_shell(G, k=None, core_number=None):
     """Returns the k-shell of G.
 
     The k-shell is the subgraph induced by nodes with core number k.
     That is, nodes in the k-core that are not in the (k+1)-core.
-
-    .. deprecated:: 3.3
-       `k_shell` will not accept `MultiGraph` objects in version 3.5.
 
     Parameters
     ----------
@@ -288,34 +271,19 @@ def k_shell(G, k=None, core_number=None):
        http://www.pnas.org/content/104/27/11150.full
     """
 
-    import warnings
-
-    if G.is_multigraph():
-        warnings.warn(
-            (
-                "\n\n`k_shell` will not accept `MultiGraph` objects in version 3.5.\n"
-                "Convert it to an undirected graph instead, using::\n\n"
-                "\tG = nx.Graph(G)\n"
-            ),
-            category=DeprecationWarning,
-            stacklevel=5,
-        )
-
     def k_filter(v, k, c):
         return c[v] == k
 
     return _core_subgraph(G, k_filter, k, core_number)
 
 
+@nx.utils.not_implemented_for("multigraph")
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
 def k_crust(G, k=None, core_number=None):
     """Returns the k-crust of G.
 
     The k-crust is the graph G with the edges of the k-core removed
     and isolated nodes found after the removal of edges are also removed.
-
-    .. deprecated:: 3.3
-       `k_crust` will not accept `MultiGraph` objects in version 3.5.
 
     Parameters
     ----------
@@ -366,20 +334,6 @@ def k_crust(G, k=None, core_number=None):
        and Eran Shir, PNAS  July 3, 2007   vol. 104  no. 27  11150-11154
        http://www.pnas.org/content/104/27/11150.full
     """
-
-    import warnings
-
-    if G.is_multigraph():
-        warnings.warn(
-            (
-                "\n\n`k_crust` will not accept `MultiGraph` objects in version 3.5.\n"
-                "Convert it to an undirected graph instead, using::\n\n"
-                "\tG = nx.Graph(G)\n"
-            ),
-            category=DeprecationWarning,
-            stacklevel=5,
-        )
-
     # Default for k is one less than in _core_subgraph, so just inline.
     #    Filter is c[v] <= k
     if core_number is None:
@@ -390,15 +344,13 @@ def k_crust(G, k=None, core_number=None):
     return G.subgraph(nodes).copy()
 
 
+@nx.utils.not_implemented_for("multigraph")
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)
 def k_corona(G, k, core_number=None):
     """Returns the k-corona of G.
 
     The k-corona is the subgraph of nodes in the k-core which have
     exactly k neighbors in the k-core.
-
-    .. deprecated:: 3.3
-       `k_corona` will not accept `MultiGraph` objects in version 3.5.
 
     Parameters
     ----------
@@ -447,19 +399,6 @@ def k_corona(G, k, core_number=None):
        Phys. Rev. E 73, 056101 (2006)
        http://link.aps.org/doi/10.1103/PhysRevE.73.056101
     """
-
-    import warnings
-
-    if G.is_multigraph():
-        warnings.warn(
-            (
-                "\n\n`k_corona` will not accept `MultiGraph` objects in version 3.5.\n"
-                "Convert it to an undirected graph instead, using::\n\n"
-                "\tG = nx.Graph(G)\n"
-            ),
-            category=DeprecationWarning,
-            stacklevel=5,
-        )
 
     def func(v, k, c):
         return c[v] == k and k == sum(1 for w in G[v] if c[w] >= k)

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -116,7 +116,7 @@ class TestCore:
     def test_k_core_multigraph(self):
         core_number = nx.core_number(self.H)
         H = nx.MultiGraph(self.H)
-        with pytest.deprecated_call():
+        with pytest.raises(nx.NetworkXNotImplemented):
             nx.k_core(H, k=0, core_number=core_number)
 
     def test_main_crust(self):
@@ -137,7 +137,7 @@ class TestCore:
     def test_k_crust_multigraph(self):
         core_number = nx.core_number(self.H)
         H = nx.MultiGraph(self.H)
-        with pytest.deprecated_call():
+        with pytest.raises(nx.NetworkXNotImplemented):
             nx.k_crust(H, k=0, core_number=core_number)
 
     def test_main_shell(self):
@@ -158,7 +158,7 @@ class TestCore:
     def test_k_shell_multigraph(self):
         core_number = nx.core_number(self.H)
         H = nx.MultiGraph(self.H)
-        with pytest.deprecated_call():
+        with pytest.raises(nx.NetworkXNotImplemented):
             nx.k_shell(H, k=0, core_number=core_number)
 
     def test_k_corona(self):
@@ -175,7 +175,7 @@ class TestCore:
     def test_k_corona_multigraph(self):
         core_number = nx.core_number(self.H)
         H = nx.MultiGraph(self.H)
-        with pytest.deprecated_call():
+        with pytest.raises(nx.NetworkXNotImplemented):
             nx.k_corona(H, k=0, core_number=core_number)
 
     def test_k_truss(self):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -123,16 +123,6 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="d_separated"
     )
-    warnings.filterwarnings("ignore", category=DeprecationWarning, message="\n\nk_core")
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\nk_shell"
-    )
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\nk_crust"
-    )
-    warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\nk_corona"
-    )
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\ntotal_spanning_tree_weight"
     )


### PR DESCRIPTION
Another FutureWarning behavior changed scheduled for 3.5