### PR TITLE
Workaround for long node names in `pydot_layout`

### DIFF
--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -99,6 +99,27 @@ def test_pydot_issue_7581(tmp_path):
     """
     G = nx.Graph()
     G.add_edges_from([("A\nbig test", "B"), ("A\nbig test", "C"), ("B", "C")])
+    # Lines longer than ~130 chars get split
+    (("=10chars= " * 14, "D"),)
+
+    graph_layout = nx.nx_pydot.pydot_layout(G, prog="dot")
+    assert isinstance(graph_layout, dict)
+
+    # Convert the graph to pydot and back into a graph. There should be no difference.
+    P = nx.nx_pydot.to_pydot(G)
+    G2 = nx.Graph(nx.nx_pydot.from_pydot(P))
+    assert graphs_equal(G, G2)
+
+
+def test_pydot_long_node_name(tmp_path):
+    """Validate that `nx_pydot.pydot_layout` handles long node names correctly. See gh-7648."""
+    G = nx.Graph()
+    G.add_edges_from(
+        [
+            # Lines longer than ~130 chars get split
+            ("=10chars= " * 14, "D"),
+        ]
+    )
 
     graph_layout = nx.nx_pydot.pydot_layout(G, prog="dot")
     assert isinstance(graph_layout, dict)


### PR DESCRIPTION
Fixes #7648.

This has a very hack-y solution for the problem in #7648. This will hopefully be resolved when pydot/pydot#420 gets merged in, but in the meantime, this should work.

- Adds the test case from the issue.
- Instead of trying to predict it, this "fix" lets pydot (or graphviz, I suppose) tell us how it will mangle long node names.