### PR TITLE
Refactored the working of chordless_cycles to handle self loops

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -575,7 +575,7 @@ def chordless_cycles(G, length_bound=None):
     multigraph = G.is_multigraph()
 
     if multigraph:
-        yield from ([v] for v, Gv in G.adj.items() if 0 < len(Gv.get(v, ())) < 2)
+        yield from ([v] for v, Gv in G.adj.items() if len(Gv.get(v, ())) == 1)
     else:
         yield from ([v] for v, Gv in G.adj.items() if v in Gv)
 
@@ -588,10 +588,10 @@ def chordless_cycles(G, length_bound=None):
     self_loop_nodes = set(nx.nodes_with_selfloops(G))
     Gless = G.subgraph(set(G) - self_loop_nodes).copy()
     if directed:
-        F = nx.DiGraph((u, v) for u, Gu in Gless.adj.items() if u not in Gu for v in Gu)
+        F = nx.DiGraph(Gless)
         B = F.to_undirected(as_view=False)
     else:
-        F = nx.Graph((u, v) for u, Gu in Gless.adj.items() if u not in Gu for v in Gu)
+        F = nx.Graph(Gless)
         B = None
 
     # If we're given a multigraph, we have a few cases to consider with parallel

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -354,15 +354,6 @@ class TestCycleEnumeration:
         expected_cycles = [[1], [2], (3, 4)]
         self.check_cycle_algorithm(G, expected_cycles, chordless=True)
 
-    def test_chordless_cycles_multigraph_self_loops(self):
-        G = nx.MultiGraph([(1, 1), (2, 2), (1, 2), (1, 2)])
-        expected_cycles = [[1], [2]]
-        self.check_cycle_algorithm(G, expected_cycles, chordless=True)
-
-        G.add_edges_from([(2, 3), (3, 4), (3, 4), (1, 3)])
-        expected_cycles = [[1], [2], (3, 4)]
-        self.check_cycle_algorithm(G, expected_cycles, chordless=True)
-
     def test_directed_chordless_cycle_undirected(self):
         g = nx.DiGraph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 0), (5, 1), (0, 2)])
         expected_cycles = [(0, 2, 3, 4, 5), (1, 2, 3, 4, 5)]

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -354,6 +354,15 @@ class TestCycleEnumeration:
         expected = [[1], [2], (3, 4)] 
         self.check_cycle_algorithm(G, expected, chordless=True)
 
+    def test_chordless_cycles_multigraph_self_loops(self):
+        G = nx.MultiGraph([(1, 1), (2, 2), (1, 2), (1, 2)])
+        expected_cycles = [[1], [2]]
+        self.check_cycle_algorithm(G, expected_cycles, chordless=True)
+
+        G.add_edges_from([(2, 3), (3, 4), (3, 4), (1, 3)])
+        expected_cycles = [[1], [2], (3, 4)]
+        self.check_cycle_algorithm(G, expected_cycles, chordless=True)
+
     def test_directed_chordless_cycle_undirected(self):
         g = nx.DiGraph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 0), (5, 1), (0, 2)])
         expected_cycles = [(0, 2, 3, 4, 5), (1, 2, 3, 4, 5)]

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -1,6 +1,6 @@
+import random
 from itertools import chain, islice, tee
 from math import inf
-from random import shuffle
 
 import pytest
 
@@ -277,7 +277,8 @@ class TestCycleEnumeration:
         # enumeration algorithms
 
         relabel = list(range(len(g)))
-        shuffle(relabel)
+        rng = random.Random(42)
+        rng.shuffle(relabel)
         label = dict(zip(g, relabel))
         unlabel = dict(zip(relabel, g))
         h = nx.relabel_nodes(g, label, copy=True)
@@ -351,7 +352,7 @@ class TestCycleEnumeration:
         self.check_cycle_algorithm(G, expected_cycles, chordless=True)
 
         G.add_edges_from([(2, 3), (3, 4), (3, 4), (1, 3)])
-        expected_cycles = [[1], [2], (3, 4)]
+        expected_cycles = [[1], [2], [3, 4]]
         self.check_cycle_algorithm(G, expected_cycles, chordless=True)
 
     def test_directed_chordless_cycle_undirected(self):

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -344,15 +344,15 @@ class TestCycleEnumeration:
 
         expected_cycles = [c for c in expected_cycles if len(c) < 2]
         self.check_cycle_algorithm(g, expected_cycles, chordless=True, length_bound=1)
-        
+
     def test_chordless_cycles_multigraph_self_loops(self):
         G = nx.MultiGraph([(1, 1), (2, 2), (1, 2), (1, 2)])
-        expected = [[1], [2]]  
-        self.check_cycle_algorithm(G, expected, chordless=True)
-        
+        expected_cycles = [[1], [2]]
+        self.check_cycle_algorithm(G, expected_cycles, chordless=True)
+
         G.add_edges_from([(2, 3), (3, 4), (3, 4), (1, 3)])
-        expected = [[1], [2], (3, 4)] 
-        self.check_cycle_algorithm(G, expected, chordless=True)
+        expected_cycles = [[1], [2], (3, 4)]
+        self.check_cycle_algorithm(G, expected_cycles, chordless=True)
 
     def test_chordless_cycles_multigraph_self_loops(self):
         G = nx.MultiGraph([(1, 1), (2, 2), (1, 2), (1, 2)])

--- a/networkx/algorithms/tests/test_cycles.py
+++ b/networkx/algorithms/tests/test_cycles.py
@@ -344,6 +344,15 @@ class TestCycleEnumeration:
 
         expected_cycles = [c for c in expected_cycles if len(c) < 2]
         self.check_cycle_algorithm(g, expected_cycles, chordless=True, length_bound=1)
+        
+    def test_chordless_cycles_multigraph_self_loops(self):
+        G = nx.MultiGraph([(1, 1), (2, 2), (1, 2), (1, 2)])
+        expected = [[1], [2]]  
+        self.check_cycle_algorithm(G, expected, chordless=True)
+        
+        G.add_edges_from([(2, 3), (3, 4), (3, 4), (1, 3)])
+        expected = [[1], [2], (3, 4)] 
+        self.check_cycle_algorithm(G, expected, chordless=True)
 
     def test_directed_chordless_cycle_undirected(self):
         g = nx.DiGraph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 0), (5, 1), (0, 2)])


### PR DESCRIPTION
This PR addresses an issue in the `chordless_cycles` function where multigraphs with self-loops were not being correctly handled. Added test cases under `test_chordless_cycles_multigraph_self_loops` that verify :
1. Self-loops as single-node chordless cycles.
2. Parallel edges in a multigraph as two-node chordless cycles.

```
def test_chordless_cycles_multigraph_self_loops(self):
        G = nx.MultiGraph([(1, 1), (2, 2), (1, 2), (1, 2)])
        expected = [[1], [2]]  
        self.check_cycle_algorithm(G, expected, chordless=True)
        
        G.add_edges_from([(2, 3), (3, 4), (3, 4), (1, 3)])
        expected = [[1], [2], (3, 4)] 
        self.check_cycle_algorithm(G, expected, chordless=True)
```

Changes made include : 
1. Interpretation of self-loops to be chordless cycles, except in multigraphs with multiple loops in parallel.
2. Removing self loop nodes from being a further part of chordless cycles of length greater than 1.

Addresing issue #7867 
