### PR TITLE
CI: remove doctests from `coverage` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           name: Run tests
           command: |
             source venv/bin/activate
-            pytest --cov=networkx --cov-report=html -n 4 --doctest-modules --durations=20 --pyargs networkx
+            pytest --cov=networkx --cov-report=html -n 4 --durations=20 --pyargs networkx
       - store_artifacts:
           path: htmlcov
           destination: coverage


### PR DESCRIPTION
The coverage job should probably not be running doctests:
1. if doctests are adding coverage, then we should flag the missing lines for additional, non-doctest coverage
2. if they aren't, we might as well exclude them.

Based on https://github.com/networkx/networkx/pull/8273#discussion_r2353936390.