### PR TITLE
fix: add suggestions from #8021 and #8029 to `is_aperiodic`

### DIFF
--- a/benchmarks/benchmarks/benchmark_aperiodic.py
+++ b/benchmarks/benchmarks/benchmark_aperiodic.py
@@ -1,9 +1,9 @@
-"""Benchmarks for DAG algorithms."""
+"""Benchmarks for `is_aperiodic`."""
 
 import networkx as nx
 
 
-class DAGBenchmarks:
+class AperiodicBenchmarks:
     timeout = 120
     seed = 42
     _graphs = [

--- a/benchmarks/benchmarks/benchmark_dag.py
+++ b/benchmarks/benchmarks/benchmark_dag.py
@@ -1,0 +1,40 @@
+"""Benchmarks for DAG algorithms."""
+
+import networkx as nx
+
+
+class DAGBenchmarks:
+    timeout = 120
+    seed = 42
+    _graphs = [
+        nx.erdos_renyi_graph(100, 0.05, seed=seed, directed=True),
+        nx.erdos_renyi_graph(100, 0.1, seed=seed, directed=True),
+        nx.erdos_renyi_graph(100, 0.5, seed=seed, directed=True),
+        nx.erdos_renyi_graph(100, 0.9, seed=seed, directed=True),
+        nx.erdos_renyi_graph(1000, 0.01, seed=seed, directed=True),
+        nx.erdos_renyi_graph(1000, 0.05, seed=seed, directed=True),
+        nx.erdos_renyi_graph(1000, 0.09, seed=seed, directed=True),
+        nx.complete_graph(100, create_using=nx.DiGraph),
+        nx.complete_graph(1000, create_using=nx.DiGraph),
+        nx.star_graph(10000).to_directed(),
+    ]
+    params = [
+        "Erdos Renyi (100, 0.05)",
+        "Erdos Renyi (100, 0.1)",
+        "Erdos Renyi (100, 0.5)",
+        "Erdos Renyi (100, 0.9)",
+        "Erdos Renyi (1000, 0.01)",
+        "Erdos Renyi (1000, 0.05)",
+        "Erdos Renyi (1000, 0.09)",
+        "Complete (100)",
+        "Complete (1000)",
+        "Star (10000)",
+    ]
+
+    param_names = ["graph"]
+
+    def setup(self, graph):
+        self.graphs_dict = dict(zip(self.params, self._graphs))
+
+    def time_is_aperiodic(self, graph):
+        _ = nx.is_aperiodic(self.graphs_dict[graph])

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -697,13 +697,19 @@ def is_aperiodic(G):
         raise nx.NetworkXError("Graph is not strongly connected.")
 
     s = nx.utils.arbitrary_element(G)
-    lvls = {s: 0}
+    levels = {s: 0}
     g = 0
-    for u, v, d in nx.bfs_labeled_edges(G, s):
-        if d == "tree":
-            lvls[v] = lvls[u] + 1
-        elif d in {"level", "reverse"} and (g := gcd(g, lvls[u] - lvls[v] + 1)) == 1:
+    # There are 3 relevant possible edge types in `dfs_labeled_edges`:
+    # "forward", "reverse", and "nontree".
+    for u, v, d in nx.dfs_labeled_edges(G, s):
+        if d == "forward":
+            # "forward" edges indicate a new node.
+            levels[v] = levels[u] + 1
+        elif d == "nontree" and (g := gcd(g, levels[u] - levels[v] + 1)) == 1:
+            # "nontree" edges indicate a previously explored node.
+            # Check whether this affects the common factor of cycle lengths.
             return True
+        # "reverse" edges indicate backtracking in DFS and can be ignored.
     return False
 
 

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -572,9 +572,10 @@ def all_topological_sorts(G):
             break
 
 
+@not_implemented_for("undirected")
 @nx._dispatchable
 def is_aperiodic(G):
-    """Returns True if `G` is aperiodic.
+    """Determine whether a directed graph is aperiodic.
 
     A strongly connected directed graph is aperiodic if there is no integer ``k > 1``
     that divides the length of every cycle in the graph.
@@ -589,22 +590,22 @@ def is_aperiodic(G):
 
     Parameters
     ----------
-    G : NetworkX DiGraph
-        A directed graph
+    G : NetworkX graph
+        A directed graph.
 
     Returns
     -------
     bool
-        True if the graph is aperiodic False otherwise
+        Whether the graph is aperiodic.
 
     Raises
     ------
+    NetworkXNotImplemented
+        If `G` is not directed.
     NetworkXError
-        If `G` is not directed
-    NetworkXError
-        If `G` is not strongly connected
+        If `G` is not strongly connected.
     NetworkXPointlessConcept
-        If `G` has no nodes
+        If `G` has no nodes.
 
     Examples
     --------
@@ -690,29 +691,20 @@ def is_aperiodic(G):
        in Shier, D. R.; Wallenius, K. T., Applied Mathematical Modeling:
        A Multidisciplinary Approach, CRC Press.
     """
-    if not G.is_directed():
-        raise nx.NetworkXError("is_aperiodic not defined for undirected graphs")
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept("Graph has no nodes.")
     if not nx.is_strongly_connected(G):
         raise nx.NetworkXError("Graph is not strongly connected.")
-    s = arbitrary_element(G)
+
+    s = nx.utils.arbitrary_element(G)
     levels = {s: 0}
-    this_level = [s]
     g = 0
-    lev = 1
-    while this_level:
-        next_level = []
-        for u in this_level:
-            for v in G[u]:
-                if v in levels:  # Non-Tree Edge
-                    g = gcd(g, levels[u] - levels[v] + 1)
-                else:  # Tree Edge
-                    next_level.append(v)
-                    levels[v] = lev
-        this_level = next_level
-        lev += 1
-    return g == 1
+    for u, v, d in nx.bfs_labeled_edges(G, s):
+        if d == "tree":
+            levels[v] = levels[u] + 1
+        elif (g := gcd(g, levels[u] - levels[v] + 1)) == 1:
+            return True
+    return False
 
 
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -697,12 +697,12 @@ def is_aperiodic(G):
         raise nx.NetworkXError("Graph is not strongly connected.")
 
     s = nx.utils.arbitrary_element(G)
-    levels = {s: 0}
+    lvls = {s: 0}
     g = 0
     for u, v, d in nx.bfs_labeled_edges(G, s):
         if d == "tree":
-            levels[v] = levels[u] + 1
-        elif (g := gcd(g, levels[u] - levels[v] + 1)) == 1:
+            lvls[v] = lvls[u] + 1
+        elif d in {"level", "reverse"} and (g := gcd(g, lvls[u] - lvls[v] + 1)) == 1:
             return True
     return False
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -618,26 +618,26 @@ def test_is_aperiodic_selfloop():
     assert nx.is_aperiodic(G)
 
 
-def test_is_aperiodic_null_graph_raises():
-    G = nx.DiGraph()
-    pytest.raises(nx.NetworkXPointlessConcept, nx.is_aperiodic, G)
-
-
 def test_is_aperiodic_undirected_raises():
     G = nx.Graph([(1, 2), (2, 3), (3, 1)])
-    pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
+    with pytest.raises(
+        nx.NetworkXNotImplemented, match="not implemented for undirected"
+    ):
+        nx.is_aperiodic(G)
 
 
-def test_is_aperiodic_disconnected_raises():
-    G = nx.DiGraph()
-    nx.add_cycle(G, [0, 1, 2])
-    G.add_edge(3, 3)
-    pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
-
-
-def test_is_aperiodic_weakly_connected_raises():
-    G = nx.DiGraph([(1, 2), (2, 3)])
-    pytest.raises(nx.NetworkXError, nx.is_aperiodic, G)
+@pytest.mark.parametrize(
+    "G",
+    [
+        nx.DiGraph([(1, 2), (2, 3)]),
+        nx.DiGraph([(0, 1), (1, 0), (2, 2)]),
+        nx.DiGraph([(0, 1), (1, 2), (0, 3), (3, 4), (4, 0)]),
+        nx.DiGraph([(0, 1), (1, 2), (2, 1)]),
+    ],
+)
+def test_is_aperiodic_not_sc_raises(G):
+    with pytest.raises(nx.NetworkXError, match="not strongly connected"):
+        nx.is_aperiodic(G)
 
 
 def test_is_aperiodic_empty_graph():

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -632,6 +632,20 @@ def test_is_aperiodic_multiedge():
     assert nx.is_aperiodic(G)
 
 
+def test_is_aperiodic_two_cycles1():
+    G = nx.DiGraph()
+    nx.add_cycle(G, [0, 1, 2, 3])
+    nx.add_cycle(G, [0, 4, 2])
+    assert nx.is_aperiodic(G)
+
+
+def test_is_aperiodic_two_cycles2():
+    G = nx.DiGraph()
+    nx.add_cycle(G, [0, 1, 2])
+    nx.add_cycle(G, [0, 4, 2])
+    assert not nx.is_aperiodic(G)
+
+
 @pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph))
 def test_is_aperiodic_undirected_raises(graph_type):
     G = graph_type([(1, 2), (2, 3), (3, 1)])

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -618,8 +618,9 @@ def test_is_aperiodic_selfloop():
     assert nx.is_aperiodic(G)
 
 
-def test_is_aperiodic_undirected_raises():
-    G = nx.Graph([(1, 2), (2, 3), (3, 1)])
+@pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph))
+def test_is_aperiodic_undirected_raises(graph_type):
+    G = graph_type([(1, 2), (2, 3), (3, 1)])
     with pytest.raises(
         nx.NetworkXNotImplemented, match="not implemented for undirected"
     ):
@@ -633,6 +634,7 @@ def test_is_aperiodic_undirected_raises():
         nx.DiGraph([(0, 1), (1, 0), (2, 2)]),
         nx.DiGraph([(0, 1), (1, 2), (0, 3), (3, 4), (4, 0)]),
         nx.DiGraph([(0, 1), (1, 2), (2, 1)]),
+        nx.empty_graph(3, create_using=nx.DiGraph),
     ],
 )
 def test_is_aperiodic_not_sc_raises(G):
@@ -640,8 +642,8 @@ def test_is_aperiodic_not_sc_raises(G):
         nx.is_aperiodic(G)
 
 
-def test_is_aperiodic_empty_graph():
-    G = nx.empty_graph(create_using=nx.DiGraph)
+def test_is_aperiodic_null_graph():
+    G = nx.DiGraph()
     with pytest.raises(nx.NetworkXPointlessConcept, match="Graph has no nodes."):
         nx.is_aperiodic(G)
 

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -618,6 +618,11 @@ def test_is_aperiodic_selfloop():
     assert nx.is_aperiodic(G)
 
 
+def test_is_aperiodic_forward_edge():
+    G = nx.DiGraph([(0, 1), (0, 2), (1, 3), (2, 3), (3, 0)])
+    assert not nx.is_aperiodic(G)
+
+
 @pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph))
 def test_is_aperiodic_undirected_raises(graph_type):
     G = graph_type([(1, 2), (2, 3), (3, 1)])

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -623,6 +623,15 @@ def test_is_aperiodic_forward_edge():
     assert not nx.is_aperiodic(G)
 
 
+def test_is_aperiodic_multiedge():
+    G = nx.MultiDiGraph()
+    nx.add_cycle(G, [0, 1, 2])
+    G.add_edge(0, 1)
+    assert not nx.is_aperiodic(G)
+    G.add_edge(1, 0)
+    assert nx.is_aperiodic(G)
+
+
 @pytest.mark.parametrize("graph_type", (nx.Graph, nx.MultiGraph))
 def test_is_aperiodic_undirected_raises(graph_type):
     G = graph_type([(1, 2), (2, 3), (3, 1)])


### PR DESCRIPTION
This PR combines some of the changes suggested in #8021 and #8029. CC @fei0319.

Changelist:
- Some docstring changes.
- Use `not_implemented_for` instead of checking manually (this changes the exception type but everyone seemed to agree no deprecation was necessary in the original PRs).
- Switch to an approach based on `bfs_labeled_edges`. I originally tried to get a working solution using `dfs_labeled_edges`, without using `nx.strongly_connected_components`, but kept finding edge cases that it wouldn't work for. I kept the BFS because it's slightly more readable; both versions are ~30% faster over 100 runs for `G = nx.complete_graph(300, create_using=nx.DiGraph)`:
```
dfs 2.1416163529793266
bfs 2.1179135239799507
old 2.9861131829966325
```
- Several changes to tests: removed a duplicate test for the null graph, used `with pytest.raises` instead of `pytest.raises`, and added the edge cases I came up with to the "not strongly connected" tests. These should be purely incremental, i.e. no previously tested behavior is now untested.

One point raised in the discussions on previous PRs remains: it's strange to have a function in `dag.py` that raises for DAGs... We should find a new home for it. :) How about `cycles.py`?