### PR TITLE
DOC: docstring changes to `to_dict_of_dicts` and `attr_matrix` and input name change in `min_fill_in_heuristic`

### DIFF
--- a/networkx/algorithms/approximation/treewidth.py
+++ b/networkx/algorithms/approximation/treewidth.py
@@ -132,16 +132,19 @@ class MinDegreeHeuristic:
         return None
 
 
-def min_fill_in_heuristic(graph):
+def min_fill_in_heuristic(graph_dict):
     """Implements the Minimum Degree heuristic.
+
+    graph_dict: dict keyed by node to sets of neighbors (no self-loops)
 
     Returns the node from the graph, where the number of edges added when
     turning the neighborhood of the chosen node into clique is as small as
     possible. This algorithm chooses the nodes using the Minimum Fill-In
     heuristic. The running time of the algorithm is :math:`O(V^3)` and it uses
-    additional constant memory."""
+    additional constant memory.
+    """
 
-    if len(graph) == 0:
+    if len(graph_dict) == 0:
         return None
 
     min_fill_in_node = None
@@ -149,20 +152,20 @@ def min_fill_in_heuristic(graph):
     min_fill_in = sys.maxsize
 
     # sort nodes by degree
-    nodes_by_degree = sorted(graph, key=lambda x: len(graph[x]))
-    min_degree = len(graph[nodes_by_degree[0]])
+    nodes_by_degree = sorted(graph_dict, key=lambda x: len(graph_dict[x]))
+    min_degree = len(graph_dict[nodes_by_degree[0]])
 
     # abort condition (handle complete graph)
-    if min_degree == len(graph) - 1:
+    if min_degree == len(graph_dict) - 1:
         return None
 
     for node in nodes_by_degree:
         num_fill_in = 0
-        nbrs = graph[node]
+        nbrs = graph_dict[node]
         for nbr in nbrs:
             # count how many nodes in nbrs current nbr is not connected to
             # subtract 1 for the node itself
-            num_fill_in += len(nbrs - graph[nbr]) - 1
+            num_fill_in += len(nbrs - graph_dict[nbr]) - 1
             if num_fill_in >= 2 * min_fill_in:
                 break
 
@@ -193,33 +196,33 @@ def treewidth_decomp(G, heuristic=min_fill_in_heuristic):
     """
 
     # make dict-of-sets structure
-    graph = {n: set(G[n]) - {n} for n in G}
+    graph_dict = {n: set(G[n]) - {n} for n in G}
 
     # stack containing nodes and neighbors in the order from the heuristic
     node_stack = []
 
     # get first node from heuristic
-    elim_node = heuristic(graph)
+    elim_node = heuristic(graph_dict)
     while elim_node is not None:
         # connect all neighbors with each other
-        nbrs = graph[elim_node]
+        nbrs = graph_dict[elim_node]
         for u, v in itertools.permutations(nbrs, 2):
-            if v not in graph[u]:
-                graph[u].add(v)
+            if v not in graph_dict[u]:
+                graph_dict[u].add(v)
 
         # push node and its current neighbors on stack
         node_stack.append((elim_node, nbrs))
 
-        # remove node from graph
-        for u in graph[elim_node]:
-            graph[u].remove(elim_node)
+        # remove node from graph_dict
+        for u in graph_dict[elim_node]:
+            graph_dict[u].remove(elim_node)
 
-        del graph[elim_node]
-        elim_node = heuristic(graph)
+        del graph_dict[elim_node]
+        elim_node = heuristic(graph_dict)
 
     # the abort condition is met; put all remaining nodes into one bag
     decomp = nx.Graph()
-    first_bag = frozenset(graph.keys())
+    first_bag = frozenset(graph_dict.keys())
     decomp.add_node(first_bag)
 
     treewidth = len(first_bag) - 1

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -259,15 +259,16 @@ def to_dict_of_dicts(G, nodelist=None, edge_data=None):
        A NetworkX graph
 
     nodelist : list
-       Use only nodes specified in nodelist
+       Use only nodes specified in nodelist. If None, all nodes in G.
 
-    edge_data : scalar, optional
+    edge_data : scalar, optional (default: the G edgedatadict for each edge)
        If provided, the value of the dictionary will be set to `edge_data` for
        all edges. Usual values could be `1` or `True`. If `edge_data` is
        `None` (the default), the edgedata in `G` is used, resulting in a
        dict-of-dict-of-dicts. If `G` is a MultiGraph, the result will be a
        dict-of-dict-of-dict-of-dicts. See Notes for an approach to customize
-       handling edge data. `edge_data` should *not* be a container.
+       handling edge data. `edge_data` should *not* be a container as it will
+       be the same container for all the edges.
 
     Returns
     -------

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -348,8 +348,8 @@ def attr_sparse_matrix(
 
     rc_order : list, optional (default: order of nodes in G)
         A list of the node attribute values. This list specifies the ordering
-        of rows and columns of the array. If no ordering is provided, then
-        the ordering will be random (and also, a return value).
+        of rows and columns of the array and the return value. If no ordering
+        is provided, then the ordering will be that of nodes in `G`.
 
     Other Parameters
     ----------------

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -191,7 +191,7 @@ def attr_matrix(
         A list of the node attribute values. This list specifies the ordering
         of rows and columns of the array. If no ordering is provided, then
         the ordering will be the same as the node order in `G`.
-        When `rc_order` is `None`, the function returns a 2-tuple `(matrix, ordering)`
+        When `rc_order` is `None`, the function returns a 2-tuple ``(matrix, ordering)``
 
     Other Parameters
     ----------------

--- a/networkx/linalg/attrmatrix.py
+++ b/networkx/linalg/attrmatrix.py
@@ -12,8 +12,8 @@ def _node_value(G, node_attr):
 
     We return a function expecting a node as its sole argument. Then, in the
     simplest scenario, the returned function will return G.nodes[u][node_attr].
-    However, we also handle the case when `node_attr` is None or when it is a
-    function itself.
+    However, we also handle the case when `node_attr` is None (returns the node)
+    or when `node_attr` is a function itself.
 
     Parameters
     ----------
@@ -169,7 +169,7 @@ def attr_matrix(
     G : graph
         The NetworkX graph used to construct the attribute matrix.
 
-    edge_attr : str, optional
+    edge_attr : str, optional (default: number of edges for each matrix element)
         Each element of the matrix represents a running total of the
         specified edge attribute for edges whose node attributes correspond
         to the rows/cols of the matrix. The attribute must be present for
@@ -177,20 +177,21 @@ def attr_matrix(
         just count the number of edges whose node attributes correspond
         to the matrix element.
 
-    node_attr : str, optional
+    node_attr : str, optional (default: use nodes of the graph)
         Each row and column in the matrix represents a particular value
         of the node attribute.  The attribute must be present for all nodes
         in the graph. Note, the values of this attribute should be reliably
         hashable. So, float values are not recommended. If no attribute is
         specified, then the rows and columns will be the nodes of the graph.
 
-    normalized : bool, optional
+    normalized : bool, optional (default: False)
         If True, then each row is normalized by the summation of its values.
 
-    rc_order : list, optional
+    rc_order : list, optional (default: order of nodes in G)
         A list of the node attribute values. This list specifies the ordering
         of rows and columns of the array. If no ordering is provided, then
-        the ordering will be random (and also, a return value).
+        the ordering will be the same as the node order in `G`.
+        When `rc_order` is `None`, the function returns a 2-tuple `(matrix, ordering)`
 
     Other Parameters
     ----------------
@@ -327,7 +328,7 @@ def attr_sparse_matrix(
     G : graph
         The NetworkX graph used to construct the NumPy matrix.
 
-    edge_attr : str, optional
+    edge_attr : str, optional (default: number of edges for each matrix element)
         Each element of the matrix represents a running total of the
         specified edge attribute for edges whose node attributes correspond
         to the rows/cols of the matrix. The attribute must be present for
@@ -335,17 +336,17 @@ def attr_sparse_matrix(
         just count the number of edges whose node attributes correspond
         to the matrix element.
 
-    node_attr : str, optional
+    node_attr : str, optional (default: use nodes of the graph)
         Each row and column in the matrix represents a particular value
         of the node attribute.  The attribute must be present for all nodes
         in the graph. Note, the values of this attribute should be reliably
         hashable. So, float values are not recommended. If no attribute is
         specified, then the rows and columns will be the nodes of the graph.
 
-    normalized : bool, optional
+    normalized : bool, optional (default: False)
         If True, then each row is normalized by the summation of its values.
 
-    rc_order : list, optional
+    rc_order : list, optional (default: order of nodes in G)
         A list of the node attribute values. This list specifies the ordering
         of rows and columns of the array. If no ordering is provided, then
         the ordering will be random (and also, a return value).


### PR DESCRIPTION
This finishes up Issue #6804 to follow-up on warts found during the `_dispatch` code audit. 
Fixes #6804

It includes:
- changing the input name `graph` to `graph_dict` in `min_fill_in_heuristic` as it needs to be a dict-of-neighbor-sets rather than a networkx graph.
- updated the doc-strings of `to_dict_of_dicts()` to explain that input `edge_data` is a scalar value, that it should not be a container, and that it's default is the full edgedata dict from the graph (which is not a scalar value). 
- updated the doc-string of `attr_matrix()` and `attr_sparse_matrix` -- but I left the code requiring that every node/edge must have the requested attribute (no default for missing values).
 
I decided not to change some of the items -- they will still be warts (and are still unchecked in that issue's list, though with a note that it is by choice not to fix it). 
