### PR TITLE
Fix `random_degree_sequence_graph` when input is an iterator

### DIFF
--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -757,10 +757,10 @@ class DegreeSequenceRandomGraph:
     # class to generate random graphs with a given degree sequence
     # use random_degree_sequence_graph()
     def __init__(self, degree, rng):
-        if not nx.is_graphical(degree):
-            raise nx.NetworkXUnfeasible("degree sequence is not graphical")
         self.rng = rng
         self.degree = list(degree)
+        if not nx.is_graphical(self.degree):
+            raise nx.NetworkXUnfeasible("degree sequence is not graphical")
         # node labels are integers 0,...,n-1
         self.m = sum(self.degree) / 2.0  # number of edges
         try:

--- a/networkx/generators/tests/test_degree_seq.py
+++ b/networkx/generators/tests/test_degree_seq.py
@@ -224,7 +224,14 @@ def test_random_degree_sequence_graph_raise():
 
 def test_random_degree_sequence_large():
     G1 = nx.fast_gnp_random_graph(100, 0.1, seed=42)
+    d1 = [d for n, d in G1.degree()]
+    G2 = nx.random_degree_sequence_graph(d1, seed=42)
+    d2 = [d for n, d in G2.degree()]
+    assert sorted(d1) == sorted(d2)
+
+
+def test_random_degree_sequence_iterator():
+    G1 = nx.fast_gnp_random_graph(100, 0.1, seed=42)
     d1 = (d for n, d in G1.degree())
     G2 = nx.random_degree_sequence_graph(d1, seed=42)
-    d2 = (d for n, d in G2.degree())
-    assert sorted(d1) == sorted(d2)
+    assert len(G2) > 0


### PR DESCRIPTION
The test `test_random_degree_sequence_large` was passing due to unintended behavior: the two generators `d1` and `d2` were both empty! So, I fixed that test (G2 _was_ empty in that test), and added a regression test for the fix so `random_degree_sequence_graph` works as intended when the degree sequence is an iterator. The docstring says the degree sequence should be a list, which is probably recommended, but we should probably handle iterators and iterables in unsurprising ways too.

@rossbar, I encountered this when trying to unblock #7902.