### PR TITLE
Don't use `assert` when using `pytest.raises`

### DIFF
--- a/networkx/algorithms/tests/test_link_prediction.py
+++ b/networkx/algorithms/tests/test_link_prediction.py
@@ -36,14 +36,14 @@ class TestResourceAllocationIndex:
 
     @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
     def test_notimplemented(self, graph_type):
-        assert pytest.raises(
+        pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]
         )
 
     def test_node_not_found(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -76,14 +76,14 @@ class TestJaccardCoefficient:
 
     @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
     def test_notimplemented(self, graph_type):
-        assert pytest.raises(
+        pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]
         )
 
     def test_node_not_found(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -121,14 +121,14 @@ class TestAdamicAdarIndex:
 
     @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
     def test_notimplemented(self, graph_type):
-        assert pytest.raises(
+        pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]
         )
 
     def test_node_not_found(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -168,19 +168,19 @@ class TestCommonNeighborCentrality:
 
     @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
     def test_notimplemented(self, graph_type):
-        assert pytest.raises(
+        pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]
         )
 
     def test_node_u_not_found(self):
         G = nx.Graph()
         G.add_edges_from([(1, 3), (2, 3)])
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 1)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 1)])
 
     def test_node_v_not_found(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -189,13 +189,11 @@ class TestCommonNeighborCentrality:
 
     def test_equal_nodes(self):
         G = nx.complete_graph(4)
-        assert pytest.raises(nx.NetworkXAlgorithmError, self.test, G, [(0, 0)], [])
+        pytest.raises(nx.NetworkXAlgorithmError, self.test, G, [(0, 0)], [])
 
     def test_equal_nodes_with_alpha_one_raises_error(self):
         G = nx.complete_graph(4)
-        assert pytest.raises(
-            nx.NetworkXAlgorithmError, self.test, G, [(0, 0)], [], alpha=1.0
-        )
+        pytest.raises(nx.NetworkXAlgorithmError, self.test, G, [(0, 0)], [], alpha=1.0)
 
     def test_all_nonexistent_edges(self):
         G = nx.Graph()
@@ -223,14 +221,14 @@ class TestPreferentialAttachment:
 
     @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
     def test_notimplemented(self, graph_type):
-        assert pytest.raises(
+        pytest.raises(
             nx.NetworkXNotImplemented, self.func, graph_type([(0, 1), (1, 2)]), [(0, 2)]
         )
 
     def test_node_not_found(self):
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (2, 3)])
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_zero_degrees(self):
         G = nx.Graph()
@@ -280,7 +278,7 @@ class TestCNSoundarajanHopcroft:
     def test_notimplemented(self, graph_type):
         G = graph_type([(0, 1), (1, 2)])
         G.add_nodes_from([0, 1, 2], community=0)
-        assert pytest.raises(nx.NetworkXNotImplemented, self.func, G, [(0, 2)])
+        pytest.raises(nx.NetworkXNotImplemented, self.func, G, [(0, 2)])
 
     def test_node_not_found(self):
         G = nx.Graph()
@@ -289,7 +287,7 @@ class TestCNSoundarajanHopcroft:
         G.nodes[1]["community"] = 1
         G.nodes[2]["community"] = 0
         G.nodes[3]["community"] = 0
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -316,7 +314,7 @@ class TestCNSoundarajanHopcroft:
 
     def test_no_community_information(self):
         G = nx.complete_graph(5)
-        assert pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 1)]))
+        pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 1)]))
 
     def test_insufficient_community_information(self):
         G = nx.Graph()
@@ -324,7 +322,7 @@ class TestCNSoundarajanHopcroft:
         G.nodes[0]["community"] = 0
         G.nodes[1]["community"] = 0
         G.nodes[3]["community"] = 0
-        assert pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 3)]))
+        pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 3)]))
 
     def test_sufficient_community_information(self):
         G = nx.Graph()
@@ -391,7 +389,7 @@ class TestRAIndexSoundarajanHopcroft:
     def test_notimplemented(self, graph_type):
         G = graph_type([(0, 1), (1, 2)])
         G.add_nodes_from([0, 1, 2], community=0)
-        assert pytest.raises(nx.NetworkXNotImplemented, self.func, G, [(0, 2)])
+        pytest.raises(nx.NetworkXNotImplemented, self.func, G, [(0, 2)])
 
     def test_node_not_found(self):
         G = nx.Graph()
@@ -400,7 +398,7 @@ class TestRAIndexSoundarajanHopcroft:
         G.nodes[1]["community"] = 1
         G.nodes[2]["community"] = 0
         G.nodes[3]["community"] = 0
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -427,7 +425,7 @@ class TestRAIndexSoundarajanHopcroft:
 
     def test_no_community_information(self):
         G = nx.complete_graph(5)
-        assert pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 1)]))
+        pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 1)]))
 
     def test_insufficient_community_information(self):
         G = nx.Graph()
@@ -435,7 +433,7 @@ class TestRAIndexSoundarajanHopcroft:
         G.nodes[0]["community"] = 0
         G.nodes[1]["community"] = 0
         G.nodes[3]["community"] = 0
-        assert pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 3)]))
+        pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 3)]))
 
     def test_sufficient_community_information(self):
         G = nx.Graph()
@@ -508,7 +506,7 @@ class TestWithinInterCluster:
     def test_notimplemented(self, graph_type):
         G = graph_type([(0, 1), (1, 2)])
         G.add_nodes_from([0, 1, 2], community=0)
-        assert pytest.raises(nx.NetworkXNotImplemented, self.func, G, [(0, 2)])
+        pytest.raises(nx.NetworkXNotImplemented, self.func, G, [(0, 2)])
 
     def test_node_not_found(self):
         G = nx.Graph()
@@ -517,7 +515,7 @@ class TestWithinInterCluster:
         G.nodes[1]["community"] = 1
         G.nodes[2]["community"] = 0
         G.nodes[3]["community"] = 0
-        assert pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
+        pytest.raises(nx.NodeNotFound, self.func, G, [(0, 4)])
 
     def test_no_common_neighbor(self):
         G = nx.Graph()
@@ -552,7 +550,7 @@ class TestWithinInterCluster:
 
     def test_no_community_information(self):
         G = nx.complete_graph(5)
-        assert pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 1)]))
+        pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 1)]))
 
     def test_insufficient_community_information(self):
         G = nx.Graph()
@@ -560,7 +558,7 @@ class TestWithinInterCluster:
         G.nodes[0]["community"] = 0
         G.nodes[1]["community"] = 0
         G.nodes[3]["community"] = 0
-        assert pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 3)]))
+        pytest.raises(nx.NetworkXAlgorithmError, list, self.func(G, [(0, 3)]))
 
     def test_sufficient_community_information(self):
         G = nx.Graph()
@@ -574,8 +572,8 @@ class TestWithinInterCluster:
     def test_invalid_delta(self):
         G = nx.complete_graph(3)
         G.add_nodes_from([0, 1, 2], community=0)
-        assert pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], 0)
-        assert pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], -0.5)
+        pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], 0)
+        pytest.raises(nx.NetworkXAlgorithmError, self.func, G, [(0, 1)], -0.5)
 
     def test_custom_community_attribute_name(self):
         G = nx.complete_graph(4)

--- a/networkx/algorithms/tests/test_threshold.py
+++ b/networkx/algorithms/tests/test_threshold.py
@@ -56,7 +56,7 @@ class TestGeneratorThreshold:
     def test_make_compact(self):
         assert nxt.make_compact(["d", "d", "d", "i", "d", "d"]) == [3, 1, 2]
         assert nxt.make_compact([3, 1, 2]) == [3, 1, 2]
-        assert pytest.raises(TypeError, nxt.make_compact, [3.0, 1.0, 2.0])
+        pytest.raises(TypeError, nxt.make_compact, [3.0, 1.0, 2.0])
 
     def test_uncompact(self):
         assert nxt.uncompact([3, 1, 2]) == ["d", "d", "d", "i", "d", "d"]
@@ -64,7 +64,7 @@ class TestGeneratorThreshold:
         assert nxt.uncompact(
             nxt.uncompact([(1, "d"), (2, "d"), (3, "i"), (0, "d")])
         ) == nxt.uncompact([(1, "d"), (2, "d"), (3, "i"), (0, "d")])
-        assert pytest.raises(TypeError, nxt.uncompact, [3.0, 1.0, 2.0])
+        pytest.raises(TypeError, nxt.uncompact, [3.0, 1.0, 2.0])
 
     def test_creation_sequence_to_weights(self):
         assert nxt.creation_sequence_to_weights([3, 1, 2]) == [
@@ -75,9 +75,7 @@ class TestGeneratorThreshold:
             0.75,
             0.75,
         ]
-        assert pytest.raises(
-            TypeError, nxt.creation_sequence_to_weights, [3.0, 1.0, 2.0]
-        )
+        pytest.raises(TypeError, nxt.creation_sequence_to_weights, [3.0, 1.0, 2.0])
 
     def test_weights_to_creation_sequence(self):
         deg = [3, 2, 2, 1]
@@ -115,9 +113,9 @@ class TestGeneratorThreshold:
 
         assert nxt.shortest_path(["d", "d", "d", "i", "d", "d"], 1, 2) == [1, 2]
         assert nxt.shortest_path([3, 1, 2], 1, 2) == [1, 2]
-        assert pytest.raises(TypeError, nxt.shortest_path, [3.0, 1.0, 2.0], 1, 2)
-        assert pytest.raises(ValueError, nxt.shortest_path, [3, 1, 2], "a", 2)
-        assert pytest.raises(ValueError, nxt.shortest_path, [3, 1, 2], 1, "b")
+        pytest.raises(TypeError, nxt.shortest_path, [3.0, 1.0, 2.0], 1, 2)
+        pytest.raises(ValueError, nxt.shortest_path, [3, 1, 2], "a", 2)
+        pytest.raises(ValueError, nxt.shortest_path, [3, 1, 2], 1, "b")
         assert nxt.shortest_path([3, 1, 2], 1, 1) == [1]
 
     def test_shortest_path_length(self):
@@ -138,7 +136,7 @@ class TestGeneratorThreshold:
             1,
             1,
         ]
-        assert pytest.raises(TypeError, nxt.shortest_path, [3.0, 1.0, 2.0], 1)
+        pytest.raises(TypeError, nxt.shortest_path, [3.0, 1.0, 2.0], 1)
 
     def test_random_threshold_sequence(self):
         assert len(nxt.random_threshold_sequence(10, 0.5)) == 10
@@ -154,15 +152,15 @@ class TestGeneratorThreshold:
             "d",
             "d",
         ]
-        assert pytest.raises(ValueError, nxt.random_threshold_sequence, 10, 1.5)
+        pytest.raises(ValueError, nxt.random_threshold_sequence, 10, 1.5)
 
     def test_right_d_threshold_sequence(self):
         assert nxt.right_d_threshold_sequence(3, 2) == ["d", "i", "d"]
-        assert pytest.raises(ValueError, nxt.right_d_threshold_sequence, 2, 3)
+        pytest.raises(ValueError, nxt.right_d_threshold_sequence, 2, 3)
 
     def test_left_d_threshold_sequence(self):
         assert nxt.left_d_threshold_sequence(3, 2) == ["d", "i", "d"]
-        assert pytest.raises(ValueError, nxt.left_d_threshold_sequence, 2, 3)
+        pytest.raises(ValueError, nxt.left_d_threshold_sequence, 2, 3)
 
     def test_weights_thresholds(self):
         wseq = [3, 4, 3, 3, 5, 6, 5, 4, 5, 6]
@@ -258,7 +256,7 @@ class TestGeneratorThreshold:
     def test_create_using(self):
         cs = "ddiiddid"
         G = nxt.threshold_graph(cs)
-        assert pytest.raises(
+        pytest.raises(
             nx.exception.NetworkXError,
             nxt.threshold_graph,
             cs,


### PR DESCRIPTION
Using `assert` with `pytest.raises` is unnecessary.

Tiny stylistic fix to encourage better practice. Some linter may check for this (not sure), but this was trivial to search-and-replace.