### PR TITLE
Remove unnecessary `dict(...)` for SSSP algos that return dicts

### DIFF
--- a/examples/basic/plot_properties.py
+++ b/examples/basic/plot_properties.py
@@ -15,7 +15,7 @@ pathlengths = []
 
 print("source vertex {target:length, }")
 for v in G.nodes():
-    spl = dict(nx.single_source_shortest_path_length(G, v))
+    spl = nx.single_source_shortest_path_length(G, v)
     print(f"{v} {spl} ")
     for p in spl:
         pathlengths.append(spl[p])

--- a/examples/drawing/plot_random_geometric_graph.py
+++ b/examples/drawing/plot_random_geometric_graph.py
@@ -25,7 +25,7 @@ for n in pos:
         dmin = d
 
 # color by path length from node near center
-p = dict(nx.single_source_shortest_path_length(G, ncenter))
+p = nx.single_source_shortest_path_length(G, ncenter)
 
 plt.figure(figsize=(8, 8))
 nx.draw_networkx_edges(G, pos, alpha=0.4)

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -459,7 +459,7 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     # Then, reachable and non reachable nodes from source in the
     # residual network form the node partition that defines
     # the minimum cut.
-    non_reachable = set(dict(nx.shortest_path_length(R, target=_t)))
+    non_reachable = set(nx.shortest_path_length(R, target=_t))
     partition = (set(flowG) - non_reachable, non_reachable)
     # Finally add again cutset edges to the residual network to make
     # sure that it is reusable.

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -111,7 +111,7 @@ class TestGenericPath:
 
     def test_shortest_path_length_target(self):
         answer = {0: 1, 1: 0, 2: 1}
-        sp = dict(nx.shortest_path_length(nx.path_graph(3), target=1))
+        sp = nx.shortest_path_length(nx.path_graph(3), target=1)
         assert sp == answer
         # with weights
         sp = nx.shortest_path_length(nx.path_graph(3), target=1, weight="weight")
@@ -147,16 +147,16 @@ class TestGenericPath:
         assert p == nx.single_source_shortest_path(self.cycle, 0)
 
     def test_single_source_shortest_path_length(self):
-        ans = dict(nx.shortest_path_length(self.cycle, 0))
+        ans = nx.shortest_path_length(self.cycle, 0)
         assert ans == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
         assert ans == nx.single_source_shortest_path_length(self.cycle, 0)
-        ans = dict(nx.shortest_path_length(self.grid, 1))
+        ans = nx.shortest_path_length(self.grid, 1)
         assert ans[16] == 6
         # now with weights
-        ans = dict(nx.shortest_path_length(self.cycle, 0, weight="weight"))
+        ans = nx.shortest_path_length(self.cycle, 0, weight="weight")
         assert ans == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
         assert ans == nx.single_source_dijkstra_path_length(self.cycle, 0)
-        ans = dict(nx.shortest_path_length(self.grid, 1, weight="weight"))
+        ans = nx.shortest_path_length(self.grid, 1, weight="weight")
         assert ans[16] == 6
         # weights and method specified
         ans = dict(

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -149,13 +149,13 @@ class TestGenericPath:
     def test_single_source_shortest_path_length(self):
         ans = dict(nx.shortest_path_length(self.cycle, 0))
         assert ans == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert ans == dict(nx.single_source_shortest_path_length(self.cycle, 0))
+        assert ans == nx.single_source_shortest_path_length(self.cycle, 0)
         ans = dict(nx.shortest_path_length(self.grid, 1))
         assert ans[16] == 6
         # now with weights
         ans = dict(nx.shortest_path_length(self.cycle, 0, weight="weight"))
         assert ans == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert ans == dict(nx.single_source_dijkstra_path_length(self.cycle, 0))
+        assert ans == nx.single_source_dijkstra_path_length(self.cycle, 0)
         ans = dict(nx.shortest_path_length(self.grid, 1, weight="weight"))
         assert ans[16] == 6
         # weights and method specified
@@ -163,14 +163,14 @@ class TestGenericPath:
             nx.shortest_path_length(self.cycle, 0, weight="weight", method="dijkstra")
         )
         assert ans == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert ans == dict(nx.single_source_dijkstra_path_length(self.cycle, 0))
+        assert ans == nx.single_source_dijkstra_path_length(self.cycle, 0)
         ans = dict(
             nx.shortest_path_length(
                 self.cycle, 0, weight="weight", method="bellman-ford"
             )
         )
         assert ans == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 2, 6: 1}
-        assert ans == dict(nx.single_source_bellman_ford_path_length(self.cycle, 0))
+        assert ans == nx.single_source_bellman_ford_path_length(self.cycle, 0)
 
     def test_single_source_all_shortest_paths(self):
         cycle_ans = {0: [[0]], 1: [[0, 1]], 2: [[0, 1, 2], [0, 3, 2]], 3: [[0, 3]]}

--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -118,7 +118,7 @@ class TestWeightedPath(WeightedTestBase):
         validate_path(
             self.XG, "s", "v", 9, nx.single_source_dijkstra_path(self.XG, "s")["v"]
         )
-        assert dict(nx.single_source_dijkstra_path_length(self.XG, "s"))["v"] == 9
+        assert nx.single_source_dijkstra_path_length(self.XG, "s")["v"] == 9
 
         validate_path(
             self.XG, "s", "v", 9, nx.single_source_dijkstra(self.XG, "s")[1]["v"]

--- a/networkx/algorithms/tests/test_dominance.py
+++ b/networkx/algorithms/tests/test_dominance.py
@@ -120,7 +120,7 @@ class TestDominanceFrontiers:
         """
         edges = [(1, 2), (2, 1), (3, 2), (4, 1), (5, 3), (5, 4)]
         G = nx.DiGraph(edges)
-        assert dict(nx.dominance_frontiers(G, 5).items()) == {
+        assert nx.dominance_frontiers(G, 5) == {
             1: {2},
             2: {1},
             3: {2},

--- a/networkx/generators/ego.py
+++ b/networkx/generators/ego.py
@@ -58,7 +58,7 @@ def ego_graph(G, n, radius=1, center=True, undirected=False, distance=None):
         if distance is not None:
             sp, _ = nx.single_source_dijkstra(G, n, cutoff=radius, weight=distance)
         else:
-            sp = dict(nx.single_source_shortest_path_length(G, n, cutoff=radius))
+            sp = nx.single_source_shortest_path_length(G, n, cutoff=radius)
 
     H = G.subgraph(sp).copy()
     if not center:

--- a/networkx/utils/rcm.py
+++ b/networkx/utils/rcm.py
@@ -149,7 +149,7 @@ def pseudo_peripheral_node(G):
     lp = 0
     v = u
     while True:
-        spl = dict(nx.shortest_path_length(G, v))
+        spl = nx.shortest_path_length(G, v)
         l = max(spl.values())
         if l <= lp:
             break


### PR DESCRIPTION
When reviewing #7877, I noticed a call to `nx.single_source_shortest_path_length` was wrapped with `dict(...)`, which is now unnecessary (and to me was confusing/surprising). So, a quick `git grep` revealed where this pattern is occurring.

I updated tests too, which I think is helpful to ensure return types are correct for backends that implement these.