### PR TITLE
MAINT: Rm print from threshold_graph

### DIFF
--- a/networkx/algorithms/tests/test_threshold.py
+++ b/networkx/algorithms/tests/test_threshold.py
@@ -11,6 +11,12 @@ import networkx.algorithms.threshold as nxt
 cnlti = nx.convert_node_labels_to_integers
 
 
+def test_threshold_graph_invalid_creation_sequence():
+    bad_creation_sequence = [2.0, 2, 1, 0]  # floats are not allowed
+    with pytest.raises(ValueError, match="not a valid creation sequence"):
+        nxt.threshold_graph(bad_creation_sequence)
+
+
 class TestGeneratorThreshold:
     def test_threshold_sequence_graph_test(self):
         G = nx.star_graph(10)

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -329,7 +329,7 @@ def threshold_graph(creation_sequence, create_using=None):
         cs = uncompact(creation_sequence)
         ci = list(enumerate(cs))
     else:
-        print("not a valid creation sequence type")
+        raise ValueError("not a valid creation sequence")
         return None
 
     G = nx.empty_graph(0, create_using)

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -546,9 +546,6 @@ def degree_correlation(creation_sequence):
     ds = degree_sequence(cs)
     for i, sym in enumerate(cs):
         if sym == "d":
-            if i != rdi[0]:
-                print("Logic error in degree_correlation", i, rdi)
-                raise ValueError
             rdi.pop(0)
         degi = ds[i]
         for dj in rdi:


### PR DESCRIPTION
Minor maintenance for threshold_graph module. There's *a lot* that could be done to improve things here but I want to keep changes small and digestible.

The first proposal is to eliminate two instances of `print` from public code. They're both a bit nuanced:
 - 971e849 replaces a `print/return None` with `raise ValueError`. Technically this is a backward-incompatible change, but the `threshold_graph` fn in which this lives is not in the `__all__` and very much seems like it is not intended for direct use by users.
 - b796aaa removes a code branch entirely. My initial impulse was to simply update the `ValueError` with the printed message, but after [looking at the code](https://github.com/networkx/networkx/blob/5cfb44f7afa9b46a863e501f817e12a572eca94b/networkx/algorithms/threshold.py#L545-L551) I don't believe it's possible to ever hit this line.
