### PR TITLE
Refactor `is_*matching` checks

### DIFF
--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -136,9 +136,9 @@ def _check_matching(G, matching, *, track_edges=False):
     for u, v in matching:
         if u == v or not G.has_edge(u, v) or u in nodes or v in nodes:
             return False, edges, nodes
-        nodes.update(edge)
+        nodes.update((u, v))
         if track_edges:
-            edges.add(edge)
+            edges.add((u, v))
             edges.add((v, u))
 
     return True, edges, nodes

--- a/networkx/algorithms/tests/test_matching.py
+++ b/networkx/algorithms/tests/test_matching.py
@@ -17,6 +17,7 @@ from networkx.utils import edges_equal
         {(5, 0)},  # for both edge orders
         {(0, 5), (2, 3)},  # node not in G, but other edge is valid matching
         {(5, 5), (2, 3)},  # Self-loop hits node not in G validation first
+        {(0, 1), (0, 2), (0, 5)},  # Ensure validity gets checked before returning
     ),
 )
 def test_is_matching_node_not_in_G(fn, edgeset):
@@ -35,6 +36,7 @@ def test_is_matching_node_not_in_G(fn, edgeset):
     (
         {(0, 1, 2), (2, 3)},  # 3-tuple
         {(0,), (2, 3)},  # 1-tuple
+        {(0, 1), (0, 2), (0,)},  # Ensure validity gets checked before returning
     ),
 )
 def test_is_matching_invalid_edge(fn, edgeset):


### PR DESCRIPTION
Inspired by #8068, this PR pulls out all the common code in the `is_*matching` functions and puts it in a new helper function: `_check_matching()`.

The only change in behavior (that I know of) with this PR is that matchings that contain an invalid edge (`len(edge) != 2` or with nodes not in `G`) always error, instead of erroring only for certain edge orderings.

I still believe this refactor can be pushed further, but some of those changes are opinionated (e.g. should matching with self-loops or edges not in `G` raise too?)... This seems like a reasonably minimal set of changes to keep the review process manageable, so let's do that first!