### PR TITLE
Add `newman_watts_graph`

### DIFF
--- a/doc/reference/generators.rst
+++ b/doc/reference/generators.rst
@@ -115,6 +115,7 @@ Random Graphs
    gnm_random_graph
    erdos_renyi_graph
    binomial_graph
+   newman_watts_graph
    newman_watts_strogatz_graph
    watts_strogatz_graph
    connected_watts_strogatz_graph

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -21,6 +21,7 @@ __all__ = [
     "gnm_random_graph",
     "erdos_renyi_graph",
     "binomial_graph",
+    "newman_watts_graph",
     "newman_watts_strogatz_graph",
     "watts_strogatz_graph",
     "connected_watts_strogatz_graph",
@@ -309,6 +310,79 @@ def gnm_random_graph(n, m, seed=None, directed=False, *, create_using=None):
     return G
 
 
+@py_random_state("seed")
+@nx._dispatchable(graphs=None, returns_graph=True)
+def newman_watts_graph(n, k, p, seed=None, *, create_using=None):
+    """Returns a Newman--Watts small-world graph.
+
+    Parameters
+    ----------
+    n : int
+        The number of nodes.
+    k : int
+        Each node is joined with its `k` nearest neighbors in a ring
+        topology.
+    p : float
+        The probability of adding a new edge for each edge.
+    seed : integer, random_state, or None (default)
+        Indicator of random number generation state.
+        See :ref:`Randomness<randomness>`.
+    create_using : Graph constructor, optional (default=nx.MultiGraph)
+        Graph type to create. If graph instance, then cleared before populated.
+        Non-multigraph or directed types are not supported and raise a ``NetworkXError``.
+
+    Notes
+    -----
+    First create a ring over $n$ nodes [1]_.  Then each node in the ring is
+    connected with its $k$ nearest neighbors (or $k - 1$ neighbors if $k$
+    is odd).  Then shortcuts are created by adding new edges as follows: for
+    each edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest
+    neighbors" with probability $p$ add a new edge $(u, w)$ with
+    randomly-chosen existing node $w$.
+
+    In contrast with :func:`watts_strogatz_graph`,
+    the edges $(u, v)$ are not removed.
+    In contrast with :func:`newman_watts_strogatz_graph` and :func:`watts_strogatz_graph`,
+    self-loops and multi-edges are allowed.
+
+    See Also
+    --------
+    newman_watts_strogatz_graph
+    watts_strogatz_graph
+
+    References
+    ----------
+    .. [1] M. E. J. Newman and D. J. Watts,
+       Scaling and percolation in the small-world network model,
+       Phys. Rev. E60(6), 7332--7342, 1999.
+       https://doi.org/10.1103/PhysRevE.60.7332
+    """
+    create_using = check_create_using(
+        create_using, directed=False, multigraph=True, default=nx.MultiGraph
+    )
+    if k > n:
+        raise nx.NetworkXError("k>=n, choose smaller k or larger n")
+
+    # If k == n the graph return is a complete graph
+    if k == n:
+        return nx.complete_graph(n, create_using)
+
+    G = empty_graph(n, create_using)
+    nodes = list(range(n))
+    # connect the k/2 neighbors
+    for j in range(1, k // 2 + 1):
+        targets = nodes[j:] + nodes[:j]  # the first j are now last
+        G.add_edges_from(zip(nodes, targets))
+    # for each edge u-v, with probability p, randomly select existing
+    # node w and add new edge u-w
+    e = list(G.edges())
+    for u, _ in e:
+        if seed.random() < p:
+            w = seed.choice(nodes)
+            G.add_edge(u, w)  # self-loops and multi-edges are allowed
+    return G
+
+
 @py_random_state(3)
 @nx._dispatchable(graphs=None, returns_graph=True)
 def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
@@ -337,13 +411,16 @@ def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     is odd).  Then shortcuts are created by adding new edges as follows: for
     each edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest
     neighbors" with probability $p$ add a new edge $(u, w)$ with
-    randomly-chosen existing node $w$,
-    disallowing self-loops and multi-edges.
+    randomly-chosen existing node $w$.
+
     In contrast with :func:`watts_strogatz_graph`,
     the edges $(u, v)$ are not removed.
+    In contrast with :func:`newman_watts_graph`,
+    self-loops and multi-edges are not allowed.
 
     See Also
     --------
+    newman_watts_graph
     watts_strogatz_graph
 
     References
@@ -409,6 +486,7 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
 
     See Also
     --------
+    newman_watts_graph
     newman_watts_strogatz_graph
     connected_watts_strogatz_graph
 
@@ -419,11 +497,13 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     Then shortcuts are created by replacing some edges as follows: for each
     edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest neighbors"
     with probability $p$ replace it with a new edge $(u, w)$ with uniformly
-    random choice of existing node $w$,
-    disallowing self-loops and multi-edges.
+    random choice of existing node $w$.
 
     In contrast with :func:`newman_watts_strogatz_graph`, the random rewiring
-    does not increase the number of edges. The rewired graph is not guaranteed
+    does not increase the number of edges.
+    In contrast with :func:`newman_watts_graph`,
+    self-loops and multi-edges are not allowed.
+    The rewired graph is not guaranteed
     to be connected as in :func:`connected_watts_strogatz_graph`.
 
     References

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -337,8 +337,10 @@ def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     is odd).  Then shortcuts are created by adding new edges as follows: for
     each edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest
     neighbors" with probability $p$ add a new edge $(u, w)$ with
-    randomly-chosen existing node $w$.  In contrast with
-    :func:`watts_strogatz_graph`, no edges are removed.
+    randomly-chosen existing node $w$,
+    disallowing self-loops and multi-edges.
+    In contrast with :func:`watts_strogatz_graph`,
+    the edges $(u, v)$ are not removed.
 
     See Also
     --------
@@ -417,7 +419,8 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     Then shortcuts are created by replacing some edges as follows: for each
     edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest neighbors"
     with probability $p$ replace it with a new edge $(u, w)$ with uniformly
-    random choice of existing node $w$.
+    random choice of existing node $w$,
+    disallowing self-loops and multi-edges.
 
     In contrast with :func:`newman_watts_strogatz_graph`, the random rewiring
     does not increase the number of edges. The rewired graph is not guaranteed

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -290,15 +290,18 @@ class TestGeneratorsRandom:
         # Test to make sure than n <= k
         pytest.raises(nx.NetworkXError, nx.watts_strogatz_graph, 10, 11, 0.25)
         pytest.raises(nx.NetworkXError, nx.newman_watts_strogatz_graph, 10, 11, 0.25)
+        pytest.raises(nx.NetworkXError, nx.newman_watts_graph, 10, 11, 0.25)
 
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
         nx.watts_strogatz_graph(10, 9, 0.25, seed=0)
         nx.newman_watts_strogatz_graph(10, 9, 0.5, seed=0)
+        nx.newman_watts_graph(10, 9, 0.5, seed=0)
 
         # Test k==n scenario
         nx.watts_strogatz_graph(10, 10, 0.25, seed=0)
         nx.newman_watts_strogatz_graph(10, 10, 0.25, seed=0)
+        nx.newman_watts_graph(10, 10, 0.25, seed=0)
 
     def test_random_kernel_graph(self):
         def integral(u, w, z):
@@ -326,14 +329,28 @@ def test_watts_strogatz(k, expected_num_nodes, expected_num_edges):
     assert G.number_of_edges() == expected_num_edges
 
 
-def test_newman_watts_strogatz_zero_probability():
-    G = nx.newman_watts_strogatz_graph(10, 2, 0.0, seed=42)
+@pytest.mark.parametrize(
+    "generator",
+    [
+        nx.newman_watts_strogatz_graph,
+        nx.newman_watts_graph,
+    ],
+)
+def test_nws_zero_probability(generator):
+    G = generator(10, 2, 0.0, seed=42)
     assert len(G) == 10
     assert G.number_of_edges() == 10
 
 
-def test_newman_watts_strogatz_nonzero_probability():
-    G = nx.newman_watts_strogatz_graph(10, 4, 0.25, seed=42)
+@pytest.mark.parametrize(
+    "generator",
+    [
+        nx.newman_watts_strogatz_graph,
+        nx.newman_watts_graph,
+    ],
+)
+def test_nws_nonzero_probability(generator):
+    G = generator(10, 4, 0.25, seed=42)
     assert len(G) == 10
     assert G.number_of_edges() >= 20
 
@@ -420,6 +437,13 @@ def test_gnm_fns_disallow_directed_and_multigraph(fn, graphtype):
 def test_watts_strogatz_disallow_directed_and_multigraph(fn, graphtype):
     with pytest.raises(nx.NetworkXError, match="must not be"):
         fn(10, 2, 0.2, create_using=graphtype)
+
+
+@pytest.mark.parametrize("graphtype", (nx.Graph, nx.DiGraph, nx.MultiDiGraph))
+def test_newman_watts_disallow_directed_and_graph(graphtype):
+    msg = r"must be a multi-graph|must not be directed"
+    with pytest.raises(nx.NetworkXError, match=msg):
+        nx.newman_watts_graph(10, 2, 0.2, create_using=graphtype)
 
 
 @pytest.mark.parametrize("graphtype", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))


### PR DESCRIPTION
Fixes #5012.

This PR adds a new random graph generator, `newman_watts_graph`, as suggested in https://github.com/networkx/networkx/issues/5015#issuecomment-901725263.
It also updates the docstrings of related functions to indicate how self-loops and multi-edges are handled by each.

I've purposely kept this change as small as possible to facilitate reviewing. The various NWS generator algorithms are very similar in structure - they could easily be refactored (and made faster, I believe), at the price of messing with the random number generation and breaking backward compatibility. How are these kinds of breaking changes typically handled in NetworkX?