### PR TITLE
MAINT: use `assert np.allclose` instead of `np.testing.assert_almost_equal`

### DIFF
--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -12,54 +12,54 @@ pytest.importorskip("scipy")
 class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
     def test_degree_assortativity_undirected(self):
         r = nx.degree_assortativity_coefficient(self.P4)
-        np.testing.assert_almost_equal(r, -1.0 / 2, decimal=4)
+        np.testing.assert_allclose(r, -1.0 / 2, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_node_kwargs(self):
         G = nx.Graph()
         edges = [(0, 1), (0, 3), (1, 2), (1, 3), (1, 4), (5, 9), (9, 0)]
         G.add_edges_from(edges)
         r = nx.degree_assortativity_coefficient(G, nodes=[1, 2, 4])
-        np.testing.assert_almost_equal(r, -1.0, decimal=4)
+        np.testing.assert_allclose(r, -1.0, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_directed(self):
         r = nx.degree_assortativity_coefficient(self.D)
-        np.testing.assert_almost_equal(r, -0.57735, decimal=4)
+        np.testing.assert_allclose(r, -0.57735, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_directed2(self):
         """Test degree assortativity for a directed graph where the set of
         in/out degree does not equal the total degree."""
         r = nx.degree_assortativity_coefficient(self.D2)
-        np.testing.assert_almost_equal(r, 0.14852, decimal=4)
+        np.testing.assert_allclose(r, 0.14852, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_multigraph(self):
         r = nx.degree_assortativity_coefficient(self.M)
-        np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
+        np.testing.assert_allclose(r, -1.0 / 7.0, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_undirected(self):
         r = nx.degree_pearson_correlation_coefficient(self.P4)
-        np.testing.assert_almost_equal(r, -1.0 / 2, decimal=4)
+        np.testing.assert_allclose(r, -1.0 / 2, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_directed(self):
         r = nx.degree_pearson_correlation_coefficient(self.D)
-        np.testing.assert_almost_equal(r, -0.57735, decimal=4)
+        np.testing.assert_allclose(r, -0.57735, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_directed2(self):
         """Test degree assortativity with Pearson for a directed graph where
         the set of in/out degree does not equal the total degree."""
         r = nx.degree_pearson_correlation_coefficient(self.D2)
-        np.testing.assert_almost_equal(r, 0.14852, decimal=4)
+        np.testing.assert_allclose(r, 0.14852, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_multigraph(self):
         r = nx.degree_pearson_correlation_coefficient(self.M)
-        np.testing.assert_almost_equal(r, -1.0 / 7.0, decimal=4)
+        np.testing.assert_allclose(r, -1.0 / 7.0, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_weighted(self):
         r = nx.degree_assortativity_coefficient(self.W, weight="weight")
-        np.testing.assert_almost_equal(r, -0.1429, decimal=4)
+        np.testing.assert_allclose(r, -0.1429, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_double_star(self):
         r = nx.degree_assortativity_coefficient(self.DS)
-        np.testing.assert_almost_equal(r, -0.9339, decimal=4)
+        np.testing.assert_allclose(r, -0.9339, atol=1.5e-4, rtol=0)
 
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
@@ -84,7 +84,7 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
                       [0.005, 0.007, 0.024, 0.016]])
         # fmt: on
         r = attribute_ac(a)
-        np.testing.assert_almost_equal(r, 0.623, decimal=3)
+        np.testing.assert_allclose(r, 0.623, atol=1.5e-3, rtol=0)
 
     def test_attribute_assortativity_coefficient2(self):
         # fmt: off
@@ -94,16 +94,16 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
                       [0.03, 0.02, 0.01, 0.22]])
         # fmt: on
         r = attribute_ac(a)
-        np.testing.assert_almost_equal(r, 0.68, decimal=2)
+        np.testing.assert_allclose(r, 0.68, atol=1.5e-2, rtol=0)
 
     def test_attribute_assortativity(self):
         a = np.array([[50, 50, 0], [50, 50, 0], [0, 0, 2]])
         r = attribute_ac(a)
-        np.testing.assert_almost_equal(r, 0.029, decimal=3)
+        np.testing.assert_allclose(r, 0.029, atol=1.5e-3, rtol=0)
 
     def test_attribute_assortativity_negative(self):
         r = nx.numeric_assortativity_coefficient(self.N, "margin")
-        np.testing.assert_almost_equal(r, -0.2903, decimal=4)
+        np.testing.assert_allclose(r, -0.2903, atol=1.5e-4, rtol=0)
 
     def test_assortativity_node_kwargs(self):
         G = nx.Graph()
@@ -111,12 +111,12 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
         G.add_nodes_from([2, 3], size=3)
         G.add_edges_from([(0, 1), (2, 3)])
         r = nx.numeric_assortativity_coefficient(G, "size", nodes=[0, 3])
-        np.testing.assert_almost_equal(r, 1.0, decimal=4)
+        np.testing.assert_allclose(r, 1.0, atol=1.5e-4, rtol=0)
 
     def test_attribute_assortativity_float(self):
         r = nx.numeric_assortativity_coefficient(self.F, "margin")
-        np.testing.assert_almost_equal(r, -0.1429, decimal=4)
+        np.testing.assert_allclose(r, -0.1429, atol=1.5e-4, rtol=0)
 
     def test_attribute_assortativity_mixed(self):
         r = nx.numeric_assortativity_coefficient(self.K, "margin")
-        np.testing.assert_almost_equal(r, 0.4340, decimal=4)
+        np.testing.assert_allclose(r, 0.4340, atol=1.5e-4, rtol=0)

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -12,54 +12,54 @@ pytest.importorskip("scipy")
 class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
     def test_degree_assortativity_undirected(self):
         r = nx.degree_assortativity_coefficient(self.P4)
-        np.testing.assert_allclose(r, -1.0 / 2, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -1.0 / 2, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_node_kwargs(self):
         G = nx.Graph()
         edges = [(0, 1), (0, 3), (1, 2), (1, 3), (1, 4), (5, 9), (9, 0)]
         G.add_edges_from(edges)
         r = nx.degree_assortativity_coefficient(G, nodes=[1, 2, 4])
-        np.testing.assert_allclose(r, -1.0, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -1.0, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_directed(self):
         r = nx.degree_assortativity_coefficient(self.D)
-        np.testing.assert_allclose(r, -0.57735, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -0.57735, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_directed2(self):
         """Test degree assortativity for a directed graph where the set of
         in/out degree does not equal the total degree."""
         r = nx.degree_assortativity_coefficient(self.D2)
-        np.testing.assert_allclose(r, 0.14852, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, 0.14852, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_multigraph(self):
         r = nx.degree_assortativity_coefficient(self.M)
-        np.testing.assert_allclose(r, -1.0 / 7.0, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -1.0 / 7.0, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_undirected(self):
         r = nx.degree_pearson_correlation_coefficient(self.P4)
-        np.testing.assert_allclose(r, -1.0 / 2, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -1.0 / 2, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_directed(self):
         r = nx.degree_pearson_correlation_coefficient(self.D)
-        np.testing.assert_allclose(r, -0.57735, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -0.57735, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_directed2(self):
         """Test degree assortativity with Pearson for a directed graph where
         the set of in/out degree does not equal the total degree."""
         r = nx.degree_pearson_correlation_coefficient(self.D2)
-        np.testing.assert_allclose(r, 0.14852, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, 0.14852, atol=1.5e-4, rtol=0)
 
     def test_degree_pearson_assortativity_multigraph(self):
         r = nx.degree_pearson_correlation_coefficient(self.M)
-        np.testing.assert_allclose(r, -1.0 / 7.0, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -1.0 / 7.0, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_weighted(self):
         r = nx.degree_assortativity_coefficient(self.W, weight="weight")
-        np.testing.assert_allclose(r, -0.1429, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -0.1429, atol=1.5e-4, rtol=0)
 
     def test_degree_assortativity_double_star(self):
         r = nx.degree_assortativity_coefficient(self.DS)
-        np.testing.assert_allclose(r, -0.9339, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -0.9339, atol=1.5e-4, rtol=0)
 
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
@@ -84,7 +84,7 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
                       [0.005, 0.007, 0.024, 0.016]])
         # fmt: on
         r = attribute_ac(a)
-        np.testing.assert_allclose(r, 0.623, atol=1.5e-3, rtol=0)
+        assert np.allclose(r, 0.623, atol=1.5e-3, rtol=0)
 
     def test_attribute_assortativity_coefficient2(self):
         # fmt: off
@@ -94,16 +94,16 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
                       [0.03, 0.02, 0.01, 0.22]])
         # fmt: on
         r = attribute_ac(a)
-        np.testing.assert_allclose(r, 0.68, atol=1.5e-2, rtol=0)
+        assert np.allclose(r, 0.68, atol=1.5e-2, rtol=0)
 
     def test_attribute_assortativity(self):
         a = np.array([[50, 50, 0], [50, 50, 0], [0, 0, 2]])
         r = attribute_ac(a)
-        np.testing.assert_allclose(r, 0.029, atol=1.5e-3, rtol=0)
+        assert np.allclose(r, 0.029, atol=1.5e-3, rtol=0)
 
     def test_attribute_assortativity_negative(self):
         r = nx.numeric_assortativity_coefficient(self.N, "margin")
-        np.testing.assert_allclose(r, -0.2903, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -0.2903, atol=1.5e-4, rtol=0)
 
     def test_assortativity_node_kwargs(self):
         G = nx.Graph()
@@ -111,12 +111,12 @@ class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
         G.add_nodes_from([2, 3], size=3)
         G.add_edges_from([(0, 1), (2, 3)])
         r = nx.numeric_assortativity_coefficient(G, "size", nodes=[0, 3])
-        np.testing.assert_allclose(r, 1.0, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, 1.0, atol=1.5e-4, rtol=0)
 
     def test_attribute_assortativity_float(self):
         r = nx.numeric_assortativity_coefficient(self.F, "margin")
-        np.testing.assert_allclose(r, -0.1429, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, -0.1429, atol=1.5e-4, rtol=0)
 
     def test_attribute_assortativity_mixed(self):
         r = nx.numeric_assortativity_coefficient(self.K, "margin")
-        np.testing.assert_allclose(r, 0.4340, atol=1.5e-4, rtol=0)
+        assert np.allclose(r, 0.4340, atol=1.5e-4, rtol=0)

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
@@ -85,7 +85,7 @@ class TestApproximateFlowBetweennessCentrality:
         epsilon = 0.1
         ba = approximate_cfbc(G, normalized=True, epsilon=0.5 * epsilon)
         for n in sorted(G):
-            np.testing.assert_allclose(b[n], ba[n], atol=epsilon)
+            assert np.allclose(b[n], ba[n], rtol=1e-7, atol=epsilon)
 
     def test_K4(self):
         "Approximate current-flow betweenness centrality: K4"
@@ -94,7 +94,7 @@ class TestApproximateFlowBetweennessCentrality:
         epsilon = 0.1
         ba = approximate_cfbc(G, normalized=False, epsilon=0.5 * epsilon)
         for n in sorted(G):
-            np.testing.assert_allclose(b[n], ba[n], atol=epsilon * len(G) ** 2)
+            assert np.allclose(b[n], ba[n], rtol=1e-7, atol=epsilon * len(G) ** 2)
 
     def test_star(self):
         "Approximate current-flow betweenness centrality: star"
@@ -104,7 +104,7 @@ class TestApproximateFlowBetweennessCentrality:
         epsilon = 0.1
         ba = approximate_cfbc(G, normalized=True, epsilon=0.5 * epsilon)
         for n in sorted(G):
-            np.testing.assert_allclose(b[n], ba[n], atol=epsilon)
+            assert np.allclose(b[n], ba[n], rtol=1e-7, atol=epsilon)
 
     def test_grid(self):
         "Approximate current-flow betweenness centrality: 2d grid"
@@ -113,14 +113,14 @@ class TestApproximateFlowBetweennessCentrality:
         epsilon = 0.1
         ba = approximate_cfbc(G, normalized=True, epsilon=0.5 * epsilon)
         for n in sorted(G):
-            np.testing.assert_allclose(b[n], ba[n], atol=epsilon)
+            assert np.allclose(b[n], ba[n], rtol=1e-7, atol=epsilon)
 
     def test_seed(self):
         G = nx.complete_graph(4)
         b = approximate_cfbc(G, normalized=False, epsilon=0.05, seed=1)
         b_answer = {0: 0.75, 1: 0.75, 2: 0.75, 3: 0.75}
         for n in sorted(G):
-            np.testing.assert_allclose(b[n], b_answer[n], atol=0.1)
+            assert np.allclose(b[n], b_answer[n], rtol=1e-7, atol=0.1)
 
     def test_solvers(self):
         "Approximate current-flow betweenness centrality: solvers"
@@ -132,7 +132,7 @@ class TestApproximateFlowBetweennessCentrality:
             )
             b_answer = {0: 0.75, 1: 0.75, 2: 0.75, 3: 0.75}
             for n in sorted(G):
-                np.testing.assert_allclose(b[n], b_answer[n], atol=epsilon)
+                assert np.allclose(b[n], b_answer[n], rtol=1e-7, atol=epsilon)
 
     def test_lower_kmax(self):
         G = nx.complete_graph(4)

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -501,11 +501,11 @@ class TestAverageShortestPathLengthNumpy:
         ans = nx.average_shortest_path_length(
             G, weight="weight", method="floyd-warshall-numpy"
         )
-        np.testing.assert_almost_equal(ans, 4)
+        np.testing.assert_allclose(ans, 4, atol=1.5e-7, rtol=0)
 
         G = nx.Graph()
         nx.add_path(G, range(5), weight=2)
         ans = nx.average_shortest_path_length(
             G, weight="weight", method="floyd-warshall-numpy"
         )
-        np.testing.assert_almost_equal(ans, 4)
+        np.testing.assert_allclose(ans, 4, atol=1.5e-7, rtol=0)

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -501,11 +501,11 @@ class TestAverageShortestPathLengthNumpy:
         ans = nx.average_shortest_path_length(
             G, weight="weight", method="floyd-warshall-numpy"
         )
-        np.testing.assert_allclose(ans, 4, atol=1.5e-7, rtol=0)
+        assert np.allclose(ans, 4, atol=1.5e-7, rtol=0)
 
         G = nx.Graph()
         nx.add_path(G, range(5), weight=2)
         ans = nx.average_shortest_path_length(
             G, weight="weight", method="floyd-warshall-numpy"
         )
-        np.testing.assert_allclose(ans, 4, atol=1.5e-7, rtol=0)
+        assert np.allclose(ans, 4, atol=1.5e-7, rtol=0)

--- a/networkx/algorithms/tests/test_cluster.py
+++ b/networkx/algorithms/tests/test_cluster.py
@@ -304,8 +304,12 @@ class TestDirectedWeightedClustering:
         G.add_edge(0, 4, weight=2)
         assert nx.clustering(G)[0] == 1 / 6
         # Relaxed comparisons to allow graphblas-algorithms to pass tests
-        np.testing.assert_allclose(nx.clustering(G, weight="weight")[0], 1 / 12)
-        np.testing.assert_allclose(nx.clustering(G, 0, weight="weight"), 1 / 12)
+        assert np.allclose(
+            nx.clustering(G, weight="weight")[0], 1 / 12, rtol=1e-07, atol=0
+        )
+        assert np.allclose(
+            nx.clustering(G, 0, weight="weight"), 1 / 12, rtol=1e-07, atol=0
+        )
 
 
 class TestWeightedClustering:
@@ -384,8 +388,12 @@ class TestWeightedClustering:
         G = nx.cycle_graph(3)
         G.add_edge(0, 4, weight=2)
         assert nx.clustering(G)[0] == 1 / 3
-        np.testing.assert_allclose(nx.clustering(G, weight="weight")[0], 1 / 6)
-        np.testing.assert_allclose(nx.clustering(G, 0, weight="weight"), 1 / 6)
+        assert np.allclose(
+            nx.clustering(G, weight="weight")[0], 1 / 6, rtol=1e-07, atol=0
+        )
+        assert np.allclose(
+            nx.clustering(G, 0, weight="weight"), 1 / 6, rtol=1e-07, atol=0
+        )
 
     def test_triangle_and_signed_edge(self):
         G = nx.cycle_graph(3)

--- a/networkx/algorithms/tests/test_non_randomness.py
+++ b/networkx/algorithms/tests/test_non_randomness.py
@@ -16,7 +16,7 @@ np = pytest.importorskip("numpy")
 )
 def test_non_randomness(k, weight, expected):
     G = nx.karate_club_graph()
-    np.testing.assert_allclose(
+    assert np.allclose(
         nx.non_randomness(G, k, weight)[0], expected, atol=1.5e-2, rtol=0
     )
 

--- a/networkx/algorithms/tests/test_non_randomness.py
+++ b/networkx/algorithms/tests/test_non_randomness.py
@@ -16,8 +16,8 @@ np = pytest.importorskip("numpy")
 )
 def test_non_randomness(k, weight, expected):
     G = nx.karate_club_graph()
-    np.testing.assert_almost_equal(
-        nx.non_randomness(G, k, weight)[0], expected, decimal=2
+    np.testing.assert_allclose(
+        nx.non_randomness(G, k, weight)[0], expected, atol=1.5e-2, rtol=0
     )
 
 

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -815,7 +815,7 @@ class TestSimilarity:
             ]
         )
         actual = nx.similarity._simrank_similarity_numpy(G)
-        np.testing.assert_allclose(expected, actual, atol=1e-7)
+        assert np.allclose(expected, actual, rtol=1e-7, atol=1e-7)
 
     def test_simrank_numpy_source_no_target(self):
         G = nx.cycle_graph(5)
@@ -829,13 +829,13 @@ class TestSimilarity:
             ]
         )
         actual = nx.similarity._simrank_similarity_numpy(G, source=0)
-        np.testing.assert_allclose(expected, actual, atol=1e-7)
+        assert np.allclose(expected, actual, rtol=1e-7, atol=1e-7)
 
     def test_simrank_numpy_source_and_target(self):
         G = nx.cycle_graph(5)
         expected = 1.0
         actual = nx.similarity._simrank_similarity_numpy(G, source=0, target=0)
-        np.testing.assert_allclose(expected, actual, atol=1e-7)
+        assert np.allclose(expected, actual, rtol=1e-7, atol=1e-7)
 
     def test_panther_similarity_unweighted(self):
         G = nx.Graph()

--- a/networkx/algorithms/tests/test_threshold.py
+++ b/networkx/algorithms/tests/test_threshold.py
@@ -254,7 +254,7 @@ class TestGeneratorThreshold:
         cs = "ddiiddid"
         G = nxt.threshold_graph(cs)
         (tgeval, tgevec) = nxt.eigenvectors(cs)
-        np.testing.assert_allclose([np.dot(lv, lv) for lv in tgevec], 1.0, rtol=1e-9)
+        assert np.allclose([np.dot(lv, lv) for lv in tgevec], 1.0, rtol=1e-9, atol=0)
         lapl = nx.laplacian_matrix(G)
 
     def test_create_using(self):

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -153,7 +153,7 @@ def assert_equal_branchings(G1, G2, attr="weight", default=1):
 
     for a, b in zip(e1, e2):
         assert a[:2] == b[:2]
-        np.testing.assert_almost_equal(a[2], b[2])
+        np.testing.assert_allclose(a[2], b[2], atol=1.5e-7, rtol=0)
 
 
 ################

--- a/networkx/algorithms/tree/tests/test_branchings.py
+++ b/networkx/algorithms/tree/tests/test_branchings.py
@@ -153,7 +153,7 @@ def assert_equal_branchings(G1, G2, attr="weight", default=1):
 
     for a, b in zip(e1, e2):
         assert a[:2] == b[:2]
-        np.testing.assert_allclose(a[2], b[2], atol=1.5e-7, rtol=0)
+        assert np.allclose(a[2], b[2], atol=1.5e-7, rtol=0)
 
 
 ################

--- a/networkx/linalg/tests/test_laplacian.py
+++ b/networkx/linalg/tests/test_laplacian.py
@@ -133,32 +133,32 @@ class TestLaplacian:
                           [ 0.    ,  0.    ,  0.    ,  0.    , -0.4082,  0.5   ]])
         # fmt: on
 
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.G, nodelist=range(5)).todense(),
             G,
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.G).todense(), GL, atol=1.5e-3, rtol=0
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.MG).todense(), GL, atol=1.5e-3, rtol=0
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.WG).todense(), GL, atol=1.5e-3, rtol=0
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.WG, weight="other").todense(),
             GL,
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.Gsl).todense(), Lsl, atol=1.5e-3, rtol=0
         )
 
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(
                 self.DiG,
                 nodelist=range(1, 1 + 6),
@@ -167,31 +167,31 @@ class TestLaplacian:
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.DiG).todense(),
             DiGL,
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.DiMG).todense(),
             DiGL,
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.DiWG).todense(),
             DiGL,
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.DiWG, weight="other").todense(),
             DiGL,
             atol=1.5e-3,
             rtol=0,
         )
-        np.testing.assert_allclose(
+        assert np.allclose(
             nx.normalized_laplacian_matrix(self.DiGsl).todense(),
             DiLsl,
             atol=1.5e-3,
@@ -228,7 +228,7 @@ def test_directed_laplacian():
                    [-0.0261, -0.0554, -0.0251, -0.6675, -0.2078,  0.9833]])
     # fmt: on
     L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # Make the graph strongly connected, so we can use a random and lazy walk
     G.add_edges_from(((2, 5), (6, 1)))
@@ -243,7 +243,7 @@ def test_directed_laplacian():
     L = nx.directed_laplacian_matrix(
         G, alpha=0.9, nodelist=sorted(G), walk_type="random"
     )
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # fmt: off
     GL = np.array([[ 0.5   , -0.1531, -0.2357,  0.    ,  0.    , -0.1614],
@@ -254,7 +254,7 @@ def test_directed_laplacian():
                    [-0.1614,  0.    ,  0.    , -0.25  , -0.125 ,  0.5   ]])
     # fmt: on
     L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G), walk_type="lazy")
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # Make a strongly connected periodic graph
     G = nx.DiGraph()
@@ -266,7 +266,7 @@ def test_directed_laplacian():
                    [-0.25 , -0.176, -0.176,  0.5  ]])
     # fmt: on
     L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
 
 def test_directed_combinatorial_laplacian():
@@ -299,7 +299,7 @@ def test_directed_combinatorial_laplacian():
     # fmt: on
 
     L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # Make the graph strongly connected, so we can use a random and lazy walk
     G.add_edges_from(((2, 5), (6, 1)))
@@ -316,7 +316,7 @@ def test_directed_combinatorial_laplacian():
     L = nx.directed_combinatorial_laplacian_matrix(
         G, alpha=0.9, nodelist=sorted(G), walk_type="random"
     )
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # fmt: off
     GL = np.array([[ 0.0698, -0.0174, -0.0233,  0.    ,  0.    , -0.0291],
@@ -330,7 +330,7 @@ def test_directed_combinatorial_laplacian():
     L = nx.directed_combinatorial_laplacian_matrix(
         G, alpha=0.9, nodelist=sorted(G), walk_type="lazy"
     )
-    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
+    assert np.allclose(L, GL, atol=1.5e-3, rtol=0)
 
     E = nx.DiGraph(nx.margulis_gabber_galil_graph(2))
     L = nx.directed_combinatorial_laplacian_matrix(E)
@@ -342,7 +342,7 @@ def test_directed_combinatorial_laplacian():
          [ 0.        , -0.08333333, -0.08333333,  0.16666667]]
     )
     # fmt: on
-    np.testing.assert_allclose(L, expected, atol=1.5e-6, rtol=0)
+    assert np.allclose(L, expected, atol=1.5e-6, rtol=0)
 
     with pytest.raises(nx.NetworkXError):
         nx.directed_combinatorial_laplacian_matrix(G, walk_type="pagerank", alpha=100)

--- a/networkx/linalg/tests/test_laplacian.py
+++ b/networkx/linalg/tests/test_laplacian.py
@@ -133,53 +133,69 @@ class TestLaplacian:
                           [ 0.    ,  0.    ,  0.    ,  0.    , -0.4082,  0.5   ]])
         # fmt: on
 
-        np.testing.assert_almost_equal(
+        np.testing.assert_allclose(
             nx.normalized_laplacian_matrix(self.G, nodelist=range(5)).todense(),
             G,
-            decimal=3,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.G).todense(), GL, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.G).todense(), GL, atol=1.5e-3, rtol=0
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.MG).todense(), GL, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.MG).todense(), GL, atol=1.5e-3, rtol=0
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.WG).todense(), GL, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.WG).todense(), GL, atol=1.5e-3, rtol=0
         )
-        np.testing.assert_almost_equal(
+        np.testing.assert_allclose(
             nx.normalized_laplacian_matrix(self.WG, weight="other").todense(),
             GL,
-            decimal=3,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.Gsl).todense(), Lsl, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.Gsl).todense(), Lsl, atol=1.5e-3, rtol=0
         )
 
-        np.testing.assert_almost_equal(
+        np.testing.assert_allclose(
             nx.normalized_laplacian_matrix(
                 self.DiG,
                 nodelist=range(1, 1 + 6),
             ).todense(),
             DiG,
-            decimal=3,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.DiG).todense(), DiGL, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.DiG).todense(),
+            DiGL,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.DiMG).todense(), DiGL, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.DiMG).todense(),
+            DiGL,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.DiWG).todense(), DiGL, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.DiWG).todense(),
+            DiGL,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
+        np.testing.assert_allclose(
             nx.normalized_laplacian_matrix(self.DiWG, weight="other").todense(),
             DiGL,
-            decimal=3,
+            atol=1.5e-3,
+            rtol=0,
         )
-        np.testing.assert_almost_equal(
-            nx.normalized_laplacian_matrix(self.DiGsl).todense(), DiLsl, decimal=3
+        np.testing.assert_allclose(
+            nx.normalized_laplacian_matrix(self.DiGsl).todense(),
+            DiLsl,
+            atol=1.5e-3,
+            rtol=0,
         )
 
 
@@ -212,7 +228,7 @@ def test_directed_laplacian():
                    [-0.0261, -0.0554, -0.0251, -0.6675, -0.2078,  0.9833]])
     # fmt: on
     L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # Make the graph strongly connected, so we can use a random and lazy walk
     G.add_edges_from(((2, 5), (6, 1)))
@@ -227,7 +243,7 @@ def test_directed_laplacian():
     L = nx.directed_laplacian_matrix(
         G, alpha=0.9, nodelist=sorted(G), walk_type="random"
     )
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # fmt: off
     GL = np.array([[ 0.5   , -0.1531, -0.2357,  0.    ,  0.    , -0.1614],
@@ -238,7 +254,7 @@ def test_directed_laplacian():
                    [-0.1614,  0.    ,  0.    , -0.25  , -0.125 ,  0.5   ]])
     # fmt: on
     L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G), walk_type="lazy")
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # Make a strongly connected periodic graph
     G = nx.DiGraph()
@@ -250,7 +266,7 @@ def test_directed_laplacian():
                    [-0.25 , -0.176, -0.176,  0.5  ]])
     # fmt: on
     L = nx.directed_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
 
 def test_directed_combinatorial_laplacian():
@@ -283,7 +299,7 @@ def test_directed_combinatorial_laplacian():
     # fmt: on
 
     L = nx.directed_combinatorial_laplacian_matrix(G, alpha=0.9, nodelist=sorted(G))
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # Make the graph strongly connected, so we can use a random and lazy walk
     G.add_edges_from(((2, 5), (6, 1)))
@@ -300,7 +316,7 @@ def test_directed_combinatorial_laplacian():
     L = nx.directed_combinatorial_laplacian_matrix(
         G, alpha=0.9, nodelist=sorted(G), walk_type="random"
     )
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
     # fmt: off
     GL = np.array([[ 0.0698, -0.0174, -0.0233,  0.    ,  0.    , -0.0291],
@@ -314,7 +330,7 @@ def test_directed_combinatorial_laplacian():
     L = nx.directed_combinatorial_laplacian_matrix(
         G, alpha=0.9, nodelist=sorted(G), walk_type="lazy"
     )
-    np.testing.assert_almost_equal(L, GL, decimal=3)
+    np.testing.assert_allclose(L, GL, atol=1.5e-3, rtol=0)
 
     E = nx.DiGraph(nx.margulis_gabber_galil_graph(2))
     L = nx.directed_combinatorial_laplacian_matrix(E)
@@ -326,7 +342,7 @@ def test_directed_combinatorial_laplacian():
          [ 0.        , -0.08333333, -0.08333333,  0.16666667]]
     )
     # fmt: on
-    np.testing.assert_almost_equal(L, expected, decimal=6)
+    np.testing.assert_allclose(L, expected, atol=1.5e-6, rtol=0)
 
     with pytest.raises(nx.NetworkXError):
         nx.directed_combinatorial_laplacian_matrix(G, walk_type="pagerank", alpha=100)

--- a/networkx/linalg/tests/test_spectrum.py
+++ b/networkx/linalg/tests/test_spectrum.py
@@ -23,48 +23,48 @@ class TestSpectrum:
         "Laplacian eigenvalues"
         evals = np.array([0, 0, 1, 3, 4])
         e = sorted(nx.laplacian_spectrum(self.G))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.laplacian_spectrum(self.WG, weight=None))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.laplacian_spectrum(self.WG))
-        np.testing.assert_almost_equal(e, 0.5 * evals)
+        np.testing.assert_allclose(e, 0.5 * evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.laplacian_spectrum(self.WG, weight="other"))
-        np.testing.assert_almost_equal(e, 0.3 * evals)
+        np.testing.assert_allclose(e, 0.3 * evals, atol=1.5e-7, rtol=0)
 
     def test_normalized_laplacian_spectrum(self):
         "Normalized Laplacian eigenvalues"
         evals = np.array([0, 0, 0.7712864461218, 1.5, 1.7287135538781])
         e = sorted(nx.normalized_laplacian_spectrum(self.G))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.normalized_laplacian_spectrum(self.WG, weight=None))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.normalized_laplacian_spectrum(self.WG))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.normalized_laplacian_spectrum(self.WG, weight="other"))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
 
     def test_adjacency_spectrum(self):
         "Adjacency eigenvalues"
         evals = np.array([-np.sqrt(2), 0, np.sqrt(2)])
         e = sorted(nx.adjacency_spectrum(self.P))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
 
     def test_modularity_spectrum(self):
         "Modularity eigenvalues"
         evals = np.array([-1.5, 0.0, 0.0])
         e = sorted(nx.modularity_spectrum(self.P))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         # Directed modularity eigenvalues
         evals = np.array([-0.5, 0.0, 0.0])
         e = sorted(nx.modularity_spectrum(self.DG))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
 
     def test_bethe_hessian_spectrum(self):
         "Bethe Hessian eigenvalues"
         evals = np.array([0.5 * (9 - np.sqrt(33)), 4, 0.5 * (9 + np.sqrt(33))])
         e = sorted(nx.bethe_hessian_spectrum(self.P, r=2))
-        np.testing.assert_almost_equal(e, evals)
+        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
         # Collapses back to Laplacian:
         e1 = sorted(nx.bethe_hessian_spectrum(self.P, r=1))
         e2 = sorted(nx.laplacian_spectrum(self.P))
-        np.testing.assert_almost_equal(e1, e2)
+        np.testing.assert_allclose(e1, e2, atol=1.5e-7, rtol=0)

--- a/networkx/linalg/tests/test_spectrum.py
+++ b/networkx/linalg/tests/test_spectrum.py
@@ -23,48 +23,48 @@ class TestSpectrum:
         "Laplacian eigenvalues"
         evals = np.array([0, 0, 1, 3, 4])
         e = sorted(nx.laplacian_spectrum(self.G))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.laplacian_spectrum(self.WG, weight=None))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.laplacian_spectrum(self.WG))
-        np.testing.assert_allclose(e, 0.5 * evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, 0.5 * evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.laplacian_spectrum(self.WG, weight="other"))
-        np.testing.assert_allclose(e, 0.3 * evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, 0.3 * evals, atol=1.5e-7, rtol=0)
 
     def test_normalized_laplacian_spectrum(self):
         "Normalized Laplacian eigenvalues"
         evals = np.array([0, 0, 0.7712864461218, 1.5, 1.7287135538781])
         e = sorted(nx.normalized_laplacian_spectrum(self.G))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.normalized_laplacian_spectrum(self.WG, weight=None))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.normalized_laplacian_spectrum(self.WG))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         e = sorted(nx.normalized_laplacian_spectrum(self.WG, weight="other"))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
 
     def test_adjacency_spectrum(self):
         "Adjacency eigenvalues"
         evals = np.array([-np.sqrt(2), 0, np.sqrt(2)])
         e = sorted(nx.adjacency_spectrum(self.P))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
 
     def test_modularity_spectrum(self):
         "Modularity eigenvalues"
         evals = np.array([-1.5, 0.0, 0.0])
         e = sorted(nx.modularity_spectrum(self.P))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         # Directed modularity eigenvalues
         evals = np.array([-0.5, 0.0, 0.0])
         e = sorted(nx.modularity_spectrum(self.DG))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
 
     def test_bethe_hessian_spectrum(self):
         "Bethe Hessian eigenvalues"
         evals = np.array([0.5 * (9 - np.sqrt(33)), 4, 0.5 * (9 + np.sqrt(33))])
         e = sorted(nx.bethe_hessian_spectrum(self.P, r=2))
-        np.testing.assert_allclose(e, evals, atol=1.5e-7, rtol=0)
+        assert np.allclose(e, evals, atol=1.5e-7, rtol=0)
         # Collapses back to Laplacian:
         e1 = sorted(nx.bethe_hessian_spectrum(self.P, r=1))
         e2 = sorted(nx.laplacian_spectrum(self.P))
-        np.testing.assert_allclose(e1, e2, atol=1.5e-7, rtol=0)
+        assert np.allclose(e1, e2, atol=1.5e-7, rtol=0)

--- a/networkx/utils/tests/test_misc.py
+++ b/networkx/utils/tests/test_misc.py
@@ -94,46 +94,46 @@ class TestNumpyArray:
     def test__dict_to_numpy_array1(self):
         d = {"a": 1, "b": 2}
         a = _dict_to_numpy_array1(d, mapping={"a": 0, "b": 1})
-        np.testing.assert_allclose(a, np.array([1, 2]))
+        assert np.allclose(a, np.array([1, 2]), rtol=1e-7, atol=0)
         a = _dict_to_numpy_array1(d, mapping={"b": 0, "a": 1})
-        np.testing.assert_allclose(a, np.array([2, 1]))
+        assert np.allclose(a, np.array([2, 1]), rtol=1e-7, atol=0)
 
         a = _dict_to_numpy_array1(d)
-        np.testing.assert_allclose(a.sum(), 3)
+        assert np.allclose(a.sum(), 3, rtol=1e-7, atol=0)
 
     def test__dict_to_numpy_array2(self):
         d = {"a": {"a": 1, "b": 2}, "b": {"a": 10, "b": 20}}
 
         mapping = {"a": 1, "b": 0}
         a = _dict_to_numpy_array2(d, mapping=mapping)
-        np.testing.assert_allclose(a, np.array([[20, 10], [2, 1]]))
+        assert np.allclose(a, np.array([[20, 10], [2, 1]]), rtol=1e-7, atol=0)
 
         a = _dict_to_numpy_array2(d)
-        np.testing.assert_allclose(a.sum(), 33)
+        assert np.allclose(a.sum(), 33, rtol=1e-7, atol=0)
 
     def test_dict_to_numpy_array_a(self):
         d = {"a": {"a": 1, "b": 2}, "b": {"a": 10, "b": 20}}
 
         mapping = {"a": 0, "b": 1}
         a = dict_to_numpy_array(d, mapping=mapping)
-        np.testing.assert_allclose(a, np.array([[1, 2], [10, 20]]))
+        assert np.allclose(a, np.array([[1, 2], [10, 20]]), rtol=1e-7, atol=0)
 
         mapping = {"a": 1, "b": 0}
         a = dict_to_numpy_array(d, mapping=mapping)
-        np.testing.assert_allclose(a, np.array([[20, 10], [2, 1]]))
+        assert np.allclose(a, np.array([[20, 10], [2, 1]]), rtol=1e-7, atol=0)
 
         a = _dict_to_numpy_array2(d)
-        np.testing.assert_allclose(a.sum(), 33)
+        assert np.allclose(a.sum(), 33, rtol=1e-7, atol=0)
 
     def test_dict_to_numpy_array_b(self):
         d = {"a": 1, "b": 2}
 
         mapping = {"a": 0, "b": 1}
         a = dict_to_numpy_array(d, mapping=mapping)
-        np.testing.assert_allclose(a, np.array([1, 2]))
+        assert np.allclose(a, np.array([1, 2]), rtol=1e-7, atol=0)
 
         a = _dict_to_numpy_array1(d)
-        np.testing.assert_allclose(a.sum(), 3)
+        assert np.allclose(a.sum(), 3, rtol=1e-7, atol=0)
 
 
 def test_pairwise():


### PR DESCRIPTION
Inspired by https://github.com/scipy/scipy/pull/23592.
~NumPy recommends that `assert_allclose` be used instead of [`assert_almost_equal`](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_almost_equal.html).~ [Ross suggested](https://github.com/networkx/networkx/pull/8278#pullrequestreview-3241858655) using `assert np.allclose` instead.
NetworkX has no uses of `assert_array_almost_equal` or `assert_approx_equal`.

From the linked SciPy PR:
> For `assert_almost_equal` [...], the `decimal` parameter becomes `atol=1.5e-(decimal), rtol=0` in `assert_allclose()`.

~The default value is `decimal=7`, which has thus been replaced with `atol=1.5e-7, rtol=0`.
As `assert_allclose` was introduced in NumPy 2.0.0, it should be good for the NetworkX 3.6 release according to [SPEC 0](https://scientific-python.org/specs/spec-0000/#support-window).~

