### PR TITLE
Enforce correct graph types for graph matchers

### DIFF
--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -174,16 +174,21 @@ class GraphMatcher:
         >>> G2 = nx.path_graph(4)
         >>> GM = isomorphism.GraphMatcher(G1, G2)
         """
-        if G1.is_directed() and G2.is_directed():
+        if G1.is_directed() != G2.is_directed():
+            raise nx.NetworkXError("G1 and G2 must have the same directedness")
+
+        is_directed_matcher = self._is_directed_matcher()
+        if not is_directed_matcher and (G1.is_directed() or G2.is_directed()):
             raise nx.NetworkXError(
                 "(Multi-)GraphMatcher() not defined for directed graphs. "
                 "Use (Multi-)DiGraphMatcher() instead."
             )
-        self._init(G1, G2)
 
-    def _init(self, G1, G2):
-        if G1.is_directed() != G2.is_directed():
-            raise nx.NetworkXError("G1 and G2 must have the same directedness")
+        if is_directed_matcher and not (G1.is_directed() and G2.is_directed()):
+            raise nx.NetworkXError(
+                "(Multi-)DiGraphMatcher() not defined for undirected graphs. "
+                "Use (Multi-)GraphMatcher() instead."
+            )
 
         self.G1 = G1
         self.G2 = G2
@@ -203,6 +208,9 @@ class GraphMatcher:
 
         # Initialize state
         self.initialize()
+
+    def _is_directed_matcher(self):
+        return False
 
     def reset_recursion_limit(self):
         """Restores the recursion limit."""
@@ -631,12 +639,10 @@ class DiGraphMatcher(GraphMatcher):
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
         >>> DiGM = isomorphism.DiGraphMatcher(G1, G2)
         """
-        if not G1.is_directed() and not G2.is_directed():
-            raise nx.NetworkXError(
-                "(Multi-)DiGraphMatcher() not defined for undirected graphs. "
-                "Use (Multi-)GraphMatcher() instead."
-            )
-        super()._init(G1, G2)
+        super().__init__(G1, G2)
+
+    def _is_directed_matcher(self):
+        return True
 
     def candidate_pairs_iter(self):
         """Iterator over candidate pairs of nodes in G1 and G2."""

--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -146,6 +146,8 @@ polynomial-time algorithm is known to exist).
 
 import sys
 
+import networkx as nx
+
 __all__ = ["GraphMatcher", "DiGraphMatcher"]
 
 
@@ -172,6 +174,17 @@ class GraphMatcher:
         >>> G2 = nx.path_graph(4)
         >>> GM = isomorphism.GraphMatcher(G1, G2)
         """
+        if G1.is_directed() and G2.is_directed():
+            raise nx.NetworkXError(
+                "(Multi-)GraphMatcher() not defined for directed graphs. "
+                "Use (Multi-)DiGraphMatcher() instead."
+            )
+        self._init(G1, G2)
+
+    def _init(self, G1, G2):
+        if G1.is_directed() != G2.is_directed():
+            raise nx.NetworkXError("G1 and G2 must have the same directedness")
+
         self.G1 = G1
         self.G2 = G2
         self.G1_nodes = set(G1.nodes())
@@ -618,7 +631,12 @@ class DiGraphMatcher(GraphMatcher):
         >>> G2 = nx.DiGraph(nx.path_graph(4, create_using=nx.DiGraph()))
         >>> DiGM = isomorphism.DiGraphMatcher(G1, G2)
         """
-        super().__init__(G1, G2)
+        if not G1.is_directed() and not G2.is_directed():
+            raise nx.NetworkXError(
+                "(Multi-)DiGraphMatcher() not defined for undirected graphs. "
+                "Use (Multi-)GraphMatcher() instead."
+            )
+        super()._init(G1, G2)
 
     def candidate_pairs_iter(self):
         """Iterator over candidate pairs of nodes in G1 and G2."""

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -6,6 +6,8 @@ import importlib.resources
 import random
 import struct
 
+import pytest
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
@@ -213,6 +215,34 @@ def test_multiedge():
             assert gm.is_isomorphic()
             # Testing if monomorphism works in multigraphs
             assert gm.subgraph_is_monomorphic()
+
+
+@pytest.mark.parametrize("G1", [nx.Graph(), nx.MultiGraph()])
+@pytest.mark.parametrize("G2", [nx.Graph(), nx.MultiGraph()])
+def test_matcher_raises(G1, G2):
+    undirected_matchers = [iso.GraphMatcher, iso.MultiGraphMatcher]
+    directed_matchers = [iso.DiGraphMatcher, iso.MultiDiGraphMatcher]
+
+    for matcher in undirected_matchers:
+        matcher(G1, G2)
+
+        msg = r"\(Multi-\)GraphMatcher\(\) not defined for directed graphs"
+        with pytest.raises(nx.NetworkXError, match=msg):
+            matcher(G1.to_directed(), G2.to_directed())
+
+    for matcher in directed_matchers:
+        matcher(G1.to_directed(), G2.to_directed())
+
+        msg = r"\(Multi-\)DiGraphMatcher\(\) not defined for undirected graphs"
+        with pytest.raises(nx.NetworkXError, match=msg):
+            matcher(G1, G2)
+
+    for matcher in undirected_matchers + directed_matchers:
+        msg = r"G1 and G2 must have the same directedness"
+        with pytest.raises(nx.NetworkXError, match=msg):
+            matcher(G1, G2.to_directed())
+        with pytest.raises(nx.NetworkXError, match=msg):
+            matcher(G1.to_directed(), G2)
 
 
 def test_selfloop():


### PR DESCRIPTION
Fixes #7964.

Check that both graphs have the correct directedness in `(Multi-)(Di-)GraphMatcher` initialization.

@dschult, you mentioned switching to a function-oriented interface in the linked issue. Is this something that has been discussed previously/is there some kind of consensus on what that should look like? I feel the graph matching subsection of the codebase could use a revamp (there are still untouched lines of code from 2007 in there! :) ). I'd give it a shot, but it would entail some significant, opinionated API changes, and I'm curious what people think about that.