### PR TITLE
Lowest common ancestor improvements and fixes

### DIFF
--- a/doc/reference/algorithms/lowest_common_ancestors.rst
+++ b/doc/reference/algorithms/lowest_common_ancestors.rst
@@ -6,6 +6,7 @@ Lowest Common Ancestor
 .. autosummary::
    :toctree: generated/
 
+   all_pairs_all_lowest_common_ancestors
    all_pairs_lowest_common_ancestor
    tree_all_pairs_lowest_common_ancestor
    lowest_common_ancestor

--- a/doc/reference/algorithms/lowest_common_ancestors.rst
+++ b/doc/reference/algorithms/lowest_common_ancestors.rst
@@ -6,6 +6,7 @@ Lowest Common Ancestor
 .. autosummary::
    :toctree: generated/
 
+   is_lowest_common_ancestor
    all_pairs_all_lowest_common_ancestors
    all_pairs_lowest_common_ancestor
    tree_all_pairs_lowest_common_ancestor

--- a/doc/reference/algorithms/lowest_common_ancestors.rst
+++ b/doc/reference/algorithms/lowest_common_ancestors.rst
@@ -9,4 +9,5 @@ Lowest Common Ancestor
    all_pairs_all_lowest_common_ancestors
    all_pairs_lowest_common_ancestor
    tree_all_pairs_lowest_common_ancestor
+   all_lowest_common_ancestors
    lowest_common_ancestor

--- a/doc/reference/algorithms/lowest_common_ancestors.rst
+++ b/doc/reference/algorithms/lowest_common_ancestors.rst
@@ -9,6 +9,6 @@ Lowest Common Ancestor
    is_lowest_common_ancestor
    all_pairs_all_lowest_common_ancestors
    all_pairs_lowest_common_ancestor
-   tree_all_pairs_lowest_common_ancestor
    all_lowest_common_ancestors
    lowest_common_ancestor
+   tree_all_pairs_lowest_common_ancestor

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -11,6 +11,7 @@ __all__ = [
     "all_pairs_all_lowest_common_ancestors",
     "all_pairs_lowest_common_ancestor",
     "tree_all_pairs_lowest_common_ancestor",
+    "all_lowest_common_ancestors",
     "lowest_common_ancestor",
 ]
 

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -198,9 +198,14 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
         def key(lca):
             return lca
 
-    for (u, v), lca in all_pairs_all_lowest_common_ancestors(G, pairs):
-        if len(lca) > 0:
-            yield ((u, v), min(lca, key=key))
+    all_pairs_all_lca = all_pairs_all_lowest_common_ancestors(G, pairs)
+
+    def generate_lca():
+        for (u, v), lca in all_pairs_all_lca:
+            if len(lca) > 0:
+                yield ((u, v), min(lca, key=key))
+
+    return generate_lca()
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -247,6 +247,8 @@ def all_lowest_common_ancestors(G, node1, node2):
     lowest_common_ancestor, all_pairs_all_lowest_common_ancestors
     """
     ans = list(all_pairs_all_lowest_common_ancestors(G, pairs=[(node1, node2)]))
+    assert len(ans) == 1
+    assert len(ans[0]) == 2
 
     return ans[0][1]
 

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -22,10 +22,9 @@ __all__ = [
 def is_lowest_common_ancestor(G, u, v, x):
     """Return True if x is a lowest common ancestor of u and v.
 
-    A node is a lowest common ancestor of two nodes if:
-
-    1. It is an ancestor of both nodes
-    2. None of its descendants is a common ancestor of both nodes
+    The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
+    of both nodes and has no descendants that are also ancestors of both nodes.
+    Nodes may have multiple LCAs in a DAG (Directed Acyclic Graph).
 
     Parameters
     ----------
@@ -118,9 +117,19 @@ def all_pairs_all_lowest_common_ancestors(G, pairs=None):
     The default behavior is to yield the lowest common ancestor for all
     possible combinations of nodes in `G`, including self-pairings:
 
+    >>> from pprint import pprint
     >>> G = nx.DiGraph([(0, 1), (0, 3), (1, 2)])
-    >>> dict(nx.all_pairs_all_lowest_common_ancestors(G))
-    {(0, 0): [0], (0, 1): [0], (0, 3): [0], (0, 2): [0], (1, 1): [1], (1, 3): [0], (1, 2): [1], (3, 3): [3], (3, 2): [0], (2, 2): [2]}
+    >>> pprint(dict(nx.all_pairs_all_lowest_common_ancestors(G)))
+    {(0, 0): [0],
+     (0, 1): [0],
+     (0, 2): [0],
+     (0, 3): [0],
+     (1, 1): [1],
+     (1, 2): [1],
+     (1, 3): [0],
+     (2, 2): [2],
+     (3, 2): [0],
+     (3, 3): [3]}
 
     The pairs argument can be used to limit the output to only the
     specified node pairings:
@@ -243,9 +252,19 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
     The default behavior is to yield the lowest common ancestor for all
     possible combinations of nodes in `G`, including self-pairings:
 
+    >>> from pprint import pprint
     >>> G = nx.DiGraph([(0, 1), (0, 3), (1, 2)])
-    >>> dict(nx.all_pairs_lowest_common_ancestor(G))
-    {(0, 0): 0, (0, 1): 0, (0, 3): 0, (0, 2): 0, (1, 1): 1, (1, 3): 0, (1, 2): 1, (3, 3): 3, (3, 2): 0, (2, 2): 2}
+    >>> pprint(dict(nx.all_pairs_lowest_common_ancestor(G)))
+    {(0, 0): 0,
+     (0, 1): 0,
+     (0, 2): 0,
+     (0, 3): 0,
+     (1, 1): 1,
+     (1, 2): 1,
+     (1, 3): 0,
+     (2, 2): 2,
+     (3, 2): 0,
+     (3, 3): 3}
 
     The pairs argument can be used to limit the output to only the
     specified node pairings:

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -8,6 +8,7 @@ import networkx as nx
 from networkx.utils import UnionFind, arbitrary_element, not_implemented_for
 
 __all__ = [
+    "is_lowest_common_ancestor",
     "all_pairs_all_lowest_common_ancestors",
     "all_pairs_lowest_common_ancestor",
     "tree_all_pairs_lowest_common_ancestor",
@@ -312,6 +313,69 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
         assert len(ans) == 1
         return ans[0][1]
     return default
+
+
+@not_implemented_for("undirected")
+@nx._dispatchable
+def is_lowest_common_ancestor(G, u, v, x):
+    """Return True if x is a lowest common ancestor of u and v.
+
+    A node is a lowest common ancestor of two nodes if:
+
+    1. It is an ancestor of both nodes
+    2. None of its descendants is a common ancestor of both nodes
+
+    Parameters
+    ----------
+    G : NetworkX directed graph
+    u, v : nodes in the graph G
+    x : the node to verify as a possible lowest common ancestor
+
+    Returns
+    -------
+    bool
+        True if x is a lowest common ancestor of u and v, False otherwise.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> nx.add_path(G, [0, 1, 3])
+    >>> nx.add_path(G, [0, 2, 3])
+    >>> nx.is_lowest_common_ancestor(G, 1, 2, 0)  # 0 is a common ancestor of 1 and 2
+    True
+    >>> nx.is_lowest_common_ancestor(G, 1, 2, 3)  # 3 is not an ancestor of 1 or 2
+    False
+    >>> nx.is_lowest_common_ancestor(G, 3, 3, 3)  # A node is its own LCA
+    True
+    >>> nx.is_lowest_common_ancestor(G, 1, 3, 0)  # 0 is an ancestor of both 1 and 3
+    False
+    >>> nx.is_lowest_common_ancestor(G, 1, 3, 1)  # 1 is an ancestor of both 1 and 3
+    True
+
+    Notes
+    -----
+    Only defined on non-null directed acyclic graphs.
+    Raises NetworkXError if G is not a DAG.
+    """
+    if not nx.is_directed_acyclic_graph(G):
+        raise nx.NetworkXError("LCA only defined on directed acyclic graphs.")
+
+    # Check if x is an ancestor of both u and v
+    u_ancestors = nx.ancestors(G, u).union({u})
+    v_ancestors = nx.ancestors(G, v).union({v})
+
+    # x must be an ancestor of both u and v
+    if x not in u_ancestors or x not in v_ancestors:
+        return False
+
+    # None of x's descendants can be ancestors of both u and v
+    if any(
+        successor in u_ancestors and successor in v_ancestors
+        for successor in G.successors(x)
+    ):
+        return False
+
+    return True
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -364,6 +364,13 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
     -----
     Only defined on non-null directed acyclic graphs.
 
+    When `key` is None, the implementation uses a more efficient algorithm
+    that returns a single, arbitrary LCA for pairs with multiple LCAs. The
+    returned LCA in this case is implementation-dependent and should not be
+    relied upon to be consistent across different runs.
+    Additionally, isomorphic graphs with different construction orders
+    may yield different results.
+
     See Also
     --------
     all_pairs_all_lowest_common_ancestors
@@ -469,6 +476,15 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
     >>> nx.add_path(G, (0, 4, 3))
     >>> nx.lowest_common_ancestor(G, 2, 4)
     0
+
+    Notes
+    -----
+    When `key` is None, the implementation uses a more efficient algorithm
+    that returns a single, arbitrary LCA for pairs with multiple LCAs. The
+    returned LCA in this case is implementation-dependent and should not be
+    relied upon to be consistent across different runs.
+    Additionally, isomorphic graphs with different construction orders
+    may yield different results.
 
     See Also
     --------

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -41,7 +41,7 @@ def is_lowest_common_ancestor(G, u, v, x):
     Raises
     ------
     NetworkXError
-        If G is not a DAG.
+        If G is not a DAG (Directed Acyclic Graph).
 
     Examples
     --------

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -87,7 +87,7 @@ def all_pairs_all_lowest_common_ancestors(G, pairs=None):
 
     The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
-    Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
+    Nodes may have multiple LCAs in a DAG (Directed Acyclic Graph).
 
     Parameters
     ----------
@@ -198,7 +198,7 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
 
     The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
-    Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
+    Nodes may have multiple LCAs in a DAG (Directed Acyclic Graph).
 
     If there are multiple LCAs and key is provided, returns the LCA that has the
     minimal value according to the key function. If key is None, returns an
@@ -285,7 +285,7 @@ def all_lowest_common_ancestors(G, node1, node2):
 
     The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
-    Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
+    Nodes may have multiple LCAs in a DAG (Directed Acyclic Graph).
 
     Parameters
     ----------
@@ -329,7 +329,7 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
 
     The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
-    Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
+    Nodes may have multiple LCAs in a DAG (Directed Acyclic Graph).
 
     If there are multiple LCAs and key is provided, returns the LCA that has the
     minimal value according to the key function. If key is None, returns an

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -11,10 +11,73 @@ __all__ = [
     "is_lowest_common_ancestor",
     "all_pairs_all_lowest_common_ancestors",
     "all_pairs_lowest_common_ancestor",
-    "tree_all_pairs_lowest_common_ancestor",
     "all_lowest_common_ancestors",
     "lowest_common_ancestor",
+    "tree_all_pairs_lowest_common_ancestor",
 ]
+
+
+@not_implemented_for("undirected")
+@nx._dispatchable
+def is_lowest_common_ancestor(G, u, v, x):
+    """Return True if x is a lowest common ancestor of u and v.
+
+    A node is a lowest common ancestor of two nodes if:
+
+    1. It is an ancestor of both nodes
+    2. None of its descendants is a common ancestor of both nodes
+
+    Parameters
+    ----------
+    G : NetworkX directed graph
+    u, v : nodes in the graph G
+    x : the node to verify as a possible lowest common ancestor
+
+    Returns
+    -------
+    bool
+        True if x is a lowest common ancestor of u and v, False otherwise.
+
+    Raises
+    ------
+    NetworkXError
+        If G is not a DAG.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> nx.add_path(G, [0, 1, 3])
+    >>> nx.add_path(G, [0, 2, 3])
+    >>> nx.is_lowest_common_ancestor(G, 1, 2, 0)  # 0 is a common ancestor of 1 and 2
+    True
+    >>> nx.is_lowest_common_ancestor(G, 1, 2, 3)  # 3 is not an ancestor of 1 or 2
+    False
+    >>> nx.is_lowest_common_ancestor(G, 3, 3, 3)  # A node is its own LCA
+    True
+    >>> nx.is_lowest_common_ancestor(G, 1, 3, 0)  # 0 is an ancestor of both 1 and 3
+    False
+    >>> nx.is_lowest_common_ancestor(G, 1, 3, 1)  # 1 is an ancestor of both 1 and 3
+    True
+    """
+    if not nx.is_directed_acyclic_graph(G):
+        raise nx.NetworkXError("LCA only defined on directed acyclic graphs.")
+
+    # Check if x is an ancestor of both u and v
+    u_ancestors = nx.ancestors(G, u).union({u})
+    v_ancestors = nx.ancestors(G, v).union({v})
+
+    # x must be an ancestor of both u and v
+    if x not in u_ancestors or x not in v_ancestors:
+        return False
+
+    # None of x's descendants can be ancestors of both u and v
+    if any(
+        successor in u_ancestors and successor in v_ancestors
+        for successor in G.successors(x)
+    ):
+        return False
+
+    return True
 
 
 @not_implemented_for("undirected")
@@ -313,69 +376,6 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
         assert len(ans) == 1
         return ans[0][1]
     return default
-
-
-@not_implemented_for("undirected")
-@nx._dispatchable
-def is_lowest_common_ancestor(G, u, v, x):
-    """Return True if x is a lowest common ancestor of u and v.
-
-    A node is a lowest common ancestor of two nodes if:
-
-    1. It is an ancestor of both nodes
-    2. None of its descendants is a common ancestor of both nodes
-
-    Parameters
-    ----------
-    G : NetworkX directed graph
-    u, v : nodes in the graph G
-    x : the node to verify as a possible lowest common ancestor
-
-    Returns
-    -------
-    bool
-        True if x is a lowest common ancestor of u and v, False otherwise.
-
-    Examples
-    --------
-    >>> G = nx.DiGraph()
-    >>> nx.add_path(G, [0, 1, 3])
-    >>> nx.add_path(G, [0, 2, 3])
-    >>> nx.is_lowest_common_ancestor(G, 1, 2, 0)  # 0 is a common ancestor of 1 and 2
-    True
-    >>> nx.is_lowest_common_ancestor(G, 1, 2, 3)  # 3 is not an ancestor of 1 or 2
-    False
-    >>> nx.is_lowest_common_ancestor(G, 3, 3, 3)  # A node is its own LCA
-    True
-    >>> nx.is_lowest_common_ancestor(G, 1, 3, 0)  # 0 is an ancestor of both 1 and 3
-    False
-    >>> nx.is_lowest_common_ancestor(G, 1, 3, 1)  # 1 is an ancestor of both 1 and 3
-    True
-
-    Notes
-    -----
-    Only defined on non-null directed acyclic graphs.
-    Raises NetworkXError if G is not a DAG.
-    """
-    if not nx.is_directed_acyclic_graph(G):
-        raise nx.NetworkXError("LCA only defined on directed acyclic graphs.")
-
-    # Check if x is an ancestor of both u and v
-    u_ancestors = nx.ancestors(G, u).union({u})
-    v_ancestors = nx.ancestors(G, v).union({v})
-
-    # x must be an ancestor of both u and v
-    if x not in u_ancestors or x not in v_ancestors:
-        return False
-
-    # None of x's descendants can be ancestors of both u and v
-    if any(
-        successor in u_ancestors and successor in v_ancestors
-        for successor in G.successors(x)
-    ):
-        return False
-
-    return True
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -136,8 +136,11 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
     of both nodes and has no descendants that are also ancestors of both nodes.
     Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
 
-    If there are multiple LCAs, the minimal one according to the key
-    function is returned. If you want to get all LCAs, use
+    If there are multiple LCAs and key is provided, returns the LCA that has the
+    minimal value according to the key function. If key is None, returns an
+    arbitrary LCA.
+
+    If you want to get all LCAs, use
     :func:`all_pairs_all_lowest_common_ancestors`.
 
     Parameters
@@ -150,8 +153,8 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
 
     key : callable, optional
         Function to choose among multiple LCAs; the returned LCA is the minimal
-        element in the set of LCAs according to this key. If None, the default
-        ordering of nodes is used.
+        element in the set of LCAs according to this key. If None, an arbitrary
+        LCA is returned.
 
     Yields
     ------
@@ -195,16 +198,18 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
     all_pairs_all_lowest_common_ancestors
     """
     if key is None:
+        select_lca = nx.utils.arbitrary_element
+    else:
 
-        def key(lca):
-            return lca
+        def select_lca(lca):
+            return min(lca, key=key)
 
     all_pairs_all_lca = all_pairs_all_lowest_common_ancestors(G, pairs)
 
     def generate_lca():
         for (u, v), lca in all_pairs_all_lca:
             if len(lca) > 0:
-                yield ((u, v), min(lca, key=key))
+                yield ((u, v), select_lca(lca))
 
     return generate_lca()
 
@@ -262,8 +267,11 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
     of both nodes and has no descendants that are also ancestors of both nodes.
     Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
 
-    If there are multiple LCAs, the minimal one according to the key
-    function is returned. If you want to get all LCAs, use
+    If there are multiple LCAs and key is provided, returns the LCA that has the
+    minimal value according to the key function. If key is None, returns an
+    arbitrary LCA.
+
+    If you want to get all LCAs, use
     :func:`all_lowest_common_ancestors`.
 
     Parameters
@@ -277,7 +285,7 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
 
     key : callable, optional
         Function to choose among multiple LCAs; if multiple LCAs exist, the one
-        with the minimal key value is returned. If None, default ordering is used.
+        with the minimal key value is returned. If None, an arbitrary LCA is returned.
 
     Returns
     -------

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -21,7 +21,7 @@ __all__ = [
 def all_pairs_all_lowest_common_ancestors(G, pairs=None):
     """Return lists of lowest common ancestors of all pairs or the provided pairs.
 
-    The lowest common ancestor of a pair of nodes is a node that is an ancestor
+    The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
     Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
 
@@ -132,7 +132,7 @@ def all_pairs_all_lowest_common_ancestors(G, pairs=None):
 def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
     """Return the lowest common ancestor of all pairs or the provided pairs.
 
-    The lowest common ancestor of a pair of nodes is a node that is an ancestor
+    The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
     Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
 
@@ -219,7 +219,7 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
 def all_lowest_common_ancestors(G, node1, node2):
     """Compute all lowest common ancestors for the given pair of nodes.
 
-    The lowest common ancestor of a pair of nodes is a node that is an ancestor
+    The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
     Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
 
@@ -263,7 +263,7 @@ def all_lowest_common_ancestors(G, node1, node2):
 def lowest_common_ancestor(G, node1, node2, default=None, key=None):
     """Compute the lowest common ancestor of the given pair of nodes.
 
-    The lowest common ancestor of a pair of nodes is a node that is an ancestor
+    The LCA (Lowest Common Ancestor) of a pair of nodes is a node that is an ancestor
     of both nodes and has no descendants that are also ancestors of both nodes.
     Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
 

--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -81,7 +81,7 @@ def all_pairs_all_lowest_common_ancestors(G, pairs=None):
 
     See Also
     --------
-    all_pairs_lowest_common_ancestor, lowest_common_ancestor
+    all_pairs_lowest_common_ancestor
     """
     if not nx.is_directed_acyclic_graph(G):
         raise nx.NetworkXError("LCA only defined on directed acyclic graphs.")
@@ -191,7 +191,7 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
 
     See Also
     --------
-    all_pairs_all_lowest_common_ancestors, lowest_common_ancestor
+    all_pairs_all_lowest_common_ancestors
     """
     if key is None:
 
@@ -210,8 +210,58 @@ def all_pairs_lowest_common_ancestor(G, pairs=None, key=None):
 
 @not_implemented_for("undirected")
 @nx._dispatchable
+def all_lowest_common_ancestors(G, node1, node2):
+    """Compute all lowest common ancestors for the given pair of nodes.
+
+    The lowest common ancestor of a pair of nodes is a node that is an ancestor
+    of both nodes and has no descendants that are also ancestors of both nodes.
+    Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
+
+    Parameters
+    ----------
+    G : NetworkX directed graph
+
+    node1, node2 : nodes in the graph
+
+    Returns
+    -------
+    list
+        A list containing all lowest common ancestors of node1 and node2.
+        Returns an empty list if they have no common ancestors.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> nx.add_path(G, (0, 1, 2, 3))
+    >>> nx.add_path(G, (0, 4, 3))
+    >>> nx.all_lowest_common_ancestors(G, 2, 4)
+    [0]
+
+    >>> G = nx.DiGraph([(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4)])
+    >>> nx.all_lowest_common_ancestors(G, 3, 4)
+    [1, 2]
+
+    See Also
+    --------
+    lowest_common_ancestor, all_pairs_all_lowest_common_ancestors
+    """
+    ans = list(all_pairs_all_lowest_common_ancestors(G, pairs=[(node1, node2)]))
+
+    return ans[0][1]
+
+
+@not_implemented_for("undirected")
+@nx._dispatchable
 def lowest_common_ancestor(G, node1, node2, default=None, key=None):
     """Compute the lowest common ancestor of the given pair of nodes.
+
+    The lowest common ancestor of a pair of nodes is a node that is an ancestor
+    of both nodes and has no descendants that are also ancestors of both nodes.
+    Nodes may have multiple lowest common ancestors in a DAG (Directed Acyclic Graph).
+
+    If there are multiple LCAs, the minimal one according to the key
+    function is returned. If you want to get all LCAs, use
+    :func:`all_lowest_common_ancestors`.
 
     Parameters
     ----------
@@ -243,7 +293,7 @@ def lowest_common_ancestor(G, node1, node2, default=None, key=None):
 
     See Also
     --------
-    all_pairs_lowest_common_ancestor, all_pairs_all_lowest_common_ancestors
+    all_lowest_common_ancestors, all_pairs_lowest_common_ancestor
     """
 
     ans = list(all_pairs_lowest_common_ancestor(G, pairs=[(node1, node2)], key=key))

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -17,7 +17,7 @@ def get_pair(dictionary, n1, n2):
 
 
 def is_lca(G, u, v, lca):
-    """Assert that node lca is a valid lowest common ancestor for nodes u and v.
+    """Returns True if lca is a lowest common ancestor of u and v.
 
     A node is a lowest common ancestor of two nodes if:
     1. It is an ancestor of both nodes
@@ -28,6 +28,11 @@ def is_lca(G, u, v, lca):
     G : NetworkX directed graph
     u, v : nodes in the graph G
     lca : the node to verify as a possible lowest common ancestor
+
+    Returns
+    -------
+    bool
+        True if lca is a lowest common ancestor of u and v, False otherwise.
     """
     # Check if lca is an ancestor of both u and v
     u_ancestors = nx.ancestors(G, u).union({u})
@@ -38,10 +43,29 @@ def is_lca(G, u, v, lca):
         return False
 
     # None of lca's descendants can be ancestors of both u and v
-    for successor in G.successors(lca):
-        if successor in u_ancestors and successor in v_ancestors:
-            return False
+    if any(
+        successor in u_ancestors and successor in v_ancestors
+        for successor in G.successors(lca)
+    ):
+        return False
+
     return True
+
+
+def test_is_lca():
+    G = nx.DiGraph()
+    nx.add_path(G, (0, 1, 3))
+    nx.add_path(G, (0, 2, 3))
+
+    # Case 1: 1 and 2's lowest common ancestor is 0
+    assert is_lca(G, 1, 2, 0)
+    # Case 2: 1/2 is not the lowest common ancestor of 1 and 2
+    assert not is_lca(G, 1, 2, 1)
+    assert not is_lca(G, 1, 2, 2)
+    # Case 3: A non-ancestor node (3) will return False for 1 and 2
+    assert not is_lca(G, 1, 2, 3)
+    # Case 4: The same node is its own ancestor
+    assert is_lca(G, 3, 3, 3)
 
 
 class TestTreeLCA:
@@ -543,7 +567,7 @@ class TestAllPairsAllLowestCommonAncestors:
             assert is_lca(G, 3, 4, lca)
 
 
-@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("seed", range(5))
 def test_random_dag_all_pairs_all_lcas(seed):
     # Test random DAGs for correctness of LCAs
     rng = random.Random(seed)
@@ -556,10 +580,10 @@ def test_random_dag_all_pairs_all_lcas(seed):
     for (u, v), lcas in result.items():
         lcas = set(lcas)
         for node in G.nodes():
-            if node not in lcas:
-                assert not is_lca(G, u, v, node)
-            else:
+            if node in lcas:
                 assert is_lca(G, u, v, node)
+            else:
+                assert not is_lca(G, u, v, node)
 
 
 def test_all_lowest_common_ancestors_simple():

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -7,6 +7,7 @@ import networkx as nx
 
 tree_all_pairs_lca = nx.tree_all_pairs_lowest_common_ancestor
 all_pairs_lca = nx.all_pairs_lowest_common_ancestor
+is_lca = nx.is_lowest_common_ancestor
 
 
 def get_pair(dictionary, n1, n2):
@@ -14,58 +15,6 @@ def get_pair(dictionary, n1, n2):
         return dictionary[n1, n2]
     else:
         return dictionary[n2, n1]
-
-
-def is_lca(G, u, v, lca):
-    """Returns True if lca is a lowest common ancestor of u and v.
-
-    A node is a lowest common ancestor of two nodes if:
-    1. It is an ancestor of both nodes
-    2. None of its descendants is a common ancestor of both nodes
-
-    Parameters
-    ----------
-    G : NetworkX directed graph
-    u, v : nodes in the graph G
-    lca : the node to verify as a possible lowest common ancestor
-
-    Returns
-    -------
-    bool
-        True if lca is a lowest common ancestor of u and v, False otherwise.
-
-    Examples
-    --------
-    >>> G = nx.DiGraph()
-    >>> nx.add_path(G, [0, 1, 3])
-    >>> nx.add_path(G, [0, 2, 3])
-    >>> is_lca(G, 1, 2, 0)  # 0 is a common ancestor of 1 and 2
-    True
-    >>> is_lca(G, 1, 2, 3)  # 3 is not an ancestor of 1 or 2
-    False
-    >>> is_lca(G, 3, 3, 3)  # A node is its own LCA
-    True
-    >>> is_lca(G, 1, 3, 0)  # 0 is an ancestor of both 1 and 3
-    False
-    >>> is_lca(G, 1, 3, 1)  # 1 is an ancestor of both 1 and 3
-    True
-    """
-    # Check if lca is an ancestor of both u and v
-    u_ancestors = nx.ancestors(G, u).union({u})
-    v_ancestors = nx.ancestors(G, v).union({v})
-
-    # lca must be an ancestor of both u and v
-    if lca not in u_ancestors or lca not in v_ancestors:
-        return False
-
-    # None of lca's descendants can be ancestors of both u and v
-    if any(
-        successor in u_ancestors and successor in v_ancestors
-        for successor in G.successors(lca)
-    ):
-        return False
-
-    return True
 
 
 def test_is_lca():

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -560,3 +560,39 @@ def test_random_dag_all_pairs_all_lcas(seed):
                 assert not is_lca(G, u, v, node)
             else:
                 assert is_lca(G, u, v, node)
+
+
+def test_all_lowest_common_ancestors_simple():
+    G = nx.DiGraph()
+    nx.add_path(G, (0, 1, 2, 3))
+    nx.add_path(G, (0, 4, 3))
+    assert nx.all_lowest_common_ancestors(G, 2, 4) == [0]
+
+
+def test_all_lowest_common_ancestors_multiple():
+    G = nx.DiGraph()
+    edges = [(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4)]
+    G.add_edges_from(edges)
+    lcas = nx.all_lowest_common_ancestors(G, 3, 4)
+    assert sorted(lcas) == [1, 2]
+    for lca in lcas:
+        assert is_lca(G, 3, 4, lca)
+
+
+def test_all_lowest_common_ancestors_node_not_found():
+    G = nx.DiGraph()
+    G.add_nodes_from([1, 2])
+    with pytest.raises(nx.NodeNotFound):
+        nx.all_lowest_common_ancestors(G, 1, 3)
+
+
+def test_all_lowest_common_ancestors_empty_graph():
+    G = nx.DiGraph()
+    with pytest.raises(nx.NetworkXPointlessConcept):
+        nx.all_lowest_common_ancestors(G, 0, 0)
+
+
+def test_all_lowest_common_ancestors_non_dag():
+    G = nx.DiGraph([(1, 2), (2, 1)])
+    with pytest.raises(nx.NetworkXError):
+        nx.all_lowest_common_ancestors(G, 1, 2)

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -369,6 +369,19 @@ class TestDAGLCA:
         assert lca == 2
         assert is_lca(G, 1, 3, lca)
 
+    def test_all_pairs_lca_key_parameter(self):
+        # Test that key parameter selects among multiple LCAs for all_pairs_lowest_common_ancestor
+        G = nx.DiGraph()
+        edges = [(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4)]
+        G.add_edges_from(edges)
+        # nodes 3 and 4 have LCAs {1, 2}
+        # default yields smallest id
+        result_default = dict(all_pairs_lca(G, pairs=[(3, 4)]))
+        assert result_default[(3, 4)] == 1
+        # with key chooses largest id
+        result_key = dict(all_pairs_lca(G, pairs=[(3, 4)], key=lambda x: -x))
+        assert result_key[(3, 4)] == 2
+
 
 class TestMultiDiGraph_DAGLCA(TestDAGLCA):
     @classmethod
@@ -474,6 +487,18 @@ def test_lca_dont_rely_on_single_successor():
     lca = nx.lowest_common_ancestor(G, 0, 1)
     assert lca == 2
     assert is_lca(G, 0, 1, lca)
+
+
+def test_lowest_common_ancestor_key_parameter():
+    # Test that key parameter selects among multiple LCAs
+    G = nx.DiGraph()
+    edges = [(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4)]
+    G.add_edges_from(edges)
+    # nodes 3 and 4 have LCAs {1, 2}
+    # default returns smallest by node id
+    assert nx.lowest_common_ancestor(G, 3, 4) == 1
+    # key parameter to choose largest id
+    assert nx.lowest_common_ancestor(G, 3, 4, key=lambda x: -x) == 2
 
 
 class TestAllPairsAllLowestCommonAncestors:

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -586,6 +586,12 @@ def test_random_dag_all_pairs_all_lcas(seed):
                 assert not is_lca(G, u, v, node)
 
 
+def test_all_lowest_common_ancestors_no_lca():
+    G = nx.DiGraph()
+    G.add_nodes_from([1, 2])
+    assert nx.all_lowest_common_ancestors(G, 1, 2) == []
+
+
 def test_all_lowest_common_ancestors_simple():
     G = nx.DiGraph()
     nx.add_path(G, (0, 1, 2, 3))

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -33,6 +33,22 @@ def is_lca(G, u, v, lca):
     -------
     bool
         True if lca is a lowest common ancestor of u and v, False otherwise.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> nx.add_path(G, [0, 1, 3])
+    >>> nx.add_path(G, [0, 2, 3])
+    >>> is_lca(G, 1, 2, 0)  # 0 is a common ancestor of 1 and 2
+    True
+    >>> is_lca(G, 1, 2, 3)  # 3 is not an ancestor of 1 or 2
+    False
+    >>> is_lca(G, 3, 3, 3)  # A node is its own LCA
+    True
+    >>> is_lca(G, 1, 3, 0)  # 0 is an ancestor of both 1 and 3
+    False
+    >>> is_lca(G, 1, 3, 1)  # 1 is an ancestor of both 1 and 3
+    True
     """
     # Check if lca is an ancestor of both u and v
     u_ancestors = nx.ancestors(G, u).union({u})

--- a/networkx/algorithms/tests/test_lowest_common_ancestors.py
+++ b/networkx/algorithms/tests/test_lowest_common_ancestors.py
@@ -514,15 +514,33 @@ def test_lca_dont_rely_on_single_successor():
 
 
 def test_lowest_common_ancestor_key_parameter():
-    # Test that key parameter selects among multiple LCAs
+    # Test behavior of key parameter and arbitrary selection
     G = nx.DiGraph()
     edges = [(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4)]
     G.add_edges_from(edges)
     # nodes 3 and 4 have LCAs {1, 2}
-    # default returns smallest by node id
-    assert nx.lowest_common_ancestor(G, 3, 4) == 1
-    # key parameter to choose largest id
+    # without key, returns arbitrary LCA
+    lca = nx.lowest_common_ancestor(G, 3, 4)
+    assert lca in {1, 2}
+    # with key, returns specific LCA
+    assert nx.lowest_common_ancestor(G, 3, 4, key=lambda x: x) == 1
     assert nx.lowest_common_ancestor(G, 3, 4, key=lambda x: -x) == 2
+
+
+def test_all_pairs_lca_key_parameter():
+    # Test behavior of key parameter and arbitrary selection
+    G = nx.DiGraph()
+    edges = [(0, 1), (0, 2), (1, 3), (2, 3), (1, 4), (2, 4)]
+    G.add_edges_from(edges)
+    # nodes 3 and 4 have LCAs {1, 2}
+    # without key, returns arbitrary LCA
+    result = dict(all_pairs_lca(G, pairs=[(3, 4)]))
+    assert result[(3, 4)] in {1, 2}
+    # with key chooses specific LCA
+    result_min = dict(all_pairs_lca(G, pairs=[(3, 4)], key=lambda x: x))
+    assert result_min[(3, 4)] == 1
+    result_max = dict(all_pairs_lca(G, pairs=[(3, 4)], key=lambda x: -x))
+    assert result_max[(3, 4)] == 2
 
 
 class TestAllPairsAllLowestCommonAncestors:


### PR DESCRIPTION
There are several problems in the current implementation of `networkx/algorithms/lowest_common_ancestors.py` and its tests.

- **Nodes can have multiple LCAs in a DAG (Directed Acyclic Graph)**, but all related methods (`all_pairs_lowest_common_ancestor`, `lowest_common_ancestor`) return only one of them.

- **The LCA returned by the methods is non-deterministic.**

  If you run the following code 10 times, perhaps half of them print `a` and the others print `b`. Technically both results are correct, as `c` and `d` have two LCAs, but such inconsistency is confusing.

  ```python
  import networkx as nx
  G = nx.DiGraph([
      ('r', 'a'),
      ('r', 'b'),
      ('a', 'c'),
      ('b', 'c'),
      ('a', 'd'),
      ('b', 'd')
  ])
  # Could be either 'a' or 'b'
  print(nx.lowest_common_ancestor(G, 'c', 'd'))
  ```

  This is due to the non-deterministic nature of Python sets, on which the current LCA implementation depends heavily. The iteration orders of a Python set can vary across sessions, even the set is constructed identically.

- **The tests are incorrect.**

  The tests for DAG LCA assume that all the LCAs of a pair of nodes have the same distance from the roots of the DAG, and validate the returned LCAs based on the assumption. It happens to work, but it is incorrect.

  According to [Wikipedia](https://en.wikipedia.org/wiki/Lowest_common_ancestor#Extension_to_directed_acyclic_graphs), the LCA of a pair of nodes is a node that is an ancestor of both nodes and has no descendants that are also ancestors of both nodes. This does not guarantee the distance equality from the roots.

## Changes

- Add `all_pairs_all_lowest_common_ancestors` and `all_lowest_common_ancestors`, providing versions of the existing methods that return all LCAs in lists. The new methods are implemented in the same way as the old ones, with only a few lines changed.
- Add an optional parameter `key` for `all_pairs_lowest_common_ancestor` and `lowest_common_ancestor` so they can return the minimal LCA according to `key` and be deterministic.
- Fix old tests and add tests for the new methods.

Fixes #6777 
Fixes #6233 
