### PR TITLE
Fix `is_aperiodic`

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -628,9 +628,9 @@ def is_aperiodic(G):
 
     Notes
     -----
-    This uses the method outlined in [1]_, which runs in $O(m)$ time
-    given $m$ edges in `G`. Note that a graph is not aperiodic if it is
-    acyclic as every integer trivial divides length 0 cycles.
+    This uses the method outlined in [1]_, which runs in $O(n + m)$ time
+    given $n$ nodes and $m$ edges in `G`. Note that a graph is not aperiodic
+    if it is acyclic as every integer trivial divides length 0 cycles.
 
     References
     ----------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -592,7 +592,7 @@ def is_aperiodic(G):
 
     Raises
     ------
-    NetworkXError
+    NetworkXNotImplemented
         If `G` is not directed
 
     Examples

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -631,7 +631,7 @@ def is_aperiodic(G):
     -----
     This uses the method outlined in [1]_, which runs in $O(n + m)$ time
     given $n$ nodes and $m$ edges in `G`. Note that a graph is not aperiodic
-    if it is acyclic as every integer trivial divides length 0 cycles.
+    if it is acyclic as every integer trivially divides length 0 cycles.
 
     References
     ----------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -643,13 +643,12 @@ def is_aperiodic(G):
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
 
-    seen = set()
-    g = 0
+    scc = nx.strongly_connected_components(G)
+    sg = (G.subgraph(c) for c in scc)
 
-    for s in G:
-        if s in seen:
-            continue
-        seen.add(s)
+    g = 0
+    for H in sg:
+        s = nx.utils.arbitrary_element(H)
 
         current_layer = [s]
         level = {s: 0}
@@ -658,17 +657,18 @@ def is_aperiodic(G):
         while current_layer:
             next_layer = []
             for u in current_layer:
-                for v in G.successors(u):
+                for v in H.successors(u):
                     if v in level:  # Non-Tree Edge
                         g = gcd(g, level[u] - level[v] + 1)
-                    elif v not in seen:  # Tree Edge
+                        if g == 1:
+                            return True
+                    else:  # Tree Edge
                         next_layer.append(v)
                         level[v] = level_count
-                        seen.add(v)
             current_layer = next_layer
             level_count += 1
 
-    return g == 1
+    return False
 
 
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -649,24 +649,15 @@ def is_aperiodic(G):
     g = 0
     for H in sg:
         s = nx.utils.arbitrary_element(H)
-
-        current_layer = [s]
         level = {s: 0}
-        level_count = 1
 
-        while current_layer:
-            next_layer = []
-            for u in current_layer:
-                for v in H.successors(u):
-                    if v in level:  # Non-Tree Edge
-                        g = gcd(g, level[u] - level[v] + 1)
-                        if g == 1:
-                            return True
-                    else:  # Tree Edge
-                        next_layer.append(v)
-                        level[v] = level_count
-            current_layer = next_layer
-            level_count += 1
+        for u, v, d in nx.bfs_labeled_edges(H, s):
+            if d == "tree":
+                level[v] = level[u] + 1
+            else:
+                g = gcd(g, level[u] - level[v] + 1)
+                if g == 1:
+                    return True
 
     return False
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -572,6 +572,7 @@ def all_topological_sorts(G):
             break
 
 
+@not_implemented_for("undirected")
 @nx._dispatchable
 def is_aperiodic(G):
     """Returns True if `G` is aperiodic.
@@ -639,8 +640,6 @@ def is_aperiodic(G):
        in Shier, D. R.; Wallenius, K. T., Applied Mathematical Modeling:
        A Multidisciplinary Approach, CRC Press.
     """
-    if not G.is_directed():
-        raise nx.NetworkXError("is_aperiodic not defined for undirected graphs")
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -631,7 +631,11 @@ def is_aperiodic(G):
     -----
     This uses the method outlined in [1]_, which runs in $O(n + m)$ time
     given $n$ nodes and $m$ edges in `G`. Note that a graph is not aperiodic
-    if it is acyclic, as every integer divides all cycles (because there are no cycles to divide).
+    if it is acyclic, as every integer divides all cycles (because there are
+    no cycles to divide).
+
+    Self-loops (edges from a node to itself) are considered as cycles of length 1
+    in this implementation.
 
     References
     ----------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -631,7 +631,7 @@ def is_aperiodic(G):
     -----
     This uses the method outlined in [1]_, which runs in $O(n + m)$ time
     given $n$ nodes and $m$ edges in `G`. Note that a graph is not aperiodic
-    if it is acyclic as every integer trivially divides length 0 cycles.
+    if it is acyclic, as every integer divides all cycles (because there are no cycles to divide).
 
     References
     ----------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -643,26 +643,33 @@ def is_aperiodic(G):
         raise nx.NetworkXError("is_aperiodic not defined for undirected graphs")
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
-    s = arbitrary_element(G)
-    levels = {s: 0}
-    this_level = [s]
+
+    seen = set()
     g = 0
-    lev = 1
-    while this_level:
-        next_level = []
-        for u in this_level:
-            for v in G[u]:
-                if v in levels:  # Non-Tree Edge
-                    g = gcd(g, levels[u] - levels[v] + 1)
-                else:  # Tree Edge
-                    next_level.append(v)
-                    levels[v] = lev
-        this_level = next_level
-        lev += 1
-    if len(levels) == len(G):  # All nodes in tree
-        return g == 1
-    else:
-        return g == 1 and nx.is_aperiodic(G.subgraph(set(G) - set(levels)))
+
+    for s in G:
+        if s in seen:
+            continue
+        seen.add(s)
+
+        current_layer = [s]
+        level = {s: 0}
+        level_count = 1
+
+        while current_layer:
+            next_layer = []
+            for u in current_layer:
+                for v in G.successors(u):
+                    if v in level:  # Non-Tree Edge
+                        g = gcd(g, level[u] - level[v] + 1)
+                    elif v not in seen:  # Tree Edge
+                        next_layer.append(v)
+                        level[v] = level_count
+                        seen.add(v)
+            current_layer = next_layer
+            level_count += 1
+
+    return g == 1
 
 
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -1,9 +1,9 @@
-import random
 from collections import deque
 from itertools import combinations, permutations
 from math import gcd
 
 import pytest
+from numpy.random import default_rng
 
 import networkx as nx
 from networkx.utils import edges_equal, pairwise
@@ -685,18 +685,18 @@ def test_is_aperiodic_acyclic_component2():
 
 @pytest.mark.parametrize("seed", range(10))
 def test_is_aperiodic_random(seed):
-    rng = random.Random(seed)
+    rng = default_rng(seed)
 
-    cycles = [rng.randint(3, 10) for _ in range(2)]
+    cycles = list(rng.integers(3, 11, size=2))
     g = gcd(*cycles)
     while g != 1:
-        new_cycle = rng.randint(3, 10)
+        new_cycle = rng.integers(3, 11)
         cycles.append(new_cycle)
         g = gcd(g, new_cycle)
 
     G = nx.DiGraph()
     for cycle in cycles:
-        cycle_nodes = [rng.randint(0, 10) for _ in range(cycle)]
+        cycle_nodes = rng.integers(0, 11, size=cycle)
         nx.add_cycle(G, cycle_nodes)
 
     assert nx.is_aperiodic(G)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -1,9 +1,9 @@
+import random
 from collections import deque
 from itertools import combinations, permutations
 from math import gcd
 
 import pytest
-from numpy.random import default_rng
 
 import networkx as nx
 from networkx.utils import edges_equal, pairwise
@@ -685,18 +685,18 @@ def test_is_aperiodic_acyclic_component2():
 
 @pytest.mark.parametrize("seed", range(10))
 def test_is_aperiodic_random(seed):
-    rng = default_rng(seed)
+    rng = random.Random(seed)
 
-    cycles = list(rng.integers(3, 11, size=2))
+    cycles = [rng.randint(3, 10) for _ in range(2)]
     g = gcd(*cycles)
     while g != 1:
-        new_cycle = rng.integers(3, 11)
+        new_cycle = rng.randint(3, 10)
         cycles.append(new_cycle)
         g = gcd(g, new_cycle)
 
     G = nx.DiGraph()
     for cycle in cycles:
-        cycle_nodes = rng.integers(0, 11, size=cycle)
+        cycle_nodes = [rng.randint(0, 10) for _ in range(cycle)]
         nx.add_cycle(G, cycle_nodes)
 
     assert nx.is_aperiodic(G)

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -665,7 +665,7 @@ def test_is_aperiodic_disconnected2():
     G = nx.DiGraph()
     nx.add_cycle(G, [0, 1, 2])
     G.add_edge(3, 3)
-    assert not nx.is_aperiodic(G)
+    assert nx.is_aperiodic(G)
 
 
 def test_is_aperiodic_acyclic_component():

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -630,7 +630,7 @@ def test_is_aperiodic_selfloop():
 
 def test_is_aperiodic_undirected_raises():
     G = nx.Graph()
-    pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
+    pytest.raises(nx.NetworkXNotImplemented, nx.is_aperiodic, G)
 
 
 def test_is_aperiodic_empty_graph():

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -683,23 +683,42 @@ def test_is_aperiodic_acyclic_component2():
     assert nx.is_aperiodic(G)
 
 
-@pytest.mark.parametrize("seed", range(10))
-def test_is_aperiodic_random(seed):
+def random_aperiodic_graph(seed, n, n_cycle, l, r):
     rng = random.Random(seed)
 
-    cycles = [rng.randint(3, 10) for _ in range(2)]
+    cycles = [rng.randint(l, r) for _ in range(n_cycle)]
     g = gcd(*cycles)
     while g != 1:
-        new_cycle = rng.randint(3, 10)
+        new_cycle = rng.randint(l, r)
         cycles.append(new_cycle)
         g = gcd(g, new_cycle)
 
     G = nx.DiGraph()
     for cycle in cycles:
-        cycle_nodes = [rng.randint(0, 10) for _ in range(cycle)]
+        cycle_nodes = [rng.randint(0, n - 1) for _ in range(cycle)]
         nx.add_cycle(G, cycle_nodes)
 
+    return G
+
+
+def to_periodic_graph(G, k):
+    n = max(G.nodes()) + 1
+    H = nx.DiGraph()
+
+    for u, v in G.edges():
+        x = [u] + [n + i for i in range(k - 1)] + [v]
+        n += k - 1
+        H.add_edges_from(nx.utils.pairwise(x))
+
+    return H
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_is_aperiodic_random(seed):
+    G = random_aperiodic_graph(seed, n=10, n_cycle=3, l=3, r=6)
     assert nx.is_aperiodic(G)
+    for k in range(2, 5):
+        assert not nx.is_aperiodic(to_periodic_graph(G, k))
 
 
 class TestDagToBranching:

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -683,6 +683,24 @@ def test_is_aperiodic_acyclic_component2():
     assert nx.is_aperiodic(G)
 
 
+def test_is_aperiodic_scc_division():
+    """Tests that `is_aperiodic` correctly divides the graph into
+    SCCs (Strongly Connected Components) before checking for aperiodicity.
+    """
+    G = nx.DiGraph()
+
+    # Would detect a length-2 cycle if not divided into SCCs
+    # The subgraph is actually acyclic
+    nx.add_path(G, [1, 2])
+    nx.add_path(G, [1, 3, 4])
+    G.add_edge(4, 2)
+
+    # A length-3 cycle
+    nx.add_cycle(G, [5, 6, 7])
+
+    assert not nx.is_aperiodic(G)
+
+
 def random_aperiodic_graph(seed, n, n_cycle, l, r):
     rng = random.Random(seed)
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -1,5 +1,7 @@
+import random
 from collections import deque
 from itertools import combinations, permutations
+from math import gcd
 
 import pytest
 
@@ -611,6 +613,14 @@ def test_is_aperiodic_cycle4():
     assert nx.is_aperiodic(G)
 
 
+def test_is_aperiodic_cycle5():
+    G = nx.DiGraph()
+    nx.add_cycle(G, [1, 2, 3, 4])
+    nx.add_cycle(G, [5, 6, 7])
+    G.add_edge(5, 1)
+    assert nx.is_aperiodic(G)
+
+
 def test_is_aperiodic_selfloop():
     G = nx.DiGraph()
     nx.add_cycle(G, [1, 2, 3, 4])
@@ -656,6 +666,40 @@ def test_is_aperiodic_disconnected2():
     nx.add_cycle(G, [0, 1, 2])
     G.add_edge(3, 3)
     assert not nx.is_aperiodic(G)
+
+
+def test_is_aperiodic_acyclic_component():
+    G = nx.DiGraph()
+    G.add_node(0)
+    G.add_edge(1, 1)
+    assert nx.is_aperiodic(G)
+
+
+def test_is_aperiodic_acyclic_component2():
+    G = nx.DiGraph()
+    G.add_node(0)
+    nx.add_cycle(G, [1, 2, 3])
+    nx.add_cycle(G, [2, 3, 4, 5])
+    assert nx.is_aperiodic(G)
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_is_aperiodic_random(seed):
+    rng = random.Random(seed)
+
+    cycles = [rng.randint(3, 10) for _ in range(2)]
+    g = gcd(*cycles)
+    while g != 1:
+        new_cycle = rng.randint(3, 10)
+        cycles.append(new_cycle)
+        g = gcd(g, new_cycle)
+
+    G = nx.DiGraph()
+    for cycle in cycles:
+        cycle_nodes = [rng.randint(0, 10) for _ in range(cycle)]
+        nx.add_cycle(G, cycle_nodes)
+
+    assert nx.is_aperiodic(G)
 
 
 class TestDagToBranching:


### PR DESCRIPTION
The current implementation of `is_aperiodic` ([link](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.dag.is_aperiodic.html#networkx.algorithms.dag.is_aperiodic)) is incorrect. It short-circuits when `g != 1` with return value `False`. However, `g != 1` for the currently explored nodes doesn't necessarily mean the graph is not aperiodic.

One of the current tests is incorrect (`G` contains a self-loop and is therefore aperiodic. But the test claims that it is not aperiodic):

```python
def test_is_aperiodic_disconnected2():
    G = nx.DiGraph()
    nx.add_cycle(G, [0, 1, 2])
    G.add_edge(3, 3)
    assert not nx.is_aperiodic(G)
```

Several tests that fail with the current implementation are added. Preview:

```python
def test_is_aperiodic_cycle5():
    G = nx.DiGraph()
    nx.add_cycle(G, [1, 2, 3, 4])
    nx.add_cycle(G, [5, 6, 7])
    G.add_edge(5, 1)
    assert nx.is_aperiodic(G)


def test_is_aperiodic_acyclic_component():
    G = nx.DiGraph()
    G.add_node(0)
    G.add_edge(1, 1)
    assert nx.is_aperiodic(G)


def test_is_aperiodic_acyclic_component2():
    G = nx.DiGraph()
    G.add_node(0)
    nx.add_cycle(G, [1, 2, 3])
    nx.add_cycle(G, [2, 3, 4, 5])
    assert nx.is_aperiodic(G)
```

The fixed new implementation works in the same manner as the original one, but is no longer recursive.
