### PR TITLE
maint: perf improvements for writing edge- and adjlists

### DIFF
--- a/benchmarks/benchmarks/benchmark_readwrite.py
+++ b/benchmarks/benchmarks/benchmark_readwrite.py
@@ -35,5 +35,5 @@ class EdgelistCompleteGraph:
                 self.G[u][v].update({"weight": 1})
 
     def time_write_edgelist(self, graph_type, n, data):
-        # data = ("weight",) corresponds to `read_weighted_edgelist`.
+        # data = ("weight",) corresponds to `write_weighted_edgelist`.
         _ = nx.write_edgelist(self.G, path="benchmark_edgelist.txt", data=data)

--- a/benchmarks/benchmarks/benchmark_readwrite.py
+++ b/benchmarks/benchmarks/benchmark_readwrite.py
@@ -16,6 +16,9 @@ class AdjlistCompleteGraph:
     def time_generate_adjlist(self, graph_type, n):
         _ = list(nx.generate_adjlist(self.G))
 
+    def time_write_adjlist(self, graph_type, n):
+        _ = nx.write_adjlist(self.G, path="benchmark_write_adjlist.txt")
+
     def time_write_multiline_adjlist(self, graph_type, n):
         _ = nx.write_multiline_adjlist(
             self.G, path="benchmark_write_multiline_adjlist.txt"

--- a/benchmarks/benchmarks/benchmark_readwrite.py
+++ b/benchmarks/benchmarks/benchmark_readwrite.py
@@ -1,0 +1,39 @@
+import networkx as nx
+
+
+class AdjlistCompleteGraph:
+    params = [("Graph", "DiGraph", "MultiGraph", "MultiDiGraph"), (100, 200)]
+    param_names = ["graph_type", "n"]
+
+    def setup(self, graph_type, n):
+        self.create_using = getattr(nx, graph_type)
+        self.G = nx.complete_graph(n, create_using=self.create_using)
+        if self.G.is_multigraph():
+            self.G.add_edges_from(self.G.edges)
+
+    def time_generate_adjlist(self, graph_type, n):
+        _ = list(nx.generate_adjlist(self.G))
+
+
+class EdgelistCompleteGraph:
+    params = [
+        ("Graph", "DiGraph", "MultiGraph", "MultiDiGraph"),
+        (100, 200),
+        (True, False, ("weight",)),
+    ]
+    param_names = ["graph_type", "n", "data"]
+
+    def setup(self, graph_type, n, data):
+        self.create_using = getattr(nx, graph_type)
+        self.G = nx.complete_graph(n, create_using=self.create_using)
+        if self.G.is_multigraph():
+            self.G.add_edges_from(self.G.edges)
+            for u, v, k in self.G.edges(keys=True):
+                self.G[u][v][k].update({"weight": 1})
+        else:
+            for u, v in self.G.edges():
+                self.G[u][v].update({"weight": 1})
+
+    def time_write_edgelist(self, graph_type, n, data):
+        # data = ("weight",) corresponds to `read_weighted_edgelist`.
+        _ = nx.write_edgelist(self.G, path="benchmark_edgelist.txt", data=data)

--- a/benchmarks/benchmarks/benchmark_readwrite.py
+++ b/benchmarks/benchmarks/benchmark_readwrite.py
@@ -1,3 +1,5 @@
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 import networkx as nx
 
 
@@ -14,6 +16,11 @@ class AdjlistCompleteGraph:
     def time_generate_adjlist(self, graph_type, n):
         _ = list(nx.generate_adjlist(self.G))
 
+    def time_write_multiline_adjlist(self, graph_type, n):
+        _ = nx.write_multiline_adjlist(
+            self.G, path="benchmark_write_multiline_adjlist.txt"
+        )
+
 
 class EdgelistCompleteGraph:
     params = [
@@ -26,14 +33,28 @@ class EdgelistCompleteGraph:
     def setup(self, graph_type, n, data):
         self.create_using = getattr(nx, graph_type)
         self.G = nx.complete_graph(n, create_using=self.create_using)
-        if self.G.is_multigraph():
-            self.G.add_edges_from(self.G.edges)
-            for u, v, k in self.G.edges(keys=True):
-                self.G[u][v][k].update({"weight": 1})
-        else:
-            for u, v in self.G.edges():
-                self.G[u][v].update({"weight": 1})
+        graphs = [self.G]
+        if not self.G.is_directed():
+            self.B = nx.bipartite.complete_bipartite_graph(
+                n // 2, n // 2, create_using=self.create_using
+            )
+            graphs.append(self.B)
+        for graph in graphs:
+            if graph.is_multigraph():
+                graph.add_edges_from(graph.edges)
+                for u, v, k in graph.edges(keys=True):
+                    graph[u][v][k].update({"weight": 1})
+            else:
+                for u, v in graph.edges():
+                    graph[u][v].update({"weight": 1})
 
     def time_write_edgelist(self, graph_type, n, data):
         # data = ("weight",) corresponds to `write_weighted_edgelist`.
-        _ = nx.write_edgelist(self.G, path="benchmark_edgelist.txt", data=data)
+        _ = nx.write_edgelist(self.G, path="benchmark_write_edgelist.txt", data=data)
+
+    def time_bipartite_write_edgelist(self, graph_type, n, data):
+        if graph_type in {"DiGraph", "MultiDiGraph"}:
+            raise SkipNotImplemented(f"bipartite graph not defined for {graph_type}")
+        _ = nx.bipartite.write_edgelist(
+            self.B, path="benchmark_write_bipartite_edgelist.txt", data=data
+        )

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -74,9 +74,8 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     write_edgelist
     generate_edgelist
     """
-    for line in generate_edgelist(G, delimiter, data):
-        line += "\n"
-        path.write(line.encode(encoding))
+    to_write = tuple(generate_edgelist(G, delimiter, data)) + ("",)
+    path.write("\n".join(to_write).encode(encoding))
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -29,7 +29,7 @@ import networkx as nx
 from networkx.utils import not_implemented_for, open_file
 
 
-@open_file(1, mode="wb")
+@open_file("path", mode="wb")
 def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="utf-8"):
     """Write a bipartite graph as a list of edges.
 

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -74,6 +74,7 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     write_edgelist
     generate_edgelist
     """
+    # Add empty string to ensure file ends with newline.
     to_write = tuple(generate_edgelist(G, delimiter, data)) + ("",)
     path.write("\n".join(to_write).encode(encoding))
 

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -161,11 +161,11 @@ def write_adjlist(G, path, comments="#", delimiter=" ", encoding="utf-8"):
         + comments
         + f" GMT {time.asctime(time.gmtime())}\n"
         + comments
-        + f" {G.name}\n"
+        + f" {G.name}"
     )
 
-    to_write = tuple(generate_adjlist(G, delimiter)) + ("",)
-    path.write(header.encode(encoding) + "\n".join(to_write).encode(encoding))
+    to_write = (header,) + tuple(generate_adjlist(G, delimiter)) + ("",)
+    path.write("\n".join(to_write).encode(encoding))
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -163,11 +163,9 @@ def write_adjlist(G, path, comments="#", delimiter=" ", encoding="utf-8"):
         + comments
         + f" {G.name}\n"
     )
-    path.write(header.encode(encoding))
 
-    for line in generate_adjlist(G, delimiter):
-        line += "\n"
-        path.write(line.encode(encoding))
+    to_write = tuple(generate_adjlist(G, delimiter)) + ("",)
+    path.write(header.encode(encoding) + "\n".join(to_write).encode(encoding))
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -163,7 +163,7 @@ def write_adjlist(G, path, comments="#", delimiter=" ", encoding="utf-8"):
         + comments
         + f" {G.name}"
     )
-
+    # Add empty string to ensure file ends with newline.
     to_write = (header,) + tuple(generate_adjlist(G, delimiter)) + ("",)
     path.write("\n".join(to_write).encode(encoding))
 

--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -106,7 +106,7 @@ def generate_adjlist(G, delimiter=" "):
         yield delimiter.join(nodes)
 
 
-@open_file(1, mode="wb")
+@open_file("path", mode="wb")
 def write_adjlist(G, path, comments="#", delimiter=" ", encoding="utf-8"):
     """Write graph G in single-line adjacency-list format to path.
 

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -167,10 +167,8 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     read_edgelist
     write_weighted_edgelist
     """
-
-    for line in generate_edgelist(G, delimiter, data):
-        line += "\n"
-        path.write(line.encode(encoding))
+    to_write = list(generate_edgelist(G, delimiter, data)) + [""]
+    path.write("\n".join(to_write).encode(encoding))
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -123,7 +123,7 @@ def generate_edgelist(G, delimiter=" ", data=True):
             yield delimiter.join(map(str, e))
 
 
-@open_file(1, mode="wb")
+@open_file("path", mode="wb")
 def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="utf-8"):
     """Write graph as a list of edges.
 
@@ -167,7 +167,7 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     read_edgelist
     write_weighted_edgelist
     """
-    to_write = list(generate_edgelist(G, delimiter, data)) + [""]
+    to_write = tuple(generate_edgelist(G, delimiter, data)) + ("",)
     path.write("\n".join(to_write).encode(encoding))
 
 

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -167,6 +167,7 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     read_edgelist
     write_weighted_edgelist
     """
+    # Add empty string to ensure file ends with newline.
     to_write = tuple(generate_edgelist(G, delimiter, data)) + ("",)
     path.write("\n".join(to_write).encode(encoding))
 

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -184,7 +184,7 @@ def write_multiline_adjlist(G, path, delimiter=" ", comments="#", encoding="utf-
         + comments
         + f" {G.name}"
     )
-
+    # Add empty string to ensure file ends with newline.
     to_write = (header,) + tuple(generate_multiline_adjlist(G, delimiter)) + ("",)
     path.write("\n".join(to_write).encode(encoding))
 

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -182,11 +182,11 @@ def write_multiline_adjlist(G, path, delimiter=" ", comments="#", encoding="utf-
         + comments
         + f" GMT {time.asctime(time.gmtime())}\n"
         + comments
-        + f" {G.name}\n"
+        + f" {G.name}"
     )
 
-    to_write = tuple(generate_multiline_adjlist(G, delimiter)) + ("",)
-    path.write(header.encode(encoding) + "\n".join(to_write).encode(encoding))
+    to_write = (header,) + tuple(generate_multiline_adjlist(G, delimiter)) + ("",)
+    path.write("\n".join(to_write).encode(encoding))
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -133,7 +133,7 @@ def generate_multiline_adjlist(G, delimiter=" "):
                 seen.add(s)
 
 
-@open_file(1, mode="wb")
+@open_file("path", mode="wb")
 def write_multiline_adjlist(G, path, delimiter=" ", comments="#", encoding="utf-8"):
     """Write the graph G in multiline adjacency list format to path
 

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -184,11 +184,9 @@ def write_multiline_adjlist(G, path, delimiter=" ", comments="#", encoding="utf-
         + comments
         + f" {G.name}\n"
     )
-    path.write(header.encode(encoding))
 
-    for multiline in generate_multiline_adjlist(G, delimiter):
-        multiline += "\n"
-        path.write(multiline.encode(encoding))
+    to_write = tuple(generate_multiline_adjlist(G, delimiter)) + ("",)
+    path.write(header.encode(encoding) + "\n".join(to_write).encode(encoding))
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)


### PR DESCRIPTION
Uses `str.join` instead of adding line breaks manually, allowing a single file write.
Also adds benchmarks for this change and the change to `generate_adjlist` in #8146 (5400927 being the last commit _before_ that change got merged).

<details>
<summary> asv continuous --bench listCompleteGraph 5400927 maint/edgelist </summary>

```
| Change   | Before [54009272] <jj/keep/35f6b59dc342b28e93cd93769199988bbcc90f44~1>   | After [a2efd001] <jj/keep/a2efd0015e82073914c71d20f024eaf8424c39e9>   |   Ratio | Benchmark (Parameter)                                                                                   |
|----------|--------------------------------------------------------------------------|-----------------------------------------------------------------------|---------|---------------------------------------------------------------------------------------------------------|
| -        | 12.9±0.3ms                                                               | 11.4±0.3ms                                                            |    0.88 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('Graph', 200, ('weight',))      |
| -        | 3.91±0.1ms                                                               | 3.42±0.09ms                                                           |    0.88 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('MultiGraph', 100, ('weight',)) |
| -        | 6.54±0.2ms                                                               | 5.73±0.2ms                                                            |    0.88 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('Graph', 100, True)                       |
| -        | 7.31±0.2ms                                                               | 6.42±0.08ms                                                           |    0.88 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiGraph', 100, True)                  |
| -        | 13.7±0.2ms                                                               | 11.9±0.2ms                                                            |    0.87 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiDiGraph', 100, ('weight',))         |
| -        | 53.6±1ms                                                                 | 46.0±1ms                                                              |    0.86 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiDiGraph', 200, True)                |
| -        | 29.4±0.4ms                                                               | 24.8±0.3ms                                                            |    0.84 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiGraph', 200, True)                  |
| -        | 49.0±0.5ms                                                               | 40.6±0.6ms                                                            |    0.83 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('DiGraph', 200, ('weight',))              |
| -        | 48.2±0.4ms                                                               | 40.1±1ms                                                              |    0.83 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('DiGraph', 200, True)                     |
| -        | 56.1±0.3ms                                                               | 46.6±0.5ms                                                            |    0.83 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiDiGraph', 200, ('weight',))         |
| -        | 3.33±0.2ms                                                               | 2.74±0.09ms                                                           |    0.82 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('Graph', 100, True)             |
| -        | 3.63±0.2ms                                                               | 2.96±0.03ms                                                           |    0.82 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('MultiGraph', 100, True)        |
| -        | 29.6±0.4ms                                                               | 24.4±0.3ms                                                            |    0.82 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiGraph', 200, ('weight',))           |
| -        | 12.7±0.9ms                                                               | 10.2±0.2ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('DiGraph', 100, ('weight',))              |
| -        | 27.5±0.4ms                                                               | 22.3±0.3ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('Graph', 200, ('weight',))                |
| -        | 27.1±1ms                                                                 | 21.9±0.4ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('Graph', 200, True)                       |
| -        | 14.6±0.3ms                                                               | 11.8±0.4ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiDiGraph', 100, True)                |
| -        | 33.8±0.3ms                                                               | 27.4±0.1ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiDiGraph', 200, False)               |
| -        | 7.64±0.09ms                                                              | 6.19±0.05ms                                                           |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiGraph', 100, ('weight',))           |
| -        | 4.87±0.09ms                                                              | 3.93±0.1ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiGraph', 100, False)                 |
| -        | 19.0±0.3ms                                                               | 15.3±0.1ms                                                            |    0.81 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiGraph', 200, False)                 |
| -        | 12.3±0.3ms                                                               | 9.78±0.3ms                                                            |    0.8  | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('Graph', 200, True)             |
| -        | 2.52±0.1ms                                                               | 2.02±0.04ms                                                           |    0.8  | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('MultiGraph', 100, False)       |
| -        | 6.91±0.3ms                                                               | 5.53±0.2ms                                                            |    0.8  | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('Graph', 100, ('weight',))                |
| -        | 3.82±0.4ms                                                               | 3.04±0.1ms                                                            |    0.8  | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('Graph', 100, False)                      |
| -        | 15.4±0.2ms                                                               | 12.2±0.2ms                                                            |    0.79 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('MultiGraph', 200, ('weight',)) |
| -        | 8.99±0.5ms                                                               | 7.14±0.09ms                                                           |    0.79 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('MultiDiGraph', 100, False)               |
| -        | 3.74±0.1ms                                                               | 2.94±0.08ms                                                           |    0.78 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('Graph', 100, ('weight',))      |
| -        | 7.80±0.2ms                                                               | 6.09±0.4ms                                                            |    0.78 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('Graph', 200, False)            |
| -        | 9.53±0.4ms                                                               | 7.41±0.3ms                                                            |    0.78 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('MultiGraph', 200, False)       |
| -        | 4.06±0.1ms                                                               | 3.13±0.2ms                                                            |    0.77 | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('MultiGraph', 100)                |
| -        | 14.4±0.7ms                                                               | 11.0±0.2ms                                                            |    0.77 | benchmark_readwrite.EdgelistCompleteGraph.time_bipartite_write_edgelist('MultiGraph', 200, True)        |
| -        | 26.4±0.6ms                                                               | 20.3±0.3ms                                                            |    0.77 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('DiGraph', 200, False)                    |
| -        | 14.3±0.4ms                                                               | 11.0±0.2ms                                                            |    0.77 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('Graph', 200, False)                      |
| -        | 28.2±0.8ms                                                               | 21.1±0.3ms                                                            |    0.75 | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('MultiDiGraph', 200)              |
| -        | 3.37±0.1ms                                                               | 2.48±0.08ms                                                           |    0.74 | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('Graph', 100)                     |
| -        | 7.24±0.3ms                                                               | 5.37±0.08ms                                                           |    0.74 | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('MultiDiGraph', 100)              |
| -        | 15.9±0.3ms                                                               | 11.7±0.2ms                                                            |    0.74 | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('MultiGraph', 200)                |
| -        | 6.77±0.2ms                                                               | 5.01±0.2ms                                                            |    0.74 | benchmark_readwrite.EdgelistCompleteGraph.time_write_edgelist('DiGraph', 100, False)                    |
| -        | 13.0±0.3ms                                                               | 9.13±0.6ms                                                            |    0.7  | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('Graph', 200)                     |
| -        | 5.57±0.08ms                                                              | 3.64±0.08ms                                                           |    0.65 | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('DiGraph', 100)                   |
| -        | 1.82±0.1ms                                                               | 1.14±0.07ms                                                           |    0.62 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('Graph', 100)                               |
| -        | 22.1±1ms                                                                 | 13.2±0.1ms                                                            |    0.6  | benchmark_readwrite.AdjlistCompleteGraph.time_write_multiline_adjlist('DiGraph', 200)                   |
| -        | 1.48±0.1ms                                                               | 854±20μs                                                              |    0.58 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('Graph', 100)                            |
| -        | 2.73±0.07ms                                                              | 1.55±0.05ms                                                           |    0.57 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('DiGraph', 100)                             |
| -        | 6.61±0.2ms                                                               | 3.76±0.1ms                                                            |    0.57 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('Graph', 200)                               |
| -        | 2.26±0.07ms                                                              | 1.25±0.03ms                                                           |    0.55 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('DiGraph', 100)                          |
| -        | 6.19±0.2ms                                                               | 3.35±0.04ms                                                           |    0.54 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('Graph', 200)                            |
| -        | 9.62±0.3ms                                                               | 5.08±0.06ms                                                           |    0.53 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('DiGraph', 200)                          |
| -        | 10.4±0.3ms                                                               | 5.59±0.2ms                                                            |    0.53 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('DiGraph', 200)                             |
| -        | 2.36±0.1ms                                                               | 1.22±0.03ms                                                           |    0.52 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('MultiGraph', 100)                          |
| -        | 8.68±0.2ms                                                               | 4.44±0.4ms                                                            |    0.51 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('MultiGraph', 200)                          |
| -        | 3.54±0.04ms                                                              | 1.79±0.09ms                                                           |    0.5  | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('MultiDiGraph', 100)                        |
| -        | 2.02±0.06ms                                                              | 949±10μs                                                              |    0.47 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('MultiGraph', 100)                       |
| -        | 8.07±0.4ms                                                               | 3.75±0.02ms                                                           |    0.46 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('MultiGraph', 200)                       |
| -        | 14.2±0.3ms                                                               | 6.57±0.2ms                                                            |    0.46 | benchmark_readwrite.AdjlistCompleteGraph.time_write_adjlist('MultiDiGraph', 200)                        |
| -        | 3.24±0.1ms                                                               | 1.44±0.03ms                                                           |    0.44 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('MultiDiGraph', 100)                     |
| -        | 13.6±0.5ms                                                               | 5.91±0.1ms                                                            |    0.44 | benchmark_readwrite.AdjlistCompleteGraph.time_generate_adjlist('MultiDiGraph', 200)                     |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```
</details>