### PR TITLE
Refactor tree_isomorphism to improve code reuse and readability

### DIFF
--- a/networkx/algorithms/isomorphism/tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tree_isomorphism.py
@@ -18,6 +18,8 @@ by Matthew Suderman
 http://crypto.cs.mcgill.ca/~crepeau/CS250/2004/HW5+.pdf
 """
 
+from collections import defaultdict
+
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
@@ -69,28 +71,6 @@ def root_trees(t1, root1, t2, root2):
         namemap[new] = old
 
     return (dT, namemap, newroot1, newroot2)
-
-
-# figure out the level of each node, with 0 at root
-@nx._dispatchable
-def assign_levels(G, root):
-    level = {}
-    level[root] = 0
-    for v1, v2 in nx.bfs_edges(G, root):
-        level[v2] = level[v1] + 1
-
-    return level
-
-
-# now group the nodes at each level
-def group_by_levels(levels):
-    L = {}
-    for n, lev in levels.items():
-        if lev not in L:
-            L[lev] = []
-        L[lev].append(n)
-
-    return L
 
 
 @nx._dispatchable(graphs={"t1": 0, "t2": 2})
@@ -150,14 +130,13 @@ def rooted_tree_isomorphism(t1, root1, t2, root2):
     # with unique names
     (dT, namemap, newroot1, newroot2) = root_trees(t1, root1, t2, root2)
 
-    # compute the distance from the root, with 0 for our
-    levels = assign_levels(dT, 0)
+    # Group nodes by their distance from the root
+    L = defaultdict(list)
+    for n, dist in nx.shortest_path_length(dT, source=0).items():
+        L[dist].append(n)
 
     # height
-    h = max(levels.values())
-
-    # collect nodes into a dict by level
-    L = group_by_levels(levels)
+    h = max(L)
 
     # each node has a label, initially set to 0
     label = {v: 0 for v in dT}

--- a/networkx/algorithms/isomorphism/tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tree_isomorphism.py
@@ -256,15 +256,9 @@ def tree_isomorphism(t1, t2):
     if not nx.is_tree(t2):
         raise nx.NetworkXError("t2 is not a tree")
 
-    # To be isomorphic, t1 and t2 must have the same number of nodes.
-    if nx.number_of_nodes(t1) != nx.number_of_nodes(t2):
-        return []
-
-    # Another shortcut is that the sorted degree sequences need to be the same.
-    degree_sequence1 = sorted(d for (_, d) in t1.degree())
-    degree_sequence2 = sorted(d for (_, d) in t2.degree())
-
-    if degree_sequence1 != degree_sequence2:
+    # To be isomorphic, t1 and t2 must have the same number of nodes and sorted
+    # degree sequences
+    if not nx.faster_could_be_isomorphic(t1, t2):
         return []
 
     # A tree can have either 1 or 2 centers.


### PR DESCRIPTION
A few more minor improvements while working my way through the tree_isomorphism module (fun!)

There are two main bits in this PR where I've attempted to replace custom code with built-in functions:
 1. `tree_isomorphism` essentially implements the `faster_could_be_isomorphic` check before it actually begins searching for tree isomorphisms. I've replaced it with an explicit call to `faster_could_be_isomorphic`.
 2. `rooted_tree_isomorphism` relied on two helper functions `assign_levels` and `group_by_levels` to set up the algorithm. Upon closer inspection, I think these two functions are equivalent to grouping nodes by their shortest path length to the root node - so I've replaced them with the 3-liner to do this grouping (using `defaultdict(list)`). Technically these functions are "public", but they are so specialized here that I doubt they see heavy use in user-code. In other words, I'm hoping we can get away with simply removing them without a deprecation cycle... however if we want to be safe I'm happy to do so!