### PR TITLE
johnson add options to calculate distance

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -927,7 +927,8 @@ class TestJohnsonAlgorithm(WeightedTestBase):
         G.add_weighted_edges_from(
             [("0", "3", 3), ("0", "1", -5), ("0", "2", 2), ("1", "2", 4), ("2", "3", 1)]
         )
-        paths = nx.johnson(G)
+        dist = {}
+        paths = nx.johnson(G, multi_source_dist=dist)
         assert paths == {
             "1": {"1": ["1"], "3": ["1", "2", "3"], "2": ["1", "2"]},
             "0": {
@@ -938,6 +939,17 @@ class TestJohnsonAlgorithm(WeightedTestBase):
             },
             "3": {"3": ["3"]},
             "2": {"3": ["2", "3"], "2": ["2"]},
+        }
+        assert dist == {
+            "1": {"1": 0, "3": 5, "2": 4},
+            "0": {
+                "1": -5,
+                "0": 0,
+                "3": 0,
+                "2": -1,
+            },
+            "3": {"3": 0},
+            "2": {"3": 1, "2": 0},
         }
 
     def test_unweighted_graph(self):


### PR DESCRIPTION
Currently, the Johnson algorithm only returns the shortest paths without providing their corresponding distances. Users who need the actual distances must traverse each path manually to compute them, which is time-consuming.

Additionally, some users may only be interested in the distances and not the paths.

This PR updates the johnson function to accept two optional arguments:

* multi_source_dist: when provided, it will store the computed distances.

* need_paths (default: True): when set to False, the algorithm will not store paths in each Dijkstra run, returning None for the paths and saving computation time.