### PR TITLE
MAINT: Support PEP 639 for license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     'discrete mathematics',
     'math',
 ]
-license = "BSD-3-Clause"
+license-expression = "BSD-3-Clause"
 license-files = ["LICENSE.txt"]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'setuptools.build_meta'
-requires = ['setuptools>=61.2']
+requires = ['setuptools>=77']
 
 [project]
 name = 'networkx'
@@ -17,11 +17,12 @@ keywords = [
     'discrete mathematics',
     'math',
 ]
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
     'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.11',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'setuptools.build_meta'
-requires = ['setuptools>=77']
+requires = ['setuptools>=77.0.3']
 
 [project]
 name = 'networkx'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     'discrete mathematics',
     'math',
 ]
-license-expression = "BSD-3-Clause"
+license = "BSD-3-Clause"
 license-files = ["LICENSE.txt"]
 classifiers = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
While building the wheel, the warning pops up multiple times. Hopefully the setuptools bump shouldn't be consequential.
