### PR TITLE
Fix intermittent test failures in expander graph generator tests

### DIFF
--- a/networkx/generators/expanders.py
+++ b/networkx/generators/expanders.py
@@ -272,7 +272,7 @@ def maybe_regular_expander(n, d, *, create_using=None, max_tries=100, seed=None)
     References
     ----------
     .. [1] Joel Friedman,
-       A Proof of Alon’s Second Eigenvalue Conjecture and Related Problems, 2004
+       A Proof of Alon's Second Eigenvalue Conjecture and Related Problems, 2004
        https://arxiv.org/abs/cs/0405020
 
     """

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -71,6 +71,16 @@ def test_maybe_regular_expander(d, n):
     assert nx.is_k_regular(G, d), "Should be d-regular"
 
 
+def test_maybe_regular_expander_max_tries():
+    pytest.importorskip("numpy")
+    d, n = 4, 10
+    msg = "Too many iterations in maybe_regular_expander"
+    with pytest.raises(nx.NetworkXError, match=msg):
+        nx.maybe_regular_expander(n, d, max_tries=100, seed=6818)  # See gh-8048
+
+    nx.maybe_regular_expander(n, d, max_tries=130, seed=6818)
+
+
 @pytest.mark.parametrize("n", (3, 5, 6, 10))
 def test_is_regular_expander(n):
     pytest.importorskip("numpy")

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -64,7 +64,7 @@ def test_paley_graph(p):
 @pytest.mark.parametrize("d, n", [(2, 7), (4, 10), (4, 16)])
 def test_maybe_regular_expander(d, n):
     pytest.importorskip("numpy")
-    G = nx.maybe_regular_expander(n, d)
+    G = nx.maybe_regular_expander(n, d, seed=1729)
 
     assert len(G) == n, "Should have n nodes"
     assert len(G.edges) == n * d / 2, "Should have n*d/2 edges"
@@ -84,7 +84,7 @@ def test_is_regular_expander(n):
 def test_random_regular_expander(d, n):
     pytest.importorskip("numpy")
     pytest.importorskip("scipy")
-    G = nx.random_regular_expander_graph(n, d)
+    G = nx.random_regular_expander_graph(n, d, seed=1729)
 
     assert len(G) == n, "Should have n nodes"
     assert len(G.edges) == n * d / 2, "Should have n*d/2 edges"
@@ -95,7 +95,7 @@ def test_random_regular_expander(d, n):
 def test_random_regular_expander_explicit_construction():
     pytest.importorskip("numpy")
     pytest.importorskip("scipy")
-    G = nx.random_regular_expander_graph(d=4, n=5)
+    G = nx.random_regular_expander_graph(d=4, n=5, seed=1729)
 
     assert len(G) == 5 and len(G.edges) == 10, "Should be a complete graph"
 

--- a/networkx/generators/tests/test_expanders.py
+++ b/networkx/generators/tests/test_expanders.py
@@ -125,7 +125,6 @@ def test_paley_graph_badinput():
 
 def test_maybe_regular_expander_badinput():
     pytest.importorskip("numpy")
-    pytest.importorskip("scipy")
 
     with pytest.raises(nx.NetworkXError, match="n must be a positive integer"):
         nx.maybe_regular_expander(n=-1, d=2)


### PR DESCRIPTION
Fixes gh-8046.

This adds an explicit seed to the `maybe_regular_expander` and `random_regular_expander_graph` (is there a reason for the inconsistency in appending `_graph` to generator names?) tests which avoids stochastic failures when the maximum number of iterations gets exceeded.

Since this is a simple fix and the linked issue has a discussion surrounding _how_ it should be fixed, this can also be left as a good first issue imo.
