### PR TITLE
TST: Add a nonslow test for `all_node_cuts` with shortest augmenting path flow function

### DIFF
--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -267,3 +267,14 @@ def test_all_node_cuts_simple_case():
     assert len(actual) == len(expected)
     for cut in actual:
         assert cut in expected
+
+
+def test_all_node_cuts_sap():
+    """Non-slow test for `all_node_cuts` using the shortest augmenting path flow."""
+    G = nx.cycle_graph(5)
+    node_conn = nx.node_connectivity(G)
+    all_cuts = nx.all_node_cuts(G, flow_func=flow.shortest_augmenting_path)
+    # Only test a limited number of cut sets to reduce test time.
+    for cut in itertools.islice(all_cuts, MAX_CUTSETS_TO_TEST):
+        assert node_conn == len(cut)
+        assert not nx.is_connected(nx.restricted_view(G, cut, []))


### PR DESCRIPTION
Towards #8223.

Initially, I hoped to fix the coverage difference between `slow` and non-`slow` tests by removing the `slow` marker from the alternative flow function test, but `preflow_push` still takes a long time and so I couldn't just remove the marker. I decided to leave the change (9927206) because IMO it's slightly cleaner this way, probably easier to debug if it fails at some point, and if in the future we decide to mark individual flow functions as `slow` using fixtures then this will be slightly easier to update. Note that recomputing the node connectivity takes negligible time compared to `all_node_cuts`.

ca6f248 adds only the `shortest_augmenting_path` flow function case, for one graph. This ensures we hit this branch
https://github.com/networkx/networkx/blob/6fad2d34112d5d860ef9f3dd997936c77d454b09/networkx/algorithms/connectivity/kcutsets.py#L118-L119
which was previously only being hit in the `slow` test.

---

These tests have a decent amount of redundant code. Might be worth trying to clean some of that up in follow-ups!