### PR TITLE
Expire deprecation of compute_v_structures.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -43,7 +43,6 @@ Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
 Version 3.6
 ~~~~~~~~~~~
-* Remove ``compute_v_structures`` from ``algorithms/dag.py``.
 * Remove ``link`` kwarg from ``readwrite/json_graph/node_link.py``;
   Remove the ``FutureWarning`` re: the default value of ``edges`` and change the
   default value to ``"edges"``.

--- a/doc/reference/algorithms/dag.rst
+++ b/doc/reference/algorithms/dag.rst
@@ -21,6 +21,5 @@ Directed Acyclic Graphs
    dag_longest_path
    dag_longest_path_length
    dag_to_branching
-   compute_v_structures
    colliders
    v_structures

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -30,7 +30,6 @@ __all__ = [
     "dag_longest_path",
     "dag_longest_path_length",
     "dag_to_branching",
-    "compute_v_structures",
 ]
 
 chaini = chain.from_iterable
@@ -1273,81 +1272,6 @@ def dag_to_branching(G):
     B.remove_node(0)
     B.remove_node(-1)
     return B
-
-
-@not_implemented_for("undirected")
-@nx._dispatchable
-def compute_v_structures(G):
-    """Yields 3-node tuples that represent the v-structures in `G`.
-
-    .. deprecated:: 3.4
-
-       `compute_v_structures` actually yields colliders. It will be removed in
-       version 3.6. Use `nx.dag.v_structures` or `nx.dag.colliders` instead.
-
-    Colliders are triples in the directed acyclic graph (DAG) where two parent nodes
-    point to the same child node. V-structures are colliders where the two parent
-    nodes are not adjacent. In a causal graph setting, the parents do not directly
-    depend on each other, but conditioning on the child node provides an association.
-
-    Parameters
-    ----------
-    G : graph
-        A networkx `~networkx.DiGraph`.
-
-    Yields
-    ------
-    A 3-tuple representation of a v-structure
-        Each v-structure is a 3-tuple with the parent, collider, and other parent.
-
-    Raises
-    ------
-    NetworkXNotImplemented
-        If `G` is an undirected graph.
-
-    Examples
-    --------
-    >>> G = nx.DiGraph([(1, 2), (0, 4), (3, 1), (2, 4), (0, 5), (4, 5), (1, 5)])
-    >>> nx.is_directed_acyclic_graph(G)
-    True
-    >>> list(nx.compute_v_structures(G))
-    [(0, 4, 2), (0, 5, 4), (0, 5, 1), (4, 5, 1)]
-
-    See Also
-    --------
-    v_structures
-    colliders
-
-    Notes
-    -----
-    This function was written to be used on DAGs, however it works on cyclic graphs
-    too. Since colliders are referred to in the cyclic causal graph literature
-    [2]_ we allow cyclic graphs in this function. It is suggested that you test if
-    your input graph is acyclic as in the example if you want that property.
-
-    References
-    ----------
-    .. [1]  `Pearl's PRIMER <https://bayes.cs.ucla.edu/PRIMER/primer-ch2.pdf>`_
-            Ch-2 page 50: v-structures def.
-    .. [2] A Hyttinen, P.O. Hoyer, F. Eberhardt, M J ̈arvisalo, (2013)
-           "Discovering cyclic causal models with latent variables:
-           a general SAT-based procedure", UAI'13: Proceedings of the Twenty-Ninth
-           Conference on Uncertainty in Artificial Intelligence, pg 301–310,
-           `doi:10.5555/3023638.3023669 <https://dl.acm.org/doi/10.5555/3023638.3023669>`_
-    """
-    import warnings
-
-    warnings.warn(
-        (
-            "\n\n`compute_v_structures` actually yields colliders. It will be\n"
-            "removed in version 3.6. Use `nx.dag.v_structures` or `nx.dag.colliders`\n"
-            "instead.\n"
-        ),
-        category=DeprecationWarning,
-        stacklevel=5,
-    )
-
-    return colliders(G)
 
 
 @not_implemented_for("undirected")

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -784,32 +784,6 @@ def test_ancestors_descendants_undirected():
     nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}
 
 
-def test_compute_v_structures_raise():
-    G = nx.Graph()
-    with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):
-        nx.compute_v_structures(G)
-
-
-def test_compute_v_structures():
-    edges = [(0, 1), (0, 2), (3, 2)]
-    G = nx.DiGraph(edges)
-
-    v_structs = set(nx.compute_v_structures(G))
-    assert len(v_structs) == 1
-    assert (0, 2, 3) in v_structs
-
-    edges = [("A", "B"), ("C", "B"), ("B", "D"), ("D", "E"), ("G", "E")]
-    G = nx.DiGraph(edges)
-    v_structs = set(nx.compute_v_structures(G))
-    assert len(v_structs) == 2
-
-
-def test_compute_v_structures_deprecated():
-    G = nx.DiGraph()
-    with pytest.deprecated_call():
-        nx.compute_v_structures(G)
-
-
 def test_v_structures_raise():
     G = nx.Graph()
     with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -116,9 +116,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="\n\n`compute_v_structures"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="Keyword argument 'link'"
     )
     warnings.filterwarnings(


### PR DESCRIPTION
With the NX 3.6 release on the horizon, I wanted to make sure we get the scheduled deprication expirations in. This is the first of 2 removals slated for 3.6: removing the `compute_v_structures` fn.