### PR TITLE
MAINT: `louvain`: avoid multiple `is_directed` checks and clean up autoformatting in helper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@
 
 repos:
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.6.2
+    rev: 787fb9f542b140ba0b2aced38e6a3e68021647a3 # frozen: v3.5.3
     hooks:
       - id: prettier
         files: \.(html|md|toml|yml|yaml)
         args: [--prose-wrap=preserve]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
     hooks:
       # Sanity checks
       - id: check-added-large-files
@@ -36,7 +36,7 @@ repos:
         exclude: test_p2g.py
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: f0fe93c067104b76ffb58852abe79673a8429bd1 # frozen: v0.11.8
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes", "--exit-non-zero-on-fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@
 
 repos:
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: 787fb9f542b140ba0b2aced38e6a3e68021647a3 # frozen: v3.5.3
+    rev: v3.6.2
     hooks:
       - id: prettier
         files: \.(html|md|toml|yml|yaml)
         args: [--prose-wrap=preserve]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: v6.0.0
     hooks:
       # Sanity checks
       - id: check-added-large-files
@@ -36,7 +36,7 @@ repos:
         exclude: test_p2g.py
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: f0fe93c067104b76ffb58852abe79673a8429bd1 # frozen: v0.11.8
+    rev: v0.13.2
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes", "--exit-non-zero-on-fix"]

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -98,7 +98,7 @@ def louvain_communities(
     --------
     >>> import networkx as nx
     >>> G = nx.petersen_graph()
-    >>> nx.community.louvain_communities(G, seed=123)
+    >>> nx.community.louvain_communities(G, seed=6)
     [{0, 4, 5, 7, 9}, {1, 2, 3, 6, 8}]
 
     Notes

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -251,6 +251,14 @@ def _one_level(G, m, partition, resolution=1, is_directed=False, seed=None):
         out_degrees = dict(G.out_degree(weight="weight"))
         Stot_in = list(in_degrees.values())
         Stot_out = list(out_degrees.values())
+
+        def _inc_or_dec(com, sign, u):
+            Stot_in[com] += sign * in_degrees[u]
+            Stot_out[com] += sign * out_degrees[u]
+
+        def _get_prod(com, u):
+            return out_degrees[u] * Stot_in[com] + in_degrees[u] * Stot_out[com]
+
         # Calculate weights for both in and out neighbors without considering self-loops
         nbrs = {}
         for u in G:
@@ -264,6 +272,13 @@ def _one_level(G, m, partition, resolution=1, is_directed=False, seed=None):
     else:
         degrees = dict(G.degree(weight="weight"))
         Stot = list(degrees.values())
+
+        def _inc_or_dec(com, sign, u):
+            Stot[com] += sign * degrees[u]
+
+        def _get_prod(com, u):
+            return degrees[u] * Stot[com] / 2
+
         nbrs = {u: {v: data["weight"] for v, data in G[u].items() if v != u} for u in G}
     rand_nodes = list(G.nodes)
     seed.shuffle(rand_nodes)
@@ -273,45 +288,26 @@ def _one_level(G, m, partition, resolution=1, is_directed=False, seed=None):
     while nb_moves > 0:
         nb_moves = 0
         for u in rand_nodes:
-            if is_directed:
-                idu = in_degrees[u]
-                odu = out_degrees[u]
-
-                def _inc_or_dec(com, sign):
-                    Stot_in[com] += sign * idu
-                    Stot_out[com] += sign * odu
-
-                def _get_prod(com):
-                    return odu * Stot_in[com] + idu * Stot_out[com]
-            else:
-                du = degrees[u]
-
-                def _inc_or_dec(com, sign):
-                    Stot[com] += sign * du
-
-                def _get_prod(com):
-                    return du * Stot[com] / 2
-
             # Get current community and neighbor weights.
             best_com = node2com[u]
             weights2com = _neighbor_weights(nbrs[u], node2com)
 
             # Calculate modularity for current community.
-            _inc_or_dec(best_com, -1)
-            bc_prod = _get_prod(best_com)
+            _inc_or_dec(best_com, -1, u)
+            bc_prod = _get_prod(best_com, u)
 
             # Multiply everything by `m` compared to formula because we only care about argmax.
             best_mod = weights2com[best_com] - factor * bc_prod
 
             # Find best community among neighbors.
             for nbr_com, wt in weights2com.items():
-                nc_prod = _get_prod(nbr_com)
+                nc_prod = _get_prod(nbr_com, u)
                 new_mod = wt - factor * nc_prod
                 if new_mod > best_mod:
                     best_mod = new_mod
                     best_com = nbr_com
 
-            _inc_or_dec(best_com, 1)
+            _inc_or_dec(best_com, 1, u)
 
             if best_com != node2com[u]:
                 com = G.nodes[u].get("nodes", {u})

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -269,6 +269,7 @@ def _one_level(G, m, partition, resolution=1, is_directed=False, seed=None):
     seed.shuffle(rand_nodes)
     nb_moves = 1
     improvement = False
+    factor = resolution / m
     while nb_moves > 0:
         nb_moves = 0
         for u in rand_nodes:
@@ -292,22 +293,22 @@ def _one_level(G, m, partition, resolution=1, is_directed=False, seed=None):
                     return du * Stot[com] / 2
 
             # Get current community and neighbor weights.
-            best_mod = 0
             best_com = node2com[u]
             weights2com = _neighbor_weights(nbrs[u], node2com)
 
             # Calculate modularity for current community.
             _inc_or_dec(best_com, -1)
             bc_prod = _get_prod(best_com)
+
             # Multiply everything by `m` compared to formula because we only care about argmax.
-            remove_cost = -weights2com[best_com] + resolution * bc_prod / m
+            best_mod = weights2com[best_com] - factor * bc_prod
 
             # Find best community among neighbors.
             for nbr_com, wt in weights2com.items():
                 nc_prod = _get_prod(nbr_com)
-                gain = remove_cost + wt - resolution * nc_prod / m
-                if gain > best_mod:
-                    best_mod = gain
+                new_mod = wt - factor * nc_prod
+                if new_mod > best_mod:
+                    best_mod = new_mod
                     best_com = nbr_com
 
             _inc_or_dec(best_com, 1)


### PR DESCRIPTION
Some minor code maintenance to the `_one_level` helper in `louvain_communities`:
- Avoid checking `is_directed` multiple times inside nested loops.
- Clean up autoformatting and handle directed and undirected case more symmetrically.
- Add some comments and blank lines to clarify what is happening at each step.