### PR TITLE
Make test file names unique to be threadsafe

### DIFF
--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -58,16 +58,16 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     >>> G.add_nodes_from([0, 2], bipartite=0)
     >>> G.add_nodes_from([1, 3], bipartite=1)
     >>> nx.write_edgelist(G, "test.edgelist")
-    >>> fh = open("test.edgelist", "wb")
+    >>> fh = open("test.edgelist_open", "wb")
     >>> nx.write_edgelist(G, fh)
     >>> nx.write_edgelist(G, "test.edgelist.gz")
-    >>> nx.write_edgelist(G, "test.edgelist.gz", data=False)
+    >>> nx.write_edgelist(G, "test.edgelist_nodata.gz", data=False)
 
     >>> G = nx.Graph()
     >>> G.add_edge(1, 2, weight=7, color="red")
-    >>> nx.write_edgelist(G, "test.edgelist", data=False)
-    >>> nx.write_edgelist(G, "test.edgelist", data=["color"])
-    >>> nx.write_edgelist(G, "test.edgelist", data=["color", "weight"])
+    >>> nx.write_edgelist(G, "test.edgelist_bigger_nodata", data=False)
+    >>> nx.write_edgelist(G, "test.edgelist_color", data=["color"])
+    >>> nx.write_edgelist(G, "test.edgelist_color_weight", data=["color", "weight"])
 
     See Also
     --------

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -111,12 +111,12 @@ def write_adjlist(G, path, comments="#", delimiter=" ", encoding="utf-8"):
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_adjlist(G, "test.adjlist")
+    >>> nx.write_adjlist(G, "path4.adjlist")
 
     The path can be a filehandle or a string with the name of the file. If a
     filehandle is provided, it has to be opened in 'wb' mode.
 
-    >>> fh = open("test.adjlist", "wb")
+    >>> fh = open("path4.adjlist2", "wb")
     >>> nx.write_adjlist(G, fh)
 
     Notes

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -154,13 +154,13 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     >>> fh = open("test.edgelist", "wb")
     >>> nx.write_edgelist(G, fh)
     >>> nx.write_edgelist(G, "test.edgelist.gz")
-    >>> nx.write_edgelist(G, "test.edgelist.gz", data=False)
+    >>> nx.write_edgelist(G, "test.edgelist_nodata.gz", data=False)
 
     >>> G = nx.Graph()
     >>> G.add_edge(1, 2, weight=7, color="red")
-    >>> nx.write_edgelist(G, "test.edgelist", data=False)
-    >>> nx.write_edgelist(G, "test.edgelist", data=["color"])
-    >>> nx.write_edgelist(G, "test.edgelist", data=["color", "weight"])
+    >>> nx.write_edgelist(G, "test.edgelist_bigger_nodata", data=False)
+    >>> nx.write_edgelist(G, "test.edgelist_color", data=["color"])
+    >>> nx.write_edgelist(G, "test.edgelist_color_weight", data=["color", "weight"])
 
     See Also
     --------
@@ -340,23 +340,23 @@ def read_edgelist(
 
     Examples
     --------
-    >>> nx.write_edgelist(nx.path_graph(4), "test.edgelist")
-    >>> G = nx.read_edgelist("test.edgelist")
+    >>> nx.write_edgelist(nx.path_graph(4), "test.edgelist_P4")
+    >>> G = nx.read_edgelist("test.edgelist_P4")
 
-    >>> fh = open("test.edgelist", "rb")
+    >>> fh = open("test.edgelist_P4", "rb")
     >>> G = nx.read_edgelist(fh)
     >>> fh.close()
 
-    >>> G = nx.read_edgelist("test.edgelist", nodetype=int)
-    >>> G = nx.read_edgelist("test.edgelist", create_using=nx.DiGraph)
+    >>> G = nx.read_edgelist("test.edgelist_P4", nodetype=int)
+    >>> G = nx.read_edgelist("test.edgelist_P4", create_using=nx.DiGraph)
 
     Edgelist with data in a list:
 
     >>> textline = "1 2 3"
-    >>> fh = open("test.edgelist", "w")
+    >>> fh = open("test.textline", "w")
     >>> d = fh.write(textline)
     >>> fh.close()
-    >>> G = nx.read_edgelist("test.edgelist", nodetype=int, data=(("weight", float),))
+    >>> G = nx.read_edgelist("test.textline", nodetype=int, data=(("weight", float),))
     >>> list(G)
     [1, 2]
     >>> list(G.edges(data=True))

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -163,18 +163,18 @@ def read_gml(path, label="label", destringizer=None):
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_gml(G, "test.gml")
+    >>> nx.write_gml(G, "test_path4.gml")
 
     GML values are interpreted as strings by default:
 
-    >>> H = nx.read_gml("test.gml")
+    >>> H = nx.read_gml("test_path4.gml")
     >>> H.nodes
     NodeView(('0', '1', '2', '3'))
 
     When a `destringizer` is provided, GML values are converted to the provided type.
     For example, integer nodes can be recovered as shown below:
 
-    >>> J = nx.read_gml("test.gml", destringizer=int)
+    >>> J = nx.read_gml("test_path4.gml", destringizer=int)
     >>> J.nodes
     NodeView((0, 1, 2, 3))
 
@@ -868,12 +868,12 @@ def write_gml(G, path, stringizer=None):
 
     Examples
     --------
-    >>> G = nx.path_graph(4)
-    >>> nx.write_gml(G, "test.gml")
+    >>> G = nx.path_graph(5)
+    >>> nx.write_gml(G, "test_path5.gml")
 
     Filenames ending in .gz or .bz2 will be compressed.
 
-    >>> nx.write_gml(G, "test.gml.gz")
+    >>> nx.write_gml(G, "test_path5.gml.gz")
     """
     for line in generate_gml(G, stringizer):
         path.write((line + "\n").encode("ascii"))

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -157,17 +157,17 @@ def write_multiline_adjlist(G, path, delimiter=" ", comments="#", encoding="utf-
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_multiline_adjlist(G, "test.adjlist")
+    >>> nx.write_multiline_adjlist(G, "test.multi_adjlist")
 
     The path can be a file handle or a string with the name of the file. If a
     file handle is provided, it has to be opened in 'wb' mode.
 
-    >>> fh = open("test.adjlist", "wb")
+    >>> fh = open("test.multi_adjlist2", "wb")
     >>> nx.write_multiline_adjlist(G, fh)
 
     Filenames ending in .gz or .bz2 will be compressed.
 
-    >>> nx.write_multiline_adjlist(G, "test.adjlist.gz")
+    >>> nx.write_multiline_adjlist(G, "test.multi_adjlist.gz")
 
     See Also
     --------
@@ -341,38 +341,38 @@ def read_multiline_adjlist(
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_multiline_adjlist(G, "test.adjlist")
-    >>> G = nx.read_multiline_adjlist("test.adjlist")
+    >>> nx.write_multiline_adjlist(G, "test.multi_adjlistP4")
+    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4")
 
     The path can be a file or a string with the name of the file. If a
     file s provided, it has to be opened in 'rb' mode.
 
-    >>> fh = open("test.adjlist", "rb")
+    >>> fh = open("test.multi_adjlistP4", "rb")
     >>> G = nx.read_multiline_adjlist(fh)
 
     Filenames ending in .gz or .bz2 will be compressed.
 
-    >>> nx.write_multiline_adjlist(G, "test.adjlist.gz")
-    >>> G = nx.read_multiline_adjlist("test.adjlist.gz")
+    >>> nx.write_multiline_adjlist(G, "test.multi_adjlistP4.gz")
+    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4.gz")
 
     The optional nodetype is a function to convert node strings to nodetype.
 
     For example
 
-    >>> G = nx.read_multiline_adjlist("test.adjlist", nodetype=int)
+    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4", nodetype=int)
 
     will attempt to convert all nodes to integer type.
 
     The optional edgetype is a function to convert edge data strings to
     edgetype.
 
-    >>> G = nx.read_multiline_adjlist("test.adjlist")
+    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4")
 
     The optional create_using parameter is a NetworkX graph container.
     The default is Graph(), an undirected graph.  To read the data as
     a directed graph use
 
-    >>> G = nx.read_multiline_adjlist("test.adjlist", create_using=nx.DiGraph)
+    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4", create_using=nx.DiGraph)
 
     Notes
     -----

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -111,7 +111,7 @@ def write_pajek(G, path, encoding="UTF-8"):
     Examples
     --------
     >>> G = nx.path_graph(4)
-    >>> nx.write_pajek(G, "test.net")
+    >>> nx.write_pajek(G, "test.netP4")
 
     Warnings
     --------


### PR DESCRIPTION
When running tests in parallel, the test filenames should be unique or they overwrite each other.

Fixes #7995 
hopefully... :)  But for sure this could be a problem anyway.

There was talk about making these all tempfile examples, but the point of the examples is to show the various ways you can save to files -- so we would lose the point of the examples. There still might be a solution there, but I'm putting this out there as a way to avoid the intermittent failures.