### PR TITLE
BUG: add check for isolated nodes in `degree_sequence_tree`

### DIFF
--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -38,6 +38,7 @@ Random Sequence Generators
    :toctree: generated/
 
    powerlaw_sequence
+   is_valid_tree_degree_sequence
    cumulative_distribution
    discrete_sequence
    zipf_rv

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -651,18 +651,10 @@ def degree_sequence_tree(deg_sequence, create_using=None):
     the degree sequence must have
     len(deg_sequence)-sum(deg_sequence)/2=1
     """
-    # The sum of the degree sequence must be even (for any undirected graph).
-    if (degree_sum := sum(deg_sequence)) % 2 != 0:
-        msg = "Invalid degree sequence: sum of degrees must be even, not odd"
-        raise nx.NetworkXError(msg)
-    if (degree_len := len(deg_sequence)) - degree_sum // 2 != 1:
-        msg = (
-            "Invalid degree sequence: tree must have number of nodes equal"
-            " to one less than the number of edges"
-        )
-        raise nx.NetworkXError(msg)
-    if deg_sequence != [0] and any(d <= 0 for d in deg_sequence):
-        raise ValueError("nontrivial tree cannot have isolated nodes")
+    deg_sequence = list(deg_sequence)
+    valid, reason = nx.utils.is_valid_tree_degree_sequence(deg_sequence)
+    if not valid:
+        raise nx.NetworkXError(reason)
 
     G = nx.empty_graph(0, create_using)
     if G.is_directed():
@@ -686,7 +678,7 @@ def degree_sequence_tree(deg_sequence, create_using=None):
         last += nedges
 
     # in case we added one too many
-    if len(G) > degree_len:
+    if len(G) > len(deg_sequence):
         G.remove_node(0)
     return G
 

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -652,16 +652,18 @@ def degree_sequence_tree(deg_sequence, create_using=None):
     len(deg_sequence)-sum(deg_sequence)/2=1
     """
     # The sum of the degree sequence must be even (for any undirected graph).
-    degree_sum = sum(deg_sequence)
-    if degree_sum % 2 != 0:
+    if (degree_sum := sum(deg_sequence)) % 2 != 0:
         msg = "Invalid degree sequence: sum of degrees must be even, not odd"
         raise nx.NetworkXError(msg)
-    if len(deg_sequence) - degree_sum // 2 != 1:
+    if (degree_len := len(deg_sequence)) - degree_sum // 2 != 1:
         msg = (
             "Invalid degree sequence: tree must have number of nodes equal"
             " to one less than the number of edges"
         )
         raise nx.NetworkXError(msg)
+    if deg_sequence != [0] and any(d <= 0 for d in deg_sequence):
+        raise ValueError("nontrivial tree cannot have isolated nodes")
+
     G = nx.empty_graph(0, create_using)
     if G.is_directed():
         raise nx.NetworkXError("Directed Graph not supported")
@@ -684,7 +686,7 @@ def degree_sequence_tree(deg_sequence, create_using=None):
         last += nedges
 
     # in case we added one too many
-    if len(G) > len(deg_sequence):
+    if len(G) > degree_len:
         G.remove_node(0)
     return G
 

--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -1315,13 +1315,9 @@ def random_powerlaw_tree_sequence(n, gamma=3, seed=None, tries=100):
     # round to integer values in the range [0,n]
     swap = [min(n, max(round(s), 0)) for s in z]
 
-    for deg in swap:
-        # If this degree sequence can be the degree sequence of a tree, return
-        # it. It can be a tree if the number of edges is one fewer than the
-        # number of nodes, or in other words, `n - sum(zseq) / 2 == 1`. We
-        # use an equivalent condition below that avoids floating point
-        # operations.
-        if 2 * n - sum(zseq) == 2:
+    for _ in swap:
+        valid, _ = nx.utils.is_valid_tree_degree_sequence(zseq)
+        if valid:
             return zseq
         index = seed.randint(0, n - 1)
         zseq[index] = swap.pop()

--- a/networkx/utils/random_sequence.py
+++ b/networkx/utils/random_sequence.py
@@ -8,6 +8,7 @@ from networkx.utils import py_random_state
 
 __all__ = [
     "powerlaw_sequence",
+    "is_valid_tree_degree_sequence",
     "zipf_rv",
     "cumulative_distribution",
     "discrete_sequence",
@@ -27,6 +28,38 @@ def powerlaw_sequence(n, exponent=2.0, seed=None):
     Return sample sequence of length n from a power law distribution.
     """
     return [seed.paretovariate(exponent - 1) for i in range(n)]
+
+
+def is_valid_tree_degree_sequence(degree_sequence):
+    """Check if a degree sequence is valid for a tree.
+
+    Two conditions must be met for a degree sequence to be valid for a tree:
+
+    1. The number of nodes must be one more than the number of edges.
+    2. The degree sequence must be trivial or have only strictly positive
+       node degrees.
+
+    Parameters
+    ----------
+    degree_sequence : iterable
+        Iterable of node degrees.
+
+    Returns
+    -------
+    bool
+        Whether the degree sequence is valid for a tree.
+    str
+        Reason for invalidity, or dummy string if valid.
+    """
+    seq = list(degree_sequence)
+    l = len(seq)
+    s = sum(seq)
+
+    if 2 * l - s != 2:
+        return False, "tree must have one more node than number of edges"
+    elif seq != [0] and any(d <= 0 for d in seq):
+        return False, "nontrivial tree must have strictly positive node degrees"
+    return True, ""
 
 
 @py_random_state(2)

--- a/networkx/utils/tests/test_random_sequence.py
+++ b/networkx/utils/tests/test_random_sequence.py
@@ -1,38 +1,49 @@
 import pytest
 
-from networkx.utils import (
-    powerlaw_sequence,
-    random_weighted_sample,
-    weighted_choice,
-    zipf_rv,
-)
+import networkx as nx
 
 
 def test_degree_sequences():
-    seq = powerlaw_sequence(10, seed=1)
-    seq = powerlaw_sequence(10)
+    seq = nx.utils.powerlaw_sequence(10, seed=1)
+    seq = nx.utils.powerlaw_sequence(10)
     assert len(seq) == 10
 
 
+@pytest.mark.parametrize(
+    ("deg_seq", "valid", "reason"),
+    [
+        ([], False, "must have one more node"),
+        ([0], True, ""),
+        ([2], False, "must have one more node"),
+        ([2, 0], False, "must have strictly positive"),
+        ([3, 1, 1, 1], True, ""),
+    ],
+)
+def test_valid_degree_sequence(deg_seq, valid, reason):
+    v, r = nx.utils.is_valid_tree_degree_sequence(deg_seq)
+    assert v == valid
+    assert reason in r
+
+
 def test_zipf_rv():
-    r = zipf_rv(2.3, xmin=2, seed=1)
-    r = zipf_rv(2.3, 2, 1)
-    r = zipf_rv(2.3)
+    r = nx.utils.zipf_rv(2.3, xmin=2, seed=1)
+    r = nx.utils.zipf_rv(2.3, 2, 1)
+    r = nx.utils.zipf_rv(2.3)
     assert type(r), int
-    pytest.raises(ValueError, zipf_rv, 0.5)
-    pytest.raises(ValueError, zipf_rv, 2, xmin=0)
+    pytest.raises(ValueError, nx.utils.zipf_rv, 0.5)
+    pytest.raises(ValueError, nx.utils.zipf_rv, 2, xmin=0)
 
 
 def test_random_weighted_sample():
     mapping = {"a": 10, "b": 20}
-    s = random_weighted_sample(mapping, 2, seed=1)
-    s = random_weighted_sample(mapping, 2)
+    s = nx.utils.random_weighted_sample(mapping, 2, seed=1)
+    s = nx.utils.random_weighted_sample(mapping, 2)
     assert sorted(s) == sorted(mapping.keys())
-    pytest.raises(ValueError, random_weighted_sample, mapping, 3)
+    pytest.raises(ValueError, nx.utils.random_weighted_sample, mapping, 3)
 
 
 def test_random_weighted_choice():
     mapping = {"a": 10, "b": 0}
-    c = weighted_choice(mapping, seed=1)
-    c = weighted_choice(mapping)
+    c = nx.utils.weighted_choice(mapping, seed=1)
+    c = nx.utils.weighted_choice(mapping)
     assert c == "a"


### PR DESCRIPTION
Fixes #8227.

This PR adds the check suggested in the linked issue for zero-degree nodes, which cannot appear in a valid degree sequence.

To do so, a utility function `is_valid_tree_degree_sequence` has been added, which returns whether a degree sequence follows two basic rules: the number of nodes must be equal to one more than the number of edges, and there cannot be any negative degrees in the degree sequence unless the degree sequence represents the trivial graph. It also gives a string representing which of the two checks was failed, to simplify error reporting downstream; I wasn't sure whether returning the string was worth doing; perhaps downstream functions using this utility function should just raise with a generic `"invalid degree sequence for tree"` message.

This change affects `random_powerlaw_tree_sequence` in that it now becomes (significantly?) less likely to yield a "valid" sequence in the given number of `tries`.