### PR TITLE
Bidirectional dijkstra optimization: from 1.1x to 25x faster

### DIFF
--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -2399,7 +2399,7 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
     dists = [{}, {}]  # dictionary of final distances
     preds = [{source: None}, {target: None}]  # dictionary of preds
 
-    def _walk(curr, dir):
+    def path(curr, dir):
         ret = []
         while curr is not None:
             ret.append(curr)
@@ -2435,7 +2435,7 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
         if v in dists[1 - dir]:
             # if we have scanned v in both directions we are done
             # we have now discovered the shortest path
-            return (finaldist, _walk(meetnode, 0) + _walk(preds[1][meetnode], 1))
+            return (finaldist, path(meetnode, 0) + path(preds[1][meetnode], 1))
 
         for w, d in neighs[dir][v].items():
             # weight(v, w, d) for forward and weight(w, v, d) for back direction
@@ -2443,18 +2443,18 @@ def bidirectional_dijkstra(G, source, target, weight="weight"):
             if cost is None:
                 continue
             vwLength = dist + cost
-            if (w_dist := dists[dir].get(w)) is not None:
-                if vwLength < w_dist:
+            if w in dists[dir]:
+                if vwLength < dists[dir][w]:
                     raise ValueError("Contradictory paths found: negative weights?")
-            elif (seen_dist := seen[dir].get(w)) is None or vwLength < seen_dist:
+            elif w not in seen[dir] or vwLength < seen[dir][w]:
                 # relaxing
-                seen_dist = seen[dir][w] = vwLength
+                seen[dir][w] = vwLength
                 heappush(fringe[dir], (vwLength, next(c), w))
                 preds[dir][w] = v
-                if (seen_dist_rev := seen[1 - dir].get(w)) is not None:
+                if w in seen[1 - dir]:
                     # see if this path is better than the already
                     # discovered shortest path
-                    finaldist_w = seen_dist + seen_dist_rev
+                    finaldist_w = vwLength + seen[1 - dir][w]
                     if finaldist is None or finaldist > finaldist_w:
                         finaldist, meetnode = finaldist_w, w
     raise nx.NetworkXNoPath(f"No path between {source} and {target}.")


### PR DESCRIPTION
This PR improves the bi-directional Dijkstra algorithm used for point-to-point shortest-path queries in NetworkX. This algorithm sits at the core of NetworkX [shortest-path simplified interface](https://networkx.org/documentation/stable/reference/algorithms/shortest_paths.html). Every calls to `nx.shortest_path` method specifying both source, target and weight relies on this algorithm. 

Currently, this implementation does not benefit from optimizations introduced in https://github.com/networkx/networkx/pull/8191 and https://github.com/networkx/networkx/pull/8023 for regular Dijkstra (unidirectional).

In this PR, I introduce a **Path-construction optimization:** which prevents the algorithm from constructing paths to all visited nodes, computing only the path to the target.

### Results 
Benchmarks from https://github.com/networkx/networkx/pull/8059 show improvements ranging from ~10% faster to up to 25× faster in corner cases where the shortest path spans multiple nodes.

| Change   | Before [50d0e03e] <main>   | After [55fb31db] <bidirectional_dijkstra_optimization>   | Ratio   | Benchmark (Parameter)                                                                                                      |
|----------|----------------------------|----------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------|
| -        | 186±0.2μs                  | 146±0.4μs                                                | 0.78    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('dijkstra_relaxation_worst_case(100)')                      |
| -        | 2.83±0.09ms                | 1.71±0.02ms                                              | 0.60    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('dijkstra_relaxation_worst_case(1000)')                     |
| -        | 192±4ms                    | 21.4±0.6ms                                               | 0.11    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('dijkstra_relaxation_worst_case(10000)')                    |
| -        | 760±4ms                    | 45.8±0.3ms                                               | 0.06    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('dijkstra_relaxation_worst_case(20000)')                    |
|          | 4.25±0.01μs                | 4.02±0.01μs                                              | 0.95    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 10, 0.1, seed=42)')   |
| -        | 10.8±0.09μs                | 9.31±0.3μs                                               | 0.86    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 10, 0.5, seed=42)')   |
| -        | 10.9±0.01μs                | 9.31±0.03μs                                              | 0.85    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 10, 0.9, seed=42)')   |
| -        | 129±0.5μs                  | 106±2μs                                                  | 0.83    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 100, 0.1, seed=42)')  |
| -        | 403±4μs                    | 335±6μs                                                  | 0.83    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 100, 0.5, seed=42)')  |
| -        | 373±0.4μs                  | 306±1μs                                                  | 0.82    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 100, 0.9, seed=42)')  |
| -        | 3.07±0.01ms                | 2.40±0ms                                                 | 0.78    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 1000, 0.1, seed=42)') |
| -        | 20.6±0.3ms                 | 18.0±0.8ms                                               | 0.87    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 1000, 0.5, seed=42)') |
|          | 17.2±1ms                   | 15.2±0.3ms                                               | ~0.88   | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, gnp_random_graph, 1000, 0.9, seed=42)') |
| -        | 69.1±2μs                   | 58.9±1μs                                                 | 0.85    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, path_graph, 100)')                      |
| -        | 965±10μs                   | 537±4μs                                                  | 0.56    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, path_graph, 1000)')                     |
| -        | 82.0±2ms                   | 5.43±0.2ms                                               | 0.07    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, path_graph, 10000)')                    |
| -        | 297±6ms                    | 11.5±0.5ms                                               | 0.04    | benchmark_algorithms.WeightedGraphBenchmark.time_shortest_path('weighted_graph(42, path_graph, 20000)')                    |
