### PR TITLE
pass numpy seed by value not index

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -448,7 +448,7 @@ def bipartite_layout(
     return pos
 
 
-@np_random_state(10)
+@np_random_state("seed")
 def spring_layout(
     G,
     k=None,


### PR DESCRIPTION
This PR replaces `@np_random_state(10)` with `@np_random_state("seed")` in the `spring_layout` function to ensure correct handling of the seed argument. Using a positional index assumes that seed is always passed as the 11th positional argument, which is fragile and fails when seed is passed as a keyword (the common case).

By switching to the argument name "seed", we make the decorator robust to both positional and keyword usage, aligning with best practices and preventing subtle bugs in layout reproducibility.

We ran into an issue when parallelizing our tests with networks.