### PR TITLE
Use `minupper` instead of `maxupper` for a tighter Diameter bound in `_extrema_bounding`

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -152,7 +152,7 @@ def _extrema_bounding(G, compute="diameter", weight=None):
             ruled_out = {
                 i
                 for i in candidates
-                if ecc_upper[i] <= maxlower and 2 * ecc_lower[i] >= maxupper
+                if ecc_upper[i] <= maxlower and 2 * ecc_lower[i] >= minupper
             }
         elif compute == "radius":
             ruled_out = {


### PR DESCRIPTION
This PR refines the candidate filtering condition in `_extrema_bounding` when computing the diameter of a graph.
Previously, the filtering condition was:
```
if ecc_upper[i] <= maxlower and 2 * ecc_lower[i] >= maxupper
```
While using `maxupper` is not incorrect, it provides a looser bound, potentially delaying the removal of certain nodes. Using `minupper` instead ensures a tighter constraint for more efficient pruning:
```
if ecc_upper[i] <= maxlower and 2 * ecc_lower[i] >= minupper
```
