### PR TITLE
Set length threshold in FR and use np.clip

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -704,7 +704,9 @@ def _fruchterman_reingold(
         )
         # update positions
         length = np.linalg.norm(displacement, axis=-1)
-        length = np.where(length < 0.01, 0.1, length)
+        # Threshold the minimum length prior to position scaling
+        # See gh-8113 for detailed discussion of the threshold
+        length = np.clip(length, a_min=0.01, a_max=None)
         delta_pos = np.einsum("ij,i->ij", displacement, t / length)
         if fixed is not None:
             # don't change positions of fixed nodes
@@ -796,7 +798,9 @@ def _sparse_fruchterman_reingold(
             ).sum(axis=1)
         # update positions
         length = np.sqrt((displacement**2).sum(axis=0))
-        length = np.where(length < 0.01, 0.1, length)
+        # Threshold the minimum length prior to position scaling
+        # See gh-8113 for detailed discussion of the threshold
+        length = np.clip(length, a_min=0.01, a_max=None)
         delta_pos = (displacement * t / length).T
         pos += delta_pos
         # cool temperature

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -564,10 +564,11 @@ def spring_layout(
     >>> # suppress the returned dict and store on the graph directly
     >>> _ = nx.spring_layout(G, seed=123, store_pos_as="pos")
     >>> pprint(nx.get_node_attributes(G, "pos"))
-    {0: array([-0.61520994, -1.        ]),
-     1: array([-0.21840965, -0.35501755]),
-     2: array([0.21841264, 0.35502078]),
-     3: array([0.61520696, 0.99999677])}
+    {0: array([-0.61495802, -1.        ]),
+     1: array([-0.21789544, -0.35432583]),
+     2: array([0.21847843, 0.35527369]),
+     3: array([0.61437502, 0.99905215])}
+
 
     # The same using longer but equivalent function name
     >>> pos = nx.fruchterman_reingold_layout(G)

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -790,7 +790,7 @@ def _sparse_fruchterman_reingold(
             # distance between points
             distance = np.sqrt((delta**2).sum(axis=0))
             # enforce minimum distance of 0.01
-            distance = np.where(distance < 0.01, 0.01, distance)
+            distance = np.clip(distance, a_min=0.01, a_max=None)
             # the adjacency matrix row
             Ai = A.getrowview(i).toarray()  # TODO: revisit w/ sparse 1D container
             # displacement "force"


### PR DESCRIPTION
Closes #8113 

I have been convinced by @HirokiHamaguchi 's and @rudyarthur 's careful analysis of the thresholding in the FR layout that it's worth considering setting the length fill value to be equal to the threshold. While the change itself in source code is quite small, bear in mind this *will* break backward compatibility; i.e. `spring_layout` will no longer produce *identical* layouts to previous versions of NetworkX even when seeded identically. This is evidenced by the required change in the doctest.

IMO given how little the layouts will change (especially for the default number of iterations) and the minor improvements for some cases (see @HirokiHamaguchi 's analysis in #8113), I'm willing to accept this breakage. That's just my opinion though - if others feel different please share your perspective!

Switching to a fill value that matches the threshold also enables another minor improvement - we can use `np.clip` instead of `np.where` or any other mask-based approach, which is both faster and arguably more readable. I've included that change as well (and in another unrelated location where `np.where` could be replaced with `clip`).

Finally, I added a code comment explaining the clipping and referencing back to #8113. It may be a bit unorthodox to link to a GH discussion in source code, but the discussion there is so rich I feel it's worth pointing to.