### PR TITLE
Fix `minimum_node_cut` behavior for complete graphs

### DIFF
--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -413,9 +413,12 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
 
     # Global minimum node cut.
     # Analog to the algorithm 11 for global node connectivity in [1].
+    n = len(G)
     if G.is_directed():
         if not nx.is_weakly_connected(G):
             raise nx.NetworkXError("Input graph is not connected")
+        if G.number_of_edges() == n * (n - 1):
+            raise nx.NetworkXError("Input graph is complete, it has no node cuts.")
         iter_func = itertools.permutations
 
         def neighbors(v):
@@ -424,6 +427,8 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     else:
         if not nx.is_connected(G):
             raise nx.NetworkXError("Input graph is not connected")
+        if G.number_of_edges() == n * (n - 1) / 2:
+            raise nx.NetworkXError("Input graph is complete, it has no node cuts.")
         iter_func = itertools.combinations
         neighbors = G.neighbors
 
@@ -448,7 +453,6 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
         this_cut = minimum_st_node_cut(G, x, y, **kwargs)
         if len(min_cut) >= len(this_cut):
             min_cut = this_cut
-
     return min_cut
 
 

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -271,17 +271,16 @@ def test_not_connected():
 
 def tests_min_cut_complete():
     G = nx.complete_graph(5)
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            assert 4 == len(interface_func(G, flow_func=flow_func))
+    for flow_func in flow_funcs:
+        assert 4 == len(nx.minimum_edge_cut(G, flow_func=flow_func))
+        pytest.raises(nx.NetworkXError, nx.minimum_node_cut, G, flow_func=flow_func)
 
 
 def tests_min_cut_complete_directed():
     G = nx.complete_graph(5)
-    G = G.to_directed()
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            assert 4 == len(interface_func(G, flow_func=flow_func))
+    for flow_func in flow_funcs:
+        assert 4 == len(nx.minimum_edge_cut(G, flow_func=flow_func))
+        pytest.raises(nx.NetworkXError, nx.minimum_node_cut, G, flow_func=flow_func)
 
 
 def tests_minimum_st_node_cut():


### PR DESCRIPTION
This addresses issue #8004 . 
As complete graphs have no node cuts, an error message stating this is returned instead of a set of `n-1` nodes, as was the case previously. 

Changes:

- Added checks for complete graphs, which return an error message stating that complete graphs have no node cuts.
- Fixed tests that now behave correctly when it comes to complete graphs.

Closes: #8004