### PR TITLE
STY: Rm local variable remapping of heappush and heappop.

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -293,14 +293,12 @@ def _single_source_dijkstra_path_basic(G, s, weight):
     sigma = dict.fromkeys(G, 0.0)  # sigma[v]=0 for v in G
     D = {}
     sigma[s] = 1.0
-    push = heappush
-    pop = heappop
     seen = {s: 0}
     c = count()
     Q = []  # use Q as heap with (distance,node id) tuples
-    push(Q, (0, next(c), s, s))
+    heappush(Q, (0, next(c), s, s))
     while Q:
-        (dist, _, pred, v) = pop(Q)
+        (dist, _, pred, v) = heappop(Q)
         if v in D:
             continue  # already searched this node.
         sigma[v] += sigma[pred]  # count paths
@@ -310,7 +308,7 @@ def _single_source_dijkstra_path_basic(G, s, weight):
             vw_dist = dist + weight(v, w, edgedata)
             if w not in D and (w not in seen or vw_dist < seen[w]):
                 seen[w] = vw_dist
-                push(Q, (vw_dist, next(c), v, w))
+                heappush(Q, (vw_dist, next(c), v, w))
                 sigma[w] = 0.0
                 P[w] = [v]
             elif vw_dist == seen[w]:  # handle equal paths

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -102,8 +102,6 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
         def heuristic(u, v):
             return 0
 
-    push = heappush
-    pop = heappop
     weight = _weight_function(G, weight)
 
     G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
@@ -125,7 +123,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
 
     while queue:
         # Pop the smallest item from queue.
-        _, __, curnode, dist, parent = pop(queue)
+        _, __, curnode, dist, parent = heappop(queue)
 
         if curnode == target:
             path = [curnode]
@@ -168,7 +166,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
                 continue
 
             enqueued[neighbor] = ncost, h
-            push(queue, (ncost + h, next(c), neighbor, ncost, curnode))
+            heappush(queue, (ncost + h, next(c), neighbor, ncost, curnode))
 
     raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -836,8 +836,6 @@ def _dijkstra_multisource(
     """
     G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
 
-    push = heappush
-    pop = heappop
     dist = {}  # dictionary of final distances
     seen = {}
     # fringe is heapq with 3-tuples (distance,c,node)
@@ -846,9 +844,9 @@ def _dijkstra_multisource(
     fringe = []
     for source in sources:
         seen[source] = 0
-        push(fringe, (0, next(c), source))
+        heappush(fringe, (0, next(c), source))
     while fringe:
-        (d, _, v) = pop(fringe)
+        (d, _, v) = heappop(fringe)
         if v in dist:
             continue  # already searched this node.
         dist[v] = d
@@ -870,7 +868,7 @@ def _dijkstra_multisource(
                     pred[u].append(v)
             elif u not in seen or vu_dist < seen[u]:
                 seen[u] = vu_dist
-                push(fringe, (vu_dist, next(c), u))
+                heappush(fringe, (vu_dist, next(c), u))
                 if paths is not None:
                     paths[u] = paths[v] + [u]
                 if pred is not None:
@@ -2375,8 +2373,6 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
         return (0, [source])
 
     weight = _weight_function(G, weight)
-    push = heappush
-    pop = heappop
     # Init:  [Forward, Backward]
     dists = [{}, {}]  # dictionary of final distances
     paths = [{source: [source]}, {target: [target]}]  # dictionary of paths
@@ -2384,8 +2380,8 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
     seen = [{source: 0}, {target: 0}]  # dict of distances to seen nodes
     c = count()
     # initialize fringe heap
-    push(fringe[0], (0, next(c), source))
-    push(fringe[1], (0, next(c), target))
+    heappush(fringe[0], (0, next(c), source))
+    heappush(fringe[1], (0, next(c), target))
     # neighs for extracting correct neighbor information
     if G.is_directed():
         neighs = [G._succ, G._pred]
@@ -2400,7 +2396,7 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
         # dir == 0 is forward direction and dir == 1 is back
         dir = 1 - dir
         # extract closest to expand
-        (dist, _, v) = pop(fringe[dir])
+        (dist, _, v) = heappop(fringe[dir])
         if v in dists[dir]:
             # Shortest path to v has already been found
             continue
@@ -2423,7 +2419,7 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
             elif w not in seen[dir] or vwLength < seen[dir][w]:
                 # relaxing
                 seen[dir][w] = vwLength
-                push(fringe[dir], (vwLength, next(c), w))
+                heappush(fringe[dir], (vwLength, next(c), w))
                 paths[dir][w] = paths[dir][v] + [w]
                 if w in seen[0] and w in seen[1]:
                     # see if this path is better than the already

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -886,8 +886,6 @@ def _bidirectional_dijkstra(
             Gsucc = filter_iter(Gsucc)
 
     wt = _weight_function(G, weight)
-    push = heappush
-    pop = heappop
     # Init:   Forward             Backward
     dists = [{}, {}]  # dictionary of final distances
     paths = [{source: [source]}, {target: [target]}]  # dictionary of paths
@@ -897,8 +895,8 @@ def _bidirectional_dijkstra(
     # nodes seen
     c = count()
     # initialize fringe heap
-    push(fringe[0], (0, next(c), source))
-    push(fringe[1], (0, next(c), target))
+    heappush(fringe[0], (0, next(c), source))
+    heappush(fringe[1], (0, next(c), target))
     # neighs for extracting correct neighbor information
     neighs = [Gsucc, Gpred]
     # variables to hold shortest discovered path
@@ -910,7 +908,7 @@ def _bidirectional_dijkstra(
         # dir == 0 is forward direction and dir == 1 is back
         dir = 1 - dir
         # extract closest to expand
-        (dist, _, v) = pop(fringe[dir])
+        (dist, _, v) = heappop(fringe[dir])
         if v in dists[dir]:
             # Shortest path to v has already been found
             continue
@@ -936,7 +934,7 @@ def _bidirectional_dijkstra(
             elif w not in seen[dir] or vwLength < seen[dir][w]:
                 # relaxing
                 seen[dir][w] = vwLength
-                push(fringe[dir], (vwLength, next(c), w))
+                heappush(fringe[dir], (vwLength, next(c), w))
                 paths[dir][w] = paths[dir][v] + [w]
                 if w in seen[0] and w in seen[1]:
                     # see if this path is better than the already

--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -283,8 +283,6 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
 
     """
     is_multigraph = G.is_multigraph()
-    push = heappush
-    pop = heappop
 
     nodes = set(G)
     c = count()
@@ -304,7 +302,7 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
                             continue
                         msg = f"NaN found as an edge weight. Edge {(u, v, k, d)}"
                         raise ValueError(msg)
-                    push(frontier, (wt, next(c), u, v, k, d))
+                    heappush(frontier, (wt, next(c), u, v, k, d))
         else:
             for v, d in G.adj[u].items():
                 wt = d.get(weight, 1) * sign
@@ -313,12 +311,12 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
                         continue
                     msg = f"NaN found as an edge weight. Edge {(u, v, d)}"
                     raise ValueError(msg)
-                push(frontier, (wt, next(c), u, v, d))
+                heappush(frontier, (wt, next(c), u, v, d))
         while nodes and frontier:
             if is_multigraph:
-                W, _, u, v, k, d = pop(frontier)
+                W, _, u, v, k, d = heappop(frontier)
             else:
-                W, _, u, v, d = pop(frontier)
+                W, _, u, v, d = heappop(frontier)
             if v in visited or v not in nodes:
                 continue
             # Multigraphs need to handle edge keys in addition to edge data.
@@ -346,7 +344,7 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
                                 continue
                             msg = f"NaN found as an edge weight. Edge {(v, w, k2, d2)}"
                             raise ValueError(msg)
-                        push(frontier, (new_weight, next(c), v, w, k2, d2))
+                        heappush(frontier, (new_weight, next(c), v, w, k2, d2))
             else:
                 for w, d2 in G.adj[v].items():
                     if w in visited:
@@ -357,7 +355,7 @@ def prim_mst_edges(G, minimum, weight="weight", keys=True, data=True, ignore_nan
                             continue
                         msg = f"NaN found as an edge weight. Edge {(v, w, d2)}"
                         raise ValueError(msg)
-                    push(frontier, (new_weight, next(c), v, w, d2))
+                    heappush(frontier, (new_weight, next(c), v, w, d2))
 
 
 ALGORITHMS = {

--- a/networkx/utils/heaps.py
+++ b/networkx/utils/heaps.py
@@ -292,14 +292,13 @@ class BinaryHeap(MinHeap):
         if not dict:
             raise nx.NetworkXError("heap is empty")
         heap = self._heap
-        pop = heappop
         # Repeatedly remove stale key-value pairs until a up-to-date one is
         # met.
         while True:
             value, _, key = heap[0]
             if key in dict and value == dict[key]:
                 break
-            pop(heap)
+            heappop(heap)
         return (key, value)
 
     def pop(self):
@@ -307,12 +306,11 @@ class BinaryHeap(MinHeap):
         if not dict:
             raise nx.NetworkXError("heap is empty")
         heap = self._heap
-        pop = heappop
         # Repeatedly remove stale key-value pairs until a up-to-date one is
         # met.
         while True:
             value, _, key = heap[0]
-            pop(heap)
+            heappop(heap)
             if key in dict and value == dict[key]:
                 break
         del dict[key]


### PR DESCRIPTION
There is a consistent pattern in the codebase where `heappush` and `heappop` are renamed to `push` and `pop` in the functions where they are used. IMO this indirection makes the code less readable; especially in diffs, where the renaming often occurs in one of the unchanged bits of code and is therefore not immediately obvious.

This PR replaces all of the `push = heappush` and `pop = heappop` with just calling `heappush` and `heappop` directly. IMO this is a (very minor) readability improvement[^1]; however, it's so minor that I'm also happy just to close if others think it's not worth the code churn!

[^1]: explicit is better than implicit