### PR TITLE
Remove unused imports

### DIFF
--- a/doc/release/contribs.py
+++ b/doc/release/contribs.py
@@ -2,7 +2,6 @@
 # https://github.com/scikit-image/scikit-image/blob/main/tools/generate_release_notes.py
 from subprocess import check_output
 import sys
-import string
 import shlex
 
 if len(sys.argv) < 2 or len(sys.argv) > 3:

--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -4,7 +4,7 @@ Cycle finding algorithms
 ========================
 """
 
-from collections import Counter, defaultdict
+from collections import defaultdict
 from itertools import combinations, product
 from math import inf
 

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -2,7 +2,6 @@
 
 import bz2
 import importlib.resources
-import os
 import pickle
 
 import pytest

--- a/networkx/algorithms/flow/tests/test_mincost.py
+++ b/networkx/algorithms/flow/tests/test_mincost.py
@@ -1,6 +1,5 @@
 import bz2
 import importlib.resources
-import os
 import pickle
 
 import pytest

--- a/networkx/algorithms/flow/tests/test_networksimplex.py
+++ b/networkx/algorithms/flow/tests/test_networksimplex.py
@@ -1,6 +1,5 @@
 import bz2
 import importlib.resources
-import os
 import pickle
 
 import pytest

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -3,7 +3,6 @@ Tests for VF2 isomorphism algorithm.
 """
 
 import importlib.resources
-import os
 import random
 import struct
 

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,7 +1,5 @@
 """PageRank analysis of graph structure."""
 
-from warnings import warn
-
 import networkx as nx
 
 __all__ = ["pagerank", "google_matrix"]

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -1,6 +1,5 @@
 """Functions for computing and verifying matchings in a graph."""
 
-from collections import Counter
 from itertools import combinations, repeat
 
 import networkx as nx

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 import networkx as nx

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -5,8 +5,6 @@ These algorithms work with undirected and directed graphs.
 
 """
 
-import warnings
-
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/shortest_paths/unweighted.py
+++ b/networkx/algorithms/shortest_paths/unweighted.py
@@ -2,8 +2,6 @@
 Shortest path algorithms for unweighted graphs.
 """
 
-import warnings
-
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/tests/test_smallworld.py
+++ b/networkx/algorithms/tests/test_smallworld.py
@@ -2,8 +2,6 @@ import pytest
 
 pytest.importorskip("numpy")
 
-import random
-
 import networkx as nx
 from networkx import lattice_reference, omega, random_reference, sigma
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -13,7 +13,6 @@ General guidelines for writing good tests:
 """
 
 import os
-import sys
 import warnings
 from importlib.metadata import entry_points
 

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -16,7 +16,6 @@ See Also
 nx_agraph, nx_pydot
 """
 
-import warnings
 from collections.abc import Collection, Generator, Iterator
 
 import networkx as nx

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -18,7 +18,6 @@ See Also
  - DOT Language:  http://www.graphviz.org/doc/info/lang.html
 """
 
-import os
 import tempfile
 
 import networkx as nx

--- a/networkx/drawing/nx_latex.py
+++ b/networkx/drawing/nx_latex.py
@@ -127,9 +127,6 @@ TikZ:          https://tikz.dev/
 TikZ options details:   https://tikz.dev/tikz-actions
 """
 
-import numbers
-import os
-
 import networkx as nx
 
 __all__ = [

--- a/networkx/generators/atlas.py
+++ b/networkx/generators/atlas.py
@@ -4,8 +4,6 @@ Generators for the small graph atlas.
 
 import gzip
 import importlib.resources
-import os
-import os.path
 from itertools import islice
 
 import networkx as nx

--- a/networkx/generators/trees.py
+++ b/networkx/generators/trees.py
@@ -28,7 +28,6 @@ with a designated root node. A rooted forest is a disjoint union
 of rooted trees.
 """
 
-import warnings
 from collections import Counter, defaultdict
 from math import comb, factorial
 

--- a/networkx/linalg/algebraicconnectivity.py
+++ b/networkx/linalg/algebraicconnectivity.py
@@ -2,8 +2,6 @@
 Algebraic connectivity and Fiedler vectors of undirected graphs.
 """
 
-from functools import partial
-
 import networkx as nx
 from networkx.utils import (
     not_implemented_for,

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -30,7 +30,6 @@ Several example graphs in GML format may be found on Mark Newman's
 
 import html.entities as htmlentitydefs
 import re
-import warnings
 from ast import literal_eval
 from collections import defaultdict
 from enum import Enum

--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -3,7 +3,6 @@ Text-based visual representations of graphs
 """
 
 import sys
-import warnings
 from collections import defaultdict
 
 import networkx as nx
@@ -665,7 +664,7 @@ def _parse_network_text(lines):
         The graph corresponding to the lines in network text format.
     """
     from itertools import chain
-    from typing import Any, NamedTuple, Union
+    from typing import Any, NamedTuple
 
     class ParseStackFrame(NamedTuple):
         node: Any

--- a/networkx/tests/test_lazy_imports.py
+++ b/networkx/tests/test_lazy_imports.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import types
 

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -1,7 +1,5 @@
 import collections
-import os
 import typing
-import warnings
 from dataclasses import dataclass
 
 __all__ = ["Config"]

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -4,11 +4,7 @@ import gzip
 import inspect
 import itertools
 import re
-import warnings
 from collections import defaultdict
-from contextlib import contextmanager
-from functools import wraps
-from inspect import Parameter, signature
 from os.path import splitext
 from pathlib import Path
 

--- a/networkx/utils/misc.py
+++ b/networkx/utils/misc.py
@@ -12,10 +12,8 @@ can be accessed, for example, as
 """
 
 import random
-import sys
-import uuid
 import warnings
-from collections import defaultdict, deque
+from collections import defaultdict
 from collections.abc import Iterable, Iterator, Sized
 from itertools import chain, tee
 


### PR DESCRIPTION
Some more cleanup since we're in the mood for linting.

I did this by adding
```yaml
  - repo: https://github.com/PyCQA/autoflake
    rev: 0544741e2b4a22b472d9d93e37d4ea9153820bb1 # frozen: v2.3.1
    hooks:
      - id: autoflake
        args: [--in-place]
```
to `.pre-commit-config.yaml` locally.

I'll let somebody else decide whether we want to add this check to `.pre-commit-config.yaml`. Ideally, it would probably be best if `ruff` could take care of this to have it run faster and not add another tool that we need to update, but I haven't tried to do this.

Like a lot of other linting, I think it would be fine to run this every couple of years or so.