### PR TITLE
Update readwrite docstrings for the `path` parameter

### DIFF
--- a/examples/drawing/plot_chess_masters.py
+++ b/examples/drawing/plot_chess_masters.py
@@ -36,7 +36,7 @@ game_details = ["Event", "Date", "Result", "ECO", "Site"]
 def chess_pgn_graph(pgn_file="chess_masters_WCC.pgn.bz2"):
     """Read chess games in pgn format in pgn_file.
 
-    Filenames ending in .bz2 will be uncompressed.
+    Filenames ending in .bz2 will be decompressed.
 
     Return the MultiDiGraph of players connected by a chess game.
     Edges contain game data in a dict.

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -287,7 +287,7 @@ def read_edgelist(
     path : file or string
        File or filename to read. If a file is provided, it must be
        opened in 'rb' mode.
-       Filenames ending in .gz or .bz2 will be uncompressed.
+       Filenames ending in .gz or .bz2 will be decompressed.
     comments : string, optional
        The character used to indicate the start of a comment.
     delimiter : string, optional

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -343,6 +343,7 @@ def view_pygraphviz(
     path : str, None
         The filename used to save the image.  If None, save to a temporary
         file.  File formats are the same as those from pygraphviz.agraph.draw.
+        Filenames ending in .gz or .bz2 will be compressed.
     show : bool, default = True
         Whether to display the graph with :mod:`PIL.Image.show`,
         default is `True`. If `False`, the rendered graph is still available

--- a/networkx/drawing/nx_latex.py
+++ b/networkx/drawing/nx_latex.py
@@ -496,8 +496,9 @@ def write_latex(Gbunch, path, **options):
         If Gbunch is a graph, it is drawn in a figure environment.
         If Gbunch is an iterable of graphs, each is drawn in a subfigure
         environment within a single figure environment.
-    path : filename
-        Filename or file handle to write to
+    path : string or file
+        Filename or file handle to write to.
+        Filenames ending in .gz or .bz2 will be compressed.
     options : dict
         By default, TikZ is used with options: (others are ignored)::
 

--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -39,7 +39,13 @@ __all__ = [
 def write_dot(G, path):
     """Write NetworkX graph G to Graphviz dot format on path.
 
-    Path can be a string or a file handle.
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    path : string or file
+       Filename or file handle for data output.
+       Filenames ending in .gz or .bz2 will be compressed.
     """
     P = to_pydot(G)
     path.write(P.to_string())
@@ -58,7 +64,8 @@ def read_dot(path):
     Parameters
     ----------
     path : str or file
-        Filename or file handle.
+        Filename or file handle to read.
+        Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -239,7 +239,7 @@ def read_adjlist(
     ----------
     path : string or file
        Filename or file handle to read.
-       Filenames ending in .gz or .bz2 will be uncompressed.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
        Graph type to create. If graph instance, then cleared before populated.

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -316,7 +316,7 @@ def read_edgelist(
     path : file or string
        File or filename to read. If a file is provided, it must be
        opened in 'rb' mode.
-       Filenames ending in .gz or .bz2 will be uncompressed.
+       Filenames ending in .gz or .bz2 will be decompressed.
     comments : string, optional
        The character used to indicate the start of a comment. To specify that
        no character should be treated as a comment, use ``comments=None``.
@@ -441,7 +441,7 @@ def read_weighted_edgelist(
     path : file or string
        File or filename to read. If a file is provided, it must be
        opened in 'rb' mode.
-       Filenames ending in .gz or .bz2 will be uncompressed.
+       Filenames ending in .gz or .bz2 will be decompressed.
     comments : string, optional
        The character used to indicate the start of a comment.
     delimiter : string, optional

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -144,8 +144,8 @@ def read_gexf(path, node_type=None, relabel=False, version="1.2draft"):
     Parameters
     ----------
     path : file or string
-       File or file name to read.
-       File names ending in .gz or .bz2 will be decompressed.
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
     node_type: Python type (default: None)
        Convert node ids to this type if not None.
     relabel : bool (default: False)

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -120,7 +120,8 @@ def read_gml(path, label="label", destringizer=None):
     Parameters
     ----------
     path : file or string
-        Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
+        Filename or file handle to read.
+        Filenames ending in .gz or .bz2 will be decompressed.
 
     label : string, optional
         If not None, the parsed nodes will be renamed according to node

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -119,8 +119,8 @@ def read_gml(path, label="label", destringizer=None):
 
     Parameters
     ----------
-    path : filename or filehandle
-        The filename or filehandle to read from.
+    path : file or string
+        Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
 
     label : string, optional
         If not None, the parsed nodes will be renamed according to node
@@ -823,9 +823,9 @@ def write_gml(G, path, stringizer=None):
     G : NetworkX graph
         The graph to be converted to GML.
 
-    path : filename or filehandle
-        The filename or filehandle to write. Files whose names end with .gz or
-        .bz2 will be compressed.
+    path : string or file
+        Filename or file handle to write to.
+        Filenames ending in .gz or .bz2 will be compressed.
 
     stringizer : callable, optional
         A `stringizer` which converts non-int/non-float/non-dict values into

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -192,7 +192,7 @@ def read_graph6(path):
     Parameters
     ----------
     path : file or string
-       File or filename to write.
+       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------
@@ -258,8 +258,8 @@ def write_graph6(G, path, nodes=None, header=True):
     ----------
     G : Graph (undirected)
 
-    path : str
-       The path naming the file to which to write the graph.
+    path : file or string
+       File or filename to write.                                                                                           Filenames ending in .gz or .bz2 will be compressed.
 
     nodes: list or iterable
        Nodes are labeled 0...n-1 in the order provided.  If None the ordering

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -192,7 +192,8 @@ def read_graph6(path):
     Parameters
     ----------
     path : file or string
-       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------
@@ -259,7 +260,8 @@ def write_graph6(G, path, nodes=None, header=True):
     G : Graph (undirected)
 
     path : file or string
-       File or filename to write.                                                                                           Filenames ending in .gz or .bz2 will be compressed.
+       File or filename to write.
+       Filenames ending in .gz or .bz2 will be compressed.
 
     nodes: list or iterable
        Nodes are labeled 0...n-1 in the order provided.  If None the ordering

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -241,7 +241,8 @@ def read_graphml(path, node_type=str, edge_key_type=int, force_multigraph=False)
     Parameters
     ----------
     path : file or string
-       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     node_type: Python type (default: str)
        Convert node ids to this type

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -241,8 +241,7 @@ def read_graphml(path, node_type=str, edge_key_type=int, force_multigraph=False)
     Parameters
     ----------
     path : file or string
-       File or filename to write.
-       Filenames ending in .gz or .bz2 will be compressed.
+       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
 
     node_type: Python type (default: str)
        Convert node ids to this type

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -26,7 +26,8 @@ def read_leda(path, encoding="UTF-8"):
     Parameters
     ----------
     path : file or string
-       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -26,8 +26,7 @@ def read_leda(path, encoding="UTF-8"):
     Parameters
     ----------
     path : file or string
-       File or filename to read.  Filenames ending in .gz or .bz2  will be
-       uncompressed.
+       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -317,7 +317,7 @@ def read_multiline_adjlist(
     ----------
     path : string or file
        Filename or file handle to read.
-       Filenames ending in .gz or .bz2 will be uncompressed.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
        Graph type to create. If graph instance, then cleared before populated.

--- a/networkx/readwrite/p2g.py
+++ b/networkx/readwrite/p2g.py
@@ -62,6 +62,12 @@ def write_p2g(G, path, encoding="utf-8"):
 def read_p2g(path, encoding="utf-8"):
     """Read graph in p2g format from path.
 
+    Parameters
+    ----------
+    path : string or file
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
+
     Returns
     -------
     MultiDiGraph

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -137,8 +137,7 @@ def read_pajek(path, encoding="UTF-8"):
     Parameters
     ----------
     path : file or string
-       File or filename to write.
-       Filenames ending in .gz or .bz2 will be uncompressed.
+       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -137,7 +137,8 @@ def read_pajek(path, encoding="UTF-8"):
     Parameters
     ----------
     path : file or string
-       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -258,7 +258,7 @@ def read_sparse6(path):
     Parameters
     ----------
     path : file or string
-       File or filename to write.
+       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------
@@ -324,7 +324,8 @@ def write_sparse6(G, path, nodes=None, header=True):
     G : Graph (undirected)
 
     path : file or string
-       File or filename to write
+       File or filename to write.
+       Filenames ending in .gz or .bz2 will be compressed.
 
     nodes: list or iterable
        Nodes are labeled 0...n-1 in the order provided.  If None the ordering

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -258,7 +258,8 @@ def read_sparse6(path):
     Parameters
     ----------
     path : file or string
-       Filename or file handle to read.                                                                                     Filenames ending in .gz or .bz2 will be decompressed.
+       Filename or file handle to read.
+       Filenames ending in .gz or .bz2 will be decompressed.
 
     Returns
     -------


### PR DESCRIPTION
Some read functions said "write", and some didn't describe the ability to compress or decompress. Also, I prefer "decompressed" over "uncompressed".