### PR TITLE
Added "initial_node" param to generate_random_paths() to allow a starting node to be specified for generated walks

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1645,7 +1645,13 @@ def panther_similarity(
 @np_random_state(5)
 @nx._dispatchable(edge_attrs="weight")
 def generate_random_paths(
-    G, sample_size, path_length=5, index_map=None, weight="weight", seed=None
+    G,
+    sample_size,
+    path_length=5,
+    index_map=None,
+    weight="weight",
+    seed=None,
+    initial_node=None,
 ):
     """Randomly generate `sample_size` paths of length `path_length`.
 
@@ -1669,6 +1675,9 @@ def generate_random_paths(
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
+    initial_node : node, optional
+        Node to use as the starting point for all generated paths.
+        If None then starting nodes are selected at random with uniform probability.
 
     Returns
     -------
@@ -1716,9 +1725,16 @@ def generate_random_paths(
     num_nodes = G.number_of_nodes()
 
     for path_index in range(sample_size):
-        # Sample current vertex v = v_i uniformly at random
-        node_index = randint_fn(num_nodes)
-        node = node_map[node_index]
+        if initial_node is None:
+            # Sample current vertex v = v_i uniformly at random
+            node_index = randint_fn(num_nodes)
+            node = node_map[node_index]
+        else:
+            if initial_node not in node_map:
+                raise nx.NodeNotFound(f"Initial node {initial_node} not in G")
+
+            node = initial_node
+            node_index = node_map.index(node)
 
         # Add v into p_r and add p_r into the path set
         # of v, i.e., P_v

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1651,6 +1651,7 @@ def generate_random_paths(
     index_map=None,
     weight="weight",
     seed=None,
+    *,
     source=None,
 ):
     """Randomly generate `sample_size` paths of length `path_length`.
@@ -1675,7 +1676,7 @@ def generate_random_paths(
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
-    initial_node : node, optional
+    source : node, optional
         Node to use as the starting point for all generated paths.
         If None then starting nodes are selected at random with uniform probability.
 
@@ -1725,15 +1726,15 @@ def generate_random_paths(
     num_nodes = G.number_of_nodes()
 
     for path_index in range(sample_size):
-        if initial_node is None:
+        if source is None:
             # Sample current vertex v = v_i uniformly at random
             node_index = randint_fn(num_nodes)
             node = node_map[node_index]
         else:
-            if initial_node not in node_map:
-                raise nx.NodeNotFound(f"Initial node {initial_node} not in G")
+            if source not in node_map:
+                raise nx.NodeNotFound(f"Initial node {source} not in G")
 
-            node = initial_node
+            node = source
             node_index = node_map.index(node)
 
         # Add v into p_r and add p_r into the path set

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -1651,7 +1651,7 @@ def generate_random_paths(
     index_map=None,
     weight="weight",
     seed=None,
-    initial_node=None,
+    source=None,
 ):
     """Randomly generate `sample_size` paths of length `path_length`.
 

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -848,7 +848,7 @@ class TestSimilarity:
         index_map = {}
         num_paths = 10
         path_length = 2
-        initial_node = 1
+        source = 1
         G = nx.Graph()
         G.add_edge(0, 1)
         G.add_edge(0, 2)
@@ -861,7 +861,7 @@ class TestSimilarity:
             path_length=path_length,
             index_map=index_map,
             seed=42,
-            initial_node=initial_node,
+            source=source,
         )
         expected_paths = [
             [1, 0, 3],

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -844,6 +844,48 @@ class TestSimilarity:
         ):
             nx.panther_similarity(G, source=1)
 
+    def test_generate_random_paths_with_start(self):
+        index_map = {}
+        num_paths = 10
+        path_length = 2
+        initial_node = 1
+        G = nx.Graph()
+        G.add_edge(0, 1)
+        G.add_edge(0, 2)
+        G.add_edge(0, 3)
+        G.add_edge(1, 2)
+        G.add_edge(2, 4)
+        paths = nx.generate_random_paths(
+            G,
+            num_paths,
+            path_length=path_length,
+            index_map=index_map,
+            seed=42,
+            initial_node=initial_node,
+        )
+        expected_paths = [
+            [1, 0, 3],
+            [1, 2, 1],
+            [1, 0, 1],
+            [1, 0, 3],
+            [1, 2, 4],
+            [1, 0, 3],
+            [1, 2, 0],
+            [1, 0, 1],
+            [1, 0, 2],
+            [1, 0, 1],
+        ]
+        expected_map = {
+            0: {0, 2, 3, 5, 6, 7, 8, 9},
+            1: {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            2: {1, 4, 6, 8},
+            3: {0, 3, 5},
+            4: {4},
+        }
+
+        assert expected_paths == list(paths)
+        assert expected_map == index_map
+
     def test_generate_random_paths_unweighted(self):
         index_map = {}
         num_paths = 10


### PR DESCRIPTION
Small modification to allow the user to specify an initial node to begin all walks from.