### PR TITLE
Fix over-indentation of list in chordless_cycles docstring

### DIFF
--- a/networkx/algorithms/cycles.py
+++ b/networkx/algorithms/cycles.py
@@ -511,19 +511,19 @@ def chordless_cycles(G, length_bound=None):
     We use an algorithm strongly inspired by that of Dias et al [1]_.  It has
     been modified in the following ways:
 
-        1. Recursion is avoided, per Python's limitations
+        1. Recursion is avoided, per Python's limitations.
 
         2. The labeling function is not necessary, because the starting paths
-            are chosen (and deleted from the host graph) to prevent multiple
-            occurrences of the same path
+           are chosen (and deleted from the host graph) to prevent multiple
+           occurrences of the same path.
 
-        3. The search is optionally bounded at a specified length
+        3. The search is optionally bounded at a specified length.
 
         4. Support for directed graphs is provided by extending cycles along
-            forward edges, and blocking nodes along forward and reverse edges
+           forward edges, and blocking nodes along forward and reverse edges.
 
         5. Support for multigraphs is provided by omitting digons from the set
-            of forward edges
+           of forward edges.
 
     Parameters
     ----------


### PR DESCRIPTION
And add trailing periods to match earlier list.

This fixes a minor graphical oddity in the https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.cycles.chordless_cycles.html#chordless-cycles rendering.
