### PR TITLE
Fix round-trip to and from pygraphviz.AGraph setting spurious graph attributes

### DIFF
--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -104,9 +104,15 @@ def from_agraph(A, create_using=None):
 
     # add default attributes for graph, nodes, and edges
     # hang them on N.graph_attr
-    N.graph["graph"] = dict(A.graph_attr)
-    N.graph["node"] = dict(A.node_attr)
-    N.graph["edge"] = dict(A.edge_attr)
+    graph_default_dict = dict(A.graph_attr)
+    if graph_default_dict:
+        N.graph["graph"] = graph_default_dict
+    node_default_dict = dict(A.node_attr)
+    if node_default_dict and node_default_dict != {"label": "\\N"}:
+        N.graph["node"] = node_default_dict
+    edge_default_dict = dict(A.edge_attr)
+    if edge_default_dict:
+        N.graph["edge"] = edge_default_dict
     return N
 
 

--- a/networkx/drawing/tests/test_agraph.py
+++ b/networkx/drawing/tests/test_agraph.py
@@ -174,13 +174,10 @@ class TestAGraph:
         G = nx.Graph()
         A = nx.nx_agraph.to_agraph(G)
         H = nx.nx_agraph.from_agraph(A)
-        # assert graphs_equal(G, H)
+        assert graphs_equal(G, H)
         AA = nx.nx_agraph.to_agraph(H)
         HH = nx.nx_agraph.from_agraph(AA)
         assert graphs_equal(H, HH)
-        G.graph["graph"] = {}
-        G.graph["node"] = {}
-        G.graph["edge"] = {}
         assert graphs_equal(G, HH)
 
     @pytest.mark.xfail(reason="integer->string node conversion in round trip")


### PR DESCRIPTION
It looks like, for historical reasons, pygraphviz is adding a default node attribute named 'label' and assigning it the value '\\N'.  The NetworkX code has been accommodating that, and tests for the **second** round-trip resulting in graph attributes the same as the results for the first round-trip.

The test of this strange behavior recently started failing because the default node attribute for label is being reported as of GraphViz v13.0. See #8119. So we need to fix something. And it'd be nice to have it work across graphviz and pygraphviz versions.

This PR checks if pygraphviz reports either 1) no node attributes or 2) node attributes that are named 'label' and have the value '\\N'.  If either happens, we don't set any graph attributes in the graph created by `from_agraph`. Similarly we also check whether no graph attributes or no edge attributes are are reported and in that case we also don't update the newly created graph attribute dict. 

The result is that a round-trip with no default attribute values set creates a networkx graph without any graph attributes set during the round-trip. The avoids the original (very old) issue with the round-trip not being the same as the original graph. And it avoids the difference between graphviz versions. 

I will also make a PR to pygraphviz to remove the addition of node label default values set to `'\\N'` as it hopefully is no longer needed. But this workaround should continue to work across any version changes of graphviz and pygraphviz.  Fingers crossed.  But for now -- does this do what we want it to do?