### PR TITLE
DOC: Add docstring for `number_of_cliques`

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -549,6 +549,7 @@ def node_clique_number(G, nodes=None, cliques=None, separate_nodes=False):
         It accepts a `nodes` argument which restricts consideration to
         maximal cliques containing all the given `nodes`.
         The search for the cliques is optimized for `nodes`.
+    number_of_cliques
     """
     if cliques is None:
         if nodes is not None:
@@ -582,10 +583,66 @@ def node_clique_number(G, nodes=None, cliques=None, separate_nodes=False):
 
 
 def number_of_cliques(G, nodes=None, cliques=None):
-    """Returns the number of maximal cliques for each node.
+    """Return the number of maximal cliques each node is part of.
 
-    Returns a single or list depending on input nodes.
+    Output is a single node or list depending on input nodes.
     Optional list of cliques can be input if already computed.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+
+    nodes : list or None, optional (default=None)
+        A list of nodes to return the number of maximal cliques for.
+        If `None`, return the number of maximal cliques for all nodes.
+
+    cliques : list or None, optional (default=None)
+        A precomputed list of maximal cliques to use for the calculation.
+
+    Returns
+    -------
+    int or dict
+        If `nodes` is a single node, return the number of maximal cliques it is
+        part of. If `nodes` is a list, return a dictionary keyed by node to the
+        number of maximal cliques it is part of.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is not undirected.
+
+    See Also
+    --------
+    find_cliques
+    node_clique_number
+
+    Examples
+    --------
+    Compute the number of maximal cliques a node is part of:
+
+    >>> G = nx.complete_graph(3)
+    >>> nx.add_cycle(G, [0, 3, 4])
+    >>> nx.number_of_cliques(G, nodes=0)
+    2
+    >>> nx.number_of_cliques(G, nodes=1)
+    1
+
+    Or, for a list of nodes:
+
+    >>> nx.number_of_cliques(G, nodes=[0, 1])
+    {0: 2, 1: 1}
+
+    If no explicit `nodes` are provided, all nodes are considered:
+
+    >>> nx.number_of_cliques(G)
+    {0: 2, 1: 1, 2: 1, 3: 1, 4: 1}
+
+    The list of maximal cliques can also be precomputed:
+
+    >>> cl = nx.find_cliques(G)
+    >>> nx.number_of_cliques(G, cliques=cl)
+    {0: 2, 1: 1, 2: 1, 3: 1, 4: 1}
     """
     if cliques is None:
         cliques = find_cliques(G)


### PR DESCRIPTION
While working on #8214, I saw this function doesn't have a proper docstring despite being part of the public API.