### PR TITLE
MAINT: Use pytest-cov to generate html reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,0 @@
-# Allow coverage to decrease by 0.05%.
-coverage:
-  status:
-    project:
-      default:
-        threshold: 0.05%
-
-# Don't post a comment on pull requests.
-comment: off

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,6 +41,9 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
+        id: cov-upload-zip
         with:
           name: coverage-report-${{ matrix.python-version }}
           path: htmlcov
+      
+      - run: echo "::notice::https://remote-unzip.deno.dev/${{ github.repository }}/artifacts/${{ steps.cov-upload-zip.outputs.artifact-id }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Test NetworkX
         run: |
-          pytest --cov=networkx --runslow -n auto --doctest-modules --durations=20 --pyargs networkx
+          pytest --cov=networkx --cov-report=html --runslow -n auto --doctest-modules --durations=20 --pyargs networkx
 
-      - name: Upload to codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.python-version }}
+          path: htmlcov

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,10 @@ NetworkX
     :target: https://github.com/networkx/networkx/actions?query=workflow%3Atest
 
 .. image::
-    https://codecov.io/gh/networkx/networkx/branch/main/graph/badge.svg?
-    :target: https://app.codecov.io/gh/networkx/networkx/branch/main
+    https://img.shields.io/github/actions/workflow/status/networkx/networkx/coverage.yml?branch=main&label=coverage
+    :target: https://github.com/networkx/networkx/actions/workflows/coverage.yml
+
+
 
 .. image::
     https://img.shields.io/pypi/v/networkx.svg?


### PR DESCRIPTION
Fixes https://github.com/networkx/networkx/issues/8157, upload the coverage report to github instead of using the `codecov-action` github action.