### PR TITLE
Rm extraneous print from nx.display.

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -893,7 +893,6 @@ def display(
         ]
 
     edge_subgraph = G.edge_subgraph(visible_edges)
-    print(nx.get_node_attributes(node_subgraph, pos))
     nx.set_node_attributes(
         edge_subgraph, nx.get_node_attributes(node_subgraph, pos), name=pos
     )


### PR DESCRIPTION
I'm trying out `nx.display` in an nx-guide I'm working on and noticed that some attributes are printed during drawing. 