### PR TITLE
Update deploy-docs yml to use Python 3.12 when deploying the docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Before install
         run: |


### PR DESCRIPTION
I'm not sure what the big-scale implications are of changing this. So please check if it makes sense.

nx-parallel is used when deploying the docs in a yml file that runs with Python 3.11. We just shifted the python version requirements of nx-parallel to Python 3.12+ so we could use `itertools.batched` (which was added in 3.12).  We could of course write our own version of that tools and include it in nx-parallel and then remove it again after the Python 3.14 release.  But we'd prefer to just up  the requirements-- it is unlikely we will have a release of nx-parallel before October anyway.

Is there a reason the docs are deployed using Python 3.11?
We are using the latest github `main` branch for nx-parallel and nx-cugraph when building our docs. Is it OK to make the docs with a newer Python than our minimal requirement?

This PR tries to update the deploy-docs  so they use Python 3.12 when deploying.