### PR TITLE
MAINT: Consolidate bipartite Havel--Hakimi graph generators

### DIFF
--- a/networkx/algorithms/bipartite/generators.py
+++ b/networkx/algorithms/bipartite/generators.py
@@ -214,9 +214,9 @@ def havel_hakimi_graph(aseq, bseq, create_using=None):
     Parameters
     ----------
     aseq : list
-       Degree sequence for node set ``A``.
+        Degree sequence for node set ``A``.
     bseq : list
-       Degree sequence for node set ``B``.
+        Degree sequence for node set ``B``.
     create_using : NetworkX graph constructor, optional (default=nx.MultiGraph)
         Graph type to create. If graph instance, then cleared before populated.
 
@@ -254,9 +254,9 @@ def reverse_havel_hakimi_graph(aseq, bseq, create_using=None):
     Parameters
     ----------
     aseq : list
-       Degree sequence for node set ``A``.
+        Degree sequence for node set ``A``.
     bseq : list
-       Degree sequence for node set ``B``.
+        Degree sequence for node set ``B``.
     create_using : NetworkX graph constructor, optional (default=nx.MultiGraph)
         Graph type to create. If graph instance, then cleared before populated.
 
@@ -294,9 +294,9 @@ def alternating_havel_hakimi_graph(aseq, bseq, create_using=None):
     Parameters
     ----------
     aseq : list
-       Degree sequence for node set ``A``.
+        Degree sequence for node set ``A``.
     bseq : list
-       Degree sequence for node set ``B``.
+        Degree sequence for node set ``B``.
     create_using : NetworkX graph constructor, optional (default=nx.MultiGraph)
         Graph type to create. If graph instance, then cleared before populated.
 


### PR DESCRIPTION
This PR refactors `havel_hakimi_graph`, `reverse_havel_hakimi_graph`, and `alternating_havel_hakimi_graph` from `nx.bipartite` to avoid duplicating large parts of the code.

In particular, the only difference in these methods is in how the target nodes in set `B` of the bipartite graph are selected; the highest degree nodes in `A` are connected to

- the highest degree nodes in `B` for `hhg`,
- the lowest degree nodes in `B` for `rhhg`,
- an alternating sequence of highest and lowest degree nodes in `B` for `ahhg`.

This PR pulls out the shared code into a helper function, and uses a `match` statement to determine the correct target nodes.

Other changes include

- a check for negative degrees
- batched edge addition and single pass removal of completed degrees (instead of calling `list.remove` in a loop.
- some docstring revamps.

------

If this gets merged, I'd like to suggest an API change to expose this helper function as the new `nx.bipartite.havel_hakimi_graph` (with the `method` parameter), where users can directly specify the method they want to use to connect nodes. This would simplify the addition of other methods later but perhaps more importantly would improve visibility of the various flavors of Havel--Hakimi graph generators and would avoid having multiple docstrings saying essentially the same thing minus the description of how the connections are chosen (which would become part of the parameter description for the `method` parameter).