### PR TITLE
Nodelists for `from_biadjacency_matrix`

### DIFF
--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -112,8 +112,13 @@ def biadjacency_matrix(
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)
-def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight",
-                            top_nodelist=None, bottom_nodelist=None):
+def from_biadjacency_matrix(
+    A,
+    create_using=None,
+    edge_attribute="weight",
+    top_nodelist=None,
+    bottom_nodelist=None,
+):
     r"""Creates a new bipartite graph from a biadjacency matrix given as a
     SciPy sparse array.
 
@@ -151,8 +156,11 @@ def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight",
     """
     G = nx.empty_graph(0, create_using)
     n, m = A.shape
-    # Check lengths of nodelists match dimensions of A, if not specified set them to []
-    top_nodelist, bottom_nodelist = _validate_initialize_bipartite_nodelists(A, top_nodelist, bottom_nodelist)
+    # Check lengths of nodelists match dimensions of A, if not specified set
+    # them to []
+    top_nodelist, bottom_nodelist = _validate_initialize_bipartite_nodelists(
+        A, top_nodelist, bottom_nodelist
+    )
 
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n), bipartite=0)
@@ -171,23 +179,32 @@ def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight",
     G.add_weighted_edges_from(triples, weight=edge_attribute)
 
     # If the user provided nodelists, relabel the nodes of the graph inplace
-    mapping = dict(itertools.chain(zip(range(n), top_nodelist), zip(range(n, n + m), bottom_nodelist)))
+    mapping = dict(
+        itertools.chain(
+            zip(range(n), top_nodelist), zip(range(n, n + m), bottom_nodelist)
+        )
+    )
     if len(mapping):
         nx.relabel_nodes(G, mapping, copy=False)
     return G
+
 
 def _validate_initialize_bipartite_nodelists(A, top_nodelist, bottom_nodelist):
     n, m = A.shape
     # Validate nodelists if provided
     if top_nodelist is not None:
         if len(top_nodelist) != n:
-            raise ValueError("Length of top_nodelist does not match number of rows in A ({n})")
+            raise ValueError(
+                "Length of top_nodelist does not match number of rows in A ({n})"
+            )
     else:
         top_nodelist = []
-    
+
     if bottom_nodelist is not None:
         if len(bottom_nodelist) != m:
-            raise ValueError("Length of bottom_nodelist does not match number of columns in A ({m})")
+            raise ValueError(
+                "Length of bottom_nodelist does not match number of columns in A ({m})"
+            )
     else:
         bottom_nodelist = []
 

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -124,20 +124,49 @@ def from_biadjacency_matrix(
 
     Parameters
     ----------
-    A: scipy sparse array
+    A : scipy sparse array
       A biadjacency matrix representation of a graph
 
-    create_using: NetworkX graph
+    create_using : NetworkX graph
        Use specified graph for result.  The default is Graph()
 
-    edge_attribute: string
+    edge_attribute : string
        Name of edge attribute to store matrix numeric value. The data will
        have the same type as the matrix entry (int, float, (real,imag)).
+
+    top_nodelist : list, optional
+        A nodelist for the nodes represented by the rows of the matrix `A`. Will
+        be represented in the graph as nodes with the `bipartite` attribute set
+        to 0. Must be the same length as the number of rows in `A`.
+
+    bottom_nodelist : list, optional
+        A nodelist for the nodes represented by the columns of the matrix `A`. Will
+        be represented in the graph as nodes with the `bipartite` attribute set
+        to 1. Must be the same length as the number of columns in `A`.
+
+    Returns
+    ---------
+    G : NetworkX graph
+        A bipartite graph with edges from the biadjacency matrix `A`, and
+        nodes from the nodelists if provided.
+
+    Raises
+    --------
+    ValueError
+        If `top_nodelist` or `bottom_nodelist` are provided and are not the same
+        length as the number of rows or columns in `A`, respectively.
 
     Notes
     -----
     The nodes are labeled with the attribute `bipartite` set to an integer
-    0 or 1 representing membership in part 0 or part 1 of the bipartite graph.
+    0 or 1 representing membership in the `top` set (`bipartite=0`) or `bottom`
+    set (`bipartite=1`) of the bipartite graph.
+
+    If `top_nodelist` is not specified, the `top` nodes will be labeled with
+    integers from $0$ to $n-1$, where $n$ is the number of rows in `A`.
+
+    If `bottom_nodelist` is not specified, the `bottom` nodes will be labeled with
+    integers from $n$ to $n+m-1$, where $m$ is the number of columns in `A`.
 
     If `create_using` is an instance of :class:`networkx.MultiGraph` or
     :class:`networkx.MultiDiGraph` and the entries of `A` are of

--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -112,7 +112,8 @@ def biadjacency_matrix(
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)
-def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight"):
+def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight",
+                            top_nodelist=None, bottom_nodelist=None):
     r"""Creates a new bipartite graph from a biadjacency matrix given as a
     SciPy sparse array.
 
@@ -150,6 +151,9 @@ def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight"):
     """
     G = nx.empty_graph(0, create_using)
     n, m = A.shape
+    # Check lengths of nodelists match dimensions of A, if not specified set them to []
+    top_nodelist, bottom_nodelist = _validate_initialize_bipartite_nodelists(A, top_nodelist, bottom_nodelist)
+
     # Make sure we get even the isolated nodes of the graph.
     G.add_nodes_from(range(n), bipartite=0)
     G.add_nodes_from(range(n, n + m), bipartite=1)
@@ -165,4 +169,26 @@ def from_biadjacency_matrix(A, create_using=None, edge_attribute="weight"):
         chain = itertools.chain.from_iterable
         triples = chain(((u, v, 1) for d in range(w)) for (u, v, w) in triples)
     G.add_weighted_edges_from(triples, weight=edge_attribute)
+
+    # If the user provided nodelists, relabel the nodes of the graph inplace
+    mapping = dict(itertools.chain(zip(range(n), top_nodelist), zip(range(n, n + m), bottom_nodelist)))
+    if len(mapping):
+        nx.relabel_nodes(G, mapping, copy=False)
     return G
+
+def _validate_initialize_bipartite_nodelists(A, top_nodelist, bottom_nodelist):
+    n, m = A.shape
+    # Validate nodelists if provided
+    if top_nodelist is not None:
+        if len(top_nodelist) != n:
+            raise ValueError("Length of top_nodelist does not match number of rows in A ({n})")
+    else:
+        top_nodelist = []
+    
+    if bottom_nodelist is not None:
+        if len(bottom_nodelist) != m:
+            raise ValueError("Length of bottom_nodelist does not match number of columns in A ({m})")
+    else:
+        bottom_nodelist = []
+
+    return top_nodelist, bottom_nodelist

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -80,3 +80,37 @@ class TestBiadjacencyMatrix:
         M = sp.sparse.csc_array([[1, 2], [0, 3]])
         B = bipartite.from_biadjacency_matrix(M, create_using=nx.MultiGraph())
         assert edges_equal(B.edges(), [(0, 2), (0, 3), (0, 3), (1, 3), (1, 3), (1, 3)])
+
+    def test_from_biadjacency_nodelist(self):
+        M = sp.sparse.csc_array([[1, 2], [0, 3]])
+        top_nodelist = ["a", "b"]
+        bottom_nodelist = ["c", "d"]
+        B = bipartite.from_biadjacency_matrix(
+            M,
+            create_using=nx.MultiGraph(),
+            top_nodelist=top_nodelist,
+            bottom_nodelist=bottom_nodelist,
+        )
+        assert edges_equal(
+            B.edges(),
+            [("a", "c"), ("a", "d"), ("a", "d"), ("b", "d"), ("b", "d"), ("b", "d")],
+        )
+
+    def test_invalid_from_biadjacency_nodelist(self):
+        M = sp.sparse.csc_array([[1, 2], [0, 3]])
+        # For when top nodelist has the wrong length
+        top_nodelist_invalid = ["a", "b", "c"]
+        # For when bottom nodelist has the wrong length
+        bottom_nodelist_invalid = ["c", "d", "e"]
+        with pytest.raises(ValueError):
+            bipartite.from_biadjacency_matrix(
+                M,
+                create_using=nx.MultiGraph(),
+                top_nodelist=top_nodelist_invalid,
+            )
+        with pytest.raises(ValueError):
+            bipartite.from_biadjacency_matrix(
+                M,
+                create_using=nx.MultiGraph(),
+                bottom_nodelist=bottom_nodelist_invalid,
+            )


### PR DESCRIPTION
This pull request is a follow up to the discussion in #7960.

It adds two optional arguments to the `from_biadjacency_matrix` function: `top_nodelist` and `bottom_nodelist`. If either are specified, then the returned graph will use the provided lists to label the `bipartite=0` and `bipartite=1` nodes respectively. Otherwise, behavior is identical to before.