### PR TITLE
Add note about cycles in `maximum_flow()`

### DIFF
--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -116,6 +116,10 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     True, it can optionally terminate the algorithm as soon as the maximum flow
     value and the minimum cut can be determined.
 
+    Note that the resulting maximum flow may contain flow cycles,
+    back-flow to the source, or some flow exiting the sink.
+    These are possible if there are cycles in the network.
+
     Examples
     --------
     >>> G = nx.DiGraph()


### PR DESCRIPTION
Fixes #6740.

This adds the clarification in https://github.com/networkx/networkx/issues/6740#issuecomment-2726729072 (approved by the issue author) that seemingly never got added to the docstring.
I'm not sure how important or valuable the change actually is, but let's get the issue closed anyways.
