### PR TITLE
Refactor network_simplex test of faux_infinity.

### DIFF
--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -417,38 +417,22 @@ def test_graphs_type_exceptions():
     pytest.raises(nx.NetworkXError, nx.network_simplex, G)
 
 
-def create_graph(
-    has_large_capacity: bool = False,
-    has_large_weight: bool = False,
-    has_large_demand: bool = False,
-):
-    large_value = 1000000000
+@pytest.fixture()
+def faux_inf_example():
+    """Base test graph for probing faux_infinity bound. See gh-7562"""
     G = nx.DiGraph()
 
     # Add nodes with demands
-    if has_large_demand:
-        G.add_node("s0", demand=-large_value)
-        G.add_node("c1", demand=large_value)
-    else:
-        G.add_node("s0", demand=-4)
-        G.add_node("c1", demand=4)
-
+    G.add_node("s0", demand=-4)
     G.add_node("s1", demand=-4)
     G.add_node("ns", demand=0)
     G.add_node("nc", demand=0)
     G.add_node("c0", demand=4)
+    G.add_node("c1", demand=4)
 
-    # Add edges
-    if has_large_capacity:
-        G.add_edge("s0", "ns", weight=1, capacity=large_value)
-    else:
-        G.add_edge("s0", "ns")
-
-    if has_large_weight:
-        G.add_edge("s1", "ns", weight=large_value)
-    else:
-        G.add_edge("s1", "ns", weight=1)
-
+    # Uniformly weighted edges
+    G.add_edge("s0", "ns", weight=1)
+    G.add_edge("s1", "ns", weight=1)
     G.add_edge("ns", "nc", weight=1)
     G.add_edge("nc", "c0", weight=1)
     G.add_edge("nc", "c1", weight=1)
@@ -456,25 +440,29 @@ def create_graph(
     return G
 
 
-@pytest.mark.parametrize(
-    "has_large_capacity, has_large_weight, has_large_demand",
-    [
-        (True, True, True),
-        (True, True, False),
-        (True, False, True),
-        (True, False, False),
-        (False, True, True),
-        (False, True, False),
-        (False, False, True),
-        (False, False, False),
-    ],
-)
-def test_network_simplex_large_capacities(
-    has_large_capacity: bool, has_large_weight: bool, has_large_demand: bool
+@pytest.mark.parametrize("large_capacity", [True, False])
+@pytest.mark.parametrize("large_demand", [True, False])
+@pytest.mark.parametrize("large_weight", [True, False])
+def test_network_simplex_faux_infinity(
+    faux_inf_example, large_capacity, large_demand, large_weight
 ):
-    """Address issues raised in ticket #7562."""
-    graph = create_graph(has_large_capacity, has_large_weight, has_large_demand)
-    flow_value, flow_dict = nx.network_simplex(graph)
+    """network_simplex should not raise an exception as a result of faux_infinity
+    for these cases. See gh-7562"""
+    G = faux_inf_example
+    lv = 1_000_000_000
+
+    # Modify the base graph with combinations of large values for capacity,
+    # demand, and weight to probe faux_inifity
+    if large_capacity:
+        G["s0"]["ns"]["capacity"] = lv
+    if large_demand:
+        G.nodes["s0"]["demand"] = -lv
+        G.nodes["c1"]["demand"] = lv
+    if large_weight:
+        G["s1"]["ns"]["weight"] = lv
+
+    # Execute without raising
+    fc, fd = nx.network_simplex(G)
 
 
 def test_network_simplex_unbounded_flow():


### PR DESCRIPTION
Follow-up to #7796 

Just a refactor of the test for the `faux_infinity` bound that was added in #7796. The tests themselves should be the same, I've just modified the organization to:
 1) move the modifications of weight/demand/capacity into the test itself to make it more clear how the base example is being modified, and
 2) Use stacked fixtures to simplify the generation of test cases.