### PR TITLE
Ensure that backend names are valid Python identifiers

### DIFF
--- a/doc/reference/backends.rst
+++ b/doc/reference/backends.rst
@@ -374,7 +374,7 @@ Creating a custom backend
 
     The ``get_info`` should return a dictionary with following key-value pairs:
         - ``backend_name`` : str or None
-            It is the name passed in the ``backend`` kwarg.
+            It is the name passed in the ``backend`` kwarg and must be a valid Python identifier.
         - ``project`` : str or None
             The name of your backend project.
         - ``package`` : str or None
@@ -423,7 +423,7 @@ Creating a custom backend
 3.  Defining a Backend Graph class
 
     The backend must create an object with an attribute ``__networkx_backend__`` that holds
-    a string with the entry point name::
+    a string with the entry point name, which must be a valid Python identifier::
 
         class BackendGraph:
             __networkx_backend__ = "backend_name"

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -61,8 +61,8 @@ def _get_backends(group, *, load_and_call=False):
     Notes
     ------
     If a backend is defined more than once, a warning is issued.
-    If a backend name is not a valid Python identifier, the backend will be
-    ignored and a warning will be issued.
+    If a backend name is not a valid Python identifier, the backend is
+    ignored and a warning is issued.
     The "nx_loopback" backend is removed if it exists, as it is only available during testing.
     A warning is displayed if an error occurs while loading a backend.
     """

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -61,13 +61,21 @@ def _get_backends(group, *, load_and_call=False):
     Notes
     ------
     If a backend is defined more than once, a warning is issued.
+    If a backend name is not a valid Python identifier, the backend will be
+    ignored and a warning will be issued.
     The "nx_loopback" backend is removed if it exists, as it is only available during testing.
     A warning is displayed if an error occurs while loading a backend.
     """
     items = entry_points(group=group)
     rv = {}
     for ep in items:
-        if ep.name in rv:
+        if not ep.name.isidentifier():
+            warnings.warn(
+                f"networkx backend name is not a valid identifier: {ep.name!r}. Ignoring.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        elif ep.name in rv:
             warnings.warn(
                 f"networkx backend defined more than once: {ep.name}",
                 RuntimeWarning,


### PR DESCRIPTION
In #8115, a user encountered an error when a backend name was not a valid Python identifier.

@amcandio suggested we guard against this https://github.com/networkx/networkx/issues/8115#issuecomment-3092681130.

Notably, it's possible for users to encounter this when e.g. `networkx.egg-info/entry_points.txt` file has an *old* entry for `nx-loopback` instead of `nx_loopback`, as may have happened in #8115.

This PR ignores backends that are not valid identifiers, displays a warning when this happens, and updates documentation to indicate that backends must be valid Python identifiers.

Instead of checking when creating the config as suggested in https://github.com/networkx/networkx/issues/8115#issuecomment-3094631390, this PR checks when loading the entry points for backends.

If an invalidly named backend uses both `networkx.backends` and `networkx.backend_info` entry points, two warnings will be issued.