### PR TITLE
Expire deprecation of link kwarg in node_link fns.

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -41,12 +41,6 @@ Todo
 
 Make sure to review ``networkx/conftest.py`` after removing deprecated code.
 
-Version 3.6
-~~~~~~~~~~~
-* Remove ``link`` kwarg from ``readwrite/json_graph/node_link.py``;
-  Remove the ``FutureWarning`` re: the default value of ``edges`` and change the
-  default value to ``"edges"``.
-
 Version 3.7
 ~~~~~~~~~~~
 * Remove ``graph_could_be_isomorphic``, ``fast_graph_could_be_isomorphic``, and

--- a/examples/external/javascript_force.py
+++ b/examples/external/javascript_force.py
@@ -22,7 +22,7 @@ G = nx.barbell_graph(6, 3)
 for n in G:
     G.nodes[n]["name"] = n
 # write json formatted data
-d = nx.json_graph.node_link_data(G)  # node-link format to serialize
+d = nx.json_graph.node_link_data(G, edges="links")  # node-link format to serialize
 # write json
 json.dump(d, open("force/force.json", "w"))
 print("Wrote node-link JSON data to force/force.json")

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -116,9 +116,6 @@ def set_warnings():
         "ignore", category=DeprecationWarning, message="\n\nThe `normalized`"
     )
     warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, message="Keyword argument 'link'"
-    )
-    warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="maybe_regular_expander"
     )
 

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -30,9 +30,8 @@ def node_link_data(
     target="target",
     name="id",
     key="key",
-    edges=None,
+    edges="edges",
     nodes="nodes",
-    link=None,
 ):
     """Returns data in node-link format that is suitable for JSON serialization
     and use in JavaScript documents.
@@ -52,13 +51,6 @@ def node_link_data(
         A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
     nodes : string
         A string that provides the 'nodes' attribute name for storing NetworkX-internal graph data.
-    link : string
-        .. deprecated:: 3.4
-
-           The `link` argument is deprecated and will be removed in version `3.6`.
-           Use the `edges` keyword instead.
-
-        A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------
@@ -74,7 +66,7 @@ def node_link_data(
     --------
     >>> from pprint import pprint
     >>> G = nx.Graph([("A", "B")])
-    >>> data1 = nx.node_link_data(G, edges="edges")
+    >>> data1 = nx.node_link_data(G)
     >>> pprint(data1)
     {'directed': False,
      'edges': [{'source': 'A', 'target': 'B'}],
@@ -96,7 +88,7 @@ def node_link_data(
     >>> s1 = json.dumps(G, default=nx.node_link_data)
     >>> pprint(s1)
     ('{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"id": "A"}, '
-     '{"id": "B"}], "links": [{"source": "A", "target": "B"}]}')
+     '{"id": "B"}], "edges": [{"source": "A", "target": "B"}]}')
 
     The attribute names for storing NetworkX-internal graph data can
     be specified as keyword options.
@@ -114,7 +106,7 @@ def node_link_data(
 
     Notes
     -----
-    Graph, node, and link attributes are stored in this format.  Note that
+    Graph, node, and edge attributes are stored in this format.  Note that
     attribute keys will be converted to strings in order to comply with JSON.
 
     Attribute 'key' is only used for multigraphs.
@@ -126,34 +118,6 @@ def node_link_data(
     --------
     node_link_graph, adjacency_data, tree_data
     """
-    # TODO: Remove between the lines when `link` deprecation expires
-    # -------------------------------------------------------------
-    if link is not None:
-        warnings.warn(
-            "Keyword argument 'link' is deprecated; use 'edges' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if edges is not None:
-            raise ValueError(
-                "Both 'edges' and 'link' are specified. Use 'edges', 'link' will be remove in a future release"
-            )
-        else:
-            edges = link
-    else:
-        if edges is None:
-            warnings.warn(
-                (
-                    '\nThe default value will be `edges="edges" in NetworkX 3.6.\n\n'
-                    "To make this warning go away, explicitly set the edges kwarg, e.g.:\n\n"
-                    '  nx.node_link_data(G, edges="links") to preserve current behavior, or\n'
-                    '  nx.node_link_data(G, edges="edges") for forward compatibility.'
-                ),
-                FutureWarning,
-            )
-            edges = "links"
-    # ------------------------------------------------------------
-
     multigraph = G.is_multigraph()
 
     # Allow 'key' to be omitted from attrs if the graph is not a multigraph.
@@ -186,9 +150,8 @@ def node_link_graph(
     target="target",
     name="id",
     key="key",
-    edges=None,
+    edges="edges",
     nodes="nodes",
-    link=None,
 ):
     """Returns graph from node-link data format.
 
@@ -217,13 +180,6 @@ def node_link_graph(
         A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
     nodes : string
         A string that provides the 'nodes' attribute name for storing NetworkX-internal graph data.
-    link : string
-        .. deprecated:: 3.4
-
-           The `link` argument is deprecated and will be removed in version `3.6`.
-           Use the `edges` keyword instead.
-
-        A string that provides the 'edges' attribute name for storing NetworkX-internal graph data.
 
     Returns
     -------
@@ -237,7 +193,7 @@ def node_link_graph(
 
     >>> from pprint import pprint
     >>> G = nx.Graph([("A", "B")])
-    >>> data = nx.node_link_data(G, edges="edges")
+    >>> data = nx.node_link_data(G)
     >>> pprint(data)
     {'directed': False,
      'edges': [{'source': 'A', 'target': 'B'}],
@@ -247,15 +203,15 @@ def node_link_graph(
 
     Revert data in node-link format to a graph.
 
-    >>> H = nx.node_link_graph(data, edges="edges")
+    >>> H = nx.node_link_graph(data)
     >>> print(H.edges)
     [('A', 'B')]
 
     To serialize and deserialize a graph with JSON,
 
     >>> import json
-    >>> d = json.dumps(nx.node_link_data(G, edges="edges"))
-    >>> H = nx.node_link_graph(json.loads(d), edges="edges")
+    >>> d = json.dumps(nx.node_link_data(G))
+    >>> H = nx.node_link_graph(json.loads(d))
     >>> print(G.edges, H.edges)
     [('A', 'B')] [('A', 'B')]
 
@@ -271,34 +227,6 @@ def node_link_graph(
     --------
     node_link_data, adjacency_data, tree_data
     """
-    # TODO: Remove between the lines when `link` deprecation expires
-    # -------------------------------------------------------------
-    if link is not None:
-        warnings.warn(
-            "Keyword argument 'link' is deprecated; use 'edges' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if edges is not None:
-            raise ValueError(
-                "Both 'edges' and 'link' are specified. Use 'edges', 'link' will be remove in a future release"
-            )
-        else:
-            edges = link
-    else:
-        if edges is None:
-            warnings.warn(
-                (
-                    '\nThe default value will be changed to `edges="edges" in NetworkX 3.6.\n\n'
-                    "To make this warning go away, explicitly set the edges kwarg, e.g.:\n\n"
-                    '  nx.node_link_graph(data, edges="links") to preserve current behavior, or\n'
-                    '  nx.node_link_graph(data, edges="edges") for forward compatibility.'
-                ),
-                FutureWarning,
-            )
-            edges = "links"
-    # -------------------------------------------------------------
-
     multigraph = data.get("multigraph", multigraph)
     directed = data.get("directed", directed)
     if multigraph:

--- a/networkx/readwrite/json_graph/tests/test_node_link.py
+++ b/networkx/readwrite/json_graph/tests/test_node_link.py
@@ -6,69 +6,15 @@ import networkx as nx
 from networkx.readwrite.json_graph import node_link_data, node_link_graph
 
 
-def test_node_link_edges_default_future_warning():
-    "Test FutureWarning is raised when `edges=None` in node_link_data and node_link_graph"
-    G = nx.Graph([(1, 2)])
-    with pytest.warns(FutureWarning, match="\nThe default value will be"):
-        data = nx.node_link_data(G)  # edges=None, the default
-    with pytest.warns(FutureWarning, match="\nThe default value will be"):
-        H = nx.node_link_graph(data)  # edges=None, the default
-
-
-def test_node_link_deprecated_link_param():
-    G = nx.Graph([(1, 2)])
-    with pytest.warns(DeprecationWarning, match="Keyword argument 'link'"):
-        data = nx.node_link_data(G, link="links")
-    with pytest.warns(DeprecationWarning, match="Keyword argument 'link'"):
-        H = nx.node_link_graph(data, link="links")
-
-
 class TestNodeLink:
-    # TODO: To be removed when signature change complete
-    def test_custom_attrs_dep(self):
-        G = nx.path_graph(4)
-        G.add_node(1, color="red")
-        G.add_edge(1, 2, width=7)
-        G.graph[1] = "one"
-        G.graph["foo"] = "bar"
-
-        attrs = {
-            "source": "c_source",
-            "target": "c_target",
-            "name": "c_id",
-            "key": "c_key",
-            "link": "c_links",
-        }
-
-        H = node_link_graph(node_link_data(G, **attrs), multigraph=False, **attrs)
-        assert nx.is_isomorphic(G, H)
-        assert H.graph["foo"] == "bar"
-        assert H.nodes[1]["color"] == "red"
-        assert H[1][2]["width"] == 7
-
-        # provide only a partial dictionary of keywords.
-        # This is similar to an example in the doc string
-        attrs = {
-            "link": "c_links",
-            "source": "c_source",
-            "target": "c_target",
-        }
-        H = node_link_graph(node_link_data(G, **attrs), multigraph=False, **attrs)
-        assert nx.is_isomorphic(G, H)
-        assert H.graph["foo"] == "bar"
-        assert H.nodes[1]["color"] == "red"
-        assert H[1][2]["width"] == 7
-
     def test_exception_dep(self):
         G = nx.MultiDiGraph()
         with pytest.raises(nx.NetworkXError):
-            with pytest.warns(FutureWarning, match="\nThe default value will be"):
-                node_link_data(G, name="node", source="node", target="node", key="node")
+            node_link_data(G, name="node", source="node", target="node", key="node")
 
     def test_graph(self):
         G = nx.path_graph(4)
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(node_link_data(G))
+        H = node_link_graph(node_link_data(G))
         assert nx.is_isomorphic(G, H)
 
     def test_graph_attributes(self):
@@ -78,16 +24,13 @@ class TestNodeLink:
         G.graph[1] = "one"
         G.graph["foo"] = "bar"
 
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(node_link_data(G))
+        H = node_link_graph(node_link_data(G))
         assert H.graph["foo"] == "bar"
         assert H.nodes[1]["color"] == "red"
         assert H[1][2]["width"] == 7
 
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            d = json.dumps(node_link_data(G))
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(json.loads(d))
+        d = json.dumps(node_link_data(G))
+        H = node_link_graph(json.loads(d))
         assert H.graph["foo"] == "bar"
         assert H.graph["1"] == "one"
         assert H.nodes[1]["color"] == "red"
@@ -95,28 +38,24 @@ class TestNodeLink:
 
     def test_digraph(self):
         G = nx.DiGraph()
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(node_link_data(G))
+        H = node_link_graph(node_link_data(G))
         assert H.is_directed()
 
     def test_multigraph(self):
         G = nx.MultiGraph()
         G.add_edge(1, 2, key="first")
         G.add_edge(1, 2, key="second", color="blue")
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(node_link_data(G))
+        H = node_link_graph(node_link_data(G))
         assert nx.is_isomorphic(G, H)
         assert H[1][2]["second"]["color"] == "blue"
 
     def test_graph_with_tuple_nodes(self):
         G = nx.Graph()
         G.add_edge((0, 0), (1, 0), color=[255, 255, 0])
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            d = node_link_data(G)
+        d = node_link_data(G)
         dumped_d = json.dumps(d)
         dd = json.loads(dumped_d)
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(dd)
+        H = node_link_graph(dd)
         assert H.nodes[(0, 0)] == G.nodes[(0, 0)]
         assert H[(0, 0)][(1, 0)]["color"] == [255, 255, 0]
 
@@ -124,20 +63,17 @@ class TestNodeLink:
         q = "qualité"
         G = nx.Graph()
         G.add_node(1, **{q: q})
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            s = node_link_data(G)
+        s = node_link_data(G)
         output = json.dumps(s, ensure_ascii=False)
         data = json.loads(output)
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(data)
+        H = node_link_graph(data)
         assert H.nodes[1][q] == q
 
     def test_exception(self):
         G = nx.MultiDiGraph()
         attrs = {"name": "node", "source": "node", "target": "node", "key": "node"}
         with pytest.raises(nx.NetworkXError):
-            with pytest.warns(FutureWarning, match="\nThe default value will be"):
-                node_link_data(G, **attrs)
+            node_link_data(G, **attrs)
 
     def test_string_ids(self):
         q = "qualité"
@@ -145,12 +81,10 @@ class TestNodeLink:
         G.add_node("A")
         G.add_node(q)
         G.add_edge("A", q)
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            data = node_link_data(G)
-        assert data["links"][0]["source"] == "A"
-        assert data["links"][0]["target"] == q
-        with pytest.warns(FutureWarning, match="\nThe default value will be"):
-            H = node_link_graph(data)
+        data = node_link_data(G)
+        assert data["edges"][0]["source"] == "A"
+        assert data["edges"][0]["target"] == q
+        H = node_link_graph(data)
         assert nx.is_isomorphic(G, H)
 
     def test_custom_attrs(self):
@@ -165,7 +99,7 @@ class TestNodeLink:
             "target": "c_target",
             "name": "c_id",
             "key": "c_key",
-            "link": "c_links",
+            "edges": "c_links",
         }
 
         H = node_link_graph(node_link_data(G, **attrs), multigraph=False, **attrs)


### PR DESCRIPTION
... and the 2nd of 2 deprication expirations for 3.6 - see also #8281 

This one's a little trickier as it involves removing a kwarg named `link` from `node_link_graph` and `node_link_data`, and replacing it with the more NetworkX-y `edges`. Note that most of the changes to the test suite involve removing a context manager that was ensuring a `FutureWarning` was being raised - the underlying tested code remains the same.