### PR TITLE
Add `edge_attrs="weight"` to `forceatlas2_layout` dispatch decorator

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1452,7 +1452,7 @@ def arf_layout(
 
 
 @np_random_state("seed")
-@nx._dispatchable(mutates_input={"store_pos_as": 15})
+@nx._dispatchable(edge_attrs="weight", mutates_input={"store_pos_as": 15})
 def forceatlas2_layout(
     G,
     pos=None,
@@ -1503,9 +1503,9 @@ def forceatlas2_layout(
         Maps nodes to their masses, influencing the attraction to other nodes.
     node_size : dict or None, optional
         Maps nodes to their sizes, preventing crowding by creating a halo effect.
-    weight : string or None, optional (default='weight')
+    weight : string or None, optional (default: None)
         The edge attribute that holds the numerical value used for
-        the edge weight.  If None, then all edge weights are 1.
+        the edge weight. If None, then all edge weights are 1.
     dissuade_hubs : bool (default: False)
         Prevents the clustering of hub nodes.
     linlog : bool (default: False)


### PR DESCRIPTION
This is a follow up to #7794 and #7915. The `weight=` parameter wasn't documented when `@nx._dispatchable` was added to FA2, so I/we completely missed its use. Anyway, this change makes sure the edge attribute is preserved if necessary when converting to a different backend.

Also, the default weight is None, not "weight".

CC @nv-rliu @rlratzel 