### PR TITLE
Faster `could_be_isomorphic` and `number_of_cliques`

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -8,7 +8,7 @@ see the Wikipedia article on the clique problem [1]_.
 
 """
 
-from collections import defaultdict, deque
+from collections import Counter, defaultdict, deque
 from itertools import chain, combinations, islice
 
 import networkx as nx
@@ -156,7 +156,10 @@ def find_cliques(G, nodes=None):
     node. The following produces a dictionary keyed by node whose
     values are the number of maximal cliques in `G` that contain the node:
 
-    >>> pprint({n: sum(1 for c in nx.find_cliques(G) if n in c) for n in G})
+    >>> from collections import Counter
+    >>> from itertools import chain
+    >>> counts = Counter(chain.from_iterable(nx.find_cliques(G)))
+    >>> pprint(dict(counts))
     {0: 13,
      1: 6,
      2: 7,
@@ -581,7 +584,7 @@ def number_of_cliques(G, nodes=None, cliques=None):
     Optional list of cliques can be input if already computed.
     """
     if cliques is None:
-        cliques = list(find_cliques(G))
+        cliques = find_cliques(G)
 
     if nodes is None:
         nodes = list(G.nodes())  # none, get entire graph
@@ -589,11 +592,10 @@ def number_of_cliques(G, nodes=None, cliques=None):
     if not isinstance(nodes, list):  # check for a list
         v = nodes
         # assume it is a single value
-        numcliq = len([1 for c in cliques if v in c])
+        numcliq = sum(1 for c in cliques if v in c)
     else:
-        numcliq = {}
-        for v in nodes:
-            numcliq[v] = len([1 for c in cliques if v in c])
+        numcliq = Counter(chain.from_iterable(cliques))
+        numcliq = {v: numcliq[v] for v in nodes}  # return a dict
     return numcliq
 
 

--- a/networkx/algorithms/isomorphism/isomorph.py
+++ b/networkx/algorithms/isomorphism/isomorph.py
@@ -2,6 +2,9 @@
 Graph isomorphism functions.
 """
 
+from collections import Counter
+from itertools import chain
+
 import networkx as nx
 from networkx.exception import NetworkXError
 
@@ -40,14 +43,14 @@ def could_be_isomorphic(G1, G2):
     d1 = G1.degree()
     t1 = nx.triangles(G1)
     clqs_1 = list(nx.find_cliques(G1))
-    c1 = {n: sum(1 for c in clqs_1 if n in c) for n in G1}  # number of cliques
+    c1 = Counter(chain.from_iterable(nx.find_cliques(G1)))  # number of cliques
     props1 = [[d, t1[v], c1[v]] for v, d in d1]
     props1.sort()
 
     d2 = G2.degree()
     t2 = nx.triangles(G2)
     clqs_2 = list(nx.find_cliques(G2))
-    c2 = {n: sum(1 for c in clqs_2 if n in c) for n in G2}  # number of cliques
+    c2 = Counter(chain.from_iterable(nx.find_cliques(G2)))  # number of cliques
     props2 = [[d, t2[v], c2[v]] for v, d in d2]
     props2.sort()
 


### PR DESCRIPTION
When looking at #7852, @rossbar noticed `could_be_isomorphic` could be made much faster by counting cliques faster. Same change applies to `number_of_cliques` too, and I updated the recipe in the docstring of `find_cliques` to avoid the slow recipe.

Additional changes that could be made (preferably in other PR(s)):
- Recipe in `find_cliques` could be replaced by `number_of_cliques` (or at least mention it)
- `could_be_isomorphic` could also use `number_of_cliques`, but used simple one-liner for performance
- Docstring of `number_of_cliques` doesn't describe parameters or return types, and incorrectly says returns a list