### PR TITLE
Move coverage configuration to pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-branch = True
-source = networkx
-omit = */tests/*, conftest.py, *testing/test.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,11 @@ networkx = ['tests/*.py']
 [tool.changelist]
 ignored_user_logins = ["dependabot[bot]", "pre-commit-ci[bot]", "web-flow"]
 
+[tool.coverage.run]
+branch = true
+source = ["networkx"]
+omit = ["*/tests/*", "conftest.py", "*testing/test.py"]
+
 [tool.ruff.lint]
 extend-select = [
 #  "B",        # flake8-bugbear


### PR DESCRIPTION
Meta-proposal to move the `coverage` configuration options to `pyproject.toml`. The main benefit to my mind is removing one more hidden file from the root directory of the repo. Pyproject-based configuration is fully supported (at least for our relatively simple use-case) according to the [coverage docs](https://coverage.readthedocs.io/en/latest/config.html#sample-file).