### PR TITLE
feat: add directed star graph

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -810,6 +810,33 @@ def star_graph(n, create_using=None):
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
        Graph type to create. If graph instance, then cleared before populated.
 
+    Examples
+    --------
+    A star graph with 3 spokes can be generated with
+
+    >>> G = nx.star_graph(3)
+    >>> sorted(G.edges)
+    [(0, 1), (0, 2), (0, 3)]
+
+    For directed graphs, the convention is to have edges pointing from the hub
+    to the spokes:
+
+    >>> DG1 = nx.star_graph(3, create_using=nx.DiGraph)
+    >>> sorted(DG1.edges)
+    [(0, 1), (0, 2), (0, 3)]
+
+    Other possible definitions have edges pointing from the spokes to the hub:
+
+    >>> DG2 = nx.star_graph(3, create_using=nx.DiGraph).reverse()
+    >>> sorted(DG2.edges)
+    [(1, 0), (2, 0), (3, 0)]
+
+    or have bidirectional edges:
+
+    >>> DG3 = nx.star_graph(3).to_directed()
+    >>> sorted(DG3.edges)
+    [(0, 1), (0, 2), (0, 3), (1, 0), (2, 0), (3, 0)]
+
     Notes
     -----
     The graph has ``n + 1`` nodes for integer `n`.
@@ -823,8 +850,6 @@ def star_graph(n, create_using=None):
     if len(nodes) > 1:
         hub, *spokes = nodes
         G.add_edges_from((hub, node) for node in spokes)
-        if G.is_directed():
-            G.add_edges_from((node, hub) for node in spokes)
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -819,12 +819,12 @@ def star_graph(n, create_using=None):
     if isinstance(n, numbers.Integral):
         nodes.append(int(n))  # there should be n+1 nodes
     G = empty_graph(nodes, create_using)
-    if G.is_directed():
-        raise NetworkXError("Directed Graph not supported")
 
     if len(nodes) > 1:
         hub, *spokes = nodes
         G.add_edges_from((hub, node) for node in spokes)
+        if G.is_directed():
+            G.add_edges_from((node, hub) for node in spokes)
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -792,9 +792,9 @@ def path_graph(n, create_using=None):
 @nx._dispatchable(graphs=None, returns_graph=True)
 @nodes_or_number(0)
 def star_graph(n, create_using=None):
-    """Return the star graph
+    """Return the star graph with `n` outer nodes.
 
-    The star graph consists of one center node connected to n outer nodes.
+    The star graph consists of one center node connected to `n` outer nodes.
 
     .. plot::
 
@@ -803,21 +803,21 @@ def star_graph(n, create_using=None):
     Parameters
     ----------
     n : int or iterable
-        If an integer, node labels are 0 to n with center 0.
+        If an integer, node labels are ``0`` to `n`, with center ``0``.
         If an iterable of nodes, the center is the first.
-        Warning: n is not checked for duplicates and if present the
+        Warning: `n` is not checked for duplicates and if present, the
         resulting graph may not be as desired. Make sure you have no duplicates.
     create_using : NetworkX graph constructor, optional (default=nx.Graph)
        Graph type to create. If graph instance, then cleared before populated.
 
     Notes
     -----
-    The graph has n+1 nodes for integer n.
-    So star_graph(3) is the same as star_graph(range(4)).
+    The graph has ``n + 1`` nodes for integer `n`.
+    So ``star_graph(3)`` is the same as ``star_graph(range(4))``.
     """
     n, nodes = n
     if isinstance(n, numbers.Integral):
-        nodes.append(int(n))  # there should be n+1 nodes
+        nodes.append(int(n))  # There should be n + 1 nodes.
     G = empty_graph(nodes, create_using)
 
     if len(nodes) > 1:

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -792,7 +792,7 @@ def path_graph(n, create_using=None):
 @nx._dispatchable(graphs=None, returns_graph=True)
 @nodes_or_number(0)
 def star_graph(n, create_using=None):
-    """Return the star graph.
+    """Return a star graph.
 
     The star graph consists of one center node connected to `n` outer nodes.
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -792,7 +792,7 @@ def path_graph(n, create_using=None):
 @nx._dispatchable(graphs=None, returns_graph=True)
 @nodes_or_number(0)
 def star_graph(n, create_using=None):
-    """Return the star graph with `n` outer nodes.
+    """Return the star graph.
 
     The star graph consists of one center node connected to `n` outer nodes.
 

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -451,11 +451,6 @@ class TestGeneratorClassic:
         s = nx.star_graph(10)
         assert sorted(d for n, d in s.degree()) == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 10]
 
-        for cu in [nx.DiGraph, nx.MultiDiGraph]:
-            ds = nx.star_graph(3, create_using=cu)
-            ref = cu([(0, 1), (1, 0), (0, 2), (2, 0), (0, 3), (3, 0)])
-            assert ds.edges == ref.edges
-
         ms = nx.star_graph(10, create_using=nx.MultiGraph)
         assert edges_equal(ms.edges(), s.edges())
 
@@ -473,6 +468,12 @@ class TestGeneratorClassic:
         G = nx.star_graph("abcdefg")
         assert len(G) == 7
         assert G.size() == 6
+
+    @pytest.mark.parametrize("graph_type", (nx.DiGraph, nx.MultiDiGraph))
+    def test_star_graph_directed(self, graph_type):
+        dg = nx.star_graph(3, create_using=graph_type)
+        assert sorted([(u, v) for u, v, *d in dg.edges]) == [(0, 1), (0, 2), (0, 3)]
+
 
     def test_non_int_integers_for_star_graph(self):
         np = pytest.importorskip("numpy")

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -451,7 +451,10 @@ class TestGeneratorClassic:
         s = nx.star_graph(10)
         assert sorted(d for n, d in s.degree()) == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 10]
 
-        pytest.raises(nx.NetworkXError, nx.star_graph, 10, create_using=nx.DiGraph)
+        for cu in [nx.DiGraph, nx.MultiDiGraph]:
+            ds = nx.star_graph(3, create_using=cu)
+            ref = cu([(0, 1), (1, 0), (0, 2), (2, 0), (0, 3), (3, 0)])
+            assert ds.edges == ref.edges
 
         ms = nx.star_graph(10, create_using=nx.MultiGraph)
         assert edges_equal(ms.edges(), s.edges())

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -474,7 +474,6 @@ class TestGeneratorClassic:
         dg = nx.star_graph(3, create_using=graph_type)
         assert sorted([(u, v) for u, v, *d in dg.edges]) == [(0, 1), (0, 2), (0, 3)]
 
-
     def test_non_int_integers_for_star_graph(self):
         np = pytest.importorskip("numpy")
         G = nx.star_graph(np.int32(3))


### PR DESCRIPTION
While working on #8148, directed star graphs would have been useful to easily created directed graphs with many "leaf nodes" in their DFS tree. This PR implements adds that possibility and adds a test for it.