### PR TITLE
Maintenance for broadcasting.py

### DIFF
--- a/networkx/algorithms/broadcasting.py
+++ b/networkx/algorithms/broadcasting.py
@@ -145,11 +145,8 @@ def tree_broadcast_time(G, node=None):
         (Ed. D. Z. Du and C. Tian.) Springer, pp. 240-253, 2019.
     """
     b_T, b_C = tree_broadcast_center(G)
-    if node is not None:
-        return b_T + min(nx.shortest_path_length(G, node, u) for u in b_C)
-    dist_from_center = dict.fromkeys(G, len(G))
-    for u in b_C:
-        for v, dist in nx.shortest_path_length(G, u).items():
-            if dist < dist_from_center[v]:
-                dist_from_center[v] = dist
-    return b_T + max(dist_from_center.values())
+    if node is None:
+        return b_T + len(list(nx.bfs_layers(G, sources=b_C))) - 1
+    for depth, layer in enumerate(nx.bfs_layers(G, sources=b_C)):
+        if node in layer:
+            return b_T + depth

--- a/networkx/algorithms/broadcasting.py
+++ b/networkx/algorithms/broadcasting.py
@@ -66,7 +66,7 @@ def tree_broadcast_center(G):
     """
     # Assert that the graph G is a tree
     if not nx.is_tree(G):
-        NetworkXError("Input graph is not a tree")
+        raise NetworkXError("input graph is not a tree")
     # step 0
     if G.number_of_nodes() == 2:
         return 1, set(G.nodes())

--- a/networkx/algorithms/broadcasting.py
+++ b/networkx/algorithms/broadcasting.py
@@ -110,32 +110,38 @@ def tree_broadcast_center(G):
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def tree_broadcast_time(G, node=None):
-    """Return the Broadcast Time of the tree `G`.
+    """Return the broadcast time of the tree `G`.
 
     The minimum broadcast time of a node is defined as the minimum amount
-    of time required to complete broadcasting starting from the
-    originator. The broadcast time of a graph is the maximum over
+    of time required to complete broadcasting starting from that node.
+    The broadcast time of a graph is the maximum over
     all nodes of the minimum broadcast time from that node [1]_.
     This function returns the minimum broadcast time of `node`.
-    If `node` is None the broadcast time for the graph is returned.
+    If `node` is `None`, the broadcast time for the graph is returned.
 
     Parameters
     ----------
-    G : undirected graph
-        The graph should be an undirected tree
-    node: int, optional
-        index of starting node. If `None`, the algorithm returns the broadcast
-        time of the tree.
+    G : Graph
+        The graph should be an undirected tree.
+
+    node: node, optional (default=None)
+        Starting node for the broadcasting. If `None`, the algorithm returns the broadcast
+        time of the graph instead.
 
     Returns
     -------
-    BT : int
-        Broadcast Time of a node in a tree
+    int
+        Broadcast time of `node` in `G`, or broadcast time of `G` if no node is provided.
 
     Raises
     ------
     NetworkXNotImplemented
-        If the graph is directed or is a multigraph.
+        If `G` is directed or is a multigraph.
+
+    NetworkXError
+        If `G` is not a tree.
+
+        If `node` is not a node in `G`.
 
     References
     ----------

--- a/networkx/algorithms/broadcasting.py
+++ b/networkx/algorithms/broadcasting.py
@@ -13,7 +13,6 @@ following constraints:
 """
 
 import networkx as nx
-from networkx import NetworkXError
 from networkx.utils import not_implemented_for
 
 __all__ = [
@@ -69,7 +68,7 @@ def tree_broadcast_center(G):
     """
     # Assert that the graph G is a tree
     if not nx.is_tree(G):
-        raise NetworkXError("input graph is not a tree")
+        raise nx.NetworkXError("input graph is not a tree")
     # step 0
     if len(G) in {1, 2}:
         return len(G) - 1, set(G.nodes())

--- a/networkx/algorithms/broadcasting.py
+++ b/networkx/algorithms/broadcasting.py
@@ -138,10 +138,11 @@ def tree_broadcast_time(G, node=None):
     NetworkXNotImplemented
         If `G` is directed or is a multigraph.
 
+    NodeNotFound
+        If `node` is not a node in `G`.
+
     NetworkXError
         If `G` is not a tree.
-
-        If `node` is not a node in `G`.
 
     References
     ----------
@@ -150,6 +151,9 @@ def tree_broadcast_time(G, node=None):
         In Computing and Combinatorics. COCOON 2019
         (Ed. D. Z. Du and C. Tian.) Springer, pp. 240-253, 2019.
     """
+    if node is not None and node not in G:
+        err = f"node {node} not in G"
+        raise nx.NodeNotFound(err)
     b_T, b_C = tree_broadcast_center(G)
     if node is None:
         return b_T + len(list(nx.bfs_layers(G, sources=b_C))) - 1

--- a/networkx/algorithms/tests/test_broadcasting.py
+++ b/networkx/algorithms/tests/test_broadcasting.py
@@ -82,19 +82,21 @@ def test_binomial_tree_broadcast():
         assert nx.tree_broadcast_time(G) == 2 * i - 1
 
 
+@pytest.mark.parametrize("fn", [nx.tree_broadcast_center, nx.tree_broadcast_time])
 @pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph])
-def test_raises_graph_type(graph_type):
+def test_raises_graph_type(fn, graph_type):
     """Check that `tree_broadcast_time` properly raises for directed and multigraph types."""
     G = nx.path_graph(5, create_using=graph_type)
     with pytest.raises(nx.NetworkXNotImplemented, match=r"not implemented for"):
-        nx.tree_broadcast_time(G)
+        fn(G)
 
 
-def test_raises_not_tree():
-    """Check that `tree_broadcast_time` properly raises for nontree graphs."""
+@pytest.mark.parametrize("fn", [nx.tree_broadcast_center, nx.tree_broadcast_time])
+def test_raises_not_tree(fn):
+    """Check that broadcast functions properly raise for nontree graphs."""
     G = nx.empty_graph(5)
     with pytest.raises(nx.NetworkXError, match=r"not a tree"):
-        nx.tree_broadcast_time(G)
+        fn(G)
 
 
 def test_raises_node_not_in_G():

--- a/networkx/algorithms/tests/test_broadcasting.py
+++ b/networkx/algorithms/tests/test_broadcasting.py
@@ -85,7 +85,7 @@ def test_binomial_tree_broadcast(n):
 @pytest.mark.parametrize("fn", [nx.tree_broadcast_center, nx.tree_broadcast_time])
 @pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph])
 def test_raises_graph_type(fn, graph_type):
-    """Check that `tree_broadcast_time` properly raises for directed and multigraph types."""
+    """Check that broadcast functions properly raise for directed and multigraph types."""
     G = nx.path_graph(5, create_using=graph_type)
     with pytest.raises(nx.NetworkXNotImplemented, match=r"not implemented for"):
         fn(G)

--- a/networkx/algorithms/tests/test_broadcasting.py
+++ b/networkx/algorithms/tests/test_broadcasting.py
@@ -100,5 +100,5 @@ def test_raises_not_tree():
 def test_raises_node_not_in_G():
     """Check that `tree_broadcast_time` properly raises for invalid nodes."""
     G = nx.path_graph(5)
-    with pytest.raises(nx.NetworkNotFound, match=r"node.*not in graph"):
+    with pytest.raises(nx.NodeNotFound, match=r"node.*not in G"):
         nx.tree_broadcast_time(G, node=10)

--- a/networkx/algorithms/tests/test_broadcasting.py
+++ b/networkx/algorithms/tests/test_broadcasting.py
@@ -1,5 +1,5 @@
 """Unit tests for the broadcasting module."""
-
+import pytest
 import math
 
 import networkx as nx
@@ -80,3 +80,25 @@ def test_binomial_tree_broadcast():
         assert b_T == i
         assert b_C == {0, 2 ** (i - 1)}
         assert nx.tree_broadcast_time(G) == 2 * i - 1
+
+
+@pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph])
+def test_raises_graph_type(graph_type):
+    """Check that `tree_broadcast_time` properly raises for directed and multigraph types."""
+    G = nx.path_graph(5, create_using=graph_type)
+    with pytest.raises(nx.NetworkXNotImplemented, match=r"not implemented for"):
+        nx.tree_broadcast_time(G)
+
+
+def test_raises_not_tree():
+    """Check that `tree_broadcast_time` properly raises for nontree graphs."""
+    G = nx.empty_graph(5)
+    with pytest.raises(nx.NetworkXError, match=r"not a tree"):
+        nx.tree_broadcast_time(G)
+
+
+def test_raises_node_not_in_G():
+    """Check that `tree_broadcast_time` properly raises for invalid nodes."""
+    G = nx.path_graph(5)
+    with pytest.raises(nx.NetworkNotFound, match=r"node.*not in graph"):
+        nx.tree_broadcast_time(G, node=10)

--- a/networkx/algorithms/tests/test_broadcasting.py
+++ b/networkx/algorithms/tests/test_broadcasting.py
@@ -42,18 +42,18 @@ def test_example_tree_broadcast():
     assert nx.tree_broadcast_time(G) == 10
 
 
-def test_path_broadcast():
-    for i in range(2, 12):
-        G = nx.path_graph(i)
-        b_T, b_C = nx.tree_broadcast_center(G)
-        assert b_T == math.ceil(i / 2)
-        assert b_C == {
-            math.ceil(i / 2),
-            math.floor(i / 2),
-            math.ceil(i / 2 - 1),
-            math.floor(i / 2 - 1),
-        }
-        assert nx.tree_broadcast_time(G) == i - 1
+@pytest.mark.parametrize("n", range(2, 12))
+def test_path_broadcast(n):
+    G = nx.path_graph(n)
+    b_T, b_C = nx.tree_broadcast_center(G)
+    assert b_T == math.ceil(n / 2)
+    assert b_C == {
+        math.ceil(n / 2),
+        n // 2,
+        math.ceil(n / 2 - 1),
+        n // 2 - 1,
+    }
+    assert nx.tree_broadcast_time(G) == n - 1
 
 
 def test_empty_graph_broadcast():
@@ -64,22 +64,22 @@ def test_empty_graph_broadcast():
     assert nx.tree_broadcast_time(H) == 0
 
 
-def test_star_broadcast():
-    for i in range(4, 12):
-        G = nx.star_graph(i)
-        b_T, b_C = nx.tree_broadcast_center(G)
-        assert b_T == i
-        assert b_C == set(G.nodes())
-        assert nx.tree_broadcast_time(G) == b_T
+@pytest.mark.parametrize("n", range(4, 12))
+def test_star_broadcast(n):
+    G = nx.star_graph(n)
+    b_T, b_C = nx.tree_broadcast_center(G)
+    assert b_T == n
+    assert b_C == set(G.nodes())
+    assert nx.tree_broadcast_time(G) == b_T
 
 
-def test_binomial_tree_broadcast():
-    for i in range(2, 8):
-        G = nx.binomial_tree(i)
-        b_T, b_C = nx.tree_broadcast_center(G)
-        assert b_T == i
-        assert b_C == {0, 2 ** (i - 1)}
-        assert nx.tree_broadcast_time(G) == 2 * i - 1
+@pytest.mark.parametrize("n", range(2, 8))
+def test_binomial_tree_broadcast(n):
+    G = nx.binomial_tree(n)
+    b_T, b_C = nx.tree_broadcast_center(G)
+    assert b_T == n
+    assert b_C == {0, 2 ** (n - 1)}
+    assert nx.tree_broadcast_time(G) == 2 * n - 1
 
 
 @pytest.mark.parametrize("fn", [nx.tree_broadcast_center, nx.tree_broadcast_time])


### PR DESCRIPTION
Some code maintenance for broadcasting.py. The commit messages give a good overview of what each change does, but for clarity, here's the list again.

- Clean up the docstring for both functions
- Speed up the shortest path calculation by doing all sources at once
- Ensure the proper errors get raised, and clarify this in the docstring.
- Remove an import from within networkx
- Parametrize the existing tests which were just wrapping a `for` loop.