### PR TITLE
Fix docstring example of `nx.generate_random_paths(index_map=...)`

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1711,9 +1711,7 @@ def generate_random_paths(
 
     >>> G = nx.star_graph(3)
     >>> index_map = {}
-    >>> random_paths = dict(
-    ...     enumerate(nx.generate_random_paths(G, 3, index_map=index_map))
-    ... )
+    >>> random_paths = list(nx.generate_random_paths(G, 3, index_map=index_map))
     >>> paths_containing_node_0 = [
     ...     random_paths[path_idx] for path_idx in index_map.get(0, [])
     ... ]

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1711,9 +1711,11 @@ def generate_random_paths(
 
     >>> G = nx.star_graph(3)
     >>> index_map = {}
-    >>> random_path = nx.generate_random_paths(G, 3, index_map=index_map)
+    >>> random_paths = dict(
+    ...     enumerate(nx.generate_random_paths(G, 3, index_map=index_map))
+    ... )
     >>> paths_containing_node_0 = [
-    ...     random_path[path_idx] for path_idx in index_map.get(0, [])
+    ...     random_paths[path_idx] for path_idx in index_map.get(0, [])
     ... ]
 
     References


### PR DESCRIPTION
As discovered in https://github.com/networkx/networkx/pull/7817#issuecomment-2635286426, the docstring example with using `index_map` is incorrect, because it was trying to index into a generator.

This argument is a little awkward to use since this function is a generator and `index_map` will be updated incrementally, but I believe the updated docstring example is what was intended.