### PR TITLE
MAINT: remove `try except` for `tomllib` in `generate_requirements`

### DIFF
--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -1,16 +1,9 @@
 #!/usr/bin/env python
 """Generate requirements/*.txt files from pyproject.toml."""
 
-import sys
 from pathlib import Path
 
-try:  # standard module since Python 3.11
-    import tomllib as toml
-except ImportError:
-    try:  # available for older Python via pip
-        import tomli as toml
-    except ImportError:
-        sys.exit("Please install `tomli` first: `pip install tomli`")
+import tomllib as toml
 
 script_pth = Path(__file__)
 repo_dir = script_pth.parent.parent


### PR DESCRIPTION
With the minimum supported Python version being 3.11, this is no longer necessary.