### PR TITLE
enh: short-circuit in `is_regular` for directed graphs

### DIFF
--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -32,16 +32,16 @@ def is_regular(G):
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
+    n = nx.utils.arbitrary_element(G)
     if not G.is_directed():
-        ds = (d for _, d in G.degree)
-        d1 = next(ds)
-        return all(d == d1 for d in ds)
+        d1 = G.degree[n]
+        return all(d == d1 for _, d in G.degree)
     else:
-        ids = (id for _, id in G.in_degree)
-        ods = (od for _, od in G.out_degree)
-        d_in = next(ids)
-        d_out = next(ods)
-        return all(id == d_in and od == d_out for id, od in zip(ids, ods))
+        di1 = G.in_degree[n]
+        do1 = G.out_degree[n]
+        indeg = (d == di1 for _, d in G.in_degree)
+        outdeg = (d == do1 for _, d in G.out_degree)
+        return all(indeg) and all(outdeg)
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -32,16 +32,16 @@ def is_regular(G):
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
-    n = nx.utils.arbitrary_element(G)
+    n1 = nx.utils.arbitrary_element(G)
     if not G.is_directed():
-        d1 = G.degree[n]
-        return all(d == d1 for _, d in G.degree)
+        d1 = G.degree(n1)
+        return all(d1 == d for _, d in G.degree)
     else:
-        di1 = G.in_degree[n]
-        do1 = G.out_degree[n]
-        indeg = (d == di1 for _, d in G.in_degree)
-        outdeg = (d == do1 for _, d in G.out_degree)
-        return all(indeg) and all(outdeg)
+        d_in = G.in_degree(n1)
+        in_regular = (d_in == d for _, d in G.in_degree)
+        d_out = G.out_degree(n1)
+        out_regular = (d_out == d for _, d in G.out_degree)
+        return all(in_regular) and all(out_regular)
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -8,7 +8,7 @@ __all__ = ["is_regular", "is_k_regular", "k_factor"]
 
 @nx._dispatchable
 def is_regular(G):
-    """Determines whether a graph is a regular graph.
+    """Determines whether a graph is regular.
 
     A regular graph is a graph where all nodes have the same degree. A regular
     digraph is a graph where all nodes have the same indegree and all nodes
@@ -41,7 +41,7 @@ def is_regular(G):
         ods = (od for _, od in G.out_degree)
         d_in = next(ids)
         d_out = next(ods)
-        return all(d_in == id and d_out == od for id, od in zip(ids, ods))
+        return all(id == d_in and od == d_out for id, od in zip(ids, ods))
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -8,11 +8,11 @@ __all__ = ["is_regular", "is_k_regular", "k_factor"]
 
 @nx._dispatchable
 def is_regular(G):
-    """Determines whether the graph ``G`` is a regular graph.
+    """Determines whether a graph is a regular graph.
 
-    A regular graph is a graph where each vertex has the same degree. A
-    regular digraph is a graph where the indegree and outdegree of each
-    vertex are equal.
+    A regular graph is a graph where all nodes have the same degree. A regular
+    digraph is a graph where all nodes have the same indegree and all nodes
+    have the same outdegree.
 
     Parameters
     ----------

--- a/networkx/algorithms/regular.py
+++ b/networkx/algorithms/regular.py
@@ -32,16 +32,16 @@ def is_regular(G):
     """
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
-    n1 = nx.utils.arbitrary_element(G)
     if not G.is_directed():
-        d1 = G.degree(n1)
-        return all(d1 == d for _, d in G.degree)
+        ds = (d for _, d in G.degree)
+        d1 = next(ds)
+        return all(d == d1 for d in ds)
     else:
-        d_in = G.in_degree(n1)
-        in_regular = all(d_in == d for _, d in G.in_degree)
-        d_out = G.out_degree(n1)
-        out_regular = all(d_out == d for _, d in G.out_degree)
-        return in_regular and out_regular
+        ids = (id for _, id in G.in_degree)
+        ods = (od for _, od in G.out_degree)
+        d_in = next(ids)
+        d_out = next(ods)
+        return all(d_in == id and d_out == od for id, od in zip(ids, ods))
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/tests/test_regular.py
+++ b/networkx/algorithms/tests/test_regular.py
@@ -49,28 +49,27 @@ class TestKFactor:
 
 
 class TestIsRegular:
-    def test_is_regular1(self):
-        g = gen.cycle_graph(4)
-        assert reg.is_regular(g)
+    @pytest.mark.parametrize(
+        "graph,expected",
+        [
+            (nx.cycle_graph(5), True),
+            (nx.complete_graph(5), True),
+            (nx.path_graph(5), False),
+            (nx.lollipop_graph(5, 5), False),
+            (nx.cycle_graph(5, create_using=nx.DiGraph), True),
+            (nx.Graph([(0, 1)]), True),
+            (nx.DiGraph([(0, 1)]), False),
+            (nx.MultiGraph([(0, 1), (0, 1)]), True),
+            (nx.MultiDiGraph([(0, 1), (0, 1)]), False),
+        ],
+    )
+    def test_is_regular(self, graph, expected):
+        assert reg.is_regular(graph) == expected
 
-    def test_is_regular2(self):
-        g = gen.complete_graph(5)
-        assert reg.is_regular(g)
-
-    def test_is_regular3(self):
-        g = gen.lollipop_graph(5, 5)
-        assert not reg.is_regular(g)
-
-    def test_is_regular4(self):
-        g = nx.DiGraph()
-        g.add_edges_from([(0, 1), (1, 2), (2, 0)])
-        assert reg.is_regular(g)
-
-
-def test_is_regular_empty_graph_raises():
-    G = nx.Graph()
-    with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes"):
-        nx.is_regular(G)
+    def test_is_regular_empty_graph_raises(self):
+        graph = nx.Graph()
+        with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes"):
+            nx.is_regular(graph)
 
 
 class TestIsKRegular:

--- a/networkx/algorithms/tests/test_regular.py
+++ b/networkx/algorithms/tests/test_regular.py
@@ -52,11 +52,11 @@ class TestIsRegular:
     @pytest.mark.parametrize(
         "graph,expected",
         [
-            (nx.cycle_graph(5), True),
+            (nx.cycle_graph(4), True),
             (nx.complete_graph(5), True),
             (nx.path_graph(5), False),
             (nx.lollipop_graph(5, 5), False),
-            (nx.cycle_graph(5, create_using=nx.DiGraph), True),
+            (nx.cycle_graph(3, create_using=nx.DiGraph), True),
             (nx.Graph([(0, 1)]), True),
             (nx.DiGraph([(0, 1)]), False),
             (nx.MultiGraph([(0, 1), (0, 1)]), True),
@@ -67,9 +67,9 @@ class TestIsRegular:
         assert reg.is_regular(graph) == expected
 
     def test_is_regular_empty_graph_raises(self):
-        graph = nx.Graph()
+        G = nx.Graph()
         with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes"):
-            nx.is_regular(graph)
+            nx.is_regular(G)
 
 
 class TestIsKRegular:


### PR DESCRIPTION
This PR adds a small performance improvement, allowing `is_regular` to avoid checking all in-/outdegrees when a directed graph has nodes with different out-/indegrees. I've also slightly tweaked the docstring and added/refactored a few tests to check everything works as it should.