### PR TITLE
refactor: improve `generate_adjlist`

### DIFF
--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -29,19 +29,20 @@ from networkx.utils import open_file
 
 
 def generate_adjlist(G, delimiter=" "):
-    """Generate a single line of the graph G in adjacency list format.
+    """Generate lines representing a graph in adjacency list format.
 
     Parameters
     ----------
     G : NetworkX graph
 
-    delimiter : string, optional
-       Separator for node labels
+    delimiter : str, default=" "
+        Separator for node labels.
 
-    Returns
-    -------
-    lines : string
-        Lines of data in adjlist format.
+    Yields
+    ------
+    str
+        Adjacency list for a node in `G`. The first item is the node label,
+        followed by the labels of its neighbors.
 
     Examples
     --------
@@ -55,6 +56,24 @@ def generate_adjlist(G, delimiter=" "):
     4 5
     5 6
     6
+
+    When `G` is undirected, each edge is only listed once. For directed graphs,
+    edges appear twice.
+
+    >>> G = nx.complete_graph(3, create_using=nx.DiGraph)
+    >>> for line in nx.generate_adjlist(G):
+    ...     print(line)
+    0 1 2
+    1 0 2
+    2 0 1
+
+    Node labels are shown multiple times for multiedges.
+
+    >>> G = nx.MultiGraph([(0, 1), (0, 1)])
+    >>> for line in nx.generate_adjlist(G):
+    ...     print(line)
+    0 1 1
+    1
 
     See Also
     --------

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -69,21 +69,21 @@ def generate_adjlist(G, delimiter=" "):
     NB: This option is not available for data that isn't user-generated.
 
     """
-    directed = G.is_directed()
     seen = set()
+    is_directed = G.is_directed()
+    is_multigraph = G.is_multigraph()
     for s, nbrs in G.adjacency():
-        line = str(s) + delimiter
+        nodes = [str(s)]
         for t, data in nbrs.items():
-            if not directed and t in seen:
+            if t in seen:
                 continue
-            if G.is_multigraph():
-                for d in data.values():
-                    line += str(t) + delimiter
+            if is_multigraph and len(data) > 1:
+                nodes.extend((str(t),) * len(data))
             else:
-                line += str(t) + delimiter
-        if not directed:
+                nodes.append(str(t))
+        if not is_directed:
             seen.add(s)
-        yield line[: -len(delimiter)]
+        yield delimiter.join(nodes)
 
 
 @open_file(1, mode="wb")

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -10,6 +10,87 @@ import networkx as nx
 from networkx.utils import edges_equal, graphs_equal, nodes_equal
 
 
+class TestGenerateAdjlist:
+    @pytest.mark.parametrize("graph_type", [nx.Graph, nx.MultiGraph])
+    def test_undirected(self, graph_type):
+        G = nx.complete_graph(5, create_using=graph_type)
+        lines = [
+            "0 1 2 3 4",
+            "1 2 3 4",
+            "2 3 4",
+            "3 4",
+            "4",
+        ]
+        assert list(nx.generate_adjlist(G)) == lines
+
+    @pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiDiGraph])
+    def test_directed(self, graph_type):
+        G = nx.complete_graph(5, create_using=graph_type)
+        lines = [
+            "0 1 2 3 4",
+            "1 0 2 3 4",
+            "2 0 1 3 4",
+            "3 0 1 2 4",
+            "4 0 1 2 3",
+        ]
+        assert list(nx.generate_adjlist(G)) == lines
+
+    @pytest.mark.parametrize("delimiter", [" ", ",", "\t"])
+    def test_delimiter(self, delimiter):
+        G = nx.complete_graph(3)
+        lines = [
+            f"0{delimiter}1{delimiter}2",
+            f"1{delimiter}2",
+            f"2",
+        ]
+        assert list(nx.generate_adjlist(G, delimiter=delimiter)) == lines
+
+    def test_multiple_edges_undirected(self):
+        G = nx.complete_graph(3, create_using=nx.MultiGraph)
+        G.add_edge(0, 1)
+        lines = [
+            "0 1 1 2",
+            "1 2",
+            "2",
+        ]
+        assert list(nx.generate_adjlist(G)) == lines
+
+    def test_multiple_edges_directed(self):
+        G = nx.complete_graph(3, create_using=nx.MultiDiGraph)
+        G.add_edge(0, 1)
+        lines = [
+            "0 1 1 2",
+            "1 0 2",
+            "2 0 1",
+        ]
+        assert list(nx.generate_adjlist(G)) == lines
+
+        G.add_edge(1, 0)
+        lines[1] = "1 0 0 2"
+        assert list(nx.generate_adjlist(G)) == lines
+
+    def test_multiple_edges_with_data(self):
+        G = nx.complete_graph(3, create_using=nx.MultiGraph)
+        G.add_edge(0, 1, weight=1)
+        G.add_edge(0, 1, weight=2)
+        lines = [
+            "0 1 1 1 2",
+            "1 2",
+            "2",
+        ]
+        assert list(nx.generate_adjlist(G)) == lines
+
+    def test_with_self_loop(self):
+        G = nx.complete_graph(3)
+        G.add_edge(0, 0)
+        lines = [
+            "0 1 2 0",
+            "1 2",
+            "2",
+        ]
+        assert list(nx.generate_adjlist(G)) == lines
+
+
 class TestAdjlist:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
This is a reasonably simple PR for `generate_adjlist` that makes it more readable and efficient.

A more complete changelist is the following:
- Add examples of how directed graphs and multigraphs are handled.
- Avoid string concatenation and manual delimiter handling by building lists and joining them with `.join()`.
- Add tests for `generate_adjlist`, which was previously untested.

`write_adjlist`, which does have several tests already, internally uses `generate_adjlist`. Those tests are unchanged and still pass, which might make verifying correctness of the new implementation simpler.