### PR TITLE
Update copyright license years

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ NetworkX is distributed with the 3-clause BSD license.
 
 ::
 
-   Copyright (C) 2004-2024, NetworkX Developers
+   Copyright (c) 2004-2024, NetworkX Developers
    Aric Hagberg <hagberg@lanl.gov>
    Dan Schult <dschult@colgate.edu>
    Pieter Swart <swart@lanl.gov>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ NetworkX is distributed with the 3-clause BSD license.
 
 ::
 
-   Copyright (c) 2004-2024, NetworkX Developers
+   Copyright (c) 2004-2025, NetworkX Developers
    Aric Hagberg <hagberg@lanl.gov>
    Dan Schult <dschult@colgate.edu>
    Pieter Swart <swart@lanl.gov>

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ License
 
 Released under the `3-clause BSD license <https://github.com/networkx/networkx/blob/main/LICENSE.txt>`_::
 
-    Copyright (c) 2004-2024, NetworkX Developers
+    Copyright (c) 2004-2025, NetworkX Developers
     Aric Hagberg <hagberg@lanl.gov>
     Dan Schult <dschult@colgate.edu>
     Pieter Swart <swart@lanl.gov>

--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,9 @@ see the `contributor guide <https://networkx.org/documentation/latest/developer/
 License
 -------
 
-Released under the `3-Clause BSD license <https://github.com/networkx/networkx/blob/main/LICENSE.txt>`_::
+Released under the `3-clause BSD license <https://github.com/networkx/networkx/blob/main/LICENSE.txt>`_::
 
-    Copyright (C) 2004-2024 NetworkX Developers
+    Copyright (c) 2004-2024, NetworkX Developers
     Aric Hagberg <hagberg@lanl.gov>
     Dan Schult <dschult@colgate.edu>
     Pieter Swart <swart@lanl.gov>


### PR DESCRIPTION
Changes license formatting to match the 3-clause BSD pattern.
Updates copyright license years for 2025.
