### PR TITLE
BUG: Raise on directed graphs in `nx.find_cliques_recursive`

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -297,7 +297,7 @@ def find_cliques(G, nodes=None):
         pass
 
 
-# TODO Should this also be not implemented for directed graphs?
+@not_implemented_for("directed")
 @nx._dispatchable
 def find_cliques_recursive(G, nodes=None):
     """Returns all maximal cliques in a graph.
@@ -318,6 +318,7 @@ def find_cliques_recursive(G, nodes=None):
     Parameters
     ----------
     G : NetworkX graph
+        An undirected graph.
 
     nodes : list, optional (default=None)
         If provided, only yield *maximal cliques* containing all nodes in `nodes`.
@@ -333,6 +334,9 @@ def find_cliques_recursive(G, nodes=None):
 
     Raises
     ------
+    NetworkXNotImplemented
+        If `G` is directed.
+
     ValueError
         If `nodes` is not a clique.
 

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -67,6 +67,15 @@ class TestCliques:
         with pytest.raises(ValueError):
             list(nx.find_cliques_recursive(self.G, [2, 6, 4, 1]))
 
+    def test_find_cliques_directed(self):
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        msg = "not implemented for directed"
+        with pytest.raises(nx.NetworkXNotImplemented, match=msg):
+            list(nx.find_cliques(G))
+
+        with pytest.raises(nx.NetworkXNotImplemented, match=msg):
+            list(nx.find_cliques_recursive(G))
+
     def test_number_of_cliques(self):
         G = self.G
         assert nx.number_of_cliques(G, 1) == 1


### PR DESCRIPTION
Fixes #8209.


This PR adds the `not_implemented_for("directed")` decorator to `nx.find_cliques_recursive`, similarly to `nx.find_cliques`. It also adds a test (for both functions) that directed graphs now raise `nx.NetworkXNotImplemented`.