### PR TITLE
Rm stray instances of sparse matrices from test suite.

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -2,8 +2,6 @@ import pytest
 
 np = pytest.importorskip("numpy")
 sp = pytest.importorskip("scipy")
-sparse = pytest.importorskip("scipy.sparse")
-
 
 import networkx as nx
 from networkx.algorithms import bipartite

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -71,7 +71,7 @@ class TestBiadjacencyMatrix:
         assert nx.is_isomorphic(B1, B2)
 
     def test_from_biadjacency_weight(self):
-        M = sparse.csc_matrix([[1, 2], [0, 3]])
+        M = sp.sparse.csc_array([[1, 2], [0, 3]])
         B = bipartite.from_biadjacency_matrix(M)
         assert edges_equal(B.edges(), [(0, 2), (0, 3), (1, 3)])
         B = bipartite.from_biadjacency_matrix(M, edge_attribute="weight")
@@ -79,6 +79,6 @@ class TestBiadjacencyMatrix:
         assert edges_equal(B.edges(data=True), e)
 
     def test_from_biadjacency_multigraph(self):
-        M = sparse.csc_matrix([[1, 2], [0, 3]])
+        M = sp.sparse.csc_array([[1, 2], [0, 3]])
         B = bipartite.from_biadjacency_matrix(M, create_using=nx.MultiGraph())
         assert edges_equal(B.edges(), [(0, 2), (0, 3), (0, 3), (1, 3), (1, 3), (1, 3)])


### PR DESCRIPTION
Caught a couple remaining instances of `csc_matrix` while combing over code for #7859 !