### PR TITLE
Add square_clustering to algorithm benchmarks.

### DIFF
--- a/benchmarks/benchmarks/benchmark_algorithms.py
+++ b/benchmarks/benchmarks/benchmark_algorithms.py
@@ -73,3 +73,6 @@ class AlgorithmBenchmarksConnectedGraphsOnly:
         # Added to ensure the connectivity check doesn't affect
         # performance too much (see gh-6888, gh-7549).
         _ = nx.eigenvector_centrality_numpy(self.graphs_dict[graph])
+
+    def time_square_clustering(self, graph):
+        _ = nx.square_clustering(self.graphs_dict[graph])


### PR DESCRIPTION
This one was easy - I just plugged it directly into the existing algorithm benchmarks. Note however that I chose the test cases that excluded the drug interaction network, as the existing implementation can be quite expensive!

Here's an example incantation and some results:

```bash
$ asv continuous --bench AlgorithmBenchmarksConnectedGraphsOnly.time_square_clustering 2d1ad6b1 main
$ asv compare 2d1ad6b1 main
```

<details>
  <summary>Benchmarking results</summary>
<pre>
All benchmarks:

| Change   | Before [2d1ad6b1] <faster_square_clustering>   | After [f87c3611] <main>   |   Ratio | Benchmark (Parameter)                                                                                        |
|----------|------------------------------------------------|---------------------------|---------|--------------------------------------------------------------------------------------------------------------|
| +        | 3.59±0.02ms                                    | 10.5±0.6ms                |    2.92 | benchmark_algorithms.AlgorithmBenchmarksConnectedGraphsOnly.time_square_clustering('Erdos Renyi (100, 0.1)') |
| +        | 22.7±0.7ms                                     | 583±2ms                   |   25.68 | benchmark_algorithms.AlgorithmBenchmarksConnectedGraphsOnly.time_square_clustering('Erdos Renyi (100, 0.5)') |
| +        | 26.9±0.8ms                                     | 2.14±0s                   |   79.38 | benchmark_algorithms.AlgorithmBenchmarksConnectedGraphsOnly.time_square_clustering('Erdos Renyi (100, 0.9)') |
</pre>
</details>

