### PR TITLE
Fix pydot get_strict error on CI

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -113,7 +113,7 @@ def from_pydot(P):
 
     """
 
-    if P.get_strict(None):  # pydot bug: get_strict() shouldn't take argument
+    if P.get_strict():  # pydot bug: get_strict() shouldn't take argument
         multiedges = False
     else:
         multiedges = True


### PR DESCRIPTION
Recent change to pydot removed an optional arg to pydot's `get_strict` method. We were only passing in None. So I removed it and we'll see how the CI fares.