### PR TITLE
TST: ensure determinism in `nx_pylab` drawing tests

### DIFF
--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -903,8 +903,8 @@ def test_return_types():
 
     G = nx.frucht_graph(create_using=nx.Graph)
     dG = nx.frucht_graph(create_using=nx.DiGraph)
-    pos = nx.spring_layout(G)
-    dpos = nx.spring_layout(dG)
+    pos = nx.spring_layout(G, seed=42)
+    dpos = nx.spring_layout(dG, seed=42)
     # nodes
     nodes = nx.draw_networkx_nodes(G, pos)
     assert isinstance(nodes, PathCollection)
@@ -925,7 +925,7 @@ def test_return_types():
 
 def test_labels_and_colors():
     G = nx.cubical_graph()
-    pos = nx.spring_layout(G)  # positions for all nodes
+    pos = nx.spring_layout(G, seed=42)  # positions for all nodes
     # nodes
     nx.draw_networkx_nodes(
         G, pos, nodelist=[0, 1, 2, 3], node_color="r", node_size=500, alpha=0.75

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -554,42 +554,28 @@ def subplots():
         nx.draw_forceatlas2,
     ],
 )
-def test_draw(function):
+def test_draw(function, subplots, tmpdir):
+    fig, _ = subplots
     options = {"node_color": "black", "node_size": 100, "width": 3}
     try:
         function(barbell, **options)
-        plt.savefig("test.ps")
     except ModuleNotFoundError:  # draw_kamada_kawai requires scipy
         pass
-    finally:
-        try:
-            os.unlink("test.ps")
-        except OSError:
-            pass
+    fig.savefig(tmpdir.join("test.ps"))
 
 
-def test_draw_shell_nlist():
-    try:
-        nlist = [list(range(4)), list(range(4, 10)), list(range(10, 14))]
-        nx.draw_shell(barbell, nlist=nlist)
-        plt.savefig("test.ps")
-    finally:
-        try:
-            os.unlink("test.ps")
-        except OSError:
-            pass
+def test_draw_shell_nlist(subplots, tmpdir):
+    fig, _ = subplots
+    nlist = [list(range(4)), list(range(4, 10)), list(range(10, 14))]
+    nx.draw_shell(barbell, nlist=nlist)
+    fig.savefig(tmpdir.join("test.ps"))
 
 
-def test_draw_bipartite():
-    try:
-        G = nx.complete_bipartite_graph(2, 5)
-        nx.draw_bipartite(G)
-        plt.savefig("test.ps")
-    finally:
-        try:
-            os.unlink("test.ps")
-        except OSError:
-            pass
+def test_draw_bipartite(subplots, tmpdir):
+    fig, _ = subplots
+    G = nx.complete_bipartite_graph(2, 5)
+    nx.draw_bipartite(G)
+    fig.savefig(tmpdir.join("test.ps"))
 
 
 def test_edge_colormap():

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -555,12 +555,11 @@ def subplots():
     ],
 )
 def test_draw(function, subplots, tmpdir):
+    if function == nx.draw_kamada_kawai:
+        pytest.importorskip("scipy", reason="draw_kamada_kawai requires scipy")
     fig, _ = subplots
     options = {"node_color": "black", "node_size": 100, "width": 3}
-    try:
-        function(barbell, **options)
-    except ModuleNotFoundError:  # draw_kamada_kawai requires scipy
-        pass
+    function(barbell, **options)
     fig.savefig(tmpdir.join("test.ps"))
 
 

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -551,6 +551,7 @@ def subplots():
         nx.draw_spectral,
         nx.draw_spring,
         nx.draw_shell,
+        nx.draw_forceatlas2,
     ],
 )
 def test_draw(function):

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -586,6 +586,16 @@ def test_edge_colormap():
     # plt.show()
 
 
+def test_draw_networkx_edge_labels(subplots, tmpdir):
+    fig, _ = subplots
+    edge = (0, 1)
+    G = nx.DiGraph([edge])
+    pos = {n: (n, n) for n in G}
+    nx.draw(G, pos=pos)
+    nx.draw_networkx_edge_labels(G, pos, edge_labels={edge: "edge"})
+    fig.savefig(tmpdir.join("test.ps"))
+
+
 def test_arrows():
     nx.draw_spring(barbell.to_directed())
     # plt.show()

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -541,21 +541,23 @@ def subplots():
     plt.close()
 
 
-def test_draw():
+@pytest.mark.parametrize(
+    "function",
+    [
+        nx.draw_circular,
+        nx.draw_kamada_kawai,
+        nx.draw_planar,
+        nx.draw_random,
+        nx.draw_spectral,
+        nx.draw_spring,
+        nx.draw_shell,
+    ],
+)
+def test_draw(function):
+    options = {"node_color": "black", "node_size": 100, "width": 3}
     try:
-        functions = [
-            nx.draw_circular,
-            nx.draw_kamada_kawai,
-            nx.draw_planar,
-            nx.draw_random,
-            nx.draw_spectral,
-            nx.draw_spring,
-            nx.draw_shell,
-        ]
-        options = [{"node_color": "black", "node_size": 100, "width": 3}]
-        for function, option in itertools.product(functions, options):
-            function(barbell, **option)
-            plt.savefig("test.ps")
+        function(barbell, **options)
+        plt.savefig("test.ps")
     except ModuleNotFoundError:  # draw_kamada_kawai requires scipy
         pass
     finally:

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -554,27 +554,27 @@ def subplots():
         nx.draw_forceatlas2,
     ],
 )
-def test_draw(function, subplots, tmpdir):
+def test_draw(function, subplots, tmp_path):
     if function == nx.draw_kamada_kawai:
         pytest.importorskip("scipy", reason="draw_kamada_kawai requires scipy")
     fig, _ = subplots
     options = {"node_color": "black", "node_size": 100, "width": 3}
     function(barbell, **options)
-    fig.savefig(tmpdir.join("test.ps"))
+    fig.savefig(tmp_path / "test.ps")
 
 
-def test_draw_shell_nlist(subplots, tmpdir):
+def test_draw_shell_nlist(subplots, tmp_path):
     fig, _ = subplots
     nlist = [list(range(4)), list(range(4, 10)), list(range(10, 14))]
     nx.draw_shell(barbell, nlist=nlist)
-    fig.savefig(tmpdir.join("test.ps"))
+    fig.savefig(tmp_path / "test.ps")
 
 
-def test_draw_bipartite(subplots, tmpdir):
+def test_draw_bipartite(subplots, tmp_path):
     fig, _ = subplots
     G = nx.complete_bipartite_graph(2, 5)
     nx.draw_bipartite(G)
-    fig.savefig(tmpdir.join("test.ps"))
+    fig.savefig(tmp_path / "test.ps")
 
 
 def test_edge_colormap():
@@ -585,14 +585,14 @@ def test_edge_colormap():
     # plt.show()
 
 
-def test_draw_networkx_edge_labels(subplots, tmpdir):
+def test_draw_networkx_edge_labels(subplots, tmp_path):
     fig, _ = subplots
     edge = (0, 1)
     G = nx.DiGraph([edge])
     pos = {n: (n, n) for n in G}
     nx.draw(G, pos=pos)
     nx.draw_networkx_edge_labels(G, pos, edge_labels={edge: "edge"})
-    fig.savefig(tmpdir.join("test.ps"))
+    fig.savefig(tmp_path / "test.ps")
 
 
 def test_arrows():


### PR DESCRIPTION
Towards #8223.

This PR is an attempt to find out more about why the `draw` method of `CurvedArrowText` sometimes gets hit, and sometimes doesn't.
https://github.com/networkx/networkx/blob/6fad2d34112d5d860ef9f3dd997936c77d454b09/networkx/drawing/nx_pylab.py#L248-L254
In #8223 for example, running only the non-`slow` tests covered these lines, whereas running all tests didn't (as such, I guess this doesn't strictly belong in #8223, but it'd be good to fix this anyways).

I can confirm this is _not_ an issue with `pytest-cov`; adding an `assert False` in the `draw` method sometimes fails, and sometimes doesn't. Perhaps even more surprisingly, it's not immediately obvious to me where the randomness is coming from, here. `draw_planar` is one of the functions for which we hit the failing `assert` I added most often, yet it has no obvious source of randomness.

5c2eb6d adds an explicit `seed` value to some random tests; this had no effect on coverage but is a reasonable change regardless.
a8a72e7 parametrized the `test_draw` test, to make it easier to debug which functions were hitting the code path.
faf4ae3 just added a missing function to the `function` parameter.

cc @rossbar (you somewhat recently worked on `draw_bipartite`, which also sometimes hits this code path) and @dg-pb (you wrote the original `CurvedArrowText`).