### PR TITLE
Fix write_gexf timeformat for dynamic Graphs

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -643,21 +643,21 @@ class GEXFWriter(GEXF):
         return node_or_edge_data
 
     def alter_graph_mode_timeformat(self, start_or_end):
-        # If 'start' or 'end' appears, alter Graph mode to dynamic and
-        # set timeformat
-        if self.graph_element.get("mode") == "static":
-            if start_or_end is not None:
-                if isinstance(start_or_end, str):
-                    timeformat = "date"
-                elif isinstance(start_or_end, float):
-                    timeformat = "double"
-                elif isinstance(start_or_end, int):
-                    timeformat = "long"
-                else:
-                    raise nx.NetworkXError(
-                        "timeformat should be of the type int, float or str"
-                    )
-                self.graph_element.set("timeformat", timeformat)
+        # If 'start' or 'end' appears, set timeformat
+        if start_or_end is not None:
+            if isinstance(start_or_end, str):
+                timeformat = "date"
+            elif isinstance(start_or_end, float):
+                timeformat = "double"
+            elif isinstance(start_or_end, int):
+                timeformat = "long"
+            else:
+                raise nx.NetworkXError(
+                    "timeformat should be of the type int, float or str"
+                )
+            self.graph_element.set("timeformat", timeformat)
+            # If Graph mode is static, alter to dynamic
+            if self.graph_element.get("mode") == "static":
                 self.graph_element.set("mode", "dynamic")
 
     def write(self, fh):

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -6,6 +6,28 @@ import pytest
 import networkx as nx
 
 
+@pytest.mark.parametrize("time_attr", ("start", "end"))
+@pytest.mark.parametrize("dyn_attr", ("static", "dynamic"))
+def test_dynamic_graph_has_timeformat(time_attr, dyn_attr, tmp_path):
+    """Ensure that graphs which have a 'start' or 'stop' attribute get a
+    'timeformat' attribute upon parsing. See gh-7914."""
+    G = nx.MultiGraph(mode=dyn_attr)
+    G.add_node(0)
+    G.nodes[0][time_attr] = 1
+    # Write out
+    fname = tmp_path / "foo.gexf"
+    nx.write_gexf(G, fname)
+    # Check that timeformat is added to saved data
+    with open(fname) as fh:
+        assert 'timeformat="long"' in fh.read()
+    # Round-trip
+    H = nx.read_gexf(fname)
+    # If any node has a "start" or "end" attr, it is considered dynamic
+    # regardless of the graph "mode" attr
+    assert H.graph["mode"] == "dynamic"
+    assert nx.utils.nodes_equal(G.edges, H.edges)
+
+
 class TestGEXF:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
When using write_gexf on a Graph containing start/end attributes, the Graph timeformat parameter was not set, breaking compatibility with the [gexf draft](https://gexf.net/1.2draft/gexf-12draft-primer.pdf). This ensures that the timeformat parameter is set in the .gexf <graph> tag.
 
Before this fix, the .gexf file obtained when using write_gexf on a dynamic graph would not contain a timeformat attribute in the graph tag. This made read_gexf unable to parse the Graph.

After this fix, the timeformat argument for the graph tag is saved on line 6 of the gexf file, ensuring that a dynamic Graph exported through write_gexf can then be loaded again through read_gexf.