### PR TITLE
maint: use `nx.circulant_graph` to generate Harary graphs

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -448,10 +448,8 @@ def circulant_graph(n, offsets, create_using=None):
 
     """
     G = empty_graph(n, create_using)
-    for i in range(n):
-        for j in offsets:
-            G.add_edge(i, (i - j) % n)
-            G.add_edge(i, (i + j) % n)
+    G.add_edges_from((i, (i - j) % n) for i in range(n) for j in offsets)
+    G.add_edges_from((i, (i + j) % n) for i in range(n) for j in offsets)
     return G
 
 

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -72,42 +72,26 @@ def hnm_harary_graph(n, m, create_using=None):
     if m > n * (n - 1) // 2:
         raise NetworkXError("The number of edges must be <= n(n-1)/2")
 
-    # Construct an empty graph with n nodes first.
-    H = nx.empty_graph(n, create_using)
     # Get the floor of average node degree.
     d = 2 * m // n
 
-    if (n % 2 == 0) or (d % 2 == 0):
-        # Start with a regular graph of d degrees.
-        offset = d // 2
-        H.add_edges_from(
-            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
-        H.add_edges_from(
-            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
+    n_or_d_even = (n % 2 == 0) or (d % 2 == 0)
 
+    offset = (d if n_or_d_even else d - 1) // 2
+    H = nx.circulant_graph(n, range(1, offset + 1), create_using=create_using)
+
+    half = n // 2
+    if n_or_d_even:
         if d % 2 == 1:
             # If d is odd; n must be even.
-            half = n // 2
             # Add edges diagonally.
             H.add_edges_from((i, i + half) for i in range(half))
 
         r = 2 * m % n
         if r > 0:
-            # Add remaining edges at offset+1.
+            # Add remaining edges at offset + 1.
             H.add_edges_from((i, i + offset + 1) for i in range(r // 2))
     else:
-        # Start with a regular graph of (d - 1) degrees.
-        offset = (d - 1) // 2
-        H.add_edges_from(
-            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
-        H.add_edges_from(
-            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
-
-        half = n // 2
         # Add the remaining m - n * offset edges between i and i + half.
         H.add_edges_from((i, (i + half) % n) for i in range(m - n * offset))
 
@@ -164,36 +148,20 @@ def hkn_harary_graph(k, n, create_using=None):
 
     # In case of connectivity 1, simply return the path graph.
     if k == 1:
-        H = nx.path_graph(n, create_using)
-        return H
+        return nx.path_graph(n, create_using)
 
-    # Construct an empty graph with n nodes first.
-    H = nx.empty_graph(n, create_using)
+    k_or_n_even = (k % 2 == 0) or (n % 2 == 0)
 
-    # Test the parity of k and n.
-    if (k % 2 == 0) or (n % 2 == 0):
-        # Construct a regular graph with k degrees.
-        offset = k // 2
-        H.add_edges_from(
-            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
-        H.add_edges_from(
-            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
+    offset = (k if k_or_n_even else k - 1) // 2
+    H = nx.circulant_graph(n, range(1, offset + 1), create_using=create_using)
+
+    half = n // 2
+    if k_or_n_even:
         if k % 2 == 1:
             # If k is odd; n must be even.
-            half = n // 2
             # Add edges diagonally.
             H.add_edges_from((i, i + half) for i in range(half))
     else:
-        # Construct a regular graph with (k - 1) degrees.
-        H.add_edges_from(
-            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
-        H.add_edges_from(
-            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
-        )
-        half = n // 2
         # Add half + 1 edges between i and i + half.
         H.add_edges_from((i, (i + half) % n) for i in range(half + 1))
 

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -53,7 +53,7 @@ def hnm_harary_graph(n, m, create_using=None):
     Notes
     -----
     This algorithm runs in $O(m)$ time.
-    It is implemented by following the Reference [2]_.
+    The implementation follows [2]_.
 
     References
     ----------
@@ -130,7 +130,7 @@ def hkn_harary_graph(k, n, create_using=None):
     Notes
     -----
     This algorithm runs in $O(kn)$ time.
-    It is implemented by following the Reference [2]_.
+    The implementation follows [2]_.
 
     References
     ----------

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -25,29 +25,28 @@ __all__ = ["hnm_harary_graph", "hkn_harary_graph"]
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def hnm_harary_graph(n, m, create_using=None):
-    """Returns the Harary graph with given numbers of nodes and edges.
+    r"""Return the Harary graph with given numbers of nodes and edges.
 
-    The Harary graph $H_{n,m}$ is the graph that maximizes node connectivity
+    The Harary graph $H_{n, m}$ is the graph that maximizes node connectivity
     with $n$ nodes and $m$ edges.
 
-    This maximum node connectivity is known to be floor($2m/n$). [1]_
+    This maximum node connectivity is known to be $\lfloor 2m/n \rfloor$. [1]_
 
     Parameters
     ----------
     n: integer
-       The number of nodes the generated graph is to contain
+        The number of nodes the generated graph is to contain.
 
     m: integer
-       The number of edges the generated graph is to contain
+        The number of edges the generated graph is to contain.
 
-    create_using : NetworkX graph constructor, optional Graph type
-     to create (default=nx.Graph). If graph instance, then cleared
-     before populated.
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+        Graph type to create. If graph instance, then cleared before populated.
 
     Returns
     -------
     NetworkX graph
-        The Harary graph $H_{n,m}$.
+        The Harary graph $H_{n, m}$.
 
     See Also
     --------
@@ -91,6 +90,7 @@ def hnm_harary_graph(n, m, create_using=None):
         )
 
         if d % 2 == 1:
+            # If d is odd, n must be even.
             half = n // 2
             # Add edges diagonally.
             H.add_edges_from((i, i + half) for i in range(half))

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -75,13 +75,11 @@ def hnm_harary_graph(n, m, create_using=None):
     # Get the floor of average node degree.
     d = 2 * m // n
 
-    n_or_d_even = (n % 2 == 0) or (d % 2 == 0)
-
-    offset = (d if n_or_d_even else d - 1) // 2
+    offset = d // 2
     H = nx.circulant_graph(n, range(1, offset + 1), create_using=create_using)
 
     half = n // 2
-    if n_or_d_even:
+    if (n % 2 == 0) or (d % 2 == 0):
         if d % 2 == 1:
             # If d is odd; n must be even.
             # Add edges diagonally.
@@ -150,13 +148,11 @@ def hkn_harary_graph(k, n, create_using=None):
     if k == 1:
         return nx.path_graph(n, create_using)
 
-    k_or_n_even = (k % 2 == 0) or (n % 2 == 0)
-
-    offset = (k if k_or_n_even else k - 1) // 2
+    offset = k // 2
     H = nx.circulant_graph(n, range(1, offset + 1), create_using=create_using)
 
     half = n // 2
-    if k_or_n_even:
+    if (k % 2 == 0) or (n % 2 == 0):
         if k % 2 == 1:
             # If k is odd; n must be even.
             # Add edges diagonally.

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -90,7 +90,7 @@ def hnm_harary_graph(n, m, create_using=None):
         )
 
         if d % 2 == 1:
-            # If d is odd, n must be even.
+            # If d is odd; n must be even.
             half = n // 2
             # Add edges diagonally.
             H.add_edges_from((i, i + half) for i in range(half))
@@ -165,38 +165,39 @@ def hkn_harary_graph(k, n, create_using=None):
     if n < k + 1:
         raise NetworkXError("The number of nodes must be >= k+1 !")
 
-    # in case of connectivity 1, simply return the path graph
+    # In case of connectivity 1, simply return the path graph.
     if k == 1:
         H = nx.path_graph(n, create_using)
         return H
 
-    # Construct an empty graph with n nodes first
+    # Construct an empty graph with n nodes first.
     H = nx.empty_graph(n, create_using)
 
-    # Test the parity of k and n
+    # Test the parity of k and n.
     if (k % 2 == 0) or (n % 2 == 0):
-        # Construct a regular graph with k degrees
+        # Construct a regular graph with k degrees.
         offset = k // 2
-        for i in range(n):
-            for j in range(1, offset + 1):
-                H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)
-        if k & 1:
-            # odd degree; n must be even in this case
+        H.add_edges_from(
+            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+        H.add_edges_from(
+            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+        if k % 2 == 1:
+            # If k is odd; n must be even.
             half = n // 2
-            for i in range(half):
-                # add edges diagonally
-                H.add_edge(i, i + half)
+            # Add edges diagonally.
+            H.add_edges_from((i, i + half) for i in range(half))
     else:
-        # Construct a regular graph with (k - 1) degrees
-        offset = (k - 1) // 2
-        for i in range(n):
-            for j in range(1, offset + 1):
-                H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)
+        # Construct a regular graph with (k - 1) degrees.
+        H.add_edges_from(
+            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+        H.add_edges_from(
+            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
         half = n // 2
-        for i in range(half + 1):
-            # add half+1 edges between i and i+half
-            H.add_edge(i, (i + half) % n)
+        # Add half + 1 edges between i and i + half.
+        H.add_edges_from((i, (i + half) % n) for i in range(half + 1))
 
     return H

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -15,6 +15,8 @@ References
 
 """
 
+import itertools
+
 import networkx as nx
 from networkx.exception import NetworkXError
 
@@ -73,42 +75,43 @@ def hnm_harary_graph(n, m, create_using=None):
     if m > n * (n - 1) // 2:
         raise NetworkXError("The number of edges must be <= n(n-1)/2")
 
-    # Construct an empty graph with n nodes first
+    # Construct an empty graph with n nodes first.
     H = nx.empty_graph(n, create_using)
-    # Get the floor of average node degree
+    # Get the floor of average node degree.
     d = 2 * m // n
 
-    # Test the parity of n and d
     if (n % 2 == 0) or (d % 2 == 0):
-        # Start with a regular graph of d degrees
+        # Start with a regular graph of d degrees.
         offset = d // 2
-        for i in range(n):
-            for j in range(1, offset + 1):
-                H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)
-        if d & 1:
-            # in case d is odd; n must be even in this case
+        H.add_edges_from(
+            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+        H.add_edges_from(
+            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+
+        if d % 2 == 1:
             half = n // 2
-            for i in range(half):
-                # add edges diagonally
-                H.add_edge(i, i + half)
-        # Get the remainder of 2*m modulo n
+            # Add edges diagonally.
+            H.add_edges_from((i, i + half) for i in range(half))
+
         r = 2 * m % n
         if r > 0:
-            # add remaining edges at offset+1
-            for i in range(r // 2):
-                H.add_edge(i, i + offset + 1)
+            # Add remaining edges at offset+1.
+            H.add_edges_from((i, i + offset + 1) for i in range(r // 2))
     else:
-        # Start with a regular graph of (d - 1) degrees
+        # Start with a regular graph of (d - 1) degrees.
         offset = (d - 1) // 2
-        for i in range(n):
-            for j in range(1, offset + 1):
-                H.add_edge(i, (i - j) % n)
-                H.add_edge(i, (i + j) % n)
+        H.add_edges_from(
+            (i, (i - j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+        H.add_edges_from(
+            (i, (i + j) % n) for i in range(n) for j in range(1, offset + 1)
+        )
+
         half = n // 2
-        for i in range(m - n * offset):
-            # add the remaining m - n*offset edges between i and i+half
-            H.add_edge(i, (i + half) % n)
+        # Add the remaining m - n * offset edges between i and i + half.
+        H.add_edges_from((i, (i + half) % n) for i in range(m - n * offset))
 
     return H
 

--- a/networkx/generators/harary_graph.py
+++ b/networkx/generators/harary_graph.py
@@ -15,8 +15,6 @@ References
 
 """
 
-import itertools
-
 import networkx as nx
 from networkx.exception import NetworkXError
 
@@ -118,29 +116,28 @@ def hnm_harary_graph(n, m, create_using=None):
 
 @nx._dispatchable(graphs=None, returns_graph=True)
 def hkn_harary_graph(k, n, create_using=None):
-    """Returns the Harary graph with given node connectivity and node number.
+    r"""Return the Harary graph with given node connectivity and node number.
 
-    The Harary graph $H_{k,n}$ is the graph that minimizes the number of
+    The Harary graph $H_{k, n}$ is the graph that minimizes the number of
     edges needed with given node connectivity $k$ and node number $n$.
 
-    This smallest number of edges is known to be ceil($kn/2$) [1]_.
+    This smallest number of edges is known to be $\lceil kn/2 \rceil$ [1]_.
 
     Parameters
     ----------
     k: integer
-       The node connectivity of the generated graph
+        The node connectivity of the generated graph.
 
     n: integer
-       The number of nodes the generated graph is to contain
+        The number of nodes the generated graph is to contain.
 
-    create_using : NetworkX graph constructor, optional Graph type
-     to create (default=nx.Graph). If graph instance, then cleared
-     before populated.
+    create_using : NetworkX graph constructor, optional (default=nx.Graph)
+        Graph type to create. If graph instance, then cleared before populated.
 
     Returns
     -------
     NetworkX graph
-        The Harary graph $H_{k,n}$.
+        The Harary graph $H_{k, n}$.
 
     See Also
     --------


### PR DESCRIPTION
This PR does a few related things:
- Batch edge addition in `nx.circulant_graph`.
- Clean up docstrings for the Harary graph generators.
- Use `nx.circulant_graph` in the Harary graph generators + batch edge additions where possible.