### PR TITLE
Add Python 3.14 to testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ["3.13"]
+        python-version: ["3.13", "3.14-dev", "3.14t-dev"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -124,15 +124,15 @@ def grid_graph(dim, periodic=False):
     >>> len(G)
     6
     """
+    from collections.abc import Iterable
+
     from networkx.algorithms.operators.product import cartesian_product
 
     if not dim:
         return empty_graph(0)
 
-    try:
-        func = (cycle_graph if p else path_graph for p in periodic)
-    except TypeError:
-        func = repeat(cycle_graph if periodic else path_graph)
+    periodic = repeat(periodic) if not isinstance(periodic, Iterable) else periodic
+    func = (cycle_graph if p else path_graph for p in periodic)
 
     G = next(func)(dim[0])
     for current_dim in dim[1:]:


### PR DESCRIPTION
Inspired by #8091 - adds Python 3.14 to the testing matrix in CI. Specifically, it adds 3.14 testing *only* to the `base` jobs, i.e. the ones without dependencies. This is to avoid conflicts for default dependencies that do not yet supply 3.14 wheels (it looks like only NumPy does so at this point).

Also includes a fix for #8091 which fails on Pythoon 3.14. I'm happy to break this out in a follow-up PR if folks prefer to keep the CI config/code changes separate.
Fizes #8091

Finally - I arbitrarily chose to include 3.14 both with and without free-threaded support (the `3.14t-dev`). In principle this shouldn't affect networkx at all (i.e. networkx without dependencies) so we could remove it.