### PR TITLE
Fix typo in `min_edge_cover` docstring

### DIFF
--- a/networkx/algorithms/covering.py
+++ b/networkx/algorithms/covering.py
@@ -66,10 +66,10 @@ def min_edge_cover(G, matching_algorithm=None):
     is bounded by the worst-case running time of the function
     ``matching_algorithm``.
 
-    Minimum edge cover for `G` can also be found using the `min_edge_covering`
-    function in :mod:`networkx.algorithms.bipartite.covering` which is
+    Minimum edge cover for `G` can also be found using
+    :func:`~networkx.algorithms.bipartite.covering.min_edge_covering` which is
     simply this function with a default matching algorithm of
-    :func:`~networkx.algorithms.bipartite.matching.hopcraft_karp_matching`
+    :func:`~networkx.algorithms.bipartite.matching.hopcroft_karp_matching`
     """
     if len(G) == 0:
         return set()


### PR DESCRIPTION
Came across this while hunting down test failures in #8074.