### PR TITLE
ENH: adds ISMAGS support for directed and multigraph with tests and refactor

### DIFF
--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -257,15 +257,15 @@ def color_degree_by_node(G, n_colors, e_colors):
 class EdgeLookup:
     """Class to handle getitem for undirected edges.
 
-    Note that `items()` iterates over one of the two representations of the edge
+    Note that ``items()`` iterates over one of the two representations of the edge
     (u, v) and (v, u). So this technically doesn't violate the Mapping
-    invariant that (k,v) pairs reported by `items()` satisfy `.__getitem__(k) == v`.
+    invariant that (k,v) pairs reported by ``items()`` satisfy ``.__getitem__(k) == v``.
     But we are violating the spirit of the protocol by having keys available
-    for lookup by `__getitem__` that are not reported by `items()`.
+    for lookup by ``__getitem__`` that are not reported by ``items()``.
 
     Note that if we used frozensets for undirected edges we would have the same
-    behavior we see here. You could `__getitem__` either `{u, v}` or `{v, u}`
-    and get the same value -- yet `items()` would only report one of the two.
+    behavior we see here. You could ``__getitem__`` either ``{u, v}`` or ``{v, u}``
+    and get the same value -- yet ``items()`` would only report one of the two.
     So from that perspective we *are* following the Mapping protocol. Our keys
     are undirected edges. We are using 2-tuples as an imperfect representation
     of these edges. We are not using 2-tuples as keys. Only as imperfect edges
@@ -566,8 +566,9 @@ class ISMAGS:
             gt_ = g_things[gt] if not g_multiedge else self.graph[gt[0]][gt[1]]
             if thing_matcher(sgt_, gt_):
                 if sgc in sgc_to_gc or gc in gc_to_sgc:
-                    raise NetworkXError(
-                        f"Matching function {thing_matcher} seems not transitive.\n"
+                    raise nx.NetworkXError(
+                        f"Matching function {thing_matcher} seems not both commutative"
+                        " and transitive.\n"
                         f"Partitions found: {sg_partition=}\n{g_partition=}"
                     )
                 sgc_to_gc[sgc] = gc

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -1106,14 +1106,15 @@ class ISMAGS:
                         # Before refinement they were the same color. So we need to
                         # include all possible orderings/colors within each size.
                         permutations = cls._get_permutations_by_length(refined_part)
-                        assert all(len(p) == 1 for p in permutations)
                         # Add all permutations of the refined parts to each possible
-                        # bottom. So the number of new possible bottoms increases
+                        # bottom. So the number of new possible bottoms is multiplied
                         # by the number of permutations of the refined parts.
                         new_partitions = []
                         for new_partition in more_bottoms:
                             for p in permutations:
-                                new_partitions.append(new_partition + list(p[0]))
+                                # p is tuple-of-tuples-of-sets. Flatten to list-of-sets
+                                flat_p = [s for tup in p for s in tup]
+                                new_partitions.append(new_partition + flat_p)
                         more_bottoms = new_partitions
 
             # reverse more_bottoms to keep the "finding identity" bottom first

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -473,8 +473,7 @@ class ISMAGS:
             # heuristic is length of smallest set in candidates list of sets.
             # Using smallest len avoids computing the intersection of the sets
             # for all nodes.
-            #start_sgn = min(candidates, key=lambda n: min(len(x) for x in candidates[n]))
-            start_sgn = min(candidates, key=lambda n: min(candidates[n], key=len))
+            start_sgn = min(candidates, key=lambda n: min(len(x) for x in candidates[n]))
             candidates[start_sgn] = (frozenset.intersection(*candidates[start_sgn]),)
             yield from self._map_nodes(start_sgn, candidates, constraints)
         else:
@@ -831,7 +830,7 @@ class ISMAGS:
 
                 # Add gn2_options to the right collection. Since cc
                 # is a dict of frozensets of frozensets of node indices it's
-                # a bit clunky. 
+                # a bit clunky.
                 cc[sgn2] = cc[sgn2].union({frozenset(gn2_options)})
 
             for sgn2 in left_to_map:
@@ -845,7 +844,7 @@ class ISMAGS:
                 cc[sgn2].add(frozenset(gn2_options))
 
             # The next node is the one that is unmapped and has fewest candidates
-            next_sgn = min(left_to_map, key=lambda n: min(cc[n], key=len))
+            next_sgn = min(left_to_map, key=lambda n: min(len(x) for x in cc[n]))
             yield from self._map_nodes(next_sgn, cc, constraints, mapping, to_be_mapped)
             # Unmap sgn-gn. Strictly not necessary since it'd get overwritten
             # when making a new mapping for sgn.
@@ -876,7 +875,7 @@ class ISMAGS:
             # theory.
             for nodes in sorted(to_be_mapped, key=sorted):
                 # Find the isomorphism between subgraph[to_be_mapped] <= graph
-                next_sgn = min(nodes, key=lambda n: min(candidates[n], key=len))
+                next_sgn = min(nodes, key=lambda n: min(len(x) for x in candidates[n]))
                 isomorphs = self._map_nodes(
                     next_sgn, candidates, constraints, to_be_mapped=nodes
                 )

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -298,26 +298,26 @@ def are_all_equal(iterable):
     return all(item == first for item in iterator)
 
 
-def make_partition(things, thing_matcher):
+def make_partition(items, test):
     """
-    Partition things into sets based on the outcome of ``thing_matcher(item1, item2)``.
-    Pairs of things for which `thing_matcher` returns `True` end up in the same set.
+    Partitions items into sets based on the outcome of ``test(item1, item2)``.
+    Pairs of items for which `test` returns `True` end up in the same set.
 
     Parameters
     ----------
-    things : collections.abc.Iterable[collections.abc.Hashable]
-        Things to partition
+    items : collections.abc.Iterable[collections.abc.Hashable]
+        Items to partition
     test : collections.abc.Callable[collections.abc.Hashable, collections.abc.Hashable]
-        A function that will be called with 2 things taken from `things`.
-        Should return `True` if those 2 things match so need to end up in the same
+        A function that will be called with 2 arguments, taken from items.
+        Should return `True` if those 2 items match/tests so need to end up in the same
         part of the partition, and `False` otherwise.
 
     Returns
     -------
     list[set]
         A partition as a list of sets (the parts). Each set contains some of
-        the things in `things`, such that all things are in one part and every
-        pair of things in each part matches. The following will be true:
+        the items in `items`, such that all items are in exactly one part and every
+        pair of items in each part matches. The following will be true:
         ``all(thing_matcher(*pair) for pair in itertools.combinations(set, 2))``
 
     Notes
@@ -325,16 +325,16 @@ def make_partition(things, thing_matcher):
     The function `test` is assumed to be transitive: if ``test(a, b)`` and
     ``test(b, c)`` return ``True``, then ``test(a, c)`` must also be ``True``.
     """
-    part_by_1st_thing = {}
-    for thing1 in things:
-        for thing2, part in part_by_1st_thing.items():
-            if thing_matcher(thing1, thing2):
-                part.add(thing1)
+    partitions = []
+    for item in items:
+        for partition in partitions:
+            p_item = next(iter(partition))
+            if test(item, p_item):
+                partition.add(item)
                 break
         else:  # No break
-            part_by_1st_thing[thing1] = {thing1}
-    return list(part_by_1st_thing.values())
-    partition = []
+            partitions.append({item})
+    return partitions
 
 
 def node_to_part_ID_dict(partition):
@@ -1125,7 +1125,6 @@ class ISMAGS:
                             for p in permutations:
                                 new_partitions.append(new_partition + list(p[0]))
                         more_bottoms = new_partitions
-
 
             # reverse more_bottoms to keep the "finding identity" bottom first
             possible_bottoms.extend(more_bottoms[::-1])

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -280,18 +280,6 @@ class ISMAGS:
     ----------
     graph: networkx.Graph
     subgraph: networkx.Graph
-    node_equality: collections.abc.Callable
-        The function called to see if two nodes should be considered equal.
-        It's signature looks like this:
-        ``f(graph1: networkx.Graph, node1, graph2: networkx.Graph, node2) -> bool``.
-        `node1` is a node in `graph1`, and `node2` a node in `graph2`.
-        Constructed from the argument `node_match`.
-    edge_equality: collections.abc.Callable
-        The function called to see if two edges should be considered equal.
-        It's signature looks like this:
-        ``f(graph1: networkx.Graph, edge1, graph2: networkx.Graph, edge2) -> bool``.
-        `edge1` is an edge in `graph1`, and `edge2` an edge in `graph2`.
-        Constructed from the argument `edge_match`.
 
     Notes
     -----

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -23,9 +23,9 @@ True
 
 In addition, this implementation also provides an interface to find the
 largest common induced subgraph [2]_ between any two graphs, again taking
-symmetry into account. Given `graph` and `subgraph` the algorithm will remove
-nodes from the `subgraph` until `subgraph` is isomorphic to a subgraph of
-`graph`. Since only the symmetry of `subgraph` is taken into account it is
+symmetry into account. Given ``graph`` and ``subgraph`` the algorithm will remove
+nodes from the ``subgraph`` until ``subgraph`` is isomorphic to a subgraph of
+``graph``. Since only the symmetry of ``subgraph`` is taken into account it is
 worth thinking about how you provide your graphs:
 
 >>> graph1 = nx.path_graph(4)
@@ -91,156 +91,159 @@ Notes
 -----
 - Node and edge equality is assumed to be transitive: if A is equal to B, and
   B is equal to C, then A is equal to C.
-- ISMAGS does a symmetry analysis to find the constraints on isomorphisms if
-  we preclude yielding isomorphisms that differ by a symmetry of the subgraph.
-  For example, is the subgraph is a 4-cycle, every isomorphism would have a
-  symmetric version with the nodes rotated relative to the original isomorphism.
-  By encoding these symmetries as constraints we reduce the search space for
-  isomorphisms and we also simplify processing the resulting isomorphisms.
-
-  **Symmetry Analysis**
-
-  The constraints in ISMAGS are based off the handling in `nauty` and it's many
-  variants, in particular `saucy`, as discussed in the ISMAGS paper [1]_.
-  That paper cites [3]_ for details on symmetry handling. Figure 2 of that paper
-  describes the DFS approach to symmetries used here and relying on a data structure
-  called an Ordered Pair Partitions(OPP). This consists of a pair of partitions
-  where each part represents nodes with the same degree-by-color over all colors.
-  We refine these partitions simultaneously in a way to result in permutations
-  of the nodes that preserve the graph structure. We thus find automorphisms
-  for the subgraph of interest. From those we identify pairs of nodes which
-  are structurally equivalent. We then constrain our problem by requiring the
-  first of the pair to always be assigned first in the isomorphism -- thus
-  constraining the isomorphisms reported to only one example from the set of all
-  symmetrically equivalent isomorphisms. These constraints are computed once
-  based on the subgraph symmetries and then used throughout the DFS search for
-  isomorphisms.
-
-  Finding the symmetries involves a DFS of the OPP wherein we "couple" a node
-  to a node in its degree-by-color part of the partition. This "coupling" is done
-  via assigning a new color in the top partition to the node being coupled,
-  and the same new color in the bottom partition to the node being coupled to.
-  This new color has only one node in each partition. The new color also requires
-  that we "refine" both top and bottom partitions by splitting parts until each
-  part represents a common degree-by-color value. Those refinements introduce
-  new colors as the parts are split during refinement. Parts do not get combined
-  during refinement. So the coupling/refining process always results in at least
-  one new part with only one node in both the top and bottom partition. In practice
-  we usually refine into many new one-node parts in both partitions.
-  We continue in this way until each node has its own part/color in the top partition
-  -- and the node in the bottom partition with that color is the symmetric node.
-  That is, an OPP represents an automorphism, and thus a symmetry
-  of the subgraph when each color has a single node in the top partition and a single
-  node in the bottom partition. From those automorphisms we build up a set of nodes
-  that can be obtained from each other by symmetry (they are mutually symmetric).
-  That set of nodes is called an "orbit" of subgraph under symmetry.
-
-  After finding the orbits for one symmetry, we backtrack in the DFS by removing the
-  latest coupling and replacing it with a coupling from the same top node to a new
-  botom node in its degree-by-color grouping. When all possible couplings for that
-  node are considered we backtrack to the previously coupled node and recouple in
-  a DFS manner.
-
-  We can prune the DFS search tree in helpful ways. The paper [2]_ demonstrates 6
-  situations of interest in the DFS where pruning is possible:
-
-    - An **Automorphism OPP** is an OPP where every part in both partitions
-      contains a single node. The mapping/automorphism is found by mapping
-      each top node to the bottom node in the same color part. For example,
-      ``[({1}, {2}, {3}); ({2}, {3}, {1})]`` represents the mapping of each
-      not to the next in a triangle. It rotates the nodes around the triangle.
-    - The **Identity OPP** is the first automorphism found during the DFS. It
-      appears on the left side of the DFS tree and is first due to our ordering of
-      coupling nodes to be in an arbitrary but fixed ordering of the nodes. This
-      automorphism does not show any symmetries, but it ensures the orbit for each
-      node includes itself and it sets us up for handling the symmetries. Note that
-      a subgraph with no symmetries will only have the identity automorphism.
-    - A **Non-isomorphic OPP** occurs when refinement creates a different number of
-      parts in the top partition than in the bottom partition. This means no symmetries
-      will be found during further processing of that subtree of the DFS. We prune
-      the subtree and continue.
-    - A **Matching OPP** is such that each top part that has more than one node is
-      in fact equal to the bottom part with the same color. The many-node-parts match
-      exactly. The single-node parts then represent symmetries that do not permute
-      any matching nodes. Matching OPPs arise while finding the Identity Mapping. But
-      the single-node parts are identical in the two partitions, so no useful symmetries
-      are found. But after the Identity Mapping is found, every Matching OPP encountered
-      will have different nodes in at least two single-node parts of the same color.
-      So these positions in the DFS provide us with symmetries without any
-      need to find the whole automorphism. We can prune the subtree, update the orbits
-      and backtrack. Any larger symmetries that combine these symmetries with symmetries
-      of the many-node-parts do not need to be explored because the symmetry "generators"
-      found in this way provide a basis for all symmetries. We will find the symmetry
-      generators of the many-node-parts at another subtree of the DFS.
-    - An **Orbit Pruning OPP** is an OPP where the node coupling to be considered next
-      has both nodes already known to be in the same orbit. We have already identified
-      those permutations when we discovered the orbit. So we can prune the resulting
-      subtree. This is the primary pruning discussed in [1]_.
-    - A **Coset Point** in the DFS is a point of the tree when a node is first
-      back-tracked. That is, it's couplings have all been analyzed once and we backtrack
-      to its parent. So, said another way, when a node is backtracked to and is about to
-      be mapped to a different node for the first time, its child in the DFS has been
-      completely analysed. Thus the orbit for that child at this point in the DFS is
-      the full orbit for symmetries involving only that child or larger nodes in the
-      node order. All smaller nodes are mapped to themselves.
-      This orbit is due to symmetries not involving smaller nodes. Such an orbit is
-      called the "coset" of that node. The Coset Point does not lead pruning or to
-      more symmetries. It is the point in the process where we store the **coset** of
-      the node being backtracked. We use the cosets to construct the symmetry
-      constraints.
-
-  Once the pruned DFS tree has been traversed, we have collected the cosets of some
-  special nodes. Often most nodes are not coupled during the progression down the left
-  side of the DFS. They are separated from other nodes during the partition refinement
-  process after coupling. So they never get coupled directly. Thus the number of cosets
-  we find if typically many fewer than the number of nodes.
-
-  We turn those cosets into constraints on the nodes when building non-symmetric
-  isomorphisms. The node who's coset is used is paired with each other node in the
-  coset. These node-pairs form the constraints. During isomorphism construction we
-  always select the first of the constraint before the other. This removes subtrees
-  from the DFS traversal space used to build isomorphisms.
-
-  The constraints we obtain via symmetry analysis of the subgraph are used for
-  finding non-symmetric isomorphisms. We prune the isomorphism tree based on
-  the constraints we obtain from the symmetry analysis.
-
-  **Isomorphism Construction**
-
-  Once we have symmetry constraints on the isomorphisms, ISMAGS constructs the allowed
-  isomorphisms by mapping each node of the subgraph to all possible nodes (with the
-  same degree-by-color) from the graph. We partition all nodes into degree-by-color
-  parts and order the subgraph nodes we consider using smallest part size first.
-  The idea is to try to map the most difficult subgraph nodes first (most difficult
-  here means least number of graph candidates).
-
-  By considering each potential subgraph node to graph candidate mapping image in turn,
-  we perform a DFS traversal of partial mappings. If the mapping is rejected due to
-  the graph neighbors not matching the degree-by-color of the subgraph neighbors, or
-  rejected due to the constraints imposed from symmetry, we prune that subtree and
-  consider a new graph candidate node for that subgraph node. When no more graph
-  candidates remain we backtrack to the previous node in the mapping and consider a
-  new graph candidate for that node. Is we ever to a depth where all subgraph nodes
-  are mapped and no structural requirements or symmetry constraints are violated,
-  we have found an isomorphism. We yield that mapping and backtrack to find other
-  isomorphisms.
-
-  As we visit more neighbors, the graph candidate nodes have to satisfy more structural
-  restrictions. As described in the ISMAGS paper, [1]_, we store each set of structural
-  restrictions separately as a set of possible candidate nodes rather than computing
-  the intersection of that set with the known graph candidates for the subgraph node.
-  We delay taking the intersection until that node is selected to be in the mapping.
-  While choosing the node with fewest candidates, we avoid computing the intersection
-  by using the size of the minimal set to be intersected rather than the size of the
-  intersection. This may make the node ordering slightly worse via a savings of
-  many intersections most of which are not ever needed.
 
 - With a method that yields subgraph_isomorphisms, we can construct functions like
-  `is_subgraph_isomorphic` by checking for any yielded mapping. And functions like
-  `is_isomorphic` by checking whether the subgraph has the same number of nodes as
-  the graph and is also subgraph isomorphic. This subpackage also allows a `symmetry`
-  bool keyword argument so you can find isomorphisms with or without the symmetry
+  ``is_subgraph_isomorphic`` by checking for any yielded mapping. And functions like
+  ``is_isomorphic`` by checking whether the subgraph has the same number of nodes as
+  the graph and is also subgraph isomorphic. This subpackage also allows a
+  ``symmetry`` bool keyword argument so you can find isomorphisms with or
+  without the symmetry constraints.
+
+**Overview**
+
+ISMAGS does a symmetry analysis to find the constraints on isomorphisms if
+we preclude yielding isomorphisms that differ by a symmetry of the subgraph.
+For example, if the subgraph is a 4-cycle, every isomorphism would have a
+symmetric version with the nodes rotated relative to the original isomorphism.
+By encoding these symmetries as constraints we reduce the search space for
+isomorphisms and we also simplify processing the resulting isomorphisms.
+
+**Symmetry Analysis**
+
+The constraints in ISMAGS are based off the handling in ``nauty` and it's many
+variants, in particular ``saucy``, as discussed in the ISMAGS paper [1]_.
+That paper cites [3]_ for details on symmetry handling. Figure 2 of [3]_
+describes the DFS approach to symmetries used here and relying on a data structure
+called an Ordered Pair Partitions(OPP). This consists of a pair of partitions
+where each part represents nodes with the same degree-by-color over all colors.
+We refine these partitions simultaneously in a way to result in permutations
+of the nodes that preserve the graph structure. We thus find automorphisms
+for the subgraph of interest. From those we identify pairs of nodes which
+are structurally equivalent. We then constrain our problem by requiring the
+first of the pair to always be assigned first in the isomorphism -- thus
+constraining the isomorphisms reported to only one example from the set of all
+symmetrically equivalent isomorphisms. These constraints are computed once
+based on the subgraph symmetries and then used throughout the DFS search for
+isomorphisms.
+
+Finding the symmetries involves a DFS of the OPP wherein we "couple" a node
+to a node in its degree-by-color part of the partition. This "coupling" is done
+via assigning a new color in the top partition to the node being coupled,
+and the same new color in the bottom partition to the node being coupled to.
+This new color has only one node in each partition. The new color also requires
+that we "refine" both top and bottom partitions by splitting parts until each
+part represents a common degree-by-color value. Those refinements introduce
+new colors as the parts are split during refinement. Parts do not get combined
+during refinement. So the coupling/refining process always results in at least
+one new part with only one node in both the top and bottom partition. In practice
+we usually refine into many new one-node parts in both partitions.
+We continue in this way until each node has its own part/color in the top partition
+-- and the node in the bottom partition with that color is the symmetric node.
+That is, an OPP represents an automorphism, and thus a symmetry
+of the subgraph when each color has a single node in the top partition and a single
+node in the bottom partition. From those automorphisms we build up a set of nodes
+that can be obtained from each other by symmetry (they are mutually symmetric).
+That set of nodes is called an "orbit" of the subgraph under symmetry.
+
+After finding the orbits for one symmetry, we backtrack in the DFS by removing the
+latest coupling and replacing it with a coupling from the same top node to a new
+botom node in its degree-by-color grouping. When all possible couplings for that
+node are considered we backtrack to the previously coupled node and recouple in
+a DFS manner.
+
+We can prune the DFS search tree in helpful ways. The paper [2]_ demonstrates 6
+situations of interest in the DFS where pruning is possible:
+
+- An **Automorphism OPP** is an OPP where every part in both partitions
+  contains a single node. The mapping/automorphism is found by mapping
+  each top node to the bottom node in the same color part. For example,
+  ``[({1}, {2}, {3}); ({2}, {3}, {1})]`` represents the mapping of each
+  node to the next in a triangle. It rotates the nodes around the triangle.
+- The **Identity OPP** is the first automorphism found during the DFS. It
+  appears on the left side of the DFS tree and is first due to our ordering of
+  coupling nodes to be in an arbitrary but fixed ordering of the nodes. This
+  automorphism does not show any symmetries, but it ensures the orbit for each
+  node includes itself and it sets us up for handling the symmetries. Note that
+  a subgraph with no symmetries will only have the identity automorphism.
+- A **Non-isomorphic OPP** occurs when refinement creates a different number of
+  parts in the top partition than in the bottom partition. This means no symmetries
+  will be found during further processing of that subtree of the DFS. We prune
+  the subtree and continue.
+- A **Matching OPP** is such that each top part that has more than one node is
+  in fact equal to the bottom part with the same color. The many-node-parts match
+  exactly. The single-node parts then represent symmetries that do not permute
+  any matching nodes. Matching OPPs arise while finding the Identity Mapping. But
+  the single-node parts are identical in the two partitions, so no useful symmetries
+  are found. But after the Identity Mapping is found, every Matching OPP encountered
+  will have different nodes in at least two single-node parts of the same color.
+  So these positions in the DFS provide us with symmetries without any
+  need to find the whole automorphism. We can prune the subtree, update the orbits
+  and backtrack. Any larger symmetries that combine these symmetries with symmetries
+  of the many-node-parts do not need to be explored because the symmetry "generators"
+  found in this way provide a basis for all symmetries. We will find the symmetry
+  generators of the many-node-parts at another subtree of the DFS.
+- An **Orbit Pruning OPP** is an OPP where the node coupling to be considered next
+  has both nodes already known to be in the same orbit. We have already identified
+  those permutations when we discovered the orbit. So we can prune the resulting
+  subtree. This is the primary pruning discussed in [1]_.
+- A **Coset Point** in the DFS is a point of the tree when a node is first
+  back-tracked. That is, it's couplings have all been analyzed once and we backtrack
+  to its parent. So, said another way, when a node is backtracked to and is about to
+  be mapped to a different node for the first time, its child in the DFS has been
+  completely analysed. Thus the orbit for that child at this point in the DFS is
+  the full orbit for symmetries involving only that child or larger nodes in the
+  node order. All smaller nodes are mapped to themselves.
+  This orbit is due to symmetries not involving smaller nodes. Such an orbit is
+  called the "coset" of that node. The Coset Point does not lead pruning or to
+  more symmetries. It is the point in the process where we store the **coset** of
+  the node being backtracked. We use the cosets to construct the symmetry
   constraints.
+
+Once the pruned DFS tree has been traversed, we have collected the cosets of some
+special nodes. Often most nodes are not coupled during the progression down the left
+side of the DFS. They are separated from other nodes during the partition refinement
+process after coupling. So they never get coupled directly. Thus the number of cosets
+we find if typically many fewer than the number of nodes.
+
+We turn those cosets into constraints on the nodes when building non-symmetric
+isomorphisms. The node who's coset is used is paired with each other node in the
+coset. These node-pairs form the constraints. During isomorphism construction we
+always select the first of the constraint before the other. This removes subtrees
+from the DFS traversal space used to build isomorphisms.
+
+The constraints we obtain via symmetry analysis of the subgraph are used for
+finding non-symmetric isomorphisms. We prune the isomorphism tree based on
+the constraints we obtain from the symmetry analysis.
+
+**Isomorphism Construction**
+
+Once we have symmetry constraints on the isomorphisms, ISMAGS constructs the allowed
+isomorphisms by mapping each node of the subgraph to all possible nodes (with the
+same degree-by-color) from the graph. We partition all nodes into degree-by-color
+parts and order the subgraph nodes we consider using smallest part size first.
+The idea is to try to map the most difficult subgraph nodes first (most difficult
+here means least number of graph candidates).
+
+By considering each potential subgraph node to graph candidate mapping image in turn,
+we perform a DFS traversal of partial mappings. If the mapping is rejected due to
+the graph neighbors not matching the degree-by-color of the subgraph neighbors, or
+rejected due to the constraints imposed from symmetry, we prune that subtree and
+consider a new graph candidate node for that subgraph node. When no more graph
+candidates remain we backtrack to the previous node in the mapping and consider a
+new graph candidate for that node. If we ever get to a depth where all subgraph nodes
+are mapped and no structural requirements or symmetry constraints are violated,
+we have found an isomorphism. We yield that mapping and backtrack to find other
+isomorphisms.
+
+As we visit more neighbors, the graph candidate nodes have to satisfy more structural
+restrictions. As described in the ISMAGS paper, [1]_, we store each set of structural
+restrictions separately as a set of possible candidate nodes rather than computing
+the intersection of that set with the known graph candidates for the subgraph node.
+We delay taking the intersection until that node is selected to be in the mapping.
+While choosing the node with fewest candidates, we avoid computing the intersection
+by using the size of the minimal set to be intersected rather than the size of the
+intersection. This may make the node ordering slightly worse via a savings of
+many intersections most of which are not ever needed.
 
 References
 ----------
@@ -502,8 +505,8 @@ class ISMAGS:
             self._ge_colors = EdgeLookup(node_to_part_ID_dict(self._ge_partition))
 
     def create_aligned_partitions(self, thing_matcher, sg_things, g_things):
-        """Partitions of `things` (nodes or edges) from subgraph and graph
-        based on function `match`.
+        """Partitions of "things" (nodes or edges) from subgraph and graph
+        based on function `thing_matcher`.
 
         Returns: sg_partition, g_partition, number_of_matched_parts
 
@@ -1143,8 +1146,8 @@ class ISMAGS:
             if len(top) > 1 or len(bot) > 1:
                 # ignore parts with > 1 element when they are equal
                 # These are called matching partitions in Katebi 2012.
-                # Symmetries in matching partitions are built by looking only
-                # parts that have 1 element.
+                # Symmetries in matching partitions are built by considering
+                # only parts that have 1 element.
                 if top == bot:
                     continue
                 raise IndexError(
@@ -1221,7 +1224,7 @@ class ISMAGS:
                     # else load the OPP onto queue for further exploration
                     # Note that we check for Orbit pruning later because orbits may
                     # be updated while OPP is sitting on the queue.
-                    # Note: that we check for non-isomorphic OPPs in `_refine_opp`.
+                    # Note that we check for non-isomorphic OPPs in `_refine_opp`.
                     if finding_identity:
                         # Note: allow zero size parts in identity check
                         #       b/c largest_common_subgraph allows empty parts

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -195,32 +195,8 @@ def partition_to_color(partitions):
     -------
     dict
     """
-    colors = {}
-    for color, keys in enumerate(partitions):
-        for key in keys:
-            colors[key] = color
+    colors = {key: color for color, keys in enumerate(partitions) for key in keys}
     return colors
-
-
-def intersect(collection_of_sets):
-    """
-    Given an collection of sets, returns the intersection of those sets.
-
-    Parameters
-    ----------
-    collection_of_sets: collections.abc.Collection[set]
-        A collection of sets.
-
-    Returns
-    -------
-    set
-        An intersection of all sets in `collection_of_sets`. Will have the same
-        type as the item initially taken from `collection_of_sets`.
-    """
-    collection_of_sets = list(collection_of_sets)
-    first = collection_of_sets.pop()
-    out = reduce(set.intersection, collection_of_sets, set(first))
-    return type(first)(out)
 
 
 class ISMAGS:
@@ -482,7 +458,7 @@ class ISMAGS:
 
         if any(candidates.values()):
             start_sgn = min(candidates, key=lambda n: min(candidates[n], key=len))
-            candidates[start_sgn] = (intersect(candidates[start_sgn]),)
+            candidates[start_sgn] = (frozenset.intersection(*candidates[start_sgn]),)
             yield from self._map_nodes(start_sgn, candidates, constraints)
         else:
             return
@@ -494,10 +470,12 @@ class ISMAGS:
         it has to nodes of a specific color.
         """
         counts = Counter()
+        # FIXME directed graphs
         neighbors = graph[node]
         for neighbor in neighbors:
             n_color = node_color[neighbor]
             if (node, neighbor) in edge_color:
+                # FIXME directed graphs
                 e_color = edge_color[node, neighbor]
             else:
                 e_color = edge_color[neighbor, node]
@@ -831,7 +809,7 @@ class ISMAGS:
         # Note, we modify candidates here. Doesn't seem to affect results, but
         # remember this.
         # candidates = candidates.copy()
-        sgn_candidates = intersect(candidates[sgn])
+        sgn_candidates = frozenset.intersection(*candidates[sgn])
         candidates[sgn] = frozenset([sgn_candidates])
         for gn in sgn_candidates:
             # We're going to try to map sgn to gn.
@@ -848,7 +826,9 @@ class ISMAGS:
             left_to_map = to_be_mapped - set(mapping.keys())
 
             new_candidates = candidates.copy()
+            # FIXME directed graphs
             sgn_nbrs = set(self.subgraph[sgn])
+            # FIXME directed graphs
             not_gn_nbrs = set(self.graph.nodes) - set(self.graph[gn])
             for sgn2 in left_to_map:
                 if sgn2 not in sgn_nbrs:
@@ -871,6 +851,7 @@ class ISMAGS:
                 )
 
                 if (sgn, sgn2) in constraints:
+                    # FIXME directed graphs
                     gn2_options = {gn2 for gn2 in self.graph if gn2 > gn}
                 elif (sgn2, sgn) in constraints:
                     gn2_options = {gn2 for gn2 in self.graph if gn2 < gn}

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -806,9 +806,11 @@ class ISMAGS:
         color_degree = color_degree_by_node(graph, node_colors, edge_colors)
         while not all(are_all_equal(color_degree[n] for n in p) for p in partition):
             partition = [
-                p for part in partition
+                p
+                for part in partition
                 for p in (
-                    [part] if are_all_equal(color_degree[n] for n in part)
+                    [part]
+                    if are_all_equal(color_degree[n] for n in part)
                     else sorted(make_partition(part, equal_color), key=len)
                 )
             ]
@@ -1096,7 +1098,7 @@ class ISMAGS:
             if all(are_all_equal(color_degree[n] for n in p) for p in bottom):
                 if len(top) == len(bottom):
                     yield top, bottom
-                #else Non-isomorphic OPP (pruned here)
+                # else Non-isomorphic OPP (pruned here)
                 # either way continue to next possible bottom
                 continue
             # refine bottom partition
@@ -1251,5 +1253,5 @@ class ISMAGS:
                     # its first DFS traversal. DFS is about to go to previous node.
                     # Make copy so future orbit changes do not change the coset.
                     cosets[node] = orbits[orbit_id[node]].copy()
-                    assert len(cosets[node]) > 1, f'cosets[{node}]= {cosets[node]}'
+                    assert len(cosets[node]) > 1, f"cosets[{node}]= {cosets[node]}"
         return cosets

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -727,13 +727,13 @@ class ISMAGS:
         Find all subgraph isomorphisms honoring constraints.
         The collection `candidate_sets` is stored as a dict-of-set-of-frozenset.
         The dict is keyed by node to a collection of candidate frozensets. Any
-        viable candidate must nelong to all the frozensets in the collection.
+        viable candidate must belong to all the frozensets in the collection.
         So each frozenset added to the collection is a restriction on the candidates.
 
         According to the paper, we store the collection of sets rather than their
         intersection to delay computing many intersections with the hope of avoiding
-        them completely. having the middle collection be a set also means that
-        duplicate restrictions on candidates are ignored, avoided another intersection.
+        them completely. Having the middle collection be a set also means that
+        duplicate restrictions on candidates are ignored, avoiding another intersection.
         """
         # shortcuts for speed
         subgraph = self.subgraph

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -114,6 +114,7 @@ from functools import reduce, wraps
 
 import networkx as nx
 
+
 def are_all_equal(iterable):
     """
     Returns ``True`` if and only if all elements in `iterable` are equal; and
@@ -239,6 +240,7 @@ def color_degree_by_node(G, n_colors, e_colors):
 
 class EdgeLookup:
     """Class to handle getitem for undirected edges"""
+
     def __init__(self, edge_dict):
         self.edge_dict = edge_dict
 
@@ -367,19 +369,23 @@ class ISMAGS:
         sg_multiedge = isinstance(sg_things, nx.classes.reportviews.OutEdgeDataView)
         g_multiedge = isinstance(g_things, nx.classes.reportviews.OutEdgeDataView)
         if not sg_multiedge:
+
             def sg_match(thing1, thing2):
                 return match(sg_things[thing1], sg_things[thing2])
 
         else:  # multiedges (note nodes of multigraphs use simple case above)
+
             def sg_match(thing1, thing2):
                 (u1, v1), (u2, v2) = thing1, thing2
                 return match(self.subgraph[u1][v1], self.subgraph[u2][v2])
 
         if not g_multiedge:
+
             def g_match(thing1, thing2):
                 return match(g_things[thing1], g_things[thing2])
 
         else:  # multiedges (note nodes of multigraphs use simple case above)
+
             def g_match(thing1, thing2):
                 (u1, v1), (u2, v2) = thing1, thing2
                 return match(self.graph[u1][v1], self.graph[u2][v2])
@@ -529,7 +535,7 @@ class ISMAGS:
         candidate_sets = self._get_node_color_candidate_sets()
 
         if any(candidate_sets.values()):
-            relevant_parts = self._sgn_partition[:self.N_node_colors]
+            relevant_parts = self._sgn_partition[: self.N_node_colors]
             to_be_mapped = {frozenset(n for p in relevant_parts for n in p)}
             yield from self._largest_common_subgraph(
                 candidate_sets, constraints, to_be_mapped
@@ -716,8 +722,7 @@ class ISMAGS:
                         more_partitions = new_partitions
             possible_partitions.extend(more_partitions[::-1])
 
-
-    def _map_nodes(self, sgn, candidate_sets, constraints, mapping=None, to_be_mapped=None):
+    def _map_nodes(self, sgn, candidate_sets, constraints, to_be_mapped=None):
         """
         Find all subgraph isomorphisms honoring constraints.
         The collection `candidate_sets` is stored as a dict-of-set-of-frozenset.
@@ -732,17 +737,20 @@ class ISMAGS:
         """
         # shortcuts for speed
         subgraph = self.subgraph
+        subgraph_adj = subgraph._adj
         graph = self.graph
+        graph_adj = graph._adj
         self_ge_partition = self._ge_partition
         self_sge_colors = self._sge_colors
         is_directed = subgraph.is_directed()
+
         gn_ID_to_node = list(graph)
         gn_node_to_ID = {n: id for id, n in enumerate(graph)}
 
         mapping = {}
         rev_mapping = {}
         if to_be_mapped is None:
-            to_be_mapped = self.subgraph._adj.keys()
+            to_be_mapped = subgraph_adj.keys()
 
         # Note that we don't copy candidates here. This means we leak
         # information between the recursive branches. This is intentional!
@@ -788,8 +796,8 @@ class ISMAGS:
 
                 # update the candidate_sets for unmapped sgn based on sgn mapped
                 if not is_directed:
-                    sgn_nbrs = subgraph._adj[sgn]
-                    not_gn_nbrs = graph._adj.keys() - graph._adj[gn].keys()
+                    sgn_nbrs = subgraph_adj[sgn]
+                    not_gn_nbrs = graph_adj.keys() - graph_adj[gn].keys()
                     for sgn2 in left_to_map:
                         # edge color must match when sgn2 connected to sgn
                         if sgn2 not in sgn_nbrs:
@@ -808,9 +816,11 @@ class ISMAGS:
                             [frozenset(gn2_options)]
                         )
                 else:  # directed
-                    sgn_nbrs = subgraph._adj[sgn].keys()
+                    sgn_nbrs = subgraph_adj[sgn].keys()
                     sgn_preds = subgraph._pred[sgn].keys()
-                    not_gn_nbrs = graph._adj.keys() - graph._adj[gn].keys() - graph._pred[gn].keys()
+                    not_gn_nbrs = (
+                        graph_adj.keys() - graph_adj[gn].keys() - graph._pred[gn].keys()
+                    )
                     for sgn2 in left_to_map:
                         # edge color must match when sgn2 connected to sgn
                         if sgn2 not in sgn_nbrs:
@@ -836,10 +846,10 @@ class ISMAGS:
                 for sgn2 in left_to_map:
                     # symmetry must match. constraints mean gn2>gn iff sgn2>sgn
                     if (sgn, sgn2) in constraints:
-                        gn2_options = set(gn_ID_to_node[gn_node_to_ID[gn] + 1:])
+                        gn2_options = set(gn_ID_to_node[gn_node_to_ID[gn] + 1 :])
                         # gn2_options = {gn2 for gn2 in self.graph if gn2 > gn}
                     elif (sgn2, sgn) in constraints:
-                        gn2_options = set(gn_ID_to_node[:gn_node_to_ID[gn]])
+                        gn2_options = set(gn_ID_to_node[: gn_node_to_ID[gn]])
                         # gn2_options = {gn2 for gn2 in self.graph if gn2 < gn}
                     else:
                         continue  # pragma: no cover
@@ -1051,7 +1061,6 @@ class ISMAGS:
                         graph,
                         edge_colors,
                     )
-                    partitions=list(partitions)
                     new_q = []
                     for opp in partitions:
                         if all(len(top) <= 1 for top in opp[0]):

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -311,13 +311,13 @@ class TestSubgraphIsomorphism:
         G2.add_node("B", color="green", freq=1)
         G2.add_node("C", color="blue", freq=2)
 
-        with pytest.raises(nx.NetworkXError, match="\nInvalid partition.*\n.*multiple"):
+        with pytest.raises(nx.NetworkXError, match="\nInvalid partition"):
             iso.ISMAGS(G1, G2, node_match=non_transitive_match)
 
-        with pytest.raises(nx.NetworkXError, match="\nInvalid partition.*\n.*a part"):
+        with pytest.raises(nx.NetworkXError, match="\nInvalid partition"):
             iso.ISMAGS(G1, G2, node_match=simple_non_commutative_match)
 
-        with pytest.raises(nx.NetworkXError, match="\nInvalid partition.*\n.*a part"):
+        with pytest.raises(nx.NetworkXError, match="\nInvalid partition"):
             iso.ISMAGS(G1, G2, node_match=non_commutative_match)
 
 

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -231,49 +231,97 @@ class TestSubgraphIsomorphism:
 
 
 class TestWikipediaExample:
+    # example in wikipedia is g1a and g2b
+    # 1 have letter nodes, 2 have number nodes
+    # b have some edges reversed vs a (undirected still isomorphic)
+    # reversed edges marked with blank comment `#`
+    # isomorphism = {'a': 1, 'g': 2, 'b': 3, 'c': 6, 'h': 4, 'i': 5, 'j': 7, 'd': 8}
+
     # Nodes 'a', 'b', 'c' and 'd' form a column.
     # Nodes 'g', 'h', 'i' and 'j' form a column.
-    g1edges = [
+    g1a_edges = [
         ["a", "g"],
-        ["a", "h"],
+        ["a", "h"], #
         ["a", "i"],
-        ["b", "g"],
+        ["b", "g"], #
         ["b", "h"],
         ["b", "j"],
-        ["c", "g"],
-        ["c", "i"],
+        ["c", "g"], #
+        ["c", "i"], #
         ["c", "j"],
-        ["d", "h"],
+        ["d", "h"], #
         ["d", "i"],
-        ["d", "j"],
+        ["d", "j"], #
+    ]
+    g1b_edges = [
+        ["a", "g"],
+        ["h", "a"], #
+        ["a", "i"],
+        ["g", "b"], #
+        ["b", "h"],
+        ["b", "j"],
+        ["g", "c"], #
+        ["i", "c"], #
+        ["c", "j"],
+        ["h", "d"], #
+        ["d", "i"],
+        ["j", "d"], #
+    ]
+    g2b_edges = [
+        [1, 2],
+        [1, 4], #
+        [1, 5],
+        [3, 2], #
+        [3, 4],
+        [3, 7],
+        [6, 2], #
+        [6, 5], #
+        [6, 7],
+        [8, 4], #
+        [8, 5],
+        [8, 7], #
     ]
 
     # Nodes 1,2,3,4 form the clockwise corners of a large square.
     # Nodes 5,6,7,8 form the clockwise corners of a small square
-    g2edges = [
+    g2a_edges = [
         [1, 2],
-        [2, 3],
-        [3, 4],
-        [4, 1],
-        [5, 6],
-        [6, 7],
-        [7, 8],
-        [8, 5],
+        [4, 1], #
         [1, 5],
-        [2, 6],
+        [2, 3], #
+        [3, 4],
         [3, 7],
-        [4, 8],
+        [2, 6], #
+        [5, 6], #
+        [6, 7],
+        [4, 8], #
+        [8, 5],
+        [7, 8], #
     ]
 
     def test_graph(self):
-        g1 = nx.Graph(self.g1edges)
-        g2 = nx.Graph(self.g2edges)
-        assert iso.ISMAGS(g1, g2).is_isomorphic()
+        g1a = nx.Graph(self.g1a_edges)
+        g1b = nx.Graph(self.g1b_edges)
+        g2a = nx.Graph(self.g2a_edges)
+        g2b = nx.Graph(self.g2b_edges)
+        assert iso.ISMAGS(g1a, g1b).is_isomorphic()
+        assert iso.ISMAGS(g1a, g2a).is_isomorphic()
+        assert iso.ISMAGS(g1a, g2b).is_isomorphic()
 
-#    def test_digraph(self):
-#        g1 = nx.DiGraph(self.g1edges)
-#        g2 = nx.DiGraph(self.g2edges)
-#        assert iso.ISMAGS(g1, g2).is_isomorphic()
+    def test_digraph(self):
+        # 1 have letter nodes, 2 have number nodes
+        # b have some edges reversed vs a
+        # example in wikipedia is g1a and g2b
+        g1a = nx.DiGraph(self.g1a_edges)
+        g1b = nx.DiGraph(self.g1b_edges)
+        g2a = nx.DiGraph(self.g2a_edges)
+        g2b = nx.DiGraph(self.g2b_edges)
+        assert iso.ISMAGS(g1a, g2b).is_isomorphic()
+        assert iso.ISMAGS(g1b, g2a).is_isomorphic()
+        assert not iso.ISMAGS(g1a, g1b).is_isomorphic()
+        assert not iso.ISMAGS(g2a, g2b).is_isomorphic()
+        assert not iso.ISMAGS(g1a, g2a).is_isomorphic()
+        assert not iso.ISMAGS(g1b, g2b).is_isomorphic()
 
 
 class TestLargestCommonSubgraph:

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -60,9 +60,9 @@ data = [
         # Coupling node 4 to 8 means that 5 and 9
         # are no longer equivalent, pushing them in their own partitions.
         # However, {5, 9} was considered equivalent to {13, 17}, which is *not*
-        # taken into account in the second refinement, tripping a (former)
-        # assertion failure. Note that this is actually the minimal failing
-        # example.
+        # taken into account in the second refinement. The resulting failure
+        # has been fixed with the switch away from recursive functions.
+        # But lets keep testing it here. This was the minimal failing example.
         [],
         [
             (0, 3),
@@ -263,62 +263,62 @@ class TestWikipediaExample:
     # Nodes 'g', 'h', 'i' and 'j' form a column.
     g1a_edges = [
         ["a", "g"],
-        ["a", "h"],  #
+        ["a", "h"],  # edge direction swapped from g1b
         ["a", "i"],
-        ["b", "g"],  #
+        ["b", "g"],  # edge direction swapped from g1b
         ["b", "h"],
         ["b", "j"],
-        ["c", "g"],  #
-        ["c", "i"],  #
+        ["c", "g"],  # edge direction swapped from g1b
+        ["c", "i"],  # edge direction swapped from g1b
         ["c", "j"],
-        ["d", "h"],  #
+        ["d", "h"],  # edge direction swapped from g1b
         ["d", "i"],
-        ["d", "j"],  #
+        ["d", "j"],  # edge direction swapped from g1b
     ]
     g1b_edges = [
         ["a", "g"],
-        ["h", "a"],  #
+        ["h", "a"],  # edge direction swapped from g1a
         ["a", "i"],
-        ["g", "b"],  #
+        ["g", "b"],  # edge direction swapped from g1a
         ["b", "h"],
         ["b", "j"],
-        ["g", "c"],  #
-        ["i", "c"],  #
+        ["g", "c"],  # edge direction swapped from g1a
+        ["i", "c"],  # edge direction swapped from g1a
         ["c", "j"],
-        ["h", "d"],  #
+        ["h", "d"],  # edge direction swapped from g1a
         ["d", "i"],
-        ["j", "d"],  #
+        ["j", "d"],  # edge direction swapped from g1a
     ]
     g2b_edges = [
         [1, 2],
-        [1, 4],  #
+        [1, 4],  # edge direction swapped from g2a
         [1, 5],
-        [3, 2],  #
+        [3, 2],  # edge direction swapped from g2a
         [3, 4],
         [3, 7],
-        [6, 2],  #
-        [6, 5],  #
+        [6, 2],  # edge direction swapped from g2a
+        [6, 5],  # edge direction swapped from g2a
         [6, 7],
-        [8, 4],  #
+        [8, 4],  # edge direction swapped from g2a
         [8, 5],
-        [8, 7],  #
+        [8, 7],  # edge direction swapped from g2a
     ]
 
     # Nodes 1,2,3,4 form the clockwise corners of a large square.
     # Nodes 5,6,7,8 form the clockwise corners of a small square
     g2a_edges = [
         [1, 2],
-        [4, 1],  #
+        [4, 1],  # edge direction swapped from g2b
         [1, 5],
-        [2, 3],  #
+        [2, 3],  # edge direction swapped from g2b
         [3, 4],
         [3, 7],
-        [2, 6],  #
-        [5, 6],  #
+        [2, 6],  # edge direction swapped from g2b
+        [5, 6],  # edge direction swapped from g2b
         [6, 7],
-        [4, 8],  #
+        [4, 8],  # edge direction swapped from g2b
         [8, 5],
-        [7, 8],  #
+        [7, 8],  # edge direction swapped from g2b
     ]
 
     @pytest.mark.parametrize("graph_constructor", [nx.Graph, nx.MultiGraph])

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -22,6 +22,8 @@ def _matches_to_sets(matches):
 
 data = [
     # node_data, edge_data
+    ([0, 1, 2, 3], [(0, 0)]),
+    ([], nx.star_graph(3).edges),
     (range(1, 5), [(1, 2), (2, 4), (4, 3), (3, 1)]),
     (
         [
@@ -77,6 +79,33 @@ data = [
             (16, 17),
         ],
     ),
+    ( # check for unsortable nodes
+        [],
+        [
+            (17, 16),
+            (16, 17),
+            (17, 13),
+            (13, 12),
+            (17, "a"),
+            ("a", "b"),
+            (16, "c"),
+            ("c", "d"),
+            (16, "e"),
+            ("e", "f"),
+        ],
+    ),
+    # Example from Katebi, 2012, Fig 1-3.
+    # Node order specified to almost match their DFS order
+    (
+        [3, 5, 6, 4, 2, 1, 0],
+        set(nx.cycle_graph(4).edges) | set(nx.cycle_graph(range(4, 7)).edges)
+    ),
+    # Example from Houbraken (ISMAGS paper)
+    ([], nx.cycle_graph([1, 2, 4, 3]).edges),
+    # isolated node
+    ([0, 1, 2], [(1, 2)]),
+    # famously lots of symmetries
+    ([], nx.petersen_graph().edges),
 ]
 
 

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -141,12 +141,12 @@ class TestSelfIsomorphism:
         graph.add_edges_from([(2, 5), (5, 6)])
 
         ismags = iso.ISMAGS(graph, graph)
-        ismags_answer = list(ismags.find_isomorphisms(True))
+        ismags_answer = list(ismags.find_isomorphisms(symmetry=True))
         assert ismags_answer == [{n: n for n in graph.nodes}]
 
         graph = nx.relabel_nodes(graph, {0: 0, 1: 1, 2: 2, 3: 3, 4: 6, 5: 4, 6: 5})
         ismags = iso.ISMAGS(graph, graph)
-        ismags_answer = list(ismags.find_isomorphisms(True))
+        ismags_answer = list(ismags.find_isomorphisms(symmetry=True))
         assert ismags_answer == [{n: n for n in graph.nodes}]
 
     def test_double_star_self_isomorphism(self, graph_constructor):
@@ -159,12 +159,12 @@ class TestSelfIsomorphism:
         nx.add_path(graph, [6, 5, 2])
 
         ismags = iso.ISMAGS(graph, graph)
-        ismags_answer = list(ismags.find_isomorphisms(True))
+        ismags_answer = list(ismags.find_isomorphisms(symmetry=True))
         assert ismags_answer == [{n: n for n in graph.nodes}]
 
         graph = nx.relabel_nodes(graph, {0: 0, 1: 1, 2: 2, 3: 3, 4: 6, 5: 4, 6: 5})
         ismags = iso.ISMAGS(graph, graph)
-        ismags_answer = list(ismags.find_isomorphisms(True))
+        ismags_answer = list(ismags.find_isomorphisms(symmetry=True))
         assert ismags_answer == [{n: n for n in graph.nodes}]
 
 
@@ -304,6 +304,7 @@ class TestWikipediaExample:
         ["d", "i"],
         ["d", "j"],  # edge direction swapped from g1b
     ]
+
     g1b_edges = [
         ["a", "g"],
         ["h", "a"],  # edge direction swapped from g1a
@@ -318,6 +319,7 @@ class TestWikipediaExample:
         ["d", "i"],
         ["j", "d"],  # edge direction swapped from g1a
     ]
+
     g2b_edges = [
         [1, 2],
         [1, 4],  # edge direction swapped from g2a
@@ -392,8 +394,8 @@ class TestLargestCommonSubgraph:
         ismags = iso.ISMAGS(
             graph1, graph2, node_match=iso.categorical_node_match("color", None)
         )
-        assert list(ismags.subgraph_isomorphisms_iter(True)) == []
-        assert list(ismags.subgraph_isomorphisms_iter(False)) == []
+        assert list(ismags.subgraph_isomorphisms_iter(symmetry=True)) == []
+        assert list(ismags.subgraph_isomorphisms_iter(symmetry=False)) == []
         found_mcis = _matches_to_sets(ismags.largest_common_subgraph())
         expected = _matches_to_sets(
             [{2: 2, 3: 4, 4: 3, 5: 5}, {2: 4, 3: 2, 4: 3, 5: 5}]
@@ -403,8 +405,8 @@ class TestLargestCommonSubgraph:
         ismags = iso.ISMAGS(
             graph2, graph1, node_match=iso.categorical_node_match("color", None)
         )
-        assert list(ismags.subgraph_isomorphisms_iter(True)) == []
-        assert list(ismags.subgraph_isomorphisms_iter(False)) == []
+        assert list(ismags.subgraph_isomorphisms_iter(symmetry=True)) == []
+        assert list(ismags.subgraph_isomorphisms_iter(symmetry=False)) == []
         found_mcis = _matches_to_sets(ismags.largest_common_subgraph())
         # Same answer, but reversed.
         expected = _matches_to_sets(
@@ -424,7 +426,7 @@ class TestLargestCommonSubgraph:
         ismags1 = iso.ISMAGS(
             graph1, graph2, node_match=iso.categorical_node_match("color", None)
         )
-        assert list(ismags1.subgraph_isomorphisms_iter(True)) == []
+        assert list(ismags1.subgraph_isomorphisms_iter(symmetry=True)) == []
         found_mcis = _matches_to_sets(ismags1.largest_common_subgraph())
         expected = _matches_to_sets([{0: 0, 1: 1, 2: 2}, {1: 0, 3: 2, 2: 1}])
         assert expected == found_mcis
@@ -433,7 +435,7 @@ class TestLargestCommonSubgraph:
         ismags2 = iso.ISMAGS(
             graph2, graph1, node_match=iso.categorical_node_match("color", None)
         )
-        assert list(ismags2.subgraph_isomorphisms_iter(True)) == []
+        assert list(ismags2.subgraph_isomorphisms_iter(symmetry=True)) == []
         found_mcis = _matches_to_sets(ismags2.largest_common_subgraph())
         expected = _matches_to_sets(
             [
@@ -448,8 +450,8 @@ class TestLargestCommonSubgraph:
 
         assert expected == found_mcis
 
-        found_mcis1 = _matches_to_sets(ismags1.largest_common_subgraph(False))
-        found_mcis2 = ismags2.largest_common_subgraph(False)
+        found_mcis1 = _matches_to_sets(ismags1.largest_common_subgraph(symmetry=False))
+        found_mcis2 = ismags2.largest_common_subgraph(symmetry=False)
         found_mcis2 = [{v: k for k, v in d.items()} for d in found_mcis2]
         found_mcis2 = _matches_to_sets(found_mcis2)
 

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -79,7 +79,7 @@ data = [
             (16, 17),
         ],
     ),
-    ( # check for unsortable nodes
+    (  # check for unsortable nodes
         [],
         [
             (17, 16),
@@ -98,7 +98,7 @@ data = [
     # Node order specified to almost match their DFS order
     (
         [3, 5, 6, 4, 2, 1, 0],
-        set(nx.cycle_graph(4).edges) | set(nx.cycle_graph(range(4, 7)).edges)
+        set(nx.cycle_graph(4).edges) | set(nx.cycle_graph(range(4, 7)).edges),
     ),
     # Example from Houbraken (ISMAGS paper)
     ([], nx.cycle_graph([1, 2, 4, 3]).edges),

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -96,7 +96,7 @@ class TestSelfIsomorphism:
             graph, graph, node_match=iso.categorical_node_match("name", None)
         )
         assert ismags.is_isomorphic()
-        assert ismags.is_isomorphic(True)
+        assert ismags.is_isomorphic(symmetry=True)
         assert ismags.subgraph_is_isomorphic()
         assert list(ismags.subgraph_isomorphisms_iter(symmetry=True)) == [
             {n: n for n in graph.nodes}

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -41,7 +41,7 @@ data = [
             (4, 10),
             (10, 11),
         ],
-        id="sun:6-cycle-with-2-path-rays"
+        id="sun:6-cycle-with-2-path-rays",
     ),
     # 0-1-2-3-5
     #  /     \

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -22,16 +22,23 @@ class Testfind_start_node:
         H = nx.path_graph(range(20, 25))
         assert iso.ISMAGS(G, H).is_isomorphic()
 
-        candidates = {
-            10: frozenset([frozenset([21, 22]), frozenset([20, 23, 22])]),
-            11: frozenset([frozenset([20]), frozenset([20, 23, 22, 21])]),
-            12: frozenset([frozenset([21, 22]), frozenset([20, 23, 22])]),
-            13: frozenset([frozenset([21, 22]), frozenset([20, 23, 22])]),
+        cand_sets = {
+            10: set([frozenset([21, 22]), frozenset([20, 23, 22])]),
+            11: set([frozenset([20]), frozenset([20, 23, 22, 21])]),
+            12: set([frozenset([21, 22]), frozenset([20, 23, 22])]),
+            13: set([frozenset([21, 22]), frozenset([20, 23, 22])]),
         }
-        start_sgn = min(candidates, key=lambda n: min(len(x) for x in candidates[n]))
+        start_sgn = min(cand_sets, key=lambda n: min(len(x) for x in cand_sets[n]))
         assert start_sgn == 11
+#        old_start_sgn = min(cand_sets, key=lambda n: min(cand_sets[n], key=len))
+#        print(f"{start_sgn=} {old_start_sgn=}")
+#        print(f"{min(len(x) for x in cand_sets[start_sgn])=}")
+#        print(f"{min(cand_sets[start_sgn], key=len)=}")
+#        assert start_sgn == old_start_sgn  # fails. min numb vs min size of frozensets
 
 data = [
+    # node_data, edge_data
+    (range(1, 5), [(1, 2), (2, 4), (4, 3), (3, 1)]),
     (
         [
             (0, {"name": "a"}),
@@ -43,10 +50,9 @@ data = [
         ],
         [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)],
     ),
-    (range(1, 5), [(1, 2), (2, 4), (4, 3), (3, 1)]),
     (
         [],
-        [
+        [  # 5-cycle with 2-paths stuck onto nodes 0, 2, 4
             (0, 1),
             (1, 2),
             (2, 3),
@@ -104,6 +110,7 @@ class TestSelfIsomorphism:
             graph, graph, node_match=iso.categorical_node_match("name", None)
         )
         assert ismags.is_isomorphic()
+        assert ismags.is_isomorphic(True)
         assert ismags.subgraph_is_isomorphic()
         assert list(ismags.subgraph_isomorphisms_iter(symmetry=True)) == [
             {n: n for n in graph.nodes}

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -2,12 +2,12 @@
 Tests for ISMAGS isomorphism algorithm.
 """
 
-import pytest
 import random
+
+import pytest
 
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
-
 
 graph_classes = [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 
@@ -263,62 +263,62 @@ class TestWikipediaExample:
     # Nodes 'g', 'h', 'i' and 'j' form a column.
     g1a_edges = [
         ["a", "g"],
-        ["a", "h"], #
+        ["a", "h"],  #
         ["a", "i"],
-        ["b", "g"], #
+        ["b", "g"],  #
         ["b", "h"],
         ["b", "j"],
-        ["c", "g"], #
-        ["c", "i"], #
+        ["c", "g"],  #
+        ["c", "i"],  #
         ["c", "j"],
-        ["d", "h"], #
+        ["d", "h"],  #
         ["d", "i"],
-        ["d", "j"], #
+        ["d", "j"],  #
     ]
     g1b_edges = [
         ["a", "g"],
-        ["h", "a"], #
+        ["h", "a"],  #
         ["a", "i"],
-        ["g", "b"], #
+        ["g", "b"],  #
         ["b", "h"],
         ["b", "j"],
-        ["g", "c"], #
-        ["i", "c"], #
+        ["g", "c"],  #
+        ["i", "c"],  #
         ["c", "j"],
-        ["h", "d"], #
+        ["h", "d"],  #
         ["d", "i"],
-        ["j", "d"], #
+        ["j", "d"],  #
     ]
     g2b_edges = [
         [1, 2],
-        [1, 4], #
+        [1, 4],  #
         [1, 5],
-        [3, 2], #
+        [3, 2],  #
         [3, 4],
         [3, 7],
-        [6, 2], #
-        [6, 5], #
+        [6, 2],  #
+        [6, 5],  #
         [6, 7],
-        [8, 4], #
+        [8, 4],  #
         [8, 5],
-        [8, 7], #
+        [8, 7],  #
     ]
 
     # Nodes 1,2,3,4 form the clockwise corners of a large square.
     # Nodes 5,6,7,8 form the clockwise corners of a small square
     g2a_edges = [
         [1, 2],
-        [4, 1], #
+        [4, 1],  #
         [1, 5],
-        [2, 3], #
+        [2, 3],  #
         [3, 4],
         [3, 7],
-        [2, 6], #
-        [5, 6], #
+        [2, 6],  #
+        [5, 6],  #
         [6, 7],
-        [4, 8], #
+        [4, 8],  #
         [8, 5],
-        [7, 8], #
+        [7, 8],  #
     ]
 
     @pytest.mark.parametrize("graph_constructor", [nx.Graph, nx.MultiGraph])
@@ -517,7 +517,6 @@ class TestDiGraphISO:
         G1 = nx.DiGraph(edges1)
         G2 = nx.DiGraph(edges2)
         assert not is_isomorphic(G1, G2)
-
 
     def test_is_isomorphic(self):
         G1 = nx.Graph([[1, 2], [1, 3], [1, 5], [2, 3]])

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -118,7 +118,7 @@ class TestSelfIsomorphism:
         found.
         """
         for node_data, edge_data in self.data:
-            graph = nx.Graph()
+            graph = nx.DiGraph()
             graph.add_nodes_from(node_data)
             graph.add_edges_from(edge_data)
 
@@ -244,12 +244,14 @@ class TestWikipediaExample:
     ]
 
     def test_graph(self):
-        g1 = nx.Graph()
-        g2 = nx.Graph()
-        g1.add_edges_from(self.g1edges)
-        g2.add_edges_from(self.g2edges)
-        gm = iso.ISMAGS(g1, g2)
-        assert gm.is_isomorphic()
+        g1 = nx.Graph(self.g1edges)
+        g2 = nx.Graph(self.g2edges)
+        assert iso.ISMAGS(g1, g2).is_isomorphic()
+
+    def test_digraph(self):
+        g1 = nx.DiGraph(self.g1edges)
+        g2 = nx.DiGraph(self.g2edges)
+        assert iso.ISMAGS(g1, g2).is_isomorphic()
 
 
 class TestLargestCommonSubgraph:

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -420,7 +420,7 @@ def test_noncomparable_nodes():
     dgm = iso.DiGraphMatcher(G, H)
     assert dgm.is_isomorphic()
     # Just testing some cases
-    assert gm.subgraph_is_monomorphic()
+    assert dgm.subgraph_is_monomorphic()
 
 
 def test_monomorphism_edge_match():


### PR DESCRIPTION
With this PR, ISMAGS supports directed and multigraph inputs. If inputs do not have the same directed status an exception is raised. But multigraph and graph can be compared. So no restriction there.

Refactored methods `_refine_node_partition`, `_map_nodes`, and `_process_ordered_pair_partitions` to replace the recursive with a (DFS) queue approach.  In addition, the ISMAGS class no longer requires that nodes be sortable. 

Corrected error while handling `candidate_sets` which is a dict-of-set-of-frozensets. For each node, we want to find the minimum length of the frozensets associated with that node. So we should use `min(len(x) for x in candidate_sets[n])` rather than `min(candidate_sets[n], key=len)` which returns the smallest length frozenset. This ensures that the nodes with the fewest candidate mapping-image nodes are considered first, which in theory should return the first isomorphism faster.  (Not a correctness issue -- just a performance hit.)

In switching away from recursive methods, we somehow no longer need the bug-fix for ISMAGS. The bug arose for strange cases where symmetry was getting top/bottom partitions with different numbers of elements. I haven't chased down how that error occurred in the original code, but I suspect we were not respecting the node order or the ordering of partition list by the size of the parts. It doesn't affect the answer, but reduces the number of partitions to consider (the strange cases were aborted once detected).

This PR updates and adds tests especially DiGraph tests from VF, VF2, VF2pp.

Many comment changes, variable name changes and removal or renaming of helper functions. I also removed the manually provided cached properties in favor of just computing those attributes in the `__init__` method (they would never change unless the graphs change which would violate other assumptions).

Names: a "partition" is a list of "parts". Each "part" is a set of nodes.
We should only use the plural "partitions" when we have more than one partition.

I did not change the term "color" to "label" in this PR. I also did not move functions in or out of the class structure (to make a function oriented setup instead of methods).
I did not refactor the methods like `is_isomorphic` to be functions. We can discuss those changes for the whole isomorphism subpackage separately.

I thought about keeping the old code alongside the new, but given the needed correction and the bug-fix shortcut, I don't think we should retain that version. The Sandia folks mentioned that they saw some suspicious parts of the ismags code.

I did not use the Sandia python version of ISMAGS because it was clearly a translation of the original java code, and didn't feel right for NetworkX. It is also a command line tool used for graphs stored in a specific ascii file structure e.g. "XX00YX" to indicate which edges exist between, e.g., 3 nodes and their edge type/color/label.

Are there things I can do to make this easier to review? It's often hard to review the switch from recursive to non-recursive. And we've got 3 such conversions here. Should I split that from the handling of DiGraph changes? It might be worth reading the new ismags.py as its own new file rather than the diff, but I'm not sure.  I will wait a week or two and then review it with fresh eyes if that helps.
