### PR TITLE
Tweaks and notes from a dive into backends.py

### DIFF
--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -204,22 +204,6 @@ def _load_backend(backend_name):
 class _dispatchable:
     _is_testing = False
 
-#    class _fallback_to_nx:
-#        """Class property that returns ``nx.config.fallback_to_nx``."""
-#
-#        def __get__(self, instance, owner=None):
-#            warnings.warn(
-#                "`_dispatchable._fallback_to_nx` is deprecated and will be removed "
-#                "in NetworkX v3.5. Use `nx.config.fallback_to_nx` instead.",
-#                category=DeprecationWarning,
-#                stacklevel=2,
-#            )
-#            return nx.config.fallback_to_nx
-#
-#    # Note that chaining `@classmethod` and `@property` was removed in Python 3.13
-#    _fallback_to_nx = _fallback_to_nx()  # type: ignore[assignment,misc]
-#    _fallback_to_nx = nx.config.fallback_to_nx
-
     def __new__(
         cls,
         func=None,

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1,22 +1,26 @@
 # Notes about NetworkX namespace objects set up here:
 #
-# nx.backends.backends: dict keyed by backend name to their entry point object.
-#   Filled using ``_get_backends("networkx.backends")`` during processing this module.
+# nx.utils.backends.backends:
+#   dict keyed by backend name to the backend entry point object.
+#   Filled using ``_get_backends("networkx.backends")`` during import of this module.
 #
-# nx.backends.backend_info: dict keyed by backend name to the
-#   "networkx.backend_info" entry point object.
-#   Created as empty dict while importing this module, but filled using
-#   ``_set_configs_from_environment()`` at end of importing ``__init__.py``.
+# nx.utils.backends.backend_info:
+#   dict keyed by backend name to the metadata returned by the function indicated
+#   by the "networkx.backend_info" entry point.
+#   Created as an empty dict while importing this module, but later filled using
+#   ``_set_configs_from_environment()`` at end of importing ``networkx/__init__.py``.
 #
-# nx.config: Config object for NetworkX config setting. Creating using
-#   ``_set_configs_from_environment()`` at end of importing ``__init__.py``.
+# nx.config:
+#   Config object for NetworkX config setting. Created using
+#   ``_set_configs_from_environment()`` at end of importing ``networkx/__init__.py``.
 #
 # private dicts:
-#     nx.backends._loaded_backends:
-#         dict keyed by backend name to loaded entry_point
+#   nx.utils.backends._loaded_backends:
+#       dict used to memoize loaded backends. Keyed by backend name to loaded backends.
 #
-#     nx.backends._registered_algorithms:
-#         dict keyed by function name to dispatch wrapped function
+#   nx.utils.backends._registered_algorithms:
+#       dict of all the dispatchable functions in networkx, keyed by _dispatchable
+#       function name to the wrapped function object.
 
 import inspect
 import itertools
@@ -145,7 +149,7 @@ def _set_configs_from_environment():
         ),
     )
 
-    # Add "networkx" entry to backend_info now b/c backend_config is done reading it
+    # Add "networkx" item to backend_info now b/c backend_config is set up
     backend_info["networkx"] = {}
 
     # NETWORKX_BACKEND_PRIORITY is the same as NETWORKX_BACKEND_PRIORITY_ALGOS
@@ -347,7 +351,7 @@ class _dispatchable:
         self.__name__ = func.__name__
         # self.__doc__ = func.__doc__  # __doc__ handled as cached property
         self.__defaults__ = func.__defaults__
-        # We quietly add `backend=` keyword argument to allow backend to be specified
+        # Add `backend=` keyword argument to allow backend choice at call-time
         if func.__kwdefaults__:
             self.__kwdefaults__ = {**func.__kwdefaults__, "backend": None}
         else:

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -144,7 +144,7 @@ def _set_configs_from_environment():
         fallback_to_nx=bool(os.environ.get("NETWORKX_FALLBACK_TO_NX", False)),
         warnings_to_ignore=set(
             _comma_sep_to_list(os.environ.get("NETWORKX_WARNINGS_TO_IGNORE", ""))
-        )
+        ),
     )
 
     # add "networkx" backend_info after backend_config is done with backend_info

--- a/networkx/utils/tests/test_backends.py
+++ b/networkx/utils/tests/test_backends.py
@@ -167,14 +167,6 @@ def test_bad_backend_name():
         nx.null_graph(backend="this_backend_does_not_exist")
 
 
-def test_fallback_to_nx():
-    with pytest.warns(DeprecationWarning, match="_fallback_to_nx"):
-        # Check as class property
-        assert nx._dispatchable._fallback_to_nx == nx.config.fallback_to_nx
-        # Check as instance property
-        assert nx.pagerank.__wrapped__._fallback_to_nx == nx.config.fallback_to_nx
-
-
 def test_not_implemented_by_nx():
     assert "networkx" in nx.pagerank.backends
     assert "networkx" not in _stub_func.backends


### PR DESCRIPTION
I took a dive into some of `backends.py` and came up with these suggestions for notes and code tweaks to ease readability of some parts. Push back on any of this, and/or push up corrections, reversions, additions. 

None of these changes should be changing behavior of the code **except** that `_fallback_to_nx` seems to be due for deprecation (v3.5) so I removed it and the test of the deprecation warning. If there are other steps needed for deprecation of backend features, I can revert these or add those (or you can).
