### PR TITLE
chore: bump codecov action to v5

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,4 +40,6 @@ jobs:
           pytest --cov=networkx --runslow -n auto --doctest-modules --durations=20 --pyargs networkx
 
       - name: Upload to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This should fix the failing codecov coverage uploads in CI.
It will only work after a maintainer adds `secrets.CODECOV_TOKEN` to the GitHub repository secrets. This shouldn't take more than 3 minutes todo; there's a short but detailed walkthrough when you navigate to (presumably?) https://app.codecov.io/github/networkx/networkx/new.