### PR TITLE
Add function bfs_labeled_edges to docs

### DIFF
--- a/doc/reference/algorithms/traversal.rst
+++ b/doc/reference/algorithms/traversal.rst
@@ -34,6 +34,7 @@ Breadth First Search
    bfs_predecessors
    bfs_successors
    descendants_at_distance
+   bfs_labeled_edges
    generic_bfs_edges
 
 Beam search


### PR DESCRIPTION
Was looking for this method on a Google search and struggled a bit because it was missing in the docs.

Should we have a mechanism to prevent this? Unless some of them are hidden on purpose and I'm missing some historical context.