### PR TITLE
Improving rooted_tree_isomorphism for deep trees

### DIFF
--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -295,3 +295,12 @@ def test_negative(maxk=11):
             for j in range(i + 1, len(test_trees)):
                 trial += 1
                 assert tree_isomorphism(test_trees[i], test_trees[j]) == []
+
+
+# test case where two path graphs are isomorphic. We test with long paths to
+# catch potential RecursionError
+def test_long_paths_graphs():
+    length = 10000
+    G1 = nx.path_graph(length)
+    G2 = nx.path_graph(length)
+    rooted_tree_isomorphism(G1, 0, G2, 0) == [(x, x) for x in range(length)]

--- a/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py
@@ -297,10 +297,7 @@ def test_negative(maxk=11):
                 assert tree_isomorphism(test_trees[i], test_trees[j]) == []
 
 
-# test case where two path graphs are isomorphic. We test with long paths to
-# catch potential RecursionError
 def test_long_paths_graphs():
-    length = 10000
-    G1 = nx.path_graph(length)
-    G2 = nx.path_graph(length)
-    rooted_tree_isomorphism(G1, 0, G2, 0) == [(x, x) for x in range(length)]
+    """Smoke test for potential RecursionError. See gh-7945."""
+    G = nx.path_graph(10_000)
+    rooted_tree_isomorphism(G, 0, G, 0) == [(n, n) for n in G]

--- a/networkx/algorithms/isomorphism/tree_isomorphism.py
+++ b/networkx/algorithms/isomorphism/tree_isomorphism.py
@@ -95,11 +95,16 @@ def group_by_levels(levels):
 
 # now lets get the isomorphism by walking the ordered_children
 def generate_isomorphism(v, w, M, ordered_children):
-    # make sure tree1 comes first
-    assert v < w
-    M.append((v, w))
-    for i, (x, y) in enumerate(zip(ordered_children[v], ordered_children[w])):
-        generate_isomorphism(x, y, M, ordered_children)
+    # Start with the initial pair in the stack
+    stack = [(v, w)]
+    while stack:
+        curr_v, curr_w = stack.pop()
+        assert curr_v < curr_w
+        M.append((curr_v, curr_w))
+        # Zip children and push them in reverse order to maintain processing order.
+        stack.extend(
+            zip(reversed(ordered_children[curr_v]), reversed(ordered_children[curr_w]))
+        )
 
 
 @nx._dispatchable(graphs={"t1": 0, "t2": 2})


### PR DESCRIPTION
# Convert `generate_isomorphism` to an Iterative Implementation 

I was looking at tree isomorphism logic when reviewing https://github.com/networkx/networkx/pull/7929 and realized implementation was using a recursive approach to compute the node mapping. This can be problematic with deep trees because it can lead to `RecursionError` exceptions.

@rossbar since you are already working on this module please let me know if you are already working on this particular improvement. Happy to drop this PR!

## Summary  

This PR refactors the `generate_isomorphism` function to replace its recursive implementation with an iterative approach using an explicit stack. The change is intended to prevent potential stack overflow issues when dealing with deeply nested trees (e.g., long path graphs).  

## Changes Made  

- Converted `generate_isomorphism` from a recursive function to an iterative one using a stack.  
- Ensured that child nodes are pushed onto the stack in reverse order to maintain the original left-to-right processing order.  
- Removed the previous recursive implementation.  

## Reason for Change  

The recursive implementation could cause a `RecursionError` for deep trees, such as long path graphs. This issue was observed in test cases with large trees (e.g., `test_long_paths_graphs`). By converting the function to an iterative version, we avoid excessive recursion depth and improve performance for large inputs.  

## Implementation Details  

Previous recursive version:  

```python  
def generate_isomorphism(v, w, M, ordered_children):  
    assert v < w  
    M.append((v, w))  
    for x, y in zip(ordered_children[v], ordered_children[w]):  
        generate_isomorphism(x, y, M, ordered_children) 
``` 

New iterative version:

```python
def generate_isomorphism(v, w, M, ordered_children):  
    stack = [(v, w)]  
    while stack:  
        curr_v, curr_w = stack.pop()  
        assert curr_v < curr_w  
        M.append((curr_v, curr_w))  
        stack.extend(  
            zip(reversed(ordered_children[curr_v]), reversed(ordered_children[curr_w]))  
        )  
```

## Testing
- Verified that all existing test cases pass
- Added a new test test_long_paths_graphs to validate two long path graphs
- Ensured that tree traversal order remains unchanged.

