### PR TITLE
Propagate timeout to `optimal_edit_paths` and `optimize_graph_edit_distance`

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -224,6 +224,8 @@ def optimal_edit_paths(
     edge_del_cost=None,
     edge_ins_cost=None,
     upper_bound=None,
+    roots=None,
+    timeout=None,
 ):
     """Returns all minimum-cost edit paths transforming G1 to G2.
 
@@ -316,6 +318,16 @@ def optimal_edit_paths(
     upper_bound : numeric
         Maximum edit distance to consider.
 
+    roots : 2-tuple
+        Tuple where first element is a node in G1 and the second
+        is a node in G2.
+        These nodes are forced to be matched in the comparison to
+        allow comparison between rooted graphs.
+
+    timeout : numeric
+        Maximum number of seconds to execute.
+        After timeout is met, the current best GED is returned.
+
     Returns
     -------
     edit_paths : list of tuples (node_edit_path, edge_edit_path)
@@ -378,6 +390,8 @@ def optimal_edit_paths(
         edge_ins_cost,
         upper_bound,
         False,
+        roots,
+        timeout,
     ):
         # assert bestcost is None or cost <= bestcost
         if bestcost is not None and cost < bestcost:
@@ -400,6 +414,8 @@ def optimize_graph_edit_distance(
     edge_del_cost=None,
     edge_ins_cost=None,
     upper_bound=None,
+    roots=None,
+    timeout=None,
 ):
     """Returns consecutive approximations of GED (graph edit distance)
     between graphs G1 and G2.
@@ -494,6 +510,16 @@ def optimize_graph_edit_distance(
     upper_bound : numeric
         Maximum edit distance to consider.
 
+    roots : 2-tuple
+        Tuple where first element is a node in G1 and the second
+        is a node in G2.
+        These nodes are forced to be matched in the comparison to
+        allow comparison between rooted graphs.
+
+    timeout : numeric
+        Maximum number of seconds to execute.
+        After timeout is met, the current best GED is returned.
+
     Returns
     -------
     Generator of consecutive approximations of graph edit distance.
@@ -534,6 +560,8 @@ def optimize_graph_edit_distance(
         edge_ins_cost,
         upper_bound,
         True,
+        roots,
+        timeout,
     ):
         yield cost
 


### PR DESCRIPTION
`optimize_edit_paths` provides timeout functionality, but it is not made available to the functions `optimal_edit_paths` and `optimize_graph_edit_distance`.

This pull requests propagates the `timeout` parameter to those functions.