### PR TITLE
Consolidate could_be_isomorphic

### DIFF
--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -76,6 +76,12 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
             return False
         return True
 
+    # The property table is built and checked as each individual property is
+    # added. The reason for this is the building/checking the property table
+    # is in general much faster than computing the properties, making it
+    # worthwhile to check multiple times to enable early termination when
+    # a subset of properties don't match
+
     # Degree sequence
     if "d" in properties_to_check:
         G1_props.append(G1.degree())

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -2,8 +2,8 @@
 Graph isomorphism functions.
 """
 
-from collections import Counter
 import itertools
+from collections import Counter
 
 import networkx as nx
 from networkx.exception import NetworkXError

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -72,9 +72,7 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
         G1_ptable = [tuple(p[n] for p in G1_props) for n in G1]
         G2_ptable = [tuple(p[n] for p in G2_props) for n in G2]
 
-        if sorted(G1_ptable) != sorted(G2_ptable):
-            return False
-        return True
+        return sorted(G1_ptable) == sorted(G2_ptable)
 
     # The property table is built and checked as each individual property is
     # added. The reason for this is the building/checking the property table

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -36,7 +36,9 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
 
        Unrecognized characters are ignored. The default is ``"dtc"``, which
        compares the sequence of ``(degree, num_triangles, num_cliques)`` properties
-       between `G1` and `G2`.
+       between `G1` and `G2`. Generally, ``properties="dt"`` would be faster, and
+       ``properties="d"`` faster still. See Notes for additional details on
+       property selection.
 
     Returns
     -------
@@ -49,6 +51,14 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
     The triangle sequence contains the number of triangles each node is part of.
     The clique sequence contains for each node the number of maximal cliques
     involving that node.
+
+    Some properties are faster to compute than others. And there are other
+    properties we could include and don't. For example, ``len(G1) == len(G2)``
+    and ``G1.size() == G2.size()``. But of the three properties listed here,
+    comparing the degree distributions is the fastest. The "triangles" property
+    is slower (and also a stricter version of "could") and the "maximal cliques"
+    property is slower still, but usually faster than doing a full isomorphism
+    check.
     """
 
     # Check global properties

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -53,8 +53,7 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
     involving that node.
 
     Some properties are faster to compute than others. And there are other
-    properties we could include and don't. For example, ``len(G1) == len(G2)``
-    and ``G1.size() == G2.size()``. But of the three properties listed here,
+    properties we could include and don't. But of the three properties listed here,
     comparing the degree distributions is the fastest. The "triangles" property
     is slower (and also a stricter version of "could") and the "maximal cliques"
     property is slower still, but usually faster than doing a full isomorphism

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -68,35 +68,33 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
     properties_to_check = set(properties)
     G1_props, G2_props = [], []
 
+    def _properties_consistent():
+        # Ravel the properties into a table with # nodes rows and # properties columns
+        G1_ptable = [tuple(p[n] for p in G1_props) for n in G1]
+        G2_ptable = [tuple(p[n] for p in G2_props) for n in G2]
+
+        if sorted(G1_ptable) != sorted(G2_ptable):
+            return False
+        return True
+
     # Degree sequence
     if "d" in properties_to_check:
-        G1d, G2d = G1.degree(), G2.degree()
-        if sorted(d for _, d in G1d) != sorted(d for _, d in G2d):
+        G1_props.append(G1.degree())
+        G2_props.append(G2.degree())
+        if not _properties_consistent():
             return False
-        G1_props.append(G1d)
-        G2_props.append(G2d)
     # Sequence of triangles per node
     if "t" in properties_to_check:
-        G1t, G2t = nx.triangles(G1), nx.triangles(G2)
-        if sorted(G1t.values()) != sorted(G2t.values()):
+        G1_props.append(nx.triangles(G1))
+        G2_props.append(nx.triangles(G2))
+        if not _properties_consistent():
             return False
-        G1_props.append(G1t)
-        G2_props.append(G2t)
     # Sequence of maximal cliques per node
     if "c" in properties_to_check:
-        G1c = Counter(itertools.chain.from_iterable(nx.find_cliques(G1)))
-        G2c = Counter(itertools.chain.from_iterable(nx.find_cliques(G2)))
-        if sorted(G1c.values()) != sorted(G2c.values()):
+        G1_props.append(Counter(itertools.chain.from_iterable(nx.find_cliques(G1))))
+        G2_props.append(Counter(itertools.chain.from_iterable(nx.find_cliques(G2))))
+        if not _properties_consistent():
             return False
-        G1_props.append(G1c)
-        G2_props.append(G2c)
-
-    # Ravel the properties into a table with # nodes rows and # properties columns
-    G1_ptable = [tuple(p[n] for p in G1_props) for n in G1]
-    G2_ptable = [tuple(p[n] for p in G2_props) for n in G2]
-
-    if sorted(G1_ptable) != sorted(G2_ptable):
-        return False
 
     # All checked conditions passed
     return True

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -70,16 +70,26 @@ def could_be_isomorphic(G1, G2, *, properties="dtc"):
 
     # Degree sequence
     if "d" in properties_to_check:
-        G1_props.append(G1.degree())
-        G2_props.append(G2.degree())
+        G1d, G2d = G1.degree(), G2.degree()
+        if sorted(d for _, d in G1d) != sorted(d for _, d in G2d):
+            return False
+        G1_props.append(G1d)
+        G2_props.append(G2d)
     # Sequence of triangles per node
     if "t" in properties_to_check:
-        G1_props.append(nx.triangles(G1))
-        G2_props.append(nx.triangles(G2))
+        G1t, G2t = nx.triangles(G1), nx.triangles(G2)
+        if sorted(G1t.values()) != sorted(G2t.values()):
+            return False
+        G1_props.append(G1t)
+        G2_props.append(G2t)
     # Sequence of maximal cliques per node
     if "c" in properties_to_check:
-        G1_props.append(Counter(itertools.chain.from_iterable(nx.find_cliques(G1))))
-        G2_props.append(Counter(itertools.chain.from_iterable(nx.find_cliques(G2))))
+        G1c = Counter(itertools.chain.from_iterable(nx.find_cliques(G1)))
+        G2c = Counter(itertools.chain.from_iterable(nx.find_cliques(G2)))
+        if sorted(G1c.values()) != sorted(G2c.values()):
+            return False
+        G1_props.append(G1c)
+        G2_props.append(G2c)
 
     # Ravel the properties into a table with # nodes rows and # properties columns
     G1_ptable = [tuple(p[n] for p in G1_props) for n in G1]

--- a/networkx/algorithms/isomorphism/tests/test_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphism.py
@@ -1,7 +1,15 @@
+from functools import partial
+
 import pytest
 
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
+
+# Convenience functions for testing that the behavior of `could_be_isomorphic`
+# with the "properties" kwarg is equivalent to the corresponding function (i.e.
+# nx.fast_could_be_isomorphic or nx.faster_could_be_isomorphic)
+fast_cbi = partial(nx.could_be_isomorphic, properties="dt")
+faster_cbi = partial(nx.could_be_isomorphic, properties="d")
 
 
 def test_graph_could_be_isomorphic_variants_deprecated():
@@ -41,15 +49,17 @@ class TestIsomorph:
         assert iso.could_be_isomorphic(self.G3, self.G2)
         assert not iso.could_be_isomorphic(self.G1, self.G6)
 
-    def test_fast_could_be_isomorphic(self):
-        assert iso.fast_could_be_isomorphic(self.G3, self.G2)
-        assert not iso.fast_could_be_isomorphic(self.G3, self.G5)
-        assert not iso.fast_could_be_isomorphic(self.G1, self.G6)
+    @pytest.mark.parametrize("fn", (iso.fast_could_be_isomorphic, fast_cbi))
+    def test_fast_could_be_isomorphic(self, fn):
+        assert fn(self.G3, self.G2)
+        assert not fn(self.G3, self.G5)
+        assert not fn(self.G1, self.G6)
 
-    def test_faster_could_be_isomorphic(self):
-        assert iso.faster_could_be_isomorphic(self.G3, self.G2)
-        assert not iso.faster_could_be_isomorphic(self.G3, self.G5)
-        assert not iso.faster_could_be_isomorphic(self.G1, self.G6)
+    @pytest.mark.parametrize("fn", (iso.faster_could_be_isomorphic, faster_cbi))
+    def test_faster_could_be_isomorphic(self, fn):
+        assert fn(self.G3, self.G2)
+        assert not fn(self.G3, self.G5)
+        assert not fn(self.G1, self.G6)
 
     def test_is_isomorphic(self):
         assert iso.is_isomorphic(self.G1, self.G2)

--- a/networkx/algorithms/isomorphism/tests/test_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphism.py
@@ -26,6 +26,20 @@ def test_graph_could_be_isomorphic_variants_deprecated():
     assert nx.faster_could_be_isomorphic(G1, G2) == result
 
 
+def test_could_be_isomorphic_individual_vs_combined_dt():
+    """A test case where G and H have identical degree and triangle distributions,
+    but are different when compared together"""
+    G = nx.Graph([(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (3, 4), (4, 5), (4, 6)])
+    H = G.copy()
+    # Modify graphs to produce different clique distributions
+    G.add_edge(0, 7)
+    H.add_edge(4, 7)
+    assert nx.could_be_isomorphic(G, H, properties="d")
+    assert nx.could_be_isomorphic(G, H, properties="t")
+    assert not nx.could_be_isomorphic(G, H, properties="dt")
+    assert not nx.could_be_isomorphic(G, H, properties="c")
+
+
 class TestIsomorph:
     @classmethod
     def setup_class(cls):

--- a/networkx/algorithms/isomorphism/tests/test_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphism.py
@@ -26,6 +26,29 @@ def test_graph_could_be_isomorphic_variants_deprecated():
     assert nx.faster_could_be_isomorphic(G1, G2) == result
 
 
+@pytest.mark.parametrize("atlas_ids", [(699, 706), (864, 870)])
+def test_could_be_isomorphic_combined_properties(atlas_ids):
+    """There are two pairs of graphs from the graph atlas that have the same
+    combined degree-triangle distribution, but a different maximal clique
+    distribution. See gh-7852."""
+    G, H = (nx.graph_atlas(idx) for idx in atlas_ids)
+
+    assert not nx.is_isomorphic(G, H)
+
+    # Degree only
+    assert nx.faster_could_be_isomorphic(G, H)
+    assert nx.could_be_isomorphic(G, H, properties="d")
+    # Degrees & triangles
+    assert nx.fast_could_be_isomorphic(G, H)
+    assert nx.could_be_isomorphic(G, H, properties="dt")
+    # Full properties table (degrees, triangles, cliques)
+    assert not nx.could_be_isomorphic(G, H)
+    assert not nx.could_be_isomorphic(G, H, properties="dtc")
+    # For these two cases, the clique distribution alone is enough to verify
+    # the graphs can't be isomorphic
+    assert not nx.could_be_isomorphic(G, H, properties="c")
+
+
 def test_could_be_isomorphic_individual_vs_combined_dt():
     """A test case where G and H have identical degree and triangle distributions,
     but are different when compared together"""


### PR DESCRIPTION
This is a left-over idea from the summit that I thought I'd write up for further discussion!

NetworkX has a function `could_be_isomorphic` to check various properties of two graphs to determine whether or not they, well, could be isomorphic. `could_be_isomorphic` checks three properties: 1) degree sequences, 2) sequences of triangles, and 3) sequences of number-of-cliques.

There also exist two other functions, `fast_could_be_isomorphic` and `faster_could_be_isomorphic` that check degree+triangles and just degree, respectively. IMO, the name of these functions doesn't do a whole lot to illuminate what they are checking. There is also a lot of code duplication between these three functions as all of them check degree, two check triangles, etc.

Therefore I thought it might be worth trying to consolidate things a bit. This is one proposal to do so: adding a `mode=` kwarg to `could_be_isomorphic` to determine which properties to check. For consistency, I've used the same designation as the functions (i.e. "fast" and "faster") but one could imagine different patterns here. For example, we could do something like `check="cdt"` where "c" indicates cliques, "d" degree and "t" triangles, to allow users to specify whichever combination of property checks they'd like (e.g. `check="cd"` for cliques and degree, `check="t"` for just triangles, etc.)

I'm mostly looking for opinions here, so LMK what you think!