### PR TITLE
bugfix: use supergraph to compute superpos in plot_clusters example

### DIFF
--- a/examples/drawing/plot_clusters.py
+++ b/examples/drawing/plot_clusters.py
@@ -20,7 +20,7 @@ communities = nx.community.greedy_modularity_communities(G)
 # Compute positions for the node clusters as if they were themselves nodes in a
 # supergraph using a larger scale factor
 supergraph = nx.cycle_graph(len(communities))
-superpos = nx.spring_layout(supergraph, scale=50, seed=429)
+superpos = nx.spring_layout(supergraph, scale=2, seed=429)
 
 # Use the "supernode" positions as the center of each node cluster
 centers = list(superpos.values())

--- a/examples/drawing/plot_clusters.py
+++ b/examples/drawing/plot_clusters.py
@@ -20,7 +20,7 @@ communities = nx.community.greedy_modularity_communities(G)
 # Compute positions for the node clusters as if they were themselves nodes in a
 # supergraph using a larger scale factor
 supergraph = nx.cycle_graph(len(communities))
-superpos = nx.spring_layout(G, scale=50, seed=429)
+superpos = nx.spring_layout(supergraph, scale=50, seed=429)
 
 # Use the "supernode" positions as the center of each node cluster
 centers = list(superpos.values())


### PR DESCRIPTION
The `superpos` positions should be computed using `supergraph`, not the original graph `G`.