### PR TITLE
Some light refactoring to make the tree isomorphism tests more readable

### DIFF
--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -4,10 +4,6 @@ import time
 import pytest
 
 import networkx as nx
-from networkx.algorithms.isomorphism.tree_isomorphism import (
-    rooted_tree_isomorphism,
-    tree_isomorphism,
-)
 
 
 def test_long_paths_graphs():
@@ -124,7 +120,7 @@ def test_hardcoded():
     t2.add_edges_from(edges_2)
     root2 = "n"
 
-    isomorphism = sorted(rooted_tree_isomorphism(t1, root1, t2, root2))
+    isomorphism = sorted(nx.isomorphism.rooted_tree_isomorphism(t1, root1, t2, root2))
 
     # is correct by hand
     assert isomorphism in (isomorphism1, isomorphism2)
@@ -141,7 +137,7 @@ def test_hardcoded():
     t2.add_edges_from(edges_2)
     root2 = "n"
 
-    isomorphism = sorted(rooted_tree_isomorphism(t1, root1, t2, root2))
+    isomorphism = sorted(nx.isomorphism.rooted_tree_isomorphism(t1, root1, t2, root2))
 
     # is correct by hand
     assert isomorphism in (isomorphism1, isomorphism2)
@@ -185,13 +181,13 @@ def test_trivial_rooted_tree_isomorphism():
     t2 = nx.Graph()
     t2.add_node("n")
 
-    assert rooted_tree_isomorphism(t1, "a", t2, "n") == [("a", "n")]
+    assert nx.isomorphism.rooted_tree_isomorphism(t1, "a", t2, "n") == [("a", "n")]
 
 
 def test_rooted_tree_isomorphism_different_order():
     t1 = nx.Graph([("a", "b"), ("a", "c")])
     t2 = nx.Graph([("a", "b")])
-    assert tree_isomorphism(t1, t2) == []
+    assert nx.isomorphism.tree_isomorphism(t1, t2) == []
 
 
 # NOTE: number of nonisomorphic_trees grows very rapidly - do not increase n
@@ -200,7 +196,7 @@ def test_rooted_tree_isomorphism_different_order():
 def test_tree_isomorphism_all_non_isomorphic_pairs(n):
     test_trees = list(nx.nonisomorphic_trees(n))
     assert all(
-        tree_isomorphism(test_trees[i], test_trees[j]) == []
+        nx.isomorphism.tree_isomorphism(test_trees[i], test_trees[j]) == []
         for i in range(len(test_trees) - 1)
         for j in range(i + 1, len(test_trees))
     )

--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -6,10 +6,11 @@ import pytest
 import networkx as nx
 
 
-def test_long_paths_graphs():
-    """Smoke test for potential RecursionError. See gh-7945."""
-    G = nx.path_graph(10_000)
-    rooted_tree_isomorphism(G, 0, G, 0) == [(n, n) for n in G]
+def _check_isomorphism(t1, t2, isomorphism):
+    assert nx.is_directed(t1) == nx.is_directed(t2)
+    # Apply mapping and check for equality
+    H = nx.relabel_nodes(t1, dict(isomorphism))
+    return nx.utils.graphs_equal(t2, H)
 
 
 @pytest.mark.parametrize("graph_constructor", (nx.DiGraph, nx.MultiGraph))
@@ -35,13 +36,6 @@ def test_input_not_tree():
         nx.isomorphism.rooted_tree_isomorphism(not_tree, 0, tree, 0)
     with pytest.raises(nx.NetworkXError, match="t2 is not a tree"):
         nx.isomorphism.rooted_tree_isomorphism(tree, 0, not_tree, 0)
-
-
-def _check_isomorphism(t1, t2, isomorphism):
-    assert nx.is_directed(t1) == nx.is_directed(t2)
-    # Apply mapping and check for equality
-    H = nx.relabel_nodes(t1, dict(isomorphism))
-    return nx.utils.graphs_equal(t2, H)
 
 
 def test_hardcoded():
@@ -200,3 +194,9 @@ def test_tree_isomorphism_all_non_isomorphic_pairs(n):
         for i in range(len(test_trees) - 1)
         for j in range(i + 1, len(test_trees))
     )
+
+
+def test_long_paths_graphs():
+    """Smoke test for potential RecursionError. See gh-7945."""
+    G = nx.path_graph(10_000)
+    nx.isomorphism.rooted_tree_isomorphism(G, 0, G, 0) == [(n, n) for n in G]

--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -152,18 +152,18 @@ def test_tree_isomorphic_all_non_isomorphic_trees_relabeled(n):
     copy of itself with an arbitrary node-remapping."""
     for tree in nx.nonisomorphic_trees(n):
         nodes = list(tree)
-        shuffled = nodes.copy()
-        random.shuffle(shuffled)
+        random.shuffle(shuffled := nodes.copy())
         node_mapping = dict(zip(nodes, shuffled))
-        # Randomly order edges to ensure no dependence on node order within edges
-        new_edges = [
-            (node_mapping[u], node_mapping[v])
-            if random.randint(0, 1)
-            else (node_mapping[v], node_mapping[u])
-            for (u, v) in tree.edges
-        ]
         # Shuffle the edge list to ensure no dependence on edge order
-        random.shuffle(new_edges)
+        random.shuffle(
+            new_edges := [
+                # Randomly order edges to ensure no dependence on node order within edges
+                (node_mapping[u], node_mapping[v])
+                if random.randint(0, 1)
+                else (node_mapping[v], node_mapping[u])
+                for (u, v) in tree.edges
+            ]
+        )
         relabeled = nx.Graph(new_edges)
         # Does not necessarily have to be the same as node_mapping
         iso_mapping = nx.isomorphism.tree_isomorphism(tree, relabeled)

--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -204,43 +204,20 @@ def test_positive(maxk=14):
             trial += 1
 
 
-# test the trivial case of a single node in each tree
-# note that nonisomorphic_trees doesn't work for k = 1
-def test_trivial():
-    # back to an undirected graph
+def test_trivial_rooted_tree_isomorphism():
     t1 = nx.Graph()
     t1.add_node("a")
-    root1 = "a"
 
     t2 = nx.Graph()
     t2.add_node("n")
-    root2 = "n"
 
-    isomorphism = rooted_tree_isomorphism(t1, root1, t2, root2)
-
-    assert isomorphism == [("a", "n")]
-
-    assert check_isomorphism(t1, t2, isomorphism)
+    assert rooted_tree_isomorphism(t1, "a", t2, "n") == [("a", "n")]
 
 
-# test another trivial case where the two graphs have
-# different numbers of nodes
-def test_trivial_2():
-    edges_1 = [("a", "b"), ("a", "c")]
-
-    edges_2 = [("v", "y")]
-
-    t1 = nx.Graph()
-    t1.add_edges_from(edges_1)
-
-    t2 = nx.Graph()
-    t2.add_edges_from(edges_2)
-
-    isomorphism = tree_isomorphism(t1, t2)
-
-    # they cannot be isomorphic,
-    # since they have different numbers of nodes
-    assert isomorphism == []
+def test_rooted_tree_isomorphism_different_order():
+    t1 = nx.Graph([("a", "b"), ("a", "c")])
+    t2 = nx.Graph([("a", "b")])
+    assert tree_isomorphism(t1, t2) == []
 
 
 # the function nonisomorphic_trees generates all the non-isomorphic


### PR DESCRIPTION
Something I noticed while reviewing other related work.

The `test_tree_isomorphism.py` bit of the test suite had a lot of helper functions that IMO made the tests harder to follow than they could be.

The biggest change hereis captured in the first commit 1f3b75f which replaces the custom isomorphism checking functionality with a simpler check: essential relabel the nodes with the given isomorphism and check `nx.utils.graphs_equal`.

The other big-ish change is refactoring the two tests which check *all* nonisomorphic trees for various numbers of nodes. There are two tests:
 - one that tests that all nonisomorphic trees are isomorphic with themselves, with their nodes
   relabeled, and
 - one that tests that all pairs of nonisomorphic trees are not isomorphic with one another.

In practice I think these test cases may be overkill, but I'm not proposing to remove them here - I simply refactored them so that they are parametrized on the number of nodes `n`, which helps when the tests are run in parallel, as the maximum runtime decreases by about 30-40% for these cases.

My main intention though was to make things easier to read!