### PR TITLE
Fix graph_hash iteration counts and DiGraph handling

### DIFF
--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -77,9 +77,10 @@ def weisfeiler_lehman_graph_hash(
 
     .. Warning:: Hash values for directed graphs and graphs without edge or
         node attributes have changed in version [TBD]. In previous versions,
-        directed graphs did not distinguish in- and outgoing edges. Graphs
-        without attributes previously performed one more iteration of WL
-        than indicated by the passed argument. For these graphs, the old
+        directed graphs did not distinguish in- and outgoing edges. Also,
+        graphs without attributes set initial states such that effectively
+        one extra iteration of WL occurred than indicated by `iterations`.
+        For undirected graphs without node or edge labels, the old
         hashes can be obtained by increasing the iteration count by one.
         For more details, see `issue #7806
         <https://github.com/networkx/networkx/issues/7806>`_.
@@ -184,7 +185,7 @@ def weisfeiler_lehman_graph_hash(
         _neighborhood_aggregate = _neighborhood_aggregate_directed
         warnings.warn(
             "The hashes produced for directed graphs changed in version [TBD]"
-            " due to a bugfix (see documentation).",
+            " due to a bugfix to track in and out edges separately (see documentation).",
             UserWarning,
             stacklevel=2,
         )
@@ -409,7 +410,7 @@ def weisfeiler_lehman_subgraph_hashes(
 
     if iterations <= 0:
         raise ValueError(
-            "The WL algorithm is only meaningful when run for a positve number of iterations."
+            "The WL algorithm requires that `iterations` be positive"
         )
 
     node_labels = _init_node_labels(G, edge_attr, node_attr)

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -33,11 +33,27 @@ def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):
     Compute new labels for given node by aggregating
     the labels of each node's neighbors.
     """
-    label_list = []
-    for nbr in G.neighbors(node):
-        prefix = "" if edge_attr is None else str(G[node][nbr][edge_attr])
-        label_list.append(prefix + node_labels[nbr])
-    return node_labels[node] + "".join(sorted(label_list))
+    if nx.is_directed(G):
+        successor_labels = []
+        for nbr in G.successors(node):
+            prefix = "" if edge_attr is None else str(G[node][nbr][edge_attr])
+            successor_labels.append(prefix + node_labels[nbr])
+
+        predecessor_labels = []
+        for nbr in G.predecessors(node):
+            prefix = "" if edge_attr is None else str(G[nbr][node][edge_attr])
+            predecessor_labels.append(prefix + node_labels[nbr])
+        return (
+            node_labels[node]
+            + "".join(sorted(successor_labels))
+            + "".join(sorted(predecessor_labels))
+        )
+    else:
+        label_list = []
+        for nbr in G.neighbors(node):
+            prefix = "" if edge_attr is None else str(G[node][nbr][edge_attr])
+            label_list.append(prefix + node_labels[nbr])
+        return node_labels[node] + "".join(sorted(label_list))
 
 
 @nx.utils.not_implemented_for("multigraph")

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -169,7 +169,8 @@ def weisfeiler_lehman_graph_hash(
     # set initial node labels
     node_labels = _init_node_labels(G, edge_attr, node_attr)
 
-    # If the graph has no attributes, initial labels are the nodes' degrees. This is equivalent to doing the first iterations of WL.
+    # If the graph has no attributes, initial labels are the nodes' degrees.
+    # This is equivalent to doing the first iterations of WL.
     if not edge_attr and not node_attr:
         iterations -= 1
 
@@ -341,7 +342,8 @@ def weisfeiler_lehman_subgraph_hashes(
     else:
         node_subgraph_hashes = defaultdict(list)
 
-    # If the graph has no attributes, initial labels are the nodes' degrees. This is equivalent to doing the first iterations of WL.
+    # If the graph has no attributes, initial labels are the nodes' degrees.
+    # This is equivalent to doing the first iterations of WL.
     if not edge_attr and not node_attr:
         iterations -= 1
         for node in G.nodes():

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -36,17 +36,16 @@ def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):
     if nx.is_directed(G):
         successor_labels = []
         for nbr in G.successors(node):
-            prefix = "" if edge_attr is None else str(G[node][nbr][edge_attr])
+            prefix = "s_" + "" if edge_attr is None else str(G[node][nbr][edge_attr])
             successor_labels.append(prefix + node_labels[nbr])
 
         predecessor_labels = []
         for nbr in G.predecessors(node):
-            prefix = "" if edge_attr is None else str(G[nbr][node][edge_attr])
+            prefix = "p_" + "" if edge_attr is None else str(G[nbr][node][edge_attr])
             predecessor_labels.append(prefix + node_labels[nbr])
         return (
             node_labels[node]
             + "".join(sorted(successor_labels))
-            + "_"
             + "".join(sorted(predecessor_labels))
         )
     else:

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -150,6 +150,10 @@ def weisfeiler_lehman_graph_hash(
     # set initial node labels
     node_labels = _init_node_labels(G, edge_attr, node_attr)
 
+    # If the graph has no attributes, initial labels are the nodes' degrees. This is equivalent to doing the first iterations of WL.
+    if not edge_attr and not node_attr:
+        iterations -= 1
+
     subgraph_hash_counts = []
     for _ in range(iterations):
         node_labels = weisfeiler_lehman_step(G, node_labels, edge_attr=edge_attr)
@@ -313,12 +317,20 @@ def weisfeiler_lehman_subgraph_hashes(
         return new_labels
 
     node_labels = _init_node_labels(G, edge_attr, node_attr)
+
     if include_initial_labels:
         node_subgraph_hashes = {
             k: [_hash_label(v, digest_size)] for k, v in node_labels.items()
         }
     else:
         node_subgraph_hashes = defaultdict(list)
+
+    # If the graph has no attributes, initial labels are the nodes' degrees. This is equivalent to doing the first iterations of WL.
+    if not edge_attr and not node_attr:
+        iterations -= 1
+        for node in G.nodes():
+            hashed_label = _hash_label(node_labels[node], digest_size)
+            node_subgraph_hashes[node].append(hashed_label)
 
     for _ in range(iterations):
         node_labels = weisfeiler_lehman_step(

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -22,7 +22,10 @@ def _init_node_labels(G, edge_attr, node_attr):
     elif edge_attr:
         return {u: "" for u in G}
     else:
-        return {u: str(deg) for u, deg in G.degree()}
+        if nx.is_directed(G):
+            return {u: str(G.in_degree(u)) + str(G.out_degree(u)) for u in G}
+        else:
+            return {u: str(deg) for u, deg in G.degree()}
 
 
 def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -23,7 +23,7 @@ def _init_node_labels(G, edge_attr, node_attr):
         return {u: "" for u in G}
     else:
         if nx.is_directed(G):
-            return {u: str(G.in_degree(u)) + str(G.out_degree(u)) for u in G}
+            return {u: str(G.in_degree(u)) + "_" + str(G.out_degree(u)) for u in G}
         else:
             return {u: str(deg) for u, deg in G.degree()}
 
@@ -46,6 +46,7 @@ def _neighborhood_aggregate(G, node, node_labels, edge_attr=None):
         return (
             node_labels[node]
             + "".join(sorted(successor_labels))
+            + "_"
             + "".join(sorted(predecessor_labels))
         )
     else:

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -123,17 +123,17 @@ def weisfeiler_lehman_graph_hash(
     Omitting the `edge_attr` option, results in identical hashes.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1)
-    'c045439172215f49e0bef8c3d26c6b61'
+    '6b8542663d7310ddce1732f5f323519a'
     >>> nx.weisfeiler_lehman_graph_hash(G2)
-    'c045439172215f49e0bef8c3d26c6b61'
+    '6b8542663d7310ddce1732f5f323519a'
 
     With edge labels, the graphs are no longer assigned
     the same hash digest.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1, edge_attr="label")
-    'c653d85538bcf041d88c011f4f905f10'
+    '4e26b130c32fc56cd84eab0b3d3adebd'
     >>> nx.weisfeiler_lehman_graph_hash(G2, edge_attr="label")
-    '3dcd84af1ca855d0eff3c978d88e7ec7'
+    'b588270cd000e62a38728e4e5317c400'
 
     Notes
     -----

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -173,15 +173,12 @@ def weisfeiler_lehman_graph_hash(
     if not edge_attr and not node_attr:
         iterations -= 1
 
-    subgraph_hash_counts = []
     for _ in range(iterations):
         node_labels = weisfeiler_lehman_step(G, node_labels, edge_attr=edge_attr)
-        counter = Counter(node_labels.values())
-        # sort the counter, extend total counts
-        subgraph_hash_counts.extend(sorted(counter.items(), key=lambda x: x[0]))
 
-    # hash the final counter
-    return _hash_label(str(tuple(subgraph_hash_counts)), digest_size)
+    # hash the final labelling
+    counter = Counter(node_labels.values())
+    return _hash_label(str(sorted(counter.items(), key=lambda x: x[0])), digest_size)
 
 
 @nx.utils.not_implemented_for("multigraph")

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -205,9 +205,7 @@ def weisfeiler_lehman_graph_hash(
         return new_labels
 
     if iterations <= 0:
-        raise ValueError(
-            "The WL algorithm is only meaningful when run for a positve number of iterations."
-        )
+        raise ValueError("The WL algorithm requires that `iterations` be positive")
 
     # set initial node labels
     node_labels = _init_node_labels(G, edge_attr, node_attr)

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -25,7 +25,7 @@ def _init_node_labels(G, edge_attr, node_attr):
     else:
         warnings.warn(
             "The hashes produced for graphs without node or edge attributes"
-            "changed in version [TBD] due to a bugfix (see documentation).",
+            "changed in v3.5 due to a bugfix (see documentation).",
             UserWarning,
             stacklevel=2,
         )
@@ -76,7 +76,7 @@ def weisfeiler_lehman_graph_hash(
     """Return Weisfeiler Lehman (WL) graph hash.
 
     .. Warning:: Hash values for directed graphs and graphs without edge or
-        node attributes have changed in version [TBD]. In previous versions,
+        node attributes have changed in v3.5. In previous versions,
         directed graphs did not distinguish in- and outgoing edges. Also,
         graphs without attributes set initial states such that effectively
         one extra iteration of WL occurred than indicated by `iterations`.
@@ -184,7 +184,7 @@ def weisfeiler_lehman_graph_hash(
     if G.is_directed():
         _neighborhood_aggregate = _neighborhood_aggregate_directed
         warnings.warn(
-            "The hashes produced for directed graphs changed in version [TBD]"
+            "The hashes produced for directed graphs changed in version v3.5"
             " due to a bugfix to track in and out edges separately (see documentation).",
             UserWarning,
             stacklevel=2,
@@ -242,7 +242,7 @@ def weisfeiler_lehman_subgraph_hashes(
     Return a dictionary of subgraph hashes by node.
 
     .. Warning:: Hash values for directed graphs have changed in version
-        [TBD]. In previous versions, directed graphs did not distinguish in-
+        v3.5. In previous versions, directed graphs did not distinguish in-
         and outgoing edges.
         Graphs without attributes previously performed an extra iteration of
         WL at initialisation, which was not visible in the output of this
@@ -384,7 +384,7 @@ def weisfeiler_lehman_subgraph_hashes(
     if G.is_directed():
         _neighborhood_aggregate = _neighborhood_aggregate_directed
         warnings.warn(
-            "The hashes produced for directed graphs changed in version [TBD]"
+            "The hashes produced for directed graphs changed in v3.5"
             " due to a bugfix (see documentation).",
             UserWarning,
             stacklevel=2,
@@ -409,9 +409,7 @@ def weisfeiler_lehman_subgraph_hashes(
         return new_labels
 
     if iterations <= 0:
-        raise ValueError(
-            "The WL algorithm requires that `iterations` be positive"
-        )
+        raise ValueError("The WL algorithm requires that `iterations` be positive")
 
     node_labels = _init_node_labels(G, edge_attr, node_attr)
 

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -133,17 +133,17 @@ def weisfeiler_lehman_graph_hash(
     Omitting the `edge_attr` option, results in identical hashes.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1)
-    '6b8542663d7310ddce1732f5f323519a'
+    'c045439172215f49e0bef8c3d26c6b61'
     >>> nx.weisfeiler_lehman_graph_hash(G2)
-    '6b8542663d7310ddce1732f5f323519a'
+    'c045439172215f49e0bef8c3d26c6b61'
 
     With edge labels, the graphs are no longer assigned
     the same hash digest.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1, edge_attr="label")
-    '4e26b130c32fc56cd84eab0b3d3adebd'
+    'c653d85538bcf041d88c011f4f905f10'
     >>> nx.weisfeiler_lehman_graph_hash(G2, edge_attr="label")
-    'b588270cd000e62a38728e4e5317c400'
+    '3dcd84af1ca855d0eff3c978d88e7ec7'
 
     Notes
     -----

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -194,12 +194,15 @@ def weisfeiler_lehman_graph_hash(
     if not edge_attr and not node_attr:
         iterations -= 1
 
+    subgraph_hash_counts = []
     for _ in range(iterations):
         node_labels = weisfeiler_lehman_step(G, node_labels, edge_attr=edge_attr)
+        counter = Counter(node_labels.values())
+        # sort the counter, extend total counts
+        subgraph_hash_counts.extend(sorted(counter.items(), key=lambda x: x[0]))
 
-    # hash the final labelling
-    counter = Counter(node_labels.values())
-    return _hash_label(str(sorted(counter.items(), key=lambda x: x[0])), digest_size)
+    # hash the final counter
+    return _hash_label(str(tuple(subgraph_hash_counts)), digest_size)
 
 
 @nx.utils.not_implemented_for("multigraph")

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -96,6 +96,11 @@ def weisfeiler_lehman_graph_hash(
     h : string
         Hexadecimal string corresponding to hash of the input graph.
 
+    Raises
+    ------
+    ValueError
+        If `iterations` is not a positve number.
+
     Examples
     --------
     Two graphs with edge attributes that are isomorphic, except for
@@ -165,6 +170,11 @@ def weisfeiler_lehman_graph_hash(
             label = _neighborhood_aggregate(G, node, labels, edge_attr=edge_attr)
             new_labels[node] = _hash_label(label, digest_size)
         return new_labels
+
+    if iterations <= 0:
+        raise ValueError(
+            "The WL algorithm is only meaningful when run for a positve number of iterations."
+        )
 
     # set initial node labels
     node_labels = _init_node_labels(G, edge_attr, node_attr)
@@ -262,6 +272,12 @@ def weisfeiler_lehman_subgraph_hashes(
         A dictionary with each key given by a node in G, and each value given
         by the subgraph hashes in order of depth from the key node.
 
+
+    Raises
+    ------
+    ValueError
+        If `iterations` is not a positve number.
+
     Examples
     --------
     Finding similar nodes in different graphs:
@@ -332,6 +348,11 @@ def weisfeiler_lehman_subgraph_hashes(
             new_labels[node] = hashed_label
             node_subgraph_hashes[node].append(hashed_label)
         return new_labels
+
+    if iterations <= 0:
+        raise ValueError(
+            "The WL algorithm is only meaningful when run for a positve number of iterations."
+        )
 
     node_labels = _init_node_labels(G, edge_attr, node_attr)
 

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -219,7 +219,7 @@ def weisfeiler_lehman_subgraph_hashes(
     Each hash corresponds to a subgraph rooted at a given node u in `G`.
     Lists of subgraph hashes are sorted in increasing order of depth from
     their root node, with the hash at index i corresponding to a subgraph
-    of nodes at most i-hops distance from u. Thus, each list will contain
+    of nodes at most i-hops (i edges) distance from u. Thus, each list will contain
     `iterations` elements - a hash for a subgraph at each depth. If
     `include_initial_labels` is set to `True`, each list will additionally
     have contain a hash of the initial node label (or equivalently a
@@ -237,9 +237,9 @@ def weisfeiler_lehman_subgraph_hashes(
     along the connecting edge from this neighbor to node $u$. The resulting string
     is then hashed to compress this information into a fixed digest size.
 
-    Thus, at the $i$-th iteration, nodes within $i$ hops influence any given
+    Thus, at the i-th iteration, nodes within i hops influence any given
     hashed node label. We can therefore say that at depth $i$ for node $u$
-    we have a hash for a subgraph induced by the $i$-hop neighborhood of $u$.
+    we have a hash for a subgraph induced by the i-hop neighborhood of $u$.
 
     The output can be used to create general Weisfeiler-Lehman graph kernels,
     or generate features for graphs or nodes - for example to generate 'words' in

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -4,6 +4,7 @@ Isomorphic graphs should be assigned identical hashes.
 For now, only Weisfeiler-Lehman hashing is implemented.
 """
 
+import warnings
 from collections import Counter, defaultdict
 from hashlib import blake2b
 
@@ -22,6 +23,12 @@ def _init_node_labels(G, edge_attr, node_attr):
     elif edge_attr:
         return {u: "" for u in G}
     else:
+        warnings.warn(
+            "The hashes produced for graphs without node or edge attributes"
+            "changed in version [TBD] due to a bugfix (see documentation).",
+            UserWarning,
+            stacklevel=2,
+        )
         if nx.is_directed(G):
             return {u: str(G.in_degree(u)) + "_" + str(G.out_degree(u)) for u in G}
         else:
@@ -67,6 +74,15 @@ def weisfeiler_lehman_graph_hash(
     G, edge_attr=None, node_attr=None, iterations=3, digest_size=16
 ):
     """Return Weisfeiler Lehman (WL) graph hash.
+
+    .. Warning:: Hash values for directed graphs and graphs without edge or
+        node attributes have changed in version [TBD]. In previous versions,
+        directed graphs did not distinguish in- and outgoing edges. Graphs
+        without attributes previously performed one more iteration of WL
+        than indicated by the passed argument. For these graphs, the old
+        hashes can be obtained by increasing the iteration count by one.
+        For more details, see `issue #7806
+        <https://github.com/networkx/networkx/issues/7806>`_.
 
     The function iteratively aggregates and hashes neighborhoods of each node.
     After each node's neighbors are hashed to obtain updated node labels,
@@ -166,6 +182,12 @@ def weisfeiler_lehman_graph_hash(
 
     if G.is_directed():
         _neighborhood_aggregate = _neighborhood_aggregate_directed
+        warnings.warn(
+            "The hashes produced for directed graphs changed in version [TBD]"
+            " due to a bugfix (see documentation).",
+            UserWarning,
+            stacklevel=2,
+        )
     else:
         _neighborhood_aggregate = _neighborhood_aggregate_undirected
 
@@ -217,6 +239,18 @@ def weisfeiler_lehman_subgraph_hashes(
 ):
     """
     Return a dictionary of subgraph hashes by node.
+
+    .. Warning:: Hash values for directed graphs have changed in version
+        [TBD]. In previous versions, directed graphs did not distinguish in-
+        and outgoing edges.
+        Graphs without attributes previously performed an extra iteration of
+        WL at initialisation, which was not visible in the output of this
+        function. This hash value is now included in the returned dictionary,
+        shifting the other calculated hashes one position to the right. To
+        obtain the same last subgraph hash, increase the number of iterations
+        by one.
+        For more details, see `issue #7806
+        <https://github.com/networkx/networkx/issues/7806>`_.
 
     Dictionary keys are nodes in `G`, and values are a list of hashes.
     Each hash corresponds to a subgraph rooted at a given node u in `G`.
@@ -348,6 +382,12 @@ def weisfeiler_lehman_subgraph_hashes(
 
     if G.is_directed():
         _neighborhood_aggregate = _neighborhood_aggregate_directed
+        warnings.warn(
+            "The hashes produced for directed graphs changed in version [TBD]"
+            " due to a bugfix (see documentation).",
+            UserWarning,
+            stacklevel=2,
+        )
     else:
         _neighborhood_aggregate = _neighborhood_aggregate_undirected
 

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -123,9 +123,9 @@ def weisfeiler_lehman_graph_hash(
     Omitting the `edge_attr` option, results in identical hashes.
 
     >>> nx.weisfeiler_lehman_graph_hash(G1)
-    '7bc4dde9a09d0b94c5097b219891d81a'
+    'c045439172215f49e0bef8c3d26c6b61'
     >>> nx.weisfeiler_lehman_graph_hash(G2)
-    '7bc4dde9a09d0b94c5097b219891d81a'
+    'c045439172215f49e0bef8c3d26c6b61'
 
     With edge labels, the graphs are no longer assigned
     the same hash digest.
@@ -201,7 +201,7 @@ def weisfeiler_lehman_subgraph_hashes(
     Each hash corresponds to a subgraph rooted at a given node u in `G`.
     Lists of subgraph hashes are sorted in increasing order of depth from
     their root node, with the hash at index i corresponding to a subgraph
-    of nodes at most i edges distance from u. Thus, each list will contain
+    of nodes at most i-hops distance from u. Thus, each list will contain
     `iterations` elements - a hash for a subgraph at each depth. If
     `include_initial_labels` is set to `True`, each list will additionally
     have contain a hash of the initial node label (or equivalently a
@@ -273,25 +273,25 @@ def weisfeiler_lehman_subgraph_hashes(
     >>> G2 = nx.Graph()
     >>> G2.add_edges_from([(1, 3), (2, 3), (1, 6), (1, 5), (4, 6)])
     >>> g1_hashes = nx.weisfeiler_lehman_subgraph_hashes(
-    ...     G1, iterations=3, digest_size=8
+    ...     G1, iterations=4, digest_size=8
     ... )
     >>> g2_hashes = nx.weisfeiler_lehman_subgraph_hashes(
-    ...     G2, iterations=3, digest_size=8
+    ...     G2, iterations=4, digest_size=8
     ... )
 
     Even though G1 and G2 are not isomorphic (they have different numbers of edges),
     the hash sequence of depth 3 for node 1 in G1 and node 5 in G2 are similar:
 
     >>> g1_hashes[1]
-    ['a93b64973cfc8897', 'db1b43ae35a1878f', '57872a7d2059c1c0']
+    ['f6fc42039fba3776', 'a93b64973cfc8897', 'db1b43ae35a1878f', '57872a7d2059c1c0']
     >>> g2_hashes[5]
-    ['a93b64973cfc8897', 'db1b43ae35a1878f', '1716d2a4012fa4bc']
+    ['f6fc42039fba3776', 'a93b64973cfc8897', 'db1b43ae35a1878f', '1716d2a4012fa4bc']
 
-    The first 2 WL subgraph hashes match. From this we can conclude that it's very
-    likely the neighborhood of 2 hops around these nodes are isomorphic.
+    The first 3 WL subgraph hashes match. From this we can conclude that it's very
+    likely the neighborhood of 3 hops around these nodes are isomorphic.
 
-    However the 3-hop neighborhoods of ``G1`` and ``G2`` are not isomorphic since the
-    3rd hashes in the lists above are not equal.
+    However the 4-hop neighborhoods of ``G1`` and ``G2`` are not isomorphic since the
+    4th hashes in the lists above are not equal.
 
     These nodes may be candidates to be classified together since their local topology
     is similar.

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -251,7 +251,45 @@ def test_digest_size():
         assert len(h32) == 32 * 2
 
 
-# Unit tests for the :func:`~networkx.weisfeiler_lehman_hash_subgraphs` function
+def test_directed_bugs():
+    """
+    These were bugs for directed graphs as discussed in issue 7806
+    """
+    Ga = nx.DiGraph()
+    Gb = nx.DiGraph()
+    Ga.add_nodes_from([1, 2, 3, 4])
+    Gb.add_nodes_from([1, 2, 3, 4])
+    Ga.add_edges_from([(1, 2), (3, 2)])
+    Gb.add_edges_from([(1, 2), (3, 4)])
+    Ga_hash = nx.weisfeiler_lehman_graph_hash(Ga)
+    Gb_hash = nx.weisfeiler_lehman_graph_hash(Gb)
+    assert Ga_hash != Gb_hash
+
+    Tree1 = nx.DiGraph()
+    Tree1.add_edges_from([(0, 4), (1, 5), (2, 6), (3, 7)])
+    Tree1.add_edges_from([(4, 8), (5, 8), (6, 9), (7, 9)])
+    Tree1.add_edges_from([(8, 10), (9, 10)])
+    nx.set_node_attributes(
+        Tree1, {10: "s", 8: "a", 9: "a", 4: "b", 5: "b", 6: "b", 7: "b"}, "weight"
+    )
+    Tree2 = copy.deepcopy(Tree1)
+    nx.set_node_attributes(Tree1, {0: "d", 1: "c", 2: "d", 3: "c"}, "weight")
+    nx.set_node_attributes(Tree2, {0: "d", 1: "d", 2: "c", 3: "c"}, "weight")
+    Tree1_hash_short = nx.weisfeiler_lehman_graph_hash(
+        Tree1, iterations=1, node_attr="weight"
+    )
+    Tree2_hash_short = nx.weisfeiler_lehman_graph_hash(
+        Tree2, iterations=1, node_attr="weight"
+    )
+    assert Tree1_hash_short == Tree2_hash_short
+    Tree1_hash = nx.weisfeiler_lehman_graph_hash(
+        Tree1, node_attr="weight"
+    )  # Default is 3 iterations
+    Tree2_hash = nx.weisfeiler_lehman_graph_hash(Tree2, node_attr="weight")
+    assert Tree1_hash != Tree2_hash
+
+
+# Unit tests for the :func:`~networkx.weisfeiler_lehman_subgraph_hashes` function
 
 
 def is_subiteration(a, b):
@@ -685,41 +723,3 @@ def test_initial_node_labels_subgraph_hash():
             with_initial_label[u][1:], without_initial_label[u], strict=True
         ):
             assert a == b
-
-
-def test_directed_bugs():
-    """
-    These were bugs for directed graphs as discussed in issue 7806
-    """
-    Ga = nx.DiGraph()
-    Gb = nx.DiGraph()
-    Ga.add_nodes_from([1, 2, 3, 4])
-    Gb.add_nodes_from([1, 2, 3, 4])
-    Ga.add_edges_from([(1, 2), (3, 2)])
-    Gb.add_edges_from([(1, 2), (3, 4)])
-    Ga_hash = nx.weisfeiler_lehman_graph_hash(Ga)
-    Gb_hash = nx.weisfeiler_lehman_graph_hash(Gb)
-    assert Ga_hash != Gb_hash
-
-    Tree1 = nx.DiGraph()
-    Tree1.add_edges_from([(0, 4), (1, 5), (2, 6), (3, 7)])
-    Tree1.add_edges_from([(4, 8), (5, 8), (6, 9), (7, 9)])
-    Tree1.add_edges_from([(8, 10), (9, 10)])
-    nx.set_node_attributes(
-        Tree1, {10: "s", 8: "a", 9: "a", 4: "b", 5: "b", 6: "b", 7: "b"}, "weight"
-    )
-    Tree2 = copy.deepcopy(Tree1)
-    nx.set_node_attributes(Tree1, {0: "d", 1: "c", 2: "d", 3: "c"}, "weight")
-    nx.set_node_attributes(Tree2, {0: "d", 1: "d", 2: "c", 3: "c"}, "weight")
-    Tree1_hash_short = nx.weisfeiler_lehman_graph_hash(
-        Tree1, iterations=1, node_attr="weight"
-    )
-    Tree2_hash_short = nx.weisfeiler_lehman_graph_hash(
-        Tree2, iterations=1, node_attr="weight"
-    )
-    assert Tree1_hash_short == Tree2_hash_short
-    Tree1_hash = nx.weisfeiler_lehman_graph_hash(
-        Tree1, node_attr="weight"
-    )  # Default is 3 iterations
-    Tree2_hash = nx.weisfeiler_lehman_graph_hash(Tree2, node_attr="weight")
-    assert Tree1_hash != Tree2_hash

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -657,7 +657,7 @@ def test_isomorphic_edge_attr_and_node_attr_subgraph_hash():
 def test_iteration_depth():
     """
     All nodes should have the correct number of subgraph hashes in the output when
-    using degree as initial node labels
+    using degree as initial node labels.
     Subsequent iteration depths for the same graph should be additive for each node
     """
     n, r = 100, 10

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -4,6 +4,33 @@ import pytest
 
 import networkx as nx
 
+# Unit tests relevant for both functions in this module.
+
+
+def test_positive_iters():
+    G1 = nx.empty_graph()
+    with pytest.raises(
+        ValueError,
+        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+    ):
+        nx.weisfeiler_lehman_graph_hash(G1, iterations=-3)
+    with pytest.raises(
+        ValueError,
+        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+    ):
+        nx.weisfeiler_lehman_subgraph_hashes(G1, iterations=-3)
+    with pytest.raises(
+        ValueError,
+        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+    ):
+        nx.weisfeiler_lehman_graph_hash(G1, iterations=0)
+    with pytest.raises(
+        ValueError,
+        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+    ):
+        nx.weisfeiler_lehman_subgraph_hashes(G1, iterations=0)
+
+
 # Unit tests for the :func:`~networkx.weisfeiler_lehman_graph_hash` function
 
 

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -11,22 +11,22 @@ def test_positive_iters():
     G1 = nx.empty_graph()
     with pytest.raises(
         ValueError,
-        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+        match="The WL algorithm requires that `iterations` be positive",
     ):
         nx.weisfeiler_lehman_graph_hash(G1, iterations=-3)
     with pytest.raises(
         ValueError,
-        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+        match="The WL algorithm requires that `iterations` be positive",
     ):
         nx.weisfeiler_lehman_subgraph_hashes(G1, iterations=-3)
     with pytest.raises(
         ValueError,
-        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+        match="The WL algorithm requires that `iterations` be positive",
     ):
         nx.weisfeiler_lehman_graph_hash(G1, iterations=0)
     with pytest.raises(
         ValueError,
-        match="The WL algorithm is only meaningful when run for a positve number of iterations.",
+        match="The WL algorithm requires that `iterations` be positive",
     ):
         nx.weisfeiler_lehman_subgraph_hashes(G1, iterations=0)
 

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -413,9 +413,9 @@ def test_trivial_labels_isomorphism_directed():
 def test_trivial_labels_hashes():
     """
     Test that 'empty' labelling of nodes or edges shouldn't have a different impact
-    on the calculated hash. Note that we cannot assume it trivial weights have no
+    on the calculated hash. Note that we cannot assume that trivial weights have no
     impact at all. Without (trivial) weights, a node will start with hashing its
-    degree. This step isomitted when there áre weights.
+    degree. This step is omitted when there are weights.
     """
     n, r = 100, 10
     p = 1.0 / r

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -289,6 +289,59 @@ def test_directed_bugs():
     assert Tree1_hash != Tree2_hash
 
 
+def test_trivial_labels():
+    """
+    Test that trivial labelling of the graph should change isomorphism verdicts.
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
+        G2 = nx.erdos_renyi_graph(n, p * i, seed=42 + i)
+        equal = nx.weisfeiler_lehman_graph_hash(G1) == nx.weisfeiler_lehman_graph_hash(
+            G2
+        )
+        nx.set_node_attributes(G1, values=1, name="weight")
+        nx.set_node_attributes(G2, values=1, name="weight")
+        equal_node = nx.weisfeiler_lehman_graph_hash(
+            G1, node_attr="weight"
+        ) == nx.weisfeiler_lehman_graph_hash(G2, node_attr="weight")
+        nx.set_edge_attributes(G1, values="a", name="e_weight")
+        nx.set_edge_attributes(G2, values="a", name="e_weight")
+        equal_edge = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="e_weight"
+        ) == nx.weisfeiler_lehman_graph_hash(G2, edge_attr="e_weight")
+        equal_both = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="e_weight", node_attr="weight"
+        ) == nx.weisfeiler_lehman_graph_hash(
+            G2, edge_attr="e_weight", node_attr="weight"
+        )
+        assert equal == equal_node
+        assert equal_node == equal_edge
+        assert equal_edge == equal_both
+
+
+def test_trivial_labels():
+    """
+    Test that 'empty' labelling of nodes or edges shouldn't have a different impact on the calculated hash.
+    Note that we cannot assume it trivial weights have no impact at all. Without (trivial) weights,
+     a node will start with hashing its degree. This step isomitted when there áre weights.
+    """
+    n, r = 100, 10
+    p = 1.0 / r
+    for i in range(1, r + 1):
+        G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
+        nx.set_node_attributes(G1, values="", name="weight")
+        first = nx.weisfeiler_lehman_graph_hash(G1, node_attr="weight")
+        nx.set_edge_attributes(G1, values="", name="e_weight")
+        second = nx.weisfeiler_lehman_graph_hash(G1, edge_attr="e_weight")
+        assert first == second
+        third = nx.weisfeiler_lehman_graph_hash(
+            G1, edge_attr="e_weight", node_attr="weight"
+        )
+        assert second == third
+
+
 # Unit tests for the :func:`~networkx.weisfeiler_lehman_subgraph_hashes` function
 
 

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -49,8 +49,8 @@ def test_directed():
 def test_reversed():
     """
     A directed graph with no bi-directional edges should yield different a graph hash
-    to the same graph taken with edge directions reversed if there are no hash collisions.
-    Here we test a cycle graph which is the minimal counterexample
+    to the same graph taken with edge directions reversed if there are no hash
+    collisions. Here we test a cycle graph which is the minimal counterexample
     """
     G = nx.cycle_graph(5, create_using=nx.DiGraph)
     nx.set_node_attributes(G, {n: str(n) for n in G.nodes()}, name="label")
@@ -291,7 +291,7 @@ def test_directed_bugs():
 
 def test_trivial_labels_isomorphism():
     """
-    Test that trivial labelling of the graph should not change isomorphism verdicts.
+    Trivial labelling of the graph should not change isomorphism verdicts.
     """
     n, r = 100, 10
     p = 1.0 / r
@@ -323,7 +323,7 @@ def test_trivial_labels_isomorphism():
 
 def test_trivial_labels_isomorphism_directed():
     """
-    Test that trivial labelling of the graph should not change isomorphism verdicts on directed graphs.
+    Trivial labelling of the graph should not change isomorphism verdicts on digraphs.
     """
     n, r = 100, 10
     p = 1.0 / r
@@ -373,9 +373,10 @@ def test_trivial_labels_isomorphism_directed():
 
 def test_trivial_labels_hashes():
     """
-    Test that 'empty' labelling of nodes or edges shouldn't have a different impact on the calculated hash.
-    Note that we cannot assume it trivial weights have no impact at all. Without (trivial) weights,
-     a node will start with hashing its degree. This step isomitted when there áre weights.
+    Test that 'empty' labelling of nodes or edges shouldn't have a different impact
+    on the calculated hash. Note that we cannot assume it trivial weights have no
+    impact at all. Without (trivial) weights, a node will start with hashing its
+    degree. This step isomitted when there áre weights.
     """
     n, r = 100, 10
     p = 1.0 / r
@@ -405,9 +406,10 @@ def is_subiteration(a, b):
 
 def hexdigest_sizes_correct(a, digest_size):
     """
-    returns True if all hex digest sizes are the expected length in a node:subgraph-hashes
-    dictionary. Hex digest string length == 2 * bytes digest length since each pair of hex
-    digits encodes 1 byte (https://docs.python.org/3/library/hashlib.html)
+    returns True if all hex digest sizes are the expected length in a
+    node:subgraph-hashes dictionary. Hex digest string length == 2 * bytes digest
+    length since each pair of hex digits encodes 1 byte
+    (https://docs.python.org/3/library/hashlib.html)
     """
     hexdigest_size = digest_size * 2
     list_digest_sizes_correct = lambda l: all(len(x) == hexdigest_size for x in l)
@@ -435,8 +437,8 @@ def test_empty_graph_subgraph_hash():
 
 def test_directed_subgraph_hash():
     """
-    A directed graph with no bi-directional edges should yield different subgraph hashes
-    to the same graph taken as undirected, if all hashes don't collide.
+    A directed graph with no bi-directional edges should yield different subgraph
+    hashes to the same graph taken as undirected, if all hashes don't collide.
     """
     r = 10
     for i in range(r):
@@ -451,9 +453,9 @@ def test_directed_subgraph_hash():
 
 def test_reversed_subgraph_hash():
     """
-    A directed graph with no bi-directional edges should yield different subgraph hashes
-    to the same graph taken with edge directions reversed if there are no hash collisions.
-    Here we test a cycle graph which is the minimal counterexample
+    A directed graph with no bi-directional edges should yield different subgraph
+    hashes to the same graph taken with edge directions reversed if there are no
+    hash collisions. Here we test a cycle graph which is the minimal counterexample
     """
     G = nx.cycle_graph(5, create_using=nx.DiGraph)
     nx.set_node_attributes(G, {n: str(n) for n in G.nodes()}, name="label")
@@ -468,8 +470,8 @@ def test_reversed_subgraph_hash():
 
 def test_isomorphic_subgraph_hash():
     """
-    the subgraph hashes should be invariant to node-relabeling when the output is reindexed
-    by the same mapping and all hashes don't collide.
+    the subgraph hashes should be invariant to node-relabeling when the output is
+    reindexed by the same mapping and all hashes don't collide.
     """
     n, r = 100, 10
     p = 1.0 / r

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -298,24 +298,30 @@ def test_trivial_labels_isomorphism():
     for i in range(1, r + 1):
         G1 = nx.erdos_renyi_graph(n, p * i, seed=500 + i)
         G2 = nx.erdos_renyi_graph(n, p * i, seed=42 + i)
-        equal = nx.weisfeiler_lehman_graph_hash(G1) == nx.weisfeiler_lehman_graph_hash(
-            G2
-        )
+        G1_hash = nx.weisfeiler_lehman_graph_hash(G1)
+        G2_hash = nx.weisfeiler_lehman_graph_hash(G2)
+        equal = G1_hash == G2_hash
+
         nx.set_node_attributes(G1, values=1, name="weight")
         nx.set_node_attributes(G2, values=1, name="weight")
-        equal_node = nx.weisfeiler_lehman_graph_hash(
-            G1, node_attr="weight"
-        ) == nx.weisfeiler_lehman_graph_hash(G2, node_attr="weight")
+        G1_hash_node = nx.weisfeiler_lehman_graph_hash(G1, node_attr="weight")
+        G2_hash_node = nx.weisfeiler_lehman_graph_hash(G2, node_attr="weight")
+        equal_node = G1_hash_node == G2_hash_node
+
         nx.set_edge_attributes(G1, values="a", name="e_weight")
         nx.set_edge_attributes(G2, values="a", name="e_weight")
-        equal_edge = nx.weisfeiler_lehman_graph_hash(
-            G1, edge_attr="e_weight"
-        ) == nx.weisfeiler_lehman_graph_hash(G2, edge_attr="e_weight")
-        equal_both = nx.weisfeiler_lehman_graph_hash(
+        G1_hash_edge = nx.weisfeiler_lehman_graph_hash(G1, edge_attr="e_weight")
+        G2_hash_edge = nx.weisfeiler_lehman_graph_hash(G2, edge_attr="e_weight")
+        equal_edge = G1_hash_edge == G2_hash_edge
+
+        G1_hash_both = nx.weisfeiler_lehman_graph_hash(
             G1, edge_attr="e_weight", node_attr="weight"
-        ) == nx.weisfeiler_lehman_graph_hash(
+        )
+        G2_hash_both = nx.weisfeiler_lehman_graph_hash(
             G2, edge_attr="e_weight", node_attr="weight"
         )
+        equal_both = G1_hash_both == G2_hash_both
+
         assert equal == equal_node
         assert equal_node == equal_edge
         assert equal_edge == equal_both
@@ -330,24 +336,30 @@ def test_trivial_labels_isomorphism_directed():
     for i in range(1, r + 1):
         G1 = nx.erdos_renyi_graph(n, p * i, directed=True, seed=500 + i)
         G2 = nx.erdos_renyi_graph(n, p * i, directed=True, seed=42 + i)
-        equal = nx.weisfeiler_lehman_graph_hash(G1) == nx.weisfeiler_lehman_graph_hash(
-            G2
-        )
+        G1_hash = nx.weisfeiler_lehman_graph_hash(G1)
+        G2_hash = nx.weisfeiler_lehman_graph_hash(G2)
+        equal = G1_hash == G2_hash
+
         nx.set_node_attributes(G1, values=1, name="weight")
         nx.set_node_attributes(G2, values=1, name="weight")
-        equal_node = nx.weisfeiler_lehman_graph_hash(
-            G1, node_attr="weight"
-        ) == nx.weisfeiler_lehman_graph_hash(G2, node_attr="weight")
+        G1_hash_node = nx.weisfeiler_lehman_graph_hash(G1, node_attr="weight")
+        G2_hash_node = nx.weisfeiler_lehman_graph_hash(G2, node_attr="weight")
+        equal_node = G1_hash_node == G2_hash_node
+
         nx.set_edge_attributes(G1, values="a", name="e_weight")
         nx.set_edge_attributes(G2, values="a", name="e_weight")
-        equal_edge = nx.weisfeiler_lehman_graph_hash(
-            G1, edge_attr="e_weight"
-        ) == nx.weisfeiler_lehman_graph_hash(G2, edge_attr="e_weight")
-        equal_both = nx.weisfeiler_lehman_graph_hash(
+        G1_hash_edge = nx.weisfeiler_lehman_graph_hash(G1, edge_attr="e_weight")
+        G2_hash_edge = nx.weisfeiler_lehman_graph_hash(G2, edge_attr="e_weight")
+        equal_edge = G1_hash_edge == G2_hash_edge
+
+        G1_hash_both = nx.weisfeiler_lehman_graph_hash(
             G1, edge_attr="e_weight", node_attr="weight"
-        ) == nx.weisfeiler_lehman_graph_hash(
+        )
+        G2_hash_both = nx.weisfeiler_lehman_graph_hash(
             G2, edge_attr="e_weight", node_attr="weight"
         )
+        equal_both = G1_hash_both == G2_hash_both
+
         assert equal == equal_node
         assert equal_node == equal_edge
         assert equal_edge == equal_both

--- a/networkx/algorithms/tests/test_graph_hashing.py
+++ b/networkx/algorithms/tests/test_graph_hashing.py
@@ -1,7 +1,8 @@
+import copy
+
 import pytest
 
 import networkx as nx
-from networkx.generators import directed
 
 # Unit tests for the :func:`~networkx.weisfeiler_lehman_graph_hash` function
 
@@ -684,3 +685,41 @@ def test_initial_node_labels_subgraph_hash():
             with_initial_label[u][1:], without_initial_label[u], strict=True
         ):
             assert a == b
+
+
+def test_directed_bugs():
+    """
+    These were bugs for directed graphs as discussed in issue 7806
+    """
+    Ga = nx.DiGraph()
+    Gb = nx.DiGraph()
+    Ga.add_nodes_from([1, 2, 3, 4])
+    Gb.add_nodes_from([1, 2, 3, 4])
+    Ga.add_edges_from([(1, 2), (3, 2)])
+    Gb.add_edges_from([(1, 2), (3, 4)])
+    Ga_hash = nx.weisfeiler_lehman_graph_hash(Ga)
+    Gb_hash = nx.weisfeiler_lehman_graph_hash(Gb)
+    assert Ga_hash != Gb_hash
+
+    Tree1 = nx.DiGraph()
+    Tree1.add_edges_from([(0, 4), (1, 5), (2, 6), (3, 7)])
+    Tree1.add_edges_from([(4, 8), (5, 8), (6, 9), (7, 9)])
+    Tree1.add_edges_from([(8, 10), (9, 10)])
+    nx.set_node_attributes(
+        Tree1, {10: "s", 8: "a", 9: "a", 4: "b", 5: "b", 6: "b", 7: "b"}, "weight"
+    )
+    Tree2 = copy.deepcopy(Tree1)
+    nx.set_node_attributes(Tree1, {0: "d", 1: "c", 2: "d", 3: "c"}, "weight")
+    nx.set_node_attributes(Tree2, {0: "d", 1: "d", 2: "c", 3: "c"}, "weight")
+    Tree1_hash_short = nx.weisfeiler_lehman_graph_hash(
+        Tree1, iterations=1, node_attr="weight"
+    )
+    Tree2_hash_short = nx.weisfeiler_lehman_graph_hash(
+        Tree2, iterations=1, node_attr="weight"
+    )
+    assert Tree1_hash_short == Tree2_hash_short
+    Tree1_hash = nx.weisfeiler_lehman_graph_hash(
+        Tree1, node_attr="weight"
+    )  # Default is 3 iterations
+    Tree2_hash = nx.weisfeiler_lehman_graph_hash(Tree2, node_attr="weight")
+    assert Tree1_hash != Tree2_hash


### PR DESCRIPTION
Fixes #7806 
Includes bugfixes for the issues discussed.
Does not cover the potential extension to ```MultiGraph```s.

Extended testing, but note that a lot of the test in this module in depend on randomly generated graphs. We continued that here. However, that does not necessarily mean all edge-cases are covered (as the original bug showed).
Note that subgraph hashing requires hashing of initial labels for digest size testing. This is not necessarily (and thus omitted) for general graph hashing.

~~A small optimisation is also made to the original graph hashing method. It used to collect _all_ labels calculated during execution in a counter, and hashed that to get the final graph hash. However, the WL algorithm only relies on the colouring (labels) calculated at the last iteration, so the current versionl only hashes those to obtain the final hash.~~

