### PR TITLE
Support both pydot v3 and pydot v4.

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -112,11 +112,13 @@ def from_pydot(P):
     >>> G = nx.Graph(nx.nx_pydot.from_pydot(A))
 
     """
-
-    if P.get_strict(None):  # pydot bug: get_strict() shouldn't take argument
-        multiedges = False
-    else:
-        multiedges = True
+    # NOTE: Pydot v3 expects a dummy argument whereas Pydot v4 doesn't
+    # Remove the try-except when Pydot v4 becomes the minimum supported version
+    try:
+        strict = P.get_strict()
+    except TypeError:
+        strict = P.get_strict(None)  # pydot bug: get_strict() shouldn't take argument
+    multiedges = not strict
 
     if P.get_type() == "graph":  # undirected
         if multiedges:


### PR DESCRIPTION
Closes #8026 

I think it's relatively straightforward to deal with the signature difference between pydot v3 and v4 for `get_strict`.

My personal vote would be to support both for nx 3.5, then bump the pydot minimum version to 4.0 in nx 3.6.