### PR TITLE
Remove unused import in convert_matrix.py (networkx.utils.not_implemented_for)

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -29,7 +29,6 @@ import itertools
 from collections import defaultdict
 
 import networkx as nx
-from networkx.utils import not_implemented_for
 
 __all__ = [
     "from_pandas_adjacency",


### PR DESCRIPTION
This is a single line modification - it just removes a no longer used import.