### PR TITLE
Draft/discussion: Adding Dijkstra's algo specific doc

### DIFF
--- a/doc/reference/algorithms/dijkstra.rst
+++ b/doc/reference/algorithms/dijkstra.rst
@@ -1,0 +1,140 @@
+Dijkstra's Algorithm
+===================
+
+Dijkstra's algorithm is a classical algorithm for finding the shortest paths 
+from a single source node to all other nodes in a weighted graph with 
+non-negative edge weights. It was conceived by Edsger W. Dijkstra in 1956 
+and is widely used in routing, network optimization, and pathfinding problems.
+
+For a general overview in the shortest path problem see
+`Shortest Paths <shortest_paths.html>`_.
+
+Problem Definition
+------------------
+Given a weighted graph G = (V, E) and a source vertex s ∈ V, compute the 
+shortest-path distances d(s, v) from s to every vertex v ∈ V, where each 
+edge (u, v) ∈ E has a non-negative weight w(u, v). Optionally, the algorithm 
+can also produce the actual shortest paths.
+
+Algorithm
+---------
+Dijkstra's algorithm is a greedy, iterative algorithm. The main idea is to 
+incrementally build a set of nodes with known shortest distances, 
+selecting at each step the node with the smallest tentative distance.
+
+**Initialization**
+
+1. Assign every node a tentative distance value:
+    * `dist[s] = 0` for the source
+    * `dist[v] = ∞` for all other nodes
+2. Initialize all nodes as unvisited.
+3. Optionally, initialize a predecessor map to reconstruct shortest paths.
+
+**Iteration**
+
+While there are unvisited nodes:
+
+1. Select the unvisited node u with the smallest tentative distance.
+2. For each neighbor v of u:
+    * Compute alternative distance: `alt = dist[u] + w(u, v)`
+    * If `alt < dist[v]`, update `dist[v] = alt` and set `predecessor[v] = u`.
+3. Mark u as visited. A visited node will not be checked again.
+
+**Termination**
+
+The algorithm terminates when all nodes have been visited, or when the smallest tentative distance among unvisited nodes is infinity.
+
+Pseudocode
+----------
+.. code-block:: text
+
+    function Dijkstra(Graph, source):
+        for each vertex v in Graph:
+            dist[v] ← ∞
+            prev[v] ← UNDEFINED
+        dist[source] ← 0
+
+        Q ← priority queue of all vertices, keyed by dist
+
+        while Q is not empty:
+            u ← vertex in Q with smallest dist[u]
+            remove u from Q
+
+            for each neighbor v of u:
+                alt ← dist[u] + weight(u, v)
+                if alt < dist[v]:
+                    dist[v] ← alt
+                    prev[v] ← u
+                    decrease-key(Q, v, alt)
+
+        return dist, prev
+
+Complexity
+----------
+
+The time complexity of Dijkstra's algorithm depends on the data structure used
+to select the node with the smallest tentative distance. Using a simple array
+results in a time complexity of :math:`O(|V|^2)`, while a binary heap reduces it
+to :math:`O((|V| + |E|) \log |V|)`. Using a Fibonacci heap further improves the
+complexity to :math:`O(|V| \log |V| + |E|)`. The space complexity of the
+algorithm is :math:`O(|V| + |E|)`, which accounts for storing the graph
+representation as well as the distance and predecessor information.
+
+In practice, Fibonacci heaps have a higher constant overhead compared to binary
+heaps, which can make them slower for typical problem sizes despite their
+better asymptotic performance. NetworkX's implementation of Dijkstra's
+algorithm uses a Python built-in binary heap.
+
+Limitations
+-----------
+Dijkstra's algorithm works only with non-negative edge weights and finds the
+shortest-path tree from the source to all reachable nodes. For graphs that
+contain negative edge weights, alternative algorithms such as Bellman-Ford or
+Johnson’s algorithm are required.
+
+
+Example
+-------
+Consider the weighted graph:
+
+.. code-block:: text
+
+       (2)
+    A ------ B
+    |        |
+   (1)      (3)
+    |        |
+    C ------ D
+       (1)
+
+We can compute the shortest path from ``A`` to all vertices by doing:
+
+    >>> import networkx as nx
+    >>> # Create a weighted graph
+    >>> G = nx.Graph()
+    >>> edges = [('A', 'B', 2), ('A', 'C', 1), ('B', 'D', 3), ('C', 'D', 1)]
+    >>> G.add_weighted_edges_from(edges)
+    >>> distances = nx.single_source_dijkstra_path_length(G, source='A')
+    >>> print("Shortest distances from A:", distances)
+    Shortest distances from A: {'A': 0, 'C': 1, 'B': 2, 'D': 2}
+
+Available Functions
+-------------------
+
+.. automodule:: networkx.algorithms.shortest_paths.weighted
+.. autosummary::
+   :toctree: generated/
+
+   dijkstra_predecessor_and_distance
+   dijkstra_path
+   dijkstra_path_length
+   single_source_dijkstra
+   single_source_dijkstra_path
+   single_source_dijkstra_path_length
+   multi_source_dijkstra
+   multi_source_dijkstra_path
+   multi_source_dijkstra_path_length
+   all_pairs_dijkstra
+   all_pairs_dijkstra_path
+   all_pairs_dijkstra_path_length
+   bidirectional_dijkstra

--- a/doc/reference/algorithms/shortest_paths.rst
+++ b/doc/reference/algorithms/shortest_paths.rst
@@ -52,32 +52,32 @@ better than others. The table below summarizes the algorithms NetworkX supports
 and their typical time complexities. Here, :math:`V` is the number of nodes and
 :math:`E` is the number of edges in the graph.
 
-+----------------------+-------------+--------------------+---------------------------+------------------------------------+
-| Algorithm            | Weighted    | Query Type         | Time Complexity           | Recommended for                    |
-|                      | Supported?  |                    |                           |                                    |
-+======================+=============+====================+===========================+====================================+
-| Breadth–First Search | Unweighted  | Single-source,     | :math:`O(V + E)`          | Fastest choice for unweighted      |
-| (BFS)                | Only        | Single-pair        |                           | graphs; shortest path in hops      |
-+----------------------+-------------+--------------------+---------------------------+------------------------------------+
-| Dijkstra             | Yes, both   | Single-source,     | :math:`O((V + E) \log V)` | General-purpose choice for         |
-|                      |             | Single-pair        |                           | non-negative weights               |
-+----------------------+-------------+--------------------+---------------------------+------------------------------------+
-| Bellman–Ford         | Yes, both   | Single-source,     | :math:`O(VE)`             | Graphs with negative edge weights  |
-|                      |             | Single-pair        |                           |                                    |
-+----------------------+-------------+--------------------+---------------------------+------------------------------------+
-| Floyd–Warshall       | Yes, both   | All-pairs          | :math:`O(V^3)`            | Dense graphs or when all-pairs     |
-|                      |             |                    |                           | shortest paths are needed          |
-+----------------------+-------------+--------------------+---------------------------+------------------------------------+
-| Johnson              | Yes, both   | All-pairs          | :math:`O(V(V + E) \log V)`| All-pairs shortest paths with      |
-|                      |             |                    |                           | negative weights                   |
-+----------------------+-------------+--------------------+---------------------------+------------------------------------+
++----------------------------+-------------+--------------------+---------------------------+------------------------------------+
+| Algorithm                  | Weighted    | Query Type         | Time Complexity           | Recommended for                    |
+|                            | Supported?  |                    |                           |                                    |
++============================+=============+====================+===========================+====================================+
+| Breadth–First Search       | Unweighted  | Single-source,     | :math:`O(V + E)`          | Fastest choice for unweighted      |
+| (BFS)                      | Only        | Single-pair        |                           | graphs; shortest path in hops      |
++----------------------------+-------------+--------------------+---------------------------+------------------------------------+
+| `Dijkstra <dijkstra.html>`_| Yes, both   | Single-source,     | :math:`O((V + E) \log V)` | General-purpose choice for         |
+|                            |             | Single-pair        |                           | non-negative weights               |
++----------------------------+-------------+--------------------+---------------------------+------------------------------------+
+| Bellman–Ford               | Yes, both   | Single-source,     | :math:`O(VE)`             | Graphs with negative edge weights  |
+|                            |             | Single-pair        |                           |                                    |
++----------------------------+-------------+--------------------+---------------------------+------------------------------------+
+| Floyd–Warshall             | Yes, both   | All-pairs          | :math:`O(V^3)`            | Dense graphs or when all-pairs     |
+|                            |             |                    |                           | shortest paths are needed          |
++----------------------------+-------------+--------------------+---------------------------+------------------------------------+
+| Johnson                    | Yes, both   | All-pairs          | :math:`O(V(V + E) \log V)`| All-pairs shortest paths with      |
+|                            |             |                    |                           | negative weights                   |
++----------------------------+-------------+--------------------+---------------------------+------------------------------------+
 
 The **query type** determines whether the algorithm computes shortest paths
 from one node to all others (single-source), between two specified nodes
 (single-pair), or between all pairs of nodes (all-pairs). For example, BFS,
-Dijkstra, and Bellman–Ford are commonly used for single-source or single-pair
-queries, while Floyd–Warshall and Johnson are designed for all-pairs shortest
-paths.
+`Dijkstra <dijkstra.html>`_, and Bellman–Ford are commonly used for single-source
+or single-pair queries, while Floyd–Warshall and Johnson are designed for
+all-pairs shortest paths.
 
 Single-source algorithms can be adapted to single-pair queries by stopping
 once the target node is reached (same time complexity). They can also be
@@ -87,7 +87,8 @@ number of sources (:math:`V`).
 
 When the query is restricted to a single pair of nodes, bidirectional variants
 of some algorithms can be applied to improve efficiency. In NetworkX, both
-bidirectional breadth–first search and bidirectional Dijkstra are available.
+bidirectional breadth–first search and bidirectional
+`Dijkstra <dijkstra.html>`_ are available.
 
 A less common query type is the single-target shortest path, where the goal is
 to find paths from all nodes to a given target. This can be computed by
@@ -124,17 +125,17 @@ represents the all pairs shortest path query.
 +------------------+------------------+---------------------------------------------+
 
 By default, the simplified interface uses Breadth–First Search for unweighted
-graphs and Dijkstra's algorithm for weighted graphs (``weight`` parameter is
-not ``None``).
+graphs and `Dijkstra's <dijkstra.html>`_ algorithm for weighted graphs (
+``weight`` parameter is not ``None``).
 
 The default algorithm can be overridden to select Bellman-Ford by specifying
-the ``method`` parameter to be "bellman-ford". Algorithms other than Dijkstra,
-Bellman-Ford and Breadth–First Search are not supported in the simplified
-interface.
+the ``method`` parameter to be "bellman-ford". Algorithms other than
+`Dijkstra <dijkstra.html>`_, Bellman-Ford and Breadth–First Search are not
+supported in the simplified interface.
 
 For the case of single-pair queries (both ``source`` and ``target`` specified),
-bidirectional variants of Dijkstra and BFS are used when those methods are
-selected.
+bidirectional variants of `Dijkstra <dijkstra.html>`_ and BFS are used when
+those methods are selected.
 
 
 Simplified Interface Methods
@@ -327,3 +328,6 @@ Adding sentinel node in-place and calling shortest path functions::
     >>> G.remove_node(sentinel) # we restore graph
     >>> list(G)
     ['A', 'B', 'C', 'D', 'E']
+
+
+   


### PR DESCRIPTION
**What do people think about having an specific doc section for Dijkstra's?**

I think this could help discoverability of the shortest path docs, especially through search. From Google search data we can see that "Dijkstra" is a more popular search term than "shortest path".

https://trends.google.com/trends/explore?q=Dijkstra,shortest%20path&hl=en

<img width="1154" height="675" alt="image" src="https://github.com/user-attachments/assets/61e68d3b-4bcc-4d8a-b0ed-57faf3321b16" />
