### PR TITLE
Fix all sphinx build warnings

### DIFF
--- a/doc/reference/backends.rst
+++ b/doc/reference/backends.rst
@@ -431,9 +431,10 @@ Creating a custom backend
 
     Backend graph objects are also required to implement the methods ``is_directed()`` and
     ``is_multigraph()``. These methods return boolean values indicating the type of the graph:
-        - ``is_directed()`` should return True if the graph is directed, and False otherwise.
-        - ``is_multigraph()`` should return True if the graph allows multiple (parallel) edges
-          between node pairs, and False otherwise.
+
+    - ``is_directed()`` should return True if the graph is directed, and False otherwise.
+    - ``is_multigraph()`` should return True if the graph allows multiple (parallel) edges
+      between node pairs, and False otherwise.
 
     These methods are used by NetworkX utilities such as the ``@not_implemented_for`` decorator
     to determine whether a graph meets certain type constraints and to raise an error if the

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -121,7 +121,7 @@ Maintenance
 -----------
 
 - MAINT: wrapping ``partial`` with ``staticmethod()`` in ``test_link_prediction.py`` (`#7673 <https://github.com/networkx/networkx/pull/7673>`_).
-- Updating ``pip install``s in benchmarking workflow (`#7647 <https://github.com/networkx/networkx/pull/7647>`_).
+- Updating ``pip install`` s in benchmarking workflow (`#7647 <https://github.com/networkx/networkx/pull/7647>`_).
 - Mv changelist to release deps (`#7708 <https://github.com/networkx/networkx/pull/7708>`_).
 - Drop support for Python 3.10 (`#7668 <https://github.com/networkx/networkx/pull/7668>`_).
 - Update minimum dependencies (SPEC 0) (`#7711 <https://github.com/networkx/networkx/pull/7711>`_).

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -205,7 +205,7 @@ def display(
           - 1.0
         * - arrowstyle
           - `"arrowstyle"`
-          - "-|>" if `G` is directed else "-"
+          - ``"-|>"`` if `G` is directed else ``"-"``
         * - arrowsize
           - `"arrowsize"`
           - 10 if `G` is directed else 0
@@ -335,8 +335,8 @@ def display(
 
     arrowstyle : string, default "arrow"
         A string naming the edge attribute which stores the type of arrowhead to use for
-        each edge. Visible edges without this attribute use "-" for undirected graphs
-        and "-|>" for directed graphs.
+        each edge. Visible edges without this attribute use ``"-"`` for undirected graphs
+        and ``"-|>"`` for directed graphs.
 
         See `matplotlib.patches.ArrowStyle` for more options
 

--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -92,7 +92,7 @@ def from_graph6_bytes(bytes_in):
     Notes
     -----
     Per the graph6 spec, the header (e.g. ``b'>>graph6<<'``) must not be
-    followed by a newline ``\n``.
+    followed by a newline character.
 
     See Also
     --------


### PR DESCRIPTION
A little activity from my recent flight without internet. I'm loathe to add to the PR queue but it might be nice to have a clean doc build for the release (though certainly not critical).

In principle we could add a CI job to fail on sphinx warnings to prevent these from getting in. Personally, I don't think these should be blockers for PRs so my vote would be to keep things the way they are. Open to other opinions though!