### PR TITLE
Fixed the return type from an empty dict to an empty set

### DIFF
--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -207,8 +207,9 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
         Set of nodes that, if removed, would destroy all paths between
         source and target in G.
 
-        Returns an empty set if source and target are directly connected
-        by an edge in G, as no nodes can destroy their path.
+        Returns an empty set if source and target are either in different
+        components or are directly connected by an edge, as no node removal
+        can destroy the path.
 
     Examples
     --------

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -206,6 +206,9 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     cutset : set
         Set of nodes that, if removed, would destroy all paths between
         source and target in G.
+        
+        Returns an empty set if source and target are directly connected
+        by an edge in G, as no nodes can destroy their path.  
 
     Examples
     --------
@@ -291,7 +294,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     if mapping is None:
         raise nx.NetworkXError("Invalid auxiliary digraph.")
     if G.has_edge(s, t) or G.has_edge(t, s):
-        return {}
+        return set()
     kwargs = {"flow_func": flow_func, "residual": residual, "auxiliary": H}
 
     # The edge cut in the auxiliary digraph corresponds to the node cut in the

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -206,9 +206,9 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     cutset : set
         Set of nodes that, if removed, would destroy all paths between
         source and target in G.
-        
+
         Returns an empty set if source and target are directly connected
-        by an edge in G, as no nodes can destroy their path.  
+        by an edge in G, as no nodes can destroy their path.
 
     Examples
     --------

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -289,7 +289,7 @@ def tests_minimum_st_node_cut():
     G.add_nodes_from([0, 1, 2, 3, 7, 8, 11, 12])
     G.add_edges_from([(7, 11), (1, 11), (1, 12), (12, 8), (0, 1)])
     nodelist = minimum_st_node_cut(G, 7, 11)
-    assert nodelist == {}
+    assert nodelist == set()
 
 
 def test_invalid_auxiliary():


### PR DESCRIPTION
Addressing issues #7909 

This PR involves the suggested changes : 
1. fix the typo {} -> set()
2. Adding documentation text under the Returns section about when an empty set is returned.

Additional Changes : 
1. Fix test assertion `tests_minimum_st_node_cut()` by using set() instead of {} for empty set comparison.

