### PR TITLE
Minor follow-up to gh-8002 tests

### DIFF
--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -844,47 +844,28 @@ class TestSimilarity:
         ):
             nx.panther_similarity(G, source=1)
 
-    def test_generate_random_paths_with_start(self):
+    @pytest.mark.parametrize("num_paths", (1, 3, 10))
+    @pytest.mark.parametrize("source", (0, 1))
+    def test_generate_random_paths_with_start(self, num_paths, source):
+        G = nx.Graph([(0, 1), (0, 2), (0, 3), (1, 2), (2, 4)])
         index_map = {}
-        num_paths = 10
-        path_length = 2
-        source = 1
-        G = nx.Graph()
-        G.add_edge(0, 1)
-        G.add_edge(0, 2)
-        G.add_edge(0, 3)
-        G.add_edge(1, 2)
-        G.add_edge(2, 4)
-        paths = nx.generate_random_paths(
+
+        path_gen = nx.generate_random_paths(
             G,
             num_paths,
-            path_length=path_length,
+            path_length=2,
             index_map=index_map,
-            seed=42,
             source=source,
         )
-        expected_paths = [
-            [1, 0, 3],
-            [1, 2, 1],
-            [1, 0, 1],
-            [1, 0, 3],
-            [1, 2, 4],
-            [1, 0, 3],
-            [1, 2, 0],
-            [1, 0, 1],
-            [1, 0, 2],
-            [1, 0, 1],
-        ]
-        expected_map = {
-            0: {0, 2, 3, 5, 6, 7, 8, 9},
-            1: {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-            2: {1, 4, 6, 8},
-            3: {0, 3, 5},
-            4: {4},
-        }
+        paths = list(path_gen)
 
-        assert expected_paths == list(paths)
-        assert expected_map == index_map
+        # There should be num_paths paths
+        assert len(paths) == num_paths
+        # And they should all start with `source`
+        assert all(p[0] == source for p in paths)
+        # The index_map for the `source` node should contain the indices for
+        # all of the generated paths.
+        assert sorted(index_map[source]) == list(range(num_paths))
 
     def test_generate_random_paths_unweighted(self):
         index_map = {}

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -16,6 +16,7 @@ from networkx.generators.classic import (
 
 @pytest.mark.parametrize("source", (10, "foo"))
 def test_generate_random_paths_source_not_in_G(source):
+    pytest.importorskip("numpy")
     G = nx.complete_graph(5)
     # No exception at generator construction time
     path_gen = nx.generate_random_paths(G, sample_size=3, source=source)

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -14,6 +14,15 @@ from networkx.generators.classic import (
 )
 
 
+@pytest.mark.parametrize("source", (10, "foo"))
+def test_generate_random_paths_source_not_in_G(source):
+    G = nx.complete_graph(5)
+    # No exception at generator construction time
+    path_gen = nx.generate_random_paths(G, sample_size=3, source=source)
+    with pytest.raises(nx.NodeNotFound, match="Initial node.*not in G"):
+        next(path_gen)
+
+
 def nmatch(n1, n2):
     return n1 == n2
 


### PR DESCRIPTION
I was late reviewing #8002 (apologies!) but did eventually get a chance to look at it and just turned my comments into a PR :). Not at all important, just a minor followup!

There are two main proposals:
 - 98d5074 refactors the test added in #8002 to check properties of the generated paths (i.e. that they all start with `source`, rather than doing an exact-match on a seeded example. IMO this is a minor improvement as it's slightly more flexible and removes the dependence of the test on the random number system (in principle also increasing robustness). It's clear that the test was inspired by the one below it, so it made perfect sense but I thought it was a nice opportunity to add some flexibility!
 - 558f4d2 adds an additional test for when the `source` is not in `G`. 