### PR TITLE
Clarify order preservation as a public contract in graph documentation

### DIFF
--- a/doc/reference/classes/index.rst
+++ b/doc/reference/classes/index.rst
@@ -40,13 +40,9 @@ Basic graph types
 
 .. note:: 
    NetworkX guarantees that the order of nodes and edges reflects the order 
-   in which they were added, provided that the graph is used with CPython 3.7 
-   or later, where insertion order is a language guarantee. This ordering is 
-   preserved across all base graph types and is considered part of the 
-   NetworkX API contract.
-
-   In earlier versions of Python or alternative Python implementations,
-   insertion order is not guaranteed.
+   in which they were added across all base graph types, provided that the
+   graph is used with CPython 3.7.  Prior to this version, order
+   preservation is not guaranteed.
 
 Graph Views
 ===========

--- a/doc/reference/classes/index.rst
+++ b/doc/reference/classes/index.rst
@@ -38,10 +38,9 @@ Basic graph types
    multigraph
    multidigraph
 
-.. note:: 
-   NetworkX guarantees that the order of nodes and edges reflects the order 
-   in which they were added across all base graph types, provided that the
-   graph is used with CPython 3.7.  Prior to this version, order
+.. note:: NetworkX guarantees that the order of nodes and edges reflects the
+   order in which they were added across all base graph types, provided that
+   the graph is used with CPython 3.7.  Prior to this version, order
    preservation is not guaranteed.
 
 Graph Views

--- a/doc/reference/classes/index.rst
+++ b/doc/reference/classes/index.rst
@@ -38,10 +38,15 @@ Basic graph types
    multigraph
    multidigraph
 
-.. note:: NetworkX uses `dicts` to store the nodes and neighbors in a graph.
-   So the reporting of nodes and edges for the base graph classes may not
-   necessarily be consistent across versions and platforms; however, the reporting
-   for CPython is consistent across platforms and versions after 3.6.
+.. note:: 
+   NetworkX guarantees that the order of nodes and edges reflects the order 
+   in which they were added, provided that the graph is used with CPython 3.7 
+   or later, where insertion order is a language guarantee. This ordering is 
+   preserved across all base graph types and is considered part of the 
+   NetworkX API contract.
+
+   In earlier versions of Python or alternative Python implementations,
+   insertion order is not guaranteed.
 
 Graph Views
 ===========


### PR DESCRIPTION
Update NetworkX documentation to clearly state that insertion order is now a guaranteed behaviour for Graph, DiGraph, and related classes, aligning with the public messaging provided during the deprecation of OrderedGraph (and others).

## Motivation
The current documentation states:

> NetworkX uses dicts to store the nodes and neighbors in a graph. So the reporting of nodes and edges for the base graph classes may not necessarily be consistent across versions and platforms; however, the reporting for CPython is consistent across platforms and versions after 3.6. - [link](https://networkx.org/documentation/stable/reference/classes/index.html#:~:text=however%2C%20the%20reporting%20for%20CPython%20is%20consistent%20across%20platforms%20and%20versions%20after%203.6.)

The current language does not clearly articulate the explicit contract that **NetworkX** now upholds regarding insertion order. While the use of dictionaries underlies this behaviour, it remains an internal implementation detail, not the basis on which users should be expected to rely.  Instead of referencing incidental behaviour, the documentation should affirmatively state that order preservation is a guaranteed feature of the public API for Python ≥ 3.7, as was communicated during the deprecation of OrderedGraph (and others).

The deprecation message in question:
> OrderedGraph is deprecated and will be removed in version 3.0. Use Graph instead, which guarantees order is preserved for Python >= 3.7.” - [link](https://github.com/networkx/networkx/pull/4629/files#diff-5ea87f9002b4d7585751c9cf466f3497db7e62cef2fbb44921a050a2fb8cdd0fR56-R58)

This was a clear and a public commitment to order preservation, and now that the Ordered* classes have been removed, the documentation should reflect this guarantee more explicitly.