### PR TITLE
Fix `min_weight_matching`

### DIFF
--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -261,9 +261,9 @@ def is_perfect_matching(G, matching):
 @not_implemented_for("directed")
 @nx._dispatchable(edge_attrs="weight")
 def min_weight_matching(G, weight="weight"):
-    """Compute a minimum-weighted maximum-cardinality matching of G.
+    """Compute a minimum-weight maximum-cardinality matching of `G`.
 
-    The minimum-weighted maximum-cardinality matching is the matching
+    The minimum-weight maximum-cardinality matching is the matching
     that has the minimum weight among all maximum-cardinality matchings.
 
     Use the maximum-weight algorithm with edge weights subtracted

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -261,7 +261,10 @@ def is_perfect_matching(G, matching):
 @not_implemented_for("directed")
 @nx._dispatchable(edge_attrs="weight")
 def min_weight_matching(G, weight="weight"):
-    """Computing a minimum-weight maximal matching of G.
+    """Compute a minimum-weighted maximum-cardinality matching of G.
+
+    The minimum-weighted maximum-cardinality matching is the matching
+    that has the minimum weight among all maximum-cardinality matchings.
 
     Use the maximum-weight algorithm with edge weights subtracted
     from the maximum weight of all edges.
@@ -281,12 +284,6 @@ def min_weight_matching(G, weight="weight"):
     to the min weight matching using the original weights.
     Adding 1 to the max edge weight keeps all edge weights positive
     and as integers if they started as integers.
-
-    You might worry that adding 1 to each weight would make the algorithm
-    favor matchings with more edges. But we use the parameter
-    `maxcardinality=True` in `max_weight_matching` to ensure that the
-    number of edges in the competing matchings are the same and thus
-    the optimum does not change due to changes in the number of edges.
 
     Read the documentation of `max_weight_matching` for more information.
 

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -388,7 +388,7 @@ class TestMaxWeightMatching:
     def test_min_weight_matching_max_cardinality(self):
         G = nx.Graph()
         G.add_weighted_edges_from([(1, 2, 1000), (2, 3, 2), (3, 4, 3000)])
-        # The minimum-weight maximal matching is {(2, 3)}; the minimum weight
+        # The minimum-weight maximal matching is {(2, 3)}; the minimum-weight
         # maximum-cardinality matching is {(1, 2), (3, 4)}. See gh-8062.
         answer = {(1, 2), (3, 4)}
         assert edges_equal(nx.min_weight_matching(G), answer)

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -58,10 +58,18 @@ class TestMaxWeightMatching:
             nx.max_weight_matching(G), matching_dict_to_set({2: 3, 3: 2})
         )
         assert edges_equal(
-            nx.max_weight_matching(G, 1), matching_dict_to_set({1: 2, 2: 1, 3: 4, 4: 3})
+            nx.max_weight_matching(G, True),
+            matching_dict_to_set({1: 2, 2: 1, 3: 4, 4: 3}),
+        )
+        assert edges_equal(
+            nx.max_weight_matching(G, weight=None),
+            matching_dict_to_set({1: 2, 2: 1, 3: 4, 4: 3}),
         )
         assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 2, 3: 4})
+        )
+        assert edges_equal(
+            nx.min_weight_matching(G, weight=None), matching_dict_to_set({1: 2, 3: 4})
         )
 
     def test_square(self):

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -63,9 +63,6 @@ class TestMaxWeightMatching:
         assert edges_equal(
             nx.min_weight_matching(G), matching_dict_to_set({1: 2, 3: 4})
         )
-        assert edges_equal(
-            nx.min_weight_matching(G, 1), matching_dict_to_set({1: 2, 3: 4})
-        )
 
     def test_square(self):
         G = nx.Graph()
@@ -399,6 +396,12 @@ class TestMaxWeightMatching:
         raises(error, nx.max_weight_matching, nx.MultiDiGraph())
         raises(error, nx.max_weight_matching, nx.DiGraph())
         raises(error, nx.min_weight_matching, nx.DiGraph())
+
+    def test_min_weight_matching_max_cardinality(self):
+        G = nx.Graph()
+        G.add_weighted_edges_from([(1, 2, 1000), (2, 3, 2), (3, 4, 3000)])
+        answer = matching_dict_to_set({1: 2, 3: 4})
+        assert edges_equal(nx.min_weight_matching(G), answer)
 
 
 class TestIsMatching:

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -92,9 +92,9 @@ class TestMaxWeightMatching:
         G.add_edge(2, 3, weight=11)
         G.add_edge(3, 4, weight=5)
         assert edges_equal(nx.max_weight_matching(G), {(2, 3)})
-        assert edges_equal(nx.max_weight_matching(G, 1), {(1, 2), (3, 4)})
+        assert edges_equal(nx.max_weight_matching(G, weight=None), {(1, 2), (3, 4)})
         assert edges_equal(nx.min_weight_matching(G), {(1, 2), (3, 4)})
-        assert edges_equal(nx.min_weight_matching(G, 1), {(1, 2), (3, 4)})
+        assert edges_equal(nx.min_weight_matching(G, weight=None), {(1, 2), (3, 4)})
 
     def test_square(self):
         G = nx.Graph()

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -400,6 +400,8 @@ class TestMaxWeightMatching:
     def test_min_weight_matching_max_cardinality(self):
         G = nx.Graph()
         G.add_weighted_edges_from([(1, 2, 1000), (2, 3, 2), (3, 4, 3000)])
+        # The minimum-weight maximal matching is {(2, 3)}; the minimum weight
+        # maximum-cardinality matching is {(1, 2), (3, 4)}. See gh-8062.
         answer = matching_dict_to_set({1: 2, 3: 4})
         assert edges_equal(nx.min_weight_matching(G), answer)
 


### PR DESCRIPTION
The current `min_weight_matching` claims to compute a minimum-weight maximal matching, but it is actually computing a minimum-weighted maximum-cardinality matching.

The minimum-weight maximal matching, which it claims to solve, is NP-hard. See the [paper](https://arxiv.org/abs/1811.08506):

> As we know since 1961, all natural variants of perfect matchings and maximum matchings can be found in polynomial time, even in general graphs. Here we study a different problem — Minimum Maximal Matching (MMM). The task is — given graph G, to find an inclusion-wise maximal matching M with the smallest cardinality (or weight in the weighted version).
>
> The MMM problem was studied as early as 1980, when Yannakakis and Gavril showed, that it is NP-hard even in some restricted cases.

Changes include:

- Corrected the docstring description to fit the function behavior
- Removed an incorrect test, which mistakenly tried to set `maxcardinality` (the min version does not have such a keyword parameter)
- Added a test to show that we are computing a minimum-weighted maximum-cardinality matching instead of a minimum-weight maximal matching