### PR TITLE
Update `multigraph.add_edges_from()` to use `add_edge(u,v,k,d)`

### DIFF
--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -615,8 +615,7 @@ class MultiGraph(Graph):
                 if ne != 3:
                     raise
                 key = dd  # ne == 3 with 3rd value not dict, must be a key
-            key = self.add_edge(u, v, key)
-            self[u][v][key].update(ddd)
+            key = self.add_edge(u, v, key, **ddd)
             keylist.append(key)
         nx._clear_cache(self)
         return keylist


### PR DESCRIPTION
Currently, the `multigraph.add_edges_from()` function adds individual edges using the syntax:

https://github.com/networkx/networkx/blob/ee458799cdb8c95864a0331bd945b4bb11337db9/networkx/classes/multigraph.py#L618-L619

This could also be achieved by:

```python
key = self.add_edge(u, v, key, **ddd)
```

Beyond just saving one line of code, this latter implementation also allows users to override `add_edge`, `add_edges_from`, etc. and check if added edges (or nodes) have a required set of attributes:

```python
def add_edge(
    self,
    u_for_edge,
    v_for_edge,
    key=None,
    **attr
) -> None:
    self._validate_new_edge_attributes(dict_attr=attr)
    return super().add_edge(u_for_edge, v_for_edge, key, **attr)
```

Related to: 

- https://github.com/networkx/networkx/pull/8037