### PR TITLE
Optimizing Dijkstra's paths to target (~27x faster for graphs with long diameter)

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -834,6 +834,14 @@ def _dijkstra_multisource(
     as arguments. No need to explicitly return pred or paths.
 
     """
+    if target is None:
+        paths_dict = paths
+    else:
+        # computing paths is expensive, we compute pred instad since we only need it
+        # for one specific target
+        paths_dict = None
+        if pred is None:
+            pred = {}
     G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
 
     push = heappush
@@ -871,14 +879,23 @@ def _dijkstra_multisource(
             elif u not in seen or vu_dist < seen[u]:
                 seen[u] = vu_dist
                 push(fringe, (vu_dist, next(c), u))
-                if paths is not None:
-                    paths[u] = paths[v] + [u]
+                if paths_dict is not None:
+                    paths_dict[u] = paths_dict[v] + [u]
                 if pred is not None:
                     pred[u] = [v]
             elif vu_dist == seen[u]:
                 if pred is not None:
                     pred[u].append(v)
 
+    if target is not None and paths is not None:
+        # reconstruct the path from source to target
+        reversed_target_path = []
+        next_node = target
+        while next_node is not None:
+            reversed_target_path.append(next_node)
+            next_nodes = pred.get(next_node)
+            next_node = next_nodes and next_nodes[0]
+        paths[target] = list(reversed(reversed_target_path))
     # The optional predecessor and path dictionaries can be accessed
     # by the caller via the pred and paths objects passed as arguments.
     return dist


### PR DESCRIPTION

### Summary

Optimize Dijkstra's algorithm when a single `target` is specified by avoiding full path reconstruction for all nodes.

### Motivation

In the current implementation of `_dijkstra_multisource`, when the `paths` argument is provided, paths are computed and stored for all reachable nodes. However, if only a specific `target` node is of interest, this can be wastefully expensive.

This PR avoids storing all paths when only a `target` is specified, and instead reconstructs the path to the `target` at the end using the `pred` dictionary, which is much cheaper to maintain.

### Changes

- Skip path storage during the main loop if only a specific `target` is requested.
- Use `pred` (predecessor map) to reconstruct the path to `target` at the end.
- Add a lightweight reconstruction loop to build `paths[target]` from `pred`.

### Performance

This change reduces memory usage and computation time when:
- A `target` is specified.
- `paths` is requested.
- There is no need to compute all paths from the source(s) to every reachable node.

### Notes

- The `pred` dictionary is now always initialized when `target` and `paths` are specified (if not already provided), as it's required for final path reconstruction.
- This change preserves existing behavior and output structure.

No public API changes are introduced.

### Results

Optimization adds the most value when the shortest paths to the target has many hops. In the case of the line graph of length 10_000, computing the source from node 0 to node 999 gets ~27x faster.

```python
import networkx as nx
import timeit
 
REPEATS = 100
 
def generate_graphs():
    return {"line_10000": nx.path_graph(10_000)}

def time_dijkstra(G):
    return min(timeit.timeit(lambda: nx.single_source_dijkstra(G, 0, target=len(G)-1), number=1) for _ in range(REPEATS))

for name, G in generate_graphs().items():
    print(f"{name}: min time over {REPEATS} runs = {time_dijkstra(G):.6f} sec")   
```

#### Without optimization
```
line_10000: min time over 100 runs = 0.408241 sec
```

#### With optimization
```
line_10000: min time over 100 runs = 0.014789 sec
```