### PR TITLE
Add benchmark suite for shortest path algorithms on weighted graphs

### DIFF
--- a/benchmarks/benchmarks/benchmark_algorithms.py
+++ b/benchmarks/benchmarks/benchmark_algorithms.py
@@ -1,7 +1,12 @@
 """Benchmarks for a certain set of algorithms"""
 
+import random
 import networkx as nx
-from benchmarks.utils import fetch_drug_interaction_network
+from benchmarks.utils import (
+    BenchmarkGraph,
+    fetch_drug_interaction_network,
+    weighted_graph,
+)
 from networkx.algorithms import community
 
 
@@ -76,3 +81,47 @@ class AlgorithmBenchmarksConnectedGraphsOnly:
 
     def time_square_clustering(self, graph):
         _ = nx.square_clustering(self.graphs_dict[graph])
+
+
+def _make_weighted_benchmark_graphs(seed):
+    erdos_renyi_graphs = [
+        (nx.erdos_renyi_graph, (nodes, p), {"seed": seed})
+        for nodes in [10, 100]
+        for p in [0.1, 0.5, 0.9]
+    ]
+
+    path_graphs = [
+        (nx.path_graph, (nodes,), {})
+        for nodes in [1_000, 10_000, 20_000]
+    ]
+
+    all_graphs = {}
+    for graph_func, args, kwargs in path_graphs + erdos_renyi_graphs:
+        g = BenchmarkGraph.from_func(
+            weighted_graph, seed, graph_func, *args, **kwargs
+        )
+        all_graphs[g.name] = g
+    return all_graphs
+
+
+class WeightedGraphBenchmark:
+    """Benchmark for shortest path algorithms on various weighted graphs."""
+
+    timeout = 120
+    _seed = 42
+    param_names = ["graph"]
+
+    _graphs = _make_weighted_benchmark_graphs(_seed)
+    params = list(_graphs)
+
+    def setup(self, graph):
+        self.G = self._graphs[graph].graph()
+        self.nodes = sorted(self.G)
+
+    def time_weighted_single_source_dijkstra(self, graph):
+        source = self.nodes[0]
+        target = self.nodes[-1]
+        try:
+            _ = nx.single_source_dijkstra(self.G, source, target)
+        except nx.NetworkXNoPath:
+            pass

--- a/benchmarks/benchmarks/utils.py
+++ b/benchmarks/benchmarks/utils.py
@@ -1,6 +1,100 @@
+import random
+from dataclasses import dataclass
+from typing import Callable
+
 import pandas as pd
 
 import networkx as nx
+
+
+@dataclass
+class BenchmarkGraph:
+    """A graph used for benchmarking.
+
+    Attributes
+    ----------
+    name : str
+        The name of the graph.
+    graph : Callable[[], nx.Graph]
+        Function to generate the graph
+    """
+
+    name: str
+    graph: Callable[[], nx.Graph]
+
+    @classmethod
+    def from_func(cls, func, *args, **kwargs) -> "BenchmarkGraph":
+        """
+        Create a BenchmarkGraph from a graph-generating function and its arguments.
+
+        Parameters:
+            func (Callable): The graph-generating function.
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
+
+        Returns:
+            BenchmarkGraph: An instance with the generated name and graph.
+        """
+        return cls(
+            name = _benchmark_name_from_func_call(func, *args, **kwargs),
+            graph = lambda: func(*args, **kwargs)
+        )
+
+
+def _benchmark_name_from_func_call(func, *args, **kwargs) -> str:
+    """Generate a string name for a graph-generating function and its arguments.
+
+    This function takes a graph constructor (such as a NetworkX generator),
+    along with its positional and keyword arguments, and returns a string
+    of the form: 'function_name(arg1, arg2, ..., kwarg1=val1, ...)'.
+
+    Parameters:
+        func (Callable): The graph-generating function.
+        *args: Positional arguments to pass to the function.
+        **kwargs: Keyword arguments to pass to the function.
+
+    Returns:
+        str: A string representation of the function and its arguments,
+             suitable for labeling graphs in benchmarks or plots.
+
+    Example:
+        >>> _benchmark_name_from_func_call(nx.erdos_renyi_graph, 100, 0.1)
+        'erdos_renyi_graph(100, 0.1)'
+
+        >>> _benchmark_name_from_func_call(nx.grid_2d_graph, 5, 5, periodic=True)
+        'grid_2d_graph(5, 5, periodic=True)'
+    """
+
+    def to_str(value):
+        if callable(value):
+            return value.__name__
+        else:
+            return str(value)
+
+    args_str = ", ".join(map(to_str, args))
+    kwargs_str = ", ".join(f"{k}={to_str(v)}" for k, v in kwargs.items())
+    all_args = ", ".join(filter(None, [args_str, kwargs_str]))
+    return f"{to_str(func)}({all_args})"
+
+
+def weighted_graph(weight_seed, graph_func, *args, **kwargs) -> nx.Graph:
+    """
+    Generate a graph using the given function and assign random edge weights.
+
+    Parameters:
+        weight_seed (int): Seed for the random number generator.
+        graph_func (Callable): The graph-generating function.
+        *args: Positional arguments for the graph function.
+        **kwargs: Keyword arguments for the graph function.
+
+    Returns:
+        nx.Graph: A graph with randomly weighted edges.
+    """
+    rng = random.Random(weight_seed)
+    G = graph_func(*args, **kwargs)
+    for u, v in G.edges():
+        G[u][v]["weight"] = rng.randint(1, len(G))
+    return G
 
 
 def fetch_drug_interaction_network():


### PR DESCRIPTION

This PR introduces a new benchmarking suite for evaluating shortest path algorithms on weighted graphs. This benchmark was used to evaluate https://github.com/networkx/networkx/pull/8023. It includes the following changes:

### Graphs added

- **`WeightedGraphBenchmark` class**:
  - Benchmarks `networkx.single_source_dijkstra` on various weighted graphs.
  - Supports both `path_graph` (sizes: 1,000–20,000) and `erdos_renyi_graph` (sizes: 10, 100; probabilities: 0.1, 0.5, 0.9).
  - Graphs are generated with consistent edge weights using a fixed random seed for reproducibility.

### Utilities added

- **Graph utility functions in `benchmarks/utils.py`**:
  - `BenchmarkGraph`: A dataclass wrapper for benchmark-ready graphs.
  - `weighted_graph`: Utility to assign random integer weights to edges.
  - `_benchmark_name_from_func_call`: Generates human-readable graph names from function calls for better benchmark output labeling.
