### PR TITLE
TST: test `topo_sort` skips visited nodes in `goldberg_radzik`

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -889,6 +889,17 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         nx.bidirectional_dijkstra(D, 1, 3)
         # FIXME nx.goldberg_radzik(D, 1)
 
+    def test_skip_visited_unweighted(self):
+        """Check that `goldberg_radzik` correctly skips visited nodes in `topo_sort`.
+
+        This doesn't reliably get tested by other tests because iterating over
+        the `relabeled` set is not deterministic.
+        """
+        G = nx.Graph([(0, 4), (0, 5), (1, 3), (1, 4), (2, 3), (2, 5), (3, 5), (3, 6)])
+
+        _, dist = nx.goldberg_radzik(G, 4)
+        assert dist == {0: 1, 1: 1, 2: 3, 3: 2, 4: 0, 5: 2, 6: 3}
+
 
 class TestJohnsonAlgorithm(WeightedTestBase):
     def test_single_node_graph(self):

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -2120,7 +2120,7 @@ def goldberg_radzik(G, source, weight="weight"):
         """Relax out-edges of relabeled nodes."""
         relabeled = set()
         # Scan nodes in to_scan in topological order and relax incident
-        # out-edges. Add the relabled nodes to labeled.
+        # out-edges. Add the relabeled nodes to labeled.
         for u in to_scan:
             d_u = d[u]
             for v, e in G_succ[u].items():
@@ -2131,7 +2131,7 @@ def goldberg_radzik(G, source, weight="weight"):
                     relabeled.add(v)
         return relabeled
 
-    # Set of nodes relabled in the last round of scan operations. Denoted by B
+    # Set of nodes relabeled in the last round of scan operations. Denoted by B
     # in Goldberg and Radzik's paper.
     relabeled = {source}
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -2101,14 +2101,13 @@ def goldberg_radzik(G, source, weight="weight"):
                 t = d[u] + weight(u, v, e)
                 d_v = d[v]
                 if t < d_v:
-                    is_neg = t < d_v
                     d[v] = t
                     pred[v] = u
                     if v not in neg_count:
-                        neg_count[v] = neg_count[u] + int(is_neg)
+                        neg_count[v] = neg_count[u] + 1
                         stack.append((v, iter(G_succ[v].items())))
                         in_stack.add(v)
-                    elif v in in_stack and neg_count[u] + int(is_neg) > neg_count[v]:
+                    elif v in in_stack and neg_count[u] + 1 > neg_count[v]:
                         # (u, v) is a back edge, and the cycle formed by the
                         # path v to u and (u, v) contains at least one edge of
                         # negative reduced cost. The cycle must be of negative

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -2075,10 +2075,7 @@ def goldberg_radzik(G, source, weight="weight"):
         #
         # neg_count also doubles as the DFS visit marker array.
         neg_count = {}
-        for u in relabeled:
-            # Skip visited nodes.
-            if u in neg_count:
-                continue
+        for u in relabeled - neg_count.keys():
             d_u = d[u]
             # Skip nodes without out-edges of negative reduced costs.
             if all(d_u + weight(u, v, e) >= d[v] for v, e in G_succ[u].items()):


### PR DESCRIPTION
Closes #8223.

The branch
https://github.com/networkx/networkx/blob/e8a8c1944440bd8cf216381366df40a8210a0743/networkx/algorithms/shortest_paths/weighted.py#L2079-L2081
was not reliably being entered because iterating over `relabeled` is not deterministic.

This PR adds a test that guarantees the branch would have been entered/the set difference is doing something.