### PR TITLE
TST: Test maintenance for `test_clique.py`

### DIFF
--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -44,9 +44,8 @@ def test_find_cliques2(find_clique_fn):
     assert sorted(map(sorted, hcl)) == expected
 
 
-def test_find_cliques_trivial(find_clique_fn):
-    TG = nx.Graph()
-    assert list(find_clique_fn(TG)) == []
+def test_find_cliques_null(find_clique_fn):
+    assert list(find_clique_fn(nx.null_graph())) == []
 
 
 def test_find_cliques_not_clique(G, find_clique_fn):
@@ -54,8 +53,9 @@ def test_find_cliques_not_clique(G, find_clique_fn):
         list(find_clique_fn(G, [2, 6, 4, 1]))
 
 
-def test_find_cliques_directed(find_clique_fn):
-    DG = nx.path_graph(4, create_using=nx.DiGraph)
+@pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiDiGraph])
+def test_find_cliques_directed(find_clique_fn, graph_type):
+    DG = nx.path_graph(4, create_using=graph_type)
     msg = "not implemented for directed"
     with pytest.raises(nx.NetworkXNotImplemented, match=msg):
         list(find_clique_fn(DG))

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -61,16 +61,13 @@ def test_find_cliques_directed(find_clique_fn):
         list(find_clique_fn(DG))
 
 
-def test_number_of_cliques(G):
-    cl = list(nx.find_cliques(G))
-    assert nx.number_of_cliques(G, 1) == 1
-    assert list(nx.number_of_cliques(G, [1]).values()) == [1]
-    assert list(nx.number_of_cliques(G, [1, 2]).values()) == [1, 2]
-    assert nx.number_of_cliques(G, [1, 2]) == {1: 1, 2: 2}
-    assert nx.number_of_cliques(G, 2) == 2
+@pytest.fixture
+def cl(G):
+    return list(nx.find_cliques(G))
 
-    noc = nx.number_of_cliques(G)
-    assert noc == {
+
+def test_number_of_cliques_default_args(G, cl):
+    expected = {
         1: 1,
         2: 2,
         3: 1,
@@ -83,58 +80,32 @@ def test_number_of_cliques(G):
         10: 1,
         11: 1,
     }
-
-    noc = nx.number_of_cliques(G, nodes=list(G))
-    assert noc == {
-        1: 1,
-        2: 2,
-        3: 1,
-        4: 2,
-        5: 1,
-        6: 2,
-        7: 1,
-        8: 1,
-        9: 1,
-        10: 1,
-        11: 1,
-    }
-    assert nx.number_of_cliques(G, nodes=[2, 3, 4]) == {2: 2, 3: 1, 4: 2}
-    assert nx.number_of_cliques(G, cliques=cl) == {
-        1: 1,
-        2: 2,
-        3: 1,
-        4: 2,
-        5: 1,
-        6: 2,
-        7: 1,
-        8: 1,
-        9: 1,
-        10: 1,
-        11: 1,
-    }
-    assert nx.number_of_cliques(G, list(G), cliques=cl) == {
-        1: 1,
-        2: 2,
-        3: 1,
-        4: 2,
-        5: 1,
-        6: 2,
-        7: 1,
-        8: 1,
-        9: 1,
-        10: 1,
-        11: 1,
-    }
+    assert nx.number_of_cliques(G) == expected
+    assert nx.number_of_cliques(G, nodes=list(G)) == expected
+    assert nx.number_of_cliques(G, cliques=cl) == expected
+    assert nx.number_of_cliques(G, nodes=list(G), cliques=cl) == expected
 
 
-def test_node_clique_number(G):
-    cl = list(nx.find_cliques(G))
-    assert nx.node_clique_number(G, 1) == 4
-    assert list(nx.node_clique_number(G, [1]).values()) == [4]
-    assert list(nx.node_clique_number(G, [1, 2]).values()) == [4, 4]
-    assert nx.node_clique_number(G, [1, 2]) == {1: 4, 2: 4}
-    assert nx.node_clique_number(G, 1) == 4
-    assert nx.node_clique_number(G) == {
+@pytest.mark.parametrize(
+    ("nodes", "expected"),
+    [
+        (1, 1),
+        ([1], {1: 1}),
+        ([1, 2], {1: 1, 2: 2}),
+        (2, 2),
+        (
+            [2, 3, 4],
+            {2: 2, 3: 1, 4: 2},
+        ),
+    ],
+)
+def test_number_of_cliques_nodes(G, cl, nodes, expected):
+    assert nx.number_of_cliques(G, nodes=nodes) == expected
+    assert nx.number_of_cliques(G, nodes=nodes, cliques=cl) == expected
+
+
+def test_node_clique_number_default_args(G, cl):
+    expected = {
         1: 4,
         2: 4,
         3: 4,
@@ -147,21 +118,18 @@ def test_node_clique_number(G):
         10: 2,
         11: 2,
     }
-    assert nx.node_clique_number(G, cliques=cl) == {
-        1: 4,
-        2: 4,
-        3: 4,
-        4: 3,
-        5: 3,
-        6: 4,
-        7: 3,
-        8: 2,
-        9: 2,
-        10: 2,
-        11: 2,
-    }
-    assert nx.node_clique_number(G, [1, 2], cliques=cl) == {1: 4, 2: 4}
-    assert nx.node_clique_number(G, 1, cliques=cl) == 4
+    assert nx.node_clique_number(G) == expected
+    assert nx.node_clique_number(G, nodes=list(G)) == expected
+    assert nx.node_clique_number(G, cliques=cl) == expected
+    assert nx.node_clique_number(G, nodes=list(G), cliques=cl) == expected
+
+
+@pytest.mark.parametrize(
+    ("nodes", "expected"), [(1, 4), ([1], {1: 4}), ([1, 2], {1: 4, 2: 4}), (2, 4)]
+)
+def test_node_clique_number_nodes(G, cl, nodes, expected):
+    assert nx.node_clique_number(G, nodes=nodes) == expected
+    assert nx.node_clique_number(G, nodes=nodes, cliques=cl) == expected
 
 
 def test_make_clique_bipartite(G):

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -61,222 +61,221 @@ def test_find_cliques_directed(find_clique_fn):
         list(find_clique_fn(DG))
 
 
-class TestCliques:
-    def setup_method(self):
-        z = [3, 4, 3, 4, 2, 4, 2, 1, 1, 1, 1]
-        self.G = cnlti(nx.generators.havel_hakimi_graph(z), first_label=1)
-        self.cl = list(nx.find_cliques(self.G))
+def test_number_of_cliques(G):
+    cl = list(nx.find_cliques(G))
+    assert nx.number_of_cliques(G, 1) == 1
+    assert list(nx.number_of_cliques(G, [1]).values()) == [1]
+    assert list(nx.number_of_cliques(G, [1, 2]).values()) == [1, 2]
+    assert nx.number_of_cliques(G, [1, 2]) == {1: 1, 2: 2}
+    assert nx.number_of_cliques(G, 2) == 2
 
-    def test_number_of_cliques(self):
-        G = self.G
-        assert nx.number_of_cliques(G, 1) == 1
-        assert list(nx.number_of_cliques(G, [1]).values()) == [1]
-        assert list(nx.number_of_cliques(G, [1, 2]).values()) == [1, 2]
-        assert nx.number_of_cliques(G, [1, 2]) == {1: 1, 2: 2}
-        assert nx.number_of_cliques(G, 2) == 2
-        assert nx.number_of_cliques(G) == {
-            1: 1,
-            2: 2,
-            3: 1,
-            4: 2,
-            5: 1,
-            6: 2,
-            7: 1,
-            8: 1,
-            9: 1,
-            10: 1,
-            11: 1,
-        }
-        assert nx.number_of_cliques(G, nodes=list(G)) == {
-            1: 1,
-            2: 2,
-            3: 1,
-            4: 2,
-            5: 1,
-            6: 2,
-            7: 1,
-            8: 1,
-            9: 1,
-            10: 1,
-            11: 1,
-        }
-        assert nx.number_of_cliques(G, nodes=[2, 3, 4]) == {2: 2, 3: 1, 4: 2}
-        assert nx.number_of_cliques(G, cliques=self.cl) == {
-            1: 1,
-            2: 2,
-            3: 1,
-            4: 2,
-            5: 1,
-            6: 2,
-            7: 1,
-            8: 1,
-            9: 1,
-            10: 1,
-            11: 1,
-        }
-        assert nx.number_of_cliques(G, list(G), cliques=self.cl) == {
-            1: 1,
-            2: 2,
-            3: 1,
-            4: 2,
-            5: 1,
-            6: 2,
-            7: 1,
-            8: 1,
-            9: 1,
-            10: 1,
-            11: 1,
-        }
+    noc = nx.number_of_cliques(G)
+    assert noc == {
+        1: 1,
+        2: 2,
+        3: 1,
+        4: 2,
+        5: 1,
+        6: 2,
+        7: 1,
+        8: 1,
+        9: 1,
+        10: 1,
+        11: 1,
+    }
 
-    def test_node_clique_number(self):
-        G = self.G
-        assert nx.node_clique_number(G, 1) == 4
-        assert list(nx.node_clique_number(G, [1]).values()) == [4]
-        assert list(nx.node_clique_number(G, [1, 2]).values()) == [4, 4]
-        assert nx.node_clique_number(G, [1, 2]) == {1: 4, 2: 4}
-        assert nx.node_clique_number(G, 1) == 4
-        assert nx.node_clique_number(G) == {
-            1: 4,
-            2: 4,
-            3: 4,
-            4: 3,
-            5: 3,
-            6: 4,
-            7: 3,
-            8: 2,
-            9: 2,
-            10: 2,
-            11: 2,
-        }
-        assert nx.node_clique_number(G, cliques=self.cl) == {
-            1: 4,
-            2: 4,
-            3: 4,
-            4: 3,
-            5: 3,
-            6: 4,
-            7: 3,
-            8: 2,
-            9: 2,
-            10: 2,
-            11: 2,
-        }
-        assert nx.node_clique_number(G, [1, 2], cliques=self.cl) == {1: 4, 2: 4}
-        assert nx.node_clique_number(G, 1, cliques=self.cl) == 4
-
-    def test_make_clique_bipartite(self):
-        G = self.G
-        B = nx.make_clique_bipartite(G)
-        assert sorted(B) == [-5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-        # Project onto the nodes of the original graph.
-        H = nx.projected_graph(B, range(1, 12))
-        assert H.adj == G.adj
-        # Project onto the nodes representing the cliques.
-        H1 = nx.projected_graph(B, range(-5, 0))
-        # Relabel the negative numbers as positive ones.
-        H1 = nx.relabel_nodes(H1, {-v: v for v in range(1, 6)})
-        assert sorted(H1) == [1, 2, 3, 4, 5]
-
-    def test_make_max_clique_graph(self):
-        """Tests that the maximal clique graph is the same as the bipartite
-        clique graph after being projected onto the nodes representing the
-        cliques.
-
-        """
-        G = self.G
-        B = nx.make_clique_bipartite(G)
-        # Project onto the nodes representing the cliques.
-        H1 = nx.projected_graph(B, range(-5, 0))
-        # Relabel the negative numbers as nonnegative ones, starting at
-        # 0.
-        H1 = nx.relabel_nodes(H1, {-v: v - 1 for v in range(1, 6)})
-        H2 = nx.make_max_clique_graph(G)
-        assert H1.adj == H2.adj
-
-    def test_make_max_clique_graph_create_using(self):
-        G = nx.Graph([(1, 2), (3, 1), (4, 1), (5, 6)])
-        E = nx.Graph([(0, 1), (0, 2), (1, 2)])
-        E.add_node(3)
-        assert nx.is_isomorphic(nx.make_max_clique_graph(G, create_using=nx.Graph), E)
+    noc = nx.number_of_cliques(G, nodes=list(G))
+    assert noc == {
+        1: 1,
+        2: 2,
+        3: 1,
+        4: 2,
+        5: 1,
+        6: 2,
+        7: 1,
+        8: 1,
+        9: 1,
+        10: 1,
+        11: 1,
+    }
+    assert nx.number_of_cliques(G, nodes=[2, 3, 4]) == {2: 2, 3: 1, 4: 2}
+    assert nx.number_of_cliques(G, cliques=cl) == {
+        1: 1,
+        2: 2,
+        3: 1,
+        4: 2,
+        5: 1,
+        6: 2,
+        7: 1,
+        8: 1,
+        9: 1,
+        10: 1,
+        11: 1,
+    }
+    assert nx.number_of_cliques(G, list(G), cliques=cl) == {
+        1: 1,
+        2: 2,
+        3: 1,
+        4: 2,
+        5: 1,
+        6: 2,
+        7: 1,
+        8: 1,
+        9: 1,
+        10: 1,
+        11: 1,
+    }
 
 
-class TestEnumerateAllCliques:
-    def test_paper_figure_4(self):
-        # Same graph as given in Fig. 4 of paper enumerate_all_cliques is
-        # based on.
-        # http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1559964&isnumber=33129
-        G = nx.Graph()
-        edges_fig_4 = [
-            ("a", "b"),
-            ("a", "c"),
-            ("a", "d"),
-            ("a", "e"),
-            ("b", "c"),
-            ("b", "d"),
-            ("b", "e"),
-            ("c", "d"),
-            ("c", "e"),
-            ("d", "e"),
-            ("f", "b"),
-            ("f", "c"),
-            ("f", "g"),
-            ("g", "f"),
-            ("g", "c"),
-            ("g", "d"),
-            ("g", "e"),
-        ]
-        G.add_edges_from(edges_fig_4)
+def test_node_clique_number(G):
+    cl = list(nx.find_cliques(G))
+    assert nx.node_clique_number(G, 1) == 4
+    assert list(nx.node_clique_number(G, [1]).values()) == [4]
+    assert list(nx.node_clique_number(G, [1, 2]).values()) == [4, 4]
+    assert nx.node_clique_number(G, [1, 2]) == {1: 4, 2: 4}
+    assert nx.node_clique_number(G, 1) == 4
+    assert nx.node_clique_number(G) == {
+        1: 4,
+        2: 4,
+        3: 4,
+        4: 3,
+        5: 3,
+        6: 4,
+        7: 3,
+        8: 2,
+        9: 2,
+        10: 2,
+        11: 2,
+    }
+    assert nx.node_clique_number(G, cliques=cl) == {
+        1: 4,
+        2: 4,
+        3: 4,
+        4: 3,
+        5: 3,
+        6: 4,
+        7: 3,
+        8: 2,
+        9: 2,
+        10: 2,
+        11: 2,
+    }
+    assert nx.node_clique_number(G, [1, 2], cliques=cl) == {1: 4, 2: 4}
+    assert nx.node_clique_number(G, 1, cliques=cl) == 4
 
-        cliques = list(nx.enumerate_all_cliques(G))
-        clique_sizes = list(map(len, cliques))
-        assert sorted(clique_sizes) == clique_sizes
 
-        expected_cliques = [
-            ["a"],
-            ["b"],
-            ["c"],
-            ["d"],
-            ["e"],
-            ["f"],
-            ["g"],
-            ["a", "b"],
-            ["a", "b", "d"],
-            ["a", "b", "d", "e"],
-            ["a", "b", "e"],
-            ["a", "c"],
-            ["a", "c", "d"],
-            ["a", "c", "d", "e"],
-            ["a", "c", "e"],
-            ["a", "d"],
-            ["a", "d", "e"],
-            ["a", "e"],
-            ["b", "c"],
-            ["b", "c", "d"],
-            ["b", "c", "d", "e"],
-            ["b", "c", "e"],
-            ["b", "c", "f"],
-            ["b", "d"],
-            ["b", "d", "e"],
-            ["b", "e"],
-            ["b", "f"],
-            ["c", "d"],
-            ["c", "d", "e"],
-            ["c", "d", "e", "g"],
-            ["c", "d", "g"],
-            ["c", "e"],
-            ["c", "e", "g"],
-            ["c", "f"],
-            ["c", "f", "g"],
-            ["c", "g"],
-            ["d", "e"],
-            ["d", "e", "g"],
-            ["d", "g"],
-            ["e", "g"],
-            ["f", "g"],
-            ["a", "b", "c"],
-            ["a", "b", "c", "d"],
-            ["a", "b", "c", "d", "e"],
-            ["a", "b", "c", "e"],
-        ]
+def test_make_clique_bipartite(G):
+    B = nx.make_clique_bipartite(G)
+    assert sorted(B) == [-5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    # Project onto the nodes of the original graph.
+    H = nx.projected_graph(B, range(1, 12))
+    assert H.adj == G.adj
+    # Project onto the nodes representing the cliques.
+    H1 = nx.projected_graph(B, range(-5, 0))
+    # Relabel the negative numbers as positive ones.
+    H1 = nx.relabel_nodes(H1, {-v: v for v in range(1, 6)})
+    assert sorted(H1) == [1, 2, 3, 4, 5]
 
-        assert sorted(map(sorted, cliques)) == sorted(map(sorted, expected_cliques))
+
+def test_make_max_clique_graph(G):
+    """Tests that the maximal clique graph is the same as the bipartite
+    clique graph after being projected onto the nodes representing the
+    cliques.
+
+    """
+    B = nx.make_clique_bipartite(G)
+    # Project onto the nodes representing the cliques.
+    H1 = nx.projected_graph(B, range(-5, 0))
+    # Relabel the negative numbers as nonnegative ones, starting at
+    # 0.
+    H1 = nx.relabel_nodes(H1, {-v: v - 1 for v in range(1, 6)})
+    H2 = nx.make_max_clique_graph(G)
+    assert H1.adj == H2.adj
+
+
+def test_make_max_clique_graph_create_using():
+    G = nx.Graph([(1, 2), (3, 1), (4, 1), (5, 6)])
+    E = nx.Graph([(0, 1), (0, 2), (1, 2)])
+    E.add_node(3)
+    assert nx.is_isomorphic(nx.make_max_clique_graph(G, create_using=nx.Graph), E)
+
+
+def test_enumerate_all_cliques():
+    # Same graph as given in Fig. 4 of paper enumerate_all_cliques is
+    # based on.
+    # http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1559964&isnumber=33129
+    G = nx.Graph()
+    edges_fig_4 = [
+        ("a", "b"),
+        ("a", "c"),
+        ("a", "d"),
+        ("a", "e"),
+        ("b", "c"),
+        ("b", "d"),
+        ("b", "e"),
+        ("c", "d"),
+        ("c", "e"),
+        ("d", "e"),
+        ("f", "b"),
+        ("f", "c"),
+        ("f", "g"),
+        ("g", "f"),
+        ("g", "c"),
+        ("g", "d"),
+        ("g", "e"),
+    ]
+    G.add_edges_from(edges_fig_4)
+
+    cliques = list(nx.enumerate_all_cliques(G))
+    clique_sizes = list(map(len, cliques))
+    assert sorted(clique_sizes) == clique_sizes
+
+    expected_cliques = [
+        ["a"],
+        ["b"],
+        ["c"],
+        ["d"],
+        ["e"],
+        ["f"],
+        ["g"],
+        ["a", "b"],
+        ["a", "b", "d"],
+        ["a", "b", "d", "e"],
+        ["a", "b", "e"],
+        ["a", "c"],
+        ["a", "c", "d"],
+        ["a", "c", "d", "e"],
+        ["a", "c", "e"],
+        ["a", "d"],
+        ["a", "d", "e"],
+        ["a", "e"],
+        ["b", "c"],
+        ["b", "c", "d"],
+        ["b", "c", "d", "e"],
+        ["b", "c", "e"],
+        ["b", "c", "f"],
+        ["b", "d"],
+        ["b", "d", "e"],
+        ["b", "e"],
+        ["b", "f"],
+        ["c", "d"],
+        ["c", "d", "e"],
+        ["c", "d", "e", "g"],
+        ["c", "d", "g"],
+        ["c", "e"],
+        ["c", "e", "g"],
+        ["c", "f"],
+        ["c", "f", "g"],
+        ["c", "g"],
+        ["d", "e"],
+        ["d", "e", "g"],
+        ["d", "g"],
+        ["e", "g"],
+        ["f", "g"],
+        ["a", "b", "c"],
+        ["a", "b", "c", "d"],
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "e"],
+    ]
+
+    assert sorted(map(sorted, cliques)) == sorted(map(sorted, expected_cliques))


### PR DESCRIPTION
This PR follows up on #8211.

Note to reviewers: rather annoyingly, the `diff` got messed up because of indentation changes getting rid of the classes. Reviewing commit-by-commit might make things easier to follow. The following functions are unchanged (except for indentation because they are no longer part of a class and use of fixtures instead of `setup`-based class attributes): `test_make_clique_bipartite`, `test_make_max_clique_graph`, `test_make_max_clique_graph_create_using`, `test_enumerate_all_cliques`.

The changes can be summarized as follows:
- Instead of using a `setup` method, this PR uses `pytest` fixtures instead. One of those fixtures is the `find_clique_fn` which is either `nx.find_cliques` or `nx.find_cliques_recursive`. This allows us to get rid of about half the `assert` statements.
- Splits the tests for `node_clique_number` and `number_of_cliques` into two separate (parametrized) test functions, one for the default args, and one for the `nodes` arg.