### PR TITLE
Standardize documentation for `nodes` argument

### DIFF
--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -283,7 +283,7 @@ def degrees(B, nodes, weight=None):
     ----------
     B : NetworkX graph
 
-    nodes: iterable of nodes
+    nodes : iterable of nodes
       Nodes in one node set of the bipartite graph.
 
     weight : string or None, optional (default=None)

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -230,7 +230,7 @@ def density(B, nodes):
     ----------
     B : NetworkX graph
 
-    nodes: iterable of nodes
+    nodes : iterable of nodes
       Nodes in one node set of the bipartite graph.
 
     Returns

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -118,7 +118,7 @@ def is_bipartite_node_set(G, nodes):
     ----------
     G : NetworkX graph
 
-    nodes: iterable of nodes
+    nodes : iterable of nodes
       Check if nodes are a one of a bipartite set.
 
     Examples

--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -118,7 +118,7 @@ def is_bipartite_node_set(G, nodes):
     ----------
     G : NetworkX graph
 
-    nodes: list or container
+    nodes: iterable of nodes
       Check if nodes are a one of a bipartite set.
 
     Examples
@@ -168,7 +168,7 @@ def sets(G, top_nodes=None):
     ----------
     G : NetworkX graph
 
-    top_nodes : container, optional
+    top_nodes : iterable of nodes, optional
       Container with all nodes in one bipartite node set. If not supplied
       it will be computed. But if more than one solution exists an exception
       will be raised.
@@ -230,7 +230,7 @@ def density(B, nodes):
     ----------
     B : NetworkX graph
 
-    nodes: list or container
+    nodes: iterable of nodes
       Nodes in one node set of the bipartite graph.
 
     Returns
@@ -283,7 +283,7 @@ def degrees(B, nodes, weight=None):
     ----------
     B : NetworkX graph
 
-    nodes: list or container
+    nodes: iterable of nodes
       Nodes in one node set of the bipartite graph.
 
     weight : string or None, optional (default=None)

--- a/networkx/algorithms/bipartite/centrality.py
+++ b/networkx/algorithms/bipartite/centrality.py
@@ -15,7 +15,7 @@ def degree_centrality(G, nodes):
     G : graph
        A bipartite network
 
-    nodes : list or container
+    nodes : iterable of nodes
       Container with all nodes in one bipartite node set.
 
     Returns
@@ -120,7 +120,7 @@ def betweenness_centrality(G, nodes):
     G : graph
         A bipartite graph
 
-    nodes : list or container
+    nodes : iterable of nodes
         Container with all nodes in one bipartite node set.
 
     Returns
@@ -195,7 +195,7 @@ def closeness_centrality(G, nodes, normalized=True):
     G : graph
         A bipartite network
 
-    nodes : list or container
+    nodes : iterable of nodes
         Container with all nodes in one bipartite node set.
 
     normalized : bool, optional

--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -68,7 +68,7 @@ def latapy_clustering(G, nodes=None, mode="dot"):
     G : graph
         A bipartite graph
 
-    nodes : list or iterable (optional)
+    nodes : iterable of nodes (optional)
         Compute bipartite clustering for these nodes. The default
         is all nodes in G.
 
@@ -157,7 +157,7 @@ def average_clustering(G, nodes=None, mode="dot"):
     G : graph
         a bipartite graph
 
-    nodes : list or iterable, optional
+    nodes : iterable of nodes, optional
         A container of nodes to use in computing the average.
         The nodes should be either the entire graph (the default) or one of the
         bipartite sets.

--- a/networkx/algorithms/bipartite/matching.py
+++ b/networkx/algorithms/bipartite/matching.py
@@ -73,9 +73,9 @@ def hopcroft_karp_matching(G, top_nodes=None):
 
       Undirected bipartite graph
 
-    top_nodes : container of nodes
+    top_nodes : iterable of nodes
 
-      Container with all nodes in one bipartite node set. If not supplied
+      Iterable with all nodes in one bipartite node set. If not supplied
       it will be computed. But if more than one solution exists an exception
       will be raised.
 
@@ -192,9 +192,9 @@ def eppstein_matching(G, top_nodes=None):
 
       Undirected bipartite graph
 
-    top_nodes : container
+    top_nodes : iterable of nodes
 
-      Container with all nodes in one bipartite node set. If not supplied
+      Iterable with all nodes in one bipartite node set. If not supplied
       it will be computed. But if more than one solution exists an exception
       will be raised.
 
@@ -439,9 +439,9 @@ def to_vertex_cover(G, matching, top_nodes=None):
       by, for example, :func:`maximum_matching`. The dictionary *must*
       represent the maximum matching.
 
-    top_nodes : container
+    top_nodes : iterable of nodes
 
-      Container with all nodes in one bipartite node set. If not supplied
+      Iterable with all nodes in one bipartite node set. If not supplied
       it will be computed. But if more than one solution exists an exception
       will be raised.
 
@@ -528,9 +528,9 @@ def minimum_weight_full_matching(G, top_nodes=None, weight="weight"):
 
       Undirected bipartite graph
 
-    top_nodes : container
+    top_nodes : iterable of nodes
 
-      Container with all nodes in one bipartite node set. If not supplied
+      Iterable of nodes with all nodes in one bipartite node set. If not supplied
       it will be computed.
 
     weight : string, optional (default='weight')

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -136,7 +136,7 @@ def weighted_projected_graph(B, nodes, ratio=False):
     B : NetworkX graph
         The input graph should be bipartite.
 
-    nodes : list or iterable
+    nodes : iterable of nodes
         Distinct nodes to project onto (the "bottom" nodes).
 
     ratio: Bool (default=False)
@@ -248,7 +248,7 @@ def collaboration_weighted_projected_graph(B, nodes):
     B : NetworkX graph
       The input graph should be bipartite.
 
-    nodes : list or iterable
+    nodes : iterable of nodes
       Nodes to project onto (the "bottom" nodes).
 
     Returns
@@ -344,7 +344,7 @@ def overlap_weighted_projected_graph(B, nodes, jaccard=True):
     B : NetworkX graph
         The input graph should be bipartite.
 
-    nodes : list or iterable
+    nodes : iterable of nodes
         Nodes to project onto (the "bottom" nodes).
 
     jaccard: Bool (default=True)
@@ -432,7 +432,7 @@ def generic_weighted_projected_graph(B, nodes, weight_function=None):
     B : NetworkX graph
         The input graph should be bipartite.
 
-    nodes : list or iterable
+    nodes : iterable of nodes
         Nodes to project onto (the "bottom" nodes).
 
     weight_function : function

--- a/networkx/algorithms/bipartite/projection.py
+++ b/networkx/algorithms/bipartite/projection.py
@@ -28,8 +28,8 @@ def projected_graph(B, nodes, multigraph=False):
     B : NetworkX graph
       The input graph should be bipartite.
 
-    nodes : list or iterable
-      Nodes to project onto (the "bottom" nodes).
+    nodes : iterable of nodes
+      Iterable of nodes to project onto (the "bottom" nodes).
 
     multigraph: bool (default=False)
        If True return a multigraph where the multiple edges represent multiple

--- a/networkx/algorithms/bipartite/redundancy.py
+++ b/networkx/algorithms/bipartite/redundancy.py
@@ -34,7 +34,7 @@ def node_redundancy(G, nodes=None):
     G : graph
         A bipartite graph
 
-    nodes : list or iterable (optional)
+    nodes : iterable of nodes (optional)
         Compute redundancy for these nodes. The default is all nodes in G.
 
     Returns

--- a/networkx/algorithms/bipartite/spectral.py
+++ b/networkx/algorithms/bipartite/spectral.py
@@ -15,7 +15,7 @@ def spectral_bipartivity(G, nodes=None, weight="weight"):
     ----------
     G : NetworkX graph
 
-    nodes : list or container  optional(default is all nodes)
+    nodes : iterable of nodes  optional(default is all nodes)
       Nodes to return value of spectral bipartivity contribution.
 
     weight : string or None  optional (default = 'weight')


### PR DESCRIPTION
Uses standardized phrase "iterable of nodes" for describing the argument type of nodes/top_nodes.  See #7990 for rational behind this change.