### PR TITLE
More `random_paths` docstring improvements

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1711,10 +1711,14 @@ def generate_random_paths(
 
     >>> G = nx.star_graph(3)
     >>> index_map = {}
-    >>> random_paths = list(nx.generate_random_paths(G, 3, index_map=index_map))
+    >>> random_paths = list(
+    ...     nx.generate_random_paths(G, 3, index_map=index_map, seed=42)
+    ... )
     >>> paths_containing_node_0 = [
     ...     random_paths[path_idx] for path_idx in index_map.get(0, [])
     ... ]
+    >>> paths_containing_node_0
+    [[2, 0, 1, 0, 2, 0], [2, 0, 3, 0, 3, 0], [1, 0, 3, 0, 3, 0]]
 
     References
     ----------

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1701,10 +1701,14 @@ def generate_random_paths(
 
     Examples
     --------
-    Note that the return value is the list of paths:
+    The generator yields `sample_size` number of paths of length `path_length`
+    drawn from `G`:
 
-    >>> G = nx.star_graph(3)
-    >>> random_path = nx.generate_random_paths(G, 2)
+    >>> G = nx.complete_graph(5)
+    >>> next(nx.generate_random_paths(G, sample_size=1, path_length=3, seed=42))
+    [3, 4, 2, 3]
+    >>> list(nx.generate_random_paths(G, sample_size=3, path_length=4, seed=42))
+    [[3, 4, 2, 3, 0], [2, 0, 2, 1, 0], [2, 0, 4, 3, 0]]
 
     By passing a dictionary into `index_map`, it will build an
     inverted index mapping of nodes to the paths in which that node is present:

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1713,16 +1713,18 @@ def generate_random_paths(
     By passing a dictionary into `index_map`, it will build an
     inverted index mapping of nodes to the paths in which that node is present:
 
-    >>> G = nx.star_graph(3)
+    >>> G = nx.wheel_graph(10)
     >>> index_map = {}
     >>> random_paths = list(
-    ...     nx.generate_random_paths(G, 3, index_map=index_map, seed=42)
+    ...     nx.generate_random_paths(G, sample_size=3, index_map=index_map, seed=2771)
     ... )
+    >>> random_paths
+    [[3, 2, 1, 9, 8, 7], [4, 0, 5, 6, 7, 8], [3, 0, 5, 0, 9, 8]]
     >>> paths_containing_node_0 = [
     ...     random_paths[path_idx] for path_idx in index_map.get(0, [])
     ... ]
     >>> paths_containing_node_0
-    [[2, 0, 1, 0, 2, 0], [2, 0, 3, 0, 3, 0], [1, 0, 3, 0, 3, 0]]
+    [[4, 0, 5, 6, 7, 8], [3, 0, 5, 0, 9, 8]]
 
     References
     ----------


### PR DESCRIPTION
Follow-up to #7832 

Incorporates @Schefflera-Arboricola 's suggestions and then extends them further. The main changes are:
 1. The original wording in the first example implied that `generate_random_paths` is a function. I've reworded to make it clear that it's a generator, and extended the example to illustrate this more clearly.
 2. Seeded the second example per @Schefflera-Arboricola 's suggestion, but also changed the example so that there is at least one output path that *doesn't* contain node 0 to better illustrate the usage of `index_map`.