### PR TITLE
Fix BC scaling for source nodes with k and endpoints=False

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -402,21 +402,12 @@ def _rescale(betweenness, n, *, normalized, directed, k, endpoints, sampled_node
     # Without this, k == n would be a special case that would violate the
     # assumption that node `v` is not one of the (s, t) node pairs.
     if normalized:
-        if K_source > 1:
-            scale_source = 1 / ((K_source - 1) * (N - 1))
-        else:
-            # NaN for undefined 0/0; there is no data for source node when k=1
-            scale_source = math.nan
+        # NaN for undefined 0/0; there is no data for source node when k=1
+        scale_source = 1 / ((K_source - 1) * (N - 1)) if K_source > 1 else math.nan
         scale_nonsource = 1 / (K_source * (N - 1))
     else:
-        # Like above, we need to handle source nodes and non-source nodes
-        # differently when using k while excluding endpoints.
         correction = 1 if directed else 2
-        if K_source > 1:
-            scale_source = N / ((K_source - 1) * correction)
-        else:
-            # NaN for undefined 0/0; there is no data for source node when k=1
-            scale_source = math.nan
+        scale_source = N / ((K_source - 1) * correction) if K_source > 1 else math.nan
         scale_nonsource = N / (K_source * correction)
 
     sampled_nodes = set(sampled_nodes)

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -322,6 +322,77 @@ class TestBetweennessCentrality:
         )
         assert b == pytest.approx(expected)
 
+    @pytest.mark.parametrize(
+        ("normalized", "endpoints", "is_directed", "k", "expected"),
+        [
+            (
+                *(True, True, True, None),  # Use *() splatting for better autoformat
+                {0: 14 / 20, 1: 14 / 20, 2: 14 / 20, 3: 14 / 20, 4: 14 / 20},
+            ),
+            (
+                *(True, True, True, 3),
+                {0: 9 / 12, 1: 11 / 12, 2: 9 / 12, 3: 6 / 12, 4: 7 / 12},
+            ),
+            (
+                *(True, True, False, None),
+                {0: 10 / 20, 1: 10 / 20, 2: 10 / 20, 3: 10 / 20, 4: 10 / 20},
+            ),
+            (
+                *(True, True, False, 3),
+                {0: 8 / 12, 1: 7 / 12, 2: 4 / 12, 3: 4 / 12, 4: 7 / 12},
+            ),
+            (
+                *(True, False, True, None),
+                {0: 6 / 12, 1: 6 / 12, 2: 6 / 12, 3: 6 / 12, 4: 6 / 12},
+            ),
+            (
+                *(True, False, True, 3),
+                # Use 6 instead of 9 for denominator for source nodes 0, 1, and 4
+                {0: 3 / 6, 1: 5 / 6, 2: 6 / 9, 3: 3 / 9, 4: 1 / 6},
+            ),
+            (
+                *(True, False, False, None),
+                {0: 2 / 12, 1: 2 / 12, 2: 2 / 12, 3: 2 / 12, 4: 2 / 12},
+            ),
+            (
+                *(True, False, False, 3),
+                # Use 6 instead of 9 for denominator for source nodes 0, 1, and 4
+                {0: 2 / 6, 1: 1 / 6, 2: 1 / 9, 3: 1 / 9, 4: 1 / 6},
+            ),
+            (*(False, True, True, None), {0: 14, 1: 14, 2: 14, 3: 14, 4: 14}),
+            (
+                *(False, True, True, 3),
+                {0: 9 * 5 / 3, 1: 11 * 5 / 3, 2: 9 * 5 / 3, 3: 6 * 5 / 3, 4: 7 * 5 / 3},
+            ),
+            (*(False, True, False, None), {0: 5, 1: 5, 2: 5, 3: 5, 4: 5}),
+            (
+                *(False, True, False, 3),
+                {0: 8 * 5 / 6, 1: 7 * 5 / 6, 2: 4 * 5 / 6, 3: 4 * 5 / 6, 4: 7 * 5 / 6},
+            ),
+            (*(False, False, True, None), {0: 6, 1: 6, 2: 6, 3: 6, 4: 6}),
+            (
+                *(False, False, True, 3),
+                # Use 2 instead of 3 for denominator for source nodes 0, 1, and 4
+                {0: 3 * 4 / 2, 1: 5 * 4 / 2, 2: 6 * 4 / 3, 3: 3 * 4 / 3, 4: 1 * 4 / 2},
+            ),
+            (*(False, False, False, None), {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}),
+            (
+                *(False, False, False, 3),
+                # Use 4 instead of 6 for denominator for source nodes 0, 1, and 4
+                {0: 2 * 4 / 4, 1: 1 * 4 / 4, 2: 1 * 4 / 6, 3: 1 * 4 / 6, 4: 1 * 4 / 4},
+            ),
+        ],
+    )
+    def test_scale_with_k_on_cycle_graph(
+        self, normalized, endpoints, is_directed, k, expected
+    ):
+        # seed=1 selects nodes 0, 1, and 4 as the initial nodes when using k=3.
+        G = nx.cycle_graph(5, create_using=nx.DiGraph if is_directed else nx.Graph)
+        b = nx.betweenness_centrality(
+            G, k=k, seed=1, endpoints=endpoints, normalized=normalized
+        )
+        assert b == pytest.approx(expected)
+
     def test_k_out_of_bounds_raises(self):
         G = nx.cycle_graph(4)
         with pytest.raises(ValueError, match="larger"):

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 import networkx as nx
@@ -295,18 +297,18 @@ class TestBetweennessCentrality:
             (True, True, True, 1, {0: 1.0, 1: 1.0, 2: 0.25, 3: 0.25, 4: 0.25}),
             (True, True, False, None, {0: 1.0, 1: 0.4, 2: 0.4, 3: 0.4, 4: 0.4}),
             (True, True, False, 1, {0: 1.0, 1: 1.0, 2: 0.25, 3: 0.25, 4: 0.25}),
-            (True, False, True, None, {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
-            (True, False, True, 1, {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
+            (True, False, True, None, {0: 1.0, 1: 0, 2: 0.0, 3: 0.0, 4: 0.0}),
+            (True, False, True, 1, {0: 1.0, 1: math.nan, 2: 0.0, 3: 0.0, 4: 0.0}),
             (True, False, False, None, {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
-            (True, False, False, 1, {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
+            (True, False, False, 1, {0: 1.0, 1: math.nan, 2: 0.0, 3: 0.0, 4: 0.0}),
             (False, True, True, None, {0: 20.0, 1: 8.0, 2: 8.0, 3: 8.0, 4: 8.0}),
             (False, True, True, 1, {0: 20.0, 1: 20.0, 2: 5.0, 3: 5.0, 4: 5.0}),
             (False, True, False, None, {0: 10.0, 1: 4.0, 2: 4.0, 3: 4.0, 4: 4.0}),
             (False, True, False, 1, {0: 10.0, 1: 10.0, 2: 2.5, 3: 2.5, 4: 2.5}),
             (False, False, True, None, {0: 12.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
-            (False, False, True, 1, {0: 12.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
+            (False, False, True, 1, {0: 12.0, 1: math.nan, 2: 0.0, 3: 0.0, 4: 0.0}),
             (False, False, False, None, {0: 6.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
-            (False, False, False, 1, {0: 6.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}),
+            (False, False, False, 1, {0: 6.0, 1: math.nan, 2: 0.0, 3: 0.0, 4: 0.0}),
         ],
     )
     def test_scale_with_k_on_star_graph(
@@ -320,7 +322,7 @@ class TestBetweennessCentrality:
         b = nx.betweenness_centrality(
             G, k=k, seed=1, endpoints=endpoints, normalized=normalized
         )
-        assert b == pytest.approx(expected)
+        assert b == pytest.approx(expected, nan_ok=True)
 
     @pytest.mark.parametrize(
         ("normalized", "endpoints", "is_directed", "k", "expected"),

--- a/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_betweenness_centrality.py
@@ -359,23 +359,23 @@ class TestBetweennessCentrality:
                 # Use 6 instead of 9 for denominator for source nodes 0, 1, and 4
                 {0: 2 / 6, 1: 1 / 6, 2: 1 / 9, 3: 1 / 9, 4: 1 / 6},
             ),
-            (*(False, True, True, None), {0: 14, 1: 14, 2: 14, 3: 14, 4: 14}),
+            (False, True, True, None, {0: 14, 1: 14, 2: 14, 3: 14, 4: 14}),
             (
                 *(False, True, True, 3),
                 {0: 9 * 5 / 3, 1: 11 * 5 / 3, 2: 9 * 5 / 3, 3: 6 * 5 / 3, 4: 7 * 5 / 3},
             ),
-            (*(False, True, False, None), {0: 5, 1: 5, 2: 5, 3: 5, 4: 5}),
+            (False, True, False, None, {0: 5, 1: 5, 2: 5, 3: 5, 4: 5}),
             (
                 *(False, True, False, 3),
                 {0: 8 * 5 / 6, 1: 7 * 5 / 6, 2: 4 * 5 / 6, 3: 4 * 5 / 6, 4: 7 * 5 / 6},
             ),
-            (*(False, False, True, None), {0: 6, 1: 6, 2: 6, 3: 6, 4: 6}),
+            (False, False, True, None, {0: 6, 1: 6, 2: 6, 3: 6, 4: 6}),
             (
                 *(False, False, True, 3),
                 # Use 2 instead of 3 for denominator for source nodes 0, 1, and 4
                 {0: 3 * 4 / 2, 1: 5 * 4 / 2, 2: 6 * 4 / 3, 3: 3 * 4 / 3, 4: 1 * 4 / 2},
             ),
-            (*(False, False, False, None), {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}),
+            (False, False, False, None, {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}),
             (
                 *(False, False, False, 3),
                 # Use 4 instead of 6 for denominator for source nodes 0, 1, and 4


### PR DESCRIPTION
This is a follow up to #7908 and specifically @dschult's question from https://github.com/networkx/networkx/pull/7908#pullrequestreview-2711295366:
> The case with k < n and endpoints is False still confuses me. It seems like the number of valid (s, t) node pairs that could have a path through v where s != t should depend on whether node v was in the sample or not in the sample. The largest possible count for nodes in the sample (when endpoints is False) is (k-1)*(n-2), but for nodes not in the sample the count can be k*(n-2). Why are we using k*(n-2) for all the nodes?

After investigating this, I think source nodes and non-source nodes do indeed need to scale differently when `k` is given and `endpoints=False`.

I added a test that exercises this. I don't fully grok the test results, but I trust the scaling logic more than I did.

CC @ChuckHastings @rlratzel 