### PR TITLE
Optimizing Dijkstra: reducing dict lookups (up to 10% faster)

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -857,8 +857,9 @@ def _dijkstra_multisource(
         heappush(fringe, (0, next(c), source))
     while fringe:
         (v_dist, _, v) = heappop(fringe)
-        if dist.setdefault(v, v_dist) < v_dist:
+        if v in dist:
             continue  # already searched this node.
+        dist[v] = v_dist
         if v == target:
             break
         for u, e in G_succ[v].items():


### PR DESCRIPTION
## Optimize `single_source_dijkstra_path_length` by reducing redundant dictionary lookups

### Summary
This PR refactors Dijkstra loops to avoid redundant dictionary lookups when checking distances and visited nodes.  
Instead of accessing `dist[u]` or `seen[u]` multiple times it stores the result of `dict.get()` in a local variable and reuses it. 

This potentially saves hash computations and  equality checks, especially when:
- **Nodes are strings**: Python caches string hashes, so hashing is cheap, but equality checks on long strings are avoided.
- **Nodes are objects with custom, uncached hashes**: both hash computation and equality checks can be expensive, so avoiding duplicate lookups saves time.
- **Nodes are integers**: hashes are trivial, so gains are minimal here.

### Benchmark Results
Benchmarks were run using the suite from [#8059](https://github.com/networkx/networkx/pull/8059), both with integer nodes and with artificially long string node labels. Benchmark was extended to call `nx.single_source_dijkstra_path_length` and to test with long strings following transformation was used:

```
self.G = nx.relabel_nodes(self.G, {x: f"{'node-prefix_' * 10}{x}" for x in self.G})
```

Even though Ratio is higher than 1 in some benchmarks, there is no conclusive increase after looking at variability of measurements.


#### Integer Nodes
Performance is essentially unchanged or slightly improved (within noise), as expected for cheap hashes and equality checks.

| Change   | Before [a25405fc]    | After [8a2cb3a8]   | Ratio   | Benchmark (Parameter)                                                                                                                               |
|----------|-----------------------------------------------|-------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
|          | 127±0.3μs                                     | 124±0.3μs                                       | 0.98    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(100)')                      |
|          | 1.50±0.01ms                                   | 1.50±0.01ms                                     | 1.00    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(1000)')                     |
|          | 17.9±0.04ms                                   | 17.7±0.08ms                                     | 0.99    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(10000)')                    |
|          | 40.2±0.2ms                                    | 39.0±0.7ms                                      | 0.97    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(20000)')                    |
|          | 5.60±0.1μs                                    | 5.40±0.01μs                                     | 0.96    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 10, 0.1, seed=42)')   |
|          | 10.2±0.08μs                                   | 9.82±0.02μs                                     | 0.96    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 10, 0.5, seed=42)')   |
|          | 15.9±0.02μs                                   | 15.0±0.03μs                                     | 0.94    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 10, 0.9, seed=42)')   |
|          | 184±0.3μs                                     | 175±0.3μs                                       | 0.95    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 100, 0.1, seed=42)')  |
|          | 683±6μs                                       | 677±40μs                                        | 0.99    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 100, 0.5, seed=42)')  |
|          | 1.16±0ms                                      | 1.08±0ms                                        | 0.94    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 100, 0.9, seed=42)')  |
|          | 19.6±2ms                                      | 15.2±0.08ms                                     | ~0.77   | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 1000, 0.1, seed=42)') |
|          | 110±4ms                                       | 105±5ms                                         | 0.95    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 1000, 0.5, seed=42)') |
|          | 215±10ms                                      | 198±3ms                                         | 0.92    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 1000, 0.9, seed=42)') |
|          | 44.6±0.2μs                                    | 43.8±0.1μs                                      | 0.98    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 100)')                      |
|          | 430±10μs                                      | 436±3μs                                         | 1.01    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 1000)')                     |
|          | 4.26±0.07ms                                   | 4.16±0.04ms                                     | 0.98    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 10000)')                    |
|          | 8.56±0.1ms                                    | 8.41±0.07ms                                     | 0.98    | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 20000)')                    |


#### Long String Nodes
When node labels are long strings, hashing is still cached, but avoiding duplicate lookups saves equality comparisons. This leads to more noticeable improvements.


| Change   | Before [a25405fc]    | After [8a2cb3a8]   | Ratio   | Benchmark (Parameter)                                                                                                                               |
|----------|-----------------------------------------------|-------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
|          | 132±1μs                                       | 128±0.7μs                                       |    0.97 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(100)')                      |
|          | 1.61±0.01ms                                   | 1.53±0ms                                        |    0.95 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(1000)')                     |
|          | 19.1±0.09ms                                   | 18.5±0.05ms                                     |    0.97 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(10000)')                    |
|          | 41.1±2ms                                      | 39.6±0.2ms                                      |    0.96 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('dijkstra_relaxation_worst_case(20000)')                    |
|          | 5.52±0.04μs                                   | 5.37±0.06μs                                     |    0.97 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 10, 0.1, seed=42)')   |
|          | 10.7±0.05μs                                   | 9.90±0.08μs                                     |    0.93 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 10, 0.5, seed=42)')   |
| -        | 16.7±0.4μs                                    | 15.2±0.02μs                                     |    0.91 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 10, 0.9, seed=42)')   |
|          | 202±6μs                                       | 184±0.5μs                                       |    0.91 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 100, 0.1, seed=42)')  |
|          | 759±30μs                                      | 694±20μs                                        |    0.92 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 100, 0.5, seed=42)')  |
| -        | 1.29±0.07ms                                   | 1.14±0ms                                        |    0.89 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 100, 0.9, seed=42)')  |
|          | 18.2±0.4ms                                    | 17.8±0.4ms                                      |    0.98 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 1000, 0.1, seed=42)') |
|          | 111±4ms                                       | 107±2ms                                         |    0.96 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 1000, 0.5, seed=42)') |
|          | 227±5ms                                       | 244±20ms                                        |    1.08 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, gnp_random_graph, 1000, 0.9, seed=42)') |
|          | 49.8±0.6μs                                    | 46.6±0.6μs                                      |    0.93 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 100)')                      |
|          | 490±3μs                                       | 447±2μs                                         |    0.91 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 1000)')                     |
|          | 5.08±0.07ms                                   | 4.72±0.08ms                                     |    0.93 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 10000)')                    |
|          | 10.3±0.05ms                                   | 9.49±0.07ms                                     |    0.92 | benchmark_algorithms.WeightedGraphBenchmark.time_weighted_single_source_dijkstra_length('weighted_graph(42, path_graph, 20000)')                    |
