### PR TITLE
Fix typo in extra name

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements/example.txt
-          pip install --upgrade .[default,tests,extra,doc]
+          pip install --upgrade .[default,test,extra,doc]
           # Install trusted backends, but not their dependencies.
           # We only need to use the "networkx.backend_info" entry-point.
           # This is the nightly wheel for nx-cugraph.


### PR DESCRIPTION
With #8101 getting closed, this pulls out the change to the extra name in the doc deploy action.

This fixes the following warning/error hidden in the logs.
> WARNING: networkx 3.5 does not provide the extra 'tests'