### PR TITLE
fix bug of _sparse_fruchterman_reingold and remove try/except idiom

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -757,7 +757,7 @@ def _sparse_fruchterman_reingold(
     if k is None:
         k = np.sqrt(1.0 / nnodes)
 
-    if method == "energy":
+    if method != "force":
         return _energy_fruchterman_reingold(
             A, nnodes, k, pos, fixed, iterations, threshold, dim, gravity
         )

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -582,7 +582,7 @@ def test_bipartite_layout_default_nodes():
 def test_spring_layout_graph_size_heuristic(
     num_nodes, expected_method, extra_layout_kwargs
 ):
-    """Expect 'force' layout for n < 500 and 'energy' for n > 500"""
+    """Expect 'force' layout for n < 500 and 'energy' for n >= 500"""
     G = nx.cycle_graph(num_nodes)
     # Seeded layout to compare explicit method to one determined by "auto"
     seed = 163674319

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -566,3 +566,30 @@ def test_bipartite_layout_default_nodes():
     for nodeset in nx.bipartite.sets(G):
         xs = [pos[k][0] for k in nodeset]
         assert all(x == pytest.approx(xs[0]) for x in xs)
+
+
+@pytest.mark.parametrize(
+    ("num_nodes", "expected_method"), [(100, "force"), (501, "energy")]
+)
+@pytest.mark.parametrize(
+    "extra_layout_kwargs",
+    [
+        {},  # No extra kwargs
+        {"pos": {0: (0, 0)}, "fixed": [0]},  # Fixed node position
+        {"dim": 3},  # 3D layout
+    ],
+)
+def test_spring_layout_graph_size_heuristic(
+    num_nodes, expected_method, extra_layout_kwargs
+):
+    """Expect 'force' layout for n < 500 and 'energy' for n > 500"""
+    G = nx.cycle_graph(num_nodes)
+    # Seeded layout to compare explicit method to one determined by "auto"
+    seed = 163674319
+
+    # Compare explicit method to auto method
+    expected = nx.spring_layout(
+        G, method=expected_method, seed=seed, **extra_layout_kwargs
+    )
+    actual = nx.spring_layout(G, method="auto", seed=seed, **extra_layout_kwargs)
+    assert np.allclose(list(expected.values()), list(actual.values()), atol=1e-5)


### PR DESCRIPTION
# Fix bug in _sparse_fruchterman_reingold

Dear NetworkX maintainers,

I am Hiroki Hamaguchi, a contributor to NetworkX and the author of [this previous pull request](https://github.com/networkx/networkx/pull/7889).

I sincerely apologize, but I have discovered a bug introduced in that PR. Specifically, when `method="auto"` is specified, the `nx.spring_layout` function does not use the new `_energy_fruchterman_reingold` function as intended.

The fix is trivial, and I would appreciate it if you could kindly review and merge the proposed correction.

Thank you very much for your time and consideration.

---

**Added based on discussion (details in comments below)**
I believe the try/except block [using ValueError as a signal to try a different branch of code] is unnecessary.
A ValueError can occur in the following situations:

pos is a NumPy array and if pos == None is evaluated
(Raises: ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all())

fixed is a NumPy array and if fixed == None is evaluated
(Same error as above)

dim is set to -1, leading to calls like np.random.random((nnodes, dim)) or np.zeros(dim)
(Raises: ValueError: negative dimensions are not allowed)

However, the first two issues are already addressed in the current code using if pos is None and if fixed is None, so the try/except block is redundant.
For the third case, this ValueError is raised in the current version of NetworkX, so it is not related to the try/except block.

---

Based on this, I fixed the bug [about "method" keyword] and cleaned up the code as suggested in the current PR.

I also tested the code with the following configurations and confirmed it works successfully:

(Please refer to [here](https://github.com/HirokiHamaguchi/Initial_Placement_for_Fruchterman-Reingold_Force_Model_with_Coordinate_Newton_Direction/blob/474bee4702e2d2a21f1b015ecc0d86cae11fcf63/app/test_for_issue.ipynb) for the results)

1. Different `method` values:

   * `"auto"` (len(G)=499 and 500)
   * `"energy"`
   * `"force"`

2. Providing an initial layout via the `pos` argument

3. Fixing certain nodes using the `fixed` argument

4. Changing layout dimensionality with the `dim` argument:

   * A 3D layout using `dim=3`
   * An invalid layout with `dim=-1` to confirm error handling
