### PR TITLE
Clarify subgraph node/edge order is not preserved

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1838,6 +1838,16 @@ class Graph:
                 )
             SG.graph.update(G.graph)
 
+        Subgraphs are not guaranteed to preserve the order of nodes or edges
+        as they appear in the original graph. For example:
+
+        >>> G = nx.Graph()
+        >>> G.add_nodes_from(reversed(range(10)))
+        >>> list(G)
+        [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        >>> list(G.subgraph([1, 3, 2]))
+        [1, 2, 3]
+
         Examples
         --------
         >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc


### PR DESCRIPTION
Based on discussions from https://github.com/networkx/networkx/issues/8054, users may expect subgraphs to preserve node and edge order. This updates the documentation to clarify that order is not guaranteed to be maintained when creating subgraphs.