### PR TITLE
TST: add seed for `random_cograph` test

### DIFF
--- a/networkx/generators/tests/test_cographs.py
+++ b/networkx/generators/tests/test_cographs.py
@@ -1,11 +1,18 @@
 """Unit tests for the :mod:`networkx.generators.cographs` module."""
 
+import pytest
+
 import networkx as nx
 
 
-def test_random_cograph():
-    n = 3
-    G = nx.random_cograph(n, seed=42)
+@pytest.mark.parametrize("n", [3, 4, 5])
+@pytest.mark.parametrize("seed", [42, 43])
+def test_random_cograph(n, seed):
+    """Test the generation of random cographs.
+
+    Parametrized on `seed` to ensure we hit all code branches.
+    """
+    G = nx.random_cograph(n, seed=seed)
 
     assert len(G) == 2**n
 

--- a/networkx/generators/tests/test_cographs.py
+++ b/networkx/generators/tests/test_cographs.py
@@ -16,10 +16,5 @@ def test_random_cograph(n, seed):
 
     assert len(G) == 2**n
 
-    # Every connected subgraph of G has diameter <= 2
-    if nx.is_connected(G):
-        assert nx.diameter(G) <= 2
-    else:
-        components = nx.connected_components(G)
-        for component in components:
-            assert nx.diameter(G.subgraph(component)) <= 2
+    # Every connected subgraph of G has diameter <= 2.
+    assert all(nx.diameter(G.subgraph(c)) <= 2 for c in nx.connected_components(G))

--- a/networkx/generators/tests/test_cographs.py
+++ b/networkx/generators/tests/test_cographs.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 def test_random_cograph():
     n = 3
-    G = nx.random_cograph(n)
+    G = nx.random_cograph(n, seed=42)
 
     assert len(G) == 2**n
 


### PR DESCRIPTION
Towards #8223.

This test would sometimes fail to hit one of these branches.
https://github.com/networkx/networkx/blob/main/networkx/generators/cographs.py#L63-L66

Adding a fixed seed of 42 resolves the spurious coverage misses.