### PR TITLE
Fix typo in forceatlas2_layout

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1461,7 +1461,7 @@ def forceatlas2_layout(
     jitter_tolerance=1.0,
     scaling_ratio=2.0,
     gravity=1.0,
-    distributed_action=False,
+    distributed_attraction=False,
     strong_gravity=False,
     node_mass=None,
     node_size=None,
@@ -1670,7 +1670,7 @@ def forceatlas2_layout(
         else:
             attraction = -np.einsum("ijk, ij -> ik", diff, A)
 
-        if distributed_action:
+        if distributed_attraction:
             attraction /= mass[:, None]
 
         # repulsion

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1461,7 +1461,7 @@ def forceatlas2_layout(
     jitter_tolerance=1.0,
     scaling_ratio=2.0,
     gravity=1.0,
-    distributed_attraction=False,
+    distributed_action=False,
     strong_gravity=False,
     node_mass=None,
     node_size=None,
@@ -1670,7 +1670,7 @@ def forceatlas2_layout(
         else:
             attraction = -np.einsum("ijk, ij -> ik", diff, A)
 
-        if distributed_attraction:
+        if distributed_action:
             attraction /= mass[:, None]
 
         # repulsion

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1495,7 +1495,7 @@ def forceatlas2_layout(
         Determines the amount of attraction on nodes to the center. Prevents islands
         (i.e. weakly connected or disconnected parts of the graph)
         from drifting away.
-    distributed_attraction : bool (default: False)
+    distributed_action : bool (default: False)
         Distributes the attraction force evenly among nodes.
     strong_gravity : bool (default: False)
         Applies a strong gravitational pull towards the center.


### PR DESCRIPTION
As the docstring suggests, the argument should be `distributed_attraction` instead of `distributed_action`.