### PR TITLE
feat(cytoscape): adds read_cytoscape and write_cytoscape

### DIFF
--- a/doc/reference/readwrite/cytoscape.rst
+++ b/doc/reference/readwrite/cytoscape.rst
@@ -1,0 +1,10 @@
+Cytoscape
+=======
+.. automodule:: networkx.readwrite.cytoscape
+.. autosummary::
+   :toctree: generated/
+
+   read_cytoscape
+   write_cytoscape
+
+

--- a/networkx/readwrite/__init__.py
+++ b/networkx/readwrite/__init__.py
@@ -14,4 +14,5 @@ from networkx.readwrite.gml import *
 from networkx.readwrite.graphml import *
 from networkx.readwrite.gexf import *
 from networkx.readwrite.json_graph import *
+from networkx.readwrite.cytoscape import *
 from networkx.readwrite.text import *

--- a/networkx/readwrite/cytoscape.py
+++ b/networkx/readwrite/cytoscape.py
@@ -1,0 +1,103 @@
+import json
+
+import networkx as nx
+from networkx.utils import open_file
+
+__all__ = ["write_cytoscape", "read_cytoscape"]
+
+
+@open_file(1, mode="wb")
+def write_cytoscape(G, path, name="name", id="id", **kwargs):
+    """Write G in Cytoscape JSON format to path.
+
+    This function uses Python's json module.
+
+    Parameters
+    ----------
+    G : graph
+       A networkx graph
+    path : file or string
+       File or filename to write.
+       Filenames ending in .gz or .bz2 will be compressed.
+    name : string
+        A string which is mapped to the 'name' node element in cyjs format.
+        Must not have the same value as `ident`.
+    ident : string
+        A string which is mapped to the 'id' node element in cyjs format.
+        Must not have the same value as `name`.
+
+    Raises
+    ------
+    NetworkXError
+        If the values for `name` and `ident` are identical.
+
+    See Also
+    --------
+    read_cytoscape: read a graph from a Cytoscape JSON file (cyjs)
+    cytoscape_data: convert a NetworkX graph to a Python dictionary following Cytcoscape data structure.
+
+    References
+    ----------
+    .. [1] Cytoscape user's manual:
+       http://manual.cytoscape.org/en/stable/index.html
+
+    Examples
+    --------
+    >>> G = nx.path_graph(4)
+    >>> nx.write_cytoscape(G, "fourpath.cyjs")
+    """
+    import json
+
+    data = nx.json_graph.cytoscape_data(G, name=name, ident=id)
+    path.write(json.dumps(data, **kwargs).encode("ascii"))
+
+
+@open_file(0, mode="rb")
+@nx._dispatchable(graphs=None, returns_graph=True)
+def read_cytoscape(path, name="name", ident="ident", **kwargs):
+    """Read graph in GML format from `path`.
+
+    Parameters
+    ----------
+    path : file or string
+        Filename or file handle to read.
+        Filenames ending in .gz or .bz2 will be decompressed.
+    name : string
+        A string which is mapped to the 'name' node element in cyjs format.
+        Must not have the same value as `ident`.
+    ident : string
+        A string which is mapped to the 'id' node element in cyjs format.
+        Must not have the same value as `name`.
+
+    Returns
+    -------
+    graph : a NetworkX graph instance
+        The `graph` can be an instance of `Graph`, `DiGraph`, `MultiGraph`, or
+        `MultiDiGraph` depending on the input data.
+
+    Raises
+    ------
+    NetworkXError
+        If the `name` and `ident` attributes are identical.
+
+    See Also
+    --------
+    write_cytoscape: write a graph to a Cytoscape JSON file (cyjs).
+    cytoscape_graph: convert a dictionary following Cytoscape data structure to a graph.
+
+    References
+    ----------
+    .. [1] Cytoscape user's manual:
+       http://manual.cytoscape.org/en/stable/index.html
+
+    Examples
+    --------
+    >>> G = nx.path_graph(4)
+    >>> nx.write_cytoscape(G, "test.cyjs")
+    >>> H = nx.read_cytoscape("test.cyjs")
+    >>> H.nodes
+    NodeView((0, 1, 2, 3))
+    """
+
+    data = json.load(path, **kwargs)
+    return nx.json_graph.cytoscape_graph(data, name=name, ident=ident)

--- a/networkx/readwrite/json_graph/cytoscape.py
+++ b/networkx/readwrite/json_graph/cytoscape.py
@@ -4,7 +4,7 @@ __all__ = ["cytoscape_data", "cytoscape_graph"]
 
 
 def cytoscape_data(G, name="name", ident="id"):
-    """Returns data in Cytoscape JSON format (cyjs).
+    """Returns data in a dictionary, following the Cytoscape adjacency data structure (cyjs).
 
     Parameters
     ----------
@@ -83,7 +83,7 @@ def cytoscape_data(G, name="name", ident="id"):
 @nx._dispatchable(graphs=None, returns_graph=True)
 def cytoscape_graph(data, name="name", ident="id"):
     """
-    Create a NetworkX graph from a dictionary in cytoscape JSON format.
+    Create a NetworkX graph from a dictionary in cytoscape data structure.
 
     Parameters
     ----------

--- a/networkx/readwrite/tests/cytoscape.py
+++ b/networkx/readwrite/tests/cytoscape.py
@@ -1,0 +1,48 @@
+import pytest
+
+import networkx as nx
+
+
+def write_and_read(G, tmp_path):
+    fname = tmp_path / "cytoscape.cyjs"
+    nx.write_cytoscape(G, fname)
+    return nx.read_cytoscape(fname)
+
+
+def test_graph(tmp_path):
+    G = nx.path_graph(4)
+    H = write_and_read(G, tmp_path)
+    assert nx.is_isomorphic(G, H)
+
+
+def test_digraph(tmp_path):
+    G = nx.DiGraph()
+    nx.add_path(G, [1, 2, 3])
+    H = write_and_read(G, tmp_path)
+    assert H.is_directed()
+    assert nx.is_isomorphic(G, H)
+
+
+def test_multidigraph(tmp_path):
+    G = nx.MultiDiGraph()
+    nx.add_path(G, [1, 2, 3])
+    H = write_and_read(G, tmp_path)
+    assert H.is_directed()
+    assert H.is_multigraph()
+
+
+def test_multigraph(tmp_path):
+    G = nx.MultiGraph()
+    G.add_edge(1, 2, key="first")
+    G.add_edge(1, 2, key="second", color="blue")
+    H = write_and_read(G, tmp_path)
+    assert nx.is_isomorphic(G, H)
+    assert H[1][2]["second"]["color"] == "blue"
+
+
+def test_exception(tmp_path):
+    with pytest.raises(nx.NetworkXError):
+        G = nx.MultiDiGraph()
+        fname = tmp_path / "cytoscape.cyjs"
+        nx.write_cytoscape(G, fname, name="foo", ident="foo")
+        H = nx.read_cytoscape(fname, name="foo", ident="foo")


### PR DESCRIPTION
- Follows the same API conventions as other file formats.
- Fixes #7913 ("Cytoscape JSON is not valid") by allowing to read/write valid CYJS files.

Refs: #7913