### PR TITLE
complete_to_chordal_graph review

### DIFF
--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -18,7 +18,11 @@ __all__ = [
     "chordal_graph_cliques",
     "chordal_graph_treewidth",
     "NetworkXTreewidthBoundExceeded",
+    "triangulate",
     "complete_to_chordal_graph",
+    "minimal_elimination_order",
+    "perfect_elimination_order",
+    "is_perfect_elimination_graph",
 ]
 
 


### PR DESCRIPTION
See issue #6873.

complete_to_chordal_graph(G) returns a chordal graph H and a dictionary alpha giving the elimination ordering. alpha is sometimes meaningless (e.g., when G is already chordal — it's all zeros).

Implemented changes as suggested here: https://github.com/networkx/networkx/issues/6873#issuecomment-1880386482

_triangulate_with_mcs: private function using original code without checking is_chordal

triangulate: returns the graph constructed using _triangulate_with_mcs
complete_to_chordal_graph: checks for chordality too and returns graph as well as alpha (same as original behaviour)
minimal_elimination_order(G) – return alpha only.
perfect_elimination_order(G) – raise if G is not chordal.
is_perfect_elimination_graph(G) – alias for is_chordal(G)

