### PR TITLE
Optimise harmonic centrality

### DIFF
--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -81,7 +81,7 @@ def harmonic_centrality(G, nbunch=None, distance=None, sources=None):
     for v in sources:
         dist = spl(v)
         for u, d_uv in dist.items():
-            if u in nbunch and d_uv != 0:
+            if d_uv != 0 and u in nbunch:
                 centrality[v if transposed else u] += 1 / d_uv
 
     return centrality

--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -81,6 +81,7 @@ def harmonic_centrality(G, nbunch=None, distance=None, sources=None):
     for v in sources:
         dist = spl(v)
         for u, d_uv in dist.items():
+            # Ignore self-loops and edges with 0 weight
             if d_uv != 0 and u in nbunch:
                 centrality[v if transposed else u] += 1 / d_uv
 

--- a/networkx/algorithms/centrality/harmonic.py
+++ b/networkx/algorithms/centrality/harmonic.py
@@ -80,10 +80,8 @@ def harmonic_centrality(G, nbunch=None, distance=None, sources=None):
     spl = partial(nx.shortest_path_length, G, weight=distance)
     for v in sources:
         dist = spl(v)
-        for u in nbunch.intersection(dist):
-            d = dist[u]
-            if d == 0:  # handle u == v and edges with 0 weight
-                continue
-            centrality[v if transposed else u] += 1 / d
+        for u, d_uv in dist.items():
+            if u in nbunch and d_uv != 0:
+                centrality[v if transposed else u] += 1 / d_uv
 
     return centrality


### PR DESCRIPTION
In the current implementation of harmonic centrality, we compute `nbunch.intersection(dist)` for every source node. This creates a temporary set at each iteration, which is unnecessary and slightly inefficient since we can achieve the same logic with a conditional check during iteration over `dist.items()`.

### What I changed
I replaced:
```py
for v in sources:
        dist = spl(v)
        for u in nbunch.intersection(dist):
            d = dist[u]
            if d == 0:  # handle u == v and edges with 0 weight
                continue
            centrality[v if transposed else u] += 1 / d
```
with:
```py
for v in sources:
        dist = spl(v)
        for u, d_uv in dist.items():
            if u in nbunch and d_uv != 0:
                centrality[v if transposed else u] += 1 / d_uv
```

### Benchmarking results
I ran the following benchmark command to compare performance:
```sh
asv compare f750ce5b a9371f78
```
[EDIT]: 
The most notable performance improvement is observed for `wheel_graph(100)` but other benchmarks also show modest improvements.

| Change   | Before [f750ce5b] <main>   | After [a9371f78] <hc>   | Ratio   | Benchmark (Parameter)                                                                                                                                                                    |
|----------|----------------------------|-------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| -        | 1.76±0.06ms                | 1.58±0.01ms             |    0.89 | benchmark_harmonic_centrality.HarmonicCentralityBenchmarks.time_harmonic_centrality('wheel_graph(100)') [Akshita-MacBook-Pro.local/virtualenv-py3.12-numpy-pandas-scipy] |
|          | 2.63±0.1ms                 | 2.41±0ms                  | 0.92    | benchmark_harmonic_centrality.HarmonicCentralityBenchmarks.time_harmonic_centrality('directed_wheel(100)') [py3.12]                   |
|          | 795±5μs                    | 768±2μs                   | 0.97    | benchmark_harmonic_centrality.HarmonicCentralityBenchmarks.time_harmonic_centrality_node_subset('directed_wheel(1000)') [py3.12]     |
|          | 70.3±0.6μs                 | 65.6±0.08μs               | 0.93    | benchmark_harmonic_centrality.HarmonicCentralityBenchmarks.time_harmonic_centrality_node_subset('wheel_graph(100)') [py3.12]         |
|          | 19.3±0.2μs                 | 17.9±0.04μs               | 0.93    | benchmark_harmonic_centrality.HarmonicCentralityBenchmarks.time_harmonic_centrality_single_node('wheel_graph(100)') [py3.12]         |
|          | 149±0.9μs                  | 142±0.2μs                 | 0.95    | benchmark_harmonic_centrality.HarmonicCentralityBenchmarks.time_harmonic_centrality_single_node('wheel_graph(1000)') [py3.12]        |
|        |            ...             |            ...            |   ...   | ...