### PR TITLE
Update `from_numpy_array()` to handle a container of (node, attribute dict) tuples as `nodelist`

### DIFF
--- a/networkx/convert_matrix.py
+++ b/networkx/convert_matrix.py
@@ -1307,8 +1307,12 @@ def from_numpy_array(
     if G.is_multigraph() and not G.is_directed():
         triples = ((u, v, d) for u, v, d in triples if u <= v)
     # Remap nodes if user provided custom `nodelist`
+    # Also handles the case where nodelist is provided as a container of (node, attribute dict) tuples
     if not _default_nodes:
-        idx_to_node = dict(enumerate(nodelist))
+        if type(nodelist[0]) != tuple:
+            idx_to_node = dict(enumerate(nodelist))
+        else:
+            idx_to_node = dict(enumerate([node for node, attr in nodelist]))
         triples = ((idx_to_node[u], idx_to_node[v], d) for u, v, d in triples)
     G.add_edges_from(triples)
     return G


### PR DESCRIPTION
The [`from_numpy_array()`](https://networkx.org/documentation/stable/reference/generated/networkx.convert_matrix.from_numpy_array.html#from-numpy-array) function currently accepts a `nodelist` - but that node list cannot contain any node attributes.

My pull requests updates the function to allow passing a container of (node, attribute dict) tuples - just like the [`add_nodes_from()`](https://networkx.org/documentation/stable/reference/classes/generated/networkx.Graph.add_nodes_from.html) function already allows.

For example, this would not have worked previously:
```python
import numpy as np
import networkx as nx

data = np.array([
    [0, 1, 0],
    [1, 0, 5],
    [0, 0, 0]
])

dt = [('amount', float), ('type', 'U10')]
A = np.zeros(data.shape, dtype=dt)

A['amount'] = data.astype(float)
A['type'] = 'flow'

nodelist = (
    ('N1', {'type': 'production', 'unit': 'kg'),
    ('N2', {'type': 'production', 'unit': 'kg'),
    ('N3', {'type': 'production', 'unit': 'kg')
)

custom_graph = nx.from_numpy_array(
    A,
    nodelist=nodelist,
    create_using=nx.MultiDiGraph,
)
```