### PR TITLE
Fix use of triple backticks in docstrings

### DIFF
--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -110,7 +110,7 @@ Without any knowledge about the system (candidate d-separating set is empty)
 a causal graph ``u -> v -> w`` allows all three nodes to be dependent. But
 if we know the outcome of ``v``, the conditional probabilities of outcomes for
 ``u`` and ``w`` are independent of each other. That is, once we know the outcome
-for ```v`, the probabilities for ``w`` do not depend on the outcome for ``u``.
+for ``v``, the probabilities for ``w`` do not depend on the outcome for ``u``.
 This is the idea behind ``v`` blocking the path if it is "known" (in the candidate
 d-separating set).
 
@@ -121,7 +121,7 @@ make the conditional probabilities independent.
 
 The direction of the causal edges does impact dependence precisely in the
 case of a collider e.g. ``u -> v <- w``. In that situation, both ``u`` and ``w``
-influence ``v```. But they do not directly influence each other. So without any
+influence ``v``. But they do not directly influence each other. So without any
 knowledge of any outcomes, ``u`` and ``w`` are independent. That is the idea behind
 colliders blocking the path. But, if ``v`` is known, the conditional probabilities
 of ``u`` and ``w`` can be dependent. This is the heart of Berkson's Paradox [6]_.

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -174,10 +174,10 @@ def from_pandas_adjacency(df, create_using=None):
     appropriate Python data type.
 
     If you have node attributes stored in a separate dataframe `df_nodes`,
-    you can load those attributes to the graph `G` using the following code:
+    you can load those attributes to the graph `G` using the following code::
 
-    >>> df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
-    >>> G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
+        df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
+        G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
 
     If `df` has a user-specified compound data type the names
     of the data fields will be used as attribute keys in the resulting
@@ -358,10 +358,10 @@ def from_pandas_edgelist(
         is a multigraph.
 
     If you have node attributes stored in a separate dataframe `df_nodes`,
-    you can load those attributes to the graph `G` using the following code:
+    you can load those attributes to the graph `G` using the following code::
 
-    >>> df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
-    >>> G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
+        df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
+        G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
 
     See Also
     --------

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -176,10 +176,8 @@ def from_pandas_adjacency(df, create_using=None):
     If you have node attributes stored in a separate dataframe `df_nodes`,
     you can load those attributes to the graph `G` using the following code:
 
-    ```
-    df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
-    G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
-    ```
+    >>> df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
+    >>> G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
 
     If `df` has a user-specified compound data type the names
     of the data fields will be used as attribute keys in the resulting
@@ -362,10 +360,8 @@ def from_pandas_edgelist(
     If you have node attributes stored in a separate dataframe `df_nodes`,
     you can load those attributes to the graph `G` using the following code:
 
-    ```
-    df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
-    G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
-    ```
+    >>> df_nodes = pd.DataFrame({"node_id": [1, 2, 3], "attribute1": ["A", "B", "C"]})
+    >>> G.add_nodes_from((n, dict(d)) for n, d in df_nodes.iterrows())
 
     See Also
     --------

--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -357,6 +357,8 @@ def from_pandas_edgelist(
         this column are used for the edge keys when adding edges if create_using
         is a multigraph.
 
+    Notes
+    -----
     If you have node attributes stored in a separate dataframe `df_nodes`,
     you can load those attributes to the graph `G` using the following code::
 


### PR DESCRIPTION
I noticed the docstring for `from_pandas_edgelist` was not rendering a code block correctly because it used triple backticks <code>```</code>, so I did a quick grep to fix their use in docstrings. See incorrect docs here:
- https://networkx.org/documentation/stable/reference/generated/networkx.convert_matrix.from_pandas_edgelist.html
- https://networkx.org/documentation/stable/reference/generated/networkx.convert_matrix.from_pandas_adjacency.html
- https://networkx.org/documentation/stable/reference/algorithms/d_separation.html