### PR TITLE
Making not_implemented_for decorator depend on dispatchable functions

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -16,6 +16,7 @@ __all__ = [
     "number_of_edges",
     "density",
     "is_directed",
+    "is_multigraph",
     "freeze",
     "is_frozen",
     "subgraph",
@@ -160,9 +161,16 @@ def degree_histogram(G):
     return [counts.get(i, 0) for i in range(max(counts) + 1 if counts else 0)]
 
 
+@nx._dispatchable
 def is_directed(G):
     """Return True if graph is directed."""
     return G.is_directed()
+
+
+@nx._dispatchable
+def is_multigraph(G):
+    """Returns True if graph is a multigraph, False otherwise."""
+    return G.is_multigraph()
 
 
 def frozen(*args, **kwargs):

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -81,8 +81,8 @@ def not_implemented_for(*graph_types):
     errmsg = f"not implemented for {' '.join(graph_types)} type"
 
     def _not_implemented_for(g):
-        if (mval is None or mval == g.is_multigraph()) and (
-            dval is None or dval == g.is_directed()
+        if (mval is None or mval == nx.is_multigraph(g)) and (
+            dval is None or dval == nx.is_directed(g)
         ):
             raise nx.NetworkXNotImplemented(errmsg)
 


### PR DESCRIPTION
This PR makes `nx.is_multigraph` and `nx.is_directed` function dispatchable so its behavior can be modified by custom backends. In addition to this, it makes `not_implemented_for` decorator depend on `nx.is_multigraph` and `nx.is_directed`.

This allows backends graph class to not be forced to implement `is_directed` and `is_multigraph` methods, they just need to define its custom behavior based on the new dispatchable functions