### PR TITLE
Improve runtime of number_of_nonisomorphic_trees().

### DIFF
--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -45,6 +45,9 @@ def nonisomorphic_trees(order):
 def number_of_nonisomorphic_trees(order):
     """Returns the number of nonisomorphic trees
 
+    Based on an algorithm by Alois P. Heinz in
+    `OEIS entry A000055 <https://oeis.org/A000055>`_. Complexity is ``O(n ** 3)``
+
     Parameters
     ----------
     order : int
@@ -52,11 +55,8 @@ def number_of_nonisomorphic_trees(order):
 
     Returns
     -------
-    length : Number of nonisomorphic graphs for the given order
-
-    References
-    ----------
-    Based on an algorithm by Alois P. Heinz. Complexity is O(n ** 3).
+    int
+       Number of nonisomorphic graphs for the given order
     """
     if order < 2:
         raise ValueError

--- a/networkx/generators/nonisomorphic_trees.py
+++ b/networkx/generators/nonisomorphic_trees.py
@@ -9,6 +9,8 @@ the root.
 
 __all__ = ["nonisomorphic_trees", "number_of_nonisomorphic_trees"]
 
+from functools import lru_cache
+
 import networkx as nx
 
 
@@ -54,9 +56,37 @@ def number_of_nonisomorphic_trees(order):
 
     References
     ----------
-
+    Based on an algorithm by Alois P. Heinz. Complexity is O(n ** 3).
     """
-    return sum(1 for _ in nonisomorphic_trees(order))
+    if order < 2:
+        raise ValueError
+    return _unlabeled_trees(order)
+
+
+@lru_cache(None)
+def _unlabeled_trees(n):
+    """Implements OEIS A000055 (number of unlabeled trees)."""
+
+    value = 0
+    for k in range(n + 1):
+        value += _rooted_trees(k) * _rooted_trees(n - k)
+    if n % 2 == 0:
+        value -= _rooted_trees(n // 2)
+    return _rooted_trees(n) - value // 2
+
+
+@lru_cache(None)
+def _rooted_trees(n):
+    """Implements OEIS A000081 (number of unlabeled rooted trees)."""
+
+    if n < 2:
+        return n
+    value = 0
+    for j in range(1, n):
+        for d in range(1, n):
+            if j % d == 0:
+                value += d * _rooted_trees(d) * _rooted_trees(n - j)
+    return value // (n - 1)
 
 
 def _next_rooted_tree(predecessor, p=None):

--- a/networkx/generators/tests/test_nonisomorphic_trees.py
+++ b/networkx/generators/tests/test_nonisomorphic_trees.py
@@ -42,6 +42,10 @@ class TestGeneratorNonIsomorphicTrees:
         assert nx.number_of_nonisomorphic_trees(6) == 6
         assert nx.number_of_nonisomorphic_trees(7) == 11
         assert nx.number_of_nonisomorphic_trees(8) == 23
+        assert nx.number_of_nonisomorphic_trees(9) == 47
+        assert nx.number_of_nonisomorphic_trees(10) == 106
+        assert nx.number_of_nonisomorphic_trees(20) == 823065
+        assert nx.number_of_nonisomorphic_trees(30) == 14830871802
 
     def test_nonisomorphic_trees(self):
         def f(x):


### PR DESCRIPTION
The current implementation of number_of_nonisomorphic_trees() constructs all trees and output the amount of trees created, which is exponential. The proposed implementation computes directly the number, using an O(n**3) formula.