### PR TITLE
Fix behavior for iterable `sources` argument in `bfs_layers`

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -417,7 +417,7 @@ def bfs_layers(G, sources):
 
     Yields
     ------
-    layers: list of nodes
+    layer : list of nodes
         Yields list of nodes at the same distance from `sources`.
 
     Examples

--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -411,13 +411,14 @@ def bfs_layers(G, sources):
     G : NetworkX graph
         A graph over which to find the layers using breadth-first search.
 
-    sources : node in `G` or list of nodes in `G`
-        Specify starting nodes for single source or multiple sources breadth-first search
+    sources : node in `G` or iterable of nodes in `G`
+        Specify starting nodes for single source or multiple sources
+        breadth-first search.
 
     Yields
     ------
-    layer: list of nodes
-        Yields list of nodes at the same distance from sources
+    layers: list of nodes
+        Yields list of nodes at the same distance from `sources`.
 
     Examples
     --------
@@ -434,8 +435,8 @@ def bfs_layers(G, sources):
     if sources in G:
         sources = [sources]
 
-    current_layer = list(sources)
     visited = set(sources)
+    current_layer = list(visited)
 
     for source in current_layer:
         if source not in G:

--- a/networkx/algorithms/traversal/tests/test_bfs.py
+++ b/networkx/algorithms/traversal/tests/test_bfs.py
@@ -58,8 +58,8 @@ class TestBFS:
             2: [2, 3],
             3: [4],
         }
-        assert dict(enumerate(nx.bfs_layers(self.G, sources=[0]))) == expected
-        assert dict(enumerate(nx.bfs_layers(self.G, sources=0))) == expected
+        for sources in [0, [0], (i for i in [0]), [0, 0]]:
+            assert dict(enumerate(nx.bfs_layers(self.G, sources))) == expected
 
     def test_bfs_layers_missing_source(self):
         with pytest.raises(nx.NetworkXError):


### PR DESCRIPTION
This addresses the issue reported in #8009.
It makes sense to me to ensure the function works correctly for generators as well; especially since the fix is as simple as this.
I also thought it was more reasonable to gracefully handle duplicate nodes in the `sources` argument; at every depth other than 0, nodes never appear multiple times (because of the `visited` set), and I see no convincing reason to have the sources be handled any differently.

List of changes:
* Avoid silent failure when `sources` is a generator
* Only handle duplicate nodes once
* Add test cases where `sources` is a generator and list with duplicate elements
* Minor clarifications in docstring

Fixes gh-8009.