### PR TITLE
MAINT: Ignore graph hashing warnings in tests

### DIFF
--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -24,7 +24,7 @@ def _init_node_labels(G, edge_attr, node_attr):
         return {u: "" for u in G}
     else:
         warnings.warn(
-            "The hashes produced for graphs without node or edge attributes"
+            "The hashes produced for graphs without node or edge attributes "
             "changed in v3.5 due to a bugfix (see documentation).",
             UserWarning,
             stacklevel=2,

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -108,6 +108,11 @@ def set_warnings():
         message=r"Exited (at iteration \d+|postprocessing) with accuracies.*",
     )
     warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        message=r"The hashes produced for ",
+    )
+    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
The graph hashing warnings were showing up while testing. 
This sets `conftest.py` to ignore the UserWarnings about graph hashes.
I also added a missing space to the warning message.