### PR TITLE
A minimal fix for `is_aperiodic`

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -608,35 +608,43 @@ def is_aperiodic(G):
 
     Examples
     --------
-    A graph consisting of a length-2 cycle. Therefore ``k = 2``
+    A graph consisting of one cycle, the length of which is 2. Therefore ``k = 2``
     divides the length of every cycle in the graph and thus the graph
-    is *not aperiodic*.
+    is *not aperiodic*::
 
-    >>> G = nx.DiGraph([(1, 2), (2, 1)])
-    >>> nx.is_aperiodic(G)
-    False
+        >>> DG = nx.DiGraph([(1, 2), (2, 1)])
+        >>> nx.is_aperiodic(DG)
+        False
 
-    A graph consisting of two length-3 cycles that share a common edge. One can
-    find two cycles of [1, 2, 3] and [1, 4, 2, 3] of length 3 and length 4,
-    respectively. There is no single value of ``k > 1`` that divides the length
-    of every cycle in the graph and thus the graph is *aperiodic*.
+    A graph consisting of two cycles: one of length 2 and the other of length 3.
+    The cycle lengths are coprime, so there is no single value of k where ``k > 1``
+    that divides each cycle length and therefore the graph is *aperiodic*::
 
-    >>> G = nx.DiGraph()
-    >>> nx.add_cycle(G, [1, 2, 3])
-    >>> nx.add_cycle(G, [2, 1, 4])
-    >>> nx.is_aperiodic(G)
-    True
+        >>> DG = nx.DiGraph([(1, 2), (2, 3), (3, 1), (1, 4), (4, 1)])
+        >>> nx.is_aperiodic(DG)
+        True
+
+    A graph created from cycles of the same length can still be aperiodic since
+    the cycles can overlap and form new cycles of different lengths. For example,
+    the following graph contains a cycle [4, 2, 3, 1] of length 4, which is coprime
+    with the explicitly added cycles of length 3, so the graph is aperiodic::
+
+        >>> DG = nx.DiGraph()
+        >>> nx.add_cycle(DG, [1, 2, 3])
+        >>> nx.add_cycle(DG, [2, 1, 4])
+        >>> nx.is_aperiodic(DG)
+        True
 
     A single-node graph's aperiodicity depends on whether it has a self-loop:
-    it is aperiodic if a self-loop exists, and periodic otherwise.
+    it is aperiodic if a self-loop exists, and periodic otherwise::
 
-    >>> G = nx.DiGraph()
-    >>> G.add_node(1)
-    >>> nx.is_aperiodic(G)
-    False
-    >>> G.add_edge(1, 1)
-    >>> nx.is_aperiodic(G)
-    True
+        >>> G = nx.DiGraph()
+        >>> G.add_node(1)
+        >>> nx.is_aperiodic(G)
+        False
+        >>> G.add_edge(1, 1)
+        >>> nx.is_aperiodic(G)
+        True
 
     A Markov chain can be modeled as a directed graph, with nodes representing
     states and edges representing transitions with non-zero probability.
@@ -644,31 +652,31 @@ def is_aperiodic(G):
     which are those that are *strongly connected* as graphs.
 
     The following Markov chain is irreducible and aperiodic, and thus
-    ergodic. It is guaranteed to have a unique stationary distribution.
+    ergodic. It is guaranteed to have a unique stationary distribution::
 
-    >>> G = nx.DiGraph()
-    >>> nx.add_cycle(G, [1, 2, 3, 4])
-    >>> G.add_edge(1, 3)
-    >>> nx.is_aperiodic(G)
-    True
+        >>> G = nx.DiGraph()
+        >>> nx.add_cycle(G, [1, 2, 3, 4])
+        >>> G.add_edge(1, 3)
+        >>> nx.is_aperiodic(G)
+        True
 
     Reducible Markov chains can sometimes have a unique stationary distribution.
     This occurs if the chain has exactly one closed communicating class and
     that class itself is aperiodic (see [1]_). You can use
     :func:`~networkx.algorithms.components.attracting_components`
-    to find these closed communicating classes.
+    to find these closed communicating classes::
 
-    >>> G = nx.DiGraph([(1, 3), (2, 3)])
-    >>> nx.add_cycle(G, [3, 4, 5, 6])
-    >>> nx.add_cycle(G, [3, 5, 6])
-    >>> communicating_classes = list(nx.strongly_connected_components(G))
-    >>> len(communicating_classes)
-    3
-    >>> closed_communicating_classes = list(nx.attracting_components(G))
-    >>> len(closed_communicating_classes)
-    1
-    >>> nx.is_aperiodic(G.subgraph(closed_communicating_classes[0]))
-    True
+        >>> G = nx.DiGraph([(1, 3), (2, 3)])
+        >>> nx.add_cycle(G, [3, 4, 5, 6])
+        >>> nx.add_cycle(G, [3, 5, 6])
+        >>> communicating_classes = list(nx.strongly_connected_components(G))
+        >>> len(communicating_classes)
+        3
+        >>> closed_communicating_classes = list(nx.attracting_components(G))
+        >>> len(closed_communicating_classes)
+        1
+        >>> nx.is_aperiodic(G.subgraph(closed_communicating_classes[0]))
+        True
 
     Notes
     -----
@@ -704,10 +712,7 @@ def is_aperiodic(G):
                     levels[v] = lev
         this_level = next_level
         lev += 1
-    if len(levels) == len(G):  # All nodes in tree
-        return g == 1
-    else:
-        return g == 1 and nx.is_aperiodic(G.subgraph(set(G) - set(levels)))
+    return g == 1
 
 
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -576,7 +576,7 @@ def all_topological_sorts(G):
 def is_aperiodic(G):
     """Returns True if `G` is aperiodic.
 
-    A strongly connected directed graph is aperiodic if there is no integer k > 1
+    A strongly connected directed graph is aperiodic if there is no integer ``k > 1``
     that divides the length of every cycle in the graph.
 
     This function requires the graph `G` to be strongly connected and will raise
@@ -626,7 +626,7 @@ def is_aperiodic(G):
 
     A graph created from cycles of the same length can still be aperiodic since
     the cycles can overlap and form new cycles of different lengths. For example,
-    the following graph contains a cycle [4, 2, 3, 1] of length 4, which is coprime
+    the following graph contains a cycle ``[4, 2, 3, 1]`` of length 4, which is coprime
     with the explicitly added cycles of length 3, so the graph is aperiodic::
 
         >>> DG = nx.DiGraph()

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -636,7 +636,7 @@ def test_is_aperiodic_disconnected_raises():
 
 
 def test_is_aperiodic_weakly_connected_raises():
-    G = nx.Graph([(1, 2), (2, 3)])
+    G = nx.DiGraph([(1, 2), (2, 3)])
     pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
 
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -618,8 +618,18 @@ def test_is_aperiodic_selfloop():
     assert nx.is_aperiodic(G)
 
 
+def test_is_aperiodic_null_graph_raises():
+    G = nx.DiGraph()
+    pytest.raises(nx.NetworkXPointlessConcept, nx.is_aperiodic, G)
+
+
 def test_is_aperiodic_undirected_raises():
-    G = nx.Graph()
+    G = nx.Graph([(1, 2), (2, 3), (3, 1)])
+    pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
+
+
+def test_is_aperiodic_not_strongly_connected_raises():
+    G = nx.Graph([(1, 2), (2, 3)])
     pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
 
 
@@ -635,27 +645,12 @@ def test_is_aperiodic_bipartite():
     assert not nx.is_aperiodic(G)
 
 
-def test_is_aperiodic_rary_tree():
-    G = nx.full_rary_tree(3, 27, create_using=nx.DiGraph())
-    assert not nx.is_aperiodic(G)
-
-
-def test_is_aperiodic_disconnected():
-    # disconnected graph
+def test_is_aperiodic_single_node():
     G = nx.DiGraph()
-    nx.add_cycle(G, [1, 2, 3, 4])
-    nx.add_cycle(G, [5, 6, 7, 8])
+    G.add_node(0)
     assert not nx.is_aperiodic(G)
-    G.add_edge(1, 3)
-    G.add_edge(5, 7)
+    G.add_edge(0, 0)
     assert nx.is_aperiodic(G)
-
-
-def test_is_aperiodic_disconnected2():
-    G = nx.DiGraph()
-    nx.add_cycle(G, [0, 1, 2])
-    G.add_edge(3, 3)
-    assert not nx.is_aperiodic(G)
 
 
 class TestDagToBranching:

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -628,7 +628,14 @@ def test_is_aperiodic_undirected_raises():
     pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
 
 
-def test_is_aperiodic_not_strongly_connected_raises():
+def test_is_aperiodic_disconnected_raises():
+    G = nx.DiGraph()
+    nx.add_cycle(G, [0, 1, 2])
+    G.add_edge(3, 3)
+    pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
+
+
+def test_is_aperiodic_weakly_connected_raises():
     G = nx.Graph([(1, 2), (2, 3)])
     pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
 


### PR DESCRIPTION
This is a minimal fix for `is_aperiodic`. See #8021 .

Description: The original logic of `is_aperiodic` can be used to calculate period of a graph, so it is moved to `_period`, with an extra check to make sure it do not go outside the current strongly connected component. `is_aperiodic` now simply returns `_period(G) == 1`.