### PR TITLE
Improve special cases in dispatch testing (paying off tech debt)

### DIFF
--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -43,7 +43,9 @@ class CurrentEdge:
         self._curr = next(self._it)
 
     def __eq__(self, other):
-        return self._edges == other._edges
+        return (getattr(self, "_curr", None), self._edges) == (
+            (getattr(other, "_curr", None), other._edges)
+        )
 
 
 class Level:

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -42,6 +42,9 @@ class CurrentEdge:
         self._it = iter(self._edges.items())
         self._curr = next(self._it)
 
+    def __eq__(self, other):
+        return self._edges == other._edges
+
 
 class Level:
     """Active and inactive nodes in a level."""

--- a/networkx/algorithms/minors/contraction.py
+++ b/networkx/algorithms/minors/contraction.py
@@ -563,7 +563,7 @@ identified_nodes = contracted_nodes
 
 
 @nx._dispatchable(
-    preserve_edge_attrs=True, mutates_input={"not copy": 3}, returns_graph=True
+    preserve_all_attrs=True, mutates_input={"not copy": 3}, returns_graph=True
 )
 def contracted_edge(G, edge, self_loops=True, copy=True):
     """Returns the graph that results from contracting the specified edge.

--- a/networkx/generators/spectral_graph_forge.py
+++ b/networkx/generators/spectral_graph_forge.py
@@ -7,7 +7,7 @@ __all__ = ["spectral_graph_forge"]
 
 
 @np_random_state(3)
-@nx._dispatchable(returns_graph=True)
+@nx._dispatchable(preserve_edge_attrs={"G": {"weight": 1}}, returns_graph=True)
 def spectral_graph_forge(G, alpha, transformation="identity", seed=None):
     """Returns a random simple graph with spectrum resembling that of `G`
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1608,11 +1608,6 @@ class _dispatchable:
             and "networkx" in self.backends
             and self.name
             not in {
-                # These need `nx.algorithms.flow.utils.CurrentEdge` to define __eq__
-                # "boykov_kolmogorov",
-                # "preflow_push",
-                # "shortest_augmenting_path",
-                # "spectral_graph_forge",
                 # Has graphs as node values (unable to compare)
                 "quotient_graph",
                 # We don't handle tempfile.NamedTemporaryFile arguments


### PR DESCRIPTION
These changes are intended to unblock #7902 (CC @rossbar) and to try to make dispatch tests more maintainable (see #7904).

This actually took _a lot_ of experimentation, and I suspect there's even more debt we could pay off, but I think this is a nice increment. To summarize:

We are more methodological about when we create two different arguments to run with the backend and with networkx. As before, we run with networkx and compare results when the _result_ is a graph. In this case, we check that the output graphs match _exactly_, and return the networkx graph in order to preserve iteration order (b/c some tests are sensitive). We are more careful about doing this when functions _mutate_ input graphs--we now ensure that input graphs are _different_ when calling the function with both the backend and with networkx. @rossbar, I think this is why the latest attempted "fix" for #7902 didn't work--an input graph was mutated, then used in a subsequent call.

This PR _deletes_ a lot of weird, bespoke code that I suspect nobody understands is likely to be difficult to maintain. This code was originally added so tests would pass. Now we have a different (and less bespoke) way for tests to pass.

This also adds a feature: we compare that input graphs are (very loosely) equal for functions that mutate input graphs. This makes the tests more strict and may affect backends.

Generally, making _any_ changes to this code has a risk of affecting backends. `nx-cugraph` has a few test failures when run against this PR, but I think at least some are true failures.

This code is still more complicated than I would prefer, but we're doing something pretty complex, and I believe enabling backends to run networkx tests is worth the trouble.