### PR TITLE
Expire total_spanning_tree_weight deprecation

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -43,7 +43,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
 Version 3.5
 ~~~~~~~~~~~
-* Remove ``total_spanning_tree_weight`` from ``linalg/laplacianmatrix.py``
 * Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 
   ``generators/nonisomorphic_trees``.
 

--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -25,7 +25,6 @@ Laplacian Matrix
    normalized_laplacian_matrix
    directed_laplacian_matrix
    directed_combinatorial_laplacian_matrix
-   total_spanning_tree_weight
 
 Bethe Hessian Matrix
 --------------------

--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -885,9 +885,9 @@ def spanning_tree_distribution(G, z):
         # Create the laplacian matrices
         for u, v, d in G.edges(data=True):
             d[lambda_key] = exp(gamma[(u, v)])
-        G_Kirchhoff = nx.total_spanning_tree_weight(G, lambda_key)
+        G_Kirchhoff = nx.number_of_spanning_trees(G, weight=lambda_key)
         G_e = nx.contracted_edge(G, e, self_loops=False)
-        G_e_Kirchhoff = nx.total_spanning_tree_weight(G_e, lambda_key)
+        G_e_Kirchhoff = nx.number_of_spanning_trees(G_e, weight=lambda_key)
 
         # Multiply by the weight of the contracted edge since it is not included
         # in the total weight of the contracted graph.

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -891,7 +891,7 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
             spanning trees in the graph.
         """
         if multiplicative:
-            return nx.total_spanning_tree_weight(G, weight)
+            return number_of_spanning_trees(G, weight=weight)
         else:
             # There are two cases for the total spanning tree additive weight.
             # 1. There is one edge in the graph. Then the only spanning tree is
@@ -906,13 +906,14 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
             #    can be accomplished by contracting the edge and finding the
             #    multiplicative total spanning tree weight if the weight of each edge
             #    is assumed to be 1, which is conveniently built into networkx already,
-            #    by calling total_spanning_tree_weight with weight=None.
+            #    by calling number_of_spanning_trees with weight=None.
             #    Note that with no edges the returned value is just zero.
             else:
                 total = 0
                 for u, v, w in G.edges(data=weight):
-                    total += w * nx.total_spanning_tree_weight(
-                        nx.contracted_edge(G, edge=(u, v), self_loops=False), None
+                    total += w * nx.number_of_spanning_trees(
+                        nx.contracted_edge(G, edge=(u, v), self_loops=False),
+                        weight=None,
                     )
                 return total
 
@@ -946,11 +947,11 @@ def random_spanning_tree(G, weight=None, *, multiplicative=True, seed=None):
             if multiplicative:
                 threshold = e_weight * G_e_total_tree_weight / G_total_tree_weight
             else:
-                numerator = (
-                    st_cached_value + e_weight
-                ) * nx.total_spanning_tree_weight(prepared_G_e) + G_e_total_tree_weight
+                numerator = (st_cached_value + e_weight) * nx.number_of_spanning_trees(
+                    prepared_G_e
+                ) + G_e_total_tree_weight
                 denominator = (
-                    st_cached_value * nx.total_spanning_tree_weight(prepared_G)
+                    st_cached_value * nx.number_of_spanning_trees(prepared_G)
                     + G_total_tree_weight
                 )
                 threshold = numerator / denominator

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -112,9 +112,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\ntotal_spanning_tree_weight"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message=r"\n\nThe 'create=matrix'"
     )
     warnings.filterwarnings(

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -14,7 +14,6 @@ from networkx.utils import not_implemented_for
 __all__ = [
     "laplacian_matrix",
     "normalized_laplacian_matrix",
-    "total_spanning_tree_weight",
     "directed_laplacian_matrix",
     "directed_combinatorial_laplacian_matrix",
 ]
@@ -245,102 +244,6 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
     # TODO: rm csr_array wrapper when spdiags can produce arrays
     DH = sp.sparse.csr_array(sp.sparse.spdiags(diags_sqrt, 0, n, n, format="csr"))
     return DH @ (L @ DH)
-
-
-@nx._dispatchable(edge_attrs="weight")
-def total_spanning_tree_weight(G, weight=None, root=None):
-    """
-    Returns the total weight of all spanning trees of `G`.
-
-    Kirchoff's Tree Matrix Theorem [1]_, [2]_ states that the determinant of any
-    cofactor of the Laplacian matrix of a graph is the number of spanning trees
-    in the graph. For a weighted Laplacian matrix, it is the sum across all
-    spanning trees of the multiplicative weight of each tree. That is, the
-    weight of each tree is the product of its edge weights.
-
-    For unweighted graphs, the total weight equals the number of spanning trees in `G`.
-
-    For directed graphs, the total weight follows by summing over all directed
-    spanning trees in `G` that start in the `root` node [3]_.
-
-    .. deprecated:: 3.3
-
-       ``total_spanning_tree_weight`` is deprecated and will be removed in v3.5.
-       Use ``nx.number_of_spanning_trees(G)`` instead.
-
-    Parameters
-    ----------
-    G : NetworkX Graph
-
-    weight : string or None, optional (default=None)
-        The key for the edge attribute holding the edge weight.
-        If None, then each edge has weight 1.
-
-    root : node (only required for directed graphs)
-       A node in the directed graph `G`.
-
-    Returns
-    -------
-    total_weight : float
-        Undirected graphs:
-            The sum of the total multiplicative weights for all spanning trees in `G`.
-        Directed graphs:
-            The sum of the total multiplicative weights for all spanning trees of `G`,
-            rooted at node `root`.
-
-    Raises
-    ------
-    NetworkXPointlessConcept
-        If `G` does not contain any nodes.
-
-    NetworkXError
-        If the graph `G` is not (weakly) connected,
-        or if `G` is directed and the root node is not specified or not in G.
-
-    Examples
-    --------
-    >>> G = nx.complete_graph(5)
-    >>> round(nx.total_spanning_tree_weight(G))
-    125
-
-    >>> G = nx.Graph()
-    >>> G.add_edge(1, 2, weight=2)
-    >>> G.add_edge(1, 3, weight=1)
-    >>> G.add_edge(2, 3, weight=1)
-    >>> round(nx.total_spanning_tree_weight(G, "weight"))
-    5
-
-    Notes
-    -----
-    Self-loops are excluded. Multi-edges are contracted in one edge
-    equal to the sum of the weights.
-
-    References
-    ----------
-    .. [1] Wikipedia
-       "Kirchhoff's theorem."
-       https://en.wikipedia.org/wiki/Kirchhoff%27s_theorem
-    .. [2] Kirchhoff, G. R.
-        Über die Auflösung der Gleichungen, auf welche man
-        bei der Untersuchung der linearen Vertheilung
-        Galvanischer Ströme geführt wird
-        Annalen der Physik und Chemie, vol. 72, pp. 497-508, 1847.
-    .. [3] Margoliash, J.
-        "Matrix-Tree Theorem for Directed Graphs"
-        https://www.math.uchicago.edu/~may/VIGRE/VIGRE2010/REUPapers/Margoliash.pdf
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\ntotal_spanning_tree_weight is deprecated and will be removed in v3.5.\n"
-            "Use `nx.number_of_spanning_trees(G)` instead."
-        ),
-        category=DeprecationWarning,
-        stacklevel=3,
-    )
-
-    return nx.number_of_spanning_trees(G, weight=weight, root=root)
 
 
 ###############################################################################


### PR DESCRIPTION
Removes `total_spanning_tree_weight` and replaces internal usages with `number_of_spanning_trees`. `total_spanning_tree_weight` is scheduled for removal in v3.5