### PR TITLE
Add benchmarks for multisrc_dijkstra over many small graphs.

### DIFF
--- a/benchmarks/benchmarks/benchmark_shortest_path.py
+++ b/benchmarks/benchmarks/benchmark_shortest_path.py
@@ -1,0 +1,49 @@
+"""Benchmarks for a certain set of algorithms"""
+
+import random
+
+import networkx as nx
+
+
+class UndirectedGraphAtlasSevenNodesConnected:
+    timeout = 120
+    seed = 0xDEADC0DE
+    params = ["unweighted", "uniform", "increasing", "random"]
+    param_names = ["edge_weights"]
+
+    def setup(self, edge_weights):
+        connected_sevens = [
+            G for G in nx.graph_atlas_g() if (len(G) == 7) and nx.is_connected(G)
+        ]
+
+        match edge_weights:
+            case "uniform":
+                for G in connected_sevens:
+                    nx.set_edge_attributes(G, values=5, name="weight")
+            case "random":
+                random.seed(self.seed)
+                for G in connected_sevens:
+                    nx.set_edge_attributes(
+                        G,
+                        values={e: random.randint(1, len(G)) for e in G.edges},
+                        name="weight",
+                    )
+            case "increasing":
+                for G in connected_sevens:
+                    nx.set_edge_attributes(
+                        G, {e: max(e) for e in G.edges}, name="weight"
+                    )
+            case _:
+                pass  # Default case ("unweighted")
+
+        self.graphs = connected_sevens
+
+    def time_multi_source_dijkstra_over_atlas(self, edge_weights):
+        """How long it takes to compute dijkstra multisource paths over many
+        small graphs."""
+        for G in self.graphs:
+            _ = nx.multi_source_dijkstra(G, sources=[0, 1])
+
+    def time_multi_source_dijkstra_over_atlas_with_target(self, edge_weights):
+        for G in self.graphs:
+            _ = nx.multi_source_dijkstra(G, sources=[0, 1], target=6)


### PR DESCRIPTION
Adds another benchmark for #8023 

One of the concerns I expressed there (after reviewing the original benchmark results) was degradation in performance when computing shortest paths over many small graphs. Therefore, I decided to add an explicit benchmark for this case! The idea is to compute dijkstra multisource over all connected graphs of 7 nodes (drawn from `graph_atlas_g`) with various weighting schemes.

The good news: according to these benchmarks, there is no performance degradation in #8023 for the looping-over-many-small-graphs case!