### PR TITLE
Add `tournament_matrix` to docs

### DIFF
--- a/doc/reference/algorithms/tournament.rst
+++ b/doc/reference/algorithms/tournament.rst
@@ -12,3 +12,4 @@ Tournament
    is_tournament
    random_tournament
    score_sequence
+   tournament_matrix

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -34,6 +34,7 @@ __all__ = [
     "is_tournament",
     "random_tournament",
     "score_sequence",
+    "tournament_matrix",
 ]
 
 


### PR DESCRIPTION
Also adding to `__all__`, which doesn't have much of an effect since everything is kept within `tournament` module anyway.

It's a shame to keep such a pretty doc from the world!
![tournament_matrix](https://github.com/user-attachments/assets/356646d6-95ac-4122-9a12-c5b59cc7d039)
