### PR TITLE
Add sg_execution_times.rst to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doc/networkx_reference.pdf
 doc/networkx_tutorial.pdf
 doc/build
 doc/ghpages_build
+doc/sg_execution_times.rst
 .coverage
 *.class
 


### PR DESCRIPTION
When running the `make` command to build the docs locally, the file `sg_execution_times.rst` is created. I've added it to the `.gitignore` for convenience/QoL.