### PR TITLE
Take 2: add test for (and fix) the pydot long node name problem

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -348,9 +348,8 @@ def pydot_layout(G, prog="neato", root=None):
     Q = Q_list[0]
 
     node_pos = {}
-    for n in G.nodes():
+    for n, node in zip(G.nodes(), Q.get_nodes()[-len(G) :]):
         str_n = str(n)
-        node = Q.get_node(pydot.quote_id_if_necessary(str_n))
 
         if isinstance(node, list):
             node = node[0]

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -109,6 +109,17 @@ def test_pydot_issue_7581(tmp_path):
     assert graphs_equal(G, G2)
 
 
+def test_pydot_long_node_name(tmp_path):
+    """Validate that `nx_pydot.pydot_layout` handles long node names correctly. See gh-7648."""
+    G = nx.Graph()
+    G.add_edges_from(
+        [
+            # Lines longer than ~130 chars get split
+            ("=10chars= " * 14, "D"),
+        ]
+    )
+
+
 @pytest.mark.parametrize(
     "graph_type", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 )


### PR DESCRIPTION
Fixes #7648.

This leverages the fact that (apparently?) the graph's nodes end up in order at the end of the pydot graph object.
I added the test from the issue to validate it works.

If we really don't want to fix this, let's at least add an `xfail` test for the long node name situation so we're made aware if the issue ever gets fixed upstream.