### PR TITLE
Replace `random_lobster` with `random_lobster_graph`

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -53,3 +53,4 @@ Version 3.7
 * Remove ``graph_could_be_isomorphic``, ``fast_graph_could_be_isomorphic``, and
   ``faster_graph_could_be_isomorphic``, from
   ``networkx.algorithms.isomorphism.isomorph``.
+* Remove ``random_lobster`` from ``networkx.generators.random_graphs``.

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -30,6 +30,7 @@ __all__ = [
     "extended_barabasi_albert_graph",
     "powerlaw_cluster_graph",
     "random_lobster",
+    "random_lobster_graph",
     "random_shell_graph",
     "random_powerlaw_tree",
     "random_powerlaw_tree_sequence",
@@ -1097,7 +1098,7 @@ def powerlaw_cluster_graph(n, m, p, seed=None, *, create_using=None):
 
 @py_random_state(3)
 @nx._dispatchable(graphs=None, returns_graph=True)
-def random_lobster(n, p1, p2, seed=None, *, create_using=None):
+def random_lobster_graph(n, p1, p2, seed=None, *, create_using=None):
     """Returns a random lobster graph.
 
     A lobster is a tree that reduces to a caterpillar when pruning all
@@ -1120,7 +1121,7 @@ def random_lobster(n, p1, p2, seed=None, *, create_using=None):
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
-    create_using : Graph constructor, optional (default=nx.Grap)
+    create_using : Graph constructor, optional (default=nx.Graph)
         Graph type to create. If graph instance, then cleared before populated.
         Multigraph and directed types are not supported and raise a ``NetworkXError``.
 
@@ -1148,6 +1149,25 @@ def random_lobster(n, p1, p2, seed=None, *, create_using=None):
                 current_node += 1
                 L.add_edge(cat_node, current_node)
     return L  # voila, un lobster!
+
+
+@py_random_state(3)
+@nx._dispatchable(graphs=None, returns_graph=True)
+def random_lobster(n, p1, p2, seed=None, *, create_using=None):
+    """
+    .. deprecated:: 3.5
+       `random_lobster` is a deprecated alias
+       for `random_lobster_graph`.
+       Use `random_lobster_graph` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "`random_lobster` is deprecated, use `random_lobster_graph` instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return random_lobster_graph(n, p1, p2, seed=seed, create_using=create_using)
 
 
 @py_random_state(1)

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -157,15 +157,15 @@ class TestGeneratorsRandom:
             non_leafs = [n for n in g if g.degree(n) > 1]
             return is_caterpillar(g.subgraph(non_leafs))
 
-        G = nx.random_lobster(10, 0.1, 0.5, seed)
+        G = nx.random_lobster_graph(10, 0.1, 0.5, seed)
         assert max(G.degree(n) for n in G.nodes()) > 3
         assert is_lobster(G)
-        pytest.raises(nx.NetworkXError, nx.random_lobster, 10, 0.1, 1, seed)
-        pytest.raises(nx.NetworkXError, nx.random_lobster, 10, 1, 1, seed)
-        pytest.raises(nx.NetworkXError, nx.random_lobster, 10, 1, 0.5, seed)
+        pytest.raises(nx.NetworkXError, nx.random_lobster_graph, 10, 0.1, 1, seed)
+        pytest.raises(nx.NetworkXError, nx.random_lobster_graph, 10, 1, 1, seed)
+        pytest.raises(nx.NetworkXError, nx.random_lobster_graph, 10, 1, 0.5, seed)
 
         # docstring says this should be a caterpillar
-        G = nx.random_lobster(10, 0.1, 0.0, seed)
+        G = nx.random_lobster_graph(10, 0.1, 0.0, seed)
         assert is_caterpillar(G)
 
         # difficult to find seed that requires few tries
@@ -367,7 +367,7 @@ def test_connected_watts_strogatz_zero_tries():
         (nx.dual_barabasi_albert_graph, {"n": 40, "m1": 3, "m2": 2, "p": 0.1}),
         (nx.extended_barabasi_albert_graph, {"n": 40, "m": 3, "p": 0.1, "q": 0.2}),
         (nx.powerlaw_cluster_graph, {"n": 40, "m": 3, "p": 0.1}),
-        (nx.random_lobster, {"n": 40, "p1": 0.1, "p2": 0.2}),
+        (nx.random_lobster_graph, {"n": 40, "p1": 0.1, "p2": 0.2}),
         (nx.random_shell_graph, {"constructor": [(10, 20, 0.8), (20, 40, 0.8)]}),
         (nx.random_powerlaw_tree, {"n": 10, "seed": 14, "tries": 1}),
         (
@@ -455,7 +455,7 @@ def test_powerlaw_cluster_disallow_directed_and_multigraph(graphtype):
 @pytest.mark.parametrize("graphtype", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))
 def test_random_lobster_disallow_directed_and_multigraph(graphtype):
     with pytest.raises(nx.NetworkXError, match="must not be"):
-        nx.random_lobster(10, 0.1, 0.1, create_using=graphtype)
+        nx.random_lobster_graph(10, 0.1, 0.1, create_using=graphtype)
 
 
 @pytest.mark.parametrize("graphtype", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))

--- a/networkx/tests/test_all_random_functions.py
+++ b/networkx/tests/test_all_random_functions.py
@@ -190,7 +190,7 @@ def run_all_random_functions(seed):
     t(nx.barabasi_albert_graph, n, m, seed=seed)
     t(nx.extended_barabasi_albert_graph, n, m, p, q, seed=seed)
     t(nx.powerlaw_cluster_graph, n, m, p, seed=seed)
-    t(nx.random_lobster, n, p1, p2, seed=seed)
+    t(nx.random_lobster_graph, n, p1, p2, seed=seed)
     t(nx.random_powerlaw_tree, n, seed=seed, tries=5000)
     t(nx.random_powerlaw_tree_sequence, 10, seed=seed, tries=5000)
     t(nx.random_labeled_tree, n, seed=seed)


### PR DESCRIPTION
This renames the `random_lobster` generator to use the `_graph` suffix: `random_lobster_graph`.