### PR TITLE
CI: Move slow tests from coverage to dedicated run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           name: Run tests
           command: |
             source venv/bin/activate
-            pytest --cov=networkx --cov-report=html -n 4 --runslow --doctest-modules --durations=20 --pyargs networkx
+            pytest --cov=networkx --cov-report=html -n 4 --doctest-modules --durations=20 --pyargs networkx
       - store_artifacts:
           path: htmlcov
           destination: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,3 +185,25 @@ jobs:
       - name: Test NetworkX
         run: |
           pytest -n auto --doctest-modules --durations=10 --pyargs networkx
+
+  slow-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install packages
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+          python -m pip list
+
+      - name: Run slow tests
+        # NOTE: --runslow adds slow tests to the collection while -k slow
+        # filters out tests that are *not* marked slow, leaving only the
+        # slow tests
+        run: |
+          pytest -n auto --durations=20 --runslow -k slow --pyargs networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[test]
+          python -m pip install .[default,test]
           python -m pip list
 
       - name: Run slow tests


### PR DESCRIPTION
Follow-up to #8178

We recently moved away from codecov for publishing code coverage results instead relying on circleci artifact system.

As noted in the discussion in #8178, NX has traditionally run it's "slow" tests in the coverage job to ensure maximum coverage. The downside is that the slow tests take *extra* long with the coverage plugin, bumping the test runtimes up into the 20 min range.

This PR splits the slow tests out of the coverage job and moves them to their own dedicated job. Thus the slow tests are still being run with each workflow, but without adding the extra burden to the already expensive coverage job.

Note that this will likely lead to a drop in reported coverage for some functions, but this is being actively tracked/worked on in #8223. Note also that some of the "lost" coverage is actually misleading - many of the covered lines originate from the `test_all_random_functions` test module, which is really a collection of smoke tests and often doesn't probe the behavior of the underlying function. In other words, there are some cases where the coverage numbers are artificially inflated by the slow tests (namely the random seed test), so this split makes coverage issues easier to identify and fix properly!