### PR TITLE
Support backend dispatch via graph types (e.g., numpy.ndarray or pandas.DataFrame)

### DIFF
--- a/networkx/algorithms/components/tests/test_connected.py
+++ b/networkx/algorithms/components/tests/test_connected.py
@@ -72,12 +72,13 @@ class TestConnected:
         }
         assert {frozenset(g) for g in cc(G)} == C
 
-    def test_connected_components_nx_loopback(self):
+    @pytest.mark.parametrize("type_based_dispatch", [False, True])
+    def test_connected_components_nx_loopback(self, type_based_dispatch):
         # This tests the @nx._dispatchable mechanism, treating nx.connected_components
         # as if it were a re-implementation from another package.
         # Test duplicated from above
         cc = nx.connected_components
-        G = dispatch_interface.convert(self.G)
+        G = dispatch_interface.convert(self.G, type_based_dispatch)
         C = {
             frozenset([0, 1, 2, 3]),
             frozenset([4, 5, 6, 7, 8, 9]),

--- a/networkx/classes/tests/dispatch_interface.py
+++ b/networkx/classes/tests/dispatch_interface.py
@@ -13,39 +13,80 @@
 import networkx as nx
 from networkx import DiGraph, Graph, MultiDiGraph, MultiGraph, PlanarEmbedding
 from networkx.classes.reportviews import NodeView
+from networkx.utils.configs import Config
+
+
+class LoopbackGraphTypeBased(Graph):
+    __networkx_backend__ = None
 
 
 class LoopbackGraph(Graph):
     __networkx_backend__ = "nx_loopback"
 
 
+class LoopbackDiGraphTypeBased(DiGraph):
+    __networkx_backend__ = None
+
+
 class LoopbackDiGraph(DiGraph):
     __networkx_backend__ = "nx_loopback"
+
+
+class LoopbackMultiGraphTypeBased(MultiGraph):
+    __networkx_backend__ = None
 
 
 class LoopbackMultiGraph(MultiGraph):
     __networkx_backend__ = "nx_loopback"
 
 
+class LoopbackMultiDiGraphTypeBased(MultiDiGraph):
+    __networkx_backend__ = None
+
+
 class LoopbackMultiDiGraph(MultiDiGraph):
     __networkx_backend__ = "nx_loopback"
+
+
+class LoopbackPlanarEmbeddingTypeBased(PlanarEmbedding):
+    __networkx_backend__ = None
 
 
 class LoopbackPlanarEmbedding(PlanarEmbedding):
     __networkx_backend__ = "nx_loopback"
 
 
-def convert(graph):
+def convert(graph, type_based_dispatch):
     if isinstance(graph, PlanarEmbedding):
-        return LoopbackPlanarEmbedding(graph)
+        return (
+            LoopbackPlanarEmbeddingTypeBased(graph)
+            if type_based_dispatch
+            else LoopbackPlanarEmbedding(graph)
+        )
     if isinstance(graph, MultiDiGraph):
-        return LoopbackMultiDiGraph(graph)
+        return (
+            LoopbackMultiDiGraphTypeBased(graph)
+            if type_based_dispatch
+            else LoopbackMultiDiGraph(graph)
+        )
     if isinstance(graph, MultiGraph):
-        return LoopbackMultiGraph(graph)
+        return (
+            LoopbackMultiGraphTypeBased(graph)
+            if type_based_dispatch
+            else LoopbackMultiGraph(graph)
+        )
     if isinstance(graph, DiGraph):
-        return LoopbackDiGraph(graph)
+        return (
+            LoopbackDiGraphTypeBased(graph)
+            if type_based_dispatch
+            else LoopbackDiGraph(graph)
+        )
     if isinstance(graph, Graph):
-        return LoopbackGraph(graph)
+        return (
+            LoopbackGraphTypeBased(graph)
+            if type_based_dispatch
+            else LoopbackGraph(graph)
+        )
     raise TypeError(f"Unsupported type of graph: {type(graph)}")
 
 
@@ -67,6 +108,7 @@ class LoopbackBackendInterface:
         preserve_graph_attrs=None,
         name=None,
         graph_name=None,
+        type_based_dispatch=False,
     ):
         if name in {
             # Raise if input graph changes. See test_dag.py::test_topological_sort6
@@ -81,21 +123,43 @@ class LoopbackBackendInterface:
             new_graph = Graph()
             new_graph.add_nodes_from(graph.items())
             graph = new_graph
-            G = LoopbackGraph()
+            G = LoopbackGraphTypeBased() if type_based_dispatch else LoopbackGraph()
         elif not isinstance(graph, Graph):
             raise TypeError(
                 f"Bad type for graph argument {graph_name} in {name}: {type(graph)}"
             )
-        elif graph.__class__ in {Graph, LoopbackGraph}:
-            G = LoopbackGraph()
-        elif graph.__class__ in {DiGraph, LoopbackDiGraph}:
-            G = LoopbackDiGraph()
-        elif graph.__class__ in {MultiGraph, LoopbackMultiGraph}:
-            G = LoopbackMultiGraph()
-        elif graph.__class__ in {MultiDiGraph, LoopbackMultiDiGraph}:
-            G = LoopbackMultiDiGraph()
-        elif graph.__class__ in {PlanarEmbedding, LoopbackPlanarEmbedding}:
-            G = LoopbackDiGraph()  # or LoopbackPlanarEmbedding
+        elif graph.__class__ in {Graph, LoopbackGraph, LoopbackGraphTypeBased}:
+            G = LoopbackGraphTypeBased() if type_based_dispatch else LoopbackGraph()
+        elif graph.__class__ in {DiGraph, LoopbackDiGraph, LoopbackDiGraphTypeBased}:
+            G = LoopbackDiGraphTypeBased() if type_based_dispatch else LoopbackDiGraph()
+        elif graph.__class__ in {
+            MultiGraph,
+            LoopbackMultiGraph,
+            LoopbackMultiGraphTypeBased,
+        }:
+            G = (
+                LoopbackMultiGraphTypeBased()
+                if type_based_dispatch
+                else LoopbackMultiGraph()
+            )
+        elif graph.__class__ in {
+            MultiDiGraph,
+            LoopbackMultiDiGraph,
+            LoopbackMultiDiGraphTypeBased,
+        }:
+            G = (
+                LoopbackMultiDiGraphTypeBased()
+                if type_based_dispatch
+                else LoopbackMultiDiGraph()
+            )
+        elif graph.__class__ in {
+            PlanarEmbedding,
+            LoopbackPlanarEmbedding,
+            LoopbackDiGraphTypeBased,
+        }:
+            G = (
+                LoopbackDiGraphTypeBased() if type_based_dispatch else LoopbackDiGraph()
+            )  # or LoopbackPlanarEmbedding
         else:
             # Would be nice to handle these better some day
             # nx.algorithms.approximation.kcomponents._AntiGraph

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -19,6 +19,13 @@ from importlib.metadata import entry_points
 import pytest
 
 import networkx as nx
+from networkx.classes.tests.dispatch_interface import (
+    LoopbackDiGraphTypeBased,
+    LoopbackGraphTypeBased,
+    LoopbackMultiDiGraphTypeBased,
+    LoopbackMultiGraphTypeBased,
+    LoopbackPlanarEmbeddingTypeBased,
+)
 
 
 def pytest_addoption(parser):
@@ -63,9 +70,21 @@ def pytest_configure(config):
         nx.utils.backends.backends["nx_loopback"] = loopback_ep["nx_loopback"]
         nx.utils.backends.backend_info["nx_loopback"] = {}
         nx.config.backends = nx.utils.Config(
-            nx_loopback=nx.utils.Config(),
+            nx_loopback=nx.utils.Config(
+                graph_types=[
+                    LoopbackGraphTypeBased,
+                    LoopbackDiGraphTypeBased,
+                    LoopbackMultiGraphTypeBased,
+                    LoopbackMultiDiGraphTypeBased,
+                    LoopbackPlanarEmbeddingTypeBased,
+                ]
+            ),
             **nx.config.backends,
         )
+        for graph_type in getattr(nx.config.backends["nx_loopback"], "graph_types", []):
+            nx.config.graph_type_backends_map.setdefault(graph_type, []).append(
+                "nx_loopback"
+            )
         fallback_to_nx = config.getoption("--fallback-to-nx")
         if not fallback_to_nx:
             fallback_to_nx = os.environ.get("NETWORKX_FALLBACK_TO_NX")

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -131,6 +131,7 @@ def _set_configs_from_environment():
             if not isinstance(cfg, Config):
                 cfg = Config(**cfg)
         backend_config[backend] = cfg
+
     backend_config = Config(**backend_config)
     # Setting doc of backends_config type is not setting doc of Config
     # Config has __new__ method that returns instance with a unique type!
@@ -141,6 +142,7 @@ def _set_configs_from_environment():
     config = NetworkXConfig(
         backend_priority=backend_priority,
         backends=backend_config,
+        graph_type_backends_map={},
         cache_converted_graphs=bool(
             os.environ.get("NETWORKX_CACHE_CONVERTED_GRAPHS", True)
         ),
@@ -149,6 +151,9 @@ def _set_configs_from_environment():
             _comma_sep_to_list(os.environ.get("NETWORKX_WARNINGS_TO_IGNORE", ""))
         ),
     )
+    for backend, cfg in backend_config.items():
+        for graph_type in getattr(cfg, "graph_types", []):
+            config.graph_type_backends_map.setdefault(graph_type, []).append(backend)
 
     # Add "networkx" item to backend_info now b/c backend_config is set up
     backend_info["networkx"] = {}
@@ -202,6 +207,17 @@ def _load_backend(backend_name):
     if not hasattr(rv, "should_run"):
         rv.should_run = _always_run
     return rv
+
+
+def _graph_backends(g, default=None):
+    ret = [
+        getattr(g, "__networkx_backend__", None),
+    ] + nx.config.graph_type_backends_map.get(type(g), [])
+    return [x for x in ret if x is not None] or ([default] if default else [])
+
+
+def _needs_conversion(g, backend_name):
+    return all(b != backend_name for b in _graph_backends(g, "networkx"))
 
 
 class _dispatchable:
@@ -587,19 +603,22 @@ class _dispatchable:
                     args[self.graphs[gname]] = list_of_graphs
 
             graph_backend_names = {
-                getattr(g, "__networkx_backend__", None)
+                backend
                 for gname, g in graphs_resolved.items()
                 if gname not in self.list_graphs
+                for backend in _graph_backends(g)
             }
             for gname in self.list_graphs & graphs_resolved.keys():
                 graph_backend_names.update(
-                    getattr(g, "__networkx_backend__", None)
+                    backend
                     for g in graphs_resolved[gname]
+                    for backend in _graph_backends(g)
                 )
         else:
             graph_backend_names = {
-                getattr(g, "__networkx_backend__", None)
+                backend
                 for g in graphs_resolved.values()
+                for backend in _graph_backends(g)
             }
 
         backend_priority = nx.config.backend_priority.get(
@@ -1287,7 +1306,7 @@ class _dispatchable:
                         use_cache=use_cache,
                         mutations=mutations,
                     )
-                    if getattr(g, "__networkx_backend__", "networkx") != backend_name
+                    if _needs_conversion(g, backend_name)
                     else g
                     for g in bound.arguments[gname]
                 ]
@@ -1315,7 +1334,7 @@ class _dispatchable:
                     preserve_graph = gname in preserve_graph_attrs
                 else:
                     preserve_graph = preserve_graph_attrs
-                if getattr(graph, "__networkx_backend__", "networkx") != backend_name:
+                if _needs_conversion(graph, backend_name):
                     bound.arguments[gname] = self._convert_graph(
                         backend_name,
                         graph,
@@ -1395,7 +1414,7 @@ class _dispatchable:
                 _logger.debug(
                     "Using cached converted graph (from '%s' to '%s' backend) "
                     "in call to '%s' for '%s' argument",
-                    getattr(graph, "__networkx_backend__", None),
+                    _graph_backends(graph),
                     backend_name,
                     self.name,
                     graph_name,
@@ -1403,9 +1422,10 @@ class _dispatchable:
                 return rv
 
         if backend_name == "networkx":
+            backend_names = _graph_backends(graph)
             # Perhaps we should check that "__networkx_backend__" attribute exists
             # and return the original object if not.
-            if not hasattr(graph, "__networkx_backend__"):
+            if not backend_names:
                 _logger.debug(
                     "Unable to convert input to 'networkx' backend in call to '%s' for "
                     "'%s argument, because it is not from a backend (i.e., it does not "
@@ -1417,13 +1437,15 @@ class _dispatchable:
                 )
                 # This may fail, but let it fail in the networkx function
                 return graph
-            backend = _load_backend(graph.__networkx_backend__)
-            try:
-                rv = backend.convert_to_nx(graph)
-            except Exception:
-                if nx_cache is not None:
-                    _set_to_cache(cache, key, FAILED_TO_CONVERT)
-                raise
+            for backend_name in backend_names:
+                backend = _load_backend(backend_name)
+                try:
+                    rv = backend.convert_to_nx(graph)
+                    break
+                except Exception:
+                    if nx_cache is not None:
+                        _set_to_cache(cache, key, FAILED_TO_CONVERT)
+                    raise
         else:
             backend = _load_backend(backend_name)
             try:
@@ -1449,7 +1471,7 @@ class _dispatchable:
             _logger.debug(
                 "Caching converted graph (from '%s' to '%s' backend) "
                 "in call to '%s' for '%s' argument",
-                getattr(graph, "__networkx_backend__", None),
+                _graph_backends(graph),
                 backend_name,
                 self.name,
                 graph_name,
@@ -1730,11 +1752,10 @@ class _dispatchable:
             self._returns_graph
             != (
                 isinstance(result, nx.Graph)
-                or hasattr(result, "__networkx_backend__")
+                or _graph_backends(result)
                 or isinstance(result, tuple | list)
                 and any(
-                    isinstance(x, nx.Graph) or hasattr(x, "__networkx_backend__")
-                    for x in result
+                    isinstance(x, nx.Graph) or _graph_backends(result) for x in result
                 )
             )
             and not (

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -337,6 +337,7 @@ class NetworkXConfig(Config):
     backend_priority: BackendPriorities
     backends: Config
     cache_converted_graphs: bool
+    graph_type_backends_map: dict[type, list[str]]
     fallback_to_nx: bool
     warnings_to_ignore: set[str]
 


### PR DESCRIPTION

### Motivation
NetworkX currently dispatches to backends using the `__networkx_backend__` attribute. This works well for custom Python graph classes, but it limits interoperability with immutable or third-party data types such as `numpy.ndarray` or `pandas.DataFrame`, where:

- You cannot set custom attributes.
- Monkey patching is not feasible or appropriate.
- Wrapping the object adds boilerplate and indirection.

This PR is a follow up from https://github.com/networkx/networkx/issues/8030 and introduces type-based backend dispatch, enabling seamless integration with such data types by allowing backends to register support for them explicitly.

Having multiple backends register the same type is allowed, and resolution of which backend to used is determined by internal's dispatch logic (backend priority). 

### What's new
- Backends can now register supported types using a graph_types field in their Config entry.
- New internal utility: `_graph_backends(obj)` returns a list of matching backend configurations for the object, using either the `__networkx_backend__` attribute or a new type-based mechanism.
- New internal utility `_needs_conversion()` determines whether a graph object requires conversion based on backend configuration.

### Usage Example
A backend can register support for numpy.ndarray like this:

```python
import numpy as np
import networkx as nx

nx.config.backends["array"] = nx.utils.Config(
    graph_types=[np.ndarray],
)
```

or either by declaring its config like this:
```
[project.entry-points."networkx.backend_info"]
array = "get_info"
```

```python
import numpy as np
import networkx as nx

def get_info():
    return {"default_config": nx.utils.Config(graph_types=[np.array]), ...}

```

Now, calling a NetworkX algorithm with a NumPy array will automatically dispatch through the backend:

```python
A = np.array([
    [0, 1, 0],
    [1, 0, 1],
    [0, 1, 0],
])

nx.is_connected(A)  # Uses the 'array' backend
```
