### PR TITLE
Optimizing is_reachable

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -107,7 +107,7 @@ def number_connected_components(G):
     For undirected graphs only.
 
     """
-    return sum(1 for cc in connected_components(G))
+    return sum(1 for _ in connected_components(G))
 
 
 @not_implemented_for("directed")
@@ -154,7 +154,7 @@ def is_connected(G):
         raise nx.NetworkXPointlessConcept(
             "Connectivity is undefined for the null graph."
         )
-    return sum(1 for node in _plain_bfs(G, n, arbitrary_element(G))) == len(G)
+    return len(_plain_bfs(G, n, arbitrary_element(G))) == n
 
 
 @not_implemented_for("directed")


### PR DESCRIPTION
## The change

`is_reachable` implementation relies on counting amount of elements of the connected component returned by `_plain_bfs(G, n, arbitrary_element(G)`. Since `_plain_bfs` already returns a set, we can just call `len` which is faster.

```
-    return sum(1 for node in _plain_bfs(G, n, arbitrary_element(G))) == len(G)
+    return len(_plain_bfs(G, n, arbitrary_element(G))) == n
```

Extra: a nit renaming unused variable `cc` to `_`.

### Quick benchmarking:

```python
import networkx as nx
import timeit

n = 30_000
G = nx.path_graph(n)

def check_connected():
    nx.is_connected(G)

number_of_runs = 100
total_time = timeit.timeit(check_connected, number=number_of_runs)
print(f"Average time over {number_of_runs} runs: {total_time / number_of_runs:.6f} seconds")
```

#### Before:
```
Average time over 100 runs: 0.006738 seconds
```
#### After:
```
Average time over 100 runs: 0.005971 seconds
```
 
Which is 11% faster on graphs with multiple nodes.