### PR TITLE
Add nx-guides link to navbar without dropdown.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -147,7 +147,7 @@ html_theme_options = {
     "external_links": [{"name": "Guides", "url": "https://networkx.org/nx-guides/"}],
     "navbar_end": ["theme-switcher", "navbar-icon-links", "version-switcher"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page"],
-    "header_links_before_dropdown": 7,
+    "header_links_before_dropdown": 8,
     "switcher": {
         "json_url": (
             "https://networkx.org/documentation/latest/_static/version_switcher.json"


### PR DESCRIPTION
Minor doc config tweak: this prevents the link to `nx-guides` from being hidden in a dropdown in the top-level navbar on the page. Related to a discussion at the community meeting several weeks ago!