### PR TITLE
MAINT: consolidate rescaling helpers for betweenness centralities

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -212,7 +212,7 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
 
     Notes
     -----
-    The algorithm is from Ulrik Brandes [1]_.
+    The algorithm is from Ulrik Brandes [2]_.
 
     For weighted graphs the edge weights must be greater than zero.
     Zero edge weights can produce an infinite number of equal length

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -170,7 +170,7 @@ def edge_betweenness_centrality_subset(
 
     Notes
     -----
-    The basic algorithm is from [1]_.
+    The basic algorithm is from [2]_.
 
     For weighted graphs the edge weights must be greater than zero.
     Zero edge weights can produce an infinite number of equal length


### PR DESCRIPTION
This PR refactors the rescaling code in `betweenness.py` and `betweenness_subset.py` to use the common `_rescale` function. Previously, these were separate functions for each situation (subset or not, node or edge).

Only one of the four cases (`_rescale` in `betweenness.py`, the version we keep) uses the more complicated logic with `k`, `endpoints`, and `sampled_nodes`. By reworking the helper function to no longer use a `k` parameter (instead relying on `sampled_nodes` being either `None`, or having length `k`), and giving default values to the other parameters, we end up being able to reuse the same code each time (modulo an off-by one change for edge betweenness centralities).

It also fixes an incorrect reference for the edge betweenness centralities.

One thing that stood out to me while working on this is that the (removed in this PR) function `_rescale_e` in `betweenness.py` had a `k` parameter, but never set it to anything other than `None` (and it didn't have a `sampled_nodes` parameter at all). None of the tests seem to catch this no matter what I set it to, but it'd be good to make sure this is supposed to be ignored!