### PR TITLE
Refactor `(n)w(s)_graph` generators

### DIFF
--- a/doc/reference/generators.rst
+++ b/doc/reference/generators.rst
@@ -115,6 +115,7 @@ Random Graphs
    gnm_random_graph
    erdos_renyi_graph
    binomial_graph
+   newman_watts_graph
    newman_watts_strogatz_graph
    watts_strogatz_graph
    connected_watts_strogatz_graph

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -312,6 +312,75 @@ def gnm_random_graph(n, m, seed=None, directed=False, *, create_using=None):
 
 @py_random_state("seed")
 @nx._dispatchable(graphs=None, returns_graph=True)
+def _newman_watts_strogatz_graph_helper(
+    n, k, p, seed=None, *, create_using=None, remove_edges=False, allow_multiedges=False
+):
+    """Returns a Newman--Watts--Strogatz-type small-world graph.
+
+    Parameters
+    ----------
+    n : int
+        The number of nodes.
+    k : int
+        Each node is joined with its `k` nearest neighbors in a ring
+        topology.
+    p : float
+        The probability of adding a new edge for each edge.
+    seed : integer, random_state, or None, optional (default=None)
+        Indicator of random number generation state.
+        See :ref:`Randomness<randomness>`.
+    create_using : Graph constructor, optional (default=nx.MultiGraph)
+        Graph type to create. If graph instance, then cleared before populated.
+        Unsupported types raise a ``NetworkXError``.
+    remove_edges : bool, optional (default=False)
+        Whether to remove an edge when a new edge is added (which corresponds to a rewiring).
+    allow_multiedges : bool, optional (default=False)
+        Whether to allow self-loops and multiple edges between the same pair of nodes.
+        If `True`, `create_using` must be a multigraph type.
+    """
+    create_using = check_create_using(
+        create_using,
+        directed=False,
+        multigraph=allow_multiedges,
+        default=nx.MultiGraph if allow_multiedges else nx.Graph,
+    )
+    if k >= n:
+        raise nx.NetworkXError("k >= n, choose smaller k or larger n")
+
+    # If k == n - 1, return a complete graph.
+    if k == n - 1:
+        return nx.complete_graph(n, create_using)
+
+    G = empty_graph(n, create_using)
+    nodes = list(range(n))
+
+    # Connect the k/2 neighbors on each side.
+    for j in range(1, k // 2 + 1):
+        targets = nodes[j:] + nodes[:j]  # The first j are now last.
+        G.add_edges_from(zip(nodes, targets))
+
+    # For each edge u-v, with probability p, randomly select existing
+    # node w and add new edge u-w.
+    e = list(G.edges())
+    nodes_set = set(nodes)
+    for u, v in e:
+        if seed.random() < p:
+            if allow_multiedges:
+                w = seed.choice(nodes)
+                G.add_edge(u, w)
+            elif G.degree(u) < n - 1:
+                available_nodes = list(nodes_set - {u} - G._adj[u].keys())
+                w = seed.choice(available_nodes)
+                G.add_edge(u, w)
+            else:
+                continue
+            if remove_edges:
+                G.remove_edge(u, v)
+    return G
+
+
+@py_random_state("seed")
+@nx._dispatchable(graphs=None, returns_graph=True)
 def newman_watts_graph(n, k, p, seed=None, *, create_using=None):
     """Returns a Newman--Watts small-world graph.
 
@@ -357,30 +426,15 @@ def newman_watts_graph(n, k, p, seed=None, *, create_using=None):
        Phys. Rev. E60(6), 7332--7342, 1999.
        https://doi.org/10.1103/PhysRevE.60.7332
     """
-    create_using = check_create_using(
-        create_using, directed=False, multigraph=True, default=nx.MultiGraph
+    return _newman_watts_strogatz_graph_helper(
+        n,
+        k,
+        p,
+        seed,
+        create_using=create_using,
+        remove_edges=False,
+        allow_multiedges=True,
     )
-    if k > n:
-        raise nx.NetworkXError("k>=n, choose smaller k or larger n")
-
-    # If k == n the graph return is a complete graph
-    if k == n:
-        return nx.complete_graph(n, create_using)
-
-    G = empty_graph(n, create_using)
-    nodes = list(range(n))
-    # connect the k/2 neighbors
-    for j in range(1, k // 2 + 1):
-        targets = nodes[j:] + nodes[:j]  # the first j are now last
-        G.add_edges_from(zip(nodes, targets))
-    # for each edge u-v, with probability p, randomly select existing
-    # node w and add new edge u-w
-    e = list(G.edges())
-    for u, _ in e:
-        if seed.random() < p:
-            w = seed.choice(nodes)
-            G.add_edge(u, w)  # self-loops and multi-edges are allowed
-    return G
 
 
 @py_random_state(3)
@@ -430,37 +484,15 @@ def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
        Physics Letters A, 263, 341, 1999.
        https://doi.org/10.1016/S0375-9601(99)00757-4
     """
-    create_using = check_create_using(create_using, directed=False, multigraph=False)
-    if k > n:
-        raise nx.NetworkXError("k>=n, choose smaller k or larger n")
-
-    # If k == n the graph return is a complete graph
-    if k == n:
-        return nx.complete_graph(n, create_using)
-
-    G = empty_graph(n, create_using)
-    nlist = list(G.nodes())
-    fromv = nlist
-    # connect the k/2 neighbors
-    for j in range(1, k // 2 + 1):
-        tov = fromv[j:] + fromv[0:j]  # the first j are now last
-        for i in range(len(fromv)):
-            G.add_edge(fromv[i], tov[i])
-    # for each edge u-v, with probability p, randomly select existing
-    # node w and add new edge u-w
-    e = list(G.edges())
-    for u, v in e:
-        if seed.random() < p:
-            w = seed.choice(nlist)
-            # no self-loops and reject if edge u-w exists
-            # is that the correct NWS model?
-            while w == u or G.has_edge(u, w):
-                w = seed.choice(nlist)
-                if G.degree(u) >= n - 1:
-                    break  # skip this rewiring
-            else:
-                G.add_edge(u, w)
-    return G
+    return _newman_watts_strogatz_graph_helper(
+        n,
+        k,
+        p,
+        seed,
+        create_using=create_using,
+        remove_edges=False,
+        allow_multiedges=False,
+    )
 
 
 @py_random_state(3)
@@ -512,39 +544,15 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
        Collective dynamics of small-world networks,
        Nature, 393, pp. 440--442, 1998.
     """
-    create_using = check_create_using(create_using, directed=False, multigraph=False)
-    if k > n:
-        raise nx.NetworkXError("k>n, choose smaller k or larger n")
-
-    # If k == n, the graph is complete not Watts-Strogatz
-    if k == n:
-        G = nx.complete_graph(n, create_using)
-        return G
-
-    G = nx.empty_graph(n, create_using=create_using)
-    nodes = list(range(n))  # nodes are labeled 0 to n-1
-    # connect each node to k/2 neighbors
-    for j in range(1, k // 2 + 1):
-        targets = nodes[j:] + nodes[0:j]  # first j nodes are now last in list
-        G.add_edges_from(zip(nodes, targets))
-    # rewire edges from each node
-    # loop over all nodes in order (label) and neighbors in order (distance)
-    # no self loops or multiple edges allowed
-    for j in range(1, k // 2 + 1):  # outer loop is neighbors
-        targets = nodes[j:] + nodes[0:j]  # first j nodes are now last in list
-        # inner loop in node order
-        for u, v in zip(nodes, targets):
-            if seed.random() < p:
-                w = seed.choice(nodes)
-                # Enforce no self-loops or multiple edges
-                while w == u or G.has_edge(u, w):
-                    w = seed.choice(nodes)
-                    if G.degree(u) >= n - 1:
-                        break  # skip this rewiring
-                else:
-                    G.remove_edge(u, v)
-                    G.add_edge(u, w)
-    return G
+    return _newman_watts_strogatz_graph_helper(
+        n,
+        k,
+        p,
+        seed,
+        create_using=create_using,
+        remove_edges=True,
+        allow_multiedges=False,
+    )
 
 
 @py_random_state(4)

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -21,6 +21,7 @@ __all__ = [
     "gnm_random_graph",
     "erdos_renyi_graph",
     "binomial_graph",
+    "newman_watts_graph",
     "newman_watts_strogatz_graph",
     "watts_strogatz_graph",
     "connected_watts_strogatz_graph",
@@ -309,6 +310,79 @@ def gnm_random_graph(n, m, seed=None, directed=False, *, create_using=None):
     return G
 
 
+@py_random_state("seed")
+@nx._dispatchable(graphs=None, returns_graph=True)
+def newman_watts_graph(n, k, p, seed=None, *, create_using=None):
+    """Returns a Newman--Watts small-world graph.
+
+    Parameters
+    ----------
+    n : int
+        The number of nodes.
+    k : int
+        Each node is joined with its `k` nearest neighbors in a ring
+        topology.
+    p : float
+        The probability of adding a new edge for each edge.
+    seed : integer, random_state, or None (default)
+        Indicator of random number generation state.
+        See :ref:`Randomness<randomness>`.
+    create_using : Graph constructor, optional (default=nx.MultiGraph)
+        Graph type to create. If graph instance, then cleared before populated.
+        Non-multigraph or directed types are not supported and raise a ``NetworkXError``.
+
+    Notes
+    -----
+    First create a ring over $n$ nodes [1]_.  Then each node in the ring is
+    connected with its $k$ nearest neighbors (or $k - 1$ neighbors if $k$
+    is odd).  Then shortcuts are created by adding new edges as follows: for
+    each edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest
+    neighbors" with probability $p$ add a new edge $(u, w)$ with
+    randomly-chosen existing node $w$.
+
+    In contrast with :func:`watts_strogatz_graph`,
+    the edges $(u, v)$ are not removed.
+    In contrast with :func:`newman_watts_strogatz_graph` and :func:`watts_strogatz_graph`,
+    self-loops and multi-edges are allowed.
+
+    See Also
+    --------
+    newman_watts_strogatz_graph
+    watts_strogatz_graph
+
+    References
+    ----------
+    .. [1] M. E. J. Newman and D. J. Watts,
+       Scaling and percolation in the small-world network model,
+       Phys. Rev. E60(6), 7332--7342, 1999.
+       https://doi.org/10.1103/PhysRevE.60.7332
+    """
+    create_using = check_create_using(
+        create_using, directed=False, multigraph=True, default=nx.MultiGraph
+    )
+    if k > n:
+        raise nx.NetworkXError("k>=n, choose smaller k or larger n")
+
+    # If k == n the graph return is a complete graph
+    if k == n:
+        return nx.complete_graph(n, create_using)
+
+    G = empty_graph(n, create_using)
+    nodes = list(range(n))
+    # connect the k/2 neighbors
+    for j in range(1, k // 2 + 1):
+        targets = nodes[j:] + nodes[:j]  # the first j are now last
+        G.add_edges_from(zip(nodes, targets))
+    # for each edge u-v, with probability p, randomly select existing
+    # node w and add new edge u-w
+    e = list(G.edges())
+    for u, _ in e:
+        if seed.random() < p:
+            w = seed.choice(nodes)
+            G.add_edge(u, w)  # self-loops and multi-edges are allowed
+    return G
+
+
 @py_random_state(3)
 @nx._dispatchable(graphs=None, returns_graph=True)
 def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
@@ -337,13 +411,16 @@ def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     is odd).  Then shortcuts are created by adding new edges as follows: for
     each edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest
     neighbors" with probability $p$ add a new edge $(u, w)$ with
-    randomly-chosen existing node $w$,
-    disallowing self-loops and multi-edges.
+    randomly-chosen existing node $w$.
+
     In contrast with :func:`watts_strogatz_graph`,
     the edges $(u, v)$ are not removed.
+    In contrast with :func:`newman_watts_graph`,
+    self-loops and multi-edges are not allowed.
 
     See Also
     --------
+    newman_watts_graph
     watts_strogatz_graph
 
     References
@@ -409,6 +486,7 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
 
     See Also
     --------
+    newman_watts_graph
     newman_watts_strogatz_graph
     connected_watts_strogatz_graph
 
@@ -419,11 +497,13 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     Then shortcuts are created by replacing some edges as follows: for each
     edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest neighbors"
     with probability $p$ replace it with a new edge $(u, w)$ with uniformly
-    random choice of existing node $w$,
-    disallowing self-loops and multi-edges.
+    random choice of existing node $w$.
 
     In contrast with :func:`newman_watts_strogatz_graph`, the random rewiring
-    does not increase the number of edges. The rewired graph is not guaranteed
+    does not increase the number of edges.
+    In contrast with :func:`newman_watts_graph`,
+    self-loops and multi-edges are not allowed.
+    The rewired graph is not guaranteed
     to be connected as in :func:`connected_watts_strogatz_graph`.
 
     References

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -337,8 +337,10 @@ def newman_watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     is odd).  Then shortcuts are created by adding new edges as follows: for
     each edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest
     neighbors" with probability $p$ add a new edge $(u, w)$ with
-    randomly-chosen existing node $w$.  In contrast with
-    :func:`watts_strogatz_graph`, no edges are removed.
+    randomly-chosen existing node $w$,
+    disallowing self-loops and multi-edges.
+    In contrast with :func:`watts_strogatz_graph`,
+    the edges $(u, v)$ are not removed.
 
     See Also
     --------
@@ -417,7 +419,8 @@ def watts_strogatz_graph(n, k, p, seed=None, *, create_using=None):
     Then shortcuts are created by replacing some edges as follows: for each
     edge $(u, v)$ in the underlying "$n$-ring with $k$ nearest neighbors"
     with probability $p$ replace it with a new edge $(u, w)$ with uniformly
-    random choice of existing node $w$.
+    random choice of existing node $w$,
+    disallowing self-loops and multi-edges.
 
     In contrast with :func:`newman_watts_strogatz_graph`, the random rewiring
     does not increase the number of edges. The rewired graph is not guaranteed

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -291,6 +291,9 @@ class TestGeneratorsRandom:
         pytest.raises(nx.NetworkXError, nx.watts_strogatz_graph, 10, 11, 0.25)
         pytest.raises(nx.NetworkXError, nx.newman_watts_strogatz_graph, 10, 11, 0.25)
         pytest.raises(nx.NetworkXError, nx.newman_watts_graph, 10, 11, 0.25)
+        pytest.raises(nx.NetworkXError, nx.watts_strogatz_graph, 10, 10, 0.25)
+        pytest.raises(nx.NetworkXError, nx.newman_watts_strogatz_graph, 10, 10, 0.25)
+        pytest.raises(nx.NetworkXError, nx.newman_watts_graph, 10, 10, 0.25)
 
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
@@ -298,10 +301,13 @@ class TestGeneratorsRandom:
         nx.newman_watts_strogatz_graph(10, 9, 0.5, seed=0)
         nx.newman_watts_graph(10, 9, 0.5, seed=0)
 
-        # Test k==n scenario
-        nx.watts_strogatz_graph(10, 10, 0.25, seed=0)
-        nx.newman_watts_strogatz_graph(10, 10, 0.25, seed=0)
-        nx.newman_watts_graph(10, 10, 0.25, seed=0)
+        # Test k==n-1 (complete graph) scenario
+        K10 = nx.complete_graph(10)
+        assert nx.is_isomorphic(K10, nx.watts_strogatz_graph(10, 9, 0.25, seed=0))
+        assert nx.is_isomorphic(
+            K10, nx.newman_watts_strogatz_graph(10, 9, 0.25, seed=0)
+        )
+        assert nx.is_isomorphic(K10, nx.newman_watts_graph(10, 9, 0.25, seed=0))
 
     def test_random_kernel_graph(self):
         def integral(u, w, z):

--- a/networkx/generators/tests/test_random_graphs.py
+++ b/networkx/generators/tests/test_random_graphs.py
@@ -290,15 +290,18 @@ class TestGeneratorsRandom:
         # Test to make sure than n <= k
         pytest.raises(nx.NetworkXError, nx.watts_strogatz_graph, 10, 11, 0.25)
         pytest.raises(nx.NetworkXError, nx.newman_watts_strogatz_graph, 10, 11, 0.25)
+        pytest.raises(nx.NetworkXError, nx.newman_watts_graph, 10, 11, 0.25)
 
         # could create an infinite loop, now doesn't
         # infinite loop used to occur when a node has degree n-1 and needs to rewire
         nx.watts_strogatz_graph(10, 9, 0.25, seed=0)
         nx.newman_watts_strogatz_graph(10, 9, 0.5, seed=0)
+        nx.newman_watts_graph(10, 9, 0.5, seed=0)
 
         # Test k==n scenario
         nx.watts_strogatz_graph(10, 10, 0.25, seed=0)
         nx.newman_watts_strogatz_graph(10, 10, 0.25, seed=0)
+        nx.newman_watts_graph(10, 10, 0.25, seed=0)
 
     def test_random_kernel_graph(self):
         def integral(u, w, z):
@@ -326,14 +329,28 @@ def test_watts_strogatz(k, expected_num_nodes, expected_num_edges):
     assert G.number_of_edges() == expected_num_edges
 
 
-def test_newman_watts_strogatz_zero_probability():
-    G = nx.newman_watts_strogatz_graph(10, 2, 0.0, seed=42)
+@pytest.mark.parametrize(
+    "generator",
+    [
+        nx.newman_watts_strogatz_graph,
+        nx.newman_watts_graph,
+    ],
+)
+def test_nws_zero_probability(generator):
+    G = generator(10, 2, 0.0, seed=42)
     assert len(G) == 10
     assert G.number_of_edges() == 10
 
 
-def test_newman_watts_strogatz_nonzero_probability():
-    G = nx.newman_watts_strogatz_graph(10, 4, 0.25, seed=42)
+@pytest.mark.parametrize(
+    "generator",
+    [
+        nx.newman_watts_strogatz_graph,
+        nx.newman_watts_graph,
+    ],
+)
+def test_nws_nonzero_probability(generator):
+    G = generator(10, 4, 0.25, seed=42)
     assert len(G) == 10
     assert G.number_of_edges() >= 20
 
@@ -420,6 +437,13 @@ def test_gnm_fns_disallow_directed_and_multigraph(fn, graphtype):
 def test_watts_strogatz_disallow_directed_and_multigraph(fn, graphtype):
     with pytest.raises(nx.NetworkXError, match="must not be"):
         fn(10, 2, 0.2, create_using=graphtype)
+
+
+@pytest.mark.parametrize("graphtype", (nx.Graph, nx.DiGraph, nx.MultiDiGraph))
+def test_newman_watts_disallow_directed_and_graph(graphtype):
+    msg = r"must be a multi-graph|must not be directed"
+    with pytest.raises(nx.NetworkXError, match=msg):
+        nx.newman_watts_graph(10, 2, 0.2, create_using=graphtype)
 
 
 @pytest.mark.parametrize("graphtype", (nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph))


### PR DESCRIPTION
Fixes #5012, although #8053 should be looked at first.

This PR builds on #8053, adding a private helper method `_newman_watts_strogatz_graph_helper` (the name should probably be changed!). This reduces code duplication, since the 3 existing (counting the new `newman_watts_graph` in #8053) generators have a common structure: they build the ring topology, connecting each node to its `k` (or `k - 1`) nearest neighbors, then loop over all edges, and stochastically add new edges. `newman_watts_strogatz_graph` and `watts_strogatz_graph` don't allow multiedges or self-loops, whereas `newman_watts_graph` does. If an edge has been added, `watts_strogatz_graph` deletes the existing edge (so it corresponds to a rewiring); the other two don't.

By using two boolean flags, `allow_multiedges` and `remove_edges`, these three can be simplified, since the rest of the structure is the exact same. Doing so would even make it possible to neatly include a fourth model (I suppose `newman_strogatz_graph` is the last remaining option?) that allows multiedges but rewires at each stage.

This PR also corrects (?) the behavior of the generators for `k == n`. Currently, this is treated as the "complete graph" case, but in the definition (and the error message, which refers to `k >= n` but only gets raised for `k > n`), `k` is referred to as the number of neighbors of each node, which for the complete graph cannot exceed `n - 1`. Finally, it corrects (and `parametrize`s) the tests checking for this "big `k`" behavior.