### PR TITLE
fix: resolve failure to pickle.loads(pickle.dumps(PlanarEmbedding()))

### DIFF
--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -858,11 +858,11 @@ class PlanarEmbedding(nx.DiGraph):
 
     def __init__(self, incoming_graph_data=None, **attr):
         super().__init__(incoming_graph_data=incoming_graph_data, **attr)
-        self.add_edge = self.__forbidden
-        self.add_edges_from = self.__forbidden
-        self.add_weighted_edges_from = self.__forbidden
+        self.add_edge = self._forbidden
+        self.add_edges_from = self._forbidden
+        self.add_weighted_edges_from = self._forbidden
 
-    def __forbidden(self, *args, **kwargs):
+    def _forbidden(self, *args, **kwargs):
         """Forbidden operation
 
         Any edge additions to a PlanarEmbedding should be done using

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -766,6 +766,17 @@ class LRPlanarity:
         return self.side[e]
 
 
+def _PlanarEmbedding__forbidden(self, *args, **kwargs):
+    """Forbidden operation
+
+    Any edge additions to a PlanarEmbedding should be done using
+    method `add_half_edge`.
+    """
+    raise NotImplementedError(
+        "Use `add_half_edge` method to add edges to a PlanarEmbedding."
+    )
+
+
 class PlanarEmbedding(nx.DiGraph):
     """Represents a planar graph with its planar embedding.
 
@@ -858,19 +869,9 @@ class PlanarEmbedding(nx.DiGraph):
 
     def __init__(self, incoming_graph_data=None, **attr):
         super().__init__(incoming_graph_data=incoming_graph_data, **attr)
-        self.add_edge = self.__forbidden
-        self.add_edges_from = self.__forbidden
-        self.add_weighted_edges_from = self.__forbidden
-
-    def __forbidden(self, *args, **kwargs):
-        """Forbidden operation
-
-        Any edge additions to a PlanarEmbedding should be done using
-        method `add_half_edge`.
-        """
-        raise NotImplementedError(
-            "Use `add_half_edge` method to add edges to a PlanarEmbedding."
-        )
+        self.add_edge = __forbidden
+        self.add_edges_from = __forbidden
+        self.add_weighted_edges_from = __forbidden
 
     def get_data(self):
         """Converts the adjacency structure into a better readable structure.

--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -766,17 +766,6 @@ class LRPlanarity:
         return self.side[e]
 
 
-def _PlanarEmbedding__forbidden(self, *args, **kwargs):
-    """Forbidden operation
-
-    Any edge additions to a PlanarEmbedding should be done using
-    method `add_half_edge`.
-    """
-    raise NotImplementedError(
-        "Use `add_half_edge` method to add edges to a PlanarEmbedding."
-    )
-
-
 class PlanarEmbedding(nx.DiGraph):
     """Represents a planar graph with its planar embedding.
 
@@ -869,9 +858,19 @@ class PlanarEmbedding(nx.DiGraph):
 
     def __init__(self, incoming_graph_data=None, **attr):
         super().__init__(incoming_graph_data=incoming_graph_data, **attr)
-        self.add_edge = __forbidden
-        self.add_edges_from = __forbidden
-        self.add_weighted_edges_from = __forbidden
+        self.add_edge = self.__forbidden
+        self.add_edges_from = self.__forbidden
+        self.add_weighted_edges_from = self.__forbidden
+
+    def __forbidden(self, *args, **kwargs):
+        """Forbidden operation
+
+        Any edge additions to a PlanarEmbedding should be done using
+        method `add_half_edge`.
+        """
+        raise NotImplementedError(
+            "Use `add_half_edge` method to add edges to a PlanarEmbedding."
+        )
 
     def get_data(self):
         """Converts the adjacency structure into a better readable structure.


### PR DESCRIPTION
Fixes #8185

Trying to `pickle.loads(pickle.dumps(PlanarEmbedding()))` raises: AttributeError: 'PlanarEmbedding' object has no attribute '__forbidden'