### PR TITLE
Expire deprecation of create kwarg in nonisomorphic_trees.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -41,11 +41,6 @@ Todo
 
 Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
-Version 3.5
-~~~~~~~~~~~
-* Remove ``create`` keyword argument from ``nonisomorphic_trees`` in 
-  ``generators/nonisomorphic_trees``.
-
 Version 3.6
 ~~~~~~~~~~~
 * Remove ``compute_v_structures`` from ``algorithms/dag.py``.

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -112,9 +112,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message=r"\n\nThe 'create=matrix'"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\n`compute_v_structures"
     )
     warnings.filterwarnings(

--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -13,7 +13,7 @@ import networkx as nx
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)
-def nonisomorphic_trees(order, create="graph"):
+def nonisomorphic_trees(order):
     """Generates lists of nonisomorphic trees
 
     Parameters
@@ -21,26 +21,10 @@ def nonisomorphic_trees(order, create="graph"):
     order : int
        order of the desired tree(s)
 
-    create : one of {"graph", "matrix"} (default="graph")
-       If ``"graph"`` is selected a list of ``Graph`` instances will be returned,
-       if matrix is selected a list of adjacency matrices will be returned.
-
-       .. deprecated:: 3.3
-
-          The `create` argument is deprecated and will be removed in NetworkX
-          version 3.5. In the future, `nonisomorphic_trees` will yield graph
-          instances by default. To generate adjacency matrices, call
-          ``nx.to_numpy_array`` on the output, e.g.::
-
-             [nx.to_numpy_array(G) for G in nx.nonisomorphic_trees(N)]
-
     Yields
     ------
-    list
-       A list of nonisomorphic trees, in one of two formats depending on the
-       value of the `create` parameter:
-       - ``create="graph"``: yields a list of `networkx.Graph` instances
-       - ``create="matrix"``: yields a list of list-of-lists representing adjacency matrices
+    list of `networkx.Graph` instances
+       A list of nonisomorphic trees
     """
 
     if order < 2:
@@ -51,24 +35,7 @@ def nonisomorphic_trees(order, create="graph"):
     while layout is not None:
         layout = _next_tree(layout)
         if layout is not None:
-            if create == "graph":
-                yield _layout_to_graph(layout)
-            elif create == "matrix":
-                import warnings
-
-                warnings.warn(
-                    (
-                        "\n\nThe 'create=matrix' argument of nonisomorphic_trees\n"
-                        "is deprecated and will be removed in version 3.5.\n"
-                        "Use ``nx.to_numpy_array`` to convert graphs to adjacency "
-                        "matrices, e.g.::\n\n"
-                        "   [nx.to_numpy_array(G) for G in nx.nonisomorphic_trees(N)]"
-                    ),
-                    category=DeprecationWarning,
-                    stacklevel=2,
-                )
-
-                yield _layout_to_matrix(layout)
+            yield _layout_to_graph(layout)
             layout = _next_rooted_tree(layout)
 
 

--- a/networkx/generators/tests/test_nonisomorphic_trees.py
+++ b/networkx/generators/tests/test_nonisomorphic_trees.py
@@ -50,19 +50,3 @@ class TestGeneratorNonIsomorphicTrees:
         assert edges_equal(f(3)[0].edges(), [(0, 1), (0, 2)])
         assert edges_equal(f(4)[0].edges(), [(0, 1), (0, 3), (1, 2)])
         assert edges_equal(f(4)[1].edges(), [(0, 1), (0, 2), (0, 3)])
-
-    def test_nonisomorphic_trees_matrix(self):
-        trees_2 = [[[0, 1], [1, 0]]]
-        with pytest.deprecated_call():
-            assert list(nx.nonisomorphic_trees(2, create="matrix")) == trees_2
-
-        trees_3 = [[[0, 1, 1], [1, 0, 0], [1, 0, 0]]]
-        with pytest.deprecated_call():
-            assert list(nx.nonisomorphic_trees(3, create="matrix")) == trees_3
-
-        trees_4 = [
-            [[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]],
-            [[0, 1, 1, 1], [1, 0, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0]],
-        ]
-        with pytest.deprecated_call():
-            assert list(nx.nonisomorphic_trees(4, create="matrix")) == trees_4


### PR DESCRIPTION
Expires the last deprecation scheduled for 3.5: removing the `create=` kwarg to `nonisomorphic_trees`.

During the removal it seemed to me there is also an opportunity to remove some redundancy in the conditionals by restructuring the loop, but that's for a separate PR!